### PR TITLE
Fix bridged button defaults

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1776,13 +1776,39 @@ class Static_Site_Importer_Theme_Generator {
 			return '';
 		}
 
-		$rules = self::button_style_bridge_rules_from_css( $css, $button_classes );
+		$rules = array_merge(
+			self::button_style_bridge_reset_rules( $button_classes ),
+			self::button_style_bridge_rules_from_css( $css, $button_classes )
+		);
 
 		if ( ! $rules ) {
 			return '';
 		}
 
 		return "\n/* Static Site Importer: preserve source anchor styles on core/button links. */\n" . implode( "\n", array_unique( $rules ) ) . "\n";
+	}
+
+	/**
+	 * Build reset rules that prevent WordPress button defaults from leaking into source-converted buttons.
+	 *
+	 * @param array<string, true> $button_classes Classes observed on generated core/button wrappers.
+	 * @return array<int, string>
+	 */
+	private static function button_style_bridge_reset_rules( array $button_classes ): array {
+		$selectors = array();
+		foreach ( array_keys( $button_classes ) as $class ) {
+			if ( preg_match( '/^[A-Za-z_-][A-Za-z0-9_-]*$/', $class ) ) {
+				$selectors[] = '.wp-block-button.' . $class . ' > .wp-block-button__link:where(.wp-element-button)';
+			}
+		}
+
+		if ( empty( $selectors ) ) {
+			return array();
+		}
+
+		return array(
+			implode( ', ', $selectors ) . ' { background: transparent; border: 0; border-radius: 0; box-shadow: none; color: inherit; display: inline; font: inherit; height: auto; line-height: inherit; max-width: none; min-width: 0; padding: 0; text-decoration: inherit; width: auto; }',
+		);
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -196,8 +196,12 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 			'.nav-cta { background: var(--accent); color: #fff; padding: 10px 24px; border-radius: 100px; transition: transform 0.08s ease; }' .
 			'.nav-cta:hover { transform: translateY(-1px); }' .
 			'a.nav-cta:focus-visible { outline: 2px solid var(--accent); }' .
+			'.btn-primary { background: var(--acid); color: var(--ink); padding: 0.9rem 2.25rem; border-radius: 8px; display: inline-flex; }' .
+			'.btn-ghost { color: var(--paper-dim); border-bottom: 1px solid var(--slate-border); padding-bottom: 2px; }' .
+			'.btn-outline { border: 1px solid var(--slate-border); color: var(--paper-dim); padding: 0.85rem 1.75rem; border-radius: 8px; }' .
 			'</style></head><body>' .
-			'<main><h1>Button Wrapper Style</h1><p><a href="#try" class="btn nav-cta">Request Access</a></p></main>' .
+			'<main><h1>Button Wrapper Style</h1><p><a href="#try" class="btn nav-cta">Request Access</a></p>' .
+			'<p><a href="#primary" class="btn-primary">Start Building</a> <a href="#ghost" class="btn-ghost">Watch Demo</a> <a href="#outline" class="btn-outline">Read Docs</a></p></main>' .
 			'</body></html>'
 		);
 
@@ -219,10 +223,25 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$style     = $this->read_file( $theme_dir . '/style.css' );
 
 		$this->assertStringContainsString( '<div class="wp-block-button btn nav-cta">', $pattern );
+		$this->assertStringContainsString( '<div class="wp-block-button btn-primary">', $pattern );
+		$this->assertStringContainsString( '<div class="wp-block-button btn-ghost">', $pattern );
+		$this->assertStringContainsString( '<div class="wp-block-button btn-outline">', $pattern );
 		$this->assertStringContainsString( '.nav-cta:not(.wp-block-button)', $style );
+		$this->assertStringContainsString( '.btn-primary:not(.wp-block-button)', $style );
+		$this->assertStringContainsString( '.btn-ghost:not(.wp-block-button)', $style );
+		$this->assertStringContainsString( '.btn-outline:not(.wp-block-button)', $style );
 		$this->assertStringNotContainsString( '.nav-cta { background: var(--accent); color: #fff; padding: 10px 24px;', $style );
