### PR TITLE
Consume route and navigation materialization plan rows

### DIFF
--- a/includes/class-static-site-importer-source-page.php
+++ b/includes/class-static-site-importer-source-page.php
@@ -148,7 +148,7 @@ class Static_Site_Importer_Source_Page {
 		}
 
 		$metadata = array();
-		foreach ( array( 'title', 'slug', 'status', 'post_type', 'entrypoint', 'body_format' ) as $key ) {
+		foreach ( array( 'title', 'slug', 'status', 'post_type', 'entrypoint', 'body_format', 'route_key', 'route_path' ) as $key ) {
 			if ( isset( $page[ $key ] ) && is_scalar( $page[ $key ] ) && '' !== trim( (string) $page[ $key ] ) ) {
 				$metadata[ $key ] = (string) $page[ $key ];
 			}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1040,7 +1040,7 @@ class Static_Site_Importer_Theme_Generator {
 		$site      = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
 		if ( ! empty( $site['pages'] ) && is_array( $site['pages'] ) ) {
 			if ( 'blocks-engine/php-transformer/materialization-plan/v1' === (string) ( $site['schema'] ?? '' ) ) {
-				return self::source_pages_from_materialization_plan_pages( $site['pages'] );
+				return self::source_pages_from_materialization_plan( $site );
 			}
 
 			if ( ! in_array( (string) ( $site['schema'] ?? '' ), array( 'block-artifact-compiler/compiled-site/v1', 'blocks-engine/php-transformer/compiled-site/v1' ), true ) ) {
@@ -1074,14 +1074,25 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Build source pages directly from Blocks Engine materialization-plan page rows.
 	 *
-	 * @param array<int,mixed> $site_pages Materialization-plan page rows.
+	 * @param array<string,mixed> $site Materialization-plan site report.
 	 * @return array<string, Static_Site_Importer_Source_Page>|WP_Error
 	 */
-	private static function source_pages_from_materialization_plan_pages( array $site_pages ) {
+	private static function source_pages_from_materialization_plan( array $site ) {
+		$site_pages = isset( $site['pages'] ) && is_array( $site['pages'] ) ? $site['pages'] : array();
+		$routes     = self::materialization_plan_routes_by_source_path( $site );
+		if ( is_wp_error( $routes ) ) {
+			return $routes;
+		}
+
 		$pages = array();
 		foreach ( $site_pages as $page_row ) {
 			if ( ! is_array( $page_row ) ) {
 				continue;
+			}
+
+			$source_path = isset( $page_row['source_path'] ) && is_scalar( $page_row['source_path'] ) ? self::normalize_route_path( (string) $page_row['source_path'] ) : '';
+			if ( '' !== $source_path && isset( $routes[ $source_path ] ) ) {
+				$page_row = array_merge( $page_row, $routes[ $source_path ] );
 			}
 
 			$page = Static_Site_Importer_Source_Page::from_materialization_plan_page( $page_row );
@@ -1093,6 +1104,56 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return $pages;
+	}
+
+	/**
+	 * Normalize native materialization-plan route rows by source path.
+	 *
+	 * @param array<string,mixed> $site Materialization-plan site report.
+	 * @return array<string,array<string,mixed>>|WP_Error Route rows keyed by normalized source path.
+	 */
+	private static function materialization_plan_routes_by_source_path( array $site ) {
+		if ( ! array_key_exists( 'routes', $site ) ) {
+			return array();
+		}
+
+		if ( ! is_array( $site['routes'] ) ) {
+			return new WP_Error( 'static_site_importer_materialization_plan_routes_invalid', 'Blocks Engine materialization_plan.routes must be an array.' );
+		}
+
+		$routes = array();
+		foreach ( $site['routes'] as $route ) {
+			if ( ! is_array( $route ) ) {
+				return new WP_Error( 'static_site_importer_materialization_plan_route_invalid', 'Blocks Engine materialization-plan route entries must be arrays.' );
+			}
+
+			$source_path = isset( $route['source_path'] ) && is_scalar( $route['source_path'] ) ? self::normalize_route_path( (string) $route['source_path'] ) : '';
+			if ( '' === $source_path ) {
+				return new WP_Error( 'static_site_importer_materialization_plan_route_missing_source', 'Blocks Engine materialization-plan route is missing source_path.' );
+			}
+
+			$normalized = array();
+			foreach ( array( 'slug', 'title', 'post_type', 'status', 'entrypoint', 'body_format' ) as $key ) {
+				if ( isset( $route[ $key ] ) && is_scalar( $route[ $key ] ) && '' !== trim( (string) $route[ $key ] ) ) {
+					$normalized[ $key ] = (string) $route[ $key ];
+				}
+			}
+
+			if ( isset( $route['route_key'] ) && is_scalar( $route['route_key'] ) && '' !== trim( (string) $route['route_key'] ) ) {
+				$normalized['route_key'] = (string) $route['route_key'];
+			}
+			if ( isset( $route['path'] ) && is_scalar( $route['path'] ) && '' !== trim( (string) $route['path'] ) ) {
+				$normalized['route_path'] = self::normalize_route_path( (string) $route['path'] );
+			}
+
+			if ( isset( $route['metadata'] ) && is_array( $route['metadata'] ) ) {
+				$normalized['metadata'] = $route['metadata'];
+			}
+
+			$routes[ $source_path ] = $normalized;
+		}
+
+		return $routes;
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -176,6 +176,13 @@ class Static_Site_Importer_Theme_Materializer {
 		}
 
 		if ( null === $template_parts ) {
+			$template_parts = self::navigation_template_parts_from_materialization_plan( $artifacts );
+			if ( is_wp_error( $template_parts ) ) {
+				return $template_parts;
+			}
+		}
+
+		if ( null === $template_parts ) {
 			$template_parts = isset( $artifacts['template_parts'] ) && is_array( $artifacts['template_parts'] ) ? $artifacts['template_parts'] : array();
 		}
 
@@ -253,6 +260,55 @@ class Static_Site_Importer_Theme_Materializer {
 					'slug'         => isset( $write['slug'] ) && is_scalar( $write['slug'] ) ? (string) $write['slug'] : '',
 					'title'        => isset( $write['title'] ) && is_scalar( $write['title'] ) ? (string) $write['title'] : '',
 					'area'         => isset( $write['area'] ) && is_scalar( $write['area'] ) ? (string) $write['area'] : '',
+					'block_markup' => $content,
+				),
+				static fn ( string $value ): bool => '' !== $value
+			);
+		}
+
+		return $template_parts;
+	}
+
+	/**
+	 * Read native navigation rows from a Blocks Engine materialization plan.
+	 *
+	 * @param array<string,mixed> $artifacts WordPress artifacts from the transformer adapter.
+	 * @return array<int,array<string,mixed>>|null|WP_Error Navigation-backed template parts, null when no rows exist.
+	 */
+	private static function navigation_template_parts_from_materialization_plan( array $artifacts ) {
+		$site = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
+		if ( 'blocks-engine/php-transformer/materialization-plan/v1' !== (string) ( $site['schema'] ?? '' ) || ! array_key_exists( 'navigation', $site ) ) {
+			return null;
+		}
+
+		if ( ! is_array( $site['navigation'] ) ) {
+			return new WP_Error( 'static_site_importer_materialization_plan_navigation_invalid', 'Blocks Engine materialization_plan.navigation must be an array.' );
+		}
+
+		$template_parts = array();
+		foreach ( $site['navigation'] as $navigation ) {
+			if ( ! is_array( $navigation ) ) {
+				return new WP_Error( 'static_site_importer_materialization_plan_navigation_row_invalid', 'Blocks Engine materialization-plan navigation entries must be arrays.' );
+			}
+
+			$content = '';
+			foreach ( array( 'block_markup', 'content' ) as $key ) {
+				if ( isset( $navigation[ $key ] ) && is_scalar( $navigation[ $key ] ) && '' !== trim( (string) $navigation[ $key ] ) ) {
+					$content = (string) $navigation[ $key ];
+					break;
+				}
+			}
+
+			if ( '' === trim( $content ) ) {
+				return new WP_Error( 'static_site_importer_materialization_plan_navigation_content_missing', 'Blocks Engine navigation rows must include non-empty block_markup or content.' );
+			}
+
+			$template_parts[] = array_filter(
+				array(
+					'source_path'  => isset( $navigation['source_path'] ) && is_scalar( $navigation['source_path'] ) ? (string) $navigation['source_path'] : '',
+					'slug'         => isset( $navigation['slug'] ) && in_array( sanitize_key( (string) $navigation['slug'] ), array( 'header', 'footer' ), true ) ? sanitize_key( (string) $navigation['slug'] ) : 'header',
+					'title'        => isset( $navigation['title'] ) && is_scalar( $navigation['title'] ) ? (string) $navigation['title'] : 'Navigation',
+					'area'         => isset( $navigation['area'] ) && in_array( sanitize_key( (string) $navigation['area'] ), array( 'header', 'footer' ), true ) ? sanitize_key( (string) $navigation['area'] ) : 'header',
 					'block_markup' => $content,
 				),
 				static fn ( string $value ): bool => '' !== $value

--- a/tests/smoke-bac-visual-repair-css.php
+++ b/tests/smoke-bac-visual-repair-css.php
@@ -169,6 +169,43 @@ $assert( str_contains( (string) ( $template_part_writes['/tmp/bac-visual-repair-
 $assert( ! str_contains( (string) ( $template_part_writes['/tmp/bac-visual-repair-smoke/parts/header.html'] ?? '' ), 'Legacy Header' ), 'legacy-template-part-is-ignored-when-plan-writes-exist' );
 $assert( array( 'parts/header.html' ) === ( $template_part_reports[0]['source_paths'] ?? array() ), 'materialization-plan-template-part-source-path-is-reported' );
 
+$navigation_part_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
+	'/tmp/bac-visual-repair-smoke',
+	array(
+		'site' => array(
+			'schema'     => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'navigation' => array(
+				array(
+					'source_path'  => 'website/index.html#main-nav',
+					'title'        => 'Main Navigation',
+					'block_markup' => '<!-- wp:navigation --><!-- wp:navigation-link {"label":"About","url":"/about/"} /--><!-- /wp:navigation -->',
+				),
+			),
+		),
+	)
+);
+$assert( is_array( $navigation_part_result ), 'materialization-plan-navigation-rows-succeed' );
+$navigation_part_writes = is_array( $navigation_part_result ) ? $navigation_part_result['writes'] : array();
+$navigation_part_reports = is_array( $navigation_part_result ) ? $navigation_part_result['reports'] : array();
+$assert( str_contains( (string) ( $navigation_part_writes['/tmp/bac-visual-repair-smoke/parts/header.html'] ?? '' ), 'wp:navigation-link' ), 'materialization-plan-navigation-row-is-used-for-header' );
+$assert( array( 'website/index.html#main-nav' ) === ( $navigation_part_reports[0]['source_paths'] ?? array() ), 'materialization-plan-navigation-source-path-is-reported' );
+
+$missing_navigation_content = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
+	'/tmp/bac-visual-repair-smoke',
+	array(
+		'site' => array(
+			'schema'     => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'navigation' => array(
+				array(
+					'source_path' => 'website/index.html#main-nav',
+				),
+			),
+		),
+	)
+);
+$assert( $missing_navigation_content instanceof WP_Error, 'materialization-plan-navigation-content-is-required' );
+$assert( 'static_site_importer_materialization_plan_navigation_content_missing' === ( $missing_navigation_content instanceof WP_Error ? $missing_navigation_content->get_error_code() : '' ), 'materialization-plan-navigation-content-error-code' );
+
 $missing_content = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
 	'/tmp/bac-visual-repair-smoke',
 	array(
@@ -197,10 +234,20 @@ $native_pages = $source_pages->invoke(
 					array(
 						'source_path'  => 'website/index.html',
 						'post_type'    => 'page',
-						'slug'         => 'home-canonical',
-						'title'        => 'Home Canonical',
+						'slug'         => 'legacy-plan-page-slug',
+						'title'        => 'Legacy Plan Page Title',
 						'entrypoint'   => true,
 						'block_markup' => '<!-- wp:paragraph --><p>Native page</p><!-- /wp:paragraph -->',
+					),
+				),
+				'routes' => array(
+					array(
+						'source_path' => 'website/index.html',
+						'path'        => '/',
+						'route_key'   => 'home-route',
+						'post_type'   => 'page',
+						'slug'        => 'home-canonical',
+						'title'       => 'Home Canonical',
 					),
 				),
 			),
@@ -219,8 +266,31 @@ $assert( is_array( $native_pages ), 'materialization-plan-pages-create-source-pa
 $native_page = is_array( $native_pages ) ? ( $native_pages['website/index.html'] ?? null ) : null;
 $assert( $native_page instanceof Static_Site_Importer_Source_Page, 'materialization-plan-page-source-key-is-used' );
 $assert( $native_page instanceof Static_Site_Importer_Source_Page && 'materialization_plan_page' === $native_page->type(), 'materialization-plan-page-type-is-native' );
-$assert( $native_page instanceof Static_Site_Importer_Source_Page && 'home-canonical' === $native_page->metadata_value( 'slug' ), 'materialization-plan-page-slug-wins-over-legacy-document' );
+$assert( $native_page instanceof Static_Site_Importer_Source_Page && 'home-canonical' === $native_page->metadata_value( 'slug' ), 'materialization-plan-route-slug-wins-over-page-and-legacy-document' );
+$assert( $native_page instanceof Static_Site_Importer_Source_Page && 'Home Canonical' === $native_page->metadata_value( 'title' ), 'materialization-plan-route-title-wins-over-page-and-legacy-document' );
+$assert( $native_page instanceof Static_Site_Importer_Source_Page && 'home-route' === $native_page->metadata_value( 'route_key' ), 'materialization-plan-route-key-is-preserved' );
 $assert( $native_page instanceof Static_Site_Importer_Source_Page && str_contains( $native_page->body(), 'Native page' ), 'materialization-plan-page-body-wins-over-legacy-document' );
+
+$malformed_routes = $source_pages->invoke(
+	null,
+	array(
+		'wordpress_artifacts' => array(
+			'site' => array(
+				'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+				'pages'  => array(
+					array(
+						'source_path'  => 'website/index.html',
+						'slug'         => 'home',
+						'block_markup' => '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->',
+					),
+				),
+				'routes' => array( 'not-a-route-row' ),
+			),
+		),
+	)
+);
+$assert( $malformed_routes instanceof WP_Error, 'materialization-plan-route-row-must-be-array' );
+$assert( 'static_site_importer_materialization_plan_route_invalid' === ( $malformed_routes instanceof WP_Error ? $malformed_routes->get_error_code() : '' ), 'materialization-plan-route-row-error-code' );
 
 $missing_page_content = $source_pages->invoke(
 	null,


### PR DESCRIPTION
## Summary
- Prefer native Blocks Engine materialization-plan `routes` rows for page identity metadata when they match plan pages by `source_path`.
- Consume native materialization-plan `navigation` rows as header template-part material when explicit template-part writes are not present.
- Preserve SSI-owned WordPress page/theme writes and existing public materialization behavior unless those native rows are present.

## Dependency
Draft until the upstream Blocks Engine routing/navigation materialization-plan row contract lands. Current Blocks Engine `trunk` exposes `pages` and `template_part_writes`, but not `routes` or `navigation` rows yet.

## Verification
- `php tests/smoke-bac-visual-repair-css.php`
- `for file in tests/smoke-*.php; do php "$file" || exit 1; done`
- `php -l includes/class-static-site-importer-theme-generator.php && php -l includes/class-static-site-importer-theme-materializer.php && php -l includes/class-static-site-importer-source-page.php && php -l tests/smoke-bac-visual-repair-css.php`
- `git diff --check`

## Known local verification gaps
- `npm run test:js-block-validation` currently fails in the reporter after an invalid block result because `summary` is null.
- `npm run test:validation` currently fails in `smoke-website-artifact-document-metadata.php` because the local runtime does not provide `blocks_engine_php_transformer_compile_artifact()`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Implementing the draft consumer slice, smoke coverage, and verification notes.
