### PR TITLE
Expose importer diagnostics for artifacts

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -7682,7 +7682,94 @@ class Static_Site_Importer_Theme_Generator {
 		$quality['diagnostic_refs']         = self::quality_diagnostic_refs( self::$conversion_report['diagnostics'] ?? array() );
 		self::$conversion_report['quality'] = $quality;
 		self::normalize_source_document_diagnostic_refs();
+		self::$conversion_report['artifact_diagnostics'] = self::codebox_artifact_diagnostics( self::$conversion_report['diagnostics'] ?? array() );
 		return $quality;
+	}
+
+	/**
+	 * Project SSI-owned diagnostics into the generic Codebox artifact diagnostics contract.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Normalized SSI diagnostics.
+	 * @return array<string,mixed>
+	 */
+	private static function codebox_artifact_diagnostics( array $diagnostics ): array {
+		$rows = array();
+		foreach ( $diagnostics as $index => $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+
+			$rows[] = self::codebox_artifact_diagnostic( $diagnostic, $index );
+		}
+
+		$summary = array(
+			'total'   => count( $rows ),
+			'error'   => count( array_filter( $rows, static fn ( array $row ): bool => 'error' === ( $row['severity'] ?? '' ) ) ),
+			'warning' => count( array_filter( $rows, static fn ( array $row ): bool => 'warning' === ( $row['severity'] ?? '' ) ) ),
+			'notice'  => count( array_filter( $rows, static fn ( array $row ): bool => 'notice' === ( $row['severity'] ?? '' ) ) ),
+			'info'    => count( array_filter( $rows, static fn ( array $row ): bool => 'info' === ( $row['severity'] ?? '' ) ) ),
+		);
+
+		return array(
+			'schema'      => 'wp-codebox/artifact-diagnostics/v1',
+			'status'      => empty( $rows ) ? 'clean' : 'reported',
+			'summary'     => $summary,
+			'diagnostics' => $rows,
+		);
+	}
+
+	/**
+	 * Convert one SSI diagnostic into a generic artifact diagnostic row.
+	 *
+	 * @param array<string,mixed> $diagnostic Normalized SSI diagnostic.
+	 * @param int                 $index      Diagnostic index.
+	 * @return array<string,mixed>
+	 */
+	private static function codebox_artifact_diagnostic( array $diagnostic, int $index ): array {
+		$type     = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : 'static_site_importer_diagnostic';
+		$id       = isset( $diagnostic['id'] ) && is_scalar( $diagnostic['id'] ) ? (string) $diagnostic['id'] : 'static-site-importer-diagnostic-' . ( $index + 1 );
+		$path     = isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : '';
+		$message  = '';
+		foreach ( array( 'message', 'reason', 'excerpt', 'error_message' ) as $field ) {
+			if ( isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) && '' !== trim( (string) $diagnostic[ $field ] ) ) {
+				$message = (string) $diagnostic[ $field ];
+				break;
+			}
+		}
+		if ( '' === $message ) {
+			$message = $type;
+		}
+
+		$row = array(
+			'id'         => $id,
+			'type'       => $type,
+			'severity'   => isset( $diagnostic['severity'] ) && is_scalar( $diagnostic['severity'] ) ? (string) $diagnostic['severity'] : self::diagnostic_severity( $type ),
+			'message'    => $message,
+			'category'   => isset( $diagnostic['category'] ) && is_scalar( $diagnostic['category'] ) ? (string) $diagnostic['category'] : self::diagnostic_category( $type ),
+			'source'     => 'static-site-importer',
+			'path'       => $path,
+			'stage'      => isset( $diagnostic['stage'] ) && is_scalar( $diagnostic['stage'] ) ? (string) $diagnostic['stage'] : 'import',
+			'code'       => isset( $diagnostic['reason_code'] ) && is_scalar( $diagnostic['reason_code'] ) ? (string) $diagnostic['reason_code'] : $type,
+			'provenance' => array(
+				'observationType' => 'static-site-importer/import-report',
+			),
+			'refs'       => array(
+				array(
+					'path' => 'import-report.json',
+					'kind' => 'static-site-importer/import-report',
+				),
+			),
+			'details'    => $diagnostic,
+		);
+
+		if ( isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) && '' !== trim( (string) $diagnostic['selector'] ) ) {
+			$row['selector'] = (string) $diagnostic['selector'];
+		}
+
+		return array_filter(
+			$row,
+			static fn ( $value ): bool => ! ( '' === $value || array() === $value || null === $value )
+		);
 	}
 
 	/**

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -134,6 +134,9 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'semantic_fidelity', $report );
 		$this->assertArrayHasKey( 'product_seeding', $report );
 		$this->assertArrayHasKey( 'diagnostics', $report );
+		$this->assertArrayHasKey( 'artifact_diagnostics', $report );
+		$this->assertSame( 'wp-codebox/artifact-diagnostics/v1', $report['artifact_diagnostics']['schema'] ?? '' );
+		$this->assertSame( count( $report['diagnostics'] ?? array() ), $report['artifact_diagnostics']['summary']['total'] ?? null );
 		$this->assertArrayNotHasKey( 'commerce', $report );
 		$this->assertSame( 0, $report['quality']['invalid_block_count'] ?? null );
 		$this->assertSame( 0, $report['quality']['invalid_block_document_count'] ?? null );
@@ -359,6 +362,25 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertSame( 'post', $report['source_documents']['bac_documents'][0]['post_type'] ?? '' );
 		$this->assertSame( 'mdx_component_skipped', $report['source_documents']['bac_documents'][0]['diagnostics'][0]['type'] ?? '' );
 		$this->assertSame( 'mdx_component_skipped', $report['diagnostics'][0]['type'] ?? '' );
+		$this->assertSame( 'wp-codebox/artifact-diagnostics/v1', $report['artifact_diagnostics']['schema'] ?? '' );
+		$this->assertSame( 'reported', $report['artifact_diagnostics']['status'] ?? '' );
+		$this->assertSame( count( $report['diagnostics'] ?? array() ), $report['artifact_diagnostics']['summary']['total'] ?? null );
+		$this->assertGreaterThanOrEqual( 1, $report['artifact_diagnostics']['summary']['warning'] ?? 0 );
+		$artifact_diagnostics = array_values(
+			array_filter(
+				$report['artifact_diagnostics']['diagnostics'] ?? array(),
+				static fn ( $diagnostic ): bool => is_array( $diagnostic ) && 'mdx_component_skipped' === ( $diagnostic['type'] ?? '' )
+			)
+		);
+		$this->assertNotEmpty( $artifact_diagnostics );
+		$artifact_diagnostic = $artifact_diagnostics[0];
+		$this->assertSame( 'mdx_component_skipped', $artifact_diagnostic['type'] ?? '' );
+		$this->assertSame( 'warning', $artifact_diagnostic['severity'] ?? '' );
+		$this->assertSame( 'BAC normalized an MDX component before SSI materialization.', $artifact_diagnostic['message'] ?? '' );
+		$this->assertSame( 'static-site-importer', $artifact_diagnostic['source'] ?? '' );
+		$this->assertSame( 'content.mdx', $artifact_diagnostic['path'] ?? '' );
+		$this->assertSame( 'mdx_component_skipped', $artifact_diagnostic['code'] ?? '' );
+		$this->assertSame( 'import-report.json', $artifact_diagnostic['refs'][0]['path'] ?? '' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Adds a top-level `artifact_diagnostics` report section using the generic `wp-codebox/artifact-diagnostics/v1` contract.
- Projects SSI-owned normalized import diagnostics into artifact diagnostic rows with severity, category, path, code, provenance, refs, and original details.
- Covers clean and reported import-report paths in fixture tests.

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/StaticSiteImporterFixtureTest.php`
- `homeboy test --path \"/Users/chubes/Developer/static-site-importer@feat-codebox-diagnostics-export\" --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the importer diagnostics projection, tests, and verification commands for Chris to review.