### PR TITLE
Fix classed logo chrome ownership drift

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -578,7 +578,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		if ( 'a' === $tag ) {
-			return self::link_element_block( $doc, $element );
+			return self::link_element_block( $doc, $element, $location );
 		}
 
 		if ( 'img' === $tag ) {
@@ -587,6 +587,17 @@ class Static_Site_Importer_Theme_Generator {
 
 		if ( self::is_link_cluster_container( $element ) ) {
 			return self::group_block( self::theme_part_child_blocks( $doc, $element, $theme_slug, $location ), $element->getAttribute( 'class' ) );
+		}
+
+		if ( self::is_identity_chrome_element( $element ) && self::element_has_only_phrasing_content( $element ) ) {
+			self::record_theme_part_semantic_diagnostic(
+				$location,
+				$element,
+				'native_group_wrapper_preserved_identity_class',
+				'Classed theme-part identity chrome was represented as a native group wrapper so the source class does not move onto a paragraph block.'
+			);
+
+			return self::group_block( self::paragraph_block( self::node_inner_html( $doc, $element ) ), $element->getAttribute( 'class' ) );
 		}
 
 		if ( self::element_has_only_phrasing_content( $element ) ) {
@@ -794,6 +805,21 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Check whether an element is classed brand/logo chrome in a shared theme part.
+	 *
+	 * @param DOMElement $element Source element.
+	 * @return bool
+	 */
+	private static function is_identity_chrome_element( DOMElement $element ): bool {
+		$tag = strtolower( $element->tagName );
+		if ( ! in_array( $tag, array( 'div', 'span' ), true ) ) {
+			return false;
+		}
+
+		return preg_match( '/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $element->getAttribute( 'class' ) ) === 1;
+	}
+
+	/**
 	 * Check whether an element can be represented as one paragraph with inline markup.
 	 *
 	 * @param DOMElement $element Source element.
@@ -852,7 +878,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * @param DOMElement  $element Anchor element.
 	 * @return string
 	 */
-	private static function link_element_block( DOMDocument $doc, DOMElement $element ): string {
+	private static function link_element_block( DOMDocument $doc, DOMElement $element, string $location = '' ): string {
 		$href  = trim( $element->getAttribute( 'href' ) );
 		$label = trim( $element->textContent );
 		if ( '' === $href || '' === $label ) {
@@ -863,6 +889,13 @@ class Static_Site_Importer_Theme_Generator {
 		if ( preg_match( '/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $class ) ) {
 			$brand_anchor = self::brand_anchor_inline_block( $doc, $element );
 			if ( null !== $brand_anchor ) {
+				self::record_theme_part_semantic_diagnostic(
+					$location,
+					$element,
+					'paragraph_wrapper_required_for_identity_anchor',
+					'Classed theme-part identity anchors have no valid native group wrapper that preserves anchor element ownership, so SSI keeps the source anchor markup inside an editable paragraph and records the approximation.'
+				);
+
 				return $brand_anchor;
 			}
 
@@ -975,6 +1008,30 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return $attributes;
+	}
+
+	/**
+	 * Record an explicit semantic approximation/recovery diagnostic for theme-part chrome.
+	 *
+	 * @param string     $location Theme part location.
+	 * @param DOMElement $element  Source element.
+	 * @param string     $code     Diagnostic code.
+	 * @param string     $message  Diagnostic message.
+	 * @return void
+	 */
+	private static function record_theme_part_semantic_diagnostic( string $location, DOMElement $element, string $code, string $message ): void {
+		if ( empty( self::$conversion_report ) ) {
+			return;
+		}
+
+		self::$conversion_report['diagnostics'][] = array(
+			'type'       => 'theme_part_semantic_fidelity',
+			'code'       => $code,
+			'source'     => 'theme-part:' . ( '' !== $location ? $location : 'unknown' ),
+			'element'    => strtolower( $element->tagName ),
+			'class_name' => trim( $element->getAttribute( 'class' ) ),
+			'message'    => $message,
+		);
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -415,6 +415,44 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Classed header/footer identity chrome does not silently move classes onto paragraphs.
+	 */
+	public function test_classed_header_footer_identity_chrome_reports_or_preserves_ownership(): void {
+		$html_path = $this->write_temp_fixture(
+			'homeboy-chrome-identity.html',
+			'<!doctype html><html><head><title>Homeboy Chrome Identity</title></head><body>' .
+			'<header><nav class="site-nav"><a href="#" class="nav-logo">HOME<span>BOY</span></a><ul><li><a href="#evidence">Evidence</a></li></ul></nav></header>' .
+			'<main id="evidence"><h1>Evidence</h1><p>Body copy.</p></main>' .
+			'<footer><div class="footer-logo">HOMEBOY</div><p>Developer operations for engineers who ship with evidence.</p></footer>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Homeboy Chrome Identity',
+				'slug'      => 'homeboy-chrome-identity',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+		$footer    = $this->read_file( $theme_dir . '/parts/footer.html' );
+		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+
+		$this->assertStringContainsString( '<a href="#" class="nav-logo">HOME<span>BOY</span></a>', $header );
+		$this->assertStringContainsString( 'paragraph_wrapper_required_for_identity_anchor', wp_json_encode( $report['diagnostics'] ?? array() ) ?: '' );
+		$this->assertStringNotContainsString( '<!-- wp:paragraph {"className":"footer-logo"} --><p class="footer-logo">HOMEBOY</p>', $footer );
+		$this->assertStringContainsString( '<!-- wp:group {"className":"footer-logo"} --><div class="wp-block-group footer-logo"><!-- wp:paragraph --><p>HOMEBOY</p><!-- /wp:paragraph --></div><!-- /wp:group -->', $footer );
+		$this->assertStringContainsString( 'native_group_wrapper_preserved_identity_class', wp_json_encode( $report['diagnostics'] ?? array() ) ?: '' );
+	}
+
+	/**
 	 * Nested section headers are page content, not shared site chrome.
 	 */
 	public function test_nested_section_header_stays_in_page_content(): void {


### PR DESCRIPTION
## Summary
- Preserve class ownership for classed text-only brand/logo chrome in theme parts by using native group wrappers instead of classed paragraphs.
- Record explicit semantic diagnostics when classed identity anchors require an editable paragraph wrapper because native blocks cannot preserve anchor element ownership.
- Add fixture coverage for the `a.nav-logo` and `div.footer-logo` benchmark shapes from issue #103.

Fixes #103.

## Validation
- `homeboy test static-site-importer` passed: 27 tests, 585 assertions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigating the theme-part conversion drift, drafting the focused PHP changes and fixture coverage, running validation, and preparing this PR. Chris remains responsible for review and testing.