### PR TITLE
Add URL import provider runtime

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -109,6 +109,43 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);
+
+		wp_register_ability(
+			'static-site-importer/import-url',
+			array(
+				'label'               => __( 'Import URL', 'static-site-importer' ),
+				'description'         => __( 'Import a source URL through a URL extraction provider and return a Static Site Importer report.', 'static-site-importer' ),
+				'category'            => STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'url'                          => array( 'type' => 'string' ),
+						'provider'                     => array( 'type' => 'string' ),
+						'provider_args'                => array( 'type' => 'object' ),
+						'work_dir'                     => array( 'type' => 'string' ),
+						'slug'                         => array( 'type' => 'string' ),
+						'name'                         => array( 'type' => 'string' ),
+						'activate'                     => array( 'type' => 'boolean' ),
+						'overwrite'                    => array( 'type' => 'boolean' ),
+						'fail_on_quality'              => array( 'type' => 'boolean' ),
+						'allow_missing_woocommerce'    => array( 'type' => 'boolean' ),
+						'report'                       => array( 'type' => 'string' ),
+						'asset_materialization_policy' => array(
+							'type' => 'string',
+							'enum' => array( 'copy_to_theme', 'use_map' ),
+						),
+						'asset_map'                    => array( 'type' => 'object' ),
+						'compiler_options'             => array( 'type' => 'object' ),
+						'source_metadata'              => array( 'type' => 'object' ),
+					),
+					'required'   => array( 'url' ),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'static_site_importer_ability_import_url',
+				'permission_callback' => 'static_site_importer_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
 	}
 }
 
@@ -124,6 +161,28 @@ if ( ! function_exists( 'static_site_importer_ability_permission_callback' ) ) {
 		}
 
 		return ! function_exists( 'current_user_can' ) || current_user_can( 'switch_themes' );
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_import_url' ) ) {
+	/**
+	 * Ability callback for URL imports.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>
+	 */
+	function static_site_importer_ability_import_url( array $input ): array {
+		$result = Static_Site_Importer_URL_Import_Runtime::import_url( $input );
+		if ( is_wp_error( $result ) ) {
+			/** @var WP_Error $result */
+			return static_site_importer_ability_error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
+		}
+
+		return array(
+			'success'               => true,
+			'result'                => $result,
+			'import_report_summary' => isset( $result['import_report_summary'] ) && is_array( $result['import_report_summary'] ) ? $result['import_report_summary'] : array(),
+		);
 	}
 }
 

