### PR TITLE
Seed WooCommerce products from validated manifests

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -182,6 +182,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::analyze_generated_theme_block_documents( $writes, $theme_dir );
 		self::record_visual_fidelity_targets( $pages, $page_ids, $permalinks, $writes, $theme_dir );
 		self::record_semantic_fidelity_targets( $pages, $page_ids, $permalinks, $writes, $theme_dir );
+		self::record_product_seeding_report( $args );
 		$quality     = self::finalize_quality_report( $args );
 		$report_json = wp_json_encode( self::$conversion_report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 		if ( false === $report_json ) {
@@ -2711,6 +2712,22 @@ class Static_Site_Importer_Theme_Generator {
 			'[class*=cta]',
 			'[class*=status]',
 		);
+	}
+
+	/**
+	 * Record WooCommerce product seeding results for an already-validated manifest.
+	 *
+	 * @param array<string, mixed> $args Import args.
+	 * @return void
+	 */
+	private static function record_product_seeding_report( array $args ): void {
+		if ( ! isset( $args['products_manifest'] ) || ! is_array( $args['products_manifest'] ) ) {
+			self::$conversion_report['product_seeding']           = Static_Site_Importer_Woo_Product_Seeder::new_report();
+			self::$conversion_report['product_seeding']['reason'] = 'no_validated_manifest';
+			return;
+		}
+
+		self::$conversion_report['product_seeding'] = Static_Site_Importer_Woo_Product_Seeder::seed( $args['products_manifest'] );
 	}
 
 	/**

--- a/includes/class-static-site-importer-woo-product-seeder.php
+++ b/includes/class-static-site-importer-woo-product-seeder.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * WooCommerce product seeding for validated store manifests.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Turns already-validated store manifest products into simple WooCommerce products.
+ */
+class Static_Site_Importer_Woo_Product_Seeder {
+
+	/**
+	 * Seed simple products from a validated manifest.
+	 *
+	 * The manifest contract is owned by the products.json validator. This class only
+	 * consumes the normalized array shape after that validation has succeeded.
+	 *
+	 * @param array<string, mixed> $manifest Validated product manifest.
+	 * @return array<string, mixed>
+	 */
+	public static function seed( array $manifest ): array {
+		$products = self::manifest_products( $manifest );
+		$report   = self::new_report( 'not_run' );
+
+		if ( empty( $products ) ) {
+			$report['status'] = 'skipped';
+			$report['reason'] = 'empty_validated_manifest';
+			return $report;
+		}
+
+		if ( ! self::woocommerce_available() ) {
+			$report['status']            = 'skipped';
+			$report['reason']            = 'woocommerce_inactive';
+			$report['counts']['skipped'] = count( $products );
+			foreach ( $products as $product ) {
+				$report['products'][] = array(
+					'slug'   => self::string_value( $product, 'slug' ),
+					'name'   => self::string_value( $product, 'name' ),
+					'status' => 'skipped',
+					'reason' => 'woocommerce_inactive',
+				);
+			}
+
+			return $report;
+		}
+
+		$report['status'] = 'completed';
+
+		foreach ( $products as $product ) {
+			$row                  = self::seed_product( $product );
+			$report['products'][] = $row;
+
+			$status = $row['status'] ?? 'error';
+			if ( isset( $report['counts'][ $status ] ) ) {
+				++$report['counts'][ $status ];
+			} else {
+				++$report['counts']['error'];
+			}
+		}
+
+		return $report;
+	}
+
+	/**
+	 * Build an initial report shape.
+	 *
+	 * @param string $status Report status.
+	 * @return array<string, mixed>
+	 */
+	public static function new_report( string $status = 'skipped' ): array {
+		return array(
+			'status'   => $status,
+			'reason'   => '',
+			'counts'   => array(
+				'created' => 0,
+				'updated' => 0,
+				'skipped' => 0,
+				'error'   => 0,
+			),
+			'products' => array(),
+		);
+	}
+
+	/**
+	 * Extract the validator-owned products list from a manifest.
+	 *
+	 * @param array<string, mixed> $manifest Validated product manifest.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function manifest_products( array $manifest ): array {
+		$products = isset( $manifest['products'] ) && is_array( $manifest['products'] ) ? $manifest['products'] : $manifest;
+
+		return array_values(
+			array_filter(
+				$products,
+				static fn ( $product ): bool => is_array( $product )
+			)
+		);
+	}
+
+	/**
+	 * Determine whether WooCommerce product APIs are available.
+	 *
+	 * @return bool
+	 */
+	private static function woocommerce_available(): bool {
+		return class_exists( 'WC_Product_Simple' ) && post_type_exists( 'product' ) && taxonomy_exists( 'product_cat' );
+	}
+
+	/**
+	 * Create or update one product.
+	 *
+	 * @param array<string, mixed> $manifest_product Validated product manifest row.
+	 * @return array<string, mixed>
+	 */
+	private static function seed_product( array $manifest_product ): array {
+		$slug = sanitize_title( self::string_value( $manifest_product, 'slug' ) );
+		$name = self::string_value( $manifest_product, 'name' );
+
+		if ( '' === $slug || '' === $name ) {
+			return array(
+				'slug'   => $slug,
+				'name'   => $name,
+				'status' => 'error',
+				'error'  => 'validated product row is missing slug or name',
+			);
+		}
+
+		$existing = get_page_by_path( $slug, OBJECT, 'product' );
+		$product  = null;
+		$status   = 'created';
+
+		if ( $existing instanceof WP_Post && function_exists( 'wc_get_product' ) ) {
+			$product = wc_get_product( $existing->ID );
+			$status  = 'updated';
+		}
+
+		if ( ! $product instanceof WC_Product_Simple ) {
+			$product = new WC_Product_Simple();
+		}
+
+		try {
+			$product->set_name( $name );
+			$product->set_slug( $slug );
+			$product->set_status( self::post_status( $manifest_product ) );
+			$product->set_description( wp_kses_post( self::string_value( $manifest_product, 'description' ) ) );
+			$product->set_short_description( wp_kses_post( self::string_value( $manifest_product, 'short_description' ) ) );
+			$product->set_regular_price( self::price_value( $manifest_product, 'regular_price' ) );
+			$product->set_sale_price( self::price_value( $manifest_product, 'sale_price' ) );
+
+			$stock_status = self::string_value( $manifest_product, 'stock_status' );
+			if ( '' !== $stock_status ) {
+				$product->set_stock_status( $stock_status );
+			}
+
+			if ( array_key_exists( 'stock_quantity', $manifest_product ) && '' !== (string) $manifest_product['stock_quantity'] ) {
+				$product->set_manage_stock( true );
+				$product->set_stock_quantity( max( 0, (int) $manifest_product['stock_quantity'] ) );
+			}
+
+			$product_id = (int) $product->save();
+			if ( $product_id <= 0 ) {
+				return array(
+					'slug'   => $slug,
+					'name'   => $name,
+					'status' => 'error',
+					'error'  => 'WooCommerce did not return a product ID',
+				);
+			}
+
+			$category_ids = self::ensure_category_ids( self::category_names( $manifest_product ) );
+			if ( ! empty( $category_ids ) ) {
+				wp_set_object_terms( $product_id, $category_ids, 'product_cat' );
+			}
+
+			return array(
+				'id'           => $product_id,
+				'slug'         => $slug,
+				'name'         => $name,
+				'status'       => $status,
+				'category_ids' => $category_ids,
+			);
+		} catch ( Throwable $exception ) {
+			return array(
+				'slug'   => $slug,
+				'name'   => $name,
+				'status' => 'error',
+				'error'  => $exception->getMessage(),
+			);
+		}
+	}
+
+	/**
+	 * Get a string manifest value.
+	 *
+	 * @param array<string, mixed> $product Product row.
+	 * @param string               $key     Field key.
+	 * @return string
+	 */
+	private static function string_value( array $product, string $key ): string {
+		$value = $product[ $key ] ?? '';
+		return is_scalar( $value ) ? trim( (string) $value ) : '';
+	}
+
+	/**
+	 * Get a WooCommerce-compatible price string.
+	 *
+	 * @param array<string, mixed> $product Product row.
+	 * @param string               $key     Field key.
+	 * @return string
+	 */
+	private static function price_value( array $product, string $key ): string {
+		$value = self::string_value( $product, $key );
+		if ( '' === $value ) {
+			return '';
+		}
+
+		return function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $value ) : (string) preg_replace( '/[^0-9.]/', '', $value );
+	}
+
+	/**
+	 * Resolve the product post status.
+	 *
+	 * @param array<string, mixed> $product Product row.
+	 * @return string
+	 */
+	private static function post_status( array $product ): string {
+		$status = self::string_value( $product, 'status' );
+		if ( '' === $status ) {
+			$status = self::string_value( $product, 'post_status' );
+		}
+
+		return in_array( $status, array( 'publish', 'draft', 'pending', 'private' ), true ) ? $status : 'publish';
+	}
+
+	/**
+	 * Extract category names from the manifest row.
+	 *
+	 * @param array<string, mixed> $product Product row.
+	 * @return array<int, string>
+	 */
+	private static function category_names( array $product ): array {
+		$categories = $product['categories'] ?? ( $product['category_names'] ?? array() );
+		if ( is_string( $categories ) ) {
+			$categories = array( $categories );
+		}
+		if ( ! is_array( $categories ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				array_map(
+					static fn ( $category ): string => is_scalar( $category ) ? trim( (string) $category ) : '',
+					$categories
+				)
+			)
+		);
+	}
+
+	/**
+	 * Ensure product categories exist and return term IDs.
+	 *
+	 * @param array<int, string> $category_names Category names.
+	 * @return array<int, int>
+	 */
+	private static function ensure_category_ids( array $category_names ): array {
+		$term_ids = array();
+		foreach ( $category_names as $category_name ) {
+			$term = term_exists( $category_name, 'product_cat' );
+			if ( 0 === $term || null === $term ) {
+				$term = wp_insert_term( $category_name, 'product_cat' );
+			}
+
+			if ( is_wp_error( $term ) ) {
+				continue;
+			}
+
+			if ( is_array( $term ) && isset( $term['term_id'] ) ) {
+				$term_ids[] = (int) $term['term_id'];
+			} elseif ( is_int( $term ) ) {
+				$term_ids[] = $term;
+			}
+		}
+
+		return array_values( array_unique( array_filter( $term_ids ) ) );
+	}
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -24,6 +24,7 @@ if ( is_readable( STATIC_SITE_IMPORTER_PATH . 'vendor/autoload.php' ) ) {
 
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-fetcher.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-generator.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-admin.php';
 

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -118,9 +118,13 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'conversion_fragments', $report );
 		$this->assertArrayHasKey( 'generated_theme', $report );
 		$this->assertArrayHasKey( 'semantic_fidelity', $report );
+		$this->assertArrayHasKey( 'product_seeding', $report );
 		$this->assertArrayHasKey( 'diagnostics', $report );
 		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['invalid_block_document_count'] ?? null );
