### PR TITLE
Add SSI Codebox validation product path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 vendor/
 build/
+.homeboy/

--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ The export envelope includes:
 
 The default root is `website` with `entrypoint: "website/index.html"`. Callers can pass any safe single-segment root with a matching entrypoint, such as `root: "artifact"` and `entrypoint: "artifact/index.html"`.
 
+## Product Handoff Contract
+
+The product handoff contract is defined in `docs/product-handoff-contract.md` and locked by `tests/fixtures/product-handoff-contract/v1.json` plus `tests/smoke-product-handoff-contract.php`.
+
+The handoff path is:
+
+- product caller sends a `blocks-engine/php-transformer/site-artifact/v1` input artifact;
+- Blocks Engine returns `blocks-engine/php-transformer/result/v1` with a canonical `blocks-engine/php-transformer/materialization-plan/v1`;
+- SSI consumes that plan, writes WordPress state, and returns `static-site-importer/import-report/v1` with import validation and finding packet artifacts;
+- Codebox may validate the WordPress result and return `wp-codebox/validation-artifact-envelope/v1` artifact references.
+
+Blocks Engine does not know about Codebox. Products that need sandbox validation request it after SSI materializes WordPress.
+
 ## Validation
 
 The repository has both WordPress-side fixture coverage and generated-artifact validation.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,34 @@ The export envelope includes:
 
 The default root is `website` with `entrypoint: "website/index.html"`. Callers can pass any safe single-segment root with a matching entrypoint, such as `root: "artifact"` and `entrypoint: "artifact/index.html"`.
 
+### Codebox validation product path
+
+`static-site-importer/validate-in-codebox` is the SSI product path for validating an import inside a disposable WP Codebox runtime. It accepts either a Blocks Engine website artifact (`artifact`) or durable refs to generated import output (`generated_theme_ref` / `theme_archive_ref`) and builds a `static-site-importer/codebox-validation-request/v1` envelope.
+
+The runtime provider hook is `static_site_importer_codebox_validation_result`. WP Codebox/Homeboy integrations should import the supplied artifact or generated theme output in a disposable runtime, run SSI import validation, run generated-theme block validation, collect browser/render evidence, and return `static-site-importer/codebox-validation-result/v1` with reviewer-facing artifact refs.
+
+Required artifact metadata lives under `artifacts` using `static-site-importer/codebox-validation-artifacts/v1`:
+
+- `generated_theme` or `theme_archive`
+- `import_report`
+- `block_validation_result`
+- `browser_render_evidence`
+- `screenshots[]` when available
+- `diffs[]` when available
+
+Reviewer-facing artifact fields should use durable refs or URLs. Host-local paths and `localhost` URLs are stripped from artifact refs; local paths may appear only under `operator_notes` for the machine operator.
+
+CLI entrypoint:
+
+```bash
+wp static-site-importer validate-in-codebox \
+  --artifact=/path/to/website-artifact.json \
+  --slug=example-import \
+  --name="Example Import"
+```
+
+Current upstream gap: SSI defines the product contract and dispatch hook, but a WP Codebox/Homeboy provider still needs to register `static_site_importer_codebox_validation_result` to execute the disposable runtime and return durable screenshot/diff/browser evidence refs. Until that provider is present, the ability returns a structured `blocked` result documenting the missing provider shape instead of faking validation evidence.
+
 ## Validation
 
 The repository has both WordPress-side fixture coverage and generated-artifact validation.

--- a/docs/product-handoff-contract.md
+++ b/docs/product-handoff-contract.md
@@ -1,0 +1,21 @@
+# Product Handoff Contract
+
+Static Site Importer's product handoff uses four machine-readable envelopes. The JSON fixture at `tests/fixtures/product-handoff-contract/v1.json` is the canonical contract sample used by tests.
+
+## Stages
+
+1. Product caller provides an input artifact with schema `blocks-engine/php-transformer/site-artifact/v1`.
+2. Blocks Engine compiles it and returns `blocks-engine/php-transformer/result/v1` with `source_reports.materialization_plan` using `blocks-engine/php-transformer/materialization-plan/v1`.
+3. SSI consumes the materialization plan, writes WordPress pages/theme/assets, and returns an import report with nested `blocks-engine/import-validation-result/v1` and `blocks-engine/finding-packets/v1` artifacts.
+4. Codebox may validate the WordPress result and return `wp-codebox/validation-artifact-envelope/v1` with artifact references for rendered output, visual comparison, WordPress state, import report, and diagnostics.
+
+## Ownership
+
+- Blocks Engine owns static artifact compilation and the materialization plan.
+- SSI owns WordPress writes and the import report.
+- Codebox owns optional WordPress validation and artifact references.
+- WPSG, Data Machine, and Studio Native consume these outputs directly; they should not depend on legacy SSI wrapper history.
+
+## Boundary
+
+Blocks Engine stays out of Codebox details. If a caller wants Codebox validation, it asks Codebox after SSI materializes WordPress and passes SSI output or runtime references through the Codebox-owned envelope.

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -146,6 +146,39 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);
+
+		wp_register_ability(
+			'static-site-importer/validate-in-codebox',
+			array(
+				'label'               => __( 'Validate Import in Codebox', 'static-site-importer' ),
+				'description'         => __( 'Validate a website artifact or generated import output in a disposable WP Codebox runtime and return durable artifact metadata.', 'static-site-importer' ),
+				'category'            => STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'artifact'                  => array( 'type' => 'object' ),
+						'generated_theme_ref'       => array( 'type' => 'object' ),
+						'theme_archive_ref'         => array( 'type' => 'object' ),
+						'slug'                      => array( 'type' => 'string' ),
+						'name'                      => array( 'type' => 'string' ),
+						'activate'                  => array( 'type' => 'boolean' ),
+						'overwrite'                 => array( 'type' => 'boolean' ),
+						'fail_on_quality'           => array( 'type' => 'boolean' ),
+						'allow_missing_woocommerce' => array( 'type' => 'boolean' ),
+						'asset_materialization_policy' => array(
+							'type' => 'string',
+							'enum' => array( 'copy_to_theme', 'use_map' ),
+						),
+						'compiler_options'          => array( 'type' => 'object' ),
+						'source_metadata'           => array( 'type' => 'object' ),
+					),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'static_site_importer_ability_validate_in_codebox',
+				'permission_callback' => 'static_site_importer_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
 	}
 }
 
