### PR TITLE
Add URL import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Static Site Importer is a WordPress plugin. It installs [Block Format Bridge](ht
 ## What It Does
 
 - Adds an **Import HTML** button on the **Appearance -> Themes** screen.
-- Accepts pasted HTML, a direct `.html` / `.htm` upload, or a ZIP containing a static-site folder with an `index.html` entry point.
-- Provides a WP-CLI importer for a local HTML entry file; the source file does not need to be named `index.html` unless you want automatic front-page assignment.
+- Accepts pasted HTML, one public HTML URL, a direct `.html` / `.htm` upload, or a ZIP containing a static-site folder with an `index.html` entry point.
+- Provides a WP-CLI importer for a local HTML entry file or one public HTML URL; the local source file does not need to be named `index.html` unless you want automatic front-page assignment.
 - Discovers readable sibling `*.html` files beside the selected entry file and imports them as WordPress pages.
 - Converts static HTML fragments through `bfb_convert( $html, 'html', 'blocks' )`.
 - Stores converted page bodies on the imported WordPress pages as `post_content`.
@@ -30,11 +30,20 @@ The current Composer dependency is [`chubes4/block-format-bridge:^0.7.1`](https:
 ## Admin Usage
 
 1. Open **Appearance -> Themes** and click **Import HTML** beside the standard **Add Theme** button.
-2. Paste a single HTML document, upload a single `.html` / `.htm` file, or upload a ZIP containing a static-site folder with an `index.html` entry point.
+2. Paste a single HTML document, enter a public `http` / `https` URL, upload a single `.html` / `.htm` file, or upload a ZIP containing a static-site folder with an `index.html` entry point.
 3. Optionally provide a theme name and slug.
 4. Leave **Activate imported theme** checked if the generated theme should become active immediately.
 
-The admin path always overwrites an existing generated theme with the same slug. Pasted HTML and direct HTML uploads are copied into a generated upload work directory as `index.html` and imported as a single-page site. ZIP uploads are for multi-page static sites or bundled HTML exports; they are extracted to an upload work directory, the selected `index.html` is used as the entry file, and sibling HTML files from that extracted site directory are imported. The importer does not require the original source model to be a single `index.html`; it needs one selected HTML entry file and imports the sibling HTML pages it can read.
+The admin path always overwrites an existing generated theme with the same slug. Pasted HTML, fetched URL HTML, and direct HTML uploads are copied into a generated upload work directory as `index.html` and imported as a single-page site. ZIP uploads are for multi-page static sites or bundled HTML exports; they are extracted to an upload work directory, the selected `index.html` is used as the entry file, and sibling HTML files from that extracted site directory are imported. The importer does not require the original source model to be a single `index.html`; it needs one selected HTML entry file and imports the sibling HTML pages it can read.
+
+URL intake rules:
+
+- Fetches one URL only; this is not a crawler and does not execute JavaScript.
+- Only `http` and `https` URLs are accepted.
+- Localhost, loopback, link-local, private, and otherwise reserved IP targets are rejected before connecting.
+- Redirect targets are revalidated with the same policy and capped.
+- Requests use a timeout and maximum response size, require an HTML-like content type, and do not forward cookies, authorization headers, or embedded URL credentials.
+- Import reports include source URL, final URL, status code, content type, fetch timestamps, response size, and redirect history.
 
 ZIP intake rules:
 
@@ -51,13 +60,24 @@ wp static-site-importer import-theme /path/to/site/index.html \
   --name="WordPress Is Dead" \
   --activate \
   --overwrite
+
+wp static-site-importer import-theme \
+  --url=https://example.com/ \
+  --slug=example-import \
+  --keep-source \
+  --report=report.json
+
+wp static-site-importer import-url https://example.com/ \
+  --slug=example-import \
+  --keep-source \
+  --report=report.json
 ```
 
 The CLI path imports all readable sibling `*.html` files in the same directory as the provided entry file. The entry file supplies the theme title, shared source chrome, background decoration, styles, and inline scripts; each sibling HTML file supplies a WordPress page body.
 
 `index.html` has special front-page behavior: it becomes the `home` page slug and, when `--activate` is used, is assigned as the site's static front page. If the imported directory has no `index.html`, the pages are still imported, but the importer does not assign `page_on_front` automatically.
 
-By default, source directories are deleted after a successful clean import so generated upload work directories do not accumulate. Sources are preserved when conversion quality checks report issues. Use `--keep-source` with CLI imports when you want to keep the original local source directory after a successful clean import for debugging or development.
+By default, source directories are deleted after a successful clean import so generated upload work directories do not accumulate. Sources are preserved when conversion quality checks report issues. Use `--keep-source` with CLI imports when you want to keep the original local source directory or fetched URL fixture after a successful clean import for debugging or development.
 
 ## Generated Theme Shape
 
@@ -124,6 +144,7 @@ PHP smokes run inside WordPress and load the plugin's bundled Block Format Bridg
 
 ```bash
 wp eval-file tests/smoke-admin-import-html-entry.php
+wp eval-file tests/smoke-url-import-entry.php
 wp eval-file tests/smoke-editor-style-support.php
 wp eval-file tests/smoke-wordpress-is-dead-fixture.php
 ```
@@ -167,7 +188,7 @@ This repo is Homeboy-managed:
 
 - The importer is intentionally static-site-to-block-theme glue. Block Format Bridge owns format conversion; HTML-to-block transform fidelity belongs upstream in BFB/h2bc.
 - The importer currently discovers flat sibling `*.html` files beside the selected entry file; it does not crawl arbitrary nested routes.
-- Admin imports accept pasted HTML, a direct `.html` / `.htm` file, or a ZIP with a root `index.html` or exactly one nested `index.html`; CLI imports take a direct HTML file path.
+- Admin imports accept pasted HTML, one public URL, a direct `.html` / `.htm` file, or a ZIP with a root `index.html` or exactly one nested `index.html`; CLI imports take a direct HTML file path or one public URL.
 - Linked local stylesheets and inline styles are copied into `style.css`; inline scripts are copied into `assets/site.js`. Other asset copying is not a general-purpose crawler yet.
 - Navigation persistence is limited to supported header/footer shapes that can be converted into deterministic `wp_navigation` entities without guessing.
 - External live triage has exercised additional static sites, but the committed first-party fixture is `tests/fixtures/wordpress-is-dead/`.

--- a/includes/class-static-site-importer-admin.php
+++ b/includes/class-static-site-importer-admin.php
@@ -32,7 +32,7 @@ class Static_Site_Importer_Admin {
 	 */
 	public static function register_import_page(): void {
 		add_submenu_page(
-			null,
+			null, // @phpstan-ignore argument.type
 			'Import HTML',
 			'Import HTML',
 			'switch_themes',
@@ -107,7 +107,7 @@ class Static_Site_Importer_Admin {
 				<div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
 			<?php endif; ?>
 
-			<p><?php echo esc_html__( 'Paste HTML, upload a single HTML file, or upload a ZIP for a multi-page static site or bundled HTML export. The importer will convert the HTML into a WordPress block theme using Block Format Bridge.', 'static-site-importer' ); ?></p>
+			<p><?php echo esc_html__( 'Paste HTML, fetch a public URL, upload a single HTML file, or upload a ZIP for a multi-page static site or bundled HTML export. The importer will convert the HTML into a WordPress block theme using Block Format Bridge.', 'static-site-importer' ); ?></p>
 
 			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data">
 				<?php wp_nonce_field( 'static_site_importer_import' ); ?>
@@ -118,7 +118,14 @@ class Static_Site_Importer_Admin {
 						<th scope="row"><label for="static-site-pasted-html"><?php echo esc_html__( 'Paste HTML', 'static-site-importer' ); ?></label></th>
 						<td>
 							<textarea id="static-site-pasted-html" name="static_site_pasted_html" class="large-text code" rows="14" placeholder="<!doctype html>"></textarea>
-							<p class="description"><?php echo esc_html__( 'Use this for one-page HTML copied from an AI builder or template source. Leave empty to import an HTML file or ZIP instead.', 'static-site-importer' ); ?></p>
+							<p class="description"><?php echo esc_html__( 'Use this for one-page HTML copied from an AI builder or template source. Leave empty to fetch a URL, import an HTML file, or import a ZIP instead.', 'static-site-importer' ); ?></p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="static-site-url"><?php echo esc_html__( 'Import from URL', 'static-site-importer' ); ?></label></th>
+						<td>
+							<input type="url" class="regular-text" id="static-site-url" name="static_site_url" placeholder="https://example.com/" />
+							<p class="description"><?php echo esc_html__( 'Fetch one public http/https HTML URL server-side and store it as index.html. Pasted HTML takes precedence when provided; credentials and cookies are never sent.', 'static-site-importer' ); ?></p>
 						</td>
 					</tr>
 					<tr>
@@ -168,15 +175,22 @@ class Static_Site_Importer_Admin {
 		check_admin_referer( 'static_site_importer_import' );
 
 		$pasted_html = isset( $_POST['static_site_pasted_html'] ) ? trim( (string) wp_unslash( $_POST['static_site_pasted_html'] ) ) : '';
-		$html_path   = '' !== $pasted_html ? self::write_pasted_html( $pasted_html ) : self::prepare_uploaded_entry_file();
+		$entry       = '' !== $pasted_html ? array(
+			'html_path' => self::write_pasted_html( $pasted_html ),
+			'metadata'  => array(),
+		) : self::prepare_entry_file();
+		if ( is_wp_error( $entry ) ) {
+			self::redirect_error( $entry->get_error_message() );
+		}
 
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
-			$html_path,
+			$entry['html_path'],
 			array(
-				'name'      => isset( $_POST['theme_name'] ) ? sanitize_text_field( wp_unslash( $_POST['theme_name'] ) ) : '',
-				'slug'      => isset( $_POST['theme_slug'] ) ? sanitize_title( wp_unslash( $_POST['theme_slug'] ) ) : '',
-				'activate'  => ! empty( $_POST['activate'] ),
-				'overwrite' => true,
+				'name'            => isset( $_POST['theme_name'] ) ? sanitize_text_field( wp_unslash( $_POST['theme_name'] ) ) : '',
+				'slug'            => isset( $_POST['theme_slug'] ) ? sanitize_title( wp_unslash( $_POST['theme_slug'] ) ) : '',
+				'activate'        => ! empty( $_POST['activate'] ),
+				'overwrite'       => true,
+				'source_metadata' => $entry['metadata'],
 			)
 		);
 
@@ -196,7 +210,7 @@ class Static_Site_Importer_Admin {
 	 */
 	private static function write_pasted_html( string $html ): string {
 		if ( '' === trim( $html ) ) {
-			self::redirect_error( 'Paste HTML content, upload a single HTML file, or upload a ZIP containing index.html.' );
+			self::redirect_error( 'Paste HTML content, enter a public URL, upload a single HTML file, or upload a ZIP containing index.html.' );
 		}
 
 		$work_dir  = self::create_work_dir();
@@ -211,22 +225,45 @@ class Static_Site_Importer_Admin {
 	}
 
 	/**
-	 * Prepare the uploaded HTML entry file.
+	 * Prepare an HTML entry file from URL, upload, or ZIP intake.
 	 *
-	 * @return string HTML entry path.
+	 * @return array{html_path:string,metadata:array<string,mixed>}|WP_Error
 	 */
-	private static function prepare_uploaded_entry_file(): string {
+	private static function prepare_entry_file() {
 		$work_dir = self::create_work_dir();
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Import nonce verified in handle_import().
+		$url = isset( $_POST['static_site_url'] ) ? trim( (string) wp_unslash( $_POST['static_site_url'] ) ) : '';
+		if ( '' !== $url ) {
+			return self::prepare_url_file( $url, $work_dir );
+		}
+
 		if ( self::has_uploaded_file( 'static_site_html' ) ) {
-			return self::prepare_uploaded_html_file( $work_dir );
+			return array(
+				'html_path' => self::prepare_uploaded_html_file( $work_dir ),
+				'metadata'  => array(),
+			);
 		}
 
 		if ( self::has_uploaded_file( 'static_site_zip' ) ) {
-			return self::prepare_uploaded_zip_file( $work_dir );
+			return array(
+				'html_path' => self::prepare_uploaded_zip_file( $work_dir ),
+				'metadata'  => array(),
+			);
 		}
 
-		self::redirect_error( 'Paste HTML content, upload a single HTML file, or upload a ZIP containing index.html.' );
+		self::redirect_error( 'Paste HTML content, enter a public URL, upload a single HTML file, or upload a ZIP containing index.html.' );
+	}
+
+	/**
+	 * Fetch a URL into an importer work directory.
+	 *
+	 * @param string $url      Source URL.
+	 * @param string $work_dir Importer work directory.
+	 * @return array{html_path:string,metadata:array<string,mixed>}|WP_Error
+	 */
+	private static function prepare_url_file( string $url, string $work_dir ) {
+		return Static_Site_Importer_URL_Fetcher::fetch_to_work_dir( $url, $work_dir );
 	}
 
 	/**

--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -21,8 +21,11 @@ class Static_Site_Importer_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <html-file>
-	 * : Path to index.html.
+	 * [<html-file>]
+	 * : Path to index.html. Optional when --url is provided.
+	 *
+	 * [--url=<url>]
+	 * : Fetch one public http/https HTML URL and import it as index.html. Redirects are validated with SSRF protections before connecting.
 	 *
 	 * [--slug=<slug>]
 	 * : Theme slug.
@@ -56,9 +59,29 @@ class Static_Site_Importer_CLI_Command {
 	 * @return void
 	 */
 	public function import_theme( array $args, array $assoc_args ): void {
-		$html_file = $args[0] ?? '';
+		$html_file       = $args[0] ?? '';
+		$source_metadata = array();
+		if ( isset( $assoc_args['url'] ) && '' !== trim( (string) $assoc_args['url'] ) ) {
+			if ( '' !== $html_file ) {
+				WP_CLI::error( 'Use either <html-file> or --url, not both.' );
+				return;
+			}
+
+			$fetch = Static_Site_Importer_URL_Fetcher::fetch_to_work_dir(
+				(string) $assoc_args['url'],
+				trailingslashit( wp_upload_dir()['basedir'] ) . 'static-site-importer/' . wp_generate_uuid4()
+			);
+			if ( is_wp_error( $fetch ) ) {
+				WP_CLI::error( $fetch->get_error_message() );
+				return;
+			}
+
+			$html_file       = $fetch['html_path'];
+			$source_metadata = $fetch['metadata'];
+		}
+
 		if ( '' === $html_file ) {
-			WP_CLI::error( 'Missing <html-file> argument.' );
+			WP_CLI::error( 'Missing <html-file> argument or --url option.' );
 			return;
 		}
 
@@ -73,6 +96,7 @@ class Static_Site_Importer_CLI_Command {
 				'fail_on_quality' => isset( $assoc_args['fail-on-quality'] ),
 				'max_fallbacks'   => isset( $assoc_args['max-fallbacks'] ) ? (int) $assoc_args['max-fallbacks'] : null,
 				'report'          => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
+				'source_metadata' => $source_metadata,
 			)
 		);
 
@@ -95,6 +119,9 @@ class Static_Site_Importer_CLI_Command {
 		if ( ! empty( $result['source_cleanup_error'] ) ) {
 			WP_CLI::warning( sprintf( 'Source cleanup skipped: %s', $result['source_cleanup_error'] ) );
 		}
+		if ( ! empty( $source_metadata['final_url'] ) ) {
+			WP_CLI::line( sprintf( 'Fetched URL: %s', $source_metadata['final_url'] ) );
+		}
 		WP_CLI::line( sprintf( 'Conversion quality: %s (%d unsupported HTML fallbacks, %d invalid blocks, %d content-loss aborts).', $result['quality']['pass'] ? 'pass' : 'needs review', $result['quality']['fallback_count'], $result['quality']['invalid_block_count'], $result['quality']['content_loss_count'] ) );
 
 		if ( ! $result['quality']['pass'] ) {
@@ -105,5 +132,55 @@ class Static_Site_Importer_CLI_Command {
 			WP_CLI::error( 'Conversion quality gate failed. Theme files were written for inspection.' );
 			return;
 		}
+	}
+
+	/**
+	 * Import one public URL as a block theme.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <url>
+	 * : Public http/https URL to fetch.
+	 *
+	 * [--slug=<slug>]
+	 * : Theme slug.
+	 *
+	 * [--name=<name>]
+	 * : Theme name.
+	 *
+	 * [--activate]
+	 * : Activate the generated theme.
+	 *
+	 * [--overwrite]
+	 * : Overwrite an existing theme directory.
+	 *
+	 * [--keep-source]
+	 * : Preserve the fetched source directory after a successful clean import.
+	 *
+	 * [--fail-on-quality]
+	 * : Exit non-zero when conversion quality checks report fallbacks, invalid blocks, or content loss.
+	 *
+	 * [--max-fallbacks=<count>]
+	 * : Exit non-zero when unsupported HTML fallback count exceeds this threshold.
+	 *
+	 * [--report=<path>]
+	 * : Copy the generated import report JSON to an external archive path.
+	 *
+	 * [--format=<format>]
+	 * : Output format. Use json for machine-readable command output.
+	 *
+	 * @param array<int, string>   $args       Positional args.
+	 * @param array<string, mixed> $assoc_args Associative args.
+	 * @return void
+	 */
+	public function import_url( array $args, array $assoc_args ): void {
+		$url = $args[0] ?? '';
+		if ( '' === trim( $url ) ) {
+			WP_CLI::error( 'Missing <url> argument.' );
+			return;
+		}
+
+		$assoc_args['url'] = $url;
+		$this->import_theme( array(), $assoc_args );
 	}
 }

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -109,7 +109,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		$permalinks              = self::page_permalinks( $page_ids );
 		$fragments               = $document->fragments();
-		self::$conversion_report = self::new_conversion_report( $html_path );
+		self::$conversion_report = self::new_conversion_report( $html_path, isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array() );
 
 		self::$active_theme_dir        = $theme_dir;
 		self::$active_theme_uri        = trailingslashit( get_theme_root_uri( $theme_slug ) ) . $theme_slug;
@@ -1845,10 +1845,16 @@ class Static_Site_Importer_Theme_Generator {
 	 * @param string $html_path Imported entry file.
 	 * @return array<string, mixed>
 	 */
-	private static function new_conversion_report( string $html_path ): array {
+	private static function new_conversion_report( string $html_path, array $source_metadata = array() ): array {
 		return array(
 			'version'              => 1,
 			'entry_file'           => $html_path,
+			'source'               => array_merge(
+				array(
+					'type' => empty( $source_metadata ) ? 'file' : (string) ( $source_metadata['source_type'] ?? 'file' ),
+				),
+				$source_metadata
+			),
 			'quality'              => array(
 				'pass'                              => true,
 				'fallback_count'                    => 0,

--- a/includes/class-static-site-importer-url-fetcher.php
+++ b/includes/class-static-site-importer-url-fetcher.php
@@ -1,0 +1,454 @@
+<?php
+/**
+ * Static URL intake.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Fetches one public HTML URL into an importer work directory.
+ */
+class Static_Site_Importer_URL_Fetcher {
+
+	private const MAX_REDIRECTS         = 5;
+	private const DEFAULT_TIMEOUT       = 10;
+	private const DEFAULT_MAX_BYTES     = 5242880;
+	private const HTML_CONTENT_TYPES    = array( 'text/html', 'application/xhtml+xml' );
+	private const REDIRECT_STATUSES     = array( 301, 302, 303, 307, 308 );
+	private const BODY_READ_CHUNK       = 8192;
+	private const HEADER_MAX_BYTES      = 65536;
+	private const CONNECT_TIMEOUT_FLOOR = 1;
+
+	/**
+	 * Fetch a public HTML URL and write it as index.html.
+	 *
+	 * @param string $url      Source URL.
+	 * @param string $work_dir Importer work directory.
+	 * @param array  $args     Fetch args.
+	 * @return array{html_path:string,metadata:array<string,mixed>}|WP_Error
+	 */
+	public static function fetch_to_work_dir( string $url, string $work_dir, array $args = array() ) {
+		$timeout   = max( self::CONNECT_TIMEOUT_FLOOR, (int) ( $args['timeout'] ?? self::DEFAULT_TIMEOUT ) );
+		$max_bytes = max( 1, (int) ( $args['max_bytes'] ?? self::DEFAULT_MAX_BYTES ) );
+		$current   = trim( $url );
+		$started   = gmdate( 'c' );
+		$redirects = array();
+
+		for ( $attempt = 0; $attempt <= self::MAX_REDIRECTS; $attempt++ ) {
+			$validation = self::validate_url( $current );
+			if ( is_wp_error( $validation ) ) {
+				return $validation;
+			}
+
+			$response = self::request_once( $validation, $timeout, $max_bytes );
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			$status = (int) $response['status_code'];
+			if ( in_array( $status, self::REDIRECT_STATUSES, true ) ) {
+				$location = self::first_header( $response['headers'], 'location' );
+				if ( '' === $location ) {
+					return new WP_Error( 'static_site_importer_url_redirect_missing_location', 'The URL returned a redirect without a Location header.' );
+				}
+
+				if ( $attempt >= self::MAX_REDIRECTS ) {
+					return new WP_Error( 'static_site_importer_url_redirect_limit', 'The URL exceeded the redirect limit.' );
+				}
+
+				$next_url = self::resolve_redirect_url( $current, $location );
+				if ( is_wp_error( $next_url ) ) {
+					return $next_url;
+				}
+
+				$redirects[] = array(
+					'from'        => $current,
+					'to'          => $next_url,
+					'status_code' => $status,
+				);
+				$current     = $next_url;
+				continue;
+			}
+
+			if ( $status < 200 || $status >= 300 ) {
+				return new WP_Error( 'static_site_importer_url_http_status', sprintf( 'The URL returned HTTP status %d.', $status ) );
+			}
+
+			$content_type = self::first_header( $response['headers'], 'content-type' );
+			if ( ! self::is_html_content_type( $content_type ) ) {
+				return new WP_Error( 'static_site_importer_url_non_html', 'The URL did not return an HTML content type.' );
+			}
+
+			if ( '' === trim( $response['body'] ) ) {
+				return new WP_Error( 'static_site_importer_url_empty_body', 'The URL returned an empty HTML response.' );
+			}
+
+			wp_mkdir_p( $work_dir );
+			$html_path = trailingslashit( $work_dir ) . 'index.html';
+			$written   = file_put_contents( $html_path, $response['body'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writes fetched static HTML to the importer source fixture.
+			if ( false === $written ) {
+				return new WP_Error( 'static_site_importer_url_write_failed', 'Failed to write fetched HTML to the import work directory.' );
+			}
+
+			return array(
+				'html_path' => $html_path,
+				'metadata'  => array(
+					'source_type'     => 'url',
+					'source_url'      => $url,
+					'final_url'       => $current,
+					'status_code'     => $status,
+					'content_type'    => $content_type,
+					'fetch_started'   => $started,
+					'fetch_completed' => gmdate( 'c' ),
+					'bytes'           => strlen( $response['body'] ),
+					'redirects'       => $redirects,
+				),
+			);
+		}
+
+		return new WP_Error( 'static_site_importer_url_redirect_limit', 'The URL exceeded the redirect limit.' );
+	}
+
+	/**
+	 * Validate a URL before connecting.
+	 *
+	 * @param string $url URL.
+	 * @return array{url:string,scheme:string,host:string,port:int,path:string,ips:array<int,string>}|WP_Error
+	 */
+	public static function validate_url( string $url ) {
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) ) {
+			return new WP_Error( 'static_site_importer_url_invalid', 'Enter a valid URL.' );
+		}
+
+		$scheme = strtolower( (string) ( $parts['scheme'] ?? '' ) );
+		if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+			return new WP_Error( 'static_site_importer_url_scheme', 'Only http and https URLs are supported.' );
+		}
+
+		if ( isset( $parts['user'] ) || isset( $parts['pass'] ) ) {
+			return new WP_Error( 'static_site_importer_url_credentials', 'URLs with embedded credentials are not supported.' );
+		}
+
+		$host = strtolower( trim( (string) ( $parts['host'] ?? '' ), "[] \t\n\r\0\x0B" ) );
+		if ( '' === $host || 'localhost' === $host || str_ends_with( $host, '.localhost' ) ) {
+			return new WP_Error( 'static_site_importer_url_host', 'Localhost URLs are not supported.' );
+		}
+
+		$port = isset( $parts['port'] ) ? (int) $parts['port'] : ( 'https' === $scheme ? 443 : 80 );
+
+		$ips = self::resolve_host_ips( $host );
+		if ( is_wp_error( $ips ) ) {
+			return $ips;
+		}
+
+		foreach ( $ips as $ip ) {
+			if ( ! self::is_public_ip( $ip ) ) {
+				return new WP_Error( 'static_site_importer_url_private_ip', 'The URL resolves to a private, loopback, link-local, or otherwise reserved IP address.' );
+			}
+		}
+
+		$path = (string) ( $parts['path'] ?? '/' );
+		if ( '' === $path ) {
+			$path = '/';
+		}
+		if ( isset( $parts['query'] ) && '' !== (string) $parts['query'] ) {
+			$path .= '?' . (string) $parts['query'];
+		}
+
+		return array(
+			'url'    => $url,
+			'scheme' => $scheme,
+			'host'   => $host,
+			'port'   => $port,
+			'path'   => $path,
+			'ips'    => array_values( $ips ),
+		);
+	}
+
+	/**
+	 * Perform one HTTP request to a prevalidated target.
+	 *
+	 * @param array $target    Validated target.
+	 * @param int   $timeout   Timeout in seconds.
+	 * @param int   $max_bytes Maximum response body size.
+	 * @return array{status_code:int,headers:array<string,array<int,string>>,body:string}|WP_Error
+	 */
+	private static function request_once( array $target, int $timeout, int $max_bytes ) {
+		$last_error = '';
+		foreach ( $target['ips'] as $ip ) {
+			$response = self::request_ip( $target, $ip, $timeout, $max_bytes );
+			if ( ! is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			$last_error = $response->get_error_message();
+		}
+
+		return new WP_Error( 'static_site_importer_url_connect_failed', '' !== $last_error ? $last_error : 'Could not connect to the URL.' );
+	}
+
+	/**
+	 * Perform one HTTP request to a resolved IP.
+	 *
+	 * @param array  $target    Validated target.
+	 * @param string $ip        Resolved public IP.
+	 * @param int    $timeout   Timeout in seconds.
+	 * @param int    $max_bytes Maximum response body size.
+	 * @return array{status_code:int,headers:array<string,array<int,string>>,body:string}|WP_Error
+	 */
+	private static function request_ip( array $target, string $ip, int $timeout, int $max_bytes ) {
+		$remote = sprintf( 'tcp://%s:%d', str_contains( $ip, ':' ) ? '[' . $ip . ']' : $ip, $target['port'] );
+		$errno  = 0;
+		$errstr = '';
+		$socket = stream_socket_client( $remote, $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT );
+		if ( false === $socket ) {
+			return new WP_Error( 'static_site_importer_url_connect_failed', sprintf( 'Could not connect to %s: %s', $target['host'], $errstr ) );
+		}
+
+		stream_set_timeout( $socket, $timeout );
+		if ( 'https' === $target['scheme'] ) {
+			stream_context_set_option( $socket, 'ssl', 'SNI_enabled', true );
+			stream_context_set_option( $socket, 'ssl', 'peer_name', $target['host'] );
+			stream_context_set_option( $socket, 'ssl', 'verify_peer', true );
+			stream_context_set_option( $socket, 'ssl', 'verify_peer_name', true );
+
+			if ( ! stream_socket_enable_crypto( $socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT ) ) {
+				fclose( $socket ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes a validated public HTTP socket, not a filesystem handle.
+				return new WP_Error( 'static_site_importer_url_tls_failed', 'Could not establish a verified TLS connection to the URL.' );
+			}
+		}
+
+		$host_header  = $target['host'];
+		$default_port = 'https' === $target['scheme'] ? 443 : 80;
+		if ( $target['port'] !== $default_port ) {
+			$host_header .= ':' . $target['port'];
+		}
+
+		$request = 'GET ' . $target['path'] . " HTTP/1.1\r\n"
+			. 'Host: ' . $host_header . "\r\n"
+			. 'User-Agent: StaticSiteImporter/1.0' . "\r\n"
+			. 'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.1' . "\r\n"
+			. "Connection: close\r\n\r\n";
+		fwrite( $socket, $request ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- Writes an HTTP request to a validated public socket.
+
+		$raw = '';
+		while ( ! feof( $socket ) ) {
+			$raw .= fread( $socket, self::BODY_READ_CHUNK ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread -- Reads a bounded HTTP response from a validated public socket.
+			if ( strlen( $raw ) > $max_bytes + self::HEADER_MAX_BYTES ) {
+				fclose( $socket ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes a validated public HTTP socket, not a filesystem handle.
+				return new WP_Error( 'static_site_importer_url_too_large', 'The URL response exceeded the maximum allowed size.' );
+			}
+		}
+
+		$meta = stream_get_meta_data( $socket );
+		fclose( $socket ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes a validated public HTTP socket, not a filesystem handle.
+		if ( ! empty( $meta['timed_out'] ) ) {
+			return new WP_Error( 'static_site_importer_url_timeout', 'The URL request timed out.' );
+		}
+
+		$separator = strpos( $raw, "\r\n\r\n" );
+		if ( false === $separator ) {
+			return new WP_Error( 'static_site_importer_url_malformed_response', 'The URL returned a malformed HTTP response.' );
+		}
+
+		$header_block = substr( $raw, 0, $separator );
+		$body         = substr( $raw, $separator + 4 );
+		if ( strlen( $body ) > $max_bytes ) {
+			return new WP_Error( 'static_site_importer_url_too_large', 'The URL response exceeded the maximum allowed size.' );
+		}
+
+		return self::parse_response( $header_block, $body );
+	}
+
+	/**
+	 * Parse an HTTP response.
+	 *
+	 * @param string $header_block Raw response headers.
+	 * @param string $body         Raw response body.
+	 * @return array{status_code:int,headers:array<string,array<int,string>>,body:string}|WP_Error
+	 */
+	private static function parse_response( string $header_block, string $body ) {
+		$lines = preg_split( "/\r\n|\n|\r/", $header_block );
+		if ( ! is_array( $lines ) ) {
+			return new WP_Error( 'static_site_importer_url_malformed_response', 'The URL returned malformed HTTP headers.' );
+		}
+
+		$status_line = (string) array_shift( $lines );
+		if ( ! preg_match( '/^HTTP\/\d(?:\.\d)?\s+(\d{3})\b/', $status_line, $matches ) ) {
+			return new WP_Error( 'static_site_importer_url_malformed_response', 'The URL returned a malformed HTTP status line.' );
+		}
+
+		$headers = array();
+		foreach ( $lines as $line ) {
+			if ( ! str_contains( $line, ':' ) ) {
+				continue;
+			}
+
+			list( $name, $value ) = explode( ':', $line, 2 );
+			$name                 = strtolower( trim( $name ) );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$headers[ $name ][] = trim( $value );
+		}
+
+		return array(
+			'status_code' => (int) $matches[1],
+			'headers'     => $headers,
+			'body'        => self::decode_body( $headers, $body ),
+		);
+	}
+
+	/**
+	 * Decode simple transfer encodings.
+	 *
+	 * @param array<string,array<int,string>> $headers Headers.
+	 * @param string                          $body    Body.
+	 * @return string
+	 */
+	private static function decode_body( array $headers, string $body ): string {
+		$encoding = strtolower( self::first_header( $headers, 'transfer-encoding' ) );
+		if ( str_contains( $encoding, 'chunked' ) ) {
+			$decoded = '';
+			$offset  = 0;
+			while ( true ) {
+				$line_end = strpos( $body, "\r\n", $offset );
+				if ( false === $line_end ) {
+					return $body;
+				}
+
+				$size = (int) hexdec( trim( substr( $body, $offset, $line_end - $offset ) ) );
+				if ( 0 === $size ) {
+					return $decoded;
+				}
+
+				$offset   = $line_end + 2;
+				$decoded .= substr( $body, $offset, $size );
+				$offset  += $size + 2;
+			}
+		}
+
+		return $body;
+	}
+
+	/**
+	 * Resolve a host and return all A/AAAA records.
+	 *
+	 * @param string $host Host.
+	 * @return array<int,string>|WP_Error
+	 */
+	private static function resolve_host_ips( string $host ) {
+		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			return array( $host );
+		}
+
+		$ips = array();
+		if ( function_exists( 'dns_get_record' ) ) {
+			$records = dns_get_record( $host, DNS_A + DNS_AAAA );
+			if ( is_array( $records ) ) {
+				foreach ( $records as $record ) {
+					if ( isset( $record['ip'] ) ) {
+						$ips[] = (string) $record['ip'];
+					}
+					if ( isset( $record['ipv6'] ) ) {
+						$ips[] = (string) $record['ipv6'];
+					}
+				}
+			}
+		}
+
+		if ( ! $ips ) {
+			$records = gethostbynamel( $host );
+			if ( is_array( $records ) ) {
+				$ips = $records;
+			}
+		}
+
+		$ips = array_values( array_unique( array_filter( $ips, static fn ( string $ip ): bool => (bool) filter_var( $ip, FILTER_VALIDATE_IP ) ) ) );
+		if ( ! $ips ) {
+			return new WP_Error( 'static_site_importer_url_dns_failed', 'The URL host could not be resolved.' );
+		}
+
+		return $ips;
+	}
+
+	/**
+	 * Determine whether an IP is public internet routable.
+	 *
+	 * @param string $ip IP address.
+	 * @return bool
+	 */
+	private static function is_public_ip( string $ip ): bool {
+		return (bool) filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
+	}
+
+	/**
+	 * Resolve redirect locations relative to the current URL.
+	 *
+	 * @param string $base_url Current URL.
+	 * @param string $location Redirect Location header.
+	 * @return string|WP_Error
+	 */
+	private static function resolve_redirect_url( string $base_url, string $location ) {
+		$location = trim( $location );
+		if ( '' === $location ) {
+			return new WP_Error( 'static_site_importer_url_redirect_missing_location', 'The URL returned an empty redirect Location header.' );
+		}
+
+		if ( preg_match( '/^[a-z][a-z0-9+.-]*:/i', $location ) ) {
+			return $location;
+		}
+
+		$base = wp_parse_url( $base_url );
+		if ( ! is_array( $base ) || empty( $base['scheme'] ) || empty( $base['host'] ) ) {
+			return new WP_Error( 'static_site_importer_url_redirect_invalid_base', 'The redirect base URL is invalid.' );
+		}
+
+		if ( str_starts_with( $location, '//' ) ) {
+			return strtolower( (string) $base['scheme'] ) . ':' . $location;
+		}
+
+		$origin = strtolower( (string) $base['scheme'] ) . '://' . (string) $base['host'];
+		if ( isset( $base['port'] ) ) {
+			$origin .= ':' . (int) $base['port'];
+		}
+
+		if ( str_starts_with( $location, '/' ) ) {
+			return $origin . $location;
+		}
+
+		$path = isset( $base['path'] ) ? (string) $base['path'] : '/';
+		$dir  = preg_replace( '#/[^/]*$#', '/', $path );
+
+		return $origin . ( '' !== $dir ? $dir : '/' ) . $location;
+	}
+
+	/**
+	 * Read the first matching header.
+	 *
+	 * @param array<string,array<int,string>> $headers Headers.
+	 * @param string                          $name    Header name.
+	 * @return string
+	 */
+	private static function first_header( array $headers, string $name ): string {
+		$name = strtolower( $name );
+		return isset( $headers[ $name ][0] ) ? (string) $headers[ $name ][0] : '';
+	}
+
+	/**
+	 * Determine whether a Content-Type is HTML.
+	 *
+	 * @param string $content_type Content-Type header.
+	 * @return bool
+	 */
+	private static function is_html_content_type( string $content_type ): bool {
+		$type = strtolower( trim( explode( ';', $content_type )[0] ) );
+		return in_array( $type, self::HTML_CONTENT_TYPES, true ) || str_ends_with( $type, '+html' );
+	}
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -23,6 +23,7 @@ if ( is_readable( STATIC_SITE_IMPORTER_PATH . 'vendor/autoload.php' ) ) {
 }
 
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-fetcher.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-generator.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-admin.php';
 

--- a/tests/smoke-admin-import-html-entry.php
+++ b/tests/smoke-admin-import-html-entry.php
@@ -36,6 +36,8 @@ $assert( ! str_contains( $source, 'Import Static Site' ), 'old-import-static-sit
 $assert( str_contains( $source, 'Import HTML' ), 'import-html-label-present' );
 $assert( str_contains( $source, 'HTML ZIP' ), 'zip-field-label-renamed' );
 $assert( str_contains( $source, 'name="static_site_pasted_html"' ), 'paste-html-textarea-present' );
+$assert( str_contains( $source, 'name="static_site_url"' ), 'url-input-present' );
+$assert( str_contains( $source, 'Static_Site_Importer_URL_Fetcher::fetch_to_work_dir' ), 'admin-url-fetcher-used' );
 $assert( str_contains( $source, 'write_pasted_html' ), 'paste-html-write-helper-present' );
 $assert( str_contains( $source, 'name="static_site_html"' ), 'single-html-upload-field-present' );
 $assert( str_contains( $source, 'accept=".html,.htm"' ), 'single-html-upload-accepts-html' );
@@ -43,12 +45,13 @@ $assert( str_contains( $source, 'name="static_site_zip"' ), 'zip-upload-field-pr
 $assert( ! str_contains( $source, 'name="static_site_zip" accept=".zip" required' ), 'zip-upload-not-required' );
 $assert( str_contains( $source, "has_uploaded_file( 'static_site_html' )" ), 'html-upload-preferred-before-zip' );
 $assert( str_contains( $source, "has_uploaded_file( 'static_site_zip' )" ), 'zip-upload-fallback-present' );
+$assert( strpos( $source, "isset( $" . "_POST['static_site_url'] )" ) < strpos( $source, "has_uploaded_file( 'static_site_html' )" ), 'url-precedes-html-upload' );
 $assert( strpos( $source, "has_uploaded_file( 'static_site_html' )" ) < strpos( $source, "has_uploaded_file( 'static_site_zip' )" ), 'html-upload-precedes-zip-fallback' );
 $assert( str_contains( $source, "in_array( $" . "ext, array( 'html', 'htm' ), true )" ), 'html-extension-validation-present' );
 $assert( str_contains( $source, "'index.html'" ), 'admin-intake-stores-index-html' );
 $assert( str_contains( $source, 'prepare_uploaded_zip_file' ), 'zip-import-helper-present' );
 $assert( str_contains( $source, 'find_index_html' ), 'zip-index-discovery-preserved' );
-$assert( str_contains( $source, 'Paste HTML content, upload a single HTML file, or upload a ZIP containing index.html.' ), 'empty-intake-validation-message-present' );
+$assert( str_contains( $source, 'Paste HTML content, enter a public URL, upload a single HTML file, or upload a ZIP containing index.html.' ), 'empty-intake-validation-message-present' );
 $assert( str_contains( $source, 'multi-page static site or bundled HTML export' ), 'zip-copy-explains-bundle-contract' );
 $assert( str_contains( $source, 'validate_zip_archive' ), 'zip-archive-validation-method-exists' );
 $assert( str_contains( $source, "class_exists( 'ZipArchive' )" ), 'ziparchive-inspection-is-conditional' );

--- a/tests/smoke-url-import-entry.php
+++ b/tests/smoke-url-import-entry.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Smoke test: URL intake exposes CLI/admin hooks and SSRF rejection basics.
+ *
+ * Run from the repository root:
+ * php tests/smoke-url-import-entry.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+
+		public function __construct( string $code, string $message ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( string $url ) {
+		return parse_url( $url );
+	}
+}
+
+$root    = dirname( __DIR__ );
+$fetcher = file_get_contents( $root . '/includes/class-static-site-importer-url-fetcher.php' );
+$cli     = file_get_contents( $root . '/includes/class-static-site-importer-cli-command.php' );
+$admin   = file_get_contents( $root . '/includes/class-static-site-importer-admin.php' );
+
+if ( false === $fetcher || false === $cli || false === $admin ) {
+	fwrite( STDERR, "FAIL [source-readable]\n" );
+	exit( 1 );
+}
+
+require_once $root . '/includes/class-static-site-importer-url-fetcher.php';
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$assert_error = static function ( string $url, string $code ) use ( $assert ): void {
+	$result = Static_Site_Importer_URL_Fetcher::validate_url( $url );
+	$assert( is_wp_error( $result ), 'url-rejected-' . $code, $url );
+	if ( is_wp_error( $result ) ) {
+		$assert( $code === $result->get_error_code(), 'url-rejected-code-' . $code, $result->get_error_code() );
+	}
+};
+
+$assert( str_contains( $fetcher, "array( 'http', 'https' )" ), 'http-https-only' );
+$assert( str_contains( $fetcher, 'FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE' ), 'private-reserved-ip-filter-present' );
+$assert( str_contains( $fetcher, 'stream_socket_client' ), 'connects-to-validated-ip' );
+$assert( str_contains( $fetcher, 'Cookie' ) === false, 'no-cookie-forwarding' );
+$assert( str_contains( $fetcher, 'Authorization' ) === false, 'no-authorization-forwarding' );
+$assert( str_contains( $fetcher, 'MAX_REDIRECTS' ), 'redirect-limit-present' );
+$assert( str_contains( $fetcher, 'DEFAULT_MAX_BYTES' ), 'max-response-size-present' );
+$assert( str_contains( $fetcher, 'text/html' ), 'html-content-type-required' );
+$assert( str_contains( $cli, '[--url=<url>]' ), 'cli-import-theme-url-option-present' );
+$assert( str_contains( $cli, 'public function import_url' ), 'cli-import-url-subcommand-present' );
+$assert( str_contains( $admin, 'name="static_site_url"' ), 'admin-url-field-present' );
+$assert( str_contains( $admin, "'source_metadata' => $" . "entry['metadata']" ), 'admin-passes-source-metadata' );
+
+$assert_error( 'ftp://example.com/', 'static_site_importer_url_scheme' );
+$assert_error( 'https://user:pass@example.com/', 'static_site_importer_url_credentials' );
+$assert_error( 'http://localhost/', 'static_site_importer_url_host' );
+$assert_error( 'http://127.0.0.1/', 'static_site_importer_url_private_ip' );
+$assert_error( 'http://169.254.169.254/', 'static_site_importer_url_private_ip' );
+$assert_error( 'http://10.0.0.1/', 'static_site_importer_url_private_ip' );
+$assert_error( 'http://[::1]/', 'static_site_importer_url_private_ip' );
+
+$public = Static_Site_Importer_URL_Fetcher::validate_url( 'http://93.184.216.34/' );
+$assert( ! is_wp_error( $public ), 'public-url-validates', is_wp_error( $public ) ? $public->get_error_message() : '' );
+if ( ! is_wp_error( $public ) ) {
+	$assert( 'http' === $public['scheme'], 'public-url-scheme' );
+	$assert( '93.184.216.34' === $public['host'], 'public-url-host' );
+	$assert( '/' === $public['path'], 'public-url-path' );
+	$assert( ! empty( $public['ips'] ), 'public-url-resolves' );
+}
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: URL import entry smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Add first-class single-URL intake for WP-CLI and the admin Import HTML screen while preserving paste, local HTML, and ZIP paths.
- Fetch public HTML into a generated source fixture as `index.html`, pass source metadata into `import-report.json`, and document the URL intake contract.
- Add SSRF protections for URL validation, redirect validation, public IP enforcement, response timeout/size limits, HTML content-type checks, and no credential/cookie forwarding.

## Testing
- `php -l static-site-importer.php && php -l includes/class-static-site-importer-url-fetcher.php && php -l includes/class-static-site-importer-cli-command.php && php -l includes/class-static-site-importer-admin.php && php -l includes/class-static-site-importer-theme-generator.php && php -l tests/smoke-url-import-entry.php && php -l tests/smoke-admin-import-html-entry.php`
- `php tests/smoke-admin-import-html-entry.php && php tests/smoke-url-import-entry.php`
- `studio wp eval-file /Users/chubes/Developer/static-site-importer@feature-import-from-url/tests/smoke-admin-import-html-entry.php && studio wp eval-file /Users/chubes/Developer/static-site-importer@feature-import-from-url/tests/smoke-url-import-entry.php`
- `homeboy lint static-site-importer --path /Users/chubes/Developer/static-site-importer@feature-import-from-url --changed-only --errors-only`
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@feature-import-from-url`
- Live fetch smoke: `Static_Site_Importer_URL_Fetcher::fetch_to_work_dir( 'https://wordpress.org/', ... )` returned HTTP 200 `text/html; charset=UTF-8` and wrote `index.html` (169205 bytes).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the URL intake implementation, SSRF validation helpers, CLI/admin wiring, docs, and smoke coverage; Chris remains responsible for review and testing.