### PR TITLE
Preserve source nav selector parity

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -577,7 +577,13 @@ class Static_Site_Importer_Theme_Generator {
 		if ( 'nav' === $tag && ! str_contains( $children, '<!-- wp:navigation ' ) ) {
 			$wrapper_tag = 'nav';
 		}
-		return self::group_block( $children, $element->getAttribute( 'class' ), $wrapper_tag );
+
+		$class_name = $element->getAttribute( 'class' );
+		if ( 'nav' === $tag && 'nav' !== $wrapper_tag ) {
+			$class_name = self::append_class_token( $class_name, 'static-site-importer-source-nav' );
+		}
+
+		return self::group_block( $children, $class_name, $wrapper_tag );
 	}
 
 	/**
@@ -2444,12 +2450,100 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string
 	 */
 	private static function style_css( string $theme_name, string $css, array $button_classes = array() ): string {
-		$button_bridge    = self::button_style_bridge_css( $css, $button_classes );
-		$editor_bridge    = self::editor_absolute_overlay_css( $css );
-		$admin_bar_bridge = self::admin_bar_top_chrome_css( $css );
-		$css              = self::scope_source_button_css( $css, $button_classes );
+		$button_bridge              = self::button_style_bridge_css( $css, $button_classes );
+		$editor_bridge              = self::editor_absolute_overlay_css( $css );
+		$admin_bar_bridge           = self::admin_bar_top_chrome_css( $css );
+		$source_nav_selector_bridge = self::source_nav_selector_bridge_css( $css );
+		$css                        = self::scope_source_button_css( $css, $button_classes );
 
-		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Imported from static HTML using Block Format Bridge.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $button_bridge . $editor_bridge . $admin_bar_bridge;
+		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Imported from static HTML using Block Format Bridge.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $button_bridge . $editor_bridge . $admin_bar_bridge . $source_nav_selector_bridge;
+	}
+
+	/**
+	 * Build selector parity rules for source nav wrappers converted to group blocks.
+	 *
+	 * @param string $css Source CSS.
+	 * @return string Additional CSS rules.
+	 */
+	private static function source_nav_selector_bridge_css( string $css ): string {
+		$css = preg_replace( '/\/\*.*?\*\//s', '', $css ) ?? $css;
+		if ( '' === trim( $css ) || ! str_contains( strtolower( $css ), 'nav' ) ) {
+			return '';
+		}
+
+		$rules = self::source_nav_selector_bridge_rules_from_css( $css );
+		if ( empty( $rules ) ) {
+			return '';
+		}
+
+		return "\n/* Static Site Importer: preserve source nav wrapper selectors on converted navigation groups. */\n" . implode( "\n", array_unique( $rules ) ) . "\n";
+	}
+
+	/**
+	 * Build source nav selector bridge rules from one CSS scope.
+	 *
+	 * @param string $css CSS to inspect.
+	 * @return array<int, string> CSS rules.
+	 */
+	private static function source_nav_selector_bridge_rules_from_css( string $css ): array {
+		$rules  = array();
+		$length = strlen( $css );
+		$offset = 0;
+
+		while ( $offset < $length && preg_match( '/\G\s*([^{}]+)\{/', $css, $match, 0, $offset ) ) {
+			$prelude    = trim( $match[1] );
+			$body_start = $offset + strlen( $match[0] );
+			$body_end   = self::find_css_block_end( $css, $body_start );
+			if ( null === $body_end ) {
+				break;
+			}
+
+			$body   = trim( substr( $css, $body_start, $body_end - $body_start ) );
+			$offset = $body_end + 1;
+
+			if ( str_starts_with( $prelude, '@' ) ) {
+				$nested = self::source_nav_selector_bridge_rules_from_css( $body );
+				foreach ( $nested as $rule ) {
+					$rules[] = $prelude . ' { ' . $rule . ' }';
+				}
+				continue;
+			}
+
+			$selectors = array();
+			foreach ( explode( ',', $prelude ) as $selector ) {
+				$rewritten = self::source_nav_selector_bridge_selector( trim( $selector ) );
+				if ( null !== $rewritten ) {
+					$selectors[] = $rewritten;
+				}
+			}
+
+			if ( empty( $selectors ) ) {
+				continue;
+			}
+
+			$rules[] = implode( ', ', array_unique( $selectors ) ) . ' { ' . $body . ' }';
+		}
+
+		return $rules;
+	}
+
+	/**
+	 * Rewrite a selector so source nav wrappers match converted group wrappers.
+	 *
+	 * @param string $selector CSS selector.
+	 * @return string|null Rewritten selector, or null when no safe nav token exists.
+	 */
+	private static function source_nav_selector_bridge_selector( string $selector ): ?string {
+		if ( '' === $selector || str_starts_with( $selector, '@' ) ) {
+			return null;
+		}
+
+		$rewritten = preg_replace( '/(^|[\s>+~])nav(?=($|[\s>+~.#:\[]))/', '$1.static-site-importer-source-nav', $selector );
+		if ( ! is_string( $rewritten ) || $rewritten === $selector ) {
+			return null;
+		}
+
+		return $rewritten;
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -235,6 +235,49 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Source nav wrapper selectors keep matching when a branded nav uses a navigation entity.
+	 */
+	public function test_branded_nav_wrapper_gets_safe_selector_parity(): void {
+		$html_path = $this->write_temp_fixture(
+			'rsm-nav-wrapper.html',
+			'<!doctype html><html><head><title>RSM Nav Wrapper</title><style>' .
+			'nav { position: fixed; top: 0; left: 0; right: 0; display: flex; justify-content: space-between; }' .
+			'nav .nav-logo { font-weight: 800; }' .
+			'@media (max-width: 700px) { nav { position: sticky; } }' .
+			'</style></head><body>' .
+			'<nav><div class="nav-logo"><span>RSM</span> / Static Site Importer</div><ul class="nav-links"><li><a href="#context">Context</a></li><li><a href="#impact">Studio Impact</a></li></ul></nav>' .
+			'<main><section id="context"><h1>RSM import</h1><p>Body copy.</p></section><section id="impact"><h2>Impact</h2><p>More copy.</p></section></main>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'RSM Nav Wrapper',
+				'slug'      => 'rsm-nav-wrapper',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+		$style     = $this->read_file( $theme_dir . '/style.css' );
+		$nav_post  = get_page_by_path( 'rsm-nav-wrapper-header-navigation', OBJECT, 'wp_navigation' );
+
+		$this->assertStringContainsString( 'static-site-importer-source-nav', $header );
+		$this->assertStringContainsString( '<!-- wp:navigation ', $header );
+		$this->assertStringNotContainsString( '"tagName":"nav"', $header );
+		$this->assertStringContainsString( '.static-site-importer-source-nav { position: fixed; top: 0; left: 0; right: 0; display: flex; justify-content: space-between; }', $style );
+		$this->assertStringContainsString( '.static-site-importer-source-nav .nav-logo { font-weight: 800; }', $style );
+		$this->assertStringContainsString( '@media (max-width: 700px) { .static-site-importer-source-nav { position: sticky; } }', $style );
+		$this->assertInstanceOf( WP_Post::class, $nav_post );
+	}
+
+	/**
 	 * Pure top-level nav fragments still become a reusable navigation entity.
 	 */
 	public function test_pure_top_level_nav_still_converts_to_navigation_entity(): void {

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -299,6 +299,45 @@ if ( false !== $wrote_fixture ) {
 	}
 }
 
+$rsm_nav_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-rsm-nav-wrapper.html';
+$wrote_rsm_nav   = file_put_contents(
+	$rsm_nav_fixture,
+	'<!doctype html><html><head><title>RSM Nav Wrapper</title><style>' .
+	'nav { position: fixed; top: 0; left: 0; right: 0; display: flex; justify-content: space-between; }' .
+	'nav .nav-logo { font-weight: 800; }' .
+	'@media (max-width: 700px) { nav { position: sticky; } }' .
+	'</style></head><body>' .
+	'<nav><div class="nav-logo"><span>RSM</span> / Static Site Importer</div><ul class="nav-links"><li><a href="#context">Context</a></li><li><a href="#impact">Studio Impact</a></li></ul></nav>' .
+	'<main><section id="context"><h1>RSM import</h1><p>Body copy.</p></section><section id="impact"><h2>Impact</h2><p>More copy.</p></section></main>' .
+	'</body></html>'
+);
+$assert( false !== $wrote_rsm_nav, 'rsm-nav-fixture-written' );
+
+if ( false !== $wrote_rsm_nav ) {
+	$rsm_nav_result = Static_Site_Importer_Theme_Generator::import_theme(
+		$rsm_nav_fixture,
+		array(
+			'name'      => 'RSM Nav Wrapper',
+			'slug'      => 'rsm-nav-wrapper',
+			'overwrite' => true,
+			'activate'  => false,
+		)
+	);
+	$assert( ! is_wp_error( $rsm_nav_result ), 'rsm-nav-import-succeeds', is_wp_error( $rsm_nav_result ) ? $rsm_nav_result->get_error_message() : '' );
+	if ( ! is_wp_error( $rsm_nav_result ) ) {
+		$rsm_nav_header = $read( $rsm_nav_result['theme_dir'] . '/parts/header.html' );
+		$rsm_nav_style  = $read( $rsm_nav_result['theme_dir'] . '/style.css' );
+		$rsm_nav_post   = get_page_by_path( 'rsm-nav-wrapper-header-navigation', OBJECT, 'wp_navigation' );
+		$assert( str_contains( $rsm_nav_header, 'static-site-importer-source-nav' ), 'rsm-nav-wrapper-gets-source-nav-class' );
+		$assert( str_contains( $rsm_nav_header, '<!-- wp:navigation ' ), 'rsm-nav-header-uses-navigation-block' );
+		$assert( ! str_contains( $rsm_nav_header, '"tagName":"nav"' ), 'rsm-nav-header-avoids-nested-nav-wrapper' );
+		$assert( str_contains( $rsm_nav_style, '.static-site-importer-source-nav { position: fixed; top: 0; left: 0; right: 0; display: flex; justify-content: space-between; }' ), 'rsm-nav-bridge-preserves-bare-nav-rule' );
+		$assert( str_contains( $rsm_nav_style, '.static-site-importer-source-nav .nav-logo { font-weight: 800; }' ), 'rsm-nav-bridge-preserves-descendant-nav-rule' );
+		$assert( str_contains( $rsm_nav_style, '@media (max-width: 700px) { .static-site-importer-source-nav { position: sticky; } }' ), 'rsm-nav-bridge-preserves-media-nav-rule' );
+		$assert( $rsm_nav_post instanceof WP_Post, 'rsm-nav-post-exists' );
+	}
+}
+
 $footer_chrome_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-footer-chrome.html';
 $wrote_footer_chrome   = file_put_contents(
 	$footer_chrome_fixture,


### PR DESCRIPTION
## Summary
- Add a source-nav parity class when SSI converts a branded source `<nav>` wrapper into a `core/group` to avoid nesting `core/navigation` inside another `<nav>`.
- Generate safe CSS bridge rules so source selectors like `nav`, `nav .nav-logo`, and media-wrapped `nav` rules continue to target the converted wrapper.
- Cover the RSM-shaped nav/header fixture in PHPUnit and smoke coverage.

Closes #66.

## Tests
- `homeboy test static-site-importer -- --filter test_branded_nav_wrapper_gets_safe_selector_parity`
- `homeboy test static-site-importer`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the conversion path, drafted the implementation and tests, and ran verification. Chris remains responsible for review and merge.