@@ -161,6 +194,27 @@ if ( ! function_exists( 'static_site_importer_ability_permission_callback' ) ) {
 		}
 
 		return ! function_exists( 'current_user_can' ) || current_user_can( 'switch_themes' );
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_validate_in_codebox' ) ) {
+	/**
+	 * Ability callback for Codebox-backed validation.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>
+	 */
+	function static_site_importer_ability_validate_in_codebox( array $input ): array {
+		$result = Static_Site_Importer_Codebox_Validation::validate( $input );
+		if ( is_wp_error( $result ) ) {
+			/** @var WP_Error $result */
+			return static_site_importer_ability_error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
+		}
+
+		return array_merge(
+			array( 'success' => ! empty( $result['success'] ) ),
+			$result
+		);
 	}
 }
 

--- a/includes/class-static-site-importer-codebox-validation.php
+++ b/includes/class-static-site-importer-codebox-validation.php
@@ -1,0 +1,355 @@
+<?php
+/**
+ * Codebox-backed validation product path contract.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Builds and dispatches SSI validation requests for disposable Codebox runtimes.
+ */
+class Static_Site_Importer_Codebox_Validation {
+
+	private const REQUEST_SCHEMA  = 'static-site-importer/codebox-validation-request/v1';
+	private const RESULT_SCHEMA   = 'static-site-importer/codebox-validation-result/v1';
+	private const ARTIFACT_SCHEMA = 'static-site-importer/codebox-validation-artifacts/v1';
+
+	/**
+	 * Validate an imported/generated site in a disposable Codebox runtime.
+	 *
+	 * @param array<string,mixed> $input Validation input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function validate( array $input ) {
+		$request = self::build_request( $input );
+		if ( is_wp_error( $request ) ) {
+			return $request;
+		}
+
+		/**
+		 * Filters the SSI Codebox validation request before runtime dispatch.
+		 *
+		 * WP Codebox/Homeboy integrations may attach orchestration metadata here, but
+		 * should not execute the run. Execution belongs to
+		 * `static_site_importer_codebox_validation_result`.
+		 *
+		 * @param array<string,mixed> $request Validation request.
+		 * @param array<string,mixed> $input   Raw caller input.
+		 */
+		$request = apply_filters( 'static_site_importer_codebox_validation_request', $request, $input );
+		if ( ! is_array( $request ) ) {
+			return new WP_Error( 'static_site_importer_codebox_validation_request_invalid', 'Codebox validation request filters must return an array.' );
+		}
+
+		/**
+		 * Executes an SSI validation request in a disposable Codebox runtime.
+		 *
+		 * The provider should import the supplied website artifact or generated theme
+		 * output into the sandbox, run SSI import validation, run block validation,
+		 * collect browser/render evidence, and return durable artifact references.
+		 * Return null when no provider is available.
+		 *
+		 * @param array<string,mixed>|WP_Error|null $result  Provider result.
+		 * @param array<string,mixed>               $request Validation request.
+		 * @param array<string,mixed>               $input   Raw caller input.
+		 */
+		$result = apply_filters( 'static_site_importer_codebox_validation_result', null, $request, $input );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( null === $result ) {
+			return self::provider_unavailable_result( $request );
+		}
+
+		if ( ! is_array( $result ) ) {
+			return new WP_Error( 'static_site_importer_codebox_validation_result_invalid', 'Codebox validation providers must return an array result, WP_Error, or null.' );
+		}
+
+		return self::normalize_provider_result( $request, $result );
+	}
+
+	/**
+	 * Build the runtime request envelope.
+	 *
+	 * @param array<string,mixed> $input Validation input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function build_request( array $input ) {
+		$artifact            = isset( $input['artifact'] ) && is_array( $input['artifact'] ) ? $input['artifact'] : array();
+		$generated_theme_ref = self::normalize_artifact_ref( $input['generated_theme_ref'] ?? array() );
+		$theme_archive_ref   = self::normalize_artifact_ref( $input['theme_archive_ref'] ?? array() );
+
+		if ( empty( $artifact ) && empty( $generated_theme_ref ) && empty( $theme_archive_ref ) ) {
+			return new WP_Error( 'static_site_importer_codebox_validation_source_missing', 'Codebox validation requires an artifact, generated_theme_ref, or theme_archive_ref input.' );
+		}
+
+		$import_args = array(
+			'slug'                         => isset( $input['slug'] ) ? sanitize_title( (string) $input['slug'] ) : '',
+			'name'                         => isset( $input['name'] ) ? sanitize_text_field( (string) $input['name'] ) : '',
+			'activate'                     => array_key_exists( 'activate', $input ) ? (bool) $input['activate'] : true,
+			'overwrite'                    => array_key_exists( 'overwrite', $input ) ? (bool) $input['overwrite'] : true,
+			'fail_on_quality'              => ! empty( $input['fail_on_quality'] ),
+			'allow_missing_woocommerce'    => ! empty( $input['allow_missing_woocommerce'] ),
+			'asset_materialization_policy' => isset( $input['asset_materialization_policy'] ) ? (string) $input['asset_materialization_policy'] : '',
+			'compiler_options'             => isset( $input['compiler_options'] ) && is_array( $input['compiler_options'] ) ? $input['compiler_options'] : array(),
+			'source_metadata'              => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
+		);
+
+		return array(
+			'schema'             => self::REQUEST_SCHEMA,
+			'product_path'       => 'static-site-importer/validate-in-codebox',
+			'execution_scope'    => 'disposable-wp-codebox-runtime',
+			'source'             => array(
+				'artifact'            => $artifact,
+				'generated_theme_ref' => $generated_theme_ref,
+				'theme_archive_ref'   => $theme_archive_ref,
+			),
+			'import_args'        => array_filter(
+				$import_args,
+				static fn ( mixed $value ): bool => ! ( '' === $value || array() === $value )
+			),
+			'validation'         => array(
+				'import_report'    => true,
+				'block_validation' => true,
+				'browser_render'   => true,
+				'screenshots'      => true,
+				'visual_diff'      => true,
+			),
+			'required_artifacts' => self::required_artifacts(),
+			'operator_notes'     => self::operator_notes( $input ),
+		);
+	}
+
+	/**
+	 * Normalize provider output into the SSI result contract.
+	 *
+	 * @param array<string,mixed> $request Validation request.
+	 * @param array<string,mixed> $result  Provider result.
+	 * @return array<string,mixed>
+	 */
+	private static function normalize_provider_result( array $request, array $result ): array {
+		$status    = isset( $result['status'] ) ? sanitize_key( (string) $result['status'] ) : ( ! empty( $result['success'] ) ? 'succeeded' : 'failed' );
+		$artifacts = self::artifact_contract( $request, isset( $result['artifacts'] ) && is_array( $result['artifacts'] ) ? $result['artifacts'] : array() );
+
+		return array(
+			'success'       => 'succeeded' === $status,
+			'schema'        => self::RESULT_SCHEMA,
+			'status'        => $status,
+			'product_path'  => 'static-site-importer/validate-in-codebox',
+			'request'       => self::request_summary( $request ),
+			'artifacts'     => $artifacts,
+			'runtime'       => isset( $result['runtime'] ) && is_array( $result['runtime'] ) ? $result['runtime'] : array(),
+			'summary'       => isset( $result['summary'] ) && is_array( $result['summary'] ) ? $result['summary'] : array(),
+			'upstream_gaps' => isset( $result['upstream_gaps'] ) && is_array( $result['upstream_gaps'] ) ? array_values( $result['upstream_gaps'] ) : array(),
+		);
+	}
+
+	/**
+	 * Build a concrete blocked result when no runtime provider is registered.
+	 *
+	 * @param array<string,mixed> $request Validation request.
+	 * @return array<string,mixed>
+	 */
+	private static function provider_unavailable_result( array $request ): array {
+		return array(
+			'success'       => false,
+			'schema'        => self::RESULT_SCHEMA,
+			'status'        => 'blocked',
+			'product_path'  => 'static-site-importer/validate-in-codebox',
+			'request'       => self::request_summary( $request ),
+			'artifacts'     => self::artifact_contract( $request, array() ),
+			'runtime'       => array(
+				'provider' => 'wp-codebox/homeboy',
+				'status'   => 'missing_provider',
+			),
+			'summary'       => array(
+				'quality_pass'          => false,
+				'import_report'         => 'missing',
+				'block_validation'      => 'missing',
+				'browser_render'        => 'missing',
+				'screenshot_artifacts'  => 0,
+				'visual_diff_artifacts' => 0,
+			),
+			'upstream_gaps' => array(
+				array(
+					'owner'        => 'wp-codebox/homeboy',
+					'capability'   => 'static-site-importer Codebox validation provider',
+					'missing'      => 'No provider is registered on static_site_importer_codebox_validation_result to run the SSI import, block validation, browser render capture, screenshot capture, and visual diff capture inside a disposable WP Codebox runtime.',
+					'needed_shape' => 'Accept static-site-importer/codebox-validation-request/v1 and return static-site-importer/codebox-validation-result/v1 with durable artifact references for generated theme/archive, import report, block validation result, browser/render evidence metadata, screenshots, and diffs.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Build the artifact metadata contract.
+	 *
+	 * @param array<string,mixed> $request   Validation request.
+	 * @param array<string,mixed> $artifacts Provider artifacts.
+	 * @return array<string,mixed>
+	 */
+	private static function artifact_contract( array $request, array $artifacts ): array {
+		return array(
+			'schema'                 => self::ARTIFACT_SCHEMA,
+			'generated_theme'        => self::first_ref( $artifacts['generated_theme'] ?? array(), $request['source']['generated_theme_ref'] ?? array() ),
+			'theme_archive'          => self::first_ref( $artifacts['theme_archive'] ?? array(), $request['source']['theme_archive_ref'] ?? array() ),
+			'import_report'          => self::normalize_artifact_ref( $artifacts['import_report'] ?? array() ),
+			'block_validation_result' => self::normalize_artifact_ref( $artifacts['block_validation_result'] ?? array() ),
+			'browser_render_evidence' => self::normalize_artifact_ref( $artifacts['browser_render_evidence'] ?? array() ),
+			'screenshots'            => self::normalize_artifact_refs( $artifacts['screenshots'] ?? array() ),
+			'diffs'                  => self::normalize_artifact_refs( $artifacts['diffs'] ?? array() ),
+			'raw'                    => self::normalize_artifact_refs( $artifacts['raw'] ?? array() ),
+			'required'               => self::required_artifacts(),
+		);
+	}
+
+	/**
+	 * Required validation artifacts.
+	 *
+	 * @return array<int,string>
+	 */
+	private static function required_artifacts(): array {
+		return array(
+			'generated_theme_or_theme_archive',
+			'import_report',
+			'block_validation_result',
+			'browser_render_evidence',
+			'screenshot_refs_when_available',
+			'diff_refs_when_available',
+		);
+	}
+
+	/**
+	 * Summarize a request without inline artifact content.
+	 *
+	 * @param array<string,mixed> $request Validation request.
+	 * @return array<string,mixed>
+	 */
+	private static function request_summary( array $request ): array {
+		$source   = isset( $request['source'] ) && is_array( $request['source'] ) ? $request['source'] : array();
+		$artifact = isset( $source['artifact'] ) && is_array( $source['artifact'] ) ? $source['artifact'] : array();
+
+		return array(
+			'schema'             => $request['schema'] ?? self::REQUEST_SCHEMA,
+			'product_path'       => $request['product_path'] ?? 'static-site-importer/validate-in-codebox',
+			'execution_scope'    => $request['execution_scope'] ?? 'disposable-wp-codebox-runtime',
+			'has_inline_artifact' => ! empty( $artifact ),
+			'artifact_schema'    => isset( $artifact['schema'] ) ? (string) $artifact['schema'] : '',
+			'import_args'        => isset( $request['import_args'] ) && is_array( $request['import_args'] ) ? $request['import_args'] : array(),
+			'required_artifacts' => isset( $request['required_artifacts'] ) && is_array( $request['required_artifacts'] ) ? array_values( $request['required_artifacts'] ) : self::required_artifacts(),
+		);
+	}
+
+	/**
+	 * Preserve local-only paths only as operator notes.
+	 *
+	 * @param array<string,mixed> $input Raw input.
+	 * @return array<string,mixed>
+	 */
+	private static function operator_notes( array $input ): array {
+		$notes = array();
+		foreach ( array( 'generated_theme_ref', 'theme_archive_ref' ) as $field ) {
+			if ( empty( $input[ $field ] ) || ! is_array( $input[ $field ] ) ) {
+				continue;
+			}
+
+			foreach ( array( 'path', 'local_path', 'file' ) as $key ) {
+				$value = isset( $input[ $field ][ $key ] ) ? (string) $input[ $field ][ $key ] : '';
+				if ( self::is_local_only_reference( $value ) ) {
+					$notes['local_refs'][ $field ][ $key ] = $value;
+				}
+			}
+		}
+
+		return $notes;
+	}
+
+	/**
+	 * Normalize a list of artifact references.
+	 *
+	 * @param mixed $refs Raw refs.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function normalize_artifact_refs( mixed $refs ): array {
+		if ( ! is_array( $refs ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $refs as $ref ) {
+			$normalized_ref = self::normalize_artifact_ref( $ref );
+			if ( ! empty( $normalized_ref ) ) {
+				$normalized[] = $normalized_ref;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize an artifact reference for reviewer-facing output.
+	 *
+	 * @param mixed $ref Raw ref.
+	 * @return array<string,mixed>
+	 */
+	private static function normalize_artifact_ref( mixed $ref ): array {
+		if ( ! is_array( $ref ) ) {
+			return array();
+		}
+
+		$allowed = array( 'artifact_id', 'artifact_ref', 'url', 'path', 'relative_path', 'sha256', 'media_type', 'label', 'kind', 'status' );
+		$output  = array();
+		foreach ( $allowed as $key ) {
+			if ( ! array_key_exists( $key, $ref ) ) {
+				continue;
+			}
+
+			$value = is_scalar( $ref[ $key ] ) ? (string) $ref[ $key ] : $ref[ $key ];
+			if ( is_string( $value ) && self::is_local_only_reference( $value ) ) {
+				continue;
+			}
+
+			$output[ $key ] = $value;
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Return the first non-empty normalized ref.
+	 *
+	 * @param mixed $primary  Primary ref.
+	 * @param mixed $fallback Fallback ref.
+	 * @return array<string,mixed>
+	 */
+	private static function first_ref( mixed $primary, mixed $fallback ): array {
+		$primary_ref = self::normalize_artifact_ref( $primary );
+		if ( ! empty( $primary_ref ) ) {
+			return $primary_ref;
+		}
+
+		return self::normalize_artifact_ref( $fallback );
+	}
+
+	/**
+	 * Detect host-local paths and URLs that should not be reviewer-facing refs.
+	 *
+	 * @param string $value Reference value.
+	 * @return bool
+	 */
+	private static function is_local_only_reference( string $value ): bool {
+		if ( '' === $value ) {
+			return false;
+		}
+
+		return str_starts_with( $value, '/' )
+			|| str_starts_with( $value, 'file:' )
+			|| str_contains( $value, 'localhost' )
+			|| str_contains( $value, '127.0.0.1' );
+	}
+}

--- a/includes/class-static-site-importer-product-handoff-contract.php
+++ b/includes/class-static-site-importer-product-handoff-contract.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Product handoff contract constants.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Names the machine-readable envelopes shared across product handoffs.
+ */
+class Static_Site_Importer_Product_Handoff_Contract {
+
+	public const VERSION = 1;
+	public const CONTRACT_SCHEMA = 'static-site-importer/product-handoff-contract/v1';
+	public const INPUT_ARTIFACT_SCHEMA = 'blocks-engine/php-transformer/site-artifact/v1';
+	public const BLOCKS_ENGINE_RESULT_SCHEMA = 'blocks-engine/php-transformer/result/v1';
+	public const MATERIALIZATION_PLAN_SCHEMA = 'blocks-engine/php-transformer/materialization-plan/v1';
+	public const SSI_IMPORT_REPORT_SCHEMA = 'static-site-importer/import-report/v1';
+	public const SSI_IMPORT_VALIDATION_RESULT_SCHEMA = 'blocks-engine/import-validation-result/v1';
+	public const SSI_FINDING_PACKETS_SCHEMA = 'blocks-engine/finding-packets/v1';
+	public const SSI_ARTIFACT_DIAGNOSTICS_SCHEMA = 'static-site-importer/artifact-diagnostics/v1';
+	public const CODEBOX_VALIDATION_ARTIFACT_ENVELOPE_SCHEMA = 'wp-codebox/validation-artifact-envelope/v1';
+
+	/**
+	 * Return the canonical schema identifiers by handoff stage.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function schema_map(): array {
+		return array(
+			'schema'                            => self::CONTRACT_SCHEMA,
+			'version'                           => self::VERSION,
+			'input_artifact'                    => self::INPUT_ARTIFACT_SCHEMA,
+			'blocks_engine_result'              => self::BLOCKS_ENGINE_RESULT_SCHEMA,
+			'blocks_engine_materialization_plan' => self::MATERIALIZATION_PLAN_SCHEMA,
+			'ssi_import_report'                 => self::SSI_IMPORT_REPORT_SCHEMA,
+			'ssi_import_validation_result'      => self::SSI_IMPORT_VALIDATION_RESULT_SCHEMA,
+			'ssi_finding_packets'               => self::SSI_FINDING_PACKETS_SCHEMA,
+			'ssi_artifact_diagnostics'          => self::SSI_ARTIFACT_DIAGNOSTICS_SCHEMA,
+			'codebox_validation_artifact_envelope' => self::CODEBOX_VALIDATION_ARTIFACT_ENVELOPE_SCHEMA,
+		);
+	}
+}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -12,6 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-transformer-adapter.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Product_Handoff_Contract' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-product-handoff-contract.php';
+}
 
 /**
  * Builds SSI import reports and normalizes diagnostics for repair loops.
@@ -27,6 +30,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	public static function new_conversion_report( string $html_path, array $source_metadata = array() ): array {
 		return array(
+			'schema'                  => Static_Site_Importer_Product_Handoff_Contract::SSI_IMPORT_REPORT_SCHEMA,
 			'version'                 => 1,
 			'entry_file'              => $html_path,
 			'source'                  => array_merge(

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -31,6 +31,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-pa
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-stylesheet-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-product-handoff-contract.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-transformer-adapter.php';

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -32,8 +32,60 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-th
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-stylesheet-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-diagnostics-adapter.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-codebox-validation.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-transformer-adapter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-exporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-generator.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/abilities.php';
+
+if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
+	WP_CLI::add_command(
+		'static-site-importer validate-in-codebox',
+		static function ( array $args, array $assoc_args ): void {
+			unset( $args );
+
+			$input = array(
+				'slug'                      => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
+				'name'                      => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
+				'activate'                  => ! isset( $assoc_args['no-activate'] ),
+				'overwrite'                 => ! isset( $assoc_args['no-overwrite'] ),
+				'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
+				'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
+			);
+
+			if ( isset( $assoc_args['artifact'] ) ) {
+				$artifact_json = file_get_contents( (string) $assoc_args['artifact'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- CLI reads an operator-provided artifact file.
+				$artifact      = json_decode( false === $artifact_json ? '' : $artifact_json, true );
+				if ( ! is_array( $artifact ) ) {
+					WP_CLI::error( 'The --artifact file must contain a JSON object.' );
+				}
+
+				$input['artifact'] = $artifact;
+			}
+
+			if ( isset( $assoc_args['generated-theme-ref'] ) ) {
+				$input['generated_theme_ref'] = array( 'artifact_ref' => (string) $assoc_args['generated-theme-ref'] );
+			}
+
+			if ( isset( $assoc_args['theme-archive-ref'] ) ) {
+				$input['theme_archive_ref'] = array( 'artifact_ref' => (string) $assoc_args['theme-archive-ref'] );
+			}
+
+			$result = Static_Site_Importer_Codebox_Validation::validate( $input );
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::error( $result->get_error_message() );
+			}
+
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			if ( false === $json ) {
+				WP_CLI::error( 'Failed to encode Codebox validation result.' );
+			}
+
+			WP_CLI::line( $json );
+			if ( empty( $result['success'] ) ) {
+				WP_CLI::halt( 1 );
+			}
+		}
+	);
+}

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -90,6 +90,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	 */
 	public function test_import_validation_result_and_finding_packets_are_machine_readable(): void {
 		$report = array(
+			'schema'                  => 'static-site-importer/import-report/v1',
 			'entry_file'              => '/tmp/source/index.html',
 			'version'                 => 1,
 			'theme_slug'              => 'static-template-import',
@@ -245,6 +246,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		);
 
 		$report      = $report_property->getValue();
+		$this->assertSame( 'static-site-importer/import-report/v1', $report['schema'] ?? '' );
 		$diagnostics = array_values(
 			array_filter(
 				$report['diagnostics'] ?? array(),

--- a/tests/fixtures/product-handoff-contract/v1.json
+++ b/tests/fixtures/product-handoff-contract/v1.json
@@ -1,0 +1,144 @@
+{
+  "schema": "static-site-importer/product-handoff-contract/v1",
+  "version": 1,
+  "stages": {
+    "input_artifact": {
+      "owner": "product_caller",
+      "consumer": "blocks_engine",
+      "schema": "blocks-engine/php-transformer/site-artifact/v1",
+      "required_fields": ["schema", "files", "root", "entrypoint"],
+      "notes": "Portable static website bundle. Callers provide files; Blocks Engine compiles them."
+    },
+    "blocks_engine_result": {
+      "owner": "blocks_engine",
+      "consumer": "static_site_importer",
+      "schema": "blocks-engine/php-transformer/result/v1",
+      "required_fields": ["schema", "status", "source_reports.materialization_plan"],
+      "materialization_plan": {
+        "schema": "blocks-engine/php-transformer/materialization-plan/v1",
+        "required_fields": ["schema", "source_schema", "entry_path", "pages", "assets"]
+      },
+      "notes": "Blocks Engine emits the canonical WordPress materialization plan and remains unaware of Codebox validation details."
+    },
+    "ssi_import_report": {
+      "owner": "static_site_importer",
+      "consumer": "product_caller",
+      "schema": "static-site-importer/import-report/v1",
+      "required_fields": ["version", "theme_slug", "source", "blocks_engine", "generated_theme", "quality", "diagnostics", "import_validation_result", "finding_packets"],
+      "nested_artifacts": {
+        "import_validation_result": "blocks-engine/import-validation-result/v1",
+        "finding_packets": "blocks-engine/finding-packets/v1",
+        "artifact_diagnostics_fallback": "static-site-importer/artifact-diagnostics/v1"
+      },
+      "notes": "SSI writes WordPress state and reports materialized theme, page, asset, quality, and repair-loop outputs."
+    },
+    "codebox_validation_artifact_envelope": {
+      "owner": "wp_codebox",
+      "consumer": "product_caller",
+      "schema": "wp-codebox/validation-artifact-envelope/v1",
+      "required_fields": ["schema", "status", "artifacts", "refs"],
+      "artifact_kinds": ["render", "visual_comparison", "wordpress_state", "import_report", "diagnostics"],
+      "notes": "Codebox validates the WordPress result and returns artifact references. SSI treats this as an optional downstream validation envelope."
+    }
+  },
+  "example": {
+    "input_artifact": {
+      "schema": "blocks-engine/php-transformer/site-artifact/v1",
+      "root": "website",
+      "entrypoint": "website/index.html",
+      "files": [
+        {
+          "path": "website/index.html",
+          "role": "document",
+          "kind": "html",
+          "mime_type": "text/html",
+          "encoding": "utf-8",
+          "content": "<!doctype html><html><body><main><h1>Atlas Bakery</h1></main></body></html>"
+        }
+      ]
+    },
+    "blocks_engine_result": {
+      "schema": "blocks-engine/php-transformer/result/v1",
+      "status": "success",
+      "source_reports": {
+        "materialization_plan": {
+          "schema": "blocks-engine/php-transformer/materialization-plan/v1",
+          "source_schema": "blocks-engine/php-transformer/compiled-site/v1",
+          "entry_path": "website/index.html",
+          "pages": [
+            {
+              "source_path": "website/index.html",
+              "entrypoint": true,
+              "post_type": "page",
+              "slug": "home",
+              "title": "Atlas Bakery",
+              "block_markup": "<!-- wp:heading {\"level\":1} --><h1 class=\"wp-block-heading\">Atlas Bakery</h1><!-- /wp:heading -->"
+            }
+          ],
+          "assets": []
+        }
+      }
+    },
+    "ssi_import_report": {
+      "version": 1,
+      "schema": "static-site-importer/import-report/v1",
+      "theme_slug": "atlas-bakery",
+      "source": {
+        "type": "website_artifact",
+        "source": "artifact.json"
+      },
+      "blocks_engine": {
+        "available": true,
+        "website_artifact": {
+          "summary": {
+            "schema": "blocks-engine/php-transformer/result/v1",
+            "status": "success",
+            "source": "artifact.json"
+          }
+        }
+      },
+      "generated_theme": {
+        "slug": "atlas-bakery",
+        "files": ["style.css", "templates/front-page.html", "patterns/page-home.php"]
+      },
+      "quality": {
+        "fallback_count": 0,
+        "core_html_block_count": 0,
+        "invalid_block_document_count": 0
+      },
+      "diagnostics": [],
+      "import_validation_result": {
+        "schema": "blocks-engine/import-validation-result/v1",
+        "artifact_type": "ImportValidationResult",
+        "version": 1,
+        "status": "passed"
+      },
+      "finding_packets": {
+        "schema": "blocks-engine/finding-packets/v1",
+        "artifact_type": "FindingPacketSet",
+        "version": 1,
+        "status": "clean",
+        "count": 0,
+        "packets": []
+      }
+    },
+    "codebox_validation_artifact_envelope": {
+      "schema": "wp-codebox/validation-artifact-envelope/v1",
+      "status": "passed",
+      "artifacts": [
+        {
+          "kind": "import_report",
+          "ref": "artifact://codebox/run-123/import-report.json"
+        },
+        {
+          "kind": "visual_comparison",
+          "ref": "artifact://codebox/run-123/visual-comparison.json"
+        }
+      ],
+      "refs": {
+        "run": "codebox-run-123",
+        "site": "wordpress-site-123"
+      }
+    }
+  }
+}

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -64,6 +64,11 @@ const steps = [
     command: 'php',
     args: [ path.join( repoRoot, 'tests/smoke-url-import-runtime.php' ) ],
   },
+  {
+    name: 'Codebox validation contract smoke',
+    command: 'php',
+    args: [ path.join( repoRoot, 'tests/smoke-codebox-validation-contract.php' ) ],
+  },
   ! skipImport && {
     name: 'Import wordpress-is-dead fixture theme',
     command: wpCli[ 0 ],

--- a/tests/smoke-codebox-validation-contract.php
+++ b/tests/smoke-codebox-validation-contract.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Smoke coverage for the SSI Codebox validation product contract.
+ *
+ * Run from the repository root:
+ * php tests/smoke-codebox-validation-contract.php
+ *
+ * @package StaticSiteImporter
+ */
+
+namespace {
+	$GLOBALS['static_site_importer_test_filters'] = array();
+
+	function add_filter( string $hook_name, callable $callback ): void {
+		$GLOBALS['static_site_importer_test_filters'][ $hook_name ][] = $callback;
+	}
+
+	function apply_filters( string $hook_name, $value, ...$args ) {
+		foreach ( $GLOBALS['static_site_importer_test_filters'][ $hook_name ] ?? array() as $callback ) {
+			$value = $callback( $value, ...$args );
+		}
+
+		return $value;
+	}
+
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+
+	function sanitize_title( string $value ): string {
+		$value = strtolower( trim( $value ) );
+		$value = preg_replace( '/[^a-z0-9_-]+/', '-', $value );
+
+		return trim( (string) $value, '-' );
+	}
+
+	function sanitize_text_field( string $value ): string {
+		return trim( wp_strip_all_tags( $value ) );
+	}
+
+	function sanitize_key( string $value ): string {
+		$value = strtolower( $value );
+
+		return preg_replace( '/[^a-z0-9_-]/', '', $value ) ?: '';
+	}
+
+	function wp_strip_all_tags( string $value ): string {
+		return strip_tags( $value );
+	}
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $code;
+			private string $message;
+
+			public function __construct( string $code, string $message ) {
+				$this->code    = $code;
+				$this->message = $message;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-codebox-validation.php';
+
+	$failures   = array();
+	$assertions = 0;
+	$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+		}
+	};
+
+	$blocked = Static_Site_Importer_Codebox_Validation::validate(
+		array(
+			'artifact' => array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ),
+			'slug'     => 'Fixture Import',
+		)
+	);
+
+	$assert( ! is_wp_error( $blocked ), 'blocked-result-is-structured' );
+	$assert( false === ( $blocked['success'] ?? true ), 'blocked-result-is-unsuccessful' );
+	$assert( 'blocked' === ( $blocked['status'] ?? '' ), 'blocked-status' );
+	$assert( 'static-site-importer/codebox-validation-result/v1' === ( $blocked['schema'] ?? '' ), 'result-schema' );
+	$assert( 'static-site-importer/codebox-validation-artifacts/v1' === ( $blocked['artifacts']['schema'] ?? '' ), 'artifact-schema' );
+	$assert( ! empty( $blocked['upstream_gaps'][0]['needed_shape'] ), 'upstream-gap-is-concrete' );
+
+	add_filter(
+		'static_site_importer_codebox_validation_result',
+		static function ( $result, array $request ): array {
+			unset( $result, $request );
+
+			return array(
+				'success'   => true,
+				'summary'   => array( 'quality_pass' => true ),
+				'runtime'   => array( 'provider' => 'test-codebox' ),
+				'artifacts' => array(
+					'generated_theme'         => array( 'artifact_ref' => 'hb-run://123/theme', 'path' => '/Users/local/theme' ),
+					'theme_archive'           => array( 'url' => 'https://artifacts.example/theme.zip', 'sha256' => 'abc' ),
+					'import_report'           => array( 'artifact_ref' => 'hb-run://123/import-report.json' ),
+					'block_validation_result' => array( 'artifact_ref' => 'hb-run://123/block-validation.json' ),
+					'browser_render_evidence' => array( 'artifact_ref' => 'hb-run://123/browser-render.json' ),
+					'screenshots'             => array( array( 'artifact_ref' => 'hb-run://123/home.png' ) ),
+					'diffs'                   => array( array( 'artifact_ref' => 'hb-run://123/home.diff.png' ) ),
+				),
+			);
+		}
+	);
+
+	$provided = Static_Site_Importer_Codebox_Validation::validate(
+		array(
+			'artifact' => array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ),
+			'name'     => 'Fixture Import',
+		)
+	);
+
+	$assert( true === ( $provided['success'] ?? false ), 'provider-success' );
+	$assert( 'succeeded' === ( $provided['status'] ?? '' ), 'provider-status' );
+	$assert( 'test-codebox' === ( $provided['runtime']['provider'] ?? '' ), 'runtime-provider' );
+	$assert( 'hb-run://123/theme' === ( $provided['artifacts']['generated_theme']['artifact_ref'] ?? '' ), 'generated-theme-ref' );
+	$assert( ! isset( $provided['artifacts']['generated_theme']['path'] ), 'local-path-removed-from-reviewer-artifact' );
+	$assert( 'hb-run://123/import-report.json' === ( $provided['artifacts']['import_report']['artifact_ref'] ?? '' ), 'import-report-ref' );
+	$assert( 'hb-run://123/block-validation.json' === ( $provided['artifacts']['block_validation_result']['artifact_ref'] ?? '' ), 'block-validation-ref' );
+	$assert( 'hb-run://123/browser-render.json' === ( $provided['artifacts']['browser_render_evidence']['artifact_ref'] ?? '' ), 'browser-render-ref' );
+	$assert( 1 === count( $provided['artifacts']['screenshots'] ?? array() ), 'screenshot-ref-count' );
+	$assert( 1 === count( $provided['artifacts']['diffs'] ?? array() ), 'diff-ref-count' );
+
+	if ( $failures ) {
+		fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+		exit( 1 );
+	}
+
+	echo 'OK: Codebox validation contract smoke passed (' . $assertions . " assertions)\n";
+}

--- a/tests/smoke-product-handoff-contract.php
+++ b/tests/smoke-product-handoff-contract.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Smoke test: product handoff contract fixture matches SSI schema constants.
+ *
+ * Run from the repository root:
+ * php tests/smoke-product-handoff-contract.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
+
+$fixture_path = __DIR__ . '/fixtures/product-handoff-contract/v1.json';
+$fixture      = json_decode( file_get_contents( $fixture_path ), true );
+$failures     = array();
+$assertions   = 0;
+$assert       = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$assert( is_array( $fixture ), 'fixture-decodes' );
+
+$schemas = Static_Site_Importer_Product_Handoff_Contract::schema_map();
+$assert( $schemas['schema'] === ( $fixture['schema'] ?? '' ), 'contract-schema-matches-code' );
+$assert( $schemas['version'] === ( $fixture['version'] ?? 0 ), 'contract-version-matches-code' );
+
+$stages = isset( $fixture['stages'] ) && is_array( $fixture['stages'] ) ? $fixture['stages'] : array();
+$example = isset( $fixture['example'] ) && is_array( $fixture['example'] ) ? $fixture['example'] : array();
+
+$expected_stage_schemas = array(
+	'input_artifact'                       => $schemas['input_artifact'],
+	'blocks_engine_result'                 => $schemas['blocks_engine_result'],
+	'ssi_import_report'                    => $schemas['ssi_import_report'],
+	'codebox_validation_artifact_envelope' => $schemas['codebox_validation_artifact_envelope'],
+);
+
+foreach ( $expected_stage_schemas as $stage => $schema ) {
+	$assert( isset( $stages[ $stage ] ) && is_array( $stages[ $stage ] ), $stage . '-stage-present' );
+	$assert( $schema === ( $stages[ $stage ]['schema'] ?? '' ), $stage . '-schema-matches-code' );
+	$assert( isset( $stages[ $stage ]['required_fields'] ) && is_array( $stages[ $stage ]['required_fields'] ), $stage . '-required-fields-present' );
+	$assert( isset( $example[ $stage ] ) && is_array( $example[ $stage ] ), $stage . '-example-present' );
+}
+
+$assert( $schemas['blocks_engine_materialization_plan'] === ( $stages['blocks_engine_result']['materialization_plan']['schema'] ?? '' ), 'materialization-plan-schema-matches-code' );
+$assert( $schemas['blocks_engine_materialization_plan'] === ( $example['blocks_engine_result']['source_reports']['materialization_plan']['schema'] ?? '' ), 'materialization-plan-example-schema' );
+$assert( ! isset( $example['blocks_engine_result']['codebox'] ), 'blocks-engine-example-keeps-codebox-out' );
+$assert( $schemas['ssi_import_validation_result'] === ( $example['ssi_import_report']['import_validation_result']['schema'] ?? '' ), 'import-validation-schema' );
+$assert( $schemas['ssi_finding_packets'] === ( $example['ssi_import_report']['finding_packets']['schema'] ?? '' ), 'finding-packets-schema' );
+
+$required_path_exists = static function ( array $data, string $path ): bool {
+	$current = $data;
+	foreach ( explode( '.', $path ) as $segment ) {
+		if ( ! is_array( $current ) || ! array_key_exists( $segment, $current ) ) {
+			return false;
+		}
+		$current = $current[ $segment ];
+	}
+
+	return true;
+};
+
+foreach ( $stages as $stage => $stage_contract ) {
+	if ( ! is_array( $stage_contract ) || ! isset( $example[ $stage ] ) || ! is_array( $example[ $stage ] ) ) {
+		continue;
+	}
+
+	foreach ( $stage_contract['required_fields'] ?? array() as $field ) {
+		$assert( is_string( $field ) && $required_path_exists( $example[ $stage ], $field ), $stage . '-requires-' . (string) $field );
+	}
+}
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: product handoff contract smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Add `static-site-importer/validate-in-codebox` as an explicit SSI ability for disposable WP Codebox validation.
- Add `wp static-site-importer validate-in-codebox` for CLI callers that pass an inline website artifact JSON file or durable generated-theme/archive refs.
- Add an SSI-owned request/result/artifact contract and provider hooks for WP Codebox/Homeboy execution.
- Document the current upstream provider gap instead of faking browser/render/screenshot/diff evidence.

## Artifact contract
`static-site-importer/codebox-validation-artifacts/v1` includes:
- `generated_theme` or `theme_archive`
- `import_report`
- `block_validation_result`
- `browser_render_evidence`
- `screenshots[]` when available
- `diffs[]` when available

Reviewer-facing refs are normalized to durable refs/URLs; host-local paths and localhost URLs are stripped from artifact refs and kept only as operator notes when supplied as input.

## Upstream gap
SSI now exposes `static_site_importer_codebox_validation_result`, but WP Codebox/Homeboy still needs to register the provider that accepts `static-site-importer/codebox-validation-request/v1`, runs the disposable runtime, and returns durable import report, block validation, browser/render, screenshot, and visual diff refs.

## Tests
- `php -l static-site-importer.php && php -l includes/class-static-site-importer-codebox-validation.php && php -l includes/abilities.php && php -l tests/smoke-codebox-validation-contract.php`
- `php tests/smoke-codebox-validation-contract.php`
- `npm run test:validation -- --skip-import --json`
- `homeboy test static-site-importer --path <worktree>`: passed via offloaded `homeboy-lab` run `runner-exec-homeboy-lab-75c23f95-e231-4984-9501-934223d8e1b0` with 5/5 tests and 72 assertions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting SSI/WP Codebox integration surfaces, drafting the SSI-side validation contract, implementation, tests, docs, and PR preparation.