### PR TITLE
Consume compiler conversion diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ This repo is Homeboy-managed:
 
 ## Boundary
 
-This plugin owns static-site and website-artifact import workflows plus generated WordPress artifacts. [Block Artifact Compiler](https://github.com/chubes4/block-artifact-compiler) owns generated website artifact and fragment compilation. [Block Format Bridge](https://github.com/chubes4/block-format-bridge) owns content-format routing, conversion reports, and adapter ergonomics. The bundled HTML-to-blocks converter owns raw HTML transform mechanics underneath BFB.
+This plugin owns static-site and website-artifact import workflows plus generated WordPress artifacts. [Block Artifact Compiler](https://github.com/chubes4/block-artifact-compiler) owns generated website artifact and fragment compilation, including the materializer-neutral `block-artifact-compiler/compiled-site/v1` page route, shared-region, and theme-asset contract. [Block Format Bridge](https://github.com/chubes4/block-format-bridge) owns content-format routing, conversion reports, and adapter ergonomics. The bundled HTML-to-blocks converter owns raw HTML transform mechanics underneath BFB.
 
 The intended dependency direction is:
 
@@ -302,6 +302,6 @@ The intended dependency direction is:
 Static Site Importer -> Block Artifact Compiler -> Block Format Bridge -> HTML to Blocks Converter
 ```
 
-SSI import reports consume BAC/BFB result envelopes for fallback and conversion-quality diagnostics. They should not depend on lower-level h2bc hook names directly.
+SSI import reports consume BAC/BFB result envelopes for fallback and conversion-quality diagnostics, and record BAC's compiled-site contract when importing website artifacts. They should not depend on lower-level h2bc hook names directly or re-derive semantic page-route intent when BAC supplies it.
 
 Imported pages remain WordPress pages for routing, titles, front-page assignment, editor visibility, and body content edits. Their imported body layouts live on the page posts as block markup in `post_content`. The generated block theme owns shared header/footer parts, optional background decoration, frontend/editor styles, scripts, and template wrappers that render page bodies through `core/post-content`; the generic `templates/page.html` stays the fallback for pages created after import.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When a generated artifact contains full-document HTML, Static Site Importer rout
 - Allows ZIP/CLI source-site imports to include nested `.md` / `.markdown` content documents; `.mdx` is skipped with explicit diagnostics because MDX runtime components are not supported.
 - Provides a WP-CLI importer for a local HTML entry file or one public HTML URL; the local source file does not need to be named `index.html` unless you want automatic front-page assignment.
 - Discovers readable sibling `*.html` files beside the selected entry file and recursive Markdown content documents under the source tree, then imports them as WordPress pages.
-- Converts static HTML fragments through `bfb_convert( $html, 'html', 'blocks' )` and Markdown content through `bfb_convert( $markdown, 'markdown', 'blocks' )`.
+- Compiles static HTML fragments through Block Artifact Compiler, which delegates deterministic format conversion to Block Format Bridge and the bundled HTML-to-blocks converter. Markdown content still routes through Block Format Bridge's Markdown adapter.
 - Stores converted page bodies on the imported WordPress pages as `post_content`.
 - Generates a block theme with shared header/footer template parts, `core/post-content` templates, page patterns for reusable/reference artifacts, `theme.json`, `style.css`, and optional `assets/site.js`.
 - Rewrites local `.html` links to the imported WordPress page permalinks.
@@ -284,7 +284,7 @@ This repo is Homeboy-managed:
 
 ## Current Boundaries And Limitations
 
-- The importer is intentionally static-site/artifact-to-block-theme glue. Block Artifact Compiler owns generated website artifact compilation; Block Format Bridge owns format conversion; HTML-to-block transform fidelity belongs upstream in BFB/h2bc.
+- The importer is intentionally static-site/artifact-to-block-theme glue. Block Artifact Compiler owns generated website artifact and fragment compilation envelopes; Block Format Bridge owns format routing and conversion reports; HTML-to-block transform fidelity belongs upstream in BFB/h2bc.
 - The importer currently discovers flat sibling `*.html` files beside the selected entry file and recursive Markdown content documents; it does not crawl arbitrary nested HTML routes.
 - Admin imports accept pasted HTML, one public URL, a direct `.html` / `.htm` file, or a ZIP with a root `index.html` or exactly one nested `index.html`; CLI imports take a direct HTML entry path or one public URL.
 - MDX, Astro, Eleventy, Hugo, and other runtime/build orchestration is out of scope. Build those projects to static HTML first, or provide plain `.md` / `.markdown` source content alongside the HTML shell.
@@ -294,6 +294,14 @@ This repo is Homeboy-managed:
 
 ## Boundary
 
-This plugin owns static-site and website-artifact import workflows plus generated WordPress artifacts. [Block Artifact Compiler](https://github.com/chubes4/block-artifact-compiler) owns generated website artifact compilation. [Block Format Bridge](https://github.com/chubes4/block-format-bridge) owns content-format conversion.
+This plugin owns static-site and website-artifact import workflows plus generated WordPress artifacts. [Block Artifact Compiler](https://github.com/chubes4/block-artifact-compiler) owns generated website artifact and fragment compilation. [Block Format Bridge](https://github.com/chubes4/block-format-bridge) owns content-format routing, conversion reports, and adapter ergonomics. The bundled HTML-to-blocks converter owns raw HTML transform mechanics underneath BFB.
+
+The intended dependency direction is:
+
+```text
+Static Site Importer -> Block Artifact Compiler -> Block Format Bridge -> HTML to Blocks Converter
+```
+
+SSI import reports consume BAC/BFB result envelopes for fallback and conversion-quality diagnostics. They should not depend on lower-level h2bc hook names directly.
 
 Imported pages remain WordPress pages for routing, titles, front-page assignment, editor visibility, and body content edits. Their imported body layouts live on the page posts as block markup in `post_content`. The generated block theme owns shared header/footer parts, optional background decoration, frontend/editor styles, scripts, and template wrappers that render page bodies through `core/post-content`; the generic `templates/page.html` stays the fallback for pages created after import.

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab"
+                "reference": "130229703353fddee53e58b758c80e61d8919bb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab",
-                "reference": "f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/130229703353fddee53e58b758c80e61d8919bb7",
+                "reference": "130229703353fddee53e58b758c80e61d8919bb7",
                 "shasum": ""
             },
             "require": {
@@ -43,7 +43,7 @@
                 "source": "https://github.com/chubes4/block-artifact-compiler/tree/main",
                 "issues": "https://github.com/chubes4/block-artifact-compiler/issues"
             },
-            "time": "2026-06-07T16:54:06+00:00"
+            "time": "2026-06-07T19:40:38+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -4651,13 +4651,6 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		self::start_conversion_fragment( $source, $html );
-		$fallback_listener     = static function ( string $element_html, array $context, array $block ) use ( $source ): void {
-			self::record_unsupported_fallback( $source, $element_html, $context, $block );
-		};
-		$content_loss_listener = static function ( int $original_text_length, int $serialized_text_length ) use ( $source ): void {
-			self::record_content_loss( $source, $original_text_length, $serialized_text_length );
-		};
-
 		$commerce_metadata_listener = static function ( array $metadata ) use ( $source ): void {
 			self::record_commerce_conversion_metadata( $source, $metadata );
 		};
@@ -4665,14 +4658,10 @@ class Static_Site_Importer_Theme_Generator {
 			self::record_commerce_conversion_metadata( $source, array_merge( array( 'type' => 'materialization_request' ), $request ) );
 		};
 
-		add_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10, 3 );
-		add_action( 'html_to_blocks_conversion_aborted_content_loss', $content_loss_listener, 10, 2 );
 		add_action( 'bfb_conversion_metadata', $commerce_metadata_listener, 10, 1 );
 		add_action( 'bfb_materialization_request', $commerce_request_listener, 10, 1 );
 		$conversion_options = self::conversion_options( $source );
 		$blocks             = self::compile_fragment_to_blocks( $html, $source, $format, $conversion_options );
-		remove_action( 'html_to_blocks_unsupported_html_fallback', $fallback_listener, 10 );
-		remove_action( 'html_to_blocks_conversion_aborted_content_loss', $content_loss_listener, 10 );
 		remove_action( 'bfb_conversion_metadata', $commerce_metadata_listener, 10 );
 		remove_action( 'bfb_materialization_request', $commerce_request_listener, 10 );
 
@@ -4729,6 +4718,112 @@ class Static_Site_Importer_Theme_Generator {
 		if ( isset( self::$conversion_report['conversion_fragments'][ $source ] ) ) {
 			self::$conversion_report['conversion_fragments'][ $source ]['compiler'] = $payload;
 		}
+
+		self::record_compiler_conversion_diagnostics( $source, $compiled );
+	}
+
+	/**
+	 * Record conversion diagnostics surfaced by the BAC/BFB result envelope.
+	 *
+	 * @param string              $source   Source fragment label.
+	 * @param array<string,mixed> $compiled Compiler result envelope.
+	 * @return void
+	 */
+	private static function record_compiler_conversion_diagnostics( string $source, array $compiled ): void {
+		$report = isset( $compiled['bfb_report'] ) && is_array( $compiled['bfb_report'] ) ? $compiled['bfb_report'] : array();
+		if ( empty( $report ) ) {
+			return;
+		}
+
+		$fallbacks = isset( $report['fallback_events'] ) && is_array( $report['fallback_events'] ) ? $report['fallback_events'] : array();
+		if ( empty( $fallbacks ) && isset( $report['fallback_diagnostics'] ) && is_array( $report['fallback_diagnostics'] ) ) {
+			$fallbacks = $report['fallback_diagnostics'];
+		}
+
+		foreach ( $fallbacks as $fallback ) {
+			if ( ! is_array( $fallback ) ) {
+				continue;
+			}
+
+			self::record_compiler_unsupported_fallback( $source, $fallback );
+		}
+
+		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) || 'possible_text_loss' !== (string) ( $diagnostic['code'] ?? '' ) ) {
+				continue;
+			}
+
+			$details                = isset( $diagnostic['details'] ) && is_array( $diagnostic['details'] ) ? $diagnostic['details'] : array();
+			$original_text_length   = isset( $details['source_text_bytes'] ) ? (int) $details['source_text_bytes'] : (int) ( $report['source_text_bytes'] ?? 0 );
+			$serialized_text_length = isset( $details['converted_text_bytes'] ) ? (int) $details['converted_text_bytes'] : (int) ( $report['converted_text_bytes'] ?? 0 );
+			self::record_content_loss( $source, $original_text_length, $serialized_text_length );
+		}
+	}
+
+	/**
+	 * Record one unsupported fallback from the compiler report surface.
+	 *
+	 * @param string              $source   Source fragment label.
+	 * @param array<string,mixed> $fallback Normalized BFB fallback diagnostic.
+	 * @return void
+	 */
+	private static function record_compiler_unsupported_fallback( string $source, array $fallback ): void {
+		$preview = isset( $fallback['preview'] ) && is_scalar( $fallback['preview'] ) ? (string) $fallback['preview'] : '';
+		if ( '' === $preview && isset( $fallback['html_excerpt'] ) && is_scalar( $fallback['html_excerpt'] ) ) {
+			$preview = (string) $fallback['html_excerpt'];
+		}
+
+		$context = array(
+			'reason'   => isset( $fallback['reason_code'] ) && is_scalar( $fallback['reason_code'] ) ? (string) $fallback['reason_code'] : (string) ( $fallback['reason'] ?? 'unknown' ),
+			'tag_name' => isset( $fallback['tag_name'] ) && is_scalar( $fallback['tag_name'] ) ? (string) $fallback['tag_name'] : (string) ( $fallback['source_tag'] ?? '' ),
+		);
+
+		if ( isset( $fallback['occurrence'] ) && is_numeric( $fallback['occurrence'] ) ) {
+			$context['occurrence'] = (int) $fallback['occurrence'];
+		}
+
+		$selector = self::fallback_selector_from_compiler_diagnostic( $fallback );
+		if ( '' !== $selector ) {
+			$context['selector'] = $selector;
+		}
+
+		$block_name = isset( $fallback['generated_block_type'] ) && is_scalar( $fallback['generated_block_type'] ) ? (string) $fallback['generated_block_type'] : (string) ( $fallback['block_name'] ?? 'core/html' );
+		$block      = array(
+			'blockName'    => '' !== $block_name ? $block_name : 'core/html',
+			'attrs'        => array( 'content' => $preview ),
+			'innerHTML'    => $preview,
+			'innerContent' => array( $preview ),
+		);
+
+		self::record_unsupported_fallback( $source, $preview, $context, $block );
+	}
+
+	/**
+	 * Build a best-effort selector from a normalized compiler fallback diagnostic.
+	 *
+	 * @param array<string,mixed> $fallback Normalized BFB fallback diagnostic.
+	 * @return string
+	 */
+	private static function fallback_selector_from_compiler_diagnostic( array $fallback ): string {
+		$tag        = isset( $fallback['source_tag'] ) && is_scalar( $fallback['source_tag'] ) ? strtolower( (string) $fallback['source_tag'] ) : '';
+		$attributes = isset( $fallback['attributes'] ) && is_array( $fallback['attributes'] ) ? $fallback['attributes'] : array();
+		$id         = isset( $attributes['id'] ) && is_scalar( $attributes['id'] ) ? sanitize_html_class( (string) $attributes['id'] ) : '';
+		$classes    = isset( $fallback['classes'] ) && is_array( $fallback['classes'] ) ? $fallback['classes'] : array();
+		$selector   = '' !== $tag ? $tag : 'html';
+
+		if ( '' !== $id ) {
+			$selector .= '#' . $id;
+		}
+
+		foreach ( $classes as $class ) {
+			$class = is_scalar( $class ) ? sanitize_html_class( (string) $class ) : '';
+			if ( '' !== $class ) {
+				$selector .= '.' . $class;
+			}
+		}
+
+		return $selector;
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -375,15 +375,13 @@ class Static_Site_Importer_Theme_Generator {
 
 		$compiler_options = isset( $args['compiler_options'] ) && is_array( $args['compiler_options'] ) ? $args['compiler_options'] : array();
 		$compiled         = bac_compile_website_artifact( $artifact, array_merge( array( 'include_bfb_report' => true ), $compiler_options ) );
-		$artifacts        = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
-		$block_markup     = isset( $artifacts['block_markup'] ) ? (string) $artifacts['block_markup'] : '';
 		$document_pages   = self::bac_document_pages( $compiled );
 		if ( is_wp_error( $document_pages ) ) {
 			return $document_pages;
 		}
 
-		if ( 'failed' === (string) ( $compiled['status'] ?? '' ) || ( '' === trim( $block_markup ) && empty( $document_pages ) ) ) {
-			return new WP_Error( 'static_site_importer_artifact_compile_failed', 'Website artifact compilation did not produce block markup.', $compiled );
+		if ( 'failed' === (string) ( $compiled['status'] ?? '' ) || empty( $document_pages ) ) {
+			return new WP_Error( 'static_site_importer_artifact_compile_failed', 'Website artifact compilation did not produce BAC compiled-site document pages.', $compiled );
 		}
 
 		return self::import_compiled_website_artifact( $compiled, $args );
@@ -398,7 +396,6 @@ class Static_Site_Importer_Theme_Generator {
 	 */
 	private static function import_compiled_website_artifact( array $compiled, array $args = array() ) {
 		$artifacts    = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
-		$block_markup = isset( $artifacts['block_markup'] ) ? trim( (string) $artifacts['block_markup'] ) : '';
 		$theme_name   = isset( $args['name'] ) && '' !== trim( (string) $args['name'] ) ? sanitize_text_field( (string) $args['name'] ) : 'Imported Website Artifact';
 		$theme_slug   = isset( $args['slug'] ) && '' !== trim( (string) $args['slug'] ) ? sanitize_title( (string) $args['slug'] ) : sanitize_title( $theme_name );
 		if ( '' === $theme_slug ) {
@@ -469,55 +466,29 @@ class Static_Site_Importer_Theme_Generator {
 		);
 		$page_ids = array();
 
-		if ( ! empty( $document_pages ) ) {
-			$page_ids = self::create_page_shells( $document_pages );
-			if ( is_wp_error( $page_ids ) ) {
-				return $page_ids;
+		$page_ids = self::create_page_shells( $document_pages );
+		if ( is_wp_error( $page_ids ) ) {
+			return $page_ids;
+		}
+
+		$permalinks     = self::page_permalinks( $page_ids );
+		$route_map      = self::source_route_map( $document_pages, $permalinks );
+		$page_artifacts = self::page_artifacts( $document_pages, $route_map, $theme_slug );
+		$result         = self::write_page_contents( $document_pages, $page_ids, $page_artifacts['contents'] );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		self::analyze_imported_page_content_documents( $document_pages, $page_artifacts['contents'] );
+
+		self::record_bac_source_documents_summary( $artifacts['documents'] ?? array(), $document_pages, $page_ids, $permalinks );
+		foreach ( array_keys( $page_artifacts['patterns'] ) as $filename ) {
+			$page = $document_pages[ $filename ] ?? null;
+			$slug = $page instanceof Static_Site_Importer_Source_Page ? self::page_slug( $filename, $page ) : self::page_slug( $filename );
+			if ( '' === $slug ) {
+				continue;
 			}
 
-			$permalinks     = self::page_permalinks( $page_ids );
-			$route_map      = self::source_route_map( $document_pages, $permalinks );
-			$page_artifacts = self::page_artifacts( $document_pages, $route_map, $theme_slug );
-			$result         = self::write_page_contents( $document_pages, $page_ids, $page_artifacts['contents'] );
-			if ( is_wp_error( $result ) ) {
-				return $result;
-			}
-			self::analyze_imported_page_content_documents( $document_pages, $page_artifacts['contents'] );
-
-			self::record_bac_source_documents_summary( $artifacts['documents'] ?? array(), $document_pages, $page_ids, $permalinks );
-			foreach ( array_keys( $page_artifacts['patterns'] ) as $filename ) {
-				$page = $document_pages[ $filename ] ?? null;
-				$slug = $page instanceof Static_Site_Importer_Source_Page ? self::page_slug( $filename, $page ) : self::page_slug( $filename );
-				if ( '' === $slug ) {
-					continue;
-				}
-
-				$writes[ $theme_dir . '/templates/page-' . $slug . '.html' ] = self::content_template( '', false );
-			}
-		} else {
-			self::record_button_wrapper_classes_from_blocks( $block_markup );
-
-			$page_slug = 'home';
-			$existing  = get_page_by_path( $page_slug, OBJECT, 'page' );
-			$postarr   = array(
-				'post_title'   => 'Home',
-				'post_name'    => $page_slug,
-				'post_status'  => 'publish',
-				'post_type'    => 'page',
-				'post_content' => wp_slash( $block_markup ),
-			);
-			if ( $existing instanceof WP_Post ) {
-				$postarr['ID'] = $existing->ID;
-			}
-
-			$page_id = wp_insert_post( $postarr, true );
-			if ( is_wp_error( $page_id ) ) {
-				return $page_id;
-			}
-
-			$page_ids                                      = array( 'index.html' => (int) $page_id );
-			$writes[ $theme_dir . '/templates/page-home.html' ] = self::content_template( '', false );
-			$writes[ $theme_dir . '/patterns/page-home.php' ]   = self::pattern_file( 'Home', sanitize_key( $theme_slug ) . '/page-home', $block_markup );
+			$writes[ $theme_dir . '/templates/page-' . $slug . '.html' ] = self::content_template( '', false );
 		}
 
 		if ( '' !== trim( $materialized['js'] ) ) {
@@ -1400,10 +1371,9 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Normalize BAC WordPress document artifacts into source pages.
 	 *
-	 * SSI intentionally supports one narrow BAC-backed document shape during the
-	 * migration: `wordpress_artifacts.documents[]` entries with `source_path`,
-	 * `post_type`, `slug`, `title`, `status`, `block_markup`, and optional
-	 * `metadata`/`diagnostics`.
+	 * SSI consumes BAC's compiled-site page contract when available, then attaches
+	 * the referenced `wordpress_artifacts.documents[]` block markup for WordPress
+	 * materialization.
 	 *
 	 * @param array<string,mixed> $compiled Compiler result envelope.
 	 * @return array<string, Static_Site_Importer_Source_Page>|WP_Error
@@ -1411,6 +1381,18 @@ class Static_Site_Importer_Theme_Generator {
 	private static function bac_document_pages( array $compiled ) {
 		$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
 		$documents = isset( $artifacts['documents'] ) && is_array( $artifacts['documents'] ) ? $artifacts['documents'] : array();
+		$site      = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
+		if ( ! empty( $documents ) ) {
+			if ( 'block-artifact-compiler/compiled-site/v1' !== (string) ( $site['schema'] ?? '' ) || ! isset( $site['pages'] ) || ! is_array( $site['pages'] ) ) {
+				return new WP_Error( 'static_site_importer_bac_compiled_site_missing', 'BAC document artifacts require the block-artifact-compiler/compiled-site/v1 site contract.' );
+			}
+
+			$documents = self::bac_documents_from_compiled_site_pages( $site['pages'], $documents );
+			if ( is_wp_error( $documents ) ) {
+				return $documents;
+			}
+		}
+
 		$pages     = array();
 
 		foreach ( $documents as $document ) {
@@ -1427,6 +1409,61 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return $pages;
+	}
+
+	/**
+	 * Attach BAC document markup to compiled-site page contracts.
+	 *
+	 * @param array<int,array<string,mixed>> $site_pages Compiled-site page rows.
+	 * @param array<int,mixed>               $documents  BAC document artifacts.
+	 * @return array<int,array<string,mixed>>|WP_Error Document artifacts ordered by compiled-site pages.
+	 */
+	private static function bac_documents_from_compiled_site_pages( array $site_pages, array $documents ) {
+		$documents_by_source = array();
+		foreach ( $documents as $document ) {
+			if ( ! is_array( $document ) ) {
+				continue;
+			}
+
+			$source_path = isset( $document['source_path'] ) && is_scalar( $document['source_path'] ) ? (string) $document['source_path'] : '';
+			if ( '' !== $source_path ) {
+				$documents_by_source[ $source_path ] = $document;
+			}
+		}
+
+		$compiled_documents = array();
+		foreach ( $site_pages as $page ) {
+			if ( ! is_array( $page ) ) {
+				continue;
+			}
+
+			$source_path = isset( $page['source_path'] ) && is_scalar( $page['source_path'] ) ? (string) $page['source_path'] : '';
+			if ( '' === $source_path ) {
+				return new WP_Error( 'static_site_importer_compiled_site_page_missing_source', 'BAC compiled-site page is missing source_path.' );
+			}
+			if ( ! isset( $documents_by_source[ $source_path ] ) ) {
+				return new WP_Error( 'static_site_importer_compiled_site_page_missing_document', sprintf( 'BAC compiled-site page does not reference a document artifact: %s', $source_path ) );
+			}
+
+			$document = array_merge( $documents_by_source[ $source_path ], array_filter(
+				array(
+					'source_path' => $source_path,
+					'slug'        => isset( $page['slug'] ) && is_scalar( $page['slug'] ) ? (string) $page['slug'] : '',
+					'route_key'   => isset( $page['route_key'] ) && is_scalar( $page['route_key'] ) ? (string) $page['route_key'] : '',
+					'post_type'   => isset( $page['post_type'] ) && is_scalar( $page['post_type'] ) ? (string) $page['post_type'] : '',
+					'title'       => isset( $page['title'] ) && is_scalar( $page['title'] ) ? (string) $page['title'] : '',
+				),
+				static fn ( string $value ): bool => '' !== $value
+			) );
+
+			if ( ! empty( $page['entrypoint'] ) ) {
+				$document['entrypoint'] = '1';
+			}
+
+			$compiled_documents[] = $document;
+		}
+
+		return $compiled_documents;
 	}
 
 	/**
@@ -4866,6 +4903,8 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return void
 	 */
 	private static function record_website_artifact_compiler_result( array $compiled ): void {
+		$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$site      = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
 		self::$conversion_report['block_artifact_compiler']['available']        = true;
 		self::$conversion_report['block_artifact_compiler']['website_artifact'] = array(
 			'summary'     => bac_summarize_result( $compiled ),
@@ -4873,6 +4912,62 @@ class Static_Site_Importer_Theme_Generator {
 			'input'       => isset( $compiled['input'] ) && is_array( $compiled['input'] ) ? $compiled['input'] : array(),
 			'diagnostics' => isset( $compiled['diagnostics'] ) && is_array( $compiled['diagnostics'] ) ? $compiled['diagnostics'] : array(),
 		);
+
+		if ( 'block-artifact-compiler/compiled-site/v1' === (string) ( $site['schema'] ?? '' ) ) {
+			self::$conversion_report['block_artifact_compiler']['compiled_site'] = self::compiled_site_report_payload( $site );
+		}
+	}
+
+	/**
+	 * Preserve the BAC compiled-site contract in the SSI import report.
+	 *
+	 * @param array<string,mixed> $site BAC compiled-site artifact.
+	 * @return array<string,mixed>
+	 */
+	private static function compiled_site_report_payload( array $site ): array {
+		$pages          = isset( $site['pages'] ) && is_array( $site['pages'] ) ? $site['pages'] : array();
+		$shared_regions = isset( $site['shared_regions'] ) && is_array( $site['shared_regions'] ) ? $site['shared_regions'] : array();
+		$theme_assets   = isset( $site['theme_assets'] ) && is_array( $site['theme_assets'] ) ? $site['theme_assets'] : array();
+
+		return array(
+			'schema'              => (string) ( $site['schema'] ?? '' ),
+			'page_count'          => count( $pages ),
+			'pages'               => self::compiled_site_pages_report_payload( $pages ),
+			'shared_region_count' => count( $shared_regions ),
+			'shared_regions'      => $shared_regions,
+			'theme_assets'        => array(
+				'styles'  => isset( $theme_assets['styles'] ) && is_array( $theme_assets['styles'] ) ? $theme_assets['styles'] : array(),
+				'scripts' => isset( $theme_assets['scripts'] ) && is_array( $theme_assets['scripts'] ) ? $theme_assets['scripts'] : array(),
+			),
+			'provenance'          => isset( $site['provenance'] ) && is_array( $site['provenance'] ) ? $site['provenance'] : array(),
+		);
+	}
+
+	/**
+	 * Normalize compiled-site page rows for reports.
+	 *
+	 * @param array<int,mixed> $pages Compiled-site page rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function compiled_site_pages_report_payload( array $pages ): array {
+		$normalized = array();
+		foreach ( $pages as $page ) {
+			if ( ! is_array( $page ) ) {
+				continue;
+			}
+
+			$normalized[] = array(
+				'source_path' => isset( $page['source_path'] ) && is_scalar( $page['source_path'] ) ? (string) $page['source_path'] : '',
+				'route_key'   => isset( $page['route_key'] ) && is_scalar( $page['route_key'] ) ? (string) $page['route_key'] : '',
+				'slug'        => isset( $page['slug'] ) && is_scalar( $page['slug'] ) ? (string) $page['slug'] : '',
+				'post_type'   => isset( $page['post_type'] ) && is_scalar( $page['post_type'] ) ? (string) $page['post_type'] : '',
+				'title'       => isset( $page['title'] ) && is_scalar( $page['title'] ) ? (string) $page['title'] : '',
+				'entrypoint'  => ! empty( $page['entrypoint'] ),
+				'artifact'    => isset( $page['artifact'] ) && is_scalar( $page['artifact'] ) ? (string) $page['artifact'] : '',
+			);
+		}
+
+		return $normalized;
 	}
 
 	/**
@@ -4907,7 +5002,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::$conversion_report['diagnostics'][] = array(
 			'type'        => 'website_artifact_materialization_contract_note',
 			'source'      => '' !== $source ? $source : 'website_artifact',
-			'message'     => 'Direct materialization consumed current BAC block_markup and files artifacts. Rich multi-page, template-part, and source-to-theme asset reference maps should be added to the BAC contract before SSI relies on them.',
+			'message'     => 'Direct materialization consumed BAC block_markup, documents, files, and compiled-site artifacts. SSI owns WordPress writes while BAC owns materializer-neutral site/theme compilation.',
 			'contract'    => 'block-artifact-compiler/result/v1',
 			'constraints' => 'report_only',
 		);

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -11,6 +11,17 @@
 class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 
 	/**
+	 * SSI should consume BAC/BFB diagnostics instead of lower-level h2bc hooks.
+	 */
+	public function test_theme_generator_does_not_register_h2bc_conversion_hooks(): void {
+		$source = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php' );
+
+		$this->assertIsString( $source );
+		$this->assertStringNotContainsString( "add_action( 'html_to_blocks_", $source );
+		$this->assertStringNotContainsString( "remove_action( 'html_to_blocks_", $source );
+	}
+
+	/**
 	 * Unsupported fallback diagnostics include routing metadata for upstream triage.
 	 */
 	public function test_fallback_diagnostic_includes_actionable_routing_metadata(): void {

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -132,6 +132,7 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 	$multi_report    = json_decode( $read( $multi_page_result['report_path'] ), true );
 	$source_docs     = $multi_report['source_documents'] ?? array();
 	$bac_documents   = $source_docs['bac_documents'] ?? array();
+	$compiled_site   = $multi_report['block_artifact_compiler']['compiled_site'] ?? array();
 	$block_documents = $multi_report['generated_theme']['block_documents'] ?? array();
 	$documents_by_source = array();
 	$pattern_documents = array();
@@ -152,6 +153,9 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 	$assert( str_ends_with( (string) ( $documents_by_source['website/index.html']['permalink'] ?? '' ), '/' ), 'entry-index-has-front-page-permalink' );
 	$assert( 'menu' === ( $documents_by_source['website/menu.html']['slug'] ?? '' ), 'menu-page-materializes' );
 	$assert( 'contact' === ( $documents_by_source['website/contact.html']['slug'] ?? '' ), 'contact-page-materializes' );
+	$assert( 'block-artifact-compiler/compiled-site/v1' === ( $compiled_site['schema'] ?? '' ), 'compiled-site-contract-is-recorded' );
+	$assert( 3 === ( $compiled_site['page_count'] ?? null ), 'compiled-site-page-count-is-recorded' );
+	$assert( 'menu' === ( $compiled_site['pages'][1]['route_key'] ?? '' ), 'compiled-site-route-key-is-recorded' );
 	$assert( array() === $pattern_documents, 'bac-document-import-does-not-generate-page-pattern-copies' );
 }
 

--- a/vendor/chubes4/block-artifact-compiler/README.md
+++ b/vendor/chubes4/block-artifact-compiler/README.md
@@ -38,8 +38,11 @@ BAC treats Markdown and MDX as source documents, not generic assets:
 - `.md` and `.markdown` normalize as `kind: markdown` with `text/markdown`
 - `.mdx` normalizes as `kind: mdx` with BAC-local MIME type `text/mdx`
 - frontmatter maps to WordPress document metadata such as title, slug, post type, excerpt, date, template, and taxonomy hints
-- Markdown bodies are converted through Block Format Bridge when available, with a core/html preservation fallback otherwise
-- MDX bodies are reduced to Markdown-compatible text where feasible, while JSX imports/components stay inspectable as candidates and diagnostics
+- Markdown bodies are converted through Block Format Bridge when available
+- missing Block Format Bridge fails compilation by default when source conversion is required
+- `allow_bfb_unavailable_fallback` can be enabled for explicit standalone/test smoke coverage; that mode preserves source content in `core/html` and emits fallback diagnostics
+- MDX bodies are reduced to Markdown-compatible text where feasible, while JSX imports/components stay inspectable as conservative candidates and diagnostics
+- MDX/JSX handling is candidate extraction only; BAC does not evaluate MDX runtime semantics or compile JSX components
 
 The compiler result returns:
 
@@ -48,6 +51,7 @@ The compiler result returns:
 - component candidates from explicit `data-component` markers and repeated semantic class tokens
 - component candidates from MDX JSX references and generated JSX/TSX component files
 - post/page-like `documents` artifacts compiled from HTML, Markdown, and MDX source documents
+- a compiled `site` artifact with page route keys, shared chrome candidates, and theme-level style/script asset roles
 - generated custom block type artifacts discovered from `block.json` roots
 - generated plugin artifacts discovered from WordPress plugin headers
 - materializer-facing plugin and custom-block requirements showing which generated artifacts are provided and which custom blocks remain external
@@ -98,6 +102,33 @@ array(
 	'wordpress_artifacts' => array(
 		'block_markup' => '<!-- wp:paragraph -->...',
 		'blocks'       => array(),
+		'site'         => array(
+			'schema'         => 'block-artifact-compiler/compiled-site/v1',
+			'pages'          => array(
+				array(
+					'source_path' => 'website/menu.html',
+					'route_key'   => 'menu',
+					'slug'        => 'menu',
+					'post_type'   => 'page',
+					'title'       => 'Menu',
+					'entrypoint'  => false,
+					'artifact'    => 'wordpress_artifacts.documents',
+				),
+			),
+			'shared_regions' => array(
+				array(
+					'role'           => 'header',
+					'source_paths'   => array( 'website/index.html', 'website/menu.html' ),
+					'source_hash'    => '...',
+					'source_excerpt' => '<header>...</header>',
+				),
+			),
+			'theme_assets'   => array(
+				'styles'  => array(),
+				'scripts' => array(),
+			),
+			'provenance'     => array(...),
+		),
 		'documents'    => array(
 			array(
 				'source_path'       => 'website/menu.html',
@@ -209,6 +240,21 @@ $compiled = bac_compile_fragment( $html, 'main:index.html', 'html', $options );
 $summary  = bac_summarize_result( $compiled );
 $markup   = $compiled['wordpress_artifacts']['block_markup'];
 ```
+
+`bac_compile_fragment()` is the compiler-facing fragment envelope for supported source formats. Callers should pass `html`, `markdown`, or `blocks` instead of bypassing BAC to call BFB directly. BAC normalizes diagnostics, provenance, block tree reporting, and the optional BFB report around those conversions.
+
+When BFB is unavailable and conversion is required, the default result status is `failed` with a `bfb_unavailable` error diagnostic. Standalone smoke tests may opt into preservation fallback explicitly:
+
+```php
+$compiled = bac_compile_fragment(
+	$markdown,
+	'content/about.md',
+	'markdown',
+	array( 'allow_bfb_unavailable_fallback' => true )
+);
+```
+
+That fallback mode is not production conversion. It preserves source content as `core/html` and reports `bfb_unavailable_fallback` so downstream importers cannot mistake it for native conversion.
 
 ## Boundaries
 

--- a/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
+++ b/vendor/chubes4/block-artifact-compiler/includes/class-block-artifact-compiler.php
@@ -29,11 +29,12 @@ class Block_Artifact_Compiler {
 		$normalized  = $this->normalize_artifact($artifact, $options);
 		$documents   = $this->compile_source_documents($normalized, $options);
 		$entry       = $this->entry_file($normalized);
+		$block_entry = $this->entry_block_file($normalized);
 		$html        = is_array($entry) ? $entry['content'] : '';
 		$entry_path  = is_array($entry) ? $entry['path'] : '';
 		$diagnostics = array_merge($normalized['diagnostics'], $documents['diagnostics']);
 
-		if ( '' === trim($html) && empty($documents['documents']) ) {
+		if ( '' === trim($html) && ! is_array($block_entry) && empty($documents['documents']) ) {
 			$diagnostics[] = $this->diagnostic('missing_entry_html', 'error', 'No HTML entry file was available to compile.');
 		}
 
@@ -41,12 +42,19 @@ class Block_Artifact_Compiler {
 			'body_html' => '',
 			'metadata'  => array(),
 		);
-		$conversion    = '' !== trim($entry_document['body_html']) ? $this->convert_html_to_blocks($entry_document['body_html'], $options) : array(
+		$conversion    = '' !== trim($entry_document['body_html']) ? $this->convert_content_to_blocks($entry_document['body_html'], 'html', $options) : array(
 			'serialized_blocks' => '',
 			'blocks'            => array(),
 			'diagnostics'       => array(),
 			'report'            => array(),
 		);
+		if ( '' === trim($entry_document['body_html']) && is_array($block_entry) ) {
+			$entry_path  = (string) $block_entry['path'];
+			$conversion = $this->convert_content_to_blocks((string) $block_entry['content'], 'blocks', $options);
+		}
+		if ( '' === trim($entry_path) && ! empty($documents['documents'][0]['source_path']) ) {
+			$entry_path = (string) $documents['documents'][0]['source_path'];
+		}
 		$source_report = $this->source_report($normalized, $entry_path, $html);
 
 		$diagnostics = array_merge($diagnostics, $conversion['diagnostics']);
@@ -54,8 +62,10 @@ class Block_Artifact_Compiler {
 		$block_types = $this->build_block_types($normalized, $diagnostics);
 		$plugins     = $this->build_plugin_artifacts($normalized, $block_types);
 		$files       = $this->wordpress_files_from_artifact($normalized);
-		if ( '' === trim($html) && ! empty($documents['documents'][0]['block_markup']) ) {
+		if ( '' === trim($html) && ! is_array($block_entry) && ! empty($documents['documents'][0]['block_markup']) ) {
 			$conversion['serialized_blocks'] = (string) $documents['documents'][0]['block_markup'];
+			$conversion['blocks']            = isset($documents['documents'][0]['blocks']) && is_array($documents['documents'][0]['blocks']) ? $documents['documents'][0]['blocks'] : array();
+			$conversion['report']            = isset($documents['documents'][0]['bfb_report']) && is_array($documents['documents'][0]['bfb_report']) ? $documents['documents'][0]['bfb_report'] : array();
 		}
 		$requirements = $this->build_artifact_requirements($conversion['serialized_blocks'], $block_types, $plugins);
 
@@ -81,6 +91,7 @@ class Block_Artifact_Compiler {
 				'blocks'       => $conversion['blocks'],
 				'block_tree'   => $this->block_tree_report($conversion['blocks'], $conversion['serialized_blocks']),
 				'document_metadata' => $entry_document['metadata'],
+				'site'         => $this->compiled_site_artifact($normalized, $documents['documents']),
 				'block_types'  => $block_types,
 				'plugins'      => $plugins,
 				'requirements' => $requirements,
@@ -439,6 +450,31 @@ class Block_Artifact_Compiler {
 	}
 
 	/**
+	 * Return the entry file when the source is already serialized block markup.
+	 *
+	 * @param  array{files:array<int,array<string,mixed>>,entrypoints?:array<int,string>} $artifact Normalized artifact.
+	 * @return array<string,mixed>|null
+	 */
+	private function entry_block_file( array $artifact ): ?array {
+		$entrypoints = $artifact['entrypoints'] ?? array();
+		foreach ( $entrypoints as $entrypoint ) {
+			foreach ( $artifact['files'] as $file ) {
+				if ( $entrypoint === $file['path'] && 'blocks' === $file['kind'] && empty($file['binary']) ) {
+					return $file;
+				}
+			}
+		}
+
+		foreach ( $artifact['files'] as $file ) {
+			if ( 'blocks' === $file['kind'] && empty($file['binary']) ) {
+				return $file;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Split a full HTML document into renderable body markup and document metadata.
 	 *
 	 * @param string $html       Source HTML.
@@ -637,17 +673,20 @@ class Block_Artifact_Compiler {
 	}
 
 	/**
-	 * Convert HTML to block markup through BFB/H2BC when available.
+	 * Convert supported source content to block markup through BFB/H2BC when available.
 	 *
-	 * @param  string              $html    Source HTML.
+	 * @param  string              $content Source content.
+	 * @param  string              $format  Source format.
 	 * @param  array<string,mixed> $options Compiler options.
 	 * @return array{serialized_blocks:string,blocks:array,diagnostics:array<int,array<string,mixed>>,report:array<string,mixed>}
 	 */
-	private function convert_html_to_blocks( string $html, array $options ): array {
-		if ( str_contains($html, '<!-- wp:') && function_exists('parse_blocks') && function_exists('serialize_blocks') ) {
-			$blocks = parse_blocks($html);
+	private function convert_content_to_blocks( string $content, string $format, array $options ): array {
+		$format = $this->normalize_fragment_format($format);
+		if ( 'blocks' === $format || str_contains($content, '<!-- wp:') ) {
+			$blocks           = function_exists('parse_blocks') ? parse_blocks($content) : array();
+			$serialized_blocks = function_exists('serialize_blocks') && ! empty($blocks) ? serialize_blocks($blocks) : $content;
 			return array(
-				'serialized_blocks' => serialize_blocks($blocks),
+				'serialized_blocks' => $serialized_blocks,
 				'blocks'            => $blocks,
 				'diagnostics'       => array(),
 				'report'            => array(
@@ -658,10 +697,10 @@ class Block_Artifact_Compiler {
 		}
 
 		if ( function_exists('bfb_convert') ) {
-			$block_markup = (string) bfb_convert($html, 'html', 'blocks', $options);
+			$block_markup = (string) bfb_convert($content, $format, 'blocks', $options);
 			$report       = array( 'status' => '' === trim($block_markup) ? 'failed' : 'success_native' );
 			if ( ! empty($options['include_bfb_report']) && function_exists('bfb_conversion_report') ) {
-				$report = bfb_conversion_report($html, 'html', $options);
+				$report = bfb_conversion_report($content, $format, $options);
 			}
 
 			return array(
@@ -672,13 +711,30 @@ class Block_Artifact_Compiler {
 			);
 		}
 
+		if ( empty($options['allow_bfb_unavailable_fallback']) ) {
+			return array(
+				'serialized_blocks' => '',
+				'blocks'            => array(),
+				'diagnostics'       => array(
+					$this->diagnostic('bfb_unavailable', 'error', 'BFB is unavailable; source conversion cannot run in production compile mode.', array( 'format' => $format )),
+				),
+				'report'            => array(
+					'status' => 'failed',
+					'source' => $format,
+				),
+			);
+		}
+
 		return array(
-			'serialized_blocks' => '<!-- wp:html -->' . "\n" . $html . "\n" . '<!-- /wp:html -->',
+			'serialized_blocks' => '<!-- wp:html -->' . "\n" . $content . "\n" . '<!-- /wp:html -->',
 			'blocks'            => array(),
 			'diagnostics'       => array(
-				$this->diagnostic('bfb_unavailable', 'warning', 'BFB is unavailable; preserved source HTML as a core/html fallback.'),
+				$this->diagnostic('bfb_unavailable_fallback', 'warning', 'BFB is unavailable; preserved source content as an explicit core/html fallback.', array( 'format' => $format )),
 			),
-			'report'            => array( 'status' => 'success_with_fallbacks' ),
+			'report'            => array(
+				'status' => 'success_with_fallbacks',
+				'source' => $format,
+			),
 		);
 	}
 
@@ -694,6 +750,151 @@ class Block_Artifact_Compiler {
 			'html'       => $this->html_structure_report($html),
 			'css'        => $this->css_structure_report($artifact['files']),
 		);
+	}
+
+	/**
+	 * Build a materializer-neutral compiled site/theme artifact.
+	 *
+	 * @param  array{files:array<int,array<string,mixed>>} $artifact  Normalized artifact.
+	 * @param  array<int,array<string,mixed>>              $documents Compiled document artifacts.
+	 * @return array<string,mixed> Compiled site artifact.
+	 */
+	private function compiled_site_artifact( array $artifact, array $documents ): array {
+		$pages = array_map(
+			static function ( array $document ): array {
+				return array(
+					'source_path' => (string) ( $document['source_path'] ?? '' ),
+					'route_key'   => (string) ( $document['slug'] ?? '' ),
+					'slug'        => (string) ( $document['slug'] ?? '' ),
+					'post_type'   => (string) ( $document['post_type'] ?? 'page' ),
+					'title'       => (string) ( $document['title'] ?? '' ),
+					'entrypoint'  => ! empty($document['entrypoint']),
+					'artifact'    => 'wordpress_artifacts.documents',
+				);
+			},
+			$documents
+		);
+
+		return array(
+			'schema'         => 'block-artifact-compiler/compiled-site/v1',
+			'pages'          => $pages,
+			'shared_regions' => $this->shared_region_contracts($artifact),
+			'theme_assets'   => $this->theme_asset_contracts($artifact),
+			'provenance'     => array(
+				'source_hash' => hash('sha256', $this->artifact_hash_payload($artifact)),
+			),
+		);
+	}
+
+	/**
+	 * Extract conservative shared region candidates from HTML documents.
+	 *
+	 * @param  array{files:array<int,array<string,mixed>>} $artifact Normalized artifact.
+	 * @return array<int,array<string,mixed>> Shared region contracts.
+	 */
+	private function shared_region_contracts( array $artifact ): array {
+		$regions = array();
+		foreach ( $artifact['files'] as $file ) {
+			if ( 'html' !== $file['kind'] || ! empty($file['binary']) ) {
+				continue;
+			}
+
+			foreach ( $this->html_region_candidates((string) $file['content']) as $region ) {
+				$key = (string) $region['role'] . ':' . (string) $region['hash'];
+				if ( ! isset($regions[ $key ]) ) {
+					$regions[ $key ] = array(
+						'role'           => $region['role'],
+						'source_paths'   => array(),
+						'source_hash'    => $region['hash'],
+						'source_excerpt' => $region['excerpt'],
+					);
+				}
+				$regions[ $key ]['source_paths'][] = $file['path'];
+			}
+		}
+
+		return array_values(
+			array_filter(
+				$regions,
+				static fn ( array $region ): bool => count($region['source_paths']) > 1
+			)
+		);
+	}
+
+	/**
+	 * Extract region candidates from one HTML document.
+	 *
+	 * @return array<int,array{role:string,hash:string,excerpt:string}>
+	 */
+	private function html_region_candidates( string $html ): array {
+		if ( '' === trim($html) || ! class_exists('DOMDocument') ) {
+			return array();
+		}
+
+		$doc      = new DOMDocument();
+		$previous = libxml_use_internal_errors(true);
+		$loaded   = $doc->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+		libxml_clear_errors();
+		libxml_use_internal_errors($previous);
+		if ( ! $loaded ) {
+			return array();
+		}
+
+		$regions = array();
+		foreach ( array( 'header', 'footer', 'main' ) as $tag ) {
+			$node = $doc->getElementsByTagName($tag)->item(0);
+			if ( ! $node instanceof DOMElement ) {
+				continue;
+			}
+			$markup = trim((string) $doc->saveHTML($node));
+			if ( '' === $markup ) {
+				continue;
+			}
+
+			$regions[] = array(
+				'role'    => $tag,
+				'hash'    => hash('sha256', $markup),
+				'excerpt' => substr(preg_replace('/\s+/', ' ', $markup) ?? $markup, 0, 240),
+			);
+		}
+
+		return $regions;
+	}
+
+	/**
+	 * Return theme-level CSS and script assets for downstream materializers.
+	 *
+	 * @param  array{files:array<int,array<string,mixed>>} $artifact Normalized artifact.
+	 * @return array<string,array<int,array<string,mixed>>> Theme asset contract.
+	 */
+	private function theme_asset_contracts( array $artifact ): array {
+		$assets = array(
+			'styles'  => array(),
+			'scripts' => array(),
+		);
+
+		foreach ( $artifact['files'] as $file ) {
+			if ( 'css' === $file['kind'] ) {
+				$assets['styles'][] = array(
+					'path'       => $file['path'],
+					'role'       => $file['role'],
+					'intent'     => $file['intent'],
+					'bytes'      => $file['bytes'],
+					'provenance' => $file['provenance'],
+				);
+			}
+			if ( 'js' === $file['kind'] ) {
+				$assets['scripts'][] = array(
+					'path'       => $file['path'],
+					'role'       => $file['role'],
+					'intent'     => $file['intent'],
+					'bytes'      => $file['bytes'],
+					'provenance' => $file['provenance'],
+				);
+			}
+		}
+
+		return $assets;
 	}
 
 	/**
@@ -920,7 +1121,7 @@ class Block_Artifact_Compiler {
 
 			if ( 'html' === $file['kind'] ) {
 				$document             = $this->entry_document_contract($file['content'], $file['path']);
-				$conversion           = $this->convert_html_to_blocks($document['body_html'], $options);
+				$conversion           = $this->convert_content_to_blocks($document['body_html'], 'html', $options);
 				$document_diagnostics = $conversion['diagnostics'];
 				$diagnostics          = array_merge($diagnostics, $document_diagnostics);
 				$metadata             = $document['metadata'];
@@ -938,6 +1139,8 @@ class Block_Artifact_Compiler {
 					'entrypoint'        => ! empty($file['entrypoint']),
 					'document_metadata' => $metadata,
 					'block_markup'      => $conversion['serialized_blocks'],
+					'blocks'            => $conversion['blocks'],
+					'bfb_report'        => $conversion['report'],
 					'diagnostics'       => $document_diagnostics,
 					'provenance'        => $file['provenance'],
 				);
@@ -956,7 +1159,7 @@ class Block_Artifact_Compiler {
 				$document_diagnostics = array_merge($document_diagnostics, $mdx['diagnostics']);
 			}
 
-			$conversion           = $this->convert_markdown_to_blocks($body, $options);
+			$conversion           = $this->convert_content_to_blocks($body, 'markdown', $options);
 			$document_diagnostics = array_merge($document_diagnostics, $conversion['diagnostics']);
 			$diagnostics          = array_merge($diagnostics, $document_diagnostics);
 
@@ -972,6 +1175,8 @@ class Block_Artifact_Compiler {
 				'taxonomies'   => $this->frontmatter_taxonomies($frontmatter),
 				'frontmatter'  => $frontmatter,
 				'block_markup' => $conversion['serialized_blocks'],
+				'blocks'       => $conversion['blocks'],
+				'bfb_report'   => $conversion['report'],
 				'diagnostics'  => $document_diagnostics,
 				'provenance'   => $file['provenance'],
 			);
@@ -981,39 +1186,6 @@ class Block_Artifact_Compiler {
 			'documents'   => $documents,
 			'components'  => $components,
 			'diagnostics' => $this->dedupe_diagnostics($diagnostics),
-		);
-	}
-
-	/**
-	 * Convert Markdown through BFB when present, otherwise preserve it in a block fallback.
-	 *
-	 * @param  array<string,mixed> $options Compiler options.
-	 * @return array{serialized_blocks:string,blocks:array,diagnostics:array<int,array<string,mixed>>,report:array<string,mixed>}
-	 */
-	private function convert_markdown_to_blocks( string $markdown, array $options ): array {
-		if ( function_exists('bfb_convert') ) {
-			$block_markup = (string) bfb_convert($markdown, 'markdown', 'blocks', $options);
-			return array(
-				'serialized_blocks' => $block_markup,
-				'blocks'            => function_exists('parse_blocks') && '' !== trim($block_markup) ? parse_blocks($block_markup) : array(),
-				'diagnostics'       => array(),
-				'report'            => array(
-					'status' => '' === trim($block_markup) ? 'failed' : 'success_native',
-					'source' => 'markdown',
-				),
-			);
-		}
-
-		return array(
-			'serialized_blocks' => '<!-- wp:html -->' . "\n" . $markdown . "\n" . '<!-- /wp:html -->',
-			'blocks'            => array(),
-			'diagnostics'       => array(
-				$this->diagnostic('bfb_unavailable', 'warning', 'BFB is unavailable; preserved source Markdown as a core/html fallback.'),
-			),
-			'report'            => array(
-				'status' => 'success_with_fallbacks',
-				'source' => 'markdown',
-			),
 		);
 	}
 
@@ -1823,15 +1995,32 @@ class Block_Artifact_Compiler {
 	 */
 	private function virtual_fragment_path( string $source, string $format ): string {
 		$path      = $this->safe_relative_path(str_replace(array( ':', '#' ), '-', $source));
-		$extension = match ( bac_sanitize_key($format) ) {
+		$extension = match ( $this->normalize_fragment_format($format) ) {
 			'css'      => 'css',
 			'js'       => 'js',
 			'markdown' => 'md',
 			'mdx'      => 'mdx',
+			'blocks'   => 'blocks.html',
 			default    => 'html',
 		};
 
 		return ( '' === $path ? 'fragment' : preg_replace('/\.[A-Za-z0-9]+$/', '', $path) ) . '.' . $extension;
+	}
+
+	/**
+	 * Normalize public fragment source formats to BFB-facing format keys.
+	 */
+	private function normalize_fragment_format( string $format ): string {
+		$format = bac_sanitize_key($format);
+		return match ( $format ) {
+			'htm', 'html'      => 'html',
+			'md', 'markdown'   => 'markdown',
+			'wp-blocks', 'block-markup', 'blocks' => 'blocks',
+			'mdx'              => 'mdx',
+			'css'              => 'css',
+			'js', 'javascript' => 'js',
+			default            => 'html',
+		};
 	}
 
 	/**
@@ -1921,7 +2110,7 @@ class Block_Artifact_Compiler {
 	}
 
 	/**
-	 * Extract MDX imports and JSX component references while producing Markdown-compatible text.
+	 * Extract conservative MDX/JSX component candidates while producing Markdown-compatible text.
 	 *
 	 * @param  array<string,mixed>                         $file     Source file.
 	 * @param  array{files:array<int,array<string,mixed>>} $artifact Normalized artifact.
@@ -1930,7 +2119,14 @@ class Block_Artifact_Compiler {
 	private function extract_mdx_semantics( string $body, array $file, array $artifact ): array {
 		$imports     = $this->extract_mdx_imports($body);
 		$components  = array();
-		$diagnostics = array();
+		$diagnostics = array(
+			$this->diagnostic(
+				'mdx_candidate_extraction_only',
+				'info',
+				'MDX/JSX handling is conservative component candidate extraction; BAC does not evaluate MDX runtime semantics.',
+				array( 'path' => $file['path'] )
+			),
+		);
 
 		if ( preg_match_all('/<([A-Z][A-Za-z0-9._-]*)(?:\s[^>]*)?\s*(?:>|\/>)/', $body, $matches) ) {
 			foreach ( $matches[1] as $name ) {
@@ -1957,7 +2153,7 @@ class Block_Artifact_Compiler {
 					$diagnostics[] = $this->diagnostic(
 						'mdx_component_unresolved',
 						'warning',
-						'MDX component reference has no matching import.',
+						'MDX component candidate has no matching import.',
 						array(
 							'path'      => $file['path'],
 							'component' => $name,
@@ -1967,7 +2163,7 @@ class Block_Artifact_Compiler {
 					$diagnostics[] = $this->diagnostic(
 						'mdx_import_unresolved',
 						'warning',
-						'MDX component import could not be linked to a generated source file.',
+						'MDX component candidate import could not be linked to a generated source file.',
 						array(
 							'path'        => $file['path'],
 							'component'   => $name,

--- a/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
+++ b/vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php
@@ -16,6 +16,12 @@ $assert = static function ( bool $condition, string $message, string $detail = '
 	exit( 1 );
 };
 
+$fallback_options = array( 'allow_bfb_unavailable_fallback' => true );
+
+$missing_bfb = bac_compile_fragment( '<main><p>Needs BFB</p></main>', 'production-fragment.html' );
+$assert( 'failed' === ( $missing_bfb['status'] ?? '' ), 'missing BFB fails by default for production fragment compilation', (string) ( $missing_bfb['status'] ?? '' ) );
+$assert( ! empty( array_filter( $missing_bfb['diagnostics'] ?? array(), static fn ( array $diagnostic ): bool => 'bfb_unavailable' === ( $diagnostic['code'] ?? '' ) && 'error' === ( $diagnostic['severity'] ?? '' ) ) ), 'missing BFB default policy emits an error diagnostic' );
+
 $result = bac_compile_website_artifact(
 	array(
 		'files' => array(
@@ -24,7 +30,8 @@ $result = bac_compile_website_artifact(
 				'content' => '<main><h1>Hello compiler</h1><p>Initial contract.</p></main>',
 			),
 		),
-	)
+	),
+	$fallback_options
 );
 
 $assert( 'block-artifact-compiler/result/v1' === ( $result['schema'] ?? '' ), 'result exposes schema' );
@@ -49,7 +56,8 @@ $schema_less = bac_compile_website_artifact(
 				'content' => '<main><p>No input schema required.</p></main>',
 			),
 		),
-	)
+	),
+	$fallback_options
 );
 $assert( 'schema-less.html' === ( $schema_less['input']['entry_path'] ?? '' ), 'bundles without schema still compile' );
 $assert( '' === ( $schema_less['input']['original_schema'] ?? null ), 'omitted bundle schema is preserved as empty original schema metadata' );
@@ -70,7 +78,8 @@ $nested_source = bac_compile_website_artifact(
 				'source'  => array( 'metadata' => 'object' ),
 			),
 		),
-	)
+	),
+	$fallback_options
 );
 restore_error_handler();
 $assert( array() === $warnings, 'non-scalar file source metadata does not emit PHP warnings', implode( '; ', $warnings ) );
@@ -88,7 +97,8 @@ $messy = bac_compile_website_artifact(
 				'content' => 'nope',
 			),
 		),
-	)
+	),
+	$fallback_options
 );
 $assert( 'success_with_warnings' === ( $messy['status'] ?? '' ), 'unsafe AI artifact inputs produce warning status', (string) ( $messy['status'] ?? '' ) );
 $assert( 2 === ( $messy['input']['rejected_count'] ?? null ), 'unsafe paths are rejected' );
@@ -106,7 +116,8 @@ $markdown = bac_compile_website_artifact(
 			'content/changelog.markdown' => "---\ntitle: Changelog\npost_type: post\n---\n# Changes",
 			'assets/logo.bin'       => 'binary-ish',
 		),
-	)
+	),
+	$fallback_options
 );
 $assert( 'success_with_warnings' === ( $markdown['status'] ?? '' ), 'markdown documents compile with fallback warnings when BFB is unavailable', (string) ( $markdown['status'] ?? '' ) );
 $assert( 2 === ( $markdown['input']['files_by_kind']['markdown'] ?? 0 ), 'md and markdown files are classified as markdown' );
@@ -123,7 +134,8 @@ $mdx = bac_compile_website_artifact(
 			'components/Hero.jsx'     => 'export default function Hero() { return <section />; }',
 			'components/ProductGrid.tsx' => 'export function ProductGrid() { return <div />; }',
 		),
-	)
+	),
+	$fallback_options
 );
 $assert( 1 === ( $mdx['input']['files_by_kind']['mdx'] ?? 0 ), 'mdx files are classified as mdx' );
 $assert( 1 === ( $mdx['input']['files_by_kind']['jsx'] ?? 0 ), 'jsx files are classified as jsx component sources' );
@@ -135,8 +147,17 @@ $assert( ! empty( array_filter( $mdx['wordpress_artifacts']['components'] ?? arr
 $assert( ! empty( array_filter( $mdx['wordpress_artifacts']['components'] ?? array(), static fn ( array $component ): bool => 'jsx-component-file' === ( $component['signal'] ?? '' ) && 'components/Hero.jsx' === ( $component['source'] ?? '' ) ) ), 'jsx source files produce component candidates' );
 $assert( ! empty( array_filter( $mdx['diagnostics'] ?? array(), static fn ( array $diagnostic ): bool => 'mdx_component_unresolved' === ( $diagnostic['code'] ?? '' ) ) ), 'unresolved mdx components emit diagnostics' );
 
-$fragment = bac_compile_fragment( '<div class="feature-card">Feature</div>', 'main:index.html' );
+$fragment = bac_compile_fragment( '<div class="feature-card">Feature</div>', 'main:index.html', 'html', $fallback_options );
 $assert( 'main-index.html' === ( $fragment['input']['entry_path'] ?? '' ), 'fragment source is normalized to virtual path' );
+
+$markdown_fragment = bac_compile_fragment( '# Feature\n\nMarkdown fragment.', 'content/feature.md', 'markdown', $fallback_options );
+$assert( 'content/feature.md' === ( $markdown_fragment['input']['entry_path'] ?? '' ), 'markdown fragment keeps a virtual markdown source path' );
+$assert( 'markdown' === ( $markdown_fragment['bfb_report']['source'] ?? '' ), 'markdown fragment routes through BAC conversion envelope' );
+$assert( str_contains( (string) ( $markdown_fragment['wordpress_artifacts']['block_markup'] ?? '' ), 'Markdown fragment.' ), 'markdown fragment exposes top-level block markup' );
+
+$blocks_fragment = bac_compile_fragment( '<!-- wp:paragraph --><p>Native blocks</p><!-- /wp:paragraph -->', 'content/native.blocks', 'blocks' );
+$assert( 'success' === ( $blocks_fragment['status'] ?? '' ), 'serialized block fragments compile without BFB' );
+$assert( str_contains( (string) ( $blocks_fragment['wordpress_artifacts']['block_markup'] ?? '' ), 'Native blocks' ), 'serialized block fragments preserve block markup' );
 
 $full_document = bac_compile_website_artifact(
 	array(
@@ -146,7 +167,8 @@ $full_document = bac_compile_website_artifact(
 				'content' => '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Ember & Rye</title><meta name="description" content="Wood-fired bakery"><link rel="stylesheet" href="/assets/site.css"></head><body><header class="site-header"><a href="/">Ember & Rye</a></header><main><section class="hero"><h1>Fire, flour, patience.</h1><p>Small-batch loaves.</p></section></main></body></html>',
 			),
 		),
-	)
+	),
+	$fallback_options
 );
 $full_document_markup = (string) ( $full_document['wordpress_artifacts']['block_markup'] ?? '' );
 $full_document_metadata = $full_document['wordpress_artifacts']['document_metadata'] ?? array();
@@ -178,7 +200,8 @@ $multi_page = bac_compile_website_artifact(
 				'content' => '<main><h1>Contact</h1><p>Email us.</p></main>',
 			),
 		)
-	)
+	),
+	$fallback_options
 );
 $multi_documents = $multi_page['wordpress_artifacts']['documents'] ?? array();
 $assert( 3 === count( $multi_documents ), 'multi-page HTML artifacts expose one document per HTML file' );
@@ -189,6 +212,28 @@ $assert( 'menu' === ( $multi_documents[1]['slug'] ?? '' ), 'nested HTML page slu
 $assert( 'Menu Page' === ( $multi_documents[1]['title'] ?? '' ), 'nested HTML document title comes from metadata' );
 $assert( 'Seasonal menu' === ( $multi_documents[1]['document_metadata']['meta'][0]['content'] ?? '' ), 'nested HTML document metadata is preserved' );
 $assert( str_contains( (string) ( $multi_documents[2]['block_markup'] ?? '' ), 'Contact' ), 'HTML document block markup preserves body content' );
+
+$compiled_site = $multi_page['wordpress_artifacts']['site'] ?? array();
+$assert( 'block-artifact-compiler/compiled-site/v1' === ( $compiled_site['schema'] ?? '' ), 'compiled site artifact exposes schema' );
+$assert( 3 === count( $compiled_site['pages'] ?? array() ), 'compiled site artifact exposes page routes' );
+$assert( 'menu' === ( $compiled_site['pages'][1]['route_key'] ?? '' ), 'compiled site page route keys come from document slugs' );
+
+$shared_chrome = bac_compile_website_artifact(
+	array(
+		'files' => array(
+			'home.html'  => '<!doctype html><html><body><header class="site-header">Shared nav</header><main><h1>Home</h1></main><footer>Shared footer</footer></body></html>',
+			'about.html' => '<!doctype html><html><body><header class="site-header">Shared nav</header><main><h1>About</h1></main><footer>Shared footer</footer></body></html>',
+			'site.css'   => 'body{font-family:sans-serif}',
+			'site.js'    => 'console.log("site")',
+		),
+	),
+	$fallback_options
+);
+$shared_regions = $shared_chrome['wordpress_artifacts']['site']['shared_regions'] ?? array();
+$assert( ! empty( array_filter( $shared_regions, static fn ( array $region ): bool => 'header' === ( $region['role'] ?? '' ) && 2 === count( $region['source_paths'] ?? array() ) ) ), 'compiled site artifact exposes shared header chrome candidates' );
+$assert( ! empty( array_filter( $shared_regions, static fn ( array $region ): bool => 'footer' === ( $region['role'] ?? '' ) && 2 === count( $region['source_paths'] ?? array() ) ) ), 'compiled site artifact exposes shared footer chrome candidates' );
+$assert( 1 === count( $shared_chrome['wordpress_artifacts']['site']['theme_assets']['styles'] ?? array() ), 'compiled site artifact exposes theme style assets' );
+$assert( 1 === count( $shared_chrome['wordpress_artifacts']['site']['theme_assets']['scripts'] ?? array() ), 'compiled site artifact exposes theme script assets' );
 
 $summary = bac_summarize_result( $messy );
 $assert( ( $summary['component_count'] ?? 0 ) > 0, 'summary exposes component count' );
@@ -223,7 +268,8 @@ $rich = bac_compile_website_artifact(
 				'content_base64' => 'not-valid-base64',
 			),
 		),
-	)
+	),
+	$fallback_options
 );
 $assert( 'pages/home.html' === ( $rich['input']['entry_path'] ?? '' ), 'explicit entrypoint selects nested HTML entry' );
 $assert( in_array( 'pages/home.html', $rich['input']['entrypoints'] ?? array(), true ), 'entrypoints are normalized into input metadata' );
@@ -277,7 +323,8 @@ $blocks = bac_compile_website_artifact(
 			'blocks/hero/editor.css'       => '.wp-block-acme-hero{outline:1px solid}',
 			'blocks/hero/render.php'       => '<?php echo $content;',
 		),
-	)
+	),
+	$fallback_options
 );
 $block_types = $blocks['wordpress_artifacts']['block_types'] ?? array();
 $assert( 1 === count( $block_types ), 'block.json roots are promoted into block type artifacts' );
@@ -314,7 +361,8 @@ $plugin_bundle = bac_compile_website_artifact(
 			),
 			'plugins/acme-blocks/blocks/hero/index.js'   => 'wp.blocks.registerBlockType("acme/hero", {});',
 		),
-	)
+	),
+	$fallback_options
 );
 $plugins = $plugin_bundle['wordpress_artifacts']['plugins'] ?? array();
 $assert( 1 === count( $plugins ), 'plugin header files are promoted into plugin artifacts' );

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -7,18 +7,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler.git",
-                "reference": "f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab"
+                "reference": "130229703353fddee53e58b758c80e61d8919bb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab",
-                "reference": "f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/130229703353fddee53e58b758c80e61d8919bb7",
+                "reference": "130229703353fddee53e58b758c80e61d8919bb7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
-            "time": "2026-06-07T16:54:06+00:00",
+            "time": "2026-06-07T19:40:38+00:00",
             "default-branch": true,
             "type": "wordpress-plugin",
             "installation-source": "dist",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -13,7 +13,7 @@
         'chubes4/block-artifact-compiler' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'f1c49b907cd94b7c10cc8c9a67cf6b5122c02cab',
+            'reference' => '130229703353fddee53e58b758c80e61d8919bb7',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../chubes4/block-artifact-compiler',
             'aliases' => array(


### PR DESCRIPTION
## Summary
- Route SSI fallback/content-quality reporting through the BAC/BFB result envelope instead of direct `html_to_blocks_*` action listeners.
- Consume BAC's `block-artifact-compiler/compiled-site/v1` contract for website-artifact page route materialization and import-report evidence.
- Remove the legacy website-artifact fallback that synthesized a single Home page from top-level `block_markup` when BAC document/page contracts were missing.
- Update README boundary docs to describe the current `SSI -> BAC -> BFB -> H2BC` stack, BAC-backed fragment compilation, and compiled-site materialization contract.

## Issues
- Closes https://github.com/chubes4/static-site-importer/issues/295
- Closes https://github.com/chubes4/static-site-importer/issues/296
- Closes https://github.com/chubes4/static-site-importer/issues/297

## Verification
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/smoke-website-artifact-document-metadata.php && php -l tests/StaticSiteImporterFallbackDiagnosticsTest.php` passed.
- `php vendor/chubes4/block-artifact-compiler/tests/contract-smoke.php` passed.
- Direct scoped PHP smoke passed: BAC/BFB fallback report records SSI quality diagnostic.
- `php -r ...` source assertion passed: no SSI `add_action( 'html_to_blocks_...` or `remove_action( 'html_to_blocks_...` registrations remain.
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-boundary-cleanup-295-297/tests/smoke-website-artifact-document-metadata.php` passed: 27 assertions. WordPress emitted ability-registration notices because the worktree plugin is loaded via `eval-file` after init.
- `npm run test:js-block-validation -- --json /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead` passed: 15 files checked, 133 blocks checked, 0 invalid blocks.
- `git diff --check` passed.

## Verification gaps
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-boundary-cleanup-295-297` did not run tests. First attempt found a stale `homeboy-lab` runner; after `homeboy runner connect homeboy-lab`, the retry failed before tests because the lab runner is missing the WP Codebox core recipe-builder module (`@automattic/wp-codebox-core` / `HOMEBOY_WP_CODEBOX_CORE_MODULE`).
- `homeboy lint static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-boundary-cleanup-295-297` ran but is not clean due existing baseline findings: short ternaries in `includes/class-static-site-importer-wp-codebox-artifact-diagnostics-normalizer.php`, existing PHPStan findings in `includes/class-static-site-importer-theme-generator.php`, and pre-existing alignment warnings outside this edited block.
- An initial JS block-validation command was run against the source fixture directory by mistake and failed because that directory is not a generated theme; the corrected generated-theme command above passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the boundary cleanup implementation, compiled-site follow-up, docs updates, regression assertions, verification commands, and PR text for Chris to review and test.