### PR TITLE
Require native transformer materialization plans

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -165,6 +165,9 @@ class Static_Site_Importer_Report_Diagnostics {
 		if ( in_array( (string) ( $site['schema'] ?? '' ), array( 'block-artifact-compiler/compiled-site/v1', 'blocks-engine/php-transformer/compiled-site/v1' ), true ) ) {
 			$report['block_artifact_compiler']['compiled_site'] = self::compiled_site_report_payload( $site );
 		}
+		if ( 'blocks-engine/php-transformer/materialization-plan/v1' === (string) ( $site['schema'] ?? '' ) ) {
+			$report['block_artifact_compiler']['materialization_plan'] = self::compiled_site_report_payload( $site );
+		}
 	}
 
 	/**

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -17,8 +17,6 @@ class Static_Site_Importer_Transformer_Adapter {
 	public const WEBSITE_ARTIFACT_SCHEMA = 'block-artifact-compiler/website-artifact/v1';
 	public const COMPILED_RESULT_SCHEMA  = 'block-artifact-compiler/result/v1';
 	private const CONVERSION_REPORT_OPTION = 'include_conversion_report';
-	private const LEGACY_BFB_REPORT_OPTION = 'include_bfb_report';
-	private const LEGACY_BFB_REPORT_FIELD  = 'bfb_report';
 
 	/**
 	 * Check whether the default Blocks Engine artifact compiler is available.
@@ -50,12 +48,11 @@ class Static_Site_Importer_Transformer_Adapter {
 			return new WP_Error( 'static_site_importer_missing_transformer', 'Blocks Engine php-transformer is required to import a website artifact.' );
 		}
 
-		$include_legacy_bfb_report = ! empty( $options[ self::LEGACY_BFB_REPORT_OPTION ] );
-		$options                   = $this->normalize_compile_options( $options );
+		$options = $this->normalize_compile_options( $options );
 		$result = blocks_engine_php_transformer_compile_artifact( $artifact, $options );
 
 		if ( is_array( $result ) ) {
-			return $this->compiled_result_from_transformer_contract( $result, $include_legacy_bfb_report );
+			return $this->compiled_result_from_transformer_contract( $result );
 		}
 
 		return new WP_Error( 'static_site_importer_transformer_compile_failed', 'Blocks Engine php-transformer did not return a compiler result.' );
@@ -64,21 +61,18 @@ class Static_Site_Importer_Transformer_Adapter {
 	/**
 	 * Project the stable transformer contracts into SSI's compiled artifact envelope.
 	 *
-	 * @param array<string,mixed> $result                    TransformerResult::toArray() output.
-	 * @param bool                $include_legacy_bfb_report Whether to expose SSI's legacy bfb_report field.
-	 * @return array<string,mixed>
+	 * @param array<string,mixed> $result TransformerResult::toArray() output.
+	 * @return array<string,mixed>|WP_Error
 	 */
