### PR TITLE
Consume materialization plan pages directly

### DIFF
--- a/includes/class-static-site-importer-source-page.php
+++ b/includes/class-static-site-importer-source-page.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Represents one importable BAC document artifact.
+ * Represents one importable source document.
  */
 class Static_Site_Importer_Source_Page {
 
@@ -128,6 +128,44 @@ class Static_Site_Importer_Source_Page {
 		$document = new Static_Site_Importer_Document( '<!doctype html><html><head><title>' . esc_html( $title ) . '</title></head><body><main>' . $content . '</main></body></html>' );
 
 		return new self( $source_key, $source_key, 'bac_document', $document, $content, 'blocks', $metadata );
+	}
+
+	/**
+	 * Create a source page from a Blocks Engine materialization-plan page row.
+	 *
+	 * @param array<string,mixed> $page Materialization-plan page row.
+	 * @return self|WP_Error
+	 */
+	public static function from_materialization_plan_page( array $page ) {
+		$source_key = self::normalize_artifact_source_key( isset( $page['source_path'] ) ? (string) $page['source_path'] : '' );
+		if ( '' === $source_key ) {
+			return new WP_Error( 'static_site_importer_materialization_plan_page_missing_source', 'Blocks Engine materialization-plan page is missing source_path.' );
+		}
+
+		$content = isset( $page['block_markup'] ) && is_scalar( $page['block_markup'] ) ? (string) $page['block_markup'] : '';
+		if ( '' === trim( $content ) ) {
+			return new WP_Error( 'static_site_importer_materialization_plan_page_empty_content', sprintf( 'Blocks Engine materialization-plan page is missing block markup: %s', $source_key ) );
+		}
+
+		$metadata = array();
+		foreach ( array( 'title', 'slug', 'status', 'post_type', 'entrypoint', 'body_format' ) as $key ) {
+			if ( isset( $page[ $key ] ) && is_scalar( $page[ $key ] ) && '' !== trim( (string) $page[ $key ] ) ) {
+				$metadata[ $key ] = (string) $page[ $key ];
+			}
+		}
+		if ( isset( $page['metadata'] ) && is_array( $page['metadata'] ) ) {
+			foreach ( $page['metadata'] as $key => $value ) {
+				if ( is_string( $key ) && is_scalar( $value ) ) {
+					$metadata[ strtolower( str_replace( '-', '_', $key ) ) ] = (string) $value;
+				}
+			}
+		}
+
+		$title       = $metadata['title'] ?? '';
+		$body_format = isset( $metadata['body_format'] ) && '' !== $metadata['body_format'] ? $metadata['body_format'] : 'blocks';
+		$document    = new Static_Site_Importer_Document( '<!doctype html><html><head><title>' . esc_html( $title ) . '</title></head><body><main>' . $content . '</main></body></html>' );
+
+		return new self( $source_key, $source_key, 'materialization_plan_page', $document, $content, $body_format, $metadata );
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1039,7 +1039,11 @@ class Static_Site_Importer_Theme_Generator {
 		$documents = isset( $artifacts['documents'] ) && is_array( $artifacts['documents'] ) ? $artifacts['documents'] : array();
 		$site      = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
 		if ( ! empty( $site['pages'] ) && is_array( $site['pages'] ) ) {
-			if ( ! in_array( (string) ( $site['schema'] ?? '' ), array( 'block-artifact-compiler/compiled-site/v1', 'blocks-engine/php-transformer/compiled-site/v1', 'blocks-engine/php-transformer/materialization-plan/v1' ), true ) ) {
+			if ( 'blocks-engine/php-transformer/materialization-plan/v1' === (string) ( $site['schema'] ?? '' ) ) {
+				return self::source_pages_from_materialization_plan_pages( $site['pages'] );
+			}
+
+			if ( ! in_array( (string) ( $site['schema'] ?? '' ), array( 'block-artifact-compiler/compiled-site/v1', 'blocks-engine/php-transformer/compiled-site/v1' ), true ) ) {
 				return new WP_Error( 'static_site_importer_compiled_site_missing', 'Website artifact document pages require a supported compiled-site contract.' );
 			}
 
@@ -1068,7 +1072,31 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Attach BAC document markup to compiled-site page contracts.
+	 * Build source pages directly from Blocks Engine materialization-plan page rows.
+	 *
+	 * @param array<int,mixed> $site_pages Materialization-plan page rows.
+	 * @return array<string, Static_Site_Importer_Source_Page>|WP_Error
+	 */
+	private static function source_pages_from_materialization_plan_pages( array $site_pages ) {
+		$pages = array();
+		foreach ( $site_pages as $page_row ) {
+			if ( ! is_array( $page_row ) ) {
+				continue;
+			}
+
+			$page = Static_Site_Importer_Source_Page::from_materialization_plan_page( $page_row );
+			if ( is_wp_error( $page ) ) {
+				return $page;
+			}
+
+			$pages[ $page->source_key() ] = $page;
+		}
+
+		return $pages;
+	}
+
+	/**
+	 * Attach document markup to compiled-site page contracts.
 	 *
 	 * @param array<int,array<string,mixed>> $site_pages Compiled-site page rows.
 	 * @param array<int,mixed>               $documents  BAC document artifacts.

--- a/tests/smoke-bac-visual-repair-css.php
+++ b/tests/smoke-bac-visual-repair-css.php
@@ -44,6 +44,18 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		return trim( strtolower( preg_replace( '/[^a-z0-9]+/', '-', $title ) ), '-' );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( string $text ): string {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
 if ( ! function_exists( 'trailingslashit' ) ) {
 	function trailingslashit( string $value ): string {
 		return rtrim( $value, '/\\' ) . '/';
@@ -51,6 +63,8 @@ if ( ! function_exists( 'trailingslashit' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-stylesheet-materializer.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-source-page.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php';
 
@@ -171,6 +185,61 @@ $missing_content = Static_Site_Importer_Theme_Materializer::template_part_artifa
 );
 $assert( $missing_content instanceof WP_Error, 'materialization-plan-template-part-content-is-required' );
 $assert( 'static_site_importer_materialization_plan_template_part_content_missing' === ( $missing_content instanceof WP_Error ? $missing_content->get_error_code() : '' ), 'materialization-plan-template-part-content-error-code' );
+
+$source_pages = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'bac_document_pages' );
+$native_pages = $source_pages->invoke(
+	null,
+	array(
+		'wordpress_artifacts' => array(
+			'site'      => array(
+				'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+				'pages'  => array(
+					array(
+						'source_path'  => 'website/index.html',
+						'post_type'    => 'page',
+						'slug'         => 'home-canonical',
+						'title'        => 'Home Canonical',
+						'entrypoint'   => true,
+						'block_markup' => '<!-- wp:paragraph --><p>Native page</p><!-- /wp:paragraph -->',
+					),
+				),
+			),
+			'documents' => array(
+				array(
+					'source_path'  => 'website/index.html',
+					'slug'         => 'legacy-home',
+					'title'        => 'Legacy Home',
+					'block_markup' => '<!-- wp:paragraph --><p>Legacy page</p><!-- /wp:paragraph -->',
+				),
+			),
+		),
+	)
+);
+$assert( is_array( $native_pages ), 'materialization-plan-pages-create-source-pages' );
+$native_page = is_array( $native_pages ) ? ( $native_pages['website/index.html'] ?? null ) : null;
+$assert( $native_page instanceof Static_Site_Importer_Source_Page, 'materialization-plan-page-source-key-is-used' );
+$assert( $native_page instanceof Static_Site_Importer_Source_Page && 'materialization_plan_page' === $native_page->type(), 'materialization-plan-page-type-is-native' );
+$assert( $native_page instanceof Static_Site_Importer_Source_Page && 'home-canonical' === $native_page->metadata_value( 'slug' ), 'materialization-plan-page-slug-wins-over-legacy-document' );
+$assert( $native_page instanceof Static_Site_Importer_Source_Page && str_contains( $native_page->body(), 'Native page' ), 'materialization-plan-page-body-wins-over-legacy-document' );
+
+$missing_page_content = $source_pages->invoke(
+	null,
+	array(
+		'wordpress_artifacts' => array(
+			'site' => array(
+				'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+				'pages'  => array(
+					array(
+						'source_path' => 'website/index.html',
+						'slug'        => 'home',
+					),
+				),
+			),
+		),
+	)
+);
+$assert( $missing_page_content instanceof WP_Error, 'materialization-plan-page-content-is-required' );
+$assert( 'static_site_importer_materialization_plan_page_empty_content' === ( $missing_page_content instanceof WP_Error ? $missing_page_content->get_error_code() : '' ), 'materialization-plan-page-content-error-code' );
 
 if ( ! empty( $failures ) ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- Route Blocks Engine materialization-plan page rows directly into SSI source pages for page materialization.
- Keep SSI-owned WordPress write policy unchanged while avoiding the BAC-shaped compiled-site document synthesis path for native materialization plans.
- Extend the existing materialization smoke to prove native page rows win over legacy documents and missing native block markup fails explicitly.

## Verification
- php tests/smoke-bac-visual-repair-css.php
- php tests/smoke-transformer-adapter.php
- php tests/smoke-website-artifact-products-manifest.php
- php -l includes/class-static-site-importer-source-page.php
- php -l includes/class-static-site-importer-theme-generator.php
- php -l tests/smoke-bac-visual-repair-css.php
- git diff --check

## Known local verification gaps
- npm run test:validation fails locally because the WP harness runtime does not expose blocks_engine_php_transformer_compile_artifact() to smoke-website-artifact-document-metadata.php.
- npm run test:js-block-validation fails locally in the existing reporter path after an invalid-block result: TypeError: Cannot convert undefined or null to object.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting SSI/Blocks Engine contracts, implementing the native materialization-plan page slice, updating smoke coverage, and running verification.