### PR TITLE
Export BAC-compatible website artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Important behavior:
 
 The export envelope includes:
 
-- `schema: "chubes4/website-artifact/v1"`, `artifact_type: "website"`, `version`, `id`, `generated_at`, `root`, and `entrypoint`.
+- `schema: "block-artifact-compiler/website-artifact/v1"`, `artifact_type: "website"`, `version`, `id`, `generated_at`, `root`, and `entrypoint`.
 - `files[]` entries with safe artifact-relative paths, `role`, `kind`, `mime_type`, `encoding`, `bytes`, `sha256`, and inline `content`.
 - UTF-8 text content by default; binary content is transported as Base64 with `encoding: "base64"`.
 - source/materialization provenance under `provenance`.

--- a/README.md
+++ b/README.md
@@ -174,20 +174,20 @@ Important behavior:
 - Imported WordPress page posts store the converted page body in `post_content`, so routing, titles, front-page assignment, editor visibility, and body edits stay native.
 - Page patterns are generated as reusable/reference copies of each converted page body; they are not the primary storage for imported page content.
 
-## Static-Site Export Artifact Set
+## Website Artifact Export
 
-`static-site-importer/export-theme` exports an imported or active block theme back to a static-site artifact set. Existing callers can continue reading the top-level `files` and `report` fields. New callers should prefer `artifact_set` for the complete export envelope.
+`static-site-importer/export-theme` exports an imported or active block theme as a BAC-compatible website artifact. SSI owns the WordPress import/export/materialization path; Block Artifact Compiler owns the website artifact compilation contract. Studio Web, Codebox, and other products should consume the exported `website_artifact` object rather than SSI-specific static-site wrappers.
 
 The export envelope includes:
 
-- `schema`, `artifact_type`, `version`, `id`, `generated_at`, `root`, and `entrypoint`.
+- `schema: "chubes4/website-artifact/v1"`, `artifact_type: "website"`, `version`, `id`, `generated_at`, `root`, and `entrypoint`.
 - `files[]` entries with safe artifact-relative paths, `role`, `kind`, `mime_type`, `encoding`, `bytes`, `sha256`, and inline `content`.
 - UTF-8 text content by default; binary content is transported as Base64 with `encoding: "base64"`.
 - source/materialization provenance under `provenance`.
 - import/validation summaries and `reports[]` references for repair loops.
 - `import-report.json` and `source-documents.json` metadata files when the exported theme has SSI import provenance.
 
-The default root remains `static-site` for backwards compatibility. Callers that need another artifact root can pass `root` with a matching `entrypoint`, such as `root: "website"` and `entrypoint: "website/index.html"`.
+The default root is `website` with `entrypoint: "website/index.html"`. Callers can pass any safe single-segment root with a matching entrypoint, such as `root: "artifact"` and `entrypoint: "artifact/index.html"`.
 
 ## Validation
 

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "098b74f84b458b1bc75c89fa333291dc186e5fa1"
+                "reference": "50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/098b74f84b458b1bc75c89fa333291dc186e5fa1",
-                "reference": "098b74f84b458b1bc75c89fa333291dc186e5fa1",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1",
+                "reference": "50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1",
                 "shasum": ""
             },
             "require": {
@@ -43,7 +43,7 @@
                 "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
                 "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
             },
