### PR TITLE
Preserve main landmarks in generated page templates

### DIFF
--- a/includes/class-static-site-importer-document.php
+++ b/includes/class-static-site-importer-document.php
@@ -149,6 +149,7 @@ class Static_Site_Importer_Document {
 		$header = $this->first_plausible_global_header( $root );
 		$nav    = $this->first_plausible_global_nav( $root, $header );
 		$footer = $this->first_element( 'footer' );
+		$main   = $this->first_element( 'main' );
 
 		$header_parts = array();
 		if ( $nav instanceof DOMElement && $header instanceof DOMElement && $this->is_leading_sibling( $root, $nav, $header ) ) {
@@ -167,6 +168,7 @@ class Static_Site_Importer_Document {
 
 		$main_parts = array();
 		$background = array();
+		$main_html  = $main instanceof DOMElement ? $this->inner_html( $main ) : '';
 
 		foreach ( iterator_to_array( $root->childNodes ) as $child ) {
 			if ( ! $child instanceof DOMElement ) {
@@ -178,7 +180,7 @@ class Static_Site_Importer_Document {
 				continue;
 			}
 
-			if ( $this->same_node( $child, $nav ) || $this->same_node( $child, $header ) || $this->same_node( $child, $footer ) ) {
+			if ( $this->same_node( $child, $nav ) || $this->same_node( $child, $header ) || $this->same_node( $child, $footer ) || $this->same_node( $child, $main ) ) {
 				continue;
 			}
 
@@ -187,13 +189,15 @@ class Static_Site_Importer_Document {
 				continue;
 			}
 
-			$main_parts[] = $this->outer_html( $child );
+			if ( ! $main instanceof DOMElement ) {
+				$main_parts[] = $this->outer_html( $child );
+			}
 		}
 
 		return array(
 			'background' => trim( implode( "\n", $background ) ),
 			'header'     => trim( $header_html ),
-			'main'       => trim( implode( "\n", $main_parts ) ),
+			'main'       => trim( $main instanceof DOMElement ? $main_html : implode( "\n", $main_parts ) ),
 			'footer'     => trim( $footer_html ),
 		);
 	}
@@ -327,6 +331,21 @@ class Static_Site_Importer_Document {
 	private function outer_html( DOMNode $node ): string {
 		$html = $this->dom->saveHTML( $node );
 		return false === $html ? '' : $html;
+	}
+
+	/**
+	 * Serialize a DOM element's child nodes.
+	 *
+	 * @param DOMElement $element Element.
+	 * @return string
+	 */
+	private function inner_html( DOMElement $element ): string {
+		$html = array();
+		foreach ( iterator_to_array( $element->childNodes ) as $child ) {
+			$html[] = $this->outer_html( $child );
+		}
+
+		return implode( '', $html );
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -3878,7 +3878,7 @@ class Static_Site_Importer_Theme_Generator {
 		return trim(
 			'<!-- wp:template-part {"slug":"header","tagName":"header"} /-->' . "\n\n" .
 			$background_blocks . "\n\n" .
-			'<!-- wp:post-content /-->' . "\n\n" .
+			'<!-- wp:post-content {"tagName":"main"} /-->' . "\n\n" .
 			$footer_part
 		) . "\n";
 	}

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -463,6 +463,54 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Semantic main content is the page body when document-level chrome surrounds it.
+	 */
+	public function test_semantic_main_content_becomes_page_body_without_stray_chrome(): void {
+		$html_path = $this->write_temp_fixture(
+			'semantic-main-page-body.html',
+			'<!doctype html><html><head><title>Semantic Main Page Body</title></head><body>' .
+			'<svg aria-hidden="true" class="hidden"><symbol id="chrome-icon"><path d="M0 0h1v1H0z"></path></symbol></svg>' .
+			'<noscript><iframe src="https://example.com/tracker" title="Body Noscript Tracker"></iframe></noscript>' .
+			'<header class="site-header"><nav><a href="#story">Story</a></nav><button>Header Search</button></header>' .
+			'<div class="utility-chrome">Utility Sidebar</div>' .
+			'<main><section id="story" class="story-grid"><h1>Main Story</h1><p>Main copy only.</p></section></main>' .
+			'<footer><p>Footer Chrome</p></footer>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Semantic Main Page Body',
+				'slug'      => 'semantic-main-page-body',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$pattern   = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-semantic-main-page-body.php' ) );
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+		$footer    = $this->read_file( $theme_dir . '/parts/footer.html' );
+		$post      = get_post( $result['pages']['semantic-main-page-body.html'] ?? 0 );
+
+		$this->assertInstanceOf( WP_Post::class, $post );
+		$this->assertStringContainsString( 'Main Story', $pattern );
+		$this->assertStringContainsString( 'Main copy only.', $pattern );
+		$this->assertStringContainsString( 'story-grid', $pattern );
+		$this->assertStringNotContainsString( 'Body Noscript Tracker', $pattern );
+		$this->assertStringNotContainsString( 'Header Search', $pattern );
+		$this->assertStringNotContainsString( 'Utility Sidebar', $pattern );
+		$this->assertStringNotContainsString( 'chrome-icon', $pattern );
+		$this->assertStringContainsString( 'Header Search', $header );
+		$this->assertStringContainsString( 'Footer Chrome', $footer );
+		$this->assertSame( trim( $pattern ), trim( $post->post_content ) );
+	}
+
+	/**
 	 * Source button styles are moved to the inner link without restyling the core/button wrapper.
 	 */
 	public function test_source_button_class_styles_do_not_double_apply_to_core_button_wrapper(): void {

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -51,10 +51,14 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$proof_pat  = $this->read_file( $theme_dir . '/patterns/page-proof.php' );
 
 		$this->assertStringContainsString( '<!-- wp:post-content', $front_page );
+		$this->assertStringContainsString( '<!-- wp:post-content {"tagName":"main"} /-->', $front_page );
 		$this->assertStringNotContainsString( '<!-- wp:pattern', $front_page );
 		$this->assertStringContainsString( '<!-- wp:post-content', $page );
+		$this->assertStringContainsString( '<!-- wp:post-content {"tagName":"main"} /-->', $page );
 		$this->assertStringContainsString( '<!-- wp:post-content', $home_tmpl );
+		$this->assertStringContainsString( '<!-- wp:post-content {"tagName":"main"} /-->', $home_tmpl );
 		$this->assertStringContainsString( '<!-- wp:post-content', $proof_tmpl );
+		$this->assertStringContainsString( '<!-- wp:post-content {"tagName":"main"} /-->', $proof_tmpl );
 		$this->assertStringNotContainsString( '<!-- wp:pattern', $home_tmpl );
 		$this->assertStringNotContainsString( '<!-- wp:pattern', $proof_tmpl );
 		$this->assertStringContainsString( 'Slug: wordpress-is-dead-fixture/page-home', $home_pat );
@@ -493,6 +497,7 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 
 		$theme_dir = $result['theme_dir'];
 		$pattern   = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-semantic-main-page-body.php' ) );
+		$template  = $this->read_file( $theme_dir . '/templates/page-semantic-main-page-body.html' );
 		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
 		$footer    = $this->read_file( $theme_dir . '/parts/footer.html' );
 		$post      = get_post( $result['pages']['semantic-main-page-body.html'] ?? 0 );
@@ -507,7 +512,18 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'chrome-icon', $pattern );
 		$this->assertStringContainsString( 'Header Search', $header );
 		$this->assertStringContainsString( 'Footer Chrome', $footer );
+		$this->assertStringContainsString( '<!-- wp:post-content {"tagName":"main"} /-->', $template );
 		$this->assertSame( trim( $pattern ), trim( $post->post_content ) );
+
+		$previous_theme = get_stylesheet();
+		switch_theme( $result['theme_slug'] );
+		$frontend_rendered = $this->render_template_for_post( $template, $post );
+		switch_theme( $previous_theme );
+
+		$this->assertSame( 1, substr_count( $frontend_rendered, '<main' ) );
+		$this->assertStringContainsString( 'Main Story', $frontend_rendered );
+		$this->assertMatchesRegularExpression( '/<main\b[^>]*>.*Main Story.*<\/main>/s', $frontend_rendered );
+		$this->assertDoesNotMatchRegularExpression( '/<main\b[^>]*>.*Header Search.*<\/main>/s', $frontend_rendered );
 	}
 
 	/**
@@ -1226,7 +1242,9 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 
 		foreach ( parse_blocks( $template ) as $block ) {
 			if ( 'core/post-content' === ( $block['blockName'] ?? '' ) ) {
-				$rendered .= do_blocks( $post->post_content );
+				$content  = do_blocks( $post->post_content );
+				$tag_name = $block['attrs']['tagName'] ?? 'div';
+				$rendered .= sprintf( '<%1$s class="entry-content wp-block-post-content">%2$s</%1$s>', tag_escape( $tag_name ), $content );
 				continue;
 			}
 


### PR DESCRIPTION
## Summary
- Preserve source `<main>` page bodies while excluding surrounding document chrome from imported page content.
- Render generated page templates with `core/post-content` using `tagName: "main"` so frontend output keeps a main landmark.
- Add fixture coverage for page-body extraction, template generation, and rendered frontend landmark preservation.

Closes #107.

## Validation
- `homeboy test static-site-importer`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the focused landmark preservation fix, adding fixture coverage, and running validation. Chris remains responsible for review and testing.