### PR TITLE
Route fallback diagnostics to Blocks Engine

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -241,7 +241,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'reason'                => isset( $context['reason'] ) ? (string) $context['reason'] : 'unknown',
 			'tag_name'              => isset( $context['tag_name'] ) ? (string) $context['tag_name'] : self::diagnostic_tag_name_from_html( $element_html ),
 			'block_name'            => isset( $block['blockName'] ) ? (string) $block['blockName'] : null,
-			'converter'             => 'html-to-blocks-converter',
+			'converter'             => 'blocks-engine-php-transformer',
 			'stage'                 => isset( $context['stage'] ) ? (string) $context['stage'] : 'html_to_blocks',
 			'html_length'           => strlen( $element_html ),
 			'html_excerpt'          => self::diagnostic_excerpt( $element_html ),

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -48,7 +48,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 						'source_html_preview'    => '<iframe id="store-widget" class="embedded checkout"></iframe>',
 						'emitted_block_preview'  => '<!-- wp:html --><iframe id="store-widget" class="embedded checkout"></iframe><!-- /wp:html -->',
 						'block_name'             => 'core/html',
-						'converter'              => 'html-to-blocks-converter',
+						'converter'              => 'blocks-engine-php-transformer',
 						'stage'                  => 'generated_theme_block_analysis',
 						'reason'                 => 'generated_document_contains_core_html',
 						'html_length'            => 64,
@@ -140,7 +140,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 					'source_html_preview'    => '<iframe id="store-widget" class="embedded checkout"></iframe>',
 					'emitted_block_preview'  => '<!-- wp:html --><iframe id="store-widget" class="embedded checkout"></iframe><!-- /wp:html -->',
 					'block_name'             => 'core/html',
-					'converter'              => 'html-to-blocks-converter',
+					'converter'              => 'blocks-engine-php-transformer',
 					'stage'                  => 'generated_theme_block_analysis',
 					'reason'                 => 'generated_document_contains_core_html',
 					'block_path'             => '0',
@@ -166,7 +166,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 'FindingPacket', $packet['artifact_type'] ?? '' );
 		$this->assertSame( 'core_html_block', $packet['type'] ?? '' );
 		$this->assertSame( 'warning', $packet['severity'] ?? '' );
-		$this->assertSame( 'html-to-blocks-converter', $packet['owner'] ?? '' );
+		$this->assertSame( 'blocks-engine-php-transformer', $packet['owner'] ?? '' );
 		$this->assertSame( 'replace_fallback_block', $packet['routing']['suggested_repair_class'] ?? '' );
 		$this->assertSame( 'templates/front-page.html', $packet['source']['path'] ?? '' );
 		$this->assertStringContainsString( '<iframe', $packet['source']['snippet'] ?? '' );
@@ -265,7 +265,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 'templates/front-page.html', $diagnostics[0]['source'] ?? '' );
 		$this->assertSame( 'aside.widget-card', $diagnostics[0]['selector'] ?? '' );
 		$this->assertSame( 'core/html', $diagnostics[0]['block_name'] ?? '' );
-		$this->assertSame( 'html-to-blocks-converter', $diagnostics[0]['converter'] ?? '' );
+		$this->assertSame( 'blocks-engine-php-transformer', $diagnostics[0]['converter'] ?? '' );
 		$this->assertSame( 'generated_theme_block_analysis', $diagnostics[0]['stage'] ?? '' );
 		$this->assertSame( 'generated_document_contains_core_html', $diagnostics[0]['reason'] ?? '' );
 		$this->assertSame( '0', $diagnostics[0]['block_path'] ?? '' );


### PR DESCRIPTION
## Summary
- route generated fallback diagnostics to `blocks-engine-php-transformer`
- update fallback diagnostic tests to expect the canonical transformer owner

## Testing
- `php -l includes/class-static-site-importer-report-diagnostics.php && php -l tests/StaticSiteImporterFallbackDiagnosticsTest.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updating diagnostic metadata, tests, and focused verification.
