### PR TITLE
Fix image logo anchor block serialization

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -813,6 +813,10 @@ class Static_Site_Importer_Theme_Generator {
 
 		$class = trim( $element->getAttribute( 'class' ) );
 		if ( preg_match( '/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $class ) ) {
+			if ( ! self::element_has_only_phrasing_content( $element ) ) {
+				return self::logo_anchor_block( $doc, $element, $href, $class );
+			}
+
 			$anchor_attrs = ' href="' . esc_url( $href ) . '"';
 			if ( '' !== $class ) {
 				$anchor_attrs .= ' class="' . esc_attr( $class ) . '"';
@@ -835,25 +839,105 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Convert an image in shared chrome to a native image block.
+	 * Build valid native blocks for a logo anchor that contains image wrappers.
 	 *
-	 * @param DOMDocument $doc     Source DOM document.
-	 * @param DOMElement  $element Image element.
+	 * @param DOMDocument $doc        Source DOM document.
+	 * @param DOMElement  $element    Anchor element.
+	 * @param string      $href       Anchor href.
+	 * @param string      $class_name Anchor class attribute.
 	 * @return string
 	 */
-	private static function image_element_block( DOMDocument $doc, DOMElement $element ): string {
+	private static function logo_anchor_block( DOMDocument $doc, DOMElement $element, string $href, string $class_name ): string {
+		$children = array();
+		foreach ( $element->childNodes as $child ) {
+			if ( $child instanceof DOMText ) {
+				$text = trim( $child->textContent );
+				if ( '' !== $text ) {
+					$children[] = self::linked_text_block( $text, $href );
+				}
+				continue;
+			}
+
+			if ( ! $child instanceof DOMElement ) {
+				continue;
+			}
+
+			$img = self::sole_descendant_image( $child );
+			if ( $img instanceof DOMElement ) {
+				$children[] = self::image_element_block( $doc, $img, trim( $child->getAttribute( 'class' ) ), $href );
+				continue;
+			}
+
+			$text = trim( $child->textContent );
+			if ( '' !== $text && self::element_has_only_phrasing_content( $child ) ) {
+				$children[] = self::linked_text_block( $text, $href, trim( $child->getAttribute( 'class' ) ) );
+				continue;
+			}
+
+			$children[] = self::theme_part_element_block( $doc, $child, '', '' );
+		}
+
+		$inner = implode( '', array_filter( $children ) );
+		if ( '' === trim( $inner ) ) {
+			return self::html_block( self::node_html( $doc, $element ) );
+		}
+
+		return self::group_block( $inner, $class_name );
+	}
+
+	/**
+	 * Find a direct or singly wrapped image child.
+	 *
+	 * @param DOMElement $element Source element.
+	 * @return DOMElement|null
+	 */
+	private static function sole_descendant_image( DOMElement $element ): ?DOMElement {
+		if ( 'img' === strtolower( $element->tagName ) ) {
+			return $element;
+		}
+
+		$children = self::direct_element_children( $element );
+		return 1 === count( $children ) && 'img' === strtolower( $children[0]->tagName ) ? $children[0] : null;
+	}
+
+	/**
+	 * Build a paragraph containing a text link.
+	 *
+	 * @param string $text       Link text.
+	 * @param string $href       Link href.
+	 * @param string $class_name Source class attribute.
+	 * @return string
+	 */
+	private static function linked_text_block( string $text, string $href, string $class_name = '' ): string {
+		return self::paragraph_block( '<a href="' . esc_url( $href ) . '">' . esc_html( $text ) . '</a>', $class_name );
+	}
+
+	/**
+	 * Convert an image in shared chrome to a native image block.
+	 *
+	 * @param DOMDocument $doc        Source DOM document.
+	 * @param DOMElement  $element    Image element.
+	 * @param string      $class_name Optional class override.
+	 * @param string      $href       Optional link href.
+	 * @return string
+	 */
+	private static function image_element_block( DOMDocument $doc, DOMElement $element, string $class_name = '', string $href = '' ): string {
 		$src = trim( $element->getAttribute( 'src' ) );
 		if ( '' === $src ) {
 			return self::html_block( self::node_html( $doc, $element ) );
 		}
 
-		$class = trim( $element->getAttribute( 'class' ) );
+		$class = trim( '' !== $class_name ? $class_name : $element->getAttribute( 'class' ) );
 		$attrs = array(
 			'url'      => esc_url_raw( $src ),
 			'sizeSlug' => 'large',
 		);
 		if ( '' !== $class ) {
 			$attrs['className'] = $class;
+		}
+		if ( '' !== $href ) {
+			$attrs['href']            = esc_url_raw( $href );
+			$attrs['linkDestination'] = 'custom';
 		}
 
 		$figure_class = trim( 'wp-block-image size-large ' . $class );
@@ -867,6 +951,10 @@ class Static_Site_Importer_Theme_Generator {
 			$img_markup .= ' ' . $name . '="' . $value . '"';
 		}
 		$img_markup .= '/>';
+
+		if ( '' !== $href ) {
+			$img_markup = '<a href="' . esc_url( $href ) . '">' . $img_markup . '</a>';
+		}
 
 		return '<!-- wp:image ' . wp_json_encode( $attrs, JSON_UNESCAPED_SLASHES ) . ' --><figure class="' . esc_attr( $figure_class ) . '">' . $img_markup . '</figure><!-- /wp:image -->';
 	}

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -197,16 +197,26 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 
 		$this->assertIsArray( $report );
 		$this->assertSame( 0, $report['quality']['core_html_block_count'] ?? null );
+		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
 		$this->assertStringNotContainsString( '<!-- wp:html -->', $header );
 		$this->assertStringNotContainsString( '<!-- wp:html -->', $footer );
+		$this->assertStringNotContainsString( '<p><a href="#" class="logo"><div', $header );
+		$this->assertStringNotContainsString( '<p><a href="#" class="footer-logo"><div', $footer );
 		$this->assertStringContainsString( 'href="#"', $header );
-		$this->assertStringContainsString( 'class="logo"', $header );
-		$this->assertStringContainsString( 'class="logo-mark"', $header );
+		$this->assertStringContainsString( '"className":"logo"', $header );
+		$this->assertStringContainsString( 'logo-mark', $header );
+		$this->assertStringContainsString( 'class="logo-name"', $header );
 		$this->assertStringContainsString( 'Relay Atlas', $header );
-		$this->assertStringContainsString( 'relay-mark.svg', $header );
+		$this->assertStringContainsString( '/assets/icons/', $header );
 		$this->assertStringContainsString( 'href="#"', $footer );
-		$this->assertStringContainsString( 'class="footer-logo"', $footer );
+		$this->assertStringContainsString( '"className":"footer-logo"', $footer );
+		$this->assertStringContainsString( 'footer-logo-mark', $footer );
 		$this->assertStringContainsString( 'Relay Atlas', $footer );
+		$this->assertStringContainsString( '/assets/icons/', $footer );
+		$this->assertNotEmpty( $report['assets']['svg_icons'] ?? array() );
+		foreach ( $report['assets']['svg_icons'] as $asset ) {
+			$this->assertFileExists( $theme_dir . '/' . ( $asset['path'] ?? '' ) );
+		}
 		$this->assertStringContainsString( '<!-- wp:navigation ', $header );
 		$this->assertStringContainsString( '<!-- wp:navigation ', $footer );
 	}

--- a/tests/fixtures/relay-atlas-logo-anchors/index.html
+++ b/tests/fixtures/relay-atlas-logo-anchors/index.html
@@ -9,8 +9,8 @@
 	<header class="site-header">
 		<div class="header-inner">
 			<a href="#" class="logo">
-				<span class="logo-mark"><img src="assets/relay-mark.svg" alt="" width="14" height="14" decoding="async"></span>
-				Relay Atlas
+				<div class="logo-mark"><svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M12 2 22 20H2Z" fill="currentColor"></path></svg></div>
+				<span class="logo-name">Relay Atlas</span>
 			</a>
 			<nav class="primary-nav" aria-label="Main navigation">
 				<ul>
@@ -31,7 +31,7 @@
 	<footer class="site-footer">
 		<div class="footer-shell">
 			<div class="footer-row">
-				<div><a href="#" class="footer-logo">Relay Atlas</a></div>
+				<div><a href="#" class="footer-logo"><div class="footer-logo-mark"><svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="currentColor"></circle></svg></div>Relay Atlas</a></div>
 				<ul class="footer-links">
 					<li><a href="#features">Features</a></li>
 					<li><a href="#pricing">Pricing</a></li>


### PR DESCRIPTION
## Summary
- Serialize non-phrasing logo anchors in SSI theme parts as valid native group/image/paragraph blocks instead of paragraph-wrapped anchor HTML.
- Preserve logo/footer-logo wrapper classes, logo-mark/footer-logo-mark image classes, logo-name text classes, href clickability, and materialized SVG image assets.
- Extend the Relay Atlas logo fixture to cover header and footer image+text logo anchors without `wp:html` fallback or invalid block reports.

Closes #88.

## Tests
- `homeboy test static-site-importer` passed: 24 tests, 512 assertions.

## h2bc / BFB release chain
- No h2bc or Block Format Bridge dependency changes were needed in this PR.
- This builds on current `main` after #82/#83 and keeps the fix scoped to SSI theme-part conversion.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused SSI converter change and fixture assertions; Chris remains responsible for review and merge.