+		$this->assertStringContainsString( '.wp-block-button.nav-cta > .wp-block-button__link:where(.wp-element-button)', $style );
+		$this->assertStringContainsString( '.wp-block-button.btn-primary > .wp-block-button__link:where(.wp-element-button)', $style );
+		$this->assertStringContainsString( '.wp-block-button.btn-ghost > .wp-block-button__link:where(.wp-element-button)', $style );
+		$this->assertStringContainsString( '.wp-block-button.btn-outline > .wp-block-button__link:where(.wp-element-button)', $style );
+		$this->assertStringContainsString( 'background: transparent; border: 0; border-radius: 0; box-shadow: none; color: inherit; display: inline;', $style );
+		$this->assertStringContainsString( 'max-width: none; min-width: 0; padding: 0; text-decoration: inherit; width: auto;', $style );
 		$this->assertStringContainsString( '.wp-block-button.nav-cta > .wp-block-button__link { background: var(--accent); color: #fff; padding: 10px 24px;', $style );
 		$this->assertStringContainsString( '.wp-block-button.nav-cta > .wp-block-button__link:hover { transform: translateY(-1px); }', $style );
+		$this->assertStringContainsString( '.wp-block-button.btn-primary > .wp-block-button__link { background: var(--acid); color: var(--ink); padding: 0.9rem 2.25rem;', $style );
+		$this->assertStringContainsString( '.wp-block-button.btn-ghost > .wp-block-button__link { color: var(--paper-dim); border-bottom: 1px solid var(--slate-border); padding-bottom: 2px;', $style );
+		$this->assertStringContainsString( '.wp-block-button.btn-outline > .wp-block-button__link { border: 1px solid var(--slate-border); color: var(--paper-dim); padding: 0.85rem 1.75rem;', $style );
 		$this->assertStringContainsString( 'a.nav-cta:focus-visible', $style );
 	}
 

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -169,6 +169,7 @@ if ( ! is_wp_error( $result ) ) {
 		$assert( $footer_nav->ID === $footer_nav_after->ID, 'second-import-reuses-footer-navigation-post' );
 	}
 	$assert( str_contains( $style, '--accent' ) && str_contains( $style, '.compare' ) && str_contains( $style, '.manifesto-list' ), 'style-preserves-source-css' );
+	$assert( str_contains( $style, '.wp-block-button.btn > .wp-block-button__link:where(.wp-element-button)' ), 'style-resets-source-button-classes-on-core-button-links' );
 	$assert( str_contains( $style, '.wp-block-button.btn > .wp-block-button__link' ), 'style-bridges-source-button-classes-to-core-button-links' );
 	$assert( str_contains( $style, '.wp-block-button.btn.primary > .wp-block-button__link' ), 'style-bridges-source-primary-button-to-core-button-link' );
 	$assert( str_contains( $style, '.wp-block-button.btn.ghost > .wp-block-button__link' ), 'style-bridges-source-ghost-button-to-core-button-link' );


### PR DESCRIPTION
## Summary
- Reset Gutenberg/Core button defaults on source-converted `core/button` inner links before applying bridged source anchor styles.
- Extend regression coverage for `nav-cta`, `btn-primary`, `btn-ghost`, and `btn-outline` source button shapes.

Closes #44.

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/StaticSiteImporterFixtureTest.php && php -l tests/smoke-wordpress-is-dead-fixture.php`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-44-button-default-reset/tests/smoke-admin-import-html-entry.php`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-44-button-default-reset/tests/smoke-editor-style-support.php`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-44-button-default-reset/tests/smoke-wordpress-is-dead-fixture.php`
- `npm run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead-fixture`
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-issue-44-button-default-reset`
- `homeboy lint static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-issue-44-button-default-reset --changed-only`

## Notes
- Repository-wide `homeboy lint static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-issue-44-button-default-reset` still reports pre-existing issues in `includes/class-static-site-importer-admin.php` and `includes/class-static-site-importer-document.php`, plus the existing ESLint path-pattern failure. Changed-file lint is clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the button bridge reset implementation and regression tests; Chris remains responsible for review and merge.