### PR TITLE
Store imported page bodies on pages

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -129,7 +129,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		$page_artifacts = self::page_artifacts( $pages, $permalinks, $theme_slug );
 
-		$result = self::write_page_shell_contents( $pages, $page_ids );
+		$result = self::write_page_contents( $pages, $page_ids, $page_artifacts['contents'] );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
@@ -139,7 +139,7 @@ class Static_Site_Importer_Theme_Generator {
 			$theme_dir . '/functions.php'             => self::functions_php( $theme_slug ),
 			$theme_dir . '/theme.json'                => self::theme_json( $theme_name, $site_css ),
 			$theme_dir . '/parts/header.html'         => $header_blocks,
-			$theme_dir . '/templates/front-page.html' => self::page_pattern_template( $background_blocks, $page_artifacts['patterns']['index.html'] ?? '', $has_footer_part ),
+			$theme_dir . '/templates/front-page.html' => self::content_template( $background_blocks, $has_footer_part ),
 			$theme_dir . '/templates/page.html'       => self::content_template( $background_blocks, $has_footer_part ),
 			$theme_dir . '/templates/index.html'      => self::content_template( $background_blocks, $has_footer_part ),
 		);
@@ -153,7 +153,7 @@ class Static_Site_Importer_Theme_Generator {
 				continue;
 			}
 
-			$writes[ $theme_dir . '/templates/page-' . $slug . '.html' ] = self::page_pattern_template( $background_blocks, $pattern_slug, $has_footer_part );
+			$writes[ $theme_dir . '/templates/page-' . $slug . '.html' ] = self::content_template( $background_blocks, $has_footer_part );
 			$writes[ $theme_dir . '/patterns/page-' . $slug . '.php' ]   = $page_artifacts['files'][ $filename ] ?? '';
 		}
 
