### PR TITLE
Route website artifact head metadata outside page blocks

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -455,6 +455,7 @@ class Static_Site_Importer_Theme_Generator {
 		if ( is_wp_error( $materialized ) ) {
 			return $materialized;
 		}
+		self::record_website_artifact_document_metadata( $artifacts );
 
 		$writes = array(
 			$theme_dir . '/style.css'                   => self::style_css( $theme_name, $materialized['css'], array_keys( self::$button_wrapper_classes ) ),
@@ -4695,6 +4696,153 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Record compiler-routed full-document metadata and head asset references.
+	 *
+	 * @param array<string,mixed> $artifacts WordPress artifacts from BAC.
+	 * @return void
+	 */
+	private static function record_website_artifact_document_metadata( array $artifacts ): void {
+		$metadata = isset( $artifacts['document_metadata'] ) && is_array( $artifacts['document_metadata'] ) ? $artifacts['document_metadata'] : array();
+		if ( 'block-artifact-compiler/document-metadata/v1' !== (string) ( $metadata['schema'] ?? '' ) ) {
+			return;
+		}
+
+		$normalized = array(
+			'schema'      => 'static-site-importer/document-metadata/v1',
+			'source'      => 'block-artifact-compiler/document_metadata',
+			'source_path' => isset( $metadata['source_path'] ) && is_scalar( $metadata['source_path'] ) ? (string) $metadata['source_path'] : '',
+			'title'       => isset( $metadata['title'] ) && is_scalar( $metadata['title'] ) ? sanitize_text_field( (string) $metadata['title'] ) : '',
+			'meta'        => self::normalize_document_metadata_rows( $metadata['meta'] ?? array(), array( 'charset', 'name', 'property', 'http_equiv', 'content' ) ),
+			'links'       => self::normalize_document_metadata_rows( $metadata['links'] ?? array(), array( 'rel', 'href', 'as', 'type', 'media', 'crossorigin', 'integrity' ) ),
+			'styles'      => self::normalize_hashed_head_assets( $metadata['styles'] ?? array() ),
+			'scripts'     => self::normalize_document_scripts( $metadata['scripts'] ?? array() ),
+		);
+
+		self::$conversion_report['generated_theme']['document_metadata'] = $normalized;
+		self::$conversion_report['diagnostics'][] = array(
+			'type'        => 'document_metadata_routed',
+			'source'      => $normalized['source_path'],
+			'severity'    => 'info',
+			'stage'       => 'website_artifact_materialization',
+			'message'     => 'Full-document head metadata/assets were routed through the generated_theme.document_metadata contract instead of generated page block content.',
+			'meta_count'  => count( $normalized['meta'] ),
+			'link_count'  => count( $normalized['links'] ),
+			'style_count' => count( $normalized['styles'] ),
+			'script_count' => count( $normalized['scripts'] ),
+		);
+	}
+
+	/**
+	 * Normalize scalar rows from the document metadata contract.
+	 *
+	 * @param mixed             $rows    Raw rows.
+	 * @param array<int,string> $allowed Allowed keys.
+	 * @return array<int,array<string,string>>
+	 */
+	private static function normalize_document_metadata_rows( mixed $rows, array $allowed ): array {
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$item = array();
+			foreach ( $allowed as $key ) {
+				if ( isset( $row[ $key ] ) && is_scalar( $row[ $key ] ) && '' !== trim( (string) $row[ $key ] ) ) {
+					$item[ $key ] = sanitize_text_field( (string) $row[ $key ] );
+				}
+			}
+
+			if ( ! empty( $item ) ) {
+				$normalized[] = $item;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize hashed inline head asset summaries.
+	 *
+	 * @param mixed $rows Raw rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function normalize_hashed_head_assets( mixed $rows ): array {
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$hash = isset( $row['hash'] ) && is_scalar( $row['hash'] ) ? preg_replace( '/[^a-f0-9]/i', '', (string) $row['hash'] ) : '';
+			$bytes = isset( $row['bytes'] ) ? max( 0, (int) $row['bytes'] ) : 0;
+			if ( '' === $hash && 0 === $bytes ) {
+				continue;
+			}
+
+			$normalized[] = array(
+				'bytes' => $bytes,
+				'hash'  => $hash,
+			);
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize script references from the document metadata contract.
+	 *
+	 * @param mixed $rows Raw rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function normalize_document_scripts( mixed $rows ): array {
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$item = array();
+			foreach ( array( 'src', 'type', 'crossorigin', 'integrity' ) as $key ) {
+				if ( isset( $row[ $key ] ) && is_scalar( $row[ $key ] ) && '' !== trim( (string) $row[ $key ] ) ) {
+					$item[ $key ] = sanitize_text_field( (string) $row[ $key ] );
+				}
+			}
+
+			foreach ( array( 'defer', 'async' ) as $key ) {
+				if ( isset( $row[ $key ] ) ) {
+					$item[ $key ] = (bool) $row[ $key ];
+				}
+			}
+
+			if ( isset( $row['inline'] ) ) {
+				$inline = self::normalize_hashed_head_assets( array( $row['inline'] ) );
+				if ( ! empty( $inline ) ) {
+					$item['inline'] = $inline[0];
+				}
+			}
+
+			if ( ! empty( $item ) ) {
+				$normalized[] = $item;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
 	 * Write compiler-emitted files that can be consumed without re-importing HTML.
 	 *
 	 * @param string              $theme_dir Theme directory.
@@ -5286,6 +5434,7 @@ class Static_Site_Importer_Theme_Generator {
 				'fragments'      => array(),
 			),
 			'generated_theme'         => array(
+				'document_metadata' => array(),
 				'block_documents' => array(),
 				'freeform_blocks' => array(),
 			),

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Smoke test: full-document website artifacts route head metadata out of blocks.
+ *
+ * Run inside a WordPress site with BAC/BFB available:
+ * wp eval-file tests/smoke-website-artifact-document-metadata.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+
+if ( ! defined( 'STATIC_SITE_IMPORTER_PATH' ) && is_readable( $plugin_root . '/static-site-importer.php' ) ) {
+	require_once $plugin_root . '/static-site-importer.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read = static function ( string $path ): string {
+	$contents = file_get_contents( $path );
+	return false === $contents ? '' : $contents;
+};
+
+$result = Static_Site_Importer_Theme_Generator::import_website_artifact(
+	array(
+		'schema' => 'block-artifact-compiler/website-artifact/v1',
+		'files'  => array(
+			array(
+				'path'    => 'index.html',
+				'content' => '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Ember & Rye</title><meta name="description" content="Wood-fired bakery"><link rel="stylesheet" href="/assets/site.css"></head><body><header class="site-header"><a href="/">Ember & Rye</a></header><main><section class="hero"><h1>Fire, flour, patience.</h1><p>Small-batch loaves.</p></section></main></body></html>',
+			),
+		),
+	),
+	array(
+		'name'        => 'Ember Rye Document Metadata',
+		'slug'        => 'ember-rye-document-metadata-smoke',
+		'overwrite'   => true,
+		'activate'    => false,
+		'keep_source' => true,
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+if ( ! is_wp_error( $result ) ) {
+	$theme_dir = $result['theme_dir'];
+	$pattern   = $read( $theme_dir . '/patterns/page-home.php' );
+	$report    = json_decode( $read( $result['report_path'] ), true );
+	$documents = array();
+	foreach ( $report['generated_theme']['block_documents'] ?? array() as $document ) {
+		if ( is_array( $document ) && isset( $document['path'] ) ) {
+			$documents[ $document['path'] ] = $document;
+		}
+	}
+	$metadata = $report['generated_theme']['document_metadata'] ?? array();
+
+	$assert( str_contains( $pattern, 'Fire, flour, patience.' ), 'body-content-is-preserved' );
+	$assert( ! str_contains( $pattern, '<meta' ), 'pattern-has-no-meta-fragments' );
+	$assert( ! str_contains( $pattern, '<title' ), 'pattern-has-no-title-fragments' );
+	$assert( ! str_contains( $pattern, '<link' ), 'pattern-has-no-link-fragments' );
+	$assert( 0 === ( $documents['patterns/page-home.php']['core_html_block_count'] ?? null ), 'report-pattern-has-zero-core-html' );
+	$assert( 0 === ( $report['quality']['core_html_block_count'] ?? null ), 'quality-core-html-count-is-zero' );
+	$assert( 'static-site-importer/document-metadata/v1' === ( $metadata['schema'] ?? '' ), 'metadata-contract-is-recorded' );
+	$assert( 'Ember & Rye' === ( $metadata['title'] ?? '' ), 'title-is-preserved-in-metadata' );
+	$assert( 'utf-8' === ( $metadata['meta'][0]['charset'] ?? '' ), 'charset-meta-is-preserved-in-metadata' );
+	$assert( 'viewport' === ( $metadata['meta'][1]['name'] ?? '' ), 'viewport-meta-is-preserved-in-metadata' );
+	$assert( '/assets/site.css' === ( $metadata['links'][0]['href'] ?? '' ), 'stylesheet-link-is-preserved-in-metadata' );
+}
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: website artifact document metadata smoke passed (' . $assertions . " assertions)\n";

--- a/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
+++ b/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
@@ -37,7 +37,11 @@ class Block_Artifact_Compiler {
 			$diagnostics[] = $this->diagnostic('missing_entry_html', 'error', 'No HTML entry file was available to compile.');
 		}
 
-		$conversion    = '' !== trim($html) ? $this->convert_html_to_blocks($html, $options) : array(
+		$entry_document = '' !== trim($html) ? $this->entry_document_contract($html, $entry_path) : array(
+			'body_html' => '',
+			'metadata'  => array(),
+		);
+		$conversion    = '' !== trim($entry_document['body_html']) ? $this->convert_html_to_blocks($entry_document['body_html'], $options) : array(
 			'serialized_blocks' => '',
 			'blocks'            => array(),
 			'diagnostics'       => array(),
@@ -48,10 +52,12 @@ class Block_Artifact_Compiler {
 		$diagnostics = array_merge($diagnostics, $conversion['diagnostics']);
 		$components  = $this->detect_components($normalized, $entry_path, $documents['components']);
 		$block_types = $this->build_block_types($normalized, $diagnostics);
+		$plugins     = $this->build_plugin_artifacts($normalized, $block_types);
 		$files       = $this->wordpress_files_from_artifact($normalized);
 		if ( '' === trim($html) && ! empty($documents['documents'][0]['block_markup']) ) {
 			$conversion['serialized_blocks'] = (string) $documents['documents'][0]['block_markup'];
 		}
+		$requirements = $this->build_artifact_requirements($conversion['serialized_blocks'], $block_types, $plugins);
 
 		return array(
 			'schema'              => self::RESULT_SCHEMA,
@@ -74,7 +80,10 @@ class Block_Artifact_Compiler {
 				'block_markup' => $conversion['serialized_blocks'],
 				'blocks'       => $conversion['blocks'],
 				'block_tree'   => $this->block_tree_report($conversion['blocks'], $conversion['serialized_blocks']),
+				'document_metadata' => $entry_document['metadata'],
 				'block_types'  => $block_types,
+				'plugins'      => $plugins,
+				'requirements' => $requirements,
 				'components'   => $components,
 				'documents'    => $documents['documents'],
 				'files'        => $files,
@@ -121,13 +130,15 @@ class Block_Artifact_Compiler {
 	 * @return array<string,mixed> Compact summary.
 	 */
 	public function summarize_result( array $compiled ): array {
-		$artifacts   = isset($compiled['wordpress_artifacts']) && is_array($compiled['wordpress_artifacts']) ? $compiled['wordpress_artifacts'] : array();
-		$block_types = isset($artifacts['block_types']) && is_array($artifacts['block_types']) ? $artifacts['block_types'] : array();
-		$components  = isset($artifacts['components']) && is_array($artifacts['components']) ? $artifacts['components'] : array();
-		$files       = isset($artifacts['files']) && is_array($artifacts['files']) ? $artifacts['files'] : array();
-		$diagnostics = isset($compiled['diagnostics']) && is_array($compiled['diagnostics']) ? $compiled['diagnostics'] : array();
-		$source      = isset($compiled['input']['source_report']) && is_array($compiled['input']['source_report']) ? $compiled['input']['source_report'] : array();
-		$block_tree  = isset($artifacts['block_tree']) && is_array($artifacts['block_tree']) ? $artifacts['block_tree'] : array();
+		$artifacts    = isset($compiled['wordpress_artifacts']) && is_array($compiled['wordpress_artifacts']) ? $compiled['wordpress_artifacts'] : array();
+		$block_types  = isset($artifacts['block_types']) && is_array($artifacts['block_types']) ? $artifacts['block_types'] : array();
+		$plugins      = isset($artifacts['plugins']) && is_array($artifacts['plugins']) ? $artifacts['plugins'] : array();
+		$requirements = isset($artifacts['requirements']) && is_array($artifacts['requirements']) ? $artifacts['requirements'] : array();
+		$components   = isset($artifacts['components']) && is_array($artifacts['components']) ? $artifacts['components'] : array();
+		$files        = isset($artifacts['files']) && is_array($artifacts['files']) ? $artifacts['files'] : array();
+		$diagnostics  = isset($compiled['diagnostics']) && is_array($compiled['diagnostics']) ? $compiled['diagnostics'] : array();
+		$source       = isset($compiled['input']['source_report']) && is_array($compiled['input']['source_report']) ? $compiled['input']['source_report'] : array();
+		$block_tree   = isset($artifacts['block_tree']) && is_array($artifacts['block_tree']) ? $artifacts['block_tree'] : array();
 
 		return array(
 			'schema'                    => isset($compiled['schema']) ? (string) $compiled['schema'] : '',
@@ -139,6 +150,8 @@ class Block_Artifact_Compiler {
 			'block_count'               => (int) ( $block_tree['block_count'] ?? 0 ),
 			'block_depth'               => (int) ( $block_tree['max_depth'] ?? 0 ),
 			'block_type_count'          => count($block_types),
+			'plugin_artifact_count'     => count($plugins),
+			'custom_block_requirement_count' => isset($requirements['custom_blocks']) && is_array($requirements['custom_blocks']) ? count($requirements['custom_blocks']) : 0,
 			'component_count'           => count($components),
 			'file_count'                => count($files),
 			'diagnostic_count'          => count($diagnostics),
@@ -423,6 +436,204 @@ class Block_Artifact_Compiler {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Split a full HTML document into renderable body markup and document metadata.
+	 *
+	 * @param string $html       Source HTML.
+	 * @param string $entry_path Source path.
+	 * @return array{body_html:string,metadata:array<string,mixed>}
+	 */
+	private function entry_document_contract( string $html, string $entry_path ): array {
+		$metadata = array(
+			'schema'      => 'block-artifact-compiler/document-metadata/v1',
+			'source_path' => $entry_path,
+			'title'       => '',
+			'meta'        => array(),
+			'links'       => array(),
+			'styles'      => array(),
+			'scripts'     => array(),
+		);
+
+		if ( '' === trim($html) || ! class_exists('DOMDocument') ) {
+			return array(
+				'body_html' => $html,
+				'metadata'  => $metadata,
+			);
+		}
+
+		$doc      = new DOMDocument();
+		$previous = libxml_use_internal_errors(true);
+		$loaded   = $doc->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+		libxml_clear_errors();
+		libxml_use_internal_errors($previous);
+		if ( ! $loaded ) {
+			return array(
+				'body_html' => $html,
+				'metadata'  => $metadata,
+			);
+		}
+
+		$head = $doc->getElementsByTagName('head')->item(0);
+		if ( $head instanceof DOMElement ) {
+			$metadata['title']   = $this->first_text_child($head, 'title');
+			$metadata['meta']    = $this->head_element_attributes($head, 'meta', array( 'charset', 'name', 'property', 'http-equiv', 'content' ));
+			$metadata['links']   = $this->head_element_attributes($head, 'link', array( 'rel', 'href', 'as', 'type', 'media', 'crossorigin', 'integrity' ));
+			$metadata['styles']  = $this->head_inline_contents($head, 'style');
+			$metadata['scripts'] = $this->head_script_contracts($head);
+		}
+
+		$body = $doc->getElementsByTagName('body')->item(0);
+		$body_html = $body instanceof DOMElement ? $this->inner_html($doc, $body) : $this->document_without_head($doc);
+
+		return array(
+			'body_html' => trim($body_html),
+			'metadata'  => $metadata,
+		);
+	}
+
+	/**
+	 * Read the first text child by tag name.
+	 *
+	 * @param DOMElement $root Root element.
+	 * @param string     $tag  Tag name.
+	 * @return string
+	 */
+	private function first_text_child( DOMElement $root, string $tag ): string {
+		$nodes = $root->getElementsByTagName($tag);
+		$node  = $nodes->length > 0 ? $nodes->item(0) : null;
+
+		return $node instanceof DOMNode ? trim((string) $node->textContent) : '';
+	}
+
+	/**
+	 * Collect safe attributes from head child elements.
+	 *
+	 * @param DOMElement        $head       Head element.
+	 * @param string            $tag        Tag name.
+	 * @param array<int,string> $attributes Attribute allow-list.
+	 * @return array<int,array<string,string>>
+	 */
+	private function head_element_attributes( DOMElement $head, string $tag, array $attributes ): array {
+		$items = array();
+		foreach ( $head->getElementsByTagName($tag) as $node ) {
+			if ( ! $node instanceof DOMElement ) {
+				continue;
+			}
+
+			$item = array();
+			foreach ( $attributes as $attribute ) {
+				$value = trim($node->getAttribute($attribute));
+				if ( '' !== $value ) {
+					$item[ str_replace('-', '_', $attribute) ] = $value;
+				}
+			}
+
+			if ( ! empty($item) ) {
+				$items[] = $item;
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Collect inline head element contents.
+	 *
+	 * @param DOMElement $head Head element.
+	 * @param string     $tag  Tag name.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function head_inline_contents( DOMElement $head, string $tag ): array {
+		$items = array();
+		foreach ( $head->getElementsByTagName($tag) as $node ) {
+			$content = trim((string) $node->textContent);
+			if ( '' === $content ) {
+				continue;
+			}
+
+			$items[] = array(
+				'content' => $content,
+				'bytes'   => strlen($content),
+				'hash'    => hash('sha256', $content),
+			);
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Collect script metadata from the document head.
+	 *
+	 * @param DOMElement $head Head element.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function head_script_contracts( DOMElement $head ): array {
+		$scripts = array();
+		foreach ( $head->getElementsByTagName('script') as $node ) {
+			if ( ! $node instanceof DOMElement ) {
+				continue;
+			}
+
+			$script = array();
+			foreach ( array( 'src', 'type', 'defer', 'async', 'crossorigin', 'integrity' ) as $attribute ) {
+				if ( $node->hasAttribute($attribute) ) {
+					$value = trim($node->getAttribute($attribute));
+					$script[ $attribute ] = '' === $value && in_array($attribute, array( 'defer', 'async' ), true) ? true : $value;
+				}
+			}
+
+			$content = trim((string) $node->textContent);
+			if ( '' !== $content ) {
+				$script['inline'] = array(
+					'bytes' => strlen($content),
+					'hash'  => hash('sha256', $content),
+				);
+			}
+
+			if ( ! empty($script) ) {
+				$scripts[] = $script;
+			}
+		}
+
+		return $scripts;
+	}
+
+	/**
+	 * Serialize a DOM element's children.
+	 *
+	 * @param DOMDocument $doc     Document.
+	 * @param DOMElement  $element Element.
+	 * @return string
+	 */
+	private function inner_html( DOMDocument $doc, DOMElement $element ): string {
+		$html = array();
+		foreach ( $element->childNodes as $child ) {
+			$serialized = $doc->saveHTML($child);
+			if ( false !== $serialized ) {
+				$html[] = $serialized;
+			}
+		}
+
+		return implode('', $html);
+	}
+
+	/**
+	 * Serialize the document after removing document-level head metadata.
+	 *
+	 * @param DOMDocument $doc Document.
+	 * @return string
+	 */
+	private function document_without_head( DOMDocument $doc ): string {
+		foreach ( iterator_to_array($doc->getElementsByTagName('head')) as $head ) {
+			if ( $head instanceof DOMNode && $head->parentNode instanceof DOMNode ) {
+				$head->parentNode->removeChild($head);
+			}
+		}
+
+		$html = $doc->saveHTML();
+		return false === $html ? '' : $html;
 	}
 
 	/**
@@ -1103,6 +1314,217 @@ class Block_Artifact_Compiler {
 	}
 
 	/**
+	 * Detect generated WordPress plugin artifact bundles without making install policy decisions.
+	 *
+	 * @param  array{files:array<int,array<string,mixed>>} $artifact    Normalized artifact.
+	 * @param  array<int,array<string,mixed>>              $block_types Generated block type artifacts.
+	 * @return array<int,array<string,mixed>> Plugin artifacts.
+	 */
+	private function build_plugin_artifacts( array $artifact, array $block_types ): array {
+		$plugin_roots = array();
+
+		foreach ( $artifact['files'] as $file ) {
+			$path = (string) $file['path'];
+			if ( ! str_ends_with(strtolower($path), '.php') ) {
+				continue;
+			}
+
+			$headers = $this->parse_plugin_headers((string) $file['content']);
+			if ( empty($headers) ) {
+				continue;
+			}
+
+			$directory = dirname($path);
+			$directory = '.' === $directory ? '' : $directory;
+			$slug      = '' === $directory ? bac_sanitize_key(basename($path, '.php')) : bac_sanitize_key(basename($directory));
+			if ( '' === $slug ) {
+				$slug = 'generated-plugin';
+			}
+
+			$plugin_roots[ $directory ] = array(
+				'slug'        => $slug,
+				'directory'   => $directory,
+				'plugin_file' => $path,
+				'headers'     => $headers,
+				'source_file' => $file,
+			);
+		}
+
+		$plugins = array();
+		foreach ( $plugin_roots as $directory => $root ) {
+			$plugin_files = $this->files_under_directory($artifact['files'], $directory);
+			$plugin_blocks = array_values(
+				array_filter(
+					$block_types,
+					static function ( array $block_type ) use ( $directory ): bool {
+						$block_directory = (string) ( $block_type['directory'] ?? '' );
+						return '' === $directory || $block_directory === $directory || str_starts_with($block_directory, $directory . '/');
+					}
+				)
+			);
+
+			$plugins[] = array(
+				'schema'      => 'chubes4/wordpress-plugin-artifact/v1',
+				'slug'        => $root['slug'],
+				'directory'   => $directory,
+				'plugin_file' => $root['plugin_file'],
+				'headers'     => $root['headers'],
+				'blocks'      => array_values(
+					array_map(
+						static function ( array $block_type ): array {
+							return array(
+								'name'            => (string) ( $block_type['name'] ?? '' ),
+								'directory'       => (string) ( $block_type['directory'] ?? '' ),
+								'block_json_path' => (string) ( $block_type['block_json_path'] ?? '' ),
+							);
+						},
+						$plugin_blocks
+					)
+				),
+				'provenance'  => array(
+					'source'      => (string) ( $root['source_file']['source'] ?? 'artifact' ),
+					'source_hash' => hash('sha256', $this->file_hash_payload($plugin_files)),
+					'files'       => array_values(array_map(static fn ( array $file ): string => $file['path'], $plugin_files)),
+				),
+				'files'       => array_values(
+					array_map(
+						static function ( array $file ): array {
+							return array(
+								'path'  => $file['path'],
+								'kind'  => $file['kind'],
+								'bytes' => $file['bytes'],
+							);
+						},
+						$plugin_files
+					)
+				),
+			);
+		}
+
+		usort(
+			$plugins,
+			static function ( array $left, array $right ): int {
+				return strcmp((string) $left['slug'], (string) $right['slug']);
+			}
+		);
+
+		return $plugins;
+	}
+
+	/**
+	 * Parse a minimal subset of WordPress plugin file headers.
+	 *
+	 * @return array<string,string> Header contract.
+	 */
+	private function parse_plugin_headers( string $content ): array {
+		$headers = array();
+		$fields  = array(
+			'name'             => 'Plugin Name',
+			'description'      => 'Description',
+			'version'          => 'Version',
+			'requires_at_least' => 'Requires at least',
+			'requires_php'     => 'Requires PHP',
+			'requires_plugins' => 'Requires Plugins',
+			'author'           => 'Author',
+			'text_domain'      => 'Text Domain',
+		);
+
+		foreach ( $fields as $target => $label ) {
+			if ( preg_match('/^[ \t*#\/]*' . preg_quote($label, '/') . ':[ \t]*(.+)$/mi', $content, $matches) ) {
+				$value = trim(strip_tags((string) $matches[1]));
+				if ( '' !== $value ) {
+					$headers[ $target ] = $value;
+				}
+			}
+		}
+
+		return isset($headers['name']) ? $headers : array();
+	}
+
+	/**
+	 * Build downstream-facing requirements detected from the generated bundle.
+	 *
+	 * @param  string                         $block_markup Serialized block markup.
+	 * @param  array<int,array<string,mixed>> $block_types  Generated block type artifacts.
+	 * @param  array<int,array<string,mixed>> $plugins      Generated plugin artifacts.
+	 * @return array<string,array<int,array<string,mixed>>> Requirement contract.
+	 */
+	private function build_artifact_requirements( string $block_markup, array $block_types, array $plugins ): array {
+		$provided_blocks = array();
+
+		foreach ( $block_types as $block_type ) {
+			$name = (string) ( $block_type['name'] ?? '' );
+			if ( '' !== $name ) {
+				$provided_blocks[ $name ] = (string) ( $block_type['directory'] ?? '' );
+			}
+		}
+
+		$custom_blocks = array();
+		foreach ( $this->detect_block_names($block_markup) as $name ) {
+			if ( str_starts_with($name, 'core/') ) {
+				continue;
+			}
+
+			$custom_blocks[ $name ] = array(
+				'name'       => $name,
+				'namespace'  => strtok($name, '/') ?: '',
+				'source'     => 'block_markup',
+				'status'     => isset($provided_blocks[ $name ]) ? 'provided' : 'external',
+				'directory'  => $provided_blocks[ $name ] ?? '',
+			);
+		}
+
+		foreach ( $provided_blocks as $name => $directory ) {
+			if ( isset($custom_blocks[ $name ]) ) {
+				continue;
+			}
+			$custom_blocks[ $name ] = array(
+				'name'       => $name,
+				'namespace'  => strtok($name, '/') ?: '',
+				'source'     => 'block_json',
+				'status'     => 'provided',
+				'directory'  => $directory,
+			);
+		}
+
+		ksort($custom_blocks);
+
+		return array(
+			'plugins'       => array_values(
+				array_map(
+					static function ( array $plugin ): array {
+						return array(
+							'slug'        => (string) ( $plugin['slug'] ?? '' ),
+							'plugin_file' => (string) ( $plugin['plugin_file'] ?? '' ),
+							'source'      => 'plugin_artifact',
+							'status'      => 'provided',
+						);
+					},
+					$plugins
+				)
+			),
+			'custom_blocks' => array_values($custom_blocks),
+		);
+	}
+
+	/**
+	 * Extract block names from serialized block comments.
+	 *
+	 * @return array<int,string> Block names.
+	 */
+	private function detect_block_names( string $block_markup ): array {
+		if ( '' === trim($block_markup) || ! preg_match_all('/<!--\s+wp:([a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*)\b/i', $block_markup, $matches) ) {
+			return array();
+		}
+
+		$names = array_map('strtolower', $matches[1]);
+		$names = array_values(array_unique($names));
+		sort($names);
+
+		return $names;
+	}
+
+	/**
 	 * Return non-entry files that SSI or another materializer may consume later.
 	 *
 	 * @param  array{files:array<int,array<string,mixed>>} $artifact Normalized artifact.
@@ -1236,7 +1658,7 @@ class Block_Artifact_Compiler {
 	 */
 	private function normalize_kind( string $kind, string $path, string $content, string $mime_type = '' ): string {
 		$kind = bac_sanitize_key($kind);
-		if ( in_array($kind, array( 'html', 'css', 'js', 'jsx', 'tsx', 'json', 'markdown', 'mdx', 'asset', 'blocks' ), true) ) {
+		if ( in_array($kind, array( 'html', 'css', 'js', 'jsx', 'tsx', 'php', 'json', 'markdown', 'mdx', 'asset', 'blocks' ), true) ) {
 			return $kind;
 		}
 		if ( str_contains($mime_type, '/') ) {
@@ -1261,6 +1683,7 @@ class Block_Artifact_Compiler {
 			'js', 'mjs'          => 'js',
 			'jsx'                => 'jsx',
 			'tsx'                => 'tsx',
+			'php'                => 'php',
 			'json'              => 'json',
 			'md', 'markdown'    => 'markdown',
 			'mdx'               => 'mdx',
@@ -1283,6 +1706,7 @@ class Block_Artifact_Compiler {
 			'js', 'mjs'          => 'application/javascript',
 			'jsx'               => 'text/jsx',
 			'tsx'               => 'text/tsx',
+			'php'               => 'application/x-httpd-php',
 			'json'              => 'application/json',
 			'md', 'markdown'    => 'text/markdown',
 			'mdx'               => 'text/mdx',
@@ -1365,7 +1789,7 @@ class Block_Artifact_Compiler {
 			return false;
 		}
 
-		return ! in_array($mime_type, array( 'application/json', 'application/javascript', 'image/svg+xml' ), true);
+		return ! in_array($mime_type, array( 'application/json', 'application/javascript', 'application/x-httpd-php', 'image/svg+xml' ), true);
 	}
 
 	/**

--- a/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
+++ b/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
@@ -138,6 +138,28 @@ $assert( ! empty( array_filter( $mdx['diagnostics'] ?? array(), static fn ( arra
 $fragment = bac_compile_fragment( '<div class="feature-card">Feature</div>', 'main:index.html' );
 $assert( 'main-index.html' === ( $fragment['input']['entry_path'] ?? '' ), 'fragment source is normalized to virtual path' );
 
+$full_document = bac_compile_website_artifact(
+	array(
+		'files' => array(
+			array(
+				'path'    => 'index.html',
+				'content' => '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Ember & Rye</title><meta name="description" content="Wood-fired bakery"><link rel="stylesheet" href="/assets/site.css"></head><body><header class="site-header"><a href="/">Ember & Rye</a></header><main><section class="hero"><h1>Fire, flour, patience.</h1><p>Small-batch loaves.</p></section></main></body></html>',
+			),
+		),
+	)
+);
+$full_document_markup = (string) ( $full_document['wordpress_artifacts']['block_markup'] ?? '' );
+$full_document_metadata = $full_document['wordpress_artifacts']['document_metadata'] ?? array();
+$assert( ! str_contains( $full_document_markup, '<meta' ), 'full document meta tags are not emitted as block content', $full_document_markup );
+$assert( ! str_contains( $full_document_markup, '<title' ), 'full document title tag is not emitted as block content', $full_document_markup );
+$assert( ! str_contains( $full_document_markup, '<link' ), 'full document link tags are not emitted as block content', $full_document_markup );
+$assert( str_contains( $full_document_markup, 'Fire, flour, patience.' ), 'full document body content is preserved in block content', $full_document_markup );
+$assert( 'block-artifact-compiler/document-metadata/v1' === ( $full_document_metadata['schema'] ?? '' ), 'full document exposes metadata contract' );
+$assert( 'Ember & Rye' === ( $full_document_metadata['title'] ?? '' ), 'full document title is routed to metadata contract' );
+$assert( 'utf-8' === ( $full_document_metadata['meta'][0]['charset'] ?? '' ), 'charset meta is routed to metadata contract' );
+$assert( 'viewport' === ( $full_document_metadata['meta'][1]['name'] ?? '' ), 'viewport meta is routed to metadata contract' );
+$assert( '/assets/site.css' === ( $full_document_metadata['links'][0]['href'] ?? '' ), 'stylesheet link is routed to metadata contract' );
+
 $summary = bac_summarize_result( $messy );
 $assert( ( $summary['component_count'] ?? 0 ) > 0, 'summary exposes component count' );
 $assert( ( $summary['source_element_count'] ?? 0 ) > 0, 'summary exposes source element count' );
@@ -245,5 +267,55 @@ $assert( in_array( 'blocks/hero/style.css', $hero['provenance']['files'] ?? arra
 
 $summary = bac_summarize_result( $blocks );
 $assert( 1 === ( $summary['block_type_count'] ?? 0 ), 'summary exposes block type count' );
+
+$plugin_bundle = bac_compile_website_artifact(
+	array(
+		'generated_html' => '<main><!-- wp:acme/hero {"headline":"Plugin block"} /--><!-- wp:vendor/card /--></main>',
+		'files'          => array(
+			'plugins/acme-blocks/acme-blocks.php'        => "<?php\n/**\n * Plugin Name: Acme Blocks\n * Description: Generated custom blocks.\n * Version: 0.1.0\n * Requires PHP: 8.1\n * Text Domain: acme-blocks\n */",
+			'plugins/acme-blocks/blocks/hero/block.json' => bac_json_encode(
+				array(
+					'apiVersion' => 3,
+					'name'       => 'acme/hero',
+					'title'      => 'Plugin Hero',
+					'category'   => 'design',
+				),
+				JSON_UNESCAPED_SLASHES
+			),
+			'plugins/acme-blocks/blocks/hero/index.js'   => 'wp.blocks.registerBlockType("acme/hero", {});',
+		),
+	)
+);
+$plugins = $plugin_bundle['wordpress_artifacts']['plugins'] ?? array();
+$assert( 1 === count( $plugins ), 'plugin header files are promoted into plugin artifacts' );
+$plugin = $plugins[0] ?? array();
+$assert( 'chubes4/wordpress-plugin-artifact/v1' === ( $plugin['schema'] ?? '' ), 'plugin artifact exposes contract schema' );
+$assert( 'acme-blocks' === ( $plugin['slug'] ?? '' ), 'plugin artifact exposes inferred slug' );
+$assert( 'Acme Blocks' === ( $plugin['headers']['name'] ?? '' ), 'plugin artifact preserves Plugin Name header' );
+$assert( '8.1' === ( $plugin['headers']['requires_php'] ?? '' ), 'plugin artifact preserves Requires PHP header' );
+$assert( 'plugins/acme-blocks/acme-blocks.php' === ( $plugin['plugin_file'] ?? '' ), 'plugin artifact exposes primary plugin file' );
+$assert( 'acme/hero' === ( $plugin['blocks'][0]['name'] ?? '' ), 'plugin artifact links generated block types in the plugin directory' );
+
+$requirements = $plugin_bundle['wordpress_artifacts']['requirements'] ?? array();
+$assert( 1 === count( $requirements['plugins'] ?? array() ), 'requirements expose provided plugin artifacts' );
+$assert( 'provided' === ( $requirements['plugins'][0]['status'] ?? '' ), 'plugin requirements mark generated plugin artifacts as provided' );
+$provided_block = null;
+$external_block = null;
+foreach ( $requirements['custom_blocks'] ?? array() as $requirement ) {
+	if ( 'acme/hero' === ( $requirement['name'] ?? '' ) ) {
+		$provided_block = $requirement;
+	}
+	if ( 'vendor/card' === ( $requirement['name'] ?? '' ) ) {
+		$external_block = $requirement;
+	}
+}
+$assert( is_array( $provided_block ), 'requirements include custom block usage satisfied by generated block.json' );
+$assert( 'provided' === ( $provided_block['status'] ?? '' ), 'provided custom block requirement is marked provided' );
+$assert( is_array( $external_block ), 'requirements include external custom block usage' );
+$assert( 'external' === ( $external_block['status'] ?? '' ), 'external custom block requirement stays external for downstream resolution' );
+
+$summary = bac_summarize_result( $plugin_bundle );
+$assert( 1 === ( $summary['plugin_artifact_count'] ?? 0 ), 'summary exposes plugin artifact count' );
+$assert( 2 === ( $summary['custom_block_requirement_count'] ?? 0 ), 'summary exposes custom block requirement count' );
 
 fwrite( STDOUT, "contract smoke passed\n" );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '318df50de1b94e59539ffc10d477e6ef083251ec',
+        'reference' => '82ae27b915eb1a5f4f581c00d9c5ec5fb2723697',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -35,7 +35,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '318df50de1b94e59539ffc10d477e6ef083251ec',
+            'reference' => '82ae27b915eb1a5f4f581c00d9c5ec5fb2723697',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- Consume BAC's `document_metadata` artifact contract during website-artifact materialization and record it in `generated_theme.document_metadata`.
- Refresh the vendored BAC copy so full-document head/title/meta/link fragments are routed out of generated page block markup.
- Add a WordPress smoke that imports an Ember & Rye style full-document artifact and proves body content is preserved while `core_html_block_count` remains `0`.

Closes #289.
Depends on chubes4/block-artifact-compiler#17.

## Context
The live proof `live-2026-06-07T13-35-09-597Z` failed because full-document head fragments were converted into `core/html` blocks in `patterns/page-home.php`.

Chris corrected the scope during implementation: this should not be solved by dropping head/meta/title/link fragments just to make `core_html_block_count` green. The fix routes document-level metadata/assets through an explicit transformer output contract and keeps meaningful rendered body structure/content in blocks.

## Tests
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/smoke-website-artifact-document-metadata.php`
- `php -l vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php`
- `php vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php`
- `studio wp eval-file /Users/chubes/Developer/static-site-importer@fix-issue-289-head-fragments/tests/smoke-website-artifact-document-metadata.php --skip-plugins`
- `studio wp eval-file /Users/chubes/Developer/static-site-importer@fix-issue-289-head-fragments/tests/smoke-extracted-chrome-fragments.php --skip-plugins`

## Notes
- Reproduced the bug by running the new smoke against the active pre-fix site plugin without `--skip-plugins`; it failed on head fragments in the pattern, non-zero `core_html_block_count`, and missing metadata contract.
- `npm run test:js-block-validation` currently fails in the baseline harness path because it reports an invalid block and then crashes printing a null summary.
- `npm run test:validation` currently cannot complete in this session because a local `.opencode` process is already bound to the harness fixture port `127.0.0.1:64157`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the SSI materialization/report changes, vendored BAC refresh, regression smoke, and PR notes; Chris remains responsible for review and merge.