### PR TITLE
Add commerce context conversion diagnostics

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -22,6 +22,16 @@ class Static_Site_Importer_Theme_Generator {
 	private static array $conversion_report = array();
 
 	/**
+	 * Validated commerce context for the active import.
+	 *
+	 * Static Site Importer does not validate product manifests here; callers that
+	 * own validation can supply the normalized context through import args.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private static array $active_commerce_context = array();
+
+	/**
 	 * Generated theme directory for import-scoped asset writes.
 	 *
 	 * @var string
@@ -121,9 +131,11 @@ class Static_Site_Importer_Theme_Generator {
 			return $page_ids;
 		}
 
-		$permalinks              = self::page_permalinks( $page_ids );
-		$fragments               = $document->fragments();
-		self::$conversion_report = self::new_conversion_report( $html_path, isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array() );
+		$permalinks                    = self::page_permalinks( $page_ids );
+		$fragments                     = $document->fragments();
+		self::$conversion_report       = self::new_conversion_report( $html_path, isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array() );
+		self::$active_commerce_context = self::commerce_context_from_args( $args );
+		self::record_commerce_context_summary();
 
 		self::$active_theme_dir         = $theme_dir;
 		self::$active_theme_uri         = trailingslashit( get_theme_root_uri( $theme_slug ) ) . $theme_slug;
@@ -2160,12 +2172,23 @@ class Static_Site_Importer_Theme_Generator {
 			self::record_content_loss( $source, $original_text_length, $serialized_text_length );
 		};
 
+		$commerce_metadata_listener = static function ( array $metadata ) use ( $source ): void {
+			self::record_commerce_conversion_metadata( $source, $metadata );
+		};
+		$commerce_request_listener  = static function ( array $request ) use ( $source ): void {
+			self::record_commerce_conversion_metadata( $source, array_merge( array( 'type' => 'materialization_request' ), $request ) );
+		};
+
 		add_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10, 3 );
 		add_action( 'html_to_blocks_conversion_aborted_content_loss', $content_loss_listener, 10, 2 );
+		add_action( 'bfb_conversion_metadata', $commerce_metadata_listener, 10, 1 );
+		add_action( 'bfb_materialization_request', $commerce_request_listener, 10, 1 );
 		// @phpstan-ignore-next-line function.notFound -- Loaded by the bundled Block Format Bridge runtime.
-		$blocks = bfb_convert( $html, 'html', 'blocks' );
+		$blocks = empty( self::$active_commerce_context ) ? bfb_convert( $html, 'html', 'blocks' ) : bfb_convert( $html, 'html', 'blocks', self::conversion_options( $source ) );
 		remove_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10 );
 		remove_action( 'html_to_blocks_conversion_aborted_content_loss', $content_loss_listener, 10 );
+		remove_action( 'bfb_conversion_metadata', $commerce_metadata_listener, 10 );
+		remove_action( 'bfb_materialization_request', $commerce_request_listener, 10 );
 
 		if ( '' === $blocks ) {
 			self::record_conversion_empty( $source, $html );
@@ -2505,6 +2528,13 @@ class Static_Site_Importer_Theme_Generator {
 				'failure_reasons'                    => array(),
 			),
 			'conversion_fragments' => array(),
+			'commerce_context'     => array(
+				'supplied'       => false,
+				'source'         => 'none',
+				'product_count'  => 0,
+				'selector_hints' => array(),
+				'diagnostics'    => array(),
+			),
 			'assets'               => array(
 				'svg_icons'   => array(),
 				'svg_sprites' => array(),
@@ -2536,6 +2566,109 @@ class Static_Site_Importer_Theme_Generator {
 				'Semantic fidelity requires browser DOM extraction; use semantic_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
 			),
 		);
+	}
+
+	/**
+	 * Resolve validated commerce context supplied by the caller.
+	 *
+	 * @param array<string, mixed> $args Import args.
+	 * @return array<string, mixed>
+	 */
+	private static function commerce_context_from_args( array $args ): array {
+		if ( isset( $args['commerce_context'] ) && is_array( $args['commerce_context'] ) ) {
+			return $args['commerce_context'];
+		}
+
+		return array();
+	}
+
+	/**
+	 * Build BFB conversion options for one source fragment.
+	 *
+	 * @param string $source Source fragment label.
+	 * @return array<string, mixed>
+	 */
+	private static function conversion_options( string $source ): array {
+		if ( empty( self::$active_commerce_context ) ) {
+			return array();
+		}
+
+		return array(
+			'context' => array(
+				'commerce' => array_merge(
+					self::$active_commerce_context,
+					array(
+						'source_fragment' => $source,
+					)
+				),
+			),
+			'source'  => array(
+				'fragment' => $source,
+			),
+		);
+	}
+
+	/**
+	 * Record whether commerce context is available for this import.
+	 *
+	 * @return void
+	 */
+	private static function record_commerce_context_summary(): void {
+		if ( empty( self::$active_commerce_context ) ) {
+			return;
+		}
+
+		$products = isset( self::$active_commerce_context['products'] ) && is_array( self::$active_commerce_context['products'] ) ? self::$active_commerce_context['products'] : array();
+		self::$conversion_report['commerce_context']['supplied']       = true;
+		self::$conversion_report['commerce_context']['source']         = isset( self::$active_commerce_context['source'] ) ? (string) self::$active_commerce_context['source'] : 'import_args';
+		self::$conversion_report['commerce_context']['product_count']  = count( $products );
+		self::$conversion_report['commerce_context']['selector_hints'] = self::commerce_selector_hints( self::$active_commerce_context );
+	}
+
+	/**
+	 * Extract source filename and selector hints from validated commerce context.
+	 *
+	 * @param array<string, mixed> $context Validated commerce context.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function commerce_selector_hints( array $context ): array {
+		$hints = array();
+		if ( isset( $context['selector_hints'] ) && is_array( $context['selector_hints'] ) ) {
+			foreach ( $context['selector_hints'] as $hint ) {
+				if ( is_array( $hint ) ) {
+					$hints[] = self::normalize_commerce_selector_hint( $hint );
+				}
+			}
+		}
+
+		$products = isset( $context['products'] ) && is_array( $context['products'] ) ? $context['products'] : array();
+		foreach ( $products as $product ) {
+			if ( is_array( $product ) ) {
+				$hint = self::normalize_commerce_selector_hint( $product );
+				if ( ! empty( $hint ) ) {
+					$hints[] = $hint;
+				}
+			}
+		}
+
+		return $hints;
+	}
+
+	/**
+	 * Normalize one commerce selector hint for report output.
+	 *
+	 * @param array<string, mixed> $source Source hint data.
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_commerce_selector_hint( array $source ): array {
+		$hint = array();
+		foreach ( array( 'source_file', 'source_filename', 'selector', 'grid_selector', 'card_selector' ) as $key ) {
+			if ( isset( $source[ $key ] ) && '' !== trim( (string) $source[ $key ] ) ) {
+				$hint[ $key ] = (string) $source[ $key ];
+			}
+		}
+
+		return $hint;
 	}
 
 	/**
@@ -2624,17 +2757,17 @@ class Static_Site_Importer_Theme_Generator {
 			$generated   = self::generated_visual_probe_markup( $writes, $theme_prefix, $pattern );
 
 			self::$conversion_report['semantic_fidelity']['comparison_targets'][] = array(
-				'source_file'            => $page['path'],
-				'source_filename'        => $filename,
-				'wordpress_page_id'      => $page_ids[ $filename ] ?? null,
-				'wordpress_url'          => $permalinks[ $filename ] ?? '',
-				'generated_template'     => $template,
-				'generated_pattern'      => $pattern,
-				'generated_theme_parts'  => $theme_parts,
-				'generated_files'        => array_values( array_filter( array_merge( array( $template, $pattern ), $theme_parts ) ) ),
-				'regions'                => self::semantic_regions( $source_html, $generated ),
-				'semantic_selectors'     => self::semantic_selectors(),
-				'comparison_hooks'       => array(
+				'source_file'           => $page['path'],
+				'source_filename'       => $filename,
+				'wordpress_page_id'     => $page_ids[ $filename ] ?? null,
+				'wordpress_url'         => $permalinks[ $filename ] ?? '',
+				'generated_template'    => $template,
+				'generated_pattern'     => $pattern,
+				'generated_theme_parts' => $theme_parts,
+				'generated_files'       => array_values( array_filter( array_merge( array( $template, $pattern ), $theme_parts ) ) ),
+				'regions'               => self::semantic_regions( $source_html, $generated ),
+				'semantic_selectors'    => self::semantic_selectors(),
+				'comparison_hooks'      => array(
 					'landmarks' => array( 'header', 'nav', 'main', 'footer', '[role=banner]', '[role=navigation]', '[role=main]', '[role=contentinfo]' ),
 					'actions'   => array( 'a', 'button', '[role=button]', '.wp-block-button__link' ),
 					'identity'  => array( '[class*=brand]', '[class*=logo]', '[class*=wordmark]', 'img[alt*=logo i]', 'svg[aria-label*=logo i]' ),
@@ -3197,6 +3330,37 @@ class Static_Site_Importer_Theme_Generator {
 			'html_length'  => strlen( $element_html ),
 			'html_excerpt' => self::diagnostic_excerpt( $element_html ),
 		);
+	}
+
+	/**
+	 * Record commerce-related metadata emitted during conversion.
+	 *
+	 * @param string               $source   Source fragment label.
+	 * @param array<string, mixed> $metadata Conversion metadata.
+	 * @return void
+	 */
+	private static function record_commerce_conversion_metadata( string $source, array $metadata ): void {
+		if ( empty( self::$active_commerce_context ) || ! self::is_commerce_metadata( $metadata ) ) {
+			return;
+		}
+
+		self::$conversion_report['commerce_context']['diagnostics'][] = array(
+			'source'   => $source,
+			'metadata' => $metadata,
+		);
+	}
+
+	/**
+	 * Determine whether conversion metadata is commerce-related.
+	 *
+	 * @param array<string, mixed> $metadata Conversion metadata.
+	 * @return bool
+	 */
+	private static function is_commerce_metadata( array $metadata ): bool {
+		$encoded  = wp_json_encode( $metadata, JSON_UNESCAPED_SLASHES );
+		$haystack = is_string( $encoded ) ? strtolower( $encoded ) : '';
+
+		return str_contains( $haystack, 'commerce' ) || str_contains( $haystack, 'product' ) || str_contains( $haystack, 'woocommerce' );
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -1276,6 +1276,77 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Validated commerce context is forwarded to BFB and summarized in the import report.
+	 */
+	public function test_commerce_context_is_forwarded_to_page_conversion_and_reported(): void {
+		$html_path = $this->write_temp_fixture(
+			'index.html',
+			'<!doctype html><html><head><title>Commerce Context</title></head><body><main><section class="product-grid"><article class="product-card"><h2>Roasted Beans</h2><p>$18.00</p></article></section></main></body></html>'
+		);
+
+		$captured_contexts = array();
+		$args_filter       = static function ( array $handler_args ) use ( &$captured_contexts ): array {
+			if ( isset( $handler_args['context']['commerce'] ) && is_array( $handler_args['context']['commerce'] ) ) {
+				$captured_contexts[] = $handler_args['context']['commerce'];
+				do_action(
+					'bfb_conversion_metadata',
+					array(
+						'type'          => 'commerce_context_received',
+						'product_count' => count( $handler_args['context']['commerce']['products'] ?? array() ),
+					)
+				);
+			}
+
+			return $handler_args;
+		};
+		add_filter( 'bfb_html_to_blocks_args', $args_filter, 10, 1 );
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'             => 'Commerce Context',
+				'slug'             => 'commerce-context',
+				'overwrite'        => true,
+				'activate'         => false,
+				'keep_source'      => true,
+				'commerce_context' => array(
+					'source'   => 'products.json',
+					'products' => array(
+						array(
+							'name'            => 'Roasted Beans',
+							'slug'            => 'roasted-beans',
+							'source_filename' => 'index.html',
+							'card_selector'   => '.product-card',
+						),
+					),
+					'selector_hints' => array(
+						array(
+							'source_filename' => 'index.html',
+							'grid_selector'   => '.product-grid',
+						),
+					),
+				),
+			)
+		);
+		remove_filter( 'bfb_html_to_blocks_args', $args_filter, 10 );
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $captured_contexts );
+		$this->assertSame( 'products.json', $captured_contexts[0]['source'] ?? '' );
+		$this->assertContains( 'main:index.html', array_column( $captured_contexts, 'source_fragment' ) );
+
+		$report = json_decode( $this->read_file( $result['report_path'] ), true );
+		$this->assertIsArray( $report );
+		$this->assertTrue( $report['commerce_context']['supplied'] ?? false );
+		$this->assertSame( 'products.json', $report['commerce_context']['source'] ?? '' );
+		$this->assertSame( 1, $report['commerce_context']['product_count'] ?? null );
+		$this->assertContains( '.product-grid', array_column( $report['commerce_context']['selector_hints'] ?? array(), 'grid_selector' ) );
+		$this->assertContains( '.product-card', array_column( $report['commerce_context']['selector_hints'] ?? array(), 'card_selector' ) );
+		$this->assertSame( 'commerce_context_received', $report['commerce_context']['diagnostics'][0]['metadata']['type'] ?? '' );
+	}
+
+	/**
 	 * Server-visible malformed block documents are counted in generated-theme quality.
 	 */
 	public function test_generated_theme_quality_reports_malformed_block_documents(): void {


### PR DESCRIPTION
## Summary
- Adds an explicit `commerce_context` import seam for already-validated product context without implementing products.json validation in this PR.
- Forwards supplied commerce context through BFB's generic `context` conversion option and source fragment metadata.
- Records commerce-context summary, selector hints, and commerce-related conversion metadata in `import-report.json`.

## Testing
- `homeboy test`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`

## Notes
- `homeboy lint` still reports pre-existing repository findings unrelated to this change, including existing PHPStan issues in `class-static-site-importer-document.php` and an unused helper/parameter in `class-static-site-importer-theme-generator.php`.
- The pre-existing local modification to `vendor/composer/installed.php` was not included in this commit.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the scoped commerce-context forwarding/reporting seam and drafting the fixture test; Chris remains responsible for review and merge decisions.