### PR TITLE
Lock in branded inline chrome conversion smoke

### DIFF
--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -61,6 +61,11 @@ const steps = [
     args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-extracted-chrome-fragments.php' ) ],
   },
   {
+    name: 'Branded inline chrome smoke',
+    command: wpCli[ 0 ],
+    args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-branded-inline-chrome.php' ) ],
+  },
+  {
     name: 'Generated theme JS block validation',
     command: process.execPath,
     args: [

--- a/tests/smoke-branded-inline-chrome.php
+++ b/tests/smoke-branded-inline-chrome.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Smoke test: simple branded inline chrome text converts to native paragraph blocks.
+ *
+ * Locks in coverage for the GitHub issue #132 examples that were emitting
+ * `wp:freeform` instead of editable native blocks:
+ *
+ * - `<div class="nav-logo">Field Notes Live '26</div>`
+ * - `<div class="footer-logo">Field Notes <em>Live</em></div>`
+ * - `<div class="footer-copy">© 2026 Field Notes Live. All rights reserved.</div>`
+ *
+ * Each must become a native `wp:paragraph` block that preserves the source
+ * class name and (for the footer logo) inline `<em>` emphasis.
+ *
+ * Run inside a WordPress site with BFB active:
+ * wp eval-file tests/smoke-branded-inline-chrome.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+
+if ( ! defined( 'STATIC_SITE_IMPORTER_PATH' ) && is_readable( $plugin_root . '/static-site-importer.php' ) ) {
+	require_once $plugin_root . '/static-site-importer.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Document', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-document.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read = static function ( string $path ): string {
+	$contents = file_get_contents( $path );
+	return false === $contents ? '' : $contents;
+};
+
+$dir = trailingslashit( get_temp_dir() ) . 'static-site-importer-branded-chrome-' . wp_generate_uuid4();
+wp_mkdir_p( $dir );
+
+$fixture = trailingslashit( $dir ) . 'index.html';
+file_put_contents(
+	$fixture,
+	'<!doctype html><html><head><title>Field Notes Live</title></head><body>' .
+	'<nav class="site-nav">' .
+		'<div class="nav-logo">Field Notes Live \'26</div>' .
+		'<ul class="nav-links"><li><a href="#theme">Theme</a></li><li><a href="#speakers">Speakers</a></li></ul>' .
+	'</nav>' .
+	'<main><section class="hero"><h1>Field Notes Live</h1><p>Bend, Oregon.</p></section></main>' .
+	'<footer class="site-footer">' .
+		'<div class="footer-logo">Field Notes <em>Live</em></div>' .
+		'<p class="footer-tagline">Bend, Oregon &mdash; September 18&ndash;19, 2026</p>' .
+		'<div class="footer-copy">&copy; 2026 Field Notes Live. All rights reserved.</div>' .
+	'</footer>' .
+	'</body></html>'
+);
+
+$result = Static_Site_Importer_Theme_Generator::import_theme(
+	$fixture,
+	array(
+		'name'      => 'Field Notes Live Branded Chrome',
+		'slug'      => 'field-notes-live-branded-chrome-smoke',
+		'overwrite' => true,
+		'activate'  => false,
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+if ( ! is_wp_error( $result ) ) {
+	$theme_dir = $result['theme_dir'];
+	$header    = $read( $theme_dir . '/parts/header.html' );
+	$footer    = $read( $theme_dir . '/parts/footer.html' );
+	$report    = json_decode( $read( $result['report_path'] ), true );
+	$chrome    = $header . $footer;
+	$documents = array();
+	foreach ( $report['generated_theme']['block_documents'] ?? array() as $document ) {
+		if ( is_array( $document ) && isset( $document['path'] ) ) {
+			$documents[ $document['path'] ] = $document;
+		}
+	}
+
+	// Issue #132 example 1: <div class="nav-logo">Field Notes Live '26</div>.
+	$assert(
+		str_contains( $header, '<!-- wp:paragraph {"className":"nav-logo"} --><p class="nav-logo">Field Notes Live \'26</p>' ),
+		'nav-logo-uses-native-paragraph-with-class'
+	);
+
+	// Issue #132 example 2: <div class="footer-logo">Field Notes <em>Live</em></div>.
+	$assert(
+		str_contains( $footer, '<!-- wp:paragraph {"className":"footer-logo"} --><p class="footer-logo">Field Notes <em>Live</em></p>' ),
+		'footer-logo-uses-native-paragraph-with-inline-em'
+	);
+
+	// Issue #132 example 3: <div class="footer-copy">&copy; 2026 ...</div>.
+	$assert(
+		str_contains( $footer, '<!-- wp:paragraph {"className":"footer-copy"}' ) && str_contains( $footer, '<p class="footer-copy">' ),
+		'footer-copy-uses-native-paragraph-with-class'
+	);
+	$assert(
+		( false !== strpos( $footer, "\xC2\xA9 2026 Field Notes Live" ) ) || str_contains( $footer, '&copy; 2026 Field Notes Live' ),
+		'footer-copy-preserves-text-content'
+	);
+
+	$assert( ! str_contains( $chrome, '<!-- wp:freeform' ), 'branded-chrome-has-no-freeform-blocks' );
+	$assert( ! str_contains( $chrome, '<!-- wp:html' ), 'branded-chrome-has-no-core-html-blocks' );
+	$assert( 0 === ( $documents['parts/header.html']['freeform_block_count'] ?? null ), 'report-header-zero-freeform' );
+	$assert( 0 === ( $documents['parts/footer.html']['freeform_block_count'] ?? null ), 'report-footer-zero-freeform' );
+	$assert( 0 === ( $documents['parts/header.html']['core_html_block_count'] ?? null ), 'report-header-zero-core-html' );
+	$assert( 0 === ( $documents['parts/footer.html']['core_html_block_count'] ?? null ), 'report-footer-zero-core-html' );
+}
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: branded inline chrome smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Add focused smoke `tests/smoke-branded-inline-chrome.php` that imports a fixture matching the GitHub issue #132 examples and asserts each branded chrome `<div>` becomes a native `wp:paragraph` with the source class preserved.
- Cover the three exact shapes called out in the issue: `<div class="nav-logo">…'26</div>`, `<div class="footer-logo">Field Notes <em>Live</em></div>`, and `<div class="footer-copy">© 2026 …</div>`. The footer logo case verifies inline `<em>` emphasis survives the conversion.
- Wire the new smoke into `tests/run-validation-harness.cjs` so the validation harness exercises it end-to-end.

The conversion path itself was already corrected by #130 (commit 90aeda2 — "Fix chrome fragment native block conversion"). The Studio BFB bench artifact that motivated #132 was generated against an older worktree before #130 landed; running the same fixtures against current `main` already produces zero `wp:freeform` chrome blocks. This PR adds the regression guard the issue's acceptance criteria asks for.

Fixes #132.

## Testing
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 eval-file wp-content/plugins/static-site-importer/tests/smoke-branded-inline-chrome.php` → `OK: branded inline chrome smoke passed (11 assertions)`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 eval-file wp-content/plugins/static-site-importer/tests/smoke-extracted-chrome-fragments.php` → `OK: extracted chrome fragments smoke passed (12 assertions)`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 eval-file wp-content/plugins/static-site-importer/tests/smoke-wordpress-is-dead-fixture.php` → `OK: wordpress-is-dead fixture smoke passed (310 assertions)`
- `node tests/run-validation-harness.cjs` → `OK: full validation harness passed (7 steps)` (admin entry, editor style, fixture fidelity, extracted chrome, branded inline chrome, JS block validation across 137 blocks / 15 files).
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/smoke-branded-inline-chrome.php` — clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the focused smoke fixture and harness wiring, traced the existing chrome conversion path to confirm #130 already covers the issue's three examples, and ran the validation harness. Chris remains responsible for review and final merge.