### PR TITLE
Materialize safe inline SVG icons

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -22,6 +22,27 @@ class Static_Site_Importer_Theme_Generator {
 	private static array $conversion_report = array();
 
 	/**
+	 * Generated theme directory for import-scoped asset writes.
+	 *
+	 * @var string
+	 */
+	private static string $active_theme_dir = '';
+
+	/**
+	 * Generated theme URI for import-scoped asset references.
+	 *
+	 * @var string
+	 */
+	private static string $active_theme_uri = '';
+
+	/**
+	 * Materialized inline SVG assets keyed by SVG content hash.
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	private static array $materialized_svg_assets = array();
+
+	/**
 	 * Import an HTML file as a block theme.
 	 *
 	 * @param string $html_path  HTML file path.
@@ -75,6 +96,10 @@ class Static_Site_Importer_Theme_Generator {
 		$permalinks              = self::page_permalinks( $page_ids );
 		$fragments               = $document->fragments();
 		self::$conversion_report = self::new_conversion_report( $html_path );
+
+		self::$active_theme_dir        = $theme_dir;
+		self::$active_theme_uri        = trailingslashit( get_theme_root_uri( $theme_slug ) ) . $theme_slug;
+		self::$materialized_svg_assets = array();
 
 		$background_blocks = self::convert_fragment( self::rewrite_internal_links( $fragments['background'], $permalinks ), 'background:index.html' );
 		$header_blocks     = self::convert_header_fragment( self::strip_active_classes( self::rewrite_internal_links( $fragments['header'], $permalinks ) ), $theme_slug );
@@ -378,6 +403,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string
 	 */
 	private static function convert_header_fragment( string $html, string $theme_slug ): string {
+		$html   = self::materialize_inline_svg_icons( $html, 'theme-part:header' );
 		$doc    = self::load_fragment_document( $html );
 		$header = self::sole_child_element( $doc );
 		if ( $header instanceof DOMElement && 'nav' === strtolower( $header->tagName ) ) {
@@ -415,6 +441,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string
 	 */
 	private static function convert_footer_fragment( string $html, string $theme_slug ): string {
+		$html   = self::materialize_inline_svg_icons( $html, 'theme-part:footer' );
 		$doc    = self::load_fragment_document( $html );
 		$footer = self::sole_child_element( $doc );
 		if ( ! $footer instanceof DOMElement || 'footer' !== strtolower( $footer->tagName ) ) {
@@ -891,6 +918,286 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Materialize safe inline SVG elements as generated theme assets.
+	 *
+	 * @param string $html   HTML fragment.
+	 * @param string $source Source fragment label.
+	 * @return string
+	 */
+	private static function materialize_inline_svg_icons( string $html, string $source ): string {
+		if ( '' === trim( $html ) || ! str_contains( strtolower( $html ), '<svg' ) || '' === self::$active_theme_dir ) {
+			return $html;
+		}
+
+		$doc      = self::load_fragment_document( $html );
+		$svgs     = iterator_to_array( $doc->getElementsByTagName( 'svg' ) );
+		$changed  = false;
+		$sequence = 0;
+
+		foreach ( $svgs as $svg ) {
+			++$sequence;
+			$svg_html = self::node_html( $doc, $svg );
+			$safe_svg = self::sanitize_inline_svg( $svg_html );
+			if ( null === $safe_svg ) {
+				self::record_unsafe_inline_svg( $source, $svg_html );
+				continue;
+			}
+
+			$asset = self::write_svg_icon_asset( $safe_svg, $source, $sequence );
+			if ( is_wp_error( $asset ) ) {
+				self::record_svg_materialization_failure( $source, $svg_html, $asset );
+				continue;
+			}
+
+			$img = $doc->createElement( 'img' );
+			$img->setAttribute( 'src', $asset['url'] );
+			$img->setAttribute( 'alt', self::svg_accessible_label( $svg ) );
+			$img->setAttribute( 'decoding', 'async' );
+			if ( $svg->hasAttribute( 'class' ) ) {
+				$img->setAttribute( 'class', $svg->getAttribute( 'class' ) );
+			}
+			foreach ( array( 'width', 'height', 'aria-hidden', 'role' ) as $attribute ) {
+				if ( $svg->hasAttribute( $attribute ) ) {
+					$img->setAttribute( $attribute, $svg->getAttribute( $attribute ) );
+				}
+			}
+
+			if ( $svg->parentNode instanceof DOMNode ) {
+				$svg->parentNode->replaceChild( $img, $svg );
+				$changed = true;
+			}
+		}
+
+		if ( ! $changed ) {
+			return $html;
+		}
+
+		$root = $doc->documentElement;
+		if ( ! $root instanceof DOMElement ) {
+			return $html;
+		}
+
+		$output = '';
+		foreach ( $root->childNodes as $child ) {
+			$fragment = $doc->saveHTML( $child );
+			if ( false !== $fragment ) {
+				$output .= $fragment;
+			}
+		}
+
+		return '' === trim( $output ) ? $html : $output;
+	}
+
+	/**
+	 * Validate an inline SVG against a conservative icon-safe subset.
+	 *
+	 * @param string $svg_html SVG markup.
+	 * @return string|null
+	 */
+	private static function sanitize_inline_svg( string $svg_html ): ?string {
+		$doc      = new DOMDocument();
+		$previous = libxml_use_internal_errors( true );
+		$loaded   = $doc->loadXML( trim( $svg_html ) );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+		if ( ! $loaded || ! $doc->documentElement instanceof DOMElement || 'svg' !== strtolower( $doc->documentElement->tagName ) ) {
+			return null;
+		}
+
+		$allowed_tags       = array_fill_keys(
+			array(
+				'svg',
+				'g',
+				'path',
+				'circle',
+				'rect',
+				'line',
+				'polyline',
+				'polygon',
+				'ellipse',
+				'title',
+				'desc',
+				'defs',
+				'clipPath',
+				'linearGradient',
+				'radialGradient',
+				'stop',
+			),
+			true
+		);
+		$allowed_attributes = array_fill_keys(
+			array(
+				'xmlns',
+				'viewBox',
+				'viewbox',
+				'width',
+				'height',
+				'fill',
+				'stroke',
+				'stroke-width',
+				'stroke-linecap',
+				'stroke-linejoin',
+				'stroke-miterlimit',
+				'stroke-dasharray',
+				'stroke-dashoffset',
+				'd',
+				'cx',
+				'cy',
+				'r',
+				'rx',
+				'ry',
+				'x',
+				'y',
+				'x1',
+				'y1',
+				'x2',
+				'y2',
+				'points',
+				'transform',
+				'opacity',
+				'fill-rule',
+				'clip-rule',
+				'clip-path',
+				'class',
+				'role',
+				'aria-hidden',
+				'aria-label',
+				'focusable',
+				'id',
+				'offset',
+				'stop-color',
+				'stop-opacity',
+				'gradientUnits',
+				'gradientTransform',
+			),
+			true
+		);
+
+		foreach ( $doc->getElementsByTagName( '*' ) as $node ) {
+			if ( ! isset( $allowed_tags[ $node->tagName ] ) ) {
+				return null;
+			}
+
+			foreach ( iterator_to_array( $node->attributes ) as $attribute ) {
+				$name  = $attribute->name;
+				$value = $attribute->value;
+				if ( str_starts_with( strtolower( $name ), 'on' ) || ! isset( $allowed_attributes[ $name ] ) || preg_match( '/(?:javascript:|data:|url\s*\()/i', $value ) ) {
+					return null;
+				}
+			}
+		}
+
+		if ( ! $doc->documentElement->hasAttribute( 'xmlns' ) ) {
+			$doc->documentElement->setAttribute( 'xmlns', 'http://www.w3.org/2000/svg' );
+		}
+		if ( $doc->documentElement->hasAttribute( 'viewbox' ) && ! $doc->documentElement->hasAttribute( 'viewBox' ) ) {
+			$doc->documentElement->setAttribute( 'viewBox', $doc->documentElement->getAttribute( 'viewbox' ) );
+			$doc->documentElement->removeAttribute( 'viewbox' );
+		}
+
+		$svg = $doc->saveXML( $doc->documentElement );
+		return false === $svg ? null : $svg;
+	}
+
+	/**
+	 * Write one sanitized SVG icon asset and return its generated metadata.
+	 *
+	 * @param string $svg      Sanitized SVG markup.
+	 * @param string $source   Source fragment label.
+	 * @param int    $sequence Sequence within the fragment.
+	 * @return array<string, string>|WP_Error
+	 */
+	private static function write_svg_icon_asset( string $svg, string $source, int $sequence ) {
+		$hash = substr( hash( 'sha256', $svg ), 0, 16 );
+		if ( isset( self::$materialized_svg_assets[ $hash ] ) ) {
+			return self::$materialized_svg_assets[ $hash ];
+		}
+
+		$name     = sanitize_title( preg_replace( '/[^A-Za-z0-9_-]+/', '-', $source ) . '-' . $sequence );
+		$name     = '' === $name ? 'icon-' . $sequence : $name;
+		$relative = 'assets/icons/' . $name . '-' . $hash . '.svg';
+		$path     = trailingslashit( self::$active_theme_dir ) . $relative;
+		$dir      = dirname( $path );
+		if ( ! wp_mkdir_p( $dir ) ) {
+			return new WP_Error( 'static_site_importer_svg_icon_mkdir_failed', sprintf( 'Failed to create SVG icon directory: %s', $dir ) );
+		}
+
+		$result = self::write_file( $path, $svg . "\n" );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// phpcs:ignore Generic.Formatting.MultipleStatementAlignment.NotSameWarning -- Keep the compact local variable readable beside the longer static writes below.
+		$asset = array(
+			'name'   => basename( $relative ),
+			'path'   => $relative,
+			'url'    => trailingslashit( self::$active_theme_uri ) . $relative,
+			'hash'   => $hash,
+			'source' => $source,
+			'block'  => 'core/image',
+		);
+		self::$materialized_svg_assets[ $hash ] = $asset;
+		self::$conversion_report['assets']['svg_icons'][] = $asset;
+
+		return $asset;
+	}
+
+	/**
+	 * Extract a safe alt label from SVG accessibility nodes/attributes.
+	 *
+	 * @param DOMElement $svg SVG element.
+	 * @return string
+	 */
+	private static function svg_accessible_label( DOMElement $svg ): string {
+		foreach ( array( 'aria-label', 'title' ) as $attribute ) {
+			$label = trim( $svg->getAttribute( $attribute ) );
+			if ( '' !== $label ) {
+				return $label;
+			}
+		}
+
+		$title = $svg->getElementsByTagName( 'title' )->item( 0 );
+		return $title instanceof DOMElement ? trim( $title->textContent ) : '';
+	}
+
+	/**
+	 * Record an unsafe inline SVG that could not be materialized.
+	 *
+	 * @param string $source   Source fragment label.
+	 * @param string $svg_html SVG markup.
+	 * @return void
+	 */
+	private static function record_unsafe_inline_svg( string $source, string $svg_html ): void {
+		++self::$conversion_report['quality']['unsafe_svg_count'];
+		self::$conversion_report['diagnostics'][] = array(
+			'type'         => 'unsafe_inline_svg',
+			'source'       => $source,
+			'html_length'  => strlen( $svg_html ),
+			'html_excerpt' => self::diagnostic_excerpt( $svg_html ),
+		);
+	}
+
+	/**
+	 * Record a filesystem failure while materializing a safe inline SVG.
+	 *
+	 * @param string   $source   Source fragment label.
+	 * @param string   $svg_html SVG markup.
+	 * @param WP_Error $error    Write error.
+	 * @return void
+	 */
+	private static function record_svg_materialization_failure( string $source, string $svg_html, WP_Error $error ): void {
+		++self::$conversion_report['quality']['svg_materialization_failure_count'];
+		self::$conversion_report['diagnostics'][] = array(
+			'type'          => 'svg_materialization_failure',
+			'source'        => $source,
+			'error_code'    => $error->get_error_code(),
+			'error_message' => $error->get_error_message(),
+			'html_length'   => strlen( $svg_html ),
+			'html_excerpt'  => self::diagnostic_excerpt( $svg_html ),
+		);
+	}
+
+	/**
 	 * Convert HTML to block markup.
 	 *
 	 * @param string $html HTML fragment.
@@ -900,6 +1207,8 @@ class Static_Site_Importer_Theme_Generator {
 		if ( '' === trim( $html ) ) {
 			return '';
 		}
+
+		$html = self::materialize_inline_svg_icons( $html, $source );
 
 		self::start_conversion_fragment( $source, $html );
 		$fallback_listener     = static function ( string $element_html, array $context, array $block ) use ( $source ): void {
@@ -935,13 +1244,18 @@ class Static_Site_Importer_Theme_Generator {
 			'version'              => 1,
 			'entry_file'           => $html_path,
 			'quality'              => array(
-				'pass'                   => true,
-				'fallback_count'         => 0,
-				'content_loss_count'     => 0,
-				'empty_conversion_count' => 0,
-				'failure_reasons'        => array(),
+				'pass'                              => true,
+				'fallback_count'                    => 0,
+				'content_loss_count'                => 0,
+				'empty_conversion_count'            => 0,
+				'unsafe_svg_count'                  => 0,
+				'svg_materialization_failure_count' => 0,
+				'failure_reasons'                   => array(),
 			),
 			'conversion_fragments' => array(),
+			'assets'               => array(
+				'svg_icons' => array(),
+			),
 			'diagnostics'          => array(),
 			'notes'                => array(
 				'Block Format Bridge owns HTML-to-block transform fidelity; Static Site Importer records converter diagnostics and quality gates the generated theme.',
@@ -1063,6 +1377,12 @@ class Static_Site_Importer_Theme_Generator {
 		if ( $quality['empty_conversion_count'] > 0 ) {
 			$reasons[] = 'empty_conversion';
 		}
+		if ( $quality['unsafe_svg_count'] > 0 ) {
+			$reasons[] = 'unsafe_inline_svg';
+		}
+		if ( $quality['svg_materialization_failure_count'] > 0 ) {
+			$reasons[] = 'svg_materialization_failure';
+		}
 
 		$quality['pass']            = empty( $reasons );
 		$quality['failure_reasons'] = $reasons;
@@ -1097,7 +1417,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return true|WP_Error
 	 */
 	private static function ensure_dirs( string $theme_dir ) {
-		foreach ( array( $theme_dir, $theme_dir . '/templates', $theme_dir . '/parts', $theme_dir . '/patterns', $theme_dir . '/assets' ) as $dir ) {
+		foreach ( array( $theme_dir, $theme_dir . '/templates', $theme_dir . '/parts', $theme_dir . '/patterns', $theme_dir . '/assets', $theme_dir . '/assets/icons' ) as $dir ) {
 			if ( ! wp_mkdir_p( $dir ) ) {
 				return new WP_Error( 'static_site_importer_mkdir_failed', sprintf( 'Failed to create directory: %s', $dir ) );
 			}

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -148,6 +148,77 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Safe inline SVG icons are materialized as theme assets and native image blocks.
+	 */
+	public function test_safe_inline_svg_icons_materialize_as_theme_assets(): void {
+		$html_path = $this->write_temp_fixture(
+			'safe-svg-icons.html',
+			'<!doctype html><html><head><title>Safe SVG Icons</title></head><body><main><section class="icons"><h1>Icons</h1><svg class="icon icon-bolt" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Bolt"><title>Bolt</title><path d="M13 2 3 14h8l-1 8 11-13h-8z" fill="currentColor"/></svg></section></main></body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Safe SVG Icons',
+				'slug'      => 'safe-svg-icons',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$pattern   = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-safe-svg-icons.php' ) );
+		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+
+		$this->assertStringContainsString( '<!-- wp:image ', $pattern );
+		$this->assertStringNotContainsString( '<!-- wp:html', $pattern );
+		$this->assertStringContainsString( '/assets/icons/', $pattern );
+		$this->assertSame( 0, $report['quality']['fallback_count'] ?? null );
+		$this->assertSame( 0, $report['quality']['unsafe_svg_count'] ?? null );
+		$this->assertNotEmpty( $report['assets']['svg_icons'] ?? array() );
+
+		$asset = $report['assets']['svg_icons'][0] ?? array();
+		$this->assertSame( 'core/image', $asset['block'] ?? '' );
+		$this->assertFileExists( $theme_dir . '/' . ( $asset['path'] ?? '' ) );
+	}
+
+	/**
+	 * Unsafe inline SVG remains visible in the import report instead of being accepted silently.
+	 */
+	public function test_unsafe_inline_svg_is_reported(): void {
+		$html_path = $this->write_temp_fixture(
+			'unsafe-svg-icons.html',
+			'<!doctype html><html><head><title>Unsafe SVG Icons</title></head><body><main><section><h1>Unsafe</h1><svg viewBox="0 0 24 24"><script>alert(1)</script><path d="M0 0h24v24H0z"/></svg></section></main></body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Unsafe SVG Icons',
+				'slug'      => 'unsafe-svg-icons',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$report = json_decode( $this->read_file( $result['report_path'] ), true );
+		$this->assertSame( 1, $report['quality']['unsafe_svg_count'] ?? null );
+		$this->assertContains( 'unsafe_inline_svg', $report['quality']['failure_reasons'] ?? array() );
+		$this->assertNotEmpty(
+			array_filter(
+				$report['diagnostics'] ?? array(),
+				static fn ( array $diagnostic ): bool => 'unsafe_inline_svg' === ( $diagnostic['type'] ?? '' )
+			)
+		);
+	}
+
+	/**
 	 * Reads a generated file.
 	 */
 	private function read_file( string $path ): string {
@@ -155,6 +226,18 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertNotFalse( $contents, 'Unable to read ' . $path );
 
 		return (string) $contents;
+	}
+
+	/**
+	 * Writes a temporary single-file static site fixture.
+	 */
+	private function write_temp_fixture( string $filename, string $html ): string {
+		$dir = trailingslashit( get_temp_dir() ) . 'static-site-importer-fixtures-' . wp_generate_uuid4();
+		$this->assertTrue( wp_mkdir_p( $dir ) );
+		$path = trailingslashit( $dir ) . $filename;
+		$this->assertNotFalse( file_put_contents( $path, $html ) );
+
+		return $path;
 	}
 
 	/**

--- a/tests/smoke-inline-svg-icons.php
+++ b/tests/smoke-inline-svg-icons.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Smoke test: safe inline SVG icons materialize as theme assets; unsafe SVG is reported.
+ *
+ * Run inside a WordPress site with BFB active:
+ * wp eval-file tests/smoke-inline-svg-icons.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+
+if ( ! defined( 'STATIC_SITE_IMPORTER_PATH' ) && is_readable( $plugin_root . '/static-site-importer.php' ) ) {
+	require_once $plugin_root . '/static-site-importer.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Document', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-document.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read = static function ( string $path ): string {
+	$contents = file_get_contents( $path );
+	return false === $contents ? '' : $contents;
+};
+
+$pattern_blocks = static function ( string $pattern_file ): string {
+	$parts = explode( '?>', $pattern_file, 2 );
+	return trim( 2 === count( $parts ) ? $parts[1] : $pattern_file );
+};
+
+$write_fixture = static function ( string $filename, string $html ): string {
+	$dir = trailingslashit( get_temp_dir() ) . 'static-site-importer-svg-' . wp_generate_uuid4();
+	wp_mkdir_p( $dir );
+	$path = trailingslashit( $dir ) . $filename;
+	file_put_contents( $path, $html );
+	return $path;
+};
+
+$safe_path = $write_fixture(
+	'safe-svg-icons.html',
+	'<!doctype html><html><head><title>Safe SVG Icons</title></head><body><main><section class="icons"><h1>Icons</h1><svg class="icon icon-bolt" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Bolt"><title>Bolt</title><path d="M13 2 3 14h8l-1 8 11-13h-8z" fill="currentColor"/></svg></section></main></body></html>'
+);
+
+$safe_result = Static_Site_Importer_Theme_Generator::import_theme(
+	$safe_path,
+	array(
+		'name'      => 'Safe SVG Icons',
+		'slug'      => 'safe-svg-icons-smoke',
+		'overwrite' => true,
+		'activate'  => false,
+	)
+);
+
+$assert( ! is_wp_error( $safe_result ), 'safe-import-succeeds', is_wp_error( $safe_result ) ? $safe_result->get_error_message() : '' );
+if ( ! is_wp_error( $safe_result ) ) {
+	$theme_dir = $safe_result['theme_dir'];
+	$pattern   = $pattern_blocks( $read( $theme_dir . '/patterns/page-safe-svg-icons.php' ) );
+	$report    = json_decode( $read( $safe_result['report_path'] ), true );
+	$asset     = $report['assets']['svg_icons'][0] ?? array();
+
+	$assert( str_contains( $pattern, '<!-- wp:image ' ), 'safe-svg-renders-core-image' );
+	$assert( ! str_contains( $pattern, '<!-- wp:html' ), 'safe-svg-does-not-render-core-html' );
+	$assert( str_contains( $pattern, '/assets/icons/' ), 'safe-svg-references-theme-asset' );
+	$assert( 0 === ( $report['quality']['fallback_count'] ?? null ), 'safe-svg-has-zero-fallbacks' );
+	$assert( 0 === ( $report['quality']['unsafe_svg_count'] ?? null ), 'safe-svg-has-zero-unsafe-svg-count' );
+	$assert( 'core/image' === ( $asset['block'] ?? '' ), 'safe-svg-report-records-native-block' );
+	$assert( isset( $asset['path'] ) && is_readable( $theme_dir . '/' . $asset['path'] ), 'safe-svg-asset-written' );
+}
+
+$unsafe_path = $write_fixture(
+	'unsafe-svg-icons.html',
+	'<!doctype html><html><head><title>Unsafe SVG Icons</title></head><body><main><section><h1>Unsafe</h1><svg viewBox="0 0 24 24"><script>alert(1)</script><path d="M0 0h24v24H0z"/></svg></section></main></body></html>'
+);
+
+$unsafe_result = Static_Site_Importer_Theme_Generator::import_theme(
+	$unsafe_path,
+	array(
+		'name'      => 'Unsafe SVG Icons',
+		'slug'      => 'unsafe-svg-icons-smoke',
+		'overwrite' => true,
+		'activate'  => false,
+	)
+);
+
+$assert( ! is_wp_error( $unsafe_result ), 'unsafe-import-succeeds', is_wp_error( $unsafe_result ) ? $unsafe_result->get_error_message() : '' );
+if ( ! is_wp_error( $unsafe_result ) ) {
+	$report      = json_decode( $read( $unsafe_result['report_path'] ), true );
+	$diagnostics = array_filter(
+		$report['diagnostics'] ?? array(),
+		static fn ( array $diagnostic ): bool => 'unsafe_inline_svg' === ( $diagnostic['type'] ?? '' )
+	);
+
+	$assert( 1 === ( $report['quality']['unsafe_svg_count'] ?? null ), 'unsafe-svg-counts-as-quality-failure' );
+	$assert( in_array( 'unsafe_inline_svg', $report['quality']['failure_reasons'] ?? array(), true ), 'unsafe-svg-adds-failure-reason' );
+	$assert( ! empty( $diagnostics ), 'unsafe-svg-emits-diagnostic' );
+}
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: inline SVG icon smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Materializes safe inline SVG icons into generated block theme assets under `assets/icons/` and replaces them with native `core/image` output before BFB conversion.
- Extends `import-report.json` with SVG asset metadata plus explicit unsafe/materialization-failure quality diagnostics.
- Adds PHPUnit and WP-CLI smoke coverage for safe SVG zero-fallback output and unsafe SVG reporting.

## Tests
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/StaticSiteImporterFixtureTest.php && php -l tests/smoke-inline-svg-icons.php`
- `studio wp eval-file "/Users/chubes/Developer/static-site-importer@materialize-svg-icons/tests/smoke-inline-svg-icons.php" --skip-plugins=static-site-importer`
- `/opt/homebrew/bin/homeboy lint static-site-importer --path "/Users/chubes/Developer/static-site-importer@materialize-svg-icons" --changed-only`
- `/opt/homebrew/bin/homeboy test static-site-importer --path "/Users/chubes/Developer/static-site-importer@materialize-svg-icons"`
- `npm run test:validation`

## Notes
- Full `homeboy lint static-site-importer --path ...` still reports existing repo-wide PHPStan/security findings outside this changed scope; changed-only lint passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the SVG materialization path, diagnostics/report updates, and test coverage; Chris remains responsible for review and validation.