+		$this->assertSame( 'skipped', $report['product_seeding']['status'] ?? '' );
+		$this->assertSame( 'no_validated_manifest', $report['product_seeding']['reason'] ?? '' );
+		$this->assertSame( array( 'created' => 0, 'updated' => 0, 'skipped' => 0, 'error' => 0 ), $report['product_seeding']['counts'] ?? array() );
 		$this->assertNotEmpty( $report['generated_theme']['block_documents'] ?? array() );
 		$this->assertSame( 'requires_external_render_check', $report['semantic_fidelity']['status'] ?? '' );
 		$this->assertSame( 'benchmark_harness', $report['semantic_fidelity']['gate_owner'] ?? '' );
@@ -198,6 +202,51 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertNotWPError( $second_result );
 		$this->assertSame( $header_nav->ID, get_page_by_path( 'wordpress-is-dead-fixture-header-navigation', OBJECT, 'wp_navigation' )->ID );
 		$this->assertSame( $footer_nav->ID, get_page_by_path( 'wordpress-is-dead-fixture-footer-navigation', OBJECT, 'wp_navigation' )->ID );
+	}
+
+	/**
+	 * A validated product manifest only records diagnostics when WooCommerce is unavailable.
+	 */
+	public function test_product_manifest_seeding_is_diagnostic_without_woocommerce(): void {
+		if ( class_exists( 'WC_Product_Simple' ) ) {
+			$this->markTestSkipped( 'WooCommerce is active; inactive diagnostic behavior is covered without loading WooCommerce.' );
+		}
+
+		$plugin_root = dirname( __DIR__ );
+		$fixture     = $plugin_root . '/tests/fixtures/wordpress-is-dead/index.html';
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$fixture,
+			array(
+				'name'              => 'Woo Product Diagnostic Fixture',
+				'slug'              => 'woo-product-diagnostic-fixture',
+				'overwrite'         => true,
+				'activate'          => false,
+				'keep_source'       => true,
+				'products_manifest' => array(
+					'products' => array(
+						array(
+							'name'              => 'Country Sourdough',
+							'slug'              => 'country-sourdough',
+							'regular_price'     => '14.00',
+							'description'       => 'A 48-hour cold-fermented loaf.',
+							'short_description' => 'Cold-fermented sourdough.',
+							'categories'        => array( 'Bread' ),
+							'status'            => 'publish',
+							'stock_status'      => 'instock',
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $result );
+
+		$report = json_decode( $this->read_file( $result['report_path'] ), true );
+		$this->assertSame( 'skipped', $report['product_seeding']['status'] ?? '' );
+		$this->assertSame( 'woocommerce_inactive', $report['product_seeding']['reason'] ?? '' );
+		$this->assertSame( array( 'created' => 0, 'updated' => 0, 'skipped' => 1, 'error' => 0 ), $report['product_seeding']['counts'] ?? array() );
+		$this->assertSame( 'country-sourdough', $report['product_seeding']['products'][0]['slug'] ?? '' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Adds a narrow WooCommerce product seeding primitive that consumes an already-validated manifest array and creates or updates simple products by slug.
- Records `product_seeding` status, product IDs, row outcomes, and created/updated/skipped/error counts in `import-report.json`.
- Keeps imports diagnostic-only when no validated manifest is provided or WooCommerce product APIs are inactive.

## Testing
- `php -l includes/class-static-site-importer-woo-product-seeder.php`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l static-site-importer.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`

Note: `studio wp eval-file tests/smoke-wordpress-is-dead-fixture.php` could not run from this worktree because Studio reported the checkout directory is not added to Studio. I did not switch into or mutate the Studio checkout because this task explicitly scoped work to this worktree only.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the scoped WooCommerce product seeding seam, import-report wiring, and diagnostic test coverage; Chris remains responsible for review and testing.