### PR TITLE
Fix mixed source link rewrites

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -136,6 +136,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		$permalinks              = self::page_permalinks( $page_ids );
+		$route_map               = self::source_route_map( $pages, $permalinks );
 		$fragments               = $document->fragments();
 		self::$conversion_report = self::new_conversion_report( $html_path, isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array() );
 		self::record_source_documents_summary( $site_dir, $pages, $permalinks );
@@ -157,12 +158,12 @@ class Static_Site_Importer_Theme_Generator {
 		);
 		self::pre_register_svg_symbol_sprites( $fragments, $pages );
 
-		$background_blocks = self::convert_fragment( self::rewrite_internal_links( $fragments['background'], $permalinks ), 'background:index.html' );
-		$header_blocks     = self::convert_header_fragment( self::strip_active_classes( self::rewrite_internal_links( $fragments['header'], $permalinks ) ), $theme_slug );
+		$background_blocks = self::convert_fragment( self::rewrite_internal_links( $fragments['background'], $route_map, basename( $html_path ), 'background:' . basename( $html_path ) ), 'background:index.html' );
+		$header_blocks     = self::convert_header_fragment( self::strip_active_classes( self::rewrite_internal_links( $fragments['header'], $route_map, basename( $html_path ), 'header:' . basename( $html_path ) ) ), $theme_slug );
 		$has_footer_part   = '' !== trim( $fragments['footer'] );
-		$footer_blocks     = $has_footer_part ? self::convert_footer_fragment( self::rewrite_internal_links( $fragments['footer'], $permalinks ), $theme_slug ) : '';
+		$footer_blocks     = $has_footer_part ? self::convert_footer_fragment( self::rewrite_internal_links( $fragments['footer'], $route_map, basename( $html_path ), 'footer:' . basename( $html_path ) ), $theme_slug ) : '';
 
