### PR TITLE
Bump bridge for inline spacing converter fix

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "41c0ca380610acee67a63dc57ad0444813306c54"
+                "reference": "388c70593881459230755607826febe17748b355"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/41c0ca380610acee67a63dc57ad0444813306c54",
-                "reference": "41c0ca380610acee67a63dc57ad0444813306c54",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/388c70593881459230755607826febe17748b355",
+                "reference": "388c70593881459230755607826febe17748b355",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
                 "source": "https://github.com/chubes4/block-format-bridge/tree/main",
                 "issues": "https://github.com/chubes4/block-format-bridge/issues"
             },
-            "time": "2026-05-17T22:33:50+00:00"
+            "time": "2026-05-17T22:53:01+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/includes/class-transform-registry.php
@@ -944,7 +944,31 @@ class HTML_To_Blocks_Transform_Registry
      */
     private static function create_inline_span_label_paragraph($element): array
     {
-        return HTML_To_Blocks_Block_Factory::create_block('core/paragraph', array('content' => \trim($element->get_outer_html())));
+        $attributes = array('content' => \trim($element->get_outer_html()));
+        self::apply_inline_preservation_paragraph_spacing($attributes);
+        return HTML_To_Blocks_Block_Factory::create_block('core/paragraph', $attributes);
+    }
+    /**
+     * Removes default paragraph margins from paragraphs standing in for inline markup.
+     *
+     * @param array $attributes Paragraph block attributes.
+     */
+    private static function apply_inline_preservation_paragraph_spacing(array &$attributes): void
+    {
+        if (!isset($attributes['style']) || !\is_array($attributes['style'])) {
+            $attributes['style'] = array();
+        }
+        if (!isset($attributes['style']['spacing']) || !\is_array($attributes['style']['spacing'])) {
+            $attributes['style']['spacing'] = array();
+        }
+        if (!isset($attributes['style']['spacing']['margin']) || !\is_array($attributes['style']['spacing']['margin'])) {
+            $attributes['style']['spacing']['margin'] = array();
+        }
+        foreach (array('top', 'right', 'bottom', 'left') as $side) {
+            if (!isset($attributes['style']['spacing']['margin'][$side])) {
+                $attributes['style']['spacing']['margin'][$side] = '0';
+            }
+        }
     }
     /**
      * Checks whether an aria-hidden div is only inline span labels.
@@ -998,6 +1022,7 @@ class HTML_To_Blocks_Transform_Registry
     private static function create_aria_hidden_inline_span_paragraph($element): array
     {
         $attributes = self::get_block_support_attributes($element, array('anchor' => \true, 'class_name' => \true, 'colors' => \true, 'typography' => \true, 'spacing' => \true, 'border' => \true));
+        self::apply_inline_preservation_paragraph_spacing($attributes);
         $attributes['content'] = \trim($element->get_inner_html());
         return HTML_To_Blocks_Block_Factory::create_block('core/paragraph', $attributes);
     }
@@ -1047,6 +1072,7 @@ class HTML_To_Blocks_Transform_Registry
     private static function create_branded_inline_anchor_paragraph($element): array
     {
         $attributes = self::get_block_support_attributes($element, array('anchor' => \true));
+        self::apply_inline_preservation_paragraph_spacing($attributes);
         $attributes['content'] = \trim($element->get_outer_html());
         return HTML_To_Blocks_Block_Factory::create_block('core/paragraph', $attributes);
     }

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-branded-link-spans.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-branded-link-spans.php
@@ -137,6 +137,7 @@ $aria_hidden_span_ruler = serialize_blocks(html_to_blocks_raw_handler(['HTML' =>
 $assert(!\str_contains($aria_hidden_span_ruler, '<!-- wp:html -->'), 'aria-hidden-span-ruler-avoids-core-html', $aria_hidden_span_ruler);
 $assert(\str_contains($aria_hidden_span_ruler, '<!-- wp:paragraph'), 'aria-hidden-span-ruler-uses-paragraph', $aria_hidden_span_ruler);
 $assert(\str_contains($aria_hidden_span_ruler, 'class="ruler"'), 'aria-hidden-span-ruler-preserves-class', $aria_hidden_span_ruler);
+$assert(\str_contains($aria_hidden_span_ruler, 'margin-top:0'), 'aria-hidden-span-ruler-resets-wrapper-margin', $aria_hidden_span_ruler);
 $assert(\str_contains($aria_hidden_span_ruler, '<span>0</span><span>6</span><span>12</span><span>18</span><span>24</span>'), 'aria-hidden-span-ruler-preserves-direct-spans', $aria_hidden_span_ruler);
 $assert(!\str_contains($aria_hidden_span_ruler, '<div class="wp-block-group ruler'), 'aria-hidden-span-ruler-does-not-add-group-wrapper', $aria_hidden_span_ruler);
 $visible_span_group = serialize_blocks(html_to_blocks_raw_handler(['HTML' => '<div class="ruler"><span>0</span><span>6</span></div>']));
@@ -146,6 +147,7 @@ $visible_diagram_span_group = serialize_blocks(html_to_blocks_raw_handler(['HTML
 $assert(!\str_contains($visible_diagram_span_group, '<!-- wp:html -->'), 'visible-diagram-span-container-avoids-core-html', $visible_diagram_span_group);
 $assert(\str_contains($visible_diagram_span_group, '<!-- wp:paragraph'), 'visible-diagram-span-container-uses-paragraph', $visible_diagram_span_group);
 $assert(\str_contains($visible_diagram_span_group, 'class="cushion-diagram"'), 'visible-diagram-span-container-preserves-class', $visible_diagram_span_group);
+$assert(\str_contains($visible_diagram_span_group, 'margin-top:0'), 'visible-diagram-span-container-resets-wrapper-margin', $visible_diagram_span_group);
 $assert(\str_contains($visible_diagram_span_group, '<span class="diagram-label fabric">performance fabric</span> <span class="diagram-label wrap">dacron wrap</span>'), 'visible-diagram-span-container-preserves-direct-spans', $visible_diagram_span_group);
 $visible_diagram_mixed_group = serialize_blocks(html_to_blocks_raw_handler(['HTML' => '<div class="cushion-diagram"><span class="diagram-label fabric">performance fabric</span><em>caption</em></div>']));
 $assert(!\str_contains($visible_diagram_mixed_group, '<!-- wp:paragraph'), 'visible-diagram-mixed-container-does-not-use-span-only-transform', $visible_diagram_mixed_group);

--- a/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-repeated-card-grid-transforms.php
+++ b/vendor/chubes4/block-format-bridge/vendor_prefixed/chubes4/html-to-blocks-converter/tests/smoke-repeated-card-grid-transforms.php
@@ -221,6 +221,7 @@ $service_card_blocks = html_to_blocks_raw_handler(['HTML' => $service_card_grid]
 $service_card_serialized = serialize_blocks($service_card_blocks);
 $service_card_names = $flatten_block_names($service_card_blocks);
 $assert(!\in_array('core/html', $service_card_names, \true), 'service-card-label-spans-avoid-core-html', 'Blocks: ' . \implode(', ', $service_card_names));
+$assert(\strpos($service_card_serialized, 'margin-top:0') !== \false, 'service-card-label-wrapper-resets-margin', $service_card_serialized);
 $assert(\strpos($service_card_serialized, '<span class="service-number">01</span>') !== \false, 'service-card-classed-span-preserved', $service_card_serialized);
 $assert(\strpos($service_card_serialized, '<span class="tag">window seats</span>') !== \false, 'service-card-tag-span-preserved', $service_card_serialized);
 $assert(\strpos($service_card_serialized, '<p class="service-number">01</p>') === \false, 'service-card-classed-span-not-rewritten-to-paragraph', $service_card_serialized);

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,12 +7,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "41c0ca380610acee67a63dc57ad0444813306c54"
+                "reference": "388c70593881459230755607826febe17748b355"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/41c0ca380610acee67a63dc57ad0444813306c54",
-                "reference": "41c0ca380610acee67a63dc57ad0444813306c54",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/388c70593881459230755607826febe17748b355",
+                "reference": "388c70593881459230755607826febe17748b355",
                 "shasum": ""
             },
             "require": {
@@ -24,7 +24,7 @@
                 "chubes4/html-to-blocks-converter": "dev-main",
                 "humbug/php-scoper": "^0.18.19"
             },
-            "time": "2026-05-17T22:33:50+00:00",
+            "time": "2026-05-17T22:53:01+00:00",
             "default-branch": true,
             "type": "wordpress-plugin",
             "installation-source": "dist",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '72dbd57947943a1898b3e035c736fdc5dc20007e',
+        'reference' => 'dfe0e259619d3bcf8f97266ecb7687c124a4f8d4',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'chubes4/block-format-bridge' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '41c0ca380610acee67a63dc57ad0444813306c54',
+            'reference' => '388c70593881459230755607826febe17748b355',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../chubes4/block-format-bridge',
             'aliases' => array(
@@ -24,7 +24,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '72dbd57947943a1898b3e035c736fdc5dc20007e',
+            'reference' => 'dfe0e259619d3bcf8f97266ecb7687c124a4f8d4',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- Bump block-format-bridge to include the refreshed converter bundle from chubes4/block-format-bridge#110.
- Keep the lockfile focused on the bridge update so importer validation uses zero-margin inline preservation paragraphs.

## Testing
- composer update chubes4/block-format-bridge --with-dependencies
- composer update nette/utils --with nette/utils:4.1.3
- Local Homeboy lint/test is currently blocked because this shell's Homeboy registry no longer lists the `wordpress` extension; CI should exercise the normal matrix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Dependency bump, lockfile hygiene, and PR description drafting.