### PR TITLE
Standardize visual parity artifact report contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ The export envelope includes:
 
 The default root is `website` with `entrypoint: "website/index.html"`. Callers can pass any safe single-segment root with a matching entrypoint, such as `root: "artifact"` and `entrypoint: "artifact/index.html"`.
 
+## Product Handoff Contract
+
+The product handoff contract is defined in `docs/product-handoff-contract.md` and locked by `tests/fixtures/product-handoff-contract/v1.json` plus `tests/smoke-product-handoff-contract.php`.
+
+The handoff path is:
+
+- product caller sends a `blocks-engine/php-transformer/site-artifact/v1` input artifact;
+- Blocks Engine returns `blocks-engine/php-transformer/result/v1` with a canonical `blocks-engine/php-transformer/materialization-plan/v1`;
+- SSI consumes that plan, writes WordPress state, and returns `static-site-importer/import-report/v1` with import validation and finding packet artifacts;
+- Codebox may validate the WordPress result and return `wp-codebox/validation-artifact-envelope/v1` artifact references.
+
+Blocks Engine does not know about Codebox. Products that need sandbox validation request it after SSI materializes WordPress.
+
 ## Validation
 
 The repository has both WordPress-side fixture coverage and generated-artifact validation.

--- a/docs/product-handoff-contract.md
+++ b/docs/product-handoff-contract.md
@@ -1,0 +1,21 @@
+# Product Handoff Contract
+
+Static Site Importer's product handoff uses four machine-readable envelopes. The JSON fixture at `tests/fixtures/product-handoff-contract/v1.json` is the canonical contract sample used by tests.
+
+## Stages
+
+1. Product caller provides an input artifact with schema `blocks-engine/php-transformer/site-artifact/v1`.
+2. Blocks Engine compiles it and returns `blocks-engine/php-transformer/result/v1` with `source_reports.materialization_plan` using `blocks-engine/php-transformer/materialization-plan/v1`.
+3. SSI consumes the materialization plan, writes WordPress pages/theme/assets, and returns an import report with nested `blocks-engine/import-validation-result/v1` and `blocks-engine/finding-packets/v1` artifacts.
+4. Codebox may validate the WordPress result and return `wp-codebox/validation-artifact-envelope/v1` with artifact references for rendered output, visual comparison, WordPress state, import report, and diagnostics.
+
+## Ownership
+
+- Blocks Engine owns static artifact compilation and the materialization plan.
+- SSI owns WordPress writes and the import report.
+- Codebox owns optional WordPress validation and artifact references.
+- WPSG, Data Machine, and Studio Native consume these outputs directly; they should not depend on legacy SSI wrapper history.
+
+## Boundary
+
+Blocks Engine stays out of Codebox details. If a caller wants Codebox validation, it asks Codebox after SSI materializes WordPress and passes SSI output or runtime references through the Codebox-owned envelope.

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -100,6 +100,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'asset_map'                    => array( 'type' => 'object' ),
 						'compiler_options'             => array( 'type' => 'object' ),
 						'source_metadata'              => array( 'type' => 'object' ),
+						'validation_artifacts'         => array( 'type' => 'object' ),
 					),
 					'required'   => array( 'artifact' ),
 				),
@@ -137,6 +138,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'asset_map'                    => array( 'type' => 'object' ),
 						'compiler_options'             => array( 'type' => 'object' ),
 						'source_metadata'              => array( 'type' => 'object' ),
+						'validation_artifacts'         => array( 'type' => 'object' ),
 					),
 					'required'   => array( 'url' ),
 				),
@@ -241,6 +243,7 @@ if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' )
 			'asset_map'                    => isset( $input['asset_map'] ) && is_array( $input['asset_map'] ) ? $input['asset_map'] : array(),
 			'compiler_options'             => isset( $input['compiler_options'] ) && is_array( $input['compiler_options'] ) ? $input['compiler_options'] : array(),
 			'source_metadata'              => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
+			'validation_artifacts'         => isset( $input['validation_artifacts'] ) && is_array( $input['validation_artifacts'] ) ? $input['validation_artifacts'] : array(),
 		);
 
 		$result = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $args );

