### PR TITLE
Use neutral BAC result schema

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -3982,7 +3982,7 @@ class Static_Site_Importer_Theme_Generator {
 			'type'        => 'website_artifact_materialization_contract_note',
 			'source'      => '' !== $source ? $source : 'website_artifact',
 			'message'     => 'Direct materialization consumed current BAC block_markup and files artifacts. Rich multi-page, template-part, and source-to-theme asset reference maps should be added to the BAC contract before SSI relies on them.',
-			'contract'    => 'chubes4/block-artifact-compiler-result/v1',
+			'contract'    => 'block-artifact-compiler/result/v1',
 			'constraints' => 'report_only',
 		);
 	}

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -281,7 +281,7 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertNotFalse( file_put_contents( $fixture_dir . '/content.mdx', '# SSI should not parse this MDX on the BAC path' ) );
 
 		$compiled = array(
-			'schema'              => 'chubes4/block-artifact-compiler-result/v1',
+			'schema'              => 'block-artifact-compiler/result/v1',
 			'status'              => 'success',
 			'input'               => array(
 				'entry_path' => 'index.html',

--- a/tests/smoke-export-theme-ability.php
+++ b/tests/smoke-export-theme-ability.php
@@ -208,7 +208,7 @@ $assert( 'smoke' === ( $artifact['report']['source_metadata']['source'] ?? '' ),
 $assert( 'completed' === ( $artifact['report']['import_report']['status'] ?? '' ), 'import-report-preserved' );
 if ( function_exists( 'bac_compile_website_artifact' ) ) {
 	$compiled = bac_compile_website_artifact( $artifact );
-	$assert( 'chubes4/block-artifact-compiler-result/v1' === ( $compiled['schema'] ?? '' ), 'bac-compiles-exported-artifact' );
+	$assert( 'block-artifact-compiler/result/v1' === ( $compiled['schema'] ?? '' ), 'bac-compiles-exported-artifact' );
 	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'bac-uses-website-entrypoint' );
 }
 $export_bfb_calls = array_filter(

--- a/vendor/chubes4/block-artifact-compiler/README.md
+++ b/vendor/chubes4/block-artifact-compiler/README.md
@@ -88,7 +88,7 @@ Result shape:
 
 ```php
 array(
-	'schema'              => 'chubes4/block-artifact-compiler-result/v1',
+	'schema'              => 'block-artifact-compiler/result/v1',
 	'status'              => 'success',
 	'input'               => array(...),
 	'wordpress_artifacts' => array(

--- a/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
+++ b/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
@@ -10,7 +10,7 @@
  */
 class Block_Artifact_Compiler {
 
-	private const RESULT_SCHEMA = 'chubes4/block-artifact-compiler-result/v1';
+	private const RESULT_SCHEMA = 'block-artifact-compiler/result/v1';
 	private const INPUT_SCHEMA  = 'block-artifact-compiler/website-artifact/v1';
 
 	private const DEFAULT_MAX_FILES       = 200;

--- a/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
+++ b/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
@@ -27,7 +27,7 @@ $result = bac_compile_website_artifact(
 	)
 );
 
-$assert( 'chubes4/block-artifact-compiler-result/v1' === ( $result['schema'] ?? '' ), 'result exposes schema' );
+$assert( 'block-artifact-compiler/result/v1' === ( $result['schema'] ?? '' ), 'result exposes schema' );
 $assert( 'block-artifact-compiler/website-artifact/v1' === ( $result['input']['schema'] ?? '' ), 'input metadata exposes canonical website artifact schema' );
 $assert( 'success_with_warnings' === ( $result['status'] ?? '' ), 'fallback status reflects missing BFB in smoke test', (string) ( $result['status'] ?? '' ) );
 $assert( 'index.html' === ( $result['input']['entry_path'] ?? '' ), 'entry path is captured' );


### PR DESCRIPTION
## Summary
- Replaces the remaining `chubes4/block-artifact-compiler-result/v1` schema references with `block-artifact-compiler/result/v1`.
- Updates SSI’s vendored BAC copy, SSI fixture/report assertions, and export smoke expectations to match the upstream BAC schema cleanup.

Upstream BAC PR: https://github.com/chubes4/block-artifact-compiler/pull/14
Follow-up to #268.

## Verification
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php`
- `php tests/smoke-export-theme-ability.php`
- `php tests/smoke-import-theme-ability.php`
- `php vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the schema namespace cleanup, tests, docs, and verification commands for Chris to review.