### PR TITLE
Prefer native materialization plan assets

### DIFF
--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -86,6 +86,7 @@ class Static_Site_Importer_Transformer_Adapter {
 
 		$artifacts['document_metadata'] = $this->document_metadata_from_compiled_site( $site_report );
 		$artifacts['documents']         = isset( $result['documents'] ) && is_array( $result['documents'] ) ? $result['documents'] : array();
+		$artifacts['files']             = $this->artifact_files_from_site_report( $site_report, $result );
 		$artifacts['site']              = $site_report;
 		$artifacts['template_parts']    = isset( $site_report['template_parts'] ) && is_array( $site_report['template_parts'] ) ? $site_report['template_parts'] : array();
 		$artifacts['visual_repair']     = isset( $site_report['visual_repair'] ) && is_array( $site_report['visual_repair'] ) ? $site_report['visual_repair'] : array();
@@ -226,6 +227,38 @@ class Static_Site_Importer_Transformer_Adapter {
 		}
 
 		return $projected;
+	}
+
+	/**
+	 * Prefer native materialization-plan asset payload rows for SSI's artifact file view.
+	 *
+	 * @param array<string,mixed> $site_report Native materialization plan or compiled-site report.
+	 * @param array<string,mixed> $result      Transformer result array.
+	 * @return array<int|string,mixed>
+	 */
+	private function artifact_files_from_site_report( array $site_report, array $result ): array {
+		$assets = isset( $site_report['assets'] ) && is_array( $site_report['assets'] ) ? $site_report['assets'] : array();
+		if ( 'blocks-engine/php-transformer/materialization-plan/v1' === (string) ( $site_report['schema'] ?? '' ) && $this->materialization_plan_assets_include_payloads( $assets ) ) {
+			return $assets;
+		}
+
+		return isset( $result['assets'] ) && is_array( $result['assets'] ) ? $result['assets'] : array();
+	}
+
+	/**
+	 * Check whether native materialization-plan asset rows can drive theme writes.
+	 *
+	 * @param array<int|string,mixed> $assets Blocks Engine materialization-plan asset rows.
+	 * @return bool
+	 */
+	private function materialization_plan_assets_include_payloads( array $assets ): bool {
+		foreach ( $assets as $asset ) {
+			if ( is_array( $asset ) && ( array_key_exists( 'content', $asset ) || array_key_exists( 'content_base64', $asset ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -114,7 +114,12 @@ namespace {
 									),
 								),
 								'assets'      => array(
-									array( 'path' => 'assets/site.css', 'role' => 'stylesheet' ),
+									array(
+										'path'    => 'assets/native-site.css',
+										'role'    => 'stylesheet',
+										'kind'    => 'css',
+										'content' => 'body { color: black; }',
+									),
 								),
 								'theme'       => array(
 									'stylesheets' => array( 'assets/site.css' ),
@@ -150,7 +155,7 @@ namespace {
 							),
 						),
 						'assets'            => array(
-							array( 'path' => 'assets/site.css', 'role' => 'stylesheet' ),
+							array( 'path' => 'assets/legacy-site.css', 'role' => 'stylesheet' ),
 						),
 						'diagnostics'       => array(),
 						'fallbacks'         => array(),
@@ -264,7 +269,8 @@ namespace {
 	$assert( 1 === count( $documents ), 'native-documents-preserve-transformer-documents-without-compiled-site-synthesis' );
 	$assert( 'content/about.md' === ( $documents[0]['source_path'] ?? '' ), 'native-document-from-transformer-documents' );
 	$assert( 'legacy/about.html' !== ( $documents[0]['source_path'] ?? '' ), 'legacy-mapping-does-not-override-native-documents' );
-	$assert( 'assets/site.css' === ( $artifacts['files'][0]['path'] ?? '' ), 'native-assets-report-preserved' );
+	$assert( 'assets/native-site.css' === ( $artifacts['files'][0]['path'] ?? '' ), 'native-materialization-plan-assets-drive-artifact-files' );
+	$assert( 'assets/legacy-site.css' !== ( $artifacts['files'][0]['path'] ?? '' ), 'legacy-assets-do-not-override-native-materialization-plan-assets' );
 	$assert( 'rye-loaf-canonical' === ( $products[0]['slug'] ?? '' ), 'native-product-slug-mapped-from-generic-report' );
 	$assert( '12.00' === ( $products[0]['regular_price'] ?? '' ), 'native-product-price-normalized-from-generic-report' );
 	$assert( array( 'Bread' ) === ( $products[0]['categories'] ?? array() ), 'native-product-categories-mapped-from-generic-report' );


### PR DESCRIPTION
## Summary
- Prefer native Blocks Engine materialization_plan.assets rows for the SSI wordpress_artifacts.files view when native asset rows include write payloads.
- Keep top-level transformer assets as the compatibility fallback for older/no-payload results.
- Update the transformer adapter smoke fixture to prove native plan assets beat stale legacy asset rows.

## Verification
- php tests/smoke-transformer-adapter.php
- php tests/smoke-url-import-runtime.php
- php tests/smoke-website-artifact-products-manifest.php
- php tests/smoke-website-artifact-document-metadata.php
- php tests/smoke-bac-visual-repair-css.php
- php tests/smoke-export-theme-ability.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Inspecting materialization-plan consumers, implementing the focused adapter cleanup, updating smoke coverage, and running verification.