### PR TITLE
Narrow legacy BFB report projection

### DIFF
--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -128,7 +128,7 @@ class Static_Site_Importer_Transformer_Adapter {
 			'provenance'          => isset( $result['provenance'] ) && is_array( $result['provenance'] ) ? $result['provenance'] : array(),
 		);
 
-		$compiled[ self::LEGACY_BFB_REPORT_FIELD ] = $this->legacy_conversion_report_from_transformer_result( $result );
+		$compiled[ self::LEGACY_BFB_REPORT_FIELD ] = $this->legacy_conversion_report_from_native_report( $result );
 
 		return $compiled;
 	}
@@ -156,48 +156,15 @@ class Static_Site_Importer_Transformer_Adapter {
 	 * @param array<string,mixed> $result TransformerResult::toArray() output.
 	 * @return array<string,mixed>
 	 */
-	private function legacy_conversion_report_from_transformer_result( array $result ): array {
+	private function legacy_conversion_report_from_native_report( array $result ): array {
 		$report = isset( $result['conversion_report'] ) && is_array( $result['conversion_report'] ) ? $result['conversion_report'] : array();
 
 		return array(
-			'status'            => $this->conversion_report_scalar( $report, $result, 'status', 'failed' ),
-			'serialized_blocks' => $this->conversion_report_scalar( $report, $result, 'serialized_blocks', '' ),
-			'diagnostics'       => $this->conversion_report_array( $report, $result, 'diagnostics' ),
-			'fallbacks'         => $this->conversion_report_array( $report, $result, 'fallbacks' ),
+			'status'            => isset( $report['status'] ) && is_scalar( $report['status'] ) ? (string) $report['status'] : 'failed',
+			'serialized_blocks' => isset( $report['serialized_blocks'] ) && is_scalar( $report['serialized_blocks'] ) ? (string) $report['serialized_blocks'] : '',
+			'diagnostics'       => isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array(),
+			'fallbacks'         => isset( $report['fallbacks'] ) && is_array( $report['fallbacks'] ) ? $report['fallbacks'] : array(),
 		);
-	}
-
-	/**
-	 * Read a scalar value from the native conversion report with an explicit legacy fallback.
-	 *
-	 * @param array<string,mixed> $report   Native conversion report payload.
-	 * @param array<string,mixed> $result   Transformer result array.
-	 * @param string              $key      Report key.
-	 * @param string              $fallback Fallback value.
-	 * @return string
-	 */
-	private function conversion_report_scalar( array $report, array $result, string $key, string $fallback ): string {
-		if ( isset( $report[ $key ] ) && is_scalar( $report[ $key ] ) ) {
-			return (string) $report[ $key ];
-		}
-
-		return isset( $result[ $key ] ) && is_scalar( $result[ $key ] ) ? (string) $result[ $key ] : $fallback;
-	}
-
-	/**
-	 * Read an array value from the native conversion report with an explicit legacy fallback.
-	 *
-	 * @param array<string,mixed> $report Native conversion report payload.
-	 * @param array<string,mixed> $result Transformer result array.
-	 * @param string              $key    Report key.
-	 * @return array<int|string,mixed>
-	 */
-	private function conversion_report_array( array $report, array $result, string $key ): array {
-		if ( isset( $report[ $key ] ) && is_array( $report[ $key ] ) ) {
-			return $report[ $key ];
-		}
-
-		return isset( $result[ $key ] ) && is_array( $result[ $key ] ) ? $result[ $key ] : array();
 	}
 
 	/**

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -124,7 +124,7 @@ namespace {
 						'blocks'            => array(
 							array( 'blockName' => 'core/paragraph', 'innerBlocks' => array() ),
 						),
-						'serialized_blocks' => '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->',
+						'serialized_blocks' => '<!-- wp:paragraph --><p>Legacy top-level Home</p><!-- /wp:paragraph -->',
 						'conversion_report' => array(
 							'status'            => 'success',
 							'serialized_blocks' => '<!-- wp:paragraph --><p>Native report Home</p><!-- /wp:paragraph -->',
@@ -152,8 +152,18 @@ namespace {
 						'assets'            => array(
 							array( 'path' => 'assets/site.css', 'role' => 'stylesheet' ),
 						),
-						'diagnostics'       => array(),
-						'fallbacks'         => array(),
+						'diagnostics'       => array(
+							array(
+								'code'    => 'legacy_top_level_diagnostic',
+								'message' => 'Legacy top-level diagnostic.',
+							),
+						),
+						'fallbacks'         => array(
+							array(
+								'source' => 'legacy-top-level',
+								'count'  => 1,
+							),
+						),
 						'legacy_mapping'    => array(
 							'block-artifact-compiler/result/v1' => array(
 								'wordpress_artifacts.site.pages.0.slug' => 'legacy.slug',
@@ -253,6 +263,8 @@ namespace {
 	$assert( '<!-- wp:paragraph --><p>Native report Home</p><!-- /wp:paragraph -->' === ( $compiled['bfb_report']['serialized_blocks'] ?? '' ), 'legacy-bfb-report-uses-native-report-serialized-blocks' );
 	$assert( 'native_report_diagnostic' === ( $compiled['bfb_report']['diagnostics'][0]['code'] ?? '' ), 'legacy-bfb-report-uses-native-report-diagnostics' );
 	$assert( 'native-conversion-report' === ( $compiled['bfb_report']['fallbacks'][0]['source'] ?? '' ), 'legacy-bfb-report-uses-native-report-fallbacks' );
+	$assert( 'legacy_top_level_diagnostic' !== ( $compiled['bfb_report']['diagnostics'][0]['code'] ?? '' ), 'legacy-bfb-report-ignores-top-level-diagnostics' );
+	$assert( 'legacy-top-level' !== ( $compiled['bfb_report']['fallbacks'][0]['source'] ?? '' ), 'legacy-bfb-report-ignores-top-level-fallbacks' );
 	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'native-artifact-report-preserved-as-input' );
 	$assert( 'blocks-engine/php-transformer/materialization-plan/v1' === ( $site['schema'] ?? '' ), 'native-materialization-plan-contract-is-used' );
 	$assert( 4 === count( $pages ), 'native-keeps-compiled-site-pages-without-adapter-filtering' );


### PR DESCRIPTION
## Summary
- Remove top-level transformer-result fallbacks from SSI's legacy bfb_report projection.
- Keep the compatibility bfb_report shape sourced only from native Blocks Engine conversion_report.
- Extend the transformer adapter smoke fixture to prove native conversion_report diagnostics/fallbacks win over legacy top-level fields.

## Tests
- php tests/smoke-transformer-adapter.php
- for file in *.php includes/*.php tests/*.php; do php -l "" >/dev/null || exit 1; done
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code inspection, implementation, focused test update, verification, and PR preparation.