### PR TITLE
fix: bridge source button styles to core links

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -736,7 +736,53 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string
 	 */
 	private static function style_css( string $theme_name, string $css ): string {
-		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Imported from static HTML using Block Format Bridge.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n";
+		$button_bridge = self::button_style_bridge_css( $css );
+
+		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Imported from static HTML using Block Format Bridge.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $button_bridge;
+	}
+
+	/**
+	 * Build compatibility rules for source anchor classes moved onto core/button wrappers.
+	 *
+	 * @param string $css Source CSS.
+	 * @return string Additional CSS rules.
+	 */
+	private static function button_style_bridge_css( string $css ): string {
+		if ( '' === trim( $css ) || ! str_contains( $css, '.' ) ) {
+			return '';
+		}
+
+		$rules = array();
+		if ( ! preg_match_all( '/([^{}]+)\{([^{}]+)\}/', $css, $matches, PREG_SET_ORDER ) ) {
+			return '';
+		}
+
+		foreach ( $matches as $match ) {
+			$declarations = trim( $match[2] );
+			if ( '' === $declarations ) {
+				continue;
+			}
+
+			$selectors = array();
+			foreach ( explode( ',', $match[1] ) as $selector ) {
+				$selector = trim( $selector );
+				if ( ! preg_match( '/^((?:\.[A-Za-z0-9_-]+)+)(:(?:hover|focus|active|visited))?$/', $selector, $selector_match ) ) {
+					continue;
+				}
+
+				$selectors[] = '.wp-block-button' . $selector_match[1] . ' > .wp-block-button__link' . ( $selector_match[2] ?? '' );
+			}
+
+			if ( $selectors ) {
+				$rules[] = implode( ', ', array_unique( $selectors ) ) . ' { ' . $declarations . ' }';
+			}
+		}
+
+		if ( ! $rules ) {
+			return '';
+		}
+
+		return "\n/* Static Site Importer: preserve source anchor styles on core/button links. */\n" . implode( "\n", array_unique( $rules ) ) . "\n";
 	}
 
 	/**

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -160,6 +160,9 @@ if ( ! is_wp_error( $result ) ) {
 		$assert( $footer_nav->ID === $footer_nav_after->ID, 'second-import-reuses-footer-navigation-post' );
 	}
 	$assert( str_contains( $style, '--accent' ) && str_contains( $style, '.compare' ) && str_contains( $style, '.manifesto-list' ), 'style-preserves-source-css' );
+	$assert( str_contains( $style, '.wp-block-button.btn > .wp-block-button__link' ), 'style-bridges-source-button-classes-to-core-button-links' );
+	$assert( str_contains( $style, '.wp-block-button.btn.primary > .wp-block-button__link' ), 'style-bridges-source-primary-button-to-core-button-link' );
+	$assert( str_contains( $style, '.wp-block-button.btn.ghost > .wp-block-button__link' ), 'style-bridges-source-ghost-button-to-core-button-link' );
 	$assert( str_contains( $functions, 'wp_enqueue_style' ), 'theme-enqueues-stylesheet' );
 	$assert( is_array( $theme_json ), 'theme-json-is-valid-json' );
 	$assert( isset( $palette['bg'] ) && '#0a0a0a' === $palette['bg']['color'], 'theme-json-exposes-bg-palette-token' );


### PR DESCRIPTION
## Summary
- Adds a generated CSS bridge so source class-only anchor rules continue to style the actual `core/button` link element after conversion.
- Extends the `wordpress-is-dead` fixture smoke with assertions for `.btn`, `.btn.primary`, and `.btn.ghost` bridge rules.

## Why

h2bc correctly maps source anchor classes to the `core/button` wrapper as `className`, but the original source CSS targeted the anchor itself. Without a bridge, WordPress' generic `.wp-block-button__link` / `.wp-element-button` styling can leak through on the clickable element.

## Tests
- `studio wp eval-file "/wordpress/wp-content/plugins/static-site-importer/tests/smoke-wordpress-is-dead-fixture.php"`
- `studio wp eval-file "/wordpress/wp-content/plugins/static-site-importer/tests/smoke-admin-import-html-entry.php"`
- `studio wp eval-file "/wordpress/wp-content/plugins/static-site-importer/tests/smoke-editor-style-support.php"`
- `npm run test:js-block-validation -- "/Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead"`
- `node --check tests/smoke-generated-theme-block-validation.cjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added the button-style bridge and TDD fixture assertions; Chris remains responsible for review and merge.
