### PR TITLE
feat(commerce): require WooCommerce for commerce-bearing imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ Optional product fields:
 
 Invalid manifests do not abort the import. The report marks the manifest invalid and records path-addressed errors such as `$.products[0].slug`. If raw HTML product cards supply product context, the optional manifest does not add a top-level `products_manifest_invalid` diagnostic.
 
+## WooCommerce Dependency
+
+Commerce-bearing imports require WooCommerce. Commerce intent is detected when any of these signals are present:
+
+- a valid `products.json` manifest with at least one product, or
+- caller-supplied `commerce_context` with at least one product, or
+- inferred commerce context from JSON-LD `Product` data or visible product cards.
+
+When intent is present and WooCommerce is not active, Static Site Importer hard-fails the import by default. Theme files are still written so the import report and generated artifacts can be inspected. The failure surfaces three ways:
+
+- `commerce.dependencies.woocommerce` block on the import report (`required`, `active`, `waived`, `sources`, `product_count`, `missing_apis`).
+- A `woocommerce_missing` error diagnostic in the report `diagnostics[]` list.
+- `quality.failure_reasons[]` contains `woocommerce_missing`, `quality.commerce_dependency_failures` is non-zero, and `quality.fail_import` is set regardless of `--fail-on-quality`.
+
+Pass `--allow-missing-woocommerce` (CLI) or `'allow_missing_woocommerce' => true` (PHP API) to import the theme without seeding products. The waiver records a `woocommerce_waived` warning diagnostic and clears the dependency failure. Non-commerce imports (no manifest, no inferred context) are unaffected: no `commerce.dependencies` block is recorded and no dependency diagnostics are emitted.
+
+The import-time auto-install of WooCommerce (`--ensure-woocommerce`) is intentionally out of scope for this gate; install WooCommerce explicitly with `wp plugin install woocommerce --activate` before retrying the import.
+
 ## CLI Usage
 
 ```bash
@@ -113,6 +131,12 @@ wp static-site-importer import-url https://example.com/ \
   --slug=example-import \
   --keep-source \
   --report=report.json
+
+# Commerce-bearing import on a host without WooCommerce: skip seeding and continue.
+wp static-site-importer import-theme /path/to/store/index.html \
+  --slug=store-no-woo \
+  --allow-missing-woocommerce \
+  --keep-source
 ```
 
 The CLI path imports all readable sibling `*.html` files in the same directory as the provided entry file plus recursive `.md` / `.markdown` content documents under the source tree. The entry file supplies the theme title, shared source chrome, background decoration, styles, and inline scripts; each source content file supplies a WordPress page body. `.mdx` files are unsupported and reported as skipped diagnostics.

--- a/includes/class-static-site-importer-admin.php
+++ b/includes/class-static-site-importer-admin.php
@@ -200,6 +200,14 @@ class Static_Site_Importer_Admin {
 			self::redirect_error( $result->get_error_message() );
 		}
 
+		if ( ! empty( $result['quality']['fail_import'] ) ) {
+			$failure_reasons = isset( $result['quality']['failure_reasons'] ) && is_array( $result['quality']['failure_reasons'] ) ? $result['quality']['failure_reasons'] : array();
+			if ( in_array( 'woocommerce_missing', $failure_reasons, true ) ) {
+				self::redirect_error( 'WooCommerce is required for this import. The source declared products but WooCommerce is not active. Install and activate WooCommerce, then retry the import.' );
+			}
+			self::redirect_error( 'Conversion quality gate failed. Theme files were written for inspection; review the import report and retry.' );
+		}
+
 		wp_safe_redirect( add_query_arg( 'static_site_imported', rawurlencode( $result['theme_name'] ), admin_url( 'admin.php?page=static-site-importer' ) ) );
 		exit;
 	}

--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -109,8 +109,44 @@ class Static_Site_Importer_CLI_Command {
 			return;
 		}
 
