### PR TITLE
test: strengthen static importer validation harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,46 @@ wp static-site-importer import-theme /path/to/index.html \
   --overwrite
 ```
 
-## Smokes
+## Validation Harness
+
+The importer uses a fixture-first TDD loop:
+
+1. `tests/fixtures/wordpress-is-dead/` is the source static site.
+2. The harness imports that fixture into a generated block theme.
+3. PHP smokes prove importer behaviour and frontend fidelity in WordPress.
+4. The JS smoke runs Gutenberg's block parser/validator over generated theme artifacts so editor-invalid block
+   serialization is caught before manual Site Editor checks.
+
+Run the full local contract from the repository root:
+
+```bash
+npm install
+npm run test:validation
+```
+
+The runner uses `studio wp --path /Users/chubes/Studio/intelligence-chubes4` by default, imports the fixture as the
+active `wordpress-is-dead` theme, then runs the PHP and JS smokes in dependency order. Override the Studio site path
+with `STATIC_SITE_IMPORTER_SITE_PATH=/path/to/site`, override the whole WP-CLI command with
+`STATIC_SITE_IMPORTER_WP_CLI="wp"`, or validate an already-imported theme without mutating it:
+
+```bash
+npm run test:validation -- --skip-import /path/to/wp-content/themes/wordpress-is-dead
+```
+
+Machine-readable output is available for future CI wiring:
+
+```bash
+npm run test:validation -- --json
+```
+
+## Individual Smokes
 
 PHP smokes run inside WordPress with Block Format Bridge active:
 
 ```bash
 wp eval-file tests/smoke-wordpress-is-dead-fixture.php
 wp eval-file tests/smoke-editor-style-support.php
+wp eval-file tests/smoke-admin-import-html-entry.php
 ```
 
 The generated-theme JavaScript smoke runs Gutenberg's block validator against imported theme artifacts:
@@ -36,16 +69,18 @@ The generated-theme JavaScript smoke runs Gutenberg's block validator against im
 ```bash
 npm install
 npm run test:js-block-validation -- /path/to/wp-content/themes/wordpress-is-dead
+npm run test:js-block-validation -- --json /path/to/wp-content/themes/wordpress-is-dead
 ```
 
 If no path is passed, the smoke uses `STATIC_SITE_IMPORTER_THEME_DIR`, then `WP_CONTENT_DIR/themes/wordpress-is-dead`
 when `WP_CONTENT_DIR` is set. It validates `parts/header.html`, `parts/footer.html`, `patterns/*.php`, and
-`templates/*.html`, and reports invalid blocks with the file, nested block path, and validation reason.
+`templates/*.html`, and reports invalid blocks with the file, nested block path, block name, validation reason, and
+failure summaries grouped by block name and file.
 
-The smoke is expected to fail against the current generated `wordpress-is-dead` theme until the upstream h2bc native
-blockability fixes in chubes4/html-to-blocks-converter#70 and chubes4/html-to-blocks-converter#71 land. The failure
-output is still useful: it identifies exactly which generated artifact and nested block would trigger Site Editor block
-validation warnings.
+When generated markup still contains editor-invalid blocks, the JS smoke is expected to fail. The failure output is the
+contract: it identifies exactly which generated artifact, block type, and nested block path would trigger Site Editor
+validation warnings. Current known failures are expected to cluster around native navigation serialization until the
+upstream navigation fix lands.
 
 ## Boundary
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "static-site-importer",
   "private": true,
   "scripts": {
-    "test:js-block-validation": "node tests/smoke-generated-theme-block-validation.cjs"
+    "test:js-block-validation": "node tests/smoke-generated-theme-block-validation.cjs",
+    "test:validation": "node tests/run-validation-harness.cjs"
   },
   "devDependencies": {
     "@wordpress/block-library": "^9.45.0",

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * End-to-end validation harness for the wordpress-is-dead fixture.
+ *
+ * Imports the fixture into the local Studio site, runs the PHP fidelity smokes,
+ * then validates generated theme artifacts through Gutenberg's JS block parser.
+ */
+
+const path = require( 'node:path' );
+const process = require( 'node:process' );
+const { spawnSync } = require( 'node:child_process' );
+
+const repoRoot = path.resolve( __dirname, '..' );
+const args = process.argv.slice( 2 );
+const skipImport = args.includes( '--skip-import' );
+const jsonMode = args.includes( '--json' );
+const sitePath = process.env.STATIC_SITE_IMPORTER_SITE_PATH || '/Users/chubes/Studio/intelligence-chubes4';
+const wpCli = process.env.STATIC_SITE_IMPORTER_WP_CLI
+  ? splitCommand( process.env.STATIC_SITE_IMPORTER_WP_CLI )
+  : [ 'studio', 'wp', '--path', sitePath ];
+const themeDir = path.resolve(
+  args.find( ( arg ) => ! arg.startsWith( '--' ) ) ||
+    process.env.STATIC_SITE_IMPORTER_THEME_DIR ||
+    '/Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead'
+);
+const fixture = path.join( repoRoot, 'tests/fixtures/wordpress-is-dead/index.html' );
+
+const steps = [
+  ! skipImport && {
+    name: 'Import wordpress-is-dead fixture theme',
+    command: wpCli[ 0 ],
+    args: [
+      ...wpCli.slice( 1 ),
+      'static-site-importer',
+      'import-theme',
+      fixture,
+      '--slug=wordpress-is-dead',
+      '--name=WordPress Is Dead',
+      '--activate',
+      '--overwrite',
+    ],
+  },
+  {
+    name: 'Admin entry smoke',
+    command: wpCli[ 0 ],
+    args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-admin-import-html-entry.php' ) ],
+  },
+  {
+    name: 'Editor style smoke',
+    command: wpCli[ 0 ],
+    args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-editor-style-support.php' ) ],
+  },
+  {
+    name: 'Fixture fidelity smoke',
+    command: wpCli[ 0 ],
+    args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-wordpress-is-dead-fixture.php' ) ],
+  },
+  {
+    name: 'Generated theme JS block validation',
+    command: process.execPath,
+    args: [
+      path.join( repoRoot, 'tests/smoke-generated-theme-block-validation.cjs' ),
+      ...( jsonMode ? [ '--json' ] : [] ),
+      themeDir,
+    ],
+  },
+].filter( Boolean );
+
+const results = [];
+
+for ( const step of steps ) {
+  if ( ! jsonMode ) {
+    console.log( `\n==> ${ step.name }` );
+  }
+
+  const startedAt = Date.now();
+  const result = spawnSync( step.command, step.args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: jsonMode ? 'pipe' : 'inherit',
+    env: process.env,
+  } );
+  const stepResult = {
+    name: step.name,
+    command: [ step.command, ...step.args ],
+    status: result.status,
+    durationMs: Date.now() - startedAt,
+  };
+
+  if ( jsonMode ) {
+    stepResult.stdout = result.stdout || '';
+    stepResult.stderr = result.stderr || '';
+  }
+
+  results.push( stepResult );
+
+  if ( result.error || result.status !== 0 ) {
+    if ( result.error ) {
+      stepResult.error = result.error.message;
+    }
+    finish( false, results );
+  }
+}
+
+finish( true, results );
+
+function finish( ok, stepResults ) {
+  if ( jsonMode ) {
+    console.log( JSON.stringify( { ok, themeDir, steps: stepResults }, null, 2 ) );
+  } else if ( ok ) {
+    console.log( `\nOK: full validation harness passed (${ stepResults.length } steps)` );
+  } else {
+    const failed = stepResults[ stepResults.length - 1 ];
+    console.error( `\nFAIL: ${ failed.name } exited with status ${ failed.status }` );
+  }
+
+  process.exit( ok ? 0 : 1 );
+}
+
+function splitCommand( command ) {
+  return command.trim().split( /\s+/ ).filter( Boolean );
+}

