### PR TITLE
Fix editor stacking for absolute overlays

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1941,9 +1941,115 @@ class Static_Site_Importer_Theme_Generator {
 	 */
 	private static function style_css( string $theme_name, string $css, array $button_classes = array() ): string {
 		$button_bridge = self::button_style_bridge_css( $css, $button_classes );
+		$editor_bridge = self::editor_absolute_overlay_css( $css );
 		$css           = self::scope_source_button_css( $css, $button_classes );
 
-		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Imported from static HTML using Block Format Bridge.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $button_bridge;
+		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Imported from static HTML using Block Format Bridge.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $button_bridge . $editor_bridge;
+	}
+
+	/**
+	 * Build editor-only wrapper normalization for imported absolute overlay blocks.
+	 *
+	 * The Site Editor inserts block-list wrappers between imported section/group blocks
+	 * and their children. When a source child is absolutely positioned, that extra
+	 * wrapper can become the visible stack item instead of the imported child.
+	 *
+	 * @param string $css Source CSS.
+	 * @return string Additional editor-only CSS rules.
+	 */
+	private static function editor_absolute_overlay_css( string $css ): string {
+		$classes = self::absolute_position_classes_from_css( $css );
+		if ( empty( $classes ) ) {
+			return '';
+		}
+
+		$selectors = array();
+		foreach ( $classes as $class ) {
+			if ( preg_match( '/^[A-Za-z_-][A-Za-z0-9_-]*$/', $class ) ) {
+				$selectors[] = '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .' . $class . ')';
+			}
+		}
+
+		if ( empty( $selectors ) ) {
+			return '';
+		}
+
+		return "\n/* Static Site Importer: let Site Editor wrappers preserve imported absolute overlay stacking. */\n" . implode( ', ', array_unique( $selectors ) ) . ' { display: contents; }' . "\n";
+	}
+
+	/**
+	 * Collect terminal selector classes from rules declaring position:absolute.
+	 *
+	 * @param string $css Source CSS.
+	 * @return array<int, string> Class names.
+	 */
+	private static function absolute_position_classes_from_css( string $css ): array {
+		$css = preg_replace( '/\/\*.*?\*\//s', '', $css ) ?? $css;
+		if ( '' === trim( $css ) || ! str_contains( $css, 'position' ) || ! str_contains( $css, '.' ) ) {
+			return array();
+		}
+
+		$classes = self::absolute_position_classes_from_css_scope( $css );
+		sort( $classes, SORT_STRING );
+
+		return $classes;
+	}
+
+	/**
+	 * Collect absolute-position classes inside one CSS block list.
+	 *
+	 * @param string $css CSS to inspect.
+	 * @return array<int, string> Class names.
+	 */
+	private static function absolute_position_classes_from_css_scope( string $css ): array {
+		$classes = array();
+		$length  = strlen( $css );
+		$offset  = 0;
+
+		while ( $offset < $length && preg_match( '/\G\s*([^{}]+)\{/', $css, $match, 0, $offset ) ) {
+			$prelude    = trim( $match[1] );
+			$body_start = $offset + strlen( $match[0] );
+			$body_end   = self::find_css_block_end( $css, $body_start );
+			if ( null === $body_end ) {
+				break;
+			}
+
+			$body   = substr( $css, $body_start, $body_end - $body_start );
+			$offset = $body_end + 1;
+
+			if ( str_starts_with( $prelude, '@' ) ) {
+				$classes = array_merge( $classes, self::absolute_position_classes_from_css_scope( $body ) );
+				continue;
+			}
+
+			if ( ! preg_match( '/(?:^|;)\s*position\s*:\s*absolute\s*(?:;|$)/i', $body ) ) {
+				continue;
+			}
+
+			foreach ( explode( ',', $prelude ) as $selector ) {
+				$classes = array_merge( $classes, self::selector_terminal_classes( trim( $selector ) ) );
+			}
+		}
+
+		return array_values( array_unique( $classes ) );
+	}
+
+	/**
+	 * Extract classes from the final compound selector that identifies the styled element.
+	 *
+	 * @param string $selector CSS selector.
+	 * @return array<int, string> Class names.
+	 */
+	private static function selector_terminal_classes( string $selector ): array {
+		if ( '' === $selector || ! preg_match( '/([^\s>+~]+)(?::[A-Za-z_-][A-Za-z0-9_-]*(?:\([^)]*\))?)*\s*$/', $selector, $selector_match ) ) {
+			return array();
+		}
+
+		if ( ! preg_match_all( '/\.([A-Za-z_-][A-Za-z0-9_-]*)/', $selector_match[1], $class_matches ) ) {
+			return array();
+		}
+
+		return array_values( array_unique( $class_matches[1] ) );
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -284,6 +284,49 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Absolute decorative children inside imported sections keep their source stack in the Site Editor.
+	 */
+	public function test_absolute_decorative_overlay_stacks_in_site_editor(): void {
+		$html_path = $this->write_temp_fixture(
+			'absolute-hero-overlay.html',
+			'<!doctype html><html><head><title>Absolute Hero Overlay</title><style>' .
+			'.hero { min-height: 100vh; display: flex; flex-direction: column; justify-content: flex-end; position: relative; overflow: hidden; }' .
+			'.hero-rip { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: clamp(220px, 42vw, 580px); color: rgba(255, 61, 0, 0.035); pointer-events: none; user-select: none; }' .
+			'.hero .container { position: relative; z-index: 1; }' .
+			'</style></head><body><main><section class="hero"><div class="hero-rip" aria-hidden="true">RIP</div><div class="container"><h1>WordPress is dead.</h1><p>Hero copy stays above the decorative overlay.</p></div></section></main></body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Absolute Hero Overlay',
+				'slug'      => 'absolute-hero-overlay',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$pattern   = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-absolute-hero-overlay.php' ) );
+		$style     = $this->read_file( $theme_dir . '/style.css' );
+		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+
+		$this->assertStringContainsString( '<!-- wp:group {"className":"hero","tagName":"section"}', $pattern );
+		$this->assertStringContainsString( 'hero-rip', $pattern );
+		$this->assertStringContainsString( '<!-- wp:group {"className":"container"}', $pattern );
+		$this->assertStringContainsString( '.hero-rip { position: absolute;', $style );
+		$this->assertStringContainsString( '.hero .container { position: relative; z-index: 1;', $style );
+		$this->assertStringContainsString( 'Static Site Importer: let Site Editor wrappers preserve imported absolute overlay stacking.', $style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .hero-rip) { display: contents; }', $style );
+		$this->assertSame( 0, $report['quality']['fallback_count'] ?? null );
+		$this->assertSame( 0, $report['quality']['core_html_block_count'] ?? null );
+		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
+	}
+
+	/**
 	 * Safe inline SVG icons are materialized as theme assets and native image blocks.
 	 */
 	public function test_safe_inline_svg_icons_materialize_as_theme_assets(): void {


### PR DESCRIPTION
## Summary
- Adds generated editor-scoped CSS that normalizes Site Editor block wrappers around imported children whose source CSS declares `position: absolute`.
- Keeps frontend output unchanged while letting decorative absolute overlays stack behind z-indexed content containers in the editor.
- Adds regression coverage for a hero section with an absolute decorative `hero-rip` child and a positioned/z-indexed content container.

Fixes #51.

## Testing
- `homeboy test`
- `homeboy lint --changed-only`
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/StaticSiteImporterFixtureTest.php`
- `/Users/chubes/.nvm/versions/node/v24.13.1/bin/npm run test:validation`
- `/Users/chubes/.nvm/versions/node/v24.13.1/bin/npm run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead`

## Notes
- Full `homeboy lint` still reports existing baseline findings in `includes/class-static-site-importer-admin.php` and `includes/class-static-site-importer-document.php`, plus the repo ESLint path issue. Changed-file lint passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the editor-scoped CSS bridge, regression test, and test/PR workflow; Chris remains responsible for review and merge.