### PR TITLE
Preserve header and footer chrome structure

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -495,7 +495,7 @@ class Static_Site_Importer_Theme_Generator {
 			return self::theme_part_element_block( $doc, $header, $theme_slug, 'header' );
 		}
 
-		$inner_blocks = self::html_block( self::node_html( $doc, $inner_children[0] ) ) . $navigation_blocks;
+		$inner_blocks = self::theme_part_element_block( $doc, $inner_children[0], $theme_slug, 'header' ) . $navigation_blocks;
 		return self::group_block( self::group_block( $inner_blocks, $inner->getAttribute( 'class' ) ), $header->getAttribute( 'class' ), 'header' );
 	}
 
@@ -536,7 +536,7 @@ class Static_Site_Importer_Theme_Generator {
 			return self::theme_part_element_block( $doc, $footer, $theme_slug, 'footer' );
 		}
 
-		$row_blocks       = self::html_block( self::node_html( $doc, $row_children[0] ) ) . $navigation_blocks;
+		$row_blocks       = self::theme_part_element_block( $doc, $row_children[0], $theme_slug, 'footer' ) . $navigation_blocks;
 		$container_blocks = self::group_block( $row_blocks, $row->getAttribute( 'class' ) );
 		return self::group_block( self::group_block( $container_blocks, $container->getAttribute( 'class' ) ), $footer->getAttribute( 'class' ), 'footer' );
 	}
