### PR TITLE
Consume Blocks Engine materialization contracts

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -49,7 +49,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			'static-site-importer/export-theme',
 			array(
 				'label'               => __( 'Export Website Artifact', 'static-site-importer' ),
-				'description'         => __( 'Export an imported or active block theme and page content as a BAC-compatible website artifact.', 'static-site-importer' ),
+				'description'         => __( 'Export an imported or active block theme and page content as a Blocks Engine website artifact.', 'static-site-importer' ),
 				'category'            => STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
 				'input_schema'        => array(
 					'type'       => 'object',

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -135,8 +135,8 @@ class Static_Site_Importer_Report_Diagnostics {
 			),
 			'diagnostics'             => array(),
 			'notes'                   => array(
-				'Blocks Engine transformer owns the website-artifact to WordPress-artifact envelope; Static Site Importer materializes the result, records compiler summaries, and owns product seeding.',
-				'Blocks Engine transformer owns HTML/block transform fidelity; Static Site Importer records converter diagnostics and quality gates the generated theme.',
+				'Blocks Engine owns the website-artifact to WordPress-artifact envelope and transform diagnostics; Static Site Importer materializes the result into WordPress.',
+				'Static Site Importer still owns WordPress writes, dependency materialization, and WooCommerce product seeding, which keeps this report helper from moving wholesale into Blocks Engine.',
 				'Generated-theme block validation uses WordPress server-side block parsing and serialization checks; editor-runtime validation remains the exact Gutenberg authority.',
 				'Visual fidelity requires browser rendering; use visual_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
 				'Semantic fidelity requires browser DOM extraction; use semantic_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
@@ -200,7 +200,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$report['diagnostics'][] = array(
 			'type'        => 'website_artifact_materialization_contract_note',
 			'source'      => '' !== $source ? $source : 'website_artifact',
-			'message'     => 'Direct materialization consumed block_markup, documents, files, and compiled-site artifacts. SSI owns WordPress writes and product seeding while Blocks Engine owns materializer-neutral site/theme compilation.',
+			'message'     => 'Direct materialization consumed block_markup, documents, files, and compiled-site artifacts. Static Site Importer owns WordPress writes and product seeding while Blocks Engine owns materializer-neutral site/theme compilation.',
 			'contract'    => 'block-artifact-compiler/result/v1',
 			'constraints' => 'report_only',
 		);
@@ -241,7 +241,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'reason'                => isset( $context['reason'] ) ? (string) $context['reason'] : 'unknown',
 			'tag_name'              => isset( $context['tag_name'] ) ? (string) $context['tag_name'] : self::diagnostic_tag_name_from_html( $element_html ),
 			'block_name'            => isset( $block['blockName'] ) ? (string) $block['blockName'] : null,
-			'converter'             => 'blocks-engine-php-transformer',
+			'engine'                => 'blocks-engine/php-transformer',
 			'stage'                 => isset( $context['stage'] ) ? (string) $context['stage'] : 'html_to_blocks',
 			'html_length'           => strlen( $element_html ),
 			'html_excerpt'          => self::diagnostic_excerpt( $element_html ),
@@ -287,7 +287,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$source_documents = isset( $report['source_documents'] ) && is_array( $report['source_documents'] ) ? $report['source_documents'] : array();
 
 		return array(
-			'schema'               => 'static-site-importer/import-validation-result/v1',
+			'schema'               => 'blocks-engine/import-validation-result/v1',
 			'artifact_type'        => 'ImportValidationResult',
 			'version'              => 1,
 			'status'               => ! empty( $quality['fail_import'] ) ? 'failed' : ( ! empty( $quality['pass'] ) ? 'passed' : 'reported' ),
@@ -351,7 +351,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		return array(
-			'schema'        => 'static-site-importer/finding-packets/v1',
+			'schema'        => 'blocks-engine/finding-packets/v1',
 			'artifact_type' => 'FindingPacketSet',
 			'version'       => 1,
 			'status'        => empty( $packets ) ? 'clean' : 'reported',
@@ -422,13 +422,13 @@ class Static_Site_Importer_Report_Diagnostics {
 		$report['artifact_diagnostics'] = Static_Site_Importer_WP_Codebox_Artifact_Diagnostics_Normalizer::build(
 			array( 'diagnostics' => $report['diagnostics'] ?? array() ),
 			array(
-				'source'          => 'static-site-importer',
+				'source'          => 'blocks-engine',
 				'stage'           => 'import',
-				'observationType' => 'static-site-importer/import-report',
+				'observationType' => 'blocks-engine/import-report',
 				'refs'            => array(
 					array(
 						'path' => 'import-report.json',
-						'kind' => 'static-site-importer/import-report',
+						'kind' => 'blocks-engine/import-report',
 					),
 				),
 			)
@@ -519,15 +519,15 @@ class Static_Site_Importer_Report_Diagnostics {
 		return array(
 			'import_report'            => array(
 				'path' => 'import-report.json',
-				'kind' => 'static-site-importer/import-report',
+				'kind' => 'blocks-engine/import-report',
 			),
 			'import_validation_result' => array(
 				'path' => 'import-validation-result.json',
-				'kind' => 'static-site-importer/import-validation-result',
+				'kind' => 'blocks-engine/import-validation-result',
 			),
 			'finding_packets'          => array(
 				'path' => 'finding-packets.json',
-				'kind' => 'static-site-importer/finding-packets',
+				'kind' => 'blocks-engine/finding-packets',
 			),
 		);
 	}
@@ -608,7 +608,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$severity = isset( $diagnostic['severity'] ) && is_scalar( $diagnostic['severity'] ) ? (string) $diagnostic['severity'] : self::diagnostic_severity( $type );
 
 		return array(
-			'schema'               => 'static-site-importer/finding-packet/v1',
+			'schema'               => 'blocks-engine/finding-packet/v1',
 			'artifact_type'        => 'FindingPacket',
 			'version'              => 1,
 			'id'                   => 'finding-' . preg_replace( '/^diag-/', '', $id ),
@@ -655,9 +655,12 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return string
 	 */
 	private static function finding_owner( array $diagnostic ): string {
-		$converter = isset( $diagnostic['converter'] ) && is_scalar( $diagnostic['converter'] ) ? (string) $diagnostic['converter'] : '';
-		if ( '' !== $converter ) {
-			return $converter;
+		$engine = isset( $diagnostic['engine'] ) && is_scalar( $diagnostic['engine'] ) ? (string) $diagnostic['engine'] : '';
+		if ( '' === $engine ) {
+			$engine = isset( $diagnostic['converter'] ) && is_scalar( $diagnostic['converter'] ) ? (string) $diagnostic['converter'] : '';
+		}
+		if ( '' !== $engine ) {
+			return $engine;
 		}
 
 		$type = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : '';
@@ -665,7 +668,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			return 'static-site-importer';
 		}
 
-		return 'block-artifact-compiler';
+		return 'blocks-engine/php-transformer';
 	}
 
 	/**
@@ -699,9 +702,9 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
-	 * Preserve the BAC compiled-site contract in the SSI import report.
+	 * Preserve the Blocks Engine compiled-site contract in the import report.
 	 *
-	 * @param array<string,mixed> $site BAC compiled-site artifact.
+	 * @param array<string,mixed> $site Blocks Engine compiled-site artifact.
 	 * @return array<string,mixed>
 	 */
 	private static function compiled_site_report_payload( array $site ): array {
@@ -1158,7 +1161,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'emitted_block_preview',
 			'block_name',
 			'block_path',
-			'converter',
+			'engine',
 			'stage',
 			'reason',
 			'message',

--- a/includes/class-static-site-importer-theme-exporter.php
+++ b/includes/class-static-site-importer-theme-exporter.php
@@ -14,7 +14,7 @@ if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
 }
 
 /**
- * Exports WordPress block themes to BAC-compatible website artifacts.
+ * Exports WordPress block themes to Blocks Engine website artifacts.
  */
 class Static_Site_Importer_Theme_Exporter {
 
@@ -402,7 +402,7 @@ class Static_Site_Importer_Theme_Exporter {
 	}
 
 	/**
-	 * Build the BAC-compatible website artifact envelope.
+	 * Build the website artifact envelope consumed by Blocks Engine.
 	 *
 	 * @param string              $theme_slug      Theme slug.
 	 * @param string              $root            Artifact root.
@@ -417,7 +417,7 @@ class Static_Site_Importer_Theme_Exporter {
 		$id           = 'website-artifact-' . $theme_slug . '-' . substr( hash( 'sha256', self::json_encode_pretty( array( $entrypoint, $files ) ) ), 0, 12 );
 
 		return array(
-			'schema'        => 'block-artifact-compiler/website-artifact/v1',
+			'schema'        => Static_Site_Importer_Transformer_Adapter::WEBSITE_ARTIFACT_SCHEMA,
 			'artifact_type' => 'website',
 			'version'       => 1,
 			'id'            => $id,

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -646,7 +646,7 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Build the BAC-compatible website artifact envelope.
+	 * Build the website artifact envelope consumed by Blocks Engine.
 	 *
 	 * @param string              $theme_slug      Theme slug.
 	 * @param string              $root            Artifact root.
@@ -661,7 +661,7 @@ class Static_Site_Importer_Theme_Generator {
 		$id           = 'website-artifact-' . $theme_slug . '-' . substr( hash( 'sha256', self::json_encode_pretty( array( $entrypoint, $files ) ) ), 0, 12 );
 
 		return array(
-			'schema'        => 'block-artifact-compiler/website-artifact/v1',
+			'schema'        => Static_Site_Importer_Transformer_Adapter::WEBSITE_ARTIFACT_SCHEMA,
 			'artifact_type' => 'website',
 			'version'       => 1,
 			'id'            => $id,
@@ -1039,7 +1039,7 @@ class Static_Site_Importer_Theme_Generator {
 		$documents = isset( $artifacts['documents'] ) && is_array( $artifacts['documents'] ) ? $artifacts['documents'] : array();
 		$site      = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
 		if ( ! empty( $site['pages'] ) && is_array( $site['pages'] ) ) {
-			if ( ! in_array( (string) ( $site['schema'] ?? '' ), array( 'block-artifact-compiler/compiled-site/v1', 'blocks-engine/php-transformer/compiled-site/v1' ), true ) ) {
+			if ( ! in_array( (string) ( $site['schema'] ?? '' ), array( 'block-artifact-compiler/compiled-site/v1', 'blocks-engine/php-transformer/compiled-site/v1', 'blocks-engine/php-transformer/materialization-plan/v1' ), true ) ) {
 				return new WP_Error( 'static_site_importer_compiled_site_missing', 'Website artifact document pages require a supported compiled-site contract.' );
 			}
 
@@ -1817,10 +1817,10 @@ class Static_Site_Importer_Theme_Generator {
 		self::$conversion_report['source_documents'] = array_merge(
 			self::$conversion_report['source_documents'],
 			array(
-				'source'             => 'block_artifact_compiler',
+				'source'             => 'blocks_engine',
 				'total_count'        => count( $records ),
-				'bac_documents'      => $records,
-				'bac_document_count' => count( $records ),
+				'blocks_engine_documents'      => $records,
+				'blocks_engine_document_count' => count( $records ),
 			)
 		);
 	}
@@ -1876,7 +1876,7 @@ class Static_Site_Importer_Theme_Generator {
 			'code'     => 'products_manifest_invalid',
 			'severity' => 'warning',
 			'source'   => self::$conversion_report['commerce']['products_manifest']['source'],
-			'message'  => 'products_manifest was supplied but does not match the Static Site Importer commerce contract.',
+			'message'  => 'products_manifest was supplied but does not match the importer product seeding contract.',
 			'errors'   => self::$conversion_report['commerce']['products_manifest']['errors'],
 		);
 	}

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Product-owned adapter for transformer APIs.
+ * Blocks Engine transformer adapter.
  *
  * @package StaticSiteImporter
  */
@@ -13,6 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Keeps SSI workflows insulated from transformer package implementation details.
  */
 class Static_Site_Importer_Transformer_Adapter {
+
+	public const WEBSITE_ARTIFACT_SCHEMA = 'block-artifact-compiler/website-artifact/v1';
+	public const COMPILED_RESULT_SCHEMA  = 'block-artifact-compiler/result/v1';
 
 	/**
 	 * Check whether the default Blocks Engine artifact compiler is available.
@@ -33,7 +36,7 @@ class Static_Site_Importer_Transformer_Adapter {
 	}
 
 	/**
-	 * Compile a website artifact into the BAC-compatible envelope SSI consumes.
+	 * Compile a website artifact through Blocks Engine into the envelope SSI consumes.
 	 *
 	 * @param array<string,mixed> $artifact Website artifact bundle.
 	 * @param array<string,mixed> $options  Compiler options.
@@ -60,57 +63,27 @@ class Static_Site_Importer_Transformer_Adapter {
 	 * @return array<string,mixed>
 	 */
 	private function compiled_result_from_transformer_contract( array $result ): array {
-		$source_reports = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
-		$source_report  = isset( $source_reports['artifact'] ) && is_array( $source_reports['artifact'] ) ? $source_reports['artifact'] : array();
-		$compiled_site  = isset( $source_reports['compiled_site'] ) && is_array( $source_reports['compiled_site'] ) ? $source_reports['compiled_site'] : array();
-		$entry_path     = isset( $source_report['entry_path'] ) && is_scalar( $source_report['entry_path'] ) ? (string) $source_report['entry_path'] : '';
-		$provenance     = isset( $result['provenance'][0] ) && is_array( $result['provenance'][0] ) ? $result['provenance'][0] : array();
-		$blocks         = isset( $result['blocks'] ) && is_array( $result['blocks'] ) ? $result['blocks'] : array();
-		$serialized     = isset( $result['serialized_blocks'] ) && is_scalar( $result['serialized_blocks'] ) ? (string) $result['serialized_blocks'] : '';
-		$products       = $this->products_manifest_from_transformer_reports( $result, $compiled_site );
+		$compiled = $this->project_transformer_result( $result, self::COMPILED_RESULT_SCHEMA );
 
-		$compiled = array(
-			'schema'              => 'block-artifact-compiler/result/v1',
-			'status'              => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : 'failed',
-			'input'               => array(
-				'schema'          => isset( $source_report['schema'] ) && is_scalar( $source_report['schema'] ) ? (string) $source_report['schema'] : 'blocks-engine/php-transformer/site-artifact/v1',
-				'entry_path'      => $entry_path,
-				'entrypoints'     => isset( $source_report['entrypoints'] ) && is_array( $source_report['entrypoints'] ) ? $source_report['entrypoints'] : array(),
-				'file_count'      => (int) ( $source_report['file_count'] ?? 0 ),
-				'accepted_count'  => (int) ( $source_report['accepted_count'] ?? 0 ),
-				'rejected_count'  => (int) ( $source_report['rejected_count'] ?? 0 ),
-				'bytes'           => (int) ( $source_report['bytes'] ?? 0 ),
-				'files_by_kind'   => isset( $source_report['files_by_kind'] ) && is_array( $source_report['files_by_kind'] ) ? $source_report['files_by_kind'] : array(),
-				'files_by_role'   => isset( $source_report['files_by_role'] ) && is_array( $source_report['files_by_role'] ) ? $source_report['files_by_role'] : array(),
-				'files_by_mime'   => isset( $source_report['files_by_mime'] ) && is_array( $source_report['files_by_mime'] ) ? $source_report['files_by_mime'] : array(),
-				'original_schema' => isset( $source_report['original_schema'] ) && is_scalar( $source_report['original_schema'] ) ? (string) $source_report['original_schema'] : '',
-				'source_report'   => $source_report,
-			),
-			'wordpress_artifacts' => array(
-				'block_markup' => $serialized,
-				'blocks'       => $blocks,
-				'block_tree'   => $this->block_tree_report( $blocks ),
-				'block_types'  => isset( $result['block_types'] ) && is_array( $result['block_types'] ) ? $result['block_types'] : array(),
-				'components'   => isset( $result['components'] ) && is_array( $result['components'] ) ? $result['components'] : array(),
-				'document_metadata' => $this->document_metadata_from_compiled_site( $compiled_site ),
-				'documents'    => isset( $result['documents'] ) && is_array( $result['documents'] ) ? $result['documents'] : array(),
-				'files'        => isset( $result['assets'] ) && is_array( $result['assets'] ) ? $result['assets'] : array(),
-				'site'         => $compiled_site,
-				'template_parts' => isset( $compiled_site['template_parts'] ) && is_array( $compiled_site['template_parts'] ) ? $compiled_site['template_parts'] : array(),
-				'visual_repair' => isset( $compiled_site['visual_repair'] ) && is_array( $compiled_site['visual_repair'] ) ? $compiled_site['visual_repair'] : array(),
-			),
-			'provenance'          => array(
-				'source_hash' => isset( $provenance['source_hash'] ) && is_scalar( $provenance['source_hash'] ) ? (string) $provenance['source_hash'] : (string) ( $source_report['source_hash'] ?? '' ),
-				'source'      => '' !== $entry_path ? $entry_path : 'website_artifact',
-			),
-			'diagnostics'         => isset( $result['diagnostics'] ) && is_array( $result['diagnostics'] ) ? $result['diagnostics'] : array(),
-			'bfb_report'          => array(
-				'status'            => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : 'failed',
-				'serialized_blocks' => $serialized,
-				'diagnostics'       => isset( $result['diagnostics'] ) && is_array( $result['diagnostics'] ) ? $result['diagnostics'] : array(),
-				'fallbacks'         => isset( $result['fallbacks'] ) && is_array( $result['fallbacks'] ) ? $result['fallbacks'] : array(),
-			),
-		);
+		$source_reports       = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
+		$compiled_site        = isset( $source_reports['compiled_site'] ) && is_array( $source_reports['compiled_site'] ) ? $source_reports['compiled_site'] : array();
+		$materialization_plan = isset( $source_reports['materialization_plan'] ) && is_array( $source_reports['materialization_plan'] ) ? $source_reports['materialization_plan'] : array();
+		$site_report          = ! empty( $materialization_plan ) ? $materialization_plan : $compiled_site;
+		$products             = $this->products_manifest_from_transformer_reports( $result, $site_report );
+		$artifacts            = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$blocks               = isset( $artifacts['blocks'] ) && is_array( $artifacts['blocks'] ) ? $artifacts['blocks'] : array();
+
+		if ( ! isset( $artifacts['block_tree'] ) ) {
+			$artifacts['block_tree'] = $this->block_tree_report( $blocks );
+		}
+
+		$artifacts['document_metadata'] = $this->document_metadata_from_compiled_site( $site_report );
+		$artifacts['documents']         = isset( $result['documents'] ) && is_array( $result['documents'] ) ? $result['documents'] : array();
+		$artifacts['site']              = $site_report;
+		$artifacts['template_parts']    = isset( $site_report['template_parts'] ) && is_array( $site_report['template_parts'] ) ? $site_report['template_parts'] : array();
+		$artifacts['visual_repair']     = isset( $site_report['visual_repair'] ) && is_array( $site_report['visual_repair'] ) ? $site_report['visual_repair'] : array();
+
+		$compiled['wordpress_artifacts'] = $artifacts;
 
 		if ( ! empty( $products ) ) {
 			$compiled['products_manifest'] = $products;
@@ -120,7 +93,82 @@ class Static_Site_Importer_Transformer_Adapter {
 	}
 
 	/**
-	 * Extract SSI products from generic compiled-site/document reports.
+	 * Apply a Blocks Engine transformer legacy projection by schema.
+	 *
+	 * @param array<string,mixed> $result TransformerResult::toArray() output.
+	 * @param string              $schema Projection schema.
+	 * @return array<string,mixed>
+	 */
+	private function project_transformer_result( array $result, string $schema ): array {
+		$mapping   = isset( $result['legacy_mapping'][ $schema ] ) && is_array( $result['legacy_mapping'][ $schema ] ) ? $result['legacy_mapping'][ $schema ] : array();
+		$projected = array( 'schema' => $schema );
+
+		foreach ( $mapping as $target_path => $source_path ) {
+			if ( ! is_string( $target_path ) || ! is_string( $source_path ) ) {
+				continue;
+			}
+
+			$found = false;
+			$value = $this->array_path_get( $result, $source_path, $found );
+			if ( $found ) {
+				$this->array_path_set( $projected, $target_path, $value );
+			}
+		}
+
+		return $projected;
+	}
+
+	/**
+	 * Read a dot-notated array path.
+	 *
+	 * @param array<string,mixed> $data  Source data.
+	 * @param string              $path  Dot-notated path.
+	 * @param bool                $found Whether the path exists.
+	 * @return mixed
+	 */
+	private function array_path_get( array $data, string $path, bool &$found ) {
+		$value = $data;
+		foreach ( explode( '.', $path ) as $part ) {
+			if ( ! is_array( $value ) || ! array_key_exists( $part, $value ) ) {
+				$found = false;
+				return null;
+			}
+
+			$value = $value[ $part ];
+		}
+
+		$found = true;
+		return $value;
+	}
+
+	/**
+	 * Write a dot-notated array path.
+	 *
+	 * @param array<string,mixed> $data  Target data.
+	 * @param string              $path  Dot-notated path.
+	 * @param mixed               $value Value to set.
+	 * @return void
+	 */
+	private function array_path_set( array &$data, string $path, $value ): void {
+		$cursor = &$data;
+		$parts  = explode( '.', $path );
+		$last   = array_pop( $parts );
+
+		foreach ( $parts as $part ) {
+			if ( ! isset( $cursor[ $part ] ) || ! is_array( $cursor[ $part ] ) ) {
+				$cursor[ $part ] = array();
+			}
+
+			$cursor = &$cursor[ $part ];
+		}
+
+		if ( null !== $last ) {
+			$cursor[ $last ] = $value;
+		}
+	}
+
+	/**
+	 * Extract commerce products from generic compiled-site/document reports.
 	 *
 	 * @param array<string,mixed> $result        Transformer result array.
 	 * @param array<string,mixed> $compiled_site Generic compiled-site report.
@@ -183,7 +231,7 @@ class Static_Site_Importer_Transformer_Adapter {
 	}
 
 	/**
-	 * Normalize one generic product report row to SSI's products manifest contract.
+	 * Normalize one generic product report row to the importer product seeding contract.
 	 *
 	 * @param array<string,mixed> $row Generic report row.
 	 * @return array<string,mixed>
@@ -441,7 +489,7 @@ class Static_Site_Importer_Transformer_Adapter {
 	}
 
 	/**
-	 * Summarize a BAC-compatible compiler result.
+	 * Summarize a compiled website artifact result.
 	 *
 	 * @param array<string,mixed> $compiled Compiler result envelope.
 	 * @return array<string,mixed>

--- a/includes/class-static-site-importer-url-import-runtime.php
+++ b/includes/class-static-site-importer-url-import-runtime.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-transformer-adapter.php';
+}
+
 /**
  * Imports a source URL through a provider that returns a website artifact.
  */
@@ -61,7 +65,7 @@ class Static_Site_Importer_URL_Import_Runtime {
 	/**
 	 * Resolve the provider output.
 	 *
-	 * Providers return an array with an `artifact` key containing a BAC website
+	 * Providers return an array with an `artifact` key containing a website
 	 * artifact, plus optional `source_metadata` and `provider` fields.
 	 *
 	 * @param array<string,mixed> $request Provider request envelope.
@@ -113,7 +117,7 @@ class Static_Site_Importer_URL_Import_Runtime {
 		return array(
 			'provider'        => 'public-url-fetcher',
 			'artifact'        => array(
-				'schema' => 'block-artifact-compiler/website-artifact/v1',
+				'schema' => Static_Site_Importer_Transformer_Adapter::WEBSITE_ARTIFACT_SCHEMA,
 				'files'  => array(
 					array(
 						'path'    => 'website/index.html',

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -48,7 +48,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 						'source_html_preview'    => '<iframe id="store-widget" class="embedded checkout"></iframe>',
 						'emitted_block_preview'  => '<!-- wp:html --><iframe id="store-widget" class="embedded checkout"></iframe><!-- /wp:html -->',
 						'block_name'             => 'core/html',
-						'converter'              => 'blocks-engine-php-transformer',
+						'engine'                 => 'blocks-engine/php-transformer',
 						'stage'                  => 'generated_theme_block_analysis',
 						'reason'                 => 'generated_document_contains_core_html',
 						'html_length'            => 64,
@@ -140,7 +140,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 					'source_html_preview'    => '<iframe id="store-widget" class="embedded checkout"></iframe>',
 					'emitted_block_preview'  => '<!-- wp:html --><iframe id="store-widget" class="embedded checkout"></iframe><!-- /wp:html -->',
 					'block_name'             => 'core/html',
-					'converter'              => 'blocks-engine-php-transformer',
+					'engine'                 => 'blocks-engine/php-transformer',
 					'stage'                  => 'generated_theme_block_analysis',
 					'reason'                 => 'generated_document_contains_core_html',
 					'block_path'             => '0',
@@ -150,7 +150,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 
 		$quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $report, array() );
 
-		$this->assertSame( 'static-site-importer/import-validation-result/v1', $report['import_validation_result']['schema'] ?? '' );
+		$this->assertSame( 'blocks-engine/import-validation-result/v1', $report['import_validation_result']['schema'] ?? '' );
 		$this->assertSame( 'ImportValidationResult', $report['import_validation_result']['artifact_type'] ?? '' );
 		$this->assertSame( 'reported', $report['import_validation_result']['status'] ?? '' );
 		$this->assertFalse( $quality['pass'] ?? true );
@@ -159,14 +159,14 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 'finding-packets.json', $report['import_validation_result']['artifacts']['finding_packets']['path'] ?? '' );
 		$this->assertSame( '/tmp/source/index.html', $report['import_validation_result']['reproduction_context']['entry_file'] ?? '' );
 
-		$this->assertSame( 'static-site-importer/finding-packets/v1', $report['finding_packets']['schema'] ?? '' );
+		$this->assertSame( 'blocks-engine/finding-packets/v1', $report['finding_packets']['schema'] ?? '' );
 		$this->assertSame( 1, $report['finding_packets']['count'] ?? 0 );
 		$packet = $report['finding_packets']['packets'][0] ?? array();
-		$this->assertSame( 'static-site-importer/finding-packet/v1', $packet['schema'] ?? '' );
+		$this->assertSame( 'blocks-engine/finding-packet/v1', $packet['schema'] ?? '' );
 		$this->assertSame( 'FindingPacket', $packet['artifact_type'] ?? '' );
 		$this->assertSame( 'core_html_block', $packet['type'] ?? '' );
 		$this->assertSame( 'warning', $packet['severity'] ?? '' );
-		$this->assertSame( 'blocks-engine-php-transformer', $packet['owner'] ?? '' );
+		$this->assertSame( 'blocks-engine/php-transformer', $packet['owner'] ?? '' );
 		$this->assertSame( 'replace_fallback_block', $packet['routing']['suggested_repair_class'] ?? '' );
 		$this->assertSame( 'templates/front-page.html', $packet['source']['path'] ?? '' );
 		$this->assertStringContainsString( '<iframe', $packet['source']['snippet'] ?? '' );
@@ -199,13 +199,13 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 				),
 			),
 			array(
-				'source'          => 'static-site-importer',
+				'source'          => 'blocks-engine',
 				'stage'           => 'import',
-				'observationType' => 'static-site-importer/import-report',
+				'observationType' => 'blocks-engine/import-report',
 				'refs'            => array(
 					array(
 						'path' => 'import-report.json',
-						'kind' => 'static-site-importer/import-report',
+						'kind' => 'blocks-engine/import-report',
 					),
 				),
 			)
@@ -217,11 +217,11 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 'diag-001', $diagnostics['diagnostics'][0]['id'] ?? '' );
 		$this->assertSame( 'unsupported_html_fallback', $diagnostics['diagnostics'][0]['type'] ?? '' );
 		$this->assertSame( 'no_transform', $diagnostics['diagnostics'][0]['code'] ?? '' );
-		$this->assertSame( 'static-site-importer', $diagnostics['diagnostics'][0]['source'] ?? '' );
+		$this->assertSame( 'blocks-engine', $diagnostics['diagnostics'][0]['source'] ?? '' );
 		$this->assertSame( 'import', $diagnostics['diagnostics'][0]['stage'] ?? '' );
 		$this->assertSame( 'index.html', $diagnostics['diagnostics'][0]['path'] ?? '' );
 		$this->assertSame( 'iframe#store-widget', $diagnostics['diagnostics'][0]['selector'] ?? '' );
-		$this->assertSame( 'static-site-importer/import-report', $diagnostics['diagnostics'][0]['provenance']['observationType'] ?? '' );
+		$this->assertSame( 'blocks-engine/import-report', $diagnostics['diagnostics'][0]['provenance']['observationType'] ?? '' );
 		$this->assertSame( 'import-report.json', $diagnostics['diagnostics'][0]['refs'][0]['path'] ?? '' );
 		$this->assertSame( 'core/html', $diagnostics['diagnostics'][0]['details']['block_name'] ?? '' );
 		$this->assertSame( 'Asset file is missing.', $diagnostics['diagnostics'][1]['message'] ?? '' );
@@ -265,7 +265,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 'templates/front-page.html', $diagnostics[0]['source'] ?? '' );
 		$this->assertSame( 'aside.widget-card', $diagnostics[0]['selector'] ?? '' );
 		$this->assertSame( 'core/html', $diagnostics[0]['block_name'] ?? '' );
-		$this->assertSame( 'blocks-engine-php-transformer', $diagnostics[0]['converter'] ?? '' );
+		$this->assertSame( 'blocks-engine/php-transformer', $diagnostics[0]['engine'] ?? '' );
 		$this->assertSame( 'generated_theme_block_analysis', $diagnostics[0]['stage'] ?? '' );
 		$this->assertSame( 'generated_document_contains_core_html', $diagnostics[0]['reason'] ?? '' );
 		$this->assertSame( '0', $diagnostics[0]['block_path'] ?? '' );

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -75,9 +75,67 @@ namespace {
 									'stylesheets' => array( 'assets/site.css' ),
 								),
 							),
+							'materialization_plan' => array(
+								'schema'      => 'blocks-engine/php-transformer/materialization-plan/v1',
+								'source_schema' => 'blocks-engine/php-transformer/compiled-site/v1',
+								'source_hash' => 'abc123',
+								'entry_path'  => 'website/index.html',
+								'pages'       => array(
+									array(
+										'source_path'  => 'website/index.html',
+										'entrypoint'   => true,
+										'post_type'    => 'page',
+										'slug'         => 'home-canonical',
+										'title'        => 'Home Canonical',
+										'block_markup' => '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->',
+									),
+									array(
+										'source_path' => 'website/menu.html',
+										'entrypoint'  => false,
+										'post_type'   => 'page',
+										'slug'        => 'menu',
+										'title'       => 'Menu Page',
+									),
+									array(
+										'source_path' => 'content/about.md',
+										'entrypoint'  => false,
+										'post_type'   => 'page',
+										'slug'        => 'about-canonical',
+										'title'       => 'About',
+									),
+									array(
+										'source_path'    => 'products/rye-loaf.md',
+										'entrypoint'     => false,
+										'post_type'      => 'product',
+										'slug'           => 'rye-loaf-canonical',
+										'title'          => 'Rye Loaf',
+										'regular_price'  => '12',
+										'categories'     => array( 'Bread' ),
+									),
+								),
+								'assets'      => array(
+									array( 'path' => 'assets/site.css', 'role' => 'stylesheet' ),
+								),
+								'theme'       => array(
+									'stylesheets' => array( 'assets/site.css' ),
+								),
+							),
 						),
 						'blocks'            => array(
 							array( 'blockName' => 'core/paragraph', 'innerBlocks' => array() ),
+						),
+						'legacy_mapping'    => array(
+							'block-artifact-compiler/result/v1' => array(
+								'status'                           => 'status',
+								'input'                            => 'source_reports.artifact',
+								'wordpress_artifacts.block_markup' => 'serialized_blocks',
+								'wordpress_artifacts.blocks'       => 'blocks',
+								'wordpress_artifacts.block_types'  => 'block_types',
+								'wordpress_artifacts.components'   => 'components',
+								'wordpress_artifacts.files'        => 'assets',
+								'diagnostics'                      => 'diagnostics',
+								'provenance'                       => 'provenance',
+							),
 						),
 						'serialized_blocks' => '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->',
 						'documents'         => array(
@@ -175,16 +233,16 @@ namespace {
 	$assert( 1 === count( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'] ), 'plugin-artifact-helper-called' );
 	$assert( true === ( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][0][1]['include_bfb_report'] ?? false ), 'compile-options-forwarded' );
 	$assert( 'block-artifact-compiler/result/v1' === ( $compiled['schema'] ?? '' ), 'native-result-mapped-to-bac-envelope' );
-	$assert( 'blocks-engine/php-transformer/compiled-site/v1' === ( $site['schema'] ?? '' ), 'native-compiled-site-contract-is-preserved' );
+	$assert( 'blocks-engine/php-transformer/materialization-plan/v1' === ( $site['schema'] ?? '' ), 'native-materialization-plan-contract-is-used' );
 	$assert( 4 === count( $pages ), 'native-keeps-compiled-site-pages-without-adapter-filtering' );
 	$assert( 'website/index.html' === ( $pages[0]['source_path'] ?? '' ), 'native-entry-source-path' );
-	$assert( 'index' === ( $pages[0]['slug'] ?? '' ), 'native-entry-slug' );
+	$assert( 'home-canonical' === ( $pages[0]['slug'] ?? '' ), 'native-entry-slug-from-materialization-plan' );
 	$assert( true === ( $pages[0]['entrypoint'] ?? false ), 'native-entrypoint' );
-	$assert( 'about' === ( $pages[2]['slug'] ?? '' ), 'native-route-slug-from-source-document-compiled-site' );
+	$assert( 'about-canonical' === ( $pages[2]['slug'] ?? '' ), 'native-route-slug-from-materialization-plan' );
 	$assert( 1 === count( $documents ), 'native-documents-preserve-transformer-documents-without-compiled-site-synthesis' );
 	$assert( 'content/about.md' === ( $documents[0]['source_path'] ?? '' ), 'native-document-from-transformer-documents' );
 	$assert( 'assets/site.css' === ( $artifacts['files'][0]['path'] ?? '' ), 'native-assets-report-preserved' );
-	$assert( 'rye-loaf' === ( $products[0]['slug'] ?? '' ), 'native-product-slug-mapped-from-generic-report' );
+	$assert( 'rye-loaf-canonical' === ( $products[0]['slug'] ?? '' ), 'native-product-slug-mapped-from-generic-report' );
 	$assert( '12.00' === ( $products[0]['regular_price'] ?? '' ), 'native-product-price-normalized-from-generic-report' );
 	$assert( array( 'Bread' ) === ( $products[0]['categories'] ?? array() ), 'native-product-categories-mapped-from-generic-report' );
 

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -109,10 +109,10 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( 0 === ( $report['quality']['core_html_block_count'] ?? null ), 'quality-core-html-count-is-zero' );
 	$assert( is_file( $result['validation_result_path'] ?? '' ), 'validation-result-artifact-is-written' );
 	$assert( is_file( $result['finding_packets_path'] ?? '' ), 'finding-packets-artifact-is-written' );
-	$assert( 'static-site-importer/import-validation-result/v1' === ( $validation_result['schema'] ?? '' ), 'validation-result-schema' );
+	$assert( 'blocks-engine/import-validation-result/v1' === ( $validation_result['schema'] ?? '' ), 'validation-result-schema' );
 	$assert( 'ImportValidationResult' === ( $validation_result['artifact_type'] ?? '' ), 'validation-result-artifact-type' );
 	$assert( 'passed' === ( $validation_result['status'] ?? '' ), 'validation-result-status-passed' );
-	$assert( 'static-site-importer/finding-packets/v1' === ( $finding_packets['schema'] ?? '' ), 'finding-packets-schema' );
+	$assert( 'blocks-engine/finding-packets/v1' === ( $finding_packets['schema'] ?? '' ), 'finding-packets-schema' );
 	$assert( 'FindingPacketSet' === ( $finding_packets['artifact_type'] ?? '' ), 'finding-packets-artifact-type' );
 	$assert( 'static-site-importer/document-metadata/v1' === ( $metadata['schema'] ?? '' ), 'metadata-contract-is-recorded' );
 	$assert( 'Ember & Rye' === ( $metadata['title'] ?? '' ), 'title-is-preserved-in-metadata' );
@@ -186,14 +186,14 @@ $assert( ! is_wp_error( $multi_page_result ), 'multi-page-import-succeeds', is_w
 if ( ! is_wp_error( $multi_page_result ) ) {
 	$multi_report    = json_decode( $read( $multi_page_result['report_path'] ), true );
 	$source_docs     = $multi_report['source_documents'] ?? array();
-	$bac_documents   = $source_docs['bac_documents'] ?? array();
+	$blocks_engine_documents = $source_docs['blocks_engine_documents'] ?? array();
 	$compiled_site   = $multi_report['block_artifact_compiler']['compiled_site'] ?? array();
 	$block_documents = $multi_report['generated_theme']['block_documents'] ?? array();
 	$template_parts  = $multi_report['generated_theme']['template_parts'] ?? array();
 	$documents_by_source = array();
 	$pattern_documents = array();
 	$template_parts_by_path = array();
-	foreach ( $bac_documents as $document ) {
+	foreach ( $blocks_engine_documents as $document ) {
 		if ( is_array( $document ) && isset( $document['source_path'] ) ) {
 			$documents_by_source[ $document['source_path'] ] = $document;
 		}
@@ -209,8 +209,8 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 		}
 	}
 
-	$assert( 3 === ( $source_docs['bac_document_count'] ?? null ), 'multi-page-bac-document-count' );
-	$assert( 'block_artifact_compiler' === ( $source_docs['source'] ?? '' ), 'multi-page-source-is-bac' );
+	$assert( 3 === ( $source_docs['blocks_engine_document_count'] ?? null ), 'multi-page-blocks-engine-document-count' );
+	$assert( 'blocks_engine' === ( $source_docs['source'] ?? '' ), 'multi-page-source-is-blocks-engine' );
 	$assert( 'home' === ( $documents_by_source['website/index.html']['slug'] ?? '' ), 'entry-index-materializes-as-home' );
 	$assert( str_ends_with( (string) ( $documents_by_source['website/index.html']['permalink'] ?? '' ), '/' ), 'entry-index-has-front-page-permalink' );
 	$assert( 'menu' === ( $documents_by_source['website/menu.html']['slug'] ?? '' ), 'menu-page-materializes' );
@@ -222,7 +222,7 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 	$assert( true === ( $template_parts_by_path['parts/header.html']['generated'] ?? null ), 'multi-page-header-template-part-is-generated-by-ssi' );
 	$assert( ! isset( $template_parts_by_path['parts/footer.html'] ), 'multi-page-does-not-synthesize-footer-template-part' );
 	$assert( ! str_contains( $read( $multi_page_result['theme_dir'] . '/templates/front-page.html' ), '"slug":"footer"' ), 'multi-page-template-does-not-reference-synthesized-footer-part' );
-	$assert( array() === $pattern_documents, 'bac-document-import-does-not-generate-page-pattern-copies' );
+	$assert( array() === $pattern_documents, 'blocks-engine-document-import-does-not-generate-page-pattern-copies' );
 }
 
 if ( ! empty( $failures ) ) {

--- a/tests/smoke-website-artifact-products-manifest.php
+++ b/tests/smoke-website-artifact-products-manifest.php
@@ -62,6 +62,19 @@ namespace {
 					),
 				),
 			),
+			'legacy_mapping' => array(
+				'block-artifact-compiler/result/v1' => array(
+					'status'                           => 'status',
+					'input'                            => 'source_reports.artifact',
+					'wordpress_artifacts.block_markup' => 'serialized_blocks',
+					'wordpress_artifacts.blocks'       => 'blocks',
+					'wordpress_artifacts.block_types'  => 'block_types',
+					'wordpress_artifacts.components'   => 'components',
+					'wordpress_artifacts.files'        => 'assets',
+					'diagnostics'                      => 'diagnostics',
+					'provenance'                       => 'provenance',
+				),
+			),
 			'provenance'     => array(
 				array( 'source_hash' => 'products-smoke' ),
 			),


### PR DESCRIPTION
## Summary
- consume Blocks Engine `materialization_plan` as the canonical compiled-site contract
- project legacy compatibility envelopes from Blocks Engine `legacy_mapping` instead of hand-building BAC shapes
- move report/diagnostic naming toward Blocks Engine ownership
- centralize website-artifact schema usage for URL import/export paths

## Why
Static Site Importer is being collapsed into Blocks Engine. This PR turns SSI into a consumer/facade for Blocks Engine materialization contracts instead of an owner of generic compiled-site/report projection.

## Testing
- `php tests/smoke-transformer-adapter.php`
- `php tests/smoke-website-artifact-products-manifest.php`
- `php tests/smoke-website-artifact-document-metadata.php`
- `php tests/smoke-url-import-runtime.php`
- `php tests/smoke-export-theme-ability.php`
- `php tests/smoke-bac-visual-repair-css.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Collapsing SSI contract projection onto Blocks Engine materialization reports and running focused smokes.
