### PR TITLE
Separate generated editor styles

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -165,13 +165,14 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		$writes = array(
-			$theme_dir . '/style.css'                 => self::style_css( $theme_name, $site_css, array_keys( self::$button_wrapper_classes ) ),
-			$theme_dir . '/functions.php'             => self::functions_php( $theme_slug ),
-			$theme_dir . '/theme.json'                => self::theme_json( $theme_name, $site_css ),
-			$theme_dir . '/parts/header.html'         => $header_blocks,
-			$theme_dir . '/templates/front-page.html' => self::content_template( $background_blocks, $has_footer_part ),
-			$theme_dir . '/templates/page.html'       => self::content_template( $background_blocks, $has_footer_part ),
-			$theme_dir . '/templates/index.html'      => self::content_template( $background_blocks, $has_footer_part ),
+			$theme_dir . '/style.css'                    => self::style_css( $theme_name, $site_css, array_keys( self::$button_wrapper_classes ) ),
+			$theme_dir . '/assets/css/editor-style.css' => self::editor_style_css( $site_css, array_keys( self::$button_wrapper_classes ) ),
+			$theme_dir . '/functions.php'                => self::functions_php( $theme_slug ),
+			$theme_dir . '/theme.json'                   => self::theme_json( $theme_name, $site_css ),
+			$theme_dir . '/parts/header.html'            => $header_blocks,
+			$theme_dir . '/templates/front-page.html'    => self::content_template( $background_blocks, $has_footer_part ),
+			$theme_dir . '/templates/page.html'          => self::content_template( $background_blocks, $has_footer_part ),
+			$theme_dir . '/templates/index.html'         => self::content_template( $background_blocks, $has_footer_part ),
 		);
 		if ( $has_footer_part ) {
 			$writes[ $theme_dir . '/parts/footer.html' ] = $footer_blocks;
@@ -3764,7 +3765,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return true|WP_Error
 	 */
 	private static function ensure_dirs( string $theme_dir ) {
-		foreach ( array( $theme_dir, $theme_dir . '/templates', $theme_dir . '/parts', $theme_dir . '/patterns', $theme_dir . '/assets', $theme_dir . '/assets/icons' ) as $dir ) {
+		foreach ( array( $theme_dir, $theme_dir . '/templates', $theme_dir . '/parts', $theme_dir . '/patterns', $theme_dir . '/assets', $theme_dir . '/assets/css', $theme_dir . '/assets/icons' ) as $dir ) {
 			if ( ! wp_mkdir_p( $dir ) ) {
 				return new WP_Error( 'static_site_importer_mkdir_failed', sprintf( 'Failed to create directory: %s', $dir ) );
 			}
@@ -3875,12 +3876,26 @@ class Static_Site_Importer_Theme_Generator {
 	 */
 	private static function style_css( string $theme_name, string $css, array $button_classes = array() ): string {
 		$button_bridge              = self::button_style_bridge_css( $css, $button_classes );
-		$editor_bridge              = self::editor_absolute_overlay_css( $css );
 		$admin_bar_bridge           = self::admin_bar_top_chrome_css( $css );
 		$source_nav_selector_bridge = self::source_nav_selector_bridge_css( $css );
 		$css                        = self::scope_source_button_css( $css, $button_classes );
 
-		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Imported from static HTML using Block Format Bridge.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $button_bridge . $editor_bridge . $admin_bar_bridge . $source_nav_selector_bridge;
+		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Imported from static HTML using Block Format Bridge.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $button_bridge . $admin_bar_bridge . $source_nav_selector_bridge;
+	}
+
+	/**
+	 * Build editor-style.css.
+	 *
+	 * @param string $css Source CSS.
+	 * @return string
+	 */
+	private static function editor_style_css( string $css, array $button_classes = array() ): string {
+		$button_bridge              = self::button_style_bridge_css( $css, $button_classes );
+		$editor_bridge              = self::editor_absolute_overlay_css( $css );
+		$source_nav_selector_bridge = self::source_nav_selector_bridge_css( $css );
+		$css                        = self::scope_source_button_css( $css, $button_classes );
+
+		return "/*\nStatic Site Importer editor styles.\nGenerated separately from frontend style.css so editor wrapper repairs do not leak to public rendering.\n*/\n\n" . $css . "\n" . $button_bridge . $source_nav_selector_bridge . $editor_bridge;
 	}
 
 	/**
@@ -4492,7 +4507,7 @@ class Static_Site_Importer_Theme_Generator {
 			" */\n\n" .
 			"add_action( 'after_setup_theme', static function (): void {\n" .
 			"\tadd_theme_support( 'editor-styles' );\n" .
-			"\tadd_editor_style( 'style.css' );\n" .
+			"\tadd_editor_style( 'assets/css/editor-style.css' );\n" .
 			"} );\n\n" .
 			"add_action( 'wp_enqueue_scripts', static function (): void {\n" .
 			"\twp_enqueue_style( '" . $style_handle . "', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );\n" .
@@ -4501,7 +4516,7 @@ class Static_Site_Importer_Theme_Generator {
 			"\t}\n" .
 			"} );\n\n" .
 			"add_action( 'enqueue_block_editor_assets', static function (): void {\n" .
-			"\twp_enqueue_style( '" . $editor_handle . "', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );\n" .
+			"\twp_enqueue_style( '" . $editor_handle . "', get_template_directory_uri() . '/assets/css/editor-style.css', array(), wp_get_theme()->get( 'Version' ) );\n" .
 			"} );\n";
 	}
 

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -84,8 +84,9 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '--accent', $style );
 		$this->assertStringContainsString( '.wp-block-button.btn > .wp-block-button__link', $style );
 		$this->assertStringContainsString( "add_theme_support( 'editor-styles' )", $functions );
-		$this->assertStringContainsString( "add_editor_style( 'style.css' )", $functions );
+		$this->assertStringContainsString( "add_editor_style( 'assets/css/editor-style.css' )", $functions );
 		$this->assertStringContainsString( "add_action( 'enqueue_block_editor_assets'", $functions );
+		$this->assertStringContainsString( "get_template_directory_uri() . '/assets/css/editor-style.css'", $functions );
 		$this->assertIsArray( $theme_json );
 
 		$palette = array();
@@ -811,10 +812,11 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertNotWPError( $result );
 		$this->assertIsArray( $result );
 
-		$theme_dir = $result['theme_dir'];
-		$pattern   = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-absolute-hero-overlay.php' ) );
-		$style     = $this->read_file( $theme_dir . '/style.css' );
-		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+		$theme_dir    = $result['theme_dir'];
+		$pattern      = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-absolute-hero-overlay.php' ) );
+		$style        = $this->read_file( $theme_dir . '/style.css' );
+		$editor_style = $this->read_file( $theme_dir . '/assets/css/editor-style.css' );
+		$report       = json_decode( $this->read_file( $result['report_path'] ), true );
 
 		$this->assertStringContainsString( '"className":"hero"', $pattern );
 		$this->assertStringContainsString( '"tagName":"section"', $pattern );
@@ -822,8 +824,10 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<!-- wp:group {"className":"container"}', $pattern );
 		$this->assertStringContainsString( '.hero-rip { position: absolute;', $style );
 		$this->assertStringContainsString( '.hero .container { position: relative; z-index: 1;', $style );
-		$this->assertStringContainsString( 'Static Site Importer: let Site Editor wrappers preserve imported absolute overlay stacking.', $style );
-		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .hero-rip)', $style );
+		$this->assertStringNotContainsString( '.editor-styles-wrapper', $style );
+		$this->assertStringContainsString( '.hero-rip { position: absolute;', $editor_style );
+		$this->assertStringContainsString( 'Static Site Importer: let Site Editor wrappers preserve imported absolute overlay stacking.', $editor_style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .hero-rip)', $editor_style );
 		$this->assertSame( 0, $report['quality']['fallback_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['core_html_block_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
@@ -858,25 +862,27 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertNotWPError( $result );
 		$this->assertIsArray( $result );
 
-		$theme_dir = $result['theme_dir'];
-		$pattern   = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-empty-css-background-layers.php' ) );
-		$style     = $this->read_file( $theme_dir . '/style.css' );
-		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+		$theme_dir    = $result['theme_dir'];
+		$pattern      = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-empty-css-background-layers.php' ) );
+		$style        = $this->read_file( $theme_dir . '/style.css' );
+		$editor_style = $this->read_file( $theme_dir . '/assets/css/editor-style.css' );
+		$report       = json_decode( $this->read_file( $result['report_path'] ), true );
 
 		foreach ( array( 'hero-bg-grid', 'hero-bg-glow', 'hero-bg-glow2' ) as $class_name ) {
 			$this->assertStringContainsString( $class_name, $pattern );
 			$this->assertStringContainsString( 'wp-block-group ' . $class_name . ' static-site-importer-decorative-layer', $pattern );
-			$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .' . $class_name . ')', $style );
+			$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .' . $class_name . ')', $editor_style );
 		}
-		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .wp-block-group.static-site-importer-decorative-layer)', $style );
-		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block.wp-block-group.static-site-importer-decorative-layer', $style );
-		$this->assertStringNotContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block.wp-block-group { display: contents; }', $style );
+		$this->assertStringNotContainsString( '.editor-styles-wrapper', $style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .wp-block-group.static-site-importer-decorative-layer)', $editor_style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block.wp-block-group.static-site-importer-decorative-layer', $editor_style );
+		$this->assertStringNotContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block.wp-block-group { display: contents; }', $editor_style );
 
-		$this->assertStringContainsString( 'Static Site Importer: hide empty decorative layer group controls in the Site Editor.', $style );
-		$this->assertStringContainsString( '.editor-styles-wrapper .wp-block-group.static-site-importer-decorative-layer .block-editor-block-variation-picker', $style );
-		$this->assertStringContainsString( '.editor-styles-wrapper .wp-block-group.static-site-importer-decorative-layer .components-placeholder', $style );
-		$this->assertStringContainsString( '.editor-styles-wrapper .wp-block-group.static-site-importer-decorative-layer .block-list-appender', $style );
-		$this->assertStringContainsString( '.editor-styles-wrapper .wp-block-group.static-site-importer-decorative-layer .block-editor-button-block-appender', $style );
+		$this->assertStringContainsString( 'Static Site Importer: hide empty decorative layer group controls in the Site Editor.', $editor_style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .wp-block-group.static-site-importer-decorative-layer .block-editor-block-variation-picker', $editor_style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .wp-block-group.static-site-importer-decorative-layer .components-placeholder', $editor_style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .wp-block-group.static-site-importer-decorative-layer .block-list-appender', $editor_style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .wp-block-group.static-site-importer-decorative-layer .block-editor-button-block-appender', $editor_style );
 		$this->assertSame( 0, $report['quality']['fallback_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['core_html_block_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
@@ -911,16 +917,18 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertNotWPError( $result );
 		$this->assertIsArray( $result );
 
-		$theme_dir = $result['theme_dir'];
-		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
-		$style     = $this->read_file( $theme_dir . '/style.css' );
-		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+		$theme_dir    = $result['theme_dir'];
+		$header       = $this->read_file( $theme_dir . '/parts/header.html' );
+		$style        = $this->read_file( $theme_dir . '/style.css' );
+		$editor_style = $this->read_file( $theme_dir . '/assets/css/editor-style.css' );
+		$report       = json_decode( $this->read_file( $result['report_path'] ), true );
 
 		$this->assertStringContainsString( '<!-- wp:group {"className":"hero-bg static-site-importer-decorative-layer"}', $header );
 		$this->assertStringContainsString( '<div class="wp-block-group hero-bg static-site-importer-decorative-layer"></div>', $header );
 		$this->assertStringNotContainsString( '<!-- wp:html --><div class="hero-bg"></div><!-- /wp:html -->', $header );
 		$this->assertStringNotContainsString( '<!-- wp:html -->', $header );
-		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .hero-bg)', $style );
+		$this->assertStringNotContainsString( '.editor-styles-wrapper', $style );
+		$this->assertStringContainsString( '.editor-styles-wrapper .block-editor-block-list__layout > .wp-block:has(> .hero-bg)', $editor_style );
 		$this->assertSame( 0, $report['quality']['fallback_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['core_html_block_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
@@ -986,7 +994,8 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertNotWPError( $result );
 		$this->assertIsArray( $result );
 
-		$style = $this->read_file( $result['theme_dir'] . '/style.css' );
+		$style        = $this->read_file( $result['theme_dir'] . '/style.css' );
+		$editor_style = $this->read_file( $result['theme_dir'] . '/assets/css/editor-style.css' );
 
 		$this->assertStringContainsString( 'Static Site Importer: offset imported fixed/sticky top chrome below the WordPress admin bar.', $style );
 		$this->assertStringContainsString( 'body.admin-bar header.site-header { top: 32px; }', $style );
@@ -995,6 +1004,9 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '@media screen and (max-width: 782px) { body.admin-bar .top-nav { top: calc(12px + 46px); } }', $style );
 		$this->assertStringNotContainsString( 'body.admin-bar .modal-header', $style );
 		$this->assertStringNotContainsString( 'body.admin-bar .site-footer', $style );
+		$this->assertStringContainsString( 'header.site-header { position: fixed; top: 0;', $editor_style );
+		$this->assertStringNotContainsString( 'Static Site Importer: offset imported fixed/sticky top chrome below the WordPress admin bar.', $editor_style );
+		$this->assertStringNotContainsString( 'body.admin-bar header.site-header', $editor_style );
 	}
 
 	/**

--- a/tests/smoke-editor-style-support.php
+++ b/tests/smoke-editor-style-support.php
@@ -35,8 +35,33 @@ $read = static function ( string $path ): string {
 	return false === $contents ? '' : $contents;
 };
 
+$copy_fixture = static function ( string $source_dir, string $target_dir ) use ( &$copy_fixture ): void {
+	if ( ! is_dir( $target_dir ) ) {
+		wp_mkdir_p( $target_dir );
+	}
+
+	foreach ( scandir( $source_dir ) ?: array() as $entry ) {
+		if ( '.' === $entry || '..' === $entry ) {
+			continue;
+		}
+
+		$source = $source_dir . '/' . $entry;
+		$target = $target_dir . '/' . $entry;
+		if ( is_dir( $source ) ) {
+			$copy_fixture( $source, $target );
+			continue;
+		}
+
+		copy( $source, $target );
+	}
+};
+
+$source_fixture = $plugin_root . '/tests/fixtures/wordpress-is-dead';
+$fixture_copy   = trailingslashit( get_temp_dir() ) . 'static-site-importer-editor-style-fixture';
+$copy_fixture( $source_fixture, $fixture_copy );
+
 $result = Static_Site_Importer_Theme_Generator::import_theme(
-	$plugin_root . '/tests/fixtures/wordpress-is-dead/index.html',
+	$fixture_copy . '/index.html',
 	array(
 		'name'      => 'Editor Style Support Fixture',
 		'slug'      => 'editor-style-support-fixture',
@@ -48,14 +73,20 @@ $result = Static_Site_Importer_Theme_Generator::import_theme(
 $assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
 
 if ( ! is_wp_error( $result ) ) {
-	$functions = $read( $result['theme_dir'] . '/functions.php' );
+	$functions    = $read( $result['theme_dir'] . '/functions.php' );
+	$style        = $read( $result['theme_dir'] . '/style.css' );
+	$editor_style = $read( $result['theme_dir'] . '/assets/css/editor-style.css' );
 
 	$assert( str_contains( $functions, "add_theme_support( 'editor-styles' )" ), 'functions-adds-editor-styles-support' );
-	$assert( str_contains( $functions, "add_editor_style( 'style.css' )" ), 'functions-registers-editor-style-css' );
+	$assert( str_contains( $functions, "add_editor_style( 'assets/css/editor-style.css' )" ), 'functions-registers-dedicated-editor-style-css' );
 	$assert( str_contains( $functions, "add_action( 'enqueue_block_editor_assets'" ), 'functions-adds-block-editor-assets-fallback' );
 	$assert( str_contains( $functions, 'wp_enqueue_style' ) && str_contains( $functions, '-editor-style' ), 'functions-enqueues-editor-style-fallback' );
-	$assert( str_contains( $functions, 'get_stylesheet_uri()' ), 'functions-reuses-generated-style-css' );
+	$assert( str_contains( $functions, "get_template_directory_uri() . '/assets/css/editor-style.css'" ), 'functions-enqueues-dedicated-editor-style-css' );
 	$assert( str_contains( $functions, 'wp_enqueue_scripts' ), 'functions-keeps-frontend-style-enqueue' );
+	$assert( str_contains( $style, '--accent' ), 'frontend-style-keeps-source-css' );
+	$assert( ! str_contains( $style, '.editor-styles-wrapper' ), 'frontend-style-excludes-editor-wrapper-rules' );
+	$assert( str_contains( $editor_style, '--accent' ), 'editor-style-keeps-source-css' );
+	$assert( ! str_contains( $editor_style, 'body.admin-bar' ), 'editor-style-excludes-frontend-admin-bar-rules' );
 }
 
 if ( $failures ) {


### PR DESCRIPTION
## Summary
- Generate `assets/css/editor-style.css` separately from frontend `style.css`.
- Keep editor wrapper normalization out of public CSS while keeping frontend admin-bar offsets out of editor CSS.
- Update fixture/smoke coverage for dedicated editor styles and fixture-safe smoke imports.

Fixes #120.

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `php -l tests/smoke-editor-style-support.php`
- `studio wp --skip-plugins eval 'require_once "/Users/chubes/Developer/static-site-importer@issue-120-style-boundaries/vendor/chubes4/block-format-bridge/block-format-bridge.php"; require_once "/Users/chubes/Developer/static-site-importer@issue-120-style-boundaries/static-site-importer.php"; require "/Users/chubes/Developer/static-site-importer@issue-120-style-boundaries/tests/smoke-editor-style-support.php";'`
- `studio wp --skip-plugins eval '<generated absolute-overlay/admin-bar boundary assertion>'`

## Notes
- `npm run test:validation` was not used as final evidence in this worktree because its WP-CLI import path invokes the installed site plugin/CLI command rather than the isolated worktree code.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and tests; Chris remains responsible for review and merge.