### PR TITLE
Show JS-revealed content in editor canvases

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -3957,10 +3957,11 @@ class Static_Site_Importer_Theme_Generator {
 	private static function editor_style_css( string $css, array $button_classes = array() ): string {
 		$button_bridge              = self::button_style_bridge_css( $css, $button_classes );
 		$editor_bridge              = self::editor_absolute_overlay_css( $css );
+		$editor_reveal_bridge       = self::editor_reveal_animation_css( $css );
 		$source_nav_selector_bridge = self::source_nav_selector_bridge_css( $css );
 		$css                        = self::scope_source_button_css( $css, $button_classes );
 
-		return "/*\nStatic Site Importer editor styles.\nGenerated separately from frontend style.css so editor wrapper repairs do not leak to public rendering.\n*/\n\n" . $css . "\n" . $button_bridge . $source_nav_selector_bridge . $editor_bridge;
+		return "/*\nStatic Site Importer editor styles.\nGenerated separately from frontend style.css so editor wrapper repairs do not leak to public rendering.\n*/\n\n" . $css . "\n" . $button_bridge . $source_nav_selector_bridge . $editor_bridge . $editor_reveal_bridge;
 	}
 
 	/**
@@ -4235,6 +4236,111 @@ class Static_Site_Importer_Theme_Generator {
 		$css .= "\n/* Static Site Importer: hide empty decorative layer group controls in the Site Editor. */\n" . implode( ', ', array_unique( $placeholder_rules ) ) . ' { display: none; }' . "\n";
 
 		return $css;
+	}
+
+	/**
+	 * Build editor-only visibility resets for JS-driven reveal animation starts.
+	 *
+	 * Source sites often initialize reveal targets with opacity:0 plus a transform,
+	 * then use frontend JavaScript to animate them into place. The editor canvas does
+	 * not run that frontend script, so scope the neutralization to editor styles.
+	 *
+	 * @param string $css Source CSS.
+	 * @return string Additional editor-only CSS rules.
+	 */
+	private static function editor_reveal_animation_css( string $css ): string {
+		$classes = self::reveal_animation_classes_from_css( $css );
+		if ( empty( $classes ) ) {
+			return '';
+		}
+
+		$selectors = array();
+		foreach ( $classes as $class ) {
+			if ( preg_match( '/^[A-Za-z_-][A-Za-z0-9_-]*$/', $class ) ) {
+				$selectors[] = '.editor-styles-wrapper .' . $class;
+			}
+		}
+
+		if ( empty( $selectors ) ) {
+			return '';
+		}
+
+		return "\n/* Static Site Importer: show JS-revealed animation content in editor canvases. */\n" . implode( ', ', array_unique( $selectors ) ) . ' { opacity: 1 !important; transform: none !important; }' . "\n";
+	}
+
+	/**
+	 * Collect terminal selector classes from rules declaring hidden transform reveals.
+	 *
+	 * @param string $css Source CSS.
+	 * @return array<int, string> Class names.
+	 */
+	private static function reveal_animation_classes_from_css( string $css ): array {
+		$css       = preg_replace( '/\/\*.*?\*\//s', '', $css ) ?? $css;
+		$lower_css = strtolower( $css );
+		if ( '' === trim( $css ) || ! str_contains( $lower_css, 'opacity' ) || ! str_contains( $lower_css, 'transform' ) || ! str_contains( $css, '.' ) ) {
+			return array();
+		}
+
+		$classes = self::reveal_animation_classes_from_css_scope( $css );
+		sort( $classes, SORT_STRING );
+
+		return $classes;
+	}
+
+	/**
+	 * Collect hidden transform reveal classes inside one CSS block list.
+	 *
+	 * @param string $css CSS to inspect.
+	 * @return array<int, string> Class names.
+	 */
+	private static function reveal_animation_classes_from_css_scope( string $css ): array {
+		$classes = array();
+		$length  = strlen( $css );
+		$offset  = 0;
+
+		while ( $offset < $length && preg_match( '/\G\s*([^{}]+)\{/', $css, $match, 0, $offset ) ) {
+			$prelude    = trim( $match[1] );
+			$body_start = $offset + strlen( $match[0] );
+			$body_end   = self::find_css_block_end( $css, $body_start );
+			if ( null === $body_end ) {
+				break;
+			}
+
+			$body   = substr( $css, $body_start, $body_end - $body_start );
+			$offset = $body_end + 1;
+
+			if ( str_starts_with( $prelude, '@' ) ) {
+				$classes = array_merge( $classes, self::reveal_animation_classes_from_css_scope( $body ) );
+				continue;
+			}
+
+			$opacity   = self::css_declaration_value( $body, 'opacity' );
+			$transform = self::css_declaration_value( $body, 'transform' );
+			if ( ! self::css_opacity_is_zero( $opacity ) || null === $transform || preg_match( '/^none\s*(?:!important\s*)?$/i', $transform ) ) {
+				continue;
+			}
+
+			foreach ( explode( ',', $prelude ) as $selector ) {
+				$classes = array_merge( $classes, self::selector_terminal_classes( trim( $selector ) ) );
+			}
+		}
+
+		return array_values( array_unique( $classes ) );
+	}
+
+	/**
+	 * Determine whether an opacity declaration hides the element.
+	 *
+	 * @param string|null $opacity Opacity declaration value.
+	 * @return bool Whether the value is zero.
+	 */
+	private static function css_opacity_is_zero( ?string $opacity ): bool {
+		if ( null === $opacity ) {
+			return false;
+		}
+
+		$opacity = trim( preg_replace( '/\s*!important\s*$/i', '', $opacity ) ?? $opacity );
+		return (bool) preg_match( '/^0(?:\.0+)?%?$/', $opacity );
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -1049,6 +1049,62 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * JS-revealed opacity/transform animation starts are visible in editor canvases.
+	 */
+	public function test_js_reveal_animation_starts_are_neutralized_in_editor_only(): void {
+		$html_path = $this->write_temp_fixture(
+			'js-reveal-animation.html',
+			'<!doctype html><html><head><title>JS Reveal Animation</title><style>' .
+			'.hero { min-height: 80vh; display: grid; place-items: center; }' .
+			'.hero-eyebrow { opacity: 0; transform: translateY(12px); transition: opacity .4s ease, transform .4s ease; }' .
+			'.hero-title, .hero-tagline { opacity: 0 !important; transform: translateY(20px); }' .
+			'@media (min-width: 800px) { .hero-meta { opacity: 0; transform: translateX(-16px); } }' .
+			'.visually-hidden { opacity: 0; }' .
+			'.spinner { opacity: 0; transform: none; }' .
+			'</style></head><body><main><section class="hero">' .
+			'<p class="hero-eyebrow">Field Notes Live</p><h1 class="hero-title">Conference content should be editable</h1>' .
+			'<p class="hero-tagline">Frontend JavaScript reveals this copy.</p><p class="hero-meta">May 2026</p>' .
+			'<span class="visually-hidden">Screen reader label</span><span class="spinner">Loading</span>' .
+			'</section></main><script>document.querySelectorAll(\'.hero-eyebrow,.hero-title,.hero-tagline,.hero-meta\').forEach(function(el){el.style.opacity=\'1\';el.style.transform=\'translateY(0)\';});</script></body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'JS Reveal Animation',
+				'slug'      => 'js-reveal-animation',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir    = $result['theme_dir'];
+		$pattern      = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-js-reveal-animation.php' ) );
+		$style        = $this->read_file( $theme_dir . '/style.css' );
+		$editor_style = $this->read_file( $theme_dir . '/assets/css/editor-style.css' );
+		$report       = json_decode( $this->read_file( $result['report_path'] ), true );
+
+		$this->assertStringContainsString( 'Conference content should be editable', $pattern );
+		$this->assertStringContainsString( '.hero-eyebrow { opacity: 0; transform: translateY(12px);', $style );
+		$this->assertStringContainsString( '.hero-title, .hero-tagline { opacity: 0 !important; transform: translateY(20px);', $style );
+		$this->assertStringNotContainsString( 'Static Site Importer: show JS-revealed animation content in editor canvases.', $style );
+		$this->assertStringContainsString( 'Static Site Importer: show JS-revealed animation content in editor canvases.', $editor_style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .hero-eyebrow', $editor_style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .hero-title', $editor_style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .hero-tagline', $editor_style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .hero-meta', $editor_style );
+		$this->assertStringContainsString( 'opacity: 1 !important; transform: none !important;', $editor_style );
+		$this->assertStringNotContainsString( '.editor-styles-wrapper .visually-hidden', $editor_style );
+		$this->assertStringNotContainsString( '.editor-styles-wrapper .spinner', $editor_style );
+		$this->assertSame( 0, $report['quality']['fallback_count'] ?? null );
+		$this->assertSame( 0, $report['quality']['core_html_block_count'] ?? null );
+		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
+	}
+
+	/**
 	 * Safe inline SVG icons are materialized as theme assets and native image blocks.
 	 */
 	public function test_safe_inline_svg_icons_materialize_as_theme_assets(): void {

--- a/tests/smoke-editor-reveal-animation-support.php
+++ b/tests/smoke-editor-reveal-animation-support.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Smoke test: generated editor styles show JS-revealed animation content.
+ *
+ * Run inside a WordPress site with BFB active:
+ * wp eval-file tests/smoke-editor-reveal-animation-support.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+if ( ! class_exists( 'Static_Site_Importer_Document', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-document.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Woo_Product_Seeder', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-woo-product-seeder.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read = static function ( string $path ): string {
+	$contents = file_get_contents( $path );
+	return false === $contents ? '' : $contents;
+};
+
+$fixture = trailingslashit( get_temp_dir() ) . 'static-site-importer-editor-reveal-animation.html';
+file_put_contents(
+	$fixture,
+	'<!doctype html><html><head><title>Editor Reveal Animation</title><style>' .
+	'.hero-eyebrow { opacity: 0; transform: translateY(12px); }' .
+	'.hero-title, .hero-tagline { opacity: 0 !important; transform: translateY(20px); }' .
+	'@media (min-width: 800px) { .hero-meta { opacity: 0; transform: translateX(-16px); } }' .
+	'.visually-hidden { opacity: 0; }' .
+	'.spinner { opacity: 0; transform: none; }' .
+	'</style></head><body><main><section class="hero"><p class="hero-eyebrow">Field Notes Live</p>' .
+	'<h1 class="hero-title">Conference content should be editable</h1><p class="hero-tagline">Frontend JavaScript reveals this copy.</p>' .
+	'<p class="hero-meta">May 2026</p><span class="visually-hidden">Screen reader label</span><span class="spinner">Loading</span>' .
+	'</section></main><script>document.querySelectorAll(\'.hero-eyebrow,.hero-title,.hero-tagline,.hero-meta\').forEach(function(el){el.style.opacity=\'1\';el.style.transform=\'translateY(0)\';});</script></body></html>'
+);
+
+$result = Static_Site_Importer_Theme_Generator::import_theme(
+	$fixture,
+	array(
+		'name'      => 'Editor Reveal Animation',
+		'slug'      => 'editor-reveal-animation',
+		'overwrite' => true,
+		'activate'  => false,
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+if ( ! is_wp_error( $result ) ) {
+	$style        = $read( $result['theme_dir'] . '/style.css' );
+	$editor_style = $read( $result['theme_dir'] . '/assets/css/editor-style.css' );
+
+	$assert( str_contains( $style, '.hero-eyebrow { opacity: 0; transform: translateY(12px);' ), 'frontend-source-opacity-transform-preserved' );
+	$assert( ! str_contains( $style, 'Static Site Importer: show JS-revealed animation content in editor canvases.' ), 'frontend-style-does-not-include-editor-reveal-bridge' );
+	$assert( str_contains( $editor_style, 'Static Site Importer: show JS-revealed animation content in editor canvases.' ), 'editor-reveal-bridge-comment-present' );
+	$assert( str_contains( $editor_style, '.editor-styles-wrapper .hero-eyebrow' ), 'editor-reveals-eyebrow' );
+	$assert( str_contains( $editor_style, '.editor-styles-wrapper .hero-title' ), 'editor-reveals-title' );
+	$assert( str_contains( $editor_style, '.editor-styles-wrapper .hero-tagline' ), 'editor-reveals-tagline' );
+	$assert( str_contains( $editor_style, '.editor-styles-wrapper .hero-meta' ), 'editor-reveals-media-query-target' );
+	$assert( str_contains( $editor_style, 'opacity: 1 !important; transform: none !important;' ), 'editor-neutralizes-hidden-transform-start' );
+	$assert( ! str_contains( $editor_style, '.editor-styles-wrapper .visually-hidden' ), 'opacity-only-hidden-class-not-neutralized' );
+	$assert( ! str_contains( $editor_style, '.editor-styles-wrapper .spinner' ), 'transform-none-hidden-class-not-neutralized' );
+}
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: editor reveal animation smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-editor-style-support.php
+++ b/tests/smoke-editor-style-support.php
@@ -16,6 +16,9 @@ $plugin_root = dirname( __DIR__ );
 if ( ! class_exists( 'Static_Site_Importer_Document', false ) ) {
 	require_once $plugin_root . '/includes/class-static-site-importer-document.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Woo_Product_Seeder', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-woo-product-seeder.php';
+}
 if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
 	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
 }


### PR DESCRIPTION
## Summary
- Detect imported CSS reveal starts that hide elements with `opacity: 0` plus a non-`none` `transform`.
- Append editor-only `.editor-styles-wrapper` overrides so Site Editor/Edit Page canvases show the imported content without changing frontend animation CSS or JS behavior.
- Add fixture and smoke coverage for opacity/transform reveal content, including nested media rules and non-reveal hidden classes.

Closes #121.

## Tests
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `php -l tests/smoke-editor-reveal-animation-support.php`
- `studio wp eval-file /Users/chubes/Developer/static-site-importer@fix-issue-121-editor-reveals/tests/smoke-editor-style-support.php`
- `studio wp --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-121-editor-reveals/tests/smoke-editor-reveal-animation-support.php`
- `npm run test:validation`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the editor-only reveal neutralization, fixture/smoke coverage, and local verification commands; Chris remains responsible for review and merge.