-		$page_artifacts = self::page_artifacts( $pages, $permalinks, $theme_slug );
+		$page_artifacts = self::page_artifacts( $pages, $route_map, $theme_slug );
 
 		$result = self::write_page_contents( $pages, $page_ids, $page_artifacts['contents'] );
 		if ( is_wp_error( $result ) ) {
@@ -428,11 +429,11 @@ class Static_Site_Importer_Theme_Generator {
 	 * Build page-specific template and pattern artifacts.
 	 *
 	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Pages.
-	 * @param array<string,string>                                                      $permalinks Permalinks keyed by filename.
+	 * @param array<string,string>                          $route_map Route map.
 	 * @param string                                                                    $theme_slug Theme slug.
 	 * @return array{patterns:array<string,string>,files:array<string,string>,contents:array<string,string>}
 	 */
-	private static function page_artifacts( array $pages, array $permalinks, string $theme_slug ): array {
+	private static function page_artifacts( array $pages, array $route_map, string $theme_slug ): array {
 		$patterns = array();
 		$files    = array();
 		$contents = array();
@@ -440,10 +441,7 @@ class Static_Site_Importer_Theme_Generator {
 		foreach ( $pages as $filename => $page ) {
 			$slug         = self::page_slug( $filename, $page );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
-			$content_body = 'markdown' === $page->body_format()
-				? self::rewrite_markdown_links( $page->body(), $permalinks, $filename )
-				: self::rewrite_internal_links( $page->body(), $permalinks );
-			$content      = self::convert_fragment( $content_body, 'main:' . $filename, $page->body_format() );
+			$content      = self::source_page_content_blocks( $page, $route_map );
 
 			$patterns[ $filename ] = $pattern_slug;
 			$files[ $filename ]    = self::pattern_file( self::page_title( $filename, $page ), $pattern_slug, $content );
@@ -507,100 +505,103 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Rewrite local source-page links to imported WordPress page permalinks.
+	 * Build a route map for source document links.
 	 *
-	 * @param string               $html       HTML fragment.
-	 * @param array<string,string> $permalinks Permalinks keyed by filename.
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Pages.
+	 * @param array<string,string>                          $permalinks Permalinks keyed by source path.
+	 * @return array<string,string>
+	 */
+	private static function source_route_map( array $pages, array $permalinks ): array {
+		$candidates = array();
+		foreach ( $pages as $source_path => $page ) {
+			$permalink = $permalinks[ $source_path ] ?? '';
+			if ( '' === $permalink ) {
+				continue;
+			}
+
+			foreach ( self::source_route_keys( $page->source_key() ) as $key ) {
+				$candidates[ $key ][ $permalink ] = true;
+			}
+		}
+
+		$route_map = array();
+		foreach ( $candidates as $key => $matches ) {
+			if ( 1 === count( $matches ) ) {
+				$route_map[ $key ] = (string) array_key_first( $matches );
+			}
+		}
+
+		return $route_map;
+	}
+
+	/**
+	 * Build deterministic route keys for a discovered source path.
+	 *
+	 * @param string $relative_path Source-relative path.
+	 * @return array<int,string>
+	 */
+	private static function source_route_keys( string $relative_path ): array {
+		$relative_path = self::normalize_route_path( $relative_path );
+		if ( '' === $relative_path ) {
+			return array();
+		}
+
+		$extensionless = preg_replace( '/\.(?:html?|md|markdown)$/i', '', $relative_path );
+		$extensionless = '' === trim( (string) $extensionless ) ? $relative_path : (string) $extensionless;
+		$extensions    = array( 'html', 'htm', 'md', 'markdown' );
+		$keys          = array( $relative_path, '/' . $relative_path, './' . $relative_path );
+
+		foreach ( $extensions as $extension ) {
+			$keys[] = $extensionless . '.' . $extension;
+			$keys[] = '/' . $extensionless . '.' . $extension;
+		}
+
+		if ( preg_match( '#(^|/)index$#i', $extensionless ) ) {
+			$clean = preg_replace( '#(^|/)index$#i', '$1', $extensionless );
+			$clean = trim( (string) $clean, '/' );
+			$keys[] = '' === $clean ? '/' : $clean;
+			$keys[] = '' === $clean ? '/' : '/' . $clean . '/';
+			if ( '' !== $clean ) {
+				$keys[] = $clean . '/';
+			}
+		} else {
+			$keys[] = $extensionless;
+			$keys[] = '/' . $extensionless;
+			$keys[] = $extensionless . '/';
+			$keys[] = '/' . $extensionless . '/';
+		}
+
+		return array_values( array_unique( array_filter( $keys, static fn ( string $key ): bool => '' !== trim( $key ) ) ) );
+	}
+
+	/**
+	 * Rewrite local document links to imported WordPress page permalinks.
+	 *
+	 * @param string               $html        HTML fragment.
+	 * @param array<string,string> $route_map   Route map.
+	 * @param string               $source_path Source-relative source path.
+	 * @param string               $source      Diagnostic source label.
 	 * @return string
 	 */
-	private static function rewrite_internal_links( string $html, array $permalinks ): string {
-		if ( '' === trim( $html ) || empty( $permalinks ) ) {
+	private static function rewrite_internal_links( string $html, array $route_map, string $source_path, string $source ): string {
+		if ( '' === trim( $html ) || empty( $route_map ) ) {
 			return $html;
 		}
 
-		$rewritten = preg_replace_callback(
+		return preg_replace_callback(
 			'/\bhref=("|\')([^"\']+)(\1)/i',
-			static function ( array $matches ) use ( $permalinks ): string {
-				$href               = html_entity_decode( $matches[2], ENT_QUOTES );
-				$parts              = explode( '#', $href, 2 );
-				$path_without_query = strtok( $parts[0], '?' );
-				$filename           = ltrim( false === $path_without_query ? $parts[0] : $path_without_query, './' );
-				if ( ! isset( $permalinks[ $filename ] ) ) {
-					$filename = basename( $filename );
-				}
-				if ( ! isset( $permalinks[ $filename ] ) ) {
+			static function ( array $matches ) use ( $route_map, $source_path, $source ): string {
+				$href        = html_entity_decode( $matches[2], ENT_QUOTES );
+				$replacement = self::resolve_route_href( $href, $source_path, $route_map );
+				if ( null === $replacement ) {
+					self::record_unresolved_internal_link( $source, $source_path, $href );
 					return $matches[0];
-				}
-
-				$replacement = $permalinks[ $filename ];
-				if ( isset( $parts[1] ) && '' !== $parts[1] ) {
-					$replacement .= '#' . $parts[1];
 				}
 
 				return 'href=' . $matches[1] . esc_url( $replacement ) . $matches[3];
 			},
 			$html
 		) ?? $html;
-
-		return preg_replace_callback(
-			'/(!?\[[^\]]*\]\()([^\s)]+)(\))/i',
-			static function ( array $matches ) use ( $permalinks ): string {
-				$href               = html_entity_decode( $matches[2], ENT_QUOTES );
-				$parts              = explode( '#', $href, 2 );
-				$path_without_query = strtok( $parts[0], '?' );
-				$filename           = basename( false === $path_without_query ? $parts[0] : $path_without_query );
-				if ( ! isset( $permalinks[ $filename ] ) ) {
-					return $matches[0];
-				}
-
-				$replacement = $permalinks[ $filename ];
-				if ( isset( $parts[1] ) && '' !== $parts[1] ) {
-					$replacement .= '#' . $parts[1];
-				}
-
-				return $matches[1] . esc_url( $replacement ) . $matches[3];
-			},
-			$rewritten
-		) ?? $rewritten;
-	}
-
-	/**
-	 * Rewrite local Markdown links to imported WordPress page permalinks.
-	 *
-	 * @param string               $markdown        Markdown source.
-	 * @param array<string,string> $permalinks      Permalinks keyed by source filename.
-	 * @param string               $source_filename Current source filename.
-	 * @return string
-	 */
-	private static function rewrite_markdown_links( string $markdown, array $permalinks, string $source_filename ): string {
-		if ( '' === trim( $markdown ) || empty( $permalinks ) ) {
-			return $markdown;
-		}
-
-		return preg_replace_callback(
-			'/\]\(([^)]+)\)/',
-			static function ( array $matches ) use ( $permalinks, $source_filename ): string {
-				$href = trim( $matches[1] );
-				if ( preg_match( '/^[a-z][a-z0-9+.-]*:/i', $href ) || str_starts_with( $href, '#' ) ) {
-					return $matches[0];
-				}
-
-				$parts = explode( '#', $href, 2 );
-				$path  = strtok( $parts[0], '?' );
-				$key   = self::resolve_source_link_key( $source_filename, false === $path ? $parts[0] : $path );
-				if ( ! isset( $permalinks[ $key ] ) ) {
-					return $matches[0];
-				}
-
-				$replacement = $permalinks[ $key ];
-				if ( isset( $parts[1] ) && '' !== $parts[1] ) {
-					$replacement .= '#' . $parts[1];
-				}
-
-				return '](' . $replacement . ')';
-			},
-			$markdown
-		) ?? $markdown;
 	}
 
 	/**
@@ -1668,6 +1669,67 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Convert one source page body to blocks after shared link rewriting.
+	 *
+	 * @param Static_Site_Importer_Source_Page $page      Source page.
+	 * @param array<string,string>             $route_map Route map.
+	 * @return string
+	 */
+	private static function source_page_content_blocks( Static_Site_Importer_Source_Page $page, array $route_map ): string {
+		$source_path = $page->source_key();
+		$source      = 'main:' . $source_path;
+		$body        = $page->body();
+
+		if ( 'markdown' === $page->body_format() ) {
+			$body = self::rewrite_markdown_links( $body, $route_map, $source_path, $source );
+		} else {
+			$body = self::rewrite_internal_links( $body, $route_map, $source_path, $source );
+		}
+
+		return self::convert_fragment( $body, $source, $page->body_format() );
+	}
+
+	/**
+	 * Rewrite Markdown inline links/images using the shared source route map.
+	 *
+	 * @param string               $markdown    Markdown source.
+	 * @param array<string,string> $route_map   Route map.
+	 * @param string               $source_path Source-relative source path.
+	 * @param string               $source      Diagnostic source label.
+	 * @return string
+	 */
+	private static function rewrite_markdown_links( string $markdown, array $route_map, string $source_path, string $source ): string {
+		if ( '' === trim( $markdown ) ) {
+			return $markdown;
+		}
+
+		return preg_replace_callback(
+			'/(\!?)\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/',
+			static function ( array $matches ) use ( $route_map, $source_path, $source ): string {
+				$prefix      = $matches[1];
+				$label       = $matches[2];
+				$destination = trim( $matches[3], '<>' );
+
+				if ( '!' === $prefix ) {
+					if ( self::is_local_url( $destination ) ) {
+						self::record_unresolved_internal_link( $source, $source_path, $destination, 'local_asset_not_materialized' );
+					}
+					return $matches[0];
+				}
+
+				$replacement = self::resolve_route_href( $destination, $source_path, $route_map );
+				if ( null === $replacement ) {
+					self::record_unresolved_internal_link( $source, $source_path, $destination );
+					return $matches[0];
+				}
+
+				return '[' . $label . '](' . $replacement . ')';
+			},
+			$markdown
+		) ?? $markdown;
+	}
+
+	/**
 	 * Build a WordPress page title from a source document.
 	 *
 	 * @param string                           $filename Source filename.
@@ -1685,11 +1747,19 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		$title = preg_replace( '/\s+[—-]\s+.+$/u', '', $page->document()->title() );
-		return '' === trim( (string) $title ) ? ucwords( str_replace( '-', ' ', self::page_slug( $filename, $page ) ) ) : trim( (string) $title );
+		if ( '' !== trim( (string) $title ) ) {
+			return trim( (string) $title );
+		}
+
+		if ( 'markdown' === $page->type() && preg_match( '/^#\s+(.+)$/m', $page->body(), $matches ) ) {
+			return trim( $matches[1] );
+		}
+
+		return ucwords( str_replace( '-', ' ', self::page_slug( $filename, $page ) ) );
 	}
 
 	/**
-	 * Build a WordPress page slug from a source filename.
+	 * Build a WordPress page slug from a source path.
 	 *
 	 * @param string                                $filename Source filename.
 	 * @param Static_Site_Importer_Source_Page|null $page     Source page.
@@ -1703,12 +1773,18 @@ class Static_Site_Importer_Theme_Generator {
 			}
 		}
 
+		$extensionless = preg_replace( '/\.(?:html?|md|markdown)$/i', '', self::normalize_route_path( $filename ) );
+		$extensionless = trim( (string) $extensionless, '/' );
+
 		if ( self::is_index_source_filename( $filename ) ) {
 			return 'home';
 		}
 
-		$slug = preg_replace( '/\.(?:html?|md|markdown)$/i', '', $filename );
-		return sanitize_title( str_replace( '/', '-', (string) $slug ) );
+		if ( str_ends_with( $extensionless, '/index' ) ) {
+			$extensionless = substr( $extensionless, 0, -6 );
+		}
+
+		return sanitize_title( str_replace( '/', '-', $extensionless ) );
 	}
 
 	/**
@@ -1754,6 +1830,93 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return trim( implode( "\n\n", array_filter( $css ) ) );
+	}
+
+	/**
+	 * Resolve a local link href through the source route map.
+	 *
+	 * @param string               $href        Link href.
+	 * @param string               $source_path Source-relative source path.
+	 * @param array<string,string> $route_map   Route map.
+	 * @return string|null
+	 */
+	private static function resolve_route_href( string $href, string $source_path, array $route_map ): ?string {
+		if ( ! self::is_local_url( $href ) || str_starts_with( $href, '#' ) ) {
+			return null;
+		}
+
+		$parts      = wp_parse_url( $href );
+		$path       = isset( $parts['path'] ) ? (string) $parts['path'] : '';
+		$query      = isset( $parts['query'] ) ? (string) $parts['query'] : '';
+		$fragment   = isset( $parts['fragment'] ) ? (string) $parts['fragment'] : '';
+		$lookup_key = str_starts_with( $path, '/' ) ? self::normalize_route_path( $path ) : self::normalize_route_path( dirname( $source_path ) . '/' . $path );
+
+		$keys = array( $lookup_key, '/' . $lookup_key );
+		if ( str_ends_with( $path, '/' ) ) {
+			$keys[] = trailingslashit( $lookup_key );
+			$keys[] = '/' . trailingslashit( $lookup_key );
+		}
+
+		foreach ( array_values( array_unique( $keys ) ) as $key ) {
+			if ( isset( $route_map[ $key ] ) ) {
+				$replacement = $route_map[ $key ];
+				if ( '' !== $query ) {
+					$replacement = add_query_arg( array(), $replacement ) . '?' . $query;
+				}
+				if ( '' !== $fragment ) {
+					$replacement .= '#' . $fragment;
+				}
+
+				return $replacement;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normalize a route-like path without resolving outside the source root.
+	 *
+	 * @param string $path Route path.
+	 * @return string
+	 */
+	private static function normalize_route_path( string $path ): string {
+		$path     = str_replace( '\\', '/', strtok( $path, '?' ) ?: $path );
+		$path     = ltrim( $path, '/' );
+		$segments = array();
+		foreach ( explode( '/', $path ) as $segment ) {
+			if ( '' === $segment || '.' === $segment ) {
+				continue;
+			}
+			if ( '..' === $segment ) {
+				array_pop( $segments );
+				continue;
+			}
+
+			$segments[] = $segment;
+		}
+
+		return implode( '/', $segments );
+	}
+
+	/**
+	 * Check whether a URL is local to the imported source tree.
+	 *
+	 * @param string $url URL or path.
+	 * @return bool
+	 */
+	private static function is_local_url( string $url ): bool {
+		$url = trim( $url );
+		if ( '' === $url || str_starts_with( $url, '#' ) ) {
+			return false;
+		}
+
+		$lower = strtolower( $url );
+		if ( preg_match( '#^[a-z][a-z0-9+.-]*:#i', $lower ) || str_starts_with( $lower, '//' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -2905,6 +3068,28 @@ class Static_Site_Importer_Theme_Generator {
 				'unresolved_links'      => $unresolved,
 				'unresolved_link_count' => count( $unresolved ),
 			)
+		);
+	}
+
+	/**
+	 * Record a local source link or asset that could not be resolved/materialized.
+	 *
+	 * @param string $source      Diagnostic source label.
+	 * @param string $source_path Source-relative source path.
+	 * @param string $href        Original href or source URL.
+	 * @param string $type        Diagnostic type.
+	 * @return void
+	 */
+	private static function record_unresolved_internal_link( string $source, string $source_path, string $href, string $type = 'unresolved_internal_link' ): void {
+		if ( ! self::is_local_url( $href ) ) {
+			return;
+		}
+
+		self::$conversion_report['diagnostics'][] = array(
+			'type'        => $type,
+			'source'      => $source,
+			'source_path' => $source_path,
+			'href'        => $href,
 		);
 	}
 

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -1644,6 +1644,60 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Mixed HTML and Markdown sources share one route map for internal link rewrites.
+	 */
+	public function test_mixed_html_markdown_source_links_rewrite_through_shared_route_map(): void {
+		$plugin_root = dirname( __DIR__ );
+		$fixture     = $plugin_root . '/tests/fixtures/mixed-source-links/index.html';
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$fixture,
+			array(
+				'name'        => 'Mixed Source Links',
+				'slug'        => 'mixed-source-links',
+				'overwrite'   => true,
+				'activate'    => false,
+				'keep_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'index.html', $result['pages'] );
+		$this->assertArrayHasKey( 'about.markdown', $result['pages'] );
+		$this->assertArrayHasKey( 'docs/intro.md', $result['pages'] );
+		$this->assertArrayHasKey( 'docs/install.markdown', $result['pages'] );
+
+		$home_permalink    = get_permalink( $result['pages']['index.html'] );
+		$about_permalink   = get_permalink( $result['pages']['about.markdown'] );
+		$intro_permalink   = get_permalink( $result['pages']['docs/intro.md'] );
+		$install_permalink = get_permalink( $result['pages']['docs/install.markdown'] );
+
+		$header_nav    = get_page_by_path( 'mixed-source-links-header-navigation', OBJECT, 'wp_navigation' );
+		$home_content  = get_post( $result['pages']['index.html'] )->post_content;
+		$about_content = get_post( $result['pages']['about.markdown'] )->post_content;
+		$intro_content = get_post( $result['pages']['docs/intro.md'] )->post_content;
+		$install       = get_post( $result['pages']['docs/install.markdown'] );
+
+		$this->assertInstanceOf( WP_Post::class, $header_nav );
+		$this->assertStringContainsString( (string) $intro_permalink, $header_nav->post_content, 'HTML chrome should rewrite HTML-to-Markdown links.' );
+		$this->assertStringContainsString( (string) $about_permalink, $header_nav->post_content, 'HTML chrome should rewrite .markdown links.' );
+		$this->assertStringContainsString( (string) $install_permalink, $header_nav->post_content, 'HTML chrome should rewrite clean root-relative Markdown routes.' );
+		$this->assertStringContainsString( (string) $intro_permalink, $home_content, 'HTML body should rewrite HTML-to-Markdown links.' );
+		$this->assertStringContainsString( (string) $home_permalink, $about_content, 'Markdown should rewrite Markdown-to-HTML links.' );
+		$this->assertStringContainsString( (string) $install_permalink, $about_content, 'Markdown should rewrite clean Markdown routes.' );
+		$this->assertStringContainsString( (string) $about_permalink, $intro_content, 'Markdown should rewrite relative Markdown-to-Markdown links.' );
+		$this->assertStringContainsString( (string) $install_permalink, $intro_content, 'Markdown should rewrite extension-swapped Markdown routes.' );
+		$this->assertInstanceOf( WP_Post::class, $install );
+		$this->assertStringContainsString( (string) $home_permalink, $install->post_content );
+
+		$report      = json_decode( $this->read_file( $result['report_path'] ), true );
+		$diagnostics = $report['diagnostics'] ?? array();
+		$this->assertContains( 'unresolved_internal_link', wp_list_pluck( $diagnostics, 'type' ) );
+		$this->assertContains( 'local_asset_not_materialized', wp_list_pluck( $diagnostics, 'type' ) );
+	}
+
+	/**
 	 * Reads a generated file.
 	 */
 	private function read_file( string $path ): string {

--- a/tests/fixtures/mixed-source-links/about.markdown
+++ b/tests/fixtures/mixed-source-links/about.markdown
@@ -1,0 +1,5 @@
+# About Mixed Sources
+
+[Home](index.html)
+
+[Install guide](/docs/install/)

--- a/tests/fixtures/mixed-source-links/docs/images/flow.svg
+++ b/tests/fixtures/mixed-source-links/docs/images/flow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle cx="5" cy="5" r="4" /></svg>

--- a/tests/fixtures/mixed-source-links/docs/install.markdown
+++ b/tests/fixtures/mixed-source-links/docs/install.markdown
@@ -1,0 +1,5 @@
+# Install
+
+[Intro](./intro.md)
+
+[Home](/)

--- a/tests/fixtures/mixed-source-links/docs/intro.md
+++ b/tests/fixtures/mixed-source-links/docs/intro.md
@@ -1,0 +1,7 @@
+# Intro
+
+[About](../about.md)
+
+[Install](install.html)
+
+![Diagram](./images/flow.svg)

--- a/tests/fixtures/mixed-source-links/index.html
+++ b/tests/fixtures/mixed-source-links/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+	<title>Mixed Source Home</title>
+</head>
+<body>
+	<header>
+		<nav>
+			<a href="docs/intro.md">Intro</a>
+			<a href="about.markdown">About</a>
+			<a href="/docs/install/">Install</a>
+			<a href="missing.md">Missing</a>
+		</nav>
+	</header>
+	<main>
+		<h1>Mixed Source Home</h1>
+		<p><a href="docs/intro.md#overview">Read the intro</a></p>
+	</main>
+</body>
+</html>

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -71,6 +71,11 @@ const steps = [
     args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-branded-inline-chrome.php' ) ],
   },
   {
+    name: 'Mixed source link rewrite smoke',
+    command: wpCli[ 0 ],
+    args: [ ...wpCli.slice( 1 ), '--skip-plugins=static-site-importer', 'eval-file', path.join( repoRoot, 'tests/smoke-mixed-source-link-rewrites.php' ) ],
+  },
+  {
     name: 'Generated theme JS block validation',
     command: process.execPath,
     args: [

--- a/tests/smoke-mixed-source-link-rewrites.php
+++ b/tests/smoke-mixed-source-link-rewrites.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Smoke test: mixed HTML/Markdown source links rewrite through one route map.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+if ( ! class_exists( 'Static_Site_Importer_Document', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-document.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Woo_Product_Seeder', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-woo-product-seeder.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read = static function ( string $path ): string {
+	$contents = file_get_contents( $path );
+	return false === $contents ? '' : $contents;
+};
+
+$fixture = $plugin_root . '/tests/fixtures/mixed-source-links/index.html';
+$result  = Static_Site_Importer_Theme_Generator::import_theme(
+	$fixture,
+	array(
+		'name'        => 'Mixed Source Links',
+		'slug'        => 'mixed-source-links-smoke',
+		'overwrite'   => true,
+		'activate'    => false,
+		'keep_source' => true,
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+if ( ! is_wp_error( $result ) ) {
+	$pages = $result['pages'];
+	foreach ( array( 'index.html', 'about.markdown', 'docs/intro.md', 'docs/install.markdown' ) as $source_path ) {
+		$assert( isset( $pages[ $source_path ] ), 'page-created-' . $source_path );
+	}
+
+	$home_permalink    = get_permalink( $pages['index.html'] ?? 0 );
+	$about_permalink   = get_permalink( $pages['about.markdown'] ?? 0 );
+	$intro_permalink   = get_permalink( $pages['docs/intro.md'] ?? 0 );
+	$install_permalink = get_permalink( $pages['docs/install.markdown'] ?? 0 );
+
+	$header_nav      = get_page_by_path( 'mixed-source-links-smoke-header-navigation', OBJECT, 'wp_navigation' );
+	$home_content    = get_post_field( 'post_content', $pages['index.html'] ?? 0 );
+	$about_content   = get_post_field( 'post_content', $pages['about.markdown'] ?? 0 );
+	$intro_content   = get_post_field( 'post_content', $pages['docs/intro.md'] ?? 0 );
+	$install_content = get_post_field( 'post_content', $pages['docs/install.markdown'] ?? 0 );
+
+	$assert( $header_nav instanceof WP_Post, 'header-navigation-created' );
+	$header_content = $header_nav instanceof WP_Post ? $header_nav->post_content : '';
+	$assert( str_contains( $header_content, (string) $intro_permalink ), 'html-chrome-to-markdown' );
+	$assert( str_contains( $header_content, (string) $about_permalink ), 'html-chrome-to-markdown-extension' );
+	$assert( str_contains( $header_content, (string) $install_permalink ), 'html-chrome-clean-route' );
+	$assert( str_contains( $home_content, (string) $intro_permalink ), 'html-body-to-markdown' );
+	$assert( str_contains( $about_content, (string) $home_permalink ), 'markdown-to-html' );
+	$assert( str_contains( $about_content, (string) $install_permalink ), 'markdown-clean-route' );
+	$assert( str_contains( $intro_content, (string) $about_permalink ), 'markdown-to-markdown-relative' );
+	$assert( str_contains( $intro_content, (string) $install_permalink ), 'markdown-to-markdown-extension-swapped' );
+	$assert( str_contains( $install_content, (string) $home_permalink ), 'markdown-root-clean-route' );
+
+	$report      = json_decode( $read( $result['report_path'] ), true );
+	$diagnostics = is_array( $report ) ? wp_list_pluck( $report['diagnostics'] ?? array(), 'type' ) : array();
+	$assert( in_array( 'unresolved_internal_link', $diagnostics, true ), 'unresolved-link-diagnostic' );
+	$assert( in_array( 'local_asset_not_materialized', $diagnostics, true ), 'local-asset-diagnostic' );
+}
+
+if ( ! empty( $failures ) ) {
+	foreach ( $failures as $failure ) {
+		fwrite( STDERR, $failure . PHP_EOL );
+	}
+	exit( 1 );
+}
+
+WP_CLI::line( sprintf( 'OK: mixed source link rewrite smoke passed (%d assertions)', $assertions ) );

--- a/tests/smoke-mixed-source-link-rewrites.php
+++ b/tests/smoke-mixed-source-link-rewrites.php
@@ -13,6 +13,9 @@ $plugin_root = dirname( __DIR__ );
 if ( ! class_exists( 'Static_Site_Importer_Document', false ) ) {
 	require_once $plugin_root . '/includes/class-static-site-importer-document.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Source_Page', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-source-page.php';
+}
 if ( ! class_exists( 'Static_Site_Importer_Woo_Product_Seeder', false ) ) {
 	require_once $plugin_root . '/includes/class-static-site-importer-woo-product-seeder.php';
 }


### PR DESCRIPTION
## Summary
- Builds a shared route map for discovered HTML and Markdown source documents before conversion, including source-relative, root-relative, extension-swapped, and deterministic clean-route keys.
- Reuses the route map for HTML fragments and Markdown bodies so HTML-to-Markdown, Markdown-to-HTML, and Markdown-to-Markdown links resolve to imported WordPress permalinks.
- Adds import-report diagnostics for unresolved local document links and Markdown local assets that are intentionally not copied/materialized in this scope.

## Tests
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `php -l tests/smoke-mixed-source-link-rewrites.php`
- `composer validate --no-check-publish`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@feat-mixed-source-link-rewrites-138/tests/smoke-mixed-source-link-rewrites.php`
- `npm run test:validation`
- `node tests/smoke-generated-theme-block-validation.cjs /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead`

## Blockers / dependencies
- Issues #136 and #137 are still open. This branch includes the minimal Markdown source discovery/title/body plumbing needed to validate #138 end-to-end, but it does not implement full frontmatter parsing or the broader Markdown import contract from #137.
- Broad asset copying/materialization and remote crawling remain out of scope; local Markdown assets are reported as diagnostics instead.

Fixes #138.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the mixed-source route-map implementation, fixture coverage, smoke validation, and PR description; Chris remains responsible for review and final acceptance.