### PR TITLE
Stabilize compact import metrics

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -287,9 +287,12 @@ class Static_Site_Importer_Theme_Generator {
 		self::analyze_generated_theme_block_documents( $writes, $theme_dir );
 		self::record_visual_fidelity_targets( $pages, $page_ids, $permalinks, $writes, $theme_dir );
 		self::record_semantic_fidelity_targets( $pages, $page_ids, $permalinks, $writes, $theme_dir );
+		self::$conversion_report['theme_slug'] = $theme_slug;
 		self::record_product_seeding_report( $args );
 		self::record_commerce_dependency_check( $args );
 		$quality     = self::finalize_quality_report( $args );
+		$summary     = self::import_report_summary( self::$conversion_report, $quality );
+		self::$conversion_report['compact_summary'] = $summary;
 		$report_json = wp_json_encode( self::$conversion_report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 		if ( false === $report_json ) {
 			return new WP_Error( 'static_site_importer_report_encode_failed', 'Failed to encode import report JSON.' );
@@ -348,7 +351,7 @@ class Static_Site_Importer_Theme_Generator {
 			'theme_dir'             => $theme_dir,
 			'report_path'           => $theme_dir . '/import-report.json',
 			'external_report_path'  => $external_report_path,
-			'import_report_summary' => self::import_report_summary( self::$conversion_report, $quality ),
+			'import_report_summary' => $summary,
 			'source_dir'            => $site_dir,
 			'source_deleted'        => $source_deleted,
 			'source_cleanup_error'  => $source_cleanup_error,
@@ -521,9 +524,12 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		self::analyze_generated_theme_block_documents( $writes, $theme_dir );
+		self::$conversion_report['theme_slug'] = $theme_slug;
 		self::record_product_seeding_report( $args );
 		self::record_commerce_dependency_check( $args );
 		$quality     = self::finalize_quality_report( $args );
+		$summary     = self::import_report_summary( self::$conversion_report, $quality );
+		self::$conversion_report['compact_summary'] = $summary;
 		$report_json = wp_json_encode( self::$conversion_report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 		if ( false === $report_json ) {
 			return new WP_Error( 'static_site_importer_report_encode_failed', 'Failed to encode import report JSON.' );
@@ -565,7 +571,7 @@ class Static_Site_Importer_Theme_Generator {
 			'theme_dir'             => $theme_dir,
 			'report_path'           => $theme_dir . '/import-report.json',
 			'external_report_path'  => $external_report_path,
-			'import_report_summary' => self::import_report_summary( self::$conversion_report, $quality ),
+			'import_report_summary' => $summary,
 			'source_dir'            => '',
 			'source_deleted'        => false,
 			'source_cleanup_error'  => '',
@@ -8058,22 +8064,165 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return array<string, mixed>
 	 */
 	private static function import_report_summary( array $report, array $quality ): array {
-		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
+		$diagnostics      = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
+		$source_documents = isset( $report['source_documents'] ) && is_array( $report['source_documents'] ) ? $report['source_documents'] : array();
 
 		return array(
-			'status'                => ! empty( $quality['fail_import'] ) ? 'failed' : 'completed',
-			'entry_file'            => isset( $report['entry_file'] ) ? (string) $report['entry_file'] : '',
-			'quality_pass'          => ! empty( $quality['pass'] ),
-			'fail_import'           => ! empty( $quality['fail_import'] ),
-			'failure_reasons'       => isset( $quality['failure_reasons'] ) && is_array( $quality['failure_reasons'] ) ? array_values( $quality['failure_reasons'] ) : array(),
-			'fallback_count'        => (int) ( $quality['fallback_count'] ?? 0 ),
-			'core_html_block_count' => (int) ( $quality['core_html_block_count'] ?? 0 ),
-			'freeform_block_count'  => (int) ( $quality['freeform_block_count'] ?? 0 ),
-			'invalid_block_count'   => (int) ( $quality['invalid_block_count'] ?? 0 ),
-			'content_loss_count'    => (int) ( $quality['content_loss_count'] ?? 0 ),
-			'diagnostic_count'      => count( $diagnostics ),
-			'diagnostics'           => self::compact_import_report_diagnostics( $diagnostics ),
+			'schema'                       => 'static-site-importer/import-metrics/v1',
+			'version'                      => 1,
+			'report_version'               => (int) ( $report['version'] ?? 0 ),
+			'status'                       => ! empty( $quality['fail_import'] ) ? 'failed' : 'completed',
+			'theme_slug'                   => isset( $report['theme_slug'] ) ? (string) $report['theme_slug'] : '',
+			'entry_file'                   => isset( $report['entry_file'] ) ? (string) $report['entry_file'] : '',
+			'compiler'                     => self::compact_import_report_compiler_summary( $report ),
+			'quality_pass'                 => ! empty( $quality['pass'] ),
+			'fail_import'                  => ! empty( $quality['fail_import'] ),
+			'failure_reasons'              => isset( $quality['failure_reasons'] ) && is_array( $quality['failure_reasons'] ) ? array_values( $quality['failure_reasons'] ) : array(),
+			'fallback_count'               => (int) ( $quality['fallback_count'] ?? 0 ),
+			'content_loss_count'           => (int) ( $quality['content_loss_count'] ?? 0 ),
+			'empty_conversion_count'       => (int) ( $quality['empty_conversion_count'] ?? 0 ),
+			'core_html_block_count'        => (int) ( $quality['core_html_block_count'] ?? 0 ),
+			'freeform_block_count'         => (int) ( $quality['freeform_block_count'] ?? 0 ),
+			'invalid_block_count'          => (int) ( $quality['invalid_block_count'] ?? 0 ),
+			'invalid_block_document_count' => (int) ( $quality['invalid_block_document_count'] ?? 0 ),
+			'source_document_count'        => (int) ( $source_documents['total_count'] ?? 0 ),
+			'unresolved_link_count'        => (int) ( $source_documents['unresolved_link_count'] ?? 0 ),
+			'diagnostic_count'             => count( $diagnostics ),
+			'diagnostic_summary'           => self::compact_import_report_diagnostic_summary( $diagnostics ),
+			'warning_summaries'            => self::compact_import_report_diagnostic_summaries_by_severity( $diagnostics, 'warning' ),
+			'error_summaries'              => self::compact_import_report_diagnostic_summaries_by_severity( $diagnostics, 'error' ),
+			'diagnostics'                  => self::compact_import_report_diagnostics( $diagnostics ),
 		);
+	}
+
+	/**
+	 * Summarize compiler evidence for compact import metrics.
+	 *
+	 * @param array<string,mixed> $report Full conversion report.
+	 * @return array<string,mixed>
+	 */
+	private static function compact_import_report_compiler_summary( array $report ): array {
+		$compiler = isset( $report['block_artifact_compiler'] ) && is_array( $report['block_artifact_compiler'] ) ? $report['block_artifact_compiler'] : array();
+		$summary  = array(
+			'available'      => ! empty( $compiler['available'] ),
+			'fragment_count' => (int) ( $compiler['fragment_count'] ?? 0 ),
+		);
+
+		$website_artifact = isset( $compiler['website_artifact'] ) && is_array( $compiler['website_artifact'] ) ? $compiler['website_artifact'] : array();
+		$compiler_summary = isset( $website_artifact['summary'] ) && is_array( $website_artifact['summary'] ) ? $website_artifact['summary'] : array();
+		if ( empty( $compiler_summary ) && ! empty( $compiler['fragments'][0]['summary'] ) && is_array( $compiler['fragments'][0]['summary'] ) ) {
+			$compiler_summary = $compiler['fragments'][0]['summary'];
+		}
+
+		foreach ( array( 'schema', 'status', 'source' ) as $field ) {
+			if ( isset( $compiler_summary[ $field ] ) && is_scalar( $compiler_summary[ $field ] ) ) {
+				$summary[ $field ] = (string) $compiler_summary[ $field ];
+			}
+		}
+
+		if ( isset( $compiler_summary['diagnostic_count'] ) ) {
+			$summary['diagnostic_count'] = (int) $compiler_summary['diagnostic_count'];
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Summarize compact diagnostics by severity.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Normalized diagnostics.
+	 * @return array<string,int>
+	 */
+	private static function compact_import_report_diagnostic_summary( array $diagnostics ): array {
+		$summary = array(
+			'total'   => 0,
+			'error'   => 0,
+			'warning' => 0,
+			'notice'  => 0,
+			'info'    => 0,
+		);
+
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+
+			++$summary['total'];
+			$severity = isset( $diagnostic['severity'] ) && is_scalar( $diagnostic['severity'] ) ? (string) $diagnostic['severity'] : 'warning';
+			if ( ! array_key_exists( $severity, $summary ) ) {
+				$severity = 'warning';
+			}
+
+			++$summary[ $severity ];
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Build concise diagnostic summaries for a severity bucket.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Normalized diagnostics.
+	 * @param string                         $severity    Severity to include.
+	 * @return array<int,array<string,string>>
+	 */
+	private static function compact_import_report_diagnostic_summaries_by_severity( array $diagnostics, string $severity ): array {
+		$summaries = array();
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+
+			$diagnostic_severity = isset( $diagnostic['severity'] ) && is_scalar( $diagnostic['severity'] ) ? (string) $diagnostic['severity'] : 'warning';
+			if ( $severity !== $diagnostic_severity ) {
+				continue;
+			}
+
+			$summaries[] = array(
+				'id'      => isset( $diagnostic['id'] ) && is_scalar( $diagnostic['id'] ) ? (string) $diagnostic['id'] : '',
+				'type'    => isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : 'static_site_importer_diagnostic',
+				'source'  => self::diagnostic_summary_source( $diagnostic ),
+				'message' => self::diagnostic_summary_message( $diagnostic ),
+			);
+
+			if ( count( $summaries ) >= 10 ) {
+				break;
+			}
+		}
+
+		return $summaries;
+	}
+
+	/**
+	 * Resolve a concise diagnostic source label.
+	 *
+	 * @param array<string,mixed> $diagnostic Normalized diagnostic.
+	 * @return string
+	 */
+	private static function diagnostic_summary_source( array $diagnostic ): string {
+		foreach ( array( 'source_path', 'source' ) as $field ) {
+			if ( isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) ) {
+				return (string) $diagnostic[ $field ];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Resolve a concise diagnostic message.
+	 *
+	 * @param array<string,mixed> $diagnostic Normalized diagnostic.
+	 * @return string
+	 */
+	private static function diagnostic_summary_message( array $diagnostic ): string {
+		foreach ( array( 'message', 'reason', 'excerpt', 'error_message', 'html_excerpt' ) as $field ) {
+			if ( isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) && '' !== trim( (string) $diagnostic[ $field ] ) ) {
+				return self::diagnostic_excerpt( (string) $diagnostic[ $field ] );
+			}
+		}
+
+		return isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : 'static_site_importer_diagnostic';
 	}
 
 	/**

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -54,8 +54,26 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$result = $summary->invoke(
 			null,
 			array(
-				'entry_file'  => '/tmp/source/index.html',
-				'diagnostics' => array(
+				'entry_file'              => '/tmp/source/index.html',
+				'version'                 => 1,
+				'theme_slug'              => 'static-template-import',
+				'block_artifact_compiler' => array(
+					'available'        => true,
+					'fragment_count'   => 0,
+					'website_artifact' => array(
+						'summary' => array(
+							'schema'           => 'block-artifact-compiler/result/v1',
+							'status'           => 'success',
+							'source'           => 'artifact.json',
+							'diagnostic_count' => 0,
+						),
+					),
+				),
+				'source_documents'        => array(
+					'total_count'           => 2,
+					'unresolved_link_count' => 1,
+				),
+				'diagnostics'             => array(
 					array(
 						'id'                     => 'diag-001-unsupported_html_fallback-no_transform-indexhtml',
 						'type'                   => 'unsupported_html_fallback',
@@ -76,13 +94,27 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 				),
 			),
 			array(
-				'pass'           => false,
-				'fail_import'    => false,
-				'fallback_count' => 1,
+				'pass'                         => false,
+				'fail_import'                  => false,
+				'failure_reasons'              => array( 'unsupported_html_fallback' ),
+				'fallback_count'               => 1,
+				'empty_conversion_count'       => 0,
+				'invalid_block_document_count' => 0,
 			)
 		);
 
+		$this->assertSame( 'static-site-importer/import-metrics/v1', $result['schema'] ?? '' );
+		$this->assertSame( 1, $result['version'] ?? 0 );
+		$this->assertSame( 1, $result['report_version'] ?? 0 );
+		$this->assertSame( 'static-template-import', $result['theme_slug'] ?? '' );
+		$this->assertSame( 'block-artifact-compiler/result/v1', $result['compiler']['schema'] ?? '' );
+		$this->assertSame( 'success', $result['compiler']['status'] ?? '' );
 		$this->assertSame( 1, $result['diagnostic_count'] ?? 0 );
+		$this->assertSame( 2, $result['source_document_count'] ?? 0 );
+		$this->assertSame( 1, $result['unresolved_link_count'] ?? 0 );
+		$this->assertSame( 1, $result['diagnostic_summary']['warning'] ?? 0 );
+		$this->assertCount( 1, $result['warning_summaries'] ?? array() );
+		$this->assertSame( 'unsupported_html_fallback', $result['warning_summaries'][0]['type'] ?? '' );
 		$this->assertCount( 1, $result['diagnostics'] ?? array() );
 		$this->assertSame( 'diag-001-unsupported_html_fallback-no_transform-indexhtml', $result['diagnostics'][0]['id'] ?? '' );
 		$this->assertSame( 'index.html', $result['diagnostics'][0]['source_path'] ?? '' );

--- a/tests/StaticSiteImporterFixtureTest.php
+++ b/tests/StaticSiteImporterFixtureTest.php
@@ -273,6 +273,17 @@ class StaticSiteImporterFixtureTest extends WP_UnitTestCase {
 		$this->assertSame( 'success', $report['block_artifact_compiler']['website_artifact']['summary']['status'] ?? '' );
 		$this->assertSame( 'index.html', $report['block_artifact_compiler']['website_artifact']['provenance']['source'] ?? '' );
 		$this->assertNotEmpty( $report['block_artifact_compiler']['website_artifact']['provenance']['source_hash'] ?? '' );
+		$this->assertSame( 'static-site-importer/import-metrics/v1', $result['import_report_summary']['schema'] ?? '' );
+		$this->assertSame( 1, $result['import_report_summary']['version'] ?? null );
+		$this->assertSame( 1, $result['import_report_summary']['report_version'] ?? null );
+		$this->assertSame( 'website-artifact-fixture', $result['import_report_summary']['theme_slug'] ?? '' );
+		$this->assertSame( 'block-artifact-compiler/result/v1', $result['import_report_summary']['compiler']['schema'] ?? '' );
+		$this->assertSame( 'success', $result['import_report_summary']['compiler']['status'] ?? '' );
+		$this->assertSame( $result['import_report_summary'], $report['compact_summary'] ?? null );
+		$this->assertSame( $report['source_documents']['total_count'] ?? null, $result['import_report_summary']['source_document_count'] ?? null );
+		$this->assertArrayHasKey( 'empty_conversion_count', $result['import_report_summary'] );
+		$this->assertArrayHasKey( 'invalid_block_document_count', $result['import_report_summary'] );
+		$this->assertArrayHasKey( 'unresolved_link_count', $result['import_report_summary'] );
 		$this->assertContains( 'website_artifact_materialization_contract_note', wp_list_pluck( $report['diagnostics'] ?? array(), 'type' ) );
 	}
 

--- a/tests/smoke-wordpress-is-dead-fixture.php
+++ b/tests/smoke-wordpress-is-dead-fixture.php
@@ -119,6 +119,16 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( ! str_contains( $front_page, 'wp:pattern' ), 'front-page-does-not-embed-page-pattern' );
 	$assert( is_array( $report ), 'import-report-is-valid-json' );
 	$assert( isset( $report['quality']['fallback_count'] ), 'import-report-includes-fallback-count' );
+	$assert( 'static-site-importer/import-metrics/v1' === ( $result['import_report_summary']['schema'] ?? '' ), 'import-result-summary-has-schema' );
+	$assert( 1 === ( $result['import_report_summary']['version'] ?? 0 ), 'import-result-summary-has-version' );
+	$assert( 1 === ( $result['import_report_summary']['report_version'] ?? 0 ), 'import-result-summary-has-report-version' );
+	$assert( 'wordpress-is-dead-fixture' === ( $result['import_report_summary']['theme_slug'] ?? '' ), 'import-result-summary-has-theme-slug' );
+	$assert( is_array( $report['compact_summary'] ?? null ), 'import-report-includes-compact-summary' );
+	$assert( ( $report['compact_summary']['diagnostic_count'] ?? -1 ) === count( $report['diagnostics'] ?? array() ), 'compact-summary-counts-diagnostics' );
+	$assert( ( $report['compact_summary']['source_document_count'] ?? -1 ) === ( $report['source_documents']['total_count'] ?? -2 ), 'compact-summary-counts-source-documents' );
+	$assert( array_key_exists( 'unresolved_link_count', $report['compact_summary'] ?? array() ), 'compact-summary-includes-unresolved-link-count' );
+	$assert( array_key_exists( 'empty_conversion_count', $report['compact_summary'] ?? array() ), 'compact-summary-includes-empty-conversion-count' );
+	$assert( array_key_exists( 'invalid_block_document_count', $report['compact_summary'] ?? array() ), 'compact-summary-includes-invalid-block-document-count' );
 	$assert( isset( $report['conversion_fragments']['main:index.html'] ), 'import-report-groups-fragments-by-source' );
 	$assert( 'requires_external_render_check' === ( $report['visual_fidelity']['status'] ?? '' ), 'import-report-declares-visual-fidelity-render-check' );
 	$assert( 'benchmark_harness' === ( $report['visual_fidelity']['gate_owner'] ?? '' ), 'import-report-delegates-visual-gate-to-benchmark-harness' );
@@ -757,6 +767,11 @@ if ( false !== $wrote_quality ) {
 		$assert( 1 === ( $quality_result['quality']['fallback_count'] ?? 0 ), 'quality-result-counts-fallbacks' );
 		$assert( false === ( $quality_result['quality']['pass'] ?? true ), 'quality-result-fails-when-fallbacks-exist' );
 		$assert( true === ( $quality_result['quality']['fail_import'] ?? false ), 'quality-gate-fails-when-max-fallbacks-exceeded' );
+		$assert( 'static-site-importer/import-metrics/v1' === ( $quality_result['import_report_summary']['schema'] ?? '' ), 'quality-summary-has-schema' );
+		$assert( 1 === ( $quality_report['compact_summary']['fallback_count'] ?? 0 ), 'quality-compact-summary-counts-fallbacks' );
+		$assert( false === ( $quality_report['compact_summary']['quality_pass'] ?? true ), 'quality-compact-summary-fails' );
+		$assert( in_array( 'unsupported_html_fallback', $quality_report['compact_summary']['failure_reasons'] ?? array(), true ), 'quality-compact-summary-includes-failure-reason' );
+		$assert( ! empty( $quality_report['compact_summary']['warning_summaries'] ?? array() ), 'quality-compact-summary-includes-warning-summaries' );
 		$fallback_diagnostics = is_array( $quality_report ) ? array_values(
 			array_filter(
 				$quality_report['diagnostics'] ?? array(),


### PR DESCRIPTION
## Summary
- Adds a stable `static-site-importer/import-metrics/v1` compact metrics payload on `import_report_summary` and persisted `import-report.json` `compact_summary`.
- Keeps the full import report intact while giving Studio Web direct counts for diagnostics, fallbacks, content loss, empty conversions, core/html, freeform, invalid blocks/documents, source documents, unresolved links, quality reasons, warning/error summaries, compiler status, and theme slug.
- Extends focused fixture/unit smoke coverage for the compact summary returned from both direct imports and website-artifact imports.

## Studio Web field map
- Theme slug: `result.theme_slug` or `result.import_report_summary.theme_slug`
- Compact metrics schema/version: `result.import_report_summary.schema`, `result.import_report_summary.version`
- Full report version: `result.import_report_summary.report_version` or `import_report.version`
- Compiler summary: `result.import_report_summary.compiler.schema`, `.status`, `.source`, `.diagnostic_count`, `.fragment_count`
- Diagnostic count: `result.import_report_summary.diagnostic_count`
- Fallback count: `result.import_report_summary.fallback_count`
- Content loss count: `result.import_report_summary.content_loss_count`
- Empty conversion count: `result.import_report_summary.empty_conversion_count`
- Core/html block count: `result.import_report_summary.core_html_block_count`
- Freeform block count: `result.import_report_summary.freeform_block_count`
- Invalid block count: `result.import_report_summary.invalid_block_count`
- Invalid block document count: `result.import_report_summary.invalid_block_document_count`
- Source document count: `result.import_report_summary.source_document_count`
- Unresolved link count: `result.import_report_summary.unresolved_link_count`
- Quality pass/failure reasons: `result.import_report_summary.quality_pass`, `result.import_report_summary.failure_reasons`, `result.import_report_summary.fail_import`
- Concise diagnostic summaries: `result.import_report_summary.warning_summaries`, `result.import_report_summary.error_summaries`, with severity counts in `result.import_report_summary.diagnostic_summary`

## Verification
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFallbackDiagnosticsTest.php`
- `php -l tests/StaticSiteImporterFixtureTest.php`
- `php -l tests/smoke-wordpress-is-dead-fixture.php`
- `git diff --check`
- `studio wp --path=/Users/chubes/Studio/intelligence-chubes4 --skip-plugins eval '...compact summary reflection smoke...'`

## Blockers / notes
- `vendor/bin/phpunit --filter StaticSiteImporterFallbackDiagnosticsTest` and `vendor/bin/phpunit --filter StaticSiteImporterFixtureTest::test_website_artifact_bundle_imports_through_block_artifact_compiler` could not run because `vendor/bin/phpunit` is not installed in this checkout.
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-issue-285-compact-import-metrics` failed before tests ran: WP Codebox recipe bootstrap reported `Recipe workflow steps[0] failed: fetch failed`.
- `studio wp --path=/Users/chubes/Studio/intelligence-chubes4 eval-file .../tests/smoke-wordpress-is-dead-fixture.php` loaded the installed plugin before the worktree class, so new compact-summary assertions failed there. Rerunning with `--skip-plugins` loaded the worktree code; the new top-level compact-summary assertions passed, while existing fixture assertions unrelated to this PR still fail in this local environment.

Fixes #285.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the compact import metrics contract, tests, verification attempts, and PR field mapping for Chris to review.