### PR TITLE
Add concrete freeform block diagnostics

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -3186,6 +3186,7 @@ class Static_Site_Importer_Theme_Generator {
 			),
 			'generated_theme'         => array(
 				'block_documents' => array(),
+				'freeform_blocks'  => array(),
 			),
 			'visual_fidelity'         => array(
 				'status'             => 'requires_external_render_check',
@@ -5138,10 +5139,12 @@ class Static_Site_Importer_Theme_Generator {
 				}
 				if ( 'core/freeform' === $name ) {
 					++$freeform_count;
+					self::record_generated_freeform_block( $source, array_merge( $path, array( $index ) ), $block, false );
 				}
 			} elseif ( '' !== trim( isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ? $block['innerHTML'] : '' ) ) {
 				++$freeform_count;
 				++$invalid_count;
+				self::record_generated_freeform_block( $source, array_merge( $path, array( $index ) ), $block, true );
 			}
 
 			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
@@ -5177,6 +5180,48 @@ class Static_Site_Importer_Theme_Generator {
 			),
 			$block
 		);
+	}
+
+	/**
+	 * Record an actionable generated freeform block diagnostic.
+	 *
+	 * @param string              $source     Theme-relative source document path.
+	 * @param array<int,int>      $path       Parsed block path.
+	 * @param array<string,mixed> $block      Parsed block.
+	 * @param bool                $malformed  Whether the block parser exposed raw HTML without a block name.
+	 * @return void
+	 */
+	private static function record_generated_freeform_block( string $source, array $path, array $block, bool $malformed ): void {
+		$html = '';
+		if ( isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ) {
+			$html = $block['innerHTML'];
+		}
+
+		$emitted = '';
+		if ( ! $malformed && function_exists( 'serialize_blocks' ) ) {
+			// @phpstan-ignore-next-line argument.type -- Parsed block shape comes from WordPress parse_blocks().
+			$emitted = serialize_blocks( array( $block ) );
+		}
+		if ( '' === trim( $emitted ) ) {
+			$emitted = $html;
+		}
+
+		$entry = self::fallback_diagnostic_entry(
+			'freeform_block',
+			$source,
+			$html,
+			array(
+				'reason' => $malformed ? 'generated_document_contains_malformed_freeform_html' : 'generated_document_contains_core_freeform',
+				'stage'  => 'generated_theme_block_analysis',
+				'path'   => implode( '.', $path ),
+			),
+			$block
+		);
+		$entry['emitted_block_preview'] = self::diagnostic_excerpt( $emitted );
+		$entry['malformed']             = $malformed;
+
+		self::$conversion_report['diagnostics'][]                         = $entry;
+		self::$conversion_report['generated_theme']['freeform_blocks'][] = $entry;
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -2089,9 +2089,19 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$report  = $report_property->getValue();
 
 		$document = $report['generated_theme']['block_documents'][0] ?? array();
+		$freeform_diagnostic = $report['generated_theme']['freeform_blocks'][0] ?? array();
 
 		$this->assertSame( 2, $document['block_count'] ?? null );
 		$this->assertSame( 1, $document['freeform_block_count'] ?? null );
+		$this->assertSame( 'freeform_block', $freeform_diagnostic['type'] ?? '' );
+		$this->assertSame( 'parts/header.html', $freeform_diagnostic['source'] ?? '' );
+		$this->assertSame( '1', $freeform_diagnostic['block_path'] ?? '' );
+		$this->assertSame( 'a.nav-logo', $freeform_diagnostic['selector'] ?? '' );
+		$this->assertSame( 'html-to-blocks-converter', $freeform_diagnostic['converter'] ?? '' );
+		$this->assertSame( 'generated_theme_block_analysis', $freeform_diagnostic['stage'] ?? '' );
+		$this->assertSame( 'generated_document_contains_core_freeform', $freeform_diagnostic['reason'] ?? '' );
+		$this->assertStringContainsString( 'class="nav-logo"', $freeform_diagnostic['source_html_preview'] ?? '' );
+		$this->assertStringContainsString( 'wp:freeform', $freeform_diagnostic['emitted_block_preview'] ?? '' );
 		$this->assertSame( 1, $quality['freeform_block_count'] ?? null );
 		$this->assertFalse( $quality['pass'] ?? true );
 		$this->assertContains( 'freeform_block', $quality['failure_reasons'] ?? array() );


### PR DESCRIPTION
## Summary
- Record generated `core/freeform` blocks as concrete import-report diagnostics with selector, block path, source HTML preview, emitted block preview, converter, stage, and reason.
- Mirror those diagnostics under `generated_theme.freeform_blocks` so downstream validation packet builders can fan out per-block evidence instead of aggregate counts.
- Extend generated-theme quality coverage to assert the concrete diagnostic fields.

## Tests
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/StaticSiteImporterFixtureTest.php`
- `git diff --check`
- `homeboy test --path . --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the diagnostics implementation and regression test; Chris remains responsible for review and merge.