### PR TITLE
Document validation issue coverage

### DIFF
--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -208,6 +208,8 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 
 	/**
 	 * Minimal semantic hero sections import as editable blocks, not freeform fallback.
+	 *
+	 * Covers validation duplicates #173, #174, #176, #177, #178, and #182.
 	 */
 	public function test_simple_main_hero_section_imports_without_freeform_fallback(): void {
 		$fixture_dir = trailingslashit( get_temp_dir() ) . 'static-site-importer-simple-hero-' . wp_generate_uuid4();
@@ -385,6 +387,8 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	 * Regression guard: the JSON branch must not return early before checking fail_import,
 	 * otherwise machine-readable consumers (wc-site-generator, CI harnesses) silently see
 	 * exit 0 on commerce-bearing imports without WooCommerce.
+	 *
+	 * Covers report-summary validation duplicates #180 and #181.
 	 */
 	public function test_cli_command_halts_non_zero_when_fail_import_is_true(): void {
 		$cli_source = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-cli-command.php' );


### PR DESCRIPTION
## Summary
- Document the merged regression coverage for the duplicated simple hero fallback reports.
- Document the merged report-summary coverage for non-zero SSI workload validation reports.
- Use this follow-up PR to close issues that PR #185 fixed before closing references were added.

## Issues
Fixes #180.
Fixes #181.
Fixes #173.
Fixes #174.
Fixes #176.
Fixes #177.
Fixes #178.
Fixes #182.

## Testing
- `homeboy lint static-site-importer --changed-since main`
- `homeboy test static-site-importer -- --filter=StaticSiteImporterFixtureTest`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added follow-up issue coverage annotations and opened the bookkeeping PR after #185 had already merged.