### PR TITLE
Clean SSI transformer contract surface

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -152,7 +152,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return void
 	 */
 	public static function record_blocks_engine_result( array &$report, array $compiled ): void {
-		$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$artifacts = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
 		$site      = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
 		$report['blocks_engine']['available']        = true;
 		$report['blocks_engine']['website_artifact'] = array(
@@ -166,7 +166,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			$report['blocks_engine']['compiled_site'] = self::compiled_site_report_payload( $site );
 		}
 		if ( 'blocks-engine/php-transformer/materialization-plan/v1' === (string) ( $site['schema'] ?? '' ) ) {
-			$report['block_artifact_compiler']['materialization_plan'] = self::compiled_site_report_payload( $site );
+			$report['blocks_engine']['materialization_plan'] = self::compiled_site_report_payload( $site );
 		}
 	}
 
@@ -178,7 +178,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return void
 	 */
 	public static function record_direct_website_artifact_source_summary( array &$report, array $compiled ): void {
-		$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$artifacts = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
 		$files     = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
 		$source    = (string) ( $compiled['provenance']['source'] ?? ( $compiled['input']['entry_path'] ?? 'website_artifact' ) );
 
@@ -204,7 +204,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'type'        => 'website_artifact_materialization_contract_note',
 			'source'      => '' !== $source ? $source : 'website_artifact',
 			'message'     => 'Direct materialization consumed block_markup, documents, files, and compiled-site artifacts. Static Site Importer owns WordPress writes and product seeding while Blocks Engine owns materializer-neutral site/theme compilation.',
-			'contract'    => 'block-artifact-compiler/result/v1',
+			'contract'    => isset( $compiled['schema'] ) && is_scalar( $compiled['schema'] ) ? (string) $compiled['schema'] : 'blocks-engine/php-transformer/result/v1',
 			'constraints' => 'report_only',
 		);
 	}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -78,7 +78,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * @return array<string,mixed>|WP_Error
 	 */
 	private static function import_compiled_website_artifact( array $compiled, array $args = array() ) {
-		$artifacts    = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$artifacts    = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
 		$theme_name   = isset( $args['name'] ) && '' !== trim( (string) $args['name'] ) ? sanitize_text_field( (string) $args['name'] ) : 'Imported Website Artifact';
 		$theme_slug   = isset( $args['slug'] ) && '' !== trim( (string) $args['slug'] ) ? sanitize_title( (string) $args['slug'] ) : sanitize_title( $theme_name );
 		if ( '' === $theme_slug ) {
@@ -1028,14 +1028,14 @@ class Static_Site_Importer_Theme_Generator {
 	 * Normalize website artifact document rows into source pages.
 	 *
 	 * SSI consumes the compiled-site page contract when available, then attaches
-	 * the referenced `wordpress_artifacts.documents[]` block markup for WordPress
+	 * the referenced `artifacts.documents[]` block markup for WordPress
 	 * materialization.
 	 *
 	 * @param array<string,mixed> $compiled Compiler result envelope.
 	 * @return array<string, Static_Site_Importer_Source_Page>|WP_Error
 	 */
 	private static function website_artifact_source_pages( array $compiled ) {
-		$artifacts = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$artifacts = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
 		$documents = isset( $artifacts['documents'] ) && is_array( $artifacts['documents'] ) ? $artifacts['documents'] : array();
 		$site      = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
 		if ( ! empty( $site['pages'] ) && is_array( $site['pages'] ) ) {

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Static_Site_Importer_Transformer_Adapter {
 
 	public const WEBSITE_ARTIFACT_SCHEMA = 'block-artifact-compiler/website-artifact/v1';
-	public const COMPILED_RESULT_SCHEMA  = 'block-artifact-compiler/result/v1';
+	public const TRANSFORMER_RESULT_SCHEMA = 'blocks-engine/php-transformer/result/v1';
 	private const CONVERSION_REPORT_OPTION = 'include_conversion_report';
 
 	/**
@@ -73,7 +73,7 @@ class Static_Site_Importer_Transformer_Adapter {
 		$source_reports       = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
 		$materialization_plan = isset( $source_reports['materialization_plan'] ) && is_array( $source_reports['materialization_plan'] ) ? $source_reports['materialization_plan'] : array();
 		$products             = $this->products_manifest_from_transformer_reports( $result, $materialization_plan );
-		$artifacts            = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$artifacts            = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
 		$blocks               = isset( $artifacts['blocks'] ) && is_array( $artifacts['blocks'] ) ? $artifacts['blocks'] : array();
 
 		if ( ! isset( $artifacts['block_tree'] ) ) {
@@ -87,7 +87,7 @@ class Static_Site_Importer_Transformer_Adapter {
 		$artifacts['template_parts']    = isset( $materialization_plan['template_parts'] ) && is_array( $materialization_plan['template_parts'] ) ? $materialization_plan['template_parts'] : array();
 		$artifacts['visual_repair']     = isset( $materialization_plan['visual_repair'] ) && is_array( $materialization_plan['visual_repair'] ) ? $materialization_plan['visual_repair'] : array();
 
-		$compiled['wordpress_artifacts'] = $artifacts;
+		$compiled['artifacts'] = $artifacts;
 
 		if ( ! empty( $products ) ) {
 			$compiled['products_manifest'] = $products;
@@ -116,10 +116,10 @@ class Static_Site_Importer_Transformer_Adapter {
 		$artifact = isset( $source_reports['artifact'] ) && is_array( $source_reports['artifact'] ) ? $source_reports['artifact'] : array();
 
 		$compiled = array(
-			'schema'              => self::COMPILED_RESULT_SCHEMA,
+			'schema'              => isset( $result['schema'] ) && is_scalar( $result['schema'] ) ? (string) $result['schema'] : self::TRANSFORMER_RESULT_SCHEMA,
 			'status'              => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : '',
 			'input'               => $artifact,
-			'wordpress_artifacts' => array(
+			'artifacts'           => array(
 				'block_markup' => isset( $result['serialized_blocks'] ) && is_scalar( $result['serialized_blocks'] ) ? (string) $result['serialized_blocks'] : '',
 				'blocks'       => isset( $result['blocks'] ) && is_array( $result['blocks'] ) ? $result['blocks'] : array(),
 				'block_types'  => isset( $result['block_types'] ) && is_array( $result['block_types'] ) ? $result['block_types'] : array(),
@@ -510,7 +510,7 @@ class Static_Site_Importer_Transformer_Adapter {
 	 * @return array<string,mixed>
 	 */
 	public function summarize_result( array $compiled ): array {
-		$artifacts   = isset( $compiled['wordpress_artifacts'] ) && is_array( $compiled['wordpress_artifacts'] ) ? $compiled['wordpress_artifacts'] : array();
+		$artifacts   = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
 		$block_tree  = isset( $artifacts['block_tree'] ) && is_array( $artifacts['block_tree'] ) ? $artifacts['block_tree'] : array();
 		$block_types = isset( $artifacts['block_types'] ) && is_array( $artifacts['block_types'] ) ? $artifacts['block_types'] : array();
 		$components  = isset( $artifacts['components'] ) && is_array( $artifacts['components'] ) ? $artifacts['components'] : array();

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -24,7 +24,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 					'fragment_count'   => 0,
 					'website_artifact' => array(
 						'summary' => array(
-							'schema'           => 'block-artifact-compiler/result/v1',
+							'schema'           => 'blocks-engine/php-transformer/result/v1',
 							'status'           => 'success',
 							'source'           => 'artifact.json',
 							'diagnostic_count' => 0,
@@ -68,7 +68,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $result['version'] ?? 0 );
 		$this->assertSame( 1, $result['report_version'] ?? 0 );
 		$this->assertSame( 'static-template-import', $result['theme_slug'] ?? '' );
-		$this->assertSame( 'block-artifact-compiler/result/v1', $result['compiler']['schema'] ?? '' );
+		$this->assertSame( 'blocks-engine/php-transformer/result/v1', $result['compiler']['schema'] ?? '' );
 		$this->assertSame( 'success', $result['compiler']['status'] ?? '' );
 		$this->assertSame( 1, $result['diagnostic_count'] ?? 0 );
 		$this->assertSame( 2, $result['source_document_count'] ?? 0 );
@@ -100,7 +100,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 			'blocks_engine'           => array(
 				'website_artifact' => array(
 					'summary'    => array(
-						'schema' => 'block-artifact-compiler/result/v1',
+						'schema' => 'blocks-engine/php-transformer/result/v1',
 						'status' => 'success',
 						'source' => 'artifact.json',
 					),

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -47,9 +47,9 @@ const steps = [
     ],
   },
   {
-    name: 'BAC visual repair CSS smoke',
+    name: 'Visual repair CSS smoke',
     command: 'php',
-    args: [ path.join( repoRoot, 'tests/smoke-bac-visual-repair-css.php' ) ],
+    args: [ path.join( repoRoot, 'tests/smoke-visual-repair-css.php' ) ],
   },
   {
     name: 'Export theme ability smoke',

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -91,7 +91,7 @@ namespace {
 						'blocks'            => array(
 							array( 'blockName' => 'core/paragraph', 'innerBlocks' => array() ),
 						),
-						'serialized_blocks' => '<!-- wp:paragraph --><p>Legacy top-level Home</p><!-- /wp:paragraph -->',
+						'serialized_blocks' => '<!-- wp:paragraph --><p>Top-level Home</p><!-- /wp:paragraph -->',
 						'conversion_report' => array(
 							'status'            => 'success',
 							'serialized_blocks' => '<!-- wp:paragraph --><p>Native report Home</p><!-- /wp:paragraph -->',
@@ -121,13 +121,13 @@ namespace {
 						),
 						'diagnostics'       => array(
 							array(
-								'code'    => 'legacy_top_level_diagnostic',
-								'message' => 'Legacy top-level diagnostic.',
+								'code'    => 'top_level_diagnostic',
+								'message' => 'Top-level diagnostic.',
 							),
 						),
 						'fallbacks'         => array(
 							array(
-								'source' => 'legacy-top-level',
+								'source' => 'top-level',
 								'count'  => 1,
 							),
 						),
@@ -204,7 +204,7 @@ namespace {
 	$assert( 'smoke' === ( $GLOBALS['ssi_transformer_adapter_format_conversion_calls'][0][3]['source'] ?? '' ), 'format-conversion-options-forwarded' );
 
 	$compiled  = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ), array( 'include_conversion_report' => true ) );
-	$artifacts = $compiled['wordpress_artifacts'] ?? array();
+	$artifacts = $compiled['artifacts'] ?? array();
 	$site      = $artifacts['site'] ?? array();
 	$pages     = $site['pages'] ?? array();
 	$documents = $artifacts['documents'] ?? array();
@@ -212,13 +212,13 @@ namespace {
 	$assert( ! is_wp_error( $compiled ), 'native-compile-succeeds' );
 	$assert( 1 === count( $GLOBALS['ssi_transformer_adapter_compile_calls'] ), 'plugin-compile-helper-called' );
 	$assert( true === ( $GLOBALS['ssi_transformer_adapter_compile_calls'][0][1]['include_conversion_report'] ?? false ), 'compile-options-forwarded-as-native-report-request' );
-	$assert( 'block-artifact-compiler/result/v1' === ( $compiled['schema'] ?? '' ), 'native-result-mapped-to-compiled-envelope' );
+	$assert( 'blocks-engine/php-transformer/result/v1' === ( $compiled['schema'] ?? '' ), 'native-result-schema-is-preserved' );
 	$assert( 'success' === ( $compiled['conversion_report']['status'] ?? '' ), 'conversion-report-shape-preserved' );
 	$assert( '<!-- wp:paragraph --><p>Native report Home</p><!-- /wp:paragraph -->' === ( $compiled['conversion_report']['serialized_blocks'] ?? '' ), 'conversion-report-uses-native-serialized-blocks' );
 	$assert( 'native_report_diagnostic' === ( $compiled['conversion_report']['diagnostics'][0]['code'] ?? '' ), 'conversion-report-uses-native-diagnostics' );
 	$assert( 'native-conversion-report' === ( $compiled['conversion_report']['fallbacks'][0]['source'] ?? '' ), 'conversion-report-uses-native-fallbacks' );
-	$assert( 'legacy_top_level_diagnostic' !== ( $compiled['conversion_report']['diagnostics'][0]['code'] ?? '' ), 'conversion-report-ignores-top-level-diagnostics' );
-	$assert( 'legacy-top-level' !== ( $compiled['conversion_report']['fallbacks'][0]['source'] ?? '' ), 'conversion-report-ignores-top-level-fallbacks' );
+	$assert( 'top_level_diagnostic' !== ( $compiled['conversion_report']['diagnostics'][0]['code'] ?? '' ), 'conversion-report-ignores-top-level-diagnostics' );
+	$assert( 'top-level' !== ( $compiled['conversion_report']['fallbacks'][0]['source'] ?? '' ), 'conversion-report-ignores-top-level-fallbacks' );
 	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'native-artifact-report-preserved-as-input' );
 	$assert( 'blocks-engine/php-transformer/materialization-plan/v1' === ( $site['schema'] ?? '' ), 'native-materialization-plan-contract-is-used' );
 	$assert( 4 === count( $pages ), 'native-keeps-materialization-plan-pages-without-adapter-filtering' );

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -233,15 +233,15 @@ $source_pages = new ReflectionMethod( Static_Site_Importer_Theme_Generator::clas
 $native_pages = $source_pages->invoke(
 	null,
 	array(
-		'wordpress_artifacts' => array(
+		'artifacts' => array(
 			'site'      => array(
 				'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
 				'pages'  => array(
 					array(
 						'source_path'  => 'website/index.html',
 						'post_type'    => 'page',
-						'slug'         => 'legacy-plan-page-slug',
-						'title'        => 'Legacy Plan Page Title',
+						'slug'         => 'planned-page-slug',
+						'title'        => 'Planned Page Title',
 						'entrypoint'   => true,
 						'block_markup' => '<!-- wp:paragraph --><p>Native page</p><!-- /wp:paragraph -->',
 					),
@@ -260,9 +260,9 @@ $native_pages = $source_pages->invoke(
 			'documents' => array(
 				array(
 					'source_path'  => 'website/index.html',
-					'slug'         => 'legacy-home',
-					'title'        => 'Legacy Home',
-					'block_markup' => '<!-- wp:paragraph --><p>Legacy page</p><!-- /wp:paragraph -->',
+					'slug'         => 'compiled-site-home',
+					'title'        => 'Compiled Site Home',
+					'block_markup' => '<!-- wp:paragraph --><p>Compiled site page</p><!-- /wp:paragraph -->',
 				),
 			),
 		),
@@ -272,15 +272,15 @@ $assert( is_array( $native_pages ), 'materialization-plan-pages-create-source-pa
 $native_page = is_array( $native_pages ) ? ( $native_pages['website/index.html'] ?? null ) : null;
 $assert( $native_page instanceof Static_Site_Importer_Source_Page, 'materialization-plan-page-source-key-is-used' );
 $assert( $native_page instanceof Static_Site_Importer_Source_Page && 'materialization_plan_page' === $native_page->type(), 'materialization-plan-page-type-is-native' );
-$assert( $native_page instanceof Static_Site_Importer_Source_Page && 'home-canonical' === $native_page->metadata_value( 'slug' ), 'materialization-plan-route-slug-wins-over-page-and-legacy-document' );
-$assert( $native_page instanceof Static_Site_Importer_Source_Page && 'Home Canonical' === $native_page->metadata_value( 'title' ), 'materialization-plan-route-title-wins-over-page-and-legacy-document' );
+$assert( $native_page instanceof Static_Site_Importer_Source_Page && 'home-canonical' === $native_page->metadata_value( 'slug' ), 'materialization-plan-route-slug-wins-over-page-and-compiled-site-document' );
+$assert( $native_page instanceof Static_Site_Importer_Source_Page && 'Home Canonical' === $native_page->metadata_value( 'title' ), 'materialization-plan-route-title-wins-over-page-and-compiled-site-document' );
 $assert( $native_page instanceof Static_Site_Importer_Source_Page && 'home-route' === $native_page->metadata_value( 'route_key' ), 'materialization-plan-route-key-is-preserved' );
-$assert( $native_page instanceof Static_Site_Importer_Source_Page && str_contains( $native_page->body(), 'Native page' ), 'materialization-plan-page-body-wins-over-legacy-document' );
+$assert( $native_page instanceof Static_Site_Importer_Source_Page && str_contains( $native_page->body(), 'Native page' ), 'materialization-plan-page-body-wins-over-compiled-site-document' );
 
 $malformed_routes = $source_pages->invoke(
 	null,
 	array(
-		'wordpress_artifacts' => array(
+		'artifacts' => array(
 			'site' => array(
 				'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
 				'pages'  => array(
@@ -301,7 +301,7 @@ $assert( 'static_site_importer_materialization_plan_route_invalid' === ( $malfor
 $missing_page_content = $source_pages->invoke(
 	null,
 	array(
-		'wordpress_artifacts' => array(
+		'artifacts' => array(
 			'site' => array(
 				'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
 				'pages'  => array(


### PR DESCRIPTION
## Summary
- Preserve the native Blocks Engine transformer result schema instead of projecting compiled results as a BAC result envelope.
- Rename SSI's internal compiled payload from `wordpress_artifacts` to neutral `artifacts`.
- Report materialization plans under `blocks_engine.materialization_plan` and fix the validation harness to call the current visual repair smoke.

## Verification
- `node tests/run-validation-harness.cjs --skip-import`
- `git diff --check`

## Intentional breakages
- Removed the internal `block-artifact-compiler/result/v1` compiled-result projection.
- Removed the internal `wordpress_artifacts` compiled payload key.
- Removed the stale `block_artifact_compiler.materialization_plan` report key.

Historical BAC/BFB mentions remain only in `docs/CHANGELOG.md`, which is generated/history and was not edited manually.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 + OpenCode
- **Used for:** Auditing stale SSI contract surfaces, editing code/tests, running focused verification, and drafting this PR description.