### PR TITLE
Isolate legacy BFB report option

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -54,7 +54,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		$compiler_options = isset( $args['compiler_options'] ) && is_array( $args['compiler_options'] ) ? $args['compiler_options'] : array();
-		$compiled         = ( new Static_Site_Importer_Transformer_Adapter() )->compile_website_artifact( $artifact, array_merge( array( 'include_bfb_report' => true ), $compiler_options ) );
+		$compiled         = ( new Static_Site_Importer_Transformer_Adapter() )->compile_website_artifact( $artifact, array_merge( array( 'include_conversion_report' => true ), $compiler_options ) );
 		if ( is_wp_error( $compiled ) ) {
 			return $compiled;
 		}

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -16,6 +16,8 @@ class Static_Site_Importer_Transformer_Adapter {
 
 	public const WEBSITE_ARTIFACT_SCHEMA = 'block-artifact-compiler/website-artifact/v1';
 	public const COMPILED_RESULT_SCHEMA  = 'block-artifact-compiler/result/v1';
+	private const CONVERSION_REPORT_OPTION = 'include_conversion_report';
+	private const LEGACY_BFB_REPORT_OPTION = 'include_bfb_report';
 
 	/**
 	 * Check whether the default Blocks Engine artifact compiler is available.
@@ -47,6 +49,7 @@ class Static_Site_Importer_Transformer_Adapter {
 			return new WP_Error( 'static_site_importer_missing_transformer', 'Blocks Engine php-transformer is required to import a website artifact.' );
 		}
 
+		$options = $this->normalize_compile_options( $options );
 		$result = blocks_engine_php_transformer_compile_artifact( $artifact, $options );
 
 		if ( is_array( $result ) ) {
@@ -124,7 +127,41 @@ class Static_Site_Importer_Transformer_Adapter {
 			'provenance'          => isset( $result['provenance'] ) && is_array( $result['provenance'] ) ? $result['provenance'] : array(),
 		);
 
+		$compiled['bfb_report'] = $this->legacy_bfb_report_from_transformer_result( $result );
+
 		return $compiled;
+	}
+
+	/**
+	 * Normalize SSI compile options before calling the Blocks Engine helper.
+	 *
+	 * @param array<string,mixed> $options Caller-provided compile options.
+	 * @return array<string,mixed>
+	 */
+	private function normalize_compile_options( array $options ): array {
+		$include_report = ! empty( $options[ self::CONVERSION_REPORT_OPTION ] ) || ! empty( $options[ self::LEGACY_BFB_REPORT_OPTION ] );
+		unset( $options[ self::LEGACY_BFB_REPORT_OPTION ] );
+
+		if ( $include_report ) {
+			$options[ self::CONVERSION_REPORT_OPTION ] = true;
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Preserve SSI's legacy BFB report field from the native Blocks Engine result.
+	 *
+	 * @param array<string,mixed> $result TransformerResult::toArray() output.
+	 * @return array<string,mixed>
+	 */
+	private function legacy_bfb_report_from_transformer_result( array $result ): array {
+		return array(
+			'status'            => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : 'failed',
+			'serialized_blocks' => isset( $result['serialized_blocks'] ) && is_scalar( $result['serialized_blocks'] ) ? (string) $result['serialized_blocks'] : '',
+			'diagnostics'       => isset( $result['diagnostics'] ) && is_array( $result['diagnostics'] ) ? $result['diagnostics'] : array(),
+			'fallbacks'         => isset( $result['fallbacks'] ) && is_array( $result['fallbacks'] ) ? $result['fallbacks'] : array(),
+		);
 	}
 
 	/**

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -218,8 +218,12 @@ namespace {
 	$products  = $compiled['products_manifest'] ?? array();
 	$assert( ! is_wp_error( $compiled ), 'native-compile-succeeds' );
 	$assert( 1 === count( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'] ), 'plugin-artifact-helper-called' );
-	$assert( true === ( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][0][1]['include_bfb_report'] ?? false ), 'compile-options-forwarded' );
+	$assert( true === ( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][0][1]['include_conversion_report'] ?? false ), 'compile-options-forwarded-as-native-report-request' );
+	$assert( ! array_key_exists( 'include_bfb_report', $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][0][1] ?? array() ), 'legacy-bfb-option-is-isolated' );
 	$assert( 'block-artifact-compiler/result/v1' === ( $compiled['schema'] ?? '' ), 'native-result-mapped-to-bac-envelope' );
+	$assert( 'success' === ( $compiled['bfb_report']['status'] ?? '' ), 'legacy-bfb-report-shape-preserved' );
+	$assert( '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->' === ( $compiled['bfb_report']['serialized_blocks'] ?? '' ), 'legacy-bfb-report-uses-native-serialized-blocks' );
+	$assert( array() === ( $compiled['bfb_report']['fallbacks'] ?? null ), 'legacy-bfb-report-uses-native-fallbacks' );
 	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'native-artifact-report-preserved-as-input' );
 	$assert( 'blocks-engine/php-transformer/materialization-plan/v1' === ( $site['schema'] ?? '' ), 'native-materialization-plan-contract-is-used' );
 	$assert( 4 === count( $pages ), 'native-keeps-compiled-site-pages-without-adapter-filtering' );


### PR DESCRIPTION
## Summary
- Request generic Blocks Engine conversion reports from SSI's website-artifact import path instead of passing the legacy BFB report option directly.
- Keep legacy `include_bfb_report` accepted only inside the transformer adapter and translate it before calling Blocks Engine.
- Preserve the existing public `bfb_report` envelope by projecting status, serialized blocks, diagnostics, and fallbacks from the native Blocks Engine result.
- Extend the transformer adapter smoke to prove the legacy option is isolated while the legacy report shape remains available.

## Verification
- `php tests/smoke-transformer-adapter.php`
- `php tests/smoke-website-artifact-products-manifest.php`
- `php tests/smoke-export-theme-ability.php`
- `php tests/smoke-website-artifact-document-metadata.php`
- `php tests/smoke-bac-visual-repair-css.php`
- `php tests/smoke-url-import-runtime.php`
- `php -l includes/class-static-site-importer-transformer-adapter.php`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/smoke-transformer-adapter.php`
- `git diff --check`

## Note
- `npm run test:validation` was attempted, but the local WordPress harness step requires the Blocks Engine php-transformer helper in the Studio site and failed with `Blocks Engine php-transformer is required to import a website artifact.` Repository-local smokes above passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Investigating the remaining BFB compatibility surface, implementing the adapter isolation slice, updating smoke coverage, and drafting this PR description.