### PR TITLE
Expose compact import summary diagnostics

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -7526,19 +7526,29 @@ class Static_Site_Importer_Theme_Generator {
 			$selector = self::diagnostic_selector_from_html( $element_html );
 		}
 
+		$emitted = '';
+		if ( function_exists( 'serialize_blocks' ) ) {
+			// @phpstan-ignore-next-line argument.type -- Parsed block shape comes from WordPress parse_blocks() or h2bc.
+			$emitted = serialize_blocks( array( $block ) );
+		}
+		if ( '' === trim( $emitted ) || preg_match( '/^<!--\s+wp:[^>]+\/-->$/', trim( $emitted ) ) ) {
+			$emitted = isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ? $block['innerHTML'] : $element_html;
+		}
+
 		$entry = array(
-			'type'                => $type,
-			'source'              => $source,
-			'selector'            => '' !== $selector ? $selector : null,
-			'excerpt'             => self::diagnostic_excerpt( wp_strip_all_tags( $element_html ) ),
-			'source_html_preview' => self::diagnostic_excerpt( $element_html ),
-			'reason'              => isset( $context['reason'] ) ? (string) $context['reason'] : 'unknown',
-			'tag_name'            => isset( $context['tag_name'] ) ? (string) $context['tag_name'] : self::diagnostic_tag_name_from_html( $element_html ),
-			'block_name'          => isset( $block['blockName'] ) ? (string) $block['blockName'] : null,
-			'converter'           => 'html-to-blocks-converter',
-			'stage'               => isset( $context['stage'] ) ? (string) $context['stage'] : 'html_to_blocks',
-			'html_length'         => strlen( $element_html ),
-			'html_excerpt'        => self::diagnostic_excerpt( $element_html ),
+			'type'                  => $type,
+			'source'                => $source,
+			'selector'              => '' !== $selector ? $selector : null,
+			'excerpt'               => self::diagnostic_excerpt( wp_strip_all_tags( $element_html ) ),
+			'source_html_preview'   => self::diagnostic_excerpt( $element_html ),
+			'emitted_block_preview' => self::diagnostic_excerpt( $emitted ),
+			'reason'                => isset( $context['reason'] ) ? (string) $context['reason'] : 'unknown',
+			'tag_name'              => isset( $context['tag_name'] ) ? (string) $context['tag_name'] : self::diagnostic_tag_name_from_html( $element_html ),
+			'block_name'            => isset( $block['blockName'] ) ? (string) $block['blockName'] : null,
+			'converter'             => 'html-to-blocks-converter',
+			'stage'                 => isset( $context['stage'] ) ? (string) $context['stage'] : 'html_to_blocks',
+			'html_length'           => strlen( $element_html ),
+			'html_excerpt'          => self::diagnostic_excerpt( $element_html ),
 		);
 
 		if ( isset( $context['occurrence'] ) ) {
@@ -8056,7 +8066,62 @@ class Static_Site_Importer_Theme_Generator {
 			'invalid_block_count'   => (int) ( $quality['invalid_block_count'] ?? 0 ),
 			'content_loss_count'    => (int) ( $quality['content_loss_count'] ?? 0 ),
 			'diagnostic_count'      => count( $diagnostics ),
+			'diagnostics'           => self::compact_import_report_diagnostics( $diagnostics ),
 		);
+	}
+
+	/**
+	 * Keep summary diagnostics compact while preserving repair-agent evidence.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Normalized diagnostics.
+	 * @return array<int,array<string,mixed>> Compact diagnostics for validation harnesses.
+	 */
+	private static function compact_import_report_diagnostics( array $diagnostics ): array {
+		$fields = array(
+			'id',
+			'type',
+			'severity',
+			'category',
+			'reason_code',
+			'suggested_repair_class',
+			'source_path',
+			'source',
+			'selector',
+			'excerpt',
+			'source_html_preview',
+			'emitted_block_preview',
+			'block_name',
+			'block_path',
+			'converter',
+			'stage',
+			'reason',
+			'message',
+			'tag_name',
+			'html_excerpt',
+			'context',
+		);
+
+		$compact = array();
+		foreach ( array_slice( $diagnostics, 0, 50 ) as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+
+			$row = array();
+			foreach ( $fields as $field ) {
+				if ( ! array_key_exists( $field, $diagnostic ) || null === $diagnostic[ $field ] || '' === $diagnostic[ $field ] || array() === $diagnostic[ $field ] ) {
+					continue;
+				}
+
+				$row[ $field ] = $diagnostic[ $field ];
+			}
+
+			if ( ! empty( $row ) ) {
+				$compact[] = $row;
+			}
+		}
+
+		return $compact;
 	}
 
 	/**

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -38,7 +38,58 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 'html_to_blocks', $diagnostic['stage'] ?? '' );
 		$this->assertSame( 'no_transform', $diagnostic['reason'] ?? '' );
 		$this->assertStringContainsString( '<iframe', $diagnostic['source_html_preview'] ?? '' );
+		$this->assertStringContainsString( '<iframe', $diagnostic['emitted_block_preview'] ?? '' );
 		$this->assertArrayHasKey( 'excerpt', $diagnostic );
+	}
+
+	/**
+	 * Import report summaries include compact machine-actionable diagnostics.
+	 */
+	public function test_import_report_summary_includes_compact_diagnostics(): void {
+		$reflection = new ReflectionClass( Static_Site_Importer_Theme_Generator::class );
+
+		$summary = $reflection->getMethod( 'import_report_summary' );
+		$summary->setAccessible( true );
+
+		$result = $summary->invoke(
+			null,
+			array(
+				'entry_file'  => '/tmp/source/index.html',
+				'diagnostics' => array(
+					array(
+						'id'                     => 'diag-001-unsupported_html_fallback-no_transform-indexhtml',
+						'type'                   => 'unsupported_html_fallback',
+						'severity'               => 'warning',
+						'category'               => 'unsupported_element',
+						'reason_code'            => 'no_transform',
+						'suggested_repair_class' => 'replace_unsupported_html',
+						'source_path'            => 'index.html',
+						'selector'               => 'iframe#store-widget.embedded.checkout',
+						'source_html_preview'    => '<iframe id="store-widget" class="embedded checkout"></iframe>',
+						'emitted_block_preview'  => '<!-- wp:html --><iframe id="store-widget" class="embedded checkout"></iframe><!-- /wp:html -->',
+						'block_name'             => 'core/html',
+						'converter'              => 'html-to-blocks-converter',
+						'stage'                  => 'html_to_blocks',
+						'reason'                 => 'no_transform',
+						'html_length'            => 64,
+					),
+				),
+			),
+			array(
+				'pass'           => false,
+				'fail_import'    => false,
+				'fallback_count' => 1,
+			)
+		);
+
+		$this->assertSame( 1, $result['diagnostic_count'] ?? 0 );
+		$this->assertCount( 1, $result['diagnostics'] ?? array() );
+		$this->assertSame( 'diag-001-unsupported_html_fallback-no_transform-indexhtml', $result['diagnostics'][0]['id'] ?? '' );
+		$this->assertSame( 'index.html', $result['diagnostics'][0]['source_path'] ?? '' );
+		$this->assertSame( 'iframe#store-widget.embedded.checkout', $result['diagnostics'][0]['selector'] ?? '' );
+		$this->assertStringContainsString( '<iframe', $result['diagnostics'][0]['source_html_preview'] ?? '' );
+		$this->assertStringContainsString( '<!-- wp:html -->', $result['diagnostics'][0]['emitted_block_preview'] ?? '' );
+		$this->assertArrayNotHasKey( 'html_length', $result['diagnostics'][0] ?? array() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Adds compact normalized diagnostics to `import_report_summary` so validation harnesses can build per-fallback repair packets without reading local-only report files.
- Includes emitted block previews for fallback/core-html diagnostics, falling back to the source fragment when serialization produces a self-closing placeholder.
- Covers summary payloads and emitted previews in the fallback diagnostics tests.

Fixes #281.

## Verification
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/StaticSiteImporterFallbackDiagnosticsTest.php`
- `homeboy test --path . --extension wordpress` -> 61 passed, 0 failed
- `homeboy lint --path . --extension wordpress` -> existing/unrelated PHPCS warnings and PHPStan bootstrap fatal (`sanitize_key()` redeclare); no new syntax failures found

## Related
- WSG validation run with thin aggregate packet: https://github.com/chubes4/wp-site-generator/actions/runs/26730626602
- Iterator tracker: https://github.com/chubes4/wp-site-generator/issues/368
- Converter issue generated without rich payload: https://github.com/chubes4/html-to-blocks-converter/issues/356

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the summary/payload gap, drafted the code/test changes, and ran local verification. Chris remains responsible for review and merge.