### PR TITLE
Fix admin bar offsets for imported fixed chrome

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1940,11 +1940,154 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string
 	 */
 	private static function style_css( string $theme_name, string $css, array $button_classes = array() ): string {
-		$button_bridge = self::button_style_bridge_css( $css, $button_classes );
-		$editor_bridge = self::editor_absolute_overlay_css( $css );
-		$css           = self::scope_source_button_css( $css, $button_classes );
+		$button_bridge    = self::button_style_bridge_css( $css, $button_classes );
+		$editor_bridge    = self::editor_absolute_overlay_css( $css );
+		$admin_bar_bridge = self::admin_bar_top_chrome_css( $css );
+		$css              = self::scope_source_button_css( $css, $button_classes );
 
-		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Imported from static HTML using Block Format Bridge.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $button_bridge . $editor_bridge;
+		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Imported from static HTML using Block Format Bridge.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $button_bridge . $editor_bridge . $admin_bar_bridge;
+	}
+
+	/**
+	 * Build frontend admin-bar offsets for imported fixed/sticky top chrome.
+	 *
+	 * WordPress adds body.admin-bar but does not offset arbitrary imported fixed
+	 * headers. Only selectors that already declare fixed/sticky positioning,
+	 * a top value, and header/nav-like naming receive generated offsets.
+	 *
+	 * @param string $css Source CSS.
+	 * @return string Additional frontend CSS rules.
+	 */
+	private static function admin_bar_top_chrome_css( string $css ): string {
+		$css = preg_replace( '/\/\*.*?\*\//s', '', $css ) ?? $css;
+		if ( '' === trim( $css ) || ! str_contains( $css, 'position' ) || ! str_contains( $css, 'top' ) ) {
+			return '';
+		}
+
+		$rules = self::admin_bar_top_chrome_rules_from_css( $css );
+		if ( empty( $rules ) ) {
+			return '';
+		}
+
+		return "\n/* Static Site Importer: offset imported fixed/sticky top chrome below the WordPress admin bar. */\n" . implode( "\n", array_unique( $rules ) ) . "\n";
+	}
+
+	/**
+	 * Build admin-bar offset rules from one CSS scope.
+	 *
+	 * @param string $css CSS to inspect.
+	 * @return array<int, string> CSS rules.
+	 */
+	private static function admin_bar_top_chrome_rules_from_css( string $css ): array {
+		$rules  = array();
+		$length = strlen( $css );
+		$offset = 0;
+
+		while ( $offset < $length && preg_match( '/\G\s*([^{}]+)\{/', $css, $match, 0, $offset ) ) {
+			$prelude    = trim( $match[1] );
+			$body_start = $offset + strlen( $match[0] );
+			$body_end   = self::find_css_block_end( $css, $body_start );
+			if ( null === $body_end ) {
+				break;
+			}
+
+			$body   = trim( substr( $css, $body_start, $body_end - $body_start ) );
+			$offset = $body_end + 1;
+
+			if ( str_starts_with( $prelude, '@' ) ) {
+				$rules = array_merge( $rules, self::admin_bar_top_chrome_rules_from_css( $body ) );
+				continue;
+			}
+
+			if ( ! preg_match( '/(?:^|;)\s*position\s*:\s*(?:fixed|sticky)\s*(?:!important\s*)?(?:;|$)/i', $body ) ) {
+				continue;
+			}
+
+			$top = self::css_declaration_value( $body, 'top' );
+			if ( null === $top ) {
+				continue;
+			}
+
+			$desktop_top = self::admin_bar_offset_top_value( $top, '32px' );
+			$mobile_top  = self::admin_bar_offset_top_value( $top, '46px' );
+			if ( null === $desktop_top || null === $mobile_top ) {
+				continue;
+			}
+
+			$selectors = array();
+			foreach ( explode( ',', $prelude ) as $selector ) {
+				$selector = trim( $selector );
+				if ( self::selector_is_plausible_top_chrome( $selector ) ) {
+					$selectors[] = 'body.admin-bar ' . $selector;
+				}
+			}
+
+			if ( empty( $selectors ) ) {
+				continue;
+			}
+
+			$selector_list = implode( ', ', array_unique( $selectors ) );
+			$rules[]       = $selector_list . ' { top: ' . $desktop_top . '; }';
+			$rules[]       = '@media screen and (max-width: 782px) { ' . $selector_list . ' { top: ' . $mobile_top . '; } }';
+		}
+
+		return $rules;
+	}
+
+	/**
+	 * Extract one CSS declaration value from a rule body.
+	 *
+	 * @param string $body     CSS declaration body.
+	 * @param string $property Property name.
+	 * @return string|null Declaration value.
+	 */
+	private static function css_declaration_value( string $body, string $property ): ?string {
+		if ( ! preg_match( '/(?:^|;)\s*' . preg_quote( $property, '/' ) . '\s*:\s*([^;]+)\s*(?:;|$)/i', $body, $match ) ) {
+			return null;
+		}
+
+		return trim( $match[1] );
+	}
+
+	/**
+	 * Add one WordPress admin-bar height to a source top value.
+	 *
+	 * @param string $top    Source top declaration value.
+	 * @param string $offset Admin-bar height.
+	 * @return string|null Offset top value, or null when unsafe to rewrite.
+	 */
+	private static function admin_bar_offset_top_value( string $top, string $offset ): ?string {
+		$top       = trim( $top );
+		$important = '';
+		if ( preg_match( '/\s*!important\s*$/i', $top ) ) {
+			$important = ' !important';
+			$top       = trim( preg_replace( '/\s*!important\s*$/i', '', $top ) ?? $top );
+		}
+
+		if ( '' === $top || preg_match( '/[;{}]/', $top ) || preg_match( '/^(?:auto|inherit|initial|revert|unset)$/i', $top ) || str_starts_with( $top, '-' ) ) {
+			return null;
+		}
+
+		if ( preg_match( '/^0(?:[a-z%]+)?$/i', $top ) ) {
+			return $offset . $important;
+		}
+
+		return 'calc(' . $top . ' + ' . $offset . ')' . $important;
+	}
+
+	/**
+	 * Determine whether a selector plausibly targets imported top chrome.
+	 *
+	 * @param string $selector CSS selector.
+	 * @return bool Whether the selector is narrow enough for admin-bar offsets.
+	 */
+	private static function selector_is_plausible_top_chrome( string $selector ): bool {
+		$selector = trim( strtolower( $selector ) );
+		if ( '' === $selector || str_starts_with( $selector, '@' ) || preg_match( '/(?:footer|bottom|modal|dialog|popup|overlay|sidebar|drawer)/', $selector ) ) {
+			return false;
+		}
+
+		return (bool) preg_match( '/(?:header|masthead|nav|navbar|navigation|topbar|app-bar|toolbar|fixed-top|sticky-top)/', $selector );
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -327,6 +327,83 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Imported fixed/sticky top chrome is offset only when the WordPress admin bar is present.
+	 */
+	public function test_fixed_top_chrome_gets_admin_bar_offsets(): void {
+		$html_path = $this->write_temp_fixture(
+			'fixed-top-chrome.html',
+			'<!doctype html><html><head><title>Fixed Top Chrome</title><style>' .
+			'header.site-header { position: fixed; top: 0; left: 0; right: 0; z-index: 10; }' .
+			'.top-nav { position: sticky; top: 12px; z-index: 9; }' .
+			'.modal-header { position: fixed; top: 0; }' .
+			'.site-footer { position: fixed; top: 0; }' .
+			'</style></head><body>' .
+			'<header class="site-header"><p>Site title</p><nav class="top-nav"><a href="#content">Content</a></nav></header>' .
+			'<main id="content"><h1>Fixed Top Chrome</h1><p>Body copy.</p></main>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Fixed Top Chrome',
+				'slug'      => 'fixed-top-chrome',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$style = $this->read_file( $result['theme_dir'] . '/style.css' );
+
+		$this->assertStringContainsString( 'Static Site Importer: offset imported fixed/sticky top chrome below the WordPress admin bar.', $style );
+		$this->assertStringContainsString( 'body.admin-bar header.site-header { top: 32px; }', $style );
+		$this->assertStringContainsString( '@media screen and (max-width: 782px) { body.admin-bar header.site-header { top: 46px; } }', $style );
+		$this->assertStringContainsString( 'body.admin-bar .top-nav { top: calc(12px + 32px); }', $style );
+		$this->assertStringContainsString( '@media screen and (max-width: 782px) { body.admin-bar .top-nav { top: calc(12px + 46px); } }', $style );
+		$this->assertStringNotContainsString( 'body.admin-bar .modal-header', $style );
+		$this->assertStringNotContainsString( 'body.admin-bar .site-footer', $style );
+	}
+
+	/**
+	 * Static headers are not offset just because they look like top chrome.
+	 */
+	public function test_static_header_does_not_get_admin_bar_offsets(): void {
+		$html_path = $this->write_temp_fixture(
+			'static-header.html',
+			'<!doctype html><html><head><title>Static Header</title><style>' .
+			'header.site-header { position: relative; top: 0; }' .
+			'.top-nav { display: flex; gap: 1rem; }' .
+			'</style></head><body>' .
+			'<header class="site-header"><nav class="top-nav"><a href="#content">Content</a></nav></header>' .
+			'<main id="content"><h1>Static Header</h1><p>Body copy.</p></main>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Static Header',
+				'slug'      => 'static-header',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$style = $this->read_file( $result['theme_dir'] . '/style.css' );
+
+		$this->assertStringContainsString( 'header.site-header { position: relative; top: 0;', $style );
+		$this->assertStringNotContainsString( 'Static Site Importer: offset imported fixed/sticky top chrome below the WordPress admin bar.', $style );
+		$this->assertStringNotContainsString( 'body.admin-bar header.site-header', $style );
+		$this->assertStringNotContainsString( 'body.admin-bar .top-nav', $style );
+	}
+
+	/**
 	 * Safe inline SVG icons are materialized as theme assets and native image blocks.
 	 */
 	public function test_safe_inline_svg_icons_materialize_as_theme_assets(): void {


### PR DESCRIPTION
## Summary
- Adds generated admin-bar offset CSS only for imported fixed/sticky top chrome selectors with header/nav-like naming.
- Preserves source `top` values by adding the WordPress admin bar height for desktop and mobile admin bars.
- Adds fixture coverage for fixed/sticky header/nav chrome and verifies static headers are not offset.

Closes #54

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-issue-54-admin-bar-offset`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the importer CSS generation change, fixture tests, and local verification steps; Chris remains responsible for review and merge.