-		if ( isset( $assoc_args['format'] ) && 'json' === (string) $assoc_args['format'] ) {
+		$failure_reasons       = isset( $result['quality']['failure_reasons'] ) && is_array( $result['quality']['failure_reasons'] ) ? $result['quality']['failure_reasons'] : array();
+		$commerce_dep_failure  = in_array( 'woocommerce_missing', $failure_reasons, true );
+		$allow_missing_woo_cli = isset( $assoc_args['allow-missing-woocommerce'] );
+		$fail_import           = ! empty( $result['quality']['fail_import'] );
+		$is_json               = isset( $assoc_args['format'] ) && 'json' === (string) $assoc_args['format'];
+
+		if ( $is_json ) {
+			// Always emit the structured payload so JSON parsers see quality.fail_import,
+			// failure_reasons, and the commerce.dependencies block on the report. When the
+			// gate trips, exit non-zero after printing so machine-readable callers (e.g.
+			// wc-site-generator) cannot mistake a failed import for success.
 			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			if ( $fail_import ) {
+				WP_CLI::halt( 1 );
+			}
+			return;
+		}
+
+		// Human format: report failures first so we never print "success" before erroring.
+		if ( $commerce_dep_failure && $fail_import ) {
+			WP_CLI::error(
+				sprintf(
+					"WooCommerce is required for this import. The source declared products but WooCommerce is not active.\nInstall and activate WooCommerce, or rerun with --allow-missing-woocommerce to import the theme without seeding products.\nTheme files were written for inspection at: %s\nImport report: %s",
+					$result['theme_dir'],
+					$result['report_path']
+				)
+			);
+			return;
+		}
+
+		if ( $fail_import ) {
+			WP_CLI::error(
+				sprintf(
+					"Conversion quality gate failed. Theme files were written for inspection at: %s\nImport report: %s",
+					$result['theme_dir'],
+					$result['report_path']
+				)
+			);
 			return;
 		}
 
@@ -135,28 +171,8 @@ class Static_Site_Importer_CLI_Command {
 			WP_CLI::warning( 'Conversion quality checks reported issues. Inspect import-report.json for source fragments and diagnostics.' );
 		}
 
-		$failure_reasons       = isset( $result['quality']['failure_reasons'] ) && is_array( $result['quality']['failure_reasons'] ) ? $result['quality']['failure_reasons'] : array();
-		$commerce_dep_failure  = in_array( 'woocommerce_missing', $failure_reasons, true );
-		$allow_missing_woo_cli = isset( $assoc_args['allow-missing-woocommerce'] );
-
-		if ( $commerce_dep_failure && ! empty( $result['quality']['fail_import'] ) ) {
-			WP_CLI::error(
-				sprintf(
-					"WooCommerce is required for this import. The source declared products but WooCommerce is not active.\nInstall and activate WooCommerce, or rerun with --allow-missing-woocommerce to import the theme without seeding products.\nTheme files were written for inspection at: %s\nImport report: %s",
-					$result['theme_dir'],
-					$result['report_path']
-				)
-			);
-			return;
-		}
-
 		if ( $allow_missing_woo_cli ) {
 			WP_CLI::warning( 'WooCommerce dependency check waived via --allow-missing-woocommerce. Products were not seeded.' );
-		}
-
-		if ( ! empty( $result['quality']['fail_import'] ) ) {
-			WP_CLI::error( 'Conversion quality gate failed. Theme files were written for inspection.' );
-			return;
 		}
 	}
 

