### PR TITLE
Add website artifact import API

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -105,6 +105,37 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);
+
+		wp_register_ability(
+			'static-site-importer/import-website-artifact',
+			array(
+				'label'               => __( 'Import Website Artifact', 'static-site-importer' ),
+				'description'         => __( 'Compile a website artifact bundle through Block Artifact Compiler and import it as a WordPress block theme.', 'static-site-importer' ),
+				'category'            => STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'artifact'                  => array( 'type' => 'object' ),
+						'slug'                      => array( 'type' => 'string' ),
+						'name'                      => array( 'type' => 'string' ),
+						'activate'                  => array( 'type' => 'boolean' ),
+						'overwrite'                 => array( 'type' => 'boolean' ),
+						'keep_source'               => array( 'type' => 'boolean' ),
+						'fail_on_quality'           => array( 'type' => 'boolean' ),
+						'max_fallbacks'             => array( 'type' => 'integer' ),
+						'allow_missing_woocommerce' => array( 'type' => 'boolean' ),
+						'report'                    => array( 'type' => 'string' ),
+						'compiler_options'          => array( 'type' => 'object' ),
+						'source_metadata'           => array( 'type' => 'object' ),
+					),
+					'required'   => array( 'artifact' ),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'static_site_importer_ability_import_website_artifact',
+				'permission_callback' => 'static_site_importer_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
 	}
 }
 
@@ -147,6 +178,46 @@ if ( ! function_exists( 'static_site_importer_ability_export_theme' ) ) {
 		return array_merge(
 			array( 'success' => true ),
 			$result
+		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' ) ) {
+	/**
+	 * Ability callback for website artifact imports.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>
+	 */
+	function static_site_importer_ability_import_website_artifact( array $input ): array {
+		$artifact = isset( $input['artifact'] ) && is_array( $input['artifact'] ) ? $input['artifact'] : array();
+		if ( empty( $artifact ) ) {
+			return static_site_importer_ability_error( 'static_site_importer_missing_website_artifact', 'The artifact input is required.' );
+		}
+
+		$args = array(
+			'slug'                      => isset( $input['slug'] ) ? (string) $input['slug'] : '',
+			'name'                      => isset( $input['name'] ) ? (string) $input['name'] : '',
+			'activate'                  => ! empty( $input['activate'] ),
+			'overwrite'                 => ! empty( $input['overwrite'] ),
+			'keep_source'               => ! empty( $input['keep_source'] ),
+			'fail_on_quality'           => ! empty( $input['fail_on_quality'] ),
+			'max_fallbacks'             => isset( $input['max_fallbacks'] ) ? (int) $input['max_fallbacks'] : null,
+			'allow_missing_woocommerce' => ! empty( $input['allow_missing_woocommerce'] ),
+			'report'                    => isset( $input['report'] ) ? (string) $input['report'] : '',
+			'compiler_options'          => isset( $input['compiler_options'] ) && is_array( $input['compiler_options'] ) ? $input['compiler_options'] : array(),
+			'source_metadata'           => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
+		);
+
+		$result = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $args );
+		if ( is_wp_error( $result ) ) {
+			/** @var WP_Error $result */
+			return static_site_importer_ability_error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
+		}
+
+		return array(
+			'success' => true,
+			'result'  => $result,
 		);
 	}
 }

