### PR TITLE
Preserve source IDs on extracted theme chrome

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -459,7 +459,7 @@ class Static_Site_Importer_Theme_Generator {
 			$permalink = get_permalink( $page_id );
 			if ( false !== $permalink ) {
 				$permalinks[ $filename ] = $permalink;
-				$basename              = basename( $filename );
+				$basename                = basename( $filename );
 				if ( ! isset( $permalinks[ $basename ] ) ) {
 					$permalinks[ $basename ] = $permalink;
 				}
@@ -606,7 +606,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		$inner_blocks = self::theme_part_element_block( $doc, $inner_children[0], $theme_slug, 'header' ) . $navigation_blocks;
-		return self::group_block( self::group_block( $inner_blocks, $inner->getAttribute( 'class' ) ), $header->getAttribute( 'class' ), 'header' );
+		return self::group_block( self::group_block( $inner_blocks, $inner->getAttribute( 'class' ), 'div', $inner->getAttribute( 'id' ) ), $header->getAttribute( 'class' ), 'header', $header->getAttribute( 'id' ) );
 	}
 
 	/**
@@ -647,8 +647,8 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		$row_blocks       = self::theme_part_element_block( $doc, $row_children[0], $theme_slug, 'footer' ) . $list_blocks;
-		$container_blocks = self::group_block( $row_blocks, $row->getAttribute( 'class' ) );
-		return self::group_block( self::group_block( $container_blocks, $container->getAttribute( 'class' ) ), $footer->getAttribute( 'class' ), 'footer' );
+		$container_blocks = self::group_block( $row_blocks, $row->getAttribute( 'class' ), 'div', $row->getAttribute( 'id' ) );
+		return self::group_block( self::group_block( $container_blocks, $container->getAttribute( 'class' ), 'div', $container->getAttribute( 'id' ) ), $footer->getAttribute( 'class' ), 'footer', $footer->getAttribute( 'id' ) );
 	}
 
 	/**
@@ -677,7 +677,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		if ( 'a' === $tag ) {
-			return self::link_element_block( $doc, $element);
+			return self::link_element_block( $doc, $element );
 		}
 
 		if ( 'img' === $tag ) {
@@ -689,7 +689,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		if ( self::is_link_cluster_container( $element ) ) {
-			return self::group_block( self::theme_part_child_blocks( $doc, $element, $theme_slug, $location ), $element->getAttribute( 'class' ) );
+			return self::group_block( self::theme_part_child_blocks( $doc, $element, $theme_slug, $location ), $element->getAttribute( 'class' ), 'div', $element->getAttribute( 'id' ) );
 		}
 
 		if ( self::element_has_only_phrasing_content( $element ) ) {
@@ -699,7 +699,7 @@ class Static_Site_Importer_Theme_Generator {
 		$children = self::theme_part_child_blocks( $doc, $element, $theme_slug, $location );
 		if ( '' === trim( $children ) ) {
 			if ( self::is_empty_decorative_theme_part_element( $element ) ) {
-				return self::group_block( '', self::append_class_token( $element->getAttribute( 'class' ), 'static-site-importer-decorative-layer' ) );
+				return self::group_block( '', self::append_class_token( $element->getAttribute( 'class' ), 'static-site-importer-decorative-layer' ), 'div', $element->getAttribute( 'id' ) );
 			}
 
 			$text = trim( $element->textContent );
@@ -720,7 +720,7 @@ class Static_Site_Importer_Theme_Generator {
 			$class_name = self::append_class_token( $class_name, 'static-site-importer-source-nav' );
 		}
 
-		return self::group_block( $children, $class_name, $wrapper_tag );
+		return self::group_block( $children, $class_name, $wrapper_tag, $element->getAttribute( 'id' ) );
 	}
 
 	/**
@@ -1398,11 +1398,13 @@ class Static_Site_Importer_Theme_Generator {
 	 * @param string $inner     Inner block markup.
 	 * @param string $class_name Source class attribute.
 	 * @param string $tag_name   Wrapper tag name.
+	 * @param string $anchor     Source ID attribute for native group anchor support.
 	 * @return string
 	 */
-	private static function group_block( string $inner, string $class_name = '', string $tag_name = 'div' ): string {
+	private static function group_block( string $inner, string $class_name = '', string $tag_name = 'div', string $anchor = '' ): string {
 		$class_name = trim( $class_name );
 		$tag_name   = strtolower( $tag_name );
+		$anchor     = trim( $anchor );
 		$attrs      = array();
 		if ( '' !== $class_name ) {
 			$attrs['className'] = $class_name;
@@ -1410,11 +1412,15 @@ class Static_Site_Importer_Theme_Generator {
 		if ( 'div' !== $tag_name ) {
 			$attrs['tagName'] = $tag_name;
 		}
+		if ( '' !== $anchor ) {
+			$attrs['anchor'] = $anchor;
+		}
 
 		$comment_attrs = empty( $attrs ) ? '' : ' ' . wp_json_encode( $attrs, JSON_UNESCAPED_SLASHES );
 		$class_attr    = trim( 'wp-block-group ' . $class_name );
+		$id_attr       = '' === $anchor ? '' : ' id="' . esc_attr( $anchor ) . '"';
 
-		return '<!-- wp:group' . $comment_attrs . ' --><' . $tag_name . ' class="' . esc_attr( $class_attr ) . '">' . $inner . '</' . $tag_name . '><!-- /wp:group -->';
+		return '<!-- wp:group' . $comment_attrs . ' --><' . $tag_name . $id_attr . ' class="' . esc_attr( $class_attr ) . '">' . $inner . '</' . $tag_name . '><!-- /wp:group -->';
 	}
 
 	/**

--- a/tests/StaticSiteImporterHeroIdChromeTest.php
+++ b/tests/StaticSiteImporterHeroIdChromeTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Focused tests for preserving source ID selector contracts in extracted chrome.
+ *
+ * @package StaticSiteImporter
+ */
+
+/**
+ * Tests source IDs targeted by CSS survive theme chrome extraction.
+ */
+class StaticSiteImporterHeroIdChromeTest extends WP_UnitTestCase {
+
+	/**
+	 * Source IDs targeted by CSS survive extracted theme chrome as native anchors.
+	 */
+	public function test_header_id_selector_survives_theme_chrome_extraction(): void {
+		$plugin_root = dirname( __DIR__ );
+		$fixture     = $plugin_root . '/tests/fixtures/hero-id-chrome/index.html';
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$fixture,
+			array(
+				'name'      => 'Hero ID Chrome',
+				'slug'      => 'hero-id-chrome',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+		$style     = $this->read_file( $theme_dir . '/style.css' );
+
+		$this->assertStringContainsString( 'header#hero', $style );
+		$this->assertStringContainsString( '"anchor":"hero"', $header );
+		$this->assertStringContainsString( '<header id="hero" class="wp-block-group hero-shell">', $header );
+		$this->assertStringContainsString( '<!-- wp:navigation ', $header );
+		$this->assertStringNotContainsString( '<!-- wp:html -->', $header );
+	}
+
+	/**
+	 * Reads a generated file.
+	 */
+	private function read_file( string $path ): string {
+		$contents = file_get_contents( $path );
+		$this->assertNotFalse( $contents, 'Unable to read ' . $path );
+
+		return (string) $contents;
+	}
+}

--- a/tests/fixtures/hero-id-chrome/index.html
+++ b/tests/fixtures/hero-id-chrome/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Hero ID Chrome</title>
+	<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+	<header id="hero" class="hero-shell">
+		<div class="hero-inner">
+			<a href="#" class="brand">Field Notes Live</a>
+			<nav class="site-nav" aria-label="Main navigation">
+				<ul>
+					<li><a href="#agenda">Agenda</a></li>
+					<li><a href="#tickets">Tickets</a></li>
+				</ul>
+			</nav>
+		</div>
+	</header>
+
+	<main>
+		<section id="agenda" class="content-shell">
+			<h1>Conference Field Notes</h1>
+			<p>Talks, workshops, and field sessions.</p>
+		</section>
+	</main>
+
+	<footer class="site-footer">
+		<div class="footer-shell">
+			<div class="footer-row">
+				<div>Field Notes Live</div>
+				<ul class="footer-links">
+					<li><a href="#agenda">Agenda</a></li>
+					<li><a href="#tickets">Tickets</a></li>
+				</ul>
+			</div>
+		</div>
+	</footer>
+</body>
+</html>

--- a/tests/fixtures/hero-id-chrome/styles.css
+++ b/tests/fixtures/hero-id-chrome/styles.css
@@ -1,0 +1,16 @@
+header#hero {
+	min-height: 80vh;
+	background: linear-gradient(135deg, #14213d, #fca311);
+}
+
+.hero-shell {
+	display: grid;
+	place-items: center;
+}
+
+.hero-inner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: min(1120px, 100% - 48px);
+}


### PR DESCRIPTION
## Summary
- Preserve source element IDs on manually serialized theme-part `core/group` wrappers by mapping them to native `anchor` attrs and matching wrapper `id` attributes.
- Add a focused `header#hero` fixture and PHPUnit assertion so extracted header chrome keeps the selector contract CSS depends on.
- Remove dead private chrome diagnostic code and an unused argument exposed by changed-only lint while keeping the fix scoped to theme chrome serialization.

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `homeboy lint --path /Users/chubes/Developer/static-site-importer@fix-issue-129-hero-anchor --changed-only --summary`
- `studio wp --skip-plugins eval '<hero-id converter smoke>'`
- `npm --prefix /Users/chubes/Developer/static-site-importer@fix-issue-129-hero-anchor run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/hero-id-chrome`

## Known test status
- `homeboy test --path /Users/chubes/Developer/static-site-importer@fix-issue-129-hero-anchor` still fails 3 existing navigation-related assertions:
  - `StaticSiteImporterFixtureTest::test_wordpress_is_dead_fixture_imports_as_block_theme`
  - `StaticSiteImporterFixtureTest::test_relay_atlas_logo_anchor_fixture_imports_without_html_islands`
  - `StaticSiteImporterFixtureTest::test_header_footer_chrome_structure_survives_theme_part_conversion`

Closes #129.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the code/test changes and ran local verification; Chris remains responsible for review and merge.