### PR TITLE
Delegate theme part brand anchors to converter

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "7d1e30890c28d2e898f03e5cd0c8d9bf5ebb97ec"
+                "reference": "69a5a8b33cafa0d2ba0517e01d410c16737ea0ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/7d1e30890c28d2e898f03e5cd0c8d9bf5ebb97ec",
-                "reference": "7d1e30890c28d2e898f03e5cd0c8d9bf5ebb97ec",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/69a5a8b33cafa0d2ba0517e01d410c16737ea0ff",
+                "reference": "69a5a8b33cafa0d2ba0517e01d410c16737ea0ff",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
                 "source": "https://github.com/chubes4/block-format-bridge/tree/main",
                 "issues": "https://github.com/chubes4/block-format-bridge/issues"
             },
-            "time": "2026-05-14T20:01:15+00:00"
+            "time": "2026-05-15T12:03:58+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -782,10 +782,6 @@ class Static_Site_Importer_Theme_Generator {
 			return self::link_element_block( $doc, $element );
 		}
 
-		if ( self::should_preserve_theme_part_source_element( $element ) ) {
-			return self::freeform_block( self::node_html( $doc, $element ) );
-		}
-
 		if ( 'img' === $tag ) {
 			return self::image_element_block( $doc, $element );
 		}
@@ -1034,22 +1030,6 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Check whether classed chrome needs exact source element ownership.
-	 *
-	 * @param DOMElement $element Source element.
-	 * @return bool
-	 */
-	private static function should_preserve_theme_part_source_element( DOMElement $element ): bool {
-		$tag = strtolower( $element->tagName );
-		if ( 'div' !== $tag || ! self::element_has_only_phrasing_content( $element ) ) {
-			return false;
-		}
-
-		$class = trim( $element->getAttribute( 'class' ) );
-		return preg_match( '/(^|[-_\s])footer-logo([-_\s]|$)/i', $class ) === 1;
-	}
-
-	/**
 	 * Check whether an element can be represented as one paragraph with inline markup.
 	 *
 	 * @param DOMElement $element Source element.
@@ -1121,21 +1101,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		$class = trim( $element->getAttribute( 'class' ) );
 		if ( preg_match( '/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $class ) ) {
-			$brand_anchor = self::brand_anchor_inline_block( $doc, $element );
-			if ( null !== $brand_anchor ) {
-				return $brand_anchor;
-			}
-
-			if ( ! self::element_has_only_phrasing_content( $element ) ) {
-				return self::logo_anchor_block( $doc, $element, $href, $class );
-			}
-
-			$anchor_attrs = ' href="' . esc_url( $href ) . '"';
-			if ( '' !== $class ) {
-				$anchor_attrs .= ' class="' . esc_attr( $class ) . '"';
-			}
-
-			return self::freeform_block( '<a' . $anchor_attrs . '>' . self::node_inner_html( $doc, $element ) . '</a>' );
+			return self::convert_fragment( self::node_html( $doc, $element ), 'theme-part:brand-anchor' );
 		}
 
 		if ( preg_match( '/(^|[-_\s])(btn|button|cta|pill)([-_\s]|$)/i', $class ) ) {
@@ -1149,170 +1115,6 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return self::paragraph_block( '<a href="' . esc_url( $href ) . '"' . ( '' !== $class ? ' class="' . esc_attr( $class ) . '"' : '' ) . '>' . esc_html( $label ) . '</a>' );
-	}
-
-	/**
-	 * Preserve one brand anchor when block-level logo wrappers can become inline spans.
-	 *
-	 * @param DOMDocument $doc     Source DOM document.
-	 * @param DOMElement  $element Anchor element.
-	 * @return string|null
-	 */
-	private static function brand_anchor_inline_block( DOMDocument $doc, DOMElement $element ): ?string {
-		$inner = self::brand_anchor_inline_children_html( $doc, $element );
-		if ( null === $inner || ( '' === trim( wp_strip_all_tags( $inner ) ) && ! str_contains( strtolower( $inner ), '<img' ) ) ) {
-			return null;
-		}
-
-		if ( ! str_contains( strtolower( $inner ), '<img' ) && empty( self::direct_element_children( $element ) ) ) {
-			return self::paragraph_block( '<a' . self::element_attribute_markup( $element ) . '>' . $inner . '</a>' );
-		}
-
-		return self::freeform_block( '<a' . self::element_attribute_markup( $element ) . '>' . $inner . '</a>' );
-	}
-
-	/**
-	 * Convert a brand anchor's children to valid phrasing HTML.
-	 *
-	 * @param DOMDocument $doc     Source DOM document.
-	 * @param DOMElement  $element Source element.
-	 * @return string|null
-	 */
-	private static function brand_anchor_inline_children_html( DOMDocument $doc, DOMElement $element ): ?string {
-		$parts = array();
-		foreach ( $element->childNodes as $child ) {
-			$part = self::brand_anchor_inline_node_html( $doc, $child );
-			if ( null === $part ) {
-				return null;
-			}
-
-			$parts[] = $part;
-		}
-
-		return implode( '', $parts );
-	}
-
-	/**
-	 * Convert one node to phrasing HTML for a preserved brand anchor.
-	 *
-	 * @param DOMDocument $doc  Source DOM document.
-	 * @param DOMNode     $node Source node.
-	 * @return string|null
-	 */
-	private static function brand_anchor_inline_node_html( DOMDocument $doc, DOMNode $node ): ?string {
-		if ( $node instanceof DOMText ) {
-			return esc_html( $node->textContent );
-		}
-
-		if ( ! $node instanceof DOMElement ) {
-			return '';
-		}
-
-		$tag = strtolower( $node->tagName );
-		if ( 'div' === $tag ) {
-			$inner = self::brand_anchor_inline_children_html( $doc, $node );
-			return null === $inner ? null : '<span' . self::element_attribute_markup( $node ) . '>' . $inner . '</span>';
-		}
-
-		if ( 'img' === $tag ) {
-			return self::node_html( $doc, $node );
-		}
-
-		if ( ! self::is_phrasing_element( $node ) ) {
-			return null;
-		}
-
-		$inner = self::brand_anchor_inline_children_html( $doc, $node );
-		return null === $inner ? null : '<' . $tag . self::element_attribute_markup( $node ) . '>' . $inner . '</' . $tag . '>';
-	}
-
-	/**
-	 * Serialize source attributes for HTML rebuilt from DOM nodes.
-	 *
-	 * @param DOMElement $element Source element.
-	 * @return string
-	 */
-	private static function element_attribute_markup( DOMElement $element ): string {
-		$attributes = '';
-		foreach ( $element->attributes as $attribute ) {
-			$attributes .= ' ' . strtolower( $attribute->name ) . '="' . esc_attr( $attribute->value ) . '"';
-		}
-
-		return $attributes;
-	}
-
-	/**
-	 * Build valid native blocks for a logo anchor that contains image wrappers.
-	 *
-	 * @param DOMDocument $doc        Source DOM document.
-	 * @param DOMElement  $element    Anchor element.
-	 * @param string      $href       Anchor href.
-	 * @param string      $class_name Anchor class attribute.
-	 * @return string
-	 */
-	private static function logo_anchor_block( DOMDocument $doc, DOMElement $element, string $href, string $class_name ): string {
-		$children = array();
-		foreach ( $element->childNodes as $child ) {
-			if ( $child instanceof DOMText ) {
-				$text = trim( $child->textContent );
-				if ( '' !== $text ) {
-					$children[] = self::linked_text_block( $text, $href );
-				}
-				continue;
-			}
-
-			if ( ! $child instanceof DOMElement ) {
-				continue;
-			}
-
-			$img = self::sole_descendant_image( $child );
-			if ( $img instanceof DOMElement ) {
-				$children[] = self::image_element_block( $doc, $img, trim( $child->getAttribute( 'class' ) ), $href );
-				continue;
-			}
-
-			$text = trim( $child->textContent );
-			if ( '' !== $text && self::element_has_only_phrasing_content( $child ) ) {
-				$children[] = self::linked_text_block( $text, $href, trim( $child->getAttribute( 'class' ) ) );
-				continue;
-			}
-
-			$children[] = self::theme_part_element_block( $doc, $child, '', '' );
-		}
-
-		$inner = implode( '', array_filter( $children ) );
-		if ( '' === trim( $inner ) ) {
-			return self::html_block( self::node_html( $doc, $element ) );
-		}
-
-		return self::group_block( $inner, $class_name );
-	}
-
-	/**
-	 * Find a direct or singly wrapped image child.
-	 *
-	 * @param DOMElement $element Source element.
-	 * @return DOMElement|null
-	 */
-	private static function sole_descendant_image( DOMElement $element ): ?DOMElement {
-		if ( 'img' === strtolower( $element->tagName ) ) {
-			return $element;
-		}
-
-		$children = self::direct_element_children( $element );
-		return 1 === count( $children ) && 'img' === strtolower( $children[0]->tagName ) ? $children[0] : null;
-	}
-
-	/**
-	 * Build a paragraph containing a text link.
-	 *
-	 * @param string $text       Link text.
-	 * @param string $href       Link href.
-	 * @param string $class_name Source class attribute.
-	 * @return string
-	 */
-	private static function linked_text_block( string $text, string $href, string $class_name = '' ): string {
-		return self::paragraph_block( '<a href="' . esc_url( $href ) . '">' . esc_html( $text ) . '</a>', $class_name );
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -259,6 +259,54 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Brand anchors in theme parts use the shared converter instead of freeform islands.
+	 */
+	public function test_theme_part_brand_anchors_import_without_freeform_blocks(): void {
+		$fixture_dir = trailingslashit( get_temp_dir() ) . 'static-site-importer-brand-anchor-' . wp_generate_uuid4();
+		$this->assertTrue( wp_mkdir_p( $fixture_dir ) );
+
+		$fixture = trailingslashit( $fixture_dir ) . 'index.html';
+		$wrote   = file_put_contents(
+			$fixture,
+			'<!doctype html><html><head><title>Brand Anchor</title></head><body>' .
+			'<header class="site-header"><div class="header-inner"><a class="brand" href="#top" aria-label="Harbor &amp; Hawthorn Tattoo home"><span>Harbor &amp; Hawthorn</span><small>Tattoo Studio</small></a><nav><a href="#booking">Booking</a></nav></div></header>' .
+			'<main id="top"><section id="booking" class="hero"><h1>Booking</h1><p>Converter-owned brand anchor fixture.</p></section></main>' .
+			'<footer class="site-footer"><div class="footer-inner"><div><a class="brand footer-brand" href="#top"><span class="brand-mark" aria-hidden="true">W</span><span><strong>Wickstead</strong><em>Refill Works</em></span></a></div><ul><li><a href="#booking">Booking</a></li></ul></div></footer>' .
+			'</body></html>'
+		);
+		$this->assertNotFalse( $wrote );
+
+		$result = Static_Site_Importer_Theme_Generator::import_theme(
+			$fixture,
+			array(
+				'name'        => 'Brand Anchor Theme Parts',
+				'slug'        => 'brand-anchor-theme-parts',
+				'overwrite'   => true,
+				'activate'    => false,
+				'keep_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+
+		$header = $this->read_file( $result['theme_dir'] . '/parts/header.html' );
+		$footer = $this->read_file( $result['theme_dir'] . '/parts/footer.html' );
+		$report = json_decode( $this->read_file( $result['report_path'] ), true );
+
+		$this->assertStringContainsString( '<!-- wp:paragraph', $header );
+		$this->assertStringContainsString( 'Harbor &amp; Hawthorn', $header );
+		$this->assertStringContainsString( 'aria-label="Harbor &amp; Hawthorn Tattoo home"', $header );
+		$this->assertStringContainsString( '<!-- wp:paragraph', $footer );
+		$this->assertStringContainsString( '<strong>Wickstead</strong>', $footer );
+		$this->assertStringContainsString( '<em>Refill Works</em>', $footer );
+		$this->assertStringNotContainsString( '<!-- wp:freeform', $header );
+		$this->assertStringNotContainsString( '<!-- wp:freeform', $footer );
+		$this->assertSame( 0, $report['quality']['freeform_block_count'] ?? null );
+		$this->assertSame( 0, $result['import_report_summary']['freeform_block_count'] ?? null );
+	}
+
+	/**
 	 * A generated store fixture records valid products.json metadata in the import report only.
 	 *
 	 * When WooCommerce is active, the import succeeds and seeds products. When WooCommerce is
@@ -831,10 +879,10 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 
 		$this->assertStringNotContainsString( '<!-- wp:html', $header );
 		$this->assertStringNotContainsString( '<!-- wp:html', $footer );
-		$this->assertStringNotContainsString( '<p><a href="#" class="nav-logo">', $header );
-		$this->assertStringNotContainsString( '<p class="footer-logo">HOMEBOY</p>', $footer );
-		$this->assertStringContainsString( '<!-- wp:freeform --><a href="#" class="nav-logo">HOME<span>BOY</span></a><!-- /wp:freeform -->', $header );
-		$this->assertStringContainsString( '<!-- wp:freeform --><div class="footer-logo">HOMEBOY</div><!-- /wp:freeform -->', $footer );
+		$this->assertStringContainsString( '<p><a href="#" class="nav-logo">HOME<span>BOY</span></a></p>', $header );
+		$this->assertStringContainsString( '<p class="footer-logo">HOMEBOY</p>', $footer );
+		$this->assertStringNotContainsString( '<!-- wp:freeform', $header );
+		$this->assertStringNotContainsString( '<!-- wp:freeform', $footer );
 	}
 
 	/**
@@ -1033,10 +1081,10 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$footer    = $this->read_file( $theme_dir . '/parts/footer.html' );
 		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
 
-		$this->assertStringContainsString( '<!-- wp:freeform --><a href="#" class="nav-logo">HOME<span>BOY</span></a><!-- /wp:freeform -->', $header );
-		$this->assertStringNotContainsString( '<p><a href="#" class="nav-logo">HOME<span>BOY</span></a></p>', $header );
-		$this->assertStringNotContainsString( '<!-- wp:paragraph {"className":"footer-logo"} --><p class="footer-logo">HOMEBOY</p>', $footer );
-		$this->assertStringContainsString( '<!-- wp:freeform --><div class="footer-logo">HOMEBOY</div><!-- /wp:freeform -->', $footer );
+		$this->assertStringContainsString( '<p><a href="#" class="nav-logo">HOME<span>BOY</span></a></p>', $header );
+		$this->assertStringContainsString( '<!-- wp:paragraph {"className":"footer-logo"} --><p class="footer-logo">HOMEBOY</p>', $footer );
+		$this->assertStringNotContainsString( '<!-- wp:freeform', $header );
+		$this->assertStringNotContainsString( '<!-- wp:freeform', $footer );
 		$this->assertStringNotContainsString( 'paragraph_wrapper_required_for_identity_anchor', wp_json_encode( $report['diagnostics'] ?? array() ) ?: '' );
 		$this->assertStringNotContainsString( 'native_group_wrapper_preserved_identity_class', wp_json_encode( $report['diagnostics'] ?? array() ) ?: '' );
 	}

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -3176,7 +3176,13 @@ class HTML_To_Blocks_Transform_Registry
      */
     private static function get_paragraph_anchor_content($anchor): string
     {
-        return $anchor->get_outer_html();
+        $html = $anchor->get_outer_html();
+        $class = $anchor->has_attribute('class') ? (string) $anchor->get_attribute('class') : '';
+        if (\preg_match('/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $class)) {
+            $html = \preg_replace('/<\s*div\b([^>]*)>/i', '<span$1>', $html) ?? $html;
+            $html = \preg_replace('/<\s*\/\s*div\s*>/i', '</span>', $html) ?? $html;
+        }
+        return $html;
     }
     /**
      * Checks whether a label is static visual UI text rather than a form label.

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/raw-handler.php
@@ -837,7 +837,7 @@ function html_to_blocks_normalise_blocks($html)
                 if (!$in_paragraph) {
                     $in_paragraph = \true;
                 }
-                $paragraph_buffer .= $element_html;
+                $paragraph_buffer .= html_to_blocks_normalise_phrasing_fragment($element_html);
             }
             continue;
         }
@@ -857,4 +857,18 @@ function html_to_blocks_normalise_blocks($html)
         $output .= '<p>' . \trim($paragraph_buffer) . '</p>';
     }
     return !empty($output) ? $output : $html;
+}
+/**
+ * Normalize standalone phrasing fragments before wrapping them in paragraphs.
+ *
+ * @param string $html HTML fragment.
+ * @return string Normalized fragment.
+ */
+function html_to_blocks_normalise_phrasing_fragment(string $html): string
+{
+    if (\preg_match('/^\s*<\s*a\b[^>]*\sclass=("|\')([^"\']*)\1/i', $html, $matches) && \preg_match('/(^|[-_\s])(brand|logo)([-_\s]|$)/i', $matches[2])) {
+        $html = \preg_replace('/<\s*div\b([^>]*)>/i', '<span$1>', $html) ?? $html;
+        $html = \preg_replace('/<\s*\/\s*div\s*>/i', '</span>', $html) ?? $html;
+    }
+    return $html;
 }

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-branded-link-spans.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-branded-link-spans.php
@@ -115,7 +115,7 @@ $assert = static function ($condition, $label, $detail = '') use (&$failures, &$
         $failures[] = 'FAIL [' . $label . ']' . ('' !== $detail ? ': ' . $detail : '');
     }
 };
-$brand_cases = ['simple-span-brand' => ['html' => '<a class="brand" href="#top" aria-label="Studio Code home"><span class="mark"></span><span>Studio Code</span></a>', 'snippets' => ['href="#top"', 'aria-label="Studio Code home"', 'class="brand"', '<span class="mark"></span>', '<span>Studio Code</span>']], 'formatted-span-brand' => ['html' => '<a class="brand" href="#top" aria-label="Wickstead Refill Works home"><span class="brand-mark" aria-hidden="true">W</span><span><strong>Wickstead</strong><em>Refill Works</em></span></a>', 'snippets' => ['href="#top"', 'aria-label="Wickstead Refill Works home"', 'class="brand"', '<span class="brand-mark" aria-hidden="true">W</span>', '<strong>Wickstead</strong>', '<em>Refill Works</em>']]];
+$brand_cases = ['simple-span-brand' => ['html' => '<a class="brand" href="#top" aria-label="Studio Code home"><span class="mark"></span><span>Studio Code</span></a>', 'snippets' => ['href="#top"', 'aria-label="Studio Code home"', 'class="brand"', '<span class="mark"></span>', '<span>Studio Code</span>']], 'formatted-span-brand' => ['html' => '<a class="brand" href="#top" aria-label="Wickstead Refill Works home"><span class="brand-mark" aria-hidden="true">W</span><span><strong>Wickstead</strong><em>Refill Works</em></span></a>', 'snippets' => ['href="#top"', 'aria-label="Wickstead Refill Works home"', 'class="brand"', '<span class="brand-mark" aria-hidden="true">W</span>', '<strong>Wickstead</strong>', '<em>Refill Works</em>']], 'div-wrapped-logo-brand' => ['html' => '<a class="footer-logo" href="#"><div class="footer-logo-mark"><img src="/logo.svg" alt="" decoding="async" width="16" height="16" aria-hidden="true"></div>Relay Atlas</a>', 'snippets' => ['href="#"', 'class="footer-logo"', '<span class="footer-logo-mark"><img src="/logo.svg" alt="" decoding="async" width="16" height="16" aria-hidden="true"></span>', 'Relay Atlas']]];
 foreach ($brand_cases as $case_name => $case) {
     foreach ([$case['html'], '<!-- wp:freeform -->' . $case['html'] . '<!-- /wp:freeform -->'] as $index => $html) {
         $serialized = serialize_blocks(html_to_blocks_raw_handler(['HTML' => $html]));
@@ -126,6 +126,7 @@ foreach ($brand_cases as $case_name => $case) {
         foreach ($case['snippets'] as $snippet) {
             $assert(\str_contains($serialized, $snippet), $label . '-preserves-' . \md5($snippet), $serialized);
         }
+        $assert(!\str_contains($serialized, '<div'), $label . '-normalizes-block-wrappers', $serialized);
     }
 }
 echo 'Assertions: ' . $assertions . \PHP_EOL;

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,12 +7,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "7d1e30890c28d2e898f03e5cd0c8d9bf5ebb97ec"
+                "reference": "69a5a8b33cafa0d2ba0517e01d410c16737ea0ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/7d1e30890c28d2e898f03e5cd0c8d9bf5ebb97ec",
-                "reference": "7d1e30890c28d2e898f03e5cd0c8d9bf5ebb97ec",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/69a5a8b33cafa0d2ba0517e01d410c16737ea0ff",
+                "reference": "69a5a8b33cafa0d2ba0517e01d410c16737ea0ff",
                 "shasum": ""
             },
             "require": {
@@ -24,7 +24,7 @@
                 "chubes4/html-to-blocks-converter": "dev-main",
                 "humbug/php-scoper": "^0.18.19"
             },
-            "time": "2026-05-14T20:01:15+00:00",
+            "time": "2026-05-15T12:03:58+00:00",
             "default-branch": true,
             "type": "wordpress-plugin",
             "installation-source": "dist",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '0c460709cb2195ac783c9c01e88dd06fe62ed985',
+        'reference' => 'ddeb8fb37fb2ed588f5bc8e39eb6f0ea3a876623',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'chubes4/block-format-bridge' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '7d1e30890c28d2e898f03e5cd0c8d9bf5ebb97ec',
+            'reference' => '69a5a8b33cafa0d2ba0517e01d410c16737ea0ff',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../chubes4/block-format-bridge',
             'aliases' => array(
@@ -24,7 +24,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '0c460709cb2195ac783c9c01e88dd06fe62ed985',
+            'reference' => 'ddeb8fb37fb2ed588f5bc8e39eb6f0ea3a876623',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- Removes SSI-owned freeform preservation for brand/logo anchors and footer-logo identity chrome.
- Delegates brand/logo anchors to Block Format Bridge/html-to-blocks-converter so native block conversion stays upstream.
- Refreshes Block Format Bridge to include the converter fix for brand/logo anchor wrapper normalization.

## Testing
- `homeboy test --path . --extension wordpress`
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/StaticSiteImporterFixtureTest.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-caused the freeform behavior to downstream special-casing, drafted the refactor and regression tests, refreshed the upstream dependency, and ran verification. Chris remains responsible for review and merge decisions.