### PR TITLE
Consume BAC HTML document artifacts

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "84ef81d485f359662e72564567c44f59cb4bc723"
+                "reference": "f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/84ef81d485f359662e72564567c44f59cb4bc723",
-                "reference": "84ef81d485f359662e72564567c44f59cb4bc723",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab",
+                "reference": "f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab",
                 "shasum": ""
             },
             "require": {
@@ -40,10 +40,10 @@
             ],
             "description": "Compile website artifacts into WordPress-native block artifact bundles.",
             "support": {
-                "source": "https://github.com/chubes4/block-artifact-compiler/tree/v0.1.2",
+                "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
                 "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
             },
-            "time": "2026-06-02T04:40:51+00:00"
+            "time": "2026-06-07T16:54:06+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/includes/class-static-site-importer-source-page.php
+++ b/includes/class-static-site-importer-source-page.php
@@ -171,7 +171,7 @@ class Static_Site_Importer_Source_Page {
 		}
 
 		$metadata = array();
-		foreach ( array( 'title', 'slug', 'status', 'post_type' ) as $key ) {
+		foreach ( array( 'title', 'slug', 'status', 'post_type', 'entrypoint' ) as $key ) {
 			if ( isset( $artifact[ $key ] ) && is_scalar( $artifact[ $key ] ) && '' !== trim( (string) $artifact[ $key ] ) ) {
 				$metadata[ $key ] = (string) $artifact[ $key ];
 			}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -482,17 +482,17 @@ class Static_Site_Importer_Theme_Generator {
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
+			self::analyze_imported_page_content_documents( $document_pages, $page_artifacts['contents'] );
 
 			self::record_bac_source_documents_summary( $artifacts['documents'] ?? array(), $document_pages, $page_ids, $permalinks );
-			foreach ( $page_artifacts['patterns'] as $filename => $pattern_slug ) {
+			foreach ( array_keys( $page_artifacts['patterns'] ) as $filename ) {
 				$page = $document_pages[ $filename ] ?? null;
 				$slug = $page instanceof Static_Site_Importer_Source_Page ? self::page_slug( $filename, $page ) : self::page_slug( $filename );
-				if ( '' === $pattern_slug || '' === $slug ) {
+				if ( '' === $slug ) {
 					continue;
 				}
 
 				$writes[ $theme_dir . '/templates/page-' . $slug . '.html' ] = self::content_template( '', false );
-				$writes[ $theme_dir . '/patterns/page-' . $slug . '.php' ]   = $page_artifacts['files'][ $filename ] ?? '';
 			}
 		} else {
 			self::record_button_wrapper_classes_from_blocks( $block_markup );
@@ -1658,6 +1658,27 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Analyze canonical imported page post content for conversion quality.
+	 *
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages    Pages.
+	 * @param array<string,string>                           $contents Converted block markup keyed by filename.
+	 * @return void
+	 */
+	private static function analyze_imported_page_content_documents( array $pages, array $contents ): void {
+		foreach ( $pages as $filename => $page ) {
+			$slug    = self::page_slug( $filename, $page );
+			$source  = '' !== $slug ? 'posts/page-' . $slug . '.post_content' : 'posts/' . sanitize_title( $filename ) . '.post_content';
+			$content = $contents[ $filename ] ?? '';
+			if ( '' === trim( $content ) ) {
+				continue;
+			}
+
+			$analysis = self::analyze_generated_block_document( $source, $content );
+			self::$conversion_report['generated_theme']['block_documents'][] = $analysis;
+		}
 	}
 
 	/**
@@ -3643,6 +3664,10 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return string
 	 */
 	private static function page_slug( string $filename, ?Static_Site_Importer_Source_Page $page = null ): string {
+		if ( $page instanceof Static_Site_Importer_Source_Page && 'bac_document' === $page->type() && self::is_index_source_filename( $filename ) && filter_var( $page->metadata_value( 'entrypoint' ), FILTER_VALIDATE_BOOLEAN ) ) {
+			return 'home';
+		}
+
 		if ( $page instanceof Static_Site_Importer_Source_Page && '' !== trim( $page->metadata_value( 'slug' ) ) ) {
 			$slug = sanitize_title( $page->metadata_value( 'slug' ) );
 			if ( '' !== $slug ) {

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -59,27 +59,92 @@ $assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $
 
 if ( ! is_wp_error( $result ) ) {
 	$theme_dir = $result['theme_dir'];
-	$pattern   = $read( $theme_dir . '/patterns/page-home.php' );
 	$report    = json_decode( $read( $result['report_path'] ), true );
+	$page_ids  = array_values( $result['pages'] ?? array() );
+	$page_id   = (int) ( $page_ids[0] ?? 0 );
+	$page      = $page_id > 0 ? get_post( $page_id ) : null;
+	$content   = $page instanceof WP_Post ? $page->post_content : '';
 	$documents = array();
+	$pattern_documents = array();
 	foreach ( $report['generated_theme']['block_documents'] ?? array() as $document ) {
 		if ( is_array( $document ) && isset( $document['path'] ) ) {
 			$documents[ $document['path'] ] = $document;
+			if ( str_starts_with( (string) $document['path'], 'patterns/page-' ) ) {
+				$pattern_documents[] = $document;
+			}
 		}
 	}
 	$metadata = $report['generated_theme']['document_metadata'] ?? array();
 
-	$assert( str_contains( $pattern, 'Fire, flour, patience.' ), 'body-content-is-preserved' );
-	$assert( ! str_contains( $pattern, '<meta' ), 'pattern-has-no-meta-fragments' );
-	$assert( ! str_contains( $pattern, '<title' ), 'pattern-has-no-title-fragments' );
-	$assert( ! str_contains( $pattern, '<link' ), 'pattern-has-no-link-fragments' );
-	$assert( 0 === ( $documents['patterns/page-home.php']['core_html_block_count'] ?? null ), 'report-pattern-has-zero-core-html' );
+	$assert( array() === $pattern_documents, 'single-document-import-does-not-generate-page-pattern-copy' );
+	$assert( str_contains( $content, 'Fire, flour, patience.' ), 'body-content-is-preserved' );
+	$assert( ! str_contains( $content, '<meta' ), 'page-content-has-no-meta-fragments' );
+	$assert( ! str_contains( $content, '<title' ), 'page-content-has-no-title-fragments' );
+	$assert( ! str_contains( $content, '<link' ), 'page-content-has-no-link-fragments' );
+	$assert( 0 === ( $documents['posts/page-home.post_content']['core_html_block_count'] ?? null ), 'report-page-content-has-zero-core-html' );
 	$assert( 0 === ( $report['quality']['core_html_block_count'] ?? null ), 'quality-core-html-count-is-zero' );
 	$assert( 'static-site-importer/document-metadata/v1' === ( $metadata['schema'] ?? '' ), 'metadata-contract-is-recorded' );
 	$assert( 'Ember & Rye' === ( $metadata['title'] ?? '' ), 'title-is-preserved-in-metadata' );
 	$assert( 'utf-8' === ( $metadata['meta'][0]['charset'] ?? '' ), 'charset-meta-is-preserved-in-metadata' );
 	$assert( 'viewport' === ( $metadata['meta'][1]['name'] ?? '' ), 'viewport-meta-is-preserved-in-metadata' );
 	$assert( '/assets/site.css' === ( $metadata['links'][0]['href'] ?? '' ), 'stylesheet-link-is-preserved-in-metadata' );
+}
+
+$multi_page_result = Static_Site_Importer_Theme_Generator::import_website_artifact(
+	array(
+		'schema'     => 'block-artifact-compiler/website-artifact/v1',
+		'entrypoint' => 'website/index.html',
+		'files'      => array(
+			array(
+				'path'    => 'website/index.html',
+				'content' => '<!doctype html><html><head><title>Home Page</title></head><body><main><h1>Home</h1><p>Welcome.</p></main></body></html>',
+			),
+			array(
+				'path'    => 'website/menu.html',
+				'content' => '<!doctype html><html><head><title>Menu Page</title></head><body><main><h1>Menu</h1><p>Pizza and small plates.</p></main></body></html>',
+			),
+			array(
+				'path'    => 'website/contact.html',
+				'content' => '<main><h1>Contact</h1><p>Email us.</p></main>',
+			),
+		)
+	),
+	array(
+		'name'        => 'Ember Rye Multi Page Artifact',
+		'slug'        => 'ember-rye-multi-page-artifact-smoke',
+		'overwrite'   => true,
+		'activate'    => false,
+		'keep_source' => true,
+	)
+);
+
+$assert( ! is_wp_error( $multi_page_result ), 'multi-page-import-succeeds', is_wp_error( $multi_page_result ) ? $multi_page_result->get_error_message() : '' );
+
+if ( ! is_wp_error( $multi_page_result ) ) {
+	$multi_report    = json_decode( $read( $multi_page_result['report_path'] ), true );
+	$source_docs     = $multi_report['source_documents'] ?? array();
+	$bac_documents   = $source_docs['bac_documents'] ?? array();
+	$block_documents = $multi_report['generated_theme']['block_documents'] ?? array();
+	$documents_by_source = array();
+	$pattern_documents = array();
+	foreach ( $bac_documents as $document ) {
+		if ( is_array( $document ) && isset( $document['source_path'] ) ) {
+			$documents_by_source[ $document['source_path'] ] = $document;
+		}
+	}
+	foreach ( $block_documents as $document ) {
+		if ( is_array( $document ) && str_starts_with( (string) ( $document['path'] ?? '' ), 'patterns/page-' ) ) {
+			$pattern_documents[] = $document;
+		}
+	}
+
+	$assert( 3 === ( $source_docs['bac_document_count'] ?? null ), 'multi-page-bac-document-count' );
+	$assert( 'block_artifact_compiler' === ( $source_docs['source'] ?? '' ), 'multi-page-source-is-bac' );
+	$assert( 'home' === ( $documents_by_source['website/index.html']['slug'] ?? '' ), 'entry-index-materializes-as-home' );
+	$assert( str_ends_with( (string) ( $documents_by_source['website/index.html']['permalink'] ?? '' ), '/' ), 'entry-index-has-front-page-permalink' );
+	$assert( 'menu' === ( $documents_by_source['website/menu.html']['slug'] ?? '' ), 'menu-page-materializes' );
+	$assert( 'contact' === ( $documents_by_source['website/contact.html']['slug'] ?? '' ), 'contact-page-materializes' );
+	$assert( array() === $pattern_documents, 'bac-document-import-does-not-generate-page-pattern-copies' );
 }
 
 if ( ! empty( $failures ) ) {

--- a/vendor/chubes4/block-artifact-compiler/README.md
+++ b/vendor/chubes4/block-artifact-compiler/README.md
@@ -47,8 +47,10 @@ The compiler result returns:
 - parsed blocks when WordPress parsing is available
 - component candidates from explicit `data-component` markers and repeated semantic class tokens
 - component candidates from MDX JSX references and generated JSX/TSX component files
-- post/page-like `documents` artifacts compiled from Markdown and MDX source documents
+- post/page-like `documents` artifacts compiled from HTML, Markdown, and MDX source documents
 - generated custom block type artifacts discovered from `block.json` roots
+- generated plugin artifacts discovered from WordPress plugin headers
+- materializer-facing plugin and custom-block requirements showing which generated artifacts are provided and which custom blocks remain external
 - generated file manifest for non-entry artifact files, including MIME type, role, encoding, binary marker, `content_base64` for binary assets, and CSS/JS intent when present or inferred
 - generated file manifest provenance, including uncompiled source documents with stable source hashes
 - diagnostics
@@ -56,6 +58,8 @@ The compiler result returns:
 - optional BFB conversion report
 
 Block type artifacts are normalized compiler output, not generation prompt constraints. Generation can produce loose files; the compiler identifies block roots, records diagnostics, and exposes a stable contract for downstream review and materialization.
+
+Plugin artifacts follow the same rule. BAC detects WordPress plugin headers, preserves safe header metadata and source file inventories, links generated `block.json` artifacts inside the plugin directory, and reports requirements without installing, activating, or resolving external plugins. Downstream materializers such as Static Site Importer can decide whether a `provided` plugin/custom-block artifact should be promoted or whether an `external` custom-block requirement needs a preinstalled dependency.
 
 ## Public API
 
@@ -94,6 +98,19 @@ array(
 	'wordpress_artifacts' => array(
 		'block_markup' => '<!-- wp:paragraph -->...',
 		'blocks'       => array(),
+		'documents'    => array(
+			array(
+				'source_path'       => 'website/menu.html',
+				'kind'              => 'html',
+				'post_type'         => 'page',
+				'slug'              => 'menu',
+				'title'             => 'Menu',
+				'entrypoint'        => false,
+				'document_metadata' => array(...),
+				'block_markup'      => '<!-- wp:paragraph -->...',
+				'provenance'        => array(...),
+			),
+		),
 		'block_types'  => array(
 			array(
 				'schema'          => 'chubes4/wordpress-block-type-artifact/v1',
@@ -128,6 +145,52 @@ array(
 					'files'       => array(...),
 				),
 				'files'           => array(),
+			),
+		),
+		'plugins'      => array(
+			array(
+				'schema'      => 'chubes4/wordpress-plugin-artifact/v1',
+				'slug'        => 'acme-blocks',
+				'directory'   => 'plugins/acme-blocks',
+				'plugin_file' => 'plugins/acme-blocks/acme-blocks.php',
+				'headers'     => array(
+					'name'         => 'Acme Blocks',
+					'version'      => '0.1.0',
+					'requires_php' => '8.1',
+				),
+				'blocks'      => array(
+					array(
+						'name'            => 'acme/hero',
+						'directory'       => 'plugins/acme-blocks/blocks/hero',
+						'block_json_path' => 'plugins/acme-blocks/blocks/hero/block.json',
+					),
+				),
+				'provenance'  => array(...),
+				'files'       => array(...),
+			),
+		),
+		'requirements' => array(
+			'plugins'       => array(
+				array(
+					'slug'        => 'acme-blocks',
+					'plugin_file' => 'plugins/acme-blocks/acme-blocks.php',
+					'source'      => 'plugin_artifact',
+					'status'      => 'provided',
+				),
+			),
+			'custom_blocks' => array(
+				array(
+					'name'      => 'acme/hero',
+					'namespace' => 'acme',
+					'source'    => 'block_json',
+					'status'    => 'provided',
+				),
+				array(
+					'name'      => 'vendor/card',
+					'namespace' => 'vendor',
+					'source'    => 'block_markup',
+					'status'    => 'external',
+				),
 			),
 		),
 		'components'   => array(),

--- a/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
+++ b/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
@@ -914,7 +914,33 @@ class Block_Artifact_Compiler {
 		$diagnostics = array();
 
 		foreach ( $artifact['files'] as $file ) {
-			if ( ! in_array($file['kind'], array( 'markdown', 'mdx' ), true) ) {
+			if ( ! in_array($file['kind'], array( 'html', 'markdown', 'mdx' ), true) ) {
+				continue;
+			}
+
+			if ( 'html' === $file['kind'] ) {
+				$document             = $this->entry_document_contract($file['content'], $file['path']);
+				$conversion           = $this->convert_html_to_blocks($document['body_html'], $options);
+				$document_diagnostics = $conversion['diagnostics'];
+				$diagnostics          = array_merge($diagnostics, $document_diagnostics);
+				$metadata             = $document['metadata'];
+
+				$documents[] = array(
+					'source_path'       => $file['path'],
+					'kind'              => 'html',
+					'post_type'         => 'page',
+					'slug'              => $this->slug_from_path($file['path']),
+					'title'             => '' !== (string) ( $metadata['title'] ?? '' ) ? (string) $metadata['title'] : $this->title_from_path($file['path']),
+					'excerpt'           => '',
+					'date'              => '',
+					'template'          => '',
+					'taxonomies'        => array(),
+					'entrypoint'        => ! empty($file['entrypoint']),
+					'document_metadata' => $metadata,
+					'block_markup'      => $conversion['serialized_blocks'],
+					'diagnostics'       => $document_diagnostics,
+					'provenance'        => $file['provenance'],
+				);
 				continue;
 			}
 

--- a/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
+++ b/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
@@ -160,6 +160,36 @@ $assert( 'utf-8' === ( $full_document_metadata['meta'][0]['charset'] ?? '' ), 'c
 $assert( 'viewport' === ( $full_document_metadata['meta'][1]['name'] ?? '' ), 'viewport meta is routed to metadata contract' );
 $assert( '/assets/site.css' === ( $full_document_metadata['links'][0]['href'] ?? '' ), 'stylesheet link is routed to metadata contract' );
 
+$multi_page = bac_compile_website_artifact(
+	array(
+		'schema'     => 'block-artifact-compiler/website-artifact/v1',
+		'entrypoint' => 'website/index.html',
+		'files'      => array(
+			array(
+				'path'    => 'website/index.html',
+				'content' => '<!doctype html><html><head><title>Home Page</title></head><body><main><h1>Home</h1><p>Welcome.</p></main></body></html>',
+			),
+			array(
+				'path'    => 'website/menu.html',
+				'content' => '<!doctype html><html><head><title>Menu Page</title><meta name="description" content="Seasonal menu"></head><body><main><h1>Menu</h1><p>Pizza and small plates.</p></main></body></html>',
+			),
+			array(
+				'path'    => 'website/contact.html',
+				'content' => '<main><h1>Contact</h1><p>Email us.</p></main>',
+			),
+		)
+	)
+);
+$multi_documents = $multi_page['wordpress_artifacts']['documents'] ?? array();
+$assert( 3 === count( $multi_documents ), 'multi-page HTML artifacts expose one document per HTML file' );
+$assert( 'index' === ( $multi_documents[0]['slug'] ?? '' ), 'entry index slug comes from filename' );
+$assert( true === ( $multi_documents[0]['entrypoint'] ?? null ), 'entry HTML document preserves entrypoint identity' );
+$assert( 'Home Page' === ( $multi_documents[0]['title'] ?? '' ), 'entry HTML document title comes from metadata' );
+$assert( 'menu' === ( $multi_documents[1]['slug'] ?? '' ), 'nested HTML page slug comes from filename' );
+$assert( 'Menu Page' === ( $multi_documents[1]['title'] ?? '' ), 'nested HTML document title comes from metadata' );
+$assert( 'Seasonal menu' === ( $multi_documents[1]['document_metadata']['meta'][0]['content'] ?? '' ), 'nested HTML document metadata is preserved' );
+$assert( str_contains( (string) ( $multi_documents[2]['block_markup'] ?? '' ), 'Contact' ), 'HTML document block markup preserves body content' );
+
 $summary = bac_summarize_result( $messy );
 $assert( ( $summary['component_count'] ?? 0 ) > 0, 'summary exposes component count' );
 $assert( ( $summary['source_element_count'] ?? 0 ) > 0, 'summary exposes source element count' );

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,18 +7,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "84ef81d485f359662e72564567c44f59cb4bc723"
+                "reference": "f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/84ef81d485f359662e72564567c44f59cb4bc723",
-                "reference": "84ef81d485f359662e72564567c44f59cb4bc723",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab",
+                "reference": "f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
-            "time": "2026-06-02T04:40:51+00:00",
+            "time": "2026-06-07T16:54:06+00:00",
             "default-branch": true,
             "type": "wordpress-plugin",
             "installation-source": "dist",
@@ -37,7 +37,7 @@
             ],
             "description": "Compile website artifacts into WordPress-native block artifact bundles.",
             "support": {
-                "source": "https://github.com/chubes4/block-artifact-compiler/tree/v0.1.2",
+                "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
                 "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
             },
             "install-path": "../chubes4/block-artifact-compiler"

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'chubes4/static-site-importer',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '82ae27b915eb1a5f4f581c00d9c5ec5fb2723697',
+        'reference' => '8296f2b91df286bfeaff1cf1e5df37817b9f5e85',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'chubes4/block-artifact-compiler' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '84ef81d485f359662e72564567c44f59cb4bc723',
+            'reference' => 'f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../chubes4/block-artifact-compiler',
             'aliases' => array(
@@ -35,7 +35,7 @@
         'chubes4/static-site-importer' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '82ae27b915eb1a5f4f581c00d9c5ec5fb2723697',
+            'reference' => '8296f2b91df286bfeaff1cf1e5df37817b9f5e85',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- Consume BAC's HTML `wordpress_artifacts.documents` contract so multi-page website artifacts materialize each accepted HTML file as a WordPress page.
- Keep BAC document page bodies in canonical page `post_content` instead of duplicating them into generated page pattern files.
- Include imported page `post_content` in SSI quality analysis so remaining `core/html` fallbacks are reported honestly against the editable content path.

## Verification
- `studio wp --skip-plugins=static-site-importer eval 'require \"/Users/chubes/Developer/static-site-importer@fix-issue-289-consume-bac-html-documents/tests/smoke-website-artifact-document-metadata.php\";'`
- `git diff --check`
- Frozen Ember & Rye BAC artifact rerun: 5 BAC documents materialized as 5 pages, no `patterns/page-*` block documents, remaining quality failure is `core_html_block_count=46` in `posts/page-*.post_content`.

## Follow-up
- The remaining frozen-artifact quality failure belongs in h2bc/BFB conversion fidelity: wrapper/layout/navigation/form fragments still become `core/html` blocks in page `post_content`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the SSI contract consumption changes, smoke coverage updates, and verification reruns for Chris to review.