### PR TITLE
Add SSI Codebox validation workload

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -2,7 +2,20 @@
   "auto_cleanup": false,
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
-    "wordpress": {}
+    "wordpress": {
+      "settings": {
+        "validation_dependencies": [
+          {
+            "type": "github",
+            "repo": "Automattic/blocks-engine",
+            "ref": "trunk",
+            "plugin_slug": "blocks-engine-php-transformer",
+            "package_path": "php-transformer",
+            "activate": true
+          }
+        ]
+      }
+    }
   },
   "id": "static-site-importer",
   "remote_path": "wp-content/plugins/static-site-importer",

--- a/tests/bench/ssi-codebox-validation.php
+++ b/tests/bench/ssi-codebox-validation.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Codebox validation workload for Static Site Importer.
+ *
+ * @package StaticSiteImporter
+ */
+
+require_once '/homeboy-extension/scripts/bench/lib/wordpress-bench-artifacts.php';
+
+return static function (): array {
+	$artifact_path = __DIR__ . '/../fixtures/website-artifact-bundle/artifact.json';
+	$artifact_json = file_get_contents( $artifact_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads an importer-owned fixture artifact.
+	$artifact      = json_decode( false === $artifact_json ? '' : $artifact_json, true );
+	if ( ! is_array( $artifact ) ) {
+		throw new RuntimeException( 'SSI Codebox validation fixture artifact is not readable JSON.' );
+	}
+
+	$result = Static_Site_Importer_Theme_Generator::import_website_artifact(
+		$artifact,
+		array(
+			'slug'        => 'ssi-codebox-validation-fixture',
+			'name'        => 'SSI Codebox Validation Fixture',
+			'activate'    => true,
+			'overwrite'   => true,
+			'source_metadata' => array(
+				'source_type' => 'homeboy-codebox-validation-workload',
+			),
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		$validation_result = array(
+			'success'      => false,
+			'schema'       => 'static-site-importer/codebox-validation-result/v1',
+			'status'       => 'failed',
+			'product_path' => 'static-site-importer/validate-in-codebox',
+			'summary'      => array(
+				'quality_pass' => false,
+				'error_code'   => $result->get_error_code(),
+				'error_message' => $result->get_error_message(),
+			),
+		);
+	} else {
+		$report_path            = (string) ( $result['report_path'] ?? '' );
+		$validation_result_path = (string) ( $result['validation_result_path'] ?? '' );
+		$finding_packets_path   = (string) ( $result['finding_packets_path'] ?? '' );
+		$validation_result = array(
+			'success'      => ! empty( $result['quality']['pass'] ),
+			'schema'       => 'static-site-importer/codebox-validation-result/v1',
+			'status'       => ! empty( $result['quality']['pass'] ) ? 'succeeded' : 'failed',
+			'product_path' => 'static-site-importer/validate-in-codebox',
+			'artifacts'    => array(
+				'schema'                  => 'static-site-importer/codebox-validation-artifacts/v1',
+				'generated_theme'         => array(
+					'artifact_ref' => (string) ( $result['theme_slug'] ?? '' ),
+					'kind'         => 'wordpress-theme-directory',
+					'status'       => 'materialized',
+				),
+				'import_report'           => array(
+					'artifact_ref' => basename( $report_path ),
+					'kind'         => 'blocks-engine/import-report',
+				),
+				'block_validation_result' => array(
+					'artifact_ref' => basename( $validation_result_path ),
+					'kind'         => 'blocks-engine/import-validation-result',
+				),
+				'raw'                     => array(
+					array(
+						'artifact_ref' => basename( $finding_packets_path ),
+						'kind'         => 'blocks-engine/finding-packets',
+					),
+				),
+			),
+			'summary'      => array(
+				'quality_pass'          => ! empty( $result['quality']['pass'] ),
+				'import_report'         => is_readable( $report_path ) ? 'captured' : 'missing',
+				'block_validation'      => is_readable( $validation_result_path ) ? 'captured' : 'missing',
+				'browser_render'        => 'pending',
+				'screenshot_artifacts'  => 0,
+				'visual_diff_artifacts' => 0,
+				'theme_slug'            => (string) ( $result['theme_slug'] ?? '' ),
+			),
+		);
+	}
+
+	$artifact_ref = homeboy_bench_write_json_artifact(
+		'ssi-codebox-validation',
+		'codebox-validation-result',
+		$validation_result
+	);
+
+	return array(
+		'metrics'   => array(
+			'ssi_codebox_validation_success'      => ! empty( $validation_result['success'] ) ? 1 : 0,
+			'ssi_codebox_validation_quality_pass' => ! empty( $validation_result['summary']['quality_pass'] ) ? 1 : 0,
+		),
+		'artifacts' => array(
+			'codebox_validation_result' => $artifact_ref,
+		),
+		'metadata'  => array(
+			'ssi_codebox_validation' => $validation_result,
+		),
+	);
+};


### PR DESCRIPTION
## Summary
- Add a product-owned Homeboy/WP Codebox bench workload for SSI validation.
- Import the website artifact fixture inside the disposable WordPress runtime and emit static-site-importer/codebox-validation-result/v1.
- Declare the Blocks Engine PHP transformer validation dependency using package_path=php-transformer so WP Codebox can activate SSI with its required plugin.

## Verification
- php -l tests/bench/ssi-codebox-validation.php
- php tests/smoke-codebox-validation-contract.php
- npm run test:validation -- --skip-import --json
- homeboy bench static-site-importer --path /Users/chubes/Developer/static-site-importer@cook-ssi-codebox-provider-glue --scenario ssi-codebox-validation (currently blocked until Extra-Chill/homeboy-extensions#1648 lands; failure proves missing package_path resolver for blocks-engine/php-transformer)

Depends on Extra-Chill/homeboy-extensions#1648.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Implementing the SSI-owned Codebox validation workload, dependency declaration, and verification.