### PR TITLE
Add selectable asset materialization policies

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -65,6 +65,10 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'allow_missing_woocommerce' => array( 'type' => 'boolean' ),
 						'report'                    => array( 'type' => 'string' ),
 						'asset_policy'              => array( 'type' => 'string' ),
+						'asset_materialization_policy' => array(
+							'type' => 'string',
+							'enum' => array( 'copy_to_theme', 'preserve', 'use_map' ),
+						),
 						'asset_map'                 => array( 'type' => 'object' ),
 						'source_metadata'           => array( 'type' => 'object' ),
 					),
@@ -128,6 +132,11 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'allow_missing_woocommerce' => array( 'type' => 'boolean' ),
 						'report'                    => array( 'type' => 'string' ),
 						'asset_policy'              => array( 'type' => 'string' ),
+						'asset_materialization_policy' => array(
+							'type' => 'string',
+							'enum' => array( 'copy_to_theme', 'preserve', 'use_map' ),
+						),
+						'asset_map'                 => array( 'type' => 'object' ),
 						'compiler_options'          => array( 'type' => 'object' ),
 						'source_metadata'           => array( 'type' => 'object' ),
 					),
@@ -210,6 +219,8 @@ if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' )
 			'allow_missing_woocommerce' => ! empty( $input['allow_missing_woocommerce'] ),
 			'report'                    => isset( $input['report'] ) ? (string) $input['report'] : '',
 			'asset_policy'              => isset( $input['asset_policy'] ) ? (string) $input['asset_policy'] : '',
+			'asset_materialization_policy' => isset( $input['asset_materialization_policy'] ) ? (string) $input['asset_materialization_policy'] : '',
+			'asset_map'                 => isset( $input['asset_map'] ) && is_array( $input['asset_map'] ) ? $input['asset_map'] : array(),
 			'compiler_options'          => isset( $input['compiler_options'] ) && is_array( $input['compiler_options'] ) ? $input['compiler_options'] : array(),
 			'source_metadata'           => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
 		);
@@ -251,6 +262,7 @@ if ( ! function_exists( 'static_site_importer_ability_import_theme' ) ) {
 			'allow_missing_woocommerce' => ! empty( $input['allow_missing_woocommerce'] ),
 			'report'                    => isset( $input['report'] ) ? (string) $input['report'] : '',
 			'asset_policy'              => isset( $input['asset_policy'] ) ? (string) $input['asset_policy'] : '',
+			'asset_materialization_policy' => isset( $input['asset_materialization_policy'] ) ? (string) $input['asset_materialization_policy'] : '',
 			'asset_map'                 => isset( $input['asset_map'] ) && is_array( $input['asset_map'] ) ? $input['asset_map'] : array(),
 			'source_metadata'           => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
 		);

