### PR TITLE
Preserve classed theme chrome elements

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -585,19 +585,12 @@ class Static_Site_Importer_Theme_Generator {
 			return self::image_element_block( $doc, $element );
 		}
 
-		if ( self::is_link_cluster_container( $element ) ) {
-			return self::group_block( self::theme_part_child_blocks( $doc, $element, $theme_slug, $location ), $element->getAttribute( 'class' ) );
+		if ( self::should_preserve_theme_part_phrasing_element( $element ) ) {
+			return self::freeform_block( self::node_html( $doc, $element ) );
 		}
 
-		if ( self::is_identity_chrome_element( $element ) && self::element_has_only_phrasing_content( $element ) ) {
-			self::record_theme_part_semantic_diagnostic(
-				$location,
-				$element,
-				'native_group_wrapper_preserved_identity_class',
-				'Classed theme-part identity chrome was represented as a native group wrapper so the source class does not move onto a paragraph block.'
-			);
-
-			return self::group_block( self::paragraph_block( self::node_inner_html( $doc, $element ) ), $element->getAttribute( 'class' ) );
+		if ( self::is_link_cluster_container( $element ) ) {
+			return self::group_block( self::theme_part_child_blocks( $doc, $element, $theme_slug, $location ), $element->getAttribute( 'class' ) );
 		}
 
 		if ( self::element_has_only_phrasing_content( $element ) ) {
@@ -805,18 +798,23 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Check whether an element is classed brand/logo chrome in a shared theme part.
+	 * Check whether classed theme chrome should keep source element ownership.
 	 *
 	 * @param DOMElement $element Source element.
 	 * @return bool
 	 */
-	private static function is_identity_chrome_element( DOMElement $element ): bool {
+	private static function should_preserve_theme_part_phrasing_element( DOMElement $element ): bool {
 		$tag = strtolower( $element->tagName );
-		if ( ! in_array( $tag, array( 'div', 'span' ), true ) ) {
+		if ( ! in_array( $tag, array( 'div', 'span' ), true ) || ! self::element_has_only_phrasing_content( $element ) ) {
 			return false;
 		}
 
-		return preg_match( '/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $element->getAttribute( 'class' ) ) === 1;
+		$class = trim( $element->getAttribute( 'class' ) );
+		if ( '' === $class ) {
+			return false;
+		}
+
+		return preg_match( '/(^|[-_\s])(brand|logo|wordmark|name|badge|meta|copy)([-_\s]|$)/i', $class ) === 1;
 	}
 
 	/**
@@ -827,6 +825,10 @@ class Static_Site_Importer_Theme_Generator {
 	 */
 	private static function element_has_only_phrasing_content( DOMElement $element ): bool {
 		if ( self::element_contains_svg_or_form( $element ) ) {
+			return false;
+		}
+
+		if ( in_array( strtolower( $element->tagName ), array( 'header', 'footer', 'main', 'nav', 'section', 'article', 'aside' ), true ) ) {
 			return false;
 		}
 
@@ -889,13 +891,6 @@ class Static_Site_Importer_Theme_Generator {
 		if ( preg_match( '/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $class ) ) {
 			$brand_anchor = self::brand_anchor_inline_block( $doc, $element );
 			if ( null !== $brand_anchor ) {
-				self::record_theme_part_semantic_diagnostic(
-					$location,
-					$element,
-					'paragraph_wrapper_required_for_identity_anchor',
-					'Classed theme-part identity anchors have no valid native group wrapper that preserves anchor element ownership, so SSI keeps the source anchor markup inside an editable paragraph and records the approximation.'
-				);
-
 				return $brand_anchor;
 			}
 
@@ -908,7 +903,7 @@ class Static_Site_Importer_Theme_Generator {
 				$anchor_attrs .= ' class="' . esc_attr( $class ) . '"';
 			}
 
-			return self::paragraph_block( '<a' . $anchor_attrs . '>' . self::node_inner_html( $doc, $element ) . '</a>' );
+			return self::freeform_block( '<a' . $anchor_attrs . '>' . self::node_inner_html( $doc, $element ) . '</a>' );
 		}
 
 		if ( preg_match( '/(^|[-_\s])(btn|button|cta|pill)([-_\s]|$)/i', $class ) ) {
@@ -937,7 +932,7 @@ class Static_Site_Importer_Theme_Generator {
 			return null;
 		}
 
-		return self::paragraph_block( '<a' . self::element_attribute_markup( $element ) . '>' . $inner . '</a>' );
+		return self::freeform_block( '<a' . self::element_attribute_markup( $element ) . '>' . $inner . '</a>' );
 	}
 
 	/**
@@ -1301,6 +1296,16 @@ class Static_Site_Importer_Theme_Generator {
 	 */
 	private static function html_block( string $html ): string {
 		return '<!-- wp:html -->' . $html . '<!-- /wp:html -->';
+	}
+
+	/**
+	 * Build an editable Classic block that preserves exact source element HTML.
+	 *
+	 * @param string $html Source HTML.
+	 * @return string
+	 */
+	private static function freeform_block( string $html ): string {
+		return '<!-- wp:freeform -->' . $html . '<!-- /wp:freeform -->';
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -483,11 +483,12 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$footer    = $this->read_file( $theme_dir . '/parts/footer.html' );
 		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
 
-		$this->assertStringContainsString( '<a href="#" class="nav-logo">HOME<span>BOY</span></a>', $header );
-		$this->assertStringContainsString( 'paragraph_wrapper_required_for_identity_anchor', wp_json_encode( $report['diagnostics'] ?? array() ) ?: '' );
+		$this->assertStringContainsString( '<!-- wp:freeform --><a href="#" class="nav-logo">HOME<span>BOY</span></a><!-- /wp:freeform -->', $header );
+		$this->assertStringNotContainsString( '<p><a href="#" class="nav-logo">HOME<span>BOY</span></a></p>', $header );
 		$this->assertStringNotContainsString( '<!-- wp:paragraph {"className":"footer-logo"} --><p class="footer-logo">HOMEBOY</p>', $footer );
-		$this->assertStringContainsString( '<!-- wp:group {"className":"footer-logo"} --><div class="wp-block-group footer-logo"><!-- wp:paragraph --><p>HOMEBOY</p><!-- /wp:paragraph --></div><!-- /wp:group -->', $footer );
-		$this->assertStringContainsString( 'native_group_wrapper_preserved_identity_class', wp_json_encode( $report['diagnostics'] ?? array() ) ?: '' );
+		$this->assertStringContainsString( '<!-- wp:freeform --><div class="footer-logo">HOMEBOY</div><!-- /wp:freeform -->', $footer );
+		$this->assertStringNotContainsString( 'paragraph_wrapper_required_for_identity_anchor', wp_json_encode( $report['diagnostics'] ?? array() ) ?: '' );
+		$this->assertStringNotContainsString( 'native_group_wrapper_preserved_identity_class', wp_json_encode( $report['diagnostics'] ?? array() ) ?: '' );
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -286,6 +286,44 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Classed theme chrome keeps source element ownership without core/html islands.
+	 */
+	public function test_classed_header_and_footer_chrome_preserve_source_elements(): void {
+		$html_path = $this->write_temp_fixture(
+			'classed-chrome.html',
+			'<!doctype html><html><head><title>Classed Chrome</title></head><body>' .
+			'<header><nav class="topbar"><a href="#" class="nav-logo">HOME<span>BOY</span></a><a href="#docs">Docs</a></nav></header>' .
+			'<main><section><h1>Classed chrome</h1><p>Body copy.</p></section></main>' .
+			'<footer><div class="footer-logo">HOMEBOY</div><p>Developer operations for engineers who ship with evidence.</p></footer>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Classed Chrome',
+				'slug'      => 'classed-chrome',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+		$footer    = $this->read_file( $theme_dir . '/parts/footer.html' );
+
+		$this->assertStringNotContainsString( '<!-- wp:html', $header );
+		$this->assertStringNotContainsString( '<!-- wp:html', $footer );
+		$this->assertStringNotContainsString( '<p><a href="#" class="nav-logo">', $header );
+		$this->assertStringNotContainsString( '<p class="footer-logo">HOMEBOY</p>', $footer );
+		$this->assertStringContainsString( '<!-- wp:freeform --><a href="#" class="nav-logo">HOME<span>BOY</span></a><!-- /wp:freeform -->', $header );
+		$this->assertStringContainsString( '<!-- wp:freeform --><div class="footer-logo">HOMEBOY</div><!-- /wp:freeform -->', $footer );
+	}
+
+	/**
 	 * A top-level nav can contain brand chrome plus a nested menu list.
 	 */
 	public function test_branded_top_level_nav_preserves_brand_and_converts_only_menu_list(): void {

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -412,10 +412,10 @@ if ( false !== $wrote_footer_chrome ) {
 
 		$assert( ! str_contains( $footer_chrome_footer, '<!-- wp:html' ), 'footer-chrome-has-no-core-html-blocks', $footer_chrome_footer );
 		$assert( ! str_contains( $footer_chrome_footer, 'core/html' ), 'footer-chrome-has-no-raw-core-html-name', $footer_chrome_footer );
-		$assert( str_contains( $footer_chrome_footer, '<!-- wp:paragraph {"className":"footer-logo"}' ), 'footer-logo-becomes-classed-paragraph' );
+		$assert( str_contains( $footer_chrome_footer, '<!-- wp:freeform --><div class="footer-logo">' ), 'footer-logo-preserves-source-wrapper' );
 		$assert( str_contains( $footer_chrome_footer, 'width:6px;height:6px;border-radius:50%;background:var(--accent);display:inline-block;' ), 'footer-logo-decorative-span-style-survives' );
 		$assert( str_contains( $footer_chrome_footer, 'Studio Code — by Automattic' ), 'footer-logo-text-survives' );
-		$assert( str_contains( $footer_chrome_footer, '<!-- wp:paragraph {"className":"footer-meta"}' ), 'footer-meta-becomes-classed-paragraph' );
+		$assert( str_contains( $footer_chrome_footer, '<!-- wp:freeform --><div class="footer-meta">' ), 'footer-meta-preserves-source-wrapper' );
 		$assert( str_contains( $footer_chrome_style, 'display: flex; align-items: center; justify-content: space-between' ), 'footer-flex-alignment-css-survives' );
 		$assert( str_contains( $footer_chrome_style, 'footer .footer-logo' ) && str_contains( $footer_chrome_style, 'gap: 8px' ), 'footer-logo-spacing-css-survives' );
 		$assert( str_contains( $footer_chrome_style, 'flex-direction: column; gap: 12px; text-align: center' ), 'footer-responsive-spacing-css-survives' );


### PR DESCRIPTION
## Summary
- Preserve classed header/footer chrome elements as editable `core/freeform` blocks when paragraph conversion would move selector ownership.
- Keep structural theme-part containers such as `nav` from collapsing into paragraphs before their child chrome can be converted.
- Add regression coverage for `a.nav-logo` and `div.footer-logo` preserving source element ownership without `core/html` islands.

Fixes #103.

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php && php -l tests/smoke-wordpress-is-dead-fixture.php`
- `homeboy test --path /Users/chubes/Developer/static-site-importer@fix-issue-103-chrome-paragraph-drift`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-103-chrome-paragraph-drift/tests/smoke-wordpress-is-dead-fixture.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the focused theme-part chrome preservation fix, adding regression coverage, and running validation; Chris remains responsible for review and testing.