### PR TITLE
Define SSI product handoff contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ The export envelope includes:
 
 The default root is `website` with `entrypoint: "website/index.html"`. Callers can pass any safe single-segment root with a matching entrypoint, such as `root: "artifact"` and `entrypoint: "artifact/index.html"`.
 
+## Product Handoff Contract
+
+The product handoff contract is defined in `docs/product-handoff-contract.md` and locked by `tests/fixtures/product-handoff-contract/v1.json` plus `tests/smoke-product-handoff-contract.php`.
+
+The handoff path is:
+
+- product caller sends a `blocks-engine/php-transformer/site-artifact/v1` input artifact;
+- Blocks Engine returns `blocks-engine/php-transformer/result/v1` with a canonical `blocks-engine/php-transformer/materialization-plan/v1`;
+- SSI consumes that plan, writes WordPress state, and returns `static-site-importer/import-report/v1` with import validation and finding packet artifacts;
+- Codebox may validate the WordPress result and return `wp-codebox/validation-artifact-envelope/v1` artifact references.
+
+Blocks Engine does not know about Codebox. Products that need sandbox validation request it after SSI materializes WordPress.
+
 ## Validation
 
 The repository has both WordPress-side fixture coverage and generated-artifact validation.

--- a/docs/product-handoff-contract.md
+++ b/docs/product-handoff-contract.md
@@ -1,0 +1,21 @@
+# Product Handoff Contract
+
+Static Site Importer's product handoff uses four machine-readable envelopes. The JSON fixture at `tests/fixtures/product-handoff-contract/v1.json` is the canonical contract sample used by tests.
+
+## Stages
+
+1. Product caller provides an input artifact with schema `blocks-engine/php-transformer/site-artifact/v1`.
+2. Blocks Engine compiles it and returns `blocks-engine/php-transformer/result/v1` with `source_reports.materialization_plan` using `blocks-engine/php-transformer/materialization-plan/v1`.
+3. SSI consumes the materialization plan, writes WordPress pages/theme/assets, and returns an import report with nested `blocks-engine/import-validation-result/v1` and `blocks-engine/finding-packets/v1` artifacts.
+4. Codebox may validate the WordPress result and return `wp-codebox/validation-artifact-envelope/v1` with artifact references for rendered output, visual comparison, WordPress state, import report, and diagnostics.
+
+## Ownership
+
+- Blocks Engine owns static artifact compilation and the materialization plan.
+- SSI owns WordPress writes and the import report.
+- Codebox owns optional WordPress validation and artifact references.
+- WPSG, Data Machine, and Studio Native consume these outputs directly; they should not depend on legacy SSI wrapper history.
+
+## Boundary
+
+Blocks Engine stays out of Codebox details. If a caller wants Codebox validation, it asks Codebox after SSI materializes WordPress and passes SSI output or runtime references through the Codebox-owned envelope.

