### PR TITLE
Add Static Site Importer block UI

### DIFF
--- a/blocks/importer/block.json
+++ b/blocks/importer/block.json
@@ -1,0 +1,30 @@
+{
+  "apiVersion": 3,
+  "name": "static-site-importer/importer",
+  "title": "Static Site Importer",
+  "category": "widgets",
+  "description": "Import a URL, HTML, or static site files into a WordPress block theme.",
+  "textdomain": "static-site-importer",
+  "attributes": {
+    "title": {
+      "type": "string",
+      "default": "Bring a site into WordPress."
+    },
+    "intro": {
+      "type": "string",
+      "default": "Paste a URL, upload site files, or add HTML. Static Site Importer will compile it into a block theme."
+    },
+    "provider": {
+      "type": "string",
+      "default": ""
+    },
+    "defaultUrl": {
+      "type": "string",
+      "default": ""
+    }
+  },
+  "editorScript": "file:./editor.js",
+  "viewScript": "file:./view.js",
+  "style": "file:./style.css",
+  "editorStyle": "file:./style.css"
+}

--- a/blocks/importer/editor.js
+++ b/blocks/importer/editor.js
@@ -1,0 +1,25 @@
+( function ( blocks, element, components ) {
+	if ( ! blocks || ! element ) {
+		return;
+	}
+
+	var el = element.createElement;
+
+	blocks.registerBlockType( 'static-site-importer/importer', {
+		edit: function () {
+			return el(
+				'div',
+				{ className: 'ssi-importer ssi-importer--editor' },
+				el( 'p', { className: 'ssi-importer__eyebrow' }, 'Static Site Importer' ),
+				el( 'h2', { className: 'ssi-importer__title' }, 'Bring a site into WordPress' ),
+				el( 'p', { className: 'ssi-importer__copy' }, 'Visitors paste a URL, upload site files, or add HTML. The block imports through Static Site Importer.' ),
+				components && components.Notice
+					? el( components.Notice, { status: 'info', isDismissible: false }, 'URL imports use the generic Static Site Importer provider hook before falling back to the built-in public URL fetcher.' )
+					: null
+			);
+		},
+		save: function () {
+			return null;
+		},
+	} );
+} )( window.wp && window.wp.blocks, window.wp && window.wp.element, window.wp && window.wp.components );