--- a/includes/class-static-site-importer-url-import-runtime.php
+++ b/includes/class-static-site-importer-url-import-runtime.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * URL import runtime/provider boundary.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Imports a source URL through a provider that returns a website artifact.
+ */
+class Static_Site_Importer_URL_Import_Runtime {
+
+	/**
+	 * Import a URL and return the normal Static Site Importer result/report envelope.
+	 *
+	 * @param array<string,mixed> $input Ability-style input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function import_url( array $input ) {
+		$url = isset( $input['url'] ) ? trim( (string) $input['url'] ) : '';
+		if ( '' === $url ) {
+			return new WP_Error( 'static_site_importer_missing_url', 'The url input is required.' );
+		}
+
+		$request = self::provider_request( $url, $input );
+		$runtime = self::resolve_provider( $request );
+		if ( is_wp_error( $runtime ) ) {
+			return $runtime;
+		}
+
+		$artifact = isset( $runtime['artifact'] ) && is_array( $runtime['artifact'] ) ? $runtime['artifact'] : array();
+		if ( empty( $artifact ) ) {
+			return new WP_Error( 'static_site_importer_url_provider_missing_artifact', 'The URL import provider did not return a website artifact.' );
+		}
+
+		$args = self::import_args( $input, $runtime );
+		return Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $args );
+	}
+
+	/**
+	 * Build a provider request envelope.
+	 *
+	 * @param string              $url   Source URL.
+	 * @param array<string,mixed> $input Ability-style input.
+	 * @return array<string,mixed>
+	 */
+	private static function provider_request( string $url, array $input ): array {
+		return array(
+			'url'             => $url,
+			'provider'        => isset( $input['provider'] ) ? (string) $input['provider'] : '',
+			'provider_args'   => isset( $input['provider_args'] ) && is_array( $input['provider_args'] ) ? $input['provider_args'] : array(),
+			'work_dir'        => isset( $input['work_dir'] ) ? (string) $input['work_dir'] : self::default_work_dir(),
+			'source_metadata' => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
+		);
+	}
+
+	/**
+	 * Resolve the provider output.
+	 *
+	 * Providers return an array with an `artifact` key containing a BAC website
+	 * artifact, plus optional `source_metadata` and `provider` fields.
+	 *
+	 * @param array<string,mixed> $request Provider request envelope.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function resolve_provider( array $request ) {
+		/**
+		 * Filters URL import provider output before the built-in public URL fetcher runs.
+		 *
+		 * Return WP_Error to fail the import, or an array with an `artifact` key to import
+		 * a provider-built website artifact. Hosted/private DLA runtimes should hook here
+		 * rather than product code spawning local processes.
+		 *
+		 * @param null|array<string,mixed>|WP_Error $provider_output Provider output.
+		 * @param array<string,mixed>               $request         Provider request.
+		 */
+		$provider_output = apply_filters( 'static_site_importer_url_import_provider', null, $request );
+		if ( is_wp_error( $provider_output ) ) {
+			return $provider_output;
+		}
+		if ( is_array( $provider_output ) ) {
+			return $provider_output;
+		}
+
+		return self::fetch_public_url_provider( $request );
+	}
+
+	/**
+	 * Built-in generic public URL provider.
+	 *
+	 * @param array<string,mixed> $request Provider request envelope.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function fetch_public_url_provider( array $request ) {
+		$fetch = Static_Site_Importer_URL_Fetcher::fetch_to_work_dir(
+			(string) $request['url'],
+			(string) $request['work_dir'],
+			isset( $request['provider_args'] ) && is_array( $request['provider_args'] ) ? $request['provider_args'] : array()
+		);
+		if ( is_wp_error( $fetch ) ) {
+			return $fetch;
+		}
+
+		$html = file_get_contents( $fetch['html_path'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads the importer-owned fetched HTML artifact.
+		if ( false === $html ) {
+			return new WP_Error( 'static_site_importer_url_artifact_read_failed', 'Failed to read fetched URL HTML.' );
+		}
+
+		return array(
+			'provider'        => 'public-url-fetcher',
+			'artifact'        => array(
+				'schema' => 'block-artifact-compiler/website-artifact/v1',
+				'files'  => array(
+					array(
+						'path'    => 'website/index.html',
+						'content' => $html,
+					),
+				),
+			),
+			'source_metadata' => isset( $fetch['metadata'] ) && is_array( $fetch['metadata'] ) ? $fetch['metadata'] : array(),
+		);
+	}
+
+	/**
+	 * Build import args for the normal website artifact importer.
+	 *
+	 * @param array<string,mixed> $input   Ability-style input.
+	 * @param array<string,mixed> $runtime Runtime/provider output.
+	 * @return array<string,mixed>
+	 */
+	private static function import_args( array $input, array $runtime ): array {
+		$source_metadata = isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array();
+		if ( isset( $runtime['source_metadata'] ) && is_array( $runtime['source_metadata'] ) ) {
+			$source_metadata = array_merge( $source_metadata, $runtime['source_metadata'] );
+		}
+		$source_metadata['url_import_provider'] = isset( $runtime['provider'] ) ? (string) $runtime['provider'] : 'public-url-fetcher';
+
+		$args = array(
+			'slug'                         => isset( $input['slug'] ) ? (string) $input['slug'] : '',
+			'name'                         => isset( $input['name'] ) ? (string) $input['name'] : '',
+			'activate'                     => ! empty( $input['activate'] ),
+			'overwrite'                    => ! empty( $input['overwrite'] ),
+			'fail_on_quality'              => ! empty( $input['fail_on_quality'] ),
+			'allow_missing_woocommerce'    => ! empty( $input['allow_missing_woocommerce'] ),
+			'materialize_dependencies'     => array_key_exists( 'materialize_dependencies', $input ) ? (bool) $input['materialize_dependencies'] : true,
+			'report'                       => isset( $input['report'] ) ? (string) $input['report'] : '',
+			'asset_materialization_policy' => isset( $input['asset_materialization_policy'] ) ? (string) $input['asset_materialization_policy'] : '',
+			'asset_map'                    => isset( $input['asset_map'] ) && is_array( $input['asset_map'] ) ? $input['asset_map'] : array(),
+			'compiler_options'             => isset( $input['compiler_options'] ) && is_array( $input['compiler_options'] ) ? $input['compiler_options'] : array(),
+			'source_metadata'              => $source_metadata,
+		);
+
+		return $args;
+	}
+
+	/**
+	 * Build the default work directory for the built-in URL provider.
+	 *
+	 * @return string
+	 */
+	private static function default_work_dir(): string {
+		$upload_dir = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
+		$base_dir   = isset( $upload_dir['basedir'] ) ? (string) $upload_dir['basedir'] : sys_get_temp_dir();
+
+		return trailingslashit( $base_dir ) . 'static-site-importer/url-import-' . wp_generate_uuid4();
+	}
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -26,6 +26,7 @@ if ( is_readable( STATIC_SITE_IMPORTER_PATH . 'vendor/autoload.php' ) ) {
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-source-page.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-fetcher.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-import-runtime.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-plugin-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-asset-reporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document-metadata-reporter.php';

--- a/tests/smoke-url-import-runtime.php
+++ b/tests/smoke-url-import-runtime.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Smoke test: URL imports use the provider boundary and return report envelopes.
+ *
+ * Run from the repository root:
+ * php tests/smoke-url-import-runtime.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private mixed $data;
+
+		public function __construct( string $code, string $message, mixed $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): mixed {
+			return $this->data;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = '' ): string {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $path ): string {
+		return rtrim( $path, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4(): string {
+		return '00000000-0000-4000-8000-000000000000';
+	}
+}
+
+$GLOBALS['ssi_url_import_filters'] = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook_name, callable $callback ): void {
+		$GLOBALS['ssi_url_import_filters'][ $hook_name ][] = $callback;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook_name, callable $callback ): void {
+		$GLOBALS['ssi_url_import_filters'][ $hook_name ][] = $callback;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {
+		foreach ( $GLOBALS['ssi_url_import_filters'][ $hook_name ] ?? array() as $callback ) {
+			$value = $callback( $value, ...$args );
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook_name ): int {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( string $hook_name ): bool {
+		return false;
+	}
+}
+
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator' ) ) {
+	class Static_Site_Importer_Theme_Generator {
+		public static array $last_artifact = array();
+		public static array $last_args     = array();
+
+		public static function import_website_artifact( array $artifact, array $args = array() ): array {
+			self::$last_artifact = $artifact;
+			self::$last_args     = $args;
+
+			return array(
+				'theme_slug'            => $args['slug'] ?? '',
+				'report_path'           => '/tmp/import-report.json',
+				'import_report_summary' => array(
+					'status'       => 'completed',
+					'quality_pass' => true,
+				),
+			);
+		}
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-import-runtime.php';
+require_once dirname( __DIR__ ) . '/includes/abilities.php';
+
+$missing = Static_Site_Importer_URL_Import_Runtime::import_url( array() );
+$assert( is_wp_error( $missing ), 'missing-url-errors' );
+$assert( 'static_site_importer_missing_url' === $missing->get_error_code(), 'missing-url-error-code' );
+
+add_filter(
+	'static_site_importer_url_import_provider',
+	static function ( mixed $output, array $request ): array {
+		return array(
+			'provider'        => 'test-private-runtime',
+			'artifact'        => array(
+				'schema' => 'block-artifact-compiler/website-artifact/v1',
+				'files'  => array(
+					array(
+						'path'    => 'website/index.html',
+						'content' => '<main><h1>Imported privately</h1></main>',
+					),
+				),
+			),
+			'source_metadata' => array(
+				'source_url' => $request['url'],
+				'visibility' => 'private',
+			),
+		);
+	}
+);
+
+$result = Static_Site_Importer_URL_Import_Runtime::import_url(
+	array(
+		'url'             => 'https://private.example.test/',
+		'slug'            => 'private-import',
+		'overwrite'       => true,
+		'source_metadata' => array( 'requested_by' => 'studio-web' ),
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'provider-import-succeeds' );
+$assert( 'private-import' === ( $result['theme_slug'] ?? '' ), 'result-passes-through' );
+$assert( 'website/index.html' === ( Static_Site_Importer_Theme_Generator::$last_artifact['files'][0]['path'] ?? '' ), 'provider-artifact-imported' );
+$assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['overwrite'] ?? null ), 'import-args-preserved' );
+$assert( 'studio-web' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['requested_by'] ?? '' ), 'caller-metadata-preserved' );
+$assert( 'private' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['visibility'] ?? '' ), 'provider-metadata-merged' );
+$assert( 'test-private-runtime' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['url_import_provider'] ?? '' ), 'provider-recorded' );
+
+$ability = static_site_importer_ability_import_url(
+	array(
+		'url' => 'https://private.example.test/',
+		'slug' => 'ability-import',
+	)
+);
+
+$assert( true === ( $ability['success'] ?? false ), 'ability-succeeds' );
+$assert( 'completed' === ( $ability['import_report_summary']['status'] ?? '' ), 'ability-returns-report-summary' );
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( PHP_EOL, $failures ) . PHP_EOL );
+	exit( 1 );
+}
+
+echo sprintf( "URL import runtime smoke passed (%d assertions).\n", $assertions );


