### PR TITLE
fix(abilities): allow import ability from WP-CLI

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -84,6 +84,10 @@ if ( ! function_exists( 'static_site_importer_ability_permission_callback' ) ) {
 	 * @return bool
 	 */
 	function static_site_importer_ability_permission_callback(): bool {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return true;
+		}
+
 		return ! function_exists( 'current_user_can' ) || current_user_can( 'switch_themes' );
 	}
 }

--- a/tests/smoke-import-theme-ability.php
+++ b/tests/smoke-import-theme-ability.php
@@ -36,7 +36,7 @@ if ( ! function_exists( 'wp_register_ability' ) ) {
 
 if ( ! function_exists( 'current_user_can' ) ) {
 	function current_user_can( string $capability ): bool {
-		return 'switch_themes' === $capability;
+		return ! empty( $GLOBALS['current_user_can_switch_themes'] ) && 'switch_themes' === $capability;
 	}
 }
 
@@ -125,7 +125,12 @@ $assert( isset( $registered_abilities['static-site-importer/import-theme'] ), 'i
 $ability = $registered_abilities['static-site-importer/import-theme'] ?? array();
 $assert( 'static_site_importer_ability_import_theme' === ( $ability['execute_callback'] ?? '' ), 'execute-callback' );
 $assert( 'static_site_importer_ability_permission_callback' === ( $ability['permission_callback'] ?? '' ), 'permission-callback' );
-$assert( static_site_importer_ability_permission_callback(), 'permission-requires-manage-options' );
+$GLOBALS['current_user_can_switch_themes'] = true;
+$assert( static_site_importer_ability_permission_callback(), 'permission-allows-theme-manager' );
+$GLOBALS['current_user_can_switch_themes'] = false;
+$assert( ! static_site_importer_ability_permission_callback(), 'permission-denies-user-without-theme-cap' );
+define( 'WP_CLI', true );
+$assert( static_site_importer_ability_permission_callback(), 'permission-allows-wp-cli' );
 
 $missing = static_site_importer_ability_import_theme( array() );
 $assert( empty( $missing['success'] ), 'missing-html-path-fails' );


### PR DESCRIPTION
## Summary
- Allow the static theme import Ability to execute under trusted WP-CLI contexts.
- Keep browser/REST permission checks tied to `switch_themes`.
- Extend smoke coverage for theme-manager, denied-user, and WP-CLI permission paths.

## Validation
- `php tests/smoke-import-theme-ability.php && php tests/smoke-url-import-entry.php`
- `php -l includes/abilities.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the downstream WP-CLI ability permission failure and added the minimal permission/test follow-up.