### PR TITLE
Expose visual parity probes

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1779,17 +1779,65 @@ class Static_Site_Importer_Theme_Generator {
 				'source_probe_counts'    => self::visual_probe_counts( $source_html ),
 				'generated_probe_counts' => self::visual_probe_counts( $generated ),
 				'comparison_hooks'       => array(
-					'screenshot'      => array(
-						'source'    => $page['path'],
-						'generated' => $permalinks[ $filename ] ?? '',
+					'screenshot'       => array(
+						'source'          => $page['path'],
+						'frontend'        => $permalinks[ $filename ] ?? '',
+						'generated'       => $permalinks[ $filename ] ?? '',
+						'editor_surface' => 'site_editor_canvas',
 					),
-					'hero'            => array( '.hero', 'header', '[class*=hero]' ),
-					'buttons'         => array( 'a[class*=btn]', 'a[class*=button]', 'a[class*=cta]', 'button', '.wp-block-button__link' ),
-					'visible_chrome'  => array( 'nav', 'header', 'footer' ),
-					'generated_files' => array_values( array_filter( array( $template, $pattern, 'parts/header.html', $footer_part, 'style.css' ) ) ),
+					'render_surfaces'  => array(
+						'source_static'      => array(
+							'type' => 'file',
+							'url'  => $page['path'],
+						),
+						'wordpress_frontend' => array(
+							'type' => 'url',
+							'url'  => $permalinks[ $filename ] ?? '',
+						),
+						'site_editor_canvas' => array(
+							'type'              => 'wp-admin',
+							'url'               => admin_url( 'site-editor.php' ),
+							'wordpress_page_id' => $page_ids[ $filename ] ?? null,
+						),
+					),
+					'layout_probes'    => self::visual_layout_probes(),
+					'hero'             => array( '.hero', 'header', '[class*=hero]' ),
+					'buttons'          => array( 'a[class*=btn]', 'a[class*=button]', 'a[class*=cta]', 'button', '.wp-block-button__link' ),
+					'visible_chrome'   => array( 'nav', 'header', 'footer', '.site-header', '.nav-shell', '.top-nav' ),
+					'code_visuals'     => array( '.code-window', '.terminal', '[class*=code-window]', '[class*=terminal]', 'pre[class*=code]' ),
+					'problem_grids'    => array( '.problem-grid', '.problems-grid', '.problem-cards', '[class*=problem][class*=grid]', '[class*=problem][class*=cards]' ),
+					'generated_files'  => array_values( array_filter( array( $template, $pattern, 'parts/header.html', $footer_part, 'style.css' ) ) ),
 				),
 			);
 		}
+	}
+
+	/**
+	 * Browser-level visual probes the benchmark harness should run for every target.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function visual_layout_probes(): array {
+		return array(
+			'nav_chrome'    => array(
+				'selectors'  => array( 'nav', '.site-header', '.nav-shell', '.top-nav', '[class*=nav]' ),
+				'assertions' => array( 'visible', 'bounding_box_nonzero', 'frontend_editor_box_parity', 'frontend_editor_display_parity' ),
+			),
+			'code_visual'   => array(
+				'selectors'  => array( '.code-window', '.terminal', '[class*=code-window]', '[class*=terminal]', 'pre[class*=code]' ),
+				'assertions' => array( 'visible', 'bounding_box_nonzero', 'frontend_editor_visibility_parity' ),
+			),
+			'problem_grid'  => array(
+				'selectors'            => array( '.problem-grid', '.problems-grid', '.problem-cards', '[class*=problem][class*=grid]', '[class*=problem][class*=cards]' ),
+				'desktop_min_width_px' => 960,
+				'min_columns'          => 2,
+				'assertions'           => array( 'visible', 'children_same_row_desktop', 'frontend_editor_column_parity' ),
+			),
+			'hero_region'   => array(
+				'selectors'  => array( '.hero', 'header', '[class*=hero]' ),
+				'assertions' => array( 'visible', 'bounding_box_nonzero', 'source_frontend_editor_box_parity' ),
+			),
+		);
 	}
 
 	/**
@@ -1836,11 +1884,13 @@ class Static_Site_Importer_Theme_Generator {
 	 */
 	private static function visual_probe_counts( string $html ): array {
 		return array(
-			'hero_candidates'    => self::visual_probe_count( $html, 'hero' ),
-			'button_candidates'  => self::visual_probe_count( $html, 'button' ),
-			'nav_candidates'     => self::visual_probe_count( $html, 'nav' ),
-			'footer_candidates'  => self::visual_probe_count( $html, 'footer' ),
-			'core_button_blocks' => self::count_block_name_in_markup( $html, 'core/button' ),
+			'hero_candidates'        => self::visual_probe_count( $html, 'hero' ),
+			'button_candidates'      => self::visual_probe_count( $html, 'button' ),
+			'nav_candidates'         => self::visual_probe_count( $html, 'nav' ),
+			'footer_candidates'      => self::visual_probe_count( $html, 'footer' ),
+			'code_visual_candidates' => self::visual_probe_count( $html, 'code_visual' ),
+			'grid_candidates'        => self::visual_probe_count( $html, 'grid' ),
+			'core_button_blocks'     => self::count_block_name_in_markup( $html, 'core/button' ),
 		);
 	}
 
