### PR TITLE
Narrow legacy BFB report exposure

### DIFF
--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -50,11 +50,12 @@ class Static_Site_Importer_Transformer_Adapter {
 			return new WP_Error( 'static_site_importer_missing_transformer', 'Blocks Engine php-transformer is required to import a website artifact.' );
 		}
 
-		$options = $this->normalize_compile_options( $options );
+		$include_legacy_bfb_report = ! empty( $options[ self::LEGACY_BFB_REPORT_OPTION ] );
+		$options                   = $this->normalize_compile_options( $options );
 		$result = blocks_engine_php_transformer_compile_artifact( $artifact, $options );
 
 		if ( is_array( $result ) ) {
-			return $this->compiled_result_from_transformer_contract( $result );
+			return $this->compiled_result_from_transformer_contract( $result, $include_legacy_bfb_report );
 		}
 
 		return new WP_Error( 'static_site_importer_transformer_compile_failed', 'Blocks Engine php-transformer did not return a compiler result.' );
@@ -63,11 +64,12 @@ class Static_Site_Importer_Transformer_Adapter {
 	/**
 	 * Project the stable transformer contracts into SSI's compiled artifact envelope.
 	 *
-	 * @param array<string,mixed> $result TransformerResult::toArray() output.
+	 * @param array<string,mixed> $result                    TransformerResult::toArray() output.
+	 * @param bool                $include_legacy_bfb_report Whether to expose SSI's legacy bfb_report field.
 	 * @return array<string,mixed>
 	 */
-	private function compiled_result_from_transformer_contract( array $result ): array {
-		$compiled = $this->compiled_result_from_native_transformer_contract( $result );
+	private function compiled_result_from_transformer_contract( array $result, bool $include_legacy_bfb_report ): array {
+		$compiled = $this->compiled_result_from_native_transformer_contract( $result, $include_legacy_bfb_report );
 		if ( empty( $compiled['wordpress_artifacts'] ) ) {
 			$compiled = $this->compiled_result_from_legacy_mapping_compatibility( $result );
 		}
@@ -103,10 +105,11 @@ class Static_Site_Importer_Transformer_Adapter {
 	/**
 	 * Build SSI's consumed compiler envelope from the native Blocks Engine result.
 	 *
-	 * @param array<string,mixed> $result TransformerResult::toArray() output.
+	 * @param array<string,mixed> $result                    TransformerResult::toArray() output.
+	 * @param bool                $include_legacy_bfb_report Whether to expose SSI's legacy bfb_report field.
 	 * @return array<string,mixed>
 	 */
-	private function compiled_result_from_native_transformer_contract( array $result ): array {
+	private function compiled_result_from_native_transformer_contract( array $result, bool $include_legacy_bfb_report ): array {
 		$source_reports = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
 		if ( empty( $source_reports ) ) {
 			return array();
@@ -129,7 +132,9 @@ class Static_Site_Importer_Transformer_Adapter {
 			'provenance'          => isset( $result['provenance'] ) && is_array( $result['provenance'] ) ? $result['provenance'] : array(),
 		);
 
-		$compiled[ self::LEGACY_BFB_REPORT_FIELD ] = $this->legacy_conversion_report_from_native_report( $result );
+		if ( $include_legacy_bfb_report ) {
+			$compiled[ self::LEGACY_BFB_REPORT_FIELD ] = $this->legacy_conversion_report_from_native_report( $result );
+		}
 
 		return $compiled;
 	}

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -287,6 +287,13 @@ namespace {
 	$assert( '12.00' === ( $products[0]['regular_price'] ?? '' ), 'native-product-price-normalized-from-generic-report' );
 	$assert( array( 'Bread' ) === ( $products[0]['categories'] ?? array() ), 'native-product-categories-mapped-from-generic-report' );
 
+	$native_report_compiled = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ), array( 'include_conversion_report' => true ) );
+	$assert( ! is_wp_error( $native_report_compiled ), 'native-report-compile-succeeds' );
+	$assert( 2 === count( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'] ), 'plugin-artifact-helper-called-for-native-report' );
+	$assert( true === ( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][1][1]['include_conversion_report'] ?? false ), 'native-report-option-forwarded' );
+	$assert( ! array_key_exists( 'include_bfb_report', $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][1][1] ?? array() ), 'native-report-options-do-not-forward-legacy-bfb-option' );
+	$assert( ! array_key_exists( 'bfb_report', is_array( $native_report_compiled ) ? $native_report_compiled : array() ), 'native-report-request-does-not-expose-legacy-bfb-report' );
+
 	if ( $failures ) {
 		fwrite( STDERR, implode( "\n", $failures ) . "\n" );
 		exit( 1 );


### PR DESCRIPTION
## Summary
- Keep SSI's legacy `bfb_report` projection behind the explicit `include_bfb_report` compatibility option.
- Let native `include_conversion_report` callers consume the Blocks Engine conversion report contract without adding the BAC/BFB-shaped legacy field.
- Extend transformer adapter smoke coverage for both explicit legacy compatibility and native report behavior.

## Verification
- `php -l includes/class-static-site-importer-transformer-adapter.php && php tests/smoke-transformer-adapter.php && php tests/smoke-website-artifact-products-manifest.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting remaining SSI compatibility surfaces, implementing the adapter cleanup, extending behavior-level smoke coverage, and running focused verification.