### PR TITLE
Load imported styles in the editor

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -423,17 +423,26 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string
 	 */
 	private static function functions_php( string $theme_slug ): string {
-		$handle = sanitize_key( $theme_slug ) . '-style';
+		$style_handle = sanitize_key( $theme_slug ) . '-style';
+		$editor_handle = sanitize_key( $theme_slug ) . '-editor-style';
+		$script_handle = sanitize_key( $theme_slug ) . '-site';
 
 		return "<?php\n" .
 			"/**\n" .
 			" * Generated theme bootstrap.\n" .
 			" */\n\n" .
+			"add_action( 'after_setup_theme', static function (): void {\n" .
+			"\tadd_theme_support( 'editor-styles' );\n" .
+			"\tadd_editor_style( 'style.css' );\n" .
+			"} );\n\n" .
 			"add_action( 'wp_enqueue_scripts', static function (): void {\n" .
-			"\twp_enqueue_style( '" . $handle . "', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );\n" .
+			"\twp_enqueue_style( '" . $style_handle . "', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );\n" .
 			"\tif ( file_exists( get_template_directory() . '/assets/site.js' ) ) {\n" .
-			"\t\twp_enqueue_script( '" . sanitize_key( $theme_slug ) . "-site', get_template_directory_uri() . '/assets/site.js', array(), wp_get_theme()->get( 'Version' ), true );\n" .
+			"\t\twp_enqueue_script( '" . $script_handle . "', get_template_directory_uri() . '/assets/site.js', array(), wp_get_theme()->get( 'Version' ), true );\n" .
 			"\t}\n" .
+			"} );\n\n" .
+			"add_action( 'enqueue_block_editor_assets', static function (): void {\n" .
+			"\twp_enqueue_style( '" . $editor_handle . "', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );\n" .
 			"} );\n";
 	}
 

--- a/tests/smoke-editor-style-support.php
+++ b/tests/smoke-editor-style-support.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Smoke test: generated themes load imported styles in the editor/Site Editor.
+ *
+ * Run inside a WordPress site with BFB active:
+ * wp eval-file tests/smoke-editor-style-support.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+if ( ! class_exists( 'Static_Site_Importer_Document', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-document.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read = static function ( string $path ): string {
+	$contents = file_get_contents( $path );
+	return false === $contents ? '' : $contents;
+};
+
+$result = Static_Site_Importer_Theme_Generator::import_theme(
+	$plugin_root . '/tests/fixtures/wordpress-is-dead/index.html',
+	array(
+		'name'      => 'Editor Style Support Fixture',
+		'slug'      => 'editor-style-support-fixture',
+		'overwrite' => true,
+		'activate'  => false,
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+if ( ! is_wp_error( $result ) ) {
+	$functions = $read( $result['theme_dir'] . '/functions.php' );
+
+	$assert( str_contains( $functions, "add_theme_support( 'editor-styles' )" ), 'functions-adds-editor-styles-support' );
+	$assert( str_contains( $functions, "add_editor_style( 'style.css' )" ), 'functions-registers-editor-style-css' );
+	$assert( str_contains( $functions, "add_action( 'enqueue_block_editor_assets'" ), 'functions-adds-block-editor-assets-fallback' );
+	$assert( str_contains( $functions, 'wp_enqueue_style' ) && str_contains( $functions, '-editor-style' ), 'functions-enqueues-editor-style-fallback' );
+	$assert( str_contains( $functions, 'get_stylesheet_uri()' ), 'functions-reuses-generated-style-css' );
+	$assert( str_contains( $functions, 'wp_enqueue_scripts' ), 'functions-keeps-frontend-style-enqueue' );
+}
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: editor style support smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Generated themes now opt into WordPress editor styles and register the imported `style.css` through `add_editor_style()`.
- Added a block-editor asset enqueue fallback so the generated stylesheet is also available to the editor chrome when needed.
- Added a targeted smoke test proving generated `functions.php` includes the editor stylesheet support.

## Tests
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/smoke-editor-style-support.php`
- `studio wp eval-file /Users/chubes/Developer/static-site-importer@site-editor-native-output/tests/smoke-editor-style-support.php`
- `studio wp eval-file /Users/chubes/Developer/static-site-importer@site-editor-native-output/tests/smoke-wordpress-is-dead-fixture.php`
- Live verified by importing `/Users/chubes/Developer/wordpress-is-dead/index.html` as the active `wordpress-is-dead` theme on `intelligence-chubes4` and confirming generated `functions.php` contains `add_theme_support( 'editor-styles' )`, `add_editor_style( 'style.css' )`, and the editor enqueue fallback.

Closes #3

## Follow-up issues filed
- #4
- #5
- #6
- #7

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generated theme editor-style support, added and ran the smoke test, live-verified the generated theme files, and filed follow-up issues for deferred Site-Editor-native work. Chris remains responsible for review and merge.
