### PR TITLE
fix: preserve pre-main nav and hero wrapped in generic page div (#157)

### DIFF
--- a/includes/class-static-site-importer-document.php
+++ b/includes/class-static-site-importer-document.php
@@ -135,18 +135,20 @@ class Static_Site_Importer_Document {
 		$body = $this->first_element( 'body' );
 		$root = $body instanceof DOMElement ? $body : $this->dom->documentElement;
 
-		$header       = $this->first_plausible_global_header( $root );
-		$nav          = $this->first_plausible_global_nav( $root, $header );
-		$footer       = $this->first_element( 'footer' );
-		$main         = $this->first_element( 'main' );
-		$body_headers = $this->body_content_headers( $root, $header, $nav );
+		$footer             = $this->first_element( 'footer' );
+		$main               = $this->first_element( 'main' );
+		$effective_children = $this->effective_root_children( $root, $main );
+
+		$header       = $this->first_plausible_global_header( $effective_children );
+		$nav          = $this->first_plausible_global_nav( $effective_children, $header );
+		$body_headers = $this->body_content_headers( $effective_children, $header, $nav );
 
 		if ( $header instanceof DOMElement && $this->contains_same_node( $body_headers, $header ) ) {
 			$header = null;
 		}
 
 		$header_parts = array();
-		if ( $nav instanceof DOMElement && $header instanceof DOMElement && $this->is_leading_sibling( $root, $nav, $header ) ) {
+		if ( $nav instanceof DOMElement && $header instanceof DOMElement && $this->is_leading_sibling_in( $effective_children, $nav, $header ) ) {
 			$header_parts[] = $this->outer_html( $nav );
 		}
 
@@ -164,11 +166,7 @@ class Static_Site_Importer_Document {
 		$background = array();
 		$main_html  = $main instanceof DOMElement ? $this->inner_html( $main ) : '';
 
-		foreach ( iterator_to_array( $root->childNodes ) as $child ) {
-			if ( ! $child instanceof DOMElement ) {
-				continue;
-			}
-
+		foreach ( $effective_children as $child ) {
 			$tag = strtolower( $child->tagName );
 			if ( in_array( $tag, array( 'style', 'script' ), true ) ) {
 				continue;
@@ -206,6 +204,78 @@ class Static_Site_Importer_Document {
 	}
 
 	/**
+	 * Resolve the effective list of body-level direct children, unwrapping a
+	 * single generic page wrapper that holds pre-main chrome.
+	 *
+	 * Some static sites wrap pre-main chrome (nav + hero header) inside a generic
+	 * `<div class="page">` sibling of `<main>`. Treating that wrapper opaquely
+	 * drops the chrome from fragment decomposition. Unwrapping it surfaces the
+	 * inner nav/header as effective body-level siblings while leaving any
+	 * direct-child main/footer alone.
+	 *
+	 * @param DOMElement      $root Page root element (typically <body>).
+	 * @param DOMElement|null $main Main landmark element if present.
+	 * @return DOMElement[]
+	 */
+	private function effective_root_children( DOMElement $root, ?DOMElement $main ): array {
+		$effective = array();
+
+		foreach ( iterator_to_array( $root->childNodes ) as $child ) {
+			if ( ! $child instanceof DOMElement ) {
+				continue;
+			}
+
+			if ( $this->is_unwrappable_page_wrapper( $child, $main ) ) {
+				foreach ( iterator_to_array( $child->childNodes ) as $grandchild ) {
+					if ( $grandchild instanceof DOMElement ) {
+						$effective[] = $grandchild;
+					}
+				}
+
+				continue;
+			}
+
+			$effective[] = $child;
+		}
+
+		return $effective;
+	}
+
+	/**
+	 * Whether a body-level element is a generic page wrapper that should be
+	 * unwrapped for fragment decomposition.
+	 *
+	 * The wrapper must be a plain `<div>` (no semantic landmark of its own),
+	 * must not contain `<main>` (so we never flatten main's container), must
+	 * not look like background chrome, and must contain at least one
+	 * meaningful pre-main landmark (`<nav>` or `<header>`). This is intentionally
+	 * narrow: it only unwraps wrappers that demonstrably hold chrome the
+	 * decomposition would otherwise drop.
+	 *
+	 * @param DOMElement      $element Candidate wrapper.
+	 * @param DOMElement|null $main    Main landmark element if present.
+	 * @return bool
+	 */
+	private function is_unwrappable_page_wrapper( DOMElement $element, ?DOMElement $main ): bool {
+		if ( 'div' !== strtolower( $element->tagName ) ) {
+			return false;
+		}
+
+		if ( $main instanceof DOMElement && $this->is_descendant_of( $main, $element ) ) {
+			return false;
+		}
+
+		if ( $this->looks_like_background_chrome( $element ) ) {
+			return false;
+		}
+
+		$has_landmark = $element->getElementsByTagName( 'nav' )->length > 0
+			|| $element->getElementsByTagName( 'header' )->length > 0;
+
+		return $has_landmark;
+	}
+
+	/**
 	 * Find the first tag in the document.
 	 *
 	 * @param string $tag Tag name.
@@ -221,12 +291,12 @@ class Static_Site_Importer_Document {
 	/**
 	 * Find a header that is plausible reusable site chrome.
 	 *
-	 * @param DOMElement $root Page root element.
+	 * @param DOMElement[] $effective_children Effective body-level direct children.
 	 * @return DOMElement|null
 	 */
-	private function first_plausible_global_header( DOMElement $root ): ?DOMElement {
+	private function first_plausible_global_header( array $effective_children ): ?DOMElement {
 		foreach ( $this->dom->getElementsByTagName( 'header' ) as $header ) {
-			if ( $this->is_plausible_global_header( $root, $header ) ) {
+			if ( $this->is_plausible_global_header( $effective_children, $header ) ) {
 				return $header;
 			}
 		}
@@ -237,17 +307,17 @@ class Static_Site_Importer_Document {
 	/**
 	 * Find a nav that is plausible reusable site chrome.
 	 *
-	 * @param DOMElement      $root   Page root element.
-	 * @param DOMElement|null $header Selected header element.
+	 * @param DOMElement[]    $effective_children Effective body-level direct children.
+	 * @param DOMElement|null $header             Selected header element.
 	 * @return DOMElement|null
 	 */
-	private function first_plausible_global_nav( DOMElement $root, ?DOMElement $header ): ?DOMElement {
+	private function first_plausible_global_nav( array $effective_children, ?DOMElement $header ): ?DOMElement {
 		foreach ( $this->dom->getElementsByTagName( 'nav' ) as $nav ) {
 			if ( $header instanceof DOMElement && $this->is_descendant_of( $nav, $header ) ) {
 				return $nav;
 			}
 
-			if ( $this->is_direct_child( $root, $nav ) || $this->has_global_chrome_signal( $nav ) ) {
+			if ( $this->contains_same_node( $effective_children, $nav ) || $this->has_global_chrome_signal( $nav ) ) {
 				return $nav;
 			}
 		}
@@ -258,39 +328,39 @@ class Static_Site_Importer_Document {
 	/**
 	 * Check whether a header looks like global site chrome rather than section content.
 	 *
-	 * @param DOMElement $root   Page root element.
-	 * @param DOMElement $header Header element.
+	 * @param DOMElement[] $effective_children Effective body-level direct children.
+	 * @param DOMElement   $header             Header element.
 	 * @return bool
 	 */
-	private function is_plausible_global_header( DOMElement $root, DOMElement $header ): bool {
+	private function is_plausible_global_header( array $effective_children, DOMElement $header ): bool {
 		if ( $this->has_global_chrome_signal( $header ) ) {
 			return true;
 		}
 
-		return $this->is_direct_child( $root, $header );
+		return $this->contains_same_node( $effective_children, $header );
 	}
 
 	/**
-	 * Collect direct-child headers that should remain in page content.
+	 * Collect effective body-level headers that should remain in page content.
 	 *
-	 * @param DOMElement      $root   Page root element.
-	 * @param DOMElement|null $header Selected header element.
-	 * @param DOMElement|null $nav    Selected nav element.
+	 * @param DOMElement[]    $effective_children Effective body-level direct children.
+	 * @param DOMElement|null $header             Selected header element.
+	 * @param DOMElement|null $nav                Selected nav element.
 	 * @return DOMElement[]
 	 */
-	private function body_content_headers( DOMElement $root, ?DOMElement $header, ?DOMElement $nav ): array {
+	private function body_content_headers( array $effective_children, ?DOMElement $header, ?DOMElement $nav ): array {
 		$body_headers = array();
 		$seen_header  = false;
 
-		foreach ( iterator_to_array( $root->childNodes ) as $child ) {
-			if ( ! $child instanceof DOMElement || 'header' !== strtolower( $child->tagName ) ) {
+		foreach ( $effective_children as $child ) {
+			if ( 'header' !== strtolower( $child->tagName ) ) {
 				continue;
 			}
 
 			if ( $header instanceof DOMElement && $this->same_node( $child, $header ) ) {
 				$seen_header = true;
 
-				if ( $nav instanceof DOMElement && ! $this->has_global_chrome_signal( $child ) && $this->is_leading_sibling( $root, $nav, $child ) ) {
+				if ( $nav instanceof DOMElement && ! $this->has_global_chrome_signal( $child ) && $this->is_leading_sibling_in( $effective_children, $nav, $child ) ) {
 					$body_headers[] = $child;
 				}
 
@@ -340,17 +410,6 @@ class Static_Site_Importer_Document {
 		}
 
 		return $element->getElementsByTagName( 'nav' )->length > 0;
-	}
-
-	/**
-	 * Check whether a candidate is a direct child of the page root.
-	 *
-	 * @param DOMElement $root      Page root element.
-	 * @param DOMElement $candidate Candidate element.
-	 * @return bool
-	 */
-	private function is_direct_child( DOMElement $root, DOMElement $candidate ): bool {
-		return $candidate->parentNode instanceof DOMNode && $candidate->parentNode->isSameNode( $root );
 	}
 
 	/**
@@ -411,19 +470,15 @@ class Static_Site_Importer_Document {
 	}
 
 	/**
-	 * Check whether one element is a direct sibling before another under the page root.
+	 * Check whether one element appears before another in an ordered effective sibling list.
 	 *
-	 * @param DOMElement $root   Page root element.
-	 * @param DOMElement $before Candidate leading element.
-	 * @param DOMElement $after  Candidate following element.
+	 * @param DOMElement[] $effective_children Ordered list of effective siblings.
+	 * @param DOMElement   $before             Candidate leading element.
+	 * @param DOMElement   $after              Candidate following element.
 	 * @return bool
 	 */
-	private function is_leading_sibling( DOMElement $root, DOMElement $before, DOMElement $after ): bool {
-		foreach ( iterator_to_array( $root->childNodes ) as $child ) {
-			if ( ! $child instanceof DOMElement ) {
-				continue;
-			}
-
+	private function is_leading_sibling_in( array $effective_children, DOMElement $before, DOMElement $after ): bool {
+		foreach ( $effective_children as $child ) {
 			if ( $child->isSameNode( $before ) ) {
 				return true;
 			}

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -445,6 +445,69 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Pre-main nav and hero header wrapped in a generic page div are preserved.
+	 *
+	 * Regression for issue #157: a `<body><div class="page">…nav, header…</div><main>…</main></body>`
+	 * shape used to drop nav + hero entirely, leaving an empty header part and a
+	 * page pattern that started at the first inner-main section. The wrapper is
+	 * a generic, non-semantic container that holds pre-main chrome only and
+	 * must be transparent to fragment decomposition.
+	 */
+	public function test_pre_main_page_wrapper_preserves_nav_and_hero_header(): void {
+		$html_path = $this->write_temp_fixture(
+			'studio-code-page-wrapper.html',
+			'<!doctype html><html><head><title>Studio Code</title></head><body>' .
+			'<div class="page">' .
+			'<nav class="nav" aria-label="Primary navigation">' .
+			'<a class="brand" href="#top"><span class="brand-mark"></span><span>Studio Code</span></a>' .
+			'<div class="nav-links"><a href="#benefits">Benefits</a><a href="#workflow">Workflow</a></div>' .
+			'</nav>' .
+			'<header class="hero" id="top">' .
+			'<div><span class="eyebrow">Product launch page</span><h1>Build with HTML. Ship as WordPress.</h1>' .
+			'<p class="lede">Studio turns static markup into a working theme.</p>' .
+			'<div class="actions"><a class="button" href="#workflow">See the workflow</a></div></div>' .
+			'<aside class="console-card">Conversion console preview.</aside>' .
+			'</header>' .
+			'</div>' .
+			'<main class="page"><section id="benefits"><h2>Benefits</h2><p>Benefit copy.</p></section></main>' .
+			'</body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'      => 'Studio Code Page Wrapper',
+				'slug'      => 'studio-code-page-wrapper',
+				'overwrite' => true,
+				'activate'  => false,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$theme_dir = $result['theme_dir'];
+		$header    = $this->read_file( $theme_dir . '/parts/header.html' );
+		$pattern   = $this->pattern_blocks( $this->read_file( $theme_dir . '/patterns/page-studio-code-page-wrapper.php' ) );
+
+		// Nav lands in the shared header part.
+		$this->assertNotSame( '', trim( $header ), 'Header part must not be empty when pre-main nav exists.' );
+		$this->assertStringContainsString( 'Studio Code', $header );
+		$this->assertStringContainsString( 'Benefits', $header );
+		$this->assertStringContainsString( 'Workflow', $header );
+
+		// Hero stays with page content (not in header part).
+		$this->assertStringNotContainsString( 'Build with HTML. Ship as WordPress.', $header );
+		$this->assertStringNotContainsString( 'Conversion console preview.', $header );
+		$this->assertStringContainsString( 'Build with HTML. Ship as WordPress.', $pattern );
+		$this->assertStringContainsString( 'Studio turns static markup', $pattern );
+		$this->assertStringContainsString( 'Conversion console preview.', $pattern );
+
+		// Page body still includes the inner-main sections.
+		$this->assertStringContainsString( 'Benefit copy.', $pattern );
+	}
+
+	/**
 	 * Classed theme chrome keeps source element ownership without core/html islands.
 	 */
 	public function test_classed_header_and_footer_chrome_preserve_source_elements(): void {


### PR DESCRIPTION
## Summary

Static sites sometimes wrap pre-main chrome inside a generic `<div class="page">` that is a sibling of `<main>`:

```html
<body>
  <div class="page">
    <nav class="nav">…</nav>
    <header class="hero" id="top">…</header>
  </div>
  <main class="page">…</main>
</body>
```

Document fragment decomposition (`Static_Site_Importer_Document::fragments`) walked `<body>`'s direct children and used direct-child checks for nav/header detection. The wrapper was opaque, so both landmarks were dropped: `parts/header.html` came out empty, and `patterns/page-home.php` started at the first inner-`<main>` section. Importer native quality still reported `pass` because no fallback / `core/html` / freeform blocks were emitted — semantic landmarks just disappeared.

## Fix

Compute an "effective" body-level children list once at the top of `fragments()`. A body-level `<div>` is unwrapped when it:

- has no `<main>` descendant (so we never flatten `<main>`'s container),
- is not background chrome (`bg-`, `orb`, `grid-`),
- contains at least one `<nav>` or `<header>` descendant.

The existing header / nav / body-content-header / sibling-order helpers then run over that flattened list instead of `$root->childNodes`. The narrow trigger keeps every other shape unchanged.

For the issue's HTML the nav now lands in `parts/header.html` and the hero `<header class="hero" id="top">` stays in the page pattern, matching the issue's stated expected output.

## Tests

- New regression: `StaticSiteImporterFixtureTest::test_pre_main_page_wrapper_preserves_nav_and_hero_header` — mirrors the issue's HTML shape; asserts nav is in `parts/header.html` (Studio Code / Benefits / Workflow), hero copy + console card live in `patterns/page-…`, and inner-main sections still round-trip.
- Full suite: `homeboy test static-site-importer` → **41 / 41 passing, 808 assertions**. No existing fixture / chrome / WiD / hero-id / multi-header / mixed-source / decorative-placeholder cases regressed.
- Lint: `homeboy lint static-site-importer` — `class-static-site-importer-document.php` reports zero findings on this branch (other lint findings present pre-existed on `main` and are unrelated).

## Closes

Fixes #157.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the fragment-decomposition fix, added the regression test, and ran the SSI test/lint suite via `homeboy`. Chris reviewed the design (single-wrapper unwrap restricted to `<div>` containers carrying `<nav>` or `<header>` and never `<main>`) and the regression coverage before merge.