--- a/blocks/importer/style.css
+++ b/blocks/importer/style.css
@@ -1,0 +1,87 @@
+.ssi-importer {
+	display: grid;
+	gap: 20px;
+	width: min(100%, 720px);
+	margin: 0 auto;
+	padding: clamp(24px, 5vw, 40px);
+	border: 1px solid color-mix(in srgb, currentColor 16%, transparent);
+	border-radius: 24px;
+	background: #fff;
+	color: #101517;
+	box-shadow: 0 18px 60px rgb(16 21 23 / 10%);
+}
+
+.ssi-importer--editor {
+	display: block;
+}
+
+.ssi-importer__eyebrow,
+.ssi-importer__label {
+	margin: 0 0 8px;
+	font-size: 12px;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+
+.ssi-importer__title {
+	margin: 0 0 12px;
+	font-size: clamp(30px, 5vw, 56px);
+	line-height: 1;
+}
+
+.ssi-importer__copy {
+	margin: 0 0 20px;
+	color: #4b565c;
+	font-size: 16px;
+	line-height: 1.55;
+}
+
+.ssi-importer__form,
+.ssi-importer__report {
+	display: grid;
+	gap: 16px;
+}
+
+.ssi-importer__field {
+	display: grid;
+	gap: 6px;
+}
+
+.ssi-importer__field input,
+.ssi-importer__field textarea,
+.ssi-importer__report textarea {
+	box-sizing: border-box;
+	width: 100%;
+	border: 1px solid #cfd7dc;
+	border-radius: 10px;
+	padding: 10px 12px;
+	font: inherit;
+}
+
+.ssi-importer__field textarea {
+	min-height: 128px;
+	resize: vertical;
+}
+
+.ssi-importer__submit {
+	justify-self: center;
+	border: 0;
+	border-radius: 999px;
+	padding: 12px 20px;
+	background: #101517;
+	color: #fff;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.ssi-importer__submit:disabled {
+	cursor: progress;
+	opacity: 0.7;
+}
+
+@media (max-width: 900px) {
+	.ssi-importer {
+		width: auto;
+	}
+}

--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -1,0 +1,135 @@
+( function () {
+	var roots = document.querySelectorAll( '[data-static-site-importer]' );
+
+	var fileToBase64 = function ( file ) {
+		return new Promise( function ( resolve, reject ) {
+			var reader = new FileReader();
+			reader.onload = function () {
+				var result = typeof reader.result === 'string' ? reader.result : '';
+				resolve( result.replace( /^data:[^,]*,/, '' ) );
+			};
+			reader.onerror = function () {
+				reject( reader.error || new Error( 'Unable to read uploaded file.' ) );
+			};
+			reader.readAsDataURL( file );
+		} );
+	};
+
+	var fileToText = function ( file ) {
+		return typeof file.text === 'function' ? file.text() : new Promise( function ( resolve, reject ) {
+			var reader = new FileReader();
+			reader.onload = function () {
+				resolve( typeof reader.result === 'string' ? reader.result : '' );
+			};
+			reader.onerror = function () {
+				reject( reader.error || new Error( 'Unable to read uploaded file.' ) );
+			};
+			reader.readAsText( file );
+		} );
+	};
+
+	var uploadedFilePath = function ( file ) {
+		return file.webkitRelativePath || file.name || 'upload';
+	};
+
+	var buildFiles = async function ( input ) {
+		var selectedFiles = input && input.files ? Array.prototype.slice.call( input.files ) : [];
+		return Promise.all( selectedFiles.map( async function ( file ) {
+			var path = uploadedFilePath( file );
+			var record = {
+				path: path,
+				name: file.name || path,
+				type: file.type || '',
+				size: file.size || 0,
+			};
+
+			if ( /\.html?$/i.test( path ) || /^text\//i.test( file.type || '' ) ) {
+				record.content = await fileToText( file );
+			} else {
+				record.content_base64 = await fileToBase64( file );
+			}
+
+			return record;
+		} ) );
+	};
+
+	var setReport = function ( root, report ) {
+		var reportEl = root.querySelector( '[data-static-site-importer-report]' );
+		if ( reportEl ) {
+			reportEl.hidden = false;
+			reportEl.value = JSON.stringify( report, null, 2 );
+		}
+	};
+
+	var showStatus = function ( root, message ) {
+		var status = root.querySelector( '[data-static-site-importer-status]' );
+		var progress = root.querySelector( '[data-static-site-importer-progress]' );
+		if ( status ) {
+			status.hidden = false;
+		}
+		if ( progress ) {
+			progress.textContent = message;
+		}
+	};
+
+	var hasSource = function ( source ) {
+		return Boolean(
+			( source.files && source.files.length > 0 ) ||
+			( source.html && source.html.trim() ) ||
+			( source.url && source.url.trim() )
+		);
+	};
+
+	roots.forEach( function ( root ) {
+		var submit = root.querySelector( '[data-static-site-importer-submit]' );
+		if ( ! submit ) {
+			return;
+		}
+
+		submit.addEventListener( 'click', async function () {
+			var sourceUrl = root.querySelector( '[data-static-site-importer-source-url]' );
+			var html = root.querySelector( '[data-static-site-importer-source-html]' );
+			var files = root.querySelector( '[data-static-site-importer-source-files]' );
+			var restUrl = root.getAttribute( 'data-static-site-importer-rest-url' );
+			var nonce = root.getAttribute( 'data-static-site-importer-nonce' );
+			var provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
+			var source = {
+				url: sourceUrl ? sourceUrl.value : '',
+				html: html ? html.value : '',
+				files: await buildFiles( files ),
+			};
+
+			if ( ! hasSource( source ) ) {
+				showStatus( root, 'Add a website URL, site files, or raw HTML to start.' );
+				return;
+			}
+
+			showStatus( root, 'Importing site into WordPress...' );
+			submit.disabled = true;
+
+			try {
+				var response = await fetch( restUrl, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-WP-Nonce': nonce,
+					},
+					body: JSON.stringify( {
+						provider: provider,
+						source: source,
+						activate: true,
+						overwrite: true,
+					} ),
+				} );
+				var report = await response.json();
+				setReport( root, report );
+				showStatus( root, response.ok && report.success ? 'Import complete.' : 'Import failed.' );
+			} catch ( error ) {
+				setReport( root, { success: false, error: { message: error.message } } );
+				showStatus( root, 'Import request failed.' );
+			} finally {
+				submit.disabled = false;
+			}
+		} );
+	} );
+} )();