@@ -286,7 +286,7 @@ class Static_Site_Importer_Theme_Generator {
 				'post_name'    => $slug,
 				'post_status'  => 'publish',
 				'post_type'    => 'page',
-				'post_content' => self::page_shell_content(),
+				'post_content' => '',
 			);
 
 			if ( $existing instanceof WP_Post ) {
@@ -310,11 +310,12 @@ class Static_Site_Importer_Theme_Generator {
 	 * @param array<string, array{path:string,document:Static_Site_Importer_Document}> $pages      Pages.
 	 * @param array<string,string>                                                      $permalinks Permalinks keyed by filename.
 	 * @param string                                                                    $theme_slug Theme slug.
-	 * @return array{patterns:array<string,string>,files:array<string,string>}
+	 * @return array{patterns:array<string,string>,files:array<string,string>,contents:array<string,string>}
 	 */
 	private static function page_artifacts( array $pages, array $permalinks, string $theme_slug ): array {
 		$patterns = array();
 		$files    = array();
+		$contents = array();
 
 		foreach ( $pages as $filename => $page ) {
 			$slug         = self::page_slug( $filename );
@@ -324,29 +325,32 @@ class Static_Site_Importer_Theme_Generator {
 
 			$patterns[ $filename ] = $pattern_slug;
 			$files[ $filename ]    = self::pattern_file( self::page_title( $filename, $page['document'] ), $pattern_slug, $content );
+			$contents[ $filename ] = $content;
 		}
 
 		return array(
 			'patterns' => $patterns,
 			'files'    => $files,
+			'contents' => $contents,
 		);
 	}
 
 	/**
-	 * Keep imported pages as routing/editing shells; their visible layout lives in page templates.
+	 * Store imported page bodies on their corresponding WordPress pages.
 	 *
 	 * @param array<string, array{path:string,document:Static_Site_Importer_Document}> $pages    Pages.
 	 * @param array<string,int>                                                         $page_ids Page IDs keyed by filename.
+	 * @param array<string,string>                                                      $contents Converted block markup keyed by filename.
 	 * @return true|WP_Error
 	 */
-	private static function write_page_shell_contents( array $pages, array $page_ids ) {
+	private static function write_page_contents( array $pages, array $page_ids, array $contents ) {
 		foreach ( array_keys( $pages ) as $filename ) {
 			$page_id = $page_ids[ $filename ] ?? 0;
 
 			$result = wp_update_post(
 				array(
 					'ID'           => $page_id,
-					'post_content' => self::page_shell_content(),
+					'post_content' => wp_slash( trim( $contents[ $filename ] ?? '' ) ),
 				),
 				true
 			);
@@ -3259,35 +3263,6 @@ class Static_Site_Importer_Theme_Generator {
 			'<!-- wp:post-content /-->' . "\n\n" .
 			$footer_part
 		) . "\n";
-	}
-
-	/**
-	 * Build a template that renders one imported page layout pattern.
-	 *
-	 * @param string $background_blocks Background decoration blocks.
-	 * @param string $pattern_slug      Pattern slug.
-	 * @param bool   $has_footer_part   Whether a shared footer template part was generated.
-	 * @return string
-	 */
-	private static function page_pattern_template( string $background_blocks, string $pattern_slug, bool $has_footer_part ): string {
-		$body        = '' === $pattern_slug ? '<!-- wp:post-content /-->' : '<!-- wp:pattern {"slug":"' . esc_attr( $pattern_slug ) . '"} /-->';
-		$footer_part = $has_footer_part ? '<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->' : '';
-
-		return trim(
-			'<!-- wp:template-part {"slug":"header","tagName":"header"} /-->' . "\n\n" .
-			$background_blocks . "\n\n" .
-			$body . "\n\n" .
-			$footer_part
-		) . "\n";
-	}
-
-	/**
-	 * Build the placeholder stored on imported page posts.
-	 *
-	 * @return string
-	 */
-	private static function page_shell_content(): string {
-		return '<!-- wp:paragraph --><p>Imported page layout lives in this page\'s generated block theme template and pattern.</p><!-- /wp:paragraph -->';
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -49,10 +49,13 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$home_pat   = $this->read_file( $theme_dir . '/patterns/page-home.php' );
 		$proof_pat  = $this->read_file( $theme_dir . '/patterns/page-proof.php' );
 
-		$this->assertStringContainsString( 'wordpress-is-dead-fixture/page-home', $front_page );
+		$this->assertStringContainsString( '<!-- wp:post-content', $front_page );
+		$this->assertStringNotContainsString( '<!-- wp:pattern', $front_page );
 		$this->assertStringContainsString( '<!-- wp:post-content', $page );
-		$this->assertStringContainsString( 'wordpress-is-dead-fixture/page-home', $home_tmpl );
-		$this->assertStringContainsString( 'wordpress-is-dead-fixture/page-proof', $proof_tmpl );
+		$this->assertStringContainsString( '<!-- wp:post-content', $home_tmpl );
+		$this->assertStringContainsString( '<!-- wp:post-content', $proof_tmpl );
+		$this->assertStringNotContainsString( '<!-- wp:pattern', $home_tmpl );
+		$this->assertStringNotContainsString( '<!-- wp:pattern', $proof_tmpl );
 		$this->assertStringContainsString( 'Slug: wordpress-is-dead-fixture/page-home', $home_pat );
 		$this->assertStringContainsString( 'Slug: wordpress-is-dead-fixture/page-proof', $proof_pat );
 		$this->assertStringNotContainsString( '<!-- wp:html /-->', $front_page );
@@ -120,14 +123,25 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 			$this->assertInstanceOf( WP_Post::class, $post, 'Missing imported page post for ' . $filename );
 			$slug         = 'index.html' === $filename ? 'home' : preg_replace( '/\.html?$/i', '', $filename );
 			$pattern_body = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-' . $slug . '.php' ) );
-			$this->assertStringContainsString( 'Imported page layout lives in this page', $post->post_content );
-			$this->assertFalse( $this->contains_selector( $post->post_content, '.hero' ) );
-			$this->assertNotEmpty( parse_blocks( $pattern_body ), 'Pattern block parse failed for ' . $filename );
+			$this->assertStringNotContainsString( 'Imported page layout lives in this page', $post->post_content );
+			$this->assertTrue( $this->contains_selector( $post->post_content, '.hero' ) );
+			$this->assertNotEmpty( parse_blocks( $post->post_content ), 'Page block parse failed for ' . $filename );
+			$this->assertNotEmpty( parse_blocks( $pattern_body ), 'Pattern snapshot block parse failed for ' . $filename );
+			$this->assertSame( trim( $pattern_body ), trim( $post->post_content ), 'Pattern snapshot should match page content for ' . $filename );
 			$pages[ $filename ] = array(
-				'stored'   => $pattern_body,
-				'rendered' => do_blocks( $pattern_body ),
+				'stored'   => $post->post_content,
+				'rendered' => do_blocks( $post->post_content ),
 			);
 		}
+
+		$previous_theme = get_stylesheet();
+		switch_theme( $result['theme_slug'] );
+		$home_post         = get_post( $result['pages']['index.html'] );
+		$frontend_rendered = $home_post instanceof WP_Post ? $this->render_template_for_post( $front_page, $home_post ) : '';
+		switch_theme( $previous_theme );
+		$this->assertStringContainsString( 'WordPress', $frontend_rendered );
+		$this->assertTrue( $this->contains_selector( $frontend_rendered, '.hero' ) );
+		$this->assertStringContainsString( 'Prompt Liberation Front', $frontend_rendered );
 
 		$this->assertStringNotContainsString( 'href="index.html"', $pages['proof.html']['stored'] );
 		$this->assert_selector_matrix( $pages );
@@ -864,6 +878,28 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$parts = explode( '?>', $pattern_file, 2 );
 
 		return trim( 2 === count( $parts ) ? $parts[1] : $pattern_file );
+	}
+
+	/**
+	 * Renders a block template with page context, matching the frontend post-content path.
+	 */
+	private function render_template_for_post( string $template, WP_Post $post ): string {
+		$rendered = '';
+		$context  = array(
+			'postId'   => $post->ID,
+			'postType' => $post->post_type,
+		);
+
+		foreach ( parse_blocks( $template ) as $block ) {
+			if ( 'core/post-content' === ( $block['blockName'] ?? '' ) ) {
+				$rendered .= do_blocks( $post->post_content );
+				continue;
+			}
+
+			$rendered .= ( new WP_Block( $block, $context ) )->render();
+		}
+
+		return $rendered;
 	}
 
 	/**

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -115,7 +115,8 @@ if ( ! is_wp_error( $result ) ) {
 	$header_nav = get_page_by_path( 'wordpress-is-dead-fixture-header-navigation', OBJECT, 'wp_navigation' );
 	$footer_nav = get_page_by_path( 'wordpress-is-dead-fixture-footer-navigation', OBJECT, 'wp_navigation' );
 
-	$assert( str_contains( $front_page, 'wp:pattern' ) && str_contains( $front_page, 'wordpress-is-dead-fixture/page-home' ), 'front-page-renders-imported-page-pattern' );
+	$assert( str_contains( $front_page, 'wp:post-content' ), 'front-page-renders-page-post-content' );
+	$assert( ! str_contains( $front_page, 'wp:pattern' ), 'front-page-does-not-embed-page-pattern' );
 	$assert( is_array( $report ), 'import-report-is-valid-json' );
 	$assert( isset( $report['quality']['fallback_count'] ), 'import-report-includes-fallback-count' );
 	$assert( isset( $report['conversion_fragments']['main:index.html'] ), 'import-report-groups-fragments-by-source' );
@@ -147,8 +148,10 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( in_array( 'style.css', $home_visual_target['comparison_hooks']['generated_files'] ?? array(), true ), 'visual-target-points-harness-at-generated-css' );
 	$assert( isset( $result['quality']['pass'] ), 'import-result-includes-quality-summary' );
 	$assert( str_contains( $page, 'wp:post-content' ), 'page-template-renders-imported-page-content' );
-	$assert( str_contains( $home_tmpl, 'wp:pattern' ) && str_contains( $home_tmpl, 'wordpress-is-dead-fixture/page-home' ), 'home-page-template-renders-home-pattern' );
-	$assert( str_contains( $proof_tmpl, 'wp:pattern' ) && str_contains( $proof_tmpl, 'wordpress-is-dead-fixture/page-proof' ), 'proof-page-template-renders-proof-pattern' );
+	$assert( str_contains( $home_tmpl, 'wp:post-content' ), 'home-page-template-renders-page-post-content' );
+	$assert( str_contains( $proof_tmpl, 'wp:post-content' ), 'proof-page-template-renders-page-post-content' );
+	$assert( ! str_contains( $home_tmpl, 'wp:pattern' ), 'home-page-template-does-not-embed-page-pattern' );
+	$assert( ! str_contains( $proof_tmpl, 'wp:pattern' ), 'proof-page-template-does-not-embed-page-pattern' );
 	$assert( str_contains( $home_pat, 'Slug: wordpress-is-dead-fixture/page-home' ), 'home-pattern-has-theme-slug' );
 	$assert( str_contains( $proof_pat, 'Slug: wordpress-is-dead-fixture/page-proof' ), 'proof-pattern-has-theme-slug' );
 	$assert( ! str_contains( $front_page, 'layout":{"type":"constrained"' ), 'front-page-template-is-neutral' );
@@ -223,11 +226,12 @@ if ( ! is_wp_error( $result ) ) {
 		if ( $post instanceof WP_Post ) {
 			$slug         = 'index.html' === $filename ? 'home' : preg_replace( '/\.html?$/i', '', $filename );
 			$pattern_body = $pattern_blocks( $read( $theme_dir . '/patterns/page-' . $slug . '.php' ) );
-			$assert( str_contains( $post->post_content, 'Imported page layout lives in this page' ), 'page-post-content-is-shell-' . $filename );
-			$assert( ! $contains_selector( $post->post_content, '.hero' ), 'page-post-content-does-not-duplicate-layout-' . $filename );
+			$assert( ! str_contains( $post->post_content, 'Imported page layout lives in this page' ), 'page-post-content-is-not-shell-' . $filename );
+			$assert( $contains_selector( $post->post_content, '.hero' ), 'page-post-content-preserves-layout-' . $filename );
+			$assert( trim( $pattern_body ) === trim( $post->post_content ), 'page-pattern-snapshot-matches-post-content-' . $filename );
 			$pages[ $filename ] = array(
-				'stored'   => $pattern_body,
-				'rendered' => do_blocks( $pattern_body ),
+				'stored'   => $post->post_content,
+				'rendered' => do_blocks( $post->post_content ),
 			);
 		}
 	}


### PR DESCRIPTION
## Summary
- Store converted imported page body blocks on the created WordPress page `post_content` instead of leaving placeholder shell content.
- Generate front/page templates with `core/post-content` while preserving header/footer template parts, global styles, and optional page pattern snapshots.
- Update fixture and smoke coverage for Edit Page content, `wp:post-content` templates, and frontend rendering through the generated template.

Closes #72.
Closes #73.

## Tests
- `homeboy test static-site-importer` passed: 19 tests, 408 assertions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the SSI architecture change, updated focused PHPUnit/smoke tests, and ran the requested Homeboy test suite. Chris remains responsible for review and merge.