### PR TITLE
Fix freeform block quality reporting

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -2522,6 +2522,7 @@ class Static_Site_Importer_Theme_Generator {
 				'content_loss_count'                 => 0,
 				'empty_conversion_count'             => 0,
 				'core_html_block_count'              => 0,
+				'freeform_block_count'               => 0,
 				'invalid_block_count'                => 0,
 				'invalid_block_document_count'       => 0,
 				'unsafe_svg_count'                   => 0,
@@ -3447,6 +3448,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		self::$conversion_report['quality']['core_html_block_count'] += $core_html_count;
+		self::$conversion_report['quality']['freeform_block_count']  += $freeform_count;
 		self::$conversion_report['quality']['invalid_block_count']   += $invalid_count;
 		if ( $invalid_count > 0 ) {
 			++self::$conversion_report['quality']['invalid_block_document_count'];
@@ -3490,6 +3492,9 @@ class Static_Site_Importer_Theme_Generator {
 				++$block_count;
 				if ( 'core/html' === $name ) {
 					++$core_html_count;
+				}
+				if ( 'core/freeform' === $name ) {
+					++$freeform_count;
 				}
 			} elseif ( '' !== trim( isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ? $block['innerHTML'] : '' ) ) {
 				++$freeform_count;
@@ -3717,6 +3722,9 @@ class Static_Site_Importer_Theme_Generator {
 		}
 		if ( $quality['core_html_block_count'] > 0 ) {
 			$reasons[] = 'core_html_block';
+		}
+		if ( $quality['freeform_block_count'] > 0 ) {
+			$reasons[] = 'freeform_block';
 		}
 		if ( $quality['invalid_block_count'] > 0 ) {
 			$reasons[] = 'invalid_block';

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -1441,6 +1441,44 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Serialized freeform blocks are counted in generated-theme quality.
+	 */
+	public function test_generated_theme_quality_reports_serialized_freeform_blocks(): void {
+		$reflection = new ReflectionClass( Static_Site_Importer_Theme_Generator::class );
+
+		$new_report = $reflection->getMethod( 'new_conversion_report' );
+		$new_report->setAccessible( true );
+
+		$report_property = $reflection->getProperty( 'conversion_report' );
+		$report_property->setAccessible( true );
+		$report_property->setValue( null, $new_report->invoke( null, '/tmp/source/index.html' ) );
+
+		$analyze = $reflection->getMethod( 'analyze_generated_theme_block_documents' );
+		$analyze->setAccessible( true );
+		$analyze->invoke(
+			null,
+			array(
+				'/tmp/generated/parts/header.html' => '<!-- wp:paragraph --><p>Native block.</p><!-- /wp:paragraph -->' .
+					'<!-- wp:freeform --><a href="#" class="nav-logo">Field Notes Live</a><!-- /wp:freeform -->',
+			),
+			'/tmp/generated'
+		);
+
+		$finalize = $reflection->getMethod( 'finalize_quality_report' );
+		$finalize->setAccessible( true );
+		$quality = $finalize->invoke( null, array() );
+		$report  = $report_property->getValue();
+
+		$document = $report['generated_theme']['block_documents'][0] ?? array();
+
+		$this->assertSame( 2, $document['block_count'] ?? null );
+		$this->assertSame( 1, $document['freeform_block_count'] ?? null );
+		$this->assertSame( 1, $quality['freeform_block_count'] ?? null );
+		$this->assertFalse( $quality['pass'] ?? true );
+		$this->assertContains( 'freeform_block', $quality['failure_reasons'] ?? array() );
+	}
+
+	/**
 	 * Server-visible malformed block documents are counted in generated-theme quality.
 	 */
 	public function test_generated_theme_quality_reports_malformed_block_documents(): void {


### PR DESCRIPTION
## Summary
- Count serialized `core/freeform` / `wp:freeform` blocks in generated theme block-document analysis.
- Aggregate freeform block counts into import report quality and fail the native-block quality gate when freeform residue is present.
- Add fixture coverage for serialized freeform blocks in generated theme documents.

## Testing
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-issue-118-freeform-report` passed: 32 tests, 668 assertions.
- `git diff --check` passed.
- `homeboy lint static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-issue-118-freeform-report --changed-only` reports existing findings in `includes/class-static-site-importer-theme-generator.php` at lines 897 and 1031; no new lint finding from this change.

Closes #118.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Issue investigation, implementation, test coverage, and verification command execution; Chris remains responsible for review and merge.