### PR TITLE
Emit semantic fidelity import targets

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -181,6 +181,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		self::analyze_generated_theme_block_documents( $writes, $theme_dir );
 		self::record_visual_fidelity_targets( $pages, $page_ids, $permalinks, $writes, $theme_dir );
+		self::record_semantic_fidelity_targets( $pages, $page_ids, $permalinks, $writes, $theme_dir );
 		$quality     = self::finalize_quality_report( $args );
 		$report_json = wp_json_encode( self::$conversion_report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 		if ( false === $report_json ) {
@@ -2364,11 +2365,20 @@ class Static_Site_Importer_Theme_Generator {
 					'Static Site Importer records source and generated DOM probes, render URLs, and theme artifacts for visual comparison; screenshot capture and computed-style/layout thresholds belong to the benchmark harness.',
 				),
 			),
+			'semantic_fidelity'    => array(
+				'status'             => 'requires_external_render_check',
+				'gate_owner'         => 'benchmark_harness',
+				'comparison_targets' => array(),
+				'notes'              => array(
+					'Static Site Importer records source/generated semantic comparison targets; browser DOM extraction and semantic fingerprint comparison belong to the benchmark harness.',
+				),
+			),
 			'diagnostics'          => array(),
 			'notes'                => array(
 				'Block Format Bridge owns HTML-to-block transform fidelity; Static Site Importer records converter diagnostics and quality gates the generated theme.',
 				'Generated-theme block validation uses WordPress server-side block parsing and serialization checks; editor-runtime validation remains the exact Gutenberg authority.',
 				'Visual fidelity requires browser rendering; use visual_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
+				'Semantic fidelity requires browser DOM extraction; use semantic_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
 			),
 		);
 	}
@@ -2435,6 +2445,117 @@ class Static_Site_Importer_Theme_Generator {
 				),
 			);
 		}
