### PR TITLE
fix: hide static importer submenu entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Static Site Importer
 
-Import a static HTML site into WordPress as a block theme using the bundled Block Format Bridge converter.
+Import a static HTML site into WordPress as a block theme using the bundled [Block Format Bridge](https://github.com/chubes4/block-format-bridge) converter.
 
-Static Site Importer is a WordPress plugin. It does not require Data Machine at runtime. The plugin installs Block Format Bridge through Composer and loads its bundled converter directly from `vendor/`.
+Static Site Importer is a WordPress plugin. It installs [Block Format Bridge](https://github.com/chubes4/block-format-bridge) through Composer and loads its bundled converter directly from `vendor/`.
 
 ## What It Does
 
-- Adds an **Import HTML** entry under **Appearance** and an **Import HTML** button on the Themes screen.
+- Adds an **Import HTML** button on the **Appearance -> Themes** screen.
 - Accepts an admin ZIP upload containing an `index.html` file.
 - Provides a WP-CLI importer for a local HTML entry file.
 - Discovers sibling `*.html` files beside the entry file and imports them as WordPress pages.
@@ -24,11 +24,11 @@ Static Site Importer is a WordPress plugin. It does not require Data Machine at 
 - Composer dependencies installed for development/source checkouts.
 - Node dependencies installed only when running the JavaScript block-validation smoke tests.
 
-The current Composer dependency is `chubes4/block-format-bridge:^0.6.7`. That package includes the prefixed HTML-to-blocks converter used by the importer, so no separate Block Format Bridge or Data Machine plugin needs to be active.
+The current Composer dependency is [`chubes4/block-format-bridge:^0.6.7`](https://github.com/chubes4/block-format-bridge). That package includes the prefixed HTML-to-blocks converter used by the importer.
 
 ## Admin Usage
 
-1. Open **Appearance -> Import HTML** or use the **Import HTML** button on **Appearance -> Themes**.
+1. Open **Appearance -> Themes** and click **Import HTML** beside the standard **Add Theme** button.
 2. Upload a ZIP containing `index.html`.
 3. Optionally provide a theme name and slug.
 4. Leave **Activate imported theme** checked if the generated theme should become active immediately.
@@ -161,6 +161,6 @@ This repo is Homeboy-managed:
 
 ## Boundary
 
-This plugin owns the static-site import workflow and generated WordPress artifacts. Block Format Bridge owns content-format conversion.
+This plugin owns the static-site import workflow and generated WordPress artifacts. [Block Format Bridge](https://github.com/chubes4/block-format-bridge) owns content-format conversion.
 
 Imported pages remain WordPress pages for routing, titles, front-page assignment, and editor visibility. Their imported body layouts live in generated block-theme artifacts: `patterns/page-*.php` plus matching `templates/page-*.html` files. The generic `templates/page.html` stays a `wp:post-content` fallback for pages created after import.

--- a/includes/class-static-site-importer-admin.php
+++ b/includes/class-static-site-importer-admin.php
@@ -20,18 +20,19 @@ class Static_Site_Importer_Admin {
 	 * @return void
 	 */
 	public static function register(): void {
-		add_action( 'admin_menu', array( __CLASS__, 'add_menu' ) );
+		add_action( 'admin_menu', array( __CLASS__, 'register_import_page' ) );
 		add_action( 'admin_head-themes.php', array( __CLASS__, 'render_themes_screen_button' ) );
 		add_action( 'admin_post_static_site_importer_import', array( __CLASS__, 'handle_import' ) );
 	}
 
 	/**
-	 * Add admin page under Appearance.
+	 * Register the import page without adding a persistent Appearance submenu item.
 	 *
 	 * @return void
 	 */
-	public static function add_menu(): void {
-		add_theme_page(
+	public static function register_import_page(): void {
+		add_submenu_page(
+			null,
 			'Import HTML',
 			'Import HTML',
 			'switch_themes',
@@ -50,7 +51,7 @@ class Static_Site_Importer_Admin {
 			return;
 		}
 
-		$url   = admin_url( 'themes.php?page=static-site-importer' );
+		$url   = admin_url( 'admin.php?page=static-site-importer' );
 		$label = __( 'Import HTML', 'static-site-importer' );
 		?>
 		<script>
@@ -185,7 +186,7 @@ class Static_Site_Importer_Admin {
 			self::redirect_error( $result->get_error_message() );
 		}
 
-		wp_safe_redirect( add_query_arg( 'static_site_imported', rawurlencode( $result['theme_name'] ), admin_url( 'themes.php?page=static-site-importer' ) ) );
+		wp_safe_redirect( add_query_arg( 'static_site_imported', rawurlencode( $result['theme_name'] ), admin_url( 'admin.php?page=static-site-importer' ) ) );
 		exit;
 	}
 
@@ -213,7 +214,7 @@ class Static_Site_Importer_Admin {
 	 * @return never
 	 */
 	private static function redirect_error( string $message ) {
-		wp_safe_redirect( add_query_arg( 'static_site_error', rawurlencode( $message ), admin_url( 'themes.php?page=static-site-importer' ) ) );
+		wp_safe_redirect( add_query_arg( 'static_site_error', rawurlencode( $message ), admin_url( 'admin.php?page=static-site-importer' ) ) );
 		exit;
 	}
 }

--- a/tests/smoke-admin-import-html-entry.php
+++ b/tests/smoke-admin-import-html-entry.php
@@ -26,7 +26,10 @@ $assert = static function ( bool $condition, string $label, string $detail = '' 
 
 $assert( str_contains( $source, "add_action( 'admin_head-themes.php'" ), 'themes-screen-hook-registered' );
 $assert( str_contains( $source, 'render_themes_screen_button' ), 'themes-screen-button-method-exists' );
-$assert( str_contains( $source, "admin_url( 'themes.php?page=static-site-importer' )" ), 'button-targets-import-page' );
+$assert( str_contains( $source, 'add_submenu_page(' ), 'hidden-import-page-registered' );
+$assert( str_contains( $source, 'register_import_page' ), 'hidden-import-page-method-exists' );
+$assert( ! str_contains( $source, 'add_theme_page(' ), 'appearance-submenu-not-registered' );
+$assert( str_contains( $source, "admin_url( 'admin.php?page=static-site-importer' )" ), 'button-targets-hidden-import-page' );
 $assert( str_contains( $source, '.page-title-action[href*="theme-install.php"]' ), 'button-anchors-to-add-theme-action' );
 $assert( str_contains( $source, 'static-site-importer-import-html-action' ), 'button-has-plugin-specific-class' );
 $assert( ! str_contains( $source, 'Import Static Site' ), 'old-import-static-site-label-removed' );


### PR DESCRIPTION
## Summary
- Hides the importer admin page from the Appearance submenu while keeping the Themes screen **Import HTML** button as the entry point.
- Updates README wording to match that UI, links Block Format Bridge, and removes the stale Data Machine mention.

## Tests
- `php -l includes/class-static-site-importer-admin.php && php tests/smoke-admin-import-html-entry.php`
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@update-readme-implementation-drift`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Small admin-entry fix and README follow-up; Chris remains reviewer.
