### PR TITLE
Preserve rich compiler reports

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1"
+                "reference": "cd059900ee33270efdf0782322c6a2e78e16b36d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1",
-                "reference": "50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/cd059900ee33270efdf0782322c6a2e78e16b36d",
+                "reference": "cd059900ee33270efdf0782322c6a2e78e16b36d",
                 "shasum": ""
             },
             "require": {
@@ -43,7 +43,7 @@
                 "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
                 "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
             },
-            "time": "2026-05-31T18:29:55+00:00"
+            "time": "2026-05-31T21:30:35+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -4513,14 +4513,48 @@ class Static_Site_Importer_Theme_Generator {
 	private static function record_block_artifact_compiler_result( string $source, array $compiled ): void {
 		$summary           = bac_summarize_result( $compiled );
 		$summary['source'] = '' !== (string) ( $summary['source'] ?? '' ) ? (string) $summary['source'] : $source;
+		$payload           = self::compiler_report_payload( $compiled, $summary );
 
 		self::$conversion_report['block_artifact_compiler']['available']      = true;
-		self::$conversion_report['block_artifact_compiler']['fragments'][]    = $summary;
+		self::$conversion_report['block_artifact_compiler']['fragments'][]    = $payload;
 		self::$conversion_report['block_artifact_compiler']['fragment_count'] = count( self::$conversion_report['block_artifact_compiler']['fragments'] );
 
 		if ( isset( self::$conversion_report['conversion_fragments'][ $source ] ) ) {
-			self::$conversion_report['conversion_fragments'][ $source ]['compiler'] = $summary;
+			self::$conversion_report['conversion_fragments'][ $source ]['compiler'] = $payload;
 		}
+	}
+
+	/**
+	 * Preserve upstream compiler evidence without embedding full block markup bodies.
+	 *
+	 * @param array<string,mixed> $compiled Compiler result envelope.
+	 * @param array<string,mixed> $summary  Compact compiler summary.
+	 * @return array<string,mixed>
+	 */
+	private static function compiler_report_payload( array $compiled, array $summary ): array {
+		$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$payload   = array_merge( $summary, array(
+			'summary'     => $summary,
+			'input'       => isset( $compiled['input'] ) && is_array( $compiled['input'] ) ? $compiled['input'] : array(),
+			'provenance'  => isset( $compiled['provenance'] ) && is_array( $compiled['provenance'] ) ? $compiled['provenance'] : array(),
+			'diagnostics' => isset( $compiled['diagnostics'] ) && is_array( $compiled['diagnostics'] ) ? $compiled['diagnostics'] : array(),
+			'bfb_report'  => isset( $compiled['bfb_report'] ) && is_array( $compiled['bfb_report'] ) ? $compiled['bfb_report'] : array(),
+			'wordpress_artifacts' => array(
+				'block_tree'  => isset( $artifacts['block_tree'] ) && is_array( $artifacts['block_tree'] ) ? $artifacts['block_tree'] : array(),
+				'block_types' => isset( $artifacts['block_types'] ) && is_array( $artifacts['block_types'] ) ? $artifacts['block_types'] : array(),
+				'components'  => isset( $artifacts['components'] ) && is_array( $artifacts['components'] ) ? $artifacts['components'] : array(),
+				'documents'   => isset( $artifacts['documents'] ) && is_array( $artifacts['documents'] ) ? $artifacts['documents'] : array(),
+				'files'       => isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array(),
+			),
+		) );
+
+		if ( isset( $artifacts['block_markup'] ) && is_scalar( $artifacts['block_markup'] ) ) {
+			$block_markup = (string) $artifacts['block_markup'];
+			$payload['wordpress_artifacts']['block_markup_length'] = strlen( $block_markup );
+			$payload['wordpress_artifacts']['block_markup_hash']   = hash( 'sha256', $block_markup );
+		}
+
+		return $payload;
 	}
 
 	/**
@@ -6180,6 +6214,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		if ( empty( $context ) ) {
 			return array(
+				'include_bfb_report' => true,
 				'source' => array(
 					'fragment' => $source,
 				),
@@ -6187,6 +6222,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return array(
+			'include_bfb_report' => true,
 			'context' => $context,
 			'source'  => array(
 				'fragment' => $source,

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -143,7 +143,14 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertTrue( $report['block_artifact_compiler']['available'] ?? false );
 		$this->assertGreaterThan( 0, $report['block_artifact_compiler']['fragment_count'] ?? 0 );
 		$this->assertNotEmpty( $report['block_artifact_compiler']['fragments'] ?? array() );
-		$this->assertArrayHasKey( 'component_count', $report['block_artifact_compiler']['fragments'][0] ?? array() );
+		$compiler_fragment = $report['block_artifact_compiler']['fragments'][0] ?? array();
+		$this->assertArrayHasKey( 'component_count', $compiler_fragment );
+		$this->assertArrayHasKey( 'input', $compiler_fragment );
+		$this->assertArrayHasKey( 'provenance', $compiler_fragment );
+		$this->assertArrayHasKey( 'diagnostics', $compiler_fragment );
+		$this->assertArrayHasKey( 'bfb_report', $compiler_fragment );
+		$this->assertArrayHasKey( 'wordpress_artifacts', $compiler_fragment );
+		$this->assertArrayHasKey( 'block_markup_hash', $compiler_fragment['wordpress_artifacts'] );
 		$this->assertNotEmpty( $report['generated_theme']['block_documents'] ?? array() );
 		$this->assertSame( 'requires_external_render_check', $report['semantic_fidelity']['status'] ?? '' );
 		$this->assertSame( 'benchmark_harness', $report['semantic_fidelity']['gate_owner'] ?? '' );

--- a/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
+++ b/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
@@ -42,6 +42,7 @@ class Block_Artifact_Compiler {
 			'diagnostics'       => array(),
 			'report'            => array(),
 		);
+		$source_report = $this->source_report( $normalized, $entry_path, $html );
 
 		$diagnostics = array_merge( $diagnostics, $conversion['diagnostics'] );
 		$components  = $this->detect_components( $normalized, $entry_path, $documents['components'] );
@@ -66,10 +67,12 @@ class Block_Artifact_Compiler {
 				'files_by_role'   => $this->count_files_by_field( $normalized['files'], 'role' ),
 				'files_by_mime'   => $this->count_files_by_field( $normalized['files'], 'mime_type' ),
 				'original_schema' => (string) ( $artifact['schema'] ?? '' ),
+				'source_report'    => $source_report,
 			),
 			'wordpress_artifacts' => array(
 				'block_markup' => $conversion['serialized_blocks'],
 				'blocks'       => $conversion['blocks'],
+				'block_tree'   => $this->block_tree_report( $conversion['blocks'], $conversion['serialized_blocks'] ),
 				'block_types'  => $block_types,
 				'components'   => $components,
 				'documents'    => $documents['documents'],
@@ -122,11 +125,18 @@ class Block_Artifact_Compiler {
 		$components  = isset( $artifacts['components'] ) && is_array( $artifacts['components'] ) ? $artifacts['components'] : array();
 		$files       = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
 		$diagnostics = isset( $compiled['diagnostics'] ) && is_array( $compiled['diagnostics'] ) ? $compiled['diagnostics'] : array();
+		$source      = isset( $compiled['input']['source_report'] ) && is_array( $compiled['input']['source_report'] ) ? $compiled['input']['source_report'] : array();
+		$block_tree  = isset( $artifacts['block_tree'] ) && is_array( $artifacts['block_tree'] ) ? $artifacts['block_tree'] : array();
 
 		return array(
 			'schema'           => isset( $compiled['schema'] ) ? (string) $compiled['schema'] : '',
 			'status'           => isset( $compiled['status'] ) ? (string) $compiled['status'] : '',
 			'source'           => isset( $compiled['provenance']['source'] ) ? (string) $compiled['provenance']['source'] : '',
+			'source_element_count' => (int) ( $source['html']['element_count'] ?? 0 ),
+			'source_class_count'   => (int) ( $source['html']['class_count'] ?? 0 ),
+			'source_css_selector_count' => (int) ( $source['css']['selector_count'] ?? 0 ),
+			'block_count'      => (int) ( $block_tree['block_count'] ?? 0 ),
+			'block_depth'      => (int) ( $block_tree['max_depth'] ?? 0 ),
 			'block_type_count' => count( $block_types ),
 			'component_count'  => count( $components ),
 			'file_count'       => count( $files ),
@@ -457,6 +467,222 @@ class Block_Artifact_Compiler {
 			),
 			'report'            => array( 'status' => 'success_with_fallbacks' ),
 		);
+	}
+
+	/**
+	 * Build source-side structural evidence before conversion mutates the document.
+	 *
+	 * @param array{files:array<int,array<string,mixed>>} $artifact Normalized artifact.
+	 * @return array<string,mixed>
+	 */
+	private function source_report( array $artifact, string $entry_path, string $html ): array {
+		return array(
+			'entry_path' => $entry_path,
+			'html'       => $this->html_structure_report( $html ),
+			'css'        => $this->css_structure_report( $artifact['files'] ),
+		);
+	}
+
+	/**
+	 * Summarize source HTML structure and selector-critical tokens.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function html_structure_report( string $html ): array {
+		$report = array(
+			'bytes'                  => strlen( $html ),
+			'text_length'            => $this->plain_text_length( $html ),
+			'element_count'          => 0,
+			'id_count'               => 0,
+			'class_count'            => 0,
+			'unique_class_count'     => 0,
+			'tag_counts'             => array(),
+			'top_classes'            => array(),
+			'landmark_counts'        => array(),
+			'max_depth'              => 0,
+		);
+
+		if ( '' === trim( $html ) || ! class_exists( 'DOMDocument' ) ) {
+			return $report;
+		}
+
+		$doc = new DOMDocument();
+		$previous = libxml_use_internal_errors( true );
+		$loaded = $doc->loadHTML( '<!doctype html><html><body>' . $html . '</body></html>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+		if ( ! $loaded ) {
+			return $report;
+		}
+
+		$classes = array();
+		$walk = function ( $node, int $depth ) use ( &$walk, &$report, &$classes ): void {
+			if ( $node instanceof DOMElement ) {
+				$tag = strtolower( $node->tagName );
+				if ( ! in_array( $tag, array( 'html', 'body' ), true ) ) {
+					++$report['element_count'];
+					$report['max_depth'] = max( (int) $report['max_depth'], max( 0, $depth - 2 ) );
+					$report['tag_counts'][ $tag ] = (int) ( $report['tag_counts'][ $tag ] ?? 0 ) + 1;
+					if ( in_array( $tag, array( 'header', 'nav', 'main', 'section', 'article', 'aside', 'footer' ), true ) ) {
+						$report['landmark_counts'][ $tag ] = (int) ( $report['landmark_counts'][ $tag ] ?? 0 ) + 1;
+					}
+					if ( '' !== trim( $node->getAttribute( 'id' ) ) ) {
+						++$report['id_count'];
+					}
+					$class_attr = trim( $node->getAttribute( 'class' ) );
+					if ( '' !== $class_attr ) {
+						foreach ( preg_split( '/\s+/', $class_attr ) ?: array() as $class ) {
+							if ( '' === $class ) {
+								continue;
+							}
+							++$report['class_count'];
+							$classes[ $class ] = (int) ( $classes[ $class ] ?? 0 ) + 1;
+						}
+					}
+				}
+			}
+
+			foreach ( $node->childNodes as $child ) {
+				$walk( $child, $depth + 1 );
+			}
+		};
+		$walk( $doc, 0 );
+
+		arsort( $classes );
+		arsort( $report['tag_counts'] );
+		$report['unique_class_count'] = count( $classes );
+		$report['top_classes'] = array_slice( $classes, 0, 40, true );
+
+		return $report;
+	}
+
+	/**
+	 * Summarize source CSS selectors that can be sensitive to DOM wrapper changes.
+	 *
+	 * @param array<int,array<string,mixed>> $files Normalized files.
+	 * @return array<string,mixed>
+	 */
+	private function css_structure_report( array $files ): array {
+		$report = array(
+			'file_count'                    => 0,
+			'bytes'                         => 0,
+			'selector_count'                => 0,
+			'direct_child_selector_count'   => 0,
+			'sibling_selector_count'        => 0,
+			'pseudo_selector_count'         => 0,
+			'class_selector_count'          => 0,
+			'id_selector_count'             => 0,
+			'layout_sensitive_selectors'    => array(),
+		);
+
+		foreach ( $files as $file ) {
+			if ( 'css' !== ( $file['kind'] ?? '' ) || ! empty( $file['binary'] ) ) {
+				continue;
+			}
+			$css = (string) ( $file['content'] ?? '' );
+			if ( '' === trim( $css ) ) {
+				continue;
+			}
+			++$report['file_count'];
+			$report['bytes'] += strlen( $css );
+			$css = preg_replace( '/\/\*.*?\*\//s', '', $css ) ?? $css;
+			if ( preg_match_all( '/([^{}@][^{}]*)\{[^{}]*\}/', $css, $matches ) ) {
+				foreach ( $matches[1] as $selector_list ) {
+					foreach ( explode( ',', (string) $selector_list ) as $selector ) {
+						$selector = trim( preg_replace( '/\s+/', ' ', $selector ) ?? $selector );
+						if ( '' === $selector ) {
+							continue;
+						}
+						++$report['selector_count'];
+						$direct = str_contains( $selector, '>' );
+						$sibling = str_contains( $selector, '+' ) || str_contains( $selector, '~' );
+						$pseudo = str_contains( $selector, ':' );
+						$report['class_selector_count'] += substr_count( $selector, '.' );
+						$report['id_selector_count'] += substr_count( $selector, '#' );
+						if ( $direct ) {
+							++$report['direct_child_selector_count'];
+						}
+						if ( $sibling ) {
+							++$report['sibling_selector_count'];
+						}
+						if ( $pseudo ) {
+							++$report['pseudo_selector_count'];
+						}
+						if ( $direct || $sibling || $pseudo ) {
+							$report['layout_sensitive_selectors'][] = $selector;
+						}
+					}
+				}
+			}
+		}
+
+		$report['layout_sensitive_selectors'] = array_slice( array_values( array_unique( $report['layout_sensitive_selectors'] ) ), 0, 80 );
+
+		return $report;
+	}
+
+	/**
+	 * Summarize the generated block tree without embedding the full serialized body.
+	 *
+	 * @param array<int,array<string,mixed>> $blocks Parsed blocks.
+	 * @return array<string,mixed>
+	 */
+	private function block_tree_report( array $blocks, string $serialized_blocks ): array {
+		$report = array(
+			'bytes'              => strlen( $serialized_blocks ),
+			'text_length'        => $this->plain_text_length( $serialized_blocks ),
+			'block_count'        => 0,
+			'max_depth'          => 0,
+			'block_name_counts'  => array(),
+			'class_count'        => 0,
+			'unique_class_count' => 0,
+			'top_classes'        => array(),
+		);
+
+		$classes = array();
+		$walk = function ( array $items, int $depth ) use ( &$walk, &$report, &$classes ): void {
+			foreach ( $items as $block ) {
+				if ( ! is_array( $block ) ) {
+					continue;
+				}
+				$name = (string) ( $block['blockName'] ?? '' );
+				if ( '' !== $name ) {
+					++$report['block_count'];
+					$report['max_depth'] = max( (int) $report['max_depth'], $depth );
+					$report['block_name_counts'][ $name ] = (int) ( $report['block_name_counts'][ $name ] ?? 0 ) + 1;
+				}
+				$class_attr = isset( $block['attrs']['className'] ) ? (string) $block['attrs']['className'] : '';
+				foreach ( preg_split( '/\s+/', trim( $class_attr ) ) ?: array() as $class ) {
+					if ( '' === $class ) {
+						continue;
+					}
+					++$report['class_count'];
+					$classes[ $class ] = (int) ( $classes[ $class ] ?? 0 ) + 1;
+				}
+				if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+					$walk( $block['innerBlocks'], $depth + 1 );
+				}
+			}
+		};
+		$walk( $blocks, 1 );
+
+		arsort( $classes );
+		arsort( $report['block_name_counts'] );
+		$report['unique_class_count'] = count( $classes );
+		$report['top_classes'] = array_slice( $classes, 0, 40, true );
+
+		return $report;
+	}
+
+	/**
+	 * Return a WordPress-compatible plain-text length in and out of WordPress.
+	 */
+	private function plain_text_length( string $html ): int {
+		if ( function_exists( 'wp_strip_all_tags' ) ) {
+			return strlen( trim( wp_strip_all_tags( $html ) ) );
+		}
+
+		return strlen( trim( strip_tags( $html ) ) );
 	}
 
 	/**

--- a/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
+++ b/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
@@ -31,7 +31,10 @@ $assert( 'block-artifact-compiler/result/v1' === ( $result['schema'] ?? '' ), 'r
 $assert( 'block-artifact-compiler/website-artifact/v1' === ( $result['input']['schema'] ?? '' ), 'input metadata exposes canonical website artifact schema' );
 $assert( 'success_with_warnings' === ( $result['status'] ?? '' ), 'fallback status reflects missing BFB in smoke test', (string) ( $result['status'] ?? '' ) );
 $assert( 'index.html' === ( $result['input']['entry_path'] ?? '' ), 'entry path is captured' );
+$assert( 3 === ( $result['input']['source_report']['html']['element_count'] ?? null ), 'source HTML element count is reported before conversion' );
+$assert( 1 === ( $result['input']['source_report']['html']['landmark_counts']['main'] ?? null ), 'source landmark counts are reported before conversion' );
 $assert( str_contains( (string) ( $result['wordpress_artifacts']['block_markup'] ?? '' ), '<!-- wp:html -->' ), 'fallback block markup is produced' );
+$assert( isset( $result['wordpress_artifacts']['block_tree'] ) && is_array( $result['wordpress_artifacts']['block_tree'] ), 'generated block tree report is exposed' );
 $assert( array() === ( $result['wordpress_artifacts']['block_types'] ?? null ), 'initial contract exposes empty block type list' );
 $assert( isset( $result['wordpress_artifacts']['components'] ) && is_array( $result['wordpress_artifacts']['components'] ), 'component candidates are exposed' );
 
@@ -92,6 +95,8 @@ $assert( 2 === ( $messy['input']['rejected_count'] ?? null ), 'unsafe paths are 
 $assert( 'index.html' === ( $messy['input']['entry_path'] ?? '' ), 'generated_html becomes index entry' );
 $assert( 1 === ( $messy['input']['files_by_kind']['css'] ?? 0 ), 'css shorthand is normalized' );
 $assert( 1 === ( $messy['input']['files_by_kind']['js'] ?? 0 ), 'js file is normalized' );
+$assert( ( $messy['input']['source_report']['html']['unique_class_count'] ?? 0 ) >= 3, 'source class inventory is reported' );
+$assert( 1 === ( $messy['input']['source_report']['css']['selector_count'] ?? null ), 'source CSS selector inventory is reported' );
 $assert( ! empty( $messy['wordpress_artifacts']['components'] ?? array() ), 'component candidates are detected' );
 
 $markdown = bac_compile_website_artifact(
@@ -135,6 +140,8 @@ $assert( 'main-index.html' === ( $fragment['input']['entry_path'] ?? '' ), 'frag
 
 $summary = bac_summarize_result( $messy );
 $assert( ( $summary['component_count'] ?? 0 ) > 0, 'summary exposes component count' );
+$assert( ( $summary['source_element_count'] ?? 0 ) > 0, 'summary exposes source element count' );
+$assert( ( $summary['source_css_selector_count'] ?? 0 ) > 0, 'summary exposes source CSS selector count' );
 
 $rich = bac_compile_website_artifact(
 	array(

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,18 +7,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1"
+                "reference": "cd059900ee33270efdf0782322c6a2e78e16b36d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1",
-                "reference": "50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/cd059900ee33270efdf0782322c6a2e78e16b36d",
+                "reference": "cd059900ee33270efdf0782322c6a2e78e16b36d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
-            "time": "2026-05-31T18:29:55+00:00",
+            "time": "2026-05-31T21:30:35+00:00",
             "default-branch": true,
             "type": "wordpress-plugin",
             "installation-source": "dist",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'c345b9ef391d648d6d1d318a4c8b8837ac413d96',
+        'reference' => 'f0b5a927c9d1b802542c9552ca5fee73f7e4ce8e',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'chubes4/block-artifact-compiler' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '50d98fd20eeee9e965d2b7e5fd4c334c92c19bd1',
+            'reference' => 'cd059900ee33270efdf0782322c6a2e78e16b36d',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../chubes4/block-artifact-compiler',
             'aliases' => array(
@@ -35,7 +35,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'c345b9ef391d648d6d1d318a4c8b8837ac413d96',
+            'reference' => 'f0b5a927c9d1b802542c9552ca5fee73f7e4ce8e',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- Preserve BAC fragment input, provenance, diagnostics, BFB report, and WordPress artifact summaries in SSI import reports.
- Request BFB conversion reports for BAC fragment conversion so downstream validation has upstream transformer evidence.
- Keep existing compact summary fields for compatibility while adding richer nested payloads.

Depends on chubes4/block-artifact-compiler#15 for source HTML/CSS and generated block-tree report fields.

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `homeboy test --path /Users/chubes/Developer/static-site-importer@fix-transformer-layout-fidelity-diagnostics --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the import-report preservation change and test updates for Chris to review and validate.