--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -48,6 +48,9 @@ class Static_Site_Importer_CLI_Command {
 	 * [--max-fallbacks=<count>]
 	 * : Exit non-zero when unsupported HTML fallback count exceeds this threshold.
 	 *
+	 * [--allow-missing-woocommerce]
+	 * : Allow commerce-bearing imports to proceed when WooCommerce is not active. Default is to fail the import. Theme files are still written either way; the waiver only suppresses product seeding without aborting.
+	 *
 	 * [--report=<path>]
 	 * : Copy the generated import report JSON to an external archive path.
 	 *
@@ -88,15 +91,16 @@ class Static_Site_Importer_CLI_Command {
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
 			$html_file,
 			array(
-				'slug'            => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
-				'name'            => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
-				'activate'        => isset( $assoc_args['activate'] ),
-				'overwrite'       => isset( $assoc_args['overwrite'] ),
-				'keep_source'     => isset( $assoc_args['keep-source'] ),
-				'fail_on_quality' => isset( $assoc_args['fail-on-quality'] ),
-				'max_fallbacks'   => isset( $assoc_args['max-fallbacks'] ) ? (int) $assoc_args['max-fallbacks'] : null,
-				'report'          => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
-				'source_metadata' => $source_metadata,
+				'slug'                      => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
+				'name'                      => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
+				'activate'                  => isset( $assoc_args['activate'] ),
+				'overwrite'                 => isset( $assoc_args['overwrite'] ),
+				'keep_source'               => isset( $assoc_args['keep-source'] ),
+				'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
+				'max_fallbacks'             => isset( $assoc_args['max-fallbacks'] ) ? (int) $assoc_args['max-fallbacks'] : null,
+				'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
+				'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
+				'source_metadata'           => $source_metadata,
 			)
 		);
 
@@ -129,6 +133,25 @@ class Static_Site_Importer_CLI_Command {
 
 		if ( ! $result['quality']['pass'] ) {
 			WP_CLI::warning( 'Conversion quality checks reported issues. Inspect import-report.json for source fragments and diagnostics.' );
+		}
+
+		$failure_reasons       = isset( $result['quality']['failure_reasons'] ) && is_array( $result['quality']['failure_reasons'] ) ? $result['quality']['failure_reasons'] : array();
+		$commerce_dep_failure  = in_array( 'woocommerce_missing', $failure_reasons, true );
+		$allow_missing_woo_cli = isset( $assoc_args['allow-missing-woocommerce'] );
+
+		if ( $commerce_dep_failure && ! empty( $result['quality']['fail_import'] ) ) {
+			WP_CLI::error(
+				sprintf(
+					"WooCommerce is required for this import. The source declared products but WooCommerce is not active.\nInstall and activate WooCommerce, or rerun with --allow-missing-woocommerce to import the theme without seeding products.\nTheme files were written for inspection at: %s\nImport report: %s",
+					$result['theme_dir'],
+					$result['report_path']
+				)
+			);
+			return;
+		}
+
+		if ( $allow_missing_woo_cli ) {
+			WP_CLI::warning( 'WooCommerce dependency check waived via --allow-missing-woocommerce. Products were not seeded.' );
 		}
 
 		if ( ! empty( $result['quality']['fail_import'] ) ) {
@@ -165,6 +188,9 @@ class Static_Site_Importer_CLI_Command {
 	 *
 	 * [--max-fallbacks=<count>]
 	 * : Exit non-zero when unsupported HTML fallback count exceeds this threshold.
+	 *
+	 * [--allow-missing-woocommerce]
+	 * : Allow commerce-bearing imports to proceed when WooCommerce is not active.
 	 *
 	 * [--report=<path>]
 	 * : Copy the generated import report JSON to an external archive path.

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -207,6 +207,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::record_visual_fidelity_targets( $pages, $page_ids, $permalinks, $writes, $theme_dir );
 		self::record_semantic_fidelity_targets( $pages, $page_ids, $permalinks, $writes, $theme_dir );
 		self::record_product_seeding_report( $args );
+		self::record_commerce_dependency_check( $args );
 		$quality     = self::finalize_quality_report( $args );
 		$report_json = wp_json_encode( self::$conversion_report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 		if ( false === $report_json ) {
@@ -3134,6 +3135,7 @@ class Static_Site_Importer_Theme_Generator {
 				'unsafe_svg_count'                   => 0,
 				'svg_materialization_failure_count'  => 0,
 				'svg_sprite_reference_failure_count' => 0,
+				'commerce_dependency_failures'       => 0,
 				'failure_reasons'                    => array(),
 			),
 			'source_documents'        => array(
@@ -4659,6 +4661,126 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Record the WooCommerce dependency check for commerce-bearing imports.
+	 *
+	 * Commerce intent is detected when the import has either a validated
+	 * products.json manifest or any commerce_context (caller-supplied,
+	 * inferred from JSON-LD, or inferred from product cards) carrying at
+	 * least one product. When intent is present, WooCommerce must be active
+	 * or the caller must explicitly waive the requirement via
+	 * allow_missing_woocommerce. Without intent, no commerce.dependencies
+	 * shape is recorded and behavior is unchanged.
+	 *
+	 * @param array<string, mixed> $args Import args.
+	 * @return void
+	 */
+	private static function record_commerce_dependency_check( array $args ): void {
+		$intent = self::commerce_dependency_intent();
+		if ( ! $intent['present'] ) {
+			return;
+		}
+
+		$woocommerce_active = Static_Site_Importer_Woo_Product_Seeder::woocommerce_available();
+		$waived             = ! empty( $args['allow_missing_woocommerce'] );
+
+		$dependencies = array(
+			'woocommerce' => array(
+				'required'      => true,
+				'active'        => $woocommerce_active,
+				'sources'       => $intent['sources'],
+				'product_count' => $intent['product_count'],
+				'waived'        => $waived,
+				'missing_apis'  => $woocommerce_active ? array() : array( 'WC_Product_Simple', 'product_post_type', 'product_cat_taxonomy' ),
+			),
+		);
+
+		if ( ! isset( self::$conversion_report['commerce'] ) || ! is_array( self::$conversion_report['commerce'] ) ) {
+			self::$conversion_report['commerce'] = array();
+		}
+		self::$conversion_report['commerce']['dependencies'] = $dependencies;
+
+		if ( $woocommerce_active ) {
+			self::$conversion_report['diagnostics'][] = array(
+				'code'          => 'woocommerce_present',
+				'severity'      => 'info',
+				'source'        => 'commerce.dependencies.woocommerce',
+				'message'       => 'WooCommerce is active; commerce-bearing import will seed products.',
+				'product_count' => $intent['product_count'],
+				'sources'       => $intent['sources'],
+			);
+			return;
+		}
+
+		if ( $waived ) {
+			self::$conversion_report['diagnostics'][] = array(
+				'code'          => 'woocommerce_waived',
+				'severity'      => 'warning',
+				'source'        => 'commerce.dependencies.woocommerce',
+				'message'       => 'Commerce-bearing import proceeded without WooCommerce because allow_missing_woocommerce was set; products were not seeded.',
+				'product_count' => $intent['product_count'],
+				'sources'       => $intent['sources'],
+			);
+			return;
+		}
+
+		++self::$conversion_report['quality']['commerce_dependency_failures'];
+		self::$conversion_report['diagnostics'][] = array(
+			'code'          => 'woocommerce_missing',
+			'severity'      => 'error',
+			'source'        => 'commerce.dependencies.woocommerce',
+			'message'       => 'WooCommerce is required for this import. The source declared products but WooCommerce is not active. Install and activate WooCommerce, or pass allow_missing_woocommerce to import the theme without seeding products.',
+			'product_count' => $intent['product_count'],
+			'sources'       => $intent['sources'],
+		);
+
+		if ( isset( self::$conversion_report['product_seeding'] ) && is_array( self::$conversion_report['product_seeding'] ) ) {
+			self::$conversion_report['product_seeding']['reason'] = 'woocommerce_required_but_missing';
+		}
+	}
+
+	/**
+	 * Detect commerce intent for the active import.
+	 *
+	 * @return array{present:bool,sources:array<int,string>,product_count:int}
+	 */
+	private static function commerce_dependency_intent(): array {
+		$sources       = array();
+		$product_count = 0;
+
+		$manifest = self::$conversion_report['commerce']['products_manifest'] ?? array();
+		if ( is_array( $manifest ) && true === ( $manifest['valid'] ?? false ) ) {
+			$manifest_count = (int) ( $manifest['product_count'] ?? 0 );
+			if ( $manifest_count > 0 ) {
+				$sources[]     = 'products_manifest';
+				$product_count = $manifest_count;
+			}
+		}
+
+		$context = self::$conversion_report['commerce_context'] ?? array();
+		if ( is_array( $context ) && true === ( $context['supplied'] ?? false ) ) {
+			$context_count = (int) ( $context['product_count'] ?? 0 );
+			if ( $context_count > 0 ) {
+				$source = (string) ( $context['source'] ?? 'commerce_context' );
+				if ( '' === $source ) {
+					$source = 'commerce_context';
+				}
+				if ( ! in_array( $source, $sources, true ) ) {
+					$sources[] = $source;
+				}
+				if ( $context_count > $product_count ) {
+					$product_count = $context_count;
+				}
+			}
+		}
+
+		return array(
+			'present'       => ! empty( $sources ),
+			'sources'       => $sources,
+			'product_count' => $product_count,
+		);
+	}
+
+	/**
 	 * Browser-level visual probes the benchmark harness should run for every target.
 	 *
 	 * @return array<string, array<string, mixed>>
@@ -5319,6 +5441,9 @@ class Static_Site_Importer_Theme_Generator {
 		if ( $quality['svg_sprite_reference_failure_count'] > 0 ) {
 			$reasons[] = 'svg_sprite_reference_failure';
 		}
+		if ( ( $quality['commerce_dependency_failures'] ?? 0 ) > 0 ) {
+			$reasons[] = 'woocommerce_missing';
+		}
 
 		$quality['pass']            = empty( $reasons );
 		$quality['failure_reasons'] = $reasons;
@@ -5327,6 +5452,12 @@ class Static_Site_Importer_Theme_Generator {
 			$quality['fail_import'] = true;
 		}
 		if ( array_key_exists( 'max_fallbacks', $args ) && null !== $args['max_fallbacks'] && $quality['fallback_count'] > (int) $args['max_fallbacks'] ) {
+			$quality['fail_import'] = true;
+		}
+		// Commerce dependency failures are always import-failing regardless of --fail-on-quality.
+		// Silently producing a no-products WordPress site for a commerce import is qualitatively
+		// worse than a layout fallback, so the gate trips even without an explicit failure flag.
+		if ( in_array( 'woocommerce_missing', $reasons, true ) ) {
 			$quality['fail_import'] = true;
 		}
 

--- a/includes/class-static-site-importer-woo-product-seeder.php
+++ b/includes/class-static-site-importer-woo-product-seeder.php
@@ -106,9 +106,12 @@ class Static_Site_Importer_Woo_Product_Seeder {
 	/**
 	 * Determine whether WooCommerce product APIs are available.
 	 *
+	 * Public so the theme generator can run a dependency gate before commerce
+	 * imports proceed without a runtime that can host the seeded products.
+	 *
 	 * @return bool
 	 */
-	private static function woocommerce_available(): bool {
+	public static function woocommerce_available(): bool {
 		return class_exists( 'WC_Product_Simple' ) && post_type_exists( 'product' ) && taxonomy_exists( 'product_cat' );
 	}
 

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -336,6 +336,34 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The CLI command must exit non-zero on quality.fail_import for both human and JSON output.
+	 *
+	 * Regression guard: the JSON branch must not return early before checking fail_import,
+	 * otherwise machine-readable consumers (wc-site-generator, CI harnesses) silently see
+	 * exit 0 on commerce-bearing imports without WooCommerce.
+	 */
+	public function test_cli_command_halts_non_zero_when_fail_import_is_true(): void {
+		$cli_source = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-cli-command.php' );
+		$this->assertIsString( $cli_source );
+
+		// JSON branch must call WP_CLI::halt( 1 ) when fail_import is true so the structured
+		// payload is still emitted but the process exit code is non-zero.
+		$this->assertMatchesRegularExpression(
+			'/\$is_json[\s\S]+?WP_CLI::halt\(\s*1\s*\)/m',
+			$cli_source,
+			'CLI JSON branch must halt(1) on fail_import; otherwise --format=json exits 0 on hard failures.'
+		);
+
+		// Human branch must error out before the success block to avoid printing success
+		// followed by an error line.
+		$this->assertMatchesRegularExpression(
+			'/if\s*\(\s*\$fail_import\s*\)\s*\{[\s\S]+?WP_CLI::error\([\s\S]+?WP_CLI::success\(/m',
+			$cli_source,
+			'CLI human branch must report fail_import via WP_CLI::error before printing the success line.'
+		);
+	}
+
+	/**
 	 * Non-commerce imports are unaffected by the WooCommerce dependency gate.
 	 *
 	 * Imports without a valid products.json and without inferred commerce context must

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -208,6 +208,9 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 
 	/**
 	 * A generated store fixture records valid products.json metadata in the import report only.
+	 *
+	 * When WooCommerce is active, the import succeeds and seeds products. When WooCommerce is
+	 * missing, the import is hard-failed by the dependency gate unless the caller waives it.
 	 */
 	public function test_products_manifest_fixture_records_valid_contract_metadata(): void {
 		$plugin_root = dirname( __DIR__ );
@@ -216,11 +219,14 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
 			$fixture,
 			array(
-				'name'        => 'Generated Store Valid',
-				'slug'        => 'generated-store-valid',
-				'overwrite'   => true,
-				'activate'    => false,
-				'keep_source' => true,
+				'name'                      => 'Generated Store Valid',
+				'slug'                      => 'generated-store-valid',
+				'overwrite'                 => true,
+				'activate'                  => false,
+				'keep_source'                => true,
+				// Waive WC so this manifest-shape test stays focused on contract metadata.
+				// Hard-fail behavior is covered by test_commerce_intent_with_missing_woocommerce_fails_import.
+				'allow_missing_woocommerce' => true,
 			)
 		);
 
@@ -244,12 +250,131 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertSame( '54.00', $manifest['products'][0]['sale_price'] ?? '' );
 		$this->assertSame( array( 'Apparel' ), $manifest['products'][0]['categories'] ?? array() );
 		$this->assertSame( 'assets/signal-hoodie.jpg', $manifest['products'][0]['image'] ?? '' );
+
+		// Dependency gate is recorded for commerce-bearing imports regardless of WC status.
+		$dependencies = $report['commerce']['dependencies']['woocommerce'] ?? array();
+		$this->assertSame( true, $dependencies['required'] ?? null );
+		$this->assertSame( class_exists( 'WC_Product_Simple' ), $dependencies['active'] ?? null );
+		$this->assertContains( 'products_manifest', $dependencies['sources'] ?? array() );
+		$this->assertSame( 2, $dependencies['product_count'] ?? null );
+
 		if ( ! class_exists( 'WC_Product_Simple' ) ) {
+			// Waived path: import succeeds, products are not seeded, waiver diagnostic is recorded.
+			$this->assertNotContains( 'woocommerce_missing', $report['quality']['failure_reasons'] ?? array() );
+			$this->assertEmpty( $report['quality']['fail_import'] ?? null );
+			$this->assertSame( true, $dependencies['waived'] ?? null );
 			$this->assertSame( 'skipped', $report['product_seeding']['status'] ?? '' );
 			$this->assertSame( 'woocommerce_inactive', $report['product_seeding']['reason'] ?? '' );
 			$this->assertSame( array( 'created' => 0, 'updated' => 0, 'skipped' => 2, 'error' => 0 ), $report['product_seeding']['counts'] ?? array() );
 			$this->assertSame( 'signal-hoodie', $report['product_seeding']['products'][0]['slug'] ?? '' );
+
+			$waiver_diagnostics = array_values(
+				array_filter(
+					$report['diagnostics'] ?? array(),
+					static fn ( $diagnostic ): bool => is_array( $diagnostic ) && 'woocommerce_waived' === ( $diagnostic['code'] ?? '' )
+				)
+			);
+			$this->assertNotEmpty( $waiver_diagnostics );
+			$this->assertSame( 'warning', $waiver_diagnostics[0]['severity'] ?? '' );
 		}
+	}
+
+	/**
+	 * Commerce-bearing imports without WooCommerce hard-fail by default.
+	 *
+	 * Theme files are still written so callers can inspect the import report; the gate
+	 * trips fail_import even without --fail-on-quality so silent half-commerce never ships.
+	 */
+	public function test_commerce_intent_with_missing_woocommerce_fails_import(): void {
+		if ( class_exists( 'WC_Product_Simple' ) ) {
+			$this->markTestSkipped( 'Requires a runtime without WooCommerce active.' );
+		}
+
+		$plugin_root = dirname( __DIR__ );
+		$fixture     = $plugin_root . '/tests/fixtures/generated-store-valid/index.html';
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$fixture,
+			array(
+				'name'        => 'Generated Store Hard Fail',
+				'slug'        => 'generated-store-hard-fail',
+				'overwrite'   => true,
+				'activate'    => false,
+				'keep_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertFileExists( $result['report_path'] );
+
+		$report = json_decode( $this->read_file( $result['report_path'] ), true );
+		$this->assertIsArray( $report );
+		$this->assertSame( true, $result['quality']['fail_import'] ?? null );
+		$this->assertContains( 'woocommerce_missing', $result['quality']['failure_reasons'] ?? array() );
+		$this->assertSame( 1, $report['quality']['commerce_dependency_failures'] ?? null );
+		$this->assertSame( false, $result['quality']['pass'] ?? null );
+
+		$dependencies = $report['commerce']['dependencies']['woocommerce'] ?? array();
+		$this->assertSame( true, $dependencies['required'] ?? null );
+		$this->assertSame( false, $dependencies['active'] ?? null );
+		$this->assertSame( false, $dependencies['waived'] ?? null );
+		$this->assertContains( 'products_manifest', $dependencies['sources'] ?? array() );
+		$this->assertSame( 2, $dependencies['product_count'] ?? null );
+
+		$diagnostics = array_values(
+			array_filter(
+				$report['diagnostics'] ?? array(),
+				static fn ( $diagnostic ): bool => is_array( $diagnostic ) && 'woocommerce_missing' === ( $diagnostic['code'] ?? '' )
+			)
+		);
+		$this->assertNotEmpty( $diagnostics );
+		$this->assertSame( 'error', $diagnostics[0]['severity'] ?? '' );
+		$this->assertSame( 2, $diagnostics[0]['product_count'] ?? null );
+
+		$this->assertSame( 'woocommerce_required_but_missing', $report['product_seeding']['reason'] ?? '' );
+	}
+
+	/**
+	 * Non-commerce imports are unaffected by the WooCommerce dependency gate.
+	 *
+	 * Imports without a valid products.json and without inferred commerce context must
+	 * not record a commerce.dependencies block, must not emit dependency diagnostics,
+	 * and must not contribute to commerce_dependency_failures.
+	 */
+	public function test_non_commerce_import_is_not_affected_by_woocommerce_dependency_gate(): void {
+		$plugin_root = dirname( __DIR__ );
+		$fixture     = $plugin_root . '/tests/fixtures/wordpress-is-dead/index.html';
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$fixture,
+			array(
+				'name'        => 'Non-Commerce Import Gate Check',
+				'slug'        => 'non-commerce-import-gate-check',
+				'overwrite'   => true,
+				'activate'    => false,
+				'keep_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$report = json_decode( $this->read_file( $result['report_path'] ), true );
+		$this->assertIsArray( $report );
+		$this->assertArrayNotHasKey( 'dependencies', $report['commerce'] ?? array() );
+		$this->assertSame( 0, $report['quality']['commerce_dependency_failures'] ?? null );
+		$this->assertNotContains( 'woocommerce_missing', $report['quality']['failure_reasons'] ?? array() );
+
+		$dependency_codes = array( 'woocommerce_missing', 'woocommerce_present', 'woocommerce_waived' );
+		foreach ( $report['diagnostics'] ?? array() as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+			$this->assertNotContains( $diagnostic['code'] ?? '', $dependency_codes );
+		}
+
+		$this->assertSame( 'no_validated_manifest', $report['product_seeding']['reason'] ?? '' );
 	}
 
 	/**
@@ -262,11 +387,13 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
 			$fixture,
 			array(
-				'name'        => 'Generated Store Invalid',
-				'slug'        => 'generated-store-invalid',
-				'overwrite'   => true,
-				'activate'    => false,
-				'keep_source' => true,
+				'name'                      => 'Generated Store Invalid',
+				'slug'                      => 'generated-store-invalid',
+				'overwrite'                 => true,
+				'activate'                  => false,
+				'keep_source'               => true,
+				// Invalid manifest never yields commerce intent, but be explicit so the focus stays on manifest validation.
+				'allow_missing_woocommerce' => true,
 			)
 		);
 
@@ -305,11 +432,13 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
 			$fixture,
 			array(
-				'name'        => 'Generated Store Inferred',
-				'slug'        => 'generated-store-inferred',
-				'overwrite'   => true,
-				'activate'    => false,
-				'keep_source' => true,
+				'name'                      => 'Generated Store Inferred',
+				'slug'                      => 'generated-store-inferred',
+				'overwrite'                 => true,
+				'activate'                  => false,
+				'keep_source'               => true,
+				// Inferred commerce context counts as intent; waive WC dependency for this inference test.
+				'allow_missing_woocommerce' => true,
 			)
 		);
 
@@ -350,11 +479,13 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
 			$fixture,
 			array(
-				'name'        => 'JSON LD Store',
-				'slug'        => 'json-ld-store',
-				'overwrite'   => true,
-				'activate'    => false,
-				'keep_source' => true,
+				'name'                      => 'JSON LD Store',
+				'slug'                      => 'json-ld-store',
+				'overwrite'                 => true,
+				'activate'                  => false,
+				'keep_source'               => true,
+				// JSON-LD inference yields commerce intent; waive WC dependency for this inference test.
+				'allow_missing_woocommerce' => true,
 			)
 		);
 
@@ -1699,12 +1830,14 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
 			$html_path,
 			array(
-				'name'             => 'Commerce Context',
-				'slug'             => 'commerce-context',
-				'overwrite'        => true,
-				'activate'         => false,
-				'keep_source'      => true,
-				'commerce_context' => array(
+				'name'                      => 'Commerce Context',
+				'slug'                      => 'commerce-context',
+				'overwrite'                 => true,
+				'activate'                  => false,
+				'keep_source'               => true,
+				// Caller-supplied commerce_context yields commerce intent; waive WC dependency for this forwarding test.
+				'allow_missing_woocommerce' => true,
+				'commerce_context'          => array(
 					'source'   => 'products.json',
 					'products' => array(
 						array(
@@ -1764,11 +1897,13 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
 			$html_path,
 			array(
-				'name'        => 'Raw HTML Store',
-				'slug'        => 'raw-html-store',
-				'overwrite'   => true,
-				'activate'    => false,
-				'keep_source' => true,
+				'name'                      => 'Raw HTML Store',
+				'slug'                      => 'raw-html-store',
+				'overwrite'                 => true,
+				'activate'                  => false,
+				'keep_source'               => true,
+				// HTML-card inference yields commerce intent; waive WC dependency for this inference test.
+				'allow_missing_woocommerce' => true,
 			)
 		);
 		remove_filter( 'bfb_html_to_blocks_args', $args_filter, 10 );
@@ -1813,11 +1948,13 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$result = Static_Site_Importer_Theme_Generator::import_theme(
 			$html_path,
 			array(
-				'name'        => 'Nested Product Prices',
-				'slug'        => 'nested-product-prices',
-				'overwrite'   => true,
-				'activate'    => false,
-				'keep_source' => true,
+				'name'                      => 'Nested Product Prices',
+				'slug'                      => 'nested-product-prices',
+				'overwrite'                 => true,
+				'activate'                  => false,
+				'keep_source'               => true,
+				// HTML-card inference yields commerce intent; waive WC dependency for this inference test.
+				'allow_missing_woocommerce' => true,
 			)
 		);
 


### PR DESCRIPTION
## Summary

Static Site Importer now hard-fails imports that declare commerce intent when WooCommerce is not active. Previously, an import with a valid `products.json` (or inferred commerce context from JSON-LD / visible product cards) would silently produce a no-products WordPress site on a host without WooCommerce — `quality.pass` stayed `true`, `product_seeding` reported `woocommerce_inactive`, and the CLI exited 0. That silent half-commerce behavior is exactly what makes wc-site-generator validation on Playgrounds without WooCommerce slip through.

The new dependency boundary: once SSI sees commerce intent, WooCommerce must be present or the caller must explicitly waive the requirement.

## Behavior change

- **Default**: commerce intent + missing WooCommerce → `quality.fail_import = true`, `failure_reasons[]` contains `woocommerce_missing`, CLI exits non-zero with a structured error message. Theme files are still written for inspection.
- **Waiver**: pass `--allow-missing-woocommerce` (CLI) or `'allow_missing_woocommerce' => true` (PHP). Import succeeds, products are not seeded, a `woocommerce_waived` warning diagnostic is recorded.
- **Non-commerce imports**: completely unaffected — no `commerce.dependencies` block, no dependency diagnostics, no failure reasons.

## Where commerce intent comes from

Centralized in `Static_Site_Importer_Theme_Generator::commerce_dependency_intent()`:

1. valid `products.json` manifest with at least one product (`commerce.products_manifest.valid && product_count > 0`),
2. caller-supplied `commerce_context` carrying products (existing arg or inferred from `json_ld` / `html_cards` strategies via `commerce_context.supplied`).

## Report shape additions

- `commerce.dependencies.woocommerce`: `{required, active, sources, product_count, waived, missing_apis}`.
- `quality.commerce_dependency_failures` counter.
- `quality.failure_reasons[]` may contain `woocommerce_missing`.
- New diagnostic codes: `woocommerce_missing` (error), `woocommerce_present` (info), `woocommerce_waived` (warning).
- `product_seeding.reason` becomes `woocommerce_required_but_missing` when the gate trips without a waiver; legacy `woocommerce_inactive` is preserved under the waiver.

The fail flag is set independently of `--fail-on-quality` because silent half-commerce is qualitatively worse than a layout fallback — the importer would otherwise produce pages referencing non-existent products/cart/checkout.

## CLI exit semantics for both formats

The CLI exits non-zero on `quality.fail_import` regardless of `--format`:

- **`--format=json`**: the structured payload is still emitted on stdout (so wc-site-generator and other parsers can read `quality.fail_import`, `failure_reasons`, and the `commerce.dependencies` block), then `WP_CLI::halt(1)` fires when the gate trips. Machine-readable callers always see exit 0 on success and non-zero on hard failures.
- **Human format**: failure is reported via `WP_CLI::error` *before* the success line, so the output is never "success then error". The waiver warning prints only on the success path.
- A regression test asserts the CLI source has the correct ordering, so we cannot reintroduce an early-return-before-gate-check shape.

## Surfaces touched

- `includes/class-static-site-importer-theme-generator.php`: new `record_commerce_dependency_check()` and `commerce_dependency_intent()` helpers; `new_conversion_report()` initializes the new counter; `finalize_quality_report()` adds the new failure reason and forces `fail_import` for it; orchestration runs the check between `record_product_seeding_report()` and `finalize_quality_report()`.
- `includes/class-static-site-importer-woo-product-seeder.php`: `woocommerce_available()` promoted to `public` so the generator can run the gate without re-implementing detection.
- `includes/class-static-site-importer-cli-command.php`: `--allow-missing-woocommerce` flag; restructured output flow so JSON consumers and human readers both observe non-zero exit on `fail_import`.
- `includes/class-static-site-importer-admin.php`: `handle_import` now checks `quality.fail_import` and surfaces a commerce-specific message via `redirect_error` so admin uploads match the CLI default.
- `README.md`: new "WooCommerce Dependency" section documenting intent detection, the gate, the waiver flag, and `--ensure-woocommerce` as future work.

## Tests

`homeboy test static-site-importer` (run by the agent on the worktree) — **52 passed, 0 failed, 0 skipped, 975 assertions** (Playground PHP-WASM + SQLite).

- New `test_commerce_intent_with_missing_woocommerce_fails_import` — asserts hard-fail path: `fail_import=true`, `failure_reasons` contains `woocommerce_missing`, `commerce_dependency_failures=1`, `commerce.dependencies.woocommerce` block recorded with `active=false, waived=false`, `woocommerce_required_but_missing` reason on `product_seeding`, error-severity diagnostic emitted.
- New `test_cli_command_halts_non_zero_when_fail_import_is_true` — regression guard that loads the CLI source and asserts the JSON branch halts non-zero on `fail_import` and the human branch errors before the success block.
- New `test_non_commerce_import_is_not_affected_by_woocommerce_dependency_gate` — asserts no behavior change for non-commerce imports.
- Updated `test_products_manifest_fixture_records_valid_contract_metadata` — now uses the waiver to stay focused on contract metadata; also asserts the new `commerce.dependencies` block and waiver diagnostic.
- Updated commerce-context, JSON-LD, and HTML-card inference tests to set `allow_missing_woocommerce => true` so they continue to assert their domain-specific behaviors without tripping the new gate.

`homeboy lint static-site-importer --changed-since main` (run by the agent on the worktree) — passed (PHPCS, PHPStan).

## Out of scope

`--ensure-woocommerce` (auto-install WooCommerce at import time) is documented as future work. Operators install WooCommerce explicitly with `wp plugin install woocommerce --activate` and retry.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (claude-opus-4-7)
- **Used for:** Drafted the dependency-gate design, the helper methods on `Theme_Generator`, the CLI flag wiring and the JSON/human output restructure, the admin redirect-error path, the new and updated tests, and the README section. The agent ran `homeboy test` and `homeboy lint --changed-since main` on the worktree; Chris is reviewing.