+	}
+
+	/**
+	 * Record source/generated targets for external semantic fidelity gates.
+	 *
+	 * @param array<string, array{path:string,document:Static_Site_Importer_Document}> $pages      Imported pages.
+	 * @param array<string, int>                                                       $page_ids   Page IDs keyed by source filename.
+	 * @param array<string, string>                                                    $permalinks Page permalinks keyed by source filename.
+	 * @param array<string, string>                                                    $writes     Generated files keyed by absolute path.
+	 * @param string                                                                   $theme_dir  Generated theme directory.
+	 * @return void
+	 */
+	private static function record_semantic_fidelity_targets( array $pages, array $page_ids, array $permalinks, array $writes, string $theme_dir ): void {
+		$theme_prefix = trailingslashit( $theme_dir );
+		$theme_parts  = self::generated_semantic_theme_parts( $writes, $theme_prefix );
+
+		foreach ( $pages as $filename => $page ) {
+			$source_html = self::read_visual_probe_file( $page['path'] );
+			$slug        = self::page_slug( $filename );
+			$template    = '' === $slug ? '' : 'templates/page-' . $slug . '.html';
+			$pattern     = '' === $slug ? '' : 'patterns/page-' . $slug . '.php';
+			$generated   = self::generated_visual_probe_markup( $writes, $theme_prefix, $pattern );
+
+			self::$conversion_report['semantic_fidelity']['comparison_targets'][] = array(
+				'source_file'            => $page['path'],
+				'source_filename'        => $filename,
+				'wordpress_page_id'      => $page_ids[ $filename ] ?? null,
+				'wordpress_url'          => $permalinks[ $filename ] ?? '',
+				'generated_template'     => $template,
+				'generated_pattern'      => $pattern,
+				'generated_theme_parts'  => $theme_parts,
+				'generated_files'        => array_values( array_filter( array_merge( array( $template, $pattern ), $theme_parts ) ) ),
+				'regions'                => self::semantic_regions( $source_html, $generated ),
+				'semantic_selectors'     => self::semantic_selectors(),
+				'comparison_hooks'       => array(
+					'landmarks' => array( 'header', 'nav', 'main', 'footer', '[role=banner]', '[role=navigation]', '[role=main]', '[role=contentinfo]' ),
+					'actions'   => array( 'a', 'button', '[role=button]', '.wp-block-button__link' ),
+					'identity'  => array( '[class*=brand]', '[class*=logo]', '[class*=wordmark]', 'img[alt*=logo i]', 'svg[aria-label*=logo i]' ),
+					'sections'  => array( '[class*=nav]', '[class*=footer]', '[class*=header]', '[class*=card]', '[class*=cta]', '[class*=status]' ),
+				),
+			);
+		}
+	}
+
+	/**
+	 * Generated theme parts that contribute shared page semantics.
+	 *
+	 * @param array<string, string> $writes       Generated files keyed by absolute path.
+	 * @param string                $theme_prefix Absolute theme directory with trailing slash.
+	 * @return array<int, string>
+	 */
+	private static function generated_semantic_theme_parts( array $writes, string $theme_prefix ): array {
+		$parts = array();
+		foreach ( array( 'parts/header.html', 'parts/footer.html' ) as $relative_path ) {
+			if ( isset( $writes[ $theme_prefix . $relative_path ] ) ) {
+				$parts[] = $relative_path;
+			}
+		}
+
+		return $parts;
+	}
+
+	/**
+	 * Broad semantic regions present in either source or generated markup.
+	 *
+	 * @param string $source_html Source HTML.
+	 * @param string $generated   Generated block markup.
+	 * @return array<int, string>
+	 */
+	private static function semantic_regions( string $source_html, string $generated ): array {
+		$regions = array();
+		$markup  = $source_html . "\n" . $generated;
+		foreach ( array( 'header', 'nav', 'main', 'footer' ) as $region ) {
+			if ( 'main' === $region || self::visual_probe_count( $markup, $region ) > 0 ) {
+				$regions[] = $region;
+			}
+		}
+
+		return $regions;
+	}
+
+	/**
+	 * Broad selectors the benchmark harness should fingerprint for semantic drift.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function semantic_selectors(): array {
+		return array(
+			'header',
+			'nav',
+			'main',
+			'footer',
+			'a',
+			'button',
+			'img',
+			'svg',
+			'[role=banner]',
+			'[role=navigation]',
+			'[role=main]',
+			'[role=contentinfo]',
+			'[role=button]',
+			'[class*=brand]',
+			'[class*=logo]',
+			'[class*=wordmark]',
+			'[class*=nav]',
+			'[class*=footer]',
+			'[class*=header]',
+			'[class*=card]',
+			'[class*=cta]',
+			'[class*=status]',
+		);
 	}
 
 	/**
@@ -2564,6 +2685,14 @@ class Static_Site_Importer_Theme_Generator {
 
 		if ( 'hero' === $probe ) {
 			return 'header' === $tag || self::class_tokens_contain_fragment( $classes, 'hero' );
+		}
+
+		if ( 'header' === $probe ) {
+			return 'header' === $tag || self::class_tokens_contain_fragment( $classes, 'header' );
+		}
+
+		if ( 'main' === $probe ) {
+			return 'main' === $tag || 'main' === strtolower( $element->getAttribute( 'role' ) ) || self::class_tokens_contain_fragment( $classes, 'main' );
 		}
 
 		if ( 'button' === $probe ) {

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -113,10 +113,39 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'quality', $report );
 		$this->assertArrayHasKey( 'conversion_fragments', $report );
 		$this->assertArrayHasKey( 'generated_theme', $report );
+		$this->assertArrayHasKey( 'semantic_fidelity', $report );
 		$this->assertArrayHasKey( 'diagnostics', $report );
 		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['invalid_block_document_count'] ?? null );
 		$this->assertNotEmpty( $report['generated_theme']['block_documents'] ?? array() );
+		$this->assertSame( 'requires_external_render_check', $report['semantic_fidelity']['status'] ?? '' );
+		$this->assertSame( 'benchmark_harness', $report['semantic_fidelity']['gate_owner'] ?? '' );
+		$semantic_targets = $report['semantic_fidelity']['comparison_targets'] ?? array();
+		$this->assertIsArray( $semantic_targets );
+		$this->assertNotEmpty( $semantic_targets );
+		$home_semantic_target = array_values(
+			array_filter(
+				$semantic_targets,
+				static fn ( $target ): bool => is_array( $target ) && 'index.html' === ( $target['source_filename'] ?? '' )
+			)
+		)[0] ?? array();
+		$this->assertNotEmpty( $home_semantic_target );
+		$this->assertStringEndsWith( '/index.html', (string) ( $home_semantic_target['source_file'] ?? '' ) );
+		$this->assertSame( 'templates/page-home.html', $home_semantic_target['generated_template'] ?? '' );
+		$this->assertSame( 'patterns/page-home.php', $home_semantic_target['generated_pattern'] ?? '' );
+		$this->assertContains( 'parts/header.html', $home_semantic_target['generated_theme_parts'] ?? array() );
+		$this->assertContains( 'parts/footer.html', $home_semantic_target['generated_theme_parts'] ?? array() );
+		$this->assertContains( 'header', $home_semantic_target['regions'] ?? array() );
+		$this->assertContains( 'nav', $home_semantic_target['regions'] ?? array() );
+		$this->assertContains( 'main', $home_semantic_target['regions'] ?? array() );
+		$this->assertContains( 'footer', $home_semantic_target['regions'] ?? array() );
+		$this->assertContains( '[class*=brand]', $home_semantic_target['semantic_selectors'] ?? array() );
+		$this->assertContains( '[class*=logo]', $home_semantic_target['semantic_selectors'] ?? array() );
+		$this->assertContains( '[class*=wordmark]', $home_semantic_target['semantic_selectors'] ?? array() );
+		$this->assertContains( '[class*=nav]', $home_semantic_target['semantic_selectors'] ?? array() );
+		$this->assertContains( '[class*=cta]', $home_semantic_target['semantic_selectors'] ?? array() );
+		$this->assertContains( '[class*=card]', $home_semantic_target['semantic_selectors'] ?? array() );
+		$this->assertContains( '[class*=status]', $home_semantic_target['semantic_selectors'] ?? array() );
 
 		$pages = array();
 		foreach ( array( 'index.html', 'manifesto.html', 'comparison.html', 'eulogy.html', 'proof.html' ) as $filename ) {

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -146,6 +146,28 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( in_array( 'frontend_editor_visibility_parity', $home_visual_target['comparison_hooks']['layout_probes']['code_visual']['assertions'] ?? array(), true ), 'code-visual-probe-checks-frontend-editor-visibility' );
 	$assert( in_array( 'frontend_editor_column_parity', $home_visual_target['comparison_hooks']['layout_probes']['problem_grid']['assertions'] ?? array(), true ), 'problem-grid-probe-checks-frontend-editor-columns' );
 	$assert( in_array( 'style.css', $home_visual_target['comparison_hooks']['generated_files'] ?? array(), true ), 'visual-target-points-harness-at-generated-css' );
+	$assert( 'requires_external_render_check' === ( $report['semantic_fidelity']['status'] ?? '' ), 'import-report-declares-semantic-fidelity-render-check' );
+	$assert( 'benchmark_harness' === ( $report['semantic_fidelity']['gate_owner'] ?? '' ), 'import-report-delegates-semantic-gate-to-benchmark-harness' );
+	$semantic_targets = $report['semantic_fidelity']['comparison_targets'] ?? array();
+	$assert( is_array( $semantic_targets ) && count( $semantic_targets ) >= 5, 'import-report-includes-semantic-comparison-targets' );
+	$home_semantic_target = array_values(
+		array_filter(
+			is_array( $semantic_targets ) ? $semantic_targets : array(),
+			static fn ( $target ): bool => is_array( $target ) && 'index.html' === ( $target['source_filename'] ?? '' )
+		)
+	)[0] ?? array();
+	$assert( str_ends_with( (string) ( $home_semantic_target['source_file'] ?? '' ), '/index.html' ), 'semantic-target-records-source-file' );
+	$assert( is_string( $home_semantic_target['wordpress_url'] ?? null ) && '' !== $home_semantic_target['wordpress_url'], 'semantic-target-records-wordpress-url' );
+	$assert( 'templates/page-home.html' === ( $home_semantic_target['generated_template'] ?? '' ), 'semantic-target-records-generated-template' );
+	$assert( 'patterns/page-home.php' === ( $home_semantic_target['generated_pattern'] ?? '' ), 'semantic-target-records-generated-pattern' );
+	$assert( in_array( 'parts/header.html', $home_semantic_target['generated_theme_parts'] ?? array(), true ), 'semantic-target-records-generated-header-part' );
+	$assert( in_array( 'parts/footer.html', $home_semantic_target['generated_theme_parts'] ?? array(), true ), 'semantic-target-records-generated-footer-part' );
+	foreach ( array( 'header', 'nav', 'main', 'footer' ) as $region ) {
+		$assert( in_array( $region, $home_semantic_target['regions'] ?? array(), true ), 'semantic-target-records-region-' . $region );
+	}
+	foreach ( array( '[class*=brand]', '[class*=logo]', '[class*=wordmark]', '[class*=nav]', '[class*=cta]', '[class*=card]', '[class*=status]' ) as $selector ) {
+		$assert( in_array( $selector, $home_semantic_target['semantic_selectors'] ?? array(), true ), 'semantic-target-records-selector-' . $selector );
+	}
 	$assert( isset( $result['quality']['pass'] ), 'import-result-includes-quality-summary' );
 	$assert( str_contains( $page, 'wp:post-content' ), 'page-template-renders-imported-page-content' );
 	$assert( str_contains( $home_tmpl, 'wp:post-content' ), 'home-page-template-renders-page-post-content' );


### PR DESCRIPTION
## Summary
- Adds a `semantic_fidelity` section to `import-report.json` alongside `visual_fidelity`.
- Emits per-page source/generated comparison targets with WordPress page IDs/URLs, generated templates/patterns/theme parts, regions, and broad semantic selectors/hooks for benchmark consumers.
- Extends fixture and smoke coverage to prove the contract is emitted for the WordPress Is Dead fixture with header/footer/brand/nav content.

Fixes #101.

## Testing
- `homeboy test static-site-importer`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the semantic fidelity import-report contract and related fixture/smoke coverage; Chris remains responsible for review and testing.