### PR TITLE
Fix issue 323: extract stylesheet materializer

### DIFF
--- a/includes/class-static-site-importer-stylesheet-materializer.php
+++ b/includes/class-static-site-importer-stylesheet-materializer.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Generated theme stylesheet materialization helpers.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Builds generated theme stylesheet write payloads.
+ */
+class Static_Site_Importer_Stylesheet_Materializer {
+
+	/**
+	 * Build stylesheet writes for a generated block theme.
+	 *
+	 * @param string                  $theme_dir            Theme directory.
+	 * @param string                  $theme_name           Theme name.
+	 * @param string                  $css                  Source CSS.
+	 * @param array<int,string>       $button_classes       Button wrapper classes observed during conversion.
+	 * @param array<int,array<mixed>> $selector_provenance BAC selector provenance rows.
+	 * @param callable                $style_builder        Callback that builds frontend style.css content.
+	 * @param callable                $editor_style_builder Callback that builds editor-style.css content.
+	 * @return array<string,string> Absolute stylesheet write paths mapped to file contents.
+	 */
+	public static function stylesheet_writes(
+		string $theme_dir,
+		string $theme_name,
+		string $css,
+		array $button_classes,
+		array $selector_provenance,
+		callable $style_builder,
+		callable $editor_style_builder
+	): array {
+		return array(
+			$theme_dir . '/style.css'                   => (string) $style_builder( $theme_name, $css, $button_classes, $selector_provenance ),
+			$theme_dir . '/assets/css/editor-style.css' => (string) $editor_style_builder( $css, $button_classes, $selector_provenance ),
+		);
+	}
+}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -195,14 +195,25 @@ class Static_Site_Importer_Theme_Generator {
 
 		$selector_provenance = self::selector_provenance_from_artifacts( $artifacts );
 
-		$writes = array(
-			$theme_dir . '/style.css'                   => self::style_css( $theme_name, $materialized['css'], array_keys( self::$button_wrapper_classes ), $selector_provenance ),
-			$theme_dir . '/assets/css/editor-style.css' => self::editor_style_css( $materialized['css'], array_keys( self::$button_wrapper_classes ), $selector_provenance ),
-			$theme_dir . '/functions.php'               => self::functions_php( $theme_slug ),
-			$theme_dir . '/theme.json'                  => self::theme_json( $theme_name, $materialized['css'] ),
-			$theme_dir . '/templates/front-page.html'   => self::content_template( '', $has_footer_part ),
-			$theme_dir . '/templates/page.html'         => self::content_template( '', $has_footer_part ),
-			$theme_dir . '/templates/index.html'        => self::content_template( '', $has_footer_part ),
+		$stylesheet_writes = Static_Site_Importer_Stylesheet_Materializer::stylesheet_writes(
+			$theme_dir,
+			$theme_name,
+			$materialized['css'],
+			array_keys( self::$button_wrapper_classes ),
+			$selector_provenance,
+			static fn ( string $name, string $css, array $classes, array $provenance ): string => self::style_css( $name, $css, $classes, $provenance ),
+			static fn ( string $css, array $classes, array $provenance ): string => self::editor_style_css( $css, $classes, $provenance )
+		);
+
+		$writes = array_merge(
+			$stylesheet_writes,
+			array(
+				$theme_dir . '/functions.php'             => self::functions_php( $theme_slug ),
+				$theme_dir . '/theme.json'                => self::theme_json( $theme_name, $materialized['css'] ),
+				$theme_dir . '/templates/front-page.html' => self::content_template( '', $has_footer_part ),
+				$theme_dir . '/templates/page.html'       => self::content_template( '', $has_footer_part ),
+				$theme_dir . '/templates/index.html'      => self::content_template( '', $has_footer_part ),
+			)
 		);
 		$writes = array_merge( $writes, $template_part_writes );
 		$result         = self::write_page_contents( $document_pages, $page_ids, $page_artifacts['contents'] );

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -27,6 +27,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-so
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-fetcher.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-plugin-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-materializer.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-stylesheet-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-wp-codebox-artifact-diagnostics-normalizer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';


### PR DESCRIPTION
## Summary
- Extract generated theme stylesheet write targeting into `Static_Site_Importer_Stylesheet_Materializer`.
- Keep SSI theme generation as the caller while preserving the existing frontend/editor stylesheet builders.
- Register the new materializer in plugin bootstrap so follow-up generator cleanup can move stylesheet ownership out incrementally.

Closes #323.

## Verification
- `php -l static-site-importer.php && php -l includes/class-static-site-importer-stylesheet-materializer.php && php -l includes/class-static-site-importer-theme-generator.php`

## Notes
- The local broad document-metadata smoke is currently blocked by this Studio site's active BAC runtime being behind the merged script metadata contract from BAC #37; PR CI should run against the committed dependency state.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped stylesheet materializer extraction, ran lint verification, and prepared the PR summary for Chris to review.