### PR TITLE
Release v1.1.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -95,12 +95,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/html-to-blocks-converter",
-                "reference": "a8e5384d5cb44f97324df51dea40baef2baaadff"
+                "reference": "984a33e78cd587f0faac25b5294b2f8f8974c25f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/a8e5384d5cb44f97324df51dea40baef2baaadff",
-                "reference": "a8e5384d5cb44f97324df51dea40baef2baaadff",
+                "url": "https://api.github.com/repos/chubes4/html-to-blocks-converter/zipball/984a33e78cd587f0faac25b5294b2f8f8974c25f",
+                "reference": "984a33e78cd587f0faac25b5294b2f8f8974c25f",
                 "shasum": ""
             },
             "require": {
@@ -124,7 +124,7 @@
             ],
             "description": "Convert raw HTML into Gutenberg block arrays using WordPress' HTML API.",
             "homepage": "https://github.com/chubes4/html-to-blocks-converter",
-            "time": "2026-06-08T12:33:03+00:00"
+            "time": "2026-06-08T22:32:19+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Static Site Importer
  * Description: Materialize compiled website artifacts into WordPress block themes.
- * Version: 1.1.3
+ * Version: 1.1.4
  * Author: Chris Huber
  * Requires at least: 6.9
  * Requires PHP: 8.1


### PR DESCRIPTION
## Summary
- Bump Static Site Importer to `1.1.4`.
- Refresh the SSI stack dependency lock to the current H2BC main after the branded-link smoke coverage landed.
- BAC and BFB were already locked to current main; only H2BC changed.

## Testing
- `php -l static-site-importer.php`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l includes/class-static-site-importer-page-materializer.php`
- `php -l includes/class-static-site-importer-asset-reporter.php`
- `php -l includes/class-static-site-importer-document-metadata-reporter.php`
- `php tests/smoke-bac-visual-repair-css.php`
- `php tests/smoke-website-artifact-products-manifest.php`
- `php tests/smoke-combined-dependency-activation.php`
- `studio wp eval-file "/Users/chubes/Developer/static-site-importer@release-v1.1.4-deps/tests/smoke-website-artifact-document-metadata.php" --skip-plugins=static-site-importer`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited open SSI-stack PRs, refreshed the dependency lock, updated the release version, and ran focused verification. Chris remains responsible for review and final acceptance.