### PR TITLE
Clean static source after successful imports

### DIFF
--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -36,8 +36,11 @@ class Static_Site_Importer_CLI_Command {
 	 * [--overwrite]
 	 * : Overwrite an existing theme directory.
 	 *
-		 * [--fail-on-quality]
-		 * : Exit non-zero when conversion quality checks report fallbacks, invalid blocks, or content loss.
+	 * [--delete-source]
+	 * : Delete the source static-site directory after a successful clean import. Sources are preserved when import quality checks report issues.
+	 *
+	 * [--fail-on-quality]
+	 * : Exit non-zero when conversion quality checks report fallbacks, invalid blocks, or content loss.
 	 *
 	 * [--max-fallbacks=<count>]
 	 * : Exit non-zero when unsupported HTML fallback count exceeds this threshold.
@@ -66,6 +69,7 @@ class Static_Site_Importer_CLI_Command {
 				'name'            => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
 				'activate'        => isset( $assoc_args['activate'] ),
 				'overwrite'       => isset( $assoc_args['overwrite'] ),
+				'delete_source'   => isset( $assoc_args['delete-source'] ),
 				'fail_on_quality' => isset( $assoc_args['fail-on-quality'] ),
 				'max_fallbacks'   => isset( $assoc_args['max-fallbacks'] ) ? (int) $assoc_args['max-fallbacks'] : null,
 				'report'          => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
@@ -87,6 +91,9 @@ class Static_Site_Importer_CLI_Command {
 		WP_CLI::line( sprintf( 'Import report: %s', $result['report_path'] ) );
 		if ( ! empty( $result['external_report_path'] ) ) {
 			WP_CLI::line( sprintf( 'External import report: %s', $result['external_report_path'] ) );
+		}
+		if ( ! empty( $result['source_cleanup_error'] ) ) {
+			WP_CLI::warning( sprintf( 'Source cleanup skipped: %s', $result['source_cleanup_error'] ) );
 		}
 		WP_CLI::line( sprintf( 'Conversion quality: %s (%d unsupported HTML fallbacks, %d invalid blocks, %d content-loss aborts).', $result['quality']['pass'] ? 'pass' : 'needs review', $result['quality']['fallback_count'], $result['quality']['invalid_block_count'], $result['quality']['content_loss_count'] ) );
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -61,7 +61,7 @@ class Static_Site_Importer_Theme_Generator {
 	 *
 	 * @param string $html_path  HTML file path.
 	 * @param array  $args       Import args.
-	 * @return array{theme_slug:string,theme_name:string,theme_dir:string,report_path:string,external_report_path:string,pages:array<string,int>,quality:array<string,mixed>}|WP_Error
+	 * @return array{theme_slug:string,theme_name:string,theme_dir:string,report_path:string,external_report_path:string,source_dir:string,source_deleted:bool,source_cleanup_error:string,pages:array<string,int>,quality:array<string,mixed>}|WP_Error
 	 */
 	public static function import_theme( string $html_path, array $args = array() ) {
 		if ( ! function_exists( 'bfb_convert' ) ) {
@@ -201,12 +201,30 @@ class Static_Site_Importer_Theme_Generator {
 			}
 		}
 
+		$source_deleted       = false;
+		$source_cleanup_error = '';
+		if ( ! empty( $args['delete_source'] ) ) {
+			if ( ! empty( $quality['pass'] ) ) {
+				$cleanup_result = self::delete_source_dir( $site_dir, $html_path );
+				if ( is_wp_error( $cleanup_result ) ) {
+					$source_cleanup_error = $cleanup_result->get_error_message();
+				} else {
+					$source_deleted = true;
+				}
+			} else {
+				$source_cleanup_error = 'import quality checks reported issues';
+			}
+		}
+
 		return array(
 			'theme_slug'           => $theme_slug,
 			'theme_name'           => $theme_name,
 			'theme_dir'            => $theme_dir,
 			'report_path'          => $theme_dir . '/import-report.json',
 			'external_report_path' => $external_report_path,
+			'source_dir'           => $site_dir,
+			'source_deleted'       => $source_deleted,
+			'source_cleanup_error' => $source_cleanup_error,
 			'pages'                => $page_ids,
 			'quality'              => $quality,
 		);
@@ -2250,6 +2268,66 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return self::write_file( $path, $content );
+	}
+
+	/**
+	 * Delete the source static-site directory after a clean import.
+	 *
+	 * @param string $site_dir  Static site source directory.
+	 * @param string $html_path Entry HTML file path.
+	 * @return true|WP_Error
+	 */
+	private static function delete_source_dir( string $site_dir, string $html_path ) {
+		$source_dir = realpath( $site_dir );
+		$entry_file = realpath( $html_path );
+		if ( false === $source_dir || false === $entry_file || ! is_dir( $source_dir ) ) {
+			return new WP_Error( 'static_site_importer_source_cleanup_missing', 'Source directory is not available.' );
+		}
+
+		if ( 0 !== strpos( $entry_file, trailingslashit( $source_dir ) ) ) {
+			return new WP_Error( 'static_site_importer_source_cleanup_mismatch', 'Entry HTML file is not inside the source directory.' );
+		}
+
+		$protected_dirs = array_filter(
+			array_map(
+				'realpath',
+				array(
+					ABSPATH,
+					WP_CONTENT_DIR,
+					get_theme_root(),
+				)
+			)
+		);
+		if ( DIRECTORY_SEPARATOR === $source_dir || in_array( $source_dir, $protected_dirs, true ) ) {
+			return new WP_Error( 'static_site_importer_source_cleanup_protected', sprintf( 'Refusing to delete protected source directory: %s', $source_dir ) );
+		}
+
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $source_dir, FilesystemIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+
+		foreach ( $iterator as $item ) {
+			$path = $item->getPathname();
+			if ( $item->isDir() && ! $item->isLink() ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Removes caller-provided temporary static-site source directories after a clean import.
+				if ( ! rmdir( $path ) ) {
+					return new WP_Error( 'static_site_importer_source_cleanup_failed', sprintf( 'Failed to remove source directory: %s', $path ) );
+				}
+				continue;
+			}
+
+			if ( ! wp_delete_file( $path ) ) {
+				return new WP_Error( 'static_site_importer_source_cleanup_failed', sprintf( 'Failed to remove source file: %s', $path ) );
+			}
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Removes caller-provided temporary static-site source directories after a clean import.
+		if ( ! rmdir( $source_dir ) ) {
+			return new WP_Error( 'static_site_importer_source_cleanup_failed', sprintf( 'Failed to remove source directory: %s', $source_dir ) );
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -584,6 +584,64 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Source cleanup is available for callers that do not need import artifacts.
+	 */
+	public function test_delete_source_removes_source_directory_after_clean_import(): void {
+		$html_path  = $this->write_temp_fixture(
+			'index.html',
+			'<!doctype html><html><head><title>Clean Import</title></head><body><main><h1>Clean Import</h1><p>Body copy.</p></main></body></html>'
+		);
+		$source_dir = dirname( $html_path );
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'          => 'Clean Import Cleanup',
+				'slug'          => 'clean-import-cleanup',
+				'overwrite'     => true,
+				'activate'      => false,
+				'delete_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['quality']['pass'] ?? false );
+		$this->assertTrue( $result['source_deleted'] ?? false );
+		$this->assertSame( '', $result['source_cleanup_error'] ?? null );
+		$this->assertFalse( file_exists( $source_dir ), 'Clean import source directory should be deleted.' );
+	}
+
+	/**
+	 * Broken imports keep source artifacts even when cleanup is requested.
+	 */
+	public function test_delete_source_preserves_source_directory_when_quality_fails(): void {
+		$html_path  = $this->write_temp_fixture(
+			'index.html',
+			'<!doctype html><html><head><title>Broken Import</title></head><body><main><h1>Broken Import</h1><svg viewBox="0 0 24 24"><script>alert(1)</script><path d="M0 0h24v24H0z"/></svg></main></body></html>'
+		);
+		$source_dir = dirname( $html_path );
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'          => 'Broken Import Cleanup',
+				'slug'          => 'broken-import-cleanup',
+				'overwrite'     => true,
+				'activate'      => false,
+				'delete_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['quality']['pass'] ?? true );
+		$this->assertFalse( $result['source_deleted'] ?? true );
+		$this->assertSame( 'import quality checks reported issues', $result['source_cleanup_error'] ?? '' );
+		$this->assertTrue( file_exists( $source_dir ), 'Failed-quality import source directory should be preserved.' );
+	}
+
+	/**
 	 * Server-visible malformed block documents are counted in generated-theme quality.
 	 */
 	public function test_generated_theme_quality_reports_malformed_block_documents(): void {


### PR DESCRIPTION
## Summary
- Adds a `--delete-source` CLI option for callers that want temporary static-site source files removed after import.
- Deletes the source directory only after a successful clean import; sources are preserved when quality checks report fallbacks, invalid blocks, content loss, unsafe SVGs, or other failures.
- Returns cleanup metadata so callers can tell whether the source was deleted or why cleanup was skipped.

## Tests
- `/opt/homebrew/bin/homeboy test --path \"/Users/chubes/Developer/static-site-importer@cleanup-source-on-success\"`
- `/opt/homebrew/bin/homeboy lint --path \"/Users/chubes/Developer/static-site-importer@cleanup-source-on-success\" --changed-only`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the cleanup option, added tests, and ran focused validation. Chris reviewed the product behavior and requested the cleanup semantics.