### PR TITLE
Fix default CLI asset policy handling

### DIFF
--- a/includes/class-static-site-importer-cli-command.php
+++ b/includes/class-static-site-importer-cli-command.php
@@ -110,10 +110,16 @@ class Static_Site_Importer_CLI_Command {
 			'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
 			'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
 			'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
-			'asset_policy'              => isset( $assoc_args['asset-policy'] ) ? (string) $assoc_args['asset-policy'] : '',
-			'asset_materialization_policy' => isset( $assoc_args['asset-materialization-policy'] ) ? (string) $assoc_args['asset-materialization-policy'] : '',
 			'source_metadata'           => $source_metadata,
 		);
+
+		if ( isset( $assoc_args['asset-policy'] ) ) {
+			$ability_args['asset_policy'] = (string) $assoc_args['asset-policy'];
+		}
+
+		if ( isset( $assoc_args['asset-materialization-policy'] ) ) {
+			$ability_args['asset_materialization_policy'] = (string) $assoc_args['asset-materialization-policy'];
+		}
 
 		if ( isset( $assoc_args['max-fallbacks'] ) ) {
 			$ability_args['max_fallbacks'] = (int) $assoc_args['max-fallbacks'];
@@ -287,10 +293,16 @@ class Static_Site_Importer_CLI_Command {
 			'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
 			'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
 			'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
-			'asset_policy'              => isset( $assoc_args['asset-policy'] ) ? (string) $assoc_args['asset-policy'] : '',
-			'asset_materialization_policy' => isset( $assoc_args['asset-materialization-policy'] ) ? (string) $assoc_args['asset-materialization-policy'] : '',
 			'source_metadata'           => array( 'artifact_file' => $artifact_file ),
 		);
+
+		if ( isset( $assoc_args['asset-policy'] ) ) {
+			$ability_args['asset_policy'] = (string) $assoc_args['asset-policy'];
+		}
+
+		if ( isset( $assoc_args['asset-materialization-policy'] ) ) {
+			$ability_args['asset_materialization_policy'] = (string) $assoc_args['asset-materialization-policy'];
+		}
 
 		if ( isset( $assoc_args['max-fallbacks'] ) ) {
 			$ability_args['max_fallbacks'] = (int) $assoc_args['max-fallbacks'];

--- a/tests/smoke-cli-ability-error.php
+++ b/tests/smoke-cli-ability-error.php
@@ -45,6 +45,14 @@ function wp_get_ability( string $name ): object|null {
 				throw new RuntimeException( 'max_fallbacks should be omitted when --max-fallbacks is absent.' );
 			}
 
+			if ( array_key_exists( 'asset_policy', $args ) ) {
+				throw new RuntimeException( 'asset_policy should be omitted when --asset-policy is absent.' );
+			}
+
+			if ( array_key_exists( 'asset_materialization_policy', $args ) ) {
+				throw new RuntimeException( 'asset_materialization_policy should be omitted when --asset-materialization-policy is absent.' );
+			}
+
 			return new WP_Error( 'fixture_error', 'Fixture ability failure.' );
 		}
 	};


### PR DESCRIPTION
## Summary
- Omits optional asset policy fields from CLI ability payloads when their flags are absent, allowing the importer defaults to apply.
- Extends the CLI ability smoke test so absent optional asset fields stay absent, matching the existing max-fallback behavior.

## Verification
- `php tests/smoke-cli-ability-error.php`
- `php tests/smoke-import-theme-ability.php`
- WP Codebox `wordpress.bench` reproduction with local Static Site Importer mounted completed successfully for `issue-377-loom-larder`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Root-cause analysis, patch drafting, local smoke verification, and PR preparation. Chris remains responsible for review and merge.