### PR TITLE
Resolve local static asset references

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -62,6 +62,13 @@ class Static_Site_Importer_Theme_Generator {
 	private static array $active_asset_map = array();
 
 	/**
+	 * Resolved local asset metadata keyed by original and rewritten references.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	private static array $active_asset_metadata = array();
+
+	/**
 	 * Materialized inline SVG assets keyed by SVG content hash.
 	 *
 	 * @var array<string, array<string, string>>
@@ -174,6 +181,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::$active_theme_uri         = trailingslashit( get_theme_root_uri( $theme_slug ) ) . $theme_slug;
 		self::$active_source_dir        = $site_dir;
 		self::$active_asset_map         = self::normalize_asset_map( isset( $args['asset_map'] ) && is_array( $args['asset_map'] ) ? $args['asset_map'] : array() );
+		self::$active_asset_metadata    = array();
 		self::$conversion_report['asset_map']['supplied']    = ! empty( self::$active_asset_map );
 		self::$conversion_report['asset_map']['entry_count'] = count( self::$active_asset_map );
 		self::$materialized_svg_assets  = array();
@@ -181,7 +189,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::$materialized_svg_sprites = array();
 		self::$button_wrapper_classes   = array();
 
-		$site_css                             = self::site_css( $site_dir, $document );
+		$site_css                             = self::site_css( $site_dir, $document, basename( $html_path ) );
 		self::$decorative_empty_group_classes = array_fill_keys(
 			self::decorative_empty_group_classes_from_css( $site_css ),
 			true
@@ -192,9 +200,9 @@ class Static_Site_Importer_Theme_Generator {
 		$background_source   = 'background:' . $entry_source;
 		$header_source       = 'header:' . $entry_source;
 		$footer_source       = 'footer:' . $entry_source;
-		$background_fragment = self::rewrite_asset_map_image_references( self::rewrite_internal_links( $fragments['background'], $route_map, $entry_source, $background_source ), $entry_source, $background_source );
-		$header_fragment     = self::rewrite_asset_map_image_references( self::rewrite_internal_links( $fragments['header'], $route_map, $entry_source, $header_source ), $entry_source, $header_source );
-		$footer_fragment     = self::rewrite_asset_map_image_references( self::rewrite_internal_links( $fragments['footer'], $route_map, $entry_source, $footer_source ), $entry_source, $footer_source );
+		$background_fragment = self::rewrite_local_asset_references( self::rewrite_internal_links( $fragments['background'], $route_map, $entry_source, $background_source ), $entry_source, $background_source );
+		$header_fragment     = self::rewrite_local_asset_references( self::rewrite_internal_links( $fragments['header'], $route_map, $entry_source, $header_source ), $entry_source, $header_source );
+		$footer_fragment     = self::rewrite_local_asset_references( self::rewrite_internal_links( $fragments['footer'], $route_map, $entry_source, $footer_source ), $entry_source, $footer_source );
 		$background_blocks   = self::convert_fragment( $background_fragment, 'background:index.html' );
 		$header_blocks       = self::convert_header_fragment( self::strip_active_classes( $header_fragment ), $theme_slug );
 		$has_footer_part     = '' !== trim( $fragments['footer'] );
@@ -377,6 +385,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::$active_theme_uri         = trailingslashit( get_theme_root_uri( $theme_slug ) ) . $theme_slug;
 		self::$active_source_dir        = '';
 		self::$active_asset_map         = self::normalize_asset_map( isset( $args['asset_map'] ) && is_array( $args['asset_map'] ) ? $args['asset_map'] : array() );
+		self::$active_asset_metadata    = array();
 		self::$conversion_report['asset_map']['supplied']    = ! empty( self::$active_asset_map );
 		self::$conversion_report['asset_map']['entry_count'] = count( self::$active_asset_map );
 		self::$materialized_svg_assets  = array();
@@ -1777,6 +1786,118 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Rewrite local HTML asset references after materializing safe source files.
+	 *
+	 * @param string $html        HTML fragment.
+	 * @param string $source_path Source-relative source path.
+	 * @param string $source      Diagnostic source label.
+	 * @return string
+	 */
+	private static function rewrite_local_asset_references( string $html, string $source_path, string $source ): string {
+		if ( '' === trim( $html ) ) {
+			return $html;
+		}
+
+		$html = self::rewrite_asset_map_image_references( $html, $source_path, $source );
+		if ( ! preg_match( '/\b(?:src|poster|srcset)\s*=|<source\b|<img\b|<video\b|<audio\b/i', $html ) ) {
+			return $html;
+		}
+
+		$doc  = self::load_fragment_document( $html );
+		$root = $doc->documentElement;
+		if ( ! $root instanceof DOMElement ) {
+			return $html;
+		}
+
+		$changed = false;
+		foreach ( $root->getElementsByTagName( '*' ) as $element ) {
+			foreach ( array( 'src', 'poster' ) as $attribute ) {
+				$value = trim( $element->getAttribute( $attribute ) );
+				if ( '' === $value || ! self::is_local_url( $value ) ) {
+					continue;
+				}
+
+				$asset = self::resolve_local_asset_reference( $value, $source_path, $source );
+				if ( null === $asset ) {
+					continue;
+				}
+
+				$element->setAttribute( $attribute, $asset['url'] );
+				self::apply_asset_metadata_to_media_element( $element, $asset );
+				$changed = true;
+			}
+
+			$srcset = trim( $element->getAttribute( 'srcset' ) );
+			if ( '' !== $srcset ) {
+				$rewritten = self::rewrite_srcset_asset_references( $srcset, $source_path, $source );
+				if ( $rewritten !== $srcset ) {
+					$element->setAttribute( 'srcset', $rewritten );
+					$changed = true;
+				}
+			}
+		}
+
+		return $changed ? self::node_inner_html( $doc, $root ) : $html;
+	}
+
+	/**
+	 * Rewrite one srcset attribute value through local asset materialization.
+	 *
+	 * @param string $srcset      Source srcset attribute.
+	 * @param string $source_path Source-relative source path.
+	 * @param string $source      Diagnostic source label.
+	 * @return string
+	 */
+	private static function rewrite_srcset_asset_references( string $srcset, string $source_path, string $source ): string {
+		$candidates = array();
+		$changed    = false;
+		foreach ( explode( ',', $srcset ) as $candidate ) {
+			$candidate = trim( $candidate );
+			if ( '' === $candidate ) {
+				continue;
+			}
+
+			$parts      = preg_split( '/\s+/', $candidate, 2 );
+			$url        = $parts[0] ?? '';
+			$descriptor = $parts[1] ?? '';
+			$asset      = self::resolve_local_asset_reference( $url, $source_path, $source );
+			if ( null !== $asset ) {
+				$url     = $asset['url'];
+				$changed = true;
+			}
+
+			$candidates[] = trim( $url . ( '' === $descriptor ? '' : ' ' . $descriptor ) );
+		}
+
+		return $changed ? implode( ', ', $candidates ) : $srcset;
+	}
+
+	/**
+	 * Add resolved metadata attributes to media elements before conversion.
+	 *
+	 * @param DOMElement          $element Media element.
+	 * @param array<string,mixed> $asset   Asset metadata.
+	 * @return void
+	 */
+	private static function apply_asset_metadata_to_media_element( DOMElement $element, array $asset ): void {
+		if ( isset( $asset['attachment_id'] ) && (int) $asset['attachment_id'] > 0 ) {
+			$attachment_id = (int) $asset['attachment_id'];
+			$element->setAttribute( 'data-id', (string) $attachment_id );
+			$element->setAttribute( 'class', self::append_class_token( $element->getAttribute( 'class' ), 'wp-image-' . $attachment_id ) );
+		}
+
+		foreach ( array( 'width', 'height' ) as $dimension ) {
+			if ( isset( $asset[ $dimension ] ) && (int) $asset[ $dimension ] > 0 && ! $element->hasAttribute( $dimension ) ) {
+				$element->setAttribute( $dimension, (string) (int) $asset[ $dimension ] );
+			}
+		}
+
+		if ( isset( $asset['alt'] ) && '' !== trim( (string) $asset['alt'] ) && '' === trim( $element->getAttribute( 'alt' ) ) ) {
+			$element->setAttribute( 'alt', (string) $asset['alt'] );
+		}
+	}
+
+	/**
 	 * Strip static active classes from shared chrome before every page reuses it.
 	 *
 	 * @param string $html HTML fragment.
@@ -2583,6 +2704,206 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Resolve a source-local asset URL, materialize it into the generated theme, and return metadata.
+	 *
+	 * @param string $url         Source URL or path.
+	 * @param string $source_path Source-relative document path.
+	 * @param string $source      Diagnostic source label.
+	 * @return array<string,mixed>|null
+	 */
+	private static function resolve_local_asset_reference( string $url, string $source_path, string $source ): ?array {
+		if ( ! self::is_local_url( $url ) ) {
+			return null;
+		}
+
+		$mapped = self::resolve_asset_map_reference( $url, $source_path, $source );
+		if ( null !== $mapped ) {
+			$entry = $mapped['entry'];
+			self::remember_asset_metadata( $url, $mapped['key'], $entry );
+			return $entry;
+		}
+
+		$key = self::asset_map_lookup_key( $url, $source_path );
+		if ( '' === $key ) {
+			self::record_local_asset_diagnostic( 'local_asset_unsafe_path', $source, $source_path, $url, '', 'Local asset reference resolves outside the static source root; leaving it unchanged.' );
+			return null;
+		}
+
+		if ( '' === self::$active_source_dir || '' === self::$active_theme_dir || '' === self::$active_theme_uri ) {
+			self::record_local_asset_diagnostic( 'local_asset_not_materialized', $source, $source_path, $url, $key, 'Local asset reference could not be materialized because the import has no active source/theme context.' );
+			return null;
+		}
+
+		$real_source_dir = realpath( self::$active_source_dir );
+		$real_source     = false === $real_source_dir ? '' : realpath( trailingslashit( $real_source_dir ) . $key );
+		if ( '' === $real_source_dir || false === $real_source || ! self::path_is_under( $real_source, $real_source_dir ) || ! is_readable( $real_source ) || ! is_file( $real_source ) ) {
+			self::record_local_asset_diagnostic( 'local_asset_not_found', $source, $source_path, $url, $key, 'Local asset reference did not resolve to a readable file under the static source root; leaving it unchanged.' );
+			return null;
+		}
+
+		$extension = strtolower( pathinfo( $real_source, PATHINFO_EXTENSION ) );
+		if ( ! in_array( $extension, array( 'svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'woff', 'woff2' ), true ) ) {
+			self::record_local_asset_diagnostic( 'local_asset_unsupported_type', $source, $source_path, $url, $key, 'Local asset reference uses an unsupported file type for theme materialization; leaving it unchanged.' );
+			return null;
+		}
+
+		$target_relative = self::materialized_asset_relative_path( $key, $real_source );
+		if ( '' === $target_relative ) {
+			self::record_local_asset_diagnostic( 'local_asset_unsafe_path', $source, $source_path, $url, $key, 'Local asset reference could not be converted to a safe generated theme asset path; leaving it unchanged.' );
+			return null;
+		}
+
+		$target_path = trailingslashit( self::$active_theme_dir ) . $target_relative;
+		if ( ! is_file( $target_path ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads local static-site assets selected for materialization.
+			$contents = file_get_contents( $real_source );
+			if ( false === $contents ) {
+				self::record_local_asset_diagnostic( 'local_asset_read_failed', $source, $source_path, $url, $key, 'Local asset reference could not be read; leaving it unchanged.' );
+				return null;
+			}
+
+			$result = self::write_file( $target_path, $contents );
+			if ( is_wp_error( $result ) ) {
+				self::record_local_asset_diagnostic( 'local_asset_write_failed', $source, $source_path, $url, $key, 'Local asset reference could not be written to the generated theme; leaving it unchanged.' );
+				return null;
+			}
+		}
+
+		$asset = array(
+			'source'      => $url,
+			'source_path' => $source_path,
+			'path'        => $key,
+			'url'         => trailingslashit( self::$active_theme_uri ) . $target_relative,
+			'mime_type'   => self::export_mime_type( $real_source ),
+			'theme_path'  => $target_relative,
+		);
+
+		$dimensions = self::image_dimensions( $real_source );
+		if ( ! empty( $dimensions ) ) {
+			$asset = array_merge( $asset, $dimensions );
+		}
+
+		self::record_local_asset_materialized( $source, $source_path, $url, $key, $asset );
+		self::remember_asset_metadata( $url, $key, $asset );
+
+		return $asset;
+	}
+
+	/**
+	 * Build a deterministic safe theme-relative path for a materialized source asset.
+	 *
+	 * @param string $key         Source-relative key.
+	 * @param string $source_path Absolute source path.
+	 * @return string
+	 */
+	private static function materialized_asset_relative_path( string $key, string $source_path ): string {
+		$normalized = self::normalize_artifact_materialization_path( 'assets/media/' . $key );
+		if ( '' === $normalized ) {
+			$basename = sanitize_file_name( basename( $source_path ) );
+			if ( '' === $basename ) {
+				return '';
+			}
+
+			$normalized = 'assets/media/' . md5( $key ) . '-' . $basename;
+		}
+
+		$directory = dirname( trailingslashit( self::$active_theme_dir ) . $normalized );
+		if ( ! is_dir( $directory ) && ! wp_mkdir_p( $directory ) ) {
+			return '';
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Infer image dimensions when PHP can read them safely.
+	 *
+	 * @param string $path Absolute image path.
+	 * @return array<string,int>
+	 */
+	private static function image_dimensions( string $path ): array {
+		if ( ! function_exists( 'getimagesize' ) ) {
+			return array();
+		}
+
+		$size = @getimagesize( $path );
+		if ( ! is_array( $size ) || empty( $size[0] ) || empty( $size[1] ) ) {
+			return array();
+		}
+
+		return array(
+			'width'  => (int) $size[0],
+			'height' => (int) $size[1],
+		);
+	}
+
+	/**
+	 * Store metadata under all keys H2BC/BFB may see during conversion.
+	 *
+	 * @param string              $url   Original source reference.
+	 * @param string              $key   Source-relative key.
+	 * @param array<string,mixed> $asset Asset metadata.
+	 * @return void
+	 */
+	private static function remember_asset_metadata( string $url, string $key, array $asset ): void {
+		foreach ( array( $url, html_entity_decode( $url, ENT_QUOTES ), $key, '/' . ltrim( $key, '/' ), $asset['url'] ?? '' ) as $metadata_key ) {
+			$metadata_key = trim( (string) $metadata_key );
+			if ( '' !== $metadata_key ) {
+				self::$active_asset_metadata[ $metadata_key ] = $asset;
+			}
+		}
+	}
+
+	/**
+	 * Record a local asset materialization row in the import report.
+	 *
+	 * @param string              $source      Diagnostic source label.
+	 * @param string              $source_path Source-relative source path.
+	 * @param string              $url         Original URL.
+	 * @param string              $key         Source-relative key.
+	 * @param array<string,mixed> $asset       Asset metadata.
+	 * @return void
+	 */
+	private static function record_local_asset_materialized( string $source, string $source_path, string $url, string $key, array $asset ): void {
+		if ( ! isset( self::$conversion_report['assets']['local'] ) || ! is_array( self::$conversion_report['assets']['local'] ) ) {
+			self::$conversion_report['assets']['local'] = array();
+		}
+
+		self::$conversion_report['assets']['local'][] = array(
+			'source'      => $source,
+			'source_path' => $source_path,
+			'url'         => $url,
+			'key'         => $key,
+			'theme_path'  => $asset['theme_path'] ?? '',
+			'mime_type'   => $asset['mime_type'] ?? '',
+		);
+	}
+
+	/**
+	 * Record an actionable local asset diagnostic.
+	 *
+	 * @param string $type        Diagnostic type.
+	 * @param string $source      Diagnostic source label.
+	 * @param string $source_path Source-relative source path.
+	 * @param string $url         Original URL.
+	 * @param string $key         Source-relative key.
+	 * @param string $message     Diagnostic message.
+	 * @return void
+	 */
+	private static function record_local_asset_diagnostic( string $type, string $source, string $source_path, string $url, string $key, string $message ): void {
+		self::$conversion_report['diagnostics'][] = array(
+			'type'                   => $type,
+			'category'               => 'unresolved_asset',
+			'suggested_repair_class' => 'materialize_or_rewrite_asset',
+			'source'                 => $source,
+			'source_path'            => $source_path,
+			'url'                    => $url,
+			'key'                    => $key,
+			'message'                => $message,
+		);
+	}
+
+	/**
 	 * Build a reference to a deterministic wp_navigation entity.
 	 *
 	 * @param DOMElement $element    Navigation source element.
@@ -2920,7 +3241,7 @@ class Static_Site_Importer_Theme_Generator {
 			$body = self::rewrite_markdown_links( $body, $route_map, $source_path, $source );
 		} else {
 			$body = self::rewrite_internal_links( $body, $route_map, $source_path, $source );
-			$body = self::rewrite_asset_map_image_references( $body, $source_path, $source );
+			$body = self::rewrite_local_asset_references( $body, $source_path, $source );
 		}
 
 		return self::convert_fragment( $body, $source, $page->body_format() );
@@ -2948,8 +3269,9 @@ class Static_Site_Importer_Theme_Generator {
 				$destination = trim( $matches[3], '<>' );
 
 				if ( '!' === $prefix ) {
-					if ( self::is_local_url( $destination ) ) {
-						self::record_unresolved_internal_link( $source, $source_path, $destination, 'local_asset_not_materialized' );
+					$asset = self::resolve_local_asset_reference( $destination, $source_path, $source );
+					if ( null !== $asset ) {
+						return '![' . $label . '](' . $asset['url'] . ')';
 					}
 					return $matches[0];
 				}
@@ -3056,10 +3378,11 @@ class Static_Site_Importer_Theme_Generator {
 	 * Collect inline and linked local CSS.
 	 *
 	 * @param string                        $site_dir Site directory.
-	 * @param Static_Site_Importer_Document $document Source document.
+	 * @param Static_Site_Importer_Document $document          Source document.
+	 * @param string                        $inline_source_path Source-relative path for inline style URL resolution.
 	 * @return string
 	 */
-	private static function site_css( string $site_dir, Static_Site_Importer_Document $document ): string {
+	private static function site_css( string $site_dir, Static_Site_Importer_Document $document, string $inline_source_path = 'index.html' ): string {
 		$css           = array();
 		$real_site_dir = realpath( $site_dir );
 		$real_site_dir = false === $real_site_dir ? $site_dir : $real_site_dir;
@@ -3073,16 +3396,49 @@ class Static_Site_Importer_Theme_Generator {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads local static-site stylesheet files from the import directory.
 			$contents = file_get_contents( $path );
 			if ( false !== $contents ) {
-				$css[] = trim( $contents );
+				$source_path = ltrim( str_replace( '\\', '/', substr( $path, strlen( trailingslashit( $real_site_dir ) ) ) ), '/' );
+				$css[]       = trim( self::rewrite_css_asset_references( $contents, $source_path, 'stylesheet:' . $source_path ) );
 			}
 		}
 
 		$inline = $document->inline_css();
 		if ( '' !== $inline ) {
-			$css[] = $inline;
+			$css[] = self::rewrite_css_asset_references( $inline, $inline_source_path, 'inline-style:' . $inline_source_path );
 		}
 
 		return trim( implode( "\n\n", array_filter( $css ) ) );
+	}
+
+	/**
+	 * Rewrite local CSS url(...) references through local asset materialization.
+	 *
+	 * @param string $css         CSS source.
+	 * @param string $source_path Source-relative stylesheet path.
+	 * @param string $source      Diagnostic source label.
+	 * @return string
+	 */
+	private static function rewrite_css_asset_references( string $css, string $source_path, string $source ): string {
+		if ( '' === trim( $css ) || ! str_contains( strtolower( $css ), 'url(' ) ) {
+			return $css;
+		}
+
+		return preg_replace_callback(
+			'/url\(\s*(["\']?)(.*?)\1\s*\)/i',
+			static function ( array $matches ) use ( $source_path, $source ): string {
+				$url = trim( html_entity_decode( (string) $matches[2], ENT_QUOTES ) );
+				if ( '' === $url || ! self::is_local_url( $url ) ) {
+					return $matches[0];
+				}
+
+				$asset = self::resolve_local_asset_reference( $url, $source_path, $source );
+				if ( null === $asset ) {
+					return $matches[0];
+				}
+
+				return 'url("' . esc_url_raw( (string) $asset['url'] ) . '")';
+			},
+			$css
+		) ?? $css;
 	}
 
 	/**
@@ -3872,7 +4228,7 @@ class Static_Site_Importer_Theme_Generator {
 		add_action( 'html_to_blocks_conversion_aborted_content_loss', $content_loss_listener, 10, 2 );
 		add_action( 'bfb_conversion_metadata', $commerce_metadata_listener, 10, 1 );
 		add_action( 'bfb_materialization_request', $commerce_request_listener, 10, 1 );
-		$conversion_options = empty( self::$active_commerce_context ) ? array() : self::conversion_options( $source );
+		$conversion_options = self::conversion_options( $source );
 		$blocks             = self::compile_fragment_to_blocks( $html, $source, $format, $conversion_options );
 		remove_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10 );
 		remove_action( 'html_to_blocks_conversion_aborted_content_loss', $content_loss_listener, 10 );
@@ -4561,6 +4917,7 @@ class Static_Site_Importer_Theme_Generator {
 			'assets'                  => array(
 				'svg_icons'   => array(),
 				'svg_sprites' => array(),
+				'local'       => array(),
 			),
 			'asset_map'               => array(
 				'supplied'         => false,
@@ -5572,19 +5929,30 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return array<string, mixed>
 	 */
 	private static function conversion_options( string $source ): array {
-		if ( empty( self::$active_commerce_context ) ) {
-			return array();
+		$context = array();
+		if ( ! empty( self::$active_commerce_context ) ) {
+			$context['commerce'] = array_merge(
+				self::$active_commerce_context,
+				array(
+					'source_fragment' => $source,
+				)
+			);
+		}
+
+		if ( ! empty( self::$active_asset_metadata ) ) {
+			$context['asset_metadata'] = self::$active_asset_metadata;
+		}
+
+		if ( empty( $context ) ) {
+			return array(
+				'source' => array(
+					'fragment' => $source,
+				),
+			);
 		}
 
 		return array(
-			'context' => array(
-				'commerce' => array_merge(
-					self::$active_commerce_context,
-					array(
-						'source_fragment' => $source,
-					)
-				),
-			),
+			'context' => $context,
 			'source'  => array(
 				'fragment' => $source,
 			),

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -544,9 +544,10 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$report = json_decode( $this->read_file( $result['report_path'] ), true );
 
 		$this->assertStringContainsString( '<!-- wp:image ', $header );
-		$this->assertStringContainsString( '/assets/media/studio-mark-', $header );
+		$this->assertStringContainsString( '/assets/media/assets/studio-mark.svg', $header );
 		$this->assertStringNotContainsString( 'src="assets/studio-mark.svg"', $header );
-		$this->assertNotEmpty( glob( $result['theme_dir'] . '/assets/media/studio-mark-*.svg' ) );
+		$this->assertFileExists( $result['theme_dir'] . '/assets/media/assets/studio-mark.svg' );
+		$this->assertSame( 'assets/studio-mark.svg', $report['assets']['local'][0]['key'] ?? null );
 		$this->assertSame( 0, $report['quality']['core_html_block_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['freeform_block_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['unsafe_svg_count'] ?? null );
@@ -2522,7 +2523,9 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$report      = json_decode( $this->read_file( $result['report_path'] ), true );
 		$diagnostics = $report['diagnostics'] ?? array();
 		$this->assertContains( 'unresolved_internal_link', wp_list_pluck( $diagnostics, 'type' ) );
-		$this->assertContains( 'local_asset_not_materialized', wp_list_pluck( $diagnostics, 'type' ) );
+		$this->assertNotContains( 'local_asset_not_materialized', wp_list_pluck( $diagnostics, 'type' ) );
+		$this->assertNotEmpty( $report['assets']['local'] ?? array() );
+		$this->assertContains( 'docs/images/flow.svg', wp_list_pluck( $report['assets']['local'] ?? array(), 'key' ) );
 	}
 
 	/**

--- a/tests/smoke-local-asset-materialization.php
+++ b/tests/smoke-local-asset-materialization.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Smoke test: source-local assets materialize and rewrite across HTML, Markdown, CSS, and unsafe paths.
+ *
+ * Run from the repository root:
+ * php tests/smoke-local-asset-materialization.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+
+		public function __construct( string $code = '' ) {
+			$this->code = $code;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( string $target ): bool {
+		return is_dir( $target ) || mkdir( $target, 0777, true );
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $value ): string {
+		return rtrim( $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( string $url ): string {
+		return $url;
+	}
+}
+
+if ( ! function_exists( 'sanitize_file_name' ) ) {
+	function sanitize_file_name( string $filename ): string {
+		return preg_replace( '/[^A-Za-z0-9._-]/', '-', $filename ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( string $url, int $component = -1 ): mixed {
+		$parts = parse_url( $url );
+		if ( -1 === $component ) {
+			return $parts;
+		}
+
+		$map = array(
+			PHP_URL_SCHEME   => 'scheme',
+			PHP_URL_HOST     => 'host',
+			PHP_URL_PORT     => 'port',
+			PHP_URL_USER     => 'user',
+			PHP_URL_PASS     => 'pass',
+			PHP_URL_PATH     => 'path',
+			PHP_URL_QUERY    => 'query',
+			PHP_URL_FRAGMENT => 'fragment',
+		);
+
+		return isset( $map[ $component ], $parts[ $map[ $component ] ] ) ? $parts[ $map[ $component ] ] : null;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php';
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$tmp        = sys_get_temp_dir() . '/ssi-local-assets-' . uniqid();
+$source_dir = $tmp . '/source';
+$theme_dir  = $tmp . '/theme';
+wp_mkdir_p( $source_dir . '/assets' );
+wp_mkdir_p( $source_dir . '/pages' );
+wp_mkdir_p( $source_dir . '/styles' );
+wp_mkdir_p( $theme_dir . '/assets/media' );
+
+$png = base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=' );
+file_put_contents( $source_dir . '/assets/hero.png', $png );
+file_put_contents( $source_dir . '/assets/bg.png', $png );
+
+$class = new ReflectionClass( Static_Site_Importer_Theme_Generator::class );
+foreach ( array(
+	'active_source_dir'     => $source_dir,
+	'active_theme_dir'      => $theme_dir,
+	'active_theme_uri'      => 'https://example.test/wp-content/themes/imported',
+	'active_asset_map'      => array(),
+	'active_asset_metadata' => array(),
+	'conversion_report'     => array(
+		'assets'      => array(
+			'local'       => array(),
+			'svg_icons'   => array(),
+			'svg_sprites' => array(),
+		),
+		'asset_map'   => array(
+			'supplied'         => false,
+			'entry_count'      => 0,
+			'resolved_count'   => 0,
+			'unresolved_count' => 0,
+			'resolved'         => array(),
+			'unresolved'       => array(),
+		),
+		'diagnostics' => array(),
+	),
+) as $property => $value ) {
+	$ref = $class->getProperty( $property );
+	$ref->setValue( null, $value );
+}
+
+$rewrite_html = $class->getMethod( 'rewrite_local_asset_references' );
+$html         = $rewrite_html->invoke(
+	null,
+	'<figure><img src="../assets/hero.png" alt="Hero"><img src="../../secret.png" alt="Unsafe"></figure>',
+	'pages/about.html',
+	'main:pages/about.html'
+);
+
+$assert( str_contains( $html, 'src="https://example.test/wp-content/themes/imported/assets/media/assets/hero.png"' ), 'html-image-src-rewritten', $html );
+$assert( is_readable( $theme_dir . '/assets/media/assets/hero.png' ), 'html-image-file-materialized' );
+$assert( str_contains( $html, 'src="../../secret.png"' ), 'unsafe-html-image-left-unchanged', $html );
+
+$rewrite_markdown = $class->getMethod( 'rewrite_markdown_links' );
+$markdown         = $rewrite_markdown->invoke( null, '![Hero](../assets/hero.png)', array(), 'pages/story.md', 'main:pages/story.md' );
+$assert( str_contains( $markdown, '](https://example.test/wp-content/themes/imported/assets/media/assets/hero.png)' ), 'markdown-image-rewritten', $markdown );
+
+$rewrite_css = $class->getMethod( 'rewrite_css_asset_references' );
+$css         = $rewrite_css->invoke( null, '.hero{background-image:url("../assets/bg.png")}', 'styles/site.css', 'stylesheet:styles/site.css' );
+$assert( str_contains( $css, 'url("https://example.test/wp-content/themes/imported/assets/media/assets/bg.png")' ), 'css-url-rewritten', $css );
+$assert( is_readable( $theme_dir . '/assets/media/assets/bg.png' ), 'css-asset-file-materialized' );
+
+$metadata = $class->getProperty( 'active_asset_metadata' )->getValue();
+$assert( isset( $metadata['../assets/hero.png'] ), 'metadata-keyed-by-original-reference' );
+$assert( isset( $metadata['assets/hero.png'] ), 'metadata-keyed-by-source-path' );
+$assert( isset( $metadata['https://example.test/wp-content/themes/imported/assets/media/assets/hero.png'] ), 'metadata-keyed-by-materialized-url' );
+
+$report      = $class->getProperty( 'conversion_report' )->getValue();
+$diagnostics = array_column( $report['diagnostics'] ?? array(), 'type' );
+$assert( in_array( 'local_asset_unsafe_path', $diagnostics, true ), 'unsafe-path-diagnostic-recorded' );
+$assert( count( $report['assets']['local'] ?? array() ) >= 2, 'local-assets-recorded' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: local asset materialization smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-mixed-source-link-rewrites.php
+++ b/tests/smoke-mixed-source-link-rewrites.php
@@ -84,7 +84,7 @@ if ( ! is_wp_error( $result ) ) {
 	$report      = json_decode( $read( $result['report_path'] ), true );
 	$diagnostics = is_array( $report ) ? wp_list_pluck( $report['diagnostics'] ?? array(), 'type' ) : array();
 	$assert( in_array( 'unresolved_internal_link', $diagnostics, true ), 'unresolved-link-diagnostic' );
-	$assert( in_array( 'local_asset_not_materialized', $diagnostics, true ), 'local-asset-diagnostic' );
+	$assert( ! in_array( 'local_asset_not_materialized', $diagnostics, true ), 'local-asset-no-longer-unmaterialized' );
 
 	$unresolved_diagnostics = is_array( $report ) ? array_values(
 		array_filter(
@@ -92,12 +92,7 @@ if ( ! is_wp_error( $result ) ) {
 			static fn ( $diagnostic ): bool => is_array( $diagnostic ) && 'unresolved_internal_link' === ( $diagnostic['type'] ?? '' )
 		)
 	) : array();
-	$asset_diagnostics      = is_array( $report ) ? array_values(
-		array_filter(
-			$report['diagnostics'] ?? array(),
-			static fn ( $diagnostic ): bool => is_array( $diagnostic ) && 'local_asset_not_materialized' === ( $diagnostic['type'] ?? '' )
-		)
-	) : array();
+	$local_assets           = is_array( $report ) ? ( $report['assets']['local'] ?? array() ) : array();
 
 	$assert( ! empty( $unresolved_diagnostics ), 'unresolved-link-diagnostic-record-present' );
 	if ( ! empty( $unresolved_diagnostics ) ) {
@@ -111,13 +106,8 @@ if ( ! is_wp_error( $result ) ) {
 		$assert( '' !== (string) ( $link['context']['href'] ?? '' ), 'unresolved-link-diagnostic-has-href-context' );
 	}
 
-	$assert( ! empty( $asset_diagnostics ), 'local-asset-diagnostic-record-present' );
-	if ( ! empty( $asset_diagnostics ) ) {
-		$asset = $asset_diagnostics[0];
-		$assert( 'unresolved_asset' === ( $asset['category'] ?? '' ), 'local-asset-diagnostic-has-category' );
-		$assert( 'materialize_or_rewrite_asset' === ( $asset['suggested_repair_class'] ?? '' ), 'local-asset-diagnostic-has-repair-class' );
-		$assert( '' !== (string) ( $asset['source_path'] ?? '' ), 'local-asset-diagnostic-has-source-path' );
-	}
+	$assert( ! empty( $local_assets ), 'local-asset-record-present' );
+	$assert( in_array( 'docs/images/flow.svg', wp_list_pluck( $local_assets, 'key' ), true ), 'markdown-local-asset-materialized' );
 
 	$source_refs = $report['source_documents']['diagnostic_refs']['unresolved_link_count'] ?? array();
 	$assert( is_array( $source_refs ) && ! empty( $source_refs ), 'source-document-count-links-to-diagnostics' );


### PR DESCRIPTION
## Summary
- Materialize source-relative local assets into generated theme media assets and rewrite HTML body/chrome references, `srcset`, media `src`/`poster`, Markdown images, and CSS `url(...)` references.
- Record local asset materialization/diagnostic report entries and pass resolved asset metadata through conversion `context.asset_metadata` for H2BC/BFB consumers.
- Update mixed-source and theme-part tests from unresolved asset diagnostics to materialized asset expectations, with a standalone smoke test for HTML/Markdown/CSS/unsafe-path coverage.

## Verification
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `php -l tests/smoke-mixed-source-link-rewrites.php`
- `php -l tests/smoke-local-asset-materialization.php`
- `php tests/smoke-local-asset-materialization.php`
- `php tests/smoke-asset-map-image-rewrites.php`
- `git diff --check`
- `homeboy test --path . --extension wordpress` (60 passed, 0 failed)

## Scope covered for #254
- HTML page body and shared chrome local `src`, `poster`, and `srcset` references.
- Markdown local image references.
- Linked and inline CSS `url(...)` references.
- Source-root containment checks and diagnostics for unsafe, missing, unsupported, read/write-failed assets.
- Resolved asset metadata forwarded as `context.asset_metadata` for converter-side image/gallery/media-text enrichment.

## Remaining follow-up
- The materializer currently copies supported local assets into theme media assets. Import-to-media-library and preserve/use-map policy selection can be layered on top of the same resolver contract.
- CSS rewriting handles practical `url(...)` references but does not attempt full CSS parsing for every edge-case grammar.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Traced the SSI/H2BC boundary, drafted the SSI local asset resolver/materializer and regression tests, and ran local verification for Chris to review.

Refs #254.