--- a/includes/class-static-site-importer-product-handoff-contract.php
+++ b/includes/class-static-site-importer-product-handoff-contract.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Product handoff contract constants.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Names the machine-readable envelopes shared across product handoffs.
+ */
+class Static_Site_Importer_Product_Handoff_Contract {
+
+	public const VERSION = 1;
+	public const CONTRACT_SCHEMA = 'static-site-importer/product-handoff-contract/v1';
+	public const INPUT_ARTIFACT_SCHEMA = 'blocks-engine/php-transformer/site-artifact/v1';
+	public const BLOCKS_ENGINE_RESULT_SCHEMA = 'blocks-engine/php-transformer/result/v1';
+	public const MATERIALIZATION_PLAN_SCHEMA = 'blocks-engine/php-transformer/materialization-plan/v1';
+	public const SSI_IMPORT_REPORT_SCHEMA = 'static-site-importer/import-report/v1';
+	public const SSI_IMPORT_VALIDATION_RESULT_SCHEMA = 'blocks-engine/import-validation-result/v1';
+	public const SSI_FINDING_PACKETS_SCHEMA = 'blocks-engine/finding-packets/v1';
+	public const SSI_ARTIFACT_DIAGNOSTICS_SCHEMA = 'static-site-importer/artifact-diagnostics/v1';
+	public const CODEBOX_VALIDATION_ARTIFACT_ENVELOPE_SCHEMA = 'wp-codebox/validation-artifact-envelope/v1';
+
+	/**
+	 * Return the canonical schema identifiers by handoff stage.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function schema_map(): array {
+		return array(
+			'schema'                            => self::CONTRACT_SCHEMA,
+			'version'                           => self::VERSION,
+			'input_artifact'                    => self::INPUT_ARTIFACT_SCHEMA,
+			'blocks_engine_result'              => self::BLOCKS_ENGINE_RESULT_SCHEMA,
+			'blocks_engine_materialization_plan' => self::MATERIALIZATION_PLAN_SCHEMA,
+			'ssi_import_report'                 => self::SSI_IMPORT_REPORT_SCHEMA,
+			'ssi_import_validation_result'      => self::SSI_IMPORT_VALIDATION_RESULT_SCHEMA,
+			'ssi_finding_packets'               => self::SSI_FINDING_PACKETS_SCHEMA,
+			'ssi_artifact_diagnostics'          => self::SSI_ARTIFACT_DIAGNOSTICS_SCHEMA,
+			'codebox_validation_artifact_envelope' => self::CODEBOX_VALIDATION_ARTIFACT_ENVELOPE_SCHEMA,
+		);
+	}
+}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -12,6 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-transformer-adapter.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Product_Handoff_Contract' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-product-handoff-contract.php';
+}
 
 /**
  * Builds SSI import reports and normalizes diagnostics for repair loops.
@@ -27,6 +30,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	public static function new_conversion_report( string $html_path, array $source_metadata = array() ): array {
 		return array(
+			'schema'                  => Static_Site_Importer_Product_Handoff_Contract::SSI_IMPORT_REPORT_SCHEMA,
 			'version'                 => 1,
 			'entry_file'              => $html_path,
 			'source'                  => array_merge(

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -118,13 +118,14 @@ class Static_Site_Importer_Report_Diagnostics {
 				'freeform_blocks'   => array(),
 			),
 			'visual_fidelity'         => array(
-				'status'             => 'requires_external_render_check',
-				'gate_owner'         => 'benchmark_harness',
+				'status'             => 'requires_runtime_visual_parity_check',
+				'gate_owner'         => 'codebox_runtime',
 				'comparison_targets' => array(),
 				'notes'              => array(
-					'Static Site Importer records source and generated DOM probes, render URLs, and theme artifacts for visual comparison; screenshot capture and computed-style/layout thresholds belong to the benchmark harness.',
+					'Static Site Importer records stable artifact slots for Codebox/runtime visual parity validation; browser rendering, screenshots, and diffs are captured by the runtime when available.',
 				),
 			),
+			'visual_parity_artifacts' => self::visual_parity_artifact_contract(),
 			'semantic_fidelity'       => array(
 				'status'             => 'requires_external_render_check',
 				'gate_owner'         => 'benchmark_harness',
@@ -138,7 +139,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'Blocks Engine owns the website-artifact to WordPress-artifact envelope and transform diagnostics; Static Site Importer materializes the result into WordPress.',
 				'Static Site Importer still owns WordPress writes, dependency materialization, and WooCommerce product seeding, which keeps this report helper from moving wholesale into Blocks Engine.',
 				'Generated-theme block validation uses WordPress server-side block parsing and serialization checks; editor-runtime validation remains the exact Gutenberg authority.',
-				'Visual fidelity requires browser rendering; use visual_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
+				'Visual fidelity requires browser rendering; use visual_parity_artifacts for durable Codebox/runtime evidence and explicit pending/not-captured slots.',
 				'Semantic fidelity requires browser DOM extraction; use semantic_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
 			),
 		);
@@ -270,6 +271,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	public static function finalize_report( array &$report, array $args ): array {
 		$quality                            = self::finalize_quality_report( $report, $args );
+		$report['visual_parity_artifacts']  = self::visual_parity_artifact_contract( isset( $args['validation_artifacts'] ) && is_array( $args['validation_artifacts'] ) ? $args['validation_artifacts'] : array() );
 		$report['compact_summary']          = self::import_report_summary( $report, $quality );
 		$report['finding_packets']          = self::finding_packets( $report );
 		$report['import_validation_result'] = self::import_validation_result( $report, $quality );
@@ -327,11 +329,12 @@ class Static_Site_Importer_Report_Diagnostics {
 					'owner'  => (string) ( $report['semantic_fidelity']['gate_owner'] ?? 'benchmark_harness' ),
 				),
 			),
-			'diagnostic_summary'  => $summary['diagnostic_summary'] ?? array(),
-			'diagnostic_refs'     => isset( $quality['diagnostic_refs'] ) && is_array( $quality['diagnostic_refs'] ) ? $quality['diagnostic_refs'] : array(),
-			'artifacts'           => self::validation_artifact_refs(),
-			'provenance'          => self::validation_provenance( $report ),
-			'reproduction_context' => self::validation_reproduction_context( $report ),
+			'diagnostic_summary'       => $summary['diagnostic_summary'] ?? array(),
+			'diagnostic_refs'          => isset( $quality['diagnostic_refs'] ) && is_array( $quality['diagnostic_refs'] ) ? $quality['diagnostic_refs'] : array(),
+			'artifacts'                => self::validation_artifact_refs(),
+			'visual_parity_artifacts' => isset( $report['visual_parity_artifacts'] ) && is_array( $report['visual_parity_artifacts'] ) ? $report['visual_parity_artifacts'] : self::visual_parity_artifact_contract(),
+			'provenance'               => self::validation_provenance( $report ),
+			'reproduction_context'      => self::validation_reproduction_context( $report ),
 		);
 	}
 
@@ -466,6 +469,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'commerce_context'             => $commerce_context,
 			'plugin_materialization'       => $plugin_materialization,
 			'product_seeding'              => $product_seeding,
+			'visual_parity_artifacts'      => isset( $report['visual_parity_artifacts'] ) && is_array( $report['visual_parity_artifacts'] ) ? $report['visual_parity_artifacts'] : self::visual_parity_artifact_contract(),
 			'diagnostic_count'             => count( $diagnostics ),
 			'diagnostic_summary'           => self::compact_import_report_diagnostic_summary( $diagnostics ),
 			'warning_summaries'            => self::compact_import_report_diagnostic_summaries_by_severity( $diagnostics, 'warning' ),
@@ -520,6 +524,158 @@ class Static_Site_Importer_Report_Diagnostics {
 				'kind' => 'blocks-engine/finding-packets',
 			),
 		);
+	}
+
+	/**
+	 * Build the stable Codebox/runtime visual parity artifact contract.
+	 *
+	 * @param array<string,mixed> $provided Runtime-provided durable artifact refs.
+	 * @return array<string,mixed>
+	 */
+	private static function visual_parity_artifact_contract( array $provided = array() ): array {
+		$slots = array(
+			'browser_render'           => array( 'kind' => 'browser_render_evidence', 'aliases' => array( 'browser-html', 'browser-artifact', 'artifact-bundle' ), 'reason' => 'Codebox/runtime browser render evidence was not provided.' ),
+			'source_screenshot'        => array( 'kind' => 'source_screenshot', 'reason' => 'Source screenshot was not captured by the runtime.' ),
+			'imported_screenshot'      => array( 'kind' => 'imported_screenshot', 'reason' => 'Imported WordPress screenshot was not captured by the runtime.' ),
+			'visual_diff'              => array( 'kind' => 'visual_diff', 'aliases' => array( 'visual_parity_artifact' ), 'reason' => 'Visual diff output was not captured by the runtime.' ),
+			'import_report'            => array( 'kind' => 'static-site-importer/import-report', 'artifact_name' => 'import-report.json' ),
+			'import_validation_result' => array( 'kind' => 'static-site-importer/import-validation-result', 'artifact_name' => 'import-validation-result.json' ),
+			'finding_packets'          => array( 'kind' => 'static-site-importer/finding-packets', 'artifact_name' => 'finding-packets.json' ),
+			'block_validation'         => array( 'kind' => 'gutenberg_block_validation', 'reason' => 'Block validation artifact was not provided by the runtime.' ),
+		);
+
+		$artifacts = array();
+		foreach ( $slots as $name => $slot ) {
+			$aliases = isset( $slot['aliases'] ) && is_array( $slot['aliases'] ) ? array_values( $slot['aliases'] ) : array();
+			$ref     = self::durable_artifact_ref( self::provided_visual_parity_artifact_ref( $provided, $name, (string) $slot['kind'], $aliases ) );
+			if ( empty( $ref ) && isset( $slot['artifact_name'] ) ) {
+				$ref = array(
+					'kind'          => (string) $slot['kind'],
+					'artifact_name' => (string) $slot['artifact_name'],
+				);
+			}
+
+			$artifacts[ $name ] = array_merge(
+				array(
+					'status' => empty( $ref ) ? 'pending' : 'captured',
+					'kind'   => (string) $slot['kind'],
+				),
+				empty( $ref )
+					? array(
+						'capture_state' => 'not_captured',
+						'reason'        => (string) ( $slot['reason'] ?? 'Artifact was not provided by the runtime.' ),
+					)
+					: array( 'ref' => $ref )
+			);
+		}
+
+		$missing = array_values(
+			array_keys(
+				array_filter(
+					$artifacts,
+					static fn ( array $artifact ): bool => 'captured' !== ( $artifact['status'] ?? '' )
+				)
+			)
+		);
+
+		return array(
+			'schema'       => 'static-site-importer/visual-parity-artifacts/v1',
+			'status'       => empty( $missing ) ? 'complete' : 'pending',
+			'owner'        => 'codebox_runtime',
+			'contract'     => 'durable_artifact_refs_only',
+			'missing'      => $missing,
+			'artifacts'    => $artifacts,
+			'local_paths'  => 'omitted',
+			'notes'        => array(
+				'Screenshot and diff slots stay pending until Codebox/runtime validation supplies durable artifact refs.',
+				'Reviewer-facing refs use artifact IDs, URLs, or artifact names; local filesystem paths are intentionally omitted.',
+			),
+		);
+	}
+
+	/**
+	 * Read a named runtime artifact ref from direct keys or artifact_refs arrays.
+	 *
+	 * @param array<string,mixed> $provided Runtime-provided artifacts.
+	 * @param string              $name     Artifact slot name.
+	 * @param string              $kind     Expected artifact kind.
+	 * @param array<int,string>   $aliases  Accepted artifact kind aliases.
+	 * @return mixed
+	 */
+	private static function provided_visual_parity_artifact_ref( array $provided, string $name, string $kind, array $aliases = array() ): mixed {
+		if ( isset( $provided[ $name ] ) ) {
+			return $provided[ $name ];
+		}
+
+		$refs = array();
+		foreach ( array( 'artifact_refs', 'artifacts' ) as $key ) {
+			if ( isset( $provided[ $key ] ) && is_array( $provided[ $key ] ) ) {
+				$refs = array_merge( $refs, array_values( $provided[ $key ] ) );
+			}
+		}
+
+		foreach ( $refs as $ref ) {
+			if ( ! is_array( $ref ) ) {
+				continue;
+			}
+
+			$ref_kind = isset( $ref['kind'] ) && is_scalar( $ref['kind'] ) ? (string) $ref['kind'] : '';
+			$ref_role = isset( $ref['role'] ) && is_scalar( $ref['role'] ) ? (string) $ref['role'] : '';
+			if ( $name === $ref_role || $kind === $ref_kind || in_array( $ref_kind, $aliases, true ) ) {
+				return $ref;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normalize a runtime artifact reference to durable fields only.
+	 *
+	 * @param mixed $ref Runtime-provided artifact reference.
+	 * @return array<string,string>
+	 */
+	private static function durable_artifact_ref( mixed $ref ): array {
+		if ( is_string( $ref ) && '' !== trim( $ref ) ) {
+			$ref = array( filter_var( $ref, FILTER_VALIDATE_URL ) ? 'url' : 'artifact_id' => $ref );
+		}
+		if ( ! is_array( $ref ) ) {
+			return array();
+		}
+
+		$durable = array();
+		foreach ( array( 'artifact_id', 'id', 'url', 'artifact_name', 'name', 'kind', 'role', 'sha256' ) as $key ) {
+			if ( ! isset( $ref[ $key ] ) || ! is_scalar( $ref[ $key ] ) ) {
+				continue;
+			}
+
+			$value = trim( (string) $ref[ $key ] );
+			if ( '' === $value || self::is_local_path_ref( $value ) ) {
+				continue;
+			}
+
+			$normalized_key             = 'id' === $key ? 'artifact_id' : ( 'name' === $key ? 'artifact_name' : $key );
+			$durable[ $normalized_key ] = $value;
+		}
+
+		if ( empty( $durable ) && isset( $ref['path'] ) && is_scalar( $ref['path'] ) ) {
+			$path = trim( (string) $ref['path'] );
+			if ( '' !== $path && ! self::is_local_path_ref( $path ) ) {
+				$durable['artifact_name'] = basename( $path );
+			}
+		}
+
+		return $durable;
+	}
+
+	/**
+	 * Determine whether a value is a local filesystem path that should not be shared.
+	 *
+	 * @param string $value Candidate artifact field value.
+	 * @return bool
+	 */
+	private static function is_local_path_ref( string $value ): bool {
+		return (bool) preg_match( '#^(?:/|[A-Za-z]:\\\\|file://|~[/\\\\]|(?:\.\.?[/\\\\]))#', $value );
 	}
 
 	/**

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -648,7 +648,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		$durable = array();
-		foreach ( array( 'artifact_id', 'id', 'url', 'artifact_name', 'name', 'kind', 'role', 'sha256' ) as $key ) {
+		foreach ( array( 'artifact_id', 'id', 'url', 'artifact_name', 'name', 'sha256' ) as $key ) {
 			if ( ! isset( $ref[ $key ] ) || ! is_scalar( $ref[ $key ] ) ) {
 				continue;
 			}
@@ -662,10 +662,23 @@ class Static_Site_Importer_Report_Diagnostics {
 			$durable[ $normalized_key ] = $value;
 		}
 
-		if ( empty( $durable ) && isset( $ref['path'] ) && is_scalar( $ref['path'] ) ) {
+		if ( ! isset( $durable['artifact_name'] ) && isset( $ref['path'] ) && is_scalar( $ref['path'] ) ) {
 			$path = trim( (string) $ref['path'] );
 			if ( '' !== $path && ! self::is_local_path_ref( $path ) ) {
 				$durable['artifact_name'] = basename( $path );
+			}
+		}
+
+		if ( ! empty( $durable ) ) {
+			foreach ( array( 'kind', 'role' ) as $key ) {
+				if ( ! isset( $ref[ $key ] ) || ! is_scalar( $ref[ $key ] ) ) {
+					continue;
+				}
+
+				$value = trim( (string) $ref[ $key ] );
+				if ( '' !== $value ) {
+					$durable[ $key ] = $value;
+				}
 			}
 		}
 

--- a/includes/class-static-site-importer-url-import-runtime.php
+++ b/includes/class-static-site-importer-url-import-runtime.php
@@ -156,6 +156,7 @@ class Static_Site_Importer_URL_Import_Runtime {
 			'asset_map'                    => isset( $input['asset_map'] ) && is_array( $input['asset_map'] ) ? $input['asset_map'] : array(),
 			'compiler_options'             => isset( $input['compiler_options'] ) && is_array( $input['compiler_options'] ) ? $input['compiler_options'] : array(),
 			'source_metadata'              => $source_metadata,
+			'validation_artifacts'         => isset( $input['validation_artifacts'] ) && is_array( $input['validation_artifacts'] ) ? $input['validation_artifacts'] : array(),
 		);
 
 		return $args;

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -31,6 +31,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-pa
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-stylesheet-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-product-handoff-contract.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-transformer-adapter.php';

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -175,6 +175,65 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Codebox/runtime visual parity artifacts use durable refs and explicit pending slots.
+	 */
+	public function test_visual_parity_artifacts_are_stable_and_omit_local_paths(): void {
+		$report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( '/tmp/source/index.html' );
+		$report['theme_slug'] = 'visual-parity-fixture';
+
+		Static_Site_Importer_Report_Diagnostics::finalize_report(
+			$report,
+			array(
+				'validation_artifacts' => array(
+					'browser_render'      => array(
+						'kind'        => 'browser_render_evidence',
+						'artifact_id' => 'codebox-run-123/render.json',
+						'url'         => 'https://artifacts.example.test/runs/123/render.json',
+						'path'        => '/tmp/codebox/render.json',
+					),
+					'imported_screenshot' => array(
+						'kind' => 'imported_screenshot',
+						'path' => 'screenshots/imported.png',
+					),
+					'visual_diff'         => array(
+						'kind' => 'visual_diff',
+						'path' => '/Users/chubes/Downloads/local-diff.png',
+					),
+					'block_validation'    => array(
+						'kind'          => 'gutenberg_block_validation',
+						'artifact_name' => 'block-validation.json',
+					),
+				),
+			)
+		);
+
+		$visual = $report['visual_parity_artifacts'] ?? array();
+		$this->assertSame( 'static-site-importer/visual-parity-artifacts/v1', $visual['schema'] ?? '' );
+		$this->assertSame( 'pending', $visual['status'] ?? '' );
+		$this->assertSame( 'codebox_runtime', $visual['owner'] ?? '' );
+		$this->assertSame( 'durable_artifact_refs_only', $visual['contract'] ?? '' );
+
+		$artifacts = $visual['artifacts'] ?? array();
+		$this->assertSame( 'captured', $artifacts['browser_render']['status'] ?? '' );
+		$this->assertSame( 'codebox-run-123/render.json', $artifacts['browser_render']['ref']['artifact_id'] ?? '' );
+		$this->assertSame( 'https://artifacts.example.test/runs/123/render.json', $artifacts['browser_render']['ref']['url'] ?? '' );
+		$this->assertArrayNotHasKey( 'path', $artifacts['browser_render']['ref'] ?? array() );
+		$this->assertSame( 'captured', $artifacts['imported_screenshot']['status'] ?? '' );
+		$this->assertSame( 'imported.png', $artifacts['imported_screenshot']['ref']['artifact_name'] ?? '' );
+		$this->assertSame( 'pending', $artifacts['source_screenshot']['status'] ?? '' );
+		$this->assertSame( 'not_captured', $artifacts['source_screenshot']['capture_state'] ?? '' );
+		$this->assertStringContainsString( 'not captured', $artifacts['source_screenshot']['reason'] ?? '' );
+		$this->assertSame( 'pending', $artifacts['visual_diff']['status'] ?? '' );
+		$this->assertSame( 'not_captured', $artifacts['visual_diff']['capture_state'] ?? '' );
+		$this->assertSame( 'captured', $artifacts['import_report']['status'] ?? '' );
+		$this->assertSame( 'import-report.json', $artifacts['import_report']['ref']['artifact_name'] ?? '' );
+		$this->assertSame( 'block-validation.json', $artifacts['block_validation']['ref']['artifact_name'] ?? '' );
+		$this->assertSame( $visual, $report['import_validation_result']['visual_parity_artifacts'] ?? array() );
+		$this->assertSame( $visual, $report['compact_summary']['visual_parity_artifacts'] ?? array() );
+		$this->assertReportValueHasNoLocalPath( $visual );
+	}
+
+	/**
 	 * Artifact diagnostics use SSI's schema when no WP Codebox PHP normalizer is available.
 	 */
 	public function test_artifact_diagnostics_adapter_emits_static_site_importer_fallback_shape(): void {
@@ -222,6 +281,27 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 'clean', $empty['status'] ?? '' );
 		$this->assertSame( array( 'total' => 0, 'error' => 0, 'warning' => 0, 'notice' => 0, 'info' => 0 ), $empty['summary'] ?? array() );
 		$this->assertSame( array(), $empty['diagnostics'] ?? null );
+	}
+
+	/**
+	 * Assert that a report value does not expose local filesystem paths.
+	 *
+	 * @param mixed $value Report value.
+	 */
+	private function assertReportValueHasNoLocalPath( mixed $value ): void {
+		if ( is_array( $value ) ) {
+			foreach ( $value as $item ) {
+				$this->assertReportValueHasNoLocalPath( $item );
+			}
+
+			return;
+		}
+
+		if ( ! is_string( $value ) ) {
+			return;
+		}
+
+		$this->assertDoesNotMatchRegularExpression( '#^(?:/|[A-Za-z]:\\\\|file://|~[/\\\\]|(?:\.\.?[/\\\\]))#', $value );
 	}
 
 	/**

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -90,6 +90,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	 */
 	public function test_import_validation_result_and_finding_packets_are_machine_readable(): void {
 		$report = array(
+			'schema'                  => 'static-site-importer/import-report/v1',
 			'entry_file'              => '/tmp/source/index.html',
 			'version'                 => 1,
 			'theme_slug'              => 'static-template-import',
@@ -245,6 +246,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		);
 
 		$report      = $report_property->getValue();
+		$this->assertSame( 'static-site-importer/import-report/v1', $report['schema'] ?? '' );
 		$diagnostics = array_values(
 			array_filter(
 				$report['diagnostics'] ?? array(),

--- a/tests/fixtures/product-handoff-contract/v1.json
+++ b/tests/fixtures/product-handoff-contract/v1.json
@@ -1,0 +1,144 @@
+{
+  "schema": "static-site-importer/product-handoff-contract/v1",
+  "version": 1,
+  "stages": {
+    "input_artifact": {
+      "owner": "product_caller",
+      "consumer": "blocks_engine",
+      "schema": "blocks-engine/php-transformer/site-artifact/v1",
+      "required_fields": ["schema", "files", "root", "entrypoint"],
+      "notes": "Portable static website bundle. Callers provide files; Blocks Engine compiles them."
+    },
+    "blocks_engine_result": {
+      "owner": "blocks_engine",
+      "consumer": "static_site_importer",
+      "schema": "blocks-engine/php-transformer/result/v1",
+      "required_fields": ["schema", "status", "source_reports.materialization_plan"],
+      "materialization_plan": {
+        "schema": "blocks-engine/php-transformer/materialization-plan/v1",
+        "required_fields": ["schema", "source_schema", "entry_path", "pages", "assets"]
+      },
+      "notes": "Blocks Engine emits the canonical WordPress materialization plan and remains unaware of Codebox validation details."
+    },
+    "ssi_import_report": {
+      "owner": "static_site_importer",
+      "consumer": "product_caller",
+      "schema": "static-site-importer/import-report/v1",
+      "required_fields": ["version", "theme_slug", "source", "blocks_engine", "generated_theme", "quality", "diagnostics", "import_validation_result", "finding_packets"],
+      "nested_artifacts": {
+        "import_validation_result": "blocks-engine/import-validation-result/v1",
+        "finding_packets": "blocks-engine/finding-packets/v1",
+        "artifact_diagnostics_fallback": "static-site-importer/artifact-diagnostics/v1"
+      },
+      "notes": "SSI writes WordPress state and reports materialized theme, page, asset, quality, and repair-loop outputs."
+    },
+    "codebox_validation_artifact_envelope": {
+      "owner": "wp_codebox",
+      "consumer": "product_caller",
+      "schema": "wp-codebox/validation-artifact-envelope/v1",
+      "required_fields": ["schema", "status", "artifacts", "refs"],
+      "artifact_kinds": ["render", "visual_comparison", "wordpress_state", "import_report", "diagnostics"],
+      "notes": "Codebox validates the WordPress result and returns artifact references. SSI treats this as an optional downstream validation envelope."
+    }
+  },
+  "example": {
+    "input_artifact": {
+      "schema": "blocks-engine/php-transformer/site-artifact/v1",
+      "root": "website",
+      "entrypoint": "website/index.html",
+      "files": [
+        {
+          "path": "website/index.html",
+          "role": "document",
+          "kind": "html",
+          "mime_type": "text/html",
+          "encoding": "utf-8",
+          "content": "<!doctype html><html><body><main><h1>Atlas Bakery</h1></main></body></html>"
+        }
+      ]
+    },
+    "blocks_engine_result": {
+      "schema": "blocks-engine/php-transformer/result/v1",
+      "status": "success",
+      "source_reports": {
+        "materialization_plan": {
+          "schema": "blocks-engine/php-transformer/materialization-plan/v1",
+          "source_schema": "blocks-engine/php-transformer/compiled-site/v1",
+          "entry_path": "website/index.html",
+          "pages": [
+            {
+              "source_path": "website/index.html",
+              "entrypoint": true,
+              "post_type": "page",
+              "slug": "home",
+              "title": "Atlas Bakery",
+              "block_markup": "<!-- wp:heading {\"level\":1} --><h1 class=\"wp-block-heading\">Atlas Bakery</h1><!-- /wp:heading -->"
+            }
+          ],
+          "assets": []
+        }
+      }
+    },
+    "ssi_import_report": {
+      "version": 1,
+      "schema": "static-site-importer/import-report/v1",
+      "theme_slug": "atlas-bakery",
+      "source": {
+        "type": "website_artifact",
+        "source": "artifact.json"
+      },
+      "blocks_engine": {
+        "available": true,
+        "website_artifact": {
+          "summary": {
+            "schema": "blocks-engine/php-transformer/result/v1",
+            "status": "success",
+            "source": "artifact.json"
+          }
+        }
+      },
+      "generated_theme": {
+        "slug": "atlas-bakery",
+        "files": ["style.css", "templates/front-page.html", "patterns/page-home.php"]
+      },
+      "quality": {
+        "fallback_count": 0,
+        "core_html_block_count": 0,
+        "invalid_block_document_count": 0
+      },
+      "diagnostics": [],
+      "import_validation_result": {
+        "schema": "blocks-engine/import-validation-result/v1",
+        "artifact_type": "ImportValidationResult",
+        "version": 1,
+        "status": "passed"
+      },
+      "finding_packets": {
+        "schema": "blocks-engine/finding-packets/v1",
+        "artifact_type": "FindingPacketSet",
+        "version": 1,
+        "status": "clean",
+        "count": 0,
+        "packets": []
+      }
+    },
+    "codebox_validation_artifact_envelope": {
+      "schema": "wp-codebox/validation-artifact-envelope/v1",
+      "status": "passed",
+      "artifacts": [
+        {
+          "kind": "import_report",
+          "ref": "artifact://codebox/run-123/import-report.json"
+        },
+        {
+          "kind": "visual_comparison",
+          "ref": "artifact://codebox/run-123/visual-comparison.json"
+        }
+      ],
+      "refs": {
+        "run": "codebox-run-123",
+        "site": "wordpress-site-123"
+      }
+    }
+  }
+}

--- a/tests/smoke-product-handoff-contract.php
+++ b/tests/smoke-product-handoff-contract.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Smoke test: product handoff contract fixture matches SSI schema constants.
+ *
+ * Run from the repository root:
+ * php tests/smoke-product-handoff-contract.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
+
+$fixture_path = __DIR__ . '/fixtures/product-handoff-contract/v1.json';
+$fixture      = json_decode( file_get_contents( $fixture_path ), true );
+$failures     = array();
+$assertions   = 0;
+$assert       = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$assert( is_array( $fixture ), 'fixture-decodes' );
+
+$schemas = Static_Site_Importer_Product_Handoff_Contract::schema_map();
+$assert( $schemas['schema'] === ( $fixture['schema'] ?? '' ), 'contract-schema-matches-code' );
+$assert( $schemas['version'] === ( $fixture['version'] ?? 0 ), 'contract-version-matches-code' );
+
+$stages = isset( $fixture['stages'] ) && is_array( $fixture['stages'] ) ? $fixture['stages'] : array();
+$example = isset( $fixture['example'] ) && is_array( $fixture['example'] ) ? $fixture['example'] : array();
+
+$expected_stage_schemas = array(
+	'input_artifact'                       => $schemas['input_artifact'],
+	'blocks_engine_result'                 => $schemas['blocks_engine_result'],
+	'ssi_import_report'                    => $schemas['ssi_import_report'],
+	'codebox_validation_artifact_envelope' => $schemas['codebox_validation_artifact_envelope'],
+);
+
+foreach ( $expected_stage_schemas as $stage => $schema ) {
+	$assert( isset( $stages[ $stage ] ) && is_array( $stages[ $stage ] ), $stage . '-stage-present' );
+	$assert( $schema === ( $stages[ $stage ]['schema'] ?? '' ), $stage . '-schema-matches-code' );
+	$assert( isset( $stages[ $stage ]['required_fields'] ) && is_array( $stages[ $stage ]['required_fields'] ), $stage . '-required-fields-present' );
+	$assert( isset( $example[ $stage ] ) && is_array( $example[ $stage ] ), $stage . '-example-present' );
+}
+
+$assert( $schemas['blocks_engine_materialization_plan'] === ( $stages['blocks_engine_result']['materialization_plan']['schema'] ?? '' ), 'materialization-plan-schema-matches-code' );
+$assert( $schemas['blocks_engine_materialization_plan'] === ( $example['blocks_engine_result']['source_reports']['materialization_plan']['schema'] ?? '' ), 'materialization-plan-example-schema' );
+$assert( ! isset( $example['blocks_engine_result']['codebox'] ), 'blocks-engine-example-keeps-codebox-out' );
+$assert( $schemas['ssi_import_validation_result'] === ( $example['ssi_import_report']['import_validation_result']['schema'] ?? '' ), 'import-validation-schema' );
+$assert( $schemas['ssi_finding_packets'] === ( $example['ssi_import_report']['finding_packets']['schema'] ?? '' ), 'finding-packets-schema' );
+
+$required_path_exists = static function ( array $data, string $path ): bool {
+	$current = $data;
+	foreach ( explode( '.', $path ) as $segment ) {
+		if ( ! is_array( $current ) || ! array_key_exists( $segment, $current ) ) {
+			return false;
+		}
+		$current = $current[ $segment ];
+	}
+
+	return true;
+};
+
+foreach ( $stages as $stage => $stage_contract ) {
+	if ( ! is_array( $stage_contract ) || ! isset( $example[ $stage ] ) || ! is_array( $example[ $stage ] ) ) {
+		continue;
+	}
+
+	foreach ( $stage_contract['required_fields'] ?? array() as $field ) {
+		$assert( is_string( $field ) && $required_path_exists( $example[ $stage ], $field ), $stage . '-requires-' . (string) $field );
+	}
+}
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: product handoff contract smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -241,6 +241,17 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( 'blocks-engine/import-validation-result/v1' === ( $validation_result['schema'] ?? '' ), 'validation-result-schema' );
 	$assert( 'ImportValidationResult' === ( $validation_result['artifact_type'] ?? '' ), 'validation-result-artifact-type' );
 	$assert( 'passed' === ( $validation_result['status'] ?? '' ), 'validation-result-status-passed' );
+	$visual_parity = $report['visual_parity_artifacts'] ?? array();
+	$visual_parity_validation = $validation_result['visual_parity_artifacts'] ?? array();
+	$assert( 'static-site-importer/visual-parity-artifacts/v1' === ( $visual_parity['schema'] ?? '' ), 'visual-parity-artifact-schema' );
+	$assert( 'pending' === ( $visual_parity['status'] ?? '' ), 'visual-parity-artifacts-pending-until-runtime-capture' );
+	$assert( 'codebox_runtime' === ( $visual_parity['owner'] ?? '' ), 'visual-parity-artifacts-owned-by-codebox-runtime' );
+	$assert( 'captured' === ( $visual_parity['artifacts']['import_report']['status'] ?? '' ), 'visual-parity-import-report-ref-captured' );
+	$assert( 'import-report.json' === ( $visual_parity['artifacts']['import_report']['ref']['artifact_name'] ?? '' ), 'visual-parity-import-report-ref-name' );
+	$assert( 'pending' === ( $visual_parity['artifacts']['source_screenshot']['status'] ?? '' ), 'visual-parity-source-screenshot-pending' );
+	$assert( 'not_captured' === ( $visual_parity['artifacts']['visual_diff']['capture_state'] ?? '' ), 'visual-parity-diff-not-captured' );
+	$assert( $visual_parity === $visual_parity_validation, 'validation-result-embeds-visual-parity-artifacts' );
+	$assert( ! static_site_importer_smoke_contains_local_path( $visual_parity ), 'visual-parity-artifacts-contain-no-local-paths' );
 	$assert( 'blocks-engine/finding-packets/v1' === ( $finding_packets['schema'] ?? '' ), 'finding-packets-schema' );
 	$assert( 'FindingPacketSet' === ( $finding_packets['artifact_type'] ?? '' ), 'finding-packets-artifact-type' );
 	$assert( 'static-site-importer/document-metadata/v1' === ( $metadata['schema'] ?? '' ), 'metadata-contract-is-recorded' );
@@ -352,6 +363,24 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 	$assert( ! isset( $template_parts_by_path['parts/footer.html'] ), 'multi-page-does-not-synthesize-footer-template-part' );
 	$assert( ! str_contains( $read( $multi_page_result['theme_dir'] . '/templates/front-page.html' ), '"slug":"footer"' ), 'multi-page-template-does-not-reference-synthesized-footer-part' );
 	$assert( array() === $pattern_documents, 'blocks-engine-document-import-does-not-generate-page-pattern-copies' );
+}
+
+function static_site_importer_smoke_contains_local_path( $value ): bool {
+	if ( is_array( $value ) ) {
+		foreach ( $value as $item ) {
+			if ( static_site_importer_smoke_contains_local_path( $item ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	if ( ! is_string( $value ) ) {
+		return false;
+	}
+
+	return (bool) preg_match( '#^(?:/|[A-Za-z]:\\\\|file://|~[/\\\\]|(?:\.\.?[/\\\\]))#', $value );
 }
 
 if ( ! empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Add an SSI-owned `visual_parity_artifacts` report section for Codebox/runtime visual parity acceptance evidence.
- Normalize runtime-supplied `validation_artifacts` into durable artifact IDs, URLs, and artifact names while omitting local filesystem paths.
- Represent unavailable screenshot, diff, browser render, and block validation outputs as explicit `pending` / `not_captured` slots with reasons.
- Embed the visual parity artifact contract in `import-report.json`, `import-validation-result.json`, and compact summaries.

## Verification
- `npm run test:validation`
- `git diff --check`
- `php -l includes/class-static-site-importer-report-diagnostics.php`
- `php -l includes/abilities.php`
- `php -l includes/class-static-site-importer-url-import-runtime.php`
- `php -l tests/StaticSiteImporterFallbackDiagnosticsTest.php`
- `php -l tests/smoke-website-artifact-document-metadata.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Implementing the report contract changes, tests, and verification.