--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -199,6 +199,125 @@ class Static_Site_Importer_CLI_Command {
 	}
 
 	/**
+	 * Import a website artifact bundle as a block theme.
+	 *
+	 * @subcommand import-website-artifact
+	 *
+	 * ## OPTIONS
+	 *
+	 * <artifact-json-file>
+	 * : Path to a JSON website artifact bundle accepted by Block Artifact Compiler.
+	 *
+	 * [--slug=<slug>]
+	 * : Theme slug.
+	 *
+	 * [--name=<name>]
+	 * : Theme name.
+	 *
+	 * [--activate]
+	 * : Activate the generated theme.
+	 *
+	 * [--overwrite]
+	 * : Overwrite an existing theme directory.
+	 *
+	 * [--keep-source]
+	 * : Preserve the temporary artifact source directory after a successful clean import.
+	 *
+	 * [--fail-on-quality]
+	 * : Exit non-zero when conversion quality checks report fallbacks, invalid blocks, or content loss.
+	 *
+	 * [--max-fallbacks=<count>]
+	 * : Exit non-zero when unsupported HTML fallback count exceeds this threshold.
+	 *
+	 * [--allow-missing-woocommerce]
+	 * : Allow commerce-bearing imports to proceed when WooCommerce is not active.
+	 *
+	 * [--report=<path>]
+	 * : Copy the generated import report JSON to an external archive path.
+	 *
+	 * [--format=<format>]
+	 * : Output format. Use json for machine-readable command output.
+	 *
+	 * @param array<int, string>   $args       Positional args.
+	 * @param array<string, mixed> $assoc_args Associative args.
+	 * @return void
+	 */
+	public function import_website_artifact( array $args, array $assoc_args ): void {
+		$artifact_file = $args[0] ?? '';
+		if ( '' === $artifact_file || ! is_file( $artifact_file ) ) {
+			$this->error_or_json( 'static_site_importer_missing_artifact_file', 'Missing readable <artifact-json-file> argument.', $assoc_args );
+			return;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads a local artifact JSON file selected for import.
+		$artifact_json = file_get_contents( $artifact_file );
+		$artifact      = is_string( $artifact_json ) ? json_decode( $artifact_json, true ) : null;
+		if ( ! is_array( $artifact ) ) {
+			$this->error_or_json( 'static_site_importer_invalid_artifact_json', 'Artifact file must contain a JSON object.', $assoc_args );
+			return;
+		}
+
+		$ability = wp_get_ability( 'static-site-importer/import-website-artifact' );
+		if ( ! $ability ) {
+			$this->error_or_json( 'static_site_importer_ability_missing', 'Static Site Importer website artifact ability is not registered.', $assoc_args );
+			return;
+		}
+
+		$ability_args = array(
+			'artifact'                  => $artifact,
+			'slug'                      => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
+			'name'                      => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
+			'activate'                  => isset( $assoc_args['activate'] ),
+			'overwrite'                 => isset( $assoc_args['overwrite'] ),
+			'keep_source'               => isset( $assoc_args['keep-source'] ),
+			'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
+			'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
+			'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
+			'source_metadata'           => array( 'artifact_file' => $artifact_file ),
+		);
+
+		if ( isset( $assoc_args['max-fallbacks'] ) ) {
+			$ability_args['max_fallbacks'] = (int) $assoc_args['max-fallbacks'];
+		}
+
+		$ability_result = $ability->execute( $ability_args );
+		if ( is_wp_error( $ability_result ) ) {
+			$this->error_or_json( (string) $ability_result->get_error_code(), $ability_result->get_error_message(), $assoc_args );
+			return;
+		}
+
+		if ( empty( $ability_result['success'] ) ) {
+			$error = isset( $ability_result['error'] ) && is_array( $ability_result['error'] ) ? $ability_result['error'] : array();
+			$this->error_or_json(
+				isset( $error['code'] ) ? (string) $error['code'] : 'static_site_importer_failed',
+				isset( $error['message'] ) ? (string) $error['message'] : 'Website artifact import failed.',
+				$assoc_args,
+				isset( $ability_result['import_report_summary'] ) && is_array( $ability_result['import_report_summary'] ) ? $ability_result['import_report_summary'] : array()
+			);
+			return;
+		}
+
+		$result  = isset( $ability_result['result'] ) && is_array( $ability_result['result'] ) ? $ability_result['result'] : array();
+		$is_json = isset( $assoc_args['format'] ) && 'json' === (string) $assoc_args['format'];
+		if ( $is_json ) {
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			if ( ! empty( $result['quality']['fail_import'] ) ) {
+				WP_CLI::halt( 1 );
+			}
+			return;
+		}
+
+		if ( ! empty( $result['quality']['fail_import'] ) ) {
+			WP_CLI::error( sprintf( "Conversion quality gate failed. Theme files were written for inspection at: %s\nImport report: %s", $result['theme_dir'], $result['report_path'] ) );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Imported website artifact as block theme "%s" (%s).', $result['theme_name'], $result['theme_slug'] ) );
+		WP_CLI::line( sprintf( 'Theme directory: %s', $result['theme_dir'] ) );
+		WP_CLI::line( sprintf( 'Import report: %s', $result['report_path'] ) );
+	}
+
+	/**
 	 * Emit a human WP-CLI error or a machine-readable JSON failure payload.
 	 *
 	 * @param string               $code           Error code.

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -153,6 +153,9 @@ class Static_Site_Importer_Theme_Generator {
 		$route_map               = self::source_route_map( $pages, $permalinks );
 		$fragments               = $document->fragments();
 		self::$conversion_report = self::new_conversion_report( $html_path, isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array() );
+		if ( isset( $args['block_artifact_compiler'] ) && is_array( $args['block_artifact_compiler'] ) ) {
+			self::record_website_artifact_compiler_result( $args['block_artifact_compiler'] );
+		}
 		self::record_source_region_selection( $document, $html_path );
 		self::record_source_documents_summary( $site_dir, $pages, $permalinks );
 		self::record_products_manifest( $site_dir );
@@ -300,6 +303,40 @@ class Static_Site_Importer_Theme_Generator {
 			'quality'               => $quality,
 			'source_documents'      => self::$conversion_report['source_documents'],
 		);
+	}
+
+	/**
+	 * Import a website artifact bundle as a block theme.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @param array<string,mixed> $args     Import args.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function import_website_artifact( array $artifact, array $args = array() ) {
+		if ( ! function_exists( 'bac_compile_website_artifact' ) || ! function_exists( 'bac_summarize_result' ) ) {
+			return new WP_Error( 'static_site_importer_missing_bac', 'Block Artifact Compiler is required to import a website artifact.' );
+		}
+
+		$compiler_options = isset( $args['compiler_options'] ) && is_array( $args['compiler_options'] ) ? $args['compiler_options'] : array();
+		$compiled         = bac_compile_website_artifact( $artifact, array_merge( array( 'include_bfb_report' => true ), $compiler_options ) );
+		$artifacts        = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$block_markup     = isset( $artifacts['block_markup'] ) ? (string) $artifacts['block_markup'] : '';
+
+		if ( 'failed' === (string) ( $compiled['status'] ?? '' ) || '' === trim( $block_markup ) ) {
+			return new WP_Error( 'static_site_importer_artifact_compile_failed', 'Website artifact compilation did not produce block markup.', $compiled );
+		}
+
+		$source = self::materialize_website_artifact_source( $compiled, $args );
+		if ( is_wp_error( $source ) ) {
+			return $source;
+		}
+
+		$import_args                              = $args;
+		$import_args['block_artifact_compiler']   = $compiled;
+		$import_args['source_metadata']           = isset( $import_args['source_metadata'] ) && is_array( $import_args['source_metadata'] ) ? $import_args['source_metadata'] : array();
+		$import_args['source_metadata']['source'] = 'website_artifact';
+
+		return self::import_theme( $source['html_path'], $import_args );
 	}
 
 	/**
@@ -3324,6 +3361,22 @@ class Static_Site_Importer_Theme_Generator {
 		if ( isset( self::$conversion_report['conversion_fragments'][ $source ] ) ) {
 			self::$conversion_report['conversion_fragments'][ $source ]['compiler'] = $summary;
 		}
+	}
+
+	/**
+	 * Record the bundle-level compiler result used by import_website_artifact().
+	 *
+	 * @param array<string,mixed> $compiled Compiler result envelope.
+	 * @return void
+	 */
+	private static function record_website_artifact_compiler_result( array $compiled ): void {
+		self::$conversion_report['block_artifact_compiler']['available']        = true;
+		self::$conversion_report['block_artifact_compiler']['website_artifact'] = array(
+			'summary'     => bac_summarize_result( $compiled ),
+			'provenance'  => isset( $compiled['provenance'] ) && is_array( $compiled['provenance'] ) ? $compiled['provenance'] : array(),
+			'input'       => isset( $compiled['input'] ) && is_array( $compiled['input'] ) ? $compiled['input'] : array(),
+			'diagnostics' => isset( $compiled['diagnostics'] ) && is_array( $compiled['diagnostics'] ) ? $compiled['diagnostics'] : array(),
+		);
 	}
 
 	/**
@@ -6551,6 +6604,124 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Materialize a compiled website artifact into an SSI source directory.
+	 *
+	 * @param array<string,mixed> $compiled Compiler result envelope.
+	 * @param array<string,mixed> $args     Import args.
+	 * @return array{source_dir:string,html_path:string}|WP_Error
+	 */
+	private static function materialize_website_artifact_source( array $compiled, array $args ) {
+		$uploads = wp_upload_dir();
+		$base    = trailingslashit( (string) $uploads['basedir'] ) . 'static-site-importer/website-artifacts/' . wp_generate_uuid4();
+		if ( ! wp_mkdir_p( $base ) ) {
+			return new WP_Error( 'static_site_importer_artifact_source_mkdir_failed', sprintf( 'Failed to create website artifact source directory: %s', $base ) );
+		}
+
+		$artifacts    = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$files        = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
+		$stylesheets  = array();
+		$scripts      = array();
+		$inline_js    = array();
+		$block_markup = isset( $artifacts['block_markup'] ) ? (string) $artifacts['block_markup'] : '';
+
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$relative = self::normalize_artifact_materialization_path( isset( $file['path'] ) ? (string) $file['path'] : '' );
+			if ( '' === $relative ) {
+				continue;
+			}
+
+			$content = isset( $file['content'] ) && is_scalar( $file['content'] ) ? (string) $file['content'] : '';
+			$dir     = dirname( $base . '/' . $relative );
+			if ( ! wp_mkdir_p( $dir ) ) {
+				return new WP_Error( 'static_site_importer_artifact_file_mkdir_failed', sprintf( 'Failed to create website artifact source directory: %s', $dir ) );
+			}
+
+			$result = self::write_file( $base . '/' . $relative, $content );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$kind = isset( $file['kind'] ) ? (string) $file['kind'] : '';
+			if ( 'css' === $kind || str_ends_with( strtolower( $relative ), '.css' ) ) {
+				$stylesheets[] = $relative;
+			} elseif ( 'js' === $kind || str_ends_with( strtolower( $relative ), '.js' ) ) {
+				$scripts[]   = $relative;
+				$inline_js[] = $content;
+			}
+		}
+
+		$title = isset( $args['name'] ) && '' !== trim( (string) $args['name'] ) ? (string) $args['name'] : 'Imported Website Artifact';
+		$html  = self::website_artifact_html_document( $title, $block_markup, $stylesheets, $scripts, $inline_js );
+		$result = self::write_file( $base . '/index.html', $html );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'source_dir' => $base,
+			'html_path'  => $base . '/index.html',
+		);
+	}
+
+	/**
+	 * Normalize compiler file paths before writing them to a temporary source tree.
+	 *
+	 * @param string $path Artifact file path.
+	 * @return string Safe relative path, or empty string when unsafe.
+	 */
+	private static function normalize_artifact_materialization_path( string $path ): string {
+		$path = str_replace( '\\', '/', trim( $path ) );
+		$path = preg_replace( '/\0+/', '', $path );
+		if ( ! is_string( $path ) || '' === $path || str_starts_with( $path, '/' ) || preg_match( '#^[a-z][a-z0-9+.-]*:#i', $path ) ) {
+			return '';
+		}
+
+		$segments = array();
+		foreach ( explode( '/', $path ) as $segment ) {
+			if ( '' === $segment || '.' === $segment ) {
+				continue;
+			}
+			if ( '..' === $segment ) {
+				return '';
+			}
+			$segments[] = preg_replace( '/[^A-Za-z0-9._-]/', '-', $segment );
+		}
+
+		return implode( '/', array_filter( $segments ) );
+	}
+
+	/**
+	 * Build the temporary HTML entry consumed by import_theme().
+	 *
+	 * @param string            $title       Document title.
+	 * @param string            $block_markup Compiled block markup.
+	 * @param array<int,string> $stylesheets Local stylesheet paths.
+	 * @param array<int,string> $scripts     Local script paths.
+	 * @param array<int,string> $inline_js   Script contents to preserve through SSI's inline JS path.
+	 * @return string HTML document.
+	 */
+	private static function website_artifact_html_document( string $title, string $block_markup, array $stylesheets, array $scripts, array $inline_js ): string {
+		$head = '<title>' . esc_html( $title ) . '</title>';
+		foreach ( array_values( array_unique( $stylesheets ) ) as $path ) {
+			$head .= "\n" . '<link rel="stylesheet" href="' . esc_attr( $path ) . '">';
+		}
+
+		$script_tags = '';
+		foreach ( array_values( array_unique( $scripts ) ) as $path ) {
+			$script_tags .= "\n" . '<script src="' . esc_attr( $path ) . '"></script>';
+		}
+		if ( ! empty( $inline_js ) ) {
+			$script_tags .= "\n" . '<script>' . implode( "\n", $inline_js ) . '</script>';
+		}
+
+		return '<!doctype html>' . "\n" . '<html><head>' . $head . '</head><body><main>' . "\n" . $block_markup . "\n" . '</main>' . $script_tags . '</body></html>' . "\n";
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -224,6 +224,46 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Website artifact bundles compile through BAC before SSI materializes the theme.
+	 */
+	public function test_website_artifact_bundle_imports_through_block_artifact_compiler(): void {
+		$artifact_json = file_get_contents( dirname( __DIR__ ) . '/tests/fixtures/website-artifact-bundle/artifact.json' );
+		$artifact      = is_string( $artifact_json ) ? json_decode( $artifact_json, true ) : null;
+		$this->assertIsArray( $artifact );
+
+		$result = Static_Site_Importer_Theme_Generator::import_website_artifact(
+			$artifact,
+			array(
+				'name'        => 'Website Artifact Fixture',
+				'slug'        => 'website-artifact-fixture',
+				'overwrite'   => true,
+				'activate'    => false,
+				'keep_source' => true,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'index.html', $result['pages'] );
+
+		$theme_dir = $result['theme_dir'];
+		$style     = $this->read_file( $theme_dir . '/style.css' );
+		$script    = $this->read_file( $theme_dir . '/assets/site.js' );
+		$report    = json_decode( $this->read_file( $result['report_path'] ), true );
+		$post      = get_post( $result['pages']['index.html'] );
+
+		$this->assertStringContainsString( '.hero{padding:4rem', $style );
+		$this->assertStringContainsString( "website-artifact", $script );
+		$this->assertInstanceOf( WP_Post::class, $post );
+		$this->assertStringContainsString( 'Website Artifact Fixture', $post->post_content );
+		$this->assertIsArray( $report );
+		$this->assertArrayHasKey( 'website_artifact', $report['block_artifact_compiler'] ?? array() );
+		$this->assertSame( 'success', $report['block_artifact_compiler']['website_artifact']['summary']['status'] ?? '' );
+		$this->assertSame( 'index.html', $report['block_artifact_compiler']['website_artifact']['provenance']['source'] ?? '' );
+		$this->assertNotEmpty( $report['block_artifact_compiler']['website_artifact']['provenance']['source_hash'] ?? '' );
+	}
+
+	/**
 	 * Recursive HTML discovery includes nested pages while skipping dependency and hidden directories.
 	 */
 	public function test_collect_pages_discovers_nested_html_sources(): void {

--- a/tests/fixtures/website-artifact-bundle/artifact.json
+++ b/tests/fixtures/website-artifact-bundle/artifact.json
@@ -1,0 +1,6 @@
+{
+  "schema": "chubes4/website-artifact/v1",
+  "html": "<main><section class=\"hero\"><h1>Website Artifact Fixture</h1><p>Compiled before SSI materialization.</p></section></main>",
+  "css": ".hero{padding:4rem;background:#f6f2ea;color:#1b1b1b}",
+  "js": "document.documentElement.dataset.fixture = 'website-artifact';"
+}

--- a/tests/smoke-import-theme-ability.php
+++ b/tests/smoke-import-theme-ability.php
@@ -107,6 +107,20 @@ class Static_Site_Importer_Theme_Generator {
 		);
 	}
 
+	public static function import_website_artifact( array $artifact, array $args = array() ): array|WP_Error {
+		self::$last_call = array( 'website-artifact', $artifact, $args );
+
+		return array(
+			'theme_slug'            => $args['slug'],
+			'theme_name'            => $args['name'],
+			'report_path'           => '/tmp/import-report.json',
+			'import_report_summary' => array(
+				'status'       => 'completed',
+				'quality_pass' => true,
+			),
+		);
+	}
+
 	public static function export_theme( array $args = array() ): array|WP_Error {
 		self::$last_call = array( 'export', $args );
 
@@ -152,6 +166,7 @@ $assert = static function ( bool $condition, string $label, string $detail = '' 
 $assert( isset( $registered_categories['static-site-importer'] ), 'category-registers-after-api-init' );
 $assert( isset( $registered_abilities['static-site-importer/import-theme'] ), 'ability-registers-after-api-init' );
 $assert( isset( $registered_abilities['static-site-importer/export-theme'] ), 'export-ability-registers-after-api-init' );
+$assert( isset( $registered_abilities['static-site-importer/import-website-artifact'] ), 'website-artifact-ability-registers-after-api-init' );
 
 static_site_importer_register_ability_category();
 static_site_importer_register_abilities();
@@ -159,6 +174,7 @@ static_site_importer_register_abilities();
 $assert( isset( $registered_categories['static-site-importer'] ), 'category-registered' );
 $assert( isset( $registered_abilities['static-site-importer/import-theme'] ), 'import-theme-ability-registered' );
 $assert( isset( $registered_abilities['static-site-importer/export-theme'] ), 'export-theme-ability-registered' );
+$assert( isset( $registered_abilities['static-site-importer/import-website-artifact'] ), 'import-website-artifact-ability-registered' );
 
 $ability = $registered_abilities['static-site-importer/import-theme'] ?? array();
 $assert( 'static_site_importer_ability_import_theme' === ( $ability['execute_callback'] ?? '' ), 'execute-callback' );
@@ -208,6 +224,36 @@ $assert( 0 === ( $args['max_fallbacks'] ?? null ), 'max-fallbacks-forwarded' );
 $assert( true === ( $args['allow_missing_woocommerce'] ?? false ), 'allow-missing-woocommerce-forwarded' );
 $assert( 123 === ( $args['asset_map']['assets/hero.jpg']['attachment_id'] ?? null ), 'asset-map-forwarded' );
 $assert( 'https://example.com/' === ( $args['source_metadata']['final_url'] ?? '' ), 'source-metadata-forwarded' );
+
+$website_artifact_ability = $registered_abilities['static-site-importer/import-website-artifact'] ?? array();
+$assert( 'static_site_importer_ability_import_website_artifact' === ( $website_artifact_ability['execute_callback'] ?? '' ), 'website-artifact-execute-callback' );
+
+$missing_artifact = static_site_importer_ability_import_website_artifact( array() );
+$assert( empty( $missing_artifact['success'] ), 'missing-website-artifact-fails' );
+$assert( 'static_site_importer_missing_website_artifact' === ( $missing_artifact['error']['code'] ?? '' ), 'missing-website-artifact-error-code' );
+
+$artifact_fixture = file_get_contents( __DIR__ . '/fixtures/website-artifact-bundle/artifact.json' );
+$artifact         = is_string( $artifact_fixture ) ? json_decode( $artifact_fixture, true ) : null;
+$assert( is_array( $artifact ), 'website-artifact-fixture-decodes' );
+$artifact_result = static_site_importer_ability_import_website_artifact(
+	array(
+		'artifact'                  => is_array( $artifact ) ? $artifact : array(),
+		'slug'                      => 'artifact-theme',
+		'name'                      => 'Artifact Theme',
+		'overwrite'                 => true,
+		'keep_source'               => true,
+		'allow_missing_woocommerce' => true,
+		'compiler_options'          => array( 'include_bfb_report' => true ),
+		'source_metadata'           => array( 'source' => 'fixture' ),
+	)
+);
+$assert( ! empty( $artifact_result['success'] ), 'website-artifact-ability-succeeds' );
+$assert( 'website-artifact' === ( Static_Site_Importer_Theme_Generator::$last_call[0] ?? '' ), 'website-artifact-forwarded' );
+$assert( str_contains( Static_Site_Importer_Theme_Generator::$last_call[1]['html'] ?? '', 'Website Artifact Fixture' ), 'website-artifact-html-forwarded' );
+$artifact_args = Static_Site_Importer_Theme_Generator::$last_call[2] ?? array();
+$assert( 'artifact-theme' === ( $artifact_args['slug'] ?? '' ), 'website-artifact-slug-forwarded' );
+$assert( true === ( $artifact_args['compiler_options']['include_bfb_report'] ?? false ), 'website-artifact-compiler-options-forwarded' );
+$assert( 'fixture' === ( $artifact_args['source_metadata']['source'] ?? '' ), 'website-artifact-source-metadata-forwarded' );
 
 $export_ability = $registered_abilities['static-site-importer/export-theme'] ?? array();
 $assert( 'static_site_importer_ability_export_theme' === ( $export_ability['execute_callback'] ?? '' ), 'export-execute-callback' );


### PR DESCRIPTION
## Summary
- Adds `Static_Site_Importer_Theme_Generator::import_website_artifact()` to compile website artifact bundles through Block Artifact Compiler before reusing the existing SSI theme import materialization path.
- Registers a first-class `static-site-importer/import-website-artifact` ability and `static-site-importer import-website-artifact` CLI shape for JSON artifact bundles.
- Records bundle-level BAC summary/provenance in import reports and adds fixture coverage for HTML/CSS/JS artifact imports.

Fixes #259.

## Verification
- `php -l includes/class-static-site-importer-theme-generator.php && php -l includes/abilities.php && php -l includes/class-static-site-importer-cli-command.php && php -l tests/smoke-import-theme-ability.php && php -l tests/StaticSiteImporterFixtureTest.php`
- `composer validate`
- `php vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php`
- `php tests/smoke-import-theme-ability.php`
- `homeboy test --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the SSI website artifact import API, ability/CLI wiring, BAC report provenance, and fixture coverage under Chris's direction.