### PR TITLE
Honor hard materialization plan report contract

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -166,7 +166,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			$report['blocks_engine']['compiled_site'] = self::compiled_site_report_payload( $site );
 		}
 		if ( 'blocks-engine/php-transformer/materialization-plan/v1' === (string) ( $site['schema'] ?? '' ) ) {
-			$report['block_artifact_compiler']['materialization_plan'] = self::compiled_site_report_payload( $site );
+			$report['blocks_engine']['materialization_plan'] = self::compiled_site_report_payload( $site );
 		}
 	}
 
@@ -203,7 +203,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$report['diagnostics'][] = array(
 			'type'        => 'website_artifact_materialization_contract_note',
 			'source'      => '' !== $source ? $source : 'website_artifact',
-			'message'     => 'Direct materialization consumed block_markup, documents, files, and compiled-site artifacts. Static Site Importer owns WordPress writes and product seeding while Blocks Engine owns materializer-neutral site/theme compilation.',
+			'message'     => 'Direct materialization consumed block_markup, documents, files, and materialization-plan artifacts. Static Site Importer owns WordPress writes and product seeding while Blocks Engine owns materializer-neutral site/theme compilation.',
 			'contract'    => 'block-artifact-compiler/result/v1',
 			'constraints' => 'report_only',
 		);

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -8,6 +8,8 @@
 
 const path = require( 'node:path' );
 const process = require( 'node:process' );
+const fs = require( 'node:fs' );
+const os = require( 'node:os' );
 const { spawnSync } = require( 'node:child_process' );
 
 const repoRoot = path.resolve( __dirname, '..' );
@@ -24,6 +26,7 @@ const themeDir = path.resolve(
     '/Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead'
 );
 const fixture = path.join( repoRoot, 'tests/fixtures/wordpress-is-dead/index.html' );
+const importFixture = skipImport ? fixture : prepareImportFixture( fixture );
 
 const steps = [
   {
@@ -47,9 +50,9 @@ const steps = [
     ],
   },
   {
-    name: 'BAC visual repair CSS smoke',
+    name: 'Visual repair CSS smoke',
     command: 'php',
-    args: [ path.join( repoRoot, 'tests/smoke-bac-visual-repair-css.php' ) ],
+    args: [ path.join( repoRoot, 'tests/smoke-visual-repair-css.php' ) ],
   },
   {
     name: 'Export theme ability smoke',
@@ -68,7 +71,7 @@ const steps = [
       ...wpCli.slice( 1 ),
       'static-site-importer',
       'import-theme',
-      fixture,
+      importFixture,
       '--slug=wordpress-is-dead',
       '--name=WordPress Is Dead',
       '--activate',
@@ -139,4 +142,14 @@ function finish( ok, stepResults ) {
 
 function splitCommand( command ) {
   return command.trim().split( /\s+/ ).filter( Boolean );
+}
+
+function prepareImportFixture( entryFile ) {
+  const sourceDir = path.dirname( entryFile );
+  const tempDir = fs.mkdtempSync( path.join( os.tmpdir(), 'static-site-importer-validation-' ) );
+  const fixtureDir = path.join( tempDir, path.basename( sourceDir ) );
+
+  fs.cpSync( sourceDir, fixtureDir, { recursive: true } );
+
+  return path.join( fixtureDir, path.basename( entryFile ) );
 }


### PR DESCRIPTION
## Summary
- Record native Blocks Engine materialization plans under `blocks_engine.materialization_plan` instead of the deleted legacy report bucket.
- Update the full validation harness to run the renamed visual repair CSS smoke.
- Import the tracked `wordpress-is-dead` fixture from a temporary copy so normal source cleanup cannot delete repository fixtures.

## Verification
- `npm run test:validation -- --json`
- `studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer eval-file /Users/chubes/Developer/static-site-importer@cook-ssi-hard-contract-e2e-fixups/tests/smoke-website-artifact-document-metadata.php`
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@cook-ssi-hard-contract-e2e-fixups`

## Notes
- The full validation harness covers transformer adapter projection, products manifest handling, document metadata, visual repair CSS, export ability, URL runtime, fixture import/activation, route/link materialization, and generated theme JS block validation.
- A later malformed PR-create command accidentally triggered a separate Homeboy run with shell-substituted body text; that failed on external Playground metadata fetch timeout and is not the verification run listed above.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Diagnosing hard-contract validation failures, editing the importer report path and validation harness, and running local/Homeboy verification.
