### PR TITLE
Preserve inline footer chrome

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -559,6 +559,10 @@ class Static_Site_Importer_Theme_Generator {
 			return self::link_element_block( $doc, $element );
 		}
 
+		if ( self::element_has_only_phrasing_content( $element ) ) {
+			return self::paragraph_block( self::node_inner_html( $doc, $element ), $element->getAttribute( 'class' ) );
+		}
+
 		$children = self::theme_part_child_blocks( $doc, $element, $theme_slug, $location );
 		if ( '' === trim( $children ) ) {
 			$text = trim( $element->textContent );
@@ -690,6 +694,58 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check whether an element can be represented as one paragraph with inline markup.
+	 *
+	 * @param DOMElement $element Source element.
+	 * @return bool
+	 */
+	private static function element_has_only_phrasing_content( DOMElement $element ): bool {
+		if ( self::element_contains_svg_or_form( $element ) ) {
+			return false;
+		}
+
+		$has_content = false;
+		foreach ( $element->childNodes as $child ) {
+			if ( $child instanceof DOMText ) {
+				$has_content = $has_content || '' !== trim( $child->textContent );
+				continue;
+			}
+
+			if ( ! $child instanceof DOMElement ) {
+				continue;
+			}
+
+			$has_content = true;
+			if ( ! self::is_phrasing_element( $child ) ) {
+				return false;
+			}
+		}
+
+		return $has_content;
+	}
+
+	/**
+	 * Check whether an element is valid phrasing content inside a paragraph.
+	 *
+	 * @param DOMElement $element Source element.
+	 * @return bool
+	 */
+	private static function is_phrasing_element( DOMElement $element ): bool {
+		$tag = strtolower( $element->tagName );
+		if ( ! in_array( $tag, array( 'a', 'abbr', 'b', 'bdi', 'bdo', 'br', 'cite', 'code', 'data', 'dfn', 'em', 'i', 'kbd', 'mark', 'q', 's', 'samp', 'small', 'span', 'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr' ), true ) ) {
+			return false;
+		}
+
+		foreach ( self::direct_element_children( $element ) as $child ) {
+			if ( ! self::is_phrasing_element( $child ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -946,6 +1002,25 @@ class Static_Site_Importer_Theme_Generator {
 	private static function node_html( DOMDocument $doc, DOMElement $node ): string {
 		$html = $doc->saveHTML( $node );
 		return false === $html ? '' : $html;
+	}
+
+	/**
+	 * Serialize a DOM element's children.
+	 *
+	 * @param DOMDocument $doc  DOM document.
+	 * @param DOMElement  $node Element.
+	 * @return string
+	 */
+	private static function node_inner_html( DOMDocument $doc, DOMElement $node ): string {
+		$html = '';
+		foreach ( $node->childNodes as $child ) {
+			$fragment = $doc->saveHTML( $child );
+			if ( false !== $fragment ) {
+				$html .= $fragment;
+			}
+		}
+
+		return trim( $html );
 	}
 
 	/**

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -299,6 +299,57 @@ if ( false !== $wrote_fixture ) {
 	}
 }
 
+$footer_chrome_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-footer-chrome.html';
+$wrote_footer_chrome   = file_put_contents(
+	$footer_chrome_fixture,
+	'<!doctype html><html><head><title>Footer Chrome</title><style>' .
+	'footer { padding: 40px 48px; border-top: 1px solid var(--rule); display: flex; align-items: center; justify-content: space-between; background: var(--paper); }' .
+	'footer .footer-logo { font-family: var(--mono); font-size: 13px; color: #888; display: flex; align-items: center; gap: 8px; }' .
+	'footer .footer-meta { font-family: var(--mono); font-size: 12px; color: #bbb; }' .
+	'@media (max-width: 900px) { footer { flex-direction: column; gap: 12px; text-align: center; } }' .
+	'</style></head><body>' .
+	'<main><section><h1>Footer chrome fixture</h1><p>Body copy.</p></section></main>' .
+	'<footer><div class="footer-logo"><span style="width:6px;height:6px;border-radius:50%;background:var(--accent);display:inline-block;"></span>Studio Code &mdash; by Automattic</div><div class="footer-meta">WordPress Studio &copy; 2025</div></footer>' .
+	'</body></html>'
+);
+$assert( false !== $wrote_footer_chrome, 'footer-chrome-fixture-written' );
+
+if ( false !== $wrote_footer_chrome ) {
+	$footer_chrome_result = Static_Site_Importer_Theme_Generator::import_theme(
+		$footer_chrome_fixture,
+		array(
+			'name'      => 'Footer Chrome',
+			'slug'      => 'footer-chrome',
+			'overwrite' => true,
+			'activate'  => false,
+		)
+	);
+	$assert( ! is_wp_error( $footer_chrome_result ), 'footer-chrome-import-succeeds', is_wp_error( $footer_chrome_result ) ? $footer_chrome_result->get_error_message() : '' );
+	if ( ! is_wp_error( $footer_chrome_result ) ) {
+		$footer_chrome_footer = $read( $footer_chrome_result['theme_dir'] . '/parts/footer.html' );
+		$footer_chrome_style  = $read( $footer_chrome_result['theme_dir'] . '/style.css' );
+		$footer_chrome_report = json_decode( $read( $footer_chrome_result['report_path'] ?? '' ), true );
+		$footer_document      = array();
+		foreach ( $footer_chrome_report['generated_theme']['block_documents'] ?? array() as $document ) {
+			if ( is_array( $document ) && 'parts/footer.html' === ( $document['path'] ?? '' ) ) {
+				$footer_document = $document;
+				break;
+			}
+		}
+
+		$assert( ! str_contains( $footer_chrome_footer, '<!-- wp:html' ), 'footer-chrome-has-no-core-html-blocks', $footer_chrome_footer );
+		$assert( ! str_contains( $footer_chrome_footer, 'core/html' ), 'footer-chrome-has-no-raw-core-html-name', $footer_chrome_footer );
+		$assert( str_contains( $footer_chrome_footer, '<!-- wp:paragraph {"className":"footer-logo"}' ), 'footer-logo-becomes-classed-paragraph' );
+		$assert( str_contains( $footer_chrome_footer, 'width:6px;height:6px;border-radius:50%;background:var(--accent);display:inline-block;' ), 'footer-logo-decorative-span-style-survives' );
+		$assert( str_contains( $footer_chrome_footer, 'Studio Code — by Automattic' ), 'footer-logo-text-survives' );
+		$assert( str_contains( $footer_chrome_footer, '<!-- wp:paragraph {"className":"footer-meta"}' ), 'footer-meta-becomes-classed-paragraph' );
+		$assert( str_contains( $footer_chrome_style, 'display: flex; align-items: center; justify-content: space-between' ), 'footer-flex-alignment-css-survives' );
+		$assert( str_contains( $footer_chrome_style, 'footer .footer-logo' ) && str_contains( $footer_chrome_style, 'gap: 8px' ), 'footer-logo-spacing-css-survives' );
+		$assert( str_contains( $footer_chrome_style, 'flex-direction: column; gap: 12px; text-align: center' ), 'footer-responsive-spacing-css-survives' );
+		$assert( 0 === ( $footer_document['core_html_block_count'] ?? -1 ), 'footer-chrome-report-has-zero-footer-core-html-blocks' );
+	}
+}
+
 $leading_nav_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-leading-nav-header.html';
 $wrote_leading_nav   = file_put_contents(
 	$leading_nav_fixture,


### PR DESCRIPTION
## Summary
- Preserve inline-only theme-part chrome as classed paragraph blocks so footer logo/meta rows keep their source classes and inline decorative markup without raw `core/html` islands.
- Add focused footer chrome fixture coverage for the Studio SSI benchmark shape, including no footer `core/html` blocks and preserved footer spacing/alignment CSS.

Fixes #64.

## Tests
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 eval-file /Users/chubes/Developer/static-site-importer/tests/smoke-wordpress-is-dead-fixture.php`
- `/Users/chubes/.nvm/versions/node/v24.13.1/bin/npm run test:validation`
- `php vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-static-site-chrome.php`
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the footer theme-part conversion path, drafted the implementation and fixture assertions, and ran validation. Chris remains responsible for review and merge.