### PR TITLE
Add media library asset import policy

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -64,6 +64,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'max_fallbacks'             => array( 'type' => 'integer' ),
 						'allow_missing_woocommerce' => array( 'type' => 'boolean' ),
 						'report'                    => array( 'type' => 'string' ),
+						'asset_policy'              => array( 'type' => 'string' ),
 						'asset_map'                 => array( 'type' => 'object' ),
 						'source_metadata'           => array( 'type' => 'object' ),
 					),
@@ -126,6 +127,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'max_fallbacks'             => array( 'type' => 'integer' ),
 						'allow_missing_woocommerce' => array( 'type' => 'boolean' ),
 						'report'                    => array( 'type' => 'string' ),
+						'asset_policy'              => array( 'type' => 'string' ),
 						'compiler_options'          => array( 'type' => 'object' ),
 						'source_metadata'           => array( 'type' => 'object' ),
 					),
@@ -207,6 +209,7 @@ if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' )
 			'max_fallbacks'             => isset( $input['max_fallbacks'] ) ? (int) $input['max_fallbacks'] : null,
 			'allow_missing_woocommerce' => ! empty( $input['allow_missing_woocommerce'] ),
 			'report'                    => isset( $input['report'] ) ? (string) $input['report'] : '',
+			'asset_policy'              => isset( $input['asset_policy'] ) ? (string) $input['asset_policy'] : '',
 			'compiler_options'          => isset( $input['compiler_options'] ) && is_array( $input['compiler_options'] ) ? $input['compiler_options'] : array(),
 			'source_metadata'           => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
 		);
@@ -247,6 +250,7 @@ if ( ! function_exists( 'static_site_importer_ability_import_theme' ) ) {
 			'max_fallbacks'             => isset( $input['max_fallbacks'] ) ? (int) $input['max_fallbacks'] : null,
 			'allow_missing_woocommerce' => ! empty( $input['allow_missing_woocommerce'] ),
 			'report'                    => isset( $input['report'] ) ? (string) $input['report'] : '',
+			'asset_policy'              => isset( $input['asset_policy'] ) ? (string) $input['asset_policy'] : '',
 			'asset_map'                 => isset( $input['asset_map'] ) && is_array( $input['asset_map'] ) ? $input['asset_map'] : array(),
 			'source_metadata'           => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
 		);

