### PR TITLE
Fix late ability registration

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -181,13 +181,13 @@ if ( ! function_exists( 'static_site_importer_failure_report_summary' ) ) {
 	}
 }
 
-if ( doing_action( 'wp_abilities_api_categories_init' ) ) {
+if ( doing_action( 'wp_abilities_api_categories_init' ) || did_action( 'wp_abilities_api_categories_init' ) ) {
 	static_site_importer_register_ability_category();
 } elseif ( ! did_action( 'wp_abilities_api_categories_init' ) ) {
 	add_action( 'wp_abilities_api_categories_init', 'static_site_importer_register_ability_category' );
 }
 
-if ( doing_action( 'wp_abilities_api_init' ) ) {
+if ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) {
 	static_site_importer_register_abilities();
 } elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
 	add_action( 'wp_abilities_api_init', 'static_site_importer_register_abilities' );

--- a/tests/smoke-import-theme-ability.php
+++ b/tests/smoke-import-theme-ability.php
@@ -42,13 +42,13 @@ if ( ! function_exists( 'current_user_can' ) ) {
 
 if ( ! function_exists( 'doing_action' ) ) {
 	function doing_action( string $hook ): bool {
-		return false;
+		return ! empty( $GLOBALS['doing_actions'][ $hook ] );
 	}
 }
 
 if ( ! function_exists( 'did_action' ) ) {
 	function did_action( string $hook ): int {
-		return 0;
+		return (int) ( $GLOBALS['did_actions'][ $hook ] ?? 0 );
 	}
 }
 
@@ -107,11 +107,9 @@ class Static_Site_Importer_Theme_Generator {
 		);
 	}
 }
-
+$GLOBALS['did_actions']['wp_abilities_api_categories_init'] = 1;
+$GLOBALS['did_actions']['wp_abilities_api_init']            = 1;
 require_once dirname( __DIR__ ) . '/includes/abilities.php';
-
-static_site_importer_register_ability_category();
-static_site_importer_register_abilities();
 
 $assertions = 0;
 $failures   = array();
@@ -122,6 +120,12 @@ $assert = static function ( bool $condition, string $label, string $detail = '' 
 		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
 	}
 };
+
+$assert( isset( $registered_categories['static-site-importer'] ), 'category-registers-after-api-init' );
+$assert( isset( $registered_abilities['static-site-importer/import-theme'] ), 'ability-registers-after-api-init' );
+
+static_site_importer_register_ability_category();
+static_site_importer_register_abilities();
 
 $assert( isset( $registered_categories['static-site-importer'] ), 'category-registered' );
 $assert( isset( $registered_abilities['static-site-importer/import-theme'] ), 'import-theme-ability-registered' );


### PR DESCRIPTION
## Summary
- Register Static Site Importer abilities immediately when the Abilities API init hooks have already fired.
- Add smoke coverage for plugins activated after the ability initialization pass.

## Testing
- `php tests/smoke-import-theme-ability.php`
- `php -l includes/abilities.php`
- `php -l tests/smoke-import-theme-ability.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the late-registration failure from Studio Web browser eval artifacts and drafted the focused fix and smoke coverage; Chris remains responsible for review and merge.