### PR TITLE
Emit import validation artifacts

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -262,10 +262,98 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return array<string, mixed>
 	 */
 	public static function finalize_report( array &$report, array $args ): array {
-		$quality                   = self::finalize_quality_report( $report, $args );
-		$report['compact_summary'] = self::import_report_summary( $report, $quality );
+		$quality                            = self::finalize_quality_report( $report, $args );
+		$report['compact_summary']          = self::import_report_summary( $report, $quality );
+		$report['finding_packets']          = self::finding_packets( $report );
+		$report['import_validation_result'] = self::import_validation_result( $report, $quality );
 
 		return $quality;
+	}
+
+	/**
+	 * Build the first-class import validation artifact for automation consumers.
+	 *
+	 * @param array<string,mixed> $report  Full import report.
+	 * @param array<string,mixed> $quality Finalized quality gate state.
+	 * @return array<string,mixed>
+	 */
+	public static function import_validation_result( array $report, array $quality ): array {
+		$summary          = self::import_report_summary( $report, $quality );
+		$diagnostics      = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
+		$source_documents = isset( $report['source_documents'] ) && is_array( $report['source_documents'] ) ? $report['source_documents'] : array();
+
+		return array(
+			'schema'               => 'static-site-importer/import-validation-result/v1',
+			'artifact_type'        => 'ImportValidationResult',
+			'version'              => 1,
+			'status'               => ! empty( $quality['fail_import'] ) ? 'failed' : ( ! empty( $quality['pass'] ) ? 'passed' : 'reported' ),
+			'quality_pass'         => ! empty( $quality['pass'] ),
+			'fail_import'          => ! empty( $quality['fail_import'] ),
+			'failure_reasons'      => isset( $quality['failure_reasons'] ) && is_array( $quality['failure_reasons'] ) ? array_values( $quality['failure_reasons'] ) : array(),
+			'counts'               => array(
+				'source_documents'              => (int) ( $source_documents['total_count'] ?? 0 ),
+				'diagnostics'                   => count( $diagnostics ),
+				'fallback_blocks'               => (int) ( $quality['fallback_count'] ?? 0 ),
+				'content_loss'                  => (int) ( $quality['content_loss_count'] ?? 0 ),
+				'empty_conversions'             => (int) ( $quality['empty_conversion_count'] ?? 0 ),
+				'core_html_blocks'              => (int) ( $quality['core_html_block_count'] ?? 0 ),
+				'freeform_blocks'               => (int) ( $quality['freeform_block_count'] ?? 0 ),
+				'invalid_blocks'                => (int) ( $quality['invalid_block_count'] ?? 0 ),
+				'invalid_block_documents'       => (int) ( $quality['invalid_block_document_count'] ?? 0 ),
+				'unsafe_svgs'                   => (int) ( $quality['unsafe_svg_count'] ?? 0 ),
+				'svg_materialization_failures'  => (int) ( $quality['svg_materialization_failure_count'] ?? 0 ),
+				'svg_sprite_reference_failures' => (int) ( $quality['svg_sprite_reference_failure_count'] ?? 0 ),
+				'commerce_dependency_failures'  => (int) ( $quality['commerce_dependency_failures'] ?? 0 ),
+			),
+			'quality_gates'        => array(
+				'fallback_blocks'              => self::validation_gate( 'fallback_blocks', (int) ( $quality['fallback_count'] ?? 0 ), $quality ),
+				'conversion_failures'          => self::validation_gate( 'conversion_failures', (int) ( $quality['content_loss_count'] ?? 0 ) + (int) ( $quality['empty_conversion_count'] ?? 0 ) + (int) ( $quality['invalid_block_count'] ?? 0 ), $quality ),
+				'generated_fallback_blocks'    => self::validation_gate( 'generated_fallback_blocks', (int) ( $quality['core_html_block_count'] ?? 0 ) + (int) ( $quality['freeform_block_count'] ?? 0 ), $quality ),
+				'asset_materialization'        => self::validation_gate( 'asset_materialization', (int) ( $quality['svg_materialization_failure_count'] ?? 0 ) + (int) ( $quality['svg_sprite_reference_failure_count'] ?? 0 ), $quality ),
+				'commerce_dependencies'        => self::validation_gate( 'commerce_dependencies', (int) ( $quality['commerce_dependency_failures'] ?? 0 ), $quality ),
+				'visual_fidelity'             => array(
+					'status' => (string) ( $report['visual_fidelity']['status'] ?? 'requires_external_render_check' ),
+					'owner'  => (string) ( $report['visual_fidelity']['gate_owner'] ?? 'benchmark_harness' ),
+				),
+				'semantic_fidelity'           => array(
+					'status' => (string) ( $report['semantic_fidelity']['status'] ?? 'requires_external_render_check' ),
+					'owner'  => (string) ( $report['semantic_fidelity']['gate_owner'] ?? 'benchmark_harness' ),
+				),
+			),
+			'diagnostic_summary'  => $summary['diagnostic_summary'] ?? array(),
+			'diagnostic_refs'     => isset( $quality['diagnostic_refs'] ) && is_array( $quality['diagnostic_refs'] ) ? $quality['diagnostic_refs'] : array(),
+			'artifacts'           => self::validation_artifact_refs(),
+			'provenance'          => self::validation_provenance( $report ),
+			'reproduction_context' => self::validation_reproduction_context( $report ),
+		);
+	}
+
+	/**
+	 * Build the finding packet artifact set for repair-loop routing.
+	 *
+	 * @param array<string,mixed> $report Full import report.
+	 * @return array<string,mixed>
+	 */
+	public static function finding_packets( array $report ): array {
+		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
+		$packets     = array();
+
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) || ! self::diagnostic_is_finding_packet_candidate( $diagnostic ) ) {
+				continue;
+			}
+
+			$packets[] = self::finding_packet_from_diagnostic( $diagnostic, $report );
+		}
+
+		return array(
+			'schema'        => 'static-site-importer/finding-packets/v1',
+			'artifact_type' => 'FindingPacketSet',
+			'version'       => 1,
+			'status'        => empty( $packets ) ? 'clean' : 'reported',
+			'count'         => count( $packets ),
+			'packets'       => $packets,
+		);
 	}
 
 	/**
@@ -390,6 +478,208 @@ class Static_Site_Importer_Report_Diagnostics {
 			'error_summaries'              => self::compact_import_report_diagnostic_summaries_by_severity( $diagnostics, 'error' ),
 			'diagnostics'                  => self::compact_import_report_diagnostics( $diagnostics ),
 		);
+	}
+
+	/**
+	 * Build a machine quality gate row.
+	 *
+	 * @param string              $name    Gate name.
+	 * @param int                 $count   Finding count.
+	 * @param array<string,mixed> $quality Finalized quality report.
+	 * @return array<string,mixed>
+	 */
+	private static function validation_gate( string $name, int $count, array $quality ): array {
+		$ref_keys = array(
+			'fallback_blocks'           => 'fallback_count',
+			'conversion_failures'       => 'content_loss_count',
+			'generated_fallback_blocks' => 'core_html_block_count',
+			'asset_materialization'     => 'svg_materialization_failure_count',
+			'commerce_dependencies'     => 'commerce_dependency_failures',
+		);
+		$ref_key  = $ref_keys[ $name ] ?? $name;
+
+		return array(
+			'name'            => $name,
+			'status'          => 0 === $count ? 'passed' : 'reported',
+			'count'           => $count,
+			'diagnostic_refs' => isset( $quality['diagnostic_refs'][ $ref_key ] ) && is_array( $quality['diagnostic_refs'][ $ref_key ] ) ? $quality['diagnostic_refs'][ $ref_key ] : array(),
+		);
+	}
+
+	/**
+	 * Stable artifact paths emitted by SSI import.
+	 *
+	 * @return array<string,array<string,string>>
+	 */
+	private static function validation_artifact_refs(): array {
+		return array(
+			'import_report'            => array(
+				'path' => 'import-report.json',
+				'kind' => 'static-site-importer/import-report',
+			),
+			'import_validation_result' => array(
+				'path' => 'import-validation-result.json',
+				'kind' => 'static-site-importer/import-validation-result',
+			),
+			'finding_packets'          => array(
+				'path' => 'finding-packets.json',
+				'kind' => 'static-site-importer/finding-packets',
+			),
+		);
+	}
+
+	/**
+	 * Build provenance for machine artifacts.
+	 *
+	 * @param array<string,mixed> $report Full import report.
+	 * @return array<string,mixed>
+	 */
+	private static function validation_provenance( array $report ): array {
+		$source   = isset( $report['source'] ) && is_array( $report['source'] ) ? $report['source'] : array();
+		$compiler = isset( $report['block_artifact_compiler']['website_artifact'] ) && is_array( $report['block_artifact_compiler']['website_artifact'] ) ? $report['block_artifact_compiler']['website_artifact'] : array();
+
+		return array(
+			'producer'            => 'static-site-importer',
+			'producer_version'    => defined( 'STATIC_SITE_IMPORTER_VERSION' ) ? STATIC_SITE_IMPORTER_VERSION : 'unknown',
+			'source'              => $source,
+			'compiler_summary'    => isset( $compiler['summary'] ) && is_array( $compiler['summary'] ) ? $compiler['summary'] : array(),
+			'compiler_input'      => isset( $compiler['input'] ) && is_array( $compiler['input'] ) ? $compiler['input'] : array(),
+			'compiler_provenance' => isset( $compiler['provenance'] ) && is_array( $compiler['provenance'] ) ? $compiler['provenance'] : array(),
+		);
+	}
+
+	/**
+	 * Build import-level reproduction context for machine artifacts.
+	 *
+	 * @param array<string,mixed> $report Full import report.
+	 * @return array<string,mixed>
+	 */
+	private static function validation_reproduction_context( array $report ): array {
+		return array(
+			'entry_file'       => isset( $report['entry_file'] ) ? (string) $report['entry_file'] : '',
+			'theme_slug'       => isset( $report['theme_slug'] ) ? (string) $report['theme_slug'] : '',
+			'source_documents' => isset( $report['source_documents'] ) && is_array( $report['source_documents'] ) ? $report['source_documents'] : array(),
+			'artifacts'        => self::validation_artifact_refs(),
+		);
+	}
+
+	/**
+	 * Determine whether a diagnostic should route as a repair finding.
+	 *
+	 * @param array<string,mixed> $diagnostic Normalized diagnostic.
+	 * @return bool
+	 */
+	private static function diagnostic_is_finding_packet_candidate( array $diagnostic ): bool {
+		$type = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : '';
+
+		return in_array(
+			$type,
+			array(
+				'unsupported_html_fallback',
+				'core_html_block',
+				'freeform_block',
+				'invalid_block_document',
+				'content_loss_abort',
+				'empty_conversion',
+				'local_asset_not_materialized',
+				'svg_materialization_failure',
+				'svg_sprite_reference_failure',
+				'commerce_dependency_failure',
+				'commerce_product_inference_unmatched',
+			),
+			true
+		);
+	}
+
+	/**
+	 * Convert one normalized diagnostic into a FindingPacket.
+	 *
+	 * @param array<string,mixed> $diagnostic Normalized diagnostic.
+	 * @param array<string,mixed> $report     Full import report.
+	 * @return array<string,mixed>
+	 */
+	private static function finding_packet_from_diagnostic( array $diagnostic, array $report ): array {
+		$id       = isset( $diagnostic['id'] ) && is_scalar( $diagnostic['id'] ) ? (string) $diagnostic['id'] : 'finding';
+		$type     = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : 'import_diagnostic';
+		$severity = isset( $diagnostic['severity'] ) && is_scalar( $diagnostic['severity'] ) ? (string) $diagnostic['severity'] : self::diagnostic_severity( $type );
+
+		return array(
+			'schema'               => 'static-site-importer/finding-packet/v1',
+			'artifact_type'        => 'FindingPacket',
+			'version'              => 1,
+			'id'                   => 'finding-' . preg_replace( '/^diag-/', '', $id ),
+			'diagnostic_id'        => $id,
+			'type'                 => $type,
+			'severity'             => $severity,
+			'category'             => isset( $diagnostic['category'] ) && is_scalar( $diagnostic['category'] ) ? (string) $diagnostic['category'] : self::diagnostic_category( $type ),
+			'owner'                => self::finding_owner( $diagnostic ),
+			'routing'              => array(
+				'component'              => self::finding_owner( $diagnostic ),
+				'stage'                  => isset( $diagnostic['stage'] ) && is_scalar( $diagnostic['stage'] ) ? (string) $diagnostic['stage'] : 'import',
+				'suggested_repair_class' => isset( $diagnostic['suggested_repair_class'] ) && is_scalar( $diagnostic['suggested_repair_class'] ) ? (string) $diagnostic['suggested_repair_class'] : self::diagnostic_repair_class( $type ),
+			),
+			'provenance'           => self::validation_provenance( $report ),
+			'reproduction_context' => array_merge(
+				self::validation_reproduction_context( $report ),
+				array(
+					'source_path' => isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : '',
+					'selector'    => isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '',
+					'block_path'  => isset( $diagnostic['block_path'] ) && is_scalar( $diagnostic['block_path'] ) ? (string) $diagnostic['block_path'] : '',
+				)
+			),
+			'source'              => array(
+				'path'         => isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : '',
+				'selector'     => isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '',
+				'snippet'      => isset( $diagnostic['source_html_preview'] ) && is_scalar( $diagnostic['source_html_preview'] ) ? (string) $diagnostic['source_html_preview'] : ( isset( $diagnostic['html_excerpt'] ) && is_scalar( $diagnostic['html_excerpt'] ) ? (string) $diagnostic['html_excerpt'] : '' ),
+			),
+			'observed'            => array(
+				'output'       => isset( $diagnostic['emitted_block_preview'] ) && is_scalar( $diagnostic['emitted_block_preview'] ) ? (string) $diagnostic['emitted_block_preview'] : '',
+				'block_name'   => isset( $diagnostic['block_name'] ) && is_scalar( $diagnostic['block_name'] ) ? (string) $diagnostic['block_name'] : '',
+				'reason_code'  => isset( $diagnostic['reason_code'] ) && is_scalar( $diagnostic['reason_code'] ) ? (string) $diagnostic['reason_code'] : self::diagnostic_reason_code( $type, $diagnostic ),
+			),
+			'expected'            => array(
+				'outcome' => self::finding_expected_outcome( $diagnostic ),
+			),
+			'refs'                => array_values( self::validation_artifact_refs() ),
+		);
+	}
+
+	/**
+	 * Route a finding to the most likely upstream owner.
+	 *
+	 * @param array<string,mixed> $diagnostic Normalized diagnostic.
+	 * @return string
+	 */
+	private static function finding_owner( array $diagnostic ): string {
+		$converter = isset( $diagnostic['converter'] ) && is_scalar( $diagnostic['converter'] ) ? (string) $diagnostic['converter'] : '';
+		if ( '' !== $converter ) {
+			return $converter;
+		}
+
+		$type = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : '';
+		if ( str_contains( $type, 'svg' ) || str_contains( $type, 'asset' ) ) {
+			return 'static-site-importer';
+		}
+
+		return 'block-artifact-compiler';
+	}
+
+	/**
+	 * Explain the target repair state for a finding.
+	 *
+	 * @param array<string,mixed> $diagnostic Normalized diagnostic.
+	 * @return string
+	 */
+	private static function finding_expected_outcome( array $diagnostic ): string {
+		$type = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : '';
+		if ( in_array( $type, array( 'unsupported_html_fallback', 'core_html_block', 'freeform_block' ), true ) ) {
+			return 'Generate first-class WordPress block markup without fallback core/html or core/freeform output.';
+		}
+		if ( in_array( $type, array( 'content_loss_abort', 'empty_conversion', 'invalid_block_document' ), true ) ) {
+			return 'Convert the source content into valid non-empty WordPress block markup without losing source content.';
+		}
+
+		return 'Import should complete without this diagnostic being reported.';
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -173,13 +173,25 @@ class Static_Site_Importer_Theme_Generator {
 		self::materialize_required_plugins( $args );
 		self::record_product_seeding_report( $args );
 		self::record_commerce_dependency_check( $args );
-		$quality     = Static_Site_Importer_Report_Diagnostics::finalize_report( self::$conversion_report, $args );
-		$report_json = wp_json_encode( self::$conversion_report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		$quality                = Static_Site_Importer_Report_Diagnostics::finalize_report( self::$conversion_report, $args );
+		$validation_result      = self::$conversion_report['import_validation_result'] ?? array();
+		$finding_packets        = self::$conversion_report['finding_packets'] ?? array();
+		$report_json            = wp_json_encode( self::$conversion_report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		$validation_result_json = wp_json_encode( $validation_result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		$finding_packets_json   = wp_json_encode( $finding_packets, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 		if ( false === $report_json ) {
 			return new WP_Error( 'static_site_importer_report_encode_failed', 'Failed to encode import report JSON.' );
 		}
+		if ( false === $validation_result_json ) {
+			return new WP_Error( 'static_site_importer_validation_result_encode_failed', 'Failed to encode import validation result JSON.' );
+		}
+		if ( false === $finding_packets_json ) {
+			return new WP_Error( 'static_site_importer_finding_packets_encode_failed', 'Failed to encode finding packets JSON.' );
+		}
 
-		$writes[ $theme_dir . '/import-report.json' ] = $report_json . "\n";
+		$writes[ $theme_dir . '/import-report.json' ]            = $report_json . "\n";
+		$writes[ $theme_dir . '/import-validation-result.json' ] = $validation_result_json . "\n";
+		$writes[ $theme_dir . '/finding-packets.json' ]          = $finding_packets_json . "\n";
 		foreach ( $writes as $path => $content ) {
 			$result = Static_Site_Importer_Theme_Materializer::write_file( $path, $content );
 			if ( is_wp_error( $result ) ) {
@@ -187,10 +199,24 @@ class Static_Site_Importer_Theme_Generator {
 			}
 		}
 
-		$external_report_path = '';
+		$external_report_path            = '';
+		$external_validation_result_path = '';
+		$external_finding_packets_path   = '';
 		if ( isset( $args['report'] ) && '' !== trim( (string) $args['report'] ) ) {
 			$external_report_path = (string) $args['report'];
 			$result               = Static_Site_Importer_Theme_Materializer::write_external_report( $external_report_path, $report_json . "\n" );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$external_report_dir              = dirname( $external_report_path );
+			$external_validation_result_path = trailingslashit( $external_report_dir ) . 'import-validation-result.json';
+			$external_finding_packets_path   = trailingslashit( $external_report_dir ) . 'finding-packets.json';
+			$result                          = Static_Site_Importer_Theme_Materializer::write_external_report( $external_validation_result_path, $validation_result_json . "\n" );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$result = Static_Site_Importer_Theme_Materializer::write_external_report( $external_finding_packets_path, $finding_packets_json . "\n" );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
@@ -214,11 +240,17 @@ class Static_Site_Importer_Theme_Generator {
 			'theme_name'            => $theme_name,
 			'theme_dir'             => $theme_dir,
 			'report_path'           => $theme_dir . '/import-report.json',
-			'external_report_path'  => $external_report_path,
-			'import_report_summary' => self::$conversion_report['compact_summary'],
-			'pages'                 => $page_ids,
-			'quality'               => $quality,
-			'source_documents'      => self::$conversion_report['source_documents'],
+			'validation_result_path'          => $theme_dir . '/import-validation-result.json',
+			'finding_packets_path'            => $theme_dir . '/finding-packets.json',
+			'external_report_path'            => $external_report_path,
+			'external_validation_result_path' => $external_validation_result_path,
+			'external_finding_packets_path'   => $external_finding_packets_path,
+			'import_report_summary'           => self::$conversion_report['compact_summary'],
+			'import_validation_result'        => $validation_result,
+			'finding_packets'                 => $finding_packets,
+			'pages'                           => $page_ids,
+			'quality'                         => $quality,
+			'source_documents'                => self::$conversion_report['source_documents'],
 		);
 	}
 

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'STATIC_SITE_IMPORTER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'STATIC_SITE_IMPORTER_URL', plugin_dir_url( __FILE__ ) );
+define( 'STATIC_SITE_IMPORTER_VERSION', '1.1.4' );
 
 if ( is_readable( STATIC_SITE_IMPORTER_PATH . 'vendor/autoload.php' ) ) {
 	require_once STATIC_SITE_IMPORTER_PATH . 'vendor/autoload.php';

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -86,6 +86,95 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Import validation and finding packet artifacts expose repair-loop contracts.
+	 */
+	public function test_import_validation_result_and_finding_packets_are_machine_readable(): void {
+		$report = array(
+			'entry_file'              => '/tmp/source/index.html',
+			'version'                 => 1,
+			'theme_slug'              => 'static-template-import',
+			'source'                  => array(
+				'type'   => 'website_artifact',
+				'source' => 'artifact.json',
+			),
+			'block_artifact_compiler' => array(
+				'website_artifact' => array(
+					'summary'    => array(
+						'schema' => 'block-artifact-compiler/result/v1',
+						'status' => 'success',
+						'source' => 'artifact.json',
+					),
+					'input'      => array( 'entry_path' => 'website/index.html' ),
+					'provenance' => array( 'source' => 'artifact.json' ),
+				),
+			),
+			'source_documents'        => array(
+				'total_count' => 1,
+			),
+			'visual_fidelity'         => array(
+				'status'     => 'requires_external_render_check',
+				'gate_owner' => 'benchmark_harness',
+			),
+			'semantic_fidelity'       => array(
+				'status'     => 'requires_external_render_check',
+				'gate_owner' => 'benchmark_harness',
+			),
+			'quality'                 => array(
+				'fallback_count'                     => 0,
+				'content_loss_count'                 => 0,
+				'empty_conversion_count'             => 0,
+				'core_html_block_count'              => 1,
+				'freeform_block_count'               => 0,
+				'invalid_block_count'                => 0,
+				'invalid_block_document_count'       => 0,
+				'unsafe_svg_count'                   => 0,
+				'svg_materialization_failure_count'  => 0,
+				'svg_sprite_reference_failure_count' => 0,
+				'commerce_dependency_failures'       => 0,
+			),
+			'diagnostics'             => array(
+				array(
+					'type'                   => 'core_html_block',
+					'source'                 => 'generated:templates/front-page.html',
+					'selector'               => 'iframe#store-widget.embedded.checkout',
+					'source_html_preview'    => '<iframe id="store-widget" class="embedded checkout"></iframe>',
+					'emitted_block_preview'  => '<!-- wp:html --><iframe id="store-widget" class="embedded checkout"></iframe><!-- /wp:html -->',
+					'block_name'             => 'core/html',
+					'converter'              => 'html-to-blocks-converter',
+					'stage'                  => 'generated_theme_block_analysis',
+					'reason'                 => 'generated_document_contains_core_html',
+					'block_path'             => '0',
+				),
+			),
+		);
+
+		$quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $report, array() );
+
+		$this->assertSame( 'static-site-importer/import-validation-result/v1', $report['import_validation_result']['schema'] ?? '' );
+		$this->assertSame( 'ImportValidationResult', $report['import_validation_result']['artifact_type'] ?? '' );
+		$this->assertSame( 'reported', $report['import_validation_result']['status'] ?? '' );
+		$this->assertFalse( $quality['pass'] ?? true );
+		$this->assertSame( 1, $report['import_validation_result']['counts']['core_html_blocks'] ?? 0 );
+		$this->assertSame( 'import-validation-result.json', $report['import_validation_result']['artifacts']['import_validation_result']['path'] ?? '' );
+		$this->assertSame( 'finding-packets.json', $report['import_validation_result']['artifacts']['finding_packets']['path'] ?? '' );
+		$this->assertSame( '/tmp/source/index.html', $report['import_validation_result']['reproduction_context']['entry_file'] ?? '' );
+
+		$this->assertSame( 'static-site-importer/finding-packets/v1', $report['finding_packets']['schema'] ?? '' );
+		$this->assertSame( 1, $report['finding_packets']['count'] ?? 0 );
+		$packet = $report['finding_packets']['packets'][0] ?? array();
+		$this->assertSame( 'static-site-importer/finding-packet/v1', $packet['schema'] ?? '' );
+		$this->assertSame( 'FindingPacket', $packet['artifact_type'] ?? '' );
+		$this->assertSame( 'core_html_block', $packet['type'] ?? '' );
+		$this->assertSame( 'warning', $packet['severity'] ?? '' );
+		$this->assertSame( 'html-to-blocks-converter', $packet['owner'] ?? '' );
+		$this->assertSame( 'replace_fallback_block', $packet['routing']['suggested_repair_class'] ?? '' );
+		$this->assertSame( 'templates/front-page.html', $packet['source']['path'] ?? '' );
+		$this->assertStringContainsString( '<iframe', $packet['source']['snippet'] ?? '' );
+		$this->assertStringContainsString( '<!-- wp:html -->', $packet['observed']['output'] ?? '' );
+		$this->assertStringContainsString( 'without fallback', $packet['expected']['outcome'] ?? '' );
+	}
+
+	/**
 	 * Artifact diagnostics use the WP Codebox normalization contract.
 	 */
 	public function test_wp_codebox_artifact_diagnostics_normalizer_accepts_import_report_shape(): void {

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -71,6 +71,8 @@ $assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $
 if ( ! is_wp_error( $result ) ) {
 	$theme_dir = $result['theme_dir'];
 	$report    = json_decode( $read( $result['report_path'] ), true );
+	$validation_result = json_decode( $read( $result['validation_result_path'] ?? '' ), true );
+	$finding_packets   = json_decode( $read( $result['finding_packets_path'] ?? '' ), true );
 	$page_ids  = array_values( $result['pages'] ?? array() );
 	$page_id   = (int) ( $page_ids[0] ?? 0 );
 	$page      = $page_id > 0 ? get_post( $page_id ) : null;
@@ -101,6 +103,13 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( ! str_contains( $content, '<script' ), 'page-content-has-no-script-fragments' );
 	$assert( 0 === ( $documents['posts/page-home.post_content']['core_html_block_count'] ?? null ), 'report-page-content-has-zero-core-html' );
 	$assert( 0 === ( $report['quality']['core_html_block_count'] ?? null ), 'quality-core-html-count-is-zero' );
+	$assert( is_file( $result['validation_result_path'] ?? '' ), 'validation-result-artifact-is-written' );
+	$assert( is_file( $result['finding_packets_path'] ?? '' ), 'finding-packets-artifact-is-written' );
+	$assert( 'static-site-importer/import-validation-result/v1' === ( $validation_result['schema'] ?? '' ), 'validation-result-schema' );
+	$assert( 'ImportValidationResult' === ( $validation_result['artifact_type'] ?? '' ), 'validation-result-artifact-type' );
+	$assert( 'passed' === ( $validation_result['status'] ?? '' ), 'validation-result-status-passed' );
+	$assert( 'static-site-importer/finding-packets/v1' === ( $finding_packets['schema'] ?? '' ), 'finding-packets-schema' );
+	$assert( 'FindingPacketSet' === ( $finding_packets['artifact_type'] ?? '' ), 'finding-packets-artifact-type' );
 	$assert( 'static-site-importer/document-metadata/v1' === ( $metadata['schema'] ?? '' ), 'metadata-contract-is-recorded' );
 	$assert( 'Ember & Rye' === ( $metadata['title'] ?? '' ), 'title-is-preserved-in-metadata' );
 	$assert( 'utf-8' === ( $metadata['meta'][0]['charset'] ?? '' ), 'charset-meta-is-preserved-in-metadata' );


### PR DESCRIPTION
## Summary
- Emits stable `import-validation-result.json` and `finding-packets.json` sidecar artifacts from the website artifact import path, alongside the existing human-readable `import-report.json`.
- Adds `ImportValidationResult` and `FindingPacket` machine contracts with quality counts, fallback/conversion failure representation, severity, routing/provenance metadata, reproduction context, source/observed/expected evidence, and stable artifact refs.
- Returns the new artifact paths/results from import and covers the artifact shapes in targeted diagnostics and import smoke tests.

Fixes #336.

## Verification
- `php -l includes/class-static-site-importer-report-diagnostics.php`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/StaticSiteImporterFallbackDiagnosticsTest.php`
- Targeted PHP artifact builder harness: `artifact builder harness ok`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@fix-issue-336-import-validation-artifacts/tests/smoke-website-artifact-document-metadata.php` passed: `OK: website artifact document metadata smoke passed (51 assertions)`
- `npm run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead` passed: `OK: JS block validation smoke passed (133 blocks across 15 files)`

## Notes
- `npm run test:validation` currently fails after importing the fixture because `tests/smoke-admin-import-html-entry.php` is missing in this checkout; the targeted import smoke above exercises the new sidecar artifacts through this worktree.
- Loading the worktree plugin via `wp eval-file --skip-plugins=static-site-importer` prints existing Abilities API registration timing notices, but the smoke completed successfully.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the artifact contract implementation, wired import sidecar writes, added targeted tests, and ran verification commands for Chris to review.