--- a/tests/smoke-generated-theme-block-validation.cjs
+++ b/tests/smoke-generated-theme-block-validation.cjs
@@ -36,18 +36,35 @@ const { parse, validateBlock } = require( '@wordpress/blocks' );
 registerCoreBlocks();
 
 const repoRoot = path.resolve( __dirname, '..' );
+const args = process.argv.slice( 2 );
+const jsonMode = args.includes( '--json' );
+const pathArg = args.find( ( arg ) => ! arg.startsWith( '--' ) );
 const defaultThemeDir = process.env.WP_CONTENT_DIR
   ? path.join( process.env.WP_CONTENT_DIR, 'themes', 'wordpress-is-dead' )
   : path.join( repoRoot, 'wordpress-is-dead' );
 const themeDir = path.resolve(
-  process.argv[ 2 ] ||
+  pathArg ||
     process.env.STATIC_SITE_IMPORTER_THEME_DIR ||
     defaultThemeDir
 );
 
 if ( ! fs.existsSync( themeDir ) ) {
-  console.error( `Theme directory does not exist: ${ themeDir }` );
-  console.error( 'Import the fixture first or pass a theme path as the first argument.' );
+  reportResult( {
+    ok: false,
+    themeDir,
+    filesChecked: 0,
+    blocksChecked: 0,
+    invalidBlocks: 1,
+    failures: [ {
+      file: '(theme)',
+      path: '(theme)',
+      blockName: '(theme)',
+      reasons: [
+        `Theme directory does not exist: ${ themeDir }`,
+        'Import the fixture first or pass a theme path as the first argument.',
+      ],
+    } ],
+  } );
   process.exit( 1 );
 }
 
