### PR TITLE
Expose mixed source site intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # Static Site Importer
 
-Import a static HTML site into WordPress pages and a companion block theme using the bundled [Block Format Bridge](https://github.com/chubes4/block-format-bridge) converter.
+Import a static site into WordPress pages and a companion block theme using the bundled [Block Format Bridge](https://github.com/chubes4/block-format-bridge) converter.
 
 Static Site Importer is a WordPress plugin. It installs [Block Format Bridge](https://github.com/chubes4/block-format-bridge) through Composer and loads its bundled converter directly from `vendor/`.
 
 ## What It Does
 
-- Adds an **Import HTML** button on the **Appearance -> Themes** screen.
-- Accepts pasted HTML, one public HTML URL, a direct `.html` / `.htm` upload, or a ZIP containing a static-site folder with an `index.html` entry point.
+- Adds an **Import Static Site** button on the **Appearance -> Themes** screen.
+- Accepts pasted HTML, one public HTML URL, a direct `.html` / `.htm` upload, or a ZIP containing a static-site folder with an `index.html` shell/chrome entry point.
+- Allows ZIP/CLI source-site imports to include nested `.md` / `.markdown` content documents; `.mdx` is skipped with explicit diagnostics because MDX runtime components are not supported.
 - Provides a WP-CLI importer for a local HTML entry file or one public HTML URL; the local source file does not need to be named `index.html` unless you want automatic front-page assignment.
-- Discovers readable sibling `*.html` files beside the selected entry file and imports them as WordPress pages.
-- Converts static HTML fragments through `bfb_convert( $html, 'html', 'blocks' )`.
+- Discovers readable sibling `*.html` files beside the selected entry file and recursive Markdown content documents under the source tree, then imports them as WordPress pages.
+- Converts static HTML fragments through `bfb_convert( $html, 'html', 'blocks' )` and Markdown content through `bfb_convert( $markdown, 'markdown', 'blocks' )`.
 - Stores converted page bodies on the imported WordPress pages as `post_content`.
 - Generates a block theme with shared header/footer template parts, `core/post-content` templates, page patterns for reusable/reference artifacts, `theme.json`, `style.css`, and optional `assets/site.js`.
 - Rewrites local `.html` links to the imported WordPress page permalinks.
@@ -29,12 +30,12 @@ The current Composer dependency is [`chubes4/block-format-bridge:^0.7.1`](https:
 
 ## Admin Usage
 
-1. Open **Appearance -> Themes** and click **Import HTML** beside the standard **Add Theme** button.
-2. Paste a single HTML document, enter a public `http` / `https` URL, upload a single `.html` / `.htm` file, or upload a ZIP containing a static-site folder with an `index.html` entry point.
+1. Open **Appearance -> Themes** and click **Import Static Site** beside the standard **Add Theme** button.
+2. Paste a single HTML document, enter a public `http` / `https` URL, upload a single `.html` / `.htm` file, or upload a ZIP containing a static-site folder with an `index.html` entry point and optional `.md` / `.markdown` content documents.
 3. Optionally provide a theme name and slug.
 4. Leave **Activate imported theme** checked if the generated theme should become active immediately.
 
-The admin path always overwrites an existing generated theme with the same slug. Pasted HTML, fetched URL HTML, and direct HTML uploads are copied into a generated upload work directory as `index.html` and imported as a single-page site. ZIP uploads are for multi-page static sites or bundled HTML exports; they are extracted to an upload work directory, the selected `index.html` is used as the entry file, and sibling HTML files from that extracted site directory are imported. The importer does not require the original source model to be a single `index.html`; it needs one selected HTML entry file and imports the sibling HTML pages it can read.
+The admin path always overwrites an existing generated theme with the same slug. Pasted HTML, fetched URL HTML, and direct HTML uploads are copied into a generated upload work directory as `index.html` and imported as a single-page site. ZIP uploads are for multi-page static sites or bundled source-site exports; they are extracted to an upload work directory, the selected `index.html` is used as the entry file, sibling HTML files from that extracted site directory are imported, and nested `.md` / `.markdown` files are imported as content pages. The importer does not require the original source model to be a single `index.html`; it needs one selected HTML entry file for shared shell/chrome and imports the source content documents it can read.
 
 URL intake rules:
 
@@ -51,6 +52,7 @@ ZIP intake rules:
 - If there is no root-level `index.html`, the ZIP may contain exactly one nested `index.html`, such as `site-export/index.html`.
 - If there are multiple nested `index.html` files and no root `index.html`, the import fails so the entry point is not guessed.
 - Archive entries with absolute paths, `../` traversal segments, or server-side executable extensions are rejected before extraction when PHP's `ZipArchive` inspection is available.
+- `.md` and `.markdown` files under the selected source tree are imported as pages. `.mdx` files are not executed or parsed as Markdown; they are skipped and listed in `import-report.json` diagnostics.
 
 ## CLI Usage
 
@@ -73,11 +75,11 @@ wp static-site-importer import-url https://example.com/ \
   --report=report.json
 ```
 
-The CLI path imports all readable sibling `*.html` files in the same directory as the provided entry file. The entry file supplies the theme title, shared source chrome, background decoration, styles, and inline scripts; each sibling HTML file supplies a WordPress page body.
+The CLI path imports all readable sibling `*.html` files in the same directory as the provided entry file plus recursive `.md` / `.markdown` content documents under the source tree. The entry file supplies the theme title, shared source chrome, background decoration, styles, and inline scripts; each source content file supplies a WordPress page body. `.mdx` files are unsupported and reported as skipped diagnostics.
 
 `index.html` has special front-page behavior: it becomes the `home` page slug and, when `--activate` is used, is assigned as the site's static front page. If the imported directory has no `index.html`, the pages are still imported, but the importer does not assign `page_on_front` automatically.
 
-By default, source directories are deleted after a successful clean import so generated upload work directories do not accumulate. Sources are preserved when conversion quality checks report issues. Use `--keep-source` with CLI imports when you want to keep the original local source directory or fetched URL fixture after a successful clean import for debugging or development.
+By default, source directories are deleted after a successful clean import so generated upload work directories do not accumulate. Sources are preserved when conversion quality checks report issues. Use `--keep-source` with CLI imports when you want to keep the original local source directory or fetched URL fixture after a successful clean import for debugging or development. Import reports include a `source_documents` summary with counts by format, skipped MDX count, unresolved local links, and Markdown parse-error diagnostics.
 
 ## Generated Theme Shape
 
@@ -147,9 +149,10 @@ wp eval-file tests/smoke-admin-import-html-entry.php
 wp eval-file tests/smoke-url-import-entry.php
 wp eval-file tests/smoke-editor-style-support.php
 wp eval-file tests/smoke-wordpress-is-dead-fixture.php
+wp eval-file tests/smoke-mixed-source-fixture.php
 ```
 
-The `wordpress-is-dead` smoke verifies the multi-page fixture, generated block-theme artifacts, internal-link rewrites, persistent navigation entities, source CSS preservation, editor style support, conservative `theme.json` palette extraction, and selector fidelity across stored/rendered paths.
+The `wordpress-is-dead` smoke verifies the multi-page fixture, generated block-theme artifacts, internal-link rewrites, persistent navigation entities, source CSS preservation, editor style support, conservative `theme.json` palette extraction, and selector fidelity across stored/rendered paths. The `mixed-source-site` smoke verifies an Astro-like source tree with `index.html`, nested Markdown content documents, explicit skipped-MDX diagnostics, report source counts, and generated page block markup.
 
 ### PHPUnit Fixture Test
 
@@ -187,11 +190,12 @@ This repo is Homeboy-managed:
 ## Current Boundaries And Limitations
 
 - The importer is intentionally static-site-to-block-theme glue. Block Format Bridge owns format conversion; HTML-to-block transform fidelity belongs upstream in BFB/h2bc.
-- The importer currently discovers flat sibling `*.html` files beside the selected entry file; it does not crawl arbitrary nested routes.
-- Admin imports accept pasted HTML, one public URL, a direct `.html` / `.htm` file, or a ZIP with a root `index.html` or exactly one nested `index.html`; CLI imports take a direct HTML file path or one public URL.
+- The importer currently discovers flat sibling `*.html` files beside the selected entry file and recursive Markdown content documents; it does not crawl arbitrary nested HTML routes.
+- Admin imports accept pasted HTML, one public URL, a direct `.html` / `.htm` file, or a ZIP with a root `index.html` or exactly one nested `index.html`; CLI imports take a direct HTML entry path or one public URL.
+- MDX, Astro, Eleventy, Hugo, and other runtime/build orchestration is out of scope. Build those projects to static HTML first, or provide plain `.md` / `.markdown` source content alongside the HTML shell.
 - Linked local stylesheets and inline styles are copied into `style.css`; inline scripts are copied into `assets/site.js`. Other asset copying is not a general-purpose crawler yet.
 - Navigation persistence is limited to supported header/footer shapes that can be converted into deterministic `wp_navigation` entities without guessing.
-- External live triage has exercised additional static sites, but the committed first-party fixture is `tests/fixtures/wordpress-is-dead/`.
+- External live triage has exercised additional static sites; committed first-party fixtures include `tests/fixtures/wordpress-is-dead/` and `tests/fixtures/mixed-source-site/`.
 
 ## Boundary
 

--- a/includes/class-static-site-importer-admin.php
+++ b/includes/class-static-site-importer-admin.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Adds the Import HTML admin entry point.
+ * Adds the source-site import admin entry point.
  */
 class Static_Site_Importer_Admin {
 
@@ -33,8 +33,8 @@ class Static_Site_Importer_Admin {
 	public static function register_import_page(): void {
 		add_submenu_page(
 			null, // @phpstan-ignore argument.type
-			'Import HTML',
-			'Import HTML',
+			'Import Static Site',
+			'Import Static Site',
 			'switch_themes',
 			'static-site-importer',
 			array( __CLASS__, 'render_page' )
@@ -42,7 +42,7 @@ class Static_Site_Importer_Admin {
 	}
 
 	/**
-	 * Add an Import HTML button beside Add Theme on Appearance -> Themes.
+	 * Add an Import Static Site button beside Add Theme on Appearance -> Themes.
 	 *
 	 * @return void
 	 */
@@ -52,7 +52,7 @@ class Static_Site_Importer_Admin {
 		}
 
 		$url   = admin_url( 'admin.php?page=static-site-importer' );
-		$label = __( 'Import HTML', 'static-site-importer' );
+		$label = __( 'Import Static Site', 'static-site-importer' );
 		?>
 		<script>
 			document.addEventListener( 'DOMContentLoaded', function () {
@@ -84,14 +84,14 @@ class Static_Site_Importer_Admin {
 	 */
 	public static function render_page(): void {
 		if ( ! current_user_can( 'switch_themes' ) ) {
-			wp_die( esc_html__( 'You are not allowed to import HTML.', 'static-site-importer' ) );
+			wp_die( esc_html__( 'You are not allowed to import static sites.', 'static-site-importer' ) );
 		}
 
 		$result = isset( $_GET['static_site_imported'] ) ? sanitize_text_field( wp_unslash( $_GET['static_site_imported'] ) ) : '';
 		$error  = isset( $_GET['static_site_error'] ) ? sanitize_text_field( wp_unslash( $_GET['static_site_error'] ) ) : '';
 		?>
 		<div class="wrap">
-			<h1><?php echo esc_html__( 'Import HTML', 'static-site-importer' ); ?></h1>
+			<h1><?php echo esc_html__( 'Import Static Site', 'static-site-importer' ); ?></h1>
 
 			<?php if ( '' !== $result ) : ?>
 				<div class="notice notice-success"><p>
@@ -107,7 +107,7 @@ class Static_Site_Importer_Admin {
 				<div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
 			<?php endif; ?>
 
-			<p><?php echo esc_html__( 'Paste HTML, fetch a public URL, upload a single HTML file, or upload a ZIP for a multi-page static site or bundled HTML export. The importer will convert the HTML into a WordPress block theme using Block Format Bridge.', 'static-site-importer' ); ?></p>
+			<p><?php echo esc_html__( 'Paste HTML, fetch a public URL, upload a single HTML file, or upload a ZIP for a source-site export. ZIP imports use index.html as the shell/chrome entry and can include .md or .markdown content documents. MDX is reported as unsupported; build MDX to static HTML before importing.', 'static-site-importer' ); ?></p>
 
 			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data">
 				<?php wp_nonce_field( 'static_site_importer_import' ); ?>
@@ -118,7 +118,7 @@ class Static_Site_Importer_Admin {
 						<th scope="row"><label for="static-site-pasted-html"><?php echo esc_html__( 'Paste HTML', 'static-site-importer' ); ?></label></th>
 						<td>
 							<textarea id="static-site-pasted-html" name="static_site_pasted_html" class="large-text code" rows="14" placeholder="<!doctype html>"></textarea>
-							<p class="description"><?php echo esc_html__( 'Use this for one-page HTML copied from an AI builder or template source. Leave empty to fetch a URL, import an HTML file, or import a ZIP instead.', 'static-site-importer' ); ?></p>
+							<p class="description"><?php echo esc_html__( 'Use this for one-page HTML copied from an AI builder or template source. Leave empty to fetch a URL, import an HTML file, or import a ZIP source site instead.', 'static-site-importer' ); ?></p>
 						</td>
 					</tr>
 					<tr>
@@ -136,10 +136,10 @@ class Static_Site_Importer_Admin {
 						</td>
 					</tr>
 					<tr>
-						<th scope="row"><label for="static-site-zip"><?php echo esc_html__( 'HTML ZIP', 'static-site-importer' ); ?></label></th>
+						<th scope="row"><label for="static-site-zip"><?php echo esc_html__( 'Source-site ZIP', 'static-site-importer' ); ?></label></th>
 						<td>
 							<input type="file" id="static-site-zip" name="static_site_zip" accept=".zip" />
-							<p class="description"><?php echo esc_html__( 'Use this for a site folder packaged as a ZIP with an index.html file and sibling HTML pages. Pasted HTML and single HTML uploads take precedence when provided.', 'static-site-importer' ); ?></p>
+							<p class="description"><?php echo esc_html__( 'Use this for a site folder packaged as a ZIP with an index.html entry, sibling HTML pages, and optional nested .md/.markdown content documents. .mdx files are skipped with import-report diagnostics. Pasted HTML and single HTML uploads take precedence when provided.', 'static-site-importer' ); ?></p>
 						</td>
 					</tr>
 					<tr>
@@ -156,7 +156,7 @@ class Static_Site_Importer_Admin {
 					</tr>
 				</table>
 
-				<?php submit_button( __( 'Import HTML', 'static-site-importer' ) ); ?>
+				<?php submit_button( __( 'Import Static Site', 'static-site-importer' ) ); ?>
 			</form>
 		</div>
 		<?php
@@ -169,7 +169,7 @@ class Static_Site_Importer_Admin {
 	 */
 	public static function handle_import(): void {
 		if ( ! current_user_can( 'switch_themes' ) ) {
-			wp_die( esc_html__( 'You are not allowed to import HTML.', 'static-site-importer' ) );
+			wp_die( esc_html__( 'You are not allowed to import static sites.', 'static-site-importer' ) );
 		}
 
 		check_admin_referer( 'static_site_importer_import' );
@@ -225,7 +225,7 @@ class Static_Site_Importer_Admin {
 	}
 
 	/**
-	 * Prepare an HTML entry file from URL, upload, or ZIP intake.
+	 * Prepare an HTML entry file from URL, upload, or source-site ZIP intake.
 	 *
 	 * @return array{html_path:string,metadata:array<string,mixed>}|WP_Error
 	 */
@@ -309,7 +309,7 @@ class Static_Site_Importer_Admin {
 	}
 
 	/**
-	 * Extract an uploaded ZIP and return its index.html path.
+	 * Extract an uploaded source-site ZIP and return its index.html path.
 	 *
 	 * @param string $work_dir Importer work directory.
 	 * @return string HTML entry path.
@@ -412,7 +412,7 @@ class Static_Site_Importer_Admin {
 
 			if ( self::is_server_side_file( $name ) ) {
 				$zip->close();
-				return new WP_Error( 'static_site_importer_server_side_file', 'The uploaded ZIP contains server-side code. Static Site Importer only accepts static HTML, CSS, JavaScript, images, fonts, and related assets.' );
+				return new WP_Error( 'static_site_importer_server_side_file', 'The uploaded ZIP contains server-side code. Static Site Importer only accepts static HTML, Markdown content, CSS, JavaScript, images, fonts, and related assets.' );
 			}
 		}
 

--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -15,17 +15,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Static_Site_Importer_CLI_Command {
 
 	/**
-	 * Import an HTML file as a block theme.
+	 * Import a static-site HTML entry as a block theme.
 	 *
 	 * @subcommand import-theme
 	 *
 	 * ## OPTIONS
 	 *
-	 * [<html-file>]
-	 * : Path to index.html. Optional when --url is provided.
+	 * [<html-entry-file>]
+	 * : Path to an HTML shell/chrome entry file. Optional when --url is provided. Sibling HTML files and nested .md/.markdown source documents in the selected source tree are imported as pages; .mdx files are skipped with explicit report diagnostics.
 	 *
 	 * [--url=<url>]
-	 * : Fetch one public http/https HTML URL and import it as index.html. Redirects are validated with SSRF protections before connecting.
+	 * : Fetch one public http/https HTML URL and import it as index.html. Redirects are validated with SSRF protections before connecting. URL intake imports a single fetched HTML document only.
 	 *
 	 * [--slug=<slug>]
 	 * : Theme slug.
@@ -63,7 +63,7 @@ class Static_Site_Importer_CLI_Command {
 		$source_metadata = array();
 		if ( isset( $assoc_args['url'] ) && '' !== trim( (string) $assoc_args['url'] ) ) {
 			if ( '' !== $html_file ) {
-				WP_CLI::error( 'Use either <html-file> or --url, not both.' );
+				WP_CLI::error( 'Use either <html-entry-file> or --url, not both.' );
 				return;
 			}
 
@@ -81,7 +81,7 @@ class Static_Site_Importer_CLI_Command {
 		}
 
 		if ( '' === $html_file ) {
-			WP_CLI::error( 'Missing <html-file> argument or --url option.' );
+			WP_CLI::error( 'Missing <html-entry-file> argument or --url option.' );
 			return;
 		}
 
@@ -122,6 +122,9 @@ class Static_Site_Importer_CLI_Command {
 		if ( ! empty( $source_metadata['final_url'] ) ) {
 			WP_CLI::line( sprintf( 'Fetched URL: %s', $source_metadata['final_url'] ) );
 		}
+		$source_documents = $result['source_documents'] ?? array();
+		$counts           = is_array( $source_documents ) && isset( $source_documents['counts_by_format'] ) && is_array( $source_documents['counts_by_format'] ) ? $source_documents['counts_by_format'] : array();
+		WP_CLI::line( sprintf( 'Source documents: %d HTML, %d Markdown, %d skipped MDX, %d unresolved links.', (int) ( $counts['html'] ?? 0 ), (int) ( $counts['markdown'] ?? 0 ), (int) ( $source_documents['skipped_mdx_count'] ?? 0 ), (int) ( $source_documents['unresolved_link_count'] ?? 0 ) ) );
 		WP_CLI::line( sprintf( 'Conversion quality: %s (%d unsupported HTML fallbacks, %d invalid blocks, %d content-loss aborts).', $result['quality']['pass'] ? 'pass' : 'needs review', $result['quality']['fallback_count'], $result['quality']['invalid_block_count'], $result['quality']['content_loss_count'] ) );
 
 		if ( ! $result['quality']['pass'] ) {

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -81,11 +81,11 @@ class Static_Site_Importer_Theme_Generator {
 	private static array $decorative_empty_group_classes = array();
 
 	/**
-	 * Import an HTML file as a block theme.
+	 * Import a static-site HTML entry file as a block theme.
 	 *
-	 * @param string $html_path  HTML file path.
+	 * @param string $html_path  HTML entry file path.
 	 * @param array  $args       Import args.
-	 * @return array{theme_slug:string,theme_name:string,theme_dir:string,report_path:string,external_report_path:string,source_dir:string,source_deleted:bool,source_cleanup_error:string,pages:array<string,int>,quality:array<string,mixed>}|WP_Error
+	 * @return array{theme_slug:string,theme_name:string,theme_dir:string,report_path:string,external_report_path:string,source_dir:string,source_deleted:bool,source_cleanup_error:string,pages:array<string,int>,quality:array<string,mixed>,source_documents:array<string,mixed>}|WP_Error
 	 */
 	public static function import_theme( string $html_path, array $args = array() ) {
 		if ( ! function_exists( 'bfb_convert' ) ) {
@@ -134,6 +134,7 @@ class Static_Site_Importer_Theme_Generator {
 		$permalinks              = self::page_permalinks( $page_ids );
 		$fragments               = $document->fragments();
 		self::$conversion_report = self::new_conversion_report( $html_path, isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array() );
+		self::record_source_documents_summary( $site_dir, $pages, $permalinks );
 		self::record_products_manifest( $site_dir );
 		self::$active_commerce_context = self::commerce_context_from_args( $args );
 		self::record_commerce_context_summary();
@@ -260,6 +261,7 @@ class Static_Site_Importer_Theme_Generator {
 			'source_cleanup_error' => $source_cleanup_error,
 			'pages'                => $page_ids,
 			'quality'              => $quality,
+			'source_documents'     => self::$conversion_report['source_documents'],
 		);
 	}
 
@@ -405,7 +407,9 @@ class Static_Site_Importer_Theme_Generator {
 		foreach ( $pages as $filename => $page ) {
 			$slug         = self::page_slug( $filename );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
-			$content_body = self::rewrite_internal_links( $page->body(), $permalinks );
+			$content_body = 'markdown' === $page->body_format()
+				? self::rewrite_markdown_links( $page->body(), $permalinks, $filename )
+				: self::rewrite_internal_links( $page->body(), $permalinks );
 			$content      = self::convert_fragment( $content_body, 'main:' . $filename, $page->body_format() );
 
 			$patterns[ $filename ] = $pattern_slug;
@@ -487,7 +491,10 @@ class Static_Site_Importer_Theme_Generator {
 				$href               = html_entity_decode( $matches[2], ENT_QUOTES );
 				$parts              = explode( '#', $href, 2 );
 				$path_without_query = strtok( $parts[0], '?' );
-				$filename           = basename( false === $path_without_query ? $parts[0] : $path_without_query );
+				$filename           = ltrim( false === $path_without_query ? $parts[0] : $path_without_query, './' );
+				if ( ! isset( $permalinks[ $filename ] ) ) {
+					$filename = basename( $filename );
+				}
 				if ( ! isset( $permalinks[ $filename ] ) ) {
 					return $matches[0];
 				}
@@ -522,6 +529,45 @@ class Static_Site_Importer_Theme_Generator {
 			},
 			$rewritten
 		) ?? $rewritten;
+	}
+
+	/**
+	 * Rewrite local Markdown links to imported WordPress page permalinks.
+	 *
+	 * @param string               $markdown        Markdown source.
+	 * @param array<string,string> $permalinks      Permalinks keyed by source filename.
+	 * @param string               $source_filename Current source filename.
+	 * @return string
+	 */
+	private static function rewrite_markdown_links( string $markdown, array $permalinks, string $source_filename ): string {
+		if ( '' === trim( $markdown ) || empty( $permalinks ) ) {
+			return $markdown;
+		}
+
+		return preg_replace_callback(
+			'/\]\(([^)]+)\)/',
+			static function ( array $matches ) use ( $permalinks, $source_filename ): string {
+				$href = trim( $matches[1] );
+				if ( preg_match( '/^[a-z][a-z0-9+.-]*:/i', $href ) || str_starts_with( $href, '#' ) ) {
+					return $matches[0];
+				}
+
+				$parts = explode( '#', $href, 2 );
+				$path  = strtok( $parts[0], '?' );
+				$key   = self::resolve_source_link_key( $source_filename, false === $path ? $parts[0] : $path );
+				if ( ! isset( $permalinks[ $key ] ) ) {
+					return $matches[0];
+				}
+
+				$replacement = $permalinks[ $key ];
+				if ( isset( $parts[1] ) && '' !== $parts[1] ) {
+					$replacement .= '#' . $parts[1];
+				}
+
+				return '](' . $replacement . ')';
+			},
+			$markdown
+		) ?? $markdown;
 	}
 
 	/**
@@ -2346,6 +2392,47 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Convert Markdown to block markup.
+	 *
+	 * @param string $markdown Markdown source.
+	 * @param string $source   Source label for diagnostics.
+	 * @return string
+	 */
+	private static function convert_markdown_document( string $markdown, string $source ): string {
+		if ( '' === trim( $markdown ) ) {
+			return '';
+		}
+
+		self::start_conversion_fragment( $source, $markdown );
+		$diagnostic_listener = static function ( string $code, string $message, array $context ) use ( $source ): void {
+			if ( 'commonmark_conversion_failed' !== $code && 'commonmark_unavailable' !== $code ) {
+				return;
+			}
+
+			++self::$conversion_report['source_documents']['markdown_parse_error_count'];
+			self::$conversion_report['diagnostics'][] = array(
+				'type'    => 'markdown_parse_error',
+				'source'  => $source,
+				'code'    => $code,
+				'message' => $message,
+				'context' => $context,
+			);
+		};
+
+		add_action( 'bfb_diagnostic', $diagnostic_listener, 10, 3 );
+		// @phpstan-ignore-next-line function.notFound -- Loaded by the bundled Block Format Bridge runtime.
+		$blocks = empty( self::$active_commerce_context ) ? bfb_convert( $markdown, 'markdown', 'blocks' ) : bfb_convert( $markdown, 'markdown', 'blocks', self::conversion_options( $source ) );
+		remove_action( 'bfb_diagnostic', $diagnostic_listener, 10 );
+
+		if ( '' === $blocks ) {
+			self::record_conversion_empty( $source, $markdown );
+		}
+		self::finish_conversion_fragment( $source, $blocks );
+
+		return $blocks;
+	}
+
+	/**
 	 * Mark empty absolute-positioned groups so editor CSS can hide only decorative placeholders.
 	 *
 	 * @param string $block_markup Serialized block markup.
@@ -2674,6 +2761,18 @@ class Static_Site_Importer_Theme_Generator {
 				'svg_sprite_reference_failure_count' => 0,
 				'failure_reasons'                    => array(),
 			),
+			'source_documents'    => array(
+				'total_count'                => 0,
+				'counts_by_format'           => array(
+					'html'     => 0,
+					'markdown' => 0,
+					'mdx'      => 0,
+				),
+				'skipped_mdx_count'          => 0,
+				'unresolved_links'           => array(),
+				'unresolved_link_count'      => 0,
+				'markdown_parse_error_count' => 0,
+			),
 			'conversion_fragments' => array(),
 			'commerce_context'     => array(
 				'supplied'       => false,
@@ -2713,6 +2812,176 @@ class Static_Site_Importer_Theme_Generator {
 				'Semantic fidelity requires browser DOM extraction; use semantic_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
 			),
 		);
+	}
+
+	/**
+	 * Record source document counts and skipped/linked source diagnostics.
+	 *
+	 * @param string                                           $site_dir    Source site directory.
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages       Imported pages.
+	 * @param array<string,string>                             $permalinks Imported page permalinks.
+	 * @return void
+	 */
+	private static function record_source_documents_summary( string $site_dir, array $pages, array $permalinks ): void {
+		$counts = array(
+			'html'     => 0,
+			'markdown' => 0,
+			'mdx'      => 0,
+		);
+		foreach ( $pages as $page ) {
+			$format = $page->type();
+			if ( isset( $counts[ $format ] ) ) {
+				++$counts[ $format ];
+			}
+		}
+
+		$mdx_files = self::collect_source_files_by_extension( $site_dir, array( 'mdx' ) );
+		$counts['mdx'] = count( $mdx_files );
+		foreach ( $mdx_files as $mdx_file ) {
+			self::$conversion_report['diagnostics'][] = array(
+				'type'    => 'unsupported_source_document',
+				'format'  => 'mdx',
+				'source'  => $mdx_file,
+				'message' => 'MDX source documents are not supported by Static Site Importer and were skipped. Build MDX to static HTML first, or provide plain .md/.markdown content.',
+			);
+		}
+
+		$unresolved = self::collect_unresolved_source_links( $pages, $permalinks );
+		self::$conversion_report['source_documents'] = array_merge(
+			self::$conversion_report['source_documents'],
+			array(
+				'total_count'           => array_sum( $counts ),
+				'counts_by_format'      => $counts,
+				'skipped_mdx_count'     => count( $mdx_files ),
+				'unresolved_links'      => $unresolved,
+				'unresolved_link_count' => count( $unresolved ),
+			)
+		);
+	}
+
+	/**
+	 * Collect source file paths by extension under a source directory.
+	 *
+	 * @param string            $site_dir   Source site directory.
+	 * @param array<int,string> $extensions Lowercase extensions.
+	 * @return array<int,string> Relative source paths.
+	 */
+	private static function collect_source_files_by_extension( string $site_dir, array $extensions ): array {
+		$files = array();
+		$root  = realpath( $site_dir );
+		if ( false === $root ) {
+			return $files;
+		}
+
+		$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $site_dir, FilesystemIterator::SKIP_DOTS ) );
+		foreach ( $iterator as $file ) {
+			if ( ! $file instanceof SplFileInfo || ! $file->isFile() || ! in_array( strtolower( $file->getExtension() ), $extensions, true ) ) {
+				continue;
+			}
+
+			$path = $file->getPathname();
+			if ( ! self::path_is_under( $path, $root ) ) {
+				continue;
+			}
+
+			$files[] = str_replace( DIRECTORY_SEPARATOR, '/', ltrim( substr( $path, strlen( trailingslashit( $root ) ) ), DIRECTORY_SEPARATOR ) );
+		}
+
+		sort( $files, SORT_STRING );
+		return $files;
+	}
+
+	/**
+	 * Collect local links that do not resolve to imported source documents.
+	 *
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Imported pages.
+	 * @param array<string,string>                             $permalinks Imported page permalinks.
+	 * @return array<int,array{source:string,href:string}>
+	 */
+	private static function collect_unresolved_source_links( array $pages, array $permalinks ): array {
+		$unresolved = array();
+		foreach ( $pages as $filename => $page ) {
+			$source = $page->body();
+			foreach ( self::extract_local_source_links( $source, 'markdown' === $page->body_format() ) as $href ) {
+				$path = strtok( explode( '#', $href, 2 )[0], '?' );
+				$key  = self::resolve_source_link_key( $filename, false === $path ? $href : $path );
+				if ( isset( $permalinks[ $key ] ) || isset( $permalinks[ basename( $key ) ] ) ) {
+					continue;
+				}
+
+				$unresolved[] = array(
+					'source' => $filename,
+					'href'   => $href,
+				);
+			}
+		}
+
+		return $unresolved;
+	}
+
+	/**
+	 * Extract local HTML or Markdown links from source content.
+	 *
+	 * @param string $source      Source content.
+	 * @param bool   $is_markdown Whether the source is Markdown.
+	 * @return array<int,string>
+	 */
+	private static function extract_local_source_links( string $source, bool $is_markdown ): array {
+		$links = array();
+		$regex = $is_markdown ? '/\]\(([^)]+)\)/' : '/\bhref=("|\')([^"\']+)(\1)/i';
+		if ( preg_match_all( $regex, $source, $matches ) ) {
+			foreach ( $is_markdown ? $matches[1] : $matches[2] as $href ) {
+				$href = trim( html_entity_decode( (string) $href, ENT_QUOTES ) );
+				if ( '' === $href || str_starts_with( $href, '#' ) || preg_match( '/^[a-z][a-z0-9+.-]*:/i', $href ) ) {
+					continue;
+				}
+
+				$extension = strtolower( pathinfo( strtok( explode( '#', $href, 2 )[0], '?' ) ?: $href, PATHINFO_EXTENSION ) );
+				if ( in_array( $extension, array( 'html', 'htm', 'md', 'markdown', 'mdx' ), true ) ) {
+					$links[] = $href;
+				}
+			}
+		}
+
+		return array_values( array_unique( $links ) );
+	}
+
+	/**
+	 * Resolve a local link against its source document path.
+	 *
+	 * @param string $source_filename Current source filename.
+	 * @param string $href_path       Link path without query or fragment.
+	 * @return string Source document key.
+	 */
+	private static function resolve_source_link_key( string $source_filename, string $href_path ): string {
+		$key = ltrim( str_replace( '\\', '/', $href_path ), './' );
+		if ( '' === $key || str_starts_with( $key, '/' ) ) {
+			return ltrim( $key, '/' );
+		}
+
+		$base_dir = dirname( $source_filename );
+		if ( '.' === $base_dir || '' === $base_dir || str_starts_with( $href_path, './' ) ) {
+			$combined = ( '.' === $base_dir || '' === $base_dir ) ? $key : $base_dir . '/' . ltrim( $href_path, './' );
+		} elseif ( ! str_contains( $key, '/' ) ) {
+			$combined = $base_dir . '/' . $key;
+		} else {
+			$combined = $key;
+		}
+
+		$parts = array();
+		foreach ( explode( '/', str_replace( '\\', '/', $combined ) ) as $part ) {
+			if ( '' === $part || '.' === $part ) {
+				continue;
+			}
+			if ( '..' === $part ) {
+				array_pop( $parts );
+				continue;
+			}
+
+			$parts[] = $part;
+		}
+
+		return implode( '/', $parts );
 	}
 
 	/**
@@ -3958,6 +4227,24 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return self::write_file( $path, $content );
+	}
+
+	/**
+	 * Determine whether a path resolves inside a base directory.
+	 *
+	 * @param string $path Path to test.
+	 * @param string $base Base directory.
+	 * @return bool
+	 */
+	private static function path_is_under( string $path, string $base ): bool {
+		$real_path = realpath( $path );
+		$real_base = realpath( $base );
+
+		if ( false === $real_path || false === $real_base ) {
+			return false;
+		}
+
+		return 0 === strpos( trailingslashit( $real_path ), trailingslashit( $real_base ) );
 	}
 
 	/**

--- a/tests/fixtures/mixed-source-site/content/component.mdx
+++ b/tests/fixtures/mixed-source-site/content/component.mdx
@@ -1,0 +1,5 @@
+export const Callout = () => <aside>Unsupported runtime component</aside>;
+
+# MDX Component
+
+This file should be skipped with an explicit diagnostic.

--- a/tests/fixtures/mixed-source-site/content/notes.markdown
+++ b/tests/fixtures/mixed-source-site/content/notes.markdown
@@ -1,0 +1,4 @@
+# Field Notes
+
+- Markdown documents become WordPress pages.
+- Links back to [the story](story.md) resolve to imported pages.

--- a/tests/fixtures/mixed-source-site/content/story.md
+++ b/tests/fixtures/mixed-source-site/content/story.md
@@ -1,0 +1,5 @@
+# Markdown Story
+
+This page came from a nested Markdown source document.
+
+[Read the notes](notes.markdown)

--- a/tests/fixtures/mixed-source-site/index.html
+++ b/tests/fixtures/mixed-source-site/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>Mixed Source Site</title>
+	<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+	<header class="site-header">
+		<a href="index.html">Mixed Source Site</a>
+		<nav>
+			<a href="content/story.md">Story</a>
+			<a href="content/notes.markdown">Notes</a>
+		</nav>
+	</header>
+	<main>
+		<h1>Mixed Source Site</h1>
+		<p>This static shell provides the shared chrome for Markdown source documents.</p>
+	</main>
+	<footer>Mixed source fixture</footer>
+</body>
+</html>

--- a/tests/fixtures/mixed-source-site/styles.css
+++ b/tests/fixtures/mixed-source-site/styles.css
@@ -1,0 +1,8 @@
+:root {
+	--accent: #2d6cdf;
+}
+
+.site-header {
+	display: flex;
+	gap: 1rem;
+}

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -56,6 +56,11 @@ const steps = [
     args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-wordpress-is-dead-fixture.php' ) ],
   },
   {
+    name: 'Mixed source fixture smoke',
+    command: wpCli[ 0 ],
+    args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-mixed-source-fixture.php' ) ],
+  },
+  {
     name: 'Extracted chrome fragments smoke',
     command: wpCli[ 0 ],
     args: [ ...wpCli.slice( 1 ), 'eval-file', path.join( repoRoot, 'tests/smoke-extracted-chrome-fragments.php' ) ],

--- a/tests/smoke-admin-import-html-entry.php
+++ b/tests/smoke-admin-import-html-entry.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Smoke test: admin UI exposes Import HTML from Appearance -> Themes.
+ * Smoke test: admin UI exposes Import Static Site from Appearance -> Themes.
  *
  * Run from the repository root:
  * php tests/smoke-admin-import-html-entry.php
@@ -32,9 +32,9 @@ $assert( ! str_contains( $source, 'add_theme_page(' ), 'appearance-submenu-not-r
 $assert( str_contains( $source, "admin_url( 'admin.php?page=static-site-importer' )" ), 'button-targets-hidden-import-page' );
 $assert( str_contains( $source, '.page-title-action[href*="theme-install.php"]' ), 'button-anchors-to-add-theme-action' );
 $assert( str_contains( $source, 'static-site-importer-import-html-action' ), 'button-has-plugin-specific-class' );
-$assert( ! str_contains( $source, 'Import Static Site' ), 'old-import-static-site-label-removed' );
-$assert( str_contains( $source, 'Import HTML' ), 'import-html-label-present' );
-$assert( str_contains( $source, 'HTML ZIP' ), 'zip-field-label-renamed' );
+$assert( str_contains( $source, 'Import Static Site' ), 'import-static-site-label-present' );
+$assert( str_contains( $source, 'Paste HTML' ), 'paste-html-label-present' );
+$assert( str_contains( $source, 'Source-site ZIP' ), 'zip-field-label-renamed' );
 $assert( str_contains( $source, 'name="static_site_pasted_html"' ), 'paste-html-textarea-present' );
 $assert( str_contains( $source, 'name="static_site_url"' ), 'url-input-present' );
 $assert( str_contains( $source, 'Static_Site_Importer_URL_Fetcher::fetch_to_work_dir' ), 'admin-url-fetcher-used' );
@@ -52,7 +52,8 @@ $assert( str_contains( $source, "'index.html'" ), 'admin-intake-stores-index-htm
 $assert( str_contains( $source, 'prepare_uploaded_zip_file' ), 'zip-import-helper-present' );
 $assert( str_contains( $source, 'find_index_html' ), 'zip-index-discovery-preserved' );
 $assert( str_contains( $source, 'Paste HTML content, enter a public URL, upload a single HTML file, or upload a ZIP containing index.html.' ), 'empty-intake-validation-message-present' );
-$assert( str_contains( $source, 'multi-page static site or bundled HTML export' ), 'zip-copy-explains-bundle-contract' );
+$assert( str_contains( $source, 'optional nested .md/.markdown content documents' ), 'zip-copy-explains-mixed-source-contract' );
+$assert( str_contains( $source, '.mdx files are skipped with import-report diagnostics' ), 'zip-copy-explains-mdx-diagnostic' );
 $assert( str_contains( $source, 'validate_zip_archive' ), 'zip-archive-validation-method-exists' );
 $assert( str_contains( $source, "class_exists( 'ZipArchive' )" ), 'ziparchive-inspection-is-conditional' );
 $assert( str_contains( $source, 'is_unsafe_archive_path' ), 'unsafe-archive-path-check-exists' );
@@ -72,4 +73,4 @@ if ( $failures ) {
 	exit( 1 );
 }
 
-echo 'OK: admin Import HTML entry smoke passed (' . $assertions . " assertions)\n";
+echo 'OK: admin Import Static Site entry smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-mixed-source-fixture.php
+++ b/tests/smoke-mixed-source-fixture.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Smoke test: mixed HTML/Markdown source-site fixture imports with report diagnostics.
+ *
+ * Run inside a WordPress site with BFB active:
+ * wp eval-file tests/smoke-mixed-source-fixture.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+
+if ( ! defined( 'STATIC_SITE_IMPORTER_PATH' ) && is_readable( $plugin_root . '/static-site-importer.php' ) ) {
+	require_once $plugin_root . '/static-site-importer.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Document', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-document.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read = static function ( string $path ): string {
+	$contents = file_get_contents( $path );
+	return false === $contents ? '' : $contents;
+};
+
+$fixture_dir = $plugin_root . '/tests/fixtures/mixed-source-site';
+$fixture     = $fixture_dir . '/index.html';
+
+$result = Static_Site_Importer_Theme_Generator::import_theme(
+	$fixture,
+	array(
+		'name'        => 'Mixed Source Fixture',
+		'slug'        => 'mixed-source-fixture',
+		'overwrite'   => true,
+		'activate'    => false,
+		'keep_source' => true,
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+if ( ! is_wp_error( $result ) ) {
+	$report       = json_decode( $read( $result['report_path'] ), true );
+	$story_id     = $result['pages']['content/story.md'] ?? 0;
+	$notes_id     = $result['pages']['content/notes.markdown'] ?? 0;
+	$story        = $story_id ? get_post( $story_id ) : null;
+	$notes        = $notes_id ? get_post( $notes_id ) : null;
+	$header       = $read( $result['theme_dir'] . '/parts/header.html' );
+	$story_pattern = $read( $result['theme_dir'] . '/patterns/page-content-story.php' );
+
+	$assert( is_array( $report ), 'report-is-json' );
+	$assert( 1 === (int) ( $report['source_documents']['counts_by_format']['html'] ?? 0 ), 'report-counts-html-entry' );
+	$assert( 2 === (int) ( $report['source_documents']['counts_by_format']['markdown'] ?? 0 ), 'report-counts-markdown-documents' );
+	$assert( 1 === (int) ( $report['source_documents']['skipped_mdx_count'] ?? 0 ), 'report-counts-skipped-mdx' );
+	$assert( 0 === (int) ( $report['source_documents']['unresolved_link_count'] ?? -1 ), 'report-has-no-unresolved-links' );
+	$assert( isset( $report['conversion_fragments']['main:content/story.md'] ), 'report-includes-markdown-conversion-fragment' );
+	$assert( $story instanceof WP_Post, 'story-page-created' );
+	$assert( $notes instanceof WP_Post, 'notes-page-created' );
+	$assert( $story instanceof WP_Post && str_contains( $story->post_content, 'Markdown Story' ), 'story-page-contains-markdown-heading' );
+	$assert( $notes instanceof WP_Post && str_contains( $notes->post_content, 'Field Notes' ), 'notes-page-contains-markdown-heading' );
+	$assert( ! str_contains( $header, '.md' ), 'header-links-rewritten-away-from-markdown-sources' );
+	$assert( str_contains( $story_pattern, 'Markdown Story' ), 'markdown-pattern-written' );
+}
+
+if ( $failures ) {
+	foreach ( $failures as $failure ) {
+		WP_CLI::warning( $failure );
+	}
+	WP_CLI::error( sprintf( 'Mixed source fixture smoke failed with %d failure(s) across %d assertion(s).', count( $failures ), $assertions ) );
+}
+
+WP_CLI::success( sprintf( 'Mixed source fixture smoke passed (%d assertions).', $assertions ) );


### PR DESCRIPTION
## Summary
- Updates admin and CLI intake language from HTML-only imports to static/source-site imports where mixed sources are supported.
- Imports recursive `.md` / `.markdown` content documents alongside an HTML entry file, rewrites local source links, and reports source document counts, skipped MDX, unresolved links, and Markdown parse diagnostics.
- Adds a mixed-source fixture and smoke coverage for Markdown-derived pages, skipped MDX diagnostics, report summaries, and generated block validation.

## Tests
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l includes/class-static-site-importer-admin.php`
- `php -l includes/class-static-site-importer-cli-command.php`
- `php -l tests/smoke-mixed-source-fixture.php`
- `node --check tests/run-validation-harness.cjs`
- `php tests/smoke-admin-import-html-entry.php`
- `studio wp --path "/Users/chubes/Studio/intelligence-chubes4" --skip-plugins=static-site-importer eval-file "/Users/chubes/Developer/static-site-importer@feat-mixed-source-intake-139/tests/smoke-mixed-source-fixture.php"`
- `npm run test:js-block-validation -- "/Users/chubes/Studio/intelligence-chubes4/wp-content/themes/mixed-source-fixture"`

## Blockers / dependencies
- No blockers found. The branch uses the bundled Block Format Bridge Markdown adapter already available in the dependency tree.
- The local Studio site has an older active plugin copy, so the mixed-source smoke was run with `--skip-plugins=static-site-importer` to load this branch's worktree plugin for validation.

Closes #139.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, fixture, docs, and targeted validation updates; Chris remains responsible for review and merge.