### PR TITLE
Fix static export ability smoke coverage

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -443,11 +443,11 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		if ( ! is_array( $include_pages ) || empty( $include_pages ) ) {
-			return array_values( $pages );
+			return self::order_front_page_first( array_values( $pages ) );
 		}
 
 		$allowed = array_fill_keys( array_map( 'strval', $include_pages ), true );
-		return array_values(
+		return self::order_front_page_first( array_values(
 			array_filter(
 				$pages,
 				static function ( $page ) use ( $allowed ): bool {
@@ -456,7 +456,35 @@ class Static_Site_Importer_Theme_Generator {
 					return isset( $allowed[ $page_id ] ) || isset( $allowed[ $page_slug ] );
 				}
 			)
+		) );
+	}
+
+	/**
+	 * Order exported pages so the configured front page becomes the entrypoint.
+	 *
+	 * @param array<int,object> $pages Pages.
+	 * @return array<int,object>
+	 */
+	private static function order_front_page_first( array $pages ): array {
+		$front_page_id = self::export_front_page_id();
+		if ( $front_page_id <= 0 ) {
+			return $pages;
+		}
+
+		usort(
+			$pages,
+			static function ( object $left, object $right ) use ( $front_page_id ): int {
+				$left_is_front  = isset( $left->ID ) && (int) $left->ID === $front_page_id;
+				$right_is_front = isset( $right->ID ) && (int) $right->ID === $front_page_id;
+				if ( $left_is_front === $right_is_front ) {
+					return 0;
+				}
+
+				return $left_is_front ? -1 : 1;
+			}
 		);
+
+		return $pages;
 	}
 
 	/**

--- a/tests/smoke-cli-ability-error.php
+++ b/tests/smoke-cli-ability-error.php
@@ -13,10 +13,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class WP_Error {
+	private string $code;
 	private string $message;
 
 	public function __construct( string $code, string $message ) {
+		$this->code    = $code;
 		$this->message = $message;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
 	}
 
 	public function get_error_message(): string {

--- a/tests/smoke-export-theme-ability.php
+++ b/tests/smoke-export-theme-ability.php
@@ -24,6 +24,19 @@ file_put_contents( $theme_dir . '/templates/front-page.html', '<!-- wp:post-cont
 file_put_contents( $theme_dir . '/import-report.json', '{"status":"completed"}' );
 
 $GLOBALS['ssi_export_theme_root'] = $theme_root;
+$GLOBALS['ssi_export_bfb_calls']  = array();
+register_shutdown_function(
+	static function () use ( $theme_root ): void {
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $theme_root, FilesystemIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $iterator as $path ) {
+			$path->isDir() ? rmdir( $path->getPathname() ) : unlink( $path->getPathname() );
+		}
+		rmdir( $theme_root );
+	}
+);
 
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
@@ -124,6 +137,7 @@ if ( ! function_exists( 'get_posts' ) ) {
 
 if ( ! function_exists( 'bfb_convert' ) ) {
 	function bfb_convert( string $content, string $from, string $to ): string {
+		$GLOBALS['ssi_export_bfb_calls'][] = array( $from, $to );
 		return str_replace( array( '<!-- wp:paragraph -->', '<!-- /wp:paragraph -->', '<!-- wp:post-content /-->' ), '', $content );
 	}
 }
@@ -138,17 +152,34 @@ $result = Static_Site_Importer_Theme_Generator::export_theme(
 		'source_metadata' => array( 'source' => 'smoke' ),
 	)
 );
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	$assertions++;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
 
-assert( ! is_wp_error( $result ) );
-assert( 'static-site-importer/static-site-artifact-set/v1' === $result['artifact_set']['schema'] );
-assert( 'static-site/index.html' === $result['artifact_set']['entrypoint'] );
-assert( 2 === count( $result['files'] ) );
-assert( 'static-site/style.css' === $result['files'][0]['path'] );
-assert( 'static-site/index.html' === $result['files'][1]['path'] );
-assert( str_contains( $result['files'][1]['content'], 'Edited Playground content' ) );
-assert( str_contains( $result['files'][1]['content'], '<link rel="stylesheet" href="style.css">' ) );
-assert( 'completed' === $result['report']['status'] );
-assert( 'smoke' === $result['report']['source_metadata']['source'] );
-assert( 'completed' === $result['report']['import_report']['status'] );
+$assert( ! is_wp_error( $result ), 'export-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+$assert( 'static-site-importer/static-site-artifact-set/v1' === ( $result['artifact_set']['schema'] ?? '' ), 'artifact-set-schema' );
+$assert( 'static-site/index.html' === ( $result['artifact_set']['entrypoint'] ?? '' ), 'entrypoint' );
+$assert( 2 === count( $result['files'] ?? array() ), 'exports-entrypoint-and-stylesheet' );
+$assert( 'static-site/style.css' === ( $result['files'][0]['path'] ?? '' ), 'stylesheet-exported' );
+$assert( 'static-site/index.html' === ( $result['files'][1]['path'] ?? '' ), 'entrypoint-exported' );
+$assert( str_contains( (string) ( $result['files'][1]['content'] ?? '' ), 'Edited Playground content' ), 'page-content-converted' );
+$assert( str_contains( (string) ( $result['files'][1]['content'] ?? '' ), '<link rel="stylesheet" href="style.css">' ), 'stylesheet-linked' );
+$assert( 'completed' === ( $result['report']['status'] ?? '' ), 'report-completed' );
+$assert( 'smoke' === ( $result['report']['source_metadata']['source'] ?? '' ), 'source-metadata-preserved' );
+$assert( 'completed' === ( $result['report']['import_report']['status'] ?? '' ), 'import-report-preserved' );
+$assert( count( $GLOBALS['ssi_export_bfb_calls'] ) >= 4, 'bfb-called-for-block-to-html' );
+foreach ( $GLOBALS['ssi_export_bfb_calls'] as $call ) {
+	$assert( 'blocks' === $call[0] && 'html' === $call[1], 'bfb-call-uses-blocks-to-html' );
+}
 
-echo "OK: export theme ability smoke passed\n";
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: export theme ability smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Orders exported pages so the configured front page is emitted as the static-site entrypoint when exporting multiple pages.
- Hardens export-theme smoke coverage so assertions run independently of PHP assert settings and proves BFB is used for blocks-to-HTML conversion.
- Updates the CLI ability WP_Error smoke stub to match the CLI command's current error-code handling.

Follow-up to #250 and #251.

## Verification
- `php -l includes/abilities.php && php -l includes/class-static-site-importer-theme-generator.php && php -l tests/smoke-import-theme-ability.php && php -l tests/smoke-export-theme-ability.php && php -l tests/smoke-cli-ability-error.php && php tests/smoke-import-theme-ability.php && php tests/smoke-export-theme-ability.php && php tests/smoke-cli-ability-error.php` passed.
- `npm run test:validation` failed in existing fixture fidelity coverage after import/admin/editor smokes passed; latest run stopped on `EADDRINUSE 127.0.0.1:61551`, and an earlier run reached existing footer fixture assertions unrelated to this export follow-up.
- `npm run test:js-block-validation` failed with existing `TypeError: Cannot convert undefined or null to object` after reporting `Block validation failed: 1 invalid block(s) in 0 file(s)`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the follow-up export ordering and smoke coverage fixes, plus running targeted verification. Chris remains responsible for review and merge.