### PR TITLE
Use native transformer result mapping

### DIFF
--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -63,7 +63,10 @@ class Static_Site_Importer_Transformer_Adapter {
 	 * @return array<string,mixed>
 	 */
 	private function compiled_result_from_transformer_contract( array $result ): array {
-		$compiled = $this->project_transformer_result( $result, self::COMPILED_RESULT_SCHEMA );
+		$compiled = $this->compiled_result_from_native_transformer_contract( $result );
+		if ( empty( $compiled['wordpress_artifacts'] ) ) {
+			$compiled = $this->project_transformer_result( $result, self::COMPILED_RESULT_SCHEMA );
+		}
 
 		$source_reports       = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
 		$compiled_site        = isset( $source_reports['compiled_site'] ) && is_array( $source_reports['compiled_site'] ) ? $source_reports['compiled_site'] : array();
@@ -88,6 +91,38 @@ class Static_Site_Importer_Transformer_Adapter {
 		if ( ! empty( $products ) ) {
 			$compiled['products_manifest'] = $products;
 		}
+
+		return $compiled;
+	}
+
+	/**
+	 * Build SSI's consumed compiler envelope from the native Blocks Engine result.
+	 *
+	 * @param array<string,mixed> $result TransformerResult::toArray() output.
+	 * @return array<string,mixed>
+	 */
+	private function compiled_result_from_native_transformer_contract( array $result ): array {
+		$source_reports = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
+		if ( empty( $source_reports ) ) {
+			return array();
+		}
+
+		$artifact = isset( $source_reports['artifact'] ) && is_array( $source_reports['artifact'] ) ? $source_reports['artifact'] : array();
+
+		$compiled = array(
+			'schema'              => self::COMPILED_RESULT_SCHEMA,
+			'status'              => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : '',
+			'input'               => $artifact,
+			'wordpress_artifacts' => array(
+				'block_markup' => isset( $result['serialized_blocks'] ) && is_scalar( $result['serialized_blocks'] ) ? (string) $result['serialized_blocks'] : '',
+				'blocks'       => isset( $result['blocks'] ) && is_array( $result['blocks'] ) ? $result['blocks'] : array(),
+				'block_types'  => isset( $result['block_types'] ) && is_array( $result['block_types'] ) ? $result['block_types'] : array(),
+				'components'   => isset( $result['components'] ) && is_array( $result['components'] ) ? $result['components'] : array(),
+				'files'        => isset( $result['assets'] ) && is_array( $result['assets'] ) ? $result['assets'] : array(),
+			),
+			'diagnostics'         => isset( $result['diagnostics'] ) && is_array( $result['diagnostics'] ) ? $result['diagnostics'] : array(),
+			'provenance'          => isset( $result['provenance'] ) && is_array( $result['provenance'] ) ? $result['provenance'] : array(),
+		);
 
 		return $compiled;
 	}

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -124,19 +124,6 @@ namespace {
 						'blocks'            => array(
 							array( 'blockName' => 'core/paragraph', 'innerBlocks' => array() ),
 						),
-						'legacy_mapping'    => array(
-							'block-artifact-compiler/result/v1' => array(
-								'status'                           => 'status',
-								'input'                            => 'source_reports.artifact',
-								'wordpress_artifacts.block_markup' => 'serialized_blocks',
-								'wordpress_artifacts.blocks'       => 'blocks',
-								'wordpress_artifacts.block_types'  => 'block_types',
-								'wordpress_artifacts.components'   => 'components',
-								'wordpress_artifacts.files'        => 'assets',
-								'diagnostics'                      => 'diagnostics',
-								'provenance'                       => 'provenance',
-							),
-						),
 						'serialized_blocks' => '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->',
 						'documents'         => array(
 							array(
@@ -233,6 +220,7 @@ namespace {
 	$assert( 1 === count( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'] ), 'plugin-artifact-helper-called' );
 	$assert( true === ( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][0][1]['include_bfb_report'] ?? false ), 'compile-options-forwarded' );
 	$assert( 'block-artifact-compiler/result/v1' === ( $compiled['schema'] ?? '' ), 'native-result-mapped-to-bac-envelope' );
+	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'native-artifact-report-preserved-as-input' );
 	$assert( 'blocks-engine/php-transformer/materialization-plan/v1' === ( $site['schema'] ?? '' ), 'native-materialization-plan-contract-is-used' );
 	$assert( 4 === count( $pages ), 'native-keeps-compiled-site-pages-without-adapter-filtering' );
 	$assert( 'website/index.html' === ( $pages[0]['source_path'] ?? '' ), 'native-entry-source-path' );

--- a/tests/smoke-website-artifact-products-manifest.php
+++ b/tests/smoke-website-artifact-products-manifest.php
@@ -62,19 +62,6 @@ namespace {
 					),
 				),
 			),
-			'legacy_mapping' => array(
-				'block-artifact-compiler/result/v1' => array(
-					'status'                           => 'status',
-					'input'                            => 'source_reports.artifact',
-					'wordpress_artifacts.block_markup' => 'serialized_blocks',
-					'wordpress_artifacts.blocks'       => 'blocks',
-					'wordpress_artifacts.block_types'  => 'block_types',
-					'wordpress_artifacts.components'   => 'components',
-					'wordpress_artifacts.files'        => 'assets',
-					'diagnostics'                      => 'diagnostics',
-					'provenance'                       => 'provenance',
-				),
-			),
 			'provenance'     => array(
 				array( 'source_hash' => 'products-smoke' ),
 			),
@@ -126,6 +113,7 @@ namespace {
 	$products = is_array( $compiled ) ? ( $compiled['products_manifest'] ?? array() ) : array();
 
 	$assert( ! is_wp_error( $compiled ), 'compile-succeeds', is_wp_error( $compiled ) ? $compiled->get_error_message() : '' );
+	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'preserves-native-artifact-input' );
 	$assert( 3 === count( $products ), 'maps-unique-product-reports' );
 	$assert( 'rye-loaf' === ( $products[0]['slug'] ?? '' ), 'maps-compiled-site-product-slug' );
 	$assert( 'Rye Loaf' === ( $products[0]['name'] ?? '' ), 'maps-title-to-name' );


### PR DESCRIPTION
## Summary
- Build SSI's consumed compiler envelope directly from native Blocks Engine transformer result fields when `source_reports` are available.
- Keep the legacy BAC projection isolated as a fallback for older transformer outputs without native source reports.
- Update adapter/product smokes so native report behavior passes without `legacy_mapping`.

## Verification
- `php tests/smoke-transformer-adapter.php`
- `php tests/smoke-website-artifact-products-manifest.php`
- `php tests/smoke-export-theme-ability.php`
- `git diff --check`

## Blockers / residual risk
- `npm run test:validation` is blocked in this local Studio runtime because `tests/smoke-website-artifact-document-metadata.php` requires `blocks_engine_php_transformer_compile_artifact()` from the Blocks Engine transformer plugin and the helper is not available here.
- `npm run test:js-block-validation` fails independently while printing validation output because `summary` is undefined in `tests/smoke-generated-theme-block-validation.cjs` after reporting one invalid block.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the adapter dependency surface, implementing the native transformer result mapping, updating smoke coverage, and running verification.