@@ -561,6 +561,10 @@ class Static_Site_Importer_Theme_Generator {
 
 		if ( 'a' === $tag ) {
 			return self::link_element_block( $doc, $element );
+		}
+
+		if ( 'img' === $tag ) {
+			return self::image_element_block( $doc, $element );
 		}
 
 		if ( self::element_has_only_phrasing_content( $element ) ) {
@@ -788,6 +792,49 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return self::paragraph_block( '<a href="' . esc_url( $href ) . '"' . ( '' !== $class ? ' class="' . esc_attr( $class ) . '"' : '' ) . '>' . esc_html( $label ) . '</a>' );
+	}
+
+	/**
+	 * Convert an image in shared chrome to a native image block.
+	 *
+	 * @param DOMDocument $doc     Source DOM document.
+	 * @param DOMElement  $element Image element.
+	 * @return string
+	 */
+	private static function image_element_block( DOMDocument $doc, DOMElement $element ): string {
+		$src = trim( $element->getAttribute( 'src' ) );
+		if ( '' === $src ) {
+			return self::html_block( self::node_html( $doc, $element ) );
+		}
+
+		$class = trim( $element->getAttribute( 'class' ) );
+		$attrs = array(
+			'url'      => esc_url_raw( $src ),
+			'sizeSlug' => 'large',
+		);
+		if ( '' !== $class ) {
+			$attrs['className'] = $class;
+		}
+
+		$figure_class = trim( 'wp-block-image size-large ' . $class );
+		$img_attrs    = array(
+			'src' => esc_url( $src ),
+			'alt' => esc_attr( $element->getAttribute( 'alt' ) ),
+		);
+		foreach ( array( 'width', 'height', 'decoding', 'loading' ) as $attribute ) {
+			$value = trim( $element->getAttribute( $attribute ) );
+			if ( '' !== $value ) {
+				$img_attrs[ $attribute ] = esc_attr( $value );
+			}
+		}
+
+		$img_markup = '<img';
+		foreach ( $img_attrs as $name => $value ) {
+			$img_markup .= ' ' . $name . '="' . $value . '"';
+		}
+		$img_markup .= '/>';
+
+		return '<!-- wp:image ' . wp_json_encode( $attrs, JSON_UNESCAPED_SLASHES ) . ' --><figure class="' . esc_attr( $figure_class ) . '">' . $img_markup . '</figure><!-- /wp:image -->';
 	}
 
 	/**
@@ -1116,6 +1163,7 @@ class Static_Site_Importer_Theme_Generator {
 		foreach ( $svgs as $svg ) {
 			++$sequence;
 			$svg_html = self::node_html( $doc, $svg );
+			$style_dimensions = $svg->hasAttribute( 'style' ) ? self::safe_svg_dimension_style( $svg->getAttribute( 'style' ) ) : array();
 			$safe_svg = self::sanitize_inline_svg( $svg_html );
 			if ( null === $safe_svg ) {
 				self::record_unsafe_inline_svg( $source, $svg_html );
@@ -1138,6 +1186,13 @@ class Static_Site_Importer_Theme_Generator {
 			foreach ( array( 'width', 'height', 'aria-hidden', 'role' ) as $attribute ) {
 				if ( $svg->hasAttribute( $attribute ) ) {
 					$img->setAttribute( $attribute, $svg->getAttribute( $attribute ) );
+				}
+			}
+			if ( is_array( $style_dimensions ) ) {
+				foreach ( array( 'width', 'height' ) as $attribute ) {
+					if ( ! $img->hasAttribute( $attribute ) && isset( $style_dimensions[ $attribute ] ) ) {
+						$img->setAttribute( $attribute, $style_dimensions[ $attribute ] );
+					}
 				}
 			}
 
@@ -1261,8 +1316,16 @@ class Static_Site_Importer_Theme_Generator {
 
 			foreach ( iterator_to_array( $node->attributes ) as $attribute ) {
 				$name  = $attribute->name;
+				$lower = strtolower( $name );
 				$value = $attribute->value;
-				if ( str_starts_with( strtolower( $name ), 'on' ) || ! isset( $allowed_attributes[ $name ] ) || preg_match( '/(?:javascript:|data:|url\s*\()/i', $value ) ) {
+				if ( 'style' === $lower ) {
+					if ( null === self::safe_svg_dimension_style( $value ) ) {
+						return null;
+					}
+					continue;
+				}
+
+				if ( str_starts_with( $lower, 'on' ) || ! isset( $allowed_attributes[ $name ] ) || preg_match( '/(?:javascript:|data:|url\s*\()/i', $value ) ) {
 					return null;
 				}
 			}
@@ -1282,6 +1345,30 @@ class Static_Site_Importer_Theme_Generator {
 
 		$svg = $doc->saveXML( $doc->documentElement );
 		return false === $svg ? null : $svg;
+	}
+
+	/**
+	 * Parse an inline SVG style attribute that only carries safe dimensions.
+	 *
+	 * @param string $style Style attribute value.
+	 * @return array{width?:string,height?:string}|null Dimensions, or null when unsafe/unsupported.
+	 */
+	private static function safe_svg_dimension_style( string $style ): ?array {
+		$dimensions = array();
+		foreach ( explode( ';', $style ) as $declaration ) {
+			$declaration = trim( $declaration );
+			if ( '' === $declaration ) {
+				continue;
+			}
+
+			if ( 1 !== preg_match( '/^(width|height)\s*:\s*([0-9]+(?:\.[0-9]+)?)px$/i', $declaration, $matches ) ) {
+				return null;
+			}
+
+			$dimensions[ strtolower( $matches[1] ) ] = $matches[2];
+		}
+
+		return $dimensions;
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -563,6 +563,10 @@ class Static_Site_Importer_Theme_Generator {
 			return self::link_element_block( $doc, $element );
 		}
 
+		if ( self::is_link_cluster_container( $element ) ) {
+			return self::group_block( self::theme_part_child_blocks( $doc, $element, $theme_slug, $location ), $element->getAttribute( 'class' ) );
+		}
+
 		if ( self::element_has_only_phrasing_content( $element ) ) {
 			return self::paragraph_block( self::node_inner_html( $doc, $element ), $element->getAttribute( 'class' ) );
 		}
@@ -704,6 +708,37 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check whether a dedicated link cluster should keep its source wrapper.
+	 *
+	 * @param DOMElement $element Source element.
+	 * @return bool
+	 */
+	private static function is_link_cluster_container( DOMElement $element ): bool {
+		$tag = strtolower( $element->tagName );
+		if ( ! in_array( $tag, array( 'div', 'span' ), true ) || self::element_has_direct_non_whitespace_text( $element ) ) {
+			return false;
+		}
+
+		$class = $element->getAttribute( 'class' );
+		if ( ! preg_match( '/(^|[-_\s])(actions?|buttons?|cta|links?)([-_\s]|$)/i', $class ) ) {
+			return false;
+		}
+
+		$children = self::direct_element_children( $element );
+		if ( count( $children ) < 2 ) {
+			return false;
+		}
+
+		foreach ( $children as $child ) {
+			if ( 'a' !== strtolower( $child->tagName ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -737,6 +737,65 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Header and footer chrome keep source layout wrappers without broad HTML fallbacks.
+	 */
+	public function test_header_footer_chrome_structure_survives_theme_part_conversion(): void {
+		$html_path = $this->write_temp_fixture(
+			'relay-atlas-chrome.html',
+			'<!doctype html><html><head><title>Relay Atlas Chrome</title></head><body>' .
+			'<nav><div class="nav-inner"><a href="/" class="nav-logo"><svg class="logo-mark" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M12 2 22 20H2Z" fill="currentColor"/></svg><span>Relay Atlas</span></a><ul class="nav-links"><li><a href="#features">Features</a></li><li><a href="#pricing">Pricing</a></li></ul><div class="nav-cta"><a href="#signin" class="login-link">Sign in</a><a href="#start" class="btn-primary">Start free</a></div></div></nav>' .
+			'<main><section id="features"><h1>Map every handoff</h1><p>Relay Atlas keeps launch teams aligned.</p></section><section id="pricing"><h2>Pricing</h2><p>Simple plans.</p></section></main>' .
+			'<footer><div class="footer-inner"><div class="footer-left"><svg class="footer-logo-mark" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="currentColor"/></svg><span>Relay Atlas</span></div><ul class="footer-links"><li><a href="#features">Features</a></li><li><a href="#pricing">Pricing</a></li></ul></div></footer>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Relay Atlas Chrome',
+				'slug'      => 'relay-atlas-chrome',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir  = $result['theme_dir'];
+		$header     = $this->read_file( $theme_dir . '/parts/header.html' );
+		$footer     = $this->read_file( $theme_dir . '/parts/footer.html' );
+		$report     = json_decode( $this->read_file( $result['report_path'] ), true );
+		$header_nav = get_page_by_path( 'relay-atlas-chrome-header-navigation', OBJECT, 'wp_navigation' );
+		$footer_nav = get_page_by_path( 'relay-atlas-chrome-footer-navigation', OBJECT, 'wp_navigation' );
+
+		foreach ( array( 'static-site-importer-source-nav', 'nav-inner', 'nav-logo', 'nav-links', 'nav-cta' ) as $class_name ) {
+			$this->assertStringContainsString( $class_name, $header );
+		}
+		foreach ( array( 'footer-inner', 'footer-left', 'footer-links' ) as $class_name ) {
+			$this->assertStringContainsString( $class_name, $footer );
+		}
+
+		$this->assertStringNotContainsString( '<!-- wp:html --><nav', $header );
+		$this->assertStringNotContainsString( '<!-- wp:html --><div class="nav-inner"', $header );
+		$this->assertStringNotContainsString( '<!-- wp:paragraph {"className":"nav-cta"}', $header );
+		$this->assertStringContainsString( '<!-- wp:group {"className":"nav-cta"}', $header );
+		$this->assertSame( 1, substr_count( $header, '"className":"nav-inner"' ) );
+
+		$this->assertStringNotContainsString( '<!-- wp:html --><footer', $footer );
+		$this->assertStringNotContainsString( '<!-- wp:html --><div class="footer-inner"', $footer );
+		$this->assertStringNotContainsString( '<!-- wp:html --><div class="footer-left"', $footer );
+		$this->assertSame( 1, substr_count( $footer, '"className":"footer-inner"' ) );
+
+		$this->assertInstanceOf( WP_Post::class, $header_nav );
+		$this->assertInstanceOf( WP_Post::class, $footer_nav );
+		$this->assertStringContainsString( '"label":"Features"', $header_nav->post_content );
+		$this->assertStringContainsString( '"label":"Pricing"', $footer_nav->post_content );
+		$this->assertSame( 0, $report['quality']['unsafe_svg_count'] ?? null );
+		$this->assertNotEmpty( $report['assets']['svg_icons'] ?? array() );
+	}
+
+	/**
 	 * Unsafe inline SVG remains visible in the import report instead of being accepted silently.
 	 */
 	public function test_unsafe_inline_svg_is_reported(): void {

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -737,6 +737,45 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Safe inline SVG icons in extracted footer chrome are materialized as native image blocks.
+	 */
+	public function test_footer_template_part_svg_icons_materialize_as_theme_assets(): void {
+		$html_path = $this->write_temp_fixture(
+			'footer-svg-icon.html',
+			'<!doctype html><html><head><title>Footer SVG Icon</title></head><body><main><h1>Footer SVG Icon</h1><p>Body copy.</p></main><footer class="site-footer"><div class="footer-inner"><div class="footer-row"><div class="footer-brand"><span>Relay Atlas</span><svg viewbox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" style="width: 12px; height: 12px;"><path d="M8 2L14 5.5V10.5L8 14L2 10.5V5.5L8 2Z"></path></svg></div><ul class="footer-nav"><li><a href="/privacy.html">Privacy</a></li></ul></div></div></footer></body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Footer SVG Icon',
+				'slug'      => 'footer-svg-icon',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$footer    = $this->read_file( $theme_dir . '/parts/footer.html' );
+		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+
+		$this->assertStringContainsString( '<!-- wp:image ', $footer );
+		$this->assertStringNotContainsString( '<!-- wp:html', $footer );
+		$this->assertStringContainsString( '/assets/icons/', $footer );
+		$this->assertSame( 0, $report['quality']['unsafe_svg_count'] ?? null );
+		$this->assertSame( 0, $report['quality']['fallback_count'] ?? null );
+		$this->assertNotEmpty( $report['assets']['svg_icons'] ?? array() );
+
+		$asset = $report['assets']['svg_icons'][0] ?? array();
+		$this->assertSame( 'theme-part:footer', $asset['source'] ?? '' );
+		$this->assertSame( 'core/image', $asset['block'] ?? '' );
+		$this->assertFileExists( $theme_dir . '/' . ( $asset['path'] ?? '' ) );
+	}
+
+	/**
 	 * Unsafe inline SVG remains visible in the import report instead of being accepted silently.
 	 */
 	public function test_unsafe_inline_svg_is_reported(): void {
@@ -767,6 +806,39 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 				static fn ( array $diagnostic ): bool => 'unsafe_inline_svg' === ( $diagnostic['type'] ?? '' )
 			)
 		);
+	}
+
+	/**
+	 * Unsafe inline SVG in extracted footer chrome remains visible in diagnostics.
+	 */
+	public function test_unsafe_footer_template_part_svg_is_reported(): void {
+		$html_path = $this->write_temp_fixture(
+			'unsafe-footer-svg-icon.html',
+			'<!doctype html><html><head><title>Unsafe Footer SVG Icon</title></head><body><main><h1>Unsafe Footer SVG Icon</h1><p>Body copy.</p></main><footer><div><div><div><span>Brand</span><svg viewBox="0 0 24 24"><script>alert(1)</script><path d="M0 0h24v24H0z"></path></svg></div><ul><li><a href="/privacy.html">Privacy</a></li></ul></div></div></footer></body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Unsafe Footer SVG Icon',
+				'slug'      => 'unsafe-footer-svg-icon',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$report      = json_decode( $this->read_file( $result['report_path'] ), true );
+		$diagnostics = array_filter(
+			$report['diagnostics'] ?? array(),
+			static fn ( array $diagnostic ): bool => 'unsafe_inline_svg' === ( $diagnostic['type'] ?? '' ) && 'theme-part:footer' === ( $diagnostic['source'] ?? '' )
+		);
+
+		$this->assertSame( 1, $report['quality']['unsafe_svg_count'] ?? null );
+		$this->assertContains( 'unsafe_inline_svg', $report['quality']['failure_reasons'] ?? array() );
+		$this->assertNotEmpty( $diagnostics );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Preserve dedicated theme-part link clusters, such as `.nav-cta`, as source wrapper groups instead of paragraph-wrapped anchor blobs.
- Add a focused Relay Atlas-style fixture covering `nav > .nav-inner > .nav-logo + ul.nav-links + .nav-cta` and `footer > .footer-inner > .footer-left + ul.footer-links` with safe SVG marks.
- Verify generated header/footer parts keep layout classes and avoid whole-subtree `wp:html` fallbacks while keeping navigation editable.

Fixes #77.

## Tests
- `homeboy test static-site-importer --filter test_header_footer_chrome_structure_survives_theme_part_conversion`
- `homeboy test static-site-importer`

## Upstream / release chain
- No upstream child-transform change is required for this fix; the drift is in SSI's theme-part chrome converter.
- Safe inline SVG materialization in theme parts remains the release-chain prerequisite for the footer SVG portion of this fixture to avoid broad fallbacks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused regression fixture, implemented the SSI theme-part converter change, ran tests, and prepared this PR summary for Chris to review.