### PR TITLE
Fix branded top-level nav conversion

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -551,7 +551,7 @@ class Static_Site_Importer_Theme_Generator {
 		if ( self::can_convert_element_to_navigation( $element ) ) {
 			$navigation = self::navigation_ref_block( $element, $theme_slug, $location );
 			if ( null !== $navigation ) {
-				return self::group_block( $navigation, $element->getAttribute( 'class' ), 'nav' === $tag ? 'nav' : 'div' );
+				return $navigation;
 			}
 		}
 
@@ -569,7 +569,10 @@ class Static_Site_Importer_Theme_Generator {
 			return self::html_block( self::node_html( $doc, $element ) );
 		}
 
-		$wrapper_tag = in_array( $tag, array( 'header', 'footer', 'nav' ), true ) ? $tag : 'div';
+		$wrapper_tag = in_array( $tag, array( 'header', 'footer' ), true ) ? $tag : 'div';
+		if ( 'nav' === $tag && ! str_contains( $children, '<!-- wp:navigation ' ) ) {
+			$wrapper_tag = 'nav';
+		}
 		return self::group_block( $children, $element->getAttribute( 'class' ), $wrapper_tag );
 	}
 
@@ -635,7 +638,11 @@ class Static_Site_Importer_Theme_Generator {
 
 		foreach ( self::direct_element_children( $element ) as $child ) {
 			$child_tag = strtolower( $child->tagName );
-			if ( 'nav' === $tag && in_array( $child_tag, array( 'a', 'ul', 'ol' ), true ) ) {
+			if ( 'nav' === $tag && in_array( $child_tag, array( 'ul', 'ol' ), true ) ) {
+				continue;
+			}
+
+			if ( 'nav' === $tag && 'a' === $child_tag && self::is_simple_navigation_anchor( $child ) ) {
 				continue;
 			}
 
@@ -644,6 +651,26 @@ class Static_Site_Importer_Theme_Generator {
 			}
 
 			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a direct nav anchor is a menu item rather than branded chrome.
+	 *
+	 * @param DOMElement $element Anchor element.
+	 * @return bool
+	 */
+	private static function is_simple_navigation_anchor( DOMElement $element ): bool {
+		if ( preg_match( '/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $element->getAttribute( 'class' ) ) ) {
+			return false;
+		}
+
+		foreach ( self::direct_element_children( $element ) as $child ) {
+			if ( 'span' !== strtolower( $child->tagName ) ) {
+				return false;
+			}
 		}
 
 		return true;
@@ -680,6 +707,10 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		$class = trim( $element->getAttribute( 'class' ) );
+		if ( preg_match( '/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $class ) ) {
+			return self::html_block( self::node_html( $doc, $element ) );
+		}
+
 		if ( preg_match( '/(^|[-_\s])(btn|button|cta|pill)([-_\s]|$)/i', $class ) ) {
 			$attrs = array( 'url' => esc_url_raw( $href ) );
 			if ( '' !== $class ) {

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -187,6 +187,92 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A top-level nav can contain brand chrome plus a nested menu list.
+	 */
+	public function test_branded_top_level_nav_preserves_brand_and_converts_only_menu_list(): void {
+		$html_path = $this->write_temp_fixture(
+			'branded-nav-header.html',
+			'<!doctype html><html><head><title>Branded Nav Header</title></head><body>' .
+			'<nav class="nav-shell">' .
+			'<a href="#" class="nav-brand"><div class="nav-logo">SC</div><span class="nav-name">Studio Code</span><span class="nav-badge">New</span></a>' .
+			'<ul class="nav-links"><li><a href="#benefits">Benefits</a></li><li><a href="#workflow">How it works</a></li><li><a href="#use-cases">Use cases</a></li><li><a href="#cta" class="nav-cta">Get started</a></li></ul>' .
+			'</nav>' .
+			'<main><section id="benefits"><h1>Benefits</h1><p>Body copy.</p></section></main>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Branded Nav Header',
+				'slug'      => 'branded-nav-header',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+		$nav_post  = get_page_by_path( 'branded-nav-header-header-navigation', OBJECT, 'wp_navigation' );
+
+		$this->assertStringContainsString( 'nav-brand', $header );
+		$this->assertStringContainsString( 'nav-logo', $header );
+		$this->assertStringContainsString( 'Studio Code', $header );
+		$this->assertStringContainsString( 'New', $header );
+		$this->assertStringContainsString( '<!-- wp:navigation ', $header );
+		$this->assertStringNotContainsString( '"tagName":"nav"', $header );
+		$this->assertStringNotContainsString( '<!-- wp:navigation-link ', $header );
+		$this->assertInstanceOf( WP_Post::class, $nav_post );
+		$this->assertStringContainsString( '"label":"Benefits"', $nav_post->post_content );
+		$this->assertStringContainsString( '"label":"How it works"', $nav_post->post_content );
+		$this->assertStringContainsString( '"label":"Use cases"', $nav_post->post_content );
+		$this->assertStringContainsString( '"label":"Get started"', $nav_post->post_content );
+		$this->assertStringNotContainsString( 'Studio Code', $nav_post->post_content );
+		$this->assertStringNotContainsString( 'SC', $nav_post->post_content );
+	}
+
+	/**
+	 * Pure top-level nav fragments still become a reusable navigation entity.
+	 */
+	public function test_pure_top_level_nav_still_converts_to_navigation_entity(): void {
+		$html_path = $this->write_temp_fixture(
+			'pure-nav-header.html',
+			'<!doctype html><html><head><title>Pure Nav Header</title></head><body>' .
+			'<nav class="top-nav"><a href="#intro">Intro</a><a href="#pricing"><span>Pricing</span></a></nav>' .
+			'<main><section id="intro"><h1>Intro</h1><p>Body copy.</p></section></main>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Pure Nav Header',
+				'slug'      => 'pure-nav-header',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+		$nav_post  = get_page_by_path( 'pure-nav-header-header-navigation', OBJECT, 'wp_navigation' );
+
+		$this->assertStringContainsString( '<!-- wp:navigation ', $header );
+		$this->assertStringContainsString( '"className":"top-nav"', $header );
+		$this->assertStringNotContainsString( '<!-- wp:navigation-link ', $header );
+		$this->assertStringNotContainsString( '"tagName":"nav"', $header );
+		$this->assertInstanceOf( WP_Post::class, $nav_post );
+		$this->assertStringContainsString( '"label":"Intro"', $nav_post->post_content );
+		$this->assertStringContainsString( '"label":"Pricing"', $nav_post->post_content );
+	}
+
+	/**
 	 * Nested section headers are page content, not shared site chrome.
 	 */
 	public function test_nested_section_header_stays_in_page_content(): void {

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -330,6 +330,83 @@ if ( false !== $wrote_leading_nav ) {
 	}
 }
 
+$branded_nav_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-branded-nav-header.html';
+$wrote_branded_nav   = file_put_contents(
+	$branded_nav_fixture,
+	'<!doctype html><html><head><title>Branded Nav Header</title></head><body>' .
+	'<nav class="nav-shell">' .
+	'<a href="#" class="nav-brand"><div class="nav-logo">SC</div><span class="nav-name">Studio Code</span><span class="nav-badge">New</span></a>' .
+	'<ul class="nav-links"><li><a href="#benefits">Benefits</a></li><li><a href="#workflow">How it works</a></li><li><a href="#use-cases">Use cases</a></li><li><a href="#cta" class="nav-cta">Get started</a></li></ul>' .
+	'</nav>' .
+	'<main><section id="benefits"><h1>Benefits</h1><p>Body copy.</p></section></main>' .
+	'</body></html>'
+);
+$assert( false !== $wrote_branded_nav, 'branded-nav-fixture-written' );
+
+if ( false !== $wrote_branded_nav ) {
+	$branded_nav_result = Static_Site_Importer_Theme_Generator::import_theme(
+		$branded_nav_fixture,
+		array(
+			'name'      => 'Branded Nav Header',
+			'slug'      => 'branded-nav-header',
+			'overwrite' => true,
+			'activate'  => false,
+		)
+	);
+	$assert( ! is_wp_error( $branded_nav_result ), 'branded-nav-import-succeeds', is_wp_error( $branded_nav_result ) ? $branded_nav_result->get_error_message() : '' );
+	if ( ! is_wp_error( $branded_nav_result ) ) {
+		$branded_nav_header = $read( $branded_nav_result['theme_dir'] . '/parts/header.html' );
+		$branded_nav_post   = get_page_by_path( 'branded-nav-header-header-navigation', OBJECT, 'wp_navigation' );
+		$assert( str_contains( $branded_nav_header, 'nav-brand' ), 'branded-nav-header-preserves-brand-anchor' );
+		$assert( str_contains( $branded_nav_header, 'nav-logo' ), 'branded-nav-header-preserves-logo-markup' );
+		$assert( str_contains( $branded_nav_header, 'Studio Code' ), 'branded-nav-header-preserves-brand-text' );
+		$assert( str_contains( $branded_nav_header, '<!-- wp:navigation ' ), 'branded-nav-header-uses-navigation-block' );
+		$assert( ! str_contains( $branded_nav_header, '"tagName":"nav"' ), 'branded-nav-header-does-not-wrap-navigation-in-nav-group' );
+		$assert( $branded_nav_post instanceof WP_Post, 'branded-nav-post-exists' );
+		if ( $branded_nav_post instanceof WP_Post ) {
+			$assert( str_contains( $branded_nav_post->post_content, '"label":"Benefits"' ), 'branded-nav-menu-includes-benefits' );
+			$assert( str_contains( $branded_nav_post->post_content, '"label":"Get started"' ), 'branded-nav-menu-includes-cta' );
+			$assert( ! str_contains( $branded_nav_post->post_content, 'Studio Code' ), 'branded-nav-post-excludes-brand-text' );
+			$assert( ! str_contains( $branded_nav_post->post_content, 'SC' ), 'branded-nav-post-excludes-logo-text' );
+		}
+	}
+}
+
+$pure_nav_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-pure-nav-header.html';
+$wrote_pure_nav   = file_put_contents(
+	$pure_nav_fixture,
+	'<!doctype html><html><head><title>Pure Nav Header</title></head><body>' .
+	'<nav class="top-nav"><a href="#intro">Intro</a><a href="#pricing"><span>Pricing</span></a></nav>' .
+	'<main><section id="intro"><h1>Intro</h1><p>Body copy.</p></section></main>' .
+	'</body></html>'
+);
+$assert( false !== $wrote_pure_nav, 'pure-nav-fixture-written' );
+
+if ( false !== $wrote_pure_nav ) {
+	$pure_nav_result = Static_Site_Importer_Theme_Generator::import_theme(
+		$pure_nav_fixture,
+		array(
+			'name'      => 'Pure Nav Header',
+			'slug'      => 'pure-nav-header',
+			'overwrite' => true,
+			'activate'  => false,
+		)
+	);
+	$assert( ! is_wp_error( $pure_nav_result ), 'pure-nav-import-succeeds', is_wp_error( $pure_nav_result ) ? $pure_nav_result->get_error_message() : '' );
+	if ( ! is_wp_error( $pure_nav_result ) ) {
+		$pure_nav_header = $read( $pure_nav_result['theme_dir'] . '/parts/header.html' );
+		$pure_nav_post   = get_page_by_path( 'pure-nav-header-header-navigation', OBJECT, 'wp_navigation' );
+		$assert( str_contains( $pure_nav_header, '<!-- wp:navigation ' ), 'pure-nav-header-uses-navigation-block' );
+		$assert( str_contains( $pure_nav_header, '"className":"top-nav"' ), 'pure-nav-header-preserves-class-on-navigation-block' );
+		$assert( ! str_contains( $pure_nav_header, '"tagName":"nav"' ), 'pure-nav-header-does-not-wrap-navigation-in-nav-group' );
+		$assert( $pure_nav_post instanceof WP_Post, 'pure-nav-post-exists' );
+		if ( $pure_nav_post instanceof WP_Post ) {
+			$assert( str_contains( $pure_nav_post->post_content, '"label":"Intro"' ), 'pure-nav-menu-includes-intro' );
+			$assert( str_contains( $pure_nav_post->post_content, '"label":"Pricing"' ), 'pure-nav-menu-includes-pricing' );
+		}
+	}
+}
+
 $nested_header_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-nested-section-header.html';
 $wrote_nested_header   = file_put_contents(
 	$nested_header_fixture,


### PR DESCRIPTION
## Summary
- Treat branded top-level `<nav>` chrome as mixed chrome plus menu links instead of one pure navigation entity.
- Preserve branded/logo anchors as raw chrome HTML while converting nested menu lists into reusable `wp_navigation` posts.
- Emit `wp:navigation` directly so it is not wrapped in a second `tagName:\"nav\"` group.

Fixes #59.

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `php -l tests/smoke-wordpress-is-dead-fixture.php`
- `studio wp --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-59-branded-nav/tests/smoke-wordpress-is-dead-fixture.php`
- `NODE_PATH=/Users/chubes/Developer/static-site-importer/node_modules npm run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead`
- `NODE_PATH=/Users/chubes/Developer/static-site-importer/node_modules STATIC_SITE_IMPORTER_WP_CLI=\"studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer\" npm run test:validation -- --skip-import`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the converter update and focused regression tests; Chris remains responsible for review and validation.