--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -54,6 +54,9 @@ class Static_Site_Importer_CLI_Command {
 	 * [--report=<path>]
 	 * : Copy the generated import report JSON to an external archive path.
 	 *
+	 * [--asset-policy=<policy>]
+	 * : Local asset handling policy. Use media-library to import supported resolved assets as WordPress attachments; defaults to theme-file materialization.
+	 *
 	 * [--format=<format>]
 	 * : Output format. Use json for machine-readable command output.
 	 *
@@ -104,6 +107,7 @@ class Static_Site_Importer_CLI_Command {
 			'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
 			'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
 			'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
+			'asset_policy'              => isset( $assoc_args['asset-policy'] ) ? (string) $assoc_args['asset-policy'] : '',
 			'source_metadata'           => $source_metadata,
 		);
 
@@ -235,6 +239,9 @@ class Static_Site_Importer_CLI_Command {
 	 * [--report=<path>]
 	 * : Copy the generated import report JSON to an external archive path.
 	 *
+	 * [--asset-policy=<policy>]
+	 * : Local asset handling policy. Use media-library to import supported resolved assets as WordPress attachments; defaults to theme-file materialization.
+	 *
 	 * [--format=<format>]
 	 * : Output format. Use json for machine-readable command output.
 	 *
@@ -273,6 +280,7 @@ class Static_Site_Importer_CLI_Command {
 			'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
 			'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
 			'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
+			'asset_policy'              => isset( $assoc_args['asset-policy'] ) ? (string) $assoc_args['asset-policy'] : '',
 			'source_metadata'           => array( 'artifact_file' => $artifact_file ),
 		);
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -69,6 +69,27 @@ class Static_Site_Importer_Theme_Generator {
 	private static array $active_asset_metadata = array();
 
 	/**
+	 * Import-scoped local asset handling policy.
+	 *
+	 * @var string
+	 */
+	private static string $active_asset_policy = 'theme';
+
+	/**
+	 * Media-library imports keyed by normalized source-relative asset path.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	private static array $active_imported_media_assets = array();
+
+	/**
+	 * Local asset report rows already recorded for this import.
+	 *
+	 * @var array<string, true>
+	 */
+	private static array $recorded_local_asset_keys = array();
+
+	/**
 	 * Materialized inline SVG assets keyed by SVG content hash.
 	 *
 	 * @var array<string, array<string, string>>
@@ -182,6 +203,10 @@ class Static_Site_Importer_Theme_Generator {
 		self::$active_source_dir        = $site_dir;
 		self::$active_asset_map         = self::normalize_asset_map( isset( $args['asset_map'] ) && is_array( $args['asset_map'] ) ? $args['asset_map'] : array() );
 		self::$active_asset_metadata    = array();
+		self::$active_asset_policy      = self::normalize_asset_policy( isset( $args['asset_policy'] ) ? (string) $args['asset_policy'] : '' );
+		self::$active_imported_media_assets = array();
+		self::$recorded_local_asset_keys    = array();
+		self::$conversion_report['assets']['policy']         = self::$active_asset_policy;
 		self::$conversion_report['asset_map']['supplied']    = ! empty( self::$active_asset_map );
 		self::$conversion_report['asset_map']['entry_count'] = count( self::$active_asset_map );
 		self::$materialized_svg_assets  = array();
@@ -386,6 +411,10 @@ class Static_Site_Importer_Theme_Generator {
 		self::$active_source_dir        = '';
 		self::$active_asset_map         = self::normalize_asset_map( isset( $args['asset_map'] ) && is_array( $args['asset_map'] ) ? $args['asset_map'] : array() );
 		self::$active_asset_metadata    = array();
+		self::$active_asset_policy      = self::normalize_asset_policy( isset( $args['asset_policy'] ) ? (string) $args['asset_policy'] : '' );
+		self::$active_imported_media_assets = array();
+		self::$recorded_local_asset_keys    = array();
+		self::$conversion_report['assets']['policy']         = self::$active_asset_policy;
 		self::$conversion_report['asset_map']['supplied']    = ! empty( self::$active_asset_map );
 		self::$conversion_report['asset_map']['entry_count'] = count( self::$active_asset_map );
 		self::$materialized_svg_assets  = array();
@@ -1822,6 +1851,10 @@ class Static_Site_Importer_Theme_Generator {
 					continue;
 				}
 
+				if ( 0 === strcasecmp( $element->tagName, 'img' ) && '' !== trim( $element->getAttribute( 'alt' ) ) ) {
+					$asset = self::add_local_asset_alt_metadata( $value, $asset, $element->getAttribute( 'alt' ) );
+				}
+
 				$element->setAttribute( $attribute, $asset['url'] );
 				self::apply_asset_metadata_to_media_element( $element, $asset );
 				$changed = true;
@@ -1880,8 +1913,8 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return void
 	 */
 	private static function apply_asset_metadata_to_media_element( DOMElement $element, array $asset ): void {
-		if ( isset( $asset['attachment_id'] ) && (int) $asset['attachment_id'] > 0 ) {
-			$attachment_id = (int) $asset['attachment_id'];
+		$attachment_id = isset( $asset['attachment_id'] ) ? (int) $asset['attachment_id'] : (int) ( $asset['id'] ?? 0 );
+		if ( $attachment_id > 0 ) {
 			$element->setAttribute( 'data-id', (string) $attachment_id );
 			$element->setAttribute( 'class', self::append_class_token( $element->getAttribute( 'class' ), 'wp-image-' . $attachment_id ) );
 		}
@@ -2567,6 +2600,18 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Normalize the optional local asset handling policy.
+	 *
+	 * @param string $policy Raw policy value.
+	 * @return string
+	 */
+	private static function normalize_asset_policy( string $policy ): string {
+		$policy = sanitize_key( $policy );
+
+		return 'media-library' === $policy ? 'media-library' : 'theme';
+	}
+
+	/**
 	 * Resolve a local source URL through the active asset map and record the lookup.
 	 *
 	 * @param string $url         Source URL or path.
@@ -2742,9 +2787,21 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		$extension = strtolower( pathinfo( $real_source, PATHINFO_EXTENSION ) );
-		if ( ! in_array( $extension, array( 'svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'woff', 'woff2' ), true ) ) {
+		if ( ! self::is_local_asset_supported( $extension ) ) {
 			self::record_local_asset_diagnostic( 'local_asset_unsupported_type', $source, $source_path, $url, $key, 'Local asset reference uses an unsupported file type for theme materialization; leaving it unchanged.' );
 			return null;
+		}
+
+		if ( 'media-library' === self::$active_asset_policy ) {
+			$asset = self::import_local_asset_to_media_library( $real_source, $key, $url, $source_path, $source );
+			if ( null === $asset ) {
+				return null;
+			}
+
+			self::record_local_asset_materialized( $source, $source_path, $url, $key, $asset );
+			self::remember_asset_metadata( $url, $key, $asset );
+
+			return $asset;
 		}
 
 		$target_relative = self::materialized_asset_relative_path( $key, $real_source );
@@ -2774,8 +2831,10 @@ class Static_Site_Importer_Theme_Generator {
 			'source_path' => $source_path,
 			'path'        => $key,
 			'url'         => trailingslashit( self::$active_theme_uri ) . $target_relative,
+			'final_url'   => trailingslashit( self::$active_theme_uri ) . $target_relative,
 			'mime_type'   => self::export_mime_type( $real_source ),
 			'theme_path'  => $target_relative,
+			'policy'      => 'theme',
 		);
 
 		$dimensions = self::image_dimensions( $real_source );
@@ -2838,6 +2897,162 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Check whether a local asset extension is supported by SSI materialization.
+	 *
+	 * @param string $extension File extension without dot.
+	 * @return bool
+	 */
+	private static function is_local_asset_supported( string $extension ): bool {
+		return in_array( $extension, array( 'svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'woff', 'woff2' ), true );
+	}
+
+	/**
+	 * Check whether a local asset can become a WordPress media attachment.
+	 *
+	 * @param string $path Absolute file path.
+	 * @return bool
+	 */
+	private static function is_media_library_asset_supported( string $path ): bool {
+		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+		if ( ! in_array( $extension, array( 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'svg' ), true ) ) {
+			return false;
+		}
+
+		if ( function_exists( 'wp_check_filetype' ) ) {
+			$type = wp_check_filetype( basename( $path ) );
+			return ! empty( $type['type'] );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Import a resolved local asset into the WordPress media library.
+	 *
+	 * @param string $real_source Absolute source file path.
+	 * @param string $key         Source-relative key.
+	 * @param string $url         Original source URL.
+	 * @param string $source_path Source-relative document path.
+	 * @param string $source      Diagnostic source label.
+	 * @return array<string,mixed>|null
+	 */
+	private static function import_local_asset_to_media_library( string $real_source, string $key, string $url, string $source_path, string $source ): ?array {
+		if ( isset( self::$active_imported_media_assets[ $key ] ) ) {
+			return self::$active_imported_media_assets[ $key ];
+		}
+
+		if ( ! self::is_media_library_asset_supported( $real_source ) ) {
+			self::record_local_asset_diagnostic( 'local_asset_unsupported_type', $source, $source_path, $url, $key, 'Local asset reference uses a file type unsupported by the media-library asset policy; leaving it unchanged.' );
+			return null;
+		}
+
+		if ( ! function_exists( 'wp_upload_bits' ) || ! function_exists( 'wp_insert_attachment' ) ) {
+			self::record_local_asset_diagnostic( 'local_asset_upload_failed', $source, $source_path, $url, $key, 'Local asset reference could not be imported because WordPress media upload functions are unavailable; leaving it unchanged.' );
+			return null;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads a validated local source asset for media upload.
+		$contents = file_get_contents( $real_source );
+		if ( false === $contents ) {
+			self::record_local_asset_diagnostic( 'local_asset_read_failed', $source, $source_path, $url, $key, 'Local asset reference could not be read; leaving it unchanged.' );
+			return null;
+		}
+
+		$filename = sanitize_file_name( basename( $real_source ) );
+		if ( '' === $filename ) {
+			self::record_local_asset_diagnostic( 'local_asset_unsafe_path', $source, $source_path, $url, $key, 'Local asset reference could not be converted to a safe media filename; leaving it unchanged.' );
+			return null;
+		}
+
+		$upload = wp_upload_bits( $filename, null, $contents );
+		if ( ! is_array( $upload ) || ! empty( $upload['error'] ) || empty( $upload['file'] ) || empty( $upload['url'] ) ) {
+			$error = is_array( $upload ) && isset( $upload['error'] ) ? (string) $upload['error'] : 'Unknown upload error.';
+			self::record_local_asset_diagnostic( 'local_asset_upload_failed', $source, $source_path, $url, $key, 'Local asset reference could not be uploaded to the media library: ' . $error );
+			return null;
+		}
+
+		$file = (string) $upload['file'];
+		$type = function_exists( 'wp_check_filetype' ) ? wp_check_filetype( $file ) : array( 'type' => self::export_mime_type( $file ) );
+		$mime = isset( $type['type'] ) ? (string) $type['type'] : self::export_mime_type( $file );
+		$id   = wp_insert_attachment(
+			array(
+				'post_mime_type' => $mime,
+				'post_title'     => preg_replace( '/\.[^.]+$/', '', $filename ),
+				'post_content'   => '',
+				'post_status'    => 'inherit',
+			),
+			$file
+		);
+		if ( is_wp_error( $id ) || (int) $id <= 0 ) {
+			$message = is_wp_error( $id ) ? $id->get_error_message() : 'WordPress did not return an attachment ID.';
+			self::record_local_asset_diagnostic( 'local_asset_upload_failed', $source, $source_path, $url, $key, 'Local asset reference uploaded but attachment creation failed: ' . $message );
+			return null;
+		}
+
+		if ( function_exists( 'wp_generate_attachment_metadata' ) && function_exists( 'wp_update_attachment_metadata' ) ) {
+			$metadata = wp_generate_attachment_metadata( (int) $id, $file );
+			if ( is_array( $metadata ) ) {
+				wp_update_attachment_metadata( (int) $id, $metadata );
+			}
+		}
+
+		$asset = array(
+			'id'            => (int) $id,
+			'attachment_id' => (int) $id,
+			'source'        => $url,
+			'source_path'   => $source_path,
+			'path'          => $key,
+			'url'           => function_exists( 'wp_get_attachment_url' ) ? (string) wp_get_attachment_url( (int) $id ) : (string) $upload['url'],
+			'final_url'     => function_exists( 'wp_get_attachment_url' ) ? (string) wp_get_attachment_url( (int) $id ) : (string) $upload['url'],
+			'mime_type'     => $mime,
+			'file'          => $file,
+			'policy'        => 'media-library',
+		);
+
+		$dimensions = self::image_dimensions( $file );
+		if ( ! empty( $dimensions ) ) {
+			$asset = array_merge( $asset, $dimensions );
+		}
+
+		self::$active_imported_media_assets[ $key ] = $asset;
+
+		return $asset;
+	}
+
+	/**
+	 * Add available alt text to cached asset metadata.
+	 *
+	 * @param string              $url   Original source reference.
+	 * @param array<string,mixed> $asset Asset metadata.
+	 * @param string              $alt   Alt text.
+	 * @return array<string,mixed>
+	 */
+	private static function add_local_asset_alt_metadata( string $url, array $asset, string $alt ): array {
+		$alt = trim( $alt );
+		$key = isset( $asset['path'] ) ? (string) $asset['path'] : '';
+		if ( '' === $alt || '' === $key ) {
+			return $asset;
+		}
+
+		if ( isset( $asset['alt'] ) && '' !== trim( (string) $asset['alt'] ) ) {
+			return $asset;
+		}
+
+		$asset['alt'] = $alt;
+		if ( isset( $asset['attachment_id'] ) && (int) $asset['attachment_id'] > 0 && function_exists( 'update_post_meta' ) ) {
+			update_post_meta( (int) $asset['attachment_id'], '_wp_attachment_image_alt', $alt );
+		}
+
+		if ( isset( self::$active_imported_media_assets[ $key ] ) ) {
+			self::$active_imported_media_assets[ $key ] = $asset;
+		}
+
+		self::remember_asset_metadata( $url, $key, $asset );
+
+		return $asset;
+	}
+
+	/**
 	 * Store metadata under all keys H2BC/BFB may see during conversion.
 	 *
 	 * @param string              $url   Original source reference.
@@ -2869,14 +3084,30 @@ class Static_Site_Importer_Theme_Generator {
 			self::$conversion_report['assets']['local'] = array();
 		}
 
-		self::$conversion_report['assets']['local'][] = array(
+		$report_key = (string) ( $asset['policy'] ?? self::$active_asset_policy ) . ':' . $key;
+		if ( isset( self::$recorded_local_asset_keys[ $report_key ] ) ) {
+			return;
+		}
+		self::$recorded_local_asset_keys[ $report_key ] = true;
+
+		$row = array(
 			'source'      => $source,
 			'source_path' => $source_path,
 			'url'         => $url,
 			'key'         => $key,
+			'policy'      => $asset['policy'] ?? self::$active_asset_policy,
 			'theme_path'  => $asset['theme_path'] ?? '',
+			'final_url'   => $asset['url'] ?? '',
 			'mime_type'   => $asset['mime_type'] ?? '',
 		);
+
+		foreach ( array( 'id', 'attachment_id', 'width', 'height', 'alt' ) as $field ) {
+			if ( isset( $asset[ $field ] ) ) {
+				$row[ $field ] = $asset[ $field ];
+			}
+		}
+
+		self::$conversion_report['assets']['local'][] = $row;
 	}
 
 	/**
@@ -3271,6 +3502,9 @@ class Static_Site_Importer_Theme_Generator {
 				if ( '!' === $prefix ) {
 					$asset = self::resolve_local_asset_reference( $destination, $source_path, $source );
 					if ( null !== $asset ) {
+						if ( '' !== trim( $label ) ) {
+							$asset = self::add_local_asset_alt_metadata( $destination, $asset, $label );
+						}
 						return '![' . $label . '](' . $asset['url'] . ')';
 					}
 					return $matches[0];
@@ -4915,6 +5149,7 @@ class Static_Site_Importer_Theme_Generator {
 				'diagnostics'    => array(),
 			),
 			'assets'                  => array(
+				'policy'      => 'theme',
 				'svg_icons'   => array(),
 				'svg_sprites' => array(),
 				'local'       => array(),

--- a/tests/smoke-media-library-asset-policy.php
+++ b/tests/smoke-media-library-asset-policy.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Smoke test: media-library asset policy imports resolved local assets as attachments.
+ *
+ * Run from the repository root:
+ * php tests/smoke-media-library-asset-policy.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+
+		public function __construct( string $code = '', string $message = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( string $target ): bool {
+		return is_dir( $target ) || mkdir( $target, 0777, true );
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $value ): string {
+		return rtrim( $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return preg_replace( '/[^a-z0-9_-]/', '', strtolower( $key ) ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'sanitize_file_name' ) ) {
+	function sanitize_file_name( string $filename ): string {
+		return preg_replace( '/[^A-Za-z0-9._-]/', '-', $filename ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( string $url ): string {
+		return $url;
+	}
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( string $url, int $component = -1 ): mixed {
+		$parts = parse_url( $url );
+		if ( -1 === $component ) {
+			return $parts;
+		}
+
+		$map = array(
+			PHP_URL_SCHEME   => 'scheme',
+			PHP_URL_HOST     => 'host',
+			PHP_URL_PORT     => 'port',
+			PHP_URL_USER     => 'user',
+			PHP_URL_PASS     => 'pass',
+			PHP_URL_PATH     => 'path',
+			PHP_URL_QUERY    => 'query',
+			PHP_URL_FRAGMENT => 'fragment',
+		);
+
+		return isset( $map[ $component ], $parts[ $map[ $component ] ] ) ? $parts[ $map[ $component ] ] : null;
+	}
+}
+
+$GLOBALS['ssi_media_uploads']     = array();
+$GLOBALS['ssi_media_next_id']     = 700;
+$GLOBALS['ssi_media_upload_base'] = sys_get_temp_dir() . '/ssi-media-uploads-' . uniqid();
+
+if ( ! function_exists( 'wp_check_filetype' ) ) {
+	function wp_check_filetype( string $filename ): array {
+		$extension = strtolower( pathinfo( $filename, PATHINFO_EXTENSION ) );
+		$types     = array(
+			'png'  => 'image/png',
+			'jpg'  => 'image/jpeg',
+			'jpeg' => 'image/jpeg',
+			'gif'  => 'image/gif',
+			'webp' => 'image/webp',
+			'avif' => 'image/avif',
+			'svg'  => 'image/svg+xml',
+		);
+
+		return array(
+			'ext'  => $extension,
+			'type' => $types[ $extension ] ?? false,
+		);
+	}
+}
+
+if ( ! function_exists( 'wp_upload_bits' ) ) {
+	function wp_upload_bits( string $name, $deprecated, string $bits ): array {
+		$dir = trailingslashit( $GLOBALS['ssi_media_upload_base'] );
+		wp_mkdir_p( $dir );
+		$file = $dir . sanitize_file_name( $name );
+		file_put_contents( $file, $bits );
+
+		return array(
+			'file'  => $file,
+			'url'   => 'https://example.test/wp-content/uploads/' . basename( $file ),
+			'error' => false,
+		);
+	}
+}
+
+if ( ! function_exists( 'wp_insert_attachment' ) ) {
+	function wp_insert_attachment( array $attachment, string $file ): int {
+		$id = ++$GLOBALS['ssi_media_next_id'];
+		$GLOBALS['ssi_media_uploads'][ $id ] = array(
+			'attachment' => $attachment,
+			'file'       => $file,
+			'url'        => 'https://example.test/wp-content/uploads/' . basename( $file ),
+			'meta'       => array(),
+		);
+
+		return $id;
+	}
+}
+
+if ( ! function_exists( 'wp_get_attachment_url' ) ) {
+	function wp_get_attachment_url( int $id ): string {
+		return $GLOBALS['ssi_media_uploads'][ $id ]['url'] ?? '';
+	}
+}
+
+if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+	function wp_generate_attachment_metadata( int $id, string $file ): array {
+		return array( 'file' => basename( $file ) );
+	}
+}
+
+if ( ! function_exists( 'wp_update_attachment_metadata' ) ) {
+	function wp_update_attachment_metadata( int $id, array $metadata ): bool {
+		$GLOBALS['ssi_media_uploads'][ $id ]['metadata'] = $metadata;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'update_post_meta' ) ) {
+	function update_post_meta( int $id, string $key, string $value ): bool {
+		$GLOBALS['ssi_media_uploads'][ $id ]['meta'][ $key ] = $value;
+		return true;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php';
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$tmp        = sys_get_temp_dir() . '/ssi-media-library-policy-' . uniqid();
+$source_dir = $tmp . '/source';
+$theme_dir  = $tmp . '/theme';
+wp_mkdir_p( $source_dir . '/assets' );
+wp_mkdir_p( $source_dir . '/pages' );
+wp_mkdir_p( $theme_dir );
+
+$png = base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=' );
+file_put_contents( $source_dir . '/assets/hero.png', $png );
+file_put_contents( $source_dir . '/assets/readme.txt', 'not media' );
+
+$class = new ReflectionClass( Static_Site_Importer_Theme_Generator::class );
+foreach ( array(
+	'active_source_dir'            => $source_dir,
+	'active_theme_dir'             => $theme_dir,
+	'active_theme_uri'             => 'https://example.test/wp-content/themes/imported',
+	'active_asset_map'             => array(),
+	'active_asset_metadata'        => array(),
+	'active_asset_policy'          => 'media-library',
+	'active_imported_media_assets' => array(),
+	'recorded_local_asset_keys'    => array(),
+	'conversion_report'            => array(
+		'assets'      => array(
+			'policy'      => 'media-library',
+			'local'       => array(),
+			'svg_icons'   => array(),
+			'svg_sprites' => array(),
+		),
+		'asset_map'   => array(
+			'supplied'         => false,
+			'entry_count'      => 0,
+			'resolved_count'   => 0,
+			'unresolved_count' => 0,
+			'resolved'         => array(),
+			'unresolved'       => array(),
+		),
+		'diagnostics' => array(),
+	),
+) as $property => $value ) {
+	$ref = $class->getProperty( $property );
+	$ref->setValue( null, $value );
+}
+
+$rewrite_html = $class->getMethod( 'rewrite_local_asset_references' );
+$html         = $rewrite_html->invoke(
+	null,
+	'<figure><img src="../assets/hero.png" alt="Hero"><img src="../assets/hero.png" alt="Duplicate"><img src="../assets/readme.txt" alt="Text"><img src="../../secret.png" alt="Unsafe"></figure>',
+	'pages/about.html',
+	'main:pages/about.html'
+);
+
+$assert( str_contains( $html, 'src="https://example.test/wp-content/uploads/hero.png"' ), 'media-url-rewritten', $html );
+$assert( str_contains( $html, 'data-id="701"' ), 'attachment-id-added', $html );
+$assert( str_contains( $html, 'wp-image-701' ), 'wp-image-class-added', $html );
+$assert( 1 === count( $GLOBALS['ssi_media_uploads'] ), 'duplicate-source-imported-once' );
+$assert( 'Hero' === ( $GLOBALS['ssi_media_uploads'][701]['meta']['_wp_attachment_image_alt'] ?? '' ), 'alt-written-to-attachment' );
+
+$metadata = $class->getProperty( 'active_asset_metadata' )->getValue();
+$asset    = $metadata['../assets/hero.png'] ?? array();
+$assert( 701 === ( $asset['attachment_id'] ?? null ), 'metadata-attachment-id' );
+$assert( 701 === ( $asset['id'] ?? null ), 'metadata-id' );
+$assert( 'https://example.test/wp-content/uploads/hero.png' === ( $asset['url'] ?? '' ), 'metadata-final-url' );
+$assert( 'https://example.test/wp-content/uploads/hero.png' === ( $asset['final_url'] ?? '' ), 'metadata-explicit-final-url' );
+$assert( 'Hero' === ( $asset['alt'] ?? '' ), 'metadata-alt' );
+$assert( 1 === ( $asset['width'] ?? null ), 'metadata-width' );
+$assert( 1 === ( $asset['height'] ?? null ), 'metadata-height' );
+
+$report = $class->getProperty( 'conversion_report' )->getValue();
+$assert( 1 === count( $report['assets']['local'] ?? array() ), 'duplicate-source-single-report-row' );
+$assert( 'media-library' === ( $report['assets']['local'][0]['policy'] ?? '' ), 'report-policy' );
+$assert( 701 === ( $report['assets']['local'][0]['attachment_id'] ?? null ), 'report-attachment-id' );
+
+$diagnostics = array_column( $report['diagnostics'] ?? array(), 'type' );
+$assert( in_array( 'local_asset_unsupported_type', $diagnostics, true ), 'unsupported-file-diagnostic-recorded' );
+$assert( in_array( 'local_asset_unsafe_path', $diagnostics, true ), 'unsafe-path-diagnostic-recorded' );
+$assert( str_contains( $html, 'src="../assets/readme.txt"' ), 'unsupported-left-unchanged', $html );
+$assert( str_contains( $html, 'src="../../secret.png"' ), 'unsafe-left-unchanged', $html );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: media-library asset policy smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Adds optional `asset_policy: media-library` handling for resolved local assets so supported files become WordPress attachments instead of theme media files.
- Reuses the existing local asset resolver/report path while adding import-scoped dedupe, attachment IDs, final URLs, alt text, dimensions, and upload diagnostics.
- Exposes the policy through the import abilities and WP-CLI, with a focused smoke test covering success, duplicate references, unsupported files, and unsafe paths.

Fixes #272.

## Tests
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l includes/abilities.php`
- `php -l includes/class-static-site-importer-cli-command.php`
- `php -l tests/smoke-media-library-asset-policy.php`
- `php tests/smoke-media-library-asset-policy.php`
- `php tests/smoke-local-asset-materialization.php`
- `php tests/smoke-import-theme-ability.php`

## Known existing failures
- `npm run test:js-block-validation` fails before this change path with `TypeError: Cannot convert undefined or null to object` in `tests/smoke-generated-theme-block-validation.cjs` after reporting invalid blocks.
- `npm run test:validation` fails existing fixture fidelity assertions around footer list/navigation and quality fallback diagnostic fields.
- `for file in tests/*.php; do php "$file" || exit 1; done` fails because PHPUnit-style tests require `WP_UnitTestCase` bootstrap and are not directly executable as smoke scripts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting the media-library asset policy implementation, focused smoke coverage, and PR/test summary for Chris to review and validate.