### PR TITLE
Make source cleanup the default

### DIFF
--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -36,8 +36,8 @@ class Static_Site_Importer_CLI_Command {
 	 * [--overwrite]
 	 * : Overwrite an existing theme directory.
 	 *
-	 * [--delete-source]
-	 * : Delete the source static-site directory after a successful clean import. Sources are preserved when import quality checks report issues.
+	 * [--keep-source]
+	 * : Preserve the source static-site directory after a successful clean import for debugging or development. Sources are always preserved when import quality checks report issues.
 	 *
 	 * [--fail-on-quality]
 	 * : Exit non-zero when conversion quality checks report fallbacks, invalid blocks, or content loss.
@@ -69,7 +69,7 @@ class Static_Site_Importer_CLI_Command {
 				'name'            => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
 				'activate'        => isset( $assoc_args['activate'] ),
 				'overwrite'       => isset( $assoc_args['overwrite'] ),
-				'delete_source'   => isset( $assoc_args['delete-source'] ),
+				'keep_source'     => isset( $assoc_args['keep-source'] ),
 				'fail_on_quality' => isset( $assoc_args['fail-on-quality'] ),
 				'max_fallbacks'   => isset( $assoc_args['max-fallbacks'] ) ? (int) $assoc_args['max-fallbacks'] : null,
 				'report'          => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -203,7 +203,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		$source_deleted       = false;
 		$source_cleanup_error = '';
-		if ( ! empty( $args['delete_source'] ) ) {
+		if ( empty( $args['keep_source'] ) ) {
 			if ( ! empty( $quality['pass'] ) ) {
 				$cleanup_result = self::delete_source_dir( $site_dir, $html_path );
 				if ( is_wp_error( $cleanup_result ) ) {

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -584,9 +584,9 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Source cleanup is available for callers that do not need import artifacts.
+	 * Source cleanup is the default after a clean import.
 	 */
-	public function test_delete_source_removes_source_directory_after_clean_import(): void {
+	public function test_source_directory_is_deleted_after_clean_import(): void {
 		$html_path  = $this->write_temp_fixture(
 			'index.html',
 			'<!doctype html><html><head><title>Clean Import</title></head><body><main><h1>Clean Import</h1><p>Body copy.</p></main></body></html>'
@@ -600,7 +600,6 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 				'slug'          => 'clean-import-cleanup',
 				'overwrite'     => true,
 				'activate'      => false,
-				'delete_source' => true,
 			)
 		);
 
@@ -613,9 +612,38 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Broken imports keep source artifacts even when cleanup is requested.
+	 * Developers can keep source artifacts for debugging and iteration.
 	 */
-	public function test_delete_source_preserves_source_directory_when_quality_fails(): void {
+	public function test_keep_source_preserves_source_directory_after_clean_import(): void {
+		$html_path  = $this->write_temp_fixture(
+			'index.html',
+			'<!doctype html><html><head><title>Kept Import</title></head><body><main><h1>Kept Import</h1><p>Body copy.</p></main></body></html>'
+		);
+		$source_dir = dirname( $html_path );
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'        => 'Kept Import Source',
+				'slug'        => 'kept-import-source',
+				'overwrite'   => true,
+				'activate'    => false,
+				'keep_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['quality']['pass'] ?? false );
+		$this->assertFalse( $result['source_deleted'] ?? true );
+		$this->assertSame( '', $result['source_cleanup_error'] ?? null );
+		$this->assertTrue( file_exists( $source_dir ), 'Clean import source directory should be preserved when requested.' );
+	}
+
+	/**
+	 * Broken imports always keep source artifacts.
+	 */
+	public function test_source_directory_is_preserved_when_quality_fails(): void {
 		$html_path  = $this->write_temp_fixture(
 			'index.html',
 			'<!doctype html><html><head><title>Broken Import</title></head><body><main><h1>Broken Import</h1><svg viewBox="0 0 24 24"><script>alert(1)</script><path d="M0 0h24v24H0z"/></svg></main></body></html>'
@@ -629,7 +657,6 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 				'slug'          => 'broken-import-cleanup',
 				'overwrite'     => true,
 				'activate'      => false,
-				'delete_source' => true,
 			)
 		);
 


### PR DESCRIPTION
## Summary
- Replaces the opt-in `--delete-source` behavior with cleanup as the default after a clean import.
- Adds `--keep-source` as the explicit developer/testing escape hatch.
- Preserves source artifacts automatically when import quality checks report issues.

## Tests
- `/opt/homebrew/bin/homeboy test --path \"/Users/chubes/Developer/static-site-importer@keep-source-opt-out\"`
- `/opt/homebrew/bin/homeboy lint --path \"/Users/chubes/Developer/static-site-importer@keep-source-opt-out\" --changed-only`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI polarity fix and updated tests after Chris clarified the cleanup default.