### PR TITLE
Materialize template-part SVG icons

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -495,7 +495,7 @@ class Static_Site_Importer_Theme_Generator {
 			return self::theme_part_element_block( $doc, $header, $theme_slug, 'header' );
 		}
 
-		$inner_blocks = self::html_block( self::node_html( $doc, $inner_children[0] ) ) . $navigation_blocks;
+		$inner_blocks = self::theme_part_element_block( $doc, $inner_children[0], $theme_slug, 'header' ) . $navigation_blocks;
 		return self::group_block( self::group_block( $inner_blocks, $inner->getAttribute( 'class' ) ), $header->getAttribute( 'class' ), 'header' );
 	}
 
@@ -536,7 +536,7 @@ class Static_Site_Importer_Theme_Generator {
 			return self::theme_part_element_block( $doc, $footer, $theme_slug, 'footer' );
 		}
 
-		$row_blocks       = self::html_block( self::node_html( $doc, $row_children[0] ) ) . $navigation_blocks;
+		$row_blocks       = self::theme_part_element_block( $doc, $row_children[0], $theme_slug, 'footer' ) . $navigation_blocks;
 		$container_blocks = self::group_block( $row_blocks, $row->getAttribute( 'class' ) );
 		return self::group_block( self::group_block( $container_blocks, $container->getAttribute( 'class' ) ), $footer->getAttribute( 'class' ), 'footer' );
 	}