--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -51,12 +51,15 @@ class Static_Site_Importer_CLI_Command {
 	 * [--allow-missing-woocommerce]
 	 * : Allow commerce-bearing imports to proceed when WooCommerce is not active. Default is to fail the import. Theme files are still written either way; the waiver only suppresses product seeding without aborting.
 	 *
-	 * [--report=<path>]
-	 * : Copy the generated import report JSON to an external archive path.
-	 *
-	 * [--asset-policy=<policy>]
-	 * : Local asset handling policy. Use media-library to import supported resolved assets as WordPress attachments; defaults to theme-file materialization.
-	 *
+		 * [--report=<path>]
+		 * : Copy the generated import report JSON to an external archive path.
+		 *
+		 * [--asset-policy=<policy>]
+		 * : Copy target for resolved local assets. Use media-library to import supported copied assets as WordPress attachments; defaults to theme.
+		 *
+		 * [--asset-materialization-policy=<policy>]
+		 * : Local asset materialization policy. One of copy_to_theme, preserve, use_map. Defaults to copy_to_theme.
+		 *
 	 * [--format=<format>]
 	 * : Output format. Use json for machine-readable command output.
 	 *
@@ -108,6 +111,7 @@ class Static_Site_Importer_CLI_Command {
 			'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
 			'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
 			'asset_policy'              => isset( $assoc_args['asset-policy'] ) ? (string) $assoc_args['asset-policy'] : '',
+			'asset_materialization_policy' => isset( $assoc_args['asset-materialization-policy'] ) ? (string) $assoc_args['asset-materialization-policy'] : '',
 			'source_metadata'           => $source_metadata,
 		);
 
@@ -236,12 +240,15 @@ class Static_Site_Importer_CLI_Command {
 	 * [--allow-missing-woocommerce]
 	 * : Allow commerce-bearing imports to proceed when WooCommerce is not active.
 	 *
-	 * [--report=<path>]
-	 * : Copy the generated import report JSON to an external archive path.
-	 *
-	 * [--asset-policy=<policy>]
-	 * : Local asset handling policy. Use media-library to import supported resolved assets as WordPress attachments; defaults to theme-file materialization.
-	 *
+		 * [--report=<path>]
+		 * : Copy the generated import report JSON to an external archive path.
+		 *
+		 * [--asset-policy=<policy>]
+		 * : Copy target for resolved local assets. Use media-library to import supported copied assets as WordPress attachments; defaults to theme.
+		 *
+		 * [--asset-materialization-policy=<policy>]
+		 * : Local asset materialization policy. One of copy_to_theme, preserve, use_map. Defaults to copy_to_theme.
+		 *
 	 * [--format=<format>]
 	 * : Output format. Use json for machine-readable command output.
 	 *
@@ -281,6 +288,7 @@ class Static_Site_Importer_CLI_Command {
 			'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
 			'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
 			'asset_policy'              => isset( $assoc_args['asset-policy'] ) ? (string) $assoc_args['asset-policy'] : '',
+			'asset_materialization_policy' => isset( $assoc_args['asset-materialization-policy'] ) ? (string) $assoc_args['asset-materialization-policy'] : '',
 			'source_metadata'           => array( 'artifact_file' => $artifact_file ),
 		);
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -62,6 +62,13 @@ class Static_Site_Importer_Theme_Generator {
 	private static array $active_asset_map = array();
 
 	/**
+	 * Active local asset materialization policy.
+	 *
+	 * @var string
+	 */
+	private static string $active_asset_materialization_policy = 'copy_to_theme';
+
+	/**
 	 * Resolved local asset metadata keyed by original and rewritten references.
 	 *
 	 * @var array<string, array<string, mixed>>
@@ -201,7 +208,13 @@ class Static_Site_Importer_Theme_Generator {
 		self::$active_theme_dir         = $theme_dir;
 		self::$active_theme_uri         = trailingslashit( get_theme_root_uri( $theme_slug ) ) . $theme_slug;
 		self::$active_source_dir        = $site_dir;
+		$asset_policy = self::normalize_asset_materialization_policy( $args['asset_materialization_policy'] ?? '' );
+		if ( is_wp_error( $asset_policy ) ) {
+			return $asset_policy;
+		}
+
 		self::$active_asset_map         = self::normalize_asset_map( isset( $args['asset_map'] ) && is_array( $args['asset_map'] ) ? $args['asset_map'] : array() );
+		self::$active_asset_materialization_policy = $asset_policy;
 		self::$active_asset_metadata    = array();
 		self::$active_asset_policy      = self::normalize_asset_policy( isset( $args['asset_policy'] ) ? (string) $args['asset_policy'] : '' );
 		self::$active_imported_media_assets = array();
@@ -209,6 +222,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::$conversion_report['assets']['policy']         = self::$active_asset_policy;
 		self::$conversion_report['asset_map']['supplied']    = ! empty( self::$active_asset_map );
 		self::$conversion_report['asset_map']['entry_count'] = count( self::$active_asset_map );
+		self::$conversion_report['assets']['local_policy']   = self::$active_asset_materialization_policy;
 		self::$materialized_svg_assets  = array();
 		self::$svg_sprite_symbols       = array();
 		self::$materialized_svg_sprites = array();
@@ -409,7 +423,13 @@ class Static_Site_Importer_Theme_Generator {
 		self::$active_theme_dir         = $theme_dir;
 		self::$active_theme_uri         = trailingslashit( get_theme_root_uri( $theme_slug ) ) . $theme_slug;
 		self::$active_source_dir        = '';
+		$asset_policy = self::normalize_asset_materialization_policy( $args['asset_materialization_policy'] ?? '' );
+		if ( is_wp_error( $asset_policy ) ) {
+			return $asset_policy;
+		}
+
 		self::$active_asset_map         = self::normalize_asset_map( isset( $args['asset_map'] ) && is_array( $args['asset_map'] ) ? $args['asset_map'] : array() );
+		self::$active_asset_materialization_policy = $asset_policy;
 		self::$active_asset_metadata    = array();
 		self::$active_asset_policy      = self::normalize_asset_policy( isset( $args['asset_policy'] ) ? (string) $args['asset_policy'] : '' );
 		self::$active_imported_media_assets = array();
@@ -417,6 +437,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::$conversion_report['assets']['policy']         = self::$active_asset_policy;
 		self::$conversion_report['asset_map']['supplied']    = ! empty( self::$active_asset_map );
 		self::$conversion_report['asset_map']['entry_count'] = count( self::$active_asset_map );
+		self::$conversion_report['assets']['local_policy']   = self::$active_asset_materialization_policy;
 		self::$materialized_svg_assets  = array();
 		self::$svg_sprite_symbols       = array();
 		self::$materialized_svg_sprites = array();
@@ -1763,7 +1784,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string
 	 */
 	private static function rewrite_asset_map_image_references( string $html, string $source_path, string $source ): string {
-		if ( '' === trim( $html ) || empty( self::$active_asset_map ) || ! str_contains( strtolower( $html ), '<img' ) ) {
+		if ( 'use_map' !== self::$active_asset_materialization_policy || '' === trim( $html ) || empty( self::$active_asset_map ) || ! str_contains( strtolower( $html ), '<img' ) ) {
 			return $html;
 		}
 
@@ -1827,7 +1848,6 @@ class Static_Site_Importer_Theme_Generator {
 			return $html;
 		}
 
-		$html = self::rewrite_asset_map_image_references( $html, $source_path, $source );
 		if ( ! preg_match( '/\b(?:src|poster|srcset)\s*=|<source\b|<img\b|<video\b|<audio\b/i', $html ) ) {
 			return $html;
 		}
@@ -2612,6 +2632,25 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Normalize and validate the local asset materialization policy.
+	 *
+	 * @param mixed $policy Raw policy value.
+	 * @return string|WP_Error
+	 */
+	private static function normalize_asset_materialization_policy( $policy ) {
+		$policy = is_string( $policy ) ? sanitize_key( $policy ) : '';
+		if ( '' === $policy ) {
+			return 'copy_to_theme';
+		}
+
+		if ( in_array( $policy, array( 'copy_to_theme', 'preserve', 'use_map' ), true ) ) {
+			return $policy;
+		}
+
+		return new WP_Error( 'static_site_importer_invalid_asset_materialization_policy', 'Asset materialization policy must be one of: copy_to_theme, preserve, use_map.' );
+	}
+
+	/**
 	 * Resolve a local source URL through the active asset map and record the lookup.
 	 *
 	 * @param string $url         Source URL or path.
@@ -2761,17 +2800,28 @@ class Static_Site_Importer_Theme_Generator {
 			return null;
 		}
 
-		$mapped = self::resolve_asset_map_reference( $url, $source_path, $source );
-		if ( null !== $mapped ) {
-			$entry = $mapped['entry'];
-			self::remember_asset_metadata( $url, $mapped['key'], $entry );
-			return $entry;
-		}
-
 		$key = self::asset_map_lookup_key( $url, $source_path );
 		if ( '' === $key ) {
 			self::record_local_asset_diagnostic( 'local_asset_unsafe_path', $source, $source_path, $url, '', 'Local asset reference resolves outside the static source root; leaving it unchanged.' );
 			return null;
+		}
+
+		if ( 'use_map' === self::$active_asset_materialization_policy ) {
+			$mapped = self::resolve_asset_map_reference( $url, $source_path, $source );
+			if ( null === $mapped ) {
+				return null;
+			}
+
+			$entry = $mapped['entry'];
+			if ( ! isset( $entry['url'] ) || '' === trim( (string) $entry['url'] ) ) {
+				self::record_local_asset_diagnostic( 'asset_map_missing_url', $source, $source_path, $url, $key, 'Asset map entry did not provide a URL; leaving the source reference unchanged.' );
+				return null;
+			}
+
+			$entry['url'] = esc_url_raw( (string) $entry['url'] );
+			self::record_local_asset_outcome( 'mapped', $source, $source_path, $url, $key, $entry );
+			self::remember_asset_metadata( $url, $key, $entry );
+			return $entry;
 		}
 
 		if ( '' === self::$active_source_dir || '' === self::$active_theme_dir || '' === self::$active_theme_uri ) {
@@ -2792,13 +2842,31 @@ class Static_Site_Importer_Theme_Generator {
 			return null;
 		}
 
+		if ( 'preserve' === self::$active_asset_materialization_policy ) {
+			$asset = array(
+				'source'      => $url,
+				'source_path' => $source_path,
+				'path'        => $key,
+				'url'         => $url,
+				'mime_type'   => self::export_mime_type( $real_source ),
+			);
+
+			$dimensions = self::image_dimensions( $real_source );
+			if ( ! empty( $dimensions ) ) {
+				$asset = array_merge( $asset, $dimensions );
+			}
+
+			self::record_local_asset_outcome( 'preserved', $source, $source_path, $url, $key, $asset );
+			return null;
+		}
+
 		if ( 'media-library' === self::$active_asset_policy ) {
 			$asset = self::import_local_asset_to_media_library( $real_source, $key, $url, $source_path, $source );
 			if ( null === $asset ) {
 				return null;
 			}
 
-			self::record_local_asset_materialized( $source, $source_path, $url, $key, $asset );
+			self::record_local_asset_outcome( 'copied', $source, $source_path, $url, $key, $asset );
 			self::remember_asset_metadata( $url, $key, $asset );
 
 			return $asset;
@@ -2842,7 +2910,7 @@ class Static_Site_Importer_Theme_Generator {
 			$asset = array_merge( $asset, $dimensions );
 		}
 
-		self::record_local_asset_materialized( $source, $source_path, $url, $key, $asset );
+		self::record_local_asset_outcome( 'copied', $source, $source_path, $url, $key, $asset );
 		self::remember_asset_metadata( $url, $key, $asset );
 
 		return $asset;
@@ -3070,7 +3138,7 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Record a local asset materialization row in the import report.
+	 * Record a local asset policy outcome row in the import report.
 	 *
 	 * @param string              $source      Diagnostic source label.
 	 * @param string              $source_path Source-relative source path.
@@ -3079,26 +3147,29 @@ class Static_Site_Importer_Theme_Generator {
 	 * @param array<string,mixed> $asset       Asset metadata.
 	 * @return void
 	 */
-	private static function record_local_asset_materialized( string $source, string $source_path, string $url, string $key, array $asset ): void {
+	private static function record_local_asset_outcome( string $outcome, string $source, string $source_path, string $url, string $key, array $asset ): void {
 		if ( ! isset( self::$conversion_report['assets']['local'] ) || ! is_array( self::$conversion_report['assets']['local'] ) ) {
 			self::$conversion_report['assets']['local'] = array();
 		}
 
-		$report_key = (string) ( $asset['policy'] ?? self::$active_asset_policy ) . ':' . $key;
+		$report_key = self::$active_asset_materialization_policy . ':' . (string) ( $asset['policy'] ?? self::$active_asset_policy ) . ':' . $key;
 		if ( isset( self::$recorded_local_asset_keys[ $report_key ] ) ) {
 			return;
 		}
 		self::$recorded_local_asset_keys[ $report_key ] = true;
 
 		$row = array(
-			'source'      => $source,
-			'source_path' => $source_path,
-			'url'         => $url,
-			'key'         => $key,
-			'policy'      => $asset['policy'] ?? self::$active_asset_policy,
-			'theme_path'  => $asset['theme_path'] ?? '',
-			'final_url'   => $asset['url'] ?? '',
-			'mime_type'   => $asset['mime_type'] ?? '',
+			'source'                 => $source,
+			'source_path'            => $source_path,
+			'url'                    => $url,
+			'key'                    => $key,
+			'policy'                 => $asset['policy'] ?? self::$active_asset_policy,
+			'materialization_policy' => self::$active_asset_materialization_policy,
+			'outcome'                => $outcome,
+			'rewritten_url'          => $asset['url'] ?? '',
+			'theme_path'             => $asset['theme_path'] ?? '',
+			'final_url'              => $asset['url'] ?? '',
+			'mime_type'              => $asset['mime_type'] ?? '',
 		);
 
 		foreach ( array( 'id', 'attachment_id', 'width', 'height', 'alt' ) as $field ) {
@@ -5149,7 +5220,8 @@ class Static_Site_Importer_Theme_Generator {
 				'diagnostics'    => array(),
 			),
 			'assets'                  => array(
-				'policy'      => 'theme',
+				'policy'       => 'theme',
+				'local_policy' => 'copy_to_theme',
 				'svg_icons'   => array(),
 				'svg_sprites' => array(),
 				'local'       => array(),

--- a/tests/smoke-asset-map-image-rewrites.php
+++ b/tests/smoke-asset-map-image-rewrites.php
@@ -54,6 +54,9 @@ $assert = static function ( bool $condition, string $label, string $detail = '' 
 
 $class = new ReflectionClass( Static_Site_Importer_Theme_Generator::class );
 
+$asset_policy = $class->getProperty( 'active_asset_materialization_policy' );
+$asset_policy->setValue( null, 'use_map' );
+
 $active_asset_map = $class->getProperty( 'active_asset_map' );
 $active_asset_map->setValue(
 	null,

--- a/tests/smoke-local-asset-materialization.php
+++ b/tests/smoke-local-asset-materialization.php
@@ -56,6 +56,12 @@ if ( ! function_exists( 'sanitize_file_name' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) ?? '';
+	}
+}
+
 if ( ! function_exists( 'wp_parse_url' ) ) {
 	function wp_parse_url( string $url, int $component = -1 ): mixed {
 		$parts = parse_url( $url );
@@ -92,45 +98,72 @@ $assert = static function ( bool $condition, string $label, string $detail = '' 
 
 $tmp        = sys_get_temp_dir() . '/ssi-local-assets-' . uniqid();
 $source_dir = $tmp . '/source';
-$theme_dir  = $tmp . '/theme';
 wp_mkdir_p( $source_dir . '/assets' );
 wp_mkdir_p( $source_dir . '/pages' );
 wp_mkdir_p( $source_dir . '/styles' );
-wp_mkdir_p( $theme_dir . '/assets/media' );
 
 $png = base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=' );
 file_put_contents( $source_dir . '/assets/hero.png', $png );
 file_put_contents( $source_dir . '/assets/bg.png', $png );
 
 $class = new ReflectionClass( Static_Site_Importer_Theme_Generator::class );
-foreach ( array(
-	'active_source_dir'     => $source_dir,
-	'active_theme_dir'      => $theme_dir,
-	'active_theme_uri'      => 'https://example.test/wp-content/themes/imported',
-	'active_asset_map'      => array(),
-	'active_asset_metadata' => array(),
-	'conversion_report'     => array(
-		'assets'      => array(
-			'local'       => array(),
-			'svg_icons'   => array(),
-			'svg_sprites' => array(),
-		),
-		'asset_map'   => array(
-			'supplied'         => false,
-			'entry_count'      => 0,
-			'resolved_count'   => 0,
-			'unresolved_count' => 0,
-			'resolved'         => array(),
-			'unresolved'       => array(),
-		),
-		'diagnostics' => array(),
-	),
-) as $property => $value ) {
+
+$set_property = static function ( string $property, mixed $value ) use ( $class ): void {
 	$ref = $class->getProperty( $property );
 	$ref->setValue( null, $value );
-}
+};
+
+$configure = static function ( string $policy, array $asset_map = array() ) use ( $source_dir, $set_property ): string {
+	$theme_dir = sys_get_temp_dir() . '/ssi-local-assets-theme-' . uniqid();
+	wp_mkdir_p( $theme_dir . '/assets/media' );
+
+	$set_property( 'active_source_dir', $source_dir );
+	$set_property( 'active_theme_dir', $theme_dir );
+	$set_property( 'active_theme_uri', 'https://example.test/wp-content/themes/imported' );
+	$set_property( 'active_asset_materialization_policy', $policy );
+	$set_property( 'active_asset_policy', 'theme' );
+	$set_property( 'active_asset_map', $asset_map );
+	$set_property( 'active_asset_metadata', array() );
+	$set_property( 'active_imported_media_assets', array() );
+	$set_property( 'recorded_local_asset_keys', array() );
+	$set_property(
+		'conversion_report',
+		array(
+			'assets'      => array(
+				'policy'       => 'theme',
+				'local_policy' => $policy,
+				'local'        => array(),
+				'svg_icons'    => array(),
+				'svg_sprites'  => array(),
+			),
+			'asset_map'   => array(
+				'supplied'         => ! empty( $asset_map ),
+				'entry_count'      => count( $asset_map ),
+				'resolved_count'   => 0,
+				'unresolved_count' => 0,
+				'resolved'         => array(),
+				'unresolved'       => array(),
+			),
+			'diagnostics' => array(),
+		)
+	);
+
+	return $theme_dir;
+};
+
+$report_outcomes = static function () use ( $class ): array {
+	$report = $class->getProperty( 'conversion_report' )->getValue();
+	return array_column( $report['assets']['local'] ?? array(), 'outcome' );
+};
 
 $rewrite_html = $class->getMethod( 'rewrite_local_asset_references' );
+$rewrite_markdown = $class->getMethod( 'rewrite_markdown_links' );
+$rewrite_css = $class->getMethod( 'rewrite_css_asset_references' );
+$normalize_policy = $class->getMethod( 'normalize_asset_materialization_policy' );
+
+$assert( 'copy_to_theme' === $normalize_policy->invoke( null, '' ), 'default-materialization-policy-copy-to-theme' );
+
+$theme_dir = $configure( 'copy_to_theme' );
 $html         = $rewrite_html->invoke(
 	null,
 	'<figure><img src="../assets/hero.png" alt="Hero"><img src="../../secret.png" alt="Unsafe"></figure>',
@@ -142,11 +175,9 @@ $assert( str_contains( $html, 'src="https://example.test/wp-content/themes/impor
 $assert( is_readable( $theme_dir . '/assets/media/assets/hero.png' ), 'html-image-file-materialized' );
 $assert( str_contains( $html, 'src="../../secret.png"' ), 'unsafe-html-image-left-unchanged', $html );
 
-$rewrite_markdown = $class->getMethod( 'rewrite_markdown_links' );
 $markdown         = $rewrite_markdown->invoke( null, '![Hero](../assets/hero.png)', array(), 'pages/story.md', 'main:pages/story.md' );
 $assert( str_contains( $markdown, '](https://example.test/wp-content/themes/imported/assets/media/assets/hero.png)' ), 'markdown-image-rewritten', $markdown );
 
-$rewrite_css = $class->getMethod( 'rewrite_css_asset_references' );
 $css         = $rewrite_css->invoke( null, '.hero{background-image:url("../assets/bg.png")}', 'styles/site.css', 'stylesheet:styles/site.css' );
 $assert( str_contains( $css, 'url("https://example.test/wp-content/themes/imported/assets/media/assets/bg.png")' ), 'css-url-rewritten', $css );
 $assert( is_readable( $theme_dir . '/assets/media/assets/bg.png' ), 'css-asset-file-materialized' );
@@ -160,6 +191,43 @@ $report      = $class->getProperty( 'conversion_report' )->getValue();
 $diagnostics = array_column( $report['diagnostics'] ?? array(), 'type' );
 $assert( in_array( 'local_asset_unsafe_path', $diagnostics, true ), 'unsafe-path-diagnostic-recorded' );
 $assert( count( $report['assets']['local'] ?? array() ) >= 2, 'local-assets-recorded' );
+$assert( 'copy_to_theme' === ( $report['assets']['local_policy'] ?? '' ), 'copy-policy-recorded' );
+$assert( in_array( 'copied', $report_outcomes(), true ), 'copy-outcome-recorded' );
+$assert( 'copy_to_theme' === ( $report['assets']['local'][0]['materialization_policy'] ?? '' ), 'copy-row-materialization-policy-recorded' );
+
+$theme_dir = $configure( 'preserve' );
+$html      = $rewrite_html->invoke( null, '<img src="../assets/hero.png" alt="Hero"><img src="../../secret.png" alt="Unsafe">', 'pages/about.html', 'main:pages/about.html' );
+$markdown  = $rewrite_markdown->invoke( null, '![Hero](../assets/hero.png)', array(), 'pages/story.md', 'main:pages/story.md' );
+$css       = $rewrite_css->invoke( null, '.hero{background-image:url("../assets/bg.png")}', 'styles/site.css', 'stylesheet:styles/site.css' );
+$report    = $class->getProperty( 'conversion_report' )->getValue();
+$assert( str_contains( $html, 'src="../assets/hero.png"' ), 'preserve-html-image-unchanged', $html );
+$assert( str_contains( $markdown, '](../assets/hero.png)' ), 'preserve-markdown-image-unchanged', $markdown );
+$assert( str_contains( $css, 'url("../assets/bg.png")' ), 'preserve-css-url-unchanged', $css );
+$assert( ! is_readable( $theme_dir . '/assets/media/assets/hero.png' ), 'preserve-does-not-copy-html-image' );
+$assert( 'preserve' === ( $report['assets']['local_policy'] ?? '' ), 'preserve-policy-recorded' );
+$assert( in_array( 'preserved', $report_outcomes(), true ), 'preserve-outcome-recorded' );
+$assert( 'preserve' === ( $report['assets']['local'][0]['materialization_policy'] ?? '' ), 'preserve-row-materialization-policy-recorded' );
+$assert( in_array( 'local_asset_unsafe_path', array_column( $report['diagnostics'] ?? array(), 'type' ), true ), 'preserve-unsafe-path-diagnostic-recorded' );
+
+$theme_dir = $configure(
+	'use_map',
+	array(
+		'assets/hero.png' => array( 'url' => 'https://cdn.example.test/hero.png' ),
+		'assets/bg.png'   => array( 'url' => 'https://cdn.example.test/bg.png' ),
+	)
+);
+$html      = $rewrite_html->invoke( null, '<img src="../assets/hero.png" alt="Hero"><img src="../../secret.png" alt="Unsafe">', 'pages/about.html', 'main:pages/about.html' );
+$markdown  = $rewrite_markdown->invoke( null, '![Hero](../assets/hero.png)', array(), 'pages/story.md', 'main:pages/story.md' );
+$css       = $rewrite_css->invoke( null, '.hero{background-image:url("../assets/bg.png")}', 'styles/site.css', 'stylesheet:styles/site.css' );
+$report    = $class->getProperty( 'conversion_report' )->getValue();
+$assert( str_contains( $html, 'src="https://cdn.example.test/hero.png"' ), 'use-map-html-image-rewritten', $html );
+$assert( str_contains( $markdown, '](https://cdn.example.test/hero.png)' ), 'use-map-markdown-image-rewritten', $markdown );
+$assert( str_contains( $css, 'url("https://cdn.example.test/bg.png")' ), 'use-map-css-url-rewritten', $css );
+$assert( ! is_readable( $theme_dir . '/assets/media/assets/hero.png' ), 'use-map-does-not-copy-html-image' );
+$assert( 'use_map' === ( $report['assets']['local_policy'] ?? '' ), 'use-map-policy-recorded' );
+$assert( in_array( 'mapped', $report_outcomes(), true ), 'use-map-outcome-recorded' );
+$assert( 'use_map' === ( $report['assets']['local'][0]['materialization_policy'] ?? '' ), 'use-map-row-materialization-policy-recorded' );
+$assert( in_array( 'local_asset_unsafe_path', array_column( $report['diagnostics'] ?? array(), 'type' ), true ), 'use-map-unsafe-path-diagnostic-recorded' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-media-library-asset-policy.php
+++ b/tests/smoke-media-library-asset-policy.php
@@ -199,15 +199,17 @@ foreach ( array(
 	'active_theme_uri'             => 'https://example.test/wp-content/themes/imported',
 	'active_asset_map'             => array(),
 	'active_asset_metadata'        => array(),
+	'active_asset_materialization_policy' => 'copy_to_theme',
 	'active_asset_policy'          => 'media-library',
 	'active_imported_media_assets' => array(),
 	'recorded_local_asset_keys'    => array(),
 	'conversion_report'            => array(
 		'assets'      => array(
-			'policy'      => 'media-library',
-			'local'       => array(),
-			'svg_icons'   => array(),
-			'svg_sprites' => array(),
+			'policy'       => 'media-library',
+			'local_policy' => 'copy_to_theme',
+			'local'        => array(),
+			'svg_icons'    => array(),
+			'svg_sprites'  => array(),
 		),
 		'asset_map'   => array(
 			'supplied'         => false,
@@ -251,6 +253,8 @@ $assert( 1 === ( $asset['height'] ?? null ), 'metadata-height' );
 $report = $class->getProperty( 'conversion_report' )->getValue();
 $assert( 1 === count( $report['assets']['local'] ?? array() ), 'duplicate-source-single-report-row' );
 $assert( 'media-library' === ( $report['assets']['local'][0]['policy'] ?? '' ), 'report-policy' );
+$assert( 'copy_to_theme' === ( $report['assets']['local'][0]['materialization_policy'] ?? '' ), 'report-materialization-policy' );
+$assert( 'copied' === ( $report['assets']['local'][0]['outcome'] ?? '' ), 'report-outcome' );
 $assert( 701 === ( $report['assets']['local'][0]['attachment_id'] ?? null ), 'report-attachment-id' );
 
 $diagnostics = array_column( $report['diagnostics'] ?? array(), 'type' );


### PR DESCRIPTION
## Summary
- Adds a validated `asset_materialization_policy` option for `copy_to_theme`, `preserve`, and `use_map`.
- Keeps `copy_to_theme` as the default while recording the selected policy and each local asset outcome in `import-report.json`.
- Extends smoke coverage for HTML images, CSS `url(...)`, Markdown images, and unsafe paths across policies.

Fixes #271.

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l includes/abilities.php`
- `php -l includes/class-static-site-importer-cli-command.php`
- `php tests/smoke-local-asset-materialization.php`
- `php tests/smoke-asset-map-image-rewrites.php`

## Known validation failures
- `npm run test:js-block-validation` fails in the existing harness with `TypeError: Cannot convert undefined or null to object` from `tests/smoke-generated-theme-block-validation.cjs`.
- `npm run test:validation` fails existing fixture fidelity checks for footer conversion and quality diagnostic shape.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, smoke test updates, and verification commands for Chris to review.