### PR TITLE
fix: resolve 5 chrome/footer/nav fixture conversion regressions

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -631,6 +631,16 @@ class Static_Site_Importer_Theme_Generator {
 
 		$container          = $footer_children[0];
 		$container_children = self::direct_element_children( $container );
+		if ( 2 === count( $container_children ) && 'div' === strtolower( $container_children[0]->tagName ) && 'ul' === strtolower( $container_children[1]->tagName ) ) {
+			$list_blocks = self::footer_navigation_or_list_block( $doc, $container_children[1], $theme_slug, 'footer' );
+			if ( null === $list_blocks ) {
+				return self::theme_part_element_block( $doc, $footer, $theme_slug, 'footer' );
+			}
+
+			$container_blocks = self::theme_part_element_block( $doc, $container_children[0], $theme_slug, 'footer' ) . $list_blocks;
+			return self::group_block( self::group_block( $container_blocks, $container->getAttribute( 'class' ) ), $footer->getAttribute( 'class' ), 'footer' );
+		}
+
 		if ( 1 !== count( $container_children ) || 'div' !== strtolower( $container_children[0]->tagName ) ) {
 			return self::theme_part_element_block( $doc, $footer, $theme_slug, 'footer' );
 		}
@@ -641,7 +651,7 @@ class Static_Site_Importer_Theme_Generator {
 			return self::theme_part_element_block( $doc, $footer, $theme_slug, 'footer' );
 		}
 
-		$list_blocks = self::footer_link_list_block( $doc, $row_children[1] );
+		$list_blocks = self::footer_navigation_or_list_block( $doc, $row_children[1], $theme_slug, 'footer' );
 		if ( null === $list_blocks ) {
 			return self::theme_part_element_block( $doc, $footer, $theme_slug, 'footer' );
 		}
@@ -678,6 +688,10 @@ class Static_Site_Importer_Theme_Generator {
 
 		if ( 'a' === $tag ) {
 			return self::link_element_block( $doc, $element );
+		}
+
+		if ( self::should_preserve_theme_part_source_element( $element ) ) {
+			return self::freeform_block( self::node_html( $doc, $element ) );
 		}
 
 		if ( 'img' === $tag ) {
@@ -917,6 +931,22 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Check whether classed chrome needs exact source element ownership.
+	 *
+	 * @param DOMElement $element Source element.
+	 * @return bool
+	 */
+	private static function should_preserve_theme_part_source_element( DOMElement $element ): bool {
+		$tag = strtolower( $element->tagName );
+		if ( ! in_array( $tag, array( 'div', 'span' ), true ) || ! self::element_has_only_phrasing_content( $element ) ) {
+			return false;
+		}
+
+		$class = trim( $element->getAttribute( 'class' ) );
+		return preg_match( '/(^|[-_\s])footer-logo([-_\s]|$)/i', $class ) === 1;
+	}
+
+	/**
 	 * Check whether an element can be represented as one paragraph with inline markup.
 	 *
 	 * @param DOMElement $element Source element.
@@ -1031,7 +1061,7 @@ class Static_Site_Importer_Theme_Generator {
 			return null;
 		}
 
-		if ( ! str_contains( strtolower( $inner ), '<img' ) ) {
+		if ( ! str_contains( strtolower( $inner ), '<img' ) && empty( self::direct_element_children( $element ) ) ) {
 			return self::paragraph_block( '<a' . self::element_attribute_markup( $element ) . '>' . $inner . '</a>' );
 		}
 
@@ -1390,6 +1420,26 @@ class Static_Site_Importer_Theme_Generator {
 		$class_attr    = trim( 'wp-block-list ' . $class );
 
 		return '<!-- wp:list' . $comment_attrs . ' --><' . $tag . ' class="' . esc_attr( $class_attr ) . '">' . implode( '', $items ) . '</' . $tag . '><!-- /wp:list -->';
+	}
+
+	/**
+	 * Build a footer navigation entity when the row owns one utility menu, otherwise a visible list.
+	 *
+	 * @param DOMDocument $doc        Source DOM document.
+	 * @param DOMElement  $element    Source list element.
+	 * @param string      $theme_slug Imported theme slug.
+	 * @param string      $location   Theme part location.
+	 * @return string|null
+	 */
+	private static function footer_navigation_or_list_block( DOMDocument $doc, DOMElement $element, string $theme_slug, string $location ): ?string {
+		if ( self::can_convert_element_to_navigation( $element ) ) {
+			$navigation = self::navigation_ref_block( $element, $theme_slug, $location );
+			if ( null !== $navigation ) {
+				return $navigation;
+			}
+		}
+
+		return self::footer_link_list_block( $doc, $element );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Fixes #134.
- Keeps footer row utility menus as reusable `wp_navigation` entities when the footer chrome owns a single menu, preserving deterministic `{theme_slug}-footer-navigation` refs.
- Preserves exact source ownership for logo/footer identity chrome that cannot safely be represented as paragraph-wrapped markup.

## Fixed tests
- `test_wordpress_is_dead_fixture_imports_as_block_theme`: footer utility links were serialized as a visible list, so the expected deterministic footer `wp_navigation` post was never created; the footer row converter now creates/reuses a navigation entity for that single utility menu.
- `test_relay_atlas_logo_anchor_fixture_imports_without_html_islands`: the footer row list used the visible list fallback instead of the reusable navigation path; the shared footer row path now emits a referenced navigation block while preserving logo anchor markup.
- `test_classed_header_and_footer_chrome_preserve_source_elements`: logo anchors with inline child markup were paragraph-wrapped; brand/logo anchors with direct child elements now use `core/freeform` to preserve exact source HTML.
- `test_classed_header_footer_identity_chrome_reports_or_preserves_ownership`: the identity logo anchor and footer logo were being moved into paragraph ownership; the converter now preserves those source elements as freeform instead of class-shifting onto paragraphs.
- `test_header_footer_chrome_structure_survives_theme_part_conversion`: direct footer brand/list rows bypassed navigation entity creation; the footer converter now handles both direct and nested brand/list row shapes.

## Related
- References #131 for the overlapping hero/logo-anchor conversion work.

## Verification
- `homeboy test static-site-importer`: passes, 33 passed / 0 failed.
- `homeboy lint static-site-importer --changed-only`: passes.
- `homeboy release static-site-importer --dry-run`: PHPUnit passes, but the dry-run fails on existing full-repo lint/PHPStan findings outside this fixture fix (`class-static-site-importer-document.php`, `class-static-site-importer-admin.php`, `class-static-site-importer-woo-product-seeder.php`). No `--skip-checks` used.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the converter fix, ran the fixture/lint/release checks, and prepared this PR summary for Chris to review.