### PR TITLE
Accept raw HTML product context

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ ZIP intake rules:
 
 ## Generated Store Contract
 
-Static store generators may include an optional `products.json` file beside the selected entry HTML file. When present, Static Site Importer validates the manifest and records the contract result under `commerce.products_manifest` in `import-report.json`. When absent, non-commerce imports keep their existing report shape and no `commerce` section is added.
+Static store generators can expose products directly in raw HTML. Product cards using `.product-card` with a visible heading and price are accepted as commerce context and do not require a separate manifest. Generators may also include an optional `products.json` file beside the selected entry HTML file. When present, Static Site Importer validates the manifest and records the contract result under `commerce.products_manifest` in `import-report.json`.
 
 Minimal schema:
 
@@ -92,7 +92,7 @@ Optional product fields:
 - `stock_quantity`: integer stock quantity.
 - `source_selectors`: array of non-empty CSS selector strings for source-product cards.
 
-Invalid manifests do not abort the import. The report marks the manifest invalid and records path-addressed diagnostics such as `$.products[0].slug` so generators can fix the exact field.
+Invalid manifests do not abort the import. The report marks the manifest invalid and records path-addressed errors such as `$.products[0].slug`. If raw HTML product cards supply product context, the optional manifest does not add a top-level `products_manifest_invalid` diagnostic.
 
 ## CLI Usage
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -142,7 +142,8 @@ class Static_Site_Importer_Theme_Generator {
 		self::record_source_region_selection( $document, $html_path );
 		self::record_source_documents_summary( $site_dir, $pages, $permalinks );
 		self::record_products_manifest( $site_dir );
-		self::$active_commerce_context = self::commerce_context_from_args( $args );
+		self::$active_commerce_context = self::commerce_context_from_args( $args, $pages );
+		self::suppress_manifest_diagnostic_when_raw_html_supplies_products();
 		self::record_commerce_context_summary();
 
 		self::$active_theme_dir         = $theme_dir;
@@ -558,8 +559,8 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		if ( preg_match( '#(^|/)index$#i', $extensionless ) ) {
-			$clean = preg_replace( '#(^|/)index$#i', '$1', $extensionless );
-			$clean = trim( (string) $clean, '/' );
+			$clean  = preg_replace( '#(^|/)index$#i', '$1', $extensionless );
+			$clean  = trim( (string) $clean, '/' );
 			$keys[] = '' === $clean ? '/' : $clean;
 			$keys[] = '' === $clean ? '/' : '/' . $clean . '/';
 			if ( '' !== $clean ) {
@@ -1900,9 +1901,10 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string
 	 */
 	private static function normalize_route_path( string $path ): string {
-		$path     = str_replace( '\\', '/', strtok( $path, '?' ) ?: $path );
-		$path     = ltrim( $path, '/' );
-		$segments = array();
+		$path_without_query = strtok( $path, '?' );
+		$path               = str_replace( '\\', '/', false === $path_without_query ? $path : $path_without_query );
+		$path               = ltrim( $path, '/' );
+		$segments           = array();
 		foreach ( explode( '/', $path ) as $segment ) {
 			if ( '' === $segment || '.' === $segment ) {
 				continue;
@@ -3303,10 +3305,11 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Resolve validated commerce context supplied by the caller.
 	 *
-	 * @param array<string, mixed> $args Import args.
+	 * @param array<string, mixed>                         $args  Import args.
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages Source pages.
 	 * @return array<string, mixed>
 	 */
-	private static function commerce_context_from_args( array $args ): array {
+	private static function commerce_context_from_args( array $args, array $pages ): array {
 		if ( isset( $args['commerce_context'] ) && is_array( $args['commerce_context'] ) ) {
 			return $args['commerce_context'];
 		}
@@ -3319,7 +3322,147 @@ class Static_Site_Importer_Theme_Generator {
 			);
 		}
 
-		return array();
+		return self::commerce_context_from_raw_html_pages( $pages );
+	}
+
+	/**
+	 * Derive product context from raw storefront HTML.
+	 *
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages Source pages.
+	 * @return array<string, mixed>
+	 */
+	private static function commerce_context_from_raw_html_pages( array $pages ): array {
+		$products       = array();
+		$selector_hints = array();
+
+		foreach ( $pages as $source_filename => $page ) {
+			if ( 'html' !== $page->body_format() ) {
+				continue;
+			}
+
+			$doc   = self::load_fragment_document( $page->body() );
+			$xpath = new DOMXPath( $doc );
+			$cards = $xpath->query( '//*[contains(concat(" ", normalize-space(@class), " "), " product-card ")]' );
+			if ( ! $cards instanceof DOMNodeList || 0 === $cards->length ) {
+				continue;
+			}
+
+			$selector_hints[] = array(
+				'source_filename' => $source_filename,
+				'grid_selector'   => '.product-grid',
+				'card_selector'   => '.product-card',
+			);
+
+			foreach ( $cards as $card ) {
+				if ( ! $card instanceof DOMElement ) {
+					continue;
+				}
+
+				$product = self::product_context_from_html_card( $xpath, $card, $source_filename );
+				if ( ! empty( $product ) ) {
+					$products[] = $product;
+				}
+			}
+		}
+
+		if ( empty( $products ) ) {
+			return array();
+		}
+
+		return array(
+			'source'         => 'raw_html_products',
+			'products'       => $products,
+			'selector_hints' => $selector_hints,
+		);
+	}
+
+	/**
+	 * Build one product context row from a product-card element.
+	 *
+	 * @param DOMXPath  $xpath           XPath helper for the source document.
+	 * @param DOMElement $card            Product card element.
+	 * @param string    $source_filename Source filename.
+	 * @return array<string, mixed>
+	 */
+	private static function product_context_from_html_card( DOMXPath $xpath, DOMElement $card, string $source_filename ): array {
+		$name = self::first_descendant_text( $xpath, $card, './/*[self::h1 or self::h2 or self::h3 or self::h4 or contains(concat(" ", normalize-space(@class), " "), " product-title ") or contains(concat(" ", normalize-space(@class), " "), " name ")]' );
+		if ( '' === $name ) {
+			return array();
+		}
+
+		$price = self::price_from_text( $card->textContent );
+		if ( '' === $price ) {
+			return array();
+		}
+
+		return array(
+			'name'             => $name,
+			'slug'             => sanitize_title( $name ),
+			'regular_price'    => $price,
+			'source_filename'  => $source_filename,
+			'card_selector'    => '.product-card',
+			'source_selectors' => array( '.product-card' ),
+		);
+	}
+
+	/**
+	 * Read the first matching descendant text.
+	 *
+	 * @param DOMXPath  $xpath XPath helper.
+	 * @param DOMElement $root  Root element.
+	 * @param string    $query XPath query.
+	 * @return string
+	 */
+	private static function first_descendant_text( DOMXPath $xpath, DOMElement $root, string $query ): string {
+		$nodes = $xpath->query( $query, $root );
+		if ( ! $nodes instanceof DOMNodeList ) {
+			return '';
+		}
+
+		foreach ( $nodes as $node ) {
+			if ( ! $node instanceof DOMNode ) {
+				continue;
+			}
+
+			$text = trim( preg_replace( '/\s+/', ' ', $node->textContent ) ?? '' );
+			if ( '' !== $text ) {
+				return $text;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract a stable decimal price from visible product-card text.
+	 *
+	 * @param string $text Visible text.
+	 * @return string
+	 */
+	private static function price_from_text( string $text ): string {
+		if ( 1 !== preg_match( '/(?:\$|USD\s*)\s*([0-9]+(?:\.[0-9]{2})?)/i', $text, $matches ) ) {
+			return '';
+		}
+
+		return number_format( (float) $matches[1], 2, '.', '' );
+	}
+
+	/**
+	 * Do not warn about an optional manifest when raw HTML supplied product context.
+	 *
+	 * @return void
+	 */
+	private static function suppress_manifest_diagnostic_when_raw_html_supplies_products(): void {
+		if ( 'raw_html_products' !== ( self::$active_commerce_context['source'] ?? '' ) || empty( self::$conversion_report['diagnostics'] ) ) {
+			return;
+		}
+
+		self::$conversion_report['diagnostics'] = array_values(
+			array_filter(
+				self::$conversion_report['diagnostics'],
+				static fn ( $diagnostic ): bool => ! is_array( $diagnostic ) || 'products_manifest_invalid' !== ( $diagnostic['code'] ?? '' )
+			)
+		);
 	}
 
 	/**
@@ -3863,6 +4006,10 @@ class Static_Site_Importer_Theme_Generator {
 			if ( is_array( $report_manifest ) && true === ( $report_manifest['valid'] ?? false ) ) {
 				$manifest = isset( $report_manifest['products'] ) && is_array( $report_manifest['products'] ) ? $report_manifest['products'] : array();
 			}
+		}
+
+		if ( null === $manifest && 'raw_html_products' === ( self::$active_commerce_context['source'] ?? '' ) ) {
+			$manifest = isset( self::$active_commerce_context['products'] ) && is_array( self::$active_commerce_context['products'] ) ? self::$active_commerce_context['products'] : array();
 		}
 
 		if ( null === $manifest ) {

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -1664,6 +1664,66 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Raw product-card HTML supplies commerce context without requiring products.json.
+	 */
+	public function test_raw_html_product_cards_supply_commerce_context(): void {
+		$html_path = $this->write_temp_fixture(
+			'index.html',
+			'<!doctype html><html><head><title>Raw HTML Store</title></head><body><main><section class="product-grid"><article class="product-card"><h2>Roasted Beans</h2><p class="price">$18.00</p></article><article class="product-card"><h2>Pour Over Kit</h2><p class="price">USD 42</p></article></section></main></body></html>'
+		);
+		$this->assertNotFalse( file_put_contents( trailingslashit( dirname( $html_path ) ) . 'products.json', '{"products":{"broken":true}}' ) );
+
+		$captured_contexts = array();
+		$args_filter       = static function ( array $handler_args ) use ( &$captured_contexts ): array {
+			if ( isset( $handler_args['context']['commerce'] ) && is_array( $handler_args['context']['commerce'] ) ) {
+				$captured_contexts[] = $handler_args['context']['commerce'];
+			}
+
+			return $handler_args;
+		};
+		add_filter( 'bfb_html_to_blocks_args', $args_filter, 10, 1 );
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'        => 'Raw HTML Store',
+				'slug'        => 'raw-html-store',
+				'overwrite'   => true,
+				'activate'    => false,
+				'keep_source' => true,
+			)
+		);
+		remove_filter( 'bfb_html_to_blocks_args', $args_filter, 10 );
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $captured_contexts );
+		$this->assertSame( 'raw_html_products', $captured_contexts[0]['source'] ?? '' );
+		$this->assertSame( 'Roasted Beans', $captured_contexts[0]['products'][0]['name'] ?? '' );
+		$this->assertSame( 'roasted-beans', $captured_contexts[0]['products'][0]['slug'] ?? '' );
+		$this->assertSame( '18.00', $captured_contexts[0]['products'][0]['regular_price'] ?? '' );
+		$this->assertSame( '42.00', $captured_contexts[0]['products'][1]['regular_price'] ?? '' );
+
+		$report      = json_decode( $this->read_file( $result['report_path'] ), true );
+		$diagnostics = array_values(
+			array_filter(
+				$report['diagnostics'] ?? array(),
+				static fn ( $diagnostic ): bool => is_array( $diagnostic ) && 'products_manifest_invalid' === ( $diagnostic['code'] ?? '' )
+			)
+		);
+
+		$this->assertIsArray( $report );
+		$this->assertTrue( $report['commerce_context']['supplied'] ?? false );
+		$this->assertSame( 'raw_html_products', $report['commerce_context']['source'] ?? '' );
+		$this->assertSame( 2, $report['commerce_context']['product_count'] ?? null );
+		$this->assertSame( array(), $diagnostics );
+		if ( ! class_exists( 'WC_Product_Simple' ) ) {
+			$this->assertSame( 'woocommerce_inactive', $report['product_seeding']['reason'] ?? '' );
+			$this->assertSame( 2, $report['product_seeding']['counts']['skipped'] ?? null );
+		}
+	}
+
+	/**
 	 * Serialized freeform blocks are counted in generated-theme quality.
 	 */
 	public function test_generated_theme_quality_reports_serialized_freeform_blocks(): void {


### PR DESCRIPTION
## Summary
- Derives commerce context from raw `.product-card` HTML when product cards include a visible heading and price.
- Uses raw HTML product context for BFB conversion and Woo product seeding instead of requiring a valid `products.json` manifest.
- Suppresses the top-level `products_manifest_invalid` diagnostic when raw HTML successfully supplies product context, while still recording manifest errors in the manifest report.

## Validation
- `git diff --check` — passed.
- `homeboy lint --path /Users/chubes/Developer/static-site-importer@accept-raw-html-products --changed-only` — passed.
- `homeboy test --path /Users/chubes/Developer/static-site-importer@accept-raw-html-products --filter StaticSiteImporterFixtureTest::test_raw_html_product_cards_supply_commerce_context` — passed, 1 test / 19 assertions.
- `homeboy test --path /Users/chubes/Developer/static-site-importer@accept-raw-html-products --filter StaticSiteImporterFixtureTest::test_invalid_products_manifest_records_errors_without_blocking_import` — passed, 1 test / 14 assertions.
- `homeboy test --path /Users/chubes/Developer/static-site-importer@accept-raw-html-products --filter StaticSiteImporterFixtureTest::test_commerce_context_is_forwarded_to_page_conversion_and_reported` — passed, 1 test / 15 assertions.
- `homeboy audit --path /Users/chubes/Developer/static-site-importer@accept-raw-html-products` — passed with existing heuristic warnings.

## Residual risk
- `homeboy test --path /Users/chubes/Developer/static-site-importer@accept-raw-html-products --changed-only` currently reports 2 failures that reproduce on `main`: `StaticSiteImporterFixtureTest::test_product_catalog_decorative_placeholders_import_as_native_blocks` and `StaticSiteImporterSourceRegionReportTest::test_pre_main_wrapper_chrome_is_reported_as_unassigned`.
- Raw HTML extraction intentionally handles the stable generated storefront shape first: `.product-card` cards with a heading and `$`/`USD` price text. Broader product markup can be added later if real generators need it.

## Related
- Refs chubes4/wc-site-generator#44

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the generator/importer boundary, implementing raw HTML product context extraction, adding regression coverage, and running validation commands. Chris remains responsible for review and merge.