### PR TITLE
fix(cli): omit absent max fallback ability input

### DIFF
--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -94,21 +94,24 @@ class Static_Site_Importer_CLI_Command {
 			return;
 		}
 
-		$ability_result = $ability->execute(
-			array(
-				'html_path'                 => $html_file,
-				'slug'                      => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
-				'name'                      => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
-				'activate'                  => isset( $assoc_args['activate'] ),
-				'overwrite'                 => isset( $assoc_args['overwrite'] ),
-				'keep_source'               => isset( $assoc_args['keep-source'] ),
-				'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
-				'max_fallbacks'             => isset( $assoc_args['max-fallbacks'] ) ? (int) $assoc_args['max-fallbacks'] : null,
-				'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
-				'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
-				'source_metadata'           => $source_metadata,
-			)
+		$ability_args = array(
+			'html_path'                 => $html_file,
+			'slug'                      => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
+			'name'                      => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
+			'activate'                  => isset( $assoc_args['activate'] ),
+			'overwrite'                 => isset( $assoc_args['overwrite'] ),
+			'keep_source'               => isset( $assoc_args['keep-source'] ),
+			'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
+			'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
+			'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
+			'source_metadata'           => $source_metadata,
 		);
+
+		if ( isset( $assoc_args['max-fallbacks'] ) ) {
+			$ability_args['max_fallbacks'] = (int) $assoc_args['max-fallbacks'];
+		}
+
+		$ability_result = $ability->execute( $ability_args );
 
 		if ( is_wp_error( $ability_result ) ) {
 			WP_CLI::error( $ability_result->get_error_message() );

--- a/tests/smoke-cli-ability-error.php
+++ b/tests/smoke-cli-ability-error.php
@@ -35,6 +35,10 @@ function wp_get_ability( string $name ): object|null {
 
 	return new class() {
 		public function execute( array $args ): WP_Error {
+			if ( array_key_exists( 'max_fallbacks', $args ) ) {
+				throw new RuntimeException( 'max_fallbacks should be omitted when --max-fallbacks is absent.' );
+			}
+
 			return new WP_Error( 'fixture_error', 'Fixture ability failure.' );
 		}
 	};


### PR DESCRIPTION
## Summary
- Omit `max_fallbacks` from the CLI Ability payload when `--max-fallbacks` is not provided, avoiding schema validation failures from `null` values.
- Add smoke coverage that fails if the absent CLI option is sent through to the Ability input.

## Testing
- `php tests/smoke-cli-ability-error.php`
- `php tests/smoke-url-import-entry.php`
- `php tests/smoke-import-theme-ability.php`
- `homeboy test --path /Users/chubes/Developer/static-site-importer@fix-cli-omit-null-max-fallbacks --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CLI Ability schema failure, drafted the focused code/test patch, and ran validation. Chris reviewed and directed the change.