### PR TITLE
Infer nested product card prices

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -3798,7 +3798,11 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		foreach ( $nodes as $node ) {
-			if ( ! $node instanceof DOMElement || self::has_descendant_product_candidate( $node ) ) {
+			if (
+				! $node instanceof DOMElement ||
+				! self::element_looks_like_product_card( $node ) ||
+				self::has_descendant_product_candidate( $node )
+			) {
 				continue;
 			}
 
@@ -3854,7 +3858,12 @@ class Static_Site_Importer_Theme_Generator {
 		$haystack  = strtolower( $element->getAttribute( 'class' ) . ' ' . $element->getAttribute( 'id' ) );
 		$valid_tag = in_array( $tag, array( 'article', 'li', 'div' ), true );
 
-		return $valid_tag && ( str_contains( $haystack, 'product' ) || $element->hasAttribute( 'data-product-slug' ) || $element->hasAttribute( 'data-product-name' ) || $element->hasAttribute( 'data-price' ) );
+		return $valid_tag && (
+			$element->hasAttribute( 'data-product-slug' ) ||
+			$element->hasAttribute( 'data-product-name' ) ||
+			$element->hasAttribute( 'data-price' ) ||
+			( str_contains( $haystack, 'product' ) && preg_match( '/(?:^|[-_\s])(?:card|item|tile)(?:$|[-_\s])/', $haystack ) )
+		);
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -1802,6 +1802,44 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Product-card inference accepts generated storefront cards with nested footer/meta prices.
+	 */
+	public function test_raw_html_product_cards_with_nested_footer_prices_supply_commerce_context(): void {
+		$html_path = $this->write_temp_fixture(
+			'index.html',
+			'<!doctype html><html><head><title>Nested Product Prices</title></head><body><main><section class="product-grid"><article class="product-card"><p class="product-kicker">Dining chair</p><h3>Pressed-Cane Dining Chair Kit</h3><p>Measured cane webbing, spline, groove cleaner...</p><div class="card-footer"><span class="price">$64</span><a class="cta" href="#planning">Measure first</a></div></article><article class="product-card"><div class="product-visual shio"></div><p class="product-kicker">Marinade staple</p><h4>Shio Koji Everyday Jar</h4><p>Salted rice koji for tender grilled chicken...</p><div class="product-meta"><span class="price">$14</span><a class="cta" href="#cart">Add to counter</a></div></article></section></main></body></html>'
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$html_path,
+			array(
+				'name'        => 'Nested Product Prices',
+				'slug'        => 'nested-product-prices',
+				'overwrite'   => true,
+				'activate'    => false,
+				'keep_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+		$inference = $report['commerce_product_inference'] ?? array();
+
+		$this->assertIsArray( $report );
+		$this->assertSame( 'html_cards', $inference['strategy'] ?? '' );
+		$this->assertSame( 2, $inference['product_count'] ?? null );
+		$this->assertSame( 0, $inference['skipped_candidate_count'] ?? null );
+		$this->assertSame( 'Pressed-Cane Dining Chair Kit', $inference['products'][0]['name'] ?? '' );
+		$this->assertSame( '64.00', $inference['products'][0]['regular_price'] ?? '' );
+		$this->assertSame( 'Shio Koji Everyday Jar', $inference['products'][1]['name'] ?? '' );
+		$this->assertSame( '14.00', $inference['products'][1]['regular_price'] ?? '' );
+		$this->assertSame( 'html_cards', $report['commerce_context']['source'] ?? '' );
+		$this->assertSame( 2, $report['commerce_context']['product_count'] ?? null );
+	}
+
+	/**
 	 * Serialized freeform blocks are counted in generated-theme quality.
 	 */
 	public function test_generated_theme_quality_reports_serialized_freeform_blocks(): void {


### PR DESCRIPTION
## Summary
- Tightens raw HTML product inference so only product-card-like candidates are extracted.
- Prevents nested helpers such as `.product-meta` and `.product-visual` from disqualifying the parent `.product-card`.
- Adds regression coverage using the `.card-footer .price` and `.product-meta .price` examples from #170.

## Validation
- `php -l includes/class-static-site-importer-theme-generator.php` passed.
- `php -l tests/StaticSiteImporterFixtureTest.php` passed.
- `git diff --check` passed.
- `homeboy lint --path /Users/chubes/Developer/static-site-importer@infer-nested-product-card-prices --changed-only` passed.
- `homeboy test --path /Users/chubes/Developer/static-site-importer@infer-nested-product-card-prices --filter StaticSiteImporterFixtureTest::test_raw_html_product_cards_with_nested_footer_prices_supply_commerce_context` passed: 1 test, 15 assertions.
- `homeboy test --path /Users/chubes/Developer/static-site-importer@infer-nested-product-card-prices --filter 'StaticSiteImporterFixtureTest::test_(static_store_product_cards_infer_commerce_context|json_ld_product_data_infers_before_product_cards|raw_html_product_cards_supply_commerce_context|raw_html_product_cards_with_nested_footer_prices_supply_commerce_context)'` passed: 4 tests, 63 assertions.

## Residual risk
- Product card inference remains intentionally conservative: class/id-based candidates need explicit data product attributes or a product + card/item/tile signal. Broader storefront naming can be added once real generated examples require it.

Fixes #170.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating issue/PR context, implementing the candidate-filtering fix, adding regression coverage, and running validation. Chris remains responsible for review and merge.