### PR TITLE
Fix nested section header chrome extraction

### DIFF
--- a/includes/class-static-site-importer-document.php
+++ b/includes/class-static-site-importer-document.php
@@ -146,8 +146,8 @@ class Static_Site_Importer_Document {
 		$body = $this->first_element( 'body' );
 		$root = $body instanceof DOMElement ? $body : $this->dom->documentElement;
 
-		$nav    = $this->first_element( 'nav' );
-		$header = $this->first_element( 'header' );
+		$header = $this->first_plausible_global_header( $root );
+		$nav    = $this->first_plausible_global_nav( $root, $header );
 		$footer = $this->first_element( 'footer' );
 
 		$header_parts = array();
@@ -209,6 +209,113 @@ class Static_Site_Importer_Document {
 		$node  = $nodes->length > 0 ? $nodes->item( 0 ) : null;
 
 		return $node instanceof DOMElement ? $node : null;
+	}
+
+	/**
+	 * Find a header that is plausible reusable site chrome.
+	 *
+	 * @param DOMElement $root Page root element.
+	 * @return DOMElement|null
+	 */
+	private function first_plausible_global_header( DOMElement $root ): ?DOMElement {
+		foreach ( $this->dom->getElementsByTagName( 'header' ) as $header ) {
+			if ( $header instanceof DOMElement && $this->is_plausible_global_header( $root, $header ) ) {
+				return $header;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Find a nav that is plausible reusable site chrome.
+	 *
+	 * @param DOMElement      $root   Page root element.
+	 * @param DOMElement|null $header Selected header element.
+	 * @return DOMElement|null
+	 */
+	private function first_plausible_global_nav( DOMElement $root, ?DOMElement $header ): ?DOMElement {
+		foreach ( $this->dom->getElementsByTagName( 'nav' ) as $nav ) {
+			if ( ! $nav instanceof DOMElement ) {
+				continue;
+			}
+
+			if ( $header instanceof DOMElement && $this->is_descendant_of( $nav, $header ) ) {
+				return $nav;
+			}
+
+			if ( $this->is_direct_child( $root, $nav ) || $this->has_global_chrome_signal( $nav ) ) {
+				return $nav;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check whether a header looks like global site chrome rather than section content.
+	 *
+	 * @param DOMElement $root   Page root element.
+	 * @param DOMElement $header Header element.
+	 * @return bool
+	 */
+	private function is_plausible_global_header( DOMElement $root, DOMElement $header ): bool {
+		if ( $this->has_global_chrome_signal( $header ) ) {
+			return true;
+		}
+
+		return $this->is_direct_child( $root, $header );
+	}
+
+	/**
+	 * Check whether an element carries explicit global-chrome signals.
+	 *
+	 * @param DOMElement $element Element.
+	 * @return bool
+	 */
+	private function has_global_chrome_signal( DOMElement $element ): bool {
+		$role = strtolower( trim( $element->getAttribute( 'role' ) ) );
+		if ( 'banner' === $role || 'navigation' === $role ) {
+			return true;
+		}
+
+		$classes = strtolower( $element->getAttribute( 'class' ) );
+		if ( preg_match( '/(^|[\s_-])(site-header|site-nav|navbar|navigation|masthead|brand|branding)([\s_-]|$)/', $classes ) ) {
+			return true;
+		}
+
+		return $element->getElementsByTagName( 'nav' )->length > 0;
+	}
+
+	/**
+	 * Check whether a candidate is a direct child of the page root.
+	 *
+	 * @param DOMElement $root      Page root element.
+	 * @param DOMElement $candidate Candidate element.
+	 * @return bool
+	 */
+	private function is_direct_child( DOMElement $root, DOMElement $candidate ): bool {
+		return $candidate->parentNode instanceof DOMNode && $candidate->parentNode->isSameNode( $root );
+	}
+
+	/**
+	 * Check whether a candidate is contained by another element.
+	 *
+	 * @param DOMElement $candidate Candidate element.
+	 * @param DOMElement $ancestor  Ancestor element.
+	 * @return bool
+	 */
+	private function is_descendant_of( DOMElement $candidate, DOMElement $ancestor ): bool {
+		$node = $candidate->parentNode;
+		while ( $node instanceof DOMNode ) {
+			if ( $node->isSameNode( $ancestor ) ) {
+				return true;
+			}
+
+			$node = $node->parentNode;
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -187,6 +187,44 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Nested section headers are page content, not shared site chrome.
+	 */
+	public function test_nested_section_header_stays_in_page_content(): void {
+		$html_path = $this->write_temp_fixture(
+			'nested-section-header.html',
+			'<!doctype html><html><head><title>Nested Section Header</title></head><body>' .
+			'<main><section class="proof"><div class="proof-inner"><header class="proof-header">' .
+			'<p class="section-label">Why It Actually Works</p>' .
+			'<h2 class="proof-heading reveal">Six reasons the assumptions are wrong.</h2>' .
+			'</header><p class="proof-copy">The section body stays with the section.</p></div></section></main>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Nested Section Header',
+				'slug'      => 'nested-section-header',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+		$pattern   = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-nested-section-header.php' ) );
+
+		$this->assertStringNotContainsString( 'proof-header', $header );
+		$this->assertStringNotContainsString( 'Six reasons the assumptions are wrong.', $header );
+		$this->assertStringContainsString( 'proof-header', $pattern );
+		$this->assertStringContainsString( 'Why It Actually Works', $pattern );
+		$this->assertStringContainsString( 'Six reasons the assumptions are wrong.', $pattern );
+	}
+
+	/**
 	 * Source button styles are moved to the inner link without restyling the core/button wrapper.
 	 */
 	public function test_source_button_class_styles_do_not_double_apply_to_core_button_wrapper(): void {

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -330,6 +330,40 @@ if ( false !== $wrote_leading_nav ) {
 	}
 }
 
+$nested_header_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-nested-section-header.html';
+$wrote_nested_header   = file_put_contents(
+	$nested_header_fixture,
+	'<!doctype html><html><head><title>Nested Section Header</title></head><body>' .
+	'<main><section class="proof"><div class="proof-inner"><header class="proof-header">' .
+	'<p class="section-label">Why It Actually Works</p>' .
+	'<h2 class="proof-heading reveal">Six reasons the assumptions are wrong.</h2>' .
+	'</header><p class="proof-copy">The section body stays with the section.</p></div></section></main>' .
+	'</body></html>'
+);
+$assert( false !== $wrote_nested_header, 'nested-header-fixture-written' );
+
+if ( false !== $wrote_nested_header ) {
+	$nested_header_result = Static_Site_Importer_Theme_Generator::import_theme(
+		$nested_header_fixture,
+		array(
+			'name'      => 'Nested Section Header',
+			'slug'      => 'nested-section-header',
+			'overwrite' => true,
+			'activate'  => false,
+		)
+	);
+	$assert( ! is_wp_error( $nested_header_result ), 'nested-header-import-succeeds', is_wp_error( $nested_header_result ) ? $nested_header_result->get_error_message() : '' );
+	if ( ! is_wp_error( $nested_header_result ) ) {
+		$nested_header = $read( $nested_header_result['theme_dir'] . '/parts/header.html' );
+		$nested_pattern = $pattern_blocks( $read( $nested_header_result['theme_dir'] . '/patterns/page-static-site-importer-nested-section-header.php' ) );
+		$assert( ! str_contains( $nested_header, 'proof-header' ), 'nested-section-header-not-extracted-to-global-header' );
+		$assert( ! str_contains( $nested_header, 'Six reasons the assumptions are wrong.' ), 'nested-section-heading-not-extracted-to-global-header' );
+		$assert( str_contains( $nested_pattern, 'proof-header' ), 'nested-section-header-class-stays-in-page-content' );
+		$assert( str_contains( $nested_pattern, 'Why It Actually Works' ), 'nested-section-label-stays-in-page-content' );
+		$assert( str_contains( $nested_pattern, 'Six reasons the assumptions are wrong.' ), 'nested-section-heading-stays-in-page-content' );
+	}
+}
+
 $quality_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-quality.html';
 $wrote_quality   = file_put_contents(
 	$quality_fixture,


### PR DESCRIPTION
## Summary
- Select only plausible global site chrome when extracting shared header/navigation fragments.
- Keep nested section/card headers such as `proof-header` in page content.
- Add fixture coverage for the issue #47 wordpress-is-dead benchmark shape.

## Tests
- `php -l includes/class-static-site-importer-document.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `php -l tests/smoke-wordpress-is-dead-fixture.php`
- `php -r '...'` nested section header fragment smoke
- `php -r '...'` leading nav/header fragment smoke
- `studio wp plugin deactivate static-site-importer && studio wp eval-file /Users/chubes/Developer/static-site-importer@fix-issue-47-header-chrome/tests/smoke-wordpress-is-dead-fixture.php; exit_code=$?; studio wp plugin activate static-site-importer; exit $exit_code`
- `/Users/chubes/.nvm/versions/node/v24.13.1/bin/npm run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead-fixture`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated issue #47, implemented the chrome extraction heuristic and fixture coverage, ran validation, and drafted this PR. Chris remains responsible for review and merge.

Fixes #47