### PR TITLE
Centralize import report artifact diagnostics

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -419,20 +419,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$quality['diagnostic_refs'] = self::quality_diagnostic_refs( $report['diagnostics'] ?? array() );
 		$report['quality']         = $quality;
 		self::normalize_source_document_diagnostic_refs( $report );
-		$report['artifact_diagnostics'] = Static_Site_Importer_WP_Codebox_Artifact_Diagnostics_Normalizer::build(
-			array( 'diagnostics' => $report['diagnostics'] ?? array() ),
-			array(
-				'source'          => 'blocks-engine',
-				'stage'           => 'import',
-				'observationType' => 'blocks-engine/import-report',
-				'refs'            => array(
-					array(
-						'path' => 'import-report.json',
-						'kind' => 'blocks-engine/import-report',
-					),
-				),
-			)
-		);
+		$report['artifact_diagnostics'] = Static_Site_Importer_WP_Codebox_Artifact_Diagnostics_Normalizer::build_for_import_report( $report );
 
 		return $quality;
 	}

--- a/includes/class-static-site-importer-wp-codebox-artifact-diagnostics-normalizer.php
+++ b/includes/class-static-site-importer-wp-codebox-artifact-diagnostics-normalizer.php
@@ -46,6 +46,29 @@ class Static_Site_Importer_WP_Codebox_Artifact_Diagnostics_Normalizer {
 	}
 
 	/**
+	 * Build artifact diagnostics for a Static Site Importer import report.
+	 *
+	 * @param array<string,mixed> $report Import report.
+	 * @return array<string,mixed>
+	 */
+	public static function build_for_import_report( array $report ): array {
+		return self::build(
+			array( 'diagnostics' => $report['diagnostics'] ?? array() ),
+			array(
+				'source'          => 'blocks-engine',
+				'stage'           => 'import',
+				'observationType' => 'blocks-engine/import-report',
+				'refs'            => array(
+					array(
+						'path' => 'import-report.json',
+						'kind' => 'blocks-engine/import-report',
+					),
+				),
+			)
+		);
+	}
+
+	/**
 	 * Normalize diagnostics from one observation/import report.
 	 *
 	 * @param mixed                $observation       Observation-like value.

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -178,7 +178,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	 * Artifact diagnostics use the WP Codebox normalization contract.
 	 */
 	public function test_wp_codebox_artifact_diagnostics_normalizer_accepts_import_report_shape(): void {
-		$diagnostics = Static_Site_Importer_WP_Codebox_Artifact_Diagnostics_Normalizer::build(
+		$diagnostics = Static_Site_Importer_WP_Codebox_Artifact_Diagnostics_Normalizer::build_for_import_report(
 			array(
 				'diagnostics' => array(
 					array(
@@ -195,17 +195,6 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 						'type'          => 'missing_asset',
 						'error_message' => 'Asset file is missing.',
 						'source_path'   => 'assets/hero.jpg',
-					),
-				),
-			),
-			array(
-				'source'          => 'blocks-engine',
-				'stage'           => 'import',
-				'observationType' => 'blocks-engine/import-report',
-				'refs'            => array(
-					array(
-						'path' => 'import-report.json',
-						'kind' => 'blocks-engine/import-report',
 					),
 				),
 			)


### PR DESCRIPTION
## Summary
- Add a dedicated import-report builder for WP Codebox artifact diagnostics.
- Route report quality generation and fallback diagnostics coverage through that builder.

## Tests
- OK: transformer adapter smoke passed (26 assertions) passed (26 assertions).
- 
> test:validation
> node tests/run-validation-harness.cjs


==> Transformer adapter smoke
OK: transformer adapter smoke passed (26 assertions)

==> Website artifact products manifest smoke
OK: website artifact products manifest smoke passed (12 assertions)

==> Website artifact document metadata smoke failed because Website artifact document metadata smoke requires the Blocks Engine php-transformer in this worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the existing isolated worktree, committing, testing, pushing, and opening this PR.