### PR TITLE
Synthesize missing artifact header parts

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-artifact-compiler",
-                "reference": "2f7c672991215e024ba83626073f216f684af2db"
+                "reference": "18abf681a29fcda28045d769269823133d482c35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/2f7c672991215e024ba83626073f216f684af2db",
-                "reference": "2f7c672991215e024ba83626073f216f684af2db",
+                "url": "https://api.github.com/repos/chubes4/block-artifact-compiler/zipball/18abf681a29fcda28045d769269823133d482c35",
+                "reference": "18abf681a29fcda28045d769269823133d482c35",
                 "shasum": ""
             },
             "require": {
@@ -39,7 +39,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Compile website artifacts into WordPress-native block artifact bundles.",
-            "time": "2026-06-08T02:21:14+00:00"
+            "time": "2026-06-08T13:31:43+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -114,10 +114,6 @@ class Static_Site_Importer_Theme_Materializer {
 	 */
 	public static function template_part_artifact_writes( string $theme_dir, array $artifacts ) {
 		$template_parts = isset( $artifacts['template_parts'] ) && is_array( $artifacts['template_parts'] ) ? $artifacts['template_parts'] : array();
-		if ( empty( $template_parts ) ) {
-			return new WP_Error( 'static_site_importer_bac_template_parts_missing', 'BAC website artifact materialization requires wordpress_artifacts.template_parts.' );
-		}
-
 		$writes  = array();
 		$reports = array();
 		foreach ( $template_parts as $template_part ) {
@@ -144,7 +140,9 @@ class Static_Site_Importer_Theme_Materializer {
 		}
 
 		if ( ! isset( $writes[ $theme_dir . '/parts/header.html' ] ) ) {
-			return new WP_Error( 'static_site_importer_bac_header_template_part_missing', 'BAC website artifact materialization requires a header template part artifact.' );
+			$header = self::default_header_template_part();
+			$writes[ $theme_dir . '/parts/header.html' ] = $header['block_markup'];
+			$reports[] = self::template_part_artifact_report_payload( 'parts/header.html', $header, $header['block_markup'] );
 		}
 
 		return array(
@@ -201,6 +199,22 @@ class Static_Site_Importer_Theme_Materializer {
 	}
 
 	/**
+	 * Build the minimal generated header required by SSI's page templates.
+	 *
+	 * @return array<string,mixed> BAC-like template part artifact.
+	 */
+	private static function default_header_template_part(): array {
+		return array(
+			'schema'       => 'static-site-importer/template-part/v1',
+			'slug'         => 'header',
+			'area'         => 'header',
+			'source_paths' => array(),
+			'generated'    => true,
+			'block_markup' => '<!-- wp:group {"tagName":"header","layout":{"type":"constrained"}} --><header class="wp-block-group"><!-- wp:site-title /--></header><!-- /wp:group -->',
+		);
+	}
+
+	/**
 	 * Build a compact report row for a materialized BAC template part artifact.
 	 *
 	 * @param string              $path          Relative generated theme path.
@@ -213,6 +227,7 @@ class Static_Site_Importer_Theme_Materializer {
 			'path'               => $path,
 			'slug'               => isset( $template_part['slug'] ) && is_scalar( $template_part['slug'] ) ? (string) $template_part['slug'] : '',
 			'area'               => isset( $template_part['area'] ) && is_scalar( $template_part['area'] ) ? (string) $template_part['area'] : '',
+			'generated'          => ! empty( $template_part['generated'] ),
 			'source_paths'       => isset( $template_part['source_paths'] ) && is_array( $template_part['source_paths'] ) ? array_values( array_filter( $template_part['source_paths'], 'is_scalar' ) ) : array(),
 			'source_hash'        => isset( $template_part['source_hash'] ) && is_scalar( $template_part['source_hash'] ) ? (string) $template_part['source_hash'] : '',
 			'block_markup_bytes' => strlen( $markup ),

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -134,8 +134,13 @@ $missing_template_parts_result = Static_Site_Importer_Theme_Generator::import_we
 	)
 );
 
-$assert( is_wp_error( $missing_template_parts_result ), 'missing-template-parts-import-fails' );
-$assert( 'static_site_importer_bac_template_parts_missing' === ( is_wp_error( $missing_template_parts_result ) ? $missing_template_parts_result->get_error_code() : '' ), 'missing-template-parts-error-code' );
+$assert( ! is_wp_error( $missing_template_parts_result ), 'missing-template-parts-import-succeeds', is_wp_error( $missing_template_parts_result ) ? $missing_template_parts_result->get_error_message() : '' );
+if ( ! is_wp_error( $missing_template_parts_result ) ) {
+	$missing_report = json_decode( $read( $missing_template_parts_result['report_path'] ), true );
+	$missing_header = $missing_report['generated_theme']['template_parts'][0] ?? array();
+	$assert( 'parts/header.html' === ( $missing_header['path'] ?? '' ), 'missing-template-parts-generates-header' );
+	$assert( true === ( $missing_header['generated'] ?? null ), 'missing-template-parts-report-marks-generated-header' );
+}
 
 $multi_page_result = Static_Site_Importer_Theme_Generator::import_website_artifact(
 	array(


### PR DESCRIPTION
## Summary
- Allows website artifact materialization to proceed when BAC supplies page documents without template parts by generating the minimal header part SSI templates require.
- Marks synthesized template parts in the import report and updates the BAC dependency lock to include the current compiled-fragment handling.

## Testing
- `php -l includes/class-static-site-importer-theme-materializer.php`
- `composer validate --no-check-publish`
- Verified through the Studio Web commerce-lite browser materialization flow with WooCommerce installation and product seeding.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the missing template-parts materialization failure, drafting the SSI fallback/test update, refreshing dependencies, and running focused verification.