-	private function compiled_result_from_transformer_contract( array $result, bool $include_legacy_bfb_report ): array {
-		$compiled = $this->compiled_result_from_native_transformer_contract( $result, $include_legacy_bfb_report );
-		if ( empty( $compiled['wordpress_artifacts'] ) ) {
-			$compiled = $this->compiled_result_from_legacy_mapping_compatibility( $result );
+	private function compiled_result_from_transformer_contract( array $result ) {
+		$compiled = $this->compiled_result_from_native_transformer_contract( $result );
+		if ( is_wp_error( $compiled ) ) {
+			return $compiled;
 		}
 
 		$source_reports       = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
-		$compiled_site        = isset( $source_reports['compiled_site'] ) && is_array( $source_reports['compiled_site'] ) ? $source_reports['compiled_site'] : array();
 		$materialization_plan = isset( $source_reports['materialization_plan'] ) && is_array( $source_reports['materialization_plan'] ) ? $source_reports['materialization_plan'] : array();
-		$site_report          = ! empty( $materialization_plan ) ? $materialization_plan : $compiled_site;
-		$products             = $this->products_manifest_from_transformer_reports( $result, $site_report );
+		$products             = $this->products_manifest_from_transformer_reports( $result, $materialization_plan );
 		$artifacts            = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
 		$blocks               = isset( $artifacts['blocks'] ) && is_array( $artifacts['blocks'] ) ? $artifacts['blocks'] : array();
 
@@ -86,12 +80,12 @@ class Static_Site_Importer_Transformer_Adapter {
 			$artifacts['block_tree'] = $this->block_tree_report( $blocks );
 		}
 
-		$artifacts['document_metadata'] = $this->document_metadata_from_compiled_site( $site_report );
+		$artifacts['document_metadata'] = $this->document_metadata_from_compiled_site( $materialization_plan );
 		$artifacts['documents']         = isset( $result['documents'] ) && is_array( $result['documents'] ) ? $result['documents'] : array();
-		$artifacts['files']             = $this->artifact_files_from_site_report( $site_report, $result );
-		$artifacts['site']              = $site_report;
-		$artifacts['template_parts']    = isset( $site_report['template_parts'] ) && is_array( $site_report['template_parts'] ) ? $site_report['template_parts'] : array();
-		$artifacts['visual_repair']     = isset( $site_report['visual_repair'] ) && is_array( $site_report['visual_repair'] ) ? $site_report['visual_repair'] : array();
+		$artifacts['files']             = $this->artifact_files_from_site_report( $materialization_plan, $result );
+		$artifacts['site']              = $materialization_plan;
+		$artifacts['template_parts']    = isset( $materialization_plan['template_parts'] ) && is_array( $materialization_plan['template_parts'] ) ? $materialization_plan['template_parts'] : array();
+		$artifacts['visual_repair']     = isset( $materialization_plan['visual_repair'] ) && is_array( $materialization_plan['visual_repair'] ) ? $materialization_plan['visual_repair'] : array();
 
 		$compiled['wordpress_artifacts'] = $artifacts;
 
@@ -105,14 +99,18 @@ class Static_Site_Importer_Transformer_Adapter {
 	/**
 	 * Build SSI's consumed compiler envelope from the native Blocks Engine result.
 	 *
-	 * @param array<string,mixed> $result                    TransformerResult::toArray() output.
-	 * @param bool                $include_legacy_bfb_report Whether to expose SSI's legacy bfb_report field.
-	 * @return array<string,mixed>
+	 * @param array<string,mixed> $result TransformerResult::toArray() output.
+	 * @return array<string,mixed>|WP_Error
 	 */
-	private function compiled_result_from_native_transformer_contract( array $result, bool $include_legacy_bfb_report ): array {
+	private function compiled_result_from_native_transformer_contract( array $result ) {
 		$source_reports = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
 		if ( empty( $source_reports ) ) {
-			return array();
+			return new WP_Error( 'static_site_importer_transformer_missing_source_reports', 'Blocks Engine php-transformer compile results must include source_reports.' );
+		}
+
+		$materialization_plan = isset( $source_reports['materialization_plan'] ) && is_array( $source_reports['materialization_plan'] ) ? $source_reports['materialization_plan'] : array();
+		if ( 'blocks-engine/php-transformer/materialization-plan/v1' !== (string) ( $materialization_plan['schema'] ?? '' ) ) {
+			return new WP_Error( 'static_site_importer_transformer_missing_materialization_plan', 'Blocks Engine php-transformer compile results must include source_reports.materialization_plan.' );
 		}
 
 		$artifact = isset( $source_reports['artifact'] ) && is_array( $source_reports['artifact'] ) ? $source_reports['artifact'] : array();
@@ -132,10 +130,6 @@ class Static_Site_Importer_Transformer_Adapter {
 			'provenance'          => isset( $result['provenance'] ) && is_array( $result['provenance'] ) ? $result['provenance'] : array(),
 		);
 
-		if ( $include_legacy_bfb_report ) {
-			$compiled[ self::LEGACY_BFB_REPORT_FIELD ] = $this->legacy_conversion_report_from_native_report( $result );
-		}
-
 		return $compiled;
 	}
 
@@ -146,59 +140,11 @@ class Static_Site_Importer_Transformer_Adapter {
 	 * @return array<string,mixed>
 	 */
 	private function normalize_compile_options( array $options ): array {
-		$include_report = ! empty( $options[ self::CONVERSION_REPORT_OPTION ] ) || ! empty( $options[ self::LEGACY_BFB_REPORT_OPTION ] );
-		unset( $options[ self::LEGACY_BFB_REPORT_OPTION ] );
-
-		if ( $include_report ) {
+		if ( ! empty( $options[ self::CONVERSION_REPORT_OPTION ] ) ) {
 			$options[ self::CONVERSION_REPORT_OPTION ] = true;
 		}
 
 		return $options;
-	}
-
-	/**
-	 * Preserve SSI's legacy report field from the native Blocks Engine conversion report.
-	 *
-	 * @param array<string,mixed> $result TransformerResult::toArray() output.
-	 * @return array<string,mixed>
-	 */
-	private function legacy_conversion_report_from_native_report( array $result ): array {
-		$report = isset( $result['conversion_report'] ) && is_array( $result['conversion_report'] ) ? $result['conversion_report'] : array();
-
-		return array(
-			'status'            => isset( $report['status'] ) && is_scalar( $report['status'] ) ? (string) $report['status'] : 'failed',
-			'serialized_blocks' => isset( $report['serialized_blocks'] ) && is_scalar( $report['serialized_blocks'] ) ? (string) $report['serialized_blocks'] : '',
-			'diagnostics'       => isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array(),
-			'fallbacks'         => isset( $report['fallbacks'] ) && is_array( $report['fallbacks'] ) ? $report['fallbacks'] : array(),
-		);
-	}
-
-	/**
-	 * Project pre-source_reports transformer output through the legacy BAC-shaped map.
-	 *
-	 * Native Blocks Engine source_reports are the importer contract. This compatibility
-	 * path exists only for older transformer results that did not expose that contract.
-	 *
-	 * @param array<string,mixed> $result TransformerResult::toArray() output.
-	 * @return array<string,mixed>
-	 */
-	private function compiled_result_from_legacy_mapping_compatibility( array $result ): array {
-		$mapping   = isset( $result['legacy_mapping'][ self::COMPILED_RESULT_SCHEMA ] ) && is_array( $result['legacy_mapping'][ self::COMPILED_RESULT_SCHEMA ] ) ? $result['legacy_mapping'][ self::COMPILED_RESULT_SCHEMA ] : array();
-		$projected = array( 'schema' => self::COMPILED_RESULT_SCHEMA );
-
-		foreach ( $mapping as $target_path => $source_path ) {
-			if ( ! is_string( $target_path ) || ! is_string( $source_path ) ) {
-				continue;
-			}
-
-			$found = false;
-			$value = $this->array_path_get( $result, $source_path, $found );
-			if ( $found ) {
-				$this->array_path_set( $projected, $target_path, $value );
-			}
-		}
-
-		return $projected;
 	}
 
 	/**
@@ -231,55 +177,6 @@ class Static_Site_Importer_Transformer_Adapter {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Read a dot-notated array path.
-	 *
-	 * @param array<string,mixed> $data  Source data.
-	 * @param string              $path  Dot-notated path.
-	 * @param bool                $found Whether the path exists.
-	 * @return mixed
-	 */
-	private function array_path_get( array $data, string $path, bool &$found ) {
-		$value = $data;
-		foreach ( explode( '.', $path ) as $part ) {
-			if ( ! is_array( $value ) || ! array_key_exists( $part, $value ) ) {
-				$found = false;
-				return null;
-			}
-
-			$value = $value[ $part ];
-		}
-
-		$found = true;
-		return $value;
-	}
-
-	/**
-	 * Write a dot-notated array path.
-	 *
-	 * @param array<string,mixed> $data  Target data.
-	 * @param string              $path  Dot-notated path.
-	 * @param mixed               $value Value to set.
-	 * @return void
-	 */
-	private function array_path_set( array &$data, string $path, $value ): void {
-		$cursor = &$data;
-		$parts  = explode( '.', $path );
-		$last   = array_pop( $parts );
-
-		foreach ( $parts as $part ) {
-			if ( ! isset( $cursor[ $part ] ) || ! is_array( $cursor[ $part ] ) ) {
-				$cursor[ $part ] = array();
-			}
-
-			$cursor = &$cursor[ $part ];
-		}
-
-		if ( null !== $last ) {
-			$cursor[ $last ] = $value;
-		}
 	}
 
 	/**

--- a/tests/smoke-generated-theme-block-validation.cjs
+++ b/tests/smoke-generated-theme-block-validation.cjs
@@ -256,7 +256,7 @@ function reportResult( result ) {
 }
 
 function printSummary( label, summary ) {
-  const entries = Object.entries( summary );
+  const entries = Object.entries( summary || {} );
   if ( ! entries.length ) {
     return;
   }

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -11,6 +11,9 @@
 namespace {
 	function blocks_engine_php_transformer_compile_artifact( array $artifact, array $options = array() ): array {
 		$GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][] = array( $artifact, $options );
+		if ( isset( $GLOBALS['ssi_transformer_adapter_result_override'] ) && is_array( $GLOBALS['ssi_transformer_adapter_result_override'] ) ) {
+			return $GLOBALS['ssi_transformer_adapter_result_override'];
+		}
 
 		return array(
 						'schema'            => 'blocks-engine/php-transformer/result/v1',
@@ -33,47 +36,6 @@ namespace {
 								'files_by_role'   => array( 'document' => 2, 'stylesheet' => 1 ),
 								'files_by_mime'   => array( 'text/html' => 2, 'text/css' => 1 ),
 								'source_hash'     => 'abc123',
-							),
-							'compiled_site' => array(
-								'schema'      => 'blocks-engine/php-transformer/compiled-site/v1',
-								'source_hash' => 'abc123',
-								'entry_path'  => 'website/index.html',
-								'pages'       => array(
-									array(
-										'source_path'  => 'website/index.html',
-										'entrypoint'   => true,
-										'slug'         => 'index',
-										'title'        => 'Home Page',
-										'block_markup' => '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->',
-									),
-									array(
-										'source_path' => 'website/menu.html',
-										'entrypoint'  => false,
-										'slug'        => 'menu',
-										'title'       => 'Menu Page',
-									),
-									array(
-										'source_path' => 'content/about.md',
-										'entrypoint'  => false,
-										'slug'        => 'about',
-										'title'       => 'About',
-									),
-									array(
-										'source_path'    => 'products/rye-loaf.md',
-										'entrypoint'     => false,
-										'post_type'      => 'product',
-										'slug'           => 'rye-loaf',
-										'title'          => 'Rye Loaf',
-										'regular_price'  => '12',
-										'categories'     => array( 'Bread' ),
-									),
-								),
-								'assets'      => array(
-									array( 'path' => 'assets/site.css', 'role' => 'stylesheet' ),
-								),
-								'theme'       => array(
-									'stylesheets' => array( 'assets/site.css' ),
-								),
 							),
 							'materialization_plan' => array(
 								'schema'      => 'blocks-engine/php-transformer/materialization-plan/v1',
@@ -169,18 +131,6 @@ namespace {
 								'count'  => 1,
 							),
 						),
-						'legacy_mapping'    => array(
-							'block-artifact-compiler/result/v1' => array(
-								'wordpress_artifacts.site.pages.0.slug' => 'legacy.slug',
-								'wordpress_artifacts.documents.0.source_path' => 'legacy.documents.0.source_path',
-							),
-						),
-						'legacy'            => array(
-							'slug'      => 'legacy-home',
-							'documents' => array(
-								array( 'source_path' => 'legacy/about.html' ),
-							),
-						),
 						'provenance'        => array(
 							array( 'source_hash' => 'abc123' ),
 						),
@@ -253,7 +203,7 @@ namespace {
 	$assert( 'html' === ( $GLOBALS['ssi_transformer_adapter_format_bridge_calls'][0][2] ?? '' ), 'format-bridge-to-format' );
 	$assert( 'smoke' === ( $GLOBALS['ssi_transformer_adapter_format_bridge_calls'][0][3]['source'] ?? '' ), 'format-bridge-options-forwarded' );
 
-	$compiled  = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ), array( 'include_bfb_report' => true ) );
+	$compiled  = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ), array( 'include_conversion_report' => true ) );
 	$artifacts = $compiled['wordpress_artifacts'] ?? array();
 	$site      = $artifacts['site'] ?? array();
 	$pages     = $site['pages'] ?? array();
@@ -262,25 +212,16 @@ namespace {
 	$assert( ! is_wp_error( $compiled ), 'native-compile-succeeds' );
 	$assert( 1 === count( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'] ), 'plugin-artifact-helper-called' );
 	$assert( true === ( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][0][1]['include_conversion_report'] ?? false ), 'compile-options-forwarded-as-native-report-request' );
-	$assert( ! array_key_exists( 'include_bfb_report', $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][0][1] ?? array() ), 'legacy-bfb-option-is-isolated' );
 	$assert( 'block-artifact-compiler/result/v1' === ( $compiled['schema'] ?? '' ), 'native-result-mapped-to-bac-envelope' );
-	$assert( 'success' === ( $compiled['bfb_report']['status'] ?? '' ), 'legacy-bfb-report-shape-preserved' );
-	$assert( '<!-- wp:paragraph --><p>Native report Home</p><!-- /wp:paragraph -->' === ( $compiled['bfb_report']['serialized_blocks'] ?? '' ), 'legacy-bfb-report-uses-native-report-serialized-blocks' );
-	$assert( 'native_report_diagnostic' === ( $compiled['bfb_report']['diagnostics'][0]['code'] ?? '' ), 'legacy-bfb-report-uses-native-report-diagnostics' );
-	$assert( 'native-conversion-report' === ( $compiled['bfb_report']['fallbacks'][0]['source'] ?? '' ), 'legacy-bfb-report-uses-native-report-fallbacks' );
-	$assert( 'legacy_top_level_diagnostic' !== ( $compiled['bfb_report']['diagnostics'][0]['code'] ?? '' ), 'legacy-bfb-report-ignores-top-level-diagnostics' );
-	$assert( 'legacy-top-level' !== ( $compiled['bfb_report']['fallbacks'][0]['source'] ?? '' ), 'legacy-bfb-report-ignores-top-level-fallbacks' );
 	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'native-artifact-report-preserved-as-input' );
 	$assert( 'blocks-engine/php-transformer/materialization-plan/v1' === ( $site['schema'] ?? '' ), 'native-materialization-plan-contract-is-used' );
-	$assert( 4 === count( $pages ), 'native-keeps-compiled-site-pages-without-adapter-filtering' );
+	$assert( 4 === count( $pages ), 'native-keeps-materialization-plan-pages-without-adapter-filtering' );
 	$assert( 'website/index.html' === ( $pages[0]['source_path'] ?? '' ), 'native-entry-source-path' );
 	$assert( 'home-canonical' === ( $pages[0]['slug'] ?? '' ), 'native-entry-slug-from-materialization-plan' );
-	$assert( 'legacy-home' !== ( $pages[0]['slug'] ?? '' ), 'legacy-mapping-does-not-override-native-materialization-plan' );
 	$assert( true === ( $pages[0]['entrypoint'] ?? false ), 'native-entrypoint' );
 	$assert( 'about-canonical' === ( $pages[2]['slug'] ?? '' ), 'native-route-slug-from-materialization-plan' );
-	$assert( 1 === count( $documents ), 'native-documents-preserve-transformer-documents-without-compiled-site-synthesis' );
+	$assert( 1 === count( $documents ), 'native-documents-preserve-transformer-documents-without-site-report-synthesis' );
 	$assert( 'content/about.md' === ( $documents[0]['source_path'] ?? '' ), 'native-document-from-transformer-documents' );
-	$assert( 'legacy/about.html' !== ( $documents[0]['source_path'] ?? '' ), 'legacy-mapping-does-not-override-native-documents' );
 	$assert( 'assets/native-site.css' === ( $artifacts['files'][0]['path'] ?? '' ), 'native-materialization-plan-assets-drive-artifact-files' );
 	$assert( 'assets/legacy-site.css' !== ( $artifacts['files'][0]['path'] ?? '' ), 'legacy-assets-do-not-override-native-materialization-plan-assets' );
 	$assert( 'rye-loaf-canonical' === ( $products[0]['slug'] ?? '' ), 'native-product-slug-mapped-from-generic-report' );
@@ -291,8 +232,18 @@ namespace {
 	$assert( ! is_wp_error( $native_report_compiled ), 'native-report-compile-succeeds' );
 	$assert( 2 === count( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'] ), 'plugin-artifact-helper-called-for-native-report' );
 	$assert( true === ( $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][1][1]['include_conversion_report'] ?? false ), 'native-report-option-forwarded' );
-	$assert( ! array_key_exists( 'include_bfb_report', $GLOBALS['ssi_transformer_adapter_artifact_compiler_calls'][1][1] ?? array() ), 'native-report-options-do-not-forward-legacy-bfb-option' );
-	$assert( ! array_key_exists( 'bfb_report', is_array( $native_report_compiled ) ? $native_report_compiled : array() ), 'native-report-request-does-not-expose-legacy-bfb-report' );
+
+	$GLOBALS['ssi_transformer_adapter_result_override'] = array(
+		'schema' => 'blocks-engine/php-transformer/result/v1',
+		'status' => 'success',
+		'source_reports' => array(
+			'artifact' => array( 'entry_path' => 'website/index.html' ),
+		),
+	);
+	$missing_plan = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ) );
+	unset( $GLOBALS['ssi_transformer_adapter_result_override'] );
+	$assert( is_wp_error( $missing_plan ), 'missing-materialization-plan-errors' );
+	$assert( 'static_site_importer_transformer_missing_materialization_plan' === ( is_wp_error( $missing_plan ) ? $missing_plan->get_error_code() : '' ), 'missing-materialization-plan-error-code' );
 
 	if ( $failures ) {
 		fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -14,6 +14,135 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $plugin_root = dirname( __DIR__ );
 
+if ( ! function_exists( 'blocks_engine_php_transformer_compile_artifact' ) ) {
+	function blocks_engine_php_transformer_compile_artifact( array $artifact, array $options = array() ): array {
+		$files       = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
+		$entry_path  = isset( $artifact['entrypoint'] ) && is_scalar( $artifact['entrypoint'] ) ? (string) $artifact['entrypoint'] : '';
+		$html_files  = array();
+		$asset_files = array();
+
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) || ! isset( $file['path'] ) || ! is_scalar( $file['path'] ) ) {
+				continue;
+			}
+
+			$path = (string) $file['path'];
+			if ( '' === $entry_path && str_ends_with( $path, '.html' ) ) {
+				$entry_path = $path;
+			}
+
+			if ( str_ends_with( $path, '.html' ) ) {
+				$html_files[] = $file;
+			} else {
+				$asset_files[] = $file;
+			}
+		}
+
+		$pages = array();
+		foreach ( $html_files as $file ) {
+			$path       = (string) $file['path'];
+			$html       = isset( $file['content'] ) && is_scalar( $file['content'] ) ? (string) $file['content'] : '';
+			$is_entry   = $path === $entry_path;
+			$slug       = static_site_importer_document_metadata_smoke_slug( $path, $is_entry );
+			$title      = static_site_importer_document_metadata_smoke_title( $html, $slug );
+			$pages[]    = array(
+				'source_path'  => $path,
+				'entrypoint'   => $is_entry,
+				'post_type'    => 'page',
+				'slug'         => $slug,
+				'title'        => $title,
+				'html'         => $html,
+				'block_markup' => static_site_importer_document_metadata_smoke_block_markup( $html, $path ),
+			);
+		}
+
+		$assets = array();
+		foreach ( $asset_files as $file ) {
+			$path = (string) $file['path'];
+			$assets[] = array(
+				'path'    => $path,
+				'role'    => str_ends_with( $path, '.css' ) ? 'stylesheet' : 'asset',
+				'content' => isset( $file['content'] ) && is_scalar( $file['content'] ) ? (string) $file['content'] : '',
+			);
+		}
+
+		$materialization_plan = array(
+			'schema'      => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'entry_path'  => $entry_path,
+			'page_count'  => count( $pages ),
+			'pages'       => $pages,
+			'assets'      => $assets,
+			'theme'       => array(
+				'stylesheets' => array_values(
+					array_map(
+						static fn ( array $asset ): string => (string) $asset['path'],
+						array_filter( $assets, static fn ( array $asset ): bool => 'stylesheet' === ( $asset['role'] ?? '' ) )
+					)
+				),
+			),
+		);
+
+		return array(
+			'schema'            => 'blocks-engine/php-transformer/result/v1',
+			'status'            => 'success',
+			'source_reports'    => array(
+				'artifact'              => array(
+					'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+					'entry_path' => $entry_path,
+				),
+				'materialization_plan' => $materialization_plan,
+			),
+			'blocks'            => array(),
+			'block_types'       => array(),
+			'components'        => array(),
+			'serialized_blocks' => isset( $pages[0]['block_markup'] ) ? (string) $pages[0]['block_markup'] : '',
+			'assets'            => $assets,
+			'diagnostics'       => array(),
+			'provenance'        => array( 'source' => $entry_path ),
+		);
+	}
+
+	function static_site_importer_document_metadata_smoke_slug( string $path, bool $is_entry ): string {
+		$basename = preg_replace( '/\.html$/', '', basename( $path ) );
+		if ( $is_entry && 'index' === $basename ) {
+			return 'home';
+		}
+
+		return sanitize_title( (string) $basename );
+	}
+
+	function static_site_importer_document_metadata_smoke_title( string $html, string $slug ): string {
+		if ( preg_match( '/<title[^>]*>(.*?)<\/title>/is', $html, $matches ) ) {
+			return html_entity_decode( trim( wp_strip_all_tags( $matches[1] ) ), ENT_QUOTES, 'UTF-8' );
+		}
+		if ( preg_match( '/<h1[^>]*>(.*?)<\/h1>/is', $html, $matches ) ) {
+			return html_entity_decode( trim( wp_strip_all_tags( $matches[1] ) ), ENT_QUOTES, 'UTF-8' );
+		}
+
+		return ucwords( str_replace( '-', ' ', $slug ) );
+	}
+
+	function static_site_importer_document_metadata_smoke_block_markup( string $html, string $path ): string {
+		$body = preg_match( '/<body[^>]*>(.*?)<\/body>/is', $html, $matches ) ? (string) $matches[1] : $html;
+		if ( str_contains( $body, 'Fire, flour, patience.' ) ) {
+			return '<!-- wp:heading --><h2 class="wp-block-heading">Fire, flour, patience.</h2><!-- /wp:heading -->' .
+				'<!-- wp:paragraph --><p>Small-batch loaves.</p><!-- /wp:paragraph -->' .
+				'<!-- wp:image --><figure class="wp-block-image"><img src="assets/logo.svg" alt="Bakery mark"/></figure><!-- /wp:image -->';
+		}
+		if ( str_contains( $body, '<h1>Home</h1>' ) ) {
+			return '<!-- wp:heading --><h2 class="wp-block-heading">Home</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Welcome.</p><!-- /wp:paragraph -->';
+		}
+		if ( str_contains( $body, '<h1>Menu</h1>' ) ) {
+			return '<!-- wp:heading --><h2 class="wp-block-heading">Menu</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Pizza and small plates.</p><!-- /wp:paragraph -->';
+		}
+		if ( str_contains( $body, '<h1>Contact</h1>' ) ) {
+			return '<!-- wp:heading --><h2 class="wp-block-heading">Contact</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Email us.</p><!-- /wp:paragraph -->';
+		}
+
+		return '<!-- wp:paragraph --><p>' . esc_html( static_site_importer_document_metadata_smoke_title( $html, $path ) ) . '</p><!-- /wp:paragraph -->';
+	}
+}
+
 if ( ! defined( 'STATIC_SITE_IMPORTER_PATH' ) && is_readable( $plugin_root . '/static-site-importer.php' ) ) {
 	require_once $plugin_root . '/static-site-importer.php';
 }
@@ -124,8 +253,8 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( true === ( $scripts[0]['defer'] ?? false ), 'script-defer-is-preserved-in-document-metadata' );
 	$style        = $read( $theme_dir . '/style.css' );
 	$editor_style = $read( $theme_dir . '/assets/css/editor-style.css' );
-	$assert( str_contains( $style, '.contact-actions .btn-ghost' ), 'style-includes-generic-compiled-site-css', $style );
-	$assert( str_contains( $editor_style, '.contact-actions .btn-ghost' ), 'editor-includes-generic-compiled-site-css', $editor_style );
+	$assert( str_contains( $style, '.contact-actions .btn-ghost' ), 'style-includes-materialization-plan-css', $style );
+	$assert( str_contains( $editor_style, '.contact-actions .btn-ghost' ), 'editor-includes-materialization-plan-css', $editor_style );
 }
 
 $missing_template_parts_result = Static_Site_Importer_Theme_Generator::import_website_artifact(
@@ -187,7 +316,7 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 	$multi_report    = json_decode( $read( $multi_page_result['report_path'] ), true );
 	$source_docs     = $multi_report['source_documents'] ?? array();
 	$blocks_engine_documents = $source_docs['blocks_engine_documents'] ?? array();
-	$compiled_site   = $multi_report['block_artifact_compiler']['compiled_site'] ?? array();
+	$materialization_plan = $multi_report['block_artifact_compiler']['materialization_plan'] ?? array();
 	$block_documents = $multi_report['generated_theme']['block_documents'] ?? array();
 	$template_parts  = $multi_report['generated_theme']['template_parts'] ?? array();
 	$documents_by_source = array();
@@ -215,9 +344,9 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 	$assert( str_ends_with( (string) ( $documents_by_source['website/index.html']['permalink'] ?? '' ), '/' ), 'entry-index-has-front-page-permalink' );
 	$assert( 'menu' === ( $documents_by_source['website/menu.html']['slug'] ?? '' ), 'menu-page-materializes' );
 	$assert( 'contact' === ( $documents_by_source['website/contact.html']['slug'] ?? '' ), 'contact-page-materializes' );
-	$assert( 'blocks-engine/php-transformer/compiled-site/v1' === ( $compiled_site['schema'] ?? '' ), 'compiled-site-contract-is-recorded' );
-	$assert( 3 === ( $compiled_site['page_count'] ?? null ), 'compiled-site-page-count-is-recorded' );
-	$assert( '' === ( $compiled_site['pages'][1]['route_key'] ?? '' ), 'compiled-site-route-key-preserves-transformer-contract' );
+	$assert( 'blocks-engine/php-transformer/materialization-plan/v1' === ( $materialization_plan['schema'] ?? '' ), 'materialization-plan-contract-is-recorded' );
+	$assert( 3 === ( $materialization_plan['page_count'] ?? null ), 'materialization-plan-page-count-is-recorded' );
+	$assert( '' === ( $materialization_plan['pages'][1]['route_key'] ?? '' ), 'materialization-plan-route-key-preserves-transformer-contract' );
 	$assert( isset( $template_parts_by_path['parts/header.html'] ), 'multi-page-header-template-part-is-recorded' );
 	$assert( true === ( $template_parts_by_path['parts/header.html']['generated'] ?? null ), 'multi-page-header-template-part-is-generated-by-ssi' );
 	$assert( ! isset( $template_parts_by_path['parts/footer.html'] ), 'multi-page-does-not-synthesize-footer-template-part' );

--- a/tests/smoke-website-artifact-products-manifest.php
+++ b/tests/smoke-website-artifact-products-manifest.php
@@ -19,8 +19,8 @@ namespace {
 					'entry_path'  => 'website/index.html',
 					'source_hash' => 'products-smoke',
 				),
-				'compiled_site' => array(
-					'schema'   => 'blocks-engine/php-transformer/compiled-site/v1',
+				'materialization_plan' => array(
+					'schema'   => 'blocks-engine/php-transformer/materialization-plan/v1',
 					'products' => array(
 						array(
 							'post_type'      => 'product',
@@ -115,7 +115,7 @@ namespace {
 	$assert( ! is_wp_error( $compiled ), 'compile-succeeds', is_wp_error( $compiled ) ? $compiled->get_error_message() : '' );
 	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'preserves-native-artifact-input' );
 	$assert( 3 === count( $products ), 'maps-unique-product-reports' );
-	$assert( 'rye-loaf' === ( $products[0]['slug'] ?? '' ), 'maps-compiled-site-product-slug' );
+	$assert( 'rye-loaf' === ( $products[0]['slug'] ?? '' ), 'maps-materialization-plan-product-slug' );
 	$assert( 'Rye Loaf' === ( $products[0]['name'] ?? '' ), 'maps-title-to-name' );
 	$assert( '12.00' === ( $products[0]['regular_price'] ?? '' ), 'normalizes-price' );
 	$assert( array( 'Bread' ) === ( $products[0]['categories'] ?? array() ), 'filters-categories-to-strings' );


### PR DESCRIPTION
## Summary
- Remove SSI transformer adapter support for legacy_mapping projection and legacy bfb_report output.
- Require native Blocks Engine compile results to include source_reports.materialization_plan, returning clear WP_Error failures when native contracts are missing.
- Update adapter/import smokes to use native materialization-plan fixtures and record materialization_plan diagnostics.
- Keep JS block validation failure reporting controlled when summary fields are absent.

## Intentional breakages
- Transformer results without source_reports now fail with static_site_importer_transformer_missing_source_reports.
- Transformer results without source_reports.materialization_plan now fail with static_site_importer_transformer_missing_materialization_plan.
- include_bfb_report no longer maps or exposes a bfb_report compatibility field.
- legacy_mapping BAC-shaped projection is no longer honored.

## Verification
- php tests/smoke-transformer-adapter.php
- php tests/smoke-website-artifact-products-manifest.php
- php tests/smoke-url-import-runtime.php
- php tests/smoke-website-artifact-document-metadata.php
- php tests/smoke-bac-visual-repair-css.php
- php tests/smoke-export-theme-ability.php
- npm run test:validation -- --skip-import /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead
- npm run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Cleanup implementation, smoke test updates, verification, and PR drafting.