### PR DESCRIPTION
## Summary
- adds a `static-site-importer/import-url` ability for URL-to-import-report execution
- introduces a generic URL import provider filter that accepts a BAC website artifact from hosted/private runtimes
- keeps the default path safe and generic by fetching public HTML through the existing URL fetcher, then importing through the normal website artifact/report pipeline

## Ownership decision
- `static-site-importer` owns the import report contract and theme materialization (`static-site-importer/import-website-artifact`, `Static_Site_Importer_Theme_Generator::import_website_artifact`).
- `studio-native-incubator` references Static Site Importer as the compiler/import-report source and documents local DLA process execution only as a gated fallback.
- `data-liberation-agent` owns extraction mechanics, but not the WordPress import report/materialization ability. This PR creates the upstream provider seam SSI needs so DLA/SecEx/private runtimes can plug in without Studio Web shelling out locally.

## Tests
- `php -l includes/class-static-site-importer-url-import-runtime.php`
- `php -l includes/abilities.php`
- `php -l tests/smoke-url-import-runtime.php`
- `php tests/smoke-url-import-runtime.php`
- `php tests/smoke-export-theme-ability.php`
- `php tests/smoke-bac-visual-repair-css.php`
- `php tests/smoke-website-artifact-products-manifest.php`

## Note
- I also ran `npm run test:js-block-validation -- --help`; that script does not implement `--help` and failed before exercising this change, so it is not counted as validation evidence.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the provider boundary, ability wiring, and smoke test; Chris remains responsible for review and acceptance.