### PR TITLE
Move Woo store fixture into SSI

### DIFF
--- a/tests/fixtures/ssi-woo-store/README.md
+++ b/tests/fixtures/ssi-woo-store/README.md
@@ -1,0 +1,17 @@
+# SSI WooCommerce Store Fixture
+
+This fixture is a static storefront used to validate Static Site Importer WooCommerce primitives before Studio consumes them.
+
+The fixture is intentionally data-only:
+
+- `products.json` declares the expected product manifest shape for the benchmark.
+- `index.html`, `shop.html`, and `about.html` reference products by stable handles.
+- `styles.css` provides local static styling and product card classes.
+
+The importer owns this fixture because product manifest validation, WooCommerce product seeding, and product context forwarding are Static Site Importer behavior.
+
+Tracked dependencies:
+
+- https://github.com/chubes4/static-site-importer/issues/111
+- https://github.com/chubes4/static-site-importer/issues/112
+- https://github.com/chubes4/static-site-importer/issues/113

--- a/tests/fixtures/ssi-woo-store/about.html
+++ b/tests/fixtures/ssi-woo-store/about.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About - Brass Cart Supply</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="index.html">Brass Cart Supply</a>
+      <nav aria-label="Primary navigation">
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+      </nav>
+    </header>
+    <main>
+      <section class="page-heading">
+        <p class="eyebrow">Why this fixture exists</p>
+        <h1>A tiny static store with real product expectations.</h1>
+        <p>This page gives the importer non-product content to convert while the shop pages exercise product references, product categories, prices, and cart-ready URLs.</p>
+      </section>
+      <section class="values">
+        <h2>Fixture assertions</h2>
+        <ul>
+          <li>Products are created by Static Site Importer from `products.json`.</li>
+          <li>Converted pages remain valid editable blocks.</li>
+          <li>Ordinary product cards convert through native blocks.</li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/ssi-woo-store/assets/canvas-prep-apron.svg
+++ b/tests/fixtures/ssi-woo-store/assets/canvas-prep-apron.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">Canvas Prep Apron</title>
+  <desc id="desc">A tan canvas apron with dark straps.</desc>
+  <rect width="640" height="480" fill="#fbf4e8" />
+  <path d="M235 105h170l55 285H180z" fill="#c69b65" stroke="#22170f" stroke-width="12" />
+  <path d="M250 105c20 55 120 55 140 0" fill="none" stroke="#22170f" stroke-width="12" />
+  <path d="M190 395h260" stroke="#22170f" stroke-width="12" />
+  <path d="M225 185h190" stroke="#765f49" stroke-width="10" />
+</svg>

--- a/tests/fixtures/ssi-woo-store/assets/ceramic-salt-cellar.svg
+++ b/tests/fixtures/ssi-woo-store/assets/ceramic-salt-cellar.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">Ceramic Salt Cellar</title>
+  <desc id="desc">A cream ceramic salt cellar with a brass spoon.</desc>
+  <rect width="640" height="480" fill="#fbf4e8" />
+  <ellipse cx="320" cy="185" rx="150" ry="58" fill="#fffaf0" stroke="#22170f" stroke-width="12" />
+  <path d="M170 185l42 150c20 42 196 42 216 0l42-150" fill="#fffaf0" stroke="#22170f" stroke-width="12" />
+  <path d="M380 205l115-60" stroke="#b98228" stroke-width="16" stroke-linecap="round" />
+  <circle cx="510" cy="138" r="24" fill="#b98228" />
+</svg>

--- a/tests/fixtures/ssi-woo-store/assets/walnut-bench-scraper.svg
+++ b/tests/fixtures/ssi-woo-store/assets/walnut-bench-scraper.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">Walnut Bench Scraper</title>
+  <desc id="desc">A stainless steel bench scraper with a walnut handle.</desc>
+  <rect width="640" height="480" fill="#fbf4e8" />
+  <rect x="150" y="170" width="340" height="190" rx="18" fill="#d8d8d8" stroke="#22170f" stroke-width="12" />
+  <rect x="170" y="120" width="300" height="70" rx="26" fill="#6f4425" stroke="#22170f" stroke-width="12" />
+  <path d="M215 150h210" stroke="#9b6a3a" stroke-width="10" stroke-linecap="round" />
+</svg>

--- a/tests/fixtures/ssi-woo-store/index.html
+++ b/tests/fixtures/ssi-woo-store/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Brass Cart Supply</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="index.html">Brass Cart Supply</a>
+      <nav aria-label="Primary navigation">
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <p class="eyebrow">Field-tested kitchen goods</p>
+        <h1>Durable tools for serious weeknight cooking.</h1>
+        <p>Brass Cart Supply curates small-batch pantry gear, linen, and prep tools for cooks who want the good stuff without restaurant supply chaos.</p>
+        <p><a class="button" href="shop.html">Browse the store</a></p>
+      </section>
+      <section class="featured-products" data-product-collection="featured">
+        <h2>Featured products</h2>
+        <div class="product-grid">
+          <article class="product-card" data-product-handle="canvas-prep-apron">
+            <p class="product-category">Linen</p>
+            <h3>Canvas Prep Apron</h3>
+            <p>Cross-back apron with reinforced towel loop and deep prep pockets.</p>
+            <p class="price">$64.00</p>
+          </article>
+          <article class="product-card" data-product-handle="walnut-bench-scraper">
+            <p class="product-category">Tools</p>
+            <h3>Walnut Bench Scraper</h3>
+            <p>Stainless scraper with a walnut grip for dough, herbs, and cleanup.</p>
+            <p class="price">$28.00</p>
+          </article>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <p>Ships from Charleston. Free shipping over $100.</p>
+    </footer>
+  </body>
+</html>

