### PR TITLE
Serialize template-part images canonically

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -856,12 +856,6 @@ class Static_Site_Importer_Theme_Generator {
 			'src' => esc_url( $src ),
 			'alt' => esc_attr( $element->getAttribute( 'alt' ) ),
 		);
-		foreach ( array( 'width', 'height', 'decoding', 'loading' ) as $attribute ) {
-			$value = trim( $element->getAttribute( $attribute ) );
-			if ( '' !== $value ) {
-				$img_attrs[ $attribute ] = esc_attr( $value );
-			}
-		}
 
 		$img_markup = '<img';
 		foreach ( $img_attrs as $name => $value ) {

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -801,7 +801,7 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	public function test_footer_template_part_svg_icons_materialize_as_theme_assets(): void {
 		$html_path = $this->write_temp_fixture(
 			'footer-svg-icon.html',
-			'<!doctype html><html><head><title>Footer SVG Icon</title></head><body><main><h1>Footer SVG Icon</h1><p>Body copy.</p></main><footer class="site-footer"><div class="footer-inner"><div class="footer-row"><div class="footer-brand"><span>Relay Atlas</span><svg viewbox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" style="width: 12px; height: 12px;"><path d="M8 2L14 5.5V10.5L8 14L2 10.5V5.5L8 2Z"></path></svg></div><ul class="footer-nav"><li><a href="/privacy.html">Privacy</a></li></ul></div></div></footer></body></html>'
+			'<!doctype html><html><head><title>Footer SVG Icon</title></head><body><main><h1>Footer SVG Icon</h1><p>Body copy.</p></main><footer class="site-footer"><div class="footer-inner"><div class="footer-row"><div class="footer-brand"><span>Relay Atlas</span><svg viewbox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" width="14" height="14"><path d="M8 2L14 5.5V10.5L8 14L2 10.5V5.5L8 2Z"></path></svg></div><ul class="footer-nav"><li><a href="/privacy.html">Privacy</a></li></ul></div></div></footer></body></html>'
 		);
 
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
@@ -824,8 +824,14 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<!-- wp:image ', $footer );
 		$this->assertStringNotContainsString( '<!-- wp:html', $footer );
 		$this->assertStringContainsString( '/assets/icons/', $footer );
+		$this->assertStringContainsString( '<figure class="wp-block-image size-large"><img src="', $footer );
+		$this->assertStringContainsString( ' alt=""/></figure>', $footer );
+		$this->assertStringNotContainsString( ' width="14"', $footer );
+		$this->assertStringNotContainsString( ' height="14"', $footer );
+		$this->assertStringNotContainsString( ' decoding="async"', $footer );
 		$this->assertSame( 0, $report['quality']['unsafe_svg_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['fallback_count'] ?? null );
+		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
 		$this->assertNotEmpty( $report['assets']['svg_icons'] ?? array() );
 
 		$asset = $report['assets']['svg_icons'][0] ?? array();


### PR DESCRIPTION
## Summary
- Strip non-canonical source image attributes from SSI template-part `core/image` serialization so Gutenberg expects the generated markup.
- Extend the footer template-part SVG materialization fixture to cover source width/height plus generated decoding and assert zero generated-theme invalid blocks.

Closes #81.

## Tests
- `homeboy test static-site-importer`
- Focused Gutenberg JS validation of canonical `core/image` markup with `@wordpress/blocks` `validateBlock()`

## Interaction with #80
- No code changes for #80. This PR keeps the existing logo-anchor/core-html scope separate and only fixes the image attribute validation failure from the same Relay Atlas benchmark evidence.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused code/test change and ran validation; Chris remains responsible for review and merge.