@@ -67,6 +84,7 @@ for ( const relativePath of targetFiles ) {
     failures.push( {
       file: relativePath,
       path: '(file)',
+      blockName: '(file)',
       reasons: [ `Missing generated artifact: ${ relativePath }` ],
     } );
     continue;
@@ -79,17 +97,11 @@ for ( const relativePath of targetFiles ) {
 }
 
 if ( failures.length ) {
-  for ( const failure of failures ) {
-    console.error( `FAIL ${ failure.file } ${ failure.path }` );
-    for ( const reason of failure.reasons ) {
-      console.error( `  - ${ reason }` );
-    }
-  }
-  console.error( `Block validation failed: ${ failures.length } invalid block(s) in ${ targetFiles.length } file(s).` );
+  reportResult( buildResult( false ) );
   process.exit( 1 );
 }
 
-console.log( `OK: JS block validation smoke passed (${ blockCount } blocks across ${ targetFiles.length } files)` );
+reportResult( buildResult( true ) );
 
 function listFiles( directory, extension ) {
   if ( ! fs.existsSync( directory ) ) {
@@ -115,6 +127,7 @@ function validateBlocks( blocks, file, trail = [] ) {
       failures.push( {
         file,
         path: blockPath.join( ' > ' ),
+        blockName: block.name || 'unknown',
         reasons: normalizeIssues( validationIssues ),
       } );
     }
@@ -193,6 +206,65 @@ function truncate( value, length = 180 ) {
 
 function countBlocks( blocks ) {
   return blocks.reduce( ( total, block ) => total + 1 + countBlocks( block.innerBlocks || [] ), 0 );
+}
+
+function buildResult( ok ) {
+  return {
+    ok,
+    themeDir,
+    filesChecked: targetFiles.length,
+    blocksChecked: blockCount,
+    invalidBlocks: failures.length,
+    failures,
+    byBlockName: summarizeFailures( 'blockName' ),
+    byFile: summarizeFailures( 'file' ),
+  };
+}
+
+function summarizeFailures( key ) {
+  const summary = {};
+  for ( const failure of failures ) {
+    const value = failure[ key ] || 'unknown';
+    summary[ value ] = ( summary[ value ] || 0 ) + 1;
+  }
+  return Object.fromEntries(
+    Object.entries( summary ).sort( ( left, right ) => right[ 1 ] - left[ 1 ] || left[ 0 ].localeCompare( right[ 0 ] ) )
+  );
+}
+
+function reportResult( result ) {
+  if ( jsonMode ) {
+    console.log( JSON.stringify( result, null, 2 ) );
+    return;
+  }
+
+  if ( result.ok ) {
+    console.log( `OK: JS block validation smoke passed (${ result.blocksChecked } blocks across ${ result.filesChecked } files)` );
+    return;
+  }
+
+  console.error( `Block validation failed: ${ result.invalidBlocks } invalid block(s) in ${ result.filesChecked } file(s).` );
+  printSummary( 'By block', result.byBlockName );
+  printSummary( 'By file', result.byFile );
+
+  for ( const failure of result.failures ) {
+    console.error( `FAIL ${ failure.file } ${ failure.path }` );
+    for ( const reason of failure.reasons ) {
+      console.error( `  - ${ reason }` );
+    }
+  }
+}
+
+function printSummary( label, summary ) {
+  const entries = Object.entries( summary );
+  if ( ! entries.length ) {
+    return;
+  }
+
+  console.error( `${ label }:` );
+  for ( const [ name, count ] of entries ) {
+    console.error( `  - ${ name }: ${ count }` );
+  }
 }
 
 function withConsoleSilenced( callback ) {


### PR DESCRIPTION
## Summary
- Add a single `npm run test:validation` harness that imports the `wordpress-is-dead` fixture, runs the PHP smokes, and then runs Gutenberg block validation against the generated theme.
- Extend the JS block validator with `--json` output plus failure summaries grouped by block name and generated file.
- Document the fixture-first validation strategy and mark known native-navigation PHP fixture checks as expected upstream failures so non-navigation fidelity remains visible.

## Test workflow
- Source fixture: `tests/fixtures/wordpress-is-dead/`.
- Generated artifact: local `wordpress-is-dead` block theme imported through WP-CLI.
- PHP fidelity checks: admin entry, editor style support, and fixture/frontend structure.
- JS editor validation: parse and validate generated `parts`, `patterns`, and `templates` with `@wordpress/blocks`.

## Tests
- `node --check tests/smoke-generated-theme-block-validation.cjs`
- `node --check tests/run-validation-harness.cjs`
- `studio wp eval-file "/Users/chubes/Developer/static-site-importer@strengthen-validation-harness/tests/smoke-admin-import-html-entry.php"` — passed, 8 assertions.
- `studio wp eval-file "/Users/chubes/Developer/static-site-importer@strengthen-validation-harness/tests/smoke-editor-style-support.php"` — passed, 7 assertions.
- `studio wp eval-file "/Users/chubes/Developer/static-site-importer@strengthen-validation-harness/tests/smoke-wordpress-is-dead-fixture.php"` — passed, 131 assertions.
- `npm run test:js-block-validation -- "/Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead"` — fails clearly on known navigation serialization only: 11 invalid blocks grouped as `core/navigation-link` (9) and `core/navigation` (2), in `parts/header.html` and `parts/footer.html`.
- `npm run test:validation` — imports and runs all steps; final JS validation currently fails on the same known navigation serialization cluster while earlier PHP steps pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Strengthened the generated-theme validation harness and documentation; Chris remains responsible for review and merge.
