### PR TITLE
Isolate legacy transformer mapping fallback

### DIFF
--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -68,7 +68,7 @@ class Static_Site_Importer_Transformer_Adapter {
 	private function compiled_result_from_transformer_contract( array $result ): array {
 		$compiled = $this->compiled_result_from_native_transformer_contract( $result );
 		if ( empty( $compiled['wordpress_artifacts'] ) ) {
-			$compiled = $this->project_transformer_result( $result, self::COMPILED_RESULT_SCHEMA );
+			$compiled = $this->compiled_result_from_legacy_mapping_compatibility( $result );
 		}
 
 		$source_reports       = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
@@ -165,15 +165,17 @@ class Static_Site_Importer_Transformer_Adapter {
 	}
 
 	/**
-	 * Apply a Blocks Engine transformer legacy projection by schema.
+	 * Project pre-source_reports transformer output through the legacy BAC-shaped map.
+	 *
+	 * Native Blocks Engine source_reports are the importer contract. This compatibility
+	 * path exists only for older transformer results that did not expose that contract.
 	 *
 	 * @param array<string,mixed> $result TransformerResult::toArray() output.
-	 * @param string              $schema Projection schema.
 	 * @return array<string,mixed>
 	 */
-	private function project_transformer_result( array $result, string $schema ): array {
-		$mapping   = isset( $result['legacy_mapping'][ $schema ] ) && is_array( $result['legacy_mapping'][ $schema ] ) ? $result['legacy_mapping'][ $schema ] : array();
-		$projected = array( 'schema' => $schema );
+	private function compiled_result_from_legacy_mapping_compatibility( array $result ): array {
+		$mapping   = isset( $result['legacy_mapping'][ self::COMPILED_RESULT_SCHEMA ] ) && is_array( $result['legacy_mapping'][ self::COMPILED_RESULT_SCHEMA ] ) ? $result['legacy_mapping'][ self::COMPILED_RESULT_SCHEMA ] : array();
+		$projected = array( 'schema' => self::COMPILED_RESULT_SCHEMA );
 
 		foreach ( $mapping as $target_path => $source_path ) {
 			if ( ! is_string( $target_path ) || ! is_string( $source_path ) ) {

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -138,6 +138,18 @@ namespace {
 						),
 						'diagnostics'       => array(),
 						'fallbacks'         => array(),
+						'legacy_mapping'    => array(
+							'block-artifact-compiler/result/v1' => array(
+								'wordpress_artifacts.site.pages.0.slug' => 'legacy.slug',
+								'wordpress_artifacts.documents.0.source_path' => 'legacy.documents.0.source_path',
+							),
+						),
+						'legacy'            => array(
+							'slug'      => 'legacy-home',
+							'documents' => array(
+								array( 'source_path' => 'legacy/about.html' ),
+							),
+						),
 						'provenance'        => array(
 							array( 'source_hash' => 'abc123' ),
 						),
@@ -229,10 +241,12 @@ namespace {
 	$assert( 4 === count( $pages ), 'native-keeps-compiled-site-pages-without-adapter-filtering' );
 	$assert( 'website/index.html' === ( $pages[0]['source_path'] ?? '' ), 'native-entry-source-path' );
 	$assert( 'home-canonical' === ( $pages[0]['slug'] ?? '' ), 'native-entry-slug-from-materialization-plan' );
+	$assert( 'legacy-home' !== ( $pages[0]['slug'] ?? '' ), 'legacy-mapping-does-not-override-native-materialization-plan' );
 	$assert( true === ( $pages[0]['entrypoint'] ?? false ), 'native-entrypoint' );
 	$assert( 'about-canonical' === ( $pages[2]['slug'] ?? '' ), 'native-route-slug-from-materialization-plan' );
 	$assert( 1 === count( $documents ), 'native-documents-preserve-transformer-documents-without-compiled-site-synthesis' );
 	$assert( 'content/about.md' === ( $documents[0]['source_path'] ?? '' ), 'native-document-from-transformer-documents' );
+	$assert( 'legacy/about.html' !== ( $documents[0]['source_path'] ?? '' ), 'legacy-mapping-does-not-override-native-documents' );
 	$assert( 'assets/site.css' === ( $artifacts['files'][0]['path'] ?? '' ), 'native-assets-report-preserved' );
 	$assert( 'rye-loaf-canonical' === ( $products[0]['slug'] ?? '' ), 'native-product-slug-mapped-from-generic-report' );
 	$assert( '12.00' === ( $products[0]['regular_price'] ?? '' ), 'native-product-price-normalized-from-generic-report' );


### PR DESCRIPTION
## Summary
- Route the remaining legacy_mapping projection through a single explicitly named compatibility method.
- Keep native Blocks Engine source_reports/materialization_plan as the adapter contract when present.
- Extend the transformer adapter smoke with conflicting legacy_mapping data to prove native materialization-plan pages/documents win.

## Tests
- php -l includes/class-static-site-importer-transformer-adapter.php
- php tests/smoke-transformer-adapter.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Isolating the legacy compatibility path, updating behavior-level smoke coverage, and running verification.