### PR TITLE
Update Block Format Bridge caption figure fix

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "cb1c13dccdb33f603dcec8349685502bee5c6bc3"
+                "reference": "f3f4a3d7d188d68be2b91e33bdfa6224dbdf9fc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/cb1c13dccdb33f603dcec8349685502bee5c6bc3",
-                "reference": "cb1c13dccdb33f603dcec8349685502bee5c6bc3",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/f3f4a3d7d188d68be2b91e33bdfa6224dbdf9fc7",
+                "reference": "f3f4a3d7d188d68be2b91e33bdfa6224dbdf9fc7",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
                 "source": "https://github.com/chubes4/block-format-bridge/tree/main",
                 "issues": "https://github.com/chubes4/block-format-bridge/issues"
             },
-            "time": "2026-05-12T21:34:48+00:00"
+            "time": "2026-05-13T19:54:21+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -2083,11 +2083,15 @@ class HTML_To_Blocks_Transform_Registry
             return self::is_decorative_figure_with_caption($element);
         }, 'transform' => function ($element) {
             $children = $element->get_child_elements();
-            $visual = $children[0];
-            $caption = $children[1];
+            $caption = \end($children);
             $caption_attrs = self::get_block_support_attributes($caption, array('class_name' => \true));
+            $inner_blocks = array();
+            if (\count($children) === 2) {
+                $inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_empty_decorative_group_attributes($children[0]));
+            }
             $caption_attrs['content'] = \trim($caption->get_inner_html());
-            return HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_common_layout_attributes($element), array(HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_empty_decorative_group_attributes($visual)), HTML_To_Blocks_Block_Factory::create_block('core/paragraph', $caption_attrs)));
+            $inner_blocks[] = HTML_To_Blocks_Block_Factory::create_block('core/paragraph', $caption_attrs);
+            return HTML_To_Blocks_Block_Factory::create_block('core/group', self::get_common_layout_attributes($element), $inner_blocks);
         }), array('blockName' => 'core/group', 'priority' => 15, 'isMatch' => function ($element) {
             return self::is_group_element($element);
         }, 'transform' => function ($element, $handler) {
@@ -2982,10 +2986,14 @@ class HTML_To_Blocks_Transform_Registry
             return \false;
         }
         $children = $element->get_child_elements();
-        if (\count($children) !== 2) {
+        if (\count($children) < 1 || \count($children) > 2) {
             return \false;
         }
-        return self::is_empty_decorative_element($children[0]) && 'FIGCAPTION' === $children[1]->get_tag_name() && \trim(wp_strip_all_tags($children[1]->get_inner_html())) !== '';
+        $caption = \end($children);
+        if ('FIGCAPTION' !== $caption->get_tag_name() || \trim(wp_strip_all_tags($caption->get_inner_html())) === '') {
+            return \false;
+        }
+        return \count($children) === 1 || self::is_empty_decorative_element($children[0]);
     }
     /**
      * Checks whether an empty element carries visual background styling.

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-decorative-visual-clusters.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-decorative-visual-clusters.php
@@ -176,6 +176,24 @@ $assert(\str_contains($stars_serialized, 'ss-quote-stars'), 'stars-wrapper-class
 $assert(\str_contains($stars_serialized, '5 out of 5 stars'), 'stars-aria-label-survives', $stars_serialized);
 $assert(\substr_count(\html_entity_decode($star_content, \ENT_QUOTES, 'UTF-8'), '★') === 5, 'five-stars-survive', $star_content);
 $assert(!\in_array('core/html', $stars_names, \true), 'stars-have-no-html-fallback', $stars_serialized);
+$caption_only_figure_html = <<<'HTML'
+<figure class="gallery-tile tile-script"><figcaption>Marked scripts at the table</figcaption></figure>
+HTML;
+$caption_only_figure_blocks = html_to_blocks_raw_handler(['HTML' => $caption_only_figure_html]);
+$caption_only_figure_serialized = serialize_blocks($caption_only_figure_blocks);
+$caption_only_figure_names = $flatten_block_names($caption_only_figure_blocks);
+$assert(\in_array('core/group', $caption_only_figure_names, \true), 'caption-only-figure-becomes-group', $caption_only_figure_serialized);
+$assert(\in_array('core/paragraph', $caption_only_figure_names, \true), 'caption-only-figure-caption-becomes-paragraph', $caption_only_figure_serialized);
+$assert(\str_contains($caption_only_figure_serialized, 'gallery-tile tile-script'), 'caption-only-figure-class-survives', $caption_only_figure_serialized);
+$assert(\str_contains($caption_only_figure_serialized, 'Marked scripts at the table'), 'caption-only-figure-caption-survives', $caption_only_figure_serialized);
+$assert(!\in_array('core/html', $caption_only_figure_names, \true), 'caption-only-figure-has-no-html-fallback', $caption_only_figure_serialized);
+$linked_figure_html = <<<'HTML'
+<figure class="product-card"><a href="/menu">View menu</a><figcaption>Menu tile</figcaption></figure>
+HTML;
+$linked_figure_blocks = html_to_blocks_raw_handler(['HTML' => $linked_figure_html]);
+$linked_figure_names = $flatten_block_names($linked_figure_blocks);
+$linked_figure_serialized = serialize_blocks($linked_figure_blocks);
+$assert(!\in_array('core/group', $linked_figure_names, \true), 'functional-figure-child-does-not-use-decorative-group-transform', $linked_figure_serialized);
 echo 'Assertions: ' . $assertions . \PHP_EOL;
 if (empty($failures)) {
     echo 'ALL PASS' . \PHP_EOL;

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,12 +7,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "cb1c13dccdb33f603dcec8349685502bee5c6bc3"
+                "reference": "f3f4a3d7d188d68be2b91e33bdfa6224dbdf9fc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/cb1c13dccdb33f603dcec8349685502bee5c6bc3",
-                "reference": "cb1c13dccdb33f603dcec8349685502bee5c6bc3",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/f3f4a3d7d188d68be2b91e33bdfa6224dbdf9fc7",
+                "reference": "f3f4a3d7d188d68be2b91e33bdfa6224dbdf9fc7",
                 "shasum": ""
             },
             "require": {
@@ -24,7 +24,7 @@
                 "chubes4/html-to-blocks-converter": "dev-main",
                 "humbug/php-scoper": "^0.18.19"
             },
-            "time": "2026-05-12T21:34:48+00:00",
+            "time": "2026-05-13T19:54:21+00:00",
             "default-branch": true,
             "type": "wordpress-plugin",
             "installation-source": "dist",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '817720fb5f766472b8bd3d44f97c3325fb612901',
+        'reference' => '47a15ddefd881158786394cc2fcef5639ab578c8',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'chubes4/block-format-bridge' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'cb1c13dccdb33f603dcec8349685502bee5c6bc3',
+            'reference' => 'f3f4a3d7d188d68be2b91e33bdfa6224dbdf9fc7',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../chubes4/block-format-bridge',
             'aliases' => array(
@@ -24,7 +24,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '817720fb5f766472b8bd3d44f97c3325fb612901',
+            'reference' => '47a15ddefd881158786394cc2fcef5639ab578c8',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- Update `chubes4/block-format-bridge` to include chubes4/block-format-bridge#105.
- Propagate the caption-only decorative figure transform into Static Site Importer validation/runtime dependencies.

## Testing
- `homeboy test --path /Users/chubes/Developer/static-site-importer@update-bfb-caption-figure --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Propagated the merged BFB dependency update and ran local validation.