### PR TITLE
Fix nested decorative overlay editor stacking

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -2515,6 +2515,9 @@ class Static_Site_Importer_Theme_Generator {
 			return '';
 		}
 
+		$selectors[] = '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .wp-block-group.static-site-importer-decorative-layer)';
+		$selectors[] = '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block.wp-block-group.static-site-importer-decorative-layer';
+
 		$group_selector    = '.editor-styles-wrapper .wp-block-group.static-site-importer-decorative-layer';
 		$placeholder_rules = array(
 			$group_selector . ' .block-editor-block-variation-picker',

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -359,7 +359,7 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '.hero-rip { position: absolute;', $style );
 		$this->assertStringContainsString( '.hero .container { position: relative; z-index: 1;', $style );
 		$this->assertStringContainsString( 'Static Site Importer: let Site Editor wrappers preserve imported absolute overlay stacking.', $style );
-		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .hero-rip) { display: contents; }', $style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .hero-rip)', $style );
 		$this->assertSame( 0, $report['quality']['fallback_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['core_html_block_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
@@ -404,6 +404,9 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 			$this->assertStringContainsString( 'wp-block-group ' . $class_name . ' static-site-importer-decorative-layer', $pattern );
 			$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .' . $class_name . ')', $style );
 		}
+		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .wp-block-group.static-site-importer-decorative-layer)', $style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block.wp-block-group.static-site-importer-decorative-layer', $style );
+		$this->assertStringNotContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block.wp-block-group { display: contents; }', $style );
 
 		$this->assertStringContainsString( 'Static Site Importer: hide empty decorative layer group controls in the Site Editor.', $style );
 		$this->assertStringContainsString( '.editor-styles-wrapper .wp-block-group.static-site-importer-decorative-layer .block-editor-block-variation-picker', $style );


### PR DESCRIPTION
## Summary
- Preserve Site Editor stacking for nested imported decorative overlay groups by normalizing Gutenberg wrappers identified with `static-site-importer-decorative-layer`.
- Keep existing absolute-class bridge CSS and placeholder/appender hiding, while avoiding broad `wp-block-group` wrapper normalization.
- Expand fixture coverage for nested decorative overlay groups and non-decorative group safety.

Fixes #60.

## Testing
- `homeboy test --path /Users/chubes/Developer/static-site-importer@fix-issue-60-nested-editor-overlays`
- `homeboy lint --path /Users/chubes/Developer/static-site-importer@fix-issue-60-nested-editor-overlays --changed-only`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the targeted CSS bridge change and fixture assertions; Chris remains responsible for review and merge.