### PR TITLE
Consume compiler script metadata

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1660,8 +1660,6 @@ class Static_Site_Importer_Theme_Generator {
 	 */
 	private static function source_page_content_blocks( Static_Site_Importer_Source_Page $page ): string {
 		$source_path = $page->source_key();
-		$source      = 'main:' . $source_path;
-		$body        = self::route_external_script_tags_from_page_body( $page->body(), $source_path, $source );
 		if ( 'blocks' !== $page->body_format() ) {
 			self::$conversion_report['diagnostics'][] = array(
 				'type'        => 'unsupported_document_artifact_format',
@@ -1673,105 +1671,7 @@ class Static_Site_Importer_Theme_Generator {
 			return '';
 		}
 
-		return trim( $body );
-	}
-
-	/**
-	 * Route generated external script references out of editable page content.
-	 *
-	 * @param string $body        Page body or block markup.
-	 * @param string $source_path Source-relative document path.
-	 * @param string $source      Diagnostic source label.
-	 * @return string Body with external script elements removed.
-	 */
-	private static function route_external_script_tags_from_page_body( string $body, string $source_path, string $source ): string {
-		if ( '' === trim( $body ) || stripos( $body, '<script' ) === false ) {
-			return $body;
-		}
-
-		$routed = preg_replace_callback(
-			'/<script\b([^>]*)>\s*<\/script>/is',
-			static function ( array $matches ) use ( $source_path, $source ): string {
-				$attributes = self::parse_simple_html_attributes( $matches[1] ?? '' );
-				$src        = isset( $attributes['src'] ) ? trim( (string) $attributes['src'] ) : '';
-				if ( '' === $src ) {
-					return $matches[0];
-				}
-
-				self::record_page_body_script_asset( $src, $source_path, $source, $attributes );
-				return '';
-			},
-			$body
-		) ?? $body;
-
-		return self::remove_empty_core_html_blocks( $routed );
-	}
-
-	/**
-	 * Remove empty raw-HTML block wrappers left after routing script tags.
-	 *
-	 * @param string $body Block markup.
-	 * @return string Block markup without empty core/html wrappers.
-	 */
-	private static function remove_empty_core_html_blocks( string $body ): string {
-		return preg_replace( '/<!--\s+wp:html\s+-->\s*<!--\s+\/wp:html\s+-->/i', '', $body ) ?? $body;
-	}
-
-	/**
-	 * Parse a conservative HTML attribute string.
-	 *
-	 * @param string $attribute_string Raw tag attribute string.
-	 * @return array<string,string|bool>
-	 */
-	private static function parse_simple_html_attributes( string $attribute_string ): array {
-		$attributes = array();
-		if ( preg_match_all( '/([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*(?:=\s*("([^"]*)"|\'([^\']*)\'|([^\s"\'>]+)))?/', $attribute_string, $matches, PREG_SET_ORDER ) ) {
-			foreach ( $matches as $match ) {
-				$name  = strtolower( $match[1] );
-				$value = true;
-				if ( isset( $match[3] ) && '' !== $match[3] ) {
-					$value = $match[3];
-				} elseif ( isset( $match[4] ) && '' !== $match[4] ) {
-					$value = $match[4];
-				} elseif ( isset( $match[5] ) && '' !== $match[5] ) {
-					$value = $match[5];
-				}
-
-				$attributes[ $name ] = is_string( $value ) ? html_entity_decode( $value, ENT_QUOTES, 'UTF-8' ) : $value;
-			}
-		}
-
-		return $attributes;
-	}
-
-	/**
-	 * Record a script reference routed out of page block content.
-	 *
-	 * @param string                    $src         Script source.
-	 * @param string                    $source_path Source-relative document path.
-	 * @param string                    $source      Diagnostic source label.
-	 * @param array<string,string|bool> $attributes  Parsed script attributes.
-	 */
-	private static function record_page_body_script_asset( string $src, string $source_path, string $source, array $attributes ): void {
-		if ( ! isset( self::$conversion_report['assets']['scripts'] ) || ! is_array( self::$conversion_report['assets']['scripts'] ) ) {
-			self::$conversion_report['assets']['scripts'] = array();
-		}
-
-		$asset = self::resolve_local_asset_reference( $src, $source_path, $source );
-		$row   = array(
-			'source'      => $source,
-			'source_path' => $source_path,
-			'src'         => esc_url_raw( $src ),
-			'placement'   => 'page_body',
-			'routed_to'   => 'theme_asset_metadata',
-			'attributes'  => array_intersect_key( $attributes, array_fill_keys( array( 'type', 'defer', 'async', 'crossorigin', 'integrity' ), true ) ),
-		);
-
-		if ( null !== $asset ) {
-			$row['asset'] = $asset;
-		}
-
-		self::$conversion_report['assets']['scripts'][] = $row;
+		return trim( $page->body() );
 	}
 
 	/**
@@ -1907,7 +1807,7 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Record compiler-routed full-document metadata and head asset references.
+	 * Record compiler-routed full-document metadata and asset references.
 	 *
 	 * @param array<string,mixed> $artifacts WordPress artifacts from BAC.
 	 * @return void
@@ -1935,7 +1835,7 @@ class Static_Site_Importer_Theme_Generator {
 			'source'      => $normalized['source_path'],
 			'severity'    => 'info',
 			'stage'       => 'website_artifact_materialization',
-			'message'     => 'Full-document head metadata/assets were routed through the generated_theme.document_metadata contract instead of generated page block content.',
+			'message'     => 'Full-document metadata/assets were routed through the generated_theme.document_metadata contract instead of generated page block content.',
 			'meta_count'  => count( $normalized['meta'] ),
 			'link_count'  => count( $normalized['links'] ),
 			'style_count' => count( $normalized['styles'] ),
@@ -2030,6 +1930,10 @@ class Static_Site_Importer_Theme_Generator {
 				if ( isset( $row[ $key ] ) && is_scalar( $row[ $key ] ) && '' !== trim( (string) $row[ $key ] ) ) {
 					$item[ $key ] = sanitize_text_field( (string) $row[ $key ] );
 				}
+			}
+
+			if ( isset( $row['placement'] ) && in_array( $row['placement'], array( 'head', 'body' ), true ) ) {
+				$item['placement'] = (string) $row['placement'];
 			}
 
 			foreach ( array( 'defer', 'async' ) as $key ) {

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -77,7 +77,6 @@ if ( ! is_wp_error( $result ) ) {
 	$content   = $page instanceof WP_Post ? $page->post_content : '';
 	$documents = array();
 	$pattern_documents = array();
-	$scripts = $report['assets']['scripts'] ?? array();
 	$template_parts = $report['generated_theme']['template_parts'] ?? array();
 	foreach ( $report['generated_theme']['block_documents'] ?? array() as $document ) {
 		if ( is_array( $document ) && isset( $document['path'] ) ) {
@@ -88,6 +87,7 @@ if ( ! is_wp_error( $result ) ) {
 		}
 	}
 	$metadata = $report['generated_theme']['document_metadata'] ?? array();
+	$scripts  = $metadata['scripts'] ?? array();
 
 	$assert( array() === $pattern_documents, 'single-document-import-does-not-generate-page-pattern-copy' );
 	$assert( str_contains( $content, 'Fire, flour, patience.' ), 'body-content-is-preserved' );
@@ -106,8 +106,9 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( 'utf-8' === ( $metadata['meta'][0]['charset'] ?? '' ), 'charset-meta-is-preserved-in-metadata' );
 	$assert( 'viewport' === ( $metadata['meta'][1]['name'] ?? '' ), 'viewport-meta-is-preserved-in-metadata' );
 	$assert( '/assets/site.css' === ( $metadata['links'][0]['href'] ?? '' ), 'stylesheet-link-is-preserved-in-metadata' );
-	$assert( str_ends_with( (string) ( $scripts[0]['src'] ?? '' ), 'assets/js/main.js' ), 'script-src-is-preserved-in-asset-metadata' );
-	$assert( true === ( $scripts[0]['attributes']['defer'] ?? false ), 'script-defer-is-preserved-in-asset-metadata' );
+	$assert( str_ends_with( (string) ( $scripts[0]['src'] ?? '' ), 'assets/js/main.js' ), 'script-src-is-preserved-in-document-metadata' );
+	$assert( 'body' === ( $scripts[0]['placement'] ?? '' ), 'script-placement-is-preserved-in-document-metadata' );
+	$assert( true === ( $scripts[0]['defer'] ?? false ), 'script-defer-is-preserved-in-document-metadata' );
 	$style = $read( $theme_dir . '/style.css' );
 	$assert( str_contains( $style, '.wp-block-group.photo-collage {display:grid;grid-template-columns:1fr 1fr;gap:24px}' ), 'source-display-rule-bridges-converted-group-wrapper' );
 	$assert( str_contains( $style, '.wp-block-group.photo-collage > .wp-block-image:first-child, .wp-block-group.photo-collage > .wp-block-image:first-child img {grid-row:span 2;height:100%}' ), 'source-image-grid-rule-bridges-native-image-block-wrapper' );


### PR DESCRIPTION
## Summary
- Removes SSI's page-body script scraper and empty `core/html` cleanup path.
- Trusts BAC compiled page body markup and consumes `document_metadata.scripts` for routed scripts.
- Updates the document metadata smoke to assert body scripts through `generated_theme.document_metadata.scripts` with `placement: body`.

Fixes #322.
Depends on chubes4/block-artifact-compiler#37.

## Testing
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/smoke-website-artifact-document-metadata.php`
- Targeted smoke with SSI worktree plus BAC #37 loaded directly: script-routing assertions passed; remaining direct-harness failures were unrelated existing `core_html`/CSS bridge assertions from bypassing the normal vendored dependency path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Removing the downstream script inference path, updating smoke expectations, and verifying against the BAC #37 contract; Chris remains responsible for review and final acceptance.