--- a/tests/fixtures/ssi-woo-store/products.json
+++ b/tests/fixtures/ssi-woo-store/products.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "currency": "USD",
+  "products": [
+    {
+      "handle": "canvas-prep-apron",
+      "name": "Canvas Prep Apron",
+      "description": "Cross-back apron with reinforced towel loop and deep prep pockets.",
+      "sku": "BCS-APRON-CANVAS",
+      "price": "64.00",
+      "regular_price": "64.00",
+      "categories": ["Linen"],
+      "images": ["assets/canvas-prep-apron.svg"],
+      "featured": true
+    },
+    {
+      "handle": "walnut-bench-scraper",
+      "name": "Walnut Bench Scraper",
+      "description": "Stainless scraper with a walnut grip for dough, herbs, and cleanup.",
+      "sku": "BCS-SCRAPER-WALNUT",
+      "price": "28.00",
+      "regular_price": "28.00",
+      "categories": ["Tools"],
+      "images": ["assets/walnut-bench-scraper.svg"],
+      "featured": true
+    },
+    {
+      "handle": "ceramic-salt-cellar",
+      "name": "Ceramic Salt Cellar",
+      "description": "Hand-thrown stoneware cellar with a wide pinch opening and cork base.",
+      "sku": "BCS-SALT-CELLAR",
+      "price": "36.00",
+      "regular_price": "36.00",
+      "categories": ["Pantry"],
+      "images": ["assets/ceramic-salt-cellar.svg"],
+      "featured": false
+    }
+  ]
+}

--- a/tests/fixtures/ssi-woo-store/shop.html
+++ b/tests/fixtures/ssi-woo-store/shop.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Shop - Brass Cart Supply</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="index.html">Brass Cart Supply</a>
+      <nav aria-label="Primary navigation">
+        <a href="shop.html">Shop</a>
+        <a href="about.html">About</a>
+      </nav>
+    </header>
+    <main>
+      <section class="page-heading">
+        <p class="eyebrow">Catalog</p>
+        <h1>Shop the fixture catalog</h1>
+        <p>Each card maps to one entry in `products.json` by `data-product-handle`.</p>
+      </section>
+      <section class="product-grid" data-product-collection="all">
+        <article class="product-card" data-product-handle="canvas-prep-apron">
+          <p class="product-category">Linen</p>
+          <h2>Canvas Prep Apron</h2>
+          <p>Cross-back apron with reinforced towel loop and deep prep pockets.</p>
+          <p class="price">$64.00</p>
+        </article>
+        <article class="product-card" data-product-handle="walnut-bench-scraper">
+          <p class="product-category">Tools</p>
+          <h2>Walnut Bench Scraper</h2>
+          <p>Stainless scraper with a walnut grip for dough, herbs, and cleanup.</p>
+          <p class="price">$28.00</p>
+        </article>
+        <article class="product-card" data-product-handle="ceramic-salt-cellar">
+          <p class="product-category">Pantry</p>
+          <h2>Ceramic Salt Cellar</h2>
+          <p>Hand-thrown stoneware cellar with a wide pinch opening and cork base.</p>
+          <p class="price">$36.00</p>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/ssi-woo-store/styles.css
+++ b/tests/fixtures/ssi-woo-store/styles.css
@@ -1,0 +1,109 @@
+:root {
+  --ink: #22170f;
+  --paper: #fbf4e8;
+  --muted: #765f49;
+  --brass: #b98228;
+  --cream: #fffaf0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: Georgia, serif;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+.site-header,
+footer {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: 1.25rem clamp(1rem, 5vw, 4rem);
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.hero,
+.page-heading,
+.featured-products,
+.values {
+  margin: 0 auto;
+  max-width: 72rem;
+  padding: clamp(2rem, 8vw, 6rem) clamp(1rem, 5vw, 4rem);
+}
+
+.hero {
+  min-height: 54vh;
+}
+
+.hero h1,
+.page-heading h1 {
+  font-size: clamp(2.75rem, 8vw, 6.5rem);
+  line-height: 0.95;
+  margin: 0 0 1rem;
+  max-width: 11ch;
+}
+
+.eyebrow,
+.product-category {
+  color: var(--muted);
+  font-family: Arial, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.button {
+  background: var(--ink);
+  border-radius: 999px;
+  color: var(--cream);
+  display: inline-block;
+  font-family: Arial, sans-serif;
+  font-weight: 700;
+  padding: 0.9rem 1.2rem;
+  text-decoration: none;
+}
+
+.product-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.product-card {
+  background: var(--cream);
+  border: 1px solid color-mix(in srgb, var(--brass), transparent 55%);
+  border-radius: 1.5rem;
+  padding: 1.25rem;
+}
+
+.product-card h2,
+.product-card h3 {
+  margin: 0 0 0.75rem;
+}
+
+.price {
+  color: var(--brass);
+  font-family: Arial, sans-serif;
+  font-weight: 700;
+}


### PR DESCRIPTION
## Summary
- Add the WooCommerce static store fixture under SSI's test fixtures, where importer behavior owns product manifest expectations.
- Keep the fixture available for external rig validation without storing importer fixtures in Homeboy Rigs.

## Tests
- `node -e "const fs=require('fs'); const p='tests/fixtures/ssi-woo-store/products.json'; const manifest=JSON.parse(fs.readFileSync(p,'utf8')); if (!Array.isArray(manifest.products) || manifest.products.length !== 3) throw new Error('bad fixture'); console.log('ssi fixture ok');"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Moved the fixture into SSI and validated the product manifest; Chris identified the ownership problem.