### PR TITLE
Wire block artifact compiler into imports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,15 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "php": "^8.1",
+    "chubes4/block-artifact-compiler": "dev-main",
     "chubes4/block-format-bridge": "dev-main"
   },
   "repositories": [
+    {
+      "name": "block-artifact-compiler",
+      "type": "vcs",
+      "url": "https://github.com/chubes4/block-artifact-compiler"
+    },
     {
       "type": "vcs",
       "url": "https://github.com/chubes4/block-format-bridge"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "php": "^8.1",
-    "chubes4/block-artifact-compiler": "dev-robust-artifact-boundary",
+    "chubes4/block-artifact-compiler": "dev-main",
     "chubes4/block-format-bridge": "dev-main"
   },
   "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "php": "^8.1",
-    "chubes4/block-artifact-compiler": "dev-main",
+    "chubes4/block-artifact-compiler": "dev-robust-artifact-boundary",
     "chubes4/block-format-bridge": "dev-main"
   },
   "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,47 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcd56b6003628ff42dd20f417bba9b7f",
+    "content-hash": "a31209c0c6954ef362d0b085e0385e70",
     "packages": [
+        {
+            "name": "chubes4/block-artifact-compiler",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chubes4/block-artifact-compiler.git",
+                "reference": "6c946d56e7615ee2ac1b46c8595e63438f461ee0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/6c946d56e7615ee2ac1b46c8595e63438f461ee0",
+                "reference": "6c946d56e7615ee2ac1b46c8595e63438f461ee0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "default-branch": true,
+            "type": "wordpress-plugin",
+            "autoload": {
+                "files": [
+                    "library.php"
+                ]
+            },
+            "scripts": {
+                "test": [
+                    "php tests/contract-smoke.php"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Compile website artifacts into WordPress-native block artifact bundles.",
+            "support": {
+                "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
+                "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
+            },
+            "time": "2026-05-31T02:36:31+00:00"
+        },
         {
             "name": "chubes4/block-format-bridge",
             "version": "dev-main",
@@ -779,6 +818,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "chubes4/block-artifact-compiler": 20,
         "chubes4/block-format-bridge": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,25 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a31209c0c6954ef362d0b085e0385e70",
+    "content-hash": "dfdbbd488d55af639b7c26f89a88e08c",
     "packages": [
         {
             "name": "chubes4/block-artifact-compiler",
-            "version": "dev-main",
+            "version": "dev-robust-artifact-boundary",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "6c946d56e7615ee2ac1b46c8595e63438f461ee0"
+                "reference": "76a96a85e79491dcd28de277f0f2874209a8d1ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/6c946d56e7615ee2ac1b46c8595e63438f461ee0",
-                "reference": "6c946d56e7615ee2ac1b46c8595e63438f461ee0",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/76a96a85e79491dcd28de277f0f2874209a8d1ad",
+                "reference": "76a96a85e79491dcd28de277f0f2874209a8d1ad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
-            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "files": [
@@ -40,10 +39,10 @@
             ],
             "description": "Compile website artifacts into WordPress-native block artifact bundles.",
             "support": {
-                "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
+                "source": "https://github.com/chubes4/block-artifact-compiler/tree/robust-artifact-boundary",
                 "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
             },
-            "time": "2026-05-31T02:36:31+00:00"
+            "time": "2026-05-31T02:47:38+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/composer.lock
+++ b/composer.lock
@@ -4,25 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dfdbbd488d55af639b7c26f89a88e08c",
+    "content-hash": "a31209c0c6954ef362d0b085e0385e70",
     "packages": [
         {
             "name": "chubes4/block-artifact-compiler",
-            "version": "dev-robust-artifact-boundary",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "76a96a85e79491dcd28de277f0f2874209a8d1ad"
+                "reference": "098b74f84b458b1bc75c89fa333291dc186e5fa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/76a96a85e79491dcd28de277f0f2874209a8d1ad",
-                "reference": "76a96a85e79491dcd28de277f0f2874209a8d1ad",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/098b74f84b458b1bc75c89fa333291dc186e5fa1",
+                "reference": "098b74f84b458b1bc75c89fa333291dc186e5fa1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
+            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "files": [
@@ -39,10 +40,10 @@
             ],
             "description": "Compile website artifacts into WordPress-native block artifact bundles.",
             "support": {
-                "source": "https://github.com/chubes4/block-artifact-compiler/tree/robust-artifact-boundary",
+                "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
                 "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
             },
-            "time": "2026-05-31T02:47:38+00:00"
+            "time": "2026-05-31T02:58:07+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -3275,8 +3275,8 @@ class Static_Site_Importer_Theme_Generator {
 		add_action( 'html_to_blocks_conversion_aborted_content_loss', $content_loss_listener, 10, 2 );
 		add_action( 'bfb_conversion_metadata', $commerce_metadata_listener, 10, 1 );
 		add_action( 'bfb_materialization_request', $commerce_request_listener, 10, 1 );
-		// @phpstan-ignore-next-line function.notFound -- Loaded by the bundled Block Format Bridge runtime.
-		$blocks = empty( self::$active_commerce_context ) ? bfb_convert( $html, $format, 'blocks' ) : bfb_convert( $html, $format, 'blocks', self::conversion_options( $source ) );
+		$conversion_options = empty( self::$active_commerce_context ) ? array() : self::conversion_options( $source );
+		$blocks             = self::compile_fragment_to_blocks( $html, $source, $format, $conversion_options );
 		remove_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10 );
 		remove_action( 'html_to_blocks_conversion_aborted_content_loss', $content_loss_listener, 10 );
 		remove_action( 'bfb_conversion_metadata', $commerce_metadata_listener, 10 );
@@ -3289,6 +3289,86 @@ class Static_Site_Importer_Theme_Generator {
 		self::finish_conversion_fragment( $source, $blocks );
 
 		return '' === $blocks ? '<!-- wp:html -->' . "\n" . $html . "\n" . '<!-- /wp:html -->' : $blocks;
+	}
+
+	/**
+	 * Compile one source fragment into serialized block markup.
+	 *
+	 * Block Artifact Compiler owns the semantic artifact envelope. SSI remains the
+	 * materializer and falls back to BFB directly when the compiler is unavailable.
+	 *
+	 * @param string               $html    Source fragment.
+	 * @param string               $source  Source label.
+	 * @param string               $format  Source format.
+	 * @param array<string, mixed> $options Conversion options.
+	 * @return string Serialized block markup.
+	 */
+	private static function compile_fragment_to_blocks( string $html, string $source, string $format, array $options ): string {
+		if ( 'html' === $format && function_exists( 'bac_compile_website_artifact' ) ) {
+			$compiled = bac_compile_website_artifact(
+				array(
+					'files' => array(
+						array(
+							'path'    => self::compiler_fragment_path( $source ),
+							'kind'    => 'html',
+							'content' => $html,
+						),
+					),
+				),
+				$options
+			);
+			self::record_block_artifact_compiler_result( $source, $compiled );
+
+			$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+			$markup    = isset( $artifacts['block_markup'] ) ? (string) $artifacts['block_markup'] : '';
+			if ( '' !== trim( $markup ) || 'failed' !== (string) ( $compiled['status'] ?? '' ) ) {
+				return $markup;
+			}
+		}
+
+		// @phpstan-ignore-next-line function.notFound -- Loaded by the bundled Block Format Bridge runtime.
+		return (string) bfb_convert( $html, $format, 'blocks', $options );
+	}
+
+	/**
+	 * Build a stable virtual source path for compiler fragment input.
+	 *
+	 * @param string $source Source label.
+	 * @return string Virtual path.
+	 */
+	private static function compiler_fragment_path( string $source ): string {
+		$path = sanitize_title( str_replace( array( ':', '/', '\\' ), '-', $source ) );
+		return ( '' === $path ? 'fragment' : $path ) . '.html';
+	}
+
+	/**
+	 * Record a compact Block Artifact Compiler summary on the import report.
+	 *
+	 * @param string              $source   Source label.
+	 * @param array<string,mixed> $compiled Compiler result envelope.
+	 * @return void
+	 */
+	private static function record_block_artifact_compiler_result( string $source, array $compiled ): void {
+		$artifacts   = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$block_types = isset( $artifacts['block_types'] ) && is_array( $artifacts['block_types'] ) ? $artifacts['block_types'] : array();
+		$files       = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
+		$diagnostics = isset( $compiled['diagnostics'] ) && is_array( $compiled['diagnostics'] ) ? $compiled['diagnostics'] : array();
+		$summary     = array(
+			'source'           => $source,
+			'schema'           => isset( $compiled['schema'] ) ? (string) $compiled['schema'] : '',
+			'status'           => isset( $compiled['status'] ) ? (string) $compiled['status'] : '',
+			'block_type_count' => count( $block_types ),
+			'file_count'       => count( $files ),
+			'diagnostic_count' => count( $diagnostics ),
+		);
+
+		self::$conversion_report['block_artifact_compiler']['available']      = true;
+		self::$conversion_report['block_artifact_compiler']['fragments'][]    = $summary;
+		self::$conversion_report['block_artifact_compiler']['fragment_count'] = count( self::$conversion_report['block_artifact_compiler']['fragments'] );
+
+		if ( isset( self::$conversion_report['conversion_fragments'][ $source ] ) ) {
+			self::$conversion_report['conversion_fragments'][ $source ]['compiler'] = $summary;
+		}
 	}
 
 	/**
@@ -3815,6 +3895,11 @@ class Static_Site_Importer_Theme_Generator {
 				'resolved'         => array(),
 				'unresolved'       => array(),
 			),
+			'block_artifact_compiler' => array(
+				'available'      => function_exists( 'bac_compile_website_artifact' ),
+				'fragment_count' => 0,
+				'fragments'      => array(),
+			),
 			'generated_theme'         => array(
 				'block_documents' => array(),
 				'freeform_blocks' => array(),
@@ -3837,6 +3922,7 @@ class Static_Site_Importer_Theme_Generator {
 			),
 			'diagnostics'             => array(),
 			'notes'                   => array(
+				'Block Artifact Compiler owns the website-artifact to WordPress-artifact envelope; Static Site Importer materializes the result and records compiler summaries.',
 				'Block Format Bridge owns HTML-to-block transform fidelity; Static Site Importer records converter diagnostics and quality gates the generated theme.',
 				'Generated-theme block validation uses WordPress server-side block parsing and serialization checks; editor-runtime validation remains the exact Gutenberg authority.',
 				'Visual fidelity requires browser rendering; use visual_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -2603,8 +2603,7 @@ class Static_Site_Importer_Theme_Generator {
 				continue;
 			}
 
-			$style_dimensions = $svg->hasAttribute( 'style' ) ? self::safe_svg_dimension_style( $svg->getAttribute( 'style' ) ) : array();
-			$sprite_use_svg   = self::svg_from_sprite_use_reference( $doc, $svg );
+			$sprite_use_svg = self::svg_from_sprite_use_reference( $doc, $svg );
 			if ( null !== $sprite_use_svg ) {
 				$asset = self::write_svg_icon_asset( $sprite_use_svg, $source, $sequence, 'svg_symbol_use' );
 				if ( is_wp_error( $asset ) ) {
@@ -2612,7 +2611,7 @@ class Static_Site_Importer_Theme_Generator {
 					continue;
 				}
 
-				$img = self::image_node_for_svg_asset( $doc, $svg, $asset, $style_dimensions );
+				$img = self::image_node_for_svg_asset( $doc, $svg, $asset );
 				$svg->parentNode->replaceChild( $img, $svg );
 				$changed = true;
 				continue;
@@ -2635,7 +2634,7 @@ class Static_Site_Importer_Theme_Generator {
 				continue;
 			}
 
-			$img = self::image_node_for_svg_asset( $doc, $svg, $asset, $style_dimensions );
+			$img = self::image_node_for_svg_asset( $doc, $svg, $asset );
 			$svg->parentNode->replaceChild( $img, $svg );
 			$changed = true;
 		}
@@ -2714,27 +2713,18 @@ class Static_Site_Importer_Theme_Generator {
 	 * @param DOMDocument                $doc              Fragment document.
 	 * @param DOMElement                 $svg              Source SVG element.
 	 * @param array<string, string>      $asset            Materialized asset metadata.
-	 * @param array{width?:string,height?:string}|null $style_dimensions Safe dimensions parsed from style.
 	 * @return DOMElement
 	 */
-	private static function image_node_for_svg_asset( DOMDocument $doc, DOMElement $svg, array $asset, ?array $style_dimensions ): DOMElement {
+	private static function image_node_for_svg_asset( DOMDocument $doc, DOMElement $svg, array $asset ): DOMElement {
 		$img = $doc->createElement( 'img' );
 		$img->setAttribute( 'src', $asset['url'] );
 		$img->setAttribute( 'alt', self::svg_accessible_label( $svg ) );
-		$img->setAttribute( 'decoding', 'async' );
 		if ( $svg->hasAttribute( 'class' ) ) {
 			$img->setAttribute( 'class', $svg->getAttribute( 'class' ) );
 		}
-		foreach ( array( 'width', 'height', 'aria-hidden', 'role' ) as $attribute ) {
+		foreach ( array( 'aria-hidden', 'role' ) as $attribute ) {
 			if ( $svg->hasAttribute( $attribute ) ) {
 				$img->setAttribute( $attribute, $svg->getAttribute( $attribute ) );
-			}
-		}
-		if ( is_array( $style_dimensions ) ) {
-			foreach ( array( 'width', 'height' ) as $attribute ) {
-				if ( ! $img->hasAttribute( $attribute ) && isset( $style_dimensions[ $attribute ] ) ) {
-					$img->setAttribute( $attribute, $style_dimensions[ $attribute ] );
-				}
 			}
 		}
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -3285,7 +3285,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * Compile one source fragment into serialized block markup.
 	 *
 	 * Block Artifact Compiler owns the semantic artifact envelope. SSI remains the
-	 * materializer and falls back to BFB directly when the compiler is unavailable.
+	 * materializer that writes the compiler result into WordPress theme artifacts.
 	 *
 	 * @param string               $html    Source fragment.
 	 * @param string               $source  Source label.
@@ -3294,19 +3294,16 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string Serialized block markup.
 	 */
 	private static function compile_fragment_to_blocks( string $html, string $source, string $format, array $options ): string {
-		if ( 'html' === $format && function_exists( 'bac_compile_fragment' ) ) {
-			$compiled = bac_compile_fragment( $html, $source, $format, $options );
-			self::record_block_artifact_compiler_result( $source, $compiled );
-
-			$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
-			$markup    = isset( $artifacts['block_markup'] ) ? (string) $artifacts['block_markup'] : '';
-			if ( '' !== trim( $markup ) || 'failed' !== (string) ( $compiled['status'] ?? '' ) ) {
-				return $markup;
-			}
+		if ( 'html' !== $format ) {
+			// @phpstan-ignore-next-line function.notFound -- Loaded by the bundled Block Format Bridge runtime.
+			return (string) bfb_convert( $html, $format, 'blocks', $options );
 		}
 
-		// @phpstan-ignore-next-line function.notFound -- Loaded by the bundled Block Format Bridge runtime.
-		return (string) bfb_convert( $html, $format, 'blocks', $options );
+		$compiled = bac_compile_fragment( $html, $source, $format, $options );
+		self::record_block_artifact_compiler_result( $source, $compiled );
+
+		$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		return isset( $artifacts['block_markup'] ) ? (string) $artifacts['block_markup'] : '';
 	}
 
 	/**
@@ -3317,7 +3314,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return void
 	 */
 	private static function record_block_artifact_compiler_result( string $source, array $compiled ): void {
-		$summary           = function_exists( 'bac_summarize_result' ) ? bac_summarize_result( $compiled ) : array();
+		$summary           = bac_summarize_result( $compiled );
 		$summary['source'] = '' !== (string) ( $summary['source'] ?? '' ) ? (string) $summary['source'] : $source;
 
 		self::$conversion_report['block_artifact_compiler']['available']      = true;
@@ -3854,7 +3851,7 @@ class Static_Site_Importer_Theme_Generator {
 				'unresolved'       => array(),
 			),
 			'block_artifact_compiler' => array(
-				'available'      => function_exists( 'bac_compile_website_artifact' ),
+				'available'      => true,
 				'fragment_count' => 0,
 				'fragments'      => array(),
 			),

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -3304,19 +3304,8 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string Serialized block markup.
 	 */
 	private static function compile_fragment_to_blocks( string $html, string $source, string $format, array $options ): string {
-		if ( 'html' === $format && function_exists( 'bac_compile_website_artifact' ) ) {
-			$compiled = bac_compile_website_artifact(
-				array(
-					'files' => array(
-						array(
-							'path'    => self::compiler_fragment_path( $source ),
-							'kind'    => 'html',
-							'content' => $html,
-						),
-					),
-				),
-				$options
-			);
+		if ( 'html' === $format && function_exists( 'bac_compile_fragment' ) ) {
+			$compiled = bac_compile_fragment( $html, $source, $format, $options );
 			self::record_block_artifact_compiler_result( $source, $compiled );
 
 			$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
@@ -3331,17 +3320,6 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Build a stable virtual source path for compiler fragment input.
-	 *
-	 * @param string $source Source label.
-	 * @return string Virtual path.
-	 */
-	private static function compiler_fragment_path( string $source ): string {
-		$path = sanitize_title( str_replace( array( ':', '/', '\\' ), '-', $source ) );
-		return ( '' === $path ? 'fragment' : $path ) . '.html';
-	}
-
-	/**
 	 * Record a compact Block Artifact Compiler summary on the import report.
 	 *
 	 * @param string              $source   Source label.
@@ -3349,18 +3327,8 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return void
 	 */
 	private static function record_block_artifact_compiler_result( string $source, array $compiled ): void {
-		$artifacts   = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
-		$block_types = isset( $artifacts['block_types'] ) && is_array( $artifacts['block_types'] ) ? $artifacts['block_types'] : array();
-		$files       = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
-		$diagnostics = isset( $compiled['diagnostics'] ) && is_array( $compiled['diagnostics'] ) ? $compiled['diagnostics'] : array();
-		$summary     = array(
-			'source'           => $source,
-			'schema'           => isset( $compiled['schema'] ) ? (string) $compiled['schema'] : '',
-			'status'           => isset( $compiled['status'] ) ? (string) $compiled['status'] : '',
-			'block_type_count' => count( $block_types ),
-			'file_count'       => count( $files ),
-			'diagnostic_count' => count( $diagnostics ),
-		);
+		$summary           = function_exists( 'bac_summarize_result' ) ? bac_summarize_result( $compiled ) : array();
+		$summary['source'] = '' !== (string) ( $summary['source'] ?? '' ) ? (string) $summary['source'] : $source;
 
 		self::$conversion_report['block_artifact_compiler']['available']      = true;
 		self::$conversion_report['block_artifact_compiler']['fragments'][]    = $summary;

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -129,6 +129,7 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $report['version'] ?? 0 );
 		$this->assertArrayHasKey( 'quality', $report );
 		$this->assertArrayHasKey( 'conversion_fragments', $report );
+		$this->assertArrayHasKey( 'block_artifact_compiler', $report );
 		$this->assertArrayHasKey( 'generated_theme', $report );
 		$this->assertArrayHasKey( 'semantic_fidelity', $report );
 		$this->assertArrayHasKey( 'product_seeding', $report );
@@ -139,6 +140,9 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertSame( 'skipped', $report['product_seeding']['status'] ?? '' );
 		$this->assertSame( 'no_validated_manifest', $report['product_seeding']['reason'] ?? '' );
 		$this->assertSame( array( 'created' => 0, 'updated' => 0, 'skipped' => 0, 'error' => 0 ), $report['product_seeding']['counts'] ?? array() );
+		$this->assertTrue( $report['block_artifact_compiler']['available'] ?? false );
+		$this->assertGreaterThan( 0, $report['block_artifact_compiler']['fragment_count'] ?? 0 );
+		$this->assertNotEmpty( $report['block_artifact_compiler']['fragments'] ?? array() );
 		$this->assertNotEmpty( $report['generated_theme']['block_documents'] ?? array() );
 		$this->assertSame( 'requires_external_render_check', $report['semantic_fidelity']['status'] ?? '' );
 		$this->assertSame( 'benchmark_harness', $report['semantic_fidelity']['gate_owner'] ?? '' );

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -143,6 +143,7 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertTrue( $report['block_artifact_compiler']['available'] ?? false );
 		$this->assertGreaterThan( 0, $report['block_artifact_compiler']['fragment_count'] ?? 0 );
 		$this->assertNotEmpty( $report['block_artifact_compiler']['fragments'] ?? array() );
+		$this->assertArrayHasKey( 'component_count', $report['block_artifact_compiler']['fragments'][0] ?? array() );
 		$this->assertNotEmpty( $report['generated_theme']['block_documents'] ?? array() );
 		$this->assertSame( 'requires_external_render_check', $report['semantic_fidelity']['status'] ?? '' );
 		$this->assertSame( 'benchmark_harness', $report['semantic_fidelity']['gate_owner'] ?? '' );

--- a/vendor/chubes4/block-artifact-compiler/.gitignore
+++ b/vendor/chubes4/block-artifact-compiler/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/node_modules/
+/.phpunit.cache/
+/.DS_Store
+*.log

--- a/vendor/chubes4/block-artifact-compiler/LICENSE
+++ b/vendor/chubes4/block-artifact-compiler/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/vendor/chubes4/block-artifact-compiler/README.md
+++ b/vendor/chubes4/block-artifact-compiler/README.md
@@ -1,0 +1,80 @@
+# Block Artifact Compiler
+
+Block Artifact Compiler is the semantic compiler layer between generated website artifacts and WordPress materialization.
+
+It is intentionally separate from Studio Web, Static Site Importer, Block Format Bridge, and HTML to Blocks Converter.
+
+```text
+Studio Web
+  -> Static Site Importer
+      -> Block Artifact Compiler
+          -> Block Format Bridge
+              -> HTML to Blocks Converter
+```
+
+## Responsibility
+
+Input: a user-owned website artifact bundle.
+
+Output: a WordPress-native artifact bundle.
+
+The initial contract returns:
+
+- serialized block markup
+- parsed block placeholder field
+- generated block type manifest placeholder
+- generated file manifest placeholder
+- diagnostics
+- provenance
+- optional BFB conversion report
+
+Future compiler passes can add component detection and generated custom block artifacts without changing the caller boundary.
+
+## Public API
+
+```php
+$result = bac_compile_website_artifact(
+	array(
+		'files' => array(
+			array(
+				'path'    => 'index.html',
+				'content' => '<main><h1>Hello</h1></main>',
+			),
+		),
+	)
+);
+```
+
+Result shape:
+
+```php
+array(
+	'schema'              => 'chubes4/block-artifact-compiler-result/v1',
+	'status'              => 'success',
+	'input'               => array(...),
+	'wordpress_artifacts' => array(
+		'block_markup' => '<!-- wp:paragraph -->...',
+		'blocks'       => array(),
+		'block_types'  => array(),
+		'files'        => array(),
+	),
+	'provenance'          => array(...),
+	'diagnostics'         => array(),
+	'bfb_report'          => array(),
+)
+```
+
+## Boundaries
+
+Block Artifact Compiler does not orchestrate agents, import WordPress sites, or deploy outputs.
+
+- Studio Web owns product orchestration, review, preview, and push flows.
+- Static Site Importer owns WordPress import and materialization.
+- Block Format Bridge owns format-to-block conversion APIs.
+- HTML to Blocks Converter owns low-level HTML-to-known-block transforms.
+
+## Smoke Test
+
+```bash
+composer test
+```

--- a/vendor/chubes4/block-artifact-compiler/README.md
+++ b/vendor/chubes4/block-artifact-compiler/README.md
@@ -18,27 +18,39 @@ Input: a user-owned website artifact bundle.
 
 Output: a WordPress-native artifact bundle.
 
-The initial contract returns:
+The contract accepts messy AI-generated artifact shapes and normalizes them into a bounded, safe envelope before lower-level conversion runs. It accepts:
+
+- `files`, `artifacts`, or `outputs` arrays
+- path-to-content maps
+- `html`, `generated_html`, `content`, or `body` strings
+- shorthand `css`, `styles`, `js`, `javascript`, or `script` strings
+
+It rejects absolute paths, `..` escapes, empty paths, oversized files, and over-budget bundles.
+
+The compiler result returns:
 
 - serialized block markup
-- parsed block placeholder field
+- parsed blocks when WordPress parsing is available
+- component candidates from explicit `data-component` markers and repeated semantic class tokens
 - generated block type manifest placeholder
-- generated file manifest placeholder
+- generated file manifest for non-entry artifact files
 - diagnostics
 - provenance
 - optional BFB conversion report
 
-Future compiler passes can add component detection and generated custom block artifacts without changing the caller boundary.
+Future compiler passes can promote component candidates into generated custom block artifacts without changing the caller boundary.
 
 ## Public API
 
 ```php
 $result = bac_compile_website_artifact(
 	array(
+		'generated_html' => '<main><h1>Hello</h1></main>',
+		'css'            => 'main { max-width: 80rem; }',
 		'files' => array(
 			array(
-				'path'    => 'index.html',
-				'content' => '<main><h1>Hello</h1></main>',
+				'path'    => 'site.js',
+				'content' => 'console.log("preview behavior");',
 			),
 		),
 	)
@@ -56,12 +68,21 @@ array(
 		'block_markup' => '<!-- wp:paragraph -->...',
 		'blocks'       => array(),
 		'block_types'  => array(),
+		'components'   => array(),
 		'files'        => array(),
 	),
 	'provenance'          => array(...),
 	'diagnostics'         => array(),
 	'bfb_report'          => array(),
 )
+```
+
+For fragment conversion callers such as Static Site Importer:
+
+```php
+$compiled = bac_compile_fragment( $html, 'main:index.html', 'html', $options );
+$summary  = bac_summarize_result( $compiled );
+$markup   = $compiled['wordpress_artifacts']['block_markup'];
 ```
 
 ## Boundaries

--- a/vendor/chubes4/block-artifact-compiler/block-artifact-compiler.php
+++ b/vendor/chubes4/block-artifact-compiler/block-artifact-compiler.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: Block Artifact Compiler
+ * Description: Compiles website artifacts into WordPress-native block artifact bundles.
+ * Version: 0.1.0
+ * Author: Chris Huber
+ * License: GPL-2.0-or-later
+ * Text Domain: block-artifact-compiler
+ *
+ * @package BlockArtifactCompiler
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once __DIR__ . '/library.php';

--- a/vendor/chubes4/block-artifact-compiler/composer.json
+++ b/vendor/chubes4/block-artifact-compiler/composer.json
@@ -1,0 +1,17 @@
+{
+  "name": "chubes4/block-artifact-compiler",
+  "description": "Compile website artifacts into WordPress-native block artifact bundles.",
+  "type": "wordpress-plugin",
+  "license": "GPL-2.0-or-later",
+  "autoload": {
+    "files": [
+      "library.php"
+    ]
+  },
+  "scripts": {
+    "test": "php tests/contract-smoke.php"
+  },
+  "require": {
+    "php": ">=8.1"
+  }
+}

--- a/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
+++ b/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Website artifact to WordPress artifact compiler.
+ *
+ * @package BlockArtifactCompiler
+ */
+
+/**
+ * Compiles website artifact bundles into WordPress-native artifact bundles.
+ */
+class Block_Artifact_Compiler {
+	private const RESULT_SCHEMA = 'chubes4/block-artifact-compiler-result/v1';
+	private const INPUT_SCHEMA  = 'chubes4/website-artifact/v1';
+
+	/**
+	 * Compile a website artifact bundle.
+	 *
+	 * This initial implementation establishes the artifact envelope and delegates
+	 * HTML-to-block conversion to BFB/H2BC when present. Component extraction and
+	 * generated custom block synthesis belong behind this same contract.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact input.
+	 * @param array<string,mixed> $options  Compiler options.
+	 * @return array<string,mixed> Compiler result envelope.
+	 */
+	public function compile( array $artifact, array $options = array() ): array {
+		$normalized = $this->normalize_artifact( $artifact );
+		$entry      = $this->entry_file( $normalized );
+		$html       = is_array( $entry ) ? (string) ( $entry['content'] ?? '' ) : '';
+		$source     = is_array( $entry ) ? (string) ( $entry['path'] ?? '' ) : '';
+
+		$diagnostics = array();
+		if ( '' === trim( $html ) ) {
+			$diagnostics[] = $this->diagnostic( 'missing_entry_html', 'error', 'No HTML entry file was available to compile.' );
+		}
+
+		$conversion = '' !== trim( $html ) ? $this->convert_html_to_blocks( $html, $options ) : array(
+			'serialized_blocks' => '',
+			'blocks'            => array(),
+			'diagnostics'       => array(),
+			'report'            => array(),
+		);
+
+		$diagnostics = array_merge( $diagnostics, $conversion['diagnostics'] );
+
+		return array(
+			'schema'              => self::RESULT_SCHEMA,
+			'status'              => $this->status_from_diagnostics( $diagnostics ),
+			'input'               => array(
+				'schema'     => self::INPUT_SCHEMA,
+				'entry_path' => $source,
+				'file_count' => count( $normalized['files'] ),
+			),
+			'wordpress_artifacts' => array(
+				'block_markup' => $conversion['serialized_blocks'],
+				'blocks'       => $conversion['blocks'],
+				'block_types'  => array(),
+				'files'        => array(),
+			),
+			'provenance'          => array(
+				'source_hash' => hash( 'sha256', $this->artifact_hash_payload( $normalized ) ),
+				'source'      => $source,
+			),
+			'diagnostics'         => $diagnostics,
+			'bfb_report'          => $conversion['report'],
+		);
+	}
+
+	/**
+	 * Normalize supported website artifact input shapes.
+	 *
+	 * @param array<string,mixed> $artifact Raw artifact.
+	 * @return array{files:array<int,array{path:string,content:string,kind:string}>}
+	 */
+	private function normalize_artifact( array $artifact ): array {
+		$files = $artifact['files'] ?? array();
+		if ( ! is_array( $files ) ) {
+			$files = array();
+		}
+
+		if ( isset( $artifact['html'] ) && is_string( $artifact['html'] ) ) {
+			$files[] = array(
+				'path'    => 'index.html',
+				'content' => $artifact['html'],
+				'kind'    => 'html',
+			);
+		}
+
+		$normalized = array();
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$path = trim( (string) ( $file['path'] ?? '' ) );
+			if ( '' === $path ) {
+				continue;
+			}
+
+			$normalized[] = array(
+				'path'    => $path,
+				'content' => (string) ( $file['content'] ?? '' ),
+				'kind'    => (string) ( $file['kind'] ?? $this->kind_from_path( $path ) ),
+			);
+		}
+
+		return array( 'files' => $normalized );
+	}
+
+	/**
+	 * Return the HTML entry file.
+	 *
+	 * @param array{files:array<int,array{path:string,content:string,kind:string}>} $artifact Normalized artifact.
+	 * @return array{path:string,content:string,kind:string}|null
+	 */
+	private function entry_file( array $artifact ): ?array {
+		foreach ( $artifact['files'] as $file ) {
+			if ( 'index.html' === strtolower( basename( $file['path'] ) ) ) {
+				return $file;
+			}
+		}
+
+		foreach ( $artifact['files'] as $file ) {
+			if ( 'html' === $file['kind'] ) {
+				return $file;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Convert HTML to block markup through BFB/H2BC when available.
+	 *
+	 * @param string              $html    Source HTML.
+	 * @param array<string,mixed> $options Compiler options.
+	 * @return array{serialized_blocks:string,blocks:array,diagnostics:array<int,array<string,mixed>>,report:array<string,mixed>}
+	 */
+	private function convert_html_to_blocks( string $html, array $options ): array {
+		if ( function_exists( 'bfb_convert' ) ) {
+			$block_markup = (string) bfb_convert( $html, 'html', 'blocks', $options );
+			$report       = array( 'status' => '' === trim( $block_markup ) ? 'failed' : 'success_native' );
+			if ( ! empty( $options['include_bfb_report'] ) && function_exists( 'bfb_conversion_report' ) ) {
+				$report = bfb_conversion_report( $html, 'html', $options );
+			}
+
+			return array(
+				'serialized_blocks' => $block_markup,
+				'blocks'            => array(),
+				'diagnostics'       => isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array(),
+				'report'            => $report,
+			);
+		}
+
+		return array(
+			'serialized_blocks' => '<!-- wp:html -->' . "\n" . $html . "\n" . '<!-- /wp:html -->',
+			'blocks'            => array(),
+			'diagnostics'       => array(
+				$this->diagnostic( 'bfb_unavailable', 'warning', 'BFB is unavailable; preserved source HTML as a core/html fallback.' ),
+			),
+			'report'            => array( 'status' => 'success_with_fallbacks' ),
+		);
+	}
+
+	/**
+	 * Infer a simple file kind from path.
+	 */
+	private function kind_from_path( string $path ): string {
+		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+		return match ( $extension ) {
+			'html', 'htm' => 'html',
+			'css'         => 'css',
+			'js', 'mjs'    => 'js',
+			default       => 'asset',
+		};
+	}
+
+	/**
+	 * Build a normalized diagnostic entry.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function diagnostic( string $code, string $severity, string $message ): array {
+		return array(
+			'code'     => $code,
+			'severity' => $severity,
+			'message'  => $message,
+		);
+	}
+
+	/**
+	 * Resolve result status from diagnostics.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 */
+	private function status_from_diagnostics( array $diagnostics ): string {
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( 'error' === ( $diagnostic['severity'] ?? '' ) ) {
+				return 'failed';
+			}
+		}
+
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( 'warning' === ( $diagnostic['severity'] ?? '' ) ) {
+				return 'success_with_warnings';
+			}
+		}
+
+		return 'success';
+	}
+
+	/**
+	 * Build a stable hash payload for provenance.
+	 *
+	 * @param array{files:array<int,array{path:string,content:string,kind:string}>} $artifact Normalized artifact.
+	 */
+	private function artifact_hash_payload( array $artifact ): string {
+		$payload = '';
+		foreach ( $artifact['files'] as $file ) {
+			$payload .= $file['path'] . "\0" . $file['kind'] . "\0" . $file['content'] . "\0";
+		}
+
+		return $payload;
+	}
+}

--- a/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
+++ b/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
@@ -6,30 +6,30 @@
  */
 
 /**
- * Compiles website artifact bundles into WordPress-native artifact bundles.
+ * Compiles arbitrary website artifact bundles into WordPress-native artifacts.
  */
 class Block_Artifact_Compiler {
 	private const RESULT_SCHEMA = 'chubes4/block-artifact-compiler-result/v1';
 	private const INPUT_SCHEMA  = 'chubes4/website-artifact/v1';
 
+	private const DEFAULT_MAX_FILES      = 200;
+	private const DEFAULT_MAX_FILE_BYTES = 2097152;
+	private const DEFAULT_MAX_TOTAL_BYTES = 10485760;
+
 	/**
 	 * Compile a website artifact bundle.
-	 *
-	 * This initial implementation establishes the artifact envelope and delegates
-	 * HTML-to-block conversion to BFB/H2BC when present. Component extraction and
-	 * generated custom block synthesis belong behind this same contract.
 	 *
 	 * @param array<string,mixed> $artifact Website artifact input.
 	 * @param array<string,mixed> $options  Compiler options.
 	 * @return array<string,mixed> Compiler result envelope.
 	 */
 	public function compile( array $artifact, array $options = array() ): array {
-		$normalized = $this->normalize_artifact( $artifact );
-		$entry      = $this->entry_file( $normalized );
-		$html       = is_array( $entry ) ? (string) ( $entry['content'] ?? '' ) : '';
-		$source     = is_array( $entry ) ? (string) ( $entry['path'] ?? '' ) : '';
+		$normalized  = $this->normalize_artifact( $artifact, $options );
+		$entry       = $this->entry_file( $normalized );
+		$html        = is_array( $entry ) ? $entry['content'] : '';
+		$entry_path  = is_array( $entry ) ? $entry['path'] : '';
+		$diagnostics = $normalized['diagnostics'];
 
-		$diagnostics = array();
 		if ( '' === trim( $html ) ) {
 			$diagnostics[] = $this->diagnostic( 'missing_entry_html', 'error', 'No HTML entry file was available to compile.' );
 		}
@@ -42,24 +42,32 @@ class Block_Artifact_Compiler {
 		);
 
 		$diagnostics = array_merge( $diagnostics, $conversion['diagnostics'] );
+		$components  = $this->detect_components( $normalized, $entry_path );
+		$files       = $this->wordpress_files_from_artifact( $normalized );
 
 		return array(
 			'schema'              => self::RESULT_SCHEMA,
 			'status'              => $this->status_from_diagnostics( $diagnostics ),
 			'input'               => array(
-				'schema'     => self::INPUT_SCHEMA,
-				'entry_path' => $source,
-				'file_count' => count( $normalized['files'] ),
+				'schema'          => self::INPUT_SCHEMA,
+				'entry_path'      => $entry_path,
+				'file_count'      => count( $normalized['files'] ),
+				'accepted_count'  => count( $normalized['files'] ),
+				'rejected_count'  => $normalized['rejected_count'],
+				'bytes'           => $normalized['bytes'],
+				'files_by_kind'   => $this->count_files_by_kind( $normalized['files'] ),
+				'original_schema' => (string) ( $artifact['schema'] ?? '' ),
 			),
 			'wordpress_artifacts' => array(
 				'block_markup' => $conversion['serialized_blocks'],
 				'blocks'       => $conversion['blocks'],
 				'block_types'  => array(),
-				'files'        => array(),
+				'components'   => $components,
+				'files'        => $files,
 			),
 			'provenance'          => array(
 				'source_hash' => hash( 'sha256', $this->artifact_hash_payload( $normalized ) ),
-				'source'      => $source,
+				'source'      => $entry_path,
 			),
 			'diagnostics'         => $diagnostics,
 			'bfb_report'          => $conversion['report'],
@@ -67,56 +75,211 @@ class Block_Artifact_Compiler {
 	}
 
 	/**
+	 * Compile a single content fragment.
+	 *
+	 * @param string               $content Source content.
+	 * @param string               $source  Source label or path.
+	 * @param string               $format  Source format.
+	 * @param array<string, mixed> $options Compiler options.
+	 * @return array<string,mixed> Compiler result envelope.
+	 */
+	public function compile_fragment( string $content, string $source = 'fragment', string $format = 'html', array $options = array() ): array {
+		$path = $this->virtual_fragment_path( $source, $format );
+
+		return $this->compile(
+			array(
+				'files' => array(
+					array(
+						'path'    => $path,
+						'kind'    => $format,
+						'content' => $content,
+					),
+				),
+			),
+			$options
+		);
+	}
+
+	/**
+	 * Summarize a compiler result for upstream import reports.
+	 *
+	 * @param array<string,mixed> $compiled Compiler result envelope.
+	 * @return array<string,mixed> Compact summary.
+	 */
+	public function summarize_result( array $compiled ): array {
+		$artifacts   = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$block_types = isset( $artifacts['block_types'] ) && is_array( $artifacts['block_types'] ) ? $artifacts['block_types'] : array();
+		$components  = isset( $artifacts['components'] ) && is_array( $artifacts['components'] ) ? $artifacts['components'] : array();
+		$files       = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
+		$diagnostics = isset( $compiled['diagnostics'] ) && is_array( $compiled['diagnostics'] ) ? $compiled['diagnostics'] : array();
+
+		return array(
+			'schema'           => isset( $compiled['schema'] ) ? (string) $compiled['schema'] : '',
+			'status'           => isset( $compiled['status'] ) ? (string) $compiled['status'] : '',
+			'source'           => isset( $compiled['provenance']['source'] ) ? (string) $compiled['provenance']['source'] : '',
+			'block_type_count' => count( $block_types ),
+			'component_count'  => count( $components ),
+			'file_count'       => count( $files ),
+			'diagnostic_count' => count( $diagnostics ),
+		);
+	}
+
+	/**
 	 * Normalize supported website artifact input shapes.
 	 *
 	 * @param array<string,mixed> $artifact Raw artifact.
-	 * @return array{files:array<int,array{path:string,content:string,kind:string}>}
+	 * @param array<string,mixed> $options  Compiler options.
+	 * @return array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>,diagnostics:array<int,array<string,mixed>>,rejected_count:int,bytes:int}
 	 */
-	private function normalize_artifact( array $artifact ): array {
-		$files = $artifact['files'] ?? array();
-		if ( ! is_array( $files ) ) {
-			$files = array();
-		}
+	private function normalize_artifact( array $artifact, array $options ): array {
+		$limits = array(
+			'max_files'      => max( 1, (int) ( $options['max_files'] ?? self::DEFAULT_MAX_FILES ) ),
+			'max_file_bytes' => max( 1, (int) ( $options['max_file_bytes'] ?? self::DEFAULT_MAX_FILE_BYTES ) ),
+			'max_total_bytes' => max( 1, (int) ( $options['max_total_bytes'] ?? self::DEFAULT_MAX_TOTAL_BYTES ) ),
+		);
+		$raw_files   = $this->extract_raw_files( $artifact );
+		$files       = array();
+		$diagnostics = array();
+		$total_bytes = 0;
+		$rejected    = 0;
+		$seen_paths  = array();
 
-		if ( isset( $artifact['html'] ) && is_string( $artifact['html'] ) ) {
-			$files[] = array(
-				'path'    => 'index.html',
-				'content' => $artifact['html'],
-				'kind'    => 'html',
-			);
-		}
-
-		$normalized = array();
-		foreach ( $files as $file ) {
-			if ( ! is_array( $file ) ) {
-				continue;
+		foreach ( $raw_files as $index => $file ) {
+			if ( count( $files ) >= $limits['max_files'] ) {
+				++$rejected;
+				$diagnostics[] = $this->diagnostic( 'file_limit_exceeded', 'warning', 'Additional artifact files were ignored because the file limit was reached.', array( 'max_files' => $limits['max_files'] ) );
+				break;
 			}
 
-			$path = trim( (string) ( $file['path'] ?? '' ) );
+			$path = $this->safe_relative_path( (string) ( $file['path'] ?? '' ) );
 			if ( '' === $path ) {
+				++$rejected;
+				$diagnostics[] = $this->diagnostic( 'unsafe_artifact_path', 'warning', 'An artifact file was ignored because its path is empty, absolute, or escapes the artifact root.', array( 'index' => $index ) );
 				continue;
 			}
 
-			$normalized[] = array(
-				'path'    => $path,
-				'content' => (string) ( $file['content'] ?? '' ),
-				'kind'    => (string) ( $file['kind'] ?? $this->kind_from_path( $path ) ),
+			$content = $this->normalize_content( $file['content'] ?? '' );
+			$bytes   = strlen( $content );
+			if ( $bytes > $limits['max_file_bytes'] ) {
+				++$rejected;
+				$diagnostics[] = $this->diagnostic( 'artifact_file_too_large', 'warning', 'An artifact file was ignored because it exceeds the per-file byte limit.', array( 'path' => $path, 'bytes' => $bytes, 'max_file_bytes' => $limits['max_file_bytes'] ) );
+				continue;
+			}
+
+			if ( $total_bytes + $bytes > $limits['max_total_bytes'] ) {
+				++$rejected;
+				$diagnostics[] = $this->diagnostic( 'artifact_total_too_large', 'warning', 'An artifact file was ignored because the bundle byte limit was reached.', array( 'path' => $path, 'bytes' => $bytes, 'max_total_bytes' => $limits['max_total_bytes'] ) );
+				continue;
+			}
+
+			$deduped_path = $this->dedupe_path( $path, $seen_paths );
+			$seen_paths[ $deduped_path ] = true;
+			$total_bytes += $bytes;
+
+			$files[] = array(
+				'path'    => $deduped_path,
+				'content' => $content,
+				'kind'    => $this->normalize_kind( (string) ( $file['kind'] ?? '' ), $deduped_path, $content ),
+				'bytes'   => $bytes,
+				'source'  => (string) ( $file['source'] ?? 'artifact' ),
 			);
 		}
 
-		return array( 'files' => $normalized );
+		return array(
+			'files'          => $files,
+			'diagnostics'    => $this->dedupe_diagnostics( $diagnostics ),
+			'rejected_count' => $rejected,
+			'bytes'          => $total_bytes,
+		);
+	}
+
+	/**
+	 * Extract file-like entries from common AI artifact shapes.
+	 *
+	 * @param array<string,mixed> $artifact Raw artifact.
+	 * @return array<int,array<string,mixed>> Raw files.
+	 */
+	private function extract_raw_files( array $artifact ): array {
+		$files = array();
+		foreach ( array( 'files', 'artifacts', 'outputs' ) as $key ) {
+			if ( isset( $artifact[ $key ] ) && is_array( $artifact[ $key ] ) ) {
+				$files = array_merge( $files, $this->normalize_file_collection( $artifact[ $key ], $key ) );
+			}
+		}
+
+		foreach ( array( 'html', 'generated_html', 'content', 'body' ) as $key ) {
+			if ( isset( $artifact[ $key ] ) && is_string( $artifact[ $key ] ) && '' !== trim( $artifact[ $key ] ) ) {
+				$files[] = array(
+					'path'    => 'index.html',
+					'content' => $artifact[ $key ],
+					'kind'    => 'html',
+					'source'  => $key,
+				);
+			}
+		}
+
+		foreach ( array( 'css' => 'style.css', 'styles' => 'style.css', 'javascript' => 'site.js', 'js' => 'site.js', 'script' => 'site.js' ) as $key => $path ) {
+			if ( isset( $artifact[ $key ] ) && is_string( $artifact[ $key ] ) && '' !== trim( $artifact[ $key ] ) ) {
+				$files[] = array(
+					'path'    => $path,
+					'content' => $artifact[ $key ],
+					'kind'    => str_contains( $path, '.css' ) ? 'css' : 'js',
+					'source'  => $key,
+				);
+			}
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Normalize a list or path=>content map into file entries.
+	 *
+	 * @param array<mixed> $collection File collection.
+	 * @param string       $source     Source key.
+	 * @return array<int,array<string,mixed>> Raw files.
+	 */
+	private function normalize_file_collection( array $collection, string $source ): array {
+		$files = array();
+		foreach ( $collection as $key => $file ) {
+			if ( is_array( $file ) ) {
+				$path = (string) ( $file['path'] ?? $file['name'] ?? $key );
+				$files[] = array(
+					'path'    => $path,
+					'content' => $file['content'] ?? $file['body'] ?? $file['text'] ?? '',
+					'kind'    => $file['kind'] ?? $file['type'] ?? '',
+					'source'  => $source,
+				);
+				continue;
+			}
+
+			if ( is_string( $file ) ) {
+				$path = is_string( $key ) ? $key : 'artifact-' . (string) $key . '.html';
+				$files[] = array(
+					'path'    => $path,
+					'content' => $file,
+					'kind'    => '',
+					'source'  => $source,
+				);
+			}
+		}
+
+		return $files;
 	}
 
 	/**
 	 * Return the HTML entry file.
 	 *
-	 * @param array{files:array<int,array{path:string,content:string,kind:string}>} $artifact Normalized artifact.
-	 * @return array{path:string,content:string,kind:string}|null
+	 * @param array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>} $artifact Normalized artifact.
+	 * @return array{path:string,content:string,kind:string,bytes:int,source:string}|null
 	 */
 	private function entry_file( array $artifact ): ?array {
-		foreach ( $artifact['files'] as $file ) {
-			if ( 'index.html' === strtolower( basename( $file['path'] ) ) ) {
-				return $file;
+		$preferred = array( 'index.html', 'index.htm', 'static-site/index.html', 'public/index.html' );
+		foreach ( $preferred as $path ) {
+			foreach ( $artifact['files'] as $file ) {
+				if ( $path === strtolower( $file['path'] ) ) {
+					return $file;
+				}
 			}
 		}
 
@@ -137,6 +300,16 @@ class Block_Artifact_Compiler {
 	 * @return array{serialized_blocks:string,blocks:array,diagnostics:array<int,array<string,mixed>>,report:array<string,mixed>}
 	 */
 	private function convert_html_to_blocks( string $html, array $options ): array {
+		if ( str_contains( $html, '<!-- wp:' ) && function_exists( 'parse_blocks' ) && function_exists( 'serialize_blocks' ) ) {
+			$blocks = parse_blocks( $html );
+			return array(
+				'serialized_blocks' => serialize_blocks( $blocks ),
+				'blocks'            => $blocks,
+				'diagnostics'       => array(),
+				'report'            => array( 'status' => 'success_native', 'source' => 'blocks' ),
+			);
+		}
+
 		if ( function_exists( 'bfb_convert' ) ) {
 			$block_markup = (string) bfb_convert( $html, 'html', 'blocks', $options );
 			$report       = array( 'status' => '' === trim( $block_markup ) ? 'failed' : 'success_native' );
@@ -146,7 +319,7 @@ class Block_Artifact_Compiler {
 
 			return array(
 				'serialized_blocks' => $block_markup,
-				'blocks'            => array(),
+				'blocks'            => function_exists( 'parse_blocks' ) && '' !== trim( $block_markup ) ? parse_blocks( $block_markup ) : array(),
 				'diagnostics'       => isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array(),
 				'report'            => $report,
 			);
@@ -163,29 +336,244 @@ class Block_Artifact_Compiler {
 	}
 
 	/**
-	 * Infer a simple file kind from path.
+	 * Build component candidates from explicit markers and repeated class tokens.
+	 *
+	 * @param array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>} $artifact Normalized artifact.
+	 * @param string $entry_path Entry path.
+	 * @return array<int,array<string,mixed>> Component candidates.
 	 */
-	private function kind_from_path( string $path ): string {
+	private function detect_components( array $artifact, string $entry_path ): array {
+		$candidates = array();
+		$classes    = array();
+
+		foreach ( $artifact['files'] as $file ) {
+			if ( 'html' !== $file['kind'] ) {
+				continue;
+			}
+
+			if ( preg_match_all( '/data-component\s*=\s*(["\'])([^"\']+)\1/i', $file['content'], $matches ) ) {
+				foreach ( $matches[2] as $name ) {
+					$key = sanitize_key( $name );
+					if ( '' !== $key ) {
+						$candidates[ 'explicit:' . $key ] = array(
+							'name'       => $key,
+							'source'     => $file['path'],
+							'signal'     => 'data-component',
+							'occurrences' => ( $candidates[ 'explicit:' . $key ]['occurrences'] ?? 0 ) + 1,
+						);
+					}
+				}
+			}
+
+			if ( preg_match_all( '/class\s*=\s*(["\'])([^"\']+)\1/i', $file['content'], $matches ) ) {
+				foreach ( $matches[2] as $class_list ) {
+					foreach ( preg_split( '/\s+/', trim( $class_list ) ) ?: array() as $class ) {
+						$class = sanitize_key( $class );
+						if ( '' === $class || strlen( $class ) < 3 ) {
+							continue;
+						}
+						$classes[ $class ] = ( $classes[ $class ] ?? 0 ) + 1;
+					}
+				}
+			}
+		}
+
+		foreach ( $classes as $class => $count ) {
+			if ( $count < 2 && ! preg_match( '/(?:card|grid|hero|nav|header|footer|feature|testimonial|pricing|product|gallery|section)/', $class ) ) {
+				continue;
+			}
+
+			$candidates[ 'class:' . $class ] = array(
+				'name'        => $class,
+				'source'      => $entry_path,
+				'signal'      => 'class-token',
+				'occurrences' => $count,
+			);
+		}
+
+		usort(
+			$candidates,
+			static function ( array $left, array $right ): int {
+				return ( $right['occurrences'] <=> $left['occurrences'] ) ?: strcmp( (string) $left['name'], (string) $right['name'] );
+			}
+		);
+
+		return array_slice( array_values( $candidates ), 0, 25 );
+	}
+
+	/**
+	 * Return non-entry files that SSI or another materializer may consume later.
+	 *
+	 * @param array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>} $artifact Normalized artifact.
+	 * @return array<int,array<string,mixed>> Files.
+	 */
+	private function wordpress_files_from_artifact( array $artifact ): array {
+		$files = array();
+		foreach ( $artifact['files'] as $file ) {
+			if ( 'html' === $file['kind'] ) {
+				continue;
+			}
+
+			$files[] = array(
+				'path'    => $file['path'],
+				'kind'    => $file['kind'],
+				'bytes'   => $file['bytes'],
+				'content' => $file['content'],
+			);
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Normalize a relative artifact path and reject unsafe locations.
+	 */
+	private function safe_relative_path( string $path ): string {
+		$path = str_replace( '\\', '/', trim( $path ) );
+		$path = preg_replace( '/\0+/', '', $path );
+		$path = ltrim( (string) $path );
+		if ( '' === $path || str_starts_with( $path, '/' ) || preg_match( '#^[a-z][a-z0-9+.-]*:#i', $path ) ) {
+			return '';
+		}
+
+		$segments = array();
+		foreach ( explode( '/', $path ) as $segment ) {
+			if ( '' === $segment || '.' === $segment ) {
+				continue;
+			}
+			if ( '..' === $segment ) {
+				return '';
+			}
+			$segments[] = preg_replace( '/[^A-Za-z0-9._-]/', '-', $segment );
+		}
+
+		return implode( '/', array_filter( $segments ) );
+	}
+
+	/**
+	 * Normalize content from scalar-ish inputs.
+	 *
+	 * @param mixed $content Raw content.
+	 */
+	private function normalize_content( mixed $content ): string {
+		if ( is_scalar( $content ) || null === $content ) {
+			return (string) $content;
+		}
+
+		$encoded = wp_json_encode( $content, JSON_UNESCAPED_SLASHES );
+		return is_string( $encoded ) ? $encoded : '';
+	}
+
+	/**
+	 * Normalize file kind from explicit kind, path, and content.
+	 */
+	private function normalize_kind( string $kind, string $path, string $content ): string {
+		$kind = sanitize_key( $kind );
+		if ( in_array( $kind, array( 'html', 'css', 'js', 'json', 'markdown', 'asset', 'blocks' ), true ) ) {
+			return $kind;
+		}
+
 		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
 		return match ( $extension ) {
-			'html', 'htm' => 'html',
-			'css'         => 'css',
-			'js', 'mjs'    => 'js',
-			default       => 'asset',
+			'html', 'htm'       => 'html',
+			'css'               => 'css',
+			'js', 'mjs'          => 'js',
+			'json'              => 'json',
+			'md', 'markdown'    => 'markdown',
+			default             => str_contains( $content, '<!-- wp:' ) ? 'blocks' : 'asset',
 		};
+	}
+
+	/**
+	 * Build a virtual path from an arbitrary fragment source label.
+	 */
+	private function virtual_fragment_path( string $source, string $format ): string {
+		$path      = $this->safe_relative_path( str_replace( array( ':', '#' ), '-', $source ) );
+		$extension = match ( sanitize_key( $format ) ) {
+			'css'      => 'css',
+			'js'       => 'js',
+			'markdown' => 'md',
+			default    => 'html',
+		};
+
+		return ( '' === $path ? 'fragment' : preg_replace( '/\.[A-Za-z0-9]+$/', '', $path ) ) . '.' . $extension;
+	}
+
+	/**
+	 * Dedupe normalized paths deterministically.
+	 *
+	 * @param array<string,bool> $seen Seen paths.
+	 */
+	private function dedupe_path( string $path, array $seen ): string {
+		if ( ! isset( $seen[ $path ] ) ) {
+			return $path;
+		}
+
+		$extension = pathinfo( $path, PATHINFO_EXTENSION );
+		$base      = '' === $extension ? $path : substr( $path, 0, -1 - strlen( $extension ) );
+		$suffix    = '' === $extension ? '' : '.' . $extension;
+		$index     = 2;
+		while ( isset( $seen[ $base . '-' . $index . $suffix ] ) ) {
+			++$index;
+		}
+
+		return $base . '-' . $index . $suffix;
+	}
+
+	/**
+	 * Count normalized files by kind.
+	 *
+	 * @param array<int,array{kind:string}> $files Files.
+	 * @return array<string,int>
+	 */
+	private function count_files_by_kind( array $files ): array {
+		$counts = array();
+		foreach ( $files as $file ) {
+			$counts[ $file['kind'] ] = ( $counts[ $file['kind'] ] ?? 0 ) + 1;
+		}
+		ksort( $counts );
+
+		return $counts;
 	}
 
 	/**
 	 * Build a normalized diagnostic entry.
 	 *
+	 * @param array<string,mixed> $details Diagnostic details.
 	 * @return array<string,mixed>
 	 */
-	private function diagnostic( string $code, string $severity, string $message ): array {
-		return array(
+	private function diagnostic( string $code, string $severity, string $message, array $details = array() ): array {
+		$diagnostic = array(
 			'code'     => $code,
 			'severity' => $severity,
 			'message'  => $message,
 		);
+		if ( ! empty( $details ) ) {
+			$diagnostic['details'] = $details;
+		}
+
+		return $diagnostic;
+	}
+
+	/**
+	 * Remove duplicate diagnostics emitted while rejecting many files.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @return array<int,array<string,mixed>> Diagnostics.
+	 */
+	private function dedupe_diagnostics( array $diagnostics ): array {
+		$deduped = array();
+		$seen    = array();
+		foreach ( $diagnostics as $diagnostic ) {
+			$key = (string) ( $diagnostic['code'] ?? '' ) . '|' . md5( wp_json_encode( $diagnostic['details'] ?? array() ) ?: '' );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$deduped[]    = $diagnostic;
+		}
+
+		return $deduped;
 	}
 
 	/**
@@ -212,7 +600,7 @@ class Block_Artifact_Compiler {
 	/**
 	 * Build a stable hash payload for provenance.
 	 *
-	 * @param array{files:array<int,array{path:string,content:string,kind:string}>} $artifact Normalized artifact.
+	 * @param array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>} $artifact Normalized artifact.
 	 */
 	private function artifact_hash_payload( array $artifact ): string {
 		$payload = '';

--- a/vendor/chubes4/block-artifact-compiler/includes/functions.php
+++ b/vendor/chubes4/block-artifact-compiler/includes/functions.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Public API functions.
+ *
+ * @package BlockArtifactCompiler
+ */
+
+if ( ! function_exists( 'bac_compile_website_artifact' ) ) {
+	/**
+	 * Compile a website artifact bundle into a WordPress-native artifact bundle.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact input.
+	 * @param array<string,mixed> $options  Compiler options.
+	 * @return array<string,mixed> Compiler result envelope.
+	 */
+	function bac_compile_website_artifact( array $artifact, array $options = array() ): array {
+		$compiler = new Block_Artifact_Compiler();
+		return $compiler->compile( $artifact, $options );
+	}
+}

--- a/vendor/chubes4/block-artifact-compiler/includes/functions.php
+++ b/vendor/chubes4/block-artifact-compiler/includes/functions.php
@@ -18,3 +18,32 @@ if ( ! function_exists( 'bac_compile_website_artifact' ) ) {
 		return $compiler->compile( $artifact, $options );
 	}
 }
+
+if ( ! function_exists( 'bac_compile_fragment' ) ) {
+	/**
+	 * Compile a single source fragment into a WordPress-native artifact envelope.
+	 *
+	 * @param string               $content Source content.
+	 * @param string               $source  Source label or path.
+	 * @param string               $format  Source format.
+	 * @param array<string, mixed> $options Compiler options.
+	 * @return array<string,mixed> Compiler result envelope.
+	 */
+	function bac_compile_fragment( string $content, string $source = 'fragment', string $format = 'html', array $options = array() ): array {
+		$compiler = new Block_Artifact_Compiler();
+		return $compiler->compile_fragment( $content, $source, $format, $options );
+	}
+}
+
+if ( ! function_exists( 'bac_summarize_result' ) ) {
+	/**
+	 * Summarize a compiler result for reports and logs.
+	 *
+	 * @param array<string,mixed> $compiled Compiler result envelope.
+	 * @return array<string,mixed> Compact summary.
+	 */
+	function bac_summarize_result( array $compiled ): array {
+		$compiler = new Block_Artifact_Compiler();
+		return $compiler->summarize_result( $compiled );
+	}
+}

--- a/vendor/chubes4/block-artifact-compiler/library.php
+++ b/vendor/chubes4/block-artifact-compiler/library.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Block Artifact Compiler library bootstrap.
+ *
+ * @package BlockArtifactCompiler
+ */
+
+require_once __DIR__ . '/includes/class-block-artifact-compiler.php';
+require_once __DIR__ . '/includes/functions.php';

--- a/vendor/chubes4/block-artifact-compiler/library.php
+++ b/vendor/chubes4/block-artifact-compiler/library.php
@@ -5,5 +5,26 @@
  * @package BlockArtifactCompiler
  */
 
+if ( ! function_exists( 'sanitize_key' ) ) {
+	/**
+	 * Minimal sanitize_key fallback for non-WordPress contract tests.
+	 */
+	function sanitize_key( string $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	/**
+	 * Minimal wp_json_encode fallback for non-WordPress contract tests.
+	 *
+	 * @param mixed $value Value to encode.
+	 * @return string|false Encoded JSON or false.
+	 */
+	function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
 require_once __DIR__ . '/includes/class-block-artifact-compiler.php';
 require_once __DIR__ . '/includes/functions.php';

--- a/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
+++ b/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Contract smoke tests.
+ *
+ * @package BlockArtifactCompiler
+ */
+
+require_once dirname( __DIR__ ) . '/library.php';
+
+$assert = static function ( bool $condition, string $message, string $detail = '' ): void {
+	if ( $condition ) {
+		return;
+	}
+
+	fwrite( STDERR, 'FAIL: ' . $message . ( '' !== $detail ? ' - ' . $detail : '' ) . PHP_EOL );
+	exit( 1 );
+};
+
+$result = bac_compile_website_artifact(
+	array(
+		'files' => array(
+			array(
+				'path'    => 'index.html',
+				'content' => '<main><h1>Hello compiler</h1><p>Initial contract.</p></main>',
+			),
+		),
+	)
+);
+
+$assert( 'chubes4/block-artifact-compiler-result/v1' === ( $result['schema'] ?? '' ), 'result exposes schema' );
+$assert( 'success_with_warnings' === ( $result['status'] ?? '' ), 'fallback status reflects missing BFB in smoke test', (string) ( $result['status'] ?? '' ) );
+$assert( 'index.html' === ( $result['input']['entry_path'] ?? '' ), 'entry path is captured' );
+$assert( str_contains( (string) ( $result['wordpress_artifacts']['block_markup'] ?? '' ), '<!-- wp:html -->' ), 'fallback block markup is produced' );
+$assert( array() === ( $result['wordpress_artifacts']['block_types'] ?? null ), 'initial contract exposes empty block type list' );
+
+$empty = bac_compile_website_artifact( array( 'files' => array() ) );
+$assert( 'failed' === ( $empty['status'] ?? '' ), 'missing HTML fails explicitly' );
+
+fwrite( STDOUT, "contract smoke passed\n" );

--- a/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
+++ b/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
@@ -32,8 +32,36 @@ $assert( 'success_with_warnings' === ( $result['status'] ?? '' ), 'fallback stat
 $assert( 'index.html' === ( $result['input']['entry_path'] ?? '' ), 'entry path is captured' );
 $assert( str_contains( (string) ( $result['wordpress_artifacts']['block_markup'] ?? '' ), '<!-- wp:html -->' ), 'fallback block markup is produced' );
 $assert( array() === ( $result['wordpress_artifacts']['block_types'] ?? null ), 'initial contract exposes empty block type list' );
+$assert( isset( $result['wordpress_artifacts']['components'] ) && is_array( $result['wordpress_artifacts']['components'] ), 'component candidates are exposed' );
 
 $empty = bac_compile_website_artifact( array( 'files' => array() ) );
 $assert( 'failed' === ( $empty['status'] ?? '' ), 'missing HTML fails explicitly' );
+
+$messy = bac_compile_website_artifact(
+	array(
+		'generated_html' => '<main><section class="hero"><h1>Messy</h1></section><article class="card product-card" data-component="Product Card">A</article><article class="card product-card">B</article></main>',
+		'css'            => '.card{border:1px solid currentColor}',
+		'files'          => array(
+			'../secret.txt' => 'nope',
+			'app.js'        => 'console.log("preview only");',
+			array(
+				'path'    => '/absolute.html',
+				'content' => 'nope',
+			),
+		),
+	)
+);
+$assert( 'success_with_warnings' === ( $messy['status'] ?? '' ), 'unsafe AI artifact inputs produce warning status', (string) ( $messy['status'] ?? '' ) );
+$assert( 2 === ( $messy['input']['rejected_count'] ?? null ), 'unsafe paths are rejected' );
+$assert( 'index.html' === ( $messy['input']['entry_path'] ?? '' ), 'generated_html becomes index entry' );
+$assert( 1 === ( $messy['input']['files_by_kind']['css'] ?? 0 ), 'css shorthand is normalized' );
+$assert( 1 === ( $messy['input']['files_by_kind']['js'] ?? 0 ), 'js file is normalized' );
+$assert( ! empty( $messy['wordpress_artifacts']['components'] ?? array() ), 'component candidates are detected' );
+
+$fragment = bac_compile_fragment( '<div class="feature-card">Feature</div>', 'main:index.html' );
+$assert( 'main-index.html' === ( $fragment['input']['entry_path'] ?? '' ), 'fragment source is normalized to virtual path' );
+
+$summary = bac_summarize_result( $messy );
+$assert( ( $summary['component_count'] ?? 0 ) > 0, 'summary exposes component count' );
 
 fwrite( STDOUT, "contract smoke passed\n" );

--- a/vendor/composer/autoload_files.php
+++ b/vendor/composer/autoload_files.php
@@ -8,5 +8,6 @@ $baseDir = dirname($vendorDir);
 return array(
     '6e3fae29631ef280660b3cdad06f25a8' => $vendorDir . '/symfony/deprecation-contracts/function.php',
     'a4a119a56e50fbb293281d9a48007e0e' => $vendorDir . '/symfony/polyfill-php80/bootstrap.php',
+    '235f04e1fc26929b57f3570ad8a9aa80' => $vendorDir . '/chubes4/block-artifact-compiler/library.php',
     '14de8177b733e3832e5f50c619a21b40' => $vendorDir . '/chubes4/block-format-bridge/library.php',
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -9,6 +9,7 @@ class ComposerStaticInit277b67919cab65478171e2e4820012bd
     public static $files = array (
         '6e3fae29631ef280660b3cdad06f25a8' => __DIR__ . '/..' . '/symfony/deprecation-contracts/function.php',
         'a4a119a56e50fbb293281d9a48007e0e' => __DIR__ . '/..' . '/symfony/polyfill-php80/bootstrap.php',
+        '235f04e1fc26929b57f3570ad8a9aa80' => __DIR__ . '/..' . '/chubes4/block-artifact-compiler/library.php',
         '14de8177b733e3832e5f50c619a21b40' => __DIR__ . '/..' . '/chubes4/block-format-bridge/library.php',
     );
 

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -1,6 +1,48 @@
 {
     "packages": [
         {
+            "name": "chubes4/block-artifact-compiler",
+            "version": "dev-main",
+            "version_normalized": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chubes4/block-artifact-compiler.git",
+                "reference": "6c946d56e7615ee2ac1b46c8595e63438f461ee0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/6c946d56e7615ee2ac1b46c8595e63438f461ee0",
+                "reference": "6c946d56e7615ee2ac1b46c8595e63438f461ee0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "time": "2026-05-31T02:36:31+00:00",
+            "default-branch": true,
+            "type": "wordpress-plugin",
+            "installation-source": "dist",
+            "autoload": {
+                "files": [
+                    "library.php"
+                ]
+            },
+            "scripts": {
+                "test": [
+                    "php tests/contract-smoke.php"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Compile website artifacts into WordPress-native block artifact bundles.",
+            "support": {
+                "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
+                "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
+            },
+            "install-path": "../chubes4/block-artifact-compiler"
+        },
+        {
             "name": "chubes4/block-format-bridge",
             "version": "dev-main",
             "version_normalized": "dev-main",

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -2,23 +2,24 @@
     "packages": [
         {
             "name": "chubes4/block-artifact-compiler",
-            "version": "dev-robust-artifact-boundary",
-            "version_normalized": "dev-robust-artifact-boundary",
+            "version": "dev-main",
+            "version_normalized": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "76a96a85e79491dcd28de277f0f2874209a8d1ad"
+                "reference": "098b74f84b458b1bc75c89fa333291dc186e5fa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/76a96a85e79491dcd28de277f0f2874209a8d1ad",
-                "reference": "76a96a85e79491dcd28de277f0f2874209a8d1ad",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/098b74f84b458b1bc75c89fa333291dc186e5fa1",
+                "reference": "098b74f84b458b1bc75c89fa333291dc186e5fa1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
-            "time": "2026-05-31T02:47:38+00:00",
+            "time": "2026-05-31T02:58:07+00:00",
+            "default-branch": true,
             "type": "wordpress-plugin",
             "installation-source": "dist",
             "autoload": {
@@ -36,7 +37,7 @@
             ],
             "description": "Compile website artifacts into WordPress-native block artifact bundles.",
             "support": {
-                "source": "https://github.com/chubes4/block-artifact-compiler/tree/robust-artifact-boundary",
+                "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
                 "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
             },
             "install-path": "../chubes4/block-artifact-compiler"

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -2,24 +2,23 @@
     "packages": [
         {
             "name": "chubes4/block-artifact-compiler",
-            "version": "dev-main",
-            "version_normalized": "dev-main",
+            "version": "dev-robust-artifact-boundary",
+            "version_normalized": "dev-robust-artifact-boundary",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "6c946d56e7615ee2ac1b46c8595e63438f461ee0"
+                "reference": "76a96a85e79491dcd28de277f0f2874209a8d1ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/6c946d56e7615ee2ac1b46c8595e63438f461ee0",
-                "reference": "6c946d56e7615ee2ac1b46c8595e63438f461ee0",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/76a96a85e79491dcd28de277f0f2874209a8d1ad",
+                "reference": "76a96a85e79491dcd28de277f0f2874209a8d1ad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
-            "time": "2026-05-31T02:36:31+00:00",
-            "default-branch": true,
+            "time": "2026-05-31T02:47:38+00:00",
             "type": "wordpress-plugin",
             "installation-source": "dist",
             "autoload": {
@@ -37,7 +36,7 @@
             ],
             "description": "Compile website artifacts into WordPress-native block artifact bundles.",
             "support": {
-                "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
+                "source": "https://github.com/chubes4/block-artifact-compiler/tree/robust-artifact-boundary",
                 "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
             },
             "install-path": "../chubes4/block-artifact-compiler"

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,13 +3,24 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'e58c9de4643ebea5ff7f0a012dfea1a406cebb3b',
+        'reference' => 'cb5019a615ef942c6034d3b9a41785553c25f52d',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
         'dev' => true,
     ),
     'versions' => array(
+        'chubes4/block-artifact-compiler' => array(
+            'pretty_version' => 'dev-main',
+            'version' => 'dev-main',
+            'reference' => '6c946d56e7615ee2ac1b46c8595e63438f461ee0',
+            'type' => 'wordpress-plugin',
+            'install_path' => __DIR__ . '/../chubes4/block-artifact-compiler',
+            'aliases' => array(
+                0 => '9999999-dev',
+            ),
+            'dev_requirement' => false,
+        ),
         'chubes4/block-format-bridge' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
@@ -24,7 +35,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'e58c9de4643ebea5ff7f0a012dfea1a406cebb3b',
+            'reference' => 'cb5019a615ef942c6034d3b9a41785553c25f52d',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '5bde1cb4cf8b7119a96bfff3e2acd2ac17ec7f80',
+        'reference' => '7c5f2340014356df3bfd9014c283a9f85df1d2de',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -11,12 +11,14 @@
     ),
     'versions' => array(
         'chubes4/block-artifact-compiler' => array(
-            'pretty_version' => 'dev-robust-artifact-boundary',
-            'version' => 'dev-robust-artifact-boundary',
-            'reference' => '76a96a85e79491dcd28de277f0f2874209a8d1ad',
+            'pretty_version' => 'dev-main',
+            'version' => 'dev-main',
+            'reference' => '098b74f84b458b1bc75c89fa333291dc186e5fa1',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../chubes4/block-artifact-compiler',
-            'aliases' => array(),
+            'aliases' => array(
+                0 => '9999999-dev',
+            ),
             'dev_requirement' => false,
         ),
         'chubes4/block-format-bridge' => array(
@@ -33,7 +35,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '5bde1cb4cf8b7119a96bfff3e2acd2ac17ec7f80',
+            'reference' => '7c5f2340014356df3bfd9014c283a9f85df1d2de',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'cb5019a615ef942c6034d3b9a41785553c25f52d',
+        'reference' => '5bde1cb4cf8b7119a96bfff3e2acd2ac17ec7f80',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -11,14 +11,12 @@
     ),
     'versions' => array(
         'chubes4/block-artifact-compiler' => array(
-            'pretty_version' => 'dev-main',
-            'version' => 'dev-main',
-            'reference' => '6c946d56e7615ee2ac1b46c8595e63438f461ee0',
+            'pretty_version' => 'dev-robust-artifact-boundary',
+            'version' => 'dev-robust-artifact-boundary',
+            'reference' => '76a96a85e79491dcd28de277f0f2874209a8d1ad',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../chubes4/block-artifact-compiler',
-            'aliases' => array(
-                0 => '9999999-dev',
-            ),
+            'aliases' => array(),
             'dev_requirement' => false,
         ),
         'chubes4/block-format-bridge' => array(
@@ -35,7 +33,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'cb5019a615ef942c6034d3b9a41785553c25f52d',
+            'reference' => '5bde1cb4cf8b7119a96bfff3e2acd2ac17ec7f80',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- Add `chubes4/block-artifact-compiler` as a bundled SSI dependency on `dev-main`.
- Route HTML fragment conversion through the compiler envelope as the required HTML artifact boundary.
- Record compiler per-fragment summaries in the SSI import report, and assert the report shape in fixture coverage.
- Drop transient SVG source dimensions/decoding before materialized SVG icons are converted to image blocks, preserving the footer SVG fixture contract.

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/StaticSiteImporterFixtureTest.php`
- `composer validate --strict`
- `php vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php`
- `homeboy test --path /Users/chubes/Developer/static-site-importer@wire-block-artifact-compiler --extension wordpress` *(passes: 58 tests, 1098 assertions)*
- GitHub Actions Homeboy matrix: PHP 8.1, 8.2, 8.3, 8.4

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Scaffolded the compiler repo, wired SSI through the compiler envelope, updated dependency metadata, removed optional compiler compatibility fallback, fixed the SVG materialization regression exposed by CI, and ran verification. Chris remains responsible for review and merge.