@@ -561,6 +561,10 @@ class Static_Site_Importer_Theme_Generator {
 
 		if ( 'a' === $tag ) {
 			return self::link_element_block( $doc, $element );
+		}
+
+		if ( 'img' === $tag ) {
+			return self::image_element_block( $doc, $element );
 		}
 
 		if ( self::element_has_only_phrasing_content( $element ) ) {
@@ -788,6 +792,49 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return self::paragraph_block( '<a href="' . esc_url( $href ) . '"' . ( '' !== $class ? ' class="' . esc_attr( $class ) . '"' : '' ) . '>' . esc_html( $label ) . '</a>' );
+	}
+
+	/**
+	 * Convert an image in shared chrome to a native image block.
+	 *
+	 * @param DOMDocument $doc     Source DOM document.
+	 * @param DOMElement  $element Image element.
+	 * @return string
+	 */
+	private static function image_element_block( DOMDocument $doc, DOMElement $element ): string {
+		$src = trim( $element->getAttribute( 'src' ) );
+		if ( '' === $src ) {
+			return self::html_block( self::node_html( $doc, $element ) );
+		}
+
+		$class = trim( $element->getAttribute( 'class' ) );
+		$attrs = array(
+			'url'      => esc_url_raw( $src ),
+			'sizeSlug' => 'large',
+		);
+		if ( '' !== $class ) {
+			$attrs['className'] = $class;
+		}
+
+		$figure_class = trim( 'wp-block-image size-large ' . $class );
+		$img_attrs    = array(
+			'src' => esc_url( $src ),
+			'alt' => esc_attr( $element->getAttribute( 'alt' ) ),
+		);
+		foreach ( array( 'width', 'height', 'decoding', 'loading' ) as $attribute ) {
+			$value = trim( $element->getAttribute( $attribute ) );
+			if ( '' !== $value ) {
+				$img_attrs[ $attribute ] = esc_attr( $value );
+			}
+		}
+
+		$img_markup = '<img';
+		foreach ( $img_attrs as $name => $value ) {
+			$img_markup .= ' ' . $name . '="' . $value . '"';
+		}
+		$img_markup .= '/>';
+
+		return '<!-- wp:image ' . wp_json_encode( $attrs, JSON_UNESCAPED_SLASHES ) . ' --><figure class="' . esc_attr( $figure_class ) . '">' . $img_markup . '</figure><!-- /wp:image -->';
 	}
 
 	/**
@@ -1116,6 +1163,7 @@ class Static_Site_Importer_Theme_Generator {
 		foreach ( $svgs as $svg ) {
 			++$sequence;
 			$svg_html = self::node_html( $doc, $svg );
+			$style_dimensions = $svg->hasAttribute( 'style' ) ? self::safe_svg_dimension_style( $svg->getAttribute( 'style' ) ) : array();
 			$safe_svg = self::sanitize_inline_svg( $svg_html );
 			if ( null === $safe_svg ) {
 				self::record_unsafe_inline_svg( $source, $svg_html );
@@ -1138,6 +1186,13 @@ class Static_Site_Importer_Theme_Generator {
 			foreach ( array( 'width', 'height', 'aria-hidden', 'role' ) as $attribute ) {
 				if ( $svg->hasAttribute( $attribute ) ) {
 					$img->setAttribute( $attribute, $svg->getAttribute( $attribute ) );
+				}
+			}
+			if ( is_array( $style_dimensions ) ) {
+				foreach ( array( 'width', 'height' ) as $attribute ) {
+					if ( ! $img->hasAttribute( $attribute ) && isset( $style_dimensions[ $attribute ] ) ) {
+						$img->setAttribute( $attribute, $style_dimensions[ $attribute ] );
+					}
 				}
 			}
 
@@ -1261,8 +1316,16 @@ class Static_Site_Importer_Theme_Generator {
 
 			foreach ( iterator_to_array( $node->attributes ) as $attribute ) {
 				$name  = $attribute->name;
+				$lower = strtolower( $name );
 				$value = $attribute->value;
-				if ( str_starts_with( strtolower( $name ), 'on' ) || ! isset( $allowed_attributes[ $name ] ) || preg_match( '/(?:javascript:|data:|url\s*\()/i', $value ) ) {
+				if ( 'style' === $lower ) {
+					if ( null === self::safe_svg_dimension_style( $value ) ) {
+						return null;
+					}
+					continue;
+				}
+
+				if ( str_starts_with( $lower, 'on' ) || ! isset( $allowed_attributes[ $name ] ) || preg_match( '/(?:javascript:|data:|url\s*\()/i', $value ) ) {
 					return null;
 				}
 			}
@@ -1282,6 +1345,30 @@ class Static_Site_Importer_Theme_Generator {
 
 		$svg = $doc->saveXML( $doc->documentElement );
 		return false === $svg ? null : $svg;
+	}
+
+	/**
+	 * Parse an inline SVG style attribute that only carries safe dimensions.
+	 *
+	 * @param string $style Style attribute value.
+	 * @return array{width?:string,height?:string}|null Dimensions, or null when unsafe/unsupported.
+	 */
+	private static function safe_svg_dimension_style( string $style ): ?array {
+		$dimensions = array();
+		foreach ( explode( ';', $style ) as $declaration ) {
+			$declaration = trim( $declaration );
+			if ( '' === $declaration ) {
+				continue;
+			}
+
+			if ( 1 !== preg_match( '/^(width|height)\s*:\s*([0-9]+(?:\.[0-9]+)?)px$/i', $declaration, $matches ) ) {
+				return null;
+			}
+
+			$dimensions[ strtolower( $matches[1] ) ] = $matches[2];
+		}
+
+		return $dimensions;
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -737,6 +737,45 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Safe inline SVG icons in extracted footer chrome are materialized as native image blocks.
+	 */
+	public function test_footer_template_part_svg_icons_materialize_as_theme_assets(): void {
+		$html_path = $this->write_temp_fixture(
+			'footer-svg-icon.html',
+			'<!doctype html><html><head><title>Footer SVG Icon</title></head><body><main><h1>Footer SVG Icon</h1><p>Body copy.</p></main><footer class="site-footer"><div class="footer-inner"><div class="footer-row"><div class="footer-brand"><span>Relay Atlas</span><svg viewbox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" style="width: 12px; height: 12px;"><path d="M8 2L14 5.5V10.5L8 14L2 10.5V5.5L8 2Z"></path></svg></div><ul class="footer-nav"><li><a href="/privacy.html">Privacy</a></li></ul></div></div></footer></body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Footer SVG Icon',
+				'slug'      => 'footer-svg-icon',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$footer    = $this->read_file( $theme_dir . '/parts/footer.html' );
+		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+
+		$this->assertStringContainsString( '<!-- wp:image ', $footer );
+		$this->assertStringNotContainsString( '<!-- wp:html', $footer );
+		$this->assertStringContainsString( '/assets/icons/', $footer );
+		$this->assertSame( 0, $report['quality']['unsafe_svg_count'] ?? null );
+		$this->assertSame( 0, $report['quality']['fallback_count'] ?? null );
+		$this->assertNotEmpty( $report['assets']['svg_icons'] ?? array() );
+
+		$asset = $report['assets']['svg_icons'][0] ?? array();
+		$this->assertSame( 'theme-part:footer', $asset['source'] ?? '' );
+		$this->assertSame( 'core/image', $asset['block'] ?? '' );
+		$this->assertFileExists( $theme_dir . '/' . ( $asset['path'] ?? '' ) );
+	}
+
+	/**
 	 * Unsafe inline SVG remains visible in the import report instead of being accepted silently.
 	 */
 	public function test_unsafe_inline_svg_is_reported(): void {
@@ -767,6 +806,39 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 				static fn ( array $diagnostic ): bool => 'unsafe_inline_svg' === ( $diagnostic['type'] ?? '' )
 			)
 		);
+	}
+
+	/**
+	 * Unsafe inline SVG in extracted footer chrome remains visible in diagnostics.
+	 */
+	public function test_unsafe_footer_template_part_svg_is_reported(): void {
+		$html_path = $this->write_temp_fixture(
+			'unsafe-footer-svg-icon.html',
+			'<!doctype html><html><head><title>Unsafe Footer SVG Icon</title></head><body><main><h1>Unsafe Footer SVG Icon</h1><p>Body copy.</p></main><footer><div><div><div><span>Brand</span><svg viewBox="0 0 24 24"><script>alert(1)</script><path d="M0 0h24v24H0z"></path></svg></div><ul><li><a href="/privacy.html">Privacy</a></li></ul></div></div></footer></body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Unsafe Footer SVG Icon',
+				'slug'      => 'unsafe-footer-svg-icon',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$report      = json_decode( $this->read_file( $result['report_path'] ), true );
+		$diagnostics = array_filter(
+			$report['diagnostics'] ?? array(),
+			static fn ( array $diagnostic ): bool => 'unsafe_inline_svg' === ( $diagnostic['type'] ?? '' ) && 'theme-part:footer' === ( $diagnostic['source'] ?? '' )
+		);
+
+		$this->assertSame( 1, $report['quality']['unsafe_svg_count'] ?? null );
+		$this->assertContains( 'unsafe_inline_svg', $report['quality']['failure_reasons'] ?? array() );
+		$this->assertNotEmpty( $diagnostics );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Materialize safe inline SVG icons before template-part chrome is converted, including footer/header branches that previously forced chrome snippets into `wp:html`.
- Add native `core/image` handling for images inside generated template parts so materialized SVG assets do not remain raw HTML islands.
- Preserve unsafe SVG reporting with focused footer-template-part coverage.

## Tests
- `homeboy test static-site-importer`

## Release chain
- No BFB/h2bc release-chain requirement: this fix is contained in the Static Site Importer template-part conversion/materialization layer.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Reproduced issue #34's footer template-part SVG gap, drafted the SSI-layer fix and tests, and ran the requested Homeboy test suite for Chris to review.