### PR TITLE
Preserve leading nav in generated header parts

### DIFF
--- a/includes/class-static-site-importer-document.php
+++ b/includes/class-static-site-importer-document.php
@@ -150,12 +150,18 @@ class Static_Site_Importer_Document {
 		$header = $this->first_element( 'header' );
 		$footer = $this->first_element( 'footer' );
 
-		$header_html = '';
-		if ( $header instanceof DOMElement ) {
-			$header_html = $this->outer_html( $header );
-		} elseif ( $nav instanceof DOMElement ) {
-			$header_html = $this->outer_html( $nav );
+		$header_parts = array();
+		if ( $nav instanceof DOMElement && $header instanceof DOMElement && $this->is_leading_sibling( $root, $nav, $header ) ) {
+			$header_parts[] = $this->outer_html( $nav );
 		}
+
+		if ( $header instanceof DOMElement ) {
+			$header_parts[] = $this->outer_html( $header );
+		} elseif ( $nav instanceof DOMElement ) {
+			$header_parts[] = $this->outer_html( $nav );
+		}
+
+		$header_html = implode( "\n", $header_parts );
 
 		$footer_html = $footer instanceof DOMElement ? $this->outer_html( $footer ) : '';
 
@@ -225,6 +231,32 @@ class Static_Site_Importer_Document {
 	 */
 	private function same_node( DOMElement $left, ?DOMElement $right ): bool {
 		return $right instanceof DOMElement && $left->isSameNode( $right );
+	}
+
+	/**
+	 * Check whether one element is a direct sibling before another under the page root.
+	 *
+	 * @param DOMElement $root   Page root element.
+	 * @param DOMElement $before Candidate leading element.
+	 * @param DOMElement $after  Candidate following element.
+	 * @return bool
+	 */
+	private function is_leading_sibling( DOMElement $root, DOMElement $before, DOMElement $after ): bool {
+		foreach ( iterator_to_array( $root->childNodes ) as $child ) {
+			if ( ! $child instanceof DOMElement ) {
+				continue;
+			}
+
+			if ( $child->isSameNode( $before ) ) {
+				return true;
+			}
+
+			if ( $child->isSameNode( $after ) ) {
+				return false;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -416,6 +416,20 @@ class Static_Site_Importer_Theme_Generator {
 		$html   = self::materialize_inline_svg_icons( $html, 'theme-part:header' );
 		$doc    = self::load_fragment_document( $html );
 		$header = self::sole_child_element( $doc );
+		$root   = $doc->documentElement;
+		if ( ! $header instanceof DOMElement && $root instanceof DOMElement ) {
+			$children = self::direct_element_children( $root );
+			if ( count( $children ) > 1 ) {
+				return implode(
+					'',
+					array_map(
+						static fn ( DOMElement $child ): string => self::theme_part_element_block( $doc, $child, $theme_slug, 'header' ),
+						$children
+					)
+				);
+			}
+		}
+
 		if ( $header instanceof DOMElement && 'nav' === strtolower( $header->tagName ) ) {
 			return self::theme_part_element_block( $doc, $header, $theme_slug, 'header' );
 		}

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -152,6 +152,41 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Leading page navigation before a hero/header belongs in the shared header part.
+	 */
+	public function test_leading_nav_before_header_is_preserved_in_header_part(): void {
+		$html_path = $this->write_temp_fixture(
+			'leading-nav-header.html',
+			'<!doctype html><html><head><title>Leading Nav Header</title></head><body>' .
+			'<nav><div class="nav-logo">Studio Code</div><div class="nav-badge">Early Access</div><a href="#get-started" class="nav-cta">Get Started</a></nav>' .
+			'<header class="hero"><h1>Launch with Studio</h1><p>Hero copy.</p></header>' .
+			'<main><section id="get-started"><h2>Get started</h2><p>Body copy.</p></section></main>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Leading Nav Header',
+				'slug'      => 'leading-nav-header',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+
+		$this->assertStringContainsString( 'Studio Code', $header );
+		$this->assertStringContainsString( 'Early Access', $header );
+		$this->assertStringContainsString( 'Get Started', $header );
+		$this->assertStringContainsString( 'Launch with Studio', $header );
+	}
+
+	/**
 	 * Safe inline SVG icons are materialized as theme assets and native image blocks.
 	 */
 	public function test_safe_inline_svg_icons_materialize_as_theme_assets(): void {

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -280,6 +280,37 @@ if ( false !== $wrote_fixture ) {
 	}
 }
 
+$leading_nav_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-leading-nav-header.html';
+$wrote_leading_nav   = file_put_contents(
+	$leading_nav_fixture,
+	'<!doctype html><html><head><title>Leading Nav Header</title></head><body>' .
+	'<nav><div class="nav-logo">Studio Code</div><div class="nav-badge">Early Access</div><a href="#get-started" class="nav-cta">Get Started</a></nav>' .
+	'<header class="hero"><h1>Launch with Studio</h1><p>Hero copy.</p></header>' .
+	'<main><section id="get-started"><h2>Get started</h2><p>Body copy.</p></section></main>' .
+	'</body></html>'
+);
+$assert( false !== $wrote_leading_nav, 'leading-nav-fixture-written' );
+
+if ( false !== $wrote_leading_nav ) {
+	$leading_nav_result = Static_Site_Importer_Theme_Generator::import_theme(
+		$leading_nav_fixture,
+		array(
+			'name'      => 'Leading Nav Header',
+			'slug'      => 'leading-nav-header',
+			'overwrite' => true,
+			'activate'  => false,
+		)
+	);
+	$assert( ! is_wp_error( $leading_nav_result ), 'leading-nav-import-succeeds', is_wp_error( $leading_nav_result ) ? $leading_nav_result->get_error_message() : '' );
+	if ( ! is_wp_error( $leading_nav_result ) ) {
+		$leading_nav_header = $read( $leading_nav_result['theme_dir'] . '/parts/header.html' );
+		$assert( str_contains( $leading_nav_header, 'Studio Code' ), 'leading-nav-header-preserves-logo' );
+		$assert( str_contains( $leading_nav_header, 'Early Access' ), 'leading-nav-header-preserves-badge' );
+		$assert( str_contains( $leading_nav_header, 'Get Started' ), 'leading-nav-header-preserves-cta' );
+		$assert( str_contains( $leading_nav_header, 'Launch with Studio' ), 'leading-nav-header-preserves-hero' );
+	}
+}
+
 $quality_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-quality.html';
 $wrote_quality   = file_put_contents(
 	$quality_fixture,


### PR DESCRIPTION
## Summary
- Preserves a top-level `<nav>` before a top-level `<header>` as part of the generated `parts/header.html` fragment.
- Converts multi-element header fragments child-by-child so leading nav chrome and hero/header blocks both survive theme assembly.
- Adds focused PHPUnit and smoke coverage for the issue #39 `nav` followed by `header.hero` shape.

Closes #39.

## Testing
- `php -l includes/class-static-site-importer-document.php`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php && php -l tests/smoke-wordpress-is-dead-fixture.php`
- `studio wp --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-39-leading-nav/tests/smoke-wordpress-is-dead-fixture.php`

Could not run JS validation scripts because `npm` is unavailable in the non-interactive shell (`zsh:1: command not found: npm`). The exact temp benchmark artifact path from the issue is no longer readable on this machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the extraction/theme assembly fix, added focused tests, and ran local verification; Chris remains responsible for review and merge.