--- a/includes/block.php
+++ b/includes/block.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Importer block registration and render callback.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the Static Site Importer block.
+ *
+ * @return void
+ */
+function static_site_importer_register_block(): void {
+	register_block_type(
+		STATIC_SITE_IMPORTER_PATH . 'blocks/importer',
+		array(
+			'render_callback' => 'static_site_importer_render_block',
+		)
+	);
+}
+
+/**
+ * Render the importer block UI.
+ *
+ * @param array<string,mixed> $attributes Block attributes.
+ * @return string
+ */
+function static_site_importer_render_block( array $attributes = array() ): string {
+	$title       = isset( $attributes['title'] ) && '' !== trim( (string) $attributes['title'] ) ? (string) $attributes['title'] : __( 'Bring a site into WordPress.', 'static-site-importer' );
+	$intro       = isset( $attributes['intro'] ) && '' !== trim( (string) $attributes['intro'] ) ? (string) $attributes['intro'] : __( 'Paste a URL, upload site files, or add HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' );
+	$provider    = isset( $attributes['provider'] ) ? sanitize_key( (string) $attributes['provider'] ) : '';
+	$default_url = isset( $attributes['defaultUrl'] ) ? esc_url_raw( (string) $attributes['defaultUrl'] ) : '';
+
+	ob_start();
+	?>
+	<div class="ssi-importer" data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>">
+		<section class="ssi-importer__panel" aria-labelledby="ssi-importer-title">
+			<p class="ssi-importer__eyebrow"><?php esc_html_e( 'Static Site Importer', 'static-site-importer' ); ?></p>
+			<h1 id="ssi-importer-title" class="ssi-importer__title"><?php echo esc_html( $title ); ?></h1>
+			<p class="ssi-importer__copy"><?php echo esc_html( $intro ); ?></p>
+
+			<form class="ssi-importer__form" data-static-site-importer-form>
+				<label class="ssi-importer__field">
+					<span class="ssi-importer__label"><?php esc_html_e( 'Website URL', 'static-site-importer' ); ?></span>
+					<input type="url" name="ssi_source_url" placeholder="https://example.com" autocomplete="url" value="<?php echo esc_attr( $default_url ); ?>" data-static-site-importer-source-url>
+				</label>
+
+				<label class="ssi-importer__field">
+					<span class="ssi-importer__label"><?php esc_html_e( 'Site files', 'static-site-importer' ); ?></span>
+					<input type="file" name="ssi_static_template[]" multiple data-static-site-importer-source-files>
+				</label>
+
+				<label class="ssi-importer__field">
+					<span class="ssi-importer__label"><?php esc_html_e( 'Raw HTML', 'static-site-importer' ); ?></span>
+					<textarea name="ssi_html" rows="6" data-static-site-importer-source-html></textarea>
+				</label>
+
+				<button type="button" class="ssi-importer__submit" data-static-site-importer-submit><?php esc_html_e( 'Start import', 'static-site-importer' ); ?></button>
+			</form>
+		</section>
+
+		<section class="ssi-importer__report" aria-live="polite" hidden data-static-site-importer-status>
+			<p class="ssi-importer__label"><?php esc_html_e( 'Import status', 'static-site-importer' ); ?></p>
+			<p data-static-site-importer-progress></p>
+			<textarea rows="10" readonly hidden data-static-site-importer-report></textarea>
+		</section>
+	</div>
+	<?php
+
+	return (string) ob_get_clean();
+}

