### PR TITLE
Support Markdown content collections

### DIFF
--- a/includes/class-static-site-importer-source-page.php
+++ b/includes/class-static-site-importer-source-page.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Static site source page model.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Represents one importable source page, regardless of source format.
+ */
+class Static_Site_Importer_Source_Page {
+
+	/**
+	 * Source path relative to the static site root.
+	 *
+	 * @var string
+	 */
+	private string $source_key;
+
+	/**
+	 * Absolute source file path.
+	 *
+	 * @var string
+	 */
+	private string $path;
+
+	/**
+	 * Source kind.
+	 *
+	 * @var string
+	 */
+	private string $type;
+
+	/**
+	 * HTML document used by the importer.
+	 *
+	 * @var Static_Site_Importer_Document
+	 */
+	private Static_Site_Importer_Document $document;
+
+	/**
+	 * Raw frontmatter captured for follow-up metadata parsing work.
+	 *
+	 * @var string
+	 */
+	private string $frontmatter;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string                        $source_key  Source key.
+	 * @param string                        $path        Absolute source path.
+	 * @param string                        $type        Source type.
+	 * @param Static_Site_Importer_Document $document    Parsed HTML document.
+	 * @param string                        $frontmatter Raw frontmatter.
+	 */
+	private function __construct( string $source_key, string $path, string $type, Static_Site_Importer_Document $document, string $frontmatter = '' ) {
+		$this->source_key  = $source_key;
+		$this->path        = $path;
+		$this->type        = $type;
+		$this->document    = $document;
+		$this->frontmatter = $frontmatter;
+	}
+
+	/**
+	 * Create a source page from an HTML file.
+	 *
+	 * @param string $site_dir Static site root.
+	 * @param string $path     Absolute HTML file path.
+	 * @return self|WP_Error
+	 */
+	public static function from_html_file( string $site_dir, string $path ) {
+		$document = Static_Site_Importer_Document::from_file( $path );
+		if ( is_wp_error( $document ) ) {
+			return $document;
+		}
+
+		return new self( self::relative_source_key( $site_dir, $path ), $path, 'html', $document );
+	}
+
+	/**
+	 * Create a source page from a Markdown file.
+	 *
+	 * This intentionally only strips and carries raw frontmatter. Issue #137 owns
+	 * full metadata parsing; this class leaves the seam without baking schema in.
+	 *
+	 * @param string $site_dir Static site root.
+	 * @param string $path     Absolute Markdown file path.
+	 * @return self|WP_Error
+	 */
+	public static function from_markdown_file( string $site_dir, string $path ) {
+		if ( ! is_file( $path ) ) {
+			return new WP_Error( 'static_site_importer_unreadable_file', sprintf( 'Markdown file is not readable: %s', $path ) );
+		}
+
+		$markdown = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads local static-site Markdown source files from the import directory.
+		if ( false === $markdown || '' === trim( $markdown ) ) {
+			return new WP_Error( 'static_site_importer_empty_file', sprintf( 'Markdown file is empty: %s', $path ) );
+		}
+
+		$parts       = self::strip_frontmatter( $markdown );
+		$content     = $parts['content'];
+		$frontmatter = $parts['frontmatter'];
+		$html        = self::markdown_to_html( $content );
+		if ( is_wp_error( $html ) ) {
+			return $html;
+		}
+
+		return new self( self::relative_source_key( $site_dir, $path ), $path, 'markdown', new Static_Site_Importer_Document( '<main>' . $html . '</main>' ), $frontmatter );
+	}
+
+	/**
+	 * Source key used by result maps and reports.
+	 *
+	 * @return string
+	 */
+	public function source_key(): string {
+		return $this->source_key;
+	}
+
+	/**
+	 * Absolute source file path.
+	 *
+	 * @return string
+	 */
+	public function path(): string {
+		return $this->path;
+	}
+
+	/**
+	 * Source type.
+	 *
+	 * @return string
+	 */
+	public function type(): string {
+		return $this->type;
+	}
+
+	/**
+	 * Parsed document.
+	 *
+	 * @return Static_Site_Importer_Document
+	 */
+	public function document(): Static_Site_Importer_Document {
+		return $this->document;
+	}
+
+	/**
+	 * Raw frontmatter for future metadata coordination.
+	 *
+	 * @return string
+	 */
+	public function frontmatter(): string {
+		return $this->frontmatter;
+	}
+
+	/**
+	 * Build a normalized source key relative to the site root.
+	 *
+	 * @param string $site_dir Static site root.
+	 * @param string $path     Absolute source path.
+	 * @return string
+	 */
+	private static function relative_source_key( string $site_dir, string $path ): string {
+		$root = realpath( $site_dir );
+		$file = realpath( $path );
+		if ( false !== $root && false !== $file && str_starts_with( $file, trailingslashit( $root ) ) ) {
+			return str_replace( DIRECTORY_SEPARATOR, '/', substr( $file, strlen( trailingslashit( $root ) ) ) );
+		}
+
+		return basename( $path );
+	}
+
+	/**
+	 * Strip leading YAML-style frontmatter without interpreting its schema.
+	 *
+	 * @param string $markdown Markdown source.
+	 * @return array{frontmatter:string,content:string}
+	 */
+	private static function strip_frontmatter( string $markdown ): array {
+		if ( 1 !== preg_match( '/\A---\R(?P<frontmatter>.*?)\R---\R?/s', $markdown, $matches ) ) {
+			return array(
+				'frontmatter' => '',
+				'content'     => $markdown,
+			);
+		}
+
+		return array(
+			'frontmatter' => (string) $matches['frontmatter'],
+			'content'     => substr( $markdown, strlen( $matches[0] ) ),
+		);
+	}
+
+	/**
+	 * Convert Markdown to HTML using the bundled CommonMark runtime.
+	 *
+	 * @param string $markdown Markdown source.
+	 * @return string|WP_Error
+	 */
+	private static function markdown_to_html( string $markdown ) {
+		if ( ! class_exists( '\League\CommonMark\CommonMarkConverter' ) ) {
+			return new WP_Error( 'static_site_importer_missing_commonmark', 'League CommonMark is required to import Markdown content files.' );
+		}
+
+		$converter = new \League\CommonMark\CommonMarkConverter();
+		return (string) $converter->convert( $markdown );
+	}
+}

