### PR TITLE
Consume template part materialization plan writes

### DIFF
--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -170,7 +170,15 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @return array{writes:array<string,string>,reports:array<int,array<string,mixed>>}|WP_Error Absolute write paths and report rows.
 	 */
 	public static function template_part_artifact_writes( string $theme_dir, array $artifacts ) {
-		$template_parts = isset( $artifacts['template_parts'] ) && is_array( $artifacts['template_parts'] ) ? $artifacts['template_parts'] : array();
+		$template_parts = self::template_part_artifacts_from_materialization_plan( $artifacts );
+		if ( is_wp_error( $template_parts ) ) {
+			return $template_parts;
+		}
+
+		if ( null === $template_parts ) {
+			$template_parts = isset( $artifacts['template_parts'] ) && is_array( $artifacts['template_parts'] ) ? $artifacts['template_parts'] : array();
+		}
+
 		$writes  = array();
 		$reports = array();
 		foreach ( $template_parts as $template_part ) {
@@ -206,6 +214,52 @@ class Static_Site_Importer_Theme_Materializer {
 			'writes'  => $writes,
 			'reports' => $reports,
 		);
+	}
+
+	/**
+	 * Read generic WordPress template-part writes from a Blocks Engine materialization plan.
+	 *
+	 * @param array<string,mixed> $artifacts WordPress artifacts from the transformer adapter.
+	 * @return array<int,array<string,mixed>>|null|WP_Error Template part artifacts, null when no plan write list exists.
+	 */
+	private static function template_part_artifacts_from_materialization_plan( array $artifacts ) {
+		$site = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
+		if ( 'blocks-engine/php-transformer/materialization-plan/v1' !== (string) ( $site['schema'] ?? '' ) || ! array_key_exists( 'template_part_writes', $site ) ) {
+			return null;
+		}
+
+		if ( ! is_array( $site['template_part_writes'] ) ) {
+			return new WP_Error( 'static_site_importer_materialization_plan_template_part_writes_invalid', 'Blocks Engine materialization_plan.template_part_writes must be an array.' );
+		}
+
+		$template_parts = array();
+		foreach ( $site['template_part_writes'] as $write ) {
+			if ( ! is_array( $write ) ) {
+				return new WP_Error( 'static_site_importer_materialization_plan_template_part_write_invalid', 'Blocks Engine template part write entries must be arrays.' );
+			}
+
+			if ( 'wp_template_part' !== (string) ( $write['type'] ?? '' ) ) {
+				continue;
+			}
+
+			$content = isset( $write['content'] ) && is_scalar( $write['content'] ) ? (string) $write['content'] : '';
+			if ( '' === trim( $content ) ) {
+				return new WP_Error( 'static_site_importer_materialization_plan_template_part_content_missing', 'Blocks Engine wp_template_part writes must include non-empty content.' );
+			}
+
+			$template_parts[] = array_filter(
+				array(
+					'source_path'  => isset( $write['source_path'] ) && is_scalar( $write['source_path'] ) ? (string) $write['source_path'] : '',
+					'slug'         => isset( $write['slug'] ) && is_scalar( $write['slug'] ) ? (string) $write['slug'] : '',
+					'title'        => isset( $write['title'] ) && is_scalar( $write['title'] ) ? (string) $write['title'] : '',
+					'area'         => isset( $write['area'] ) && is_scalar( $write['area'] ) ? (string) $write['area'] : '',
+					'block_markup' => $content,
+				),
+				static fn ( string $value ): bool => '' !== $value
+			);
+		}
+
+		return $template_parts;
 	}
 
 	/**
@@ -280,12 +334,17 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @return array<string,mixed>
 	 */
 	private static function template_part_artifact_report_payload( string $path, array $template_part, string $markup ): array {
+		$source_paths = isset( $template_part['source_paths'] ) && is_array( $template_part['source_paths'] ) ? array_values( array_filter( $template_part['source_paths'], 'is_scalar' ) ) : array();
+		if ( empty( $source_paths ) && isset( $template_part['source_path'] ) && is_scalar( $template_part['source_path'] ) && '' !== (string) $template_part['source_path'] ) {
+			$source_paths = array( (string) $template_part['source_path'] );
+		}
+
 		return array(
 			'path'               => $path,
 			'slug'               => isset( $template_part['slug'] ) && is_scalar( $template_part['slug'] ) ? (string) $template_part['slug'] : '',
 			'area'               => isset( $template_part['area'] ) && is_scalar( $template_part['area'] ) ? (string) $template_part['area'] : '',
 			'generated'          => ! empty( $template_part['generated'] ),
-			'source_paths'       => isset( $template_part['source_paths'] ) && is_array( $template_part['source_paths'] ) ? array_values( array_filter( $template_part['source_paths'], 'is_scalar' ) ) : array(),
+			'source_paths'       => $source_paths,
 			'source_hash'        => isset( $template_part['source_hash'] ) && is_scalar( $template_part['source_hash'] ) ? (string) $template_part['source_hash'] : '',
 			'block_markup_bytes' => strlen( $markup ),
 			'block_markup_hash'  => hash( 'sha256', $markup ),

--- a/tests/smoke-bac-visual-repair-css.php
+++ b/tests/smoke-bac-visual-repair-css.php
@@ -15,18 +15,43 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		private string $code;
+		private string $message;
 
-		public function __construct( string $code ) {
-			$this->code = $code;
+		public function __construct( string $code, string $message = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
 		}
 
 		public function get_error_code(): string {
 			return $this->code;
 		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $value ): string {
+		return rtrim( $value, '/\\' ) . '/';
 	}
 }
 
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-stylesheet-materializer.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php';
 
 $failures   = array();
@@ -98,6 +123,54 @@ $missing_source = $documents->invoke(
 );
 $assert( $missing_source instanceof WP_Error, 'compiled-site-page-source-is-required' );
 $assert( 'static_site_importer_compiled_site_page_missing_source' === ( $missing_source instanceof WP_Error ? $missing_source->get_error_code() : '' ), 'compiled-site-page-source-error-code' );
+
+$template_part_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
+	'/tmp/bac-visual-repair-smoke',
+	array(
+		'site'           => array(
+			'schema'               => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'template_part_writes' => array(
+				array(
+					'type'        => 'wp_template_part',
+					'source_path' => 'parts/header.html',
+					'slug'        => 'header',
+					'area'        => 'header',
+					'content'     => '<!-- wp:group {"tagName":"header"} --><header class="wp-block-group">Plan Header</header><!-- /wp:group -->',
+				),
+			),
+		),
+		'template_parts' => array(
+			array(
+				'slug'         => 'header',
+				'area'         => 'header',
+				'block_markup' => '<!-- wp:paragraph --><p>Legacy Header</p><!-- /wp:paragraph -->',
+			),
+		),
+	)
+);
+$assert( is_array( $template_part_result ), 'materialization-plan-template-part-writes-succeed' );
+$template_part_writes = is_array( $template_part_result ) ? $template_part_result['writes'] : array();
+$template_part_reports = is_array( $template_part_result ) ? $template_part_result['reports'] : array();
+$assert( str_contains( (string) ( $template_part_writes['/tmp/bac-visual-repair-smoke/parts/header.html'] ?? '' ), 'Plan Header' ), 'materialization-plan-template-part-write-is-used' );
+$assert( ! str_contains( (string) ( $template_part_writes['/tmp/bac-visual-repair-smoke/parts/header.html'] ?? '' ), 'Legacy Header' ), 'legacy-template-part-is-ignored-when-plan-writes-exist' );
+$assert( array( 'parts/header.html' ) === ( $template_part_reports[0]['source_paths'] ?? array() ), 'materialization-plan-template-part-source-path-is-reported' );
+
+$missing_content = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
+	'/tmp/bac-visual-repair-smoke',
+	array(
+		'site' => array(
+			'schema'               => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'template_part_writes' => array(
+				array(
+					'type' => 'wp_template_part',
+					'slug' => 'header',
+				),
+			),
+		),
+	)
+);
+$assert( $missing_content instanceof WP_Error, 'materialization-plan-template-part-content-is-required' );
+$assert( 'static_site_importer_materialization_plan_template_part_content_missing' === ( $missing_content instanceof WP_Error ? $missing_content->get_error_code() : '' ), 'materialization-plan-template-part-content-error-code' );
 
 if ( ! empty( $failures ) ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- Consume Blocks Engine `materialization_plan.template_part_writes[]` for generated theme template-part writes when the plan provides them.
- Keep the existing SSI fallback for older envelopes without a plan write list.
- Preserve SSI write policy and reporting, including default generated header behavior.

## Verification
- `php -l includes/class-static-site-importer-theme-materializer.php`
- `php -l tests/smoke-bac-visual-repair-css.php`
- `php tests/smoke-bac-visual-repair-css.php`
- `php tests/smoke-transformer-adapter.php`
- `php tests/smoke-website-artifact-products-manifest.php`
- `php tests/smoke-export-theme-ability.php`
- `git diff --check`

## Verification notes
- `npm run test:js-block-validation` currently fails in the JS harness while printing an invalid-block summary: `TypeError: Cannot convert undefined or null to object` in `tests/smoke-generated-theme-block-validation.cjs`.
- `npm run test:validation` currently fails at the website artifact document metadata smoke because the local runtime does not provide Blocks Engine php-transformer.
- `homeboy lint --changed-only --summary` was not run because Homeboy refused local execution under the warm-machine resource policy and the changed-only path is local-only.

## Upstream gaps
- None found for this slice. Blocks Engine exposes `template_part_writes[]` with `type`, `source_path`, `slug`, `area`, and `content`, which is sufficient for SSI to materialize supported WordPress template parts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting SSI/Blocks Engine materialization contracts, implementing the scoped template-part materialization-plan consumption, and updating smoke coverage.