--- a/includes/class-static-site-importer-url-import-runtime.php
+++ b/includes/class-static-site-importer-url-import-runtime.php
@@ -76,7 +76,7 @@ class Static_Site_Importer_URL_Import_Runtime {
 		 * Filters URL import provider output before the built-in public URL fetcher runs.
 		 *
 		 * Return WP_Error to fail the import, or an array with an `artifact` key to import
-		 * a provider-built website artifact. Hosted/private DLA runtimes should hook here
+		 * a provider-built website artifact. Hosted/private runtimes should hook here
 		 * rather than product code spawning local processes.
 		 *
 		 * @param null|array<string,mixed>|WP_Error $provider_output Provider output.

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Importer REST routes.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register Static Site Importer REST routes.
+ *
+ * @return void
+ */
+function static_site_importer_register_rest_routes(): void {
+	register_rest_route(
+		'static-site-importer/v1',
+		'/imports',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'static_site_importer_rest_create_import',
+			'permission_callback' => 'static_site_importer_rest_manage_permission',
+		)
+	);
+}
+
+/**
+ * Require a site operator for import mutations.
+ *
+ * @return true|WP_Error
+ */
+function static_site_importer_rest_manage_permission() {
+	if ( function_exists( 'current_user_can' ) && current_user_can( 'switch_themes' ) ) {
+		return true;
+	}
+
+	return new WP_Error(
+		'static_site_importer_forbidden',
+		__( 'You are not allowed to run static site imports on this site.', 'static-site-importer' ),
+		array( 'status' => function_exists( 'is_user_logged_in' ) && is_user_logged_in() ? 403 : 401 )
+	);
+}
+
+/**
+ * Create an import from a URL, raw HTML, or uploaded file bundle.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function static_site_importer_rest_create_import( WP_REST_Request $request ) {
+	$params = $request->get_json_params();
+	if ( ! is_array( $params ) ) {
+		$params = array();
+	}
+
+	$source = isset( $params['source'] ) && is_array( $params['source'] ) ? $params['source'] : array();
+	$input  = static_site_importer_rest_import_args( $params );
+
+	if ( isset( $source['url'] ) && '' !== trim( (string) $source['url'] ) ) {
+		$input['url'] = esc_url_raw( (string) $source['url'] );
+		if ( isset( $params['provider'] ) ) {
+			$input['provider'] = sanitize_key( (string) $params['provider'] );
+		}
+		if ( isset( $params['provider_args'] ) && is_array( $params['provider_args'] ) ) {
+			$input['provider_args'] = $params['provider_args'];
+		}
+
+		$result = Static_Site_Importer_URL_Import_Runtime::import_url( $input );
+	} else {
+		$artifact = static_site_importer_rest_source_artifact( $source );
+		if ( is_wp_error( $artifact ) ) {
+			return $artifact;
+		}
+
+		$result = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $input );
+	}
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return rest_ensure_response(
+		array(
+			'success'               => true,
+			'result'                => $result,
+			'import_report_summary' => isset( $result['import_report_summary'] ) && is_array( $result['import_report_summary'] ) ? $result['import_report_summary'] : array(),
+		)
+	);
+}
+
+/**
+ * Build import args from REST input.
+ *
+ * @param array<string,mixed> $params Request params.
+ * @return array<string,mixed>
+ */
+function static_site_importer_rest_import_args( array $params ): array {
+	return array(
+		'slug'                      => isset( $params['slug'] ) ? sanitize_title( (string) $params['slug'] ) : '',
+		'name'                      => isset( $params['name'] ) ? sanitize_text_field( (string) $params['name'] ) : '',
+		'activate'                  => ! empty( $params['activate'] ),
+		'overwrite'                 => ! empty( $params['overwrite'] ),
+		'fail_on_quality'           => ! empty( $params['fail_on_quality'] ),
+		'allow_missing_woocommerce' => ! empty( $params['allow_missing_woocommerce'] ),
+		'source_metadata'           => array(
+			'source' => 'static_site_importer_block',
+		),
+	);
+}
+
+/**
+ * Convert raw HTML or uploaded file JSON into a website artifact.
+ *
+ * @param array<string,mixed> $source Source payload.
+ * @return array<string,mixed>|WP_Error
+ */
+function static_site_importer_rest_source_artifact( array $source ) {
+	$files = array();
+
+	if ( isset( $source['html'] ) && '' !== trim( (string) $source['html'] ) ) {
+		$files[] = array(
+			'path'    => 'website/index.html',
+			'content' => (string) $source['html'],
+		);
+	}
+
+	if ( isset( $source['files'] ) && is_array( $source['files'] ) ) {
+		foreach ( $source['files'] as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$path = isset( $file['path'] ) ? static_site_importer_rest_artifact_path( (string) $file['path'] ) : '';
+			if ( '' === $path ) {
+				continue;
+			}
+
+			if ( isset( $file['content'] ) ) {
+				$files[] = array(
+					'path'    => $path,
+					'content' => (string) $file['content'],
+				);
+				continue;
+			}
+
+			if ( isset( $file['content_base64'] ) ) {
+				$content = base64_decode( (string) $file['content_base64'], true );
+				if ( false === $content ) {
+					return new WP_Error( 'static_site_importer_invalid_file_content', __( 'Uploaded file content could not be decoded.', 'static-site-importer' ), array( 'status' => 400 ) );
+				}
+
+				$files[] = array(
+					'path'           => $path,
+					'content_base64' => base64_encode( $content ),
+				);
+			}
+		}
+	}
+
+	if ( empty( $files ) ) {
+		return new WP_Error( 'static_site_importer_missing_source', __( 'Add a website URL, site files, or raw HTML to start.', 'static-site-importer' ), array( 'status' => 400 ) );
+	}
+
+	return array(
+		'schema'     => Static_Site_Importer_Transformer_Adapter::WEBSITE_ARTIFACT_SCHEMA,
+		'entrypoint' => static_site_importer_rest_entrypoint( $files ),
+		'files'      => $files,
+	);
+}
+
+/**
+ * Normalize uploaded file paths into artifact paths.
+ *
+ * @param string $path File path.
+ * @return string
+ */
+function static_site_importer_rest_artifact_path( string $path ): string {
+	$path = str_replace( '\\', '/', $path );
+	$path = preg_replace( '#(^|/)\.\.(?=/|$)#', '', $path );
+	$path = ltrim( (string) $path, '/' );
+	$path = preg_replace( '#/+#', '/', $path );
+
+	if ( '' === $path ) {
+		return '';
+	}
+
+	return str_starts_with( $path, 'website/' ) ? $path : 'website/' . $path;
+}
+
+/**
+ * Pick an entrypoint from artifact files.
+ *
+ * @param array<int,array<string,mixed>> $files Artifact files.
+ * @return string
+ */
+function static_site_importer_rest_entrypoint( array $files ): string {
+	foreach ( array( 'website/index.html', 'website/home.html' ) as $candidate ) {
+		foreach ( $files as $file ) {
+			if ( isset( $file['path'] ) && $candidate === (string) $file['path'] ) {
+				return $candidate;
+			}
+		}
+	}
+
+	foreach ( $files as $file ) {
+		$path = isset( $file['path'] ) ? (string) $file['path'] : '';
+		if ( preg_match( '/\.html?$/i', $path ) ) {
+			return $path;
+		}
+	}
+
+	return 'website/index.html';
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -39,8 +39,13 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-tr
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-exporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-generator.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/abilities.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/block.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/rest.php';
 
 Static_Site_Importer_Codebox_Validation::register_default_provider();
+
+add_action( 'init', 'static_site_importer_register_block' );
+add_action( 'rest_api_init', 'static_site_importer_register_rest_routes' );
 
 if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 	WP_CLI::add_command(


### PR DESCRIPTION
## Summary
- Add the canonical `static-site-importer/importer` dynamic block.
- Add `POST /static-site-importer/v1/imports` for URL, raw HTML, and uploaded file imports.
- Keep URL extraction behind the generic `static_site_importer_url_import_provider` hook with no Data Liberation Agent coupling.

## Testing
- `php -l static-site-importer.php && php -l includes/block.php && php -l includes/rest.php && php -l includes/class-static-site-importer-url-import-runtime.php`
- `node --check blocks/importer/editor.js && node --check blocks/importer/view.js`
- `php tests/smoke-url-import-runtime.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Porting the importer block into Static Site Importer, adding the REST route, and drafting focused verification.