### PR TITLE
Prefer native conversion reports for legacy SSI report

### DIFF
--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -18,6 +18,7 @@ class Static_Site_Importer_Transformer_Adapter {
 	public const COMPILED_RESULT_SCHEMA  = 'block-artifact-compiler/result/v1';
 	private const CONVERSION_REPORT_OPTION = 'include_conversion_report';
 	private const LEGACY_BFB_REPORT_OPTION = 'include_bfb_report';
+	private const LEGACY_BFB_REPORT_FIELD  = 'bfb_report';
 
 	/**
 	 * Check whether the default Blocks Engine artifact compiler is available.
@@ -127,7 +128,7 @@ class Static_Site_Importer_Transformer_Adapter {
 			'provenance'          => isset( $result['provenance'] ) && is_array( $result['provenance'] ) ? $result['provenance'] : array(),
 		);
 
-		$compiled['bfb_report'] = $this->legacy_bfb_report_from_transformer_result( $result );
+		$compiled[ self::LEGACY_BFB_REPORT_FIELD ] = $this->legacy_conversion_report_from_transformer_result( $result );
 
 		return $compiled;
 	}
@@ -150,18 +151,53 @@ class Static_Site_Importer_Transformer_Adapter {
 	}
 
 	/**
-	 * Preserve SSI's legacy BFB report field from the native Blocks Engine result.
+	 * Preserve SSI's legacy report field from the native Blocks Engine conversion report.
 	 *
 	 * @param array<string,mixed> $result TransformerResult::toArray() output.
 	 * @return array<string,mixed>
 	 */
-	private function legacy_bfb_report_from_transformer_result( array $result ): array {
+	private function legacy_conversion_report_from_transformer_result( array $result ): array {
+		$report = isset( $result['conversion_report'] ) && is_array( $result['conversion_report'] ) ? $result['conversion_report'] : array();
+
 		return array(
-			'status'            => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : 'failed',
-			'serialized_blocks' => isset( $result['serialized_blocks'] ) && is_scalar( $result['serialized_blocks'] ) ? (string) $result['serialized_blocks'] : '',
-			'diagnostics'       => isset( $result['diagnostics'] ) && is_array( $result['diagnostics'] ) ? $result['diagnostics'] : array(),
-			'fallbacks'         => isset( $result['fallbacks'] ) && is_array( $result['fallbacks'] ) ? $result['fallbacks'] : array(),
+			'status'            => $this->conversion_report_scalar( $report, $result, 'status', 'failed' ),
+			'serialized_blocks' => $this->conversion_report_scalar( $report, $result, 'serialized_blocks', '' ),
+			'diagnostics'       => $this->conversion_report_array( $report, $result, 'diagnostics' ),
+			'fallbacks'         => $this->conversion_report_array( $report, $result, 'fallbacks' ),
 		);
+	}
+
+	/**
+	 * Read a scalar value from the native conversion report with an explicit legacy fallback.
+	 *
+	 * @param array<string,mixed> $report   Native conversion report payload.
+	 * @param array<string,mixed> $result   Transformer result array.
+	 * @param string              $key      Report key.
+	 * @param string              $fallback Fallback value.
+	 * @return string
+	 */
+	private function conversion_report_scalar( array $report, array $result, string $key, string $fallback ): string {
+		if ( isset( $report[ $key ] ) && is_scalar( $report[ $key ] ) ) {
+			return (string) $report[ $key ];
+		}
+
+		return isset( $result[ $key ] ) && is_scalar( $result[ $key ] ) ? (string) $result[ $key ] : $fallback;
+	}
+
+	/**
+	 * Read an array value from the native conversion report with an explicit legacy fallback.
+	 *
+	 * @param array<string,mixed> $report Native conversion report payload.
+	 * @param array<string,mixed> $result Transformer result array.
+	 * @param string              $key    Report key.
+	 * @return array<int|string,mixed>
+	 */
+	private function conversion_report_array( array $report, array $result, string $key ): array {
+		if ( isset( $report[ $key ] ) && is_array( $report[ $key ] ) ) {
+			return $report[ $key ];
+		}
+
+		return isset( $result[ $key ] ) && is_array( $result[ $key ] ) ? $result[ $key ] : array();
 	}
 
 	/**

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -125,6 +125,22 @@ namespace {
 							array( 'blockName' => 'core/paragraph', 'innerBlocks' => array() ),
 						),
 						'serialized_blocks' => '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->',
+						'conversion_report' => array(
+							'status'            => 'success',
+							'serialized_blocks' => '<!-- wp:paragraph --><p>Native report Home</p><!-- /wp:paragraph -->',
+							'diagnostics'       => array(
+								array(
+									'code'    => 'native_report_diagnostic',
+									'message' => 'Native conversion report diagnostic.',
+								),
+							),
+							'fallbacks'         => array(
+								array(
+									'source' => 'native-conversion-report',
+									'count'  => 0,
+								),
+							),
+						),
 						'documents'         => array(
 							array(
 								'source_path'  => 'content/about.md',
@@ -222,8 +238,9 @@ namespace {
 	$assert( ! array_key_exists( 'include_bfb_report', $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][0][1] ?? array() ), 'legacy-bfb-option-is-isolated' );
 	$assert( 'block-artifact-compiler/result/v1' === ( $compiled['schema'] ?? '' ), 'native-result-mapped-to-bac-envelope' );
 	$assert( 'success' === ( $compiled['bfb_report']['status'] ?? '' ), 'legacy-bfb-report-shape-preserved' );
-	$assert( '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->' === ( $compiled['bfb_report']['serialized_blocks'] ?? '' ), 'legacy-bfb-report-uses-native-serialized-blocks' );
-	$assert( array() === ( $compiled['bfb_report']['fallbacks'] ?? null ), 'legacy-bfb-report-uses-native-fallbacks' );
+	$assert( '<!-- wp:paragraph --><p>Native report Home</p><!-- /wp:paragraph -->' === ( $compiled['bfb_report']['serialized_blocks'] ?? '' ), 'legacy-bfb-report-uses-native-report-serialized-blocks' );
+	$assert( 'native_report_diagnostic' === ( $compiled['bfb_report']['diagnostics'][0]['code'] ?? '' ), 'legacy-bfb-report-uses-native-report-diagnostics' );
+	$assert( 'native-conversion-report' === ( $compiled['bfb_report']['fallbacks'][0]['source'] ?? '' ), 'legacy-bfb-report-uses-native-report-fallbacks' );
 	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'native-artifact-report-preserved-as-input' );
 	$assert( 'blocks-engine/php-transformer/materialization-plan/v1' === ( $site['schema'] ?? '' ), 'native-materialization-plan-contract-is-used' );
 	$assert( 4 === count( $pages ), 'native-keeps-compiled-site-pages-without-adapter-filtering' );


### PR DESCRIPTION
## Summary
- Populate SSI's legacy `bfb_report` field from the native Blocks Engine `conversion_report` payload first.
- Keep the old root-field report mapping only as an explicit compatibility fallback.
- Update the transformer adapter smoke fixture so native report values differ from root result values, proving the public legacy report shape is preserved from native fields.

## Verification
- `php tests/smoke-transformer-adapter.php`
- `php -l includes/class-static-site-importer-transformer-adapter.php && php -l tests/smoke-transformer-adapter.php`
- `git diff --check`

## Notes
- `npm run test:js-block-validation` was attempted and failed in the existing validation fixture/reporting path with `TypeError: Cannot convert undefined or null to object` after reporting an invalid block summary.
- `npm run test:validation` was attempted and failed when document metadata smokes required the Blocks Engine php-transformer helper, which is not available in this worktree runtime.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Inspecting SSI conversion report compatibility paths, drafting the adapter/test changes, and running verification commands.
