### PR TITLE
fix(cli): handle import ability errors

### DIFF
--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -110,6 +110,11 @@ class Static_Site_Importer_CLI_Command {
 			)
 		);
 
+		if ( is_wp_error( $ability_result ) ) {
+			WP_CLI::error( $ability_result->get_error_message() );
+			return;
+		}
+
 		if ( empty( $ability_result['success'] ) ) {
 			$error = isset( $ability_result['error'] ) && is_array( $ability_result['error'] ) ? $ability_result['error'] : array();
 			WP_CLI::error( isset( $error['message'] ) ? (string) $error['message'] : 'Static site import failed.' );

--- a/tests/smoke-cli-ability-error.php
+++ b/tests/smoke-cli-ability-error.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Smoke test: CLI handles Ability WP_Error results without fataling.
+ *
+ * Run from the repository root:
+ * php tests/smoke-cli-ability-error.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+class WP_Error {
+	private string $message;
+
+	public function __construct( string $code, string $message ) {
+		$this->message = $message;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+}
+
+function is_wp_error( mixed $thing ): bool {
+	return $thing instanceof WP_Error;
+}
+
+function wp_get_ability( string $name ): object|null {
+	if ( 'static-site-importer/import-theme' !== $name ) {
+		return null;
+	}
+
+	return new class() {
+		public function execute( array $args ): WP_Error {
+			return new WP_Error( 'fixture_error', 'Fixture ability failure.' );
+		}
+	};
+}
+
+class WP_CLI {
+	public static function error( string $message ): void {
+		throw new RuntimeException( $message );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-cli-command.php';
+
+$command = new Static_Site_Importer_CLI_Command();
+
+try {
+	$command->import_theme( array( '/tmp/source/index.html' ), array() );
+} catch ( RuntimeException $error ) {
+	if ( 'Fixture ability failure.' !== $error->getMessage() ) {
+		fwrite( STDERR, 'FAIL [wrong-error-message]: ' . $error->getMessage() . "\n" );
+		exit( 1 );
+	}
+
+	echo "OK: CLI ability WP_Error smoke passed (1 assertion)\n";
+	exit( 0 );
+}
+
+fwrite( STDERR, "FAIL [missing-cli-error]\n" );
+exit( 1 );


### PR DESCRIPTION
## Summary
- Handles `WP_Error` results returned by the `static-site-importer/import-theme` Ability in the WP-CLI wrapper.
- Adds a CLI smoke test proving Ability errors are reported through `WP_CLI::error()` instead of fataling with object-as-array access.

## Why
The wc-site-generator static validation bench lane runs SSI through WP-CLI. After the import flow moved behind the Ability, a `WP_Error` response from the Ability caused the CLI wrapper to index the object like an array and fatal before reporting the real import error.

## Validation
- `php tests/smoke-cli-ability-error.php` passed.
- `php tests/smoke-url-import-entry.php` passed.
- `php tests/smoke-import-theme-ability.php` passed.
- `homeboy test --path /Users/chubes/Developer/static-site-importer@fix-cli-ability-wp-error --extension wordpress` passed: 52 tests, 975 assertions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the wc-site-generator validation failure, drafted the CLI guard and smoke coverage, and ran validation for Chris to review.