--- a/includes/class-static-site-importer-product-handoff-contract.php
+++ b/includes/class-static-site-importer-product-handoff-contract.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Product handoff contract constants.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Names the machine-readable envelopes shared across product handoffs.
+ */
+class Static_Site_Importer_Product_Handoff_Contract {
+
+	public const VERSION = 1;
+	public const CONTRACT_SCHEMA = 'static-site-importer/product-handoff-contract/v1';
+	public const INPUT_ARTIFACT_SCHEMA = 'blocks-engine/php-transformer/site-artifact/v1';
+	public const BLOCKS_ENGINE_RESULT_SCHEMA = 'blocks-engine/php-transformer/result/v1';
+	public const MATERIALIZATION_PLAN_SCHEMA = 'blocks-engine/php-transformer/materialization-plan/v1';
+	public const SSI_IMPORT_REPORT_SCHEMA = 'static-site-importer/import-report/v1';
+	public const SSI_IMPORT_VALIDATION_RESULT_SCHEMA = 'blocks-engine/import-validation-result/v1';
+	public const SSI_FINDING_PACKETS_SCHEMA = 'blocks-engine/finding-packets/v1';
+	public const SSI_ARTIFACT_DIAGNOSTICS_SCHEMA = 'static-site-importer/artifact-diagnostics/v1';
+	public const CODEBOX_VALIDATION_ARTIFACT_ENVELOPE_SCHEMA = 'wp-codebox/validation-artifact-envelope/v1';
+
+	/**
+	 * Return the canonical schema identifiers by handoff stage.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function schema_map(): array {
+		return array(
+			'schema'                            => self::CONTRACT_SCHEMA,
+			'version'                           => self::VERSION,
+			'input_artifact'                    => self::INPUT_ARTIFACT_SCHEMA,
+			'blocks_engine_result'              => self::BLOCKS_ENGINE_RESULT_SCHEMA,
+			'blocks_engine_materialization_plan' => self::MATERIALIZATION_PLAN_SCHEMA,
+			'ssi_import_report'                 => self::SSI_IMPORT_REPORT_SCHEMA,
+			'ssi_import_validation_result'      => self::SSI_IMPORT_VALIDATION_RESULT_SCHEMA,
+			'ssi_finding_packets'               => self::SSI_FINDING_PACKETS_SCHEMA,
+			'ssi_artifact_diagnostics'          => self::SSI_ARTIFACT_DIAGNOSTICS_SCHEMA,
+			'codebox_validation_artifact_envelope' => self::CODEBOX_VALIDATION_ARTIFACT_ENVELOPE_SCHEMA,
+		);
+	}
+}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -12,6 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-transformer-adapter.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Product_Handoff_Contract' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-product-handoff-contract.php';
+}
 
 /**
  * Builds SSI import reports and normalizes diagnostics for repair loops.
@@ -27,6 +30,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	public static function new_conversion_report( string $html_path, array $source_metadata = array() ): array {
 		return array(
+			'schema'                  => Static_Site_Importer_Product_Handoff_Contract::SSI_IMPORT_REPORT_SCHEMA,
 			'version'                 => 1,
 			'entry_file'              => $html_path,
 			'source'                  => array_merge(

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -31,6 +31,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-pa
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-stylesheet-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-product-handoff-contract.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-transformer-adapter.php';

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -90,6 +90,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	 */
 	public function test_import_validation_result_and_finding_packets_are_machine_readable(): void {
 		$report = array(
+			'schema'                  => 'static-site-importer/import-report/v1',
 			'entry_file'              => '/tmp/source/index.html',
 			'version'                 => 1,
 			'theme_slug'              => 'static-template-import',
@@ -245,6 +246,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		);
 
 		$report      = $report_property->getValue();
+		$this->assertSame( 'static-site-importer/import-report/v1', $report['schema'] ?? '' );
 		$diagnostics = array_values(
 			array_filter(
 				$report['diagnostics'] ?? array(),

--- a/tests/fixtures/product-handoff-contract/v1.json
+++ b/tests/fixtures/product-handoff-contract/v1.json
@@ -1,0 +1,144 @@
+{
+  "schema": "static-site-importer/product-handoff-contract/v1",
+  "version": 1,
+  "stages": {
+    "input_artifact": {
+      "owner": "product_caller",
+      "consumer": "blocks_engine",
+      "schema": "blocks-engine/php-transformer/site-artifact/v1",
+      "required_fields": ["schema", "files", "root", "entrypoint"],
+      "notes": "Portable static website bundle. Callers provide files; Blocks Engine compiles them."
+    },
+    "blocks_engine_result": {
+      "owner": "blocks_engine",
+      "consumer": "static_site_importer",
+      "schema": "blocks-engine/php-transformer/result/v1",
+      "required_fields": ["schema", "status", "source_reports.materialization_plan"],
+      "materialization_plan": {
+        "schema": "blocks-engine/php-transformer/materialization-plan/v1",
+        "required_fields": ["schema", "source_schema", "entry_path", "pages", "assets"]
+      },
+      "notes": "Blocks Engine emits the canonical WordPress materialization plan and remains unaware of Codebox validation details."
+    },
+    "ssi_import_report": {
+      "owner": "static_site_importer",
+      "consumer": "product_caller",
+      "schema": "static-site-importer/import-report/v1",
+      "required_fields": ["version", "theme_slug", "source", "blocks_engine", "generated_theme", "quality", "diagnostics", "import_validation_result", "finding_packets"],
+      "nested_artifacts": {
+        "import_validation_result": "blocks-engine/import-validation-result/v1",
+        "finding_packets": "blocks-engine/finding-packets/v1",
+        "artifact_diagnostics_fallback": "static-site-importer/artifact-diagnostics/v1"
+      },
+      "notes": "SSI writes WordPress state and reports materialized theme, page, asset, quality, and repair-loop outputs."
+    },
+    "codebox_validation_artifact_envelope": {
+      "owner": "wp_codebox",
+      "consumer": "product_caller",
+      "schema": "wp-codebox/validation-artifact-envelope/v1",
+      "required_fields": ["schema", "status", "artifacts", "refs"],
+      "artifact_kinds": ["render", "visual_comparison", "wordpress_state", "import_report", "diagnostics"],
+      "notes": "Codebox validates the WordPress result and returns artifact references. SSI treats this as an optional downstream validation envelope."
+    }
+  },
+  "example": {
+    "input_artifact": {
+      "schema": "blocks-engine/php-transformer/site-artifact/v1",
+      "root": "website",
+      "entrypoint": "website/index.html",
+      "files": [
+        {
+          "path": "website/index.html",
+          "role": "document",
+          "kind": "html",
+          "mime_type": "text/html",
+          "encoding": "utf-8",
+          "content": "<!doctype html><html><body><main><h1>Atlas Bakery</h1></main></body></html>"
+        }
+      ]
+    },
+    "blocks_engine_result": {
+      "schema": "blocks-engine/php-transformer/result/v1",
+      "status": "success",
+      "source_reports": {
+        "materialization_plan": {
+          "schema": "blocks-engine/php-transformer/materialization-plan/v1",
+          "source_schema": "blocks-engine/php-transformer/compiled-site/v1",
+          "entry_path": "website/index.html",
+          "pages": [
+            {
+              "source_path": "website/index.html",
+              "entrypoint": true,
+              "post_type": "page",
+              "slug": "home",
+              "title": "Atlas Bakery",
+              "block_markup": "<!-- wp:heading {\"level\":1} --><h1 class=\"wp-block-heading\">Atlas Bakery</h1><!-- /wp:heading -->"
+            }
+          ],
+          "assets": []
+        }
+      }
+    },
+    "ssi_import_report": {
+      "version": 1,
+      "schema": "static-site-importer/import-report/v1",
+      "theme_slug": "atlas-bakery",
+      "source": {
+        "type": "website_artifact",
+        "source": "artifact.json"
+      },
+      "blocks_engine": {
+        "available": true,
+        "website_artifact": {
+          "summary": {
+            "schema": "blocks-engine/php-transformer/result/v1",
+            "status": "success",
+            "source": "artifact.json"
+          }
+        }
+      },
+      "generated_theme": {
+        "slug": "atlas-bakery",
+        "files": ["style.css", "templates/front-page.html", "patterns/page-home.php"]
+      },
+      "quality": {
+        "fallback_count": 0,
+        "core_html_block_count": 0,
+        "invalid_block_document_count": 0
+      },
+      "diagnostics": [],
+      "import_validation_result": {
+        "schema": "blocks-engine/import-validation-result/v1",
+        "artifact_type": "ImportValidationResult",
+        "version": 1,
+        "status": "passed"
+      },
+      "finding_packets": {
+        "schema": "blocks-engine/finding-packets/v1",
+        "artifact_type": "FindingPacketSet",
+        "version": 1,
+        "status": "clean",
+        "count": 0,
+        "packets": []
+      }
+    },
+    "codebox_validation_artifact_envelope": {
+      "schema": "wp-codebox/validation-artifact-envelope/v1",
+      "status": "passed",
+      "artifacts": [
+        {
+          "kind": "import_report",
+          "ref": "artifact://codebox/run-123/import-report.json"
+        },
+        {
+          "kind": "visual_comparison",
+          "ref": "artifact://codebox/run-123/visual-comparison.json"
+        }
+      ],
+      "refs": {
+        "run": "codebox-run-123",
+        "site": "wordpress-site-123"
+      }
+    }
+  }
+}

--- a/tests/smoke-product-handoff-contract.php
+++ b/tests/smoke-product-handoff-contract.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Smoke test: product handoff contract fixture matches SSI schema constants.
+ *
+ * Run from the repository root:
+ * php tests/smoke-product-handoff-contract.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
+
+$fixture_path = __DIR__ . '/fixtures/product-handoff-contract/v1.json';
+$fixture      = json_decode( file_get_contents( $fixture_path ), true );
+$failures     = array();
+$assertions   = 0;
+$assert       = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$assert( is_array( $fixture ), 'fixture-decodes' );
+
+$schemas = Static_Site_Importer_Product_Handoff_Contract::schema_map();
+$assert( $schemas['schema'] === ( $fixture['schema'] ?? '' ), 'contract-schema-matches-code' );
+$assert( $schemas['version'] === ( $fixture['version'] ?? 0 ), 'contract-version-matches-code' );
+
+$stages = isset( $fixture['stages'] ) && is_array( $fixture['stages'] ) ? $fixture['stages'] : array();
+$example = isset( $fixture['example'] ) && is_array( $fixture['example'] ) ? $fixture['example'] : array();
+
+$expected_stage_schemas = array(
+	'input_artifact'                       => $schemas['input_artifact'],
+	'blocks_engine_result'                 => $schemas['blocks_engine_result'],
+	'ssi_import_report'                    => $schemas['ssi_import_report'],
+	'codebox_validation_artifact_envelope' => $schemas['codebox_validation_artifact_envelope'],
+);
+
+foreach ( $expected_stage_schemas as $stage => $schema ) {
+	$assert( isset( $stages[ $stage ] ) && is_array( $stages[ $stage ] ), $stage . '-stage-present' );
+	$assert( $schema === ( $stages[ $stage ]['schema'] ?? '' ), $stage . '-schema-matches-code' );
+	$assert( isset( $stages[ $stage ]['required_fields'] ) && is_array( $stages[ $stage ]['required_fields'] ), $stage . '-required-fields-present' );
+	$assert( isset( $example[ $stage ] ) && is_array( $example[ $stage ] ), $stage . '-example-present' );
+}
+
+$assert( $schemas['blocks_engine_materialization_plan'] === ( $stages['blocks_engine_result']['materialization_plan']['schema'] ?? '' ), 'materialization-plan-schema-matches-code' );
+$assert( $schemas['blocks_engine_materialization_plan'] === ( $example['blocks_engine_result']['source_reports']['materialization_plan']['schema'] ?? '' ), 'materialization-plan-example-schema' );
+$assert( ! isset( $example['blocks_engine_result']['codebox'] ), 'blocks-engine-example-keeps-codebox-out' );
+$assert( $schemas['ssi_import_validation_result'] === ( $example['ssi_import_report']['import_validation_result']['schema'] ?? '' ), 'import-validation-schema' );
+$assert( $schemas['ssi_finding_packets'] === ( $example['ssi_import_report']['finding_packets']['schema'] ?? '' ), 'finding-packets-schema' );
+
+$required_path_exists = static function ( array $data, string $path ): bool {
+	$current = $data;
+	foreach ( explode( '.', $path ) as $segment ) {
+		if ( ! is_array( $current ) || ! array_key_exists( $segment, $current ) ) {
+			return false;
+		}
+		$current = $current[ $segment ];
+	}
+
+	return true;
+};
+
+foreach ( $stages as $stage => $stage_contract ) {
+	if ( ! is_array( $stage_contract ) || ! isset( $example[ $stage ] ) || ! is_array( $example[ $stage ] ) ) {
+		continue;
+	}
+
+	foreach ( $stage_contract['required_fields'] ?? array() as $field ) {
+		$assert( is_string( $field ) && $required_path_exists( $example[ $stage ], $field ), $stage . '-requires-' . (string) $field );
+	}
+}
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: product handoff contract smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Define the SSI product handoff contract in code, docs, and a machine-readable fixture.
- Add a smoke test that locks input artifact, Blocks Engine result/materialization plan, SSI import report, and Codebox validation artifact envelope schemas.
- Stamp SSI import reports with `static-site-importer/import-report/v1`.

## Verification
- `php tests/smoke-product-handoff-contract.php`
- `php tests/smoke-transformer-adapter.php`
- `php tests/smoke-website-artifact-document-metadata.php`
- `php tests/smoke-website-artifact-products-manifest.php`
- `php -l includes/class-static-site-importer-product-handoff-contract.php`
- `php -l includes/class-static-site-importer-report-diagnostics.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Contract design, implementation, docs, tests, and verification.