### PR TITLE
Adopt Codebox artifact diagnostics normalization

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -7713,94 +7713,21 @@ class Static_Site_Importer_Theme_Generator {
 		$quality['diagnostic_refs']         = self::quality_diagnostic_refs( self::$conversion_report['diagnostics'] ?? array() );
 		self::$conversion_report['quality'] = $quality;
 		self::normalize_source_document_diagnostic_refs();
-		self::$conversion_report['artifact_diagnostics'] = self::codebox_artifact_diagnostics( self::$conversion_report['diagnostics'] ?? array() );
-		return $quality;
-	}
-
-	/**
-	 * Project SSI-owned diagnostics into the generic Codebox artifact diagnostics contract.
-	 *
-	 * @param array<int,array<string,mixed>> $diagnostics Normalized SSI diagnostics.
-	 * @return array<string,mixed>
-	 */
-	private static function codebox_artifact_diagnostics( array $diagnostics ): array {
-		$rows = array();
-		foreach ( $diagnostics as $index => $diagnostic ) {
-			if ( ! is_array( $diagnostic ) ) {
-				continue;
-			}
-
-			$rows[] = self::codebox_artifact_diagnostic( $diagnostic, $index );
-		}
-
-		$summary = array(
-			'total'   => count( $rows ),
-			'error'   => count( array_filter( $rows, static fn ( array $row ): bool => 'error' === ( $row['severity'] ?? '' ) ) ),
-			'warning' => count( array_filter( $rows, static fn ( array $row ): bool => 'warning' === ( $row['severity'] ?? '' ) ) ),
-			'notice'  => count( array_filter( $rows, static fn ( array $row ): bool => 'notice' === ( $row['severity'] ?? '' ) ) ),
-			'info'    => count( array_filter( $rows, static fn ( array $row ): bool => 'info' === ( $row['severity'] ?? '' ) ) ),
-		);
-
-		return array(
-			'schema'      => 'wp-codebox/artifact-diagnostics/v1',
-			'status'      => empty( $rows ) ? 'clean' : 'reported',
-			'summary'     => $summary,
-			'diagnostics' => $rows,
-		);
-	}
-
-	/**
-	 * Convert one SSI diagnostic into a generic artifact diagnostic row.
-	 *
-	 * @param array<string,mixed> $diagnostic Normalized SSI diagnostic.
-	 * @param int                 $index      Diagnostic index.
-	 * @return array<string,mixed>
-	 */
-	private static function codebox_artifact_diagnostic( array $diagnostic, int $index ): array {
-		$type     = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : 'static_site_importer_diagnostic';
-		$id       = isset( $diagnostic['id'] ) && is_scalar( $diagnostic['id'] ) ? (string) $diagnostic['id'] : 'static-site-importer-diagnostic-' . ( $index + 1 );
-		$path     = isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : '';
-		$message  = '';
-		foreach ( array( 'message', 'reason', 'excerpt', 'error_message' ) as $field ) {
-			if ( isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) && '' !== trim( (string) $diagnostic[ $field ] ) ) {
-				$message = (string) $diagnostic[ $field ];
-				break;
-			}
-		}
-		if ( '' === $message ) {
-			$message = $type;
-		}
-
-		$row = array(
-			'id'         => $id,
-			'type'       => $type,
-			'severity'   => isset( $diagnostic['severity'] ) && is_scalar( $diagnostic['severity'] ) ? (string) $diagnostic['severity'] : self::diagnostic_severity( $type ),
-			'message'    => $message,
-			'category'   => isset( $diagnostic['category'] ) && is_scalar( $diagnostic['category'] ) ? (string) $diagnostic['category'] : self::diagnostic_category( $type ),
-			'source'     => 'static-site-importer',
-			'path'       => $path,
-			'stage'      => isset( $diagnostic['stage'] ) && is_scalar( $diagnostic['stage'] ) ? (string) $diagnostic['stage'] : 'import',
-			'code'       => isset( $diagnostic['reason_code'] ) && is_scalar( $diagnostic['reason_code'] ) ? (string) $diagnostic['reason_code'] : $type,
-			'provenance' => array(
+		self::$conversion_report['artifact_diagnostics'] = Static_Site_Importer_WP_Codebox_Artifact_Diagnostics_Normalizer::build(
+			array( 'diagnostics' => self::$conversion_report['diagnostics'] ?? array() ),
+			array(
+				'source'          => 'static-site-importer',
+				'stage'           => 'import',
 				'observationType' => 'static-site-importer/import-report',
-			),
-			'refs'       => array(
-				array(
-					'path' => 'import-report.json',
-					'kind' => 'static-site-importer/import-report',
+				'refs'            => array(
+					array(
+						'path' => 'import-report.json',
+						'kind' => 'static-site-importer/import-report',
+					),
 				),
-			),
-			'details'    => $diagnostic,
+			)
 		);
-
-		if ( isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) && '' !== trim( (string) $diagnostic['selector'] ) ) {
-			$row['selector'] = (string) $diagnostic['selector'];
-		}
-
-		return array_filter(
-			$row,
-			static fn ( $value ): bool => ! ( '' === $value || array() === $value || null === $value )
-		);
+		return $quality;
 	}
 
 	/**

--- a/includes/class-static-site-importer-wp-codebox-artifact-diagnostics-normalizer.php
+++ b/includes/class-static-site-importer-wp-codebox-artifact-diagnostics-normalizer.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * WP Codebox artifact diagnostics normalization adapter.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Normalizes arbitrary observation/import-report diagnostics into the WP Codebox artifact diagnostics envelope.
+ */
+class Static_Site_Importer_WP_Codebox_Artifact_Diagnostics_Normalizer {
+
+	/**
+	 * Build a wp-codebox/artifact-diagnostics/v1 envelope.
+	 *
+	 * @param mixed                $input   Observation, observation list, or import-report shape.
+	 * @param array<string,mixed> $options Normalization defaults.
+	 * @return array<string,mixed>
+	 */
+	public static function build( mixed $input, array $options = array() ): array {
+		$observations = array_is_list( $input ) ? $input : array( $input );
+		$diagnostics  = array();
+
+		foreach ( $observations as $observation_index => $observation ) {
+			array_push( $diagnostics, ...self::diagnostics_from_observation( $observation, $observation_index, $options ) );
+		}
+
+		$summary = array(
+			'total'   => count( $diagnostics ),
+			'error'   => count( array_filter( $diagnostics, static fn ( array $diagnostic ): bool => 'error' === ( $diagnostic['severity'] ?? '' ) ) ),
+			'warning' => count( array_filter( $diagnostics, static fn ( array $diagnostic ): bool => 'warning' === ( $diagnostic['severity'] ?? '' ) ) ),
+			'notice'  => count( array_filter( $diagnostics, static fn ( array $diagnostic ): bool => 'notice' === ( $diagnostic['severity'] ?? '' ) ) ),
+			'info'    => count( array_filter( $diagnostics, static fn ( array $diagnostic ): bool => 'info' === ( $diagnostic['severity'] ?? '' ) ) ),
+		);
+
+		return array(
+			'schema'      => 'wp-codebox/artifact-diagnostics/v1',
+			'status'      => empty( $diagnostics ) ? 'clean' : 'reported',
+			'summary'     => $summary,
+			'diagnostics' => $diagnostics,
+		);
+	}
+
+	/**
+	 * Normalize diagnostics from one observation/import report.
+	 *
+	 * @param mixed                $observation       Observation-like value.
+	 * @param int                  $observation_index Observation index.
+	 * @param array<string,mixed> $options           Normalization defaults.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function diagnostics_from_observation( mixed $observation, int $observation_index, array $options ): array {
+		if ( ! is_array( $observation ) ) {
+			return array();
+		}
+
+		$payload = isset( $observation['data'] ) && is_array( $observation['data'] ) ? $observation['data'] : $observation;
+		$raw     = array_merge(
+			self::array_payload( $payload['diagnostics'] ?? null ),
+			self::array_payload( $payload['findings'] ?? null ),
+			self::array_payload( $payload['issues'] ?? null ),
+			self::array_payload( $payload['diagnostic'] ?? null )
+		);
+
+		if ( empty( $raw ) && ! array_key_exists( 'data', $observation ) && ! self::has_diagnostic_container( $observation ) ) {
+			$raw[] = $observation;
+		}
+
+		$diagnostics = array();
+		foreach ( $raw as $diagnostic_index => $diagnostic ) {
+			$normalized = self::normalize_diagnostic( $diagnostic, $observation, $observation_index, $diagnostic_index, $options );
+			if ( null !== $normalized ) {
+				$diagnostics[] = $normalized;
+			}
+		}
+
+		return $diagnostics;
+	}
+
+	/**
+	 * Detect an observation wrapper with explicit diagnostic containers.
+	 *
+	 * @param array<string,mixed> $observation Observation wrapper.
+	 * @return bool
+	 */
+	private static function has_diagnostic_container( array $observation ): bool {
+		foreach ( array( 'diagnostics', 'findings', 'issues', 'diagnostic' ) as $key ) {
+			if ( array_key_exists( $key, $observation ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Normalize one diagnostic row.
+	 *
+	 * @param mixed                $raw               Raw diagnostic row.
+	 * @param array<string,mixed> $observation       Observation wrapper.
+	 * @param int                  $observation_index Observation index.
+	 * @param int                  $diagnostic_index  Diagnostic index.
+	 * @param array<string,mixed> $options           Normalization defaults.
+	 * @return array<string,mixed>|null
+	 */
+	private static function normalize_diagnostic( mixed $raw, array $observation, int $observation_index, int $diagnostic_index, array $options ): ?array {
+		if ( ! is_array( $raw ) ) {
+			return null;
+		}
+
+		$type    = self::string_field( $raw['type'] ?? null ) ?: ( self::string_field( $raw['kind'] ?? null ) ?: ( self::string_field( $raw['code'] ?? null ) ?: ( self::string_field( $raw['reason_code'] ?? null ) ?: 'diagnostic' ) ) );
+		$message = self::string_field( $raw['message'] ?? null ) ?: ( self::string_field( $raw['summary'] ?? null ) ?: ( self::string_field( $raw['reason'] ?? null ) ?: ( self::string_field( $raw['excerpt'] ?? null ) ?: ( self::string_field( $raw['error_message'] ?? null ) ?: $type ) ) ) );
+
+		$detail_exclusions = array_flip(
+			array(
+				'id',
+				'diagnostic_id',
+				'type',
+				'kind',
+				'code',
+				'reason_code',
+				'message',
+				'summary',
+				'reason',
+				'excerpt',
+				'error_message',
+				'severity',
+				'category',
+				'source',
+				'path',
+				'source_path',
+				'selector',
+				'stage',
+				'refs',
+				'references',
+				'artifactRefs',
+			)
+		);
+		$details           = array_diff_key( $raw, $detail_exclusions );
+
+		$row = array(
+			'id'         => self::string_field( $raw['id'] ?? null ) ?: ( self::string_field( $raw['diagnostic_id'] ?? null ) ?: ( ( self::string_field( $observation['id'] ?? null ) ?: 'observation-' . $observation_index ) . '-diagnostic-' . ( $diagnostic_index + 1 ) ) ),
+			'type'       => $type,
+			'severity'   => self::normalize_severity( $raw['severity'] ?? null ),
+			'message'    => $message,
+			'category'   => self::string_field( $raw['category'] ?? null ),
+			'source'     => self::string_field( $raw['source'] ?? null ) ?: self::string_field( $options['source'] ?? null ),
+			'path'       => self::string_field( $raw['path'] ?? null ) ?: self::string_field( $raw['source_path'] ?? null ),
+			'selector'   => self::string_field( $raw['selector'] ?? null ),
+			'stage'      => self::string_field( $raw['stage'] ?? null ) ?: self::string_field( $options['stage'] ?? null ),
+			'code'       => self::string_field( $raw['code'] ?? null ) ?: self::string_field( $raw['reason_code'] ?? null ),
+			'provenance' => self::strip_empty(
+				array(
+					'observationId'   => self::string_field( $observation['id'] ?? null ),
+					'observationType' => self::string_field( $observation['type'] ?? null ) ?: self::string_field( $options['observationType'] ?? null ),
+					'observedAt'      => self::string_field( $observation['observedAt'] ?? null ),
+				)
+			),
+			'refs'       => self::diagnostic_refs( $raw['refs'] ?? ( $raw['references'] ?? ( $raw['artifactRefs'] ?? null ) ), isset( $options['refs'] ) && is_array( $options['refs'] ) ? $options['refs'] : array() ),
+			'details'    => empty( $details ) ? null : $details,
+		);
+
+		return self::strip_empty( $row );
+	}
+
+	/**
+	 * Normalize references.
+	 *
+	 * @param mixed             $raw      Raw refs.
+	 * @param array<int,mixed> $defaults Default refs.
+	 * @return array<int,array<string,string>>
+	 */
+	private static function diagnostic_refs( mixed $raw, array $defaults = array() ): array {
+		$refs = array();
+		foreach ( array_merge( $defaults, self::array_payload( $raw ) ) as $ref ) {
+			if ( ! is_array( $ref ) ) {
+				continue;
+			}
+
+			$normalized = self::strip_empty(
+				array(
+					'path' => self::string_field( $ref['path'] ?? null ),
+					'kind' => self::string_field( $ref['kind'] ?? null ),
+					'id'   => self::string_field( $ref['id'] ?? null ),
+					'url'  => self::string_field( $ref['url'] ?? null ),
+				)
+			);
+			if ( ! empty( $normalized ) ) {
+				$refs[] = $normalized;
+			}
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * Wrap object payloads like the WP Codebox normalizer.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return array<int,mixed>
+	 */
+	private static function array_payload( mixed $value ): array {
+		if ( is_array( $value ) && array_is_list( $value ) ) {
+			return $value;
+		}
+
+		return is_array( $value ) ? array( $value ) : array();
+	}
+
+	/**
+	 * Return scalar strings only when meaningful.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string|null
+	 */
+	private static function string_field( mixed $value ): ?string {
+		if ( is_string( $value ) && '' !== trim( $value ) ) {
+			return $value;
+		}
+		if ( is_int( $value ) || is_float( $value ) || is_bool( $value ) ) {
+			return (string) $value;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normalize severity.
+	 *
+	 * @param mixed $value Raw severity.
+	 * @return string
+	 */
+	private static function normalize_severity( mixed $value ): string {
+		$severity = strtolower( (string) ( self::string_field( $value ) ?? '' ) );
+
+		return in_array( $severity, array( 'error', 'warning', 'notice', 'info' ), true ) ? $severity : 'warning';
+	}
+
+	/**
+	 * Strip empty optional values from normalized rows.
+	 *
+	 * @param array<string,mixed> $row Row.
+	 * @return array<string,mixed>
+	 */
+	private static function strip_empty( array $row ): array {
+		return array_filter(
+			$row,
+			static fn ( mixed $value ): bool => ! ( '' === $value || array() === $value || null === $value )
+		);
+	}
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -26,6 +26,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-do
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-source-page.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-fetcher.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-wp-codebox-artifact-diagnostics-normalizer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-generator.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/abilities.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-admin.php';

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -125,6 +125,65 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Artifact diagnostics use the WP Codebox normalization contract.
+	 */
+	public function test_wp_codebox_artifact_diagnostics_normalizer_accepts_import_report_shape(): void {
+		$diagnostics = Static_Site_Importer_WP_Codebox_Artifact_Diagnostics_Normalizer::build(
+			array(
+				'diagnostics' => array(
+					array(
+						'id'          => 'diag-001',
+						'type'        => 'unsupported_html_fallback',
+						'severity'    => 'notice',
+						'reason_code' => 'no_transform',
+						'source_path' => 'index.html',
+						'selector'    => 'iframe#store-widget',
+						'message'     => 'Used fallback block.',
+						'block_name'  => 'core/html',
+					),
+					array(
+						'type'          => 'missing_asset',
+						'error_message' => 'Asset file is missing.',
+						'source_path'   => 'assets/hero.jpg',
+					),
+				),
+			),
+			array(
+				'source'          => 'static-site-importer',
+				'stage'           => 'import',
+				'observationType' => 'static-site-importer/import-report',
+				'refs'            => array(
+					array(
+						'path' => 'import-report.json',
+						'kind' => 'static-site-importer/import-report',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 'wp-codebox/artifact-diagnostics/v1', $diagnostics['schema'] ?? '' );
+		$this->assertSame( 'reported', $diagnostics['status'] ?? '' );
+		$this->assertSame( array( 'total' => 2, 'error' => 0, 'warning' => 1, 'notice' => 1, 'info' => 0 ), $diagnostics['summary'] ?? array() );
+		$this->assertSame( 'diag-001', $diagnostics['diagnostics'][0]['id'] ?? '' );
+		$this->assertSame( 'unsupported_html_fallback', $diagnostics['diagnostics'][0]['type'] ?? '' );
+		$this->assertSame( 'no_transform', $diagnostics['diagnostics'][0]['code'] ?? '' );
+		$this->assertSame( 'static-site-importer', $diagnostics['diagnostics'][0]['source'] ?? '' );
+		$this->assertSame( 'import', $diagnostics['diagnostics'][0]['stage'] ?? '' );
+		$this->assertSame( 'index.html', $diagnostics['diagnostics'][0]['path'] ?? '' );
+		$this->assertSame( 'iframe#store-widget', $diagnostics['diagnostics'][0]['selector'] ?? '' );
+		$this->assertSame( 'static-site-importer/import-report', $diagnostics['diagnostics'][0]['provenance']['observationType'] ?? '' );
+		$this->assertSame( 'import-report.json', $diagnostics['diagnostics'][0]['refs'][0]['path'] ?? '' );
+		$this->assertSame( 'core/html', $diagnostics['diagnostics'][0]['details']['block_name'] ?? '' );
+		$this->assertSame( 'Asset file is missing.', $diagnostics['diagnostics'][1]['message'] ?? '' );
+		$this->assertSame( 'warning', $diagnostics['diagnostics'][1]['severity'] ?? '' );
+
+		$empty = Static_Site_Importer_WP_Codebox_Artifact_Diagnostics_Normalizer::build( array( 'diagnostics' => array() ) );
+		$this->assertSame( 'clean', $empty['status'] ?? '' );
+		$this->assertSame( array( 'total' => 0, 'error' => 0, 'warning' => 0, 'notice' => 0, 'info' => 0 ), $empty['summary'] ?? array() );
+		$this->assertSame( array(), $empty['diagnostics'] ?? null );
+	}
+
+	/**
 	 * Generated core/html findings identify the generated document and block path.
 	 */
 	public function test_generated_core_html_diagnostic_includes_actionable_routing_metadata(): void {


### PR DESCRIPTION
## Summary
- Replaces the generator-local `codebox_artifact_diagnostics()` / `codebox_artifact_diagnostic()` helpers with a shared WP Codebox-shaped artifact diagnostics normalizer adapter.
- Normalizes SSI import-report diagnostics through the same option shape as Automattic/wp-codebox#749: `source`, `stage`, `observationType`, and `refs`.
- Adds focused coverage for import-report diagnostics and empty diagnostic containers.

Depends on Automattic/wp-codebox#749 for the upstream native JS/CLI seam. This PR keeps SSI's PHP report generation local while matching that contract.

## Testing
- `php -l static-site-importer.php`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l includes/class-static-site-importer-wp-codebox-artifact-diagnostics-normalizer.php`
- `php -l tests/StaticSiteImporterFallbackDiagnosticsTest.php`
- Standalone PHP normalizer contract smoke via `php -r ...`

## Notes
- `npm run test:validation` was run and failed in the active Studio-site fixture harness before completing. The failures were broad existing fixture/report and footer conversion assertions from the active site path, not the focused normalizer path in this worktree.
- I did not run the wp-site-generator end-to-end generation loop.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the PHP normalizer adapter, replacing the SSI generator-local helpers, and adding focused diagnostics coverage; Chris remains responsible for review and testing.