### PR TITLE
Fix source nav admin bar offsets

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -4040,7 +4040,8 @@ class Static_Site_Importer_Theme_Generator {
 			foreach ( explode( ',', $prelude ) as $selector ) {
 				$selector = trim( $selector );
 				if ( self::selector_is_plausible_top_chrome( $selector ) ) {
-					$selectors[] = 'body.admin-bar ' . $selector;
+					$source_nav_selector = self::source_nav_selector_bridge_selector( $selector );
+					$selectors[]         = 'body.admin-bar ' . ( $source_nav_selector ?? $selector );
 				}
 			}
 

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -509,6 +509,9 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '.static-site-importer-source-nav { position: fixed; top: 0; left: 0; right: 0; display: flex; justify-content: space-between; }', $style );
 		$this->assertStringContainsString( '.static-site-importer-source-nav .nav-logo { font-weight: 800; }', $style );
 		$this->assertStringContainsString( '@media (max-width: 700px) { .static-site-importer-source-nav { position: sticky; } }', $style );
+		$this->assertStringContainsString( 'body.admin-bar .static-site-importer-source-nav { top: 32px; }', $style );
+		$this->assertStringContainsString( '@media screen and (max-width: 782px) { body.admin-bar .static-site-importer-source-nav { top: 46px; } }', $style );
+		$this->assertStringNotContainsString( 'body.admin-bar nav { top:', $style );
 		$this->assertInstanceOf( WP_Post::class, $nav_post );
 	}
 

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -368,6 +368,9 @@ if ( false !== $wrote_rsm_nav ) {
 		$assert( str_contains( $rsm_nav_style, '.static-site-importer-source-nav { position: fixed; top: 0; left: 0; right: 0; display: flex; justify-content: space-between; }' ), 'rsm-nav-bridge-preserves-bare-nav-rule' );
 		$assert( str_contains( $rsm_nav_style, '.static-site-importer-source-nav .nav-logo { font-weight: 800; }' ), 'rsm-nav-bridge-preserves-descendant-nav-rule' );
 		$assert( str_contains( $rsm_nav_style, '@media (max-width: 700px) { .static-site-importer-source-nav { position: sticky; } }' ), 'rsm-nav-bridge-preserves-media-nav-rule' );
+		$assert( str_contains( $rsm_nav_style, 'body.admin-bar .static-site-importer-source-nav { top: 32px; }' ), 'rsm-nav-admin-bar-offset-targets-source-nav-wrapper' );
+		$assert( str_contains( $rsm_nav_style, '@media screen and (max-width: 782px) { body.admin-bar .static-site-importer-source-nav { top: 46px; } }' ), 'rsm-nav-admin-bar-mobile-offset-targets-source-nav-wrapper' );
+		$assert( ! str_contains( $rsm_nav_style, 'body.admin-bar nav { top:' ), 'rsm-nav-admin-bar-offset-avoids-original-nav-selector' );
 		$assert( $rsm_nav_post instanceof WP_Post, 'rsm-nav-post-exists' );
 	}
 }


### PR DESCRIPTION
## Summary
- Reuse the source-nav selector bridge when generating WordPress admin-bar offsets for imported fixed/sticky top chrome.
- Add fixture and smoke assertions that converted `.static-site-importer-source-nav` wrappers receive the 32px/46px admin-bar offsets instead of targeting the original `nav` selector.

Fixes #119

## Testing
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-source-nav-admin-bar-offset`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the targeted selector-bridge fix, added fixture coverage, and ran targeted verification; Chris remains responsible for review and merge.