### PR TITLE
feat(abilities): expose static theme imports

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * WordPress Abilities API integration.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'STATIC_SITE_IMPORTER_ABILITY_CATEGORY' ) ) {
+	define( 'STATIC_SITE_IMPORTER_ABILITY_CATEGORY', 'static-site-importer' );
+}
+
+if ( ! function_exists( 'static_site_importer_register_ability_category' ) ) {
+	/**
+	 * Register the Static Site Importer ability category.
+	 *
+	 * @return void
+	 */
+	function static_site_importer_register_ability_category(): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+
+		wp_register_ability_category(
+			STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
+			array(
+				'label'       => __( 'Static Site Importer', 'static-site-importer' ),
+				'description' => __( 'Static HTML site import capabilities.', 'static-site-importer' ),
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
+	/**
+	 * Register Static Site Importer abilities when the Abilities API is present.
+	 *
+	 * @return void
+	 */
+	function static_site_importer_register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'static-site-importer/import-theme',
+			array(
+				'label'               => __( 'Import Static Site Theme', 'static-site-importer' ),
+				'description'         => __( 'Import a static HTML site entry point as a WordPress block theme.', 'static-site-importer' ),
+				'category'            => STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'html_path'       => array( 'type' => 'string' ),
+						'slug'            => array( 'type' => 'string' ),
+						'name'            => array( 'type' => 'string' ),
+						'activate'        => array( 'type' => 'boolean' ),
+						'overwrite'       => array( 'type' => 'boolean' ),
+						'keep_source'     => array( 'type' => 'boolean' ),
+						'fail_on_quality' => array( 'type' => 'boolean' ),
+						'max_fallbacks'   => array( 'type' => 'integer' ),
+						'report'          => array( 'type' => 'string' ),
+						'source_metadata' => array( 'type' => 'object' ),
+					),
+					'required'   => array( 'html_path' ),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'static_site_importer_ability_import_theme',
+				'permission_callback' => 'static_site_importer_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_permission_callback' ) ) {
+	/**
+	 * Permission callback for site-mutating import abilities.
+	 *
+	 * @return bool
+	 */
+	function static_site_importer_ability_permission_callback(): bool {
+		return ! function_exists( 'current_user_can' ) || current_user_can( 'manage_options' );
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_import_theme' ) ) {
+	/**
+	 * Ability callback for static site theme imports.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>
+	 */
+	function static_site_importer_ability_import_theme( array $input ): array {
+		$html_path = isset( $input['html_path'] ) ? trim( (string) $input['html_path'] ) : '';
+		if ( '' === $html_path ) {
+			return static_site_importer_ability_error( 'static_site_importer_missing_html_path', 'The html_path input is required.' );
+		}
+
+		$args = array(
+			'slug'            => isset( $input['slug'] ) ? (string) $input['slug'] : '',
+			'name'            => isset( $input['name'] ) ? (string) $input['name'] : '',
+			'activate'        => ! empty( $input['activate'] ),
+			'overwrite'       => ! empty( $input['overwrite'] ),
+			'keep_source'     => ! empty( $input['keep_source'] ),
+			'fail_on_quality' => ! empty( $input['fail_on_quality'] ),
+			'max_fallbacks'   => isset( $input['max_fallbacks'] ) ? (int) $input['max_fallbacks'] : null,
+			'report'          => isset( $input['report'] ) ? (string) $input['report'] : '',
+			'source_metadata' => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme( $html_path, $args );
+		if ( is_wp_error( $result ) ) {
+			/** @var WP_Error $result */
+			return static_site_importer_ability_error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
+		}
+
+		return array(
+			'success' => true,
+			'result'  => $result,
+		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_error' ) ) {
+	/**
+	 * Build a structured ability error envelope.
+	 *
+	 * @param string $code    Error code.
+	 * @param string $message Error message.
+	 * @param mixed  $data    Optional error data.
+	 * @return array<string, mixed>
+	 */
+	function static_site_importer_ability_error( string $code, string $message, $data = null ): array {
+		return array(
+			'success' => false,
+			'error'   => array(
+				'code'    => $code,
+				'message' => $message,
+				'data'    => $data,
+			),
+		);
+	}
+}
+
+if ( doing_action( 'wp_abilities_api_categories_init' ) ) {
+	static_site_importer_register_ability_category();
+} elseif ( ! did_action( 'wp_abilities_api_categories_init' ) ) {
+	add_action( 'wp_abilities_api_categories_init', 'static_site_importer_register_ability_category' );
+}
+
+if ( doing_action( 'wp_abilities_api_init' ) ) {
+	static_site_importer_register_abilities();
+} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+	add_action( 'wp_abilities_api_init', 'static_site_importer_register_abilities' );
+}

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -59,11 +59,12 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'name'            => array( 'type' => 'string' ),
 						'activate'        => array( 'type' => 'boolean' ),
 						'overwrite'       => array( 'type' => 'boolean' ),
-						'keep_source'     => array( 'type' => 'boolean' ),
-						'fail_on_quality' => array( 'type' => 'boolean' ),
-						'max_fallbacks'   => array( 'type' => 'integer' ),
-						'report'          => array( 'type' => 'string' ),
-						'source_metadata' => array( 'type' => 'object' ),
+						'keep_source'               => array( 'type' => 'boolean' ),
+						'fail_on_quality'           => array( 'type' => 'boolean' ),
+						'max_fallbacks'             => array( 'type' => 'integer' ),
+						'allow_missing_woocommerce' => array( 'type' => 'boolean' ),
+						'report'                    => array( 'type' => 'string' ),
+						'source_metadata'           => array( 'type' => 'object' ),
 					),
 					'required'   => array( 'html_path' ),
 				),
@@ -83,7 +84,7 @@ if ( ! function_exists( 'static_site_importer_ability_permission_callback' ) ) {
 	 * @return bool
 	 */
 	function static_site_importer_ability_permission_callback(): bool {
-		return ! function_exists( 'current_user_can' ) || current_user_can( 'manage_options' );
+		return ! function_exists( 'current_user_can' ) || current_user_can( 'switch_themes' );
 	}
 }
 
@@ -105,11 +106,12 @@ if ( ! function_exists( 'static_site_importer_ability_import_theme' ) ) {
 			'name'            => isset( $input['name'] ) ? (string) $input['name'] : '',
 			'activate'        => ! empty( $input['activate'] ),
 			'overwrite'       => ! empty( $input['overwrite'] ),
-			'keep_source'     => ! empty( $input['keep_source'] ),
-			'fail_on_quality' => ! empty( $input['fail_on_quality'] ),
-			'max_fallbacks'   => isset( $input['max_fallbacks'] ) ? (int) $input['max_fallbacks'] : null,
-			'report'          => isset( $input['report'] ) ? (string) $input['report'] : '',
-			'source_metadata' => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
+			'keep_source'               => ! empty( $input['keep_source'] ),
+			'fail_on_quality'           => ! empty( $input['fail_on_quality'] ),
+			'max_fallbacks'             => isset( $input['max_fallbacks'] ) ? (int) $input['max_fallbacks'] : null,
+			'allow_missing_woocommerce' => ! empty( $input['allow_missing_woocommerce'] ),
+			'report'                    => isset( $input['report'] ) ? (string) $input['report'] : '',
+			'source_metadata'           => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
 		);
 
 		$result = Static_Site_Importer_Theme_Generator::import_theme( $html_path, $args );

--- a/includes/class-static-site-importer-admin.php
+++ b/includes/class-static-site-importer-admin.php
@@ -185,9 +185,14 @@ class Static_Site_Importer_Admin {
 			self::redirect_error( $entry->get_error_message() );
 		}
 
-		$result = Static_Site_Importer_Theme_Generator::import_theme(
-			$entry['html_path'],
+		$ability = wp_get_ability( 'static-site-importer/import-theme' );
+		if ( ! $ability ) {
+			self::redirect_error( 'Static Site Importer import ability is not registered.' );
+		}
+
+		$ability_result = $ability->execute(
 			array(
+				'html_path'       => $entry['html_path'],
 				'name'            => isset( $_POST['theme_name'] ) ? sanitize_text_field( wp_unslash( $_POST['theme_name'] ) ) : '',
 				'slug'            => isset( $_POST['theme_slug'] ) ? sanitize_title( wp_unslash( $_POST['theme_slug'] ) ) : '',
 				'activate'        => ! empty( $_POST['activate'] ),
@@ -196,9 +201,12 @@ class Static_Site_Importer_Admin {
 			)
 		);
 
-		if ( is_wp_error( $result ) ) {
-			self::redirect_error( $result->get_error_message() );
+		if ( empty( $ability_result['success'] ) ) {
+			$error = isset( $ability_result['error'] ) && is_array( $ability_result['error'] ) ? $ability_result['error'] : array();
+			self::redirect_error( isset( $error['message'] ) ? (string) $error['message'] : 'Static site import failed.' );
 		}
+
+		$result = isset( $ability_result['result'] ) && is_array( $ability_result['result'] ) ? $ability_result['result'] : array();
 
 		if ( ! empty( $result['quality']['fail_import'] ) ) {
 			$failure_reasons = isset( $result['quality']['failure_reasons'] ) && is_array( $result['quality']['failure_reasons'] ) ? $result['quality']['failure_reasons'] : array();

--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -88,9 +88,15 @@ class Static_Site_Importer_CLI_Command {
 			return;
 		}
 
-		$result = Static_Site_Importer_Theme_Generator::import_theme(
-			$html_file,
+		$ability = wp_get_ability( 'static-site-importer/import-theme' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Static Site Importer import ability is not registered.' );
+			return;
+		}
+
+		$ability_result = $ability->execute(
 			array(
+				'html_path'                 => $html_file,
 				'slug'                      => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
 				'name'                      => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
 				'activate'                  => isset( $assoc_args['activate'] ),
@@ -104,10 +110,13 @@ class Static_Site_Importer_CLI_Command {
 			)
 		);
 
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
+		if ( empty( $ability_result['success'] ) ) {
+			$error = isset( $ability_result['error'] ) && is_array( $ability_result['error'] ) ? $ability_result['error'] : array();
+			WP_CLI::error( isset( $error['message'] ) ? (string) $error['message'] : 'Static site import failed.' );
 			return;
 		}
+
+		$result = isset( $ability_result['result'] ) && is_array( $ability_result['result'] ) ? $ability_result['result'] : array();
 
 		$failure_reasons       = isset( $result['quality']['failure_reasons'] ) && is_array( $result['quality']['failure_reasons'] ) ? $result['quality']['failure_reasons'] : array();
 		$commerce_dep_failure  = in_array( 'woocommerce_missing', $failure_reasons, true );

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -27,6 +27,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-so
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-fetcher.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-generator.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/abilities.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-admin.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -4,7 +4,7 @@
  * Description: Import static HTML sites into WordPress pages or block themes using Block Format Bridge.
  * Version: 0.4.0
  * Author: Chris Huber
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP: 8.1
  * Text Domain: static-site-importer
  *

--- a/tests/smoke-import-theme-ability.php
+++ b/tests/smoke-import-theme-ability.php
@@ -36,7 +36,7 @@ if ( ! function_exists( 'wp_register_ability' ) ) {
 
 if ( ! function_exists( 'current_user_can' ) ) {
 	function current_user_can( string $capability ): bool {
-		return 'manage_options' === $capability;
+		return 'switch_themes' === $capability;
 	}
 }
 
@@ -138,11 +138,12 @@ $result = static_site_importer_ability_import_theme(
 		'name'            => 'Fixture Theme',
 		'activate'        => true,
 		'overwrite'       => true,
-		'keep_source'     => true,
-		'fail_on_quality' => true,
-		'max_fallbacks'   => 0,
-		'report'          => '/tmp/report.json',
-		'source_metadata' => array( 'final_url' => 'https://example.com/' ),
+		'keep_source'               => true,
+		'fail_on_quality'           => true,
+		'max_fallbacks'             => 0,
+		'allow_missing_woocommerce' => true,
+		'report'                    => '/tmp/report.json',
+		'source_metadata'           => array( 'final_url' => 'https://example.com/' ),
 	)
 );
 
@@ -152,6 +153,7 @@ $args = Static_Site_Importer_Theme_Generator::$last_call[1] ?? array();
 $assert( 'fixture-theme' === ( $args['slug'] ?? '' ), 'slug-forwarded' );
 $assert( true === ( $args['activate'] ?? false ), 'activate-forwarded' );
 $assert( 0 === ( $args['max_fallbacks'] ?? null ), 'max-fallbacks-forwarded' );
+$assert( true === ( $args['allow_missing_woocommerce'] ?? false ), 'allow-missing-woocommerce-forwarded' );
 $assert( 'https://example.com/' === ( $args['source_metadata']['final_url'] ?? '' ), 'source-metadata-forwarded' );
 
 if ( $failures ) {

--- a/tests/smoke-import-theme-ability.php
+++ b/tests/smoke-import-theme-ability.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Smoke test: static site theme import is exposed as an Ability.
+ *
+ * Run from the repository root:
+ * php tests/smoke-import-theme-ability.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$registered_categories = array();
+$registered_abilities  = array();
+$actions               = array();
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = 'default' ): string {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $name, array $args ): void {
+		$GLOBALS['registered_categories'][ $name ] = $args;
+	}
+}
+
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $name, array $args ): void {
+		$GLOBALS['registered_abilities'][ $name ] = $args;
+	}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $capability ): bool {
+		return 'manage_options' === $capability;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( string $hook ): bool {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook ): int {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable|string $callback ): void {
+		$GLOBALS['actions'][ $hook ][] = $callback;
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private mixed $data;
+
+		public function __construct( string $code, string $message, mixed $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): mixed {
+			return $this->data;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+class Static_Site_Importer_Theme_Generator {
+	public static array $last_call = array();
+
+	public static function import_theme( string $html_path, array $args = array() ): array|WP_Error {
+		self::$last_call = array( $html_path, $args );
+
+		return array(
+			'theme_slug' => $args['slug'],
+			'theme_name' => $args['name'],
+			'report_path' => '/tmp/import-report.json',
+		);
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/abilities.php';
+
+static_site_importer_register_ability_category();
+static_site_importer_register_abilities();
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$assert( isset( $registered_categories['static-site-importer'] ), 'category-registered' );
+$assert( isset( $registered_abilities['static-site-importer/import-theme'] ), 'import-theme-ability-registered' );
+
+$ability = $registered_abilities['static-site-importer/import-theme'] ?? array();
+$assert( 'static_site_importer_ability_import_theme' === ( $ability['execute_callback'] ?? '' ), 'execute-callback' );
+$assert( 'static_site_importer_ability_permission_callback' === ( $ability['permission_callback'] ?? '' ), 'permission-callback' );
+$assert( static_site_importer_ability_permission_callback(), 'permission-requires-manage-options' );
+
+$missing = static_site_importer_ability_import_theme( array() );
+$assert( empty( $missing['success'] ), 'missing-html-path-fails' );
+$assert( 'static_site_importer_missing_html_path' === ( $missing['error']['code'] ?? '' ), 'missing-html-path-error-code' );
+
+$result = static_site_importer_ability_import_theme(
+	array(
+		'html_path'       => '/tmp/source/index.html',
+		'slug'            => 'fixture-theme',
+		'name'            => 'Fixture Theme',
+		'activate'        => true,
+		'overwrite'       => true,
+		'keep_source'     => true,
+		'fail_on_quality' => true,
+		'max_fallbacks'   => 0,
+		'report'          => '/tmp/report.json',
+		'source_metadata' => array( 'final_url' => 'https://example.com/' ),
+	)
+);
+
+$assert( ! empty( $result['success'] ), 'ability-import-succeeds' );
+$assert( '/tmp/source/index.html' === ( Static_Site_Importer_Theme_Generator::$last_call[0] ?? '' ), 'html-path-forwarded' );
+$args = Static_Site_Importer_Theme_Generator::$last_call[1] ?? array();
+$assert( 'fixture-theme' === ( $args['slug'] ?? '' ), 'slug-forwarded' );
+$assert( true === ( $args['activate'] ?? false ), 'activate-forwarded' );
+$assert( 0 === ( $args['max_fallbacks'] ?? null ), 'max-fallbacks-forwarded' );
+$assert( 'https://example.com/' === ( $args['source_metadata']['final_url'] ?? '' ), 'source-metadata-forwarded' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: import theme ability smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-url-import-entry.php
+++ b/tests/smoke-url-import-entry.php
@@ -84,8 +84,12 @@ $assert( str_contains( $fetcher, 'DEFAULT_MAX_BYTES' ), 'max-response-size-prese
 $assert( str_contains( $fetcher, 'text/html' ), 'html-content-type-required' );
 $assert( str_contains( $cli, '[--url=<url>]' ), 'cli-import-theme-url-option-present' );
 $assert( str_contains( $cli, 'public function import_url' ), 'cli-import-url-subcommand-present' );
+$assert( str_contains( $cli, "wp_get_ability( 'static-site-importer/import-theme' )" ), 'cli-import-wraps-ability' );
+$assert( ! str_contains( $cli, 'Static_Site_Importer_Theme_Generator::import_theme' ), 'cli-import-does-not-call-generator-directly' );
 $assert( str_contains( $admin, 'name="static_site_url"' ), 'admin-url-field-present' );
 $assert( str_contains( $admin, "'source_metadata' => $" . "entry['metadata']" ), 'admin-passes-source-metadata' );
+$assert( str_contains( $admin, "wp_get_ability( 'static-site-importer/import-theme' )" ), 'admin-import-wraps-ability' );
+$assert( ! str_contains( $admin, 'Static_Site_Importer_Theme_Generator::import_theme' ), 'admin-import-does-not-call-generator-directly' );
 
 $assert_error( 'ftp://example.com/', 'static_site_importer_url_scheme' );
 $assert_error( 'https://user:pass@example.com/', 'static_site_importer_url_credentials' );


### PR DESCRIPTION
## Summary
- Register a `static-site-importer/import-theme` Ability for static HTML to block-theme imports.
- Use the same structured `success` / `error` envelope as existing conversion abilities.
- Add a smoke test covering registration, permissions, validation, and importer argument forwarding.

## Validation
- `php tests/smoke-import-theme-ability.php`
- `php -l includes/abilities.php && php -l static-site-importer.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added the Ability wrapper and smoke coverage after Chris clarified the Data Machine architecture boundary; Chris directed the Abilities-first design.