--- a/includes/class-static-site-importer-source-page.php
+++ b/includes/class-static-site-importer-source-page.php
@@ -43,6 +43,20 @@ class Static_Site_Importer_Source_Page {
 	private Static_Site_Importer_Document $document;
 
 	/**
+	 * Body passed to Block Format Bridge for content conversion.
+	 *
+	 * @var string
+	 */
+	private string $body;
+
+	/**
+	 * Body format passed to Block Format Bridge.
+	 *
+	 * @var string
+	 */
+	private string $body_format;
+
+	/**
 	 * Raw frontmatter captured for follow-up metadata parsing work.
 	 *
 	 * @var string
@@ -56,13 +70,17 @@ class Static_Site_Importer_Source_Page {
 	 * @param string                        $path        Absolute source path.
 	 * @param string                        $type        Source type.
 	 * @param Static_Site_Importer_Document $document    Parsed HTML document.
+	 * @param string                        $body        Conversion body.
+	 * @param string                        $body_format Conversion body format.
 	 * @param string                        $frontmatter Raw frontmatter.
 	 */
-	private function __construct( string $source_key, string $path, string $type, Static_Site_Importer_Document $document, string $frontmatter = '' ) {
+	private function __construct( string $source_key, string $path, string $type, Static_Site_Importer_Document $document, string $body, string $body_format, string $frontmatter = '' ) {
 		$this->source_key  = $source_key;
 		$this->path        = $path;
 		$this->type        = $type;
 		$this->document    = $document;
+		$this->body        = $body;
+		$this->body_format = $body_format;
 		$this->frontmatter = $frontmatter;
 	}
 
@@ -79,7 +97,9 @@ class Static_Site_Importer_Source_Page {
 			return $document;
 		}
 
-		return new self( self::relative_source_key( $site_dir, $path ), $path, 'html', $document );
+		$fragments = $document->fragments();
+
+		return new self( self::relative_source_key( $site_dir, $path ), $path, 'html', $document, $fragments['main'], 'html' );
 	}
 
 	/**
@@ -110,7 +130,7 @@ class Static_Site_Importer_Source_Page {
 			return $html;
 		}
 
-		return new self( self::relative_source_key( $site_dir, $path ), $path, 'markdown', new Static_Site_Importer_Document( '<main>' . $html . '</main>' ), $frontmatter );
+		return new self( self::relative_source_key( $site_dir, $path ), $path, 'markdown', new Static_Site_Importer_Document( '<main>' . $html . '</main>' ), $content, 'markdown', $frontmatter );
 	}
 
 	/**
@@ -147,6 +167,24 @@ class Static_Site_Importer_Source_Page {
 	 */
 	public function document(): Static_Site_Importer_Document {
 		return $this->document;
+	}
+
+	/**
+	 * Body passed to BFB for content conversion.
+	 *
+	 * @return string
+	 */
+	public function body(): string {
+		return $this->body;
+	}
+
+	/**
+	 * Body format passed to BFB for content conversion.
+	 *
+	 * @return string
+	 */
+	public function body_format(): string {
+		return $this->body_format;
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -118,12 +118,12 @@ class Static_Site_Importer_Theme_Generator {
 		$site_dir = dirname( $html_path );
 		$pages    = self::collect_pages( $site_dir );
 		if ( empty( $pages ) ) {
-			$pages = array(
-				basename( $html_path ) => array(
-					'path'     => $html_path,
-					'document' => $document,
-				),
-			);
+			$source_page = Static_Site_Importer_Source_Page::from_html_file( $site_dir, $html_path );
+			if ( is_wp_error( $source_page ) ) {
+				return $source_page;
+			}
+
+			$pages = array( $source_page->source_key() => $source_page );
 		}
 
 		$page_ids = self::create_page_shells( $pages );
@@ -264,24 +264,30 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Collect sibling HTML pages from a static site directory.
+	 * Collect importable source pages from a static site directory.
 	 *
 	 * @param string $site_dir Site directory.
-	 * @return array<string, array{path:string,document:Static_Site_Importer_Document}>
+	 * @return array<string, Static_Site_Importer_Source_Page>
 	 */
 	private static function collect_pages( string $site_dir ): array {
 		$pages = array();
 		$paths = glob( trailingslashit( $site_dir ) . '*.html' );
 		foreach ( false === $paths ? array() : $paths as $path ) {
-			$document = Static_Site_Importer_Document::from_file( $path );
-			if ( is_wp_error( $document ) ) {
+			$page = Static_Site_Importer_Source_Page::from_html_file( $site_dir, $path );
+			if ( is_wp_error( $page ) ) {
 				continue;
 			}
 
-			$pages[ basename( $path ) ] = array(
-				'path'     => $path,
-				'document' => $document,
-			);
+			$pages[ $page->source_key() ] = $page;
+		}
+
+		foreach ( self::collect_markdown_paths( $site_dir ) as $path ) {
+			$page = Static_Site_Importer_Source_Page::from_markdown_file( $site_dir, $path );
+			if ( is_wp_error( $page ) ) {
+				continue;
+			}
+
+			$pages[ $page->source_key() ] = $page;
 		}
 
 		uksort(
@@ -302,15 +308,61 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Collect Markdown source files anywhere under the static site root.
+	 *
+	 * @param string $site_dir Site directory.
+	 * @return array<int, string>
+	 */
+	private static function collect_markdown_paths( string $site_dir ): array {
+		$paths = array();
+		if ( ! is_dir( $site_dir ) ) {
+			return $paths;
+		}
+
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveCallbackFilterIterator(
+				new RecursiveDirectoryIterator( $site_dir, FilesystemIterator::SKIP_DOTS ),
+				static function ( SplFileInfo $file ): bool {
+					$name = $file->getFilename();
+					if ( $file->isDir() ) {
+						return ! in_array( $name, array( '.git', 'node_modules', 'vendor' ), true ) && ! str_starts_with( $name, '.' );
+					}
+
+					return self::is_markdown_source_path( $name );
+				}
+			)
+		);
+
+		foreach ( $iterator as $file ) {
+			if ( $file instanceof SplFileInfo && $file->isFile() ) {
+				$paths[] = $file->getPathname();
+			}
+		}
+
+		sort( $paths, SORT_NATURAL | SORT_FLAG_CASE );
+		return $paths;
+	}
+
+	/**
+	 * Check whether a path is a Markdown content source.
+	 *
+	 * @param string $path File path or basename.
+	 * @return bool
+	 */
+	private static function is_markdown_source_path( string $path ): bool {
+		return 1 === preg_match( '/\.mark?down$/i', $path ) || 1 === preg_match( '/\.md$/i', $path );
+	}
+
+	/**
 	 * Create page shells so links can be rewritten before content conversion.
 	 *
-	 * @param array<string, array{path:string,document:Static_Site_Importer_Document}> $pages Pages.
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages Pages.
 	 * @return array<string,int>|WP_Error
 	 */
 	private static function create_page_shells( array $pages ) {
 		$page_ids = array();
 		foreach ( $pages as $filename => $page ) {
-			$title = self::page_title( $filename, $page['document'] );
+			$title = self::page_title( $filename, $page );
 			$slug  = self::page_slug( $filename );
 
 			$existing = get_page_by_path( $slug, OBJECT, 'page' );
@@ -340,7 +392,7 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Build page-specific template and pattern artifacts.
 	 *
-	 * @param array<string, array{path:string,document:Static_Site_Importer_Document}> $pages      Pages.
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Pages.
 	 * @param array<string,string>                                                      $permalinks Permalinks keyed by filename.
 	 * @param string                                                                    $theme_slug Theme slug.
 	 * @return array{patterns:array<string,string>,files:array<string,string>,contents:array<string,string>}
@@ -353,11 +405,11 @@ class Static_Site_Importer_Theme_Generator {
 		foreach ( $pages as $filename => $page ) {
 			$slug         = self::page_slug( $filename );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
-			$fragments    = $page['document']->fragments();
+			$fragments    = $page->document()->fragments();
 			$content      = self::convert_fragment( self::rewrite_internal_links( $fragments['main'], $permalinks ), 'main:' . $filename );
 
 			$patterns[ $filename ] = $pattern_slug;
-			$files[ $filename ]    = self::pattern_file( self::page_title( $filename, $page['document'] ), $pattern_slug, $content );
+			$files[ $filename ]    = self::pattern_file( self::page_title( $filename, $page ), $pattern_slug, $content );
 			$contents[ $filename ] = $content;
 		}
 
@@ -371,7 +423,7 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Store imported page bodies on their corresponding WordPress pages.
 	 *
-	 * @param array<string, array{path:string,document:Static_Site_Importer_Document}> $pages    Pages.
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages    Pages.
 	 * @param array<string,int>                                                         $page_ids Page IDs keyed by filename.
 	 * @param array<string,string>                                                      $contents Converted block markup keyed by filename.
 	 * @return true|WP_Error
@@ -407,6 +459,10 @@ class Static_Site_Importer_Theme_Generator {
 			$permalink = get_permalink( $page_id );
 			if ( false !== $permalink ) {
 				$permalinks[ $filename ] = $permalink;
+				$basename              = basename( $filename );
+				if ( ! isset( $permalinks[ $basename ] ) ) {
+					$permalinks[ $basename ] = $permalink;
+				}
 			}
 		}
 
@@ -414,7 +470,7 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Rewrite local .html links to imported WordPress page permalinks.
+	 * Rewrite local source-page links to imported WordPress page permalinks.
 	 *
 	 * @param string               $html       HTML fragment.
 	 * @param array<string,string> $permalinks Permalinks keyed by filename.
@@ -1482,16 +1538,16 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Build a WordPress page title from a source document.
 	 *
-	 * @param string                        $filename Source filename.
-	 * @param Static_Site_Importer_Document $document Source document.
+	 * @param string                           $filename Source filename.
+	 * @param Static_Site_Importer_Source_Page $page     Source page.
 	 * @return string
 	 */
-	private static function page_title( string $filename, Static_Site_Importer_Document $document ): string {
+	private static function page_title( string $filename, Static_Site_Importer_Source_Page $page ): string {
 		if ( 'index.html' === $filename ) {
 			return 'Home';
 		}
 
-		$title = preg_replace( '/\s+[—-]\s+.+$/u', '', $document->title() );
+		$title = preg_replace( '/\s+[—-]\s+.+$/u', '', $page->document()->title() );
 		return '' === trim( (string) $title ) ? ucwords( str_replace( '-', ' ', self::page_slug( $filename ) ) ) : trim( (string) $title );
 	}
 
@@ -1506,7 +1562,8 @@ class Static_Site_Importer_Theme_Generator {
 			return 'home';
 		}
 
-		return sanitize_title( preg_replace( '/\.html?$/i', '', $filename ) );
+		$slug = preg_replace( '/\.(?:html?|md|markdown)$/i', '', $filename );
+		return sanitize_title( str_replace( '/', '-', (string) $slug ) );
 	}
 
 	/**
@@ -1639,8 +1696,8 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Discover sprites before converting chrome so header/footer use references can resolve.
 	 *
-	 * @param array{background:string,header:string,main:string,footer:string}              $entry_fragments Entry document fragments.
-	 * @param array<string, array{path:string,document:Static_Site_Importer_Document}> $pages           Imported pages.
+	 * @param array{background:string,header:string,main:string,footer:string} $entry_fragments Entry document fragments.
+	 * @param array<string, Static_Site_Importer_Source_Page>                  $pages           Imported pages.
 	 * @return void
 	 */
 	private static function pre_register_svg_symbol_sprites( array $entry_fragments, array $pages ): void {
@@ -1649,7 +1706,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		foreach ( $pages as $filename => $page ) {
-			$fragments = $page['document']->fragments();
+			$fragments = $page->document()->fragments();
 			self::register_svg_symbol_sprites_from_html( $fragments['main'], 'main:' . $filename );
 		}
 	}
@@ -3009,7 +3066,7 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Record practical source/generated targets for external visual fidelity gates.
 	 *
-	 * @param array<string, array{path:string,document:Static_Site_Importer_Document}> $pages          Imported pages.
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages          Imported pages.
 	 * @param array<string, int>                                                       $page_ids       Page IDs keyed by source filename.
 	 * @param array<string, string>                                                    $permalinks     Page permalinks keyed by source filename.
 	 * @param array<string, string>                                                    $writes         Generated files keyed by absolute path.
@@ -3020,7 +3077,7 @@ class Static_Site_Importer_Theme_Generator {
 		$theme_prefix = trailingslashit( $theme_dir );
 
 		foreach ( $pages as $filename => $page ) {
-			$source_html = self::read_visual_probe_file( $page['path'] );
+			$source_html = self::read_visual_probe_file( $page->path() );
 			$slug        = self::page_slug( $filename );
 			$template    = '' === $slug ? '' : 'templates/page-' . $slug . '.html';
 			$pattern     = '' === $slug ? '' : 'patterns/page-' . $slug . '.php';
@@ -3028,8 +3085,9 @@ class Static_Site_Importer_Theme_Generator {
 			$footer_part = isset( $writes[ $theme_prefix . 'parts/footer.html' ] ) ? 'parts/footer.html' : '';
 
 			self::$conversion_report['visual_fidelity']['comparison_targets'][] = array(
-				'source_file'            => $page['path'],
+				'source_file'            => $page->path(),
 				'source_filename'        => $filename,
+				'source_type'            => $page->type(),
 				'wordpress_page_id'      => $page_ids[ $filename ] ?? null,
 				'wordpress_url'          => $permalinks[ $filename ] ?? '',
 				'generated_template'     => $template,
@@ -3038,7 +3096,7 @@ class Static_Site_Importer_Theme_Generator {
 				'generated_probe_counts' => self::visual_probe_counts( $generated ),
 				'comparison_hooks'       => array(
 					'screenshot'      => array(
-						'source'         => $page['path'],
+						'source'         => $page->path(),
 						'frontend'       => $permalinks[ $filename ] ?? '',
 						'generated'      => $permalinks[ $filename ] ?? '',
 						'editor_surface' => 'site_editor_canvas',
@@ -3046,7 +3104,7 @@ class Static_Site_Importer_Theme_Generator {
 					'render_surfaces' => array(
 						'source_static'      => array(
 							'type' => 'file',
-							'url'  => $page['path'],
+							'url'  => $page->path(),
 						),
 						'wordpress_frontend' => array(
 							'type' => 'url',
@@ -3073,7 +3131,7 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Record source/generated targets for external semantic fidelity gates.
 	 *
-	 * @param array<string, array{path:string,document:Static_Site_Importer_Document}> $pages      Imported pages.
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Imported pages.
 	 * @param array<string, int>                                                       $page_ids   Page IDs keyed by source filename.
 	 * @param array<string, string>                                                    $permalinks Page permalinks keyed by source filename.
 	 * @param array<string, string>                                                    $writes     Generated files keyed by absolute path.
@@ -3085,15 +3143,16 @@ class Static_Site_Importer_Theme_Generator {
 		$theme_parts  = self::generated_semantic_theme_parts( $writes, $theme_prefix );
 
 		foreach ( $pages as $filename => $page ) {
-			$source_html = self::read_visual_probe_file( $page['path'] );
+			$source_html = self::read_visual_probe_file( $page->path() );
 			$slug        = self::page_slug( $filename );
 			$template    = '' === $slug ? '' : 'templates/page-' . $slug . '.html';
 			$pattern     = '' === $slug ? '' : 'patterns/page-' . $slug . '.php';
 			$generated   = self::generated_visual_probe_markup( $writes, $theme_prefix, $pattern );
 
 			self::$conversion_report['semantic_fidelity']['comparison_targets'][] = array(
-				'source_file'           => $page['path'],
+				'source_file'           => $page->path(),
 				'source_filename'       => $filename,
+				'source_type'           => $page->type(),
 				'wordpress_page_id'     => $page_ids[ $filename ] ?? null,
 				'wordpress_url'         => $permalinks[ $filename ] ?? '',
 				'generated_template'    => $template,

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -405,8 +405,8 @@ class Static_Site_Importer_Theme_Generator {
 		foreach ( $pages as $filename => $page ) {
 			$slug         = self::page_slug( $filename );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
-			$fragments    = $page->document()->fragments();
-			$content      = self::convert_fragment( self::rewrite_internal_links( $fragments['main'], $permalinks ), 'main:' . $filename );
+			$content_body = self::rewrite_internal_links( $page->body(), $permalinks );
+			$content      = self::convert_fragment( $content_body, 'main:' . $filename, $page->body_format() );
 
 			$patterns[ $filename ] = $pattern_slug;
 			$files[ $filename ]    = self::pattern_file( self::page_title( $filename, $page ), $pattern_slug, $content );
@@ -481,7 +481,7 @@ class Static_Site_Importer_Theme_Generator {
 			return $html;
 		}
 
-		return preg_replace_callback(
+		$rewritten = preg_replace_callback(
 			'/\bhref=("|\')([^"\']+)(\1)/i',
 			static function ( array $matches ) use ( $permalinks ): string {
 				$href               = html_entity_decode( $matches[2], ENT_QUOTES );
@@ -501,6 +501,27 @@ class Static_Site_Importer_Theme_Generator {
 			},
 			$html
 		) ?? $html;
+
+		return preg_replace_callback(
+			'/(!?\[[^\]]*\]\()([^\s)]+)(\))/i',
+			static function ( array $matches ) use ( $permalinks ): string {
+				$href               = html_entity_decode( $matches[2], ENT_QUOTES );
+				$parts              = explode( '#', $href, 2 );
+				$path_without_query = strtok( $parts[0], '?' );
+				$filename           = basename( false === $path_without_query ? $parts[0] : $path_without_query );
+				if ( ! isset( $permalinks[ $filename ] ) ) {
+					return $matches[0];
+				}
+
+				$replacement = $permalinks[ $filename ];
+				if ( isset( $parts[1] ) && '' !== $parts[1] ) {
+					$replacement .= '#' . $parts[1];
+				}
+
+				return $matches[1] . esc_url( $replacement ) . $matches[3];
+			},
+			$rewritten
+		) ?? $rewritten;
 	}
 
 	/**
@@ -2273,17 +2294,21 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Convert HTML to block markup.
+	 * Convert source content to block markup.
 	 *
-	 * @param string $html HTML fragment.
+	 * @param string $html   Source content.
+	 * @param string $source Source label.
+	 * @param string $format Source format.
 	 * @return string
 	 */
-	private static function convert_fragment( string $html, string $source = 'fragment' ): string {
+	private static function convert_fragment( string $html, string $source = 'fragment', string $format = 'html' ): string {
 		if ( '' === trim( $html ) ) {
 			return '';
 		}
 
-		$html = self::materialize_inline_svg_icons( $html, $source );
+		if ( 'html' === $format ) {
+			$html = self::materialize_inline_svg_icons( $html, $source );
+		}
 
 		self::start_conversion_fragment( $source, $html );
 		$fallback_listener     = static function ( string $element_html, array $context, array $block ) use ( $source ): void {
@@ -2305,7 +2330,7 @@ class Static_Site_Importer_Theme_Generator {
 		add_action( 'bfb_conversion_metadata', $commerce_metadata_listener, 10, 1 );
 		add_action( 'bfb_materialization_request', $commerce_request_listener, 10, 1 );
 		// @phpstan-ignore-next-line function.notFound -- Loaded by the bundled Block Format Bridge runtime.
-		$blocks = empty( self::$active_commerce_context ) ? bfb_convert( $html, 'html', 'blocks' ) : bfb_convert( $html, 'html', 'blocks', self::conversion_options( $source ) );
+		$blocks = empty( self::$active_commerce_context ) ? bfb_convert( $html, $format, 'blocks' ) : bfb_convert( $html, $format, 'blocks', self::conversion_options( $source ) );
 		remove_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10 );
 		remove_action( 'html_to_blocks_conversion_aborted_content_loss', $content_loss_listener, 10 );
 		remove_action( 'bfb_conversion_metadata', $commerce_metadata_listener, 10 );

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -23,6 +23,7 @@ if ( is_readable( STATIC_SITE_IMPORTER_PATH . 'vendor/autoload.php' ) ) {
 }
 
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-source-page.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-fetcher.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-generator.php';

--- a/tests/fixtures/astro-content-collection/index.html
+++ b/tests/fixtures/astro-content-collection/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Astro Shell</title>
+	<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+	<header class="site-header">
+		<a class="brand" href="index.html">Astro Shell</a>
+		<nav class="site-nav">
+			<a href="index.html">Home</a>
+			<a href="src/content/posts/first-post.md">First Post</a>
+			<a href="src/content/pages/about.markdown">About</a>
+		</nav>
+	</header>
+	<main class="shell-home">
+		<section class="hero">
+			<h1>HTML Shell Home</h1>
+			<p>This HTML file supplies the shared theme chrome.</p>
+		</section>
+	</main>
+	<footer class="site-footer">Static shell footer</footer>
+</body>
+</html>

--- a/tests/fixtures/astro-content-collection/src/content/pages/about.markdown
+++ b/tests/fixtures/astro-content-collection/src/content/pages/about.markdown
@@ -1,0 +1,5 @@
+# About Markdown Page
+
+This `.markdown` file should import alongside `.md` content.
+
+[First Post](../posts/first-post.md)

--- a/tests/fixtures/astro-content-collection/src/content/posts/first-post.md
+++ b/tests/fixtures/astro-content-collection/src/content/posts/first-post.md
@@ -1,0 +1,12 @@
+---
+title: First Post
+collection: posts
+---
+
+# First Markdown Post
+
+This page came from an Astro-like Markdown content collection.
+
+<div class="markdown-card">Markdown can still carry deliberate HTML islands.</div>
+
+[About](/src/content/pages/about.markdown)

--- a/tests/fixtures/astro-content-collection/styles.css
+++ b/tests/fixtures/astro-content-collection/styles.css
@@ -1,0 +1,11 @@
+.site-header,
+.site-footer {
+	display: flex;
+	gap: 1rem;
+	padding: 1rem;
+}
+
+.markdown-card {
+	border: 1px solid currentColor;
+	padding: 1rem;
+}

--- a/tests/smoke-astro-markdown-content-collections.php
+++ b/tests/smoke-astro-markdown-content-collections.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Smoke test: an Astro-like HTML shell imports Markdown content collections.
+ *
+ * Run inside a WordPress site with BFB active:
+ * wp eval-file tests/smoke-astro-markdown-content-collections.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+
+if ( ! defined( 'STATIC_SITE_IMPORTER_PATH' ) && is_readable( $plugin_root . '/static-site-importer.php' ) ) {
+	require_once $plugin_root . '/static-site-importer.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Document', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-document.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Source_Page', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-source-page.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read = static function ( string $path ): string {
+	$contents = file_get_contents( $path );
+	return false === $contents ? '' : $contents;
+};
+
+$fixture_dir = $plugin_root . '/tests/fixtures/astro-content-collection';
+$fixture     = $fixture_dir . '/index.html';
+
+foreach ( array( 'index.html', 'styles.css', 'src/content/posts/first-post.md', 'src/content/pages/about.markdown' ) as $file ) {
+	$assert( is_readable( $fixture_dir . '/' . $file ), 'fixture-file-exists-' . $file );
+}
+
+$result = Static_Site_Importer_Theme_Generator::import_theme(
+	$fixture,
+	array(
+		'name'        => 'Astro Content Collection',
+		'slug'        => 'astro-content-collection',
+		'overwrite'   => true,
+		'activate'    => false,
+		'keep_source' => true,
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+if ( ! is_wp_error( $result ) ) {
+	$theme_dir = $result['theme_dir'];
+	$header    = $read( $theme_dir . '/parts/header.html' );
+	$style     = $read( $theme_dir . '/style.css' );
+	$report    = json_decode( $read( $result['report_path'] ?? '' ), true );
+	$pages     = $result['pages'] ?? array();
+
+	$assert( isset( $pages['index.html'] ), 'html-shell-page-imported' );
+	$assert( isset( $pages['src/content/posts/first-post.md'] ), 'markdown-md-page-imported' );
+	$assert( isset( $pages['src/content/pages/about.markdown'] ), 'markdown-long-extension-page-imported' );
+	$assert( str_contains( $header, 'Astro Shell' ), 'html-shell-supplies-header-chrome' );
+	$assert( str_contains( $style, '.markdown-card' ), 'html-shell-linked-css-preserved' );
+	$assert( ! str_contains( $header, '.md' ) && ! str_contains( $header, '.markdown' ) && ! str_contains( $header, 'index.html' ), 'header-source-links-rewritten' );
+
+	$markdown_post = get_post( $pages['src/content/posts/first-post.md'] ?? 0 );
+	$about_page    = get_post( $pages['src/content/pages/about.markdown'] ?? 0 );
+	$assert( $markdown_post instanceof WP_Post, 'markdown-post-created' );
+	$assert( $about_page instanceof WP_Post, 'markdown-page-created' );
+	if ( $markdown_post instanceof WP_Post ) {
+		$assert( str_contains( $markdown_post->post_content, 'First Markdown Post' ), 'markdown-heading-converted-to-block-content' );
+		$assert( str_contains( $markdown_post->post_content, 'markdown-card' ), 'markdown-html-island-converted-to-block-content' );
+		$assert( ! str_contains( $markdown_post->post_content, 'collection: posts' ), 'frontmatter-not-imported-as-content' );
+		$assert( ! str_contains( $markdown_post->post_content, '.markdown' ), 'markdown-content-link-rewritten' );
+	}
+	if ( $about_page instanceof WP_Post ) {
+		$assert( str_contains( $about_page->post_content, 'About Markdown Page' ), 'markdown-extension-page-content-imported' );
+		$assert( ! str_contains( $about_page->post_content, '../posts/first-post.md' ), 'relative-markdown-link-rewritten-by-basename' );
+	}
+
+	$semantic_targets = $report['semantic_fidelity']['comparison_targets'] ?? array();
+	$markdown_targets = array_values(
+		array_filter(
+			is_array( $semantic_targets ) ? $semantic_targets : array(),
+			static fn ( $target ): bool => is_array( $target ) && 'markdown' === ( $target['source_type'] ?? '' )
+		)
+	);
+	$assert( count( $markdown_targets ) >= 2, 'report-records-markdown-source-targets' );
+}
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: Astro Markdown content collection smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Adds an internal `Static_Site_Importer_Source_Page` model so the importer can handle HTML and Markdown source documents without changing `index.html` as the shared chrome/theme source.
- Discovers nested `.md` and `.markdown` content files, strips leading frontmatter as a raw seam for #137, converts Markdown bodies through BFB's Markdown adapter, and records `source_type` in fidelity targets.
- Adds an Astro-like fixture and smoke test covering an HTML shell plus Markdown content collection imports and source-link rewriting.

Closes #136.

## Tests
- `php -l includes/class-static-site-importer-source-page.php`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l static-site-importer.php`
- `php -l tests/smoke-astro-markdown-content-collections.php`
- `studio wp --skip-plugins=static-site-importer eval-file "/Users/chubes/Developer/static-site-importer@feat-markdown-content-collections-136/tests/smoke-astro-markdown-content-collections.php"`
- `studio wp --skip-plugins=static-site-importer eval-file "/Users/chubes/Developer/static-site-importer@feat-markdown-content-collections-136/tests/smoke-wordpress-is-dead-fixture.php"`
- `php tests/smoke-admin-import-html-entry.php`
- `npm run test:validation`

## Notes
- Full frontmatter metadata parsing remains intentionally out of scope for #137; this only strips leading frontmatter from imported Markdown content and keeps the raw seam in the source-page model.
- MDX and full Astro project compilation remain out of scope.
- One Studio CLI invocation printed a transient language-pack setup warning before the HTML fixture smoke completed successfully; the smoke itself passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, fixture, smoke test, and validation commands; Chris remains responsible for review and final acceptance.