### PR TITLE
Use Blocks Engine site artifact schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static Site Importer is a WordPress plugin. It requires the [Blocks Engine PHP t
 Static Site Importer is the WordPress materialization layer for static website inputs. It accepts two related shapes:
 
 - Static source imports: an HTML entry file, pasted HTML document, public HTML URL, direct HTML upload, or ZIP source tree.
-- Generated website artifacts: a `block-artifact-compiler/website-artifact/v1` bundle, such as the website artifact emitted by Studio Web or WP Codebox browser runtimes.
+- Generated website artifacts: a `blocks-engine/php-transformer/site-artifact/v1` bundle, such as the website artifact emitted by Studio Web or WP Codebox browser runtimes.
 
 The conversion stack is split by responsibility:
 
@@ -198,7 +198,7 @@ Important behavior:
 
 The export envelope includes:
 
-- `schema: "block-artifact-compiler/website-artifact/v1"`, `artifact_type: "website"`, `version`, `id`, `generated_at`, `root`, and `entrypoint`.
+- `schema: "blocks-engine/php-transformer/site-artifact/v1"`, `artifact_type: "website"`, `version`, `id`, `generated_at`, `root`, and `entrypoint`.
 - `files[]` entries with safe artifact-relative paths, `role`, `kind`, `mime_type`, `encoding`, `bytes`, `sha256`, and inline `content`.
 - UTF-8 text content by default; binary content is transported as Base64 with `encoding: "base64"`.
 - source/materialization provenance under `provenance`.
@@ -308,6 +308,6 @@ The intended dependency direction is:
 Static Site Importer -> Blocks Engine PHP transformer
 ```
 
-SSI import reports consume Blocks Engine PHP transformer result envelopes for conversion-quality diagnostics, and record the compiled-site contract when importing website artifacts. Legacy schema names remain wire contracts only; SSI should not call lower-level converter packages directly or re-derive semantic page-route intent when the transformer supplies it.
+SSI import reports consume Blocks Engine PHP transformer result envelopes for conversion-quality diagnostics, and record the compiled-site contract when importing website artifacts. Blocks Engine schemas are the active wire contract; SSI should not call lower-level converter packages directly or re-derive semantic page-route intent when the transformer supplies it.
 
 Imported pages remain WordPress pages for routing, titles, front-page assignment, editor visibility, and body content edits. Their imported body layouts live on the page posts as block markup in `post_content`. The generated block theme owns shared header/footer parts, optional background decoration, frontend/editor styles, scripts, and template wrappers that render page bodies through `core/post-content`; the generic `templates/page.html` stays the fallback for pages created after import.

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -162,7 +162,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'diagnostics' => isset( $compiled['diagnostics'] ) && is_array( $compiled['diagnostics'] ) ? $compiled['diagnostics'] : array(),
 		);
 
-		if ( in_array( (string) ( $site['schema'] ?? '' ), array( 'block-artifact-compiler/compiled-site/v1', 'blocks-engine/php-transformer/compiled-site/v1' ), true ) ) {
+		if ( 'blocks-engine/php-transformer/compiled-site/v1' === (string) ( $site['schema'] ?? '' ) ) {
 			$report['blocks_engine']['compiled_site'] = self::compiled_site_report_payload( $site );
 		}
 		if ( 'blocks-engine/php-transformer/materialization-plan/v1' === (string) ( $site['schema'] ?? '' ) ) {

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1043,7 +1043,7 @@ class Static_Site_Importer_Theme_Generator {
 				return self::source_pages_from_materialization_plan( $site );
 			}
 
-			if ( ! in_array( (string) ( $site['schema'] ?? '' ), array( 'block-artifact-compiler/compiled-site/v1', 'blocks-engine/php-transformer/compiled-site/v1' ), true ) ) {
+			if ( 'blocks-engine/php-transformer/compiled-site/v1' !== (string) ( $site['schema'] ?? '' ) ) {
 				return new WP_Error( 'static_site_importer_compiled_site_missing', 'Website artifact document pages require a supported compiled-site contract.' );
 			}
 

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Static_Site_Importer_Transformer_Adapter {
 
-	public const WEBSITE_ARTIFACT_SCHEMA = 'block-artifact-compiler/website-artifact/v1';
+	public const WEBSITE_ARTIFACT_SCHEMA = 'blocks-engine/php-transformer/site-artifact/v1';
 	public const TRANSFORMER_RESULT_SCHEMA = 'blocks-engine/php-transformer/result/v1';
 	private const CONVERSION_REPORT_OPTION = 'include_conversion_report';
 

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -278,7 +278,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$analyze->invoke(
 			null,
 			array(
-				'/tmp/generated/templates/page.html' => '<!-- wp:freeform --><div class="legacy-widget"><marquee>Sale</marquee></div><!-- /wp:freeform -->',
+				'/tmp/generated/templates/page.html' => '<!-- wp:freeform --><div class="unsupported-widget"><marquee>Sale</marquee></div><!-- /wp:freeform -->',
 			),
 			'/tmp/generated'
 		);
@@ -299,7 +299,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 'generated_document_contains_core_freeform', $diagnostics[0]['reason_code'] ?? '' );
 		$this->assertSame( 'replace_fallback_block', $diagnostics[0]['suggested_repair_class'] ?? '' );
 		$this->assertSame( 'templates/page.html', $diagnostics[0]['source_path'] ?? '' );
-		$this->assertSame( 'div.legacy-widget', $diagnostics[0]['selector'] ?? '' );
+		$this->assertSame( 'div.unsupported-widget', $diagnostics[0]['selector'] ?? '' );
 		$this->assertSame( '0', $diagnostics[0]['context']['block_path'] ?? '' );
 	}
 }

--- a/tests/fixtures/website-artifact-bundle/artifact.json
+++ b/tests/fixtures/website-artifact-bundle/artifact.json
@@ -1,5 +1,5 @@
 {
-  "schema": "block-artifact-compiler/website-artifact/v1",
+  "schema": "blocks-engine/php-transformer/site-artifact/v1",
   "html": "<main><section class=\"hero\"><h1>Website Artifact Fixture</h1><p>Compiled before SSI materialization.</p></section></main>",
   "css": ".hero{padding:4rem;background:#f6f2ea;color:#1b1b1b}",
   "js": "document.documentElement.dataset.fixture = 'website-artifact';"

--- a/tests/smoke-export-theme-ability.php
+++ b/tests/smoke-export-theme-ability.php
@@ -197,10 +197,10 @@ $assert     = static function ( bool $condition, string $label, string $detail =
 $assert( ! is_wp_error( $result ), 'export-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
 $assert( true === ( $result['success'] ?? false ), 'ability-success' );
 $artifact = $result['website_artifact'] ?? array();
-$assert( ! isset( $result['artifact_set'] ), 'legacy-artifact-set-removed' );
-$assert( ! isset( $result['files'] ), 'legacy-top-level-files-removed' );
-$assert( ! isset( $result['report'] ), 'legacy-top-level-report-removed' );
-$assert( 'block-artifact-compiler/website-artifact/v1' === ( $artifact['schema'] ?? '' ), 'website-artifact-schema' );
+$assert( ! isset( $result['artifact_set'] ), 'artifact-set-wrapper-removed' );
+$assert( ! isset( $result['files'] ), 'top-level-files-wrapper-removed' );
+$assert( ! isset( $result['report'] ), 'top-level-report-wrapper-removed' );
+$assert( 'blocks-engine/php-transformer/site-artifact/v1' === ( $artifact['schema'] ?? '' ), 'website-artifact-schema' );
 $assert( 'website' === ( $artifact['artifact_type'] ?? '' ), 'artifact-type' );
 $assert( 1 === ( $artifact['version'] ?? 0 ), 'artifact-version' );
 $assert( 'website' === ( $artifact['root'] ?? '' ), 'artifact-root' );

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -25,7 +25,7 @@ namespace {
 						'source_reports'    => array(
 							'artifact'      => array(
 								'schema'          => 'blocks-engine/php-transformer/site-artifact/v1',
-								'original_schema' => 'block-artifact-compiler/website-artifact/v1',
+								'original_schema' => 'blocks-engine/php-transformer/site-artifact/v1',
 								'entry_path'      => 'website/index.html',
 								'entrypoints'     => array( 'website/index.html' ),
 								'file_count'      => 3,
@@ -117,7 +117,7 @@ namespace {
 							),
 						),
 						'assets'            => array(
-							array( 'path' => 'assets/legacy-site.css', 'role' => 'stylesheet' ),
+							array( 'path' => 'assets/top-level-site.css', 'role' => 'stylesheet' ),
 						),
 						'diagnostics'       => array(
 							array(
@@ -203,7 +203,7 @@ namespace {
 	$assert( 'html' === ( $GLOBALS['ssi_transformer_adapter_format_conversion_calls'][0][2] ?? '' ), 'format-conversion-to-format' );
 	$assert( 'smoke' === ( $GLOBALS['ssi_transformer_adapter_format_conversion_calls'][0][3]['source'] ?? '' ), 'format-conversion-options-forwarded' );
 
-	$compiled  = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ), array( 'include_conversion_report' => true ) );
+	$compiled  = $adapter->compile_website_artifact( array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ), array( 'include_conversion_report' => true ) );
 	$artifacts = $compiled['artifacts'] ?? array();
 	$site      = $artifacts['site'] ?? array();
 	$pages     = $site['pages'] ?? array();
@@ -229,12 +229,12 @@ namespace {
 	$assert( 1 === count( $documents ), 'native-documents-preserve-transformer-documents-without-site-report-synthesis' );
 	$assert( 'content/about.md' === ( $documents[0]['source_path'] ?? '' ), 'native-document-from-transformer-documents' );
 	$assert( 'assets/native-site.css' === ( $artifacts['files'][0]['path'] ?? '' ), 'native-materialization-plan-assets-drive-artifact-files' );
-	$assert( 'assets/legacy-site.css' !== ( $artifacts['files'][0]['path'] ?? '' ), 'legacy-assets-do-not-override-native-materialization-plan-assets' );
+	$assert( 'assets/top-level-site.css' !== ( $artifacts['files'][0]['path'] ?? '' ), 'top-level-assets-do-not-override-native-materialization-plan-assets' );
 	$assert( 'rye-loaf-canonical' === ( $products[0]['slug'] ?? '' ), 'native-product-slug-mapped-from-generic-report' );
 	$assert( '12.00' === ( $products[0]['regular_price'] ?? '' ), 'native-product-price-normalized-from-generic-report' );
 	$assert( array( 'Bread' ) === ( $products[0]['categories'] ?? array() ), 'native-product-categories-mapped-from-generic-report' );
 
-	$native_report_compiled = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ), array( 'include_conversion_report' => true ) );
+	$native_report_compiled = $adapter->compile_website_artifact( array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ), array( 'include_conversion_report' => true ) );
 	$assert( ! is_wp_error( $native_report_compiled ), 'native-report-compile-succeeds' );
 	$assert( 2 === count( $GLOBALS['ssi_transformer_adapter_compile_calls'] ), 'plugin-compile-helper-called-for-native-report' );
 	$assert( true === ( $GLOBALS['ssi_transformer_adapter_compile_calls'][1][1]['include_conversion_report'] ?? false ), 'native-report-option-forwarded' );
@@ -247,7 +247,7 @@ namespace {
 			'artifact' => array( 'entry_path' => 'website/index.html' ),
 		),
 	);
-	$missing_plan = $adapter->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ) );
+	$missing_plan = $adapter->compile_website_artifact( array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ) );
 	unset( $GLOBALS['ssi_transformer_adapter_result_override'] );
 	$assert( is_wp_error( $missing_plan ), 'missing-materialization-plan-errors' );
 	$assert( 'static_site_importer_transformer_missing_materialization_plan' === ( is_wp_error( $missing_plan ) ? $missing_plan->get_error_code() : '' ), 'missing-materialization-plan-error-code' );

--- a/tests/smoke-url-import-runtime.php
+++ b/tests/smoke-url-import-runtime.php
@@ -142,7 +142,7 @@ add_filter(
 		return array(
 			'provider'        => 'test-private-runtime',
 			'artifact'        => array(
-				'schema' => 'block-artifact-compiler/website-artifact/v1',
+				'schema' => 'blocks-engine/php-transformer/site-artifact/v1',
 				'files'  => array(
 					array(
 						'path'    => 'website/index.html',

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -163,7 +163,7 @@ $template_part_result = Static_Site_Importer_Theme_Materializer::template_part_a
 			array(
 				'slug'         => 'header',
 				'area'         => 'header',
-				'block_markup' => '<!-- wp:paragraph --><p>Legacy Header</p><!-- /wp:paragraph -->',
+				'block_markup' => '<!-- wp:paragraph --><p>Fallback Header</p><!-- /wp:paragraph -->',
 			),
 		),
 	)
@@ -172,7 +172,7 @@ $assert( is_array( $template_part_result ), 'materialization-plan-template-part-
 $template_part_writes = is_array( $template_part_result ) ? $template_part_result['writes'] : array();
 $template_part_reports = is_array( $template_part_result ) ? $template_part_result['reports'] : array();
 $assert( str_contains( (string) ( $template_part_writes['/tmp/visual-repair-smoke/parts/header.html'] ?? '' ), 'Plan Header' ), 'materialization-plan-template-part-write-is-used' );
-$assert( ! str_contains( (string) ( $template_part_writes['/tmp/visual-repair-smoke/parts/header.html'] ?? '' ), 'Legacy Header' ), 'legacy-template-part-is-ignored-when-plan-writes-exist' );
+$assert( ! str_contains( (string) ( $template_part_writes['/tmp/visual-repair-smoke/parts/header.html'] ?? '' ), 'Fallback Header' ), 'fallback-template-part-is-ignored-when-plan-writes-exist' );
 $assert( array( 'parts/header.html' ) === ( $template_part_reports[0]['source_paths'] ?? array() ), 'materialization-plan-template-part-source-path-is-reported' );
 
 $navigation_part_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
@@ -342,7 +342,7 @@ $asset_result    = Static_Site_Importer_Theme_Materializer::materialize_website_
 			array(
 				'path'    => 'assets/site.css',
 				'kind'    => 'css',
-				'content' => '.legacy-artifact{color:red}',
+				'content' => '.top-level-artifact{color:red}',
 			),
 		),
 	)
@@ -350,7 +350,7 @@ $asset_result    = Static_Site_Importer_Theme_Materializer::materialize_website_
 $assert( is_array( $asset_result ), 'materialization-plan-assets-succeed' );
 $asset_result = is_array( $asset_result ) ? $asset_result : array( 'css' => '', 'assets' => array() );
 $assert( str_contains( (string) $asset_result['css'], '.native-plan' ), 'materialization-plan-asset-css-wins' );
-$assert( ! str_contains( (string) $asset_result['css'], '.legacy-artifact' ), 'legacy-css-is-ignored-when-native-plan-assets-have-payloads' );
+$assert( ! str_contains( (string) $asset_result['css'], '.top-level-artifact' ), 'top-level-css-is-ignored-when-native-plan-assets-have-payloads' );
 $assert( file_exists( $asset_theme_dir . '/assets/materialized/assets/logo.png' ), 'materialization-plan-binary-asset-is-written' );
 $assert( 'materialization_plan.assets' === ( $asset_result['assets']['assets/logo.png']['origin'] ?? '' ), 'materialization-plan-asset-origin-is-reported' );
 $assert( str_ends_with( (string) ( $asset_result['assets']['assets/logo.png']['final_url'] ?? '' ), '/assets/materialized/assets/logo.png' ), 'materialization-plan-asset-final-url-shape' );
@@ -372,13 +372,13 @@ $metadata_only = Static_Site_Importer_Theme_Materializer::materialize_website_ar
 			array(
 				'path'    => 'assets/site.css',
 				'kind'    => 'css',
-				'content' => '.legacy-metadata-only{color:blue}',
+				'content' => '.top-level-metadata-only{color:blue}',
 			),
 		),
 	)
 );
-$assert( is_array( $metadata_only ), 'metadata-only-materialization-plan-assets-fall-back-to-legacy' );
-$assert( str_contains( (string) ( is_array( $metadata_only ) ? $metadata_only['css'] : '' ), '.legacy-metadata-only' ), 'legacy-assets-used-when-native-plan-assets-have-no-payload-contract' );
+$assert( is_array( $metadata_only ), 'metadata-only-materialization-plan-assets-fall-back-to-top-level-assets' );
+$assert( str_contains( (string) ( is_array( $metadata_only ) ? $metadata_only['css'] : '' ), '.top-level-metadata-only' ), 'top-level-assets-used-when-native-plan-assets-have-no-payload-contract' );
 
 $bad_asset = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files(
 	sys_get_temp_dir() . '/ssi-materialization-plan-assets-bad-' . uniqid( '', true ),

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -171,7 +171,7 @@ $read = static function ( string $path ): string {
 
 $result = Static_Site_Importer_Theme_Generator::import_website_artifact(
 	array(
-		'schema' => 'block-artifact-compiler/website-artifact/v1',
+		'schema' => 'blocks-engine/php-transformer/site-artifact/v1',
 		'files'  => array(
 			array(
 				'path'    => 'index.html',
@@ -259,7 +259,7 @@ if ( ! is_wp_error( $result ) ) {
 
 $missing_template_parts_result = Static_Site_Importer_Theme_Generator::import_website_artifact(
 	array(
-		'schema' => 'block-artifact-compiler/website-artifact/v1',
+		'schema' => 'blocks-engine/php-transformer/site-artifact/v1',
 		'files'  => array(
 			array(
 				'path'    => 'no-header.html',
@@ -285,7 +285,7 @@ if ( ! is_wp_error( $missing_template_parts_result ) ) {
 
 $multi_page_result = Static_Site_Importer_Theme_Generator::import_website_artifact(
 	array(
-		'schema'     => 'block-artifact-compiler/website-artifact/v1',
+		'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
 		'entrypoint' => 'website/index.html',
 		'files'      => array(
 			array(

--- a/tests/smoke-website-artifact-products-manifest.php
+++ b/tests/smoke-website-artifact-products-manifest.php
@@ -109,7 +109,7 @@ namespace {
 		}
 	};
 
-	$compiled = ( new Static_Site_Importer_Transformer_Adapter() )->compile_website_artifact( array( 'schema' => 'block-artifact-compiler/website-artifact/v1' ) );
+	$compiled = ( new Static_Site_Importer_Transformer_Adapter() )->compile_website_artifact( array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ) );
 	$products = is_array( $compiled ) ? ( $compiled['products_manifest'] ?? array() ) : array();
 
 	$assert( ! is_wp_error( $compiled ), 'compile-succeeds', is_wp_error( $compiled ) ? $compiled->get_error_message() : '' );


### PR DESCRIPTION
## Summary
- Replace SSI's active website artifact schema constant, exported artifact envelope, fixtures, and tests with Blocks Engine's `blocks-engine/php-transformer/site-artifact/v1` contract.
- Remove SSI runtime/report acceptance of the old `block-artifact-compiler/compiled-site/v1` report schema; only the current Blocks Engine compiled-site/materialization-plan contracts are active.
- Rename remaining test labels/data that used legacy wrapper terminology for top-level/fallback fixture paths.
- Document that Blocks Engine schemas are SSI's active wire contract; historical BAC/BFB references remain only in generated changelog history.

## Verification
- `php tests/smoke-transformer-adapter.php && php tests/smoke-export-theme-ability.php && php tests/smoke-url-import-runtime.php && php tests/smoke-website-artifact-products-manifest.php && php tests/smoke-website-artifact-document-metadata.php && php tests/smoke-visual-repair-css.php`
- `npm run test:validation -- --skip-import`
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@cook-ssi-final-schema-cleanup` (offloaded to `homeboy-lab`, run `runner-exec-homeboy-lab-996e5dee-4e4c-4f53-b780-8b2a4f45a120`)
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@cook-ssi-final-schema-cleanup` (rerun while correcting PR body, offloaded to `homeboy-lab`, run `runner-exec-homeboy-lab-2126c484-ac5a-490c-9ac4-78f4aa21a147`)
- `git diff --check`

## Intentional breakages / residual compatibility
- Intentionally breaks BAC-named website artifact emission/fixture expectations in SSI; new exports emit `blocks-engine/php-transformer/site-artifact/v1`.
- Intentionally stops treating `block-artifact-compiler/compiled-site/v1` as a supported runtime/report schema.
- Residual compatibility is limited to generic/top-level Blocks Engine transformer result fields that are still part of the current transformer output path, not BAC/BFB naming compatibility.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Audit, schema cleanup implementation, focused verification, and PR preparation.
