### PR TITLE
Delete BFB/BAC leaks from native SSI paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Important behavior:
 
 ## Website Artifact Export
 
-`static-site-importer/export-theme` exports an imported or active block theme as a BAC-compatible website artifact. SSI owns the WordPress import/export/materialization path; Blocks Engine PHP transformer owns generic website artifact compilation. Studio Web, WP Codebox, and other products should consume the exported `website_artifact` object rather than SSI-specific static-site wrappers.
+`static-site-importer/export-theme` exports an imported or active block theme as a Blocks Engine website artifact. SSI owns the WordPress import/export/materialization path; Blocks Engine PHP transformer owns generic website artifact compilation. Studio Web, WP Codebox, and other products should consume the exported `website_artifact` object rather than SSI-specific static-site wrappers.
 
 The export envelope includes:
 
@@ -249,9 +249,9 @@ wp eval-file tests/smoke-wordpress-is-dead-fixture.php
 wp eval-file tests/smoke-mixed-source-fixture.php
 ```
 
-`php tests/smoke-transformer-adapter.php` runs outside WordPress and verifies the SSI-owned transformer adapter prefers php-transformer FormatBridge for export rendering, consumes the native artifact compiler's generic compiled-site/source-document/asset reports, keeps WordPress page mapping in SSI, and still contains the isolated legacy BAC compiled-site fallback.
+`php tests/smoke-transformer-adapter.php` runs outside WordPress and verifies the SSI-owned transformer adapter uses Blocks Engine format conversion for export rendering, consumes the native compiled-site/source-document/asset reports, and keeps WordPress page mapping in SSI.
 
-The native compiled-site report may include route metadata for HTML pages before every route has block markup. SSI's adapter records the generic report fields it consumes, but only forwards pages with matching materializable document artifacts to the current WordPress page materializer. The legacy BAC fallback remains isolated for older runtimes that emit document artifacts without a compiled-site route contract.
+The native compiled-site report may include route metadata for HTML pages before every route has block markup. SSI's adapter records the generic report fields it consumes, but only forwards pages with matching materializable document artifacts to the current WordPress page materializer.
 
 The `wordpress-is-dead` smoke verifies the multi-page fixture, generated block-theme artifacts, internal-link rewrites, persistent navigation entities, source CSS preservation, editor style support, conservative `theme.json` palette extraction, and selector fidelity across stored/rendered paths. The `mixed-source-site` smoke verifies an Astro-like source tree with `index.html`, nested Markdown content documents, explicit skipped-MDX diagnostics, report source counts, and generated page block markup.
 
@@ -308,6 +308,6 @@ The intended dependency direction is:
 Static Site Importer -> Blocks Engine PHP transformer
 ```
 
-SSI import reports consume Blocks Engine PHP transformer result envelopes for conversion-quality diagnostics, and record the compiled-site contract when importing website artifacts. BAC/BFB/H2BC names remain compatibility schemas or wrapper surfaces for older consumers; SSI should not call those lower-level converter packages directly or re-derive semantic page-route intent when the transformer supplies it.
+SSI import reports consume Blocks Engine PHP transformer result envelopes for conversion-quality diagnostics, and record the compiled-site contract when importing website artifacts. Legacy schema names remain wire contracts only; SSI should not call lower-level converter packages directly or re-derive semantic page-route intent when the transformer supplies it.
 
 Imported pages remain WordPress pages for routing, titles, front-page assignment, editor visibility, and body content edits. Their imported body layouts live on the page posts as block markup in `post_content`. The generated block theme owns shared header/footer parts, optional background decoration, frontend/editor styles, scripts, and template wrappers that render page bodies through `core/post-content`; the generic `templates/page.html` stays the fallback for pages created after import.

--- a/includes/class-static-site-importer-document-metadata-reporter.php
+++ b/includes/class-static-site-importer-document-metadata-reporter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * BAC document metadata reporting helpers.
+ * Document metadata reporting helpers.
  *
  * @package StaticSiteImporter
  */