@@ -1901,6 +1951,14 @@ class Static_Site_Importer_Theme_Generator {
 
 		if ( 'footer' === $probe ) {
 			return 'footer' === $tag || self::class_tokens_contain_fragment( $classes, 'footer' );
+		}
+
+		if ( 'code_visual' === $probe ) {
+			return self::class_tokens_contain_any_fragment( $classes, array( 'code-window', 'terminal' ) ) || ( 'pre' === $tag && self::class_tokens_contain_fragment( $classes, 'code' ) );
+		}
+
+		if ( 'grid' === $probe ) {
+			return self::class_tokens_contain_any_fragment( $classes, array( 'grid', 'cards' ) );
 		}
 
 		return false;

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -136,6 +136,14 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( ( $home_visual_target['source_probe_counts']['hero_candidates'] ?? 0 ) > 0, 'visual-target-counts-source-hero-probes' );
 	$assert( ( $home_visual_target['source_probe_counts']['button_candidates'] ?? 0 ) > 0, 'visual-target-counts-source-button-probes' );
 	$assert( ( $home_visual_target['generated_probe_counts']['core_button_blocks'] ?? 0 ) > 0, 'visual-target-counts-generated-core-button-blocks' );
+	$assert( isset( $home_visual_target['comparison_hooks']['render_surfaces']['source_static'] ), 'visual-target-defines-source-render-surface' );
+	$assert( isset( $home_visual_target['comparison_hooks']['render_surfaces']['wordpress_frontend'] ), 'visual-target-defines-frontend-render-surface' );
+	$assert( isset( $home_visual_target['comparison_hooks']['render_surfaces']['site_editor_canvas'] ), 'visual-target-defines-site-editor-render-surface' );
+	$assert( isset( $home_visual_target['comparison_hooks']['layout_probes']['nav_chrome'] ), 'visual-target-defines-nav-chrome-layout-probe' );
+	$assert( isset( $home_visual_target['comparison_hooks']['layout_probes']['code_visual'] ), 'visual-target-defines-code-visual-layout-probe' );
+	$assert( isset( $home_visual_target['comparison_hooks']['layout_probes']['problem_grid'] ), 'visual-target-defines-problem-grid-layout-probe' );
+	$assert( in_array( 'frontend_editor_visibility_parity', $home_visual_target['comparison_hooks']['layout_probes']['code_visual']['assertions'] ?? array(), true ), 'code-visual-probe-checks-frontend-editor-visibility' );
+	$assert( in_array( 'frontend_editor_column_parity', $home_visual_target['comparison_hooks']['layout_probes']['problem_grid']['assertions'] ?? array(), true ), 'problem-grid-probe-checks-frontend-editor-columns' );
 	$assert( in_array( 'style.css', $home_visual_target['comparison_hooks']['generated_files'] ?? array(), true ), 'visual-target-points-harness-at-generated-css' );
 	$assert( isset( $result['quality']['pass'] ), 'import-result-includes-quality-summary' );
 	$assert( str_contains( $page, 'wp:post-content' ), 'page-template-renders-imported-page-content' );
@@ -458,6 +466,54 @@ if ( false !== $wrote_pure_nav ) {
 	}
 }
 
