### PR TITLE
feat: support single HTML admin uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Static Site Importer is a WordPress plugin. It installs [Block Format Bridge](ht
 ## What It Does
 
 - Adds an **Import HTML** button on the **Appearance -> Themes** screen.
-- Accepts pasted HTML or an admin ZIP upload containing an `index.html` file.
+- Accepts pasted HTML, a direct `.html` / `.htm` upload, or a ZIP containing an `index.html` file.
 - Provides a WP-CLI importer for a local HTML entry file.
 - Discovers sibling `*.html` files beside the entry file and imports them as WordPress pages.
 - Converts static HTML fragments through `bfb_convert( $html, 'html', 'blocks' )`.
@@ -29,11 +29,11 @@ The current Composer dependency is [`chubes4/block-format-bridge:^0.6.7`](https:
 ## Admin Usage
 
 1. Open **Appearance -> Themes** and click **Import HTML** beside the standard **Add Theme** button.
-2. Paste a single HTML document, or upload a ZIP containing `index.html`.
+2. Paste a single HTML document, upload a single `.html` / `.htm` file, or upload a ZIP containing `index.html`.
 3. Optionally provide a theme name and slug.
 4. Leave **Activate imported theme** checked if the generated theme should become active immediately.
 
-The pasted HTML path writes the submitted content to a generated upload work directory as `index.html` and imports it as a one-page block theme. The ZIP path extracts the upload to a generated work directory, finds the first `index.html`, and imports sibling HTML files from that extracted site directory. The admin path always overwrites an existing generated theme with the same slug.
+The admin path always overwrites an existing generated theme with the same slug. Pasted HTML and direct HTML uploads are copied into a generated upload work directory as `index.html` and imported as a single-page site. ZIP uploads are extracted to an upload work directory, the first `index.html` is used as the entry file, and sibling HTML files from that extracted site directory are imported.
 
 ## CLI Usage
 
@@ -154,7 +154,7 @@ This repo is Homeboy-managed:
 
 - The importer is intentionally static-site-to-block-theme glue. Block Format Bridge owns format conversion; HTML-to-block transform fidelity belongs upstream in BFB/h2bc.
 - The importer currently discovers flat sibling `*.html` files beside the entry file; it does not crawl arbitrary nested routes.
-- Admin imports accept pasted HTML for one-page imports or a ZIP with an `index.html`; CLI imports take a direct HTML file path.
+- Admin imports accept pasted HTML, a direct `.html` / `.htm` file, or a ZIP with an `index.html`; CLI imports take a direct HTML file path.
 - Linked local stylesheets and inline styles are copied into `style.css`; inline scripts are copied into `assets/site.js`. Other asset copying is not a general-purpose crawler yet.
 - Navigation persistence is limited to supported header/footer shapes that can be converted into deterministic `wp_navigation` entities without guessing.
 - External live triage has exercised additional static sites, but the committed first-party fixture is `tests/fixtures/wordpress-is-dead/`.

--- a/includes/class-static-site-importer-admin.php
+++ b/includes/class-static-site-importer-admin.php
@@ -107,7 +107,7 @@ class Static_Site_Importer_Admin {
 				<div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
 			<?php endif; ?>
 
-			<p><?php echo esc_html__( 'Paste a single HTML document or upload a ZIP containing an index.html file. The importer will convert the HTML into a WordPress block theme using Block Format Bridge.', 'static-site-importer' ); ?></p>
+			<p><?php echo esc_html__( 'Paste HTML, upload a single HTML file, or upload a ZIP containing an index.html file. The importer will convert the HTML into a WordPress block theme using Block Format Bridge.', 'static-site-importer' ); ?></p>
 
 			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data">
 				<?php wp_nonce_field( 'static_site_importer_import' ); ?>
@@ -115,17 +115,24 @@ class Static_Site_Importer_Admin {
 
 				<table class="form-table" role="presentation">
 					<tr>
-						<th scope="row"><label for="static-site-html"><?php echo esc_html__( 'Paste HTML', 'static-site-importer' ); ?></label></th>
+						<th scope="row"><label for="static-site-pasted-html"><?php echo esc_html__( 'Paste HTML', 'static-site-importer' ); ?></label></th>
 						<td>
-							<textarea id="static-site-html" name="static_site_html" class="large-text code" rows="14" placeholder="<!doctype html>"></textarea>
-							<p class="description"><?php echo esc_html__( 'Use this for one-page HTML copied from an AI builder or template source. Leave empty to import a ZIP instead.', 'static-site-importer' ); ?></p>
+							<textarea id="static-site-pasted-html" name="static_site_pasted_html" class="large-text code" rows="14" placeholder="<!doctype html>"></textarea>
+							<p class="description"><?php echo esc_html__( 'Use this for one-page HTML copied from an AI builder or template source. Leave empty to import an HTML file or ZIP instead.', 'static-site-importer' ); ?></p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="static-site-html"><?php echo esc_html__( 'Single HTML file', 'static-site-importer' ); ?></label></th>
+						<td>
+							<input type="file" id="static-site-html" name="static_site_html" accept=".html,.htm" />
+							<p class="description"><?php echo esc_html__( 'Use this for a standalone .html or .htm file. Pasted HTML takes precedence when both are provided.', 'static-site-importer' ); ?></p>
 						</td>
 					</tr>
 					<tr>
 						<th scope="row"><label for="static-site-zip"><?php echo esc_html__( 'HTML ZIP', 'static-site-importer' ); ?></label></th>
 						<td>
 							<input type="file" id="static-site-zip" name="static_site_zip" accept=".zip" />
-							<p class="description"><?php echo esc_html__( 'Upload a ZIP when importing a multi-page static site. Pasted HTML takes precedence when both fields are filled.', 'static-site-importer' ); ?></p>
+							<p class="description"><?php echo esc_html__( 'Use this for a site folder packaged as a ZIP with an index.html file and sibling HTML pages. Pasted HTML and single HTML uploads take precedence when provided.', 'static-site-importer' ); ?></p>
 						</td>
 					</tr>
 					<tr>
@@ -160,8 +167,8 @@ class Static_Site_Importer_Admin {
 
 		check_admin_referer( 'static_site_importer_import' );
 
-		$pasted_html = isset( $_POST['static_site_html'] ) ? trim( (string) wp_unslash( $_POST['static_site_html'] ) ) : '';
-		$html_path   = '' !== $pasted_html ? self::write_pasted_html( $pasted_html ) : self::html_path_from_zip_upload();
+		$pasted_html = isset( $_POST['static_site_pasted_html'] ) ? trim( (string) wp_unslash( $_POST['static_site_pasted_html'] ) ) : '';
+		$html_path   = '' !== $pasted_html ? self::write_pasted_html( $pasted_html ) : self::prepare_uploaded_entry_file();
 
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
 			$html_path,
@@ -185,11 +192,11 @@ class Static_Site_Importer_Admin {
 	 * Write pasted HTML to a generated import work directory.
 	 *
 	 * @param string $html Raw pasted HTML.
-	 * @return string
+	 * @return string HTML entry path.
 	 */
 	private static function write_pasted_html( string $html ): string {
 		if ( '' === trim( $html ) ) {
-			self::redirect_error( 'Paste HTML content or upload a ZIP containing an index.html file.' );
+			self::redirect_error( 'Paste HTML content, upload a single HTML file, or upload a ZIP containing index.html.' );
 		}
 
 		$work_dir  = self::create_work_dir();
@@ -204,22 +211,89 @@ class Static_Site_Importer_Admin {
 	}
 
 	/**
-	 * Extract the uploaded ZIP and return its index.html path.
+	 * Prepare the uploaded HTML entry file.
 	 *
-	 * @return string
+	 * @return string HTML entry path.
 	 */
-	private static function html_path_from_zip_upload(): string {
-		if ( empty( $_FILES['static_site_zip']['tmp_name'] ) ) {
-			self::redirect_error( 'Paste HTML content or upload a ZIP containing an index.html file.' );
+	private static function prepare_uploaded_entry_file(): string {
+		$work_dir = self::create_work_dir();
+
+		if ( self::has_uploaded_file( 'static_site_html' ) ) {
+			return self::prepare_uploaded_html_file( $work_dir );
 		}
 
-		$upload = wp_handle_upload( $_FILES['static_site_zip'], array( 'test_form' => false, 'mimes' => array( 'zip' => 'application/zip' ) ) );
+		if ( self::has_uploaded_file( 'static_site_zip' ) ) {
+			return self::prepare_uploaded_zip_file( $work_dir );
+		}
+
+		self::redirect_error( 'Paste HTML content, upload a single HTML file, or upload a ZIP containing index.html.' );
+	}
+
+	/**
+	 * Store a direct HTML upload in an importer work directory.
+	 *
+	 * @param string $work_dir Importer work directory.
+	 * @return string HTML entry path.
+	 */
+	private static function prepare_uploaded_html_file( string $work_dir ): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Upload nonce verified in handle_import().
+		$file = $_FILES['static_site_html'];
+		$name = isset( $file['name'] ) ? (string) $file['name'] : '';
+		$ext  = strtolower( pathinfo( $name, PATHINFO_EXTENSION ) );
+
+		if ( ! in_array( $ext, array( 'html', 'htm' ), true ) ) {
+			self::redirect_error( 'Upload an .html or .htm file.' );
+		}
+
+		if ( empty( $file['size'] ) || empty( $file['tmp_name'] ) || ! is_readable( (string) $file['tmp_name'] ) ) {
+			self::redirect_error( 'The uploaded HTML file is empty or unreadable.' );
+		}
+
+		$upload = wp_handle_upload(
+			$file,
+			array(
+				'test_form' => false,
+				'mimes'     => array(
+					'html' => 'text/html',
+					'htm'  => 'text/html',
+				),
+			)
+		);
 		if ( isset( $upload['error'] ) ) {
 			self::redirect_error( (string) $upload['error'] );
 		}
 
-		$work_dir = self::create_work_dir();
-		$result   = unzip_file( $upload['file'], $work_dir );
+		$target = trailingslashit( $work_dir ) . 'index.html';
+		if ( ! copy( $upload['file'], $target ) ) {
+			self::redirect_error( 'Could not store the uploaded HTML file.' );
+		}
+
+		return $target;
+	}
+
+	/**
+	 * Extract an uploaded ZIP and return its index.html path.
+	 *
+	 * @param string $work_dir Importer work directory.
+	 * @return string HTML entry path.
+	 */
+	private static function prepare_uploaded_zip_file( string $work_dir ): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Upload nonce verified in handle_import().
+		$zip_file = $_FILES['static_site_zip'];
+		$upload   = wp_handle_upload(
+			$zip_file,
+			array(
+				'test_form' => false,
+				'mimes'     => array(
+					'zip' => 'application/zip',
+				),
+			)
+		);
+		if ( isset( $upload['error'] ) ) {
+			self::redirect_error( (string) $upload['error'] );
+		}
+
+		$result = unzip_file( $upload['file'], $work_dir );
 		if ( is_wp_error( $result ) ) {
 			self::redirect_error( $result->get_error_message() );
 		}
@@ -233,16 +307,34 @@ class Static_Site_Importer_Admin {
 	}
 
 	/**
-	 * Create an upload work directory for an import request.
+	 * Create an importer work directory.
 	 *
-	 * @return string
+	 * @return string Directory path.
 	 */
 	private static function create_work_dir(): string {
-		$upload_dir = wp_upload_dir();
-		$work_dir   = trailingslashit( $upload_dir['basedir'] ) . 'static-site-importer/' . wp_generate_uuid4();
+		$work_dir = trailingslashit( wp_upload_dir()['basedir'] ) . 'static-site-importer/' . wp_generate_uuid4();
 		wp_mkdir_p( $work_dir );
 
 		return $work_dir;
+	}
+
+	/**
+	 * Determine whether a named upload field has a file.
+	 *
+	 * @param string $field Upload field name.
+	 * @return bool
+	 */
+	private static function has_uploaded_file( string $field ): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Upload nonce verified in handle_import().
+		if ( ! isset( $_FILES[ $field ] ) || ! is_array( $_FILES[ $field ] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Upload nonce verified in handle_import().
+		$error = $_FILES[ $field ]['error'] ?? UPLOAD_ERR_NO_FILE;
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Upload nonce verified in handle_import().
+		return UPLOAD_ERR_NO_FILE !== $error && ! empty( $_FILES[ $field ]['tmp_name'] );
 	}
 
 	/**

--- a/tests/smoke-admin-import-html-entry.php
+++ b/tests/smoke-admin-import-html-entry.php
@@ -35,12 +35,20 @@ $assert( str_contains( $source, 'static-site-importer-import-html-action' ), 'bu
 $assert( ! str_contains( $source, 'Import Static Site' ), 'old-import-static-site-label-removed' );
 $assert( str_contains( $source, 'Import HTML' ), 'import-html-label-present' );
 $assert( str_contains( $source, 'HTML ZIP' ), 'zip-field-label-renamed' );
-$assert( str_contains( $source, 'name="static_site_html"' ), 'paste-html-textarea-present' );
+$assert( str_contains( $source, 'name="static_site_pasted_html"' ), 'paste-html-textarea-present' );
 $assert( str_contains( $source, 'write_pasted_html' ), 'paste-html-write-helper-present' );
-$assert( str_contains( $source, "'index.html'" ), 'paste-html-writes-index-html' );
-$assert( str_contains( $source, 'html_path_from_zip_upload' ), 'zip-import-helper-present' );
-$assert( str_contains( $source, 'Paste HTML content or upload a ZIP containing an index.html file.' ), 'empty-intake-validation-message-present' );
-$assert( ! str_contains( $source, 'name="static_site_zip" accept=".zip" required' ), 'zip-field-not-required' );
+$assert( str_contains( $source, 'name="static_site_html"' ), 'single-html-upload-field-present' );
+$assert( str_contains( $source, 'accept=".html,.htm"' ), 'single-html-upload-accepts-html' );
+$assert( str_contains( $source, 'name="static_site_zip"' ), 'zip-upload-field-present' );
+$assert( ! str_contains( $source, 'name="static_site_zip" accept=".zip" required' ), 'zip-upload-not-required' );
+$assert( str_contains( $source, "has_uploaded_file( 'static_site_html' )" ), 'html-upload-preferred-before-zip' );
+$assert( str_contains( $source, "has_uploaded_file( 'static_site_zip' )" ), 'zip-upload-fallback-present' );
+$assert( strpos( $source, "has_uploaded_file( 'static_site_html' )" ) < strpos( $source, "has_uploaded_file( 'static_site_zip' )" ), 'html-upload-precedes-zip-fallback' );
+$assert( str_contains( $source, "in_array( $" . "ext, array( 'html', 'htm' ), true )" ), 'html-extension-validation-present' );
+$assert( str_contains( $source, "'index.html'" ), 'admin-intake-stores-index-html' );
+$assert( str_contains( $source, 'prepare_uploaded_zip_file' ), 'zip-import-helper-present' );
+$assert( str_contains( $source, 'find_index_html' ), 'zip-index-discovery-preserved' );
+$assert( str_contains( $source, 'Paste HTML content, upload a single HTML file, or upload a ZIP containing index.html.' ), 'empty-intake-validation-message-present' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- Add a direct .html/.htm upload field to the Import HTML admin form while keeping ZIP uploads supported.
- Prefer direct HTML uploads when both fields are present, validate extension/content, and copy the entry into the importer work directory as index.html before reusing the existing theme import pipeline.
- Update README/admin smoke coverage for the dual intake path.

## Tests
- php -l includes/class-static-site-importer-admin.php
- php tests/smoke-admin-import-html-entry.php
- homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@admin-single-html-upload

Note: broad homeboy lint still reports pre-existing repository-wide PHPCS/PHPStan drift; the requested test suite passes.

Closes #23.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Admin upload implementation and tests; Chris remains reviewer.