@@ -17,7 +17,7 @@ class Static_Site_Importer_Document_Metadata_Reporter {
 	 * Record compiler-routed full-document metadata and asset references.
 	 *
 	 * @param array<string,mixed> $report    Conversion report envelope, passed by reference.
-	 * @param array<string,mixed> $artifacts WordPress artifacts from BAC.
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
 	 * @return void
 	 */
 	public static function record( array &$report, array $artifacts ): void {
@@ -28,7 +28,7 @@ class Static_Site_Importer_Document_Metadata_Reporter {
 
 		$normalized = array(
 			'schema'      => 'static-site-importer/document-metadata/v1',
-			'source'      => 'block-artifact-compiler/document_metadata',
+			'source'      => 'blocks-engine/document_metadata',
 			'source_path' => isset( $metadata['source_path'] ) && is_scalar( $metadata['source_path'] ) ? (string) $metadata['source_path'] : '',
 			'title'       => isset( $metadata['title'] ) && is_scalar( $metadata['title'] ) ? sanitize_text_field( (string) $metadata['title'] ) : '',
 			'meta'        => self::normalize_document_metadata_rows( $metadata['meta'] ?? array(), array( 'charset', 'name', 'property', 'http_equiv', 'content' ) ),

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Creates, updates, and describes WordPress pages from BAC source pages.
+ * Creates, updates, and describes WordPress pages from source pages.
  */
 class Static_Site_Importer_Page_Materializer {
 	/**
@@ -165,7 +165,7 @@ class Static_Site_Importer_Page_Materializer {
 	 * @return string
 	 */
 	public static function page_slug( string $filename, ?Static_Site_Importer_Source_Page $page = null ): string {
-		if ( $page instanceof Static_Site_Importer_Source_Page && 'bac_document' === $page->type() && self::is_index_source_filename( $filename ) && filter_var( $page->metadata_value( 'entrypoint' ), FILTER_VALIDATE_BOOLEAN ) ) {
+		if ( $page instanceof Static_Site_Importer_Source_Page && 'wordpress_document_artifact' === $page->type() && self::is_index_source_filename( $filename ) && filter_var( $page->metadata_value( 'entrypoint' ), FILTER_VALIDATE_BOOLEAN ) ) {
 			return 'home';
 		}
 
@@ -219,7 +219,7 @@ class Static_Site_Importer_Page_Materializer {
 	}
 
 	/**
-	 * Prepare one BAC document body for WordPress writes.
+	 * Prepare one source page body for WordPress writes.
 	 *
 	 * @param Static_Site_Importer_Source_Page $page        Source page.
 	 * @param array<int,array<string,mixed>>    $diagnostics Diagnostics, passed by reference.
@@ -230,10 +230,10 @@ class Static_Site_Importer_Page_Materializer {
 		if ( 'blocks' !== $page->body_format() ) {
 			$diagnostics[] = array(
 				'type'        => 'unsupported_document_artifact_format',
-				'source'      => 'block-artifact-compiler/documents',
+				'source'      => 'blocks-engine/documents',
 				'source_path' => $source_path,
 				'format'      => $page->body_format(),
-				'message'     => 'Website artifact imports require BAC document artifacts with serialized block markup.',
+				'message'     => 'Website artifact imports require document artifacts with serialized block markup.',
 			);
 			return '';
 		}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -106,7 +106,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'resolved'         => array(),
 				'unresolved'       => array(),
 			),
-			'block_artifact_compiler' => array(
+			'blocks_engine'           => array(
 				'available'      => true,
 				'fragment_count' => 0,
 				'fragments'      => array(),
@@ -145,17 +145,17 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
-	 * Record the bundle-level compiler result used by import_website_artifact().
+	 * Record the bundle-level Blocks Engine result used by import_website_artifact().
 	 *
 	 * @param array<string,mixed> $report   Import report.
 	 * @param array<string,mixed> $compiled Compiler result envelope.
 	 * @return void
 	 */
-	public static function record_website_artifact_compiler_result( array &$report, array $compiled ): void {
+	public static function record_blocks_engine_result( array &$report, array $compiled ): void {
 		$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
 		$site      = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
-		$report['block_artifact_compiler']['available']        = true;
-		$report['block_artifact_compiler']['website_artifact'] = array(
+		$report['blocks_engine']['available']        = true;
+		$report['blocks_engine']['website_artifact'] = array(
 			'summary'     => ( new Static_Site_Importer_Transformer_Adapter() )->summarize_result( $compiled ),
 			'provenance'  => isset( $compiled['provenance'] ) && is_array( $compiled['provenance'] ) ? $compiled['provenance'] : array(),
 			'input'       => isset( $compiled['input'] ) && is_array( $compiled['input'] ) ? $compiled['input'] : array(),
@@ -163,7 +163,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		);
 
 		if ( in_array( (string) ( $site['schema'] ?? '' ), array( 'block-artifact-compiler/compiled-site/v1', 'blocks-engine/php-transformer/compiled-site/v1' ), true ) ) {
-			$report['block_artifact_compiler']['compiled_site'] = self::compiled_site_report_payload( $site );
+			$report['blocks_engine']['compiled_site'] = self::compiled_site_report_payload( $site );
 		}
 	}
 
@@ -527,7 +527,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	private static function validation_provenance( array $report ): array {
 		$source   = isset( $report['source'] ) && is_array( $report['source'] ) ? $report['source'] : array();
-		$compiler = isset( $report['block_artifact_compiler']['website_artifact'] ) && is_array( $report['block_artifact_compiler']['website_artifact'] ) ? $report['block_artifact_compiler']['website_artifact'] : array();
+		$compiler = isset( $report['blocks_engine']['website_artifact'] ) && is_array( $report['blocks_engine']['website_artifact'] ) ? $report['blocks_engine']['website_artifact'] : array();
 
 		return array(
 			'producer'            => 'static-site-importer',
@@ -1007,7 +1007,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return array<string,mixed>
 	 */
 	private static function compact_import_report_compiler_summary( array $report ): array {
-		$compiler = isset( $report['block_artifact_compiler'] ) && is_array( $report['block_artifact_compiler'] ) ? $report['block_artifact_compiler'] : array();
+		$compiler = isset( $report['blocks_engine'] ) && is_array( $report['blocks_engine'] ) ? $report['blocks_engine'] : array();
 		$summary  = array(
 			'available'      => ! empty( $compiler['available'] ),
 			'fragment_count' => (int) ( $compiler['fragment_count'] ?? 0 ),

--- a/includes/class-static-site-importer-source-page.php
+++ b/includes/class-static-site-importer-source-page.php
@@ -85,7 +85,7 @@ class Static_Site_Importer_Source_Page {
 	}
 
 	/**
-	 * Create a source page from a BAC WordPress document artifact.
+	 * Create a source page from a WordPress document artifact.
 	 *
 	 * @param array<string,mixed> $artifact WordPress document artifact.
 	 * @return self|WP_Error
@@ -96,7 +96,7 @@ class Static_Site_Importer_Source_Page {
 			$source_key = self::normalize_artifact_source_key( isset( $artifact['slug'] ) ? (string) $artifact['slug'] : '' );
 		}
 		if ( '' === $source_key ) {
-			return new WP_Error( 'static_site_importer_bac_document_missing_source', 'BAC document artifact is missing a source_path/path/slug.' );
+			return new WP_Error( 'static_site_importer_document_artifact_missing_source', 'WordPress document artifact is missing a source_path/path/slug.' );
 		}
 
 		$content = '';
@@ -107,7 +107,7 @@ class Static_Site_Importer_Source_Page {
 			}
 		}
 		if ( '' === trim( $content ) ) {
-			return new WP_Error( 'static_site_importer_bac_document_empty_content', sprintf( 'BAC document artifact is missing block markup: %s', $source_key ) );
+			return new WP_Error( 'static_site_importer_document_artifact_empty_content', sprintf( 'WordPress document artifact is missing block markup: %s', $source_key ) );
 		}
 
 		$metadata = array();
@@ -127,7 +127,7 @@ class Static_Site_Importer_Source_Page {
 		$title    = $metadata['title'] ?? '';
 		$document = new Static_Site_Importer_Document( '<!doctype html><html><head><title>' . esc_html( $title ) . '</title></head><body><main>' . $content . '</main></body></html>' );
 
-		return new self( $source_key, $source_key, 'bac_document', $document, $content, 'blocks', $metadata );
+		return new self( $source_key, $source_key, 'wordpress_document_artifact', $document, $content, 'blocks', $metadata );
 	}
 
 	/**
@@ -244,7 +244,7 @@ class Static_Site_Importer_Source_Page {
 	}
 
 	/**
-	 * Normalize a BAC document source key for report/result maps.
+	 * Normalize a document source key for report/result maps.
 	 *
 	 * @param string $source Source path or slug.
 	 * @return string

--- a/includes/class-static-site-importer-stylesheet-materializer.php
+++ b/includes/class-static-site-importer-stylesheet-materializer.php
@@ -20,7 +20,7 @@ class Static_Site_Importer_Stylesheet_Materializer {
 	 * @param string                  $theme_dir            Theme directory.
 	 * @param string                  $theme_name           Theme name.
 	 * @param string                  $css                  Source CSS.
-	 * @param array<string,array<int,string>> $visual_repair_styles BAC visual repair CSS content by target.
+	 * @param array<string,array<int,string>> $visual_repair_styles Visual repair CSS content by target.
 	 * @return array<string,string> Absolute stylesheet write paths mapped to file contents.
 	 */
 	public static function stylesheet_writes(
@@ -40,7 +40,7 @@ class Static_Site_Importer_Stylesheet_Materializer {
 	 *
 	 * @param string                          $theme_name           Theme name.
 	 * @param string                          $css                  Source CSS.
-	 * @param array<string,array<int,string>> $visual_repair_styles BAC visual repair CSS content by target.
+	 * @param array<string,array<int,string>> $visual_repair_styles Visual repair CSS content by target.
 	 * @return string
 	 */
 	private static function style_css( string $theme_name, string $css, array $visual_repair_styles = array() ): string {
@@ -54,7 +54,7 @@ class Static_Site_Importer_Stylesheet_Materializer {
 	 * Build editor-style.css.
 	 *
 	 * @param string                          $css                  Source CSS.
-	 * @param array<string,array<int,string>> $visual_repair_styles BAC visual repair CSS content by target.
+	 * @param array<string,array<int,string>> $visual_repair_styles Visual repair CSS content by target.
 	 * @return string
 	 */
 	private static function editor_style_css( string $css, array $visual_repair_styles = array() ): string {
@@ -64,7 +64,7 @@ class Static_Site_Importer_Stylesheet_Materializer {
 	}
 
 	/**
-	 * Return compiled BAC visual repair CSS for one stylesheet target.
+	 * Return compiled visual repair CSS for one stylesheet target.
 	 *
 	 * @param array<string,array<int,string>> $visual_repair_styles Repair CSS content by target.
 	 * @param string                          $target               Stylesheet target.

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -58,13 +58,13 @@ class Static_Site_Importer_Theme_Generator {
 		if ( is_wp_error( $compiled ) ) {
 			return $compiled;
 		}
-		$document_pages   = self::bac_document_pages( $compiled );
+		$document_pages   = self::website_artifact_source_pages( $compiled );
 		if ( is_wp_error( $document_pages ) ) {
 			return $document_pages;
 		}
 
 		if ( 'failed' === (string) ( $compiled['status'] ?? '' ) || empty( $document_pages ) ) {
-			return new WP_Error( 'static_site_importer_artifact_compile_failed', 'Website artifact compilation did not produce BAC compiled-site document pages.', $compiled );
+			return new WP_Error( 'static_site_importer_artifact_compile_failed', 'Website artifact compilation did not produce materializable document pages.', $compiled );
 		}
 
 		return self::import_compiled_website_artifact( $compiled, $args );
@@ -100,7 +100,7 @@ class Static_Site_Importer_Theme_Generator {
 		$source_metadata['source'] = 'website_artifact';
 		$html_path                 = (string) ( $compiled['provenance']['source'] ?? ( $compiled['input']['entry_path'] ?? 'website_artifact' ) );
 		self::$conversion_report   = Static_Site_Importer_Report_Diagnostics::new_conversion_report( $html_path, $source_metadata );
-		Static_Site_Importer_Report_Diagnostics::record_website_artifact_compiler_result( self::$conversion_report, $compiled );
+		Static_Site_Importer_Report_Diagnostics::record_blocks_engine_result( self::$conversion_report, $compiled );
 		Static_Site_Importer_Report_Diagnostics::record_direct_website_artifact_source_summary( self::$conversion_report, $compiled );
 		self::record_products_manifest_from_import_args( $args, $compiled );
 		self::record_commerce_context_summary( $args );
@@ -112,7 +112,7 @@ class Static_Site_Importer_Theme_Generator {
 			return $asset_policy;
 		}
 
-		$document_pages = self::bac_document_pages( $compiled );
+		$document_pages = self::website_artifact_source_pages( $compiled );
 		if ( is_wp_error( $document_pages ) ) {
 			return $document_pages;
 		}
@@ -161,7 +161,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 		self::analyze_imported_page_content_documents( $document_pages, $page_artifacts['contents'] );
 
-		self::record_bac_source_documents_summary( $artifacts['documents'] ?? array(), $document_pages, $page_ids, $permalinks );
+		self::record_source_documents_summary( $artifacts['documents'] ?? array(), $document_pages, $page_ids, $permalinks );
 		foreach ( array_keys( $page_artifacts['patterns'] ) as $filename ) {
 			$page = $document_pages[ $filename ] ?? null;
 			$slug = $page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_slug( $filename, $page ) : Static_Site_Importer_Page_Materializer::page_slug( $filename );
@@ -1025,16 +1025,16 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Normalize BAC WordPress document artifacts into source pages.
+	 * Normalize website artifact document rows into source pages.
 	 *
-	 * SSI consumes BAC's compiled-site page contract when available, then attaches
+	 * SSI consumes the compiled-site page contract when available, then attaches
 	 * the referenced `wordpress_artifacts.documents[]` block markup for WordPress
 	 * materialization.
 	 *
 	 * @param array<string,mixed> $compiled Compiler result envelope.
 	 * @return array<string, Static_Site_Importer_Source_Page>|WP_Error
 	 */
-	private static function bac_document_pages( array $compiled ) {
+	private static function website_artifact_source_pages( array $compiled ) {
 		$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
 		$documents = isset( $artifacts['documents'] ) && is_array( $artifacts['documents'] ) ? $artifacts['documents'] : array();
 		$site      = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
@@ -1160,7 +1160,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * Attach document markup to compiled-site page contracts.
 	 *
 	 * @param array<int,array<string,mixed>> $site_pages Compiled-site page rows.
-	 * @param array<int,mixed>               $documents  BAC document artifacts.
+	 * @param array<int,mixed>               $documents  Document artifacts.
 	 * @return array<int,array<string,mixed>>|WP_Error Document artifacts ordered by compiled-site pages.
 	 */
 	private static function documents_from_compiled_site_pages( array $site_pages, array $documents ) {
@@ -1184,7 +1184,7 @@ class Static_Site_Importer_Theme_Generator {
 
 			$source_path = isset( $page['source_path'] ) && is_scalar( $page['source_path'] ) ? (string) $page['source_path'] : '';
 			if ( '' === $source_path ) {
-				return new WP_Error( 'static_site_importer_compiled_site_page_missing_source', 'BAC compiled-site page is missing source_path.' );
+				return new WP_Error( 'static_site_importer_compiled_site_page_missing_source', 'Compiled-site page is missing source_path.' );
 			}
 			$metadata  = isset( $page['metadata'] ) && is_array( $page['metadata'] ) ? $page['metadata'] : array();
 			$slug      = isset( $page['slug'] ) && is_scalar( $page['slug'] ) ? sanitize_title( (string) $page['slug'] ) : '';
@@ -1203,10 +1203,10 @@ class Static_Site_Importer_Theme_Generator {
 				$post_type = 'page';
 			}
 			if ( '' === $route_key || '' === $slug || '' === $post_type ) {
-				return new WP_Error( 'static_site_importer_compiled_site_page_identity_incomplete', sprintf( 'BAC compiled-site page is missing route_key, slug, or post_type: %s', $source_path ) );
+				return new WP_Error( 'static_site_importer_compiled_site_page_identity_incomplete', sprintf( 'Compiled-site page is missing route_key, slug, or post_type: %s', $source_path ) );
 			}
 			if ( ! isset( $documents_by_source[ $source_path ] ) && ( ! isset( $page['block_markup'] ) || ! is_scalar( $page['block_markup'] ) || '' === trim( (string) $page['block_markup'] ) ) ) {
-				return new WP_Error( 'static_site_importer_compiled_site_page_missing_document', sprintf( 'BAC compiled-site page does not reference a document artifact: %s', $source_path ) );
+				return new WP_Error( 'static_site_importer_compiled_site_page_missing_document', sprintf( 'Compiled-site page does not reference a document artifact: %s', $source_path ) );
 			}
 
 			$document = array_merge( $documents_by_source[ $source_path ] ?? array(), array_filter(
@@ -1232,10 +1232,10 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Normalize BAC template part artifacts into generated theme writes.
+	 * Normalize template part artifacts into generated theme writes.
 	 *
 	 * @param string              $theme_dir Theme directory.
-	 * @param array<string,mixed> $artifacts WordPress artifacts from BAC.
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
 	 * @return array<string,string>|WP_Error Absolute write paths keyed to serialized block markup.
 	 */
 	private static function template_part_artifact_writes( string $theme_dir, array $artifacts ) {
@@ -1348,7 +1348,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * Write compiler-emitted files that can be consumed without re-importing HTML.
 	 *
 	 * @param string              $theme_dir Theme directory.
-	 * @param array<string,mixed> $artifacts WordPress artifacts from BAC.
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
 	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>}|WP_Error
 	 */
 	private static function materialize_website_artifact_files_to_theme( string $theme_dir, array $artifacts ) {
@@ -1368,9 +1368,9 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Collect BAC visual repair stylesheet artifacts by target.
+	 * Collect visual repair stylesheet artifacts by target.
 	 *
-	 * @param array<string,mixed> $artifacts BAC WordPress artifacts.
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
 	 * @return array{frontend:array<int,string>,editor:array<int,string>} Repair CSS content by stylesheet target.
 	 */
 	private static function visual_repair_styles_from_artifacts( array $artifacts ): array {
@@ -1833,15 +1833,15 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Record BAC-owned source document materialization details.
+	 * Record source document materialization details.
 	 *
-	 * @param array<int,mixed>                                   $documents  BAC document artifacts.
+	 * @param array<int,mixed>                                   $documents  Document artifacts.
 	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Imported pages/posts.
 	 * @param array<string,int>                                $page_ids   Imported post IDs keyed by source path.
 	 * @param array<string,string>                             $permalinks Imported permalinks keyed by source path.
 	 * @return void
 	 */
-	private static function record_bac_source_documents_summary( array $documents, array $pages, array $page_ids, array $permalinks ): void {
+	private static function record_source_documents_summary( array $documents, array $pages, array $page_ids, array $permalinks ): void {
 		$records = array();
 		foreach ( $documents as $document ) {
 			if ( ! is_array( $document ) ) {

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -92,7 +92,7 @@ class Static_Site_Importer_Theme_Materializer {
 	 *
 	 * @param string              $theme_dir Theme directory.
 	 * @param string              $theme_uri Theme URI.
-	 * @param array<string,mixed> $artifacts WordPress artifacts from BAC.
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
 	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|WP_Error
 	 */
 	public static function materialize_website_artifact_files( string $theme_dir, string $theme_uri, array $artifacts ) {
@@ -119,7 +119,7 @@ class Static_Site_Importer_Theme_Materializer {
 					'source'  => 'website_artifact:files',
 					'reason'  => 'unsafe_artifact_path',
 					'path'    => isset( $file['path'] ) && is_scalar( $file['path'] ) ? (string) $file['path'] : '',
-					'message' => 'A BAC file artifact was skipped because its path is not safe to materialize inside the generated theme.',
+					'message' => 'A website artifact file was skipped because its path is not safe to materialize inside the generated theme.',
 				);
 				continue;
 			}
@@ -172,7 +172,7 @@ class Static_Site_Importer_Theme_Materializer {
 	 *
 	 * @param string              $theme_dir Theme directory.
 	 * @param string              $theme_uri Theme URI.
-	 * @param array<string,mixed> $artifacts WordPress artifacts from BAC/Blocks Engine.
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
 	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|null|WP_Error
 	 */
 	private static function materialize_materialization_plan_assets( string $theme_dir, string $theme_uri, array $artifacts ) {
@@ -300,10 +300,10 @@ class Static_Site_Importer_Theme_Materializer {
 	}
 
 	/**
-	 * Normalize BAC template part artifacts into generated theme writes.
+	 * Normalize template part artifacts into generated theme writes.
 	 *
 	 * @param string              $theme_dir Theme directory.
-	 * @param array<string,mixed> $artifacts WordPress artifacts from BAC.
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
 	 * @return array{writes:array<string,string>,reports:array<int,array<string,mixed>>}|WP_Error Absolute write paths and report rows.
 	 */
 	public static function template_part_artifact_writes( string $theme_dir, array $artifacts ) {
@@ -327,21 +327,21 @@ class Static_Site_Importer_Theme_Materializer {
 		$reports = array();
 		foreach ( $template_parts as $template_part ) {
 			if ( ! is_array( $template_part ) ) {
-				return new WP_Error( 'static_site_importer_bac_template_part_invalid', 'BAC template part artifacts must be arrays.' );
+				return new WP_Error( 'static_site_importer_template_part_invalid', 'Template part artifacts must be arrays.' );
 			}
 
 			$relative = self::template_part_artifact_relative_path( $template_part );
 			if ( '' === $relative ) {
-				return new WP_Error( 'static_site_importer_bac_template_part_unsupported', 'BAC template part artifacts must resolve to a supported header or footer theme part.' );
+				return new WP_Error( 'static_site_importer_template_part_unsupported', 'Template part artifacts must resolve to a supported header or footer theme part.' );
 			}
 
 			if ( ! isset( $template_part['block_markup'] ) || ! is_scalar( $template_part['block_markup'] ) ) {
-				return new WP_Error( 'static_site_importer_bac_template_part_markup_missing', 'BAC template part artifacts must include serialized block_markup.' );
+				return new WP_Error( 'static_site_importer_template_part_markup_missing', 'Template part artifacts must include serialized block_markup.' );
 			}
 
 			$markup = (string) $template_part['block_markup'];
 			if ( '' === trim( $markup ) ) {
-				return new WP_Error( 'static_site_importer_bac_template_part_markup_empty', 'BAC template part block_markup must not be empty.' );
+				return new WP_Error( 'static_site_importer_template_part_markup_empty', 'Template part artifact block_markup must not be empty.' );
 			}
 
 			$writes[ trailingslashit( $theme_dir ) . $relative ] = $markup;
@@ -483,9 +483,9 @@ class Static_Site_Importer_Theme_Materializer {
 	}
 
 	/**
-	 * Resolve a BAC template part artifact to an SSI-supported theme part path.
+	 * Resolve a template part artifact to an SSI-supported theme part path.
 	 *
-	 * @param array<string,mixed> $template_part BAC template part artifact.
+	 * @param array<string,mixed> $template_part Template part artifact.
 	 * @return string Relative theme path, or empty string when unsupported.
 	 */
 	private static function template_part_artifact_relative_path( array $template_part ): string {
@@ -505,7 +505,7 @@ class Static_Site_Importer_Theme_Materializer {
 	/**
 	 * Build the minimal generated header required by SSI's page templates.
 	 *
-	 * @return array<string,mixed> BAC-like template part artifact.
+	 * @return array<string,mixed> Template part artifact.
 	 */
 	private static function default_header_template_part(): array {
 		return array(
@@ -519,10 +519,10 @@ class Static_Site_Importer_Theme_Materializer {
 	}
 
 	/**
-	 * Build a compact report row for a materialized BAC template part artifact.
+	 * Build a compact report row for a materialized template part artifact.
 	 *
 	 * @param string              $path          Relative generated theme path.
-	 * @param array<string,mixed> $template_part BAC template part artifact.
+	 * @param array<string,mixed> $template_part Template part artifact.
 	 * @param string              $markup        Serialized block markup.
 	 * @return array<string,mixed>
 	 */

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -17,8 +17,6 @@ class Static_Site_Importer_Transformer_Adapter {
 	public const WEBSITE_ARTIFACT_SCHEMA = 'block-artifact-compiler/website-artifact/v1';
 	public const COMPILED_RESULT_SCHEMA  = 'block-artifact-compiler/result/v1';
 	private const CONVERSION_REPORT_OPTION = 'include_conversion_report';
-	private const LEGACY_BFB_REPORT_OPTION = 'include_bfb_report';
-	private const LEGACY_BFB_REPORT_FIELD  = 'bfb_report';
 
 	/**
 	 * Check whether the default Blocks Engine artifact compiler is available.
@@ -50,12 +48,11 @@ class Static_Site_Importer_Transformer_Adapter {
 			return new WP_Error( 'static_site_importer_missing_transformer', 'Blocks Engine php-transformer is required to import a website artifact.' );
 		}
 
-		$include_legacy_bfb_report = ! empty( $options[ self::LEGACY_BFB_REPORT_OPTION ] );
-		$options                   = $this->normalize_compile_options( $options );
+		$options = $this->normalize_compile_options( $options );
 		$result = blocks_engine_php_transformer_compile_artifact( $artifact, $options );
 
 		if ( is_array( $result ) ) {
-			return $this->compiled_result_from_transformer_contract( $result, $include_legacy_bfb_report );
+			return $this->compiled_result_from_transformer_contract( $result );
 		}
 
 		return new WP_Error( 'static_site_importer_transformer_compile_failed', 'Blocks Engine php-transformer did not return a compiler result.' );
@@ -64,12 +61,11 @@ class Static_Site_Importer_Transformer_Adapter {
 	/**
 	 * Project the stable transformer contracts into SSI's compiled artifact envelope.
 	 *
-	 * @param array<string,mixed> $result                    TransformerResult::toArray() output.
-	 * @param bool                $include_legacy_bfb_report Whether to expose SSI's legacy bfb_report field.
+	 * @param array<string,mixed> $result TransformerResult::toArray() output.
 	 * @return array<string,mixed>
 	 */
-	private function compiled_result_from_transformer_contract( array $result, bool $include_legacy_bfb_report ): array {
-		$compiled = $this->compiled_result_from_native_transformer_contract( $result, $include_legacy_bfb_report );
+	private function compiled_result_from_transformer_contract( array $result ): array {
+		$compiled = $this->compiled_result_from_native_transformer_contract( $result );
 		if ( empty( $compiled['wordpress_artifacts'] ) ) {
 			$compiled = $this->compiled_result_from_legacy_mapping_compatibility( $result );
 		}
@@ -105,11 +101,10 @@ class Static_Site_Importer_Transformer_Adapter {
 	/**
 	 * Build SSI's consumed compiler envelope from the native Blocks Engine result.
 	 *
-	 * @param array<string,mixed> $result                    TransformerResult::toArray() output.
-	 * @param bool                $include_legacy_bfb_report Whether to expose SSI's legacy bfb_report field.
+	 * @param array<string,mixed> $result TransformerResult::toArray() output.
 	 * @return array<string,mixed>
 	 */
-	private function compiled_result_from_native_transformer_contract( array $result, bool $include_legacy_bfb_report ): array {
+	private function compiled_result_from_native_transformer_contract( array $result ): array {
 		$source_reports = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
 		if ( empty( $source_reports ) ) {
 			return array();
@@ -132,8 +127,8 @@ class Static_Site_Importer_Transformer_Adapter {
 			'provenance'          => isset( $result['provenance'] ) && is_array( $result['provenance'] ) ? $result['provenance'] : array(),
 		);
 
-		if ( $include_legacy_bfb_report ) {
-			$compiled[ self::LEGACY_BFB_REPORT_FIELD ] = $this->legacy_conversion_report_from_native_report( $result );
+		if ( isset( $result['conversion_report'] ) && is_array( $result['conversion_report'] ) ) {
+			$compiled['conversion_report'] = $result['conversion_report'];
 		}
 
 		return $compiled;
@@ -146,10 +141,7 @@ class Static_Site_Importer_Transformer_Adapter {
 	 * @return array<string,mixed>
 	 */
 	private function normalize_compile_options( array $options ): array {
-		$include_report = ! empty( $options[ self::CONVERSION_REPORT_OPTION ] ) || ! empty( $options[ self::LEGACY_BFB_REPORT_OPTION ] );
-		unset( $options[ self::LEGACY_BFB_REPORT_OPTION ] );
-
-		if ( $include_report ) {
+		if ( ! empty( $options[ self::CONVERSION_REPORT_OPTION ] ) ) {
 			$options[ self::CONVERSION_REPORT_OPTION ] = true;
 		}
 
@@ -157,24 +149,7 @@ class Static_Site_Importer_Transformer_Adapter {
 	}
 
 	/**
-	 * Preserve SSI's legacy report field from the native Blocks Engine conversion report.
-	 *
-	 * @param array<string,mixed> $result TransformerResult::toArray() output.
-	 * @return array<string,mixed>
-	 */
-	private function legacy_conversion_report_from_native_report( array $result ): array {
-		$report = isset( $result['conversion_report'] ) && is_array( $result['conversion_report'] ) ? $result['conversion_report'] : array();
-
-		return array(
-			'status'            => isset( $report['status'] ) && is_scalar( $report['status'] ) ? (string) $report['status'] : 'failed',
-			'serialized_blocks' => isset( $report['serialized_blocks'] ) && is_scalar( $report['serialized_blocks'] ) ? (string) $report['serialized_blocks'] : '',
-			'diagnostics'       => isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array(),
-			'fallbacks'         => isset( $report['fallbacks'] ) && is_array( $report['fallbacks'] ) ? $report['fallbacks'] : array(),
-		);
-	}
-
-	/**
-	 * Project pre-source_reports transformer output through the legacy BAC-shaped map.
+	 * Project pre-source_reports transformer output through the legacy compiled-result map.
 	 *
 	 * Native Blocks Engine source_reports are the importer contract. This compatibility
 	 * path exists only for older transformer results that did not expose that contract.
@@ -561,7 +536,7 @@ class Static_Site_Importer_Transformer_Adapter {
 	}
 
 	/**
-	 * Build a compact block tree report without depending on BAC helpers.
+	 * Build a compact block tree report from parsed blocks.
 	 *
 	 * @param array<int|string,mixed> $blocks Parsed blocks.
 	 * @return array<string,int>

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -19,7 +19,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 				'entry_file'              => '/tmp/source/index.html',
 				'version'                 => 1,
 				'theme_slug'              => 'static-template-import',
-				'block_artifact_compiler' => array(
+				'blocks_engine'           => array(
 					'available'        => true,
 					'fragment_count'   => 0,
 					'website_artifact' => array(
@@ -97,7 +97,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 				'type'   => 'website_artifact',
 				'source' => 'artifact.json',
 			),
-			'block_artifact_compiler' => array(
+			'blocks_engine'           => array(
 				'website_artifact' => array(
 					'summary'    => array(
 						'schema' => 'block-artifact-compiler/result/v1',

--- a/tests/smoke-export-theme-ability.php
+++ b/tests/smoke-export-theme-ability.php
@@ -27,10 +27,10 @@ file_put_contents( $theme_dir . '/templates/front-page.html', '<!-- wp:post-cont
 file_put_contents( $theme_dir . '/import-report.json', '{"status":"completed","source_documents":{"direct_website_artifact":{"document_count":1}}}' );
 
 $GLOBALS['ssi_export_theme_root'] = $theme_root;
-$GLOBALS['ssi_export_format_bridge_calls'] = array();
+$GLOBALS['ssi_export_format_conversion_calls'] = array();
 
 function blocks_engine_php_transformer_convert_format( string $content, string $from, string $to, array $options = array() ): array {
-	$GLOBALS['ssi_export_format_bridge_calls'][] = array( $from, $to, $options );
+	$GLOBALS['ssi_export_format_conversion_calls'][] = array( $from, $to, $options );
 	return array(
 		'schema'    => 'blocks-engine/php-transformer/result/v1',
 		'status'    => 'success',
@@ -232,11 +232,11 @@ $assert( 'smoke' === ( $artifact['provenance']['source_metadata']['source'] ?? '
 $assert( 'website/import-report.json' === ( $artifact['reports'][0]['path'] ?? '' ), 'report-ref' );
 $assert( 'smoke' === ( $artifact['report']['source_metadata']['source'] ?? '' ), 'source-metadata-preserved' );
 $assert( 'completed' === ( $artifact['report']['import_report']['status'] ?? '' ), 'import-report-preserved' );
-$export_format_bridge_calls = array_filter(
-	$GLOBALS['ssi_export_format_bridge_calls'],
+$export_format_conversion_calls = array_filter(
+	$GLOBALS['ssi_export_format_conversion_calls'],
 	static fn ( array $call ): bool => 'blocks' === $call[0] && 'html' === $call[1]
 );
-$assert( count( $export_format_bridge_calls ) >= 4, 'format-bridge-called-for-block-to-html' );
+$assert( count( $export_format_conversion_calls ) >= 4, 'format-conversion-called-for-block-to-html' );
 $assert( class_exists( 'Static_Site_Importer_Transformer_Adapter' ), 'export-routes-through-transformer-adapter' );
 
 if ( $failures ) {

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -10,7 +10,7 @@
 
 namespace {
 	function blocks_engine_php_transformer_compile_artifact( array $artifact, array $options = array() ): array {
-		$GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][] = array( $artifact, $options );
+		$GLOBALS['ssi_transformer_adapter_compile_calls'][] = array( $artifact, $options );
 
 		return array(
 						'schema'            => 'blocks-engine/php-transformer/result/v1',
@@ -188,14 +188,14 @@ namespace {
 	}
 
 	function blocks_engine_php_transformer_convert_format( string $content, string $from, string $to, array $options = array() ): array {
-		$GLOBALS['ssi_transformer_adapter_format_bridge_calls'][] = array( $content, $from, $to, $options );
+		$GLOBALS['ssi_transformer_adapter_format_conversion_calls'][] = array( $content, $from, $to, $options );
 		return array(
 			'schema'    => 'blocks-engine/php-transformer/result/v1',
 			'status'    => 'success',
 			'documents' => array(
 				array(
 					'format'  => 'html',
-					'content' => '<p>FormatBridge rendered</p>',
+					'content' => '<p>Blocks Engine rendered</p>',
 				),
 			),
 		);
@@ -205,8 +205,8 @@ namespace {
 		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 	}
 
-	$GLOBALS['ssi_transformer_adapter_format_bridge_calls'] = array();
-	$GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'] = array();
+	$GLOBALS['ssi_transformer_adapter_format_conversion_calls'] = array();
+	$GLOBALS['ssi_transformer_adapter_compile_calls'] = array();
 
 	if ( ! class_exists( 'WP_Error' ) ) {
 		class WP_Error {
@@ -247,29 +247,28 @@ namespace {
 
 	$adapter = new Static_Site_Importer_Transformer_Adapter();
 	$html    = $adapter->blocks_to_html( '<!-- wp:paragraph --><p>Edited</p><!-- /wp:paragraph -->', array( 'source' => 'smoke' ) );
-	$assert( '<p>FormatBridge rendered</p>' === $html, 'format-bridge-result-is-used' );
-	$assert( 1 === count( $GLOBALS['ssi_transformer_adapter_format_bridge_calls'] ), 'format-bridge-called' );
-	$assert( 'blocks' === ( $GLOBALS['ssi_transformer_adapter_format_bridge_calls'][0][1] ?? '' ), 'format-bridge-from-format' );
-	$assert( 'html' === ( $GLOBALS['ssi_transformer_adapter_format_bridge_calls'][0][2] ?? '' ), 'format-bridge-to-format' );
-	$assert( 'smoke' === ( $GLOBALS['ssi_transformer_adapter_format_bridge_calls'][0][3]['source'] ?? '' ), 'format-bridge-options-forwarded' );
+	$assert( '<p>Blocks Engine rendered</p>' === $html, 'format-conversion-result-is-used' );
+	$assert( 1 === count( $GLOBALS['ssi_transformer_adapter_format_conversion_calls'] ), 'format-conversion-called' );
+	$assert( 'blocks' === ( $GLOBALS['ssi_transformer_adapter_format_conversion_calls'][0][1] ?? '' ), 'format-conversion-from-format' );
+	$assert( 'html' === ( $GLOBALS['ssi_transformer_adapter_format_conversion_calls'][0][2] ?? '' ), 'format-conversion-to-format' );
+	$assert( 'smoke' === ( $GLOBALS['ssi_transformer_adapter_format_conversion_calls'][0][3]['source'] ?? '' ), 'format-conversion-options-forwarded' );
 
-	$compiled  = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ), array( 'include_bfb_report' => true ) );
+	$compiled  = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ), array( 'include_conversion_report' => true ) );
 	$artifacts = $compiled['wordpress_artifacts'] ?? array();
 	$site      = $artifacts['site'] ?? array();
 	$pages     = $site['pages'] ?? array();
 	$documents = $artifacts['documents'] ?? array();
 	$products  = $compiled['products_manifest'] ?? array();
 	$assert( ! is_wp_error( $compiled ), 'native-compile-succeeds' );
-	$assert( 1 === count( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'] ), 'plugin-artifact-helper-called' );
-	$assert( true === ( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][0][1]['include_conversion_report'] ?? false ), 'compile-options-forwarded-as-native-report-request' );
-	$assert( ! array_key_exists( 'include_bfb_report', $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][0][1] ?? array() ), 'legacy-bfb-option-is-isolated' );
-	$assert( 'block-artifact-compiler/result/v1' === ( $compiled['schema'] ?? '' ), 'native-result-mapped-to-bac-envelope' );
-	$assert( 'success' === ( $compiled['bfb_report']['status'] ?? '' ), 'legacy-bfb-report-shape-preserved' );
-	$assert( '<!-- wp:paragraph --><p>Native report Home</p><!-- /wp:paragraph -->' === ( $compiled['bfb_report']['serialized_blocks'] ?? '' ), 'legacy-bfb-report-uses-native-report-serialized-blocks' );
-	$assert( 'native_report_diagnostic' === ( $compiled['bfb_report']['diagnostics'][0]['code'] ?? '' ), 'legacy-bfb-report-uses-native-report-diagnostics' );
-	$assert( 'native-conversion-report' === ( $compiled['bfb_report']['fallbacks'][0]['source'] ?? '' ), 'legacy-bfb-report-uses-native-report-fallbacks' );
-	$assert( 'legacy_top_level_diagnostic' !== ( $compiled['bfb_report']['diagnostics'][0]['code'] ?? '' ), 'legacy-bfb-report-ignores-top-level-diagnostics' );
-	$assert( 'legacy-top-level' !== ( $compiled['bfb_report']['fallbacks'][0]['source'] ?? '' ), 'legacy-bfb-report-ignores-top-level-fallbacks' );
+	$assert( 1 === count( $GLOBALS['ssi_transformer_adapter_compile_calls'] ), 'plugin-compile-helper-called' );
+	$assert( true === ( $GLOBALS['ssi_transformer_adapter_compile_calls'][0][1]['include_conversion_report'] ?? false ), 'compile-options-forwarded-as-native-report-request' );
+	$assert( 'block-artifact-compiler/result/v1' === ( $compiled['schema'] ?? '' ), 'native-result-mapped-to-compiled-envelope' );
+	$assert( 'success' === ( $compiled['conversion_report']['status'] ?? '' ), 'conversion-report-shape-preserved' );
+	$assert( '<!-- wp:paragraph --><p>Native report Home</p><!-- /wp:paragraph -->' === ( $compiled['conversion_report']['serialized_blocks'] ?? '' ), 'conversion-report-uses-native-serialized-blocks' );
+	$assert( 'native_report_diagnostic' === ( $compiled['conversion_report']['diagnostics'][0]['code'] ?? '' ), 'conversion-report-uses-native-diagnostics' );
+	$assert( 'native-conversion-report' === ( $compiled['conversion_report']['fallbacks'][0]['source'] ?? '' ), 'conversion-report-uses-native-fallbacks' );
+	$assert( 'legacy_top_level_diagnostic' !== ( $compiled['conversion_report']['diagnostics'][0]['code'] ?? '' ), 'conversion-report-ignores-top-level-diagnostics' );
+	$assert( 'legacy-top-level' !== ( $compiled['conversion_report']['fallbacks'][0]['source'] ?? '' ), 'conversion-report-ignores-top-level-fallbacks' );
 	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'native-artifact-report-preserved-as-input' );
 	$assert( 'blocks-engine/php-transformer/materialization-plan/v1' === ( $site['schema'] ?? '' ), 'native-materialization-plan-contract-is-used' );
 	$assert( 4 === count( $pages ), 'native-keeps-compiled-site-pages-without-adapter-filtering' );
@@ -289,10 +288,9 @@ namespace {
 
 	$native_report_compiled = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ), array( 'include_conversion_report' => true ) );
 	$assert( ! is_wp_error( $native_report_compiled ), 'native-report-compile-succeeds' );
-	$assert( 2 === count( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'] ), 'plugin-artifact-helper-called-for-native-report' );
-	$assert( true === ( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][1][1]['include_conversion_report'] ?? false ), 'native-report-option-forwarded' );
-	$assert( ! array_key_exists( 'include_bfb_report', $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][1][1] ?? array() ), 'native-report-options-do-not-forward-legacy-bfb-option' );
-	$assert( ! array_key_exists( 'bfb_report', is_array( $native_report_compiled ) ? $native_report_compiled : array() ), 'native-report-request-does-not-expose-legacy-bfb-report' );
+	$assert( 2 === count( $GLOBALS['ssi_transformer_adapter_compile_calls'] ), 'plugin-compile-helper-called-for-native-report' );
+	$assert( true === ( $GLOBALS['ssi_transformer_adapter_compile_calls'][1][1]['include_conversion_report'] ?? false ), 'native-report-option-forwarded' );
+	$assert( isset( $native_report_compiled['conversion_report'] ) && is_array( $native_report_compiled['conversion_report'] ), 'native-report-request-exposes-conversion-report' );
 
 	if ( $failures ) {
 		fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Smoke test: BAC visual repair artifacts drive generated theme CSS.
+ * Smoke test: visual repair artifacts drive generated theme CSS.
  *
  * Run from the repository root:
- * php tests/smoke-bac-visual-repair-css.php
+ * php tests/smoke-visual-repair-css.php
  *
  * @package StaticSiteImporter
  */
@@ -93,17 +93,17 @@ $artifacts = array(
 				'schema'  => 'block-artifact-compiler/visual-repair-css/v1',
 				'target'  => 'frontend',
 				'path'    => 'assets/css/visual-repair.css',
-				'content' => "/* Block Artifact Compiler: visual repair artifacts. */\n.wp-block-group.hero-shell { gap: 0; }",
+				'content' => "/* Blocks Engine: visual repair artifacts. */\n.wp-block-group.hero-shell { gap: 0; }",
 			),
 			array(
 				'schema'  => 'block-artifact-compiler/visual-repair-css/v1',
 				'target'  => 'editor',
 				'path'    => 'assets/css/visual-repair-editor.css',
-				'content' => "/* Block Artifact Compiler: editor visual repair artifacts. */\n.editor-styles-wrapper .glow-orb { opacity: 1 !important; }",
+				'content' => "/* Blocks Engine: editor visual repair artifacts. */\n.editor-styles-wrapper .glow-orb { opacity: 1 !important; }",
 			),
 			array(
 				'target'  => 'frontend',
-				'content' => "/* Block Artifact Compiler: visual repair artifacts. */\n.wp-block-group.hero-shell { gap: 0; }",
+				'content' => "/* Blocks Engine: visual repair artifacts. */\n.wp-block-group.hero-shell { gap: 0; }",
 			),
 			array(
 				'target'  => 'unknown',
@@ -116,18 +116,18 @@ $artifacts = array(
 $collector = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'visual_repair_styles_from_artifacts' );
 $styles    = $collector->invoke( null, $artifacts );
 
-$writes     = Static_Site_Importer_Stylesheet_Materializer::stylesheet_writes( '/tmp/bac-visual-repair-smoke', 'BAC Visual Repair Smoke', '.hero-shell{display:grid}', $styles );
-$style_css  = (string) ( $writes['/tmp/bac-visual-repair-smoke/style.css'] ?? '' );
-$editor_css = (string) ( $writes['/tmp/bac-visual-repair-smoke/assets/css/editor-style.css'] ?? '' );
+$writes     = Static_Site_Importer_Stylesheet_Materializer::stylesheet_writes( '/tmp/visual-repair-smoke', 'Visual Repair Smoke', '.hero-shell{display:grid}', $styles );
+$style_css  = (string) ( $writes['/tmp/visual-repair-smoke/style.css'] ?? '' );
+$editor_css = (string) ( $writes['/tmp/visual-repair-smoke/assets/css/editor-style.css'] ?? '' );
 
 $assert( 2 === count( $styles['frontend'] ?? array() ), 'collector-dedupes-frontend-repair-css' );
 $assert( 2 === count( $styles['editor'] ?? array() ), 'collector-reads-editor-repair-css' );
-$assert( str_contains( $style_css, 'Block Artifact Compiler: visual repair artifacts.' ), 'style-includes-bac-frontend-repair-comment', $style_css );
-$assert( str_contains( $style_css, '.wp-block-group.hero-shell { gap: 0; }' ), 'style-includes-bac-frontend-repair-rule', $style_css );
+$assert( str_contains( $style_css, 'Blocks Engine: visual repair artifacts.' ), 'style-includes-frontend-repair-comment', $style_css );
+$assert( str_contains( $style_css, '.wp-block-group.hero-shell { gap: 0; }' ), 'style-includes-frontend-repair-rule', $style_css );
 $assert( str_contains( $style_css, '.compiled-site-repair { display: block; }' ), 'style-includes-compiled-site-repair-css', $style_css );
 $assert( ! str_contains( $style_css, 'editor visual repair artifacts' ), 'style-excludes-editor-repair-css', $style_css );
-$assert( str_contains( $editor_css, 'Block Artifact Compiler: editor visual repair artifacts.' ), 'editor-includes-bac-editor-repair-comment', $editor_css );
-$assert( str_contains( $editor_css, '.editor-styles-wrapper .glow-orb { opacity: 1 !important; }' ), 'editor-includes-bac-editor-repair-rule', $editor_css );
+$assert( str_contains( $editor_css, 'Blocks Engine: editor visual repair artifacts.' ), 'editor-includes-editor-repair-comment', $editor_css );
+$assert( str_contains( $editor_css, '.editor-styles-wrapper .glow-orb { opacity: 1 !important; }' ), 'editor-includes-editor-repair-rule', $editor_css );
 $assert( str_contains( $editor_css, '.compiled-site-repair { display: block; }' ), 'editor-includes-compiled-site-repair-css', $editor_css );
 $assert( ! str_contains( $editor_css, '.should-not-appear' ), 'unknown-target-repair-css-is-ignored', $editor_css );
 
@@ -145,7 +145,7 @@ $assert( $missing_source instanceof WP_Error, 'compiled-site-page-source-is-requ
 $assert( 'static_site_importer_compiled_site_page_missing_source' === ( $missing_source instanceof WP_Error ? $missing_source->get_error_code() : '' ), 'compiled-site-page-source-error-code' );
 
 $template_part_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
-	'/tmp/bac-visual-repair-smoke',
+	'/tmp/visual-repair-smoke',
 	array(
 		'site'           => array(
 			'schema'               => 'blocks-engine/php-transformer/materialization-plan/v1',
@@ -171,12 +171,12 @@ $template_part_result = Static_Site_Importer_Theme_Materializer::template_part_a
 $assert( is_array( $template_part_result ), 'materialization-plan-template-part-writes-succeed' );
 $template_part_writes = is_array( $template_part_result ) ? $template_part_result['writes'] : array();
 $template_part_reports = is_array( $template_part_result ) ? $template_part_result['reports'] : array();
-$assert( str_contains( (string) ( $template_part_writes['/tmp/bac-visual-repair-smoke/parts/header.html'] ?? '' ), 'Plan Header' ), 'materialization-plan-template-part-write-is-used' );
-$assert( ! str_contains( (string) ( $template_part_writes['/tmp/bac-visual-repair-smoke/parts/header.html'] ?? '' ), 'Legacy Header' ), 'legacy-template-part-is-ignored-when-plan-writes-exist' );
+$assert( str_contains( (string) ( $template_part_writes['/tmp/visual-repair-smoke/parts/header.html'] ?? '' ), 'Plan Header' ), 'materialization-plan-template-part-write-is-used' );
+$assert( ! str_contains( (string) ( $template_part_writes['/tmp/visual-repair-smoke/parts/header.html'] ?? '' ), 'Legacy Header' ), 'legacy-template-part-is-ignored-when-plan-writes-exist' );
 $assert( array( 'parts/header.html' ) === ( $template_part_reports[0]['source_paths'] ?? array() ), 'materialization-plan-template-part-source-path-is-reported' );
 
 $navigation_part_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
-	'/tmp/bac-visual-repair-smoke',
+	'/tmp/visual-repair-smoke',
 	array(
 		'site' => array(
 			'schema'     => 'blocks-engine/php-transformer/materialization-plan/v1',
@@ -193,11 +193,11 @@ $navigation_part_result = Static_Site_Importer_Theme_Materializer::template_part
 $assert( is_array( $navigation_part_result ), 'materialization-plan-navigation-rows-succeed' );
 $navigation_part_writes = is_array( $navigation_part_result ) ? $navigation_part_result['writes'] : array();
 $navigation_part_reports = is_array( $navigation_part_result ) ? $navigation_part_result['reports'] : array();
-$assert( str_contains( (string) ( $navigation_part_writes['/tmp/bac-visual-repair-smoke/parts/header.html'] ?? '' ), 'wp:navigation-link' ), 'materialization-plan-navigation-row-is-used-for-header' );
+$assert( str_contains( (string) ( $navigation_part_writes['/tmp/visual-repair-smoke/parts/header.html'] ?? '' ), 'wp:navigation-link' ), 'materialization-plan-navigation-row-is-used-for-header' );
 $assert( array( 'website/index.html#main-nav' ) === ( $navigation_part_reports[0]['source_paths'] ?? array() ), 'materialization-plan-navigation-source-path-is-reported' );
 
 $missing_navigation_content = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
-	'/tmp/bac-visual-repair-smoke',
+	'/tmp/visual-repair-smoke',
 	array(
 		'site' => array(
 			'schema'     => 'blocks-engine/php-transformer/materialization-plan/v1',
@@ -213,7 +213,7 @@ $assert( $missing_navigation_content instanceof WP_Error, 'materialization-plan-
 $assert( 'static_site_importer_materialization_plan_navigation_content_missing' === ( $missing_navigation_content instanceof WP_Error ? $missing_navigation_content->get_error_code() : '' ), 'materialization-plan-navigation-content-error-code' );
 
 $missing_content = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
-	'/tmp/bac-visual-repair-smoke',
+	'/tmp/visual-repair-smoke',
 	array(
 		'site' => array(
 			'schema'               => 'blocks-engine/php-transformer/materialization-plan/v1',
@@ -229,7 +229,7 @@ $missing_content = Static_Site_Importer_Theme_Materializer::template_part_artifa
 $assert( $missing_content instanceof WP_Error, 'materialization-plan-template-part-content-is-required' );
 $assert( 'static_site_importer_materialization_plan_template_part_content_missing' === ( $missing_content instanceof WP_Error ? $missing_content->get_error_code() : '' ), 'materialization-plan-template-part-content-error-code' );
 
-$source_pages = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'bac_document_pages' );
+$source_pages = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'website_artifact_source_pages' );
 $native_pages = $source_pages->invoke(
 	null,
 	array(
@@ -403,4 +403,4 @@ if ( ! empty( $failures ) ) {
 	exit( 1 );
 }
 
-echo 'OK: BAC visual repair CSS smoke passed (' . $assertions . " assertions)\n";
+echo 'OK: visual repair CSS smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -187,7 +187,7 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 	$multi_report    = json_decode( $read( $multi_page_result['report_path'] ), true );
 	$source_docs     = $multi_report['source_documents'] ?? array();
 	$blocks_engine_documents = $source_docs['blocks_engine_documents'] ?? array();
-	$compiled_site   = $multi_report['block_artifact_compiler']['compiled_site'] ?? array();
+	$compiled_site   = $multi_report['blocks_engine']['compiled_site'] ?? array();
 	$block_documents = $multi_report['generated_theme']['block_documents'] ?? array();
 	$template_parts  = $multi_report['generated_theme']['template_parts'] ?? array();
 	$documents_by_source = array();


### PR DESCRIPTION
## Summary
- delete the legacy `include_bfb_report` adapter branch and expose native `conversion_report` data instead
- rename native importer/report internals from BAC/BFB-shaped names to Blocks Engine/source document/materialization terms
- rename visual repair smoke coverage away from BAC wording and update report tests for the `blocks_engine` import report section

## Verification
- `php tests/smoke-transformer-adapter.php`
- `php tests/smoke-export-theme-ability.php`
- `php tests/smoke-visual-repair-css.php`
- `php tests/smoke-website-artifact-document-metadata.php`
- `php -l` on changed PHP files
- `git diff --check`

## Intentional breakages
- `include_bfb_report` no longer produces a `bfb_report` field. Native callers should request/consume `include_conversion_report` and `conversion_report`.
- Import reports now use `blocks_engine` instead of `block_artifact_compiler`.
- Source page type strings and internal helper names use `wordpress_document_artifact` / `website_artifact_source_pages` rather than `bac_document` terminology.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Cleanup implementation, test updates, focused verification, and PR drafting.