+$legacy_visual_parity_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-visual-parity-probes.html';
+if ( file_exists( $legacy_visual_parity_fixture ) ) {
+	wp_delete_file( $legacy_visual_parity_fixture );
+}
+$visual_parity_dir     = trailingslashit( get_temp_dir() ) . 'static-site-importer-visual-parity-probes-' . wp_generate_uuid4();
+$visual_parity_fixture = trailingslashit( $visual_parity_dir ) . 'index.html';
+wp_mkdir_p( $visual_parity_dir );
+$wrote_visual_parity   = file_put_contents(
+	$visual_parity_fixture,
+	'<!doctype html><html><head><title>Visual Parity Probes</title><style>' .
+	'nav { display: flex; justify-content: space-between; }' .
+	'.code-window { display: block; min-height: 120px; }' .
+	'.problem-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; }' .
+	'</style></head><body>' .
+	'<nav class="nav-shell"><a href="#hero">Visual Parity</a><a href="#problems">Problems</a></nav>' .
+	'<main><section id="hero" class="hero"><div class="code-window"><pre class="code-body">wp static-site-importer import-theme ./site</pre></div></section>' .
+	'<section id="problems"><div class="problem-grid"><article class="problem-card"><h2>Static is winning</h2><p>Fast HTML wins mindshare.</p></article><article class="problem-card"><h2>WordPress can answer</h2><p>Editable blocks preserve the work.</p></article></div></section></main>' .
+	'</body></html>'
+);
+$assert( false !== $wrote_visual_parity, 'visual-parity-fixture-written' );
+
+if ( false !== $wrote_visual_parity ) {
+	$visual_parity_result = Static_Site_Importer_Theme_Generator::import_theme(
+		$visual_parity_fixture,
+		array(
+			'name'      => 'Visual Parity Probes',
+			'slug'      => 'visual-parity-probes',
+			'overwrite' => true,
+			'activate'  => false,
+		)
+	);
+	$assert( ! is_wp_error( $visual_parity_result ), 'visual-parity-import-succeeds', is_wp_error( $visual_parity_result ) ? $visual_parity_result->get_error_message() : '' );
+	if ( ! is_wp_error( $visual_parity_result ) ) {
+		$visual_parity_report = json_decode( $read( $visual_parity_result['report_path'] ?? '' ), true );
+		$visual_target        = $visual_parity_report['visual_fidelity']['comparison_targets'][0] ?? array();
+		$layout_probes        = $visual_target['comparison_hooks']['layout_probes'] ?? array();
+
+		$assert( ( $visual_target['source_probe_counts']['code_visual_candidates'] ?? 0 ) > 0, 'visual-parity-counts-source-code-visual-probes' );
+		$assert( ( $visual_target['source_probe_counts']['grid_candidates'] ?? 0 ) > 0, 'visual-parity-counts-source-grid-probes' );
+		$assert( ( $visual_target['generated_probe_counts']['code_visual_candidates'] ?? 0 ) > 0, 'visual-parity-counts-generated-code-visual-probes' );
+		$assert( ( $visual_target['generated_probe_counts']['grid_candidates'] ?? 0 ) > 0, 'visual-parity-counts-generated-grid-probes' );
+		$assert( 2 === ( $layout_probes['problem_grid']['min_columns'] ?? 0 ), 'visual-parity-problem-grid-requires-two-desktop-columns' );
+		$assert( in_array( 'children_same_row_desktop', $layout_probes['problem_grid']['assertions'] ?? array(), true ), 'visual-parity-problem-grid-checks-same-row-desktop' );
+		$assert( in_array( '.code-window', $visual_target['comparison_hooks']['code_visuals'] ?? array(), true ), 'visual-parity-exposes-code-window-selector' );
+		$assert( in_array( '.problem-grid', $visual_target['comparison_hooks']['problem_grids'] ?? array(), true ), 'visual-parity-exposes-problem-grid-selector' );
+	}
+}
+
 $nested_header_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-nested-section-header.html';
 $wrote_nested_header   = file_put_contents(
 	$nested_header_fixture,
@@ -531,8 +587,10 @@ if ( false !== $wrote_nested_footer ) {
 	}
 }
 
-$quality_fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-quality.html';
-$wrote_quality   = file_put_contents(
+$quality_dir     = trailingslashit( get_temp_dir() ) . 'static-site-importer-quality-' . wp_generate_uuid4();
+$quality_fixture = trailingslashit( $quality_dir ) . 'index.html';
+wp_mkdir_p( $quality_dir );
+$wrote_quality = file_put_contents(
 	$quality_fixture,
 	'<!doctype html><html><head><title>Quality</title></head><body><main><section><h1>Quality smoke</h1><iframe src="https://example.com/widget"></iframe></section></main></body></html>'
 );


### PR DESCRIPTION
## Summary
- Adds source, WordPress frontend, and Site Editor canvas render-surface metadata to SSI visual fidelity targets.
- Adds benchmark-harness-ready layout probes for nav chrome, code/terminal visuals, problem grids, and hero regions.
- Covers the report contract with smoke assertions and a focused visual parity fixture.

Fixes #67.

## Tests
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/smoke-wordpress-is-dead-fixture.php`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-67-visual-parity/tests/smoke-wordpress-is-dead-fixture.php`
- `/Users/chubes/.nvm/versions/node/v24.13.1/bin/npm run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead-fixture`

## Notes
- This does not add screenshot diff execution inside SSI. SSI now emits the browser-rendering contract; the benchmark/controller can consume these probes to run screenshots and computed layout checks across the source, frontend, and Site Editor canvas.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the visual-fidelity report contract and smoke coverage; Chris remains responsible for review and merge.