### PR TITLE
Fix chrome fragment native block conversion

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -608,7 +608,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		if ( self::should_preserve_theme_part_phrasing_element( $element ) ) {
-			return self::freeform_block( self::node_html( $doc, $element ) );
+			return self::paragraph_block( self::node_inner_html( $doc, $element ), $element->getAttribute( 'class' ) );
 		}
 
 		if ( self::is_link_cluster_container( $element ) ) {
@@ -952,6 +952,10 @@ class Static_Site_Importer_Theme_Generator {
 		$inner = self::brand_anchor_inline_children_html( $doc, $element );
 		if ( null === $inner || ( '' === trim( wp_strip_all_tags( $inner ) ) && ! str_contains( strtolower( $inner ), '<img' ) ) ) {
 			return null;
+		}
+
+		if ( ! str_contains( strtolower( $inner ), '<img' ) ) {
+			return self::paragraph_block( '<a' . self::element_attribute_markup( $element ) . '>' . $inner . '</a>' );
 		}
 
 		return self::freeform_block( '<a' . self::element_attribute_markup( $element ) . '>' . $inner . '</a>' );

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -56,6 +56,11 @@ const steps = [
     args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-wordpress-is-dead-fixture.php' ) ],
   },
   {
+    name: 'Extracted chrome fragments smoke',
+    command: wpCli[ 0 ],
+    args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-extracted-chrome-fragments.php' ) ],
+  },
+  {
     name: 'Generated theme JS block validation',
     command: process.execPath,
     args: [

--- a/tests/smoke-extracted-chrome-fragments.php
+++ b/tests/smoke-extracted-chrome-fragments.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Smoke test: simple extracted header/footer chrome fragments use native blocks.
+ *
+ * Run inside a WordPress site with BFB active:
+ * wp eval-file tests/smoke-extracted-chrome-fragments.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+
+if ( ! defined( 'STATIC_SITE_IMPORTER_PATH' ) && is_readable( $plugin_root . '/static-site-importer.php' ) ) {
+	require_once $plugin_root . '/static-site-importer.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Document', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-document.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read = static function ( string $path ): string {
+	$contents = file_get_contents( $path );
+	return false === $contents ? '' : $contents;
+};
+
+$dir = trailingslashit( get_temp_dir() ) . 'static-site-importer-chrome-' . wp_generate_uuid4();
+wp_mkdir_p( $dir );
+
+$fixture = trailingslashit( $dir ) . 'index.html';
+file_put_contents(
+	$fixture,
+	'<!doctype html><html><head><title>Event Conference</title></head><body>' .
+	'<header class="site-header"><div class="header-shell"><a class="nav-logo" href="/"><div class="logo-mark">EC</div><div class="logo-text">EventConf</div></a><nav class="main-nav"><a href="/schedule/">Schedule</a><a href="/speakers/">Speakers</a></nav></div><div class="hero-meta"><div class="meta-label">When</div><div class="meta-value">June 12</div></div></header>' .
+	'<main><section class="hero"><h1>Event Conference</h1><p>Future-facing talks.</p></section></main>' .
+	'<footer class="site-footer"><div class="footer-shell"><div class="footer-row"><div class="footer-brand">EventConf 2026</div><ul class="links"><li><a href="/privacy/">Privacy</a></li></ul></div></div></footer>' .
+	'</body></html>'
+);
+
+$result = Static_Site_Importer_Theme_Generator::import_theme(
+	$fixture,
+	array(
+		'name'      => 'Event Conference Chrome',
+		'slug'      => 'event-conference-chrome-smoke',
+		'overwrite' => true,
+		'activate'  => false,
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+if ( ! is_wp_error( $result ) ) {
+	$theme_dir = $result['theme_dir'];
+	$header    = $read( $theme_dir . '/parts/header.html' );
+	$footer    = $read( $theme_dir . '/parts/footer.html' );
+	$report    = json_decode( $read( $result['report_path'] ), true );
+	$chrome    = $header . $footer;
+	$documents = array();
+	foreach ( $report['generated_theme']['block_documents'] ?? array() as $document ) {
+		if ( is_array( $document ) && isset( $document['path'] ) ) {
+			$documents[ $document['path'] ] = $document;
+		}
+	}
+
+	$assert( str_contains( $header, '<!-- wp:navigation ' ), 'header-navigation-uses-native-block' );
+	$assert( str_contains( $header, '<!-- wp:paragraph --><p><a class="nav-logo"' ), 'logo-anchor-uses-native-paragraph' );
+	$assert( str_contains( $header, '<!-- wp:paragraph {"className":"meta-label"}' ), 'meta-label-uses-native-paragraph' );
+	$assert( str_contains( $header, '<!-- wp:paragraph {"className":"meta-value"}' ), 'meta-value-uses-native-paragraph' );
+	$assert( str_contains( $footer, '<!-- wp:paragraph {"className":"footer-brand"}' ), 'footer-brand-uses-native-paragraph' );
+	$assert( ! str_contains( $chrome, '<!-- wp:freeform' ), 'chrome-has-no-freeform-blocks' );
+	$assert( ! str_contains( $chrome, '<!-- wp:html' ), 'chrome-has-no-core-html-blocks' );
+	$assert( 0 === ( $documents['parts/header.html']['freeform_block_count'] ?? null ), 'report-header-has-zero-freeform' );
+	$assert( 0 === ( $documents['parts/header.html']['core_html_block_count'] ?? null ), 'report-header-has-zero-core-html' );
+	$assert( 0 === ( $documents['parts/footer.html']['freeform_block_count'] ?? null ), 'report-footer-has-zero-freeform' );
+	$assert( 0 === ( $documents['parts/footer.html']['core_html_block_count'] ?? null ), 'report-footer-has-zero-core-html' );
+}
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: extracted chrome fragments smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -405,14 +405,16 @@ if ( false !== $wrote_footer_chrome ) {
 
 		$assert( ! str_contains( $footer_chrome_footer, '<!-- wp:html' ), 'footer-chrome-has-no-core-html-blocks', $footer_chrome_footer );
 		$assert( ! str_contains( $footer_chrome_footer, 'core/html' ), 'footer-chrome-has-no-raw-core-html-name', $footer_chrome_footer );
-		$assert( str_contains( $footer_chrome_footer, '<!-- wp:freeform --><div class="footer-logo">' ), 'footer-logo-preserves-source-wrapper' );
+		$assert( str_contains( $footer_chrome_footer, '<!-- wp:paragraph {"className":"footer-logo"}' ), 'footer-logo-uses-native-paragraph' );
 		$assert( str_contains( $footer_chrome_footer, 'width:6px;height:6px;border-radius:50%;background:var(--accent);display:inline-block;' ), 'footer-logo-decorative-span-style-survives' );
 		$assert( str_contains( $footer_chrome_footer, 'Studio Code — by Automattic' ), 'footer-logo-text-survives' );
-		$assert( str_contains( $footer_chrome_footer, '<!-- wp:freeform --><div class="footer-meta">' ), 'footer-meta-preserves-source-wrapper' );
+		$assert( str_contains( $footer_chrome_footer, '<!-- wp:paragraph {"className":"footer-meta"}' ), 'footer-meta-uses-native-paragraph' );
+		$assert( ! str_contains( $footer_chrome_footer, '<!-- wp:freeform' ), 'footer-chrome-has-no-freeform-blocks', $footer_chrome_footer );
 		$assert( str_contains( $footer_chrome_style, 'display: flex; align-items: center; justify-content: space-between' ), 'footer-flex-alignment-css-survives' );
 		$assert( str_contains( $footer_chrome_style, 'footer .footer-logo' ) && str_contains( $footer_chrome_style, 'gap: 8px' ), 'footer-logo-spacing-css-survives' );
 		$assert( str_contains( $footer_chrome_style, 'flex-direction: column; gap: 12px; text-align: center' ), 'footer-responsive-spacing-css-survives' );
 		$assert( 0 === ( $footer_document['core_html_block_count'] ?? -1 ), 'footer-chrome-report-has-zero-footer-core-html-blocks' );
+		$assert( 0 === ( $footer_document['freeform_block_count'] ?? -1 ), 'footer-chrome-report-has-zero-footer-freeform-blocks' );
 	}
 }
 


### PR DESCRIPTION
## Summary
- Convert simple classed header/footer phrasing fragments to native paragraph blocks instead of Classic/freeform blocks.
- Convert simple text-only brand/logo anchors to native paragraph blocks while preserving the existing raw fallback for image-bearing anchors.
- Add an extracted chrome smoke covering event-conference-style logo, meta, and footer brand fragments with zero `wp:freeform`/`wp:html` in generated chrome.

Fixes #128.

## Testing
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-128-chrome-fragments/tests/smoke-extracted-chrome-fragments.php`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-128-chrome-fragments/tests/smoke-wordpress-is-dead-fixture.php`
- `npm run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/event-conference-chrome-smoke`
- `npm run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead-fixture`
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/smoke-extracted-chrome-fragments.php && php -l tests/smoke-wordpress-is-dead-fixture.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small converter change and focused smoke coverage; Chris remains responsible for review and final merge.