### PR TITLE
Extract theme color tokens from imported CSS

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -77,10 +77,12 @@ class Static_Site_Importer_Theme_Generator {
 			return $result;
 		}
 
+		$site_css = self::site_css( $site_dir, $document );
+
 		$writes = array(
-			$theme_dir . '/style.css'                  => self::style_css( $theme_name, self::site_css( $site_dir, $document ) ),
+			$theme_dir . '/style.css'                  => self::style_css( $theme_name, $site_css ),
 			$theme_dir . '/functions.php'              => self::functions_php( $theme_slug ),
-			$theme_dir . '/theme.json'                 => self::theme_json( $theme_name ),
+			$theme_dir . '/theme.json'                 => self::theme_json( $theme_name, $site_css ),
 			$theme_dir . '/parts/header.html'          => $header_blocks,
 			$theme_dir . '/parts/footer.html'          => $footer_blocks,
 			$theme_dir . '/templates/front-page.html'  => self::content_template( $background_blocks ),
@@ -450,9 +452,10 @@ class Static_Site_Importer_Theme_Generator {
 	 * Build theme.json.
 	 *
 	 * @param string $theme_name Theme name.
+	 * @param string $css        Source CSS.
 	 * @return string
 	 */
-	private static function theme_json( string $theme_name ): string {
+	private static function theme_json( string $theme_name, string $css ): string {
 		$data = array(
 			'$schema'  => 'https://schemas.wp.org/trunk/theme.json',
 			'version'  => 3,
@@ -465,7 +468,88 @@ class Static_Site_Importer_Theme_Generator {
 			),
 		);
 
+		$design_tokens = self::design_tokens_from_css( $css );
+		if ( ! empty( $design_tokens['palette'] ) ) {
+			$data['settings']['color']['palette'] = $design_tokens['palette'];
+		}
+
+		if ( ! empty( $design_tokens['styles'] ) ) {
+			$data['styles']['color'] = $design_tokens['styles'];
+		}
+
 		return wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";
+	}
+
+	/**
+	 * Extract conservative design tokens from obvious :root custom properties.
+	 *
+	 * @param string $css Source CSS.
+	 * @return array{palette:array<int,array{slug:string,name:string,color:string}>,styles:array<string,string>}
+	 */
+	private static function design_tokens_from_css( string $css ): array {
+		$palette = array();
+		$styles  = array();
+		$seen    = array();
+
+		if ( '' === trim( $css ) || ! preg_match_all( '/:root\s*\{([^}]*)\}/i', $css, $root_matches ) ) {
+			return array(
+				'palette' => $palette,
+				'styles'  => $styles,
+			);
+		}
+
+		foreach ( $root_matches[1] as $root_body ) {
+			$root_body = (string) preg_replace( '/\/\*.*?\*\//s', '', $root_body );
+			if ( ! preg_match_all( '/--([A-Za-z0-9_-]+)\s*:\s*([^;{}]+);/', $root_body, $property_matches, PREG_SET_ORDER ) ) {
+				continue;
+			}
+
+			foreach ( $property_matches as $property_match ) {
+				$token_name = strtolower( $property_match[1] );
+				$color      = trim( $property_match[2] );
+				$slug       = sanitize_title( $token_name );
+
+				if ( '' === $slug || isset( $seen[ $slug ] ) || ! self::is_safe_color_value( $color ) ) {
+					continue;
+				}
+
+				$seen[ $slug ] = true;
+				$palette[]     = array(
+					'slug'  => $slug,
+					'name'  => ucwords( str_replace( array( '-', '_' ), ' ', $token_name ) ),
+					'color' => $color,
+				);
+
+				if ( ! isset( $styles['background'] ) && in_array( $slug, array( 'bg', 'background' ), true ) ) {
+					$styles['background'] = 'var(--wp--preset--color--' . $slug . ')';
+				}
+
+				if ( ! isset( $styles['text'] ) && in_array( $slug, array( 'fg', 'foreground', 'text' ), true ) ) {
+					$styles['text'] = 'var(--wp--preset--color--' . $slug . ')';
+				}
+			}
+		}
+
+		return array(
+			'palette' => $palette,
+			'styles'  => $styles,
+		);
+	}
+
+	/**
+	 * Check whether a CSS value is safe to expose as a theme palette color.
+	 *
+	 * @param string $value CSS value.
+	 * @return bool
+	 */
+	private static function is_safe_color_value( string $value ): bool {
+		$value = trim( $value );
+
+		if ( preg_match( '/^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i', $value ) ) {
+			return true;
+		}
+
+		return (bool) preg_match( '/^(?:rgb|rgba|hsl|hsla)\(\s*[-+0-9.%\s,\/]+\s*\)$/i', $value );
 	}
 
 	/**

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -91,6 +91,13 @@ if ( ! is_wp_error( $result ) ) {
 	$footer     = $read( $theme_dir . '/parts/footer.html' );
 	$style      = $read( $theme_dir . '/style.css' );
 	$functions  = $read( $theme_dir . '/functions.php' );
+	$theme_json = json_decode( $read( $theme_dir . '/theme.json' ), true );
+	$palette    = array();
+	foreach ( $theme_json['settings']['color']['palette'] ?? array() as $color ) {
+		if ( isset( $color['slug'] ) ) {
+			$palette[ $color['slug'] ] = $color;
+		}
+	}
 
 	$assert( str_contains( $front_page, 'wp:post-content' ), 'front-page-renders-imported-page-content' );
 	$assert( str_contains( $page, 'wp:post-content' ), 'page-template-renders-imported-page-content' );
@@ -103,6 +110,14 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( str_contains( $footer, 'Prompt Liberation Front' ), 'footer-preserves-footer-copy' );
 	$assert( str_contains( $style, '--accent' ) && str_contains( $style, '.compare' ) && str_contains( $style, '.manifesto-list' ), 'style-preserves-source-css' );
 	$assert( str_contains( $functions, 'wp_enqueue_style' ), 'theme-enqueues-stylesheet' );
+	$assert( is_array( $theme_json ), 'theme-json-is-valid-json' );
+	$assert( isset( $palette['bg'] ) && '#0a0a0a' === $palette['bg']['color'], 'theme-json-exposes-bg-palette-token' );
+	$assert( isset( $palette['fg'] ) && '#f4f4f0' === $palette['fg']['color'], 'theme-json-exposes-fg-palette-token' );
+	$assert( isset( $palette['muted'] ) && '#8a8a82' === $palette['muted']['color'], 'theme-json-exposes-muted-palette-token' );
+	$assert( isset( $palette['accent'] ) && '#ff3b1f' === $palette['accent']['color'], 'theme-json-exposes-accent-palette-token' );
+	$assert( ! isset( $palette['max'] ), 'theme-json-ignores-non-color-custom-properties' );
+	$assert( 'var(--wp--preset--color--bg)' === ( $theme_json['styles']['color']['background'] ?? '' ), 'theme-json-sets-background-default-from-bg' );
+	$assert( 'var(--wp--preset--color--fg)' === ( $theme_json['styles']['color']['text'] ?? '' ), 'theme-json-sets-text-default-from-fg' );
 	$assert( ! str_contains( $front_page, '<!-- wp:html /-->' ), 'front-page-has-no-empty-html-fallbacks' );
 	$assert( isset( $result['pages']['index.html'], $result['pages']['manifesto.html'], $result['pages']['comparison.html'], $result['pages']['eulogy.html'], $result['pages']['proof.html'] ), 'imports-five-html-pages' );
 


### PR DESCRIPTION
## Summary
- Extract safe color-looking custom properties from imported `:root` CSS into `theme.json` palette entries.
- Use imported `--bg` and `--fg` tokens as Site Editor background/text defaults when present.
- Extend the WordPress-is-dead fixture smoke to prove generated palette tokens and non-color token filtering.

## Tests
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/smoke-wordpress-is-dead-fixture.php`
- `git diff --check`
- `studio wp eval-file /Users/chubes/Developer/static-site-importer@theme-json-tokens/tests/smoke-wordpress-is-dead-fixture.php`

Closes #7

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the conservative CSS token extraction, extended fixture smoke coverage, and ran syntax/fixture verification.