### PR TITLE
Fix empty footer template parts

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -111,7 +111,8 @@ class Static_Site_Importer_Theme_Generator {
 
 		$background_blocks = self::convert_fragment( self::rewrite_internal_links( $fragments['background'], $permalinks ), 'background:index.html' );
 		$header_blocks     = self::convert_header_fragment( self::strip_active_classes( self::rewrite_internal_links( $fragments['header'], $permalinks ) ), $theme_slug );
-		$footer_blocks     = self::convert_footer_fragment( self::rewrite_internal_links( $fragments['footer'], $permalinks ), $theme_slug );
+		$has_footer_part   = '' !== trim( $fragments['footer'] );
+		$footer_blocks     = $has_footer_part ? self::convert_footer_fragment( self::rewrite_internal_links( $fragments['footer'], $permalinks ), $theme_slug ) : '';
 
 		$page_artifacts = self::page_artifacts( $pages, $permalinks, $theme_slug );
 
@@ -126,11 +127,13 @@ class Static_Site_Importer_Theme_Generator {
 			$theme_dir . '/functions.php'             => self::functions_php( $theme_slug ),
 			$theme_dir . '/theme.json'                => self::theme_json( $theme_name, $site_css ),
 			$theme_dir . '/parts/header.html'         => $header_blocks,
-			$theme_dir . '/parts/footer.html'         => $footer_blocks,
-			$theme_dir . '/templates/front-page.html' => self::page_pattern_template( $background_blocks, $page_artifacts['patterns']['index.html'] ?? '' ),
-			$theme_dir . '/templates/page.html'       => self::content_template( $background_blocks ),
-			$theme_dir . '/templates/index.html'      => self::content_template( $background_blocks ),
+			$theme_dir . '/templates/front-page.html' => self::page_pattern_template( $background_blocks, $page_artifacts['patterns']['index.html'] ?? '', $has_footer_part ),
+			$theme_dir . '/templates/page.html'       => self::content_template( $background_blocks, $has_footer_part ),
+			$theme_dir . '/templates/index.html'      => self::content_template( $background_blocks, $has_footer_part ),
 		);
+		if ( $has_footer_part ) {
+			$writes[ $theme_dir . '/parts/footer.html' ] = $footer_blocks;
+		}
 
 		foreach ( $page_artifacts['patterns'] as $filename => $pattern_slug ) {
 			$slug = self::page_slug( $filename );
@@ -138,7 +141,7 @@ class Static_Site_Importer_Theme_Generator {
 				continue;
 			}
 
-			$writes[ $theme_dir . '/templates/page-' . $slug . '.html' ] = self::page_pattern_template( $background_blocks, $pattern_slug );
+			$writes[ $theme_dir . '/templates/page-' . $slug . '.html' ] = self::page_pattern_template( $background_blocks, $pattern_slug, $has_footer_part );
 			$writes[ $theme_dir . '/patterns/page-' . $slug . '.php' ]   = $page_artifacts['files'][ $filename ] ?? '';
 		}
 
@@ -153,6 +156,10 @@ class Static_Site_Importer_Theme_Generator {
 		$report_json = wp_json_encode( self::$conversion_report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 		if ( false === $report_json ) {
 			return new WP_Error( 'static_site_importer_report_encode_failed', 'Failed to encode import report JSON.' );
+		}
+
+		if ( ! $has_footer_part && file_exists( $theme_dir . '/parts/footer.html' ) && ! wp_delete_file( $theme_dir . '/parts/footer.html' ) ) {
+			return new WP_Error( 'static_site_importer_stale_footer_delete_failed', 'Failed to remove stale footer template part.' );
 		}
 
 		$writes[ $theme_dir . '/import-report.json' ] = $report_json . "\n";
@@ -1324,6 +1331,7 @@ class Static_Site_Importer_Theme_Generator {
 			$template    = '' === $slug ? '' : 'templates/page-' . $slug . '.html';
 			$pattern     = '' === $slug ? '' : 'patterns/page-' . $slug . '.php';
 			$generated   = self::generated_visual_probe_markup( $writes, $theme_prefix, $pattern );
+			$footer_part = isset( $writes[ $theme_prefix . 'parts/footer.html' ] ) ? 'parts/footer.html' : '';
 
 			self::$conversion_report['visual_fidelity']['comparison_targets'][] = array(
 				'source_file'            => $page['path'],
@@ -1342,7 +1350,7 @@ class Static_Site_Importer_Theme_Generator {
 					'hero'            => array( '.hero', 'header', '[class*=hero]' ),
 					'buttons'         => array( 'a[class*=btn]', 'a[class*=button]', 'a[class*=cta]', 'button', '.wp-block-button__link' ),
 					'visible_chrome'  => array( 'nav', 'header', 'footer' ),
-					'generated_files' => array_values( array_filter( array( $template, $pattern, 'parts/header.html', 'parts/footer.html', 'style.css' ) ) ),
+					'generated_files' => array_values( array_filter( array( $template, $pattern, 'parts/header.html', $footer_part, 'style.css' ) ) ),
 				),
 			);
 		}
@@ -2577,14 +2585,17 @@ class Static_Site_Importer_Theme_Generator {
 	 * Build a template that renders imported page content.
 	 *
 	 * @param string $background_blocks Background decoration blocks.
+	 * @param bool   $has_footer_part   Whether a shared footer template part was generated.
 	 * @return string
 	 */
-	private static function content_template( string $background_blocks ): string {
+	private static function content_template( string $background_blocks, bool $has_footer_part ): string {
+		$footer_part = $has_footer_part ? '<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->' : '';
+
 		return trim(
 			'<!-- wp:template-part {"slug":"header","tagName":"header"} /-->' . "\n\n" .
 			$background_blocks . "\n\n" .
 			'<!-- wp:post-content /-->' . "\n\n" .
-			'<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->'
+			$footer_part
 		) . "\n";
 	}
 
@@ -2593,16 +2604,18 @@ class Static_Site_Importer_Theme_Generator {
 	 *
 	 * @param string $background_blocks Background decoration blocks.
 	 * @param string $pattern_slug      Pattern slug.
+	 * @param bool   $has_footer_part   Whether a shared footer template part was generated.
 	 * @return string
 	 */
-	private static function page_pattern_template( string $background_blocks, string $pattern_slug ): string {
-		$body = '' === $pattern_slug ? '<!-- wp:post-content /-->' : '<!-- wp:pattern {"slug":"' . esc_attr( $pattern_slug ) . '"} /-->';
+	private static function page_pattern_template( string $background_blocks, string $pattern_slug, bool $has_footer_part ): string {
+		$body        = '' === $pattern_slug ? '<!-- wp:post-content /-->' : '<!-- wp:pattern {"slug":"' . esc_attr( $pattern_slug ) . '"} /-->';
+		$footer_part = $has_footer_part ? '<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->' : '';
 
 		return trim(
 			'<!-- wp:template-part {"slug":"header","tagName":"header"} /-->' . "\n\n" .
 			$background_blocks . "\n\n" .
 			$body . "\n\n" .
-			'<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->'
+			$footer_part
 		) . "\n";
 	}
 

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -225,6 +225,45 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Footer-like content inside a page section is content, not an empty shared footer part.
+	 */
+	public function test_nested_footer_bar_does_not_emit_empty_footer_part(): void {
+		$html_path = $this->write_temp_fixture(
+			'nested-footer-bar.html',
+			'<!doctype html><html><head><title>Nested Footer Bar</title></head><body>' .
+			'<nav class="top-nav"><a href="/">Home</a></nav>' .
+			'<main><section class="cta"><h1>Ship the site</h1><p>CTA body.</p><div class="footer-bar"><span>Fine print stays with the CTA.</span></div></section></main>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Nested Footer Bar',
+				'slug'      => 'nested-footer-bar',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$pattern   = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-nested-footer-bar.php' ) );
+		$page      = $this->read_file( $theme_dir . '/templates/page.html' );
+		$template  = $this->read_file( $theme_dir . '/templates/page-nested-footer-bar.html' );
+		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+
+		$this->assertFileDoesNotExist( $theme_dir . '/parts/footer.html' );
+		$this->assertStringNotContainsString( '"slug":"footer"', $page );
+		$this->assertStringNotContainsString( '"slug":"footer"', $template );
+		$this->assertStringContainsString( 'footer-bar', $pattern );
+		$this->assertStringContainsString( 'Fine print stays with the CTA.', $pattern );
+		$this->assertNotContains( 'parts/footer.html', $report['visual_fidelity']['comparison_targets'][0]['comparison_hooks']['generated_files'] ?? array() );
+	}
+
+	/**
 	 * Source button styles are moved to the inner link without restyling the core/button wrapper.
 	 */
 	public function test_source_button_class_styles_do_not_double_apply_to_core_button_wrapper(): void {

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -354,13 +354,52 @@ if ( false !== $wrote_nested_header ) {
 	);
 	$assert( ! is_wp_error( $nested_header_result ), 'nested-header-import-succeeds', is_wp_error( $nested_header_result ) ? $nested_header_result->get_error_message() : '' );
 	if ( ! is_wp_error( $nested_header_result ) ) {
-		$nested_header = $read( $nested_header_result['theme_dir'] . '/parts/header.html' );
+		$nested_header  = $read( $nested_header_result['theme_dir'] . '/parts/header.html' );
 		$nested_pattern = $pattern_blocks( $read( $nested_header_result['theme_dir'] . '/patterns/page-static-site-importer-nested-section-header.php' ) );
 		$assert( ! str_contains( $nested_header, 'proof-header' ), 'nested-section-header-not-extracted-to-global-header' );
 		$assert( ! str_contains( $nested_header, 'Six reasons the assumptions are wrong.' ), 'nested-section-heading-not-extracted-to-global-header' );
 		$assert( str_contains( $nested_pattern, 'proof-header' ), 'nested-section-header-class-stays-in-page-content' );
 		$assert( str_contains( $nested_pattern, 'Why It Actually Works' ), 'nested-section-label-stays-in-page-content' );
 		$assert( str_contains( $nested_pattern, 'Six reasons the assumptions are wrong.' ), 'nested-section-heading-stays-in-page-content' );
+	}
+}
+
+$nested_footer_dir     = trailingslashit( get_temp_dir() ) . 'static-site-importer-nested-footer-' . wp_generate_uuid4();
+$nested_footer_fixture = trailingslashit( $nested_footer_dir ) . 'index.html';
+wp_mkdir_p( $nested_footer_dir );
+$wrote_nested_footer   = file_put_contents(
+	$nested_footer_fixture,
+	'<!doctype html><html><head><title>Nested Footer Bar</title></head><body>' .
+	'<nav class="top-nav"><a href="/">Home</a></nav>' .
+	'<main><section class="cta"><h1>Ship the site</h1><p>CTA body.</p><div class="footer-bar"><span>Fine print stays with the CTA.</span></div></section></main>' .
+	'</body></html>'
+);
+$assert( false !== $wrote_nested_footer, 'nested-footer-fixture-written' );
+
+if ( false !== $wrote_nested_footer ) {
+	$nested_footer_result = Static_Site_Importer_Theme_Generator::import_theme(
+		$nested_footer_fixture,
+		array(
+			'name'      => 'Nested Footer Bar',
+			'slug'      => 'nested-footer-bar',
+			'overwrite' => true,
+			'activate'  => false,
+		)
+	);
+	$assert( ! is_wp_error( $nested_footer_result ), 'nested-footer-import-succeeds', is_wp_error( $nested_footer_result ) ? $nested_footer_result->get_error_message() : '' );
+	if ( ! is_wp_error( $nested_footer_result ) ) {
+		$nested_footer_theme_dir = $nested_footer_result['theme_dir'];
+		$nested_footer_pattern   = $pattern_blocks( $read( $nested_footer_theme_dir . '/patterns/page-home.php' ) );
+		$nested_footer_page      = $read( $nested_footer_theme_dir . '/templates/page.html' );
+		$nested_footer_template  = $read( $nested_footer_theme_dir . '/templates/front-page.html' );
+		$nested_footer_report    = json_decode( $read( $nested_footer_result['report_path'] ?? '' ), true );
+
+		$assert( ! file_exists( $nested_footer_theme_dir . '/parts/footer.html' ), 'nested-footer-does-not-emit-empty-footer-part' );
+		$assert( ! str_contains( $nested_footer_page, '"slug":"footer"' ), 'nested-footer-page-template-does-not-reference-footer-part' );
+		$assert( ! str_contains( $nested_footer_template, '"slug":"footer"' ), 'nested-footer-specific-template-does-not-reference-footer-part' );
+		$assert( str_contains( $nested_footer_pattern, 'footer-bar' ), 'nested-footer-bar-remains-in-page-content' );
+		$assert( str_contains( $nested_footer_pattern, 'Fine print stays with the CTA.' ), 'nested-footer-copy-remains-in-page-content' );
+		$assert( ! in_array( 'parts/footer.html', $nested_footer_report['visual_fidelity']['comparison_targets'][0]['comparison_hooks']['generated_files'] ?? array(), true ), 'nested-footer-report-omits-footer-part-file' );
 	}
 }
 


### PR DESCRIPTION
## Summary
- Only generate and reference `parts/footer.html` when SSI extracts a real shared footer fragment.
- Remove stale generated footer parts on overwrite when the new source has no global footer chrome.
- Add issue #48 coverage for a nested `.footer-bar` inside CTA content so it remains in page content without producing an empty footer template part.

Closes #48

## Tests
- `studio wp eval-file /Users/chubes/Developer/static-site-importer@fix-issue-48-empty-footer-parts/tests/smoke-wordpress-is-dead-fixture.php --skip-plugins=static-site-importer`
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/StaticSiteImporterFixtureTest.php && php -l tests/smoke-wordpress-is-dead-fixture.php`
- `STATIC_SITE_IMPORTER_WP_CLI="studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer" STATIC_SITE_IMPORTER_THEME_DIR="/Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead-fixture" /Users/chubes/.nvm/versions/node/v24.13.1/bin/npm run test:validation -- --skip-import`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the code change, issue #48 fixture coverage, and local validation commands; Chris remains responsible for review and merge.