### PR TITLE
Document SSI artifact diagnostics boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Required artifact metadata lives under `artifacts` using `static-site-importer/c
 
 Reviewer-facing artifact fields should use durable refs or URLs. Host-local paths and `localhost` URLs are stripped from artifact refs; local paths may appear only under `operator_notes` for the machine operator.
 
+SSI-owned import reports use `static-site-importer/artifact-diagnostics/v1` for fallback artifact diagnostics. WP Codebox providers that expose a public Codebox diagnostics contract should map SSI diagnostics at the Codebox boundary instead of requiring SSI output to emit `wp-codebox/*` schemas.
+
 CLI entrypoint:
 
 ```bash


### PR DESCRIPTION
## Summary
- Documents that SSI fallback artifact diagnostics use the SSI-owned `static-site-importer/artifact-diagnostics/v1` schema.
- Clarifies that WP Codebox providers should map SSI diagnostics at the Codebox boundary when exposing a public Codebox diagnostics contract.
- Verified no `wp-codebox/artifact-diagnostics/v1` emission remains in the repository.

## Tests
- `php tests/smoke-product-handoff-contract.php`
- `php tests/smoke-codebox-validation-contract.php`
- `php -l includes/class-static-site-importer-artifact-diagnostics-adapter.php && php -l includes/class-static-site-importer-product-handoff-contract.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Repository inspection, documentation update, targeted verification, and PR preparation.