### PR TITLE
feat: support paste HTML admin imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Static Site Importer is a WordPress plugin. It installs [Block Format Bridge](ht
 ## What It Does
 
 - Adds an **Import HTML** button on the **Appearance -> Themes** screen.
-- Accepts an admin ZIP upload containing an `index.html` file.
+- Accepts pasted HTML or an admin ZIP upload containing an `index.html` file.
 - Provides a WP-CLI importer for a local HTML entry file.
 - Discovers sibling `*.html` files beside the entry file and imports them as WordPress pages.
 - Converts static HTML fragments through `bfb_convert( $html, 'html', 'blocks' )`.
@@ -29,11 +29,11 @@ The current Composer dependency is [`chubes4/block-format-bridge:^0.6.7`](https:
 ## Admin Usage
 
 1. Open **Appearance -> Themes** and click **Import HTML** beside the standard **Add Theme** button.
-2. Upload a ZIP containing `index.html`.
+2. Paste a single HTML document, or upload a ZIP containing `index.html`.
 3. Optionally provide a theme name and slug.
 4. Leave **Activate imported theme** checked if the generated theme should become active immediately.
 
-The admin path always overwrites an existing generated theme with the same slug. It extracts the ZIP to an upload work directory, finds the first `index.html`, and imports the sibling HTML files from that extracted site directory.
+The pasted HTML path writes the submitted content to a generated upload work directory as `index.html` and imports it as a one-page block theme. The ZIP path extracts the upload to a generated work directory, finds the first `index.html`, and imports sibling HTML files from that extracted site directory. The admin path always overwrites an existing generated theme with the same slug.
 
 ## CLI Usage
 
@@ -154,7 +154,7 @@ This repo is Homeboy-managed:
 
 - The importer is intentionally static-site-to-block-theme glue. Block Format Bridge owns format conversion; HTML-to-block transform fidelity belongs upstream in BFB/h2bc.
 - The importer currently discovers flat sibling `*.html` files beside the entry file; it does not crawl arbitrary nested routes.
-- Admin imports require a ZIP with an `index.html`; CLI imports take a direct HTML file path.
+- Admin imports accept pasted HTML for one-page imports or a ZIP with an `index.html`; CLI imports take a direct HTML file path.
 - Linked local stylesheets and inline styles are copied into `style.css`; inline scripts are copied into `assets/site.js`. Other asset copying is not a general-purpose crawler yet.
 - Navigation persistence is limited to supported header/footer shapes that can be converted into deterministic `wp_navigation` entities without guessing.
 - External live triage has exercised additional static sites, but the committed first-party fixture is `tests/fixtures/wordpress-is-dead/`.

--- a/includes/class-static-site-importer-admin.php
+++ b/includes/class-static-site-importer-admin.php
@@ -107,7 +107,7 @@ class Static_Site_Importer_Admin {
 				<div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
 			<?php endif; ?>
 
-			<p><?php echo esc_html__( 'Upload a ZIP containing an index.html file. The importer will convert the HTML into a WordPress block theme using Block Format Bridge.', 'static-site-importer' ); ?></p>
+			<p><?php echo esc_html__( 'Paste a single HTML document or upload a ZIP containing an index.html file. The importer will convert the HTML into a WordPress block theme using Block Format Bridge.', 'static-site-importer' ); ?></p>
 
 			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data">
 				<?php wp_nonce_field( 'static_site_importer_import' ); ?>
@@ -115,8 +115,18 @@ class Static_Site_Importer_Admin {
 
 				<table class="form-table" role="presentation">
 					<tr>
+						<th scope="row"><label for="static-site-html"><?php echo esc_html__( 'Paste HTML', 'static-site-importer' ); ?></label></th>
+						<td>
+							<textarea id="static-site-html" name="static_site_html" class="large-text code" rows="14" placeholder="<!doctype html>"></textarea>
+							<p class="description"><?php echo esc_html__( 'Use this for one-page HTML copied from an AI builder or template source. Leave empty to import a ZIP instead.', 'static-site-importer' ); ?></p>
+						</td>
+					</tr>
+					<tr>
 						<th scope="row"><label for="static-site-zip"><?php echo esc_html__( 'HTML ZIP', 'static-site-importer' ); ?></label></th>
-						<td><input type="file" id="static-site-zip" name="static_site_zip" accept=".zip" required /></td>
+						<td>
+							<input type="file" id="static-site-zip" name="static_site_zip" accept=".zip" />
+							<p class="description"><?php echo esc_html__( 'Upload a ZIP when importing a multi-page static site. Pasted HTML takes precedence when both fields are filled.', 'static-site-importer' ); ?></p>
+						</td>
 					</tr>
 					<tr>
 						<th scope="row"><label for="theme-name"><?php echo esc_html__( 'Theme name', 'static-site-importer' ); ?></label></th>
@@ -150,27 +160,8 @@ class Static_Site_Importer_Admin {
 
 		check_admin_referer( 'static_site_importer_import' );
 
-		if ( empty( $_FILES['static_site_zip']['tmp_name'] ) ) {
-			self::redirect_error( 'No ZIP file uploaded.' );
-		}
-
-		$upload = wp_handle_upload( $_FILES['static_site_zip'], array( 'test_form' => false, 'mimes' => array( 'zip' => 'application/zip' ) ) );
-		if ( isset( $upload['error'] ) ) {
-			self::redirect_error( (string) $upload['error'] );
-		}
-
-		$work_dir = trailingslashit( wp_upload_dir()['basedir'] ) . 'static-site-importer/' . wp_generate_uuid4();
-		wp_mkdir_p( $work_dir );
-
-		$result = unzip_file( $upload['file'], $work_dir );
-		if ( is_wp_error( $result ) ) {
-			self::redirect_error( $result->get_error_message() );
-		}
-
-		$html_path = self::find_index_html( $work_dir );
-		if ( ! $html_path ) {
-			self::redirect_error( 'The uploaded ZIP does not contain an index.html file.' );
-		}
+		$pasted_html = isset( $_POST['static_site_html'] ) ? trim( (string) wp_unslash( $_POST['static_site_html'] ) ) : '';
+		$html_path   = '' !== $pasted_html ? self::write_pasted_html( $pasted_html ) : self::html_path_from_zip_upload();
 
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
 			$html_path,
@@ -188,6 +179,70 @@ class Static_Site_Importer_Admin {
 
 		wp_safe_redirect( add_query_arg( 'static_site_imported', rawurlencode( $result['theme_name'] ), admin_url( 'admin.php?page=static-site-importer' ) ) );
 		exit;
+	}
+
+	/**
+	 * Write pasted HTML to a generated import work directory.
+	 *
+	 * @param string $html Raw pasted HTML.
+	 * @return string
+	 */
+	private static function write_pasted_html( string $html ): string {
+		if ( '' === trim( $html ) ) {
+			self::redirect_error( 'Paste HTML content or upload a ZIP containing an index.html file.' );
+		}
+
+		$work_dir  = self::create_work_dir();
+		$html_path = trailingslashit( $work_dir ) . 'index.html';
+		$result    = file_put_contents( $html_path, $html ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writes a generated upload work file for the existing importer.
+
+		if ( false === $result ) {
+			self::redirect_error( 'Failed to write pasted HTML to the import work directory.' );
+		}
+
+		return $html_path;
+	}
+
+	/**
+	 * Extract the uploaded ZIP and return its index.html path.
+	 *
+	 * @return string
+	 */
+	private static function html_path_from_zip_upload(): string {
+		if ( empty( $_FILES['static_site_zip']['tmp_name'] ) ) {
+			self::redirect_error( 'Paste HTML content or upload a ZIP containing an index.html file.' );
+		}
+
+		$upload = wp_handle_upload( $_FILES['static_site_zip'], array( 'test_form' => false, 'mimes' => array( 'zip' => 'application/zip' ) ) );
+		if ( isset( $upload['error'] ) ) {
+			self::redirect_error( (string) $upload['error'] );
+		}
+
+		$work_dir = self::create_work_dir();
+		$result   = unzip_file( $upload['file'], $work_dir );
+		if ( is_wp_error( $result ) ) {
+			self::redirect_error( $result->get_error_message() );
+		}
+
+		$html_path = self::find_index_html( $work_dir );
+		if ( ! $html_path ) {
+			self::redirect_error( 'The uploaded ZIP does not contain an index.html file.' );
+		}
+
+		return $html_path;
+	}
+
+	/**
+	 * Create an upload work directory for an import request.
+	 *
+	 * @return string
+	 */
+	private static function create_work_dir(): string {
+		$upload_dir = wp_upload_dir();
+		$work_dir   = trailingslashit( $upload_dir['basedir'] ) . 'static-site-importer/' . wp_generate_uuid4();
+		wp_mkdir_p( $work_dir );
+
+		return $work_dir;
 	}
 
 	/**

--- a/tests/smoke-admin-import-html-entry.php
+++ b/tests/smoke-admin-import-html-entry.php
@@ -35,6 +35,12 @@ $assert( str_contains( $source, 'static-site-importer-import-html-action' ), 'bu
 $assert( ! str_contains( $source, 'Import Static Site' ), 'old-import-static-site-label-removed' );
 $assert( str_contains( $source, 'Import HTML' ), 'import-html-label-present' );
 $assert( str_contains( $source, 'HTML ZIP' ), 'zip-field-label-renamed' );
+$assert( str_contains( $source, 'name="static_site_html"' ), 'paste-html-textarea-present' );
+$assert( str_contains( $source, 'write_pasted_html' ), 'paste-html-write-helper-present' );
+$assert( str_contains( $source, "'index.html'" ), 'paste-html-writes-index-html' );
+$assert( str_contains( $source, 'html_path_from_zip_upload' ), 'zip-import-helper-present' );
+$assert( str_contains( $source, 'Paste HTML content or upload a ZIP containing an index.html file.' ), 'empty-intake-validation-message-present' );
+$assert( ! str_contains( $source, 'name="static_site_zip" accept=".zip" required' ), 'zip-field-not-required' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- Add a paste-HTML textarea to the admin importer for one-page HTML copied from AI builders or template sources.
- Route pasted HTML through the existing theme generator by writing it to a generated upload work directory as `index.html`.
- Keep ZIP imports working as the fallback path and document both admin intake modes.

## Tests
- `php -l includes/class-static-site-importer-admin.php`
- `php tests/smoke-admin-import-html-entry.php`
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@admin-paste-html-import`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Paste-HTML import implementation and tests; Chris remains reviewer.