### PR TITLE
Bump bridge for card label span converter fix

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "ebead69fffec472bd38ca68f4225da936abe6705"
+                "reference": "41c0ca380610acee67a63dc57ad0444813306c54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/ebead69fffec472bd38ca68f4225da936abe6705",
-                "reference": "ebead69fffec472bd38ca68f4225da936abe6705",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/41c0ca380610acee67a63dc57ad0444813306c54",
+                "reference": "41c0ca380610acee67a63dc57ad0444813306c54",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
                 "source": "https://github.com/chubes4/block-format-bridge/tree/main",
                 "issues": "https://github.com/chubes4/block-format-bridge/issues"
             },
-            "time": "2026-05-17T22:09:40+00:00"
+            "time": "2026-05-17T22:33:50+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -737,6 +737,10 @@ class HTML_To_Blocks_Transform_Registry
             return self::is_visual_diagram_span_container($element);
         }, 'transform' => function ($element) {
             return self::create_aria_hidden_inline_span_paragraph($element);
+        }), array('blockName' => 'core/paragraph', 'priority' => 8, 'selector' => 'span', 'isMatch' => function ($element) {
+            return self::is_numeric_label_span($element);
+        }, 'transform' => function ($element) {
+            return self::create_inline_span_label_paragraph($element);
         }), array('blockName' => 'core/group', 'priority' => 8, 'selector' => 'div,p', 'isMatch' => function ($element) {
             return self::is_static_visual_button_container($element);
         }, 'transform' => function ($element) {
@@ -911,6 +915,36 @@ class HTML_To_Blocks_Transform_Registry
         $attributes = self::get_block_support_attributes($element, array('anchor' => \true, 'class_name' => \true, 'colors' => \true, 'typography' => \true, 'spacing' => \true, 'border' => \true));
         $attributes['content'] = $element->get_inner_html();
         return HTML_To_Blocks_Block_Factory::create_block('core/paragraph', $attributes);
+    }
+    /**
+     * Checks whether a standalone span is a numeric visual label.
+     *
+     * Number-only label spans are commonly used as service, step, or index badges.
+     * Keep the span markup inside a native paragraph so class-based presentation
+     * survives without falling back to core/html.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Element to inspect.
+     * @return bool True when the span can safely become paragraph markup.
+     */
+    private static function is_numeric_label_span($element): bool
+    {
+        if ('SPAN' !== $element->get_tag_name() || !$element->has_attribute('class')) {
+            return \false;
+        }
+        if (\preg_match('/<\s*[a-z][^>]*>/i', $element->get_inner_html()) === 1) {
+            return \false;
+        }
+        return \preg_match('/^\d+$/', \trim($element->get_text_content())) === 1;
+    }
+    /**
+     * Creates a paragraph preserving numeric label span markup.
+     *
+     * @param HTML_To_Blocks_HTML_Element $element Numeric label span.
+     * @return array Block array.
+     */
+    private static function create_inline_span_label_paragraph($element): array
+    {
+        return HTML_To_Blocks_Block_Factory::create_block('core/paragraph', array('content' => \trim($element->get_outer_html())));
     }
     /**
      * Checks whether an aria-hidden div is only inline span labels.
@@ -2293,7 +2327,7 @@ class HTML_To_Blocks_Transform_Registry
             }
         }
         if (!empty($options['layout'])) {
-            self::apply_layout_support_attributes($attributes, $classes, $style, $element);
+            self::apply_layout_support_attributes($attributes, $classes, $style);
         }
         return $attributes;
     }
@@ -2410,7 +2444,7 @@ class HTML_To_Blocks_Transform_Registry
      * @param array  $attributes Block attributes.
      * @param string $classes Source class attribute.
      */
-    private static function apply_layout_support_attributes(array &$attributes, string $classes, string $style = '', $element = null): void
+    private static function apply_layout_support_attributes(array &$attributes, string $classes, string $style = ''): void
     {
         if (\preg_match('/(?:^|\s)is-layout-(flow|constrained|flex)(?:\s|$)/i', $classes, $matches)) {
             $type = \strtolower($matches[1]);
@@ -2913,8 +2947,8 @@ class HTML_To_Blocks_Transform_Registry
         if (\in_array($tag, array('OL', 'UL'), \true)) {
             return self::create_list_block_from_element($child);
         }
-        if (self::is_numbered_card_label_span($child)) {
-            return HTML_To_Blocks_Block_Factory::create_block('core/html', array('content' => $child->get_outer_html()));
+        if (self::is_card_label_span($child)) {
+            return self::create_inline_span_label_paragraph($child);
         }
         if ('P' === $tag || 'SPAN' === $tag) {
             return HTML_To_Blocks_Block_Factory::create_block('core/paragraph', \array_merge(self::get_block_support_attributes($child, array('anchor' => \true, 'class_name' => \true)), array('content' => $child->get_inner_html())));
@@ -2925,20 +2959,20 @@ class HTML_To_Blocks_Transform_Registry
         return null;
     }
     /**
-     * Checks whether a card child span is a numbered label that should keep its tag.
+     * Checks whether a card child span is a visual label that should keep its tag.
      *
      * @param HTML_To_Blocks_HTML_Element $child Card child element.
      * @return bool True when the span should remain source HTML.
      */
-    private static function is_numbered_card_label_span($child): bool
+    private static function is_card_label_span($child): bool
     {
         if ('SPAN' !== $child->get_tag_name() || !$child->has_attribute('class')) {
             return \false;
         }
-        if (!self::class_matches($child, '/(?:^|[-_\s])(?:card[-_\s]?number|item[-_\s]?number|service[-_\s]?number)(?:$|[-_\s])/i')) {
-            return \false;
+        if (self::class_matches($child, '/(?:^|[-_\s])(?:card[-_\s]?number|item[-_\s]?number|service[-_\s]?number)(?:$|[-_\s])/i')) {
+            return \preg_match('/^\s*\d{1,3}\s*$/', $child->get_text_content()) === 1;
         }
-        return \preg_match('/^\s*\d{1,3}\s*$/', $child->get_text_content()) === 1;
+        return self::class_matches($child, '/(?:^|\s)tag(?:$|\s)/i');
     }
     /**
      * Gets a single whole-card anchor child when it is the card's only content.

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-action-text-transforms.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-action-text-transforms.php
@@ -230,10 +230,16 @@ $smoke_assert(\strpos($onmouseover_chip_block['innerHTML'], 'onmouseover') === \
 $onclick_submit_button = new HTML_To_Blocks_HTML_Element('button', ['class' => 'tab-btn', 'type' => 'submit', 'onclick' => 'submitForm()'], '<button class="tab-btn" type="submit" onclick="submitForm()">Submit</button>', 'Submit');
 $smoke_assert($find_transform($onclick_submit_button) === null, 'onclick-submit-button-falls-through');
 // -------------------------------------------------------------------------
-// Spans: classed leaf spans preserve source display semantics as fallback HTML.
+// Spans: numeric classed leaf spans become editable paragraph markup.
 // -------------------------------------------------------------------------
 $classed_leaf_span = new HTML_To_Blocks_HTML_Element('span', ['class' => 'service-number'], '<span class="service-number">01</span>', '01');
-$smoke_assert($find_transform($classed_leaf_span) === null, 'classed-leaf-span-falls-through');
+$classed_leaf_span_transform = $find_transform($classed_leaf_span);
+$smoke_assert($classed_leaf_span_transform !== null, 'numeric-classed-leaf-span-has-transform');
+$classed_leaf_span_block = \call_user_func($classed_leaf_span_transform['transform'], $classed_leaf_span);
+$smoke_assert(($classed_leaf_span_block['blockName'] ?? '') === 'core/paragraph', 'numeric-classed-leaf-span-becomes-paragraph');
+$smoke_assert(($classed_leaf_span_block['attrs']['content'] ?? '') === '<span class="service-number">01</span>', 'numeric-classed-leaf-span-preserves-markup');
+$classed_text_span = new HTML_To_Blocks_HTML_Element('span', ['class' => 'service-label'], '<span class="service-label">Repair</span>', 'Repair');
+$smoke_assert($find_transform($classed_text_span) === null, 'classed-text-leaf-span-falls-through');
 // -------------------------------------------------------------------------
 // Labels: static visual UI labels become text, real form labels fall through.
 // -------------------------------------------------------------------------

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-repeated-card-grid-transforms.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-repeated-card-grid-transforms.php
@@ -213,15 +213,16 @@ $assert(!\in_array('core/html', $wrapped_names, \true), 'generic-wrapper-does-no
 $assert(\count($unsupported_fallback_events) === 0, 'generic-wrapper-emits-no-unsupported-fallback-events', (string) \count($unsupported_fallback_events));
 $service_card_grid = <<<'HTML'
 <div class="service-grid">
-  <article class="service-card"><span class="service-number">01</span><h3>Heels &amp; soles</h3><p>Heel lifts and sole patching.</p></article>
-  <article class="service-card"><span class="service-number">02</span><h3>Boot work</h3><p>Waterproofing and zipper repair.</p></article>
+	<article class="service-card"><span class="service-number">01</span><span class="tag">window seats</span><h3>Heels &amp; soles</h3><p>Heel lifts and sole patching.</p></article>
+	<article class="service-card"><span class="service-number">02</span><h3>Boot work</h3><p>Waterproofing and zipper repair.</p></article>
 </div>
 HTML;
 $service_card_blocks = html_to_blocks_raw_handler(['HTML' => $service_card_grid]);
 $service_card_serialized = serialize_blocks($service_card_blocks);
 $service_card_names = $flatten_block_names($service_card_blocks);
-$assert(\in_array('core/html', $service_card_names, \true), 'service-card-classed-span-uses-local-html-island', 'Blocks: ' . \implode(', ', $service_card_names));
+$assert(!\in_array('core/html', $service_card_names, \true), 'service-card-label-spans-avoid-core-html', 'Blocks: ' . \implode(', ', $service_card_names));
 $assert(\strpos($service_card_serialized, '<span class="service-number">01</span>') !== \false, 'service-card-classed-span-preserved', $service_card_serialized);
+$assert(\strpos($service_card_serialized, '<span class="tag">window seats</span>') !== \false, 'service-card-tag-span-preserved', $service_card_serialized);
 $assert(\strpos($service_card_serialized, '<p class="service-number">01</p>') === \false, 'service-card-classed-span-not-rewritten-to-paragraph', $service_card_serialized);
 $assert(\strpos($service_card_serialized, '<h3 class="wp-block-heading">Heels &amp; soles</h3>') !== \false, 'service-card-heading-remains-editable', $service_card_serialized);
 $assert(\strpos($service_card_serialized, '<p>Heel lifts and sole patching.</p>') !== \false, 'service-card-copy-remains-editable', $service_card_serialized);

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,12 +7,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "ebead69fffec472bd38ca68f4225da936abe6705"
+                "reference": "41c0ca380610acee67a63dc57ad0444813306c54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/ebead69fffec472bd38ca68f4225da936abe6705",
-                "reference": "ebead69fffec472bd38ca68f4225da936abe6705",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/41c0ca380610acee67a63dc57ad0444813306c54",
+                "reference": "41c0ca380610acee67a63dc57ad0444813306c54",
                 "shasum": ""
             },
             "require": {
@@ -24,7 +24,7 @@
                 "chubes4/html-to-blocks-converter": "dev-main",
                 "humbug/php-scoper": "^0.18.19"
             },
-            "time": "2026-05-17T22:09:40+00:00",
+            "time": "2026-05-17T22:33:50+00:00",
             "default-branch": true,
             "type": "wordpress-plugin",
             "installation-source": "dist",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'c89a7d57a6ed99678a13003a072761098700d34d',
+        'reference' => '72dbd57947943a1898b3e035c736fdc5dc20007e',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'chubes4/block-format-bridge' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'ebead69fffec472bd38ca68f4225da936abe6705',
+            'reference' => '41c0ca380610acee67a63dc57ad0444813306c54',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../chubes4/block-format-bridge',
             'aliases' => array(
@@ -24,7 +24,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'c89a7d57a6ed99678a13003a072761098700d34d',
+            'reference' => '72dbd57947943a1898b3e035c736fdc5dc20007e',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- Bump block-format-bridge to include the refreshed converter bundle from chubes4/block-format-bridge#109.
- Keep the lockfile focused on the bridge update so importer validation uses the latest card label span handling.

## Testing
- homeboy lint --path \"/Users/chubes/Developer/static-site-importer@bump-block-format-bridge-h2bc\" --extension wordpress --changed-since origin/main
- homeboy test --path \"/Users/chubes/Developer/static-site-importer@bump-block-format-bridge-h2bc\" --extension wordpress --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Dependency bump, scoped validation, and PR description drafting.