### PR TITLE
Use semantic main for page body conversion

### DIFF
--- a/includes/class-static-site-importer-document.php
+++ b/includes/class-static-site-importer-document.php
@@ -149,6 +149,7 @@ class Static_Site_Importer_Document {
 		$header = $this->first_plausible_global_header( $root );
 		$nav    = $this->first_plausible_global_nav( $root, $header );
 		$footer = $this->first_element( 'footer' );
+		$main   = $this->first_element( 'main' );
 
 		$header_parts = array();
 		if ( $nav instanceof DOMElement && $header instanceof DOMElement && $this->is_leading_sibling( $root, $nav, $header ) ) {
@@ -167,6 +168,7 @@ class Static_Site_Importer_Document {
 
 		$main_parts = array();
 		$background = array();
+		$main_html  = $main instanceof DOMElement ? $this->inner_html( $main ) : '';
 
 		foreach ( iterator_to_array( $root->childNodes ) as $child ) {
 			if ( ! $child instanceof DOMElement ) {
@@ -178,7 +180,7 @@ class Static_Site_Importer_Document {
 				continue;
 			}
 
-			if ( $this->same_node( $child, $nav ) || $this->same_node( $child, $header ) || $this->same_node( $child, $footer ) ) {
+			if ( $this->same_node( $child, $nav ) || $this->same_node( $child, $header ) || $this->same_node( $child, $footer ) || $this->same_node( $child, $main ) ) {
 				continue;
 			}
 
@@ -187,13 +189,15 @@ class Static_Site_Importer_Document {
 				continue;
 			}
 
-			$main_parts[] = $this->outer_html( $child );
+			if ( ! $main instanceof DOMElement ) {
+				$main_parts[] = $this->outer_html( $child );
+			}
 		}
 
 		return array(
 			'background' => trim( implode( "\n", $background ) ),
 			'header'     => trim( $header_html ),
-			'main'       => trim( implode( "\n", $main_parts ) ),
+			'main'       => trim( $main instanceof DOMElement ? $main_html : implode( "\n", $main_parts ) ),
 			'footer'     => trim( $footer_html ),
 		);
 	}
@@ -327,6 +331,21 @@ class Static_Site_Importer_Document {
 	private function outer_html( DOMNode $node ): string {
 		$html = $this->dom->saveHTML( $node );
 		return false === $html ? '' : $html;
+	}
+
+	/**
+	 * Serialize a DOM element's child nodes.
+	 *
+	 * @param DOMElement $element Element.
+	 * @return string
+	 */
+	private function inner_html( DOMElement $element ): string {
+		$html = array();
+		foreach ( iterator_to_array( $element->childNodes ) as $child ) {
+			$html[] = $this->outer_html( $child );
+		}
+
+		return implode( '', $html );
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -463,6 +463,54 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Semantic main content is the page body when document-level chrome surrounds it.
+	 */
+	public function test_semantic_main_content_becomes_page_body_without_stray_chrome(): void {
+		$html_path = $this->write_temp_fixture(
+			'semantic-main-page-body.html',
+			'<!doctype html><html><head><title>Semantic Main Page Body</title></head><body>' .
+			'<svg aria-hidden="true" class="hidden"><symbol id="chrome-icon"><path d="M0 0h1v1H0z"></path></symbol></svg>' .
+			'<noscript><iframe src="https://example.com/tracker" title="Body Noscript Tracker"></iframe></noscript>' .
+			'<header class="site-header"><nav><a href="#story">Story</a></nav><button>Header Search</button></header>' .
+			'<div class="utility-chrome">Utility Sidebar</div>' .
+			'<main><section id="story" class="story-grid"><h1>Main Story</h1><p>Main copy only.</p></section></main>' .
+			'<footer><p>Footer Chrome</p></footer>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Semantic Main Page Body',
+				'slug'      => 'semantic-main-page-body',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$pattern   = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-semantic-main-page-body.php' ) );
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+		$footer    = $this->read_file( $theme_dir . '/parts/footer.html' );
+		$post      = get_post( $result['pages']['semantic-main-page-body.html'] ?? 0 );
+
+		$this->assertInstanceOf( WP_Post::class, $post );
+		$this->assertStringContainsString( 'Main Story', $pattern );
+		$this->assertStringContainsString( 'Main copy only.', $pattern );
+		$this->assertStringContainsString( 'story-grid', $pattern );
+		$this->assertStringNotContainsString( 'Body Noscript Tracker', $pattern );
+		$this->assertStringNotContainsString( 'Header Search', $pattern );
+		$this->assertStringNotContainsString( 'Utility Sidebar', $pattern );
+		$this->assertStringNotContainsString( 'chrome-icon', $pattern );
+		$this->assertStringContainsString( 'Header Search', $header );
+		$this->assertStringContainsString( 'Footer Chrome', $footer );
+		$this->assertSame( trim( $pattern ), trim( $post->post_content ) );
+	}
+
+	/**
 	 * Source button styles are moved to the inner link without restyling the core/button wrapper.
 	 */
 	public function test_source_button_class_styles_do_not_double_apply_to_core_button_wrapper(): void {


### PR DESCRIPTION
## Summary
- Prefer a document's semantic `<main>` children for imported page post content and page patterns.
- Keep existing body-walk behavior as the fallback when no semantic `<main>` exists.
- Add focused fixture coverage proving body-level SVG/noscript/utility chrome stays out of page content while header/footer extraction still works.

Fixes #94.

## Test evidence
- `php -l includes/class-static-site-importer-document.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `homeboy test --path /Users/chubes/Developer/static-site-importer@fix-semantic-main-page-body` — 26 passed, 0 failed
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-semantic-main-page-body/tests/smoke-wordpress-is-dead-fixture.php` — 266 assertions passed
- `node tests/run-validation-harness.cjs` — full validation harness passed, including JS block validation

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the SSI segmentation fix and focused regression coverage; Chris to review and validate before merge.