### PR TITLE
Report dropped source regions in import-report.json (#158)

### DIFF
--- a/includes/class-static-site-importer-document.php
+++ b/includes/class-static-site-importer-document.php
@@ -22,12 +22,20 @@ class Static_Site_Importer_Document {
 	private DOMDocument $dom;
 
 	/**
+	 * Raw source HTML.
+	 *
+	 * @var string
+	 */
+	private string $raw_html;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $html Source HTML.
 	 */
 	public function __construct( string $html ) {
-		$this->dom = new DOMDocument();
+		$this->dom      = new DOMDocument();
+		$this->raw_html = $html;
 
 		$previous = libxml_use_internal_errors( true );
 		$this->dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
@@ -132,6 +140,86 @@ class Static_Site_Importer_Document {
 	 * @return array{background:string,header:string,main:string,footer:string}
 	 */
 	public function fragments(): array {
+		$selection = $this->compute_selection();
+
+		return array(
+			'background' => $selection['fragments']['background'],
+			'header'     => $selection['fragments']['header'],
+			'main'       => $selection['fragments']['main'],
+			'footer'     => $selection['fragments']['footer'],
+		);
+	}
+
+	/**
+	 * Build a structured report describing source-region extraction decisions.
+	 *
+	 * Reports the selected page body, header, footer, and any meaningful source
+	 * regions that were not assigned to header/main/footer/background. Includes
+	 * selector paths, source line ranges (when available), and short excerpts so
+	 * agents can pinpoint dropped regions without diffing source against output.
+	 *
+	 * Reporting only — does not affect conversion behavior.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function selection_report(): array {
+		$selection = $this->compute_selection();
+		$body      = $this->first_element( 'body' );
+		$root      = $body instanceof DOMElement ? $body : $this->dom->documentElement;
+
+		$header_node = $selection['header_node'];
+		$nav_node    = $selection['nav_node'];
+		$footer_node = $selection['footer_node'];
+		$main_node   = $selection['main_node'];
+
+		$page_body = $this->describe_page_body( $main_node, $root );
+
+		$extracted_header = null;
+		if ( $header_node instanceof DOMElement || $nav_node instanceof DOMElement ) {
+			$extracted_header = $this->describe_extracted_header( $header_node, $nav_node, $root );
+		}
+
+		$extracted_footer = null;
+		if ( $footer_node instanceof DOMElement ) {
+			$extracted_footer = $this->describe_region( $footer_node, 'footer_element' );
+		}
+
+		$unassigned = $this->collect_unassigned_regions( $selection );
+
+		$counts = array(
+			'source_landmarks'   => array(
+				'main'   => $main_node instanceof DOMElement ? 1 : 0,
+				'header' => $this->dom->getElementsByTagName( 'header' )->length,
+				'nav'    => $this->dom->getElementsByTagName( 'nav' )->length,
+				'footer' => $this->dom->getElementsByTagName( 'footer' )->length,
+			),
+			'unassigned_regions' => count( $unassigned ),
+		);
+
+		return array(
+			'page_body'          => $page_body,
+			'extracted_header'   => $extracted_header,
+			'extracted_footer'   => $extracted_footer,
+			'unassigned_regions' => $unassigned,
+			'counts'             => $counts,
+		);
+	}
+
+	/**
+	 * Build the shared selection model used by fragments() and selection_report().
+	 *
+	 * @return array{
+	 *     fragments: array{background:string,header:string,main:string,footer:string},
+	 *     header_node: ?DOMElement,
+	 *     nav_node: ?DOMElement,
+	 *     footer_node: ?DOMElement,
+	 *     main_node: ?DOMElement,
+	 *     body_headers: DOMElement[],
+	 *     unassigned_children: DOMElement[],
+	 *     skipped_children: DOMElement[]
+	 * }
+	 */
+	private function compute_selection(): array {
 		$body = $this->first_element( 'body' );
 		$root = $body instanceof DOMElement ? $body : $this->dom->documentElement;
 
@@ -157,12 +245,13 @@ class Static_Site_Importer_Document {
 		}
 
 		$header_html = implode( "\n", $header_parts );
-
 		$footer_html = $footer instanceof DOMElement ? $this->outer_html( $footer ) : '';
 
-		$main_parts = array();
-		$background = array();
-		$main_html  = $main instanceof DOMElement ? $this->inner_html( $main ) : '';
+		$main_parts          = array();
+		$background          = array();
+		$main_html           = $main instanceof DOMElement ? $this->inner_html( $main ) : '';
+		$unassigned_children = array();
+		$skipped_children    = array();
 
 		foreach ( iterator_to_array( $root->childNodes ) as $child ) {
 			if ( ! $child instanceof DOMElement ) {
@@ -171,6 +260,7 @@ class Static_Site_Importer_Document {
 
 			$tag = strtolower( $child->tagName );
 			if ( in_array( $tag, array( 'style', 'script' ), true ) ) {
+				$skipped_children[] = $child;
 				continue;
 			}
 
@@ -190,7 +280,13 @@ class Static_Site_Importer_Document {
 
 			if ( ! $main instanceof DOMElement || $this->contains_same_node( $body_headers, $child ) ) {
 				$main_parts[] = $this->outer_html( $child );
+				continue;
 			}
+
+			// Direct child of body that is not main, not header/nav/footer chrome,
+			// not a body content header, and not background — and a <main> exists
+			// elsewhere. Today this child is silently dropped from conversion.
+			$unassigned_children[] = $child;
 		}
 
 		if ( $main instanceof DOMElement && empty( $main_parts ) ) {
@@ -198,10 +294,19 @@ class Static_Site_Importer_Document {
 		}
 
 		return array(
-			'background' => trim( implode( "\n", $background ) ),
-			'header'     => trim( $header_html ),
-			'main'       => trim( implode( "\n", $main_parts ) ),
-			'footer'     => trim( $footer_html ),
+			'fragments'           => array(
+				'background' => trim( implode( "\n", $background ) ),
+				'header'     => trim( $header_html ),
+				'main'       => trim( implode( "\n", $main_parts ) ),
+				'footer'     => trim( $footer_html ),
+			),
+			'header_node'         => $header,
+			'nav_node'            => $nav,
+			'footer_node'         => $footer,
+			'main_node'           => $main,
+			'body_headers'        => $body_headers,
+			'unassigned_children' => $unassigned_children,
+			'skipped_children'    => $skipped_children,
 		);
 	}
 
@@ -446,5 +551,319 @@ class Static_Site_Importer_Document {
 		$class = ' ' . $node->getAttribute( 'class' ) . ' ';
 
 		return str_contains( $class, ' bg-' ) || str_contains( $class, ' orb ' ) || str_contains( $class, ' grid-' );
+	}
+
+	/**
+	 * Describe the page body selection for the import report.
+	 *
+	 * @param ?DOMElement $main Selected <main> element, if any.
+	 * @param DOMElement  $root Page root element.
+	 * @return array<string,mixed>
+	 */
+	private function describe_page_body( ?DOMElement $main, DOMElement $root ): array {
+		if ( $main instanceof DOMElement ) {
+			return array(
+				'mode'       => 'semantic_main',
+				'selector'   => $this->selector_path( $main ),
+				'tag'        => strtolower( $main->tagName ),
+				'line_range' => $this->element_line_range( $main ),
+				'excerpt'    => $this->excerpt( $main ),
+			);
+		}
+
+		return array(
+			'mode'       => 'body_root_fallback',
+			'selector'   => $this->selector_path( $root ),
+			'tag'        => strtolower( $root->tagName ),
+			'line_range' => $this->element_line_range( $root ),
+			'excerpt'    => $this->excerpt( $root ),
+		);
+	}
+
+	/**
+	 * Describe the extracted header selection for the import report.
+	 *
+	 * @param ?DOMElement $header Selected header element.
+	 * @param ?DOMElement $nav    Selected nav element.
+	 * @param DOMElement  $root   Page root element.
+	 * @return array<string,mixed>
+	 */
+	private function describe_extracted_header( ?DOMElement $header, ?DOMElement $nav, DOMElement $root ): array {
+		$mode = 'none';
+		if ( $header instanceof DOMElement && $nav instanceof DOMElement && $this->is_leading_sibling( $root, $nav, $header ) ) {
+			$mode = 'leading_nav_plus_header';
+		} elseif ( $header instanceof DOMElement ) {
+			$mode = 'header_element';
+		} elseif ( $nav instanceof DOMElement ) {
+			$mode = 'nav_element_only';
+		}
+
+		$parts = array();
+		if ( $nav instanceof DOMElement ) {
+			$parts[] = $this->describe_region( $nav, 'nav' );
+		}
+		if ( $header instanceof DOMElement ) {
+			$parts[] = $this->describe_region( $header, 'header' );
+		}
+
+		return array(
+			'mode'  => $mode,
+			'parts' => $parts,
+		);
+	}
+
+	/**
+	 * Describe a single region with selector path, line range, and excerpt.
+	 *
+	 * @param DOMElement $node   Node.
+	 * @param string     $reason Reason or role label.
+	 * @return array<string,mixed>
+	 */
+	private function describe_region( DOMElement $node, string $reason ): array {
+		return array(
+			'role'       => $reason,
+			'tag'        => strtolower( $node->tagName ),
+			'selector'   => $this->selector_path( $node ),
+			'line_range' => $this->element_line_range( $node ),
+			'excerpt'    => $this->excerpt( $node ),
+		);
+	}
+
+	/**
+	 * Collect meaningful unassigned source regions for the import report.
+	 *
+	 * Looks at direct body children that the extractor dropped (because <main>
+	 * exists and they are not chrome) and reports each one. When a dropped
+	 * wrapper element contains nested landmarks (nav, header, hero, main, etc.)
+	 * those nested regions are reported as well so agents can see exactly which
+	 * source regions were excluded.
+	 *
+	 * @param array<string,mixed> $selection Shared selection model.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function collect_unassigned_regions( array $selection ): array {
+		$regions   = array();
+		$main_node = $selection['main_node'];
+		$body      = $this->first_element( 'body' );
+		$root      = $body instanceof DOMElement ? $body : $this->dom->documentElement;
+		foreach ( $selection['unassigned_children'] as $child ) {
+			$position  = ( $main_node instanceof DOMElement && $this->is_leading_sibling( $root, $child, $main_node ) ) ? 'before_main' : 'after_main';
+			$regions[] = array(
+				'role'       => 'unassigned_body_child',
+				'reason'     => 'pre_main_or_post_main_sibling_not_assigned',
+				'position'   => $position,
+				'tag'        => strtolower( $child->tagName ),
+				'selector'   => $this->selector_path( $child ),
+				'line_range' => $this->element_line_range( $child ),
+				'excerpt'    => $this->excerpt( $child ),
+			);
+
+			foreach ( $this->find_meaningful_descendants( $child ) as $nested ) {
+				$regions[] = array(
+					'role'       => 'unassigned_nested_landmark',
+					'reason'     => 'inside_unassigned_body_child',
+					'position'   => $position,
+					'tag'        => strtolower( $nested->tagName ),
+					'selector'   => $this->selector_path( $nested ),
+					'line_range' => $this->element_line_range( $nested ),
+					'excerpt'    => $this->excerpt( $nested ),
+				);
+			}
+		}
+
+		return $regions;
+	}
+
+	/**
+	 * Find meaningful descendant landmarks inside an unassigned body child.
+	 *
+	 * Returns the first matching nav, header, main, footer, and hero-like
+	 * descendants so the report can flag each dropped landmark.
+	 *
+	 * @param DOMElement $node Wrapper element.
+	 * @return DOMElement[]
+	 */
+	private function find_meaningful_descendants( DOMElement $node ): array {
+		$found = array();
+		$seen  = array();
+
+		$tags = array( 'nav', 'header', 'main', 'footer', 'aside', 'section' );
+		foreach ( $tags as $tag ) {
+			$nodes = $node->getElementsByTagName( $tag );
+			if ( 0 === $nodes->length ) {
+				continue;
+			}
+			foreach ( $nodes as $candidate ) {
+				if ( 'section' === $tag && ! $this->looks_like_hero_or_landmark( $candidate ) ) {
+					continue;
+				}
+
+				$key = spl_object_hash( $candidate );
+				if ( isset( $seen[ $key ] ) ) {
+					continue;
+				}
+
+				$seen[ $key ] = true;
+				$found[]      = $candidate;
+
+				if ( in_array( $tag, array( 'nav', 'header', 'main', 'footer' ), true ) ) {
+					break;
+				}
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Check whether a section looks like a hero-style landmark worth reporting.
+	 *
+	 * @param DOMElement $node Section element.
+	 * @return bool
+	 */
+	private function looks_like_hero_or_landmark( DOMElement $node ): bool {
+		$class = strtolower( ' ' . $node->getAttribute( 'class' ) . ' ' );
+		$id    = strtolower( $node->getAttribute( 'id' ) );
+
+		if ( '' !== $id && in_array( $id, array( 'top', 'hero', 'masthead' ), true ) ) {
+			return true;
+		}
+
+		return preg_match( '/(^|[\s_-])(hero|masthead|jumbotron|banner|intro|cta)([\s_-]|$)/', $class ) === 1;
+	}
+
+	/**
+	 * Build a CSS-like selector path from an element to its document root.
+	 *
+	 * Used in the import report so dropped regions can be matched against the
+	 * raw source HTML.
+	 *
+	 * @param DOMElement $node Element.
+	 * @return string
+	 */
+	private function selector_path( DOMElement $node ): string {
+		$parts   = array();
+		$current = $node;
+		while ( $current instanceof DOMElement ) {
+			$tag = strtolower( $current->tagName );
+			$id  = trim( $current->getAttribute( 'id' ) );
+			if ( '' !== $id ) {
+				$tag .= '#' . $id;
+			} else {
+				$class = trim( $current->getAttribute( 'class' ) );
+				if ( '' !== $class ) {
+					$first = preg_split( '/\s+/', $class )[0] ?? '';
+					if ( '' !== $first ) {
+						$tag .= '.' . $first;
+					}
+				}
+			}
+
+			array_unshift( $parts, $tag );
+			$parent  = $current->parentNode;
+			$current = $parent instanceof DOMElement ? $parent : null;
+		}
+
+		return implode( ' > ', $parts );
+	}
+
+	/**
+	 * Compute a 1-indexed line range for an element based on the raw source HTML.
+	 *
+	 * Returns null when line numbers are not available. The end line is best-effort:
+	 * it locates the matching close tag in the raw HTML starting from the open
+	 * line, falling back to the open line when the close tag cannot be found.
+	 *
+	 * @param DOMElement $node Element.
+	 * @return array{0:int,1:int}|null
+	 */
+	private function element_line_range( DOMElement $node ): ?array {
+		$start = $node->getLineNo();
+		if ( $start <= 0 ) {
+			return null;
+		}
+
+		$end = $this->locate_close_line( $node, $start );
+		if ( $end < $start ) {
+			$end = $start;
+		}
+
+		return array( $start, $end );
+	}
+
+	/**
+	 * Best-effort lookup of the line number where an element's open tag closes.
+	 *
+	 * Self-closing or void elements return the start line. Otherwise scans the
+	 * raw HTML for the matching close tag, accounting for nested same-tag elements.
+	 *
+	 * @param DOMElement $node  Element.
+	 * @param int        $start Start line.
+	 * @return int
+	 */
+	private function locate_close_line( DOMElement $node, int $start ): int {
+		$tag   = strtolower( $node->tagName );
+		$voids = array( 'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr' );
+		if ( in_array( $tag, $voids, true ) ) {
+			return $start;
+		}
+
+		$lines = preg_split( "/\r\n|\r|\n/", $this->raw_html );
+		if ( ! is_array( $lines ) ) {
+			return $start;
+		}
+
+		$total = count( $lines );
+		if ( $start - 1 >= $total ) {
+			return $start;
+		}
+
+		$open_re  = '/<' . preg_quote( $tag, '/' ) . '(?=[\s>\/])/i';
+		$close_re = '/<\/' . preg_quote( $tag, '/' ) . '\s*>/i';
+
+		$depth = 0;
+		for ( $i = $start - 1; $i < $total; $i++ ) {
+			$line   = $lines[ $i ];
+			$opens  = preg_match_all( $open_re, $line );
+			$closes = preg_match_all( $close_re, $line );
+
+			if ( false !== $opens ) {
+				$depth += (int) $opens;
+			}
+			if ( false !== $closes ) {
+				$depth -= (int) $closes;
+			}
+
+			if ( $depth <= 0 ) {
+				return $i + 1;
+			}
+		}
+
+		return $start;
+	}
+
+	/**
+	 * Build a short text excerpt for an element to aid manual review.
+	 *
+	 * @param DOMElement $node Element.
+	 * @return string
+	 */
+	private function excerpt( DOMElement $node ): string {
+		$text = preg_replace( '/\s+/', ' ', (string) $node->textContent ) ?? '';
+		$text = trim( $text );
+		if ( '' === $text ) {
+			return '';
+		}
+
+		$limit = 160;
+		if ( function_exists( 'mb_strlen' ) && mb_strlen( $text ) > $limit ) {
+			return rtrim( mb_substr( $text, 0, $limit ) ) . '…';
+		}
+
+		if ( strlen( $text ) > $limit ) {
+			return rtrim( substr( $text, 0, $limit ) ) . '…';
+		}
+
+		return $text;
 	}
 }

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -139,6 +139,7 @@ class Static_Site_Importer_Theme_Generator {
 		$route_map               = self::source_route_map( $pages, $permalinks );
 		$fragments               = $document->fragments();
 		self::$conversion_report = self::new_conversion_report( $html_path, isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array() );
+		self::record_source_region_selection( $document, $html_path );
 		self::record_source_documents_summary( $site_dir, $pages, $permalinks );
 		self::record_products_manifest( $site_dir );
 		self::$active_commerce_context = self::commerce_context_from_args( $args );
@@ -2969,15 +2970,15 @@ class Static_Site_Importer_Theme_Generator {
 	 */
 	private static function new_conversion_report( string $html_path, array $source_metadata = array() ): array {
 		return array(
-			'version'              => 1,
-			'entry_file'           => $html_path,
-			'source'               => array_merge(
+			'version'                 => 1,
+			'entry_file'              => $html_path,
+			'source'                  => array_merge(
 				array(
 					'type' => empty( $source_metadata ) ? 'file' : (string) ( $source_metadata['source_type'] ?? 'file' ),
 				),
 				$source_metadata
 			),
-			'quality'              => array(
+			'quality'                 => array(
 				'pass'                               => true,
 				'fallback_count'                     => 0,
 				'content_loss_count'                 => 0,
@@ -2991,7 +2992,7 @@ class Static_Site_Importer_Theme_Generator {
 				'svg_sprite_reference_failure_count' => 0,
 				'failure_reasons'                    => array(),
 			),
-			'source_documents'     => array(
+			'source_documents'        => array(
 				'total_count'                => 0,
 				'counts_by_format'           => array(
 					'html'     => 0,
@@ -3003,22 +3004,41 @@ class Static_Site_Importer_Theme_Generator {
 				'unresolved_link_count'      => 0,
 				'markdown_parse_error_count' => 0,
 			),
-			'conversion_fragments' => array(),
-			'commerce_context'     => array(
+			'conversion_fragments'    => array(),
+			'source_region_selection' => array(
+				'entry_file'         => '',
+				'page_body'          => null,
+				'extracted_header'   => null,
+				'extracted_footer'   => null,
+				'unassigned_regions' => array(),
+				'counts'             => array(
+					'source_landmarks'   => array(
+						'main'   => 0,
+						'header' => 0,
+						'nav'    => 0,
+						'footer' => 0,
+					),
+					'unassigned_regions' => 0,
+				),
+				'notes'              => array(
+					'Reports which source region became the page body, the extracted header/footer parts, and any meaningful direct body children that were not assigned to a generated region. Reporting only — does not change conversion behavior.',
+				),
+			),
+			'commerce_context'        => array(
 				'supplied'       => false,
 				'source'         => 'none',
 				'product_count'  => 0,
 				'selector_hints' => array(),
 				'diagnostics'    => array(),
 			),
-			'assets'               => array(
+			'assets'                  => array(
 				'svg_icons'   => array(),
 				'svg_sprites' => array(),
 			),
-			'generated_theme'      => array(
+			'generated_theme'         => array(
 				'block_documents' => array(),
 			),
-			'visual_fidelity'      => array(
+			'visual_fidelity'         => array(
 				'status'             => 'requires_external_render_check',
 				'gate_owner'         => 'benchmark_harness',
 				'comparison_targets' => array(),
@@ -3026,7 +3046,7 @@ class Static_Site_Importer_Theme_Generator {
 					'Static Site Importer records source and generated DOM probes, render URLs, and theme artifacts for visual comparison; screenshot capture and computed-style/layout thresholds belong to the benchmark harness.',
 				),
 			),
-			'semantic_fidelity'    => array(
+			'semantic_fidelity'       => array(
 				'status'             => 'requires_external_render_check',
 				'gate_owner'         => 'benchmark_harness',
 				'comparison_targets' => array(),
@@ -3034,14 +3054,52 @@ class Static_Site_Importer_Theme_Generator {
 					'Static Site Importer records source/generated semantic comparison targets; browser DOM extraction and semantic fingerprint comparison belong to the benchmark harness.',
 				),
 			),
-			'diagnostics'          => array(),
-			'notes'                => array(
+			'diagnostics'             => array(),
+			'notes'                   => array(
 				'Block Format Bridge owns HTML-to-block transform fidelity; Static Site Importer records converter diagnostics and quality gates the generated theme.',
 				'Generated-theme block validation uses WordPress server-side block parsing and serialization checks; editor-runtime validation remains the exact Gutenberg authority.',
 				'Visual fidelity requires browser rendering; use visual_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
 				'Semantic fidelity requires browser DOM extraction; use semantic_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
 			),
 		);
+	}
+
+	/**
+	 * Record page-body extraction decisions for the import report.
+	 *
+	 * Captures the page-body source mode/selector, extracted header/footer
+	 * selectors, and any meaningful direct body children that were not
+	 * assigned to a generated region. Reporting only — does not change
+	 * conversion behavior.
+	 *
+	 * @param Static_Site_Importer_Document $document  Entry document.
+	 * @param string                        $html_path Entry HTML path.
+	 * @return void
+	 */
+	private static function record_source_region_selection( Static_Site_Importer_Document $document, string $html_path ): void {
+		$selection               = $document->selection_report();
+		$selection['entry_file'] = $html_path;
+		// Preserve notes already present on the report shape.
+		$existing_notes = self::$conversion_report['source_region_selection']['notes'] ?? array();
+		if ( ! empty( $existing_notes ) ) {
+			$selection['notes'] = $existing_notes;
+		}
+
+		self::$conversion_report['source_region_selection'] = $selection;
+
+		foreach ( $selection['unassigned_regions'] as $region ) {
+			self::$conversion_report['diagnostics'][] = array(
+				'type'       => 'source_region_unassigned',
+				'role'       => $region['role'] ?? 'unassigned_body_child',
+				'reason'     => $region['reason'] ?? '',
+				'selector'   => $region['selector'] ?? '',
+				'tag'        => $region['tag'] ?? '',
+				'line_range' => $region['line_range'] ?? null,
+				'excerpt'    => $region['excerpt'] ?? '',
+				'source'     => $html_path,
+				'message'    => 'Source region was not assigned to a generated theme part or page pattern. Inspect source_region_selection.unassigned_regions in import-report.json for the selector path and source line range.',
+			);
+		}
 	}
 
 	/**

--- a/tests/StaticSiteImporterSourceRegionReportTest.php
+++ b/tests/StaticSiteImporterSourceRegionReportTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Tests the import-report source-region-selection diagnostics.
+ *
+ * @package StaticSiteImporter
+ */
+
+/**
+ * Verifies that import-report.json records page-body extraction decisions
+ * and flags meaningful source regions that were not assigned to a generated
+ * theme part or page pattern.
+ */
+class StaticSiteImporterSourceRegionReportTest extends WP_UnitTestCase {
+
+	/**
+	 * Reports dropped pre-main chrome wrappers with selectors, line ranges, and excerpts.
+	 */
+	public function test_pre_main_wrapper_chrome_is_reported_as_unassigned(): void {
+		$plugin_root = dirname( __DIR__ );
+		$fixture     = $plugin_root . '/tests/fixtures/dropped-pre-main-chrome/index.html';
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$fixture,
+			array(
+				'name'        => 'Dropped Pre-Main Chrome',
+				'slug'        => 'dropped-pre-main-chrome',
+				'overwrite'   => true,
+				'activate'    => false,
+				'keep_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertFileExists( $result['report_path'] );
+
+		$report = json_decode( $this->read_file( $result['report_path'] ), true );
+		$this->assertIsArray( $report );
+
+		$this->assertArrayHasKey( 'source_region_selection', $report, 'report should expose a source_region_selection section' );
+		$selection = $report['source_region_selection'];
+		$this->assertIsArray( $selection );
+
+		// Page body decision.
+		$this->assertSame( $fixture, $selection['entry_file'] ?? '', 'entry_file should match the imported HTML path' );
+		$this->assertArrayHasKey( 'page_body', $selection );
+		$this->assertSame( 'semantic_main', $selection['page_body']['mode'] ?? '' );
+		$this->assertSame( 'main', $selection['page_body']['tag'] ?? '' );
+		$this->assertStringContainsString( 'main.page', (string) ( $selection['page_body']['selector'] ?? '' ) );
+		$this->assertIsArray( $selection['page_body']['line_range'] ?? null );
+		$this->assertCount( 2, $selection['page_body']['line_range'] );
+		$this->assertGreaterThan( 0, $selection['page_body']['line_range'][0] );
+		$this->assertGreaterThanOrEqual(
+			$selection['page_body']['line_range'][0],
+			$selection['page_body']['line_range'][1]
+		);
+
+		// Footer was extracted as theme chrome.
+		$this->assertIsArray( $selection['extracted_footer'] ?? null );
+		$this->assertSame( 'footer', $selection['extracted_footer']['tag'] ?? '' );
+
+		// No global header/nav was selected — both live inside the dropped
+		// pre-main wrapper, so the report flags them as unassigned.
+		$unassigned = $selection['unassigned_regions'] ?? array();
+		$this->assertIsArray( $unassigned );
+		$this->assertNotEmpty( $unassigned, 'pre-main wrapper containing nav and hero should be reported as unassigned' );
+
+		// Locate the wrapper entry.
+		$wrapper = null;
+		$nav     = null;
+		$hero    = null;
+		foreach ( $unassigned as $region ) {
+			$selector = (string) ( $region['selector'] ?? '' );
+			if ( 'unassigned_body_child' === ( $region['role'] ?? '' ) && str_contains( $selector, 'div.page' ) ) {
+				$wrapper = $region;
+			}
+			if ( ( $region['tag'] ?? '' ) === 'nav' ) {
+				$nav = $region;
+			}
+			if ( ( $region['tag'] ?? '' ) === 'header' ) {
+				$hero = $region;
+			}
+		}
+
+		$this->assertNotNull( $wrapper, 'wrapper div.page should be reported as unassigned_body_child' );
+		$this->assertSame( 'before_main', $wrapper['position'] ?? '' );
+		$this->assertSame( 'pre_main_or_post_main_sibling_not_assigned', $wrapper['reason'] ?? '' );
+		$this->assertIsArray( $wrapper['line_range'] ?? null );
+		$this->assertNotEmpty( $wrapper['excerpt'] ?? '' );
+
+		$this->assertNotNull( $nav, 'nested nav inside the wrapper should be reported' );
+		$this->assertSame( 'unassigned_nested_landmark', $nav['role'] ?? '' );
+		$this->assertStringContainsString( 'nav.nav', (string) ( $nav['selector'] ?? '' ) );
+
+		$this->assertNotNull( $hero, 'nested hero header inside the wrapper should be reported' );
+		$this->assertSame( 'unassigned_nested_landmark', $hero['role'] ?? '' );
+		$this->assertStringContainsString( 'header', (string) ( $hero['selector'] ?? '' ) );
+		$this->assertStringContainsString( '#top', (string) ( $hero['selector'] ?? '' ) );
+
+		// Counts surface source landmark presence at a glance.
+		$counts = $selection['counts'] ?? array();
+		$this->assertSame( 1, $counts['source_landmarks']['main'] ?? 0 );
+		$this->assertGreaterThanOrEqual( 1, $counts['source_landmarks']['nav'] ?? 0 );
+		$this->assertGreaterThanOrEqual( 1, $counts['source_landmarks']['header'] ?? 0 );
+		$this->assertGreaterThanOrEqual( 1, $counts['source_landmarks']['footer'] ?? 0 );
+		$this->assertSame( count( $unassigned ), $counts['unassigned_regions'] ?? -1 );
+
+		// A diagnostics entry mirrors each unassigned region for tooling that
+		// scans the diagnostics list.
+		$diagnostics = $report['diagnostics'] ?? array();
+		$this->assertIsArray( $diagnostics );
+		$source_region_diagnostics = array_values(
+			array_filter(
+				$diagnostics,
+				static fn ( $entry ): bool => is_array( $entry ) && 'source_region_unassigned' === ( $entry['type'] ?? '' )
+			)
+		);
+		$this->assertNotEmpty( $source_region_diagnostics );
+		$this->assertSame( count( $unassigned ), count( $source_region_diagnostics ) );
+		$this->assertNotEmpty( $source_region_diagnostics[0]['selector'] ?? '' );
+	}
+
+	/**
+	 * Reports a sane page_body decision when the entry document already
+	 * uses a clean header/main/footer landmark layout (no unassigned regions).
+	 */
+	public function test_clean_landmark_layout_has_no_unassigned_regions(): void {
+		$plugin_root = dirname( __DIR__ );
+		$fixture     = $plugin_root . '/tests/fixtures/hero-id-chrome/index.html';
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$fixture,
+			array(
+				'name'        => 'Source Region Clean Layout',
+				'slug'        => 'source-region-clean-layout',
+				'overwrite'   => true,
+				'activate'    => false,
+				'keep_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$report = json_decode( $this->read_file( $result['report_path'] ), true );
+		$this->assertIsArray( $report );
+
+		$selection = $report['source_region_selection'] ?? array();
+		$this->assertSame( 'semantic_main', $selection['page_body']['mode'] ?? '' );
+		$this->assertSame( array(), $selection['unassigned_regions'] ?? array( 'not-set' ) );
+		$this->assertSame( 0, $selection['counts']['unassigned_regions'] ?? -1 );
+		$this->assertIsArray( $selection['extracted_header'] ?? null );
+		$this->assertNotEmpty( $selection['extracted_header']['parts'] ?? array() );
+	}
+
+	/**
+	 * Reads a generated file.
+	 */
+	private function read_file( string $path ): string {
+		$contents = file_get_contents( $path );
+		$this->assertNotFalse( $contents, 'Unable to read ' . $path );
+
+		return (string) $contents;
+	}
+}

--- a/tests/fixtures/dropped-pre-main-chrome/index.html
+++ b/tests/fixtures/dropped-pre-main-chrome/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Dropped Pre-Main Chrome</title>
+	<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+	<div class="page">
+		<nav class="nav" aria-label="Primary navigation">
+			<ul>
+				<li><a href="#benefits">Benefits</a></li>
+				<li><a href="#contact">Contact</a></li>
+			</ul>
+		</nav>
+		<header class="hero" id="top">
+			<h1>Welcome to the Pre-Main Chrome Drop Repro</h1>
+			<p>Both this nav and this hero are inside body &gt; div.page before &lt;main&gt; — they are dropped today.</p>
+		</header>
+	</div>
+
+	<main class="page">
+		<section id="benefits" class="content-shell">
+			<h2>Benefits</h2>
+			<p>This is the only region the importer keeps. The pre-main wrapper is silently dropped.</p>
+		</section>
+	</main>
+
+	<footer class="site-footer">
+		<p>Footer copy.</p>
+	</footer>
+</body>
+</html>

--- a/tests/fixtures/dropped-pre-main-chrome/styles.css
+++ b/tests/fixtures/dropped-pre-main-chrome/styles.css
@@ -1,0 +1,5 @@
+body { font-family: system-ui, sans-serif; margin: 0; }
+.nav ul { display: flex; gap: 1rem; }
+.hero { padding: 2rem; }
+main.page { padding: 1rem; }
+.site-footer { padding: 1rem; }


### PR DESCRIPTION
## Summary

Adds a `source_region_selection` section to `import-report.json` so agents can pinpoint when meaningful source regions are excluded from the generated theme without diffing source against output. Reporting only — conversion behavior is unchanged.

Repro from the issue: source had `nav + header.hero` inside `body > div.page` before `<main>`, the importer silently dropped the wrapper, quality passed, and agents had to manually inspect generated files. The new report section makes the drop immediately visible.

## What the report records

- `page_body` — selected mode (`semantic_main` / `body_root_fallback`), selector path, tag, source line range, short text excerpt.
- `extracted_header` / `extracted_footer` — selector path, tag, line range, excerpt; header includes the assembly mode (e.g. `leading_nav_plus_header`).
- `unassigned_regions` — meaningful direct body children that the extractor dropped (because `<main>` exists and they are not chrome, background, or body content headers). Each entry has selector path, tag, source line range, position relative to `<main>`, and an excerpt. Nested landmarks (`nav`, `header`, hero `section`, `main`, `footer`) inside dropped wrappers are reported as `unassigned_nested_landmark` so the exact dropped regions are visible.
- `counts` — source landmark counts and the unassigned region count.

Each unassigned region is also mirrored into `diagnostics[]` with `type: source_region_unassigned` for tooling that scans diagnostics.

Sample shape on the issue repro fixture:

```json
{
  "source_region_selection": {
    "page_body": { "mode": "semantic_main", "selector": "html > body > main.page", "line_range": [22, 27] },
    "extracted_footer": { "role": "footer_element", "selector": "html > body > footer.site-footer", "line_range": [29, 31] },
    "unassigned_regions": [
      { "role": "unassigned_body_child", "position": "before_main", "selector": "html > body > div.page", "line_range": [9, 20] },
      { "role": "unassigned_nested_landmark", "selector": "html > body > div.page > nav.nav", "line_range": [10, 15] },
      { "role": "unassigned_nested_landmark", "selector": "html > body > div.page > header#top", "line_range": [16, 19] }
    ]
  }
}
```

## Implementation

- `Document::fragments()` is now a thin wrapper over a shared `compute_selection()` model so the existing per-child selection logic produces both the conversion fragments (unchanged byte-for-byte) and a structured selection record.
- `Document::selection_report()` consumes the same model and returns the report payload. Selector paths walk up parents using `tag#id` or `tag.first-class`. Line ranges use `DOMNode::getLineNo()` for the start and a tag-aware close-line scan for the end (void elements collapse to a single line).
- `Theme_Generator::record_source_region_selection()` writes the section into the conversion report and pushes diagnostics. The new section is initialized in `new_conversion_report()` so the shape is stable even when there is nothing unassigned.

## Tests

- New fixture `tests/fixtures/dropped-pre-main-chrome/` matching the issue repro: `body > div.page > nav.nav + header.hero#top` before `<main class="page">`, with a `<footer>` sibling.
- New `StaticSiteImporterSourceRegionReportTest` with two cases:
  - The wrapper, nested nav, and nested hero header all surface in `unassigned_regions` with selector paths, line ranges, excerpts, and `position: before_main`; counts and mirrored `source_region_unassigned` diagnostics line up.
  - A clean `header/main/footer` layout (existing `hero-id-chrome` fixture) produces `unassigned_regions: []` and a non-empty `extracted_header.parts`.

42/42 tests pass on the SSI suite. Lint matches the pre-change baseline (3 pre-existing findings, no new findings).

## Repro evidence linked from the issue

- Source: `/tmp/hbi/go4/state/studio-agent-site-build/sites/gpt-5.5-ssi-58418-1777995817546-jfsw7pr1z2k/tmp/static-site/index.html` lines 403–435
- Import report: `/tmp/hbi/go4/state/.../import-report.json`
- Semantic report: `/tmp/hbssi3/.../semantic-fidelity.json`

Closes #158.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the `selection_report()` implementation, selector-path / line-range helpers, theme-generator wiring, fixture, and tests. Chris reviewed, ran lint and the SSI test suite, and signed off.