### PR TITLE
Route page scripts into asset metadata

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -3568,7 +3568,7 @@ class Static_Site_Importer_Theme_Generator {
 	private static function source_page_content_blocks( Static_Site_Importer_Source_Page $page, array $route_map ): string {
 		$source_path = $page->source_key();
 		$source      = 'main:' . $source_path;
-		$body        = $page->body();
+		$body        = self::route_external_script_tags_from_page_body( $page->body(), $source_path, $source );
 		if ( 'blocks' === $page->body_format() ) {
 			return trim( $body );
 		}
@@ -3581,6 +3581,104 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return self::convert_fragment( $body, $source, $page->body_format() );
+	}
+
+	/**
+	 * Route generated external script references out of editable page content.
+	 *
+	 * @param string $body        Page body or block markup.
+	 * @param string $source_path Source-relative document path.
+	 * @param string $source      Diagnostic source label.
+	 * @return string Body with external script elements removed.
+	 */
+	private static function route_external_script_tags_from_page_body( string $body, string $source_path, string $source ): string {
+		if ( '' === trim( $body ) || stripos( $body, '<script' ) === false ) {
+			return $body;
+		}
+
+		$routed = preg_replace_callback(
+			'/<script\b([^>]*)>\s*<\/script>/is',
+			static function ( array $matches ) use ( $source_path, $source ): string {
+				$attributes = self::parse_simple_html_attributes( $matches[1] ?? '' );
+				$src        = isset( $attributes['src'] ) ? trim( (string) $attributes['src'] ) : '';
+				if ( '' === $src ) {
+					return $matches[0];
+				}
+
+				self::record_page_body_script_asset( $src, $source_path, $source, $attributes );
+				return '';
+			},
+			$body
+		) ?? $body;
+
+		return self::remove_empty_core_html_blocks( $routed );
+	}
+
+	/**
+	 * Remove empty raw-HTML block wrappers left after routing script tags.
+	 *
+	 * @param string $body Block markup.
+	 * @return string Block markup without empty core/html wrappers.
+	 */
+	private static function remove_empty_core_html_blocks( string $body ): string {
+		return preg_replace( '/<!--\s+wp:html\s+-->\s*<!--\s+\/wp:html\s+-->/i', '', $body ) ?? $body;
+	}
+
+	/**
+	 * Parse a conservative HTML attribute string.
+	 *
+	 * @param string $attribute_string Raw tag attribute string.
+	 * @return array<string,string|bool>
+	 */
+	private static function parse_simple_html_attributes( string $attribute_string ): array {
+		$attributes = array();
+		if ( preg_match_all( '/([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*(?:=\s*("([^"]*)"|\'([^\']*)\'|([^\s"\'>]+)))?/', $attribute_string, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				$name  = strtolower( $match[1] );
+				$value = true;
+				if ( isset( $match[3] ) && '' !== $match[3] ) {
+					$value = $match[3];
+				} elseif ( isset( $match[4] ) && '' !== $match[4] ) {
+					$value = $match[4];
+				} elseif ( isset( $match[5] ) && '' !== $match[5] ) {
+					$value = $match[5];
+				}
+
+				$attributes[ $name ] = is_string( $value ) ? html_entity_decode( $value, ENT_QUOTES, 'UTF-8' ) : $value;
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Record a script reference routed out of page block content.
+	 *
+	 * @param string                    $src         Script source.
+	 * @param string                    $source_path Source-relative document path.
+	 * @param string                    $source      Diagnostic source label.
+	 * @param array<string,string|bool> $attributes  Parsed script attributes.
+	 */
+	private static function record_page_body_script_asset( string $src, string $source_path, string $source, array $attributes ): void {
+		if ( ! isset( self::$conversion_report['assets']['scripts'] ) || ! is_array( self::$conversion_report['assets']['scripts'] ) ) {
+			self::$conversion_report['assets']['scripts'] = array();
+		}
+
+		$asset = self::resolve_local_asset_reference( $src, $source_path, $source );
+		$row   = array(
+			'source'      => $source,
+			'source_path' => $source_path,
+			'src'         => esc_url_raw( $src ),
+			'placement'   => 'page_body',
+			'routed_to'   => 'theme_asset_metadata',
+			'attributes'  => array_intersect_key( $attributes, array_fill_keys( array( 'type', 'defer', 'async', 'crossorigin', 'integrity' ), true ) ),
+		);
+
+		if ( null !== $asset ) {
+			$row['asset'] = $asset;
+		}
+
+		self::$conversion_report['assets']['scripts'][] = $row;
 	}
 
 	/**

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -42,7 +42,11 @@ $result = Static_Site_Importer_Theme_Generator::import_website_artifact(
 		'files'  => array(
 			array(
 				'path'    => 'index.html',
-				'content' => '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Ember & Rye</title><meta name="description" content="Wood-fired bakery"><link rel="stylesheet" href="/assets/site.css"></head><body><header class="site-header"><a href="/">Ember & Rye</a></header><main><section class="hero"><h1>Fire, flour, patience.</h1><p>Small-batch loaves.</p></section></main></body></html>',
+				'content' => '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Ember & Rye</title><meta name="description" content="Wood-fired bakery"><link rel="stylesheet" href="/assets/site.css"></head><body><header class="site-header"><a href="/">Ember & Rye</a></header><main><section class="hero"><h1>Fire, flour, patience.</h1><p>Small-batch loaves.</p></section></main><script src="assets/js/main.js" defer></script></body></html>',
+			),
+			array(
+				'path'    => 'assets/js/main.js',
+				'content' => 'document.documentElement.dataset.ready = "true";',
 			),
 		),
 	),
@@ -66,6 +70,7 @@ if ( ! is_wp_error( $result ) ) {
 	$content   = $page instanceof WP_Post ? $page->post_content : '';
 	$documents = array();
 	$pattern_documents = array();
+	$scripts = $report['assets']['scripts'] ?? array();
 	foreach ( $report['generated_theme']['block_documents'] ?? array() as $document ) {
 		if ( is_array( $document ) && isset( $document['path'] ) ) {
 			$documents[ $document['path'] ] = $document;
@@ -81,6 +86,7 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( ! str_contains( $content, '<meta' ), 'page-content-has-no-meta-fragments' );
 	$assert( ! str_contains( $content, '<title' ), 'page-content-has-no-title-fragments' );
 	$assert( ! str_contains( $content, '<link' ), 'page-content-has-no-link-fragments' );
+	$assert( ! str_contains( $content, '<script' ), 'page-content-has-no-script-fragments' );
 	$assert( 0 === ( $documents['posts/page-home.post_content']['core_html_block_count'] ?? null ), 'report-page-content-has-zero-core-html' );
 	$assert( 0 === ( $report['quality']['core_html_block_count'] ?? null ), 'quality-core-html-count-is-zero' );
 	$assert( 'static-site-importer/document-metadata/v1' === ( $metadata['schema'] ?? '' ), 'metadata-contract-is-recorded' );
@@ -88,6 +94,8 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( 'utf-8' === ( $metadata['meta'][0]['charset'] ?? '' ), 'charset-meta-is-preserved-in-metadata' );
 	$assert( 'viewport' === ( $metadata['meta'][1]['name'] ?? '' ), 'viewport-meta-is-preserved-in-metadata' );
 	$assert( '/assets/site.css' === ( $metadata['links'][0]['href'] ?? '' ), 'stylesheet-link-is-preserved-in-metadata' );
+	$assert( str_ends_with( (string) ( $scripts[0]['src'] ?? '' ), 'assets/js/main.js' ), 'script-src-is-preserved-in-asset-metadata' );
+	$assert( true === ( $scripts[0]['attributes']['defer'] ?? false ), 'script-defer-is-preserved-in-asset-metadata' );
 }
 
 $multi_page_result = Static_Site_Importer_Theme_Generator::import_website_artifact(


### PR DESCRIPTION
## Summary
- Strip generated external page-body script tags before page content conversion/materialization.
- Record routed script references under `assets.scripts` with selected attributes and local asset resolution when available.
- Remove empty `core/html` wrappers left after routing script-only blocks.

## Testing
- `studio wp --skip-plugins=static-site-importer eval 'require "/Users/chubes/Developer/static-site-importer@fix-issue-293-script-assets/tests/smoke-website-artifact-document-metadata.php";'`
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/smoke-website-artifact-document-metadata.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the script-routing patch and smoke coverage, then ran local verification; Chris remains responsible for review and landing.

Closes #293.