-            "time": "2026-05-31T02:58:07+00:00"
+            "time": "2026-05-31T18:29:55+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -79,8 +79,8 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 		wp_register_ability(
 			'static-site-importer/export-theme',
 			array(
-				'label'               => __( 'Export Static Site Theme', 'static-site-importer' ),
-				'description'         => __( 'Export an imported or active block theme and page content as static-site artifacts.', 'static-site-importer' ),
+				'label'               => __( 'Export Website Artifact', 'static-site-importer' ),
+				'description'         => __( 'Export an imported or active block theme and page content as a BAC-compatible website artifact.', 'static-site-importer' ),
 				'category'            => STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -157,7 +157,7 @@ if ( ! function_exists( 'static_site_importer_ability_permission_callback' ) ) {
 
 if ( ! function_exists( 'static_site_importer_ability_export_theme' ) ) {
 	/**
-	 * Ability callback for static site theme exports.
+	 * Ability callback for website artifact exports.
 	 *
 	 * @param array<string, mixed> $input Ability input.
 	 * @return array<string, mixed>
@@ -166,7 +166,7 @@ if ( ! function_exists( 'static_site_importer_ability_export_theme' ) ) {
 		$args = array(
 			'theme_slug'      => isset( $input['theme_slug'] ) ? (string) $input['theme_slug'] : '',
 			'root'            => isset( $input['root'] ) ? (string) $input['root'] : '',
-			'entrypoint'      => isset( $input['entrypoint'] ) ? (string) $input['entrypoint'] : 'static-site/index.html',
+			'entrypoint'      => isset( $input['entrypoint'] ) ? (string) $input['entrypoint'] : 'website/index.html',
 			'include_pages'   => $input['include_pages'] ?? true,
 			'source_metadata' => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
 		);

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -914,7 +914,7 @@ class Static_Site_Importer_Theme_Generator {
 		$id           = 'website-artifact-' . $theme_slug . '-' . substr( hash( 'sha256', self::json_encode_pretty( array( $entrypoint, $files ) ) ), 0, 12 );
 
 		return array(
-			'schema'        => 'chubes4/website-artifact/v1',
+			'schema'        => 'block-artifact-compiler/website-artifact/v1',
 			'artifact_type' => 'website',
 			'version'       => 1,
 			'id'            => $id,

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -517,14 +517,14 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Export an imported or active block theme as static-site artifacts.
+	 * Export an imported or active block theme as a website artifact.
 	 *
 	 * @param array $args Export args.
-	 * @return array{artifact_set:array<string,mixed>,files:array<int,array<string,mixed>>,report:array<string,mixed>}|WP_Error
+	 * @return array{website_artifact:array<string,mixed>}|WP_Error
 	 */
 	public static function export_theme( array $args = array() ) {
 		if ( ! function_exists( 'bfb_convert' ) ) {
-			return new WP_Error( 'static_site_importer_missing_bfb', 'Block Format Bridge is required to export a static site.' );
+			return new WP_Error( 'static_site_importer_missing_bfb', 'Block Format Bridge is required to export a website artifact.' );
 		}
 
 		$theme_slug = isset( $args['theme_slug'] ) && '' !== trim( (string) $args['theme_slug'] ) ? sanitize_title( (string) $args['theme_slug'] ) : self::active_theme_slug();
@@ -537,7 +537,7 @@ class Static_Site_Importer_Theme_Generator {
 			return new WP_Error( 'static_site_importer_theme_not_found', sprintf( 'Theme directory not found for %s.', $theme_slug ) );
 		}
 
-		$entrypoint      = self::export_artifact_path( isset( $args['entrypoint'] ) ? (string) $args['entrypoint'] : 'static-site/index.html', 'static-site/index.html' );
+		$entrypoint      = self::export_artifact_path( isset( $args['entrypoint'] ) ? (string) $args['entrypoint'] : 'website/index.html', 'website/index.html' );
 		$root            = self::export_artifact_root( isset( $args['root'] ) ? (string) $args['root'] : '', $entrypoint );
 		$include_pages   = $args['include_pages'] ?? true;
 		$source_metadata = isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array();
@@ -634,12 +634,10 @@ class Static_Site_Importer_Theme_Generator {
 			$report['import_report'] = $import_report;
 		}
 
-		$artifact_set = self::export_artifact_set( $theme_slug, $root, $entrypoint, $files, $report, $source_metadata );
+		$website_artifact = self::export_website_artifact( $theme_slug, $root, $entrypoint, $files, $report, $source_metadata );
 
 		return array(
-			'artifact_set' => $artifact_set,
-			'files'        => $files,
-			'report'       => $report,
+			'website_artifact' => $website_artifact,
 		);
 	}
 
@@ -901,7 +899,7 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Build the richer export artifact set envelope.
+	 * Build the BAC-compatible website artifact envelope.
 	 *
 	 * @param string              $theme_slug      Theme slug.
 	 * @param string              $root            Artifact root.
@@ -911,13 +909,13 @@ class Static_Site_Importer_Theme_Generator {
 	 * @param array<string,mixed> $source_metadata Source metadata.
 	 * @return array<string,mixed>
 	 */
-	private static function export_artifact_set( string $theme_slug, string $root, string $entrypoint, array $files, array $report, array $source_metadata ): array {
+	private static function export_website_artifact( string $theme_slug, string $root, string $entrypoint, array $files, array $report, array $source_metadata ): array {
 		$generated_at = self::export_generated_at();
-		$id           = 'static-site-importer-' . $theme_slug . '-' . substr( hash( 'sha256', self::json_encode_pretty( array( $entrypoint, $files ) ) ), 0, 12 );
+		$id           = 'website-artifact-' . $theme_slug . '-' . substr( hash( 'sha256', self::json_encode_pretty( array( $entrypoint, $files ) ) ), 0, 12 );
 
 		return array(
-			'schema'        => 'static-site-importer/static-site-artifact-set/v1',
-			'artifact_type' => 'static-site',
+			'schema'        => 'chubes4/website-artifact/v1',
+			'artifact_type' => 'website',
 			'version'       => 1,
 			'id'            => $id,
 			'generated_at'  => $generated_at,
@@ -941,7 +939,7 @@ class Static_Site_Importer_Theme_Generator {
 					array(
 						'name'    => 'entrypoint-present',
 						'status'  => self::export_has_file( $files, $entrypoint ) ? 'passed' : 'failed',
-						'message' => 'The static-site entrypoint is present in the exported file set.',
+						'message' => 'The website artifact entrypoint is present in the exported file set.',
 					),
 				),
 			),
@@ -972,7 +970,7 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Export browser assets that can be replayed with the static artifact.
+	 * Export browser assets that can be replayed with the website artifact.
 	 *
 	 * @param string                    $theme_dir   Theme directory.
 	 * @param string                    $root        Artifact root.
@@ -1053,7 +1051,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		$parts = explode( '/', $entrypoint );
-		return '' !== ( $parts[0] ?? '' ) ? $parts[0] : 'static-site';
+		return '' !== ( $parts[0] ?? '' ) ? $parts[0] : 'website';
 	}
 
 	/**

--- a/tests/fixtures/website-artifact-bundle/artifact.json
+++ b/tests/fixtures/website-artifact-bundle/artifact.json
@@ -1,5 +1,5 @@
 {
-  "schema": "chubes4/website-artifact/v1",
+  "schema": "block-artifact-compiler/website-artifact/v1",
   "html": "<main><section class=\"hero\"><h1>Website Artifact Fixture</h1><p>Compiled before SSI materialization.</p></section></main>",
   "css": ".hero{padding:4rem;background:#f6f2ea;color:#1b1b1b}",
   "js": "document.documentElement.dataset.fixture = 'website-artifact';"

--- a/tests/smoke-export-theme-ability.php
+++ b/tests/smoke-export-theme-ability.php
@@ -174,7 +174,7 @@ $artifact = $result['website_artifact'] ?? array();
 $assert( ! isset( $result['artifact_set'] ), 'legacy-artifact-set-removed' );
 $assert( ! isset( $result['files'] ), 'legacy-top-level-files-removed' );
 $assert( ! isset( $result['report'] ), 'legacy-top-level-report-removed' );
-$assert( 'chubes4/website-artifact/v1' === ( $artifact['schema'] ?? '' ), 'website-artifact-schema' );
+$assert( 'block-artifact-compiler/website-artifact/v1' === ( $artifact['schema'] ?? '' ), 'website-artifact-schema' );
 $assert( 'website' === ( $artifact['artifact_type'] ?? '' ), 'artifact-type' );
 $assert( 1 === ( $artifact['version'] ?? 0 ), 'artifact-version' );
 $assert( 'website' === ( $artifact['root'] ?? '' ), 'artifact-root' );

--- a/tests/smoke-export-theme-ability.php
+++ b/tests/smoke-export-theme-ability.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Smoke test: an imported block theme can export static-site artifacts.
+ * Smoke test: an imported block theme can export website artifacts.
  *
  * Run from the repository root:
  * php tests/smoke-export-theme-ability.php
@@ -146,11 +146,16 @@ if ( ! function_exists( 'bfb_convert' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php';
+$bac_library = dirname( __DIR__ ) . '/vendor/chubes4/block-artifact-compiler/library.php';
+if ( is_readable( $bac_library ) ) {
+	require_once $bac_library;
+}
 
 $result = Static_Site_Importer_Theme_Generator::export_theme(
 	array(
 		'theme_slug'      => 'fixture-theme',
-		'entrypoint'      => 'static-site/index.html',
+		'root'            => 'website',
+		'entrypoint'      => 'website/index.html',
 		'include_pages'   => true,
 		'source_metadata' => array( 'source' => 'smoke' ),
 	)
@@ -165,42 +170,52 @@ $assert     = static function ( bool $condition, string $label, string $detail =
 };
 
 $assert( ! is_wp_error( $result ), 'export-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
-$assert( 'static-site-importer/static-site-artifact-set/v1' === ( $result['artifact_set']['schema'] ?? '' ), 'artifact-set-schema' );
-$assert( 'static-site' === ( $result['artifact_set']['artifact_type'] ?? '' ), 'artifact-type' );
-$assert( 1 === ( $result['artifact_set']['version'] ?? 0 ), 'artifact-version' );
-$assert( 'static-site' === ( $result['artifact_set']['root'] ?? '' ), 'artifact-root' );
-$assert( 'static-site/index.html' === ( $result['artifact_set']['entrypoint'] ?? '' ), 'entrypoint' );
-$assert( 6 === count( $result['files'] ?? array() ), 'exports-entrypoint-assets-and-metadata' );
-$assert( 'static-site/style.css' === ( $result['files'][0]['path'] ?? '' ), 'stylesheet-exported' );
-$assert( 'static-site/index.html' === ( $result['files'][1]['path'] ?? '' ), 'entrypoint-exported' );
-$assert( 'text/html' === ( $result['files'][1]['mime_type'] ?? '' ), 'entrypoint-mime' );
-$assert( 'utf8' === ( $result['files'][1]['encoding'] ?? '' ), 'entrypoint-encoding' );
-$assert( isset( $result['files'][1]['bytes'] ) && $result['files'][1]['bytes'] > 0, 'entrypoint-bytes' );
-$assert( isset( $result['files'][1]['sha256'] ) && 64 === strlen( (string) $result['files'][1]['sha256'] ), 'entrypoint-hash' );
-$assert( str_contains( (string) ( $result['files'][1]['content'] ?? '' ), 'Edited Playground content' ), 'page-content-converted' );
-$assert( str_contains( (string) ( $result['files'][1]['content'] ?? '' ), '<link rel="stylesheet" href="style.css">' ), 'stylesheet-linked' );
+$artifact = $result['website_artifact'] ?? array();
+$assert( ! isset( $result['artifact_set'] ), 'legacy-artifact-set-removed' );
+$assert( ! isset( $result['files'] ), 'legacy-top-level-files-removed' );
+$assert( ! isset( $result['report'] ), 'legacy-top-level-report-removed' );
+$assert( 'chubes4/website-artifact/v1' === ( $artifact['schema'] ?? '' ), 'website-artifact-schema' );
+$assert( 'website' === ( $artifact['artifact_type'] ?? '' ), 'artifact-type' );
+$assert( 1 === ( $artifact['version'] ?? 0 ), 'artifact-version' );
+$assert( 'website' === ( $artifact['root'] ?? '' ), 'artifact-root' );
+$assert( 'website/index.html' === ( $artifact['entrypoint'] ?? '' ), 'entrypoint' );
+$assert( 6 === count( $artifact['files'] ?? array() ), 'exports-entrypoint-assets-and-metadata' );
+$assert( 'website/style.css' === ( $artifact['files'][0]['path'] ?? '' ), 'stylesheet-exported' );
+$assert( 'website/index.html' === ( $artifact['files'][1]['path'] ?? '' ), 'entrypoint-exported' );
+$assert( 'text/html' === ( $artifact['files'][1]['mime_type'] ?? '' ), 'entrypoint-mime' );
+$assert( 'utf8' === ( $artifact['files'][1]['encoding'] ?? '' ), 'entrypoint-encoding' );
+$assert( isset( $artifact['files'][1]['bytes'] ) && $artifact['files'][1]['bytes'] > 0, 'entrypoint-bytes' );
+$assert( isset( $artifact['files'][1]['sha256'] ) && 64 === strlen( (string) $artifact['files'][1]['sha256'] ), 'entrypoint-hash' );
+$assert( str_contains( (string) ( $artifact['files'][1]['content'] ?? '' ), 'Edited Playground content' ), 'page-content-converted' );
+$assert( str_contains( (string) ( $artifact['files'][1]['content'] ?? '' ), '<link rel="stylesheet" href="style.css">' ), 'stylesheet-linked' );
 $files_by_path = array();
-foreach ( $result['files'] ?? array() as $file ) {
+foreach ( $artifact['files'] ?? array() as $file ) {
 	$files_by_path[ $file['path'] ?? '' ] = $file;
 }
-$assert( 'script' === ( $files_by_path['static-site/assets/app.js']['role'] ?? '' ), 'script-role' );
-$assert( 'text/javascript' === ( $files_by_path['static-site/assets/app.js']['mime_type'] ?? '' ), 'script-mime' );
-$assert( 'base64' === ( $files_by_path['static-site/assets/logo.png']['encoding'] ?? '' ), 'binary-base64-encoding' );
-$assert( 'image/png' === ( $files_by_path['static-site/assets/logo.png']['mime_type'] ?? '' ), 'binary-mime' );
-$assert( 'report' === ( $files_by_path['static-site/import-report.json']['role'] ?? '' ), 'report-role' );
-$assert( 'source-document' === ( $files_by_path['static-site/source-documents.json']['role'] ?? '' ), 'source-document-role' );
-$assert( 'completed' === ( $result['report']['status'] ?? '' ), 'report-completed' );
-$assert( 'passed' === ( $result['artifact_set']['validation']['status'] ?? '' ), 'validation-passed' );
-$assert( 'passed' === ( $result['artifact_set']['import']['status'] ?? '' ), 'import-status-passed' );
-$assert( 'static-site-importer' === ( $result['artifact_set']['provenance']['producer'] ?? '' ), 'provenance-producer' );
-$assert( 'smoke' === ( $result['artifact_set']['provenance']['source_metadata']['source'] ?? '' ), 'provenance-source-metadata' );
-$assert( 'static-site/import-report.json' === ( $result['artifact_set']['reports'][0]['path'] ?? '' ), 'report-ref' );
-$assert( 'smoke' === ( $result['report']['source_metadata']['source'] ?? '' ), 'source-metadata-preserved' );
-$assert( 'completed' === ( $result['report']['import_report']['status'] ?? '' ), 'import-report-preserved' );
-$assert( count( $GLOBALS['ssi_export_bfb_calls'] ) >= 4, 'bfb-called-for-block-to-html' );
-foreach ( $GLOBALS['ssi_export_bfb_calls'] as $call ) {
-	$assert( 'blocks' === $call[0] && 'html' === $call[1], 'bfb-call-uses-blocks-to-html' );
+$assert( 'script' === ( $files_by_path['website/assets/app.js']['role'] ?? '' ), 'script-role' );
+$assert( 'text/javascript' === ( $files_by_path['website/assets/app.js']['mime_type'] ?? '' ), 'script-mime' );
+$assert( 'base64' === ( $files_by_path['website/assets/logo.png']['encoding'] ?? '' ), 'binary-base64-encoding' );
+$assert( 'image/png' === ( $files_by_path['website/assets/logo.png']['mime_type'] ?? '' ), 'binary-mime' );
+$assert( 'report' === ( $files_by_path['website/import-report.json']['role'] ?? '' ), 'report-role' );
+$assert( 'source-document' === ( $files_by_path['website/source-documents.json']['role'] ?? '' ), 'source-document-role' );
+$assert( 'completed' === ( $artifact['report']['status'] ?? '' ), 'report-completed' );
+$assert( 'passed' === ( $artifact['validation']['status'] ?? '' ), 'validation-passed' );
+$assert( 'passed' === ( $artifact['import']['status'] ?? '' ), 'import-status-passed' );
+$assert( 'static-site-importer' === ( $artifact['provenance']['producer'] ?? '' ), 'provenance-producer' );
+$assert( 'smoke' === ( $artifact['provenance']['source_metadata']['source'] ?? '' ), 'provenance-source-metadata' );
+$assert( 'website/import-report.json' === ( $artifact['reports'][0]['path'] ?? '' ), 'report-ref' );
+$assert( 'smoke' === ( $artifact['report']['source_metadata']['source'] ?? '' ), 'source-metadata-preserved' );
+$assert( 'completed' === ( $artifact['report']['import_report']['status'] ?? '' ), 'import-report-preserved' );
+if ( function_exists( 'bac_compile_website_artifact' ) ) {
+	$compiled = bac_compile_website_artifact( $artifact );
+	$assert( 'chubes4/block-artifact-compiler-result/v1' === ( $compiled['schema'] ?? '' ), 'bac-compiles-exported-artifact' );
+	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'bac-uses-website-entrypoint' );
 }
+$export_bfb_calls = array_filter(
+	$GLOBALS['ssi_export_bfb_calls'],
+	static fn ( array $call ): bool => 'blocks' === $call[0] && 'html' === $call[1]
+);
+$assert( count( $export_bfb_calls ) >= 4, 'bfb-called-for-block-to-html' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-import-theme-ability.php
+++ b/tests/smoke-import-theme-ability.php
@@ -126,7 +126,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		return array(
 			'website_artifact' => array(
-				'schema'     => 'chubes4/website-artifact/v1',
+				'schema'     => 'block-artifact-compiler/website-artifact/v1',
 				'entrypoint' => $args['entrypoint'],
 				'files'      => array(
 					array(

--- a/tests/smoke-import-theme-ability.php
+++ b/tests/smoke-import-theme-ability.php
@@ -125,8 +125,8 @@ class Static_Site_Importer_Theme_Generator {
 		self::$last_call = array( 'export', $args );
 
 		return array(
-			'artifact_set' => array(
-				'schema'     => 'static-site-importer/static-site-artifact-set/v1',
+			'website_artifact' => array(
+				'schema'     => 'chubes4/website-artifact/v1',
 				'entrypoint' => $args['entrypoint'],
 				'files'      => array(
 					array(
@@ -137,15 +137,6 @@ class Static_Site_Importer_Theme_Generator {
 					),
 				),
 			),
-			'files'        => array(
-				array(
-					'path'    => $args['entrypoint'],
-					'content' => '<!doctype html><html><body>Fixture</body></html>',
-					'kind'    => 'document',
-					'role'    => 'entrypoint',
-				),
-			),
-			'report'       => array( 'status' => 'completed' ),
 		);
 }
 }
@@ -260,13 +251,16 @@ $assert( 'static_site_importer_ability_export_theme' === ( $export_ability['exec
 $export = static_site_importer_ability_export_theme(
 	array(
 		'theme_slug'      => 'fixture-theme',
-		'entrypoint'      => 'static-site/index.html',
+		'entrypoint'      => 'website/index.html',
 		'include_pages'   => false,
 		'source_metadata' => array( 'source' => 'smoke' ),
 	)
 );
 $assert( ! empty( $export['success'] ), 'ability-export-succeeds' );
-$assert( 'static-site/index.html' === ( $export['artifact_set']['entrypoint'] ?? '' ), 'ability-export-includes-entrypoint' );
+$assert( 'website/index.html' === ( $export['website_artifact']['entrypoint'] ?? '' ), 'ability-export-includes-entrypoint' );
+$assert( ! isset( $export['artifact_set'] ), 'ability-export-omits-legacy-artifact-set' );
+$assert( ! isset( $export['files'] ), 'ability-export-omits-legacy-files' );
+$assert( ! isset( $export['report'] ), 'ability-export-omits-legacy-report' );
 $export_args = Static_Site_Importer_Theme_Generator::$last_call[1] ?? array();
 $assert( 'fixture-theme' === ( $export_args['theme_slug'] ?? '' ), 'export-theme-slug-forwarded' );
 $assert( false === ( $export_args['include_pages'] ?? true ), 'export-include-pages-forwarded' );

--- a/vendor/chubes4/block-artifact-compiler/.github/workflows/test.yml
+++ b/vendor/chubes4/block-artifact-compiler/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  homeboy-test:
+    name: Homeboy Test (PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.1', '8.2', '8.3', '8.4']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: Extra-Chill/homeboy-action@v2
+        with:
+          commands: test
+          php-version: ${{ matrix.php-version }}
+          node-version: '24'
+          autofix: 'false'

--- a/vendor/chubes4/block-artifact-compiler/README.md
+++ b/vendor/chubes4/block-artifact-compiler/README.md
@@ -16,41 +16,68 @@ Studio Web
 
 Input: a user-owned website artifact bundle.
 
+Canonical input schema: `block-artifact-compiler/website-artifact/v1`.
+
 Output: a WordPress-native artifact bundle.
 
 The contract accepts messy AI-generated artifact shapes and normalizes them into a bounded, safe envelope before lower-level conversion runs. It accepts:
 
 - `files`, `artifacts`, or `outputs` arrays
 - path-to-content maps
+- `content_base64` payloads for binary and encoded text files
+- MIME metadata through `mime_type`, `mime`, `media_type`, or MIME-shaped `type`
+- file `role`, `intent`, and `entrypoint` metadata
+- bundle `entrypoint`, `entry`, `main`, or `entrypoints` metadata
 - `html`, `generated_html`, `content`, or `body` strings
 - shorthand `css`, `styles`, `js`, `javascript`, or `script` strings
 
-It rejects absolute paths, `..` escapes, empty paths, oversized files, and over-budget bundles.
+It rejects absolute paths, `..` escapes, empty paths, invalid base64 payloads, oversized files, and over-budget bundles. Rejections are reported as diagnostics so permissive generators can keep producing complete website bundles while BAC normalizes the safe subset for WordPress materializers.
+
+BAC treats Markdown and MDX as source documents, not generic assets:
+
+- `.md` and `.markdown` normalize as `kind: markdown` with `text/markdown`
+- `.mdx` normalizes as `kind: mdx` with BAC-local MIME type `text/mdx`
+- frontmatter maps to WordPress document metadata such as title, slug, post type, excerpt, date, template, and taxonomy hints
+- Markdown bodies are converted through Block Format Bridge when available, with a core/html preservation fallback otherwise
+- MDX bodies are reduced to Markdown-compatible text where feasible, while JSX imports/components stay inspectable as candidates and diagnostics
 
 The compiler result returns:
 
 - serialized block markup
 - parsed blocks when WordPress parsing is available
 - component candidates from explicit `data-component` markers and repeated semantic class tokens
-- generated block type manifest placeholder
-- generated file manifest for non-entry artifact files
+- component candidates from MDX JSX references and generated JSX/TSX component files
+- post/page-like `documents` artifacts compiled from Markdown and MDX source documents
+- generated custom block type artifacts discovered from `block.json` roots
+- generated file manifest for non-entry artifact files, including MIME type, role, encoding, binary marker, `content_base64` for binary assets, and CSS/JS intent when present or inferred
+- generated file manifest provenance, including uncompiled source documents with stable source hashes
 - diagnostics
 - provenance
 - optional BFB conversion report
 
-Future compiler passes can promote component candidates into generated custom block artifacts without changing the caller boundary.
+Block type artifacts are normalized compiler output, not generation prompt constraints. Generation can produce loose files; the compiler identifies block roots, records diagnostics, and exposes a stable contract for downstream review and materialization.
 
 ## Public API
 
 ```php
 $result = bac_compile_website_artifact(
 	array(
+		'schema'         => 'block-artifact-compiler/website-artifact/v1',
 		'generated_html' => '<main><h1>Hello</h1></main>',
 		'css'            => 'main { max-width: 80rem; }',
+		'entrypoints'    => array( 'index.html' ),
 		'files' => array(
 			array(
 				'path'    => 'site.js',
 				'content' => 'console.log("preview behavior");',
+				'role'    => 'script',
+				'intent'  => 'behavior',
+			),
+			array(
+				'path'           => 'assets/logo.png',
+				'content_base64' => '...',
+				'mime_type'      => 'image/png',
+				'role'           => 'brand-asset',
 			),
 		),
 	)
@@ -67,7 +94,42 @@ array(
 	'wordpress_artifacts' => array(
 		'block_markup' => '<!-- wp:paragraph -->...',
 		'blocks'       => array(),
-		'block_types'  => array(),
+		'block_types'  => array(
+			array(
+				'schema'          => 'chubes4/wordpress-block-type-artifact/v1',
+				'name'            => 'acme/hero',
+				'slug'            => 'hero',
+				'directory'       => 'blocks/hero',
+				'block_json_path' => 'blocks/hero/block.json',
+				'block_json'      => array(...),
+				'metadata'        => array(
+					'apiVersion' => 3,
+					'title'      => 'Hero',
+					'category'   => 'design',
+					'attributes' => array(...),
+					'supports'   => array(...),
+				),
+				'assets'          => array(
+					'render'        => array(),
+					'editor_script' => array(),
+					'script'        => array(),
+					'view_script'   => array(),
+					'editor_style'  => array(),
+					'style'         => array(),
+					'view_style'    => array(),
+				),
+				'dependencies'    => array(
+					'declared'    => array(...),
+					'asset_files' => array(),
+				),
+				'provenance'      => array(
+					'source'      => 'files',
+					'source_hash' => '...',
+					'files'       => array(...),
+				),
+				'files'           => array(),
+			),
+		),
 		'components'   => array(),
 		'files'        => array(),
 	),
@@ -98,4 +160,10 @@ Block Artifact Compiler does not orchestrate agents, import WordPress sites, or 
 
 ```bash
 composer test
+```
+
+## Homeboy Test
+
+```bash
+homeboy test --path /path/to/block-artifact-compiler
 ```

--- a/vendor/chubes4/block-artifact-compiler/homeboy.json
+++ b/vendor/chubes4/block-artifact-compiler/homeboy.json
@@ -1,0 +1,8 @@
+{
+  "auto_cleanup": false,
+  "extensions": {
+    "wordpress": {}
+  },
+  "id": "block-artifact-compiler",
+  "remote_path": "wp-content/plugins/block-artifact-compiler"
+}

--- a/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
+++ b/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
@@ -9,28 +9,30 @@
  * Compiles arbitrary website artifact bundles into WordPress-native artifacts.
  */
 class Block_Artifact_Compiler {
-	private const RESULT_SCHEMA = 'chubes4/block-artifact-compiler-result/v1';
-	private const INPUT_SCHEMA  = 'chubes4/website-artifact/v1';
 
-	private const DEFAULT_MAX_FILES      = 200;
-	private const DEFAULT_MAX_FILE_BYTES = 2097152;
+	private const RESULT_SCHEMA = 'chubes4/block-artifact-compiler-result/v1';
+	private const INPUT_SCHEMA  = 'block-artifact-compiler/website-artifact/v1';
+
+	private const DEFAULT_MAX_FILES       = 200;
+	private const DEFAULT_MAX_FILE_BYTES  = 2097152;
 	private const DEFAULT_MAX_TOTAL_BYTES = 10485760;
 
 	/**
 	 * Compile a website artifact bundle.
 	 *
-	 * @param array<string,mixed> $artifact Website artifact input.
-	 * @param array<string,mixed> $options  Compiler options.
+	 * @param  array<string,mixed> $artifact Website artifact input.
+	 * @param  array<string,mixed> $options  Compiler options.
 	 * @return array<string,mixed> Compiler result envelope.
 	 */
 	public function compile( array $artifact, array $options = array() ): array {
 		$normalized  = $this->normalize_artifact( $artifact, $options );
+		$documents   = $this->compile_source_documents( $normalized, $options );
 		$entry       = $this->entry_file( $normalized );
 		$html        = is_array( $entry ) ? $entry['content'] : '';
 		$entry_path  = is_array( $entry ) ? $entry['path'] : '';
-		$diagnostics = $normalized['diagnostics'];
+		$diagnostics = array_merge( $normalized['diagnostics'], $documents['diagnostics'] );
 
-		if ( '' === trim( $html ) ) {
+		if ( '' === trim( $html ) && empty( $documents['documents'] ) ) {
 			$diagnostics[] = $this->diagnostic( 'missing_entry_html', 'error', 'No HTML entry file was available to compile.' );
 		}
 
@@ -42,8 +44,12 @@ class Block_Artifact_Compiler {
 		);
 
 		$diagnostics = array_merge( $diagnostics, $conversion['diagnostics'] );
-		$components  = $this->detect_components( $normalized, $entry_path );
+		$components  = $this->detect_components( $normalized, $entry_path, $documents['components'] );
+		$block_types = $this->build_block_types( $normalized, $diagnostics );
 		$files       = $this->wordpress_files_from_artifact( $normalized );
+		if ( '' === trim( $html ) && ! empty( $documents['documents'][0]['block_markup'] ) ) {
+			$conversion['serialized_blocks'] = (string) $documents['documents'][0]['block_markup'];
+		}
 
 		return array(
 			'schema'              => self::RESULT_SCHEMA,
@@ -51,18 +57,22 @@ class Block_Artifact_Compiler {
 			'input'               => array(
 				'schema'          => self::INPUT_SCHEMA,
 				'entry_path'      => $entry_path,
+				'entrypoints'     => $normalized['entrypoints'],
 				'file_count'      => count( $normalized['files'] ),
 				'accepted_count'  => count( $normalized['files'] ),
 				'rejected_count'  => $normalized['rejected_count'],
 				'bytes'           => $normalized['bytes'],
 				'files_by_kind'   => $this->count_files_by_kind( $normalized['files'] ),
+				'files_by_role'   => $this->count_files_by_field( $normalized['files'], 'role' ),
+				'files_by_mime'   => $this->count_files_by_field( $normalized['files'], 'mime_type' ),
 				'original_schema' => (string) ( $artifact['schema'] ?? '' ),
 			),
 			'wordpress_artifacts' => array(
 				'block_markup' => $conversion['serialized_blocks'],
 				'blocks'       => $conversion['blocks'],
-				'block_types'  => array(),
+				'block_types'  => $block_types,
 				'components'   => $components,
+				'documents'    => $documents['documents'],
 				'files'        => $files,
 			),
 			'provenance'          => array(
@@ -77,10 +87,10 @@ class Block_Artifact_Compiler {
 	/**
 	 * Compile a single content fragment.
 	 *
-	 * @param string               $content Source content.
-	 * @param string               $source  Source label or path.
-	 * @param string               $format  Source format.
-	 * @param array<string, mixed> $options Compiler options.
+	 * @param  string               $content Source content.
+	 * @param  string               $source  Source label or path.
+	 * @param  string               $format  Source format.
+	 * @param  array<string, mixed> $options Compiler options.
 	 * @return array<string,mixed> Compiler result envelope.
 	 */
 	public function compile_fragment( string $content, string $source = 'fragment', string $format = 'html', array $options = array() ): array {
@@ -103,7 +113,7 @@ class Block_Artifact_Compiler {
 	/**
 	 * Summarize a compiler result for upstream import reports.
 	 *
-	 * @param array<string,mixed> $compiled Compiler result envelope.
+	 * @param  array<string,mixed> $compiled Compiler result envelope.
 	 * @return array<string,mixed> Compact summary.
 	 */
 	public function summarize_result( array $compiled ): array {
@@ -129,20 +139,31 @@ class Block_Artifact_Compiler {
 	 *
 	 * @param array<string,mixed> $artifact Raw artifact.
 	 * @param array<string,mixed> $options  Compiler options.
-	 * @return array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>,diagnostics:array<int,array<string,mixed>>,rejected_count:int,bytes:int}
+	 * @return array{files:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>,rejected_count:int,bytes:int,entrypoints:array<int,string>}
 	 */
 	private function normalize_artifact( array $artifact, array $options ): array {
-		$limits = array(
-			'max_files'      => max( 1, (int) ( $options['max_files'] ?? self::DEFAULT_MAX_FILES ) ),
-			'max_file_bytes' => max( 1, (int) ( $options['max_file_bytes'] ?? self::DEFAULT_MAX_FILE_BYTES ) ),
+		$limits      = array(
+			'max_files'       => max( 1, (int) ( $options['max_files'] ?? self::DEFAULT_MAX_FILES ) ),
+			'max_file_bytes'  => max( 1, (int) ( $options['max_file_bytes'] ?? self::DEFAULT_MAX_FILE_BYTES ) ),
 			'max_total_bytes' => max( 1, (int) ( $options['max_total_bytes'] ?? self::DEFAULT_MAX_TOTAL_BYTES ) ),
 		);
-		$raw_files   = $this->extract_raw_files( $artifact );
+		$raw_entrypoints = $this->extract_entrypoints( $artifact );
+		$raw_files       = $this->extract_raw_files( $artifact );
 		$files       = array();
 		$diagnostics = array();
 		$total_bytes = 0;
 		$rejected    = 0;
 		$seen_paths  = array();
+		$entrypoints = array();
+
+		foreach ( $raw_entrypoints as $entrypoint ) {
+			$path = $this->safe_relative_path( $entrypoint );
+			if ( '' === $path ) {
+				$diagnostics[] = $this->diagnostic( 'unsafe_entrypoint_path', 'warning', 'An artifact entrypoint was ignored because its path is empty, absolute, or escapes the artifact root.', array( 'path' => $entrypoint ) );
+				continue;
+			}
+			$entrypoints[ $path ] = true;
+		}
 
 		foreach ( $raw_files as $index => $file ) {
 			if ( count( $files ) >= $limits['max_files'] ) {
@@ -158,31 +179,92 @@ class Block_Artifact_Compiler {
 				continue;
 			}
 
-			$content = $this->normalize_content( $file['content'] ?? '' );
-			$bytes   = strlen( $content );
+			$payload = $this->normalize_file_payload( $file, $path );
+			$diagnostics = array_merge( $diagnostics, $payload['diagnostics'] );
+			if ( ! $payload['accepted'] ) {
+				++$rejected;
+				continue;
+			}
+
+			$content = $payload['content'];
+			$bytes   = $payload['bytes'];
 			if ( $bytes > $limits['max_file_bytes'] ) {
 				++$rejected;
-				$diagnostics[] = $this->diagnostic( 'artifact_file_too_large', 'warning', 'An artifact file was ignored because it exceeds the per-file byte limit.', array( 'path' => $path, 'bytes' => $bytes, 'max_file_bytes' => $limits['max_file_bytes'] ) );
+				$diagnostics[] = $this->diagnostic(
+					'artifact_file_too_large',
+					'warning',
+					'An artifact file was ignored because it exceeds the per-file byte limit.',
+					array(
+						'path'           => $path,
+						'bytes'          => $bytes,
+						'max_file_bytes' => $limits['max_file_bytes'],
+					)
+				);
 				continue;
 			}
 
 			if ( $total_bytes + $bytes > $limits['max_total_bytes'] ) {
 				++$rejected;
-				$diagnostics[] = $this->diagnostic( 'artifact_total_too_large', 'warning', 'An artifact file was ignored because the bundle byte limit was reached.', array( 'path' => $path, 'bytes' => $bytes, 'max_total_bytes' => $limits['max_total_bytes'] ) );
+				$diagnostics[] = $this->diagnostic(
+					'artifact_total_too_large',
+					'warning',
+					'An artifact file was ignored because the bundle byte limit was reached.',
+					array(
+						'path'            => $path,
+						'bytes'           => $bytes,
+						'max_total_bytes' => $limits['max_total_bytes'],
+					)
+				);
 				continue;
 			}
 
-			$deduped_path = $this->dedupe_path( $path, $seen_paths );
+			$deduped_path                = $this->dedupe_path( $path, $seen_paths );
 			$seen_paths[ $deduped_path ] = true;
 			$total_bytes += $bytes;
+			$mime_type   = $this->normalize_mime_type( (string) ( $file['mime_type'] ?? $file['mime'] ?? $file['media_type'] ?? ( str_contains( (string) ( $file['type'] ?? '' ), '/' ) ? $file['type'] : '' ) ), $deduped_path );
+			$kind        = $this->normalize_kind( (string) ( $file['kind'] ?? $file['type'] ?? '' ), $deduped_path, $content, $mime_type );
+			$is_binary   = $payload['binary'] || $this->is_binary_mime_type( $mime_type );
+			$role        = $this->normalize_role( (string) ( $file['role'] ?? '' ), $kind, $mime_type, $deduped_path );
+			$intent      = $this->normalize_intent( (string) ( $file['intent'] ?? '' ), $kind, $role );
+			$is_entry    = ! empty( $entrypoints[ $deduped_path ] ) || ! empty( $file['entrypoint'] ) || 'entry' === $role;
+			$content_base64 = $payload['content_base64'];
+			if ( $is_binary && '' === $content_base64 ) {
+				$content_base64 = base64_encode( $content );
+			}
 
-			$files[] = array(
+			if ( $is_entry ) {
+				$entrypoints[ $deduped_path ] = true;
+			}
+
+			$normalized_file = array(
 				'path'    => $deduped_path,
 				'content' => $content,
-				'kind'    => $this->normalize_kind( (string) ( $file['kind'] ?? '' ), $deduped_path, $content ),
+				'kind'    => $kind,
 				'bytes'   => $bytes,
 				'source'  => (string) ( $file['source'] ?? 'artifact' ),
+				'mime_type' => $mime_type,
+				'role'    => $role,
+				'encoding' => $payload['encoding'],
+				'binary'  => $is_binary,
+				'entrypoint' => $is_entry,
+				'provenance' => array(
+					'source_path' => $deduped_path,
+					'source'      => (string) ( $file['source'] ?? 'artifact' ),
+					'hash'        => hash( 'sha256', '' !== $content_base64 ? $content_base64 : $content ),
+				),
 			);
+
+			if ( '' !== $content_base64 ) {
+				$normalized_file['content_base64'] = $content_base64;
+			}
+			if ( '' !== $intent ) {
+				$normalized_file['intent'] = $intent;
+			}
+			$files[] = $normalized_file;
+
+			if ( 'mdx' === $kind ) {
+				$diagnostics[] = $this->diagnostic( 'mdx_source_document_detected', 'warning', 'MDX source document support is partial; BAC preserved the source and extracted inspectable document/component metadata.', array( 'path' => $deduped_path ) );
+			}
 		}
 
 		return array(
@@ -190,13 +272,14 @@ class Block_Artifact_Compiler {
 			'diagnostics'    => $this->dedupe_diagnostics( $diagnostics ),
 			'rejected_count' => $rejected,
 			'bytes'          => $total_bytes,
+			'entrypoints'    => array_keys( $entrypoints ),
 		);
 	}
 
 	/**
 	 * Extract file-like entries from common AI artifact shapes.
 	 *
-	 * @param array<string,mixed> $artifact Raw artifact.
+	 * @param  array<string,mixed> $artifact Raw artifact.
 	 * @return array<int,array<string,mixed>> Raw files.
 	 */
 	private function extract_raw_files( array $artifact ): array {
@@ -218,7 +301,13 @@ class Block_Artifact_Compiler {
 			}
 		}
 
-		foreach ( array( 'css' => 'style.css', 'styles' => 'style.css', 'javascript' => 'site.js', 'js' => 'site.js', 'script' => 'site.js' ) as $key => $path ) {
+		foreach ( array(
+			'css'        => 'style.css',
+			'styles'     => 'style.css',
+			'javascript' => 'site.js',
+			'js'         => 'site.js',
+			'script'     => 'site.js',
+		) as $key => $path ) {
 			if ( isset( $artifact[ $key ] ) && is_string( $artifact[ $key ] ) && '' !== trim( $artifact[ $key ] ) ) {
 				$files[] = array(
 					'path'    => $path,
@@ -233,28 +322,51 @@ class Block_Artifact_Compiler {
 	}
 
 	/**
+	 * Extract explicit bundle entrypoints from common artifact shapes.
+	 *
+	 * @param array<string,mixed> $artifact Raw artifact.
+	 * @return array<int,string> Entrypoint paths.
+	 */
+	private function extract_entrypoints( array $artifact ): array {
+		$entrypoints = array();
+		foreach ( array( 'entrypoint', 'entry', 'main' ) as $key ) {
+			if ( isset( $artifact[ $key ] ) && is_string( $artifact[ $key ] ) ) {
+				$entrypoints[] = $artifact[ $key ];
+			}
+		}
+
+		if ( isset( $artifact['entrypoints'] ) && is_array( $artifact['entrypoints'] ) ) {
+			foreach ( $artifact['entrypoints'] as $entrypoint ) {
+				if ( is_string( $entrypoint ) ) {
+					$entrypoints[] = $entrypoint;
+				}
+			}
+		}
+
+		return array_values( array_unique( $entrypoints ) );
+	}
+
+	/**
 	 * Normalize a list or path=>content map into file entries.
 	 *
-	 * @param array<mixed> $collection File collection.
-	 * @param string       $source     Source key.
+	 * @param  array<mixed> $collection File collection.
+	 * @param  string       $source     Source key.
 	 * @return array<int,array<string,mixed>> Raw files.
 	 */
 	private function normalize_file_collection( array $collection, string $source ): array {
 		$files = array();
 		foreach ( $collection as $key => $file ) {
 			if ( is_array( $file ) ) {
-				$path = (string) ( $file['path'] ?? $file['name'] ?? $key );
-				$files[] = array(
-					'path'    => $path,
-					'content' => $file['content'] ?? $file['body'] ?? $file['text'] ?? '',
-					'kind'    => $file['kind'] ?? $file['type'] ?? '',
-					'source'  => $source,
-				);
+				$path_source    = $file['path'] ?? $file['name'] ?? $key;
+				$artifact_source = $file['source'] ?? $source;
+				$file['path']   = is_scalar( $path_source ) ? (string) $path_source : '';
+				$file['source'] = is_scalar( $artifact_source ) ? (string) $artifact_source : $source;
+				$files[] = $file;
 				continue;
 			}
 
 			if ( is_string( $file ) ) {
-				$path = is_string( $key ) ? $key : 'artifact-' . (string) $key . '.html';
+				$path    = is_string( $key ) ? $key : 'artifact-' . (string) $key . '.html';
 				$files[] = array(
 					'path'    => $path,
 					'content' => $file,
@@ -270,21 +382,30 @@ class Block_Artifact_Compiler {
 	/**
 	 * Return the HTML entry file.
 	 *
-	 * @param array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>} $artifact Normalized artifact.
-	 * @return array{path:string,content:string,kind:string,bytes:int,source:string}|null
+	 * @param array{files:array<int,array<string,mixed>>,entrypoints?:array<int,string>} $artifact Normalized artifact.
+	 * @return array<string,mixed>|null
 	 */
 	private function entry_file( array $artifact ): ?array {
+		$entrypoints = isset( $artifact['entrypoints'] ) && is_array( $artifact['entrypoints'] ) ? $artifact['entrypoints'] : array();
+		foreach ( $entrypoints as $entrypoint ) {
+			foreach ( $artifact['files'] as $file ) {
+				if ( $entrypoint === $file['path'] && 'html' === $file['kind'] && empty( $file['binary'] ) ) {
+					return $file;
+				}
+			}
+		}
+
 		$preferred = array( 'index.html', 'index.htm', 'static-site/index.html', 'public/index.html' );
 		foreach ( $preferred as $path ) {
 			foreach ( $artifact['files'] as $file ) {
-				if ( $path === strtolower( $file['path'] ) ) {
+				if ( $path === strtolower( (string) $file['path'] ) && empty( $file['binary'] ) ) {
 					return $file;
 				}
 			}
 		}
 
 		foreach ( $artifact['files'] as $file ) {
-			if ( 'html' === $file['kind'] ) {
+			if ( 'html' === $file['kind'] && empty( $file['binary'] ) ) {
 				return $file;
 			}
 		}
@@ -295,8 +416,8 @@ class Block_Artifact_Compiler {
 	/**
 	 * Convert HTML to block markup through BFB/H2BC when available.
 	 *
-	 * @param string              $html    Source HTML.
-	 * @param array<string,mixed> $options Compiler options.
+	 * @param  string              $html    Source HTML.
+	 * @param  array<string,mixed> $options Compiler options.
 	 * @return array{serialized_blocks:string,blocks:array,diagnostics:array<int,array<string,mixed>>,report:array<string,mixed>}
 	 */
 	private function convert_html_to_blocks( string $html, array $options ): array {
@@ -306,7 +427,10 @@ class Block_Artifact_Compiler {
 				'serialized_blocks' => serialize_blocks( $blocks ),
 				'blocks'            => $blocks,
 				'diagnostics'       => array(),
-				'report'            => array( 'status' => 'success_native', 'source' => 'blocks' ),
+				'report'            => array(
+					'status' => 'success_native',
+					'source' => 'blocks',
+				),
 			);
 		}
 
@@ -336,17 +460,119 @@ class Block_Artifact_Compiler {
 	}
 
 	/**
+	 * Compile Markdown and MDX content documents into WordPress-shaped artifacts.
+	 *
+	 * @param  array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string,mime_type:string,provenance:array<string,mixed>}>} $artifact Normalized artifact.
+	 * @param  array<string,mixed>                                                                                                                           $options  Compiler options.
+	 * @return array{documents:array<int,array<string,mixed>>,components:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}
+	 */
+	private function compile_source_documents( array $artifact, array $options ): array {
+		$documents   = array();
+		$components  = array();
+		$diagnostics = array();
+
+		foreach ( $artifact['files'] as $file ) {
+			if ( ! in_array( $file['kind'], array( 'markdown', 'mdx' ), true ) ) {
+				continue;
+			}
+
+			$parsed               = $this->parse_frontmatter( $file['content'] );
+			$body                 = $parsed['body'];
+			$frontmatter          = $parsed['frontmatter'];
+			$document_diagnostics = array();
+
+			if ( 'mdx' === $file['kind'] ) {
+				$mdx                  = $this->extract_mdx_semantics( $body, $file, $artifact );
+				$body                 = $mdx['markdown_body'];
+				$components           = array_merge( $components, $mdx['components'] );
+				$document_diagnostics = array_merge( $document_diagnostics, $mdx['diagnostics'] );
+			}
+
+			$conversion           = $this->convert_markdown_to_blocks( $body, $options );
+			$document_diagnostics = array_merge( $document_diagnostics, $conversion['diagnostics'] );
+			$diagnostics          = array_merge( $diagnostics, $document_diagnostics );
+
+			$documents[] = array(
+				'source_path'  => $file['path'],
+				'kind'         => $file['kind'],
+				'post_type'    => $this->frontmatter_string( $frontmatter, array( 'post_type', 'type' ), 'page' ),
+				'slug'         => $this->frontmatter_string( $frontmatter, array( 'slug' ), $this->slug_from_path( $file['path'] ) ),
+				'title'        => $this->frontmatter_string( $frontmatter, array( 'title' ), $this->title_from_path( $file['path'] ) ),
+				'excerpt'      => $this->frontmatter_string( $frontmatter, array( 'excerpt', 'description' ), '' ),
+				'date'         => $this->frontmatter_string( $frontmatter, array( 'date', 'published', 'published_at' ), '' ),
+				'template'     => $this->frontmatter_string( $frontmatter, array( 'template', 'layout' ), '' ),
+				'taxonomies'   => $this->frontmatter_taxonomies( $frontmatter ),
+				'frontmatter'  => $frontmatter,
+				'block_markup' => $conversion['serialized_blocks'],
+				'diagnostics'  => $document_diagnostics,
+				'provenance'   => $file['provenance'],
+			);
+		}
+
+		return array(
+			'documents'   => $documents,
+			'components'  => $components,
+			'diagnostics' => $this->dedupe_diagnostics( $diagnostics ),
+		);
+	}
+
+	/**
+	 * Convert Markdown through BFB when present, otherwise preserve it in a block fallback.
+	 *
+	 * @param  array<string,mixed> $options Compiler options.
+	 * @return array{serialized_blocks:string,blocks:array,diagnostics:array<int,array<string,mixed>>,report:array<string,mixed>}
+	 */
+	private function convert_markdown_to_blocks( string $markdown, array $options ): array {
+		if ( function_exists( 'bfb_convert' ) ) {
+			$block_markup = (string) bfb_convert( $markdown, 'markdown', 'blocks', $options );
+			return array(
+				'serialized_blocks' => $block_markup,
+				'blocks'            => function_exists( 'parse_blocks' ) && '' !== trim( $block_markup ) ? parse_blocks( $block_markup ) : array(),
+				'diagnostics'       => array(),
+				'report'            => array(
+					'status' => '' === trim( $block_markup ) ? 'failed' : 'success_native',
+					'source' => 'markdown',
+				),
+			);
+		}
+
+		return array(
+			'serialized_blocks' => '<!-- wp:html -->' . "\n" . $markdown . "\n" . '<!-- /wp:html -->',
+			'blocks'            => array(),
+			'diagnostics'       => array(
+				$this->diagnostic( 'bfb_unavailable', 'warning', 'BFB is unavailable; preserved source Markdown as a core/html fallback.' ),
+			),
+			'report'            => array(
+				'status' => 'success_with_fallbacks',
+				'source' => 'markdown',
+			),
+		);
+	}
+
+	/**
 	 * Build component candidates from explicit markers and repeated class tokens.
 	 *
-	 * @param array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>} $artifact Normalized artifact.
-	 * @param string $entry_path Entry path.
+	 * @param array{files:array<int,array<string,mixed>>} $artifact Normalized artifact.
+	 * @param string                                      $entry_path Entry path.
+	 * @param array<int,array<string,mixed>>              $source_document_components Source document components.
 	 * @return array<int,array<string,mixed>> Component candidates.
 	 */
-	private function detect_components( array $artifact, string $entry_path ): array {
+	private function detect_components( array $artifact, string $entry_path, array $source_document_components = array() ): array {
 		$candidates = array();
 		$classes    = array();
 
+		foreach ( $source_document_components as $component ) {
+			$key                = 'mdx:' . (string) ( $component['source'] ?? '' ) . ':' . (string) ( $component['name'] ?? '' );
+			$candidates[ $key ] = $component;
+		}
+
 		foreach ( $artifact['files'] as $file ) {
+			if ( in_array( $file['kind'], array( 'jsx', 'tsx' ), true ) ) {
+				foreach ( $this->detect_jsx_file_components( $file ) as $component ) {
+					$candidates[ 'jsx-file:' . (string) $component['source'] . ':' . (string) $component['name'] ] = $component;
+				}
+			}
+
 			if ( 'html' !== $file['kind'] ) {
 				continue;
 			}
@@ -356,9 +582,9 @@ class Block_Artifact_Compiler {
 					$key = sanitize_key( $name );
 					if ( '' !== $key ) {
 						$candidates[ 'explicit:' . $key ] = array(
-							'name'       => $key,
-							'source'     => $file['path'],
-							'signal'     => 'data-component',
+							'name'        => $key,
+							'source'      => $file['path'],
+							'signal'      => 'data-component',
 							'occurrences' => ( $candidates[ 'explicit:' . $key ]['occurrences'] ?? 0 ) + 1,
 						);
 					}
@@ -367,7 +593,8 @@ class Block_Artifact_Compiler {
 
 			if ( preg_match_all( '/class\s*=\s*(["\'])([^"\']+)\1/i', $file['content'], $matches ) ) {
 				foreach ( $matches[2] as $class_list ) {
-					foreach ( preg_split( '/\s+/', trim( $class_list ) ) ?: array() as $class ) {
+					$class_tokens = preg_split( '/\s+/', trim( $class_list ) );
+					foreach ( false === $class_tokens ? array() : $class_tokens as $class ) {
 						$class = sanitize_key( $class );
 						if ( '' === $class || strlen( $class ) < 3 ) {
 							continue;
@@ -394,17 +621,260 @@ class Block_Artifact_Compiler {
 		usort(
 			$candidates,
 			static function ( array $left, array $right ): int {
-				return ( $right['occurrences'] <=> $left['occurrences'] ) ?: strcmp( (string) $left['name'], (string) $right['name'] );
+				$occurrence_comparison = $right['occurrences'] <=> $left['occurrences'];
+				return 0 !== $occurrence_comparison ? $occurrence_comparison : strcmp( (string) $left['name'], (string) $right['name'] );
 			}
 		);
 
-		return array_slice( array_values( $candidates ), 0, 25 );
+		return array_slice( $candidates, 0, 25 );
+	}
+
+	/**
+	 * Build generated custom block artifacts from block.json roots.
+	 *
+	 * @param array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>} $artifact Normalized artifact.
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics collected during compilation.
+	 * @return array<int,array<string,mixed>> Block type artifacts.
+	 */
+	private function build_block_types( array $artifact, array &$diagnostics ): array {
+		$block_types = array();
+		$block_roots = array();
+
+		foreach ( $artifact['files'] as $file ) {
+			if ( 'block.json' !== basename( $file['path'] ) ) {
+				continue;
+			}
+
+			$directory                 = dirname( $file['path'] );
+			$directory                 = '.' === $directory ? '' : $directory;
+			$block_roots[ $directory ] = $file;
+		}
+
+		foreach ( $block_roots as $directory => $block_json_file ) {
+			$decoded = json_decode( $block_json_file['content'], true );
+			if ( ! is_array( $decoded ) ) {
+				$decoded       = array();
+				$diagnostics[] = $this->diagnostic( 'invalid_block_json', 'warning', 'A generated block.json file could not be decoded.', array( 'path' => $block_json_file['path'] ) );
+			}
+
+			$name = isset( $decoded['name'] ) && is_string( $decoded['name'] ) ? trim( $decoded['name'] ) : '';
+			if ( '' === $name ) {
+				$name          = 'generated/' . ( '' === $directory ? 'block' : sanitize_key( basename( $directory ) ) );
+				$diagnostics[] = $this->diagnostic(
+					'block_json_missing_name',
+					'warning',
+					'A generated block.json file did not declare a name; a stable generated name was assigned.',
+					array(
+						'path' => $block_json_file['path'],
+						'name' => $name,
+					)
+				);
+			}
+
+			$block_files   = $this->files_under_directory( $artifact['files'], $directory );
+			$block_types[] = array(
+				'schema'          => 'chubes4/wordpress-block-type-artifact/v1',
+				'name'            => $name,
+				'slug'            => sanitize_key( basename( $name ) ),
+				'directory'       => $directory,
+				'block_json_path' => $block_json_file['path'],
+				'block_json'      => $decoded,
+				'metadata'        => $this->block_metadata_contract( $decoded ),
+				'assets'          => $this->block_asset_contract( $decoded, $block_files ),
+				'dependencies'    => $this->block_dependency_contract( $decoded, $block_files ),
+				'provenance'      => array(
+					'source'      => $block_json_file['source'],
+					'source_hash' => hash( 'sha256', $this->file_hash_payload( $block_files ) ),
+					'files'       => array_values( array_map( static fn ( array $file ): string => $file['path'], $block_files ) ),
+				),
+				'files'           => array_values(
+					array_map(
+						static function ( array $file ): array {
+							return array(
+								'path'  => $file['path'],
+								'kind'  => $file['kind'],
+								'bytes' => $file['bytes'],
+							);
+						},
+						$block_files
+					)
+				),
+			);
+		}
+
+		usort(
+			$block_types,
+			static function ( array $left, array $right ): int {
+				return strcmp( (string) $left['name'], (string) $right['name'] );
+			}
+		);
+
+		return $block_types;
+	}
+
+	/**
+	 * Return files that belong to a block root directory.
+	 *
+	 * @param array<int,array{path:string,content:string,kind:string,bytes:int,source:string}> $files Files.
+	 * @return array<int,array{path:string,content:string,kind:string,bytes:int,source:string}> Files.
+	 */
+	private function files_under_directory( array $files, string $directory ): array {
+		$matched = array();
+		$prefix  = '' === $directory ? '' : $directory . '/';
+		foreach ( $files as $file ) {
+			if ( '' === $prefix || str_starts_with( $file['path'], $prefix ) ) {
+				$matched[] = $file;
+			}
+		}
+
+		return $matched;
+	}
+
+	/**
+	 * Normalize block.json metadata into the block artifact contract.
+	 *
+	 * @param array<string,mixed> $block_json Decoded block.json.
+	 * @return array<string,mixed> Metadata contract.
+	 */
+	private function block_metadata_contract( array $block_json ): array {
+		$metadata = array();
+		foreach ( array( 'apiVersion', 'title', 'category', 'description', 'keywords', 'attributes', 'supports', 'usesContext', 'providesContext', 'textdomain', 'example', 'variations', 'parent', 'ancestor', 'allowedBlocks' ) as $key ) {
+			if ( array_key_exists( $key, $block_json ) ) {
+				$metadata[ $key ] = $block_json[ $key ];
+			}
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Normalize render, editor, style, and script references from block.json.
+	 *
+	 * @param array<string,mixed> $block_json Decoded block.json.
+	 * @param array<int,array{path:string,content:string,kind:string,bytes:int,source:string}> $files Block files.
+	 * @return array<string,array<int,array<string,mixed>>> Asset contract.
+	 */
+	private function block_asset_contract( array $block_json, array $files ): array {
+		$assets = array(
+			'render'        => array(),
+			'editor_script' => array(),
+			'script'        => array(),
+			'view_script'   => array(),
+			'editor_style'  => array(),
+			'style'         => array(),
+			'view_style'    => array(),
+		);
+
+		foreach (
+			array(
+				'render'       => 'render',
+				'editorScript' => 'editor_script',
+				'script'       => 'script',
+				'viewScript'   => 'view_script',
+				'editorStyle'  => 'editor_style',
+				'style'        => 'style',
+				'viewStyle'    => 'view_style',
+			) as $source_field => $target_field
+		) {
+			foreach ( $this->normalize_asset_references( $block_json[ $source_field ] ?? null, $files, $source_field ) as $reference ) {
+				$assets[ $target_field ][] = $reference;
+			}
+		}
+
+		return $assets;
+	}
+
+	/**
+	 * Normalize block.json asset references while preserving handles and generated file paths.
+	 *
+	 * @param mixed $value Asset reference value.
+	 * @param array<int,array{path:string,content:string,kind:string,bytes:int,source:string}> $files Block files.
+	 * @return array<int,array<string,mixed>> Asset references.
+	 */
+	private function normalize_asset_references( mixed $value, array $files, string $source_field ): array {
+		$references = array();
+		$values     = is_array( $value ) ? array_values( $value ) : array( $value );
+		foreach ( $values as $item ) {
+			if ( ! is_string( $item ) || '' === trim( $item ) ) {
+				continue;
+			}
+
+			$item        = trim( $item );
+			$is_file_ref = str_starts_with( $item, 'file:' );
+			$relative    = $is_file_ref ? substr( $item, 5 ) : '';
+			$file        = $is_file_ref ? $this->find_block_file_by_relative_path( $files, $relative ) : null;
+
+			$reference = array(
+				'reference'    => $item,
+				'source_field' => $source_field,
+				'type'         => $is_file_ref ? 'file' : 'handle',
+			);
+			if ( is_array( $file ) ) {
+				$reference['path']  = $file['path'];
+				$reference['kind']  = $file['kind'];
+				$reference['bytes'] = $file['bytes'];
+			}
+
+			$references[] = $reference;
+		}
+
+		return $references;
+	}
+
+	/**
+	 * Return dependency references declared by block.json and generated .asset.php files.
+	 *
+	 * @param array<string,mixed> $block_json Decoded block.json.
+	 * @param array<int,array{path:string,content:string,kind:string,bytes:int,source:string}> $files Block files.
+	 * @return array<string,mixed> Dependency contract.
+	 */
+	private function block_dependency_contract( array $block_json, array $files ): array {
+		$declared = array();
+		foreach ( array( 'editorScript', 'script', 'viewScript', 'editorStyle', 'style', 'viewStyle' ) as $field ) {
+			if ( ! array_key_exists( $field, $block_json ) ) {
+				continue;
+			}
+			$declared[ $field ] = $block_json[ $field ];
+		}
+
+		$asset_files = array();
+		foreach ( $files as $file ) {
+			if ( str_ends_with( $file['path'], '.asset.php' ) ) {
+				$asset_files[] = array(
+					'path'  => $file['path'],
+					'kind'  => $file['kind'],
+					'bytes' => $file['bytes'],
+				);
+			}
+		}
+
+		return array(
+			'declared'    => $declared,
+			'asset_files' => $asset_files,
+		);
+	}
+
+	/**
+	 * Find a block-local generated file by its block.json file: reference.
+	 *
+	 * @param array<int,array{path:string,content:string,kind:string,bytes:int,source:string}> $files Block files.
+	 * @return array{path:string,content:string,kind:string,bytes:int,source:string}|null
+	 */
+	private function find_block_file_by_relative_path( array $files, string $relative_path ): ?array {
+		$relative_path = ltrim( str_replace( '\\', '/', $relative_path ), './' );
+		foreach ( $files as $file ) {
+			if ( basename( $file['path'] ) === $relative_path || str_ends_with( $file['path'], '/' . $relative_path ) ) {
+				return $file;
+			}
+		}
+
+		return null;
 	}
 
 	/**
 	 * Return non-entry files that SSI or another materializer may consume later.
 	 *
-	 * @param array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>} $artifact Normalized artifact.
+	 * @param array{files:array<int,array<string,mixed>>} $artifact Normalized artifact.
 	 * @return array<int,array<string,mixed>> Files.
 	 */
 	private function wordpress_files_from_artifact( array $artifact ): array {
@@ -413,13 +883,27 @@ class Block_Artifact_Compiler {
 			if ( 'html' === $file['kind'] ) {
 				continue;
 			}
-
-			$files[] = array(
+			$manifest_file = array(
 				'path'    => $file['path'],
 				'kind'    => $file['kind'],
 				'bytes'   => $file['bytes'],
-				'content' => $file['content'],
+				'mime_type' => $file['mime_type'],
+				'role'    => $file['role'],
+				'encoding' => $file['encoding'],
+				'binary'  => $file['binary'],
+				'provenance' => $file['provenance'],
 			);
+
+			if ( ! empty( $file['intent'] ) ) {
+				$manifest_file['intent'] = $file['intent'];
+			}
+			if ( ! empty( $file['content_base64'] ) ) {
+				$manifest_file['content_base64'] = $file['content_base64'];
+			} else {
+				$manifest_file['content'] = $file['content'];
+			}
+
+			$files[] = $manifest_file;
 		}
 
 		return $files;
@@ -465,12 +949,77 @@ class Block_Artifact_Compiler {
 	}
 
 	/**
+	 * Normalize file payloads from text or base64 content fields.
+	 *
+	 * @param array<string,mixed> $file Raw file entry.
+	 * @return array{accepted:bool,content:string,content_base64:string,encoding:string,binary:bool,bytes:int,diagnostics:array<int,array<string,mixed>>}
+	 */
+	private function normalize_file_payload( array $file, string $path ): array {
+		$diagnostics = array();
+		if ( isset( $file['content_base64'] ) && is_string( $file['content_base64'] ) ) {
+			$base64  = preg_replace( '/\s+/', '', $file['content_base64'] ) ?? '';
+			$decoded = base64_decode( $base64, true );
+			if ( false === $decoded ) {
+				return array(
+					'accepted'       => false,
+					'content'        => '',
+					'content_base64' => '',
+					'encoding'       => 'base64',
+					'binary'         => false,
+					'bytes'          => 0,
+					'diagnostics'    => array( $this->diagnostic( 'invalid_base64_content', 'warning', 'An artifact file was ignored because content_base64 is not valid base64.', array( 'path' => $path ) ) ),
+				);
+			}
+
+			$is_binary = $this->looks_binary( $decoded );
+			if ( ! $is_binary && isset( $file['content'] ) && is_string( $file['content'] ) && '' !== $file['content'] && $file['content'] !== $decoded ) {
+				$diagnostics[] = $this->diagnostic( 'content_base64_preferred', 'info', 'Both content and content_base64 were provided; decoded content_base64 was used as the canonical payload.', array( 'path' => $path ) );
+			}
+
+			return array(
+				'accepted'       => true,
+				'content'        => $is_binary ? '' : $decoded,
+				'content_base64' => $base64,
+				'encoding'       => 'base64',
+				'binary'         => $is_binary,
+				'bytes'          => strlen( $decoded ),
+				'diagnostics'    => $diagnostics,
+			);
+		}
+
+		$content = $this->normalize_content( $file['content'] ?? $file['body'] ?? $file['text'] ?? '' );
+		return array(
+			'accepted'       => true,
+			'content'        => $content,
+			'content_base64' => '',
+			'encoding'       => 'text',
+			'binary'         => false,
+			'bytes'          => strlen( $content ),
+			'diagnostics'    => array(),
+		);
+	}
+
+	/**
 	 * Normalize file kind from explicit kind, path, and content.
 	 */
-	private function normalize_kind( string $kind, string $path, string $content ): string {
+	private function normalize_kind( string $kind, string $path, string $content, string $mime_type = '' ): string {
 		$kind = sanitize_key( $kind );
-		if ( in_array( $kind, array( 'html', 'css', 'js', 'json', 'markdown', 'asset', 'blocks' ), true ) ) {
+		if ( in_array( $kind, array( 'html', 'css', 'js', 'jsx', 'tsx', 'json', 'markdown', 'mdx', 'asset', 'blocks' ), true ) ) {
 			return $kind;
+		}
+		if ( str_contains( $mime_type, '/' ) ) {
+			if ( str_contains( $mime_type, 'html' ) ) {
+				return 'html';
+			}
+			if ( 'text/css' === $mime_type ) {
+				return 'css';
+			}
+			if ( in_array( $mime_type, array( 'application/javascript', 'text/javascript', 'application/ecmascript', 'text/ecmascript' ), true ) ) {
+				return 'js';
+			}
+			if ( 'application/json' === $mime_type ) {
+				return 'json';
+			}
 		}
 
 		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
@@ -478,10 +1027,113 @@ class Block_Artifact_Compiler {
 			'html', 'htm'       => 'html',
 			'css'               => 'css',
 			'js', 'mjs'          => 'js',
+			'jsx'                => 'jsx',
+			'tsx'                => 'tsx',
 			'json'              => 'json',
 			'md', 'markdown'    => 'markdown',
+			'mdx'               => 'mdx',
 			default             => str_contains( $content, '<!-- wp:' ) ? 'blocks' : 'asset',
 		};
+	}
+
+	/**
+	 * Normalize or infer a MIME type.
+	 */
+	private function normalize_mime_type( string $mime_type, string $path ): string {
+		$mime_type = strtolower( trim( $mime_type ) );
+		if ( preg_match( '#^[a-z0-9.+-]+/[a-z0-9.+-]+$#', $mime_type ) ) {
+			return $mime_type;
+		}
+
+		return match ( strtolower( pathinfo( $path, PATHINFO_EXTENSION ) ) ) {
+			'html', 'htm'       => 'text/html',
+			'css'               => 'text/css',
+			'js', 'mjs'          => 'application/javascript',
+			'jsx'               => 'text/jsx',
+			'tsx'               => 'text/tsx',
+			'json'              => 'application/json',
+			'md', 'markdown'    => 'text/markdown',
+			'mdx'               => 'text/mdx',
+			'txt'               => 'text/plain',
+			'svg'               => 'image/svg+xml',
+			'png'               => 'image/png',
+			'jpg', 'jpeg'       => 'image/jpeg',
+			'gif'               => 'image/gif',
+			'webp'              => 'image/webp',
+			'avif'              => 'image/avif',
+			'woff'              => 'font/woff',
+			'woff2'             => 'font/woff2',
+			'ttf'               => 'font/ttf',
+			'otf'               => 'font/otf',
+			default             => 'application/octet-stream',
+		};
+	}
+
+	/**
+	 * Normalize a file role without making policy decisions about generated output.
+	 */
+	private function normalize_role( string $role, string $kind, string $mime_type, string $path ): string {
+		$role = sanitize_key( $role );
+		if ( '' !== $role ) {
+			return $role;
+		}
+
+		if ( 'html' === $kind ) {
+			return preg_match( '#(^|/)index\.html?$#i', $path ) ? 'entry' : 'document';
+		}
+		if ( 'css' === $kind ) {
+			return 'stylesheet';
+		}
+		if ( 'js' === $kind ) {
+			return 'script';
+		}
+		if ( str_starts_with( $mime_type, 'image/' ) ) {
+			return 'image';
+		}
+		if ( str_starts_with( $mime_type, 'font/' ) ) {
+			return 'font';
+		}
+		if ( in_array( $kind, array( 'json', 'markdown' ), true ) ) {
+			return 'data';
+		}
+
+		return 'asset';
+	}
+
+	/**
+	 * Normalize CSS/JS intent metadata.
+	 */
+	private function normalize_intent( string $intent, string $kind, string $role ): string {
+		$intent = sanitize_key( $intent );
+		if ( '' !== $intent ) {
+			return $intent;
+		}
+		if ( 'css' === $kind || 'stylesheet' === $role ) {
+			return 'style';
+		}
+		if ( 'js' === $kind || 'script' === $role ) {
+			return 'behavior';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Detect binary payloads conservatively.
+	 */
+	private function looks_binary( string $content ): bool {
+		return str_contains( $content, "\0" );
+	}
+
+	/**
+	 * Return whether a MIME type should be treated as binary in result manifests.
+	 */
+	private function is_binary_mime_type( string $mime_type ): bool {
+		if ( str_starts_with( $mime_type, 'text/' ) ) {
+			return false;
+		}
+
+		return ! in_array( $mime_type, array( 'application/json', 'application/javascript', 'image/svg+xml' ), true );
 	}
 
 	/**
@@ -493,6 +1145,7 @@ class Block_Artifact_Compiler {
 			'css'      => 'css',
 			'js'       => 'js',
 			'markdown' => 'md',
+			'mdx'      => 'mdx',
 			default    => 'html',
 		};
 
@@ -523,13 +1176,27 @@ class Block_Artifact_Compiler {
 	/**
 	 * Count normalized files by kind.
 	 *
-	 * @param array<int,array{kind:string}> $files Files.
+	 * @param  array<int,array{kind:string}> $files Files.
 	 * @return array<string,int>
 	 */
 	private function count_files_by_kind( array $files ): array {
+		return $this->count_files_by_field( $files, 'kind' );
+	}
+
+	/**
+	 * Count normalized files by a manifest field.
+	 *
+	 * @param array<int,array<string,mixed>> $files Files.
+	 * @return array<string,int>
+	 */
+	private function count_files_by_field( array $files, string $field ): array {
 		$counts = array();
 		foreach ( $files as $file ) {
-			$counts[ $file['kind'] ] = ( $counts[ $file['kind'] ] ?? 0 ) + 1;
+			$value = isset( $file[ $field ] ) ? (string) $file[ $field ] : '';
+			if ( '' === $value ) {
+				continue;
+			}
+			$counts[ $value ] = ( $counts[ $value ] ?? 0 ) + 1;
 		}
 		ksort( $counts );
 
@@ -537,9 +1204,279 @@ class Block_Artifact_Compiler {
 	}
 
 	/**
+	 * Split simple YAML frontmatter from a content document.
+	 *
+	 * @return array{frontmatter:array<string,mixed>,body:string}
+	 */
+	private function parse_frontmatter( string $content ): array {
+		if ( ! preg_match( '/\A---\s*\R(.*?)\R---\s*\R?/s', $content, $matches ) ) {
+			return array(
+				'frontmatter' => array(),
+				'body'        => $content,
+			);
+		}
+
+		$frontmatter       = array();
+		$frontmatter_lines = preg_split( '/\R/', trim( $matches[1] ) );
+		foreach ( false === $frontmatter_lines ? array() : $frontmatter_lines as $line ) {
+			if ( ! preg_match( '/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/', $line, $pair ) ) {
+				continue;
+			}
+
+			$value = trim( $pair[2] );
+			$value = trim( $value, " \t\n\r\0\x0B\"'" );
+			if ( preg_match( '/^\[(.*)\]$/', $value, $list ) ) {
+				$value = array_values( array_filter( array_map( static fn ( string $item ): string => trim( $item, " \t\n\r\0\x0B\"'" ), explode( ',', $list[1] ) ), static fn ( string $item ): bool => '' !== $item ) );
+			}
+
+			$frontmatter[ sanitize_key( $pair[1] ) ] = $value;
+		}
+
+		return array(
+			'frontmatter' => $frontmatter,
+			'body'        => substr( $content, strlen( $matches[0] ) ),
+		);
+	}
+
+	/**
+	 * Extract MDX imports and JSX component references while producing Markdown-compatible text.
+	 *
+	 * @param  array<string,mixed>                         $file     Source file.
+	 * @param  array{files:array<int,array<string,mixed>>} $artifact Normalized artifact.
+	 * @return array{markdown_body:string,components:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}
+	 */
+	private function extract_mdx_semantics( string $body, array $file, array $artifact ): array {
+		$imports     = $this->extract_mdx_imports( $body );
+		$components  = array();
+		$diagnostics = array();
+
+		if ( preg_match_all( '/<([A-Z][A-Za-z0-9._-]*)(?:\s[^>]*)?\s*(?:>|\/>)/', $body, $matches ) ) {
+			foreach ( $matches[1] as $name ) {
+				$import    = $imports[ $name ] ?? null;
+				$resolved  = is_array( $import ) ? $this->resolve_component_import( (string) $import['path'], (string) $file['path'], $artifact ) : '';
+				$component = array(
+					'name'        => $name,
+					'source'      => $file['path'],
+					'signal'      => 'mdx-jsx',
+					'occurrences' => ( $components[ $name ]['occurrences'] ?? 0 ) + 1,
+					'provenance'  => array( 'source_path' => $file['path'] ),
+				);
+
+				if ( is_array( $import ) ) {
+					$component['import_path'] = $import['path'];
+				}
+				if ( '' !== $resolved ) {
+					$component['resolved_path'] = $resolved;
+				}
+
+				$components[ $name ] = $component;
+
+				if ( ! is_array( $import ) ) {
+					$diagnostics[] = $this->diagnostic(
+						'mdx_component_unresolved',
+						'warning',
+						'MDX component reference has no matching import.',
+						array(
+							'path'      => $file['path'],
+							'component' => $name,
+						)
+					);
+				} elseif ( '' === $resolved && str_starts_with( (string) $import['path'], '.' ) ) {
+					$diagnostics[] = $this->diagnostic(
+						'mdx_import_unresolved',
+						'warning',
+						'MDX component import could not be linked to a generated source file.',
+						array(
+							'path'        => $file['path'],
+							'component'   => $name,
+							'import_path' => $import['path'],
+						)
+					);
+				}
+			}
+		}
+
+		$markdown_body = preg_replace( '/^\s*import\s+[^;\r\n]+;?\s*$/m', '', $body ) ?? $body;
+		$markdown_body = preg_replace( '/^\s*export\s+[^\r\n]+\s*$/m', '', $markdown_body ) ?? $markdown_body;
+		$markdown_body = preg_replace( '/<([A-Z][A-Za-z0-9._-]*)(?:\s[^>]*)?\s*\/>/', '', $markdown_body ) ?? $markdown_body;
+		$markdown_body = preg_replace( '/<\/?[A-Z][A-Za-z0-9._-]*(?:\s[^>]*)?>/', '', $markdown_body ) ?? $markdown_body;
+
+		return array(
+			'markdown_body' => trim( $markdown_body ),
+			'components'    => array_values( $components ),
+			'diagnostics'   => $this->dedupe_diagnostics( $diagnostics ),
+		);
+	}
+
+	/**
+	 * Extract default and named import aliases from simple MDX import lines.
+	 *
+	 * @return array<string,array{path:string}>
+	 */
+	private function extract_mdx_imports( string $body ): array {
+		$imports = array();
+		if ( ! preg_match_all( '/^\s*import\s+(.+?)\s+from\s+["\']([^"\']+)["\'];?\s*$/m', $body, $matches, PREG_SET_ORDER ) ) {
+			return $imports;
+		}
+
+		foreach ( $matches as $match ) {
+			$clause = trim( $match[1] );
+			$path   = $match[2];
+			if ( preg_match( '/^([A-Z][A-Za-z0-9_]*)/', $clause, $default ) ) {
+				$imports[ $default[1] ] = array( 'path' => $path );
+			}
+			if ( preg_match( '/\{([^}]+)\}/', $clause, $named ) ) {
+				foreach ( explode( ',', $named[1] ) as $name ) {
+					$parts = preg_split( '/\s+as\s+/i', trim( $name ) );
+					$parts = false === $parts ? array() : $parts;
+					$alias = trim( (string) end( $parts ) );
+					if ( preg_match( '/^[A-Z][A-Za-z0-9_]*$/', $alias ) ) {
+						$imports[ $alias ] = array( 'path' => $path );
+					}
+				}
+			}
+		}
+
+		return $imports;
+	}
+
+	/**
+	 * Detect top-level component declarations in generated JSX/TSX files.
+	 *
+	 * @param  array<string,mixed> $file Normalized file.
+	 * @return array<int,array<string,mixed>> Component candidates.
+	 */
+	private function detect_jsx_file_components( array $file ): array {
+		$components = array();
+		$content    = (string) ( $file['content'] ?? '' );
+
+		if ( preg_match_all( '/(?:export\s+default\s+)?function\s+([A-Z][A-Za-z0-9_]*)\s*\(/', $content, $matches ) ) {
+			foreach ( $matches[1] as $name ) {
+				$components[ $name ] = true;
+			}
+		}
+
+		if ( preg_match_all( '/(?:export\s+)?(?:const|let|var)\s+([A-Z][A-Za-z0-9_]*)\s*=\s*(?:\([^)]*\)|[A-Za-z0-9_]+)\s*=>/', $content, $matches ) ) {
+			foreach ( $matches[1] as $name ) {
+				$components[ $name ] = true;
+			}
+		}
+
+		return array_map(
+			fn ( string $name ): array => array(
+				'name'        => $name,
+				'source'      => (string) ( $file['path'] ?? '' ),
+				'signal'      => 'jsx-component-file',
+				'occurrences' => 1,
+				'provenance'  => array( 'source_path' => (string) ( $file['path'] ?? '' ) ),
+			),
+			array_keys( $components )
+		);
+	}
+
+	/**
+	 * Resolve a relative component import to a generated source file path when present.
+	 *
+	 * @param array{files:array<int,array<string,mixed>>} $artifact Normalized artifact.
+	 */
+	private function resolve_component_import( string $import_path, string $source_path, array $artifact ): string {
+		if ( ! str_starts_with( $import_path, '.' ) ) {
+			return '';
+		}
+
+		$base = dirname( $source_path );
+		$path = $this->normalize_relative_import_path( ( '.' === $base ? '' : $base . '/' ) . $import_path );
+		if ( '' === $path ) {
+			return '';
+		}
+
+		$candidates = array( $path );
+		foreach ( array( 'js', 'jsx', 'ts', 'tsx', 'mdx' ) as $extension ) {
+			$candidates[] = $path . '.' . $extension;
+			$candidates[] = $path . '/index.' . $extension;
+		}
+
+		foreach ( $artifact['files'] as $file ) {
+			if ( in_array( $file['path'], $candidates, true ) ) {
+				return (string) $file['path'];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Normalize a relative import path after joining it to the importing file.
+	 */
+	private function normalize_relative_import_path( string $path ): string {
+		$segments = array();
+		foreach ( explode( '/', str_replace( '\\', '/', $path ) ) as $segment ) {
+			if ( '' === $segment || '.' === $segment ) {
+				continue;
+			}
+			if ( '..' === $segment ) {
+				array_pop( $segments );
+				continue;
+			}
+			$segments[] = preg_replace( '/[^A-Za-z0-9._-]/', '-', $segment );
+		}
+
+		return implode( '/', array_filter( $segments ) );
+	}
+
+	/**
+	 * Read a scalar frontmatter value with aliases.
+	 *
+	 * @param array<string,mixed> $frontmatter Frontmatter map.
+	 * @param array<int,string>   $keys        Keys in priority order.
+	 */
+	private function frontmatter_string( array $frontmatter, array $keys, string $fallback ): string {
+		foreach ( $keys as $key ) {
+			if ( isset( $frontmatter[ $key ] ) && is_scalar( $frontmatter[ $key ] ) && '' !== trim( (string) $frontmatter[ $key ] ) ) {
+				return (string) $frontmatter[ $key ];
+			}
+		}
+
+		return $fallback;
+	}
+
+	/**
+	 * Extract common taxonomy hints from frontmatter.
+	 *
+	 * @param  array<string,mixed> $frontmatter Frontmatter map.
+	 * @return array<string,mixed>
+	 */
+	private function frontmatter_taxonomies( array $frontmatter ): array {
+		$taxonomies = array();
+		foreach ( array( 'category', 'categories', 'tag', 'tags' ) as $key ) {
+			if ( isset( $frontmatter[ $key ] ) ) {
+				$taxonomies[ $key ] = $frontmatter[ $key ];
+			}
+		}
+
+		return $taxonomies;
+	}
+
+	/**
+	 * Build a stable slug from a source path.
+	 */
+	private function slug_from_path( string $path ): string {
+		$base = preg_replace( '/\.[A-Za-z0-9]+$/', '', basename( $path ) );
+		$base = '' === $base || null === $base ? 'document' : $base;
+		return sanitize_key( str_replace( array( '_', '.' ), '-', $base ) );
+	}
+
+	/**
+	 * Build a readable fallback title from a source path.
+	 */
+	private function title_from_path( string $path ): string {
+		return ucwords( str_replace( '-', ' ', $this->slug_from_path( $path ) ) );
+	}
+
+	/**
 	 * Build a normalized diagnostic entry.
 	 *
-	 * @param array<string,mixed> $details Diagnostic details.
+	 * @param  array<string,mixed> $details Diagnostic details.
 	 * @return array<string,mixed>
 	 */
 	private function diagnostic( string $code, string $severity, string $message, array $details = array() ): array {
@@ -558,14 +1495,15 @@ class Block_Artifact_Compiler {
 	/**
 	 * Remove duplicate diagnostics emitted while rejecting many files.
 	 *
-	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @param  array<int,array<string,mixed>> $diagnostics Diagnostics.
 	 * @return array<int,array<string,mixed>> Diagnostics.
 	 */
 	private function dedupe_diagnostics( array $diagnostics ): array {
 		$deduped = array();
 		$seen    = array();
 		foreach ( $diagnostics as $diagnostic ) {
-			$key = (string) ( $diagnostic['code'] ?? '' ) . '|' . md5( wp_json_encode( $diagnostic['details'] ?? array() ) ?: '' );
+			$details_json = wp_json_encode( $diagnostic['details'] ?? array() );
+			$key          = (string) ( $diagnostic['code'] ?? '' ) . '|' . md5( false === $details_json ? '' : $details_json );
 			if ( isset( $seen[ $key ] ) ) {
 				continue;
 			}
@@ -603,9 +1541,19 @@ class Block_Artifact_Compiler {
 	 * @param array{files:array<int,array{path:string,content:string,kind:string,bytes:int,source:string}>} $artifact Normalized artifact.
 	 */
 	private function artifact_hash_payload( array $artifact ): string {
+		return $this->file_hash_payload( $artifact['files'] );
+	}
+
+	/**
+	 * Build a stable hash payload from normalized files.
+	 *
+	 * @param array<int,array{path:string,content:string,kind:string,bytes:int,source:string}> $files Files.
+	 */
+	private function file_hash_payload( array $files ): string {
 		$payload = '';
-		foreach ( $artifact['files'] as $file ) {
-			$payload .= $file['path'] . "\0" . $file['kind'] . "\0" . $file['content'] . "\0";
+		foreach ( $files as $file ) {
+			$content = isset( $file['content_base64'] ) ? (string) $file['content_base64'] : (string) $file['content'];
+			$payload .= $file['path'] . "\0" . $file['kind'] . "\0" . ( $file['mime_type'] ?? '' ) . "\0" . $content . "\0";
 		}
 
 		return $payload;

--- a/vendor/chubes4/block-artifact-compiler/library.php
+++ b/vendor/chubes4/block-artifact-compiler/library.php
@@ -22,7 +22,8 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	 * @return string|false Encoded JSON or false.
 	 */
 	function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
-		return json_encode( $value, $flags, $depth );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- This is the non-WordPress fallback for wp_json_encode().
+		return json_encode( $value, $flags, max( 1, $depth ) );
 	}
 }
 

--- a/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
+++ b/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
@@ -28,6 +28,7 @@ $result = bac_compile_website_artifact(
 );
 
 $assert( 'chubes4/block-artifact-compiler-result/v1' === ( $result['schema'] ?? '' ), 'result exposes schema' );
+$assert( 'block-artifact-compiler/website-artifact/v1' === ( $result['input']['schema'] ?? '' ), 'input metadata exposes canonical website artifact schema' );
 $assert( 'success_with_warnings' === ( $result['status'] ?? '' ), 'fallback status reflects missing BFB in smoke test', (string) ( $result['status'] ?? '' ) );
 $assert( 'index.html' === ( $result['input']['entry_path'] ?? '' ), 'entry path is captured' );
 $assert( str_contains( (string) ( $result['wordpress_artifacts']['block_markup'] ?? '' ), '<!-- wp:html -->' ), 'fallback block markup is produced' );
@@ -36,6 +37,41 @@ $assert( isset( $result['wordpress_artifacts']['components'] ) && is_array( $res
 
 $empty = bac_compile_website_artifact( array( 'files' => array() ) );
 $assert( 'failed' === ( $empty['status'] ?? '' ), 'missing HTML fails explicitly' );
+
+$schema_less = bac_compile_website_artifact(
+	array(
+		'files' => array(
+			array(
+				'path'    => 'schema-less.html',
+				'content' => '<main><p>No input schema required.</p></main>',
+			),
+		),
+	)
+);
+$assert( 'schema-less.html' === ( $schema_less['input']['entry_path'] ?? '' ), 'bundles without schema still compile' );
+$assert( '' === ( $schema_less['input']['original_schema'] ?? null ), 'omitted bundle schema is preserved as empty original schema metadata' );
+
+$warnings = array();
+set_error_handler(
+	static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+		$warnings[] = $errstr;
+		return true;
+	}
+);
+$nested_source = bac_compile_website_artifact(
+	array(
+		'files' => array(
+			array(
+				'path'    => 'nested-source.html',
+				'content' => '<main><p>Nested source metadata.</p></main>',
+				'source'  => array( 'metadata' => 'object' ),
+			),
+		),
+	)
+);
+restore_error_handler();
+$assert( array() === $warnings, 'non-scalar file source metadata does not emit PHP warnings', implode( '; ', $warnings ) );
+$assert( 'nested-source.html' === ( $nested_source['input']['entry_path'] ?? '' ), 'non-scalar file source metadata still compiles' );
 
 $messy = bac_compile_website_artifact(
 	array(
@@ -58,10 +94,149 @@ $assert( 1 === ( $messy['input']['files_by_kind']['css'] ?? 0 ), 'css shorthand 
 $assert( 1 === ( $messy['input']['files_by_kind']['js'] ?? 0 ), 'js file is normalized' );
 $assert( ! empty( $messy['wordpress_artifacts']['components'] ?? array() ), 'component candidates are detected' );
 
+$markdown = bac_compile_website_artifact(
+	array(
+		'files' => array(
+			'content/about.md'       => "---\ntitle: About Us\nslug: about\npost_type: page\ntags: [team, story]\n---\n# About\n\nPlain Markdown content.",
+			'content/changelog.markdown' => "---\ntitle: Changelog\npost_type: post\n---\n# Changes",
+			'assets/logo.bin'       => 'binary-ish',
+		),
+	)
+);
+$assert( 'success_with_warnings' === ( $markdown['status'] ?? '' ), 'markdown documents compile with fallback warnings when BFB is unavailable', (string) ( $markdown['status'] ?? '' ) );
+$assert( 2 === ( $markdown['input']['files_by_kind']['markdown'] ?? 0 ), 'md and markdown files are classified as markdown' );
+$assert( 1 === ( $markdown['input']['files_by_kind']['asset'] ?? 0 ), 'unknown assets remain assets' );
+$assert( 2 === count( $markdown['wordpress_artifacts']['documents'] ?? array() ), 'markdown source documents produce WordPress document artifacts' );
+$assert( 'about' === ( $markdown['wordpress_artifacts']['documents'][0]['slug'] ?? '' ), 'frontmatter slug is preserved' );
+$assert( 'About Us' === ( $markdown['wordpress_artifacts']['documents'][0]['title'] ?? '' ), 'frontmatter title is preserved' );
+$assert( str_contains( (string) ( $markdown['wordpress_artifacts']['documents'][0]['block_markup'] ?? '' ), '<!-- wp:html -->' ), 'markdown body is converted or preserved as block markup' );
+
+$mdx = bac_compile_website_artifact(
+	array(
+		'files' => array(
+			'pages/home.mdx'          => "---\ntitle: Home\nslug: home\n---\nimport Hero from '../components/Hero'\nimport { ProductGrid } from '../components/ProductGrid'\n\n# Welcome\n\n<Hero />\n<ProductGrid collection=\"featured\" />\n<MissingWidget />",
+			'components/Hero.jsx'     => 'export default function Hero() { return <section />; }',
+			'components/ProductGrid.tsx' => 'export function ProductGrid() { return <div />; }',
+		),
+	)
+);
+$assert( 1 === ( $mdx['input']['files_by_kind']['mdx'] ?? 0 ), 'mdx files are classified as mdx' );
+$assert( 1 === ( $mdx['input']['files_by_kind']['jsx'] ?? 0 ), 'jsx files are classified as jsx component sources' );
+$assert( 1 === ( $mdx['input']['files_by_kind']['tsx'] ?? 0 ), 'tsx files are classified as tsx component sources' );
+$assert( 'text/mdx' === ( $mdx['wordpress_artifacts']['files'][0]['mime_type'] ?? '' ), 'mdx files preserve BAC-local MIME type in file manifest' );
+$assert( 1 === count( $mdx['wordpress_artifacts']['documents'] ?? array() ), 'mdx source document produces a document artifact' );
+$assert( count( $mdx['wordpress_artifacts']['components'] ?? array() ) >= 3, 'mdx JSX components produce component candidates' );
+$assert( ! empty( array_filter( $mdx['wordpress_artifacts']['components'] ?? array(), static fn ( array $component ): bool => 'Hero' === ( $component['name'] ?? '' ) && 'components/Hero.jsx' === ( $component['resolved_path'] ?? '' ) ) ), 'mdx imports resolve to generated source files when present' );
+$assert( ! empty( array_filter( $mdx['wordpress_artifacts']['components'] ?? array(), static fn ( array $component ): bool => 'jsx-component-file' === ( $component['signal'] ?? '' ) && 'components/Hero.jsx' === ( $component['source'] ?? '' ) ) ), 'jsx source files produce component candidates' );
+$assert( ! empty( array_filter( $mdx['diagnostics'] ?? array(), static fn ( array $diagnostic ): bool => 'mdx_component_unresolved' === ( $diagnostic['code'] ?? '' ) ) ), 'unresolved mdx components emit diagnostics' );
+
 $fragment = bac_compile_fragment( '<div class="feature-card">Feature</div>', 'main:index.html' );
 $assert( 'main-index.html' === ( $fragment['input']['entry_path'] ?? '' ), 'fragment source is normalized to virtual path' );
 
 $summary = bac_summarize_result( $messy );
 $assert( ( $summary['component_count'] ?? 0 ) > 0, 'summary exposes component count' );
+
+$rich = bac_compile_website_artifact(
+	array(
+		'schema'      => 'example/rich-website-bundle/v1',
+		'entrypoints' => array( 'pages/home.html', '../unsafe.html' ),
+		'files'       => array(
+			array(
+				'path'           => 'pages/home.html',
+				'content_base64' => base64_encode( '<main><h1>Rich bundle</h1></main>' ),
+				'mime_type'      => 'text/html',
+				'role'           => 'entry',
+			),
+			array(
+				'path'    => 'assets/app.css',
+				'content' => 'body{color:rebeccapurple}',
+				'type'    => 'text/css',
+				'intent'  => 'theme-style',
+			),
+			array(
+				'path'           => 'assets/logo.png',
+				'content_base64' => base64_encode( "\x89PNG\r\n\x1a\n" ),
+				'mime_type'      => 'image/png',
+				'role'           => 'brand-asset',
+			),
+			array(
+				'path'           => 'assets/bad.bin',
+				'content_base64' => 'not-valid-base64',
+			),
+		),
+	)
+);
+$assert( 'pages/home.html' === ( $rich['input']['entry_path'] ?? '' ), 'explicit entrypoint selects nested HTML entry' );
+$assert( in_array( 'pages/home.html', $rich['input']['entrypoints'] ?? array(), true ), 'entrypoints are normalized into input metadata' );
+$assert( 1 === ( $rich['input']['files_by_role']['brand-asset'] ?? 0 ), 'explicit asset role is preserved' );
+$assert( 1 === ( $rich['input']['files_by_mime']['image/png'] ?? 0 ), 'MIME counts are exposed' );
+$assert( 1 === ( $rich['input']['rejected_count'] ?? null ), 'invalid base64 file is rejected without blocking the bundle' );
+$has_unsafe_entrypoint = false;
+foreach ( $rich['diagnostics'] ?? array() as $diagnostic ) {
+	if ( 'unsafe_entrypoint_path' === ( $diagnostic['code'] ?? '' ) ) {
+		$has_unsafe_entrypoint = true;
+	}
+}
+$assert( $has_unsafe_entrypoint, 'unsafe entrypoint is diagnosed' );
+$asset_files = $rich['wordpress_artifacts']['files'] ?? array();
+$png_file    = null;
+foreach ( $asset_files as $asset_file ) {
+	if ( 'assets/logo.png' === ( $asset_file['path'] ?? '' ) ) {
+		$png_file = $asset_file;
+	}
+}
+$assert( is_array( $png_file ), 'binary asset appears in file manifest' );
+$assert( ! empty( $png_file['content_base64'] ?? '' ), 'binary asset keeps base64 payload' );
+$assert( true === ( $png_file['binary'] ?? null ), 'binary asset is marked binary' );
+
+$blocks = bac_compile_website_artifact(
+	array(
+		'generated_html' => '<main><h1>Block artifact page</h1></main>',
+		'files'          => array(
+			'blocks/hero/block.json'       => wp_json_encode(
+				array(
+					'apiVersion'   => 3,
+					'name'         => 'acme/hero',
+					'title'        => 'Hero',
+					'category'     => 'design',
+					'editorScript' => 'file:./index.js',
+					'viewScript'   => array( 'file:./view.js', 'wp-interactivity' ),
+					'style'        => 'file:./style.css',
+					'editorStyle'  => 'file:./editor.css',
+					'render'       => 'file:./render.php',
+					'attributes'   => array(
+						'headline' => array( 'type' => 'string' ),
+					),
+					'supports'     => array( 'align' => true ),
+				),
+				JSON_UNESCAPED_SLASHES
+			),
+			'blocks/hero/index.js'         => 'import metadata from "./block.json";',
+			'blocks/hero/index.asset.php'  => '<?php return array("dependencies" => array("wp-blocks"), "version" => "1");',
+			'blocks/hero/view.js'          => 'console.log("front");',
+			'blocks/hero/style.css'        => '.wp-block-acme-hero{padding:2rem}',
+			'blocks/hero/editor.css'       => '.wp-block-acme-hero{outline:1px solid}',
+			'blocks/hero/render.php'       => '<?php echo $content;',
+		),
+	)
+);
+$block_types = $blocks['wordpress_artifacts']['block_types'] ?? array();
+$assert( 1 === count( $block_types ), 'block.json roots are promoted into block type artifacts' );
+$hero = $block_types[0] ?? array();
+$assert( 'chubes4/wordpress-block-type-artifact/v1' === ( $hero['schema'] ?? '' ), 'block type exposes contract schema' );
+$assert( 'acme/hero' === ( $hero['name'] ?? '' ), 'block type preserves block.json name' );
+$assert( 'blocks/hero' === ( $hero['directory'] ?? '' ), 'block type exposes source directory' );
+$assert( 'blocks/hero/block.json' === ( $hero['block_json_path'] ?? '' ), 'block type exposes block.json path' );
+$assert( 3 === ( $hero['metadata']['apiVersion'] ?? null ), 'block metadata preserves apiVersion' );
+$assert( array( 'align' => true ) === ( $hero['metadata']['supports'] ?? null ), 'block metadata preserves supports' );
+$assert( 'blocks/hero/index.js' === ( $hero['assets']['editor_script'][0]['path'] ?? '' ), 'editor script file reference resolves to generated file' );
+$assert( 'wp-interactivity' === ( $hero['assets']['view_script'][1]['reference'] ?? '' ), 'script handles are preserved as dependencies/references' );
+$assert( 'blocks/hero/render.php' === ( $hero['assets']['render'][0]['path'] ?? '' ), 'render file reference resolves to generated file' );
+$assert( 'blocks/hero/index.asset.php' === ( $hero['dependencies']['asset_files'][0]['path'] ?? '' ), 'asset php dependency manifests are recorded' );
+$assert( ! empty( $hero['provenance']['source_hash'] ?? '' ), 'block type exposes provenance hash' );
+$assert( in_array( 'blocks/hero/style.css', $hero['provenance']['files'] ?? array(), true ), 'block provenance lists source files' );
+
+$summary = bac_summarize_result( $blocks );
+$assert( 1 === ( $summary['block_type_count'] ?? 0 ), 'summary exposes block type count' );
 
 fwrite( STDOUT, "contract smoke passed\n" );

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,18 +7,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "098b74f84b458b1bc75c89fa333291dc186e5fa1"
+                "reference": "50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/098b74f84b458b1bc75c89fa333291dc186e5fa1",
-                "reference": "098b74f84b458b1bc75c89fa333291dc186e5fa1",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1",
+                "reference": "50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
-            "time": "2026-05-31T02:58:07+00:00",
+            "time": "2026-05-31T18:29:55+00:00",
             "default-branch": true,
             "type": "wordpress-plugin",
             "installation-source": "dist",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '7c5f2340014356df3bfd9014c283a9f85df1d2de',
+        'reference' => 'c345b9ef391d648d6d1d318a4c8b8837ac413d96',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'chubes4/block-artifact-compiler' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '098b74f84b458b1bc75c89fa333291dc186e5fa1',
+            'reference' => '50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../chubes4/block-artifact-compiler',
             'aliases' => array(
@@ -35,7 +35,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '7c5f2340014356df3bfd9014c283a9f85df1d2de',
+            'reference' => 'c345b9ef391d648d6d1d318a4c8b8837ac413d96',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- Replaces the `export-theme` static-site artifact-set envelope with a clean `chubes4/website-artifact/v1` `website_artifact` output.
- Defaults export roots/entrypoints to `website/` and removes legacy top-level `artifact_set`, `files`, and `report` aliases.
- Updates docs and smokes to verify non-`static-site/` paths, metadata files, binary/base64 assets, report/source-document refs, and BAC compilation of the exported artifact.

Fixes #267

## Verification
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l includes/abilities.php`
- `php tests/smoke-export-theme-ability.php`
- `php tests/smoke-import-theme-ability.php`
- `git diff --check`

Homeboy:
- `homeboy test --path /Users/chubes/Developer/static-site-importer@fix-issue-267-website-artifact-export` did not execute checks because the configured `homeboy-lab` SSH snapshot failed with `No space left on device`.
- `homeboy audit --path /Users/chubes/Developer/static-site-importer@fix-issue-267-website-artifact-export` failed for the same lab workspace snapshot error.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the export contract update, tests, docs, and verification commands for Chris to review.