### PR TITLE
fix: materialize storefront products from website artifacts

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -119,6 +119,16 @@ class Static_Site_Importer_Theme_Generator {
 			return new WP_Error( 'static_site_importer_missing_bac', 'Block Artifact Compiler is required to import a website artifact.' );
 		}
 
+		if ( ! isset( $args['_products_manifest_report'] ) ) {
+			$products_manifest_report = self::products_manifest_from_website_artifact( $artifact );
+			if ( null !== $products_manifest_report ) {
+				$args['_products_manifest_report'] = $products_manifest_report;
+				if ( ! isset( $args['products_manifest'] ) && ! empty( $products_manifest_report['valid'] ) ) {
+					$args['products_manifest'] = $products_manifest_report['products'];
+				}
+			}
+		}
+
 		$compiler_options = isset( $args['compiler_options'] ) && is_array( $args['compiler_options'] ) ? $args['compiler_options'] : array();
 		$compiled         = bac_compile_website_artifact( $artifact, array_merge( array( 'include_bfb_report' => true ), $compiler_options ) );
 		$document_pages   = self::bac_document_pages( $compiled );
@@ -165,6 +175,8 @@ class Static_Site_Importer_Theme_Generator {
 		self::$conversion_report   = self::new_conversion_report( $html_path, $source_metadata );
 		self::record_website_artifact_compiler_result( $compiled );
 		self::record_direct_website_artifact_source_summary( $compiled );
+		self::record_products_manifest_from_import_args( $args );
+		self::record_commerce_context_summary( $args );
 
 		self::$active_theme_dir         = $theme_dir;
 		self::$active_theme_uri         = trailingslashit( get_theme_root_uri( $theme_slug ) ) . $theme_slug;
@@ -246,6 +258,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		self::analyze_generated_theme_block_documents( $writes, $theme_dir );
 		self::$conversion_report['theme_slug'] = $theme_slug;
+		self::materialize_required_plugins( $args );
 		self::record_product_seeding_report( $args );
 		self::record_commerce_dependency_check( $args );
 		$quality     = self::finalize_quality_report( $args );
@@ -4451,6 +4464,329 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Record a products manifest that was extracted from an in-memory website artifact.
+	 *
+	 * @param array<string, mixed> $args Import args.
+	 * @return void
+	 */
+	private static function record_products_manifest_from_import_args( array $args ): void {
+		$report = isset( $args['_products_manifest_report'] ) && is_array( $args['_products_manifest_report'] ) ? $args['_products_manifest_report'] : array();
+		if ( empty( $report ) ) {
+			return;
+		}
+
+		if ( ! isset( self::$conversion_report['commerce'] ) || ! is_array( self::$conversion_report['commerce'] ) ) {
+			self::$conversion_report['commerce'] = array();
+		}
+
+		self::$conversion_report['commerce']['products_manifest'] = array(
+			'present'       => true,
+			'path'          => isset( $report['path'] ) ? (string) $report['path'] : 'products.json',
+			'contract'      => array(
+				'schema'          => 'static-site-importer/products.json',
+				'schema_version'  => 1,
+				'required_fields' => array( 'name', 'slug', 'regular_price' ),
+				'optional_fields' => array( 'sale_price', 'description', 'short_description', 'categories', 'image', 'status', 'stock_status', 'stock_quantity', 'source_selectors' ),
+			),
+			'valid'         => true === ( $report['valid'] ?? false ),
+			'product_count' => isset( $report['products'] ) && is_array( $report['products'] ) ? count( $report['products'] ) : 0,
+			'products'      => isset( $report['products'] ) && is_array( $report['products'] ) ? $report['products'] : array(),
+			'errors'        => isset( $report['errors'] ) && is_array( $report['errors'] ) ? $report['errors'] : array(),
+		);
+
+		if ( ! empty( self::$conversion_report['commerce']['products_manifest']['valid'] ) ) {
+			return;
+		}
+
+		self::$conversion_report['diagnostics'][] = array(
+			'code'     => 'products_manifest_invalid',
+			'severity' => 'warning',
+			'source'   => self::$conversion_report['commerce']['products_manifest']['path'],
+			'message'  => 'products.json is present but does not match the Static Site Importer generated-store contract.',
+			'errors'   => self::$conversion_report['commerce']['products_manifest']['errors'],
+		);
+	}
+
+	/**
+	 * Record commerce context from an already validated manifest.
+	 *
+	 * @param array<string, mixed> $args Import args.
+	 * @return void
+	 */
+	private static function record_commerce_context_summary( array $args ): void {
+		$manifest = self::$conversion_report['commerce']['products_manifest'] ?? array();
+		$products = array();
+		$source   = 'import_args';
+		if ( is_array( $manifest ) && true === ( $manifest['valid'] ?? false ) ) {
+			$products = isset( $manifest['products'] ) && is_array( $manifest['products'] ) ? $manifest['products'] : array();
+			$source   = 'products.json';
+		} elseif ( isset( $args['commerce_context']['products'] ) && is_array( $args['commerce_context']['products'] ) ) {
+			$products = $args['commerce_context']['products'];
+			$source   = isset( $args['commerce_context']['source'] ) ? (string) $args['commerce_context']['source'] : 'commerce_context';
+		}
+
+		if ( empty( $products ) ) {
+			return;
+		}
+
+		self::$conversion_report['commerce_context'] = array(
+			'supplied'       => true,
+			'source'         => $source,
+			'product_count'  => count( $products ),
+			'selector_hints' => array(),
+			'diagnostics'    => array(),
+		);
+	}
+
+	/**
+	 * Extract and validate products.json from a website artifact bundle.
+	 *
+	 * @param array<string, mixed> $artifact Website artifact bundle.
+	 * @return array{path:string,valid:bool,products:array<int,array<string,mixed>>,errors:array<int,array<string,string>>}|null
+	 */
+	private static function products_manifest_from_website_artifact( array $artifact ): ?array {
+		$files = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$path = isset( $file['path'] ) && is_scalar( $file['path'] ) ? str_replace( '\\', '/', (string) $file['path'] ) : '';
+			if ( 'products.json' !== basename( $path ) ) {
+				continue;
+			}
+
+			$raw = self::website_artifact_file_text_content( $file );
+			if ( null === $raw ) {
+				return array(
+					'path'     => '' !== $path ? $path : 'products.json',
+					'valid'    => false,
+					'products' => array(),
+					'errors'   => array(
+						array(
+							'path'    => '$',
+							'message' => 'products.json could not be read from website artifact files.',
+						),
+					),
+				);
+			}
+
+			$data = json_decode( $raw, true );
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
+				return array(
+					'path'     => '' !== $path ? $path : 'products.json',
+					'valid'    => false,
+					'products' => array(),
+					'errors'   => array(
+						array(
+							'path'    => '$',
+							'message' => 'products.json is not valid JSON: ' . json_last_error_msg(),
+						),
+					),
+				);
+			}
+
+			$validation = self::validate_products_manifest( $data );
+			return array(
+				'path'     => '' !== $path ? $path : 'products.json',
+				'valid'    => empty( $validation['errors'] ),
+				'products' => $validation['products'],
+				'errors'   => $validation['errors'],
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get text content from a website artifact file entry.
+	 *
+	 * @param array<string, mixed> $file Artifact file entry.
+	 * @return string|null
+	 */
+	private static function website_artifact_file_text_content( array $file ): ?string {
+		if ( ! isset( $file['content'] ) || ! is_scalar( $file['content'] ) ) {
+			return null;
+		}
+
+		$content  = (string) $file['content'];
+		$encoding = isset( $file['encoding'] ) && is_scalar( $file['encoding'] ) ? strtolower( (string) $file['encoding'] ) : '';
+		if ( 'base64' !== $encoding ) {
+			return $content;
+		}
+
+		$decoded = base64_decode( $content, true );
+		return false === $decoded ? null : $decoded;
+	}
+
+	/**
+	 * Validate the generated store products manifest contract.
+	 *
+	 * @param mixed $data Decoded JSON data.
+	 * @return array{products:array<int,array<string,mixed>>,errors:array<int,array<string,string>>}
+	 */
+	private static function validate_products_manifest( $data ): array {
+		$products = array();
+		$errors   = array();
+
+		if ( ! is_array( $data ) || array_is_list( $data ) ) {
+			return array( 'products' => array(), 'errors' => array( array( 'path' => '$', 'message' => 'products.json must be an object with schema_version and products fields.' ) ) );
+		}
+
+		if ( 1 !== (int) ( $data['schema_version'] ?? 0 ) ) {
+			$errors[] = array( 'path' => '$.schema_version', 'message' => 'schema_version must be 1.' );
+		}
+		if ( ! isset( $data['products'] ) || ! is_array( $data['products'] ) || ! array_is_list( $data['products'] ) ) {
+			$errors[] = array( 'path' => '$.products', 'message' => 'products must be a JSON array.' );
+			return array( 'products' => array(), 'errors' => $errors );
+		}
+
+		foreach ( $data['products'] as $index => $product ) {
+			$path_prefix = '$.products[' . $index . ']';
+			if ( ! is_array( $product ) || array_is_list( $product ) ) {
+				$errors[] = array( 'path' => $path_prefix, 'message' => 'Product must be an object.' );
+				continue;
+			}
+
+			$name          = self::manifest_string( $product, 'name' );
+			$slug          = self::manifest_string( $product, 'slug' );
+			$regular_price = self::manifest_string( $product, 'regular_price' );
+			$sale_price    = self::manifest_string( $product, 'sale_price', false );
+			if ( '' === $name ) {
+				$errors[] = array( 'path' => $path_prefix . '.name', 'message' => 'name is required and must be a non-empty string.' );
+			}
+			if ( '' === $slug || ! preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug ) ) {
+				$errors[] = array( 'path' => $path_prefix . '.slug', 'message' => 'slug is required and must be a lowercase URL slug.' );
+			}
+			if ( '' === $regular_price || ! self::is_manifest_price( $regular_price ) ) {
+				$errors[] = array( 'path' => $path_prefix . '.regular_price', 'message' => 'regular_price is required and must be a decimal string such as "19.00".' );
+			}
+			if ( '' !== $sale_price && ! self::is_manifest_price( $sale_price ) ) {
+				$errors[] = array( 'path' => $path_prefix . '.sale_price', 'message' => 'sale_price must be a decimal string such as "15.00" when provided.' );
+			}
+			foreach ( array( 'description', 'short_description', 'status', 'stock_status', 'image' ) as $field ) {
+				if ( isset( $product[ $field ] ) && ! is_string( $product[ $field ] ) ) {
+					$errors[] = array( 'path' => $path_prefix . '.' . $field, 'message' => $field . ' must be a string when provided.' );
+				}
+			}
+			foreach ( array( 'categories', 'source_selectors' ) as $field ) {
+				if ( ! isset( $product[ $field ] ) ) {
+					continue;
+				}
+				$values = self::manifest_string_collection( $product[ $field ] );
+				if ( null === $values ) {
+					$errors[] = array( 'path' => $path_prefix . '.' . $field, 'message' => $field . ' must be an array of strings when provided.' );
+					continue;
+				}
+				foreach ( $values as $value_index => $value ) {
+					if ( '' === trim( $value ) ) {
+						$errors[] = array( 'path' => $path_prefix . '.' . $field . '[' . $value_index . ']', 'message' => $field . ' entries must be non-empty strings.' );
+					}
+				}
+			}
+			if ( isset( $product['stock_quantity'] ) && ! is_int( $product['stock_quantity'] ) ) {
+				$errors[] = array( 'path' => $path_prefix . '.stock_quantity', 'message' => 'stock_quantity must be an integer when provided.' );
+			}
+
+			$summary = array( 'name' => $name, 'slug' => $slug, 'regular_price' => $regular_price );
+			foreach ( array( 'sale_price', 'description', 'short_description', 'categories', 'image', 'status', 'stock_status', 'stock_quantity', 'source_selectors' ) as $field ) {
+				if ( array_key_exists( $field, $product ) ) {
+					$summary[ $field ] = $product[ $field ];
+				}
+			}
+			$products[] = $summary;
+		}
+
+		return array( 'products' => empty( $errors ) ? $products : array(), 'errors' => $errors );
+	}
+
+	/**
+	 * Read a string field from a decoded manifest object.
+	 *
+	 * @param array<string,mixed> $data     Manifest object.
+	 * @param string              $key      Field key.
+	 * @param bool                $required Whether missing fields should return an empty string.
+	 * @return string
+	 */
+	private static function manifest_string( array $data, string $key, bool $required = true ): string {
+		if ( ! array_key_exists( $key, $data ) || ! is_string( $data[ $key ] ) ) {
+			return '';
+		}
+
+		$value = trim( $data[ $key ] );
+		return $required || '' !== $value ? $value : '';
+	}
+
+	/**
+	 * Normalize list or keyed-map string collections from products.json.
+	 *
+	 * @param mixed $value Raw manifest field value.
+	 * @return array<int|string,string>|null
+	 */
+	private static function manifest_string_collection( $value ): ?array {
+		if ( ! is_array( $value ) ) {
+			return null;
+		}
+
+		$normalized = array();
+		foreach ( $value as $key => $entry ) {
+			if ( ! is_string( $entry ) ) {
+				return null;
+			}
+			$normalized[ $key ] = $entry;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Check whether a manifest price uses a stable decimal string format.
+	 *
+	 * @param string $price Price string.
+	 * @return bool
+	 */
+	private static function is_manifest_price( string $price ): bool {
+		return 1 === preg_match( '/^(?:0|[1-9][0-9]*)(?:\.[0-9]{2})?$/', $price );
+	}
+
+	/**
+	 * Materialize plugins required by detected source intent.
+	 *
+	 * @param array<string, mixed> $args Import args.
+	 * @return void
+	 */
+	private static function materialize_required_plugins( array $args ): void {
+		self::$conversion_report['plugin_materialization'] = array(
+			'status'  => 'skipped',
+			'plugins' => array(),
+		);
+
+		$intent = self::commerce_dependency_intent();
+		if ( ! $intent['present'] ) {
+			self::$conversion_report['plugin_materialization']['reason'] = 'no_plugin_backed_intent';
+			return;
+		}
+		if ( ! empty( $args['allow_missing_woocommerce'] ) ) {
+			self::$conversion_report['plugin_materialization']['reason'] = 'woocommerce_requirement_waived';
+			return;
+		}
+		if ( array_key_exists( 'materialize_dependencies', $args ) && false === (bool) $args['materialize_dependencies'] ) {
+			self::$conversion_report['plugin_materialization']['reason'] = 'dependency_materialization_disabled';
+			return;
+		}
+
+		$report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
+			'woocommerce',
+			'woocommerce/woocommerce.php',
+			array( 'Static_Site_Importer_Woo_Product_Seeder', 'woocommerce_available' )
+		);
+		self::$conversion_report['plugin_materialization'] = array(
+			'status'  => 'failed' === ( $report['status'] ?? '' ) ? 'failed' : 'completed',
+			'plugins' => array( 'woocommerce' => $report ),
+		);
+	}
+
+	/**
 	 * Record WooCommerce product seeding results for an already-validated manifest.
 	 *
 	 * @param array<string, mixed> $args Import args.
@@ -5320,6 +5656,10 @@ class Static_Site_Importer_Theme_Generator {
 	private static function import_report_summary( array $report, array $quality ): array {
 		$diagnostics      = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
 		$source_documents = isset( $report['source_documents'] ) && is_array( $report['source_documents'] ) ? $report['source_documents'] : array();
+		$commerce         = isset( $report['commerce'] ) && is_array( $report['commerce'] ) ? $report['commerce'] : array();
+		$commerce_context = isset( $report['commerce_context'] ) && is_array( $report['commerce_context'] ) ? $report['commerce_context'] : array();
+		$plugin_materialization = isset( $report['plugin_materialization'] ) && is_array( $report['plugin_materialization'] ) ? $report['plugin_materialization'] : array();
+		$product_seeding        = isset( $report['product_seeding'] ) && is_array( $report['product_seeding'] ) ? $report['product_seeding'] : array();
 
 		return array(
 			'schema'                       => 'static-site-importer/import-metrics/v1',
@@ -5341,6 +5681,10 @@ class Static_Site_Importer_Theme_Generator {
 			'invalid_block_document_count' => (int) ( $quality['invalid_block_document_count'] ?? 0 ),
 			'source_document_count'        => (int) ( $source_documents['total_count'] ?? 0 ),
 			'unresolved_link_count'        => (int) ( $source_documents['unresolved_link_count'] ?? 0 ),
+			'commerce'                     => $commerce,
+			'commerce_context'             => $commerce_context,
+			'plugin_materialization'       => $plugin_materialization,
+			'product_seeding'              => $product_seeding,
 			'diagnostic_count'             => count( $diagnostics ),
 			'diagnostic_summary'           => self::compact_import_report_diagnostic_summary( $diagnostics ),
 			'warning_summaries'            => self::compact_import_report_diagnostic_summaries_by_severity( $diagnostics, 'warning' ),

--- a/tests/smoke-website-artifact-products-manifest.php
+++ b/tests/smoke-website-artifact-products-manifest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Smoke coverage for direct website artifact products.json materialization.
+ *
+ * This intentionally avoids WP_UnitTestCase so it can run in lightweight agent
+ * shells while guarding the direct-artifact commerce handoff contract.
+ */
+
+$root   = dirname( __DIR__ );
+$source = file_get_contents( $root . '/includes/class-static-site-importer-theme-generator.php' );
+
+if ( false === $source ) {
+	fwrite( STDERR, "Could not read theme generator source.\n" );
+	exit( 1 );
+}
+
+$assert = static function ( bool $condition, string $message ) use ( $source ): void {
+	if ( $condition ) {
+		return;
+	}
+
+	fwrite( STDERR, "FAIL: {$message}\n" );
+	exit( 1 );
+};
+
+$assert(
+	str_contains( $source, 'products_manifest_from_website_artifact( $artifact )' ),
+	'direct artifact import extracts products.json before BAC compilation'
+);
+
+$assert(
+	str_contains( $source, "\$args['_products_manifest_report'] = \$products_manifest_report;" ),
+	'direct artifact import forwards products manifest report through import args'
+);
+
+$assert(
+	str_contains( $source, 'record_products_manifest_from_import_args( $args )' ),
+	'direct compiled artifact import records products manifest before commerce context'
+);
+
+$assert(
+	str_contains( $source, 'record_commerce_context_summary( $args )' ),
+	'direct compiled artifact import builds commerce context from products manifest'
+);
+
+$assert(
+	str_contains( $source, 'self::materialize_required_plugins( $args );' ),
+	'direct compiled artifact import materializes plugins before product seeding'
+);
+
+$assert(
+	str_contains( $source, "'products.json' !== basename( \$path )" ),
+	'direct artifact products manifest detection uses products.json basename'
+);
+
+$assert(
+	str_contains( $source, 'base64_decode( $content, true )' ),
+	'direct artifact products manifest supports base64 artifact content'
+);
+
+fwrite( STDOUT, "website artifact products manifest smoke ok\n" );


### PR DESCRIPTION
## Summary
- Teach direct website artifact imports to extract and validate `products.json` from artifact files before BAC compilation.
- Run plugin materialization before product seeding in the direct artifact path.
- Include commerce, plugin materialization, and product seeding fields in the compact import summary captured by Studio Web evidence.
- Accept keyed `source_selectors` maps emitted by Studio Web storefront artifacts.

## Verification
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php tests/smoke-website-artifact-products-manifest.php`
- `git diff --check`
- End-to-end Studio Web commerce eval passed with WooCommerce installed/activated and 4 products seeded.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the direct-artifact commerce materialization gap, drafted the implementation and smoke coverage, ran verification, and collected eval evidence for Chris to review.