### PR TITLE
Add static-site export ability

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -74,6 +74,36 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);
+
+		wp_register_ability(
+			'static-site-importer/export-theme',
+			array(
+				'label'               => __( 'Export Static Site Theme', 'static-site-importer' ),
+				'description'         => __( 'Export an imported or active block theme and page content as static-site artifacts.', 'static-site-importer' ),
+				'category'            => STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'theme_slug'      => array( 'type' => 'string' ),
+						'entrypoint'      => array( 'type' => 'string' ),
+						'include_pages'   => array(
+							'oneOf' => array(
+								array( 'type' => 'boolean' ),
+								array(
+									'type'  => 'array',
+									'items' => array( 'type' => array( 'integer', 'string' ) ),
+								),
+							),
+						),
+						'source_metadata' => array( 'type' => 'object' ),
+					),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'static_site_importer_ability_export_theme',
+				'permission_callback' => 'static_site_importer_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
 	}
 }
 
@@ -89,6 +119,34 @@ if ( ! function_exists( 'static_site_importer_ability_permission_callback' ) ) {
 		}
 
 		return ! function_exists( 'current_user_can' ) || current_user_can( 'switch_themes' );
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_export_theme' ) ) {
+	/**
+	 * Ability callback for static site theme exports.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>
+	 */
+	function static_site_importer_ability_export_theme( array $input ): array {
+		$args = array(
+			'theme_slug'      => isset( $input['theme_slug'] ) ? (string) $input['theme_slug'] : '',
+			'entrypoint'      => isset( $input['entrypoint'] ) ? (string) $input['entrypoint'] : 'static-site/index.html',
+			'include_pages'   => $input['include_pages'] ?? true,
+			'source_metadata' => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::export_theme( $args );
+		if ( is_wp_error( $result ) ) {
+			/** @var WP_Error $result */
+			return static_site_importer_ability_error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
+		}
+
+		return array_merge(
+			array( 'success' => true ),
+			$result
+		);
 	}
 }
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -286,6 +286,398 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Export an imported or active block theme as static-site artifacts.
+	 *
+	 * @param array $args Export args.
+	 * @return array{artifact_set:array<string,mixed>,files:array<int,array<string,mixed>>,report:array<string,mixed>}|WP_Error
+	 */
+	public static function export_theme( array $args = array() ) {
+		if ( ! function_exists( 'bfb_convert' ) ) {
+			return new WP_Error( 'static_site_importer_missing_bfb', 'Block Format Bridge is required to export a static site.' );
+		}
+
+		$theme_slug = isset( $args['theme_slug'] ) && '' !== trim( (string) $args['theme_slug'] ) ? sanitize_title( (string) $args['theme_slug'] ) : self::active_theme_slug();
+		if ( '' === $theme_slug ) {
+			return new WP_Error( 'static_site_importer_missing_theme_slug', 'A theme_slug input is required when no active theme can be detected.' );
+		}
+
+		$theme_dir = self::export_theme_dir( $theme_slug );
+		if ( '' === $theme_dir || ! is_dir( $theme_dir ) ) {
+			return new WP_Error( 'static_site_importer_theme_not_found', sprintf( 'Theme directory not found for %s.', $theme_slug ) );
+		}
+
+		$entrypoint      = self::export_artifact_path( isset( $args['entrypoint'] ) ? (string) $args['entrypoint'] : 'static-site/index.html', 'static-site/index.html' );
+		$include_pages   = $args['include_pages'] ?? true;
+		$source_metadata = isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array();
+		$diagnostics     = array();
+		$files           = array();
+
+		$stylesheet = self::export_theme_stylesheet_file( $theme_dir );
+		if ( null !== $stylesheet ) {
+			$files[] = $stylesheet;
+		}
+
+		$pages = self::export_pages( $include_pages );
+		if ( empty( $pages ) ) {
+			$diagnostics[] = array(
+				'level'   => 'warning',
+				'code'    => 'static_site_importer_export_no_pages',
+				'message' => 'No published pages were available to export; generated an entrypoint from theme templates only.',
+			);
+			$files[] = self::export_file_entry(
+				$entrypoint,
+				self::export_html_document( '', self::export_theme_chrome_html( $theme_dir, 'front-page' ), $theme_slug, null !== $stylesheet ),
+				'document',
+				'entrypoint'
+			);
+		} else {
+			$front_page_id = self::export_front_page_id();
+			$first         = true;
+			foreach ( $pages as $page ) {
+				$page_id   = isset( $page->ID ) ? (int) $page->ID : 0;
+				$is_front  = $first || ( $front_page_id > 0 && $page_id === $front_page_id );
+				$path      = $is_front ? $entrypoint : self::export_page_artifact_path( $page );
+				$template  = $is_front ? 'front-page' : 'page';
+				$page_html = bfb_convert( isset( $page->post_content ) ? (string) $page->post_content : '', 'blocks', 'html' );
+
+				$files[] = self::export_file_entry(
+					$path,
+					self::export_html_document( $page_html, self::export_theme_chrome_html( $theme_dir, $template ), self::export_page_title( $page, $theme_slug ), null !== $stylesheet ),
+					'document',
+					$is_front ? 'entrypoint' : 'page',
+					array(
+						'post_id'   => $page_id,
+						'post_name' => isset( $page->post_name ) ? (string) $page->post_name : '',
+					)
+				);
+
+				$first = false;
+			}
+		}
+
+		$import_report = self::read_theme_import_report( $theme_dir );
+		$report        = array(
+			'status'          => 'completed',
+			'theme_slug'      => $theme_slug,
+			'theme_dir'       => $theme_dir,
+			'entrypoint'      => $entrypoint,
+			'file_count'      => count( $files ),
+			'page_count'      => count( $pages ),
+			'source_metadata' => $source_metadata,
+			'diagnostics'     => $diagnostics,
+		);
+		if ( ! empty( $import_report ) ) {
+			$report['import_report'] = $import_report;
+		}
+
+		return array(
+			'artifact_set' => array(
+				'schema'     => 'static-site-importer/static-site-artifact-set/v1',
+				'theme_slug' => $theme_slug,
+				'entrypoint' => $entrypoint,
+				'files'      => $files,
+				'report'     => $report,
+			),
+			'files'        => $files,
+			'report'       => $report,
+		);
+	}
+
+	/**
+	 * Resolve the active theme slug.
+	 *
+	 * @return string
+	 */
+	private static function active_theme_slug(): string {
+		if ( function_exists( 'get_stylesheet' ) ) {
+			return sanitize_title( (string) get_stylesheet() );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Resolve a theme directory for export.
+	 *
+	 * @param string $theme_slug Theme slug.
+	 * @return string
+	 */
+	private static function export_theme_dir( string $theme_slug ): string {
+		if ( function_exists( 'wp_get_theme' ) ) {
+			$theme = wp_get_theme( $theme_slug );
+			if ( is_object( $theme ) && method_exists( $theme, 'exists' ) && $theme->exists() && method_exists( $theme, 'get_stylesheet_directory' ) ) {
+				return (string) $theme->get_stylesheet_directory();
+			}
+		}
+
+		if ( function_exists( 'get_theme_root' ) ) {
+			return trailingslashit( get_theme_root( $theme_slug ) ) . $theme_slug;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get published pages selected by include_pages.
+	 *
+	 * @param mixed $include_pages Include pages argument.
+	 * @return array<int,object>
+	 */
+	private static function export_pages( $include_pages ): array {
+		if ( false === $include_pages || ! function_exists( 'get_posts' ) ) {
+			$page = self::export_front_page();
+			return null === $page ? array() : array( $page );
+		}
+
+		$pages = get_posts(
+			array(
+				'post_type'      => 'page',
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'orderby'        => 'menu_order title',
+				'order'          => 'ASC',
+			)
+		);
+		if ( ! is_array( $pages ) ) {
+			return array();
+		}
+
+		if ( ! is_array( $include_pages ) || empty( $include_pages ) ) {
+			return array_values( $pages );
+		}
+
+		$allowed = array_fill_keys( array_map( 'strval', $include_pages ), true );
+		return array_values(
+			array_filter(
+				$pages,
+				static function ( $page ) use ( $allowed ): bool {
+					$page_id   = isset( $page->ID ) ? (string) $page->ID : '';
+					$page_slug = isset( $page->post_name ) ? (string) $page->post_name : '';
+					return isset( $allowed[ $page_id ] ) || isset( $allowed[ $page_slug ] );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Get the configured front page post.
+	 *
+	 * @return object|null
+	 */
+	private static function export_front_page(): ?object {
+		$front_page_id = self::export_front_page_id();
+		if ( $front_page_id > 0 && function_exists( 'get_post' ) ) {
+			$page = get_post( $front_page_id );
+			if ( is_object( $page ) ) {
+				return $page;
+			}
+		}
+
+		if ( ! function_exists( 'get_posts' ) ) {
+			return null;
+		}
+
+		$pages = get_posts(
+			array(
+				'post_type'      => 'page',
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'orderby'        => 'menu_order title',
+				'order'          => 'ASC',
+			)
+		);
+
+		return is_array( $pages ) && isset( $pages[0] ) && is_object( $pages[0] ) ? $pages[0] : null;
+	}
+
+	/**
+	 * Get the configured front page ID.
+	 *
+	 * @return int
+	 */
+	private static function export_front_page_id(): int {
+		if ( ! function_exists( 'get_option' ) || 'page' !== get_option( 'show_on_front' ) ) {
+			return 0;
+		}
+
+		return (int) get_option( 'page_on_front' );
+	}
+
+	/**
+	 * Convert template parts around exported page content.
+	 *
+	 * @param string $theme_dir Theme directory.
+	 * @param string $template  Template slug.
+	 * @return array{before:string,after:string}
+	 */
+	private static function export_theme_chrome_html( string $theme_dir, string $template ): array {
+		$before = self::convert_theme_block_file_to_html( $theme_dir . '/parts/header.html' );
+		$after  = self::convert_theme_block_file_to_html( $theme_dir . '/parts/footer.html' );
+
+		$template_html = self::read_file_if_readable( $theme_dir . '/templates/' . $template . '.html' );
+		if ( '' === $template_html && 'front-page' !== $template ) {
+			$template_html = self::read_file_if_readable( $theme_dir . '/templates/index.html' );
+		}
+
+		if ( '' !== $template_html ) {
+			$converted_template = bfb_convert( $template_html, 'blocks', 'html' );
+			if ( '' !== trim( $converted_template ) && '' === trim( $before . $after ) ) {
+				$before = $converted_template;
+			}
+		}
+
+		return array(
+			'before' => $before,
+			'after'  => $after,
+		);
+	}
+
+	/**
+	 * Convert a block markup file to HTML.
+	 *
+	 * @param string $path File path.
+	 * @return string
+	 */
+	private static function convert_theme_block_file_to_html( string $path ): string {
+		$content = self::read_file_if_readable( $path );
+		return '' === $content ? '' : bfb_convert( $content, 'blocks', 'html' );
+	}
+
+	/**
+	 * Read a file when available.
+	 *
+	 * @param string $path File path.
+	 * @return string
+	 */
+	private static function read_file_if_readable( string $path ): string {
+		if ( ! is_readable( $path ) ) {
+			return '';
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads local generated theme artifacts for export.
+		$content = file_get_contents( $path );
+		return false === $content ? '' : (string) $content;
+	}
+
+	/**
+	 * Build a full static HTML document.
+	 *
+	 * @param string                    $page_html       Converted page body HTML.
+	 * @param array{before:string,after:string} $chrome          Converted theme chrome.
+	 * @param string                    $title           Document title.
+	 * @param bool                      $include_styles  Whether to link exported CSS.
+	 * @return string
+	 */
+	private static function export_html_document( string $page_html, array $chrome, string $title, bool $include_styles ): string {
+		$head = '<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">';
+		if ( $include_styles ) {
+			$head .= '<link rel="stylesheet" href="style.css">';
+		}
+
+		return '<!doctype html>' . "\n"
+			. '<html><head>' . $head . '<title>' . esc_html( $title ) . '</title></head><body>' . "\n"
+			. trim( (string) ( $chrome['before'] ?? '' ) . "\n" . $page_html . "\n" . ( $chrome['after'] ?? '' ) ) . "\n"
+			. '</body></html>' . "\n";
+	}
+
+	/**
+	 * Build an artifact file entry.
+	 *
+	 * @param string              $path        Artifact path.
+	 * @param string              $content     File content.
+	 * @param string              $kind        File kind.
+	 * @param string              $role        File role.
+	 * @param array<string,mixed> $diagnostics Optional diagnostics/metadata.
+	 * @return array<string,mixed>
+	 */
+	private static function export_file_entry( string $path, string $content, string $kind, string $role, array $diagnostics = array() ): array {
+		$entry = array(
+			'path'    => $path,
+			'content' => $content,
+			'kind'    => $kind,
+			'role'    => $role,
+		);
+		if ( ! empty( $diagnostics ) ) {
+			$entry['diagnostics'] = $diagnostics;
+		}
+
+		return $entry;
+	}
+
+	/**
+	 * Export the theme stylesheet when present.
+	 *
+	 * @param string $theme_dir Theme directory.
+	 * @return array<string,mixed>|null
+	 */
+	private static function export_theme_stylesheet_file( string $theme_dir ): ?array {
+		$content = self::read_file_if_readable( $theme_dir . '/style.css' );
+		if ( '' === $content ) {
+			return null;
+		}
+
+		return self::export_file_entry( 'static-site/style.css', $content, 'asset', 'stylesheet' );
+	}
+
+	/**
+	 * Normalize an exported artifact path.
+	 *
+	 * @param string $path     Requested path.
+	 * @param string $fallback Fallback path.
+	 * @return string
+	 */
+	private static function export_artifact_path( string $path, string $fallback ): string {
+		$path = self::normalize_route_path( $path );
+		if ( '' === $path || str_ends_with( $path, '/' ) ) {
+			return $fallback;
+		}
+
+		return $path;
+	}
+
+	/**
+	 * Build a page artifact path.
+	 *
+	 * @param object $page Page object.
+	 * @return string
+	 */
+	private static function export_page_artifact_path( object $page ): string {
+		$slug = isset( $page->post_name ) && '' !== trim( (string) $page->post_name ) ? sanitize_title( (string) $page->post_name ) : 'page-' . ( isset( $page->ID ) ? (int) $page->ID : uniqid() );
+		return self::export_artifact_path( 'static-site/' . $slug . '/index.html', 'static-site/page/index.html' );
+	}
+
+	/**
+	 * Resolve a page title for export.
+	 *
+	 * @param object $page       Page object.
+	 * @param string $theme_slug Fallback theme slug.
+	 * @return string
+	 */
+	private static function export_page_title( object $page, string $theme_slug ): string {
+		if ( isset( $page->post_title ) && '' !== trim( (string) $page->post_title ) ) {
+			return (string) $page->post_title;
+		}
+
+		return $theme_slug;
+	}
+
+	/**
+	 * Read the import report bundled with an SSI-generated theme.
+	 *
+	 * @param string $theme_dir Theme directory.
+	 * @return array<string,mixed>
+	 */
+	private static function read_theme_import_report( string $theme_dir ): array {
+		$report = self::read_file_if_readable( $theme_dir . '/import-report.json' );
+		if ( '' === $report ) {
+			return array();
+		}
+
+		$decoded = json_decode( $report, true );
+		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/**
 	 * Collect importable source pages from a static site directory.
 	 *
 	 * @param string $site_dir Site directory.

--- a/tests/smoke-export-theme-ability.php
+++ b/tests/smoke-export-theme-ability.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Smoke test: an imported block theme can export static-site artifacts.
+ *
+ * Run from the repository root:
+ * php tests/smoke-export-theme-ability.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$theme_root = sys_get_temp_dir() . '/ssi-export-theme-' . uniqid();
+$theme_dir  = $theme_root . '/fixture-theme';
+
+mkdir( $theme_dir . '/parts', 0777, true );
+mkdir( $theme_dir . '/templates', 0777, true );
+file_put_contents( $theme_dir . '/style.css', 'body{background:#fff;}' );
+file_put_contents( $theme_dir . '/parts/header.html', '<!-- wp:paragraph --><p>Header</p><!-- /wp:paragraph -->' );
+file_put_contents( $theme_dir . '/parts/footer.html', '<!-- wp:paragraph --><p>Footer</p><!-- /wp:paragraph -->' );
+file_put_contents( $theme_dir . '/templates/front-page.html', '<!-- wp:post-content /-->' );
+file_put_contents( $theme_dir . '/import-report.json', '{"status":"completed"}' );
+
+$GLOBALS['ssi_export_theme_root'] = $theme_root;
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private mixed $data;
+
+		public function __construct( string $code, string $message, mixed $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): mixed {
+			return $this->data;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		return trim( strtolower( preg_replace( '/[^a-z0-9]+/', '-', $title ) ), '-' );
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $path ): string {
+		return rtrim( $path, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( string $text ): string {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'wp_get_theme' ) ) {
+	function wp_get_theme( string $slug ): object {
+		$dir = $GLOBALS['ssi_export_theme_root'] . '/' . $slug;
+
+		return new class( $dir ) {
+			private string $dir;
+
+			public function __construct( string $dir ) {
+				$this->dir = $dir;
+			}
+
+			public function exists(): bool {
+				return is_dir( $this->dir );
+			}
+
+			public function get_stylesheet_directory(): string {
+				return $this->dir;
+			}
+		};
+	}
+}
+
+if ( ! function_exists( 'get_theme_root' ) ) {
+	function get_theme_root( string $stylesheet = '' ): string {
+		return $GLOBALS['ssi_export_theme_root'];
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $name ) {
+		return 'show_on_front' === $name ? 'page' : ( 'page_on_front' === $name ? 42 : '' );
+	}
+}
+
+if ( ! function_exists( 'get_posts' ) ) {
+	function get_posts( array $args ): array {
+		return array(
+			(object) array(
+				'ID'           => 42,
+				'post_name'    => 'home',
+				'post_title'   => 'Edited Home',
+				'post_content' => '<!-- wp:paragraph --><p>Edited Playground content</p><!-- /wp:paragraph -->',
+			),
+		);
+	}
+}
+
+if ( ! function_exists( 'bfb_convert' ) ) {
+	function bfb_convert( string $content, string $from, string $to ): string {
+		return str_replace( array( '<!-- wp:paragraph -->', '<!-- /wp:paragraph -->', '<!-- wp:post-content /-->' ), '', $content );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php';
+
+$result = Static_Site_Importer_Theme_Generator::export_theme(
+	array(
+		'theme_slug'      => 'fixture-theme',
+		'entrypoint'      => 'static-site/index.html',
+		'include_pages'   => true,
+		'source_metadata' => array( 'source' => 'smoke' ),
+	)
+);
+
+assert( ! is_wp_error( $result ) );
+assert( 'static-site-importer/static-site-artifact-set/v1' === $result['artifact_set']['schema'] );
+assert( 'static-site/index.html' === $result['artifact_set']['entrypoint'] );
+assert( 2 === count( $result['files'] ) );
+assert( 'static-site/style.css' === $result['files'][0]['path'] );
+assert( 'static-site/index.html' === $result['files'][1]['path'] );
+assert( str_contains( $result['files'][1]['content'], 'Edited Playground content' ) );
+assert( str_contains( $result['files'][1]['content'], '<link rel="stylesheet" href="style.css">' ) );
+assert( 'completed' === $result['report']['status'] );
+assert( 'smoke' === $result['report']['source_metadata']['source'] );
+assert( 'completed' === $result['report']['import_report']['status'] );
+
+echo "OK: export theme ability smoke passed\n";

--- a/tests/smoke-import-theme-ability.php
+++ b/tests/smoke-import-theme-ability.php
@@ -106,6 +106,34 @@ class Static_Site_Importer_Theme_Generator {
 			),
 		);
 	}
+
+	public static function export_theme( array $args = array() ): array|WP_Error {
+		self::$last_call = array( 'export', $args );
+
+		return array(
+			'artifact_set' => array(
+				'schema'     => 'static-site-importer/static-site-artifact-set/v1',
+				'entrypoint' => $args['entrypoint'],
+				'files'      => array(
+					array(
+						'path'    => $args['entrypoint'],
+						'content' => '<!doctype html><html><body>Fixture</body></html>',
+						'kind'    => 'document',
+						'role'    => 'entrypoint',
+					),
+				),
+			),
+			'files'        => array(
+				array(
+					'path'    => $args['entrypoint'],
+					'content' => '<!doctype html><html><body>Fixture</body></html>',
+					'kind'    => 'document',
+					'role'    => 'entrypoint',
+				),
+			),
+			'report'       => array( 'status' => 'completed' ),
+		);
+}
 }
 $GLOBALS['did_actions']['wp_abilities_api_categories_init'] = 1;
 $GLOBALS['did_actions']['wp_abilities_api_init']            = 1;
@@ -123,12 +151,14 @@ $assert = static function ( bool $condition, string $label, string $detail = '' 
 
 $assert( isset( $registered_categories['static-site-importer'] ), 'category-registers-after-api-init' );
 $assert( isset( $registered_abilities['static-site-importer/import-theme'] ), 'ability-registers-after-api-init' );
+$assert( isset( $registered_abilities['static-site-importer/export-theme'] ), 'export-ability-registers-after-api-init' );
 
 static_site_importer_register_ability_category();
 static_site_importer_register_abilities();
 
 $assert( isset( $registered_categories['static-site-importer'] ), 'category-registered' );
 $assert( isset( $registered_abilities['static-site-importer/import-theme'] ), 'import-theme-ability-registered' );
+$assert( isset( $registered_abilities['static-site-importer/export-theme'] ), 'export-theme-ability-registered' );
 
 $ability = $registered_abilities['static-site-importer/import-theme'] ?? array();
 $assert( 'static_site_importer_ability_import_theme' === ( $ability['execute_callback'] ?? '' ), 'execute-callback' );
@@ -171,6 +201,22 @@ $assert( true === ( $args['activate'] ?? false ), 'activate-forwarded' );
 $assert( 0 === ( $args['max_fallbacks'] ?? null ), 'max-fallbacks-forwarded' );
 $assert( true === ( $args['allow_missing_woocommerce'] ?? false ), 'allow-missing-woocommerce-forwarded' );
 $assert( 'https://example.com/' === ( $args['source_metadata']['final_url'] ?? '' ), 'source-metadata-forwarded' );
+
+$export_ability = $registered_abilities['static-site-importer/export-theme'] ?? array();
+$assert( 'static_site_importer_ability_export_theme' === ( $export_ability['execute_callback'] ?? '' ), 'export-execute-callback' );
+$export = static_site_importer_ability_export_theme(
+	array(
+		'theme_slug'      => 'fixture-theme',
+		'entrypoint'      => 'static-site/index.html',
+		'include_pages'   => false,
+		'source_metadata' => array( 'source' => 'smoke' ),
+	)
+);
+$assert( ! empty( $export['success'] ), 'ability-export-succeeds' );
+$assert( 'static-site/index.html' === ( $export['artifact_set']['entrypoint'] ?? '' ), 'ability-export-includes-entrypoint' );
+$export_args = Static_Site_Importer_Theme_Generator::$last_call[1] ?? array();
+$assert( 'fixture-theme' === ( $export_args['theme_slug'] ?? '' ), 'export-theme-slug-forwarded' );
+$assert( false === ( $export_args['include_pages'] ?? true ), 'export-include-pages-forwarded' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- Registers `static-site-importer/export-theme` through the WordPress Abilities API.
- Exports the active/imported block theme and published page content into static-site artifact files.
- Adds smoke coverage for ability registration and a basic theme/page export path.

## Verification
- `php -l includes/abilities.php && php -l includes/class-static-site-importer-theme-generator.php && php -l tests/smoke-import-theme-ability.php && php tests/smoke-import-theme-ability.php`
- `php -l tests/smoke-export-theme-ability.php && php tests/smoke-export-theme-ability.php`

## Related
- Fixes #250
- Unblocks Studio Web capture flow: https://github.a8c.com/chubes4/studio-web/issues/99

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the export ability contract and smoke tests; Chris remains responsible for review and merge.