### PR TITLE
Clean importer block JavaScript lint

### DIFF
--- a/blocks/importer/editor.js
+++ b/blocks/importer/editor.js
@@ -3,10 +3,10 @@
 		return;
 	}
 
-	var el = element.createElement;
+	const el = element.createElement;
 
 	blocks.registerBlockType( 'static-site-importer/importer', {
-		edit: function () {
+		edit() {
 			return el(
 				'div',
 				{ className: 'ssi-importer ssi-importer--editor' },
@@ -18,7 +18,7 @@
 					: null
 			);
 		},
-		save: function () {
+		save() {
 			return null;
 		},
 	} );

--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -1,11 +1,13 @@
-( function () {
-	var roots = document.querySelectorAll( '[data-static-site-importer]' );
+/* global FileReader */
 
-	var fileToBase64 = function ( file ) {
+( function () {
+	const roots = document.querySelectorAll( '[data-static-site-importer]' );
+
+	const fileToBase64 = function ( file ) {
 		return new Promise( function ( resolve, reject ) {
-			var reader = new FileReader();
+			const reader = new FileReader();
 			reader.onload = function () {
-				var result = typeof reader.result === 'string' ? reader.result : '';
+				const result = typeof reader.result === 'string' ? reader.result : '';
 				resolve( result.replace( /^data:[^,]*,/, '' ) );
 			};
 			reader.onerror = function () {
@@ -15,9 +17,9 @@
 		} );
 	};
 
-	var fileToText = function ( file ) {
+	const fileToText = function ( file ) {
 		return typeof file.text === 'function' ? file.text() : new Promise( function ( resolve, reject ) {
-			var reader = new FileReader();
+			const reader = new FileReader();
 			reader.onload = function () {
 				resolve( typeof reader.result === 'string' ? reader.result : '' );
 			};
@@ -28,16 +30,16 @@
 		} );
 	};
 
-	var uploadedFilePath = function ( file ) {
+	const uploadedFilePath = function ( file ) {
 		return file.webkitRelativePath || file.name || 'upload';
 	};
 
-	var buildFiles = async function ( input ) {
-		var selectedFiles = input && input.files ? Array.prototype.slice.call( input.files ) : [];
+	const buildFiles = async function ( input ) {
+		const selectedFiles = input && input.files ? Array.prototype.slice.call( input.files ) : [];
 		return Promise.all( selectedFiles.map( async function ( file ) {
-			var path = uploadedFilePath( file );
-			var record = {
-				path: path,
+			const path = uploadedFilePath( file );
+			const record = {
+				path,
 				name: file.name || path,
 				type: file.type || '',
 				size: file.size || 0,
@@ -53,17 +55,17 @@
 		} ) );
 	};
 
-	var setReport = function ( root, report ) {
-		var reportEl = root.querySelector( '[data-static-site-importer-report]' );
+	const setReport = function ( root, report ) {
+		const reportEl = root.querySelector( '[data-static-site-importer-report]' );
 		if ( reportEl ) {
 			reportEl.hidden = false;
 			reportEl.value = JSON.stringify( report, null, 2 );
 		}
 	};
 
-	var showStatus = function ( root, message ) {
-		var status = root.querySelector( '[data-static-site-importer-status]' );
-		var progress = root.querySelector( '[data-static-site-importer-progress]' );
+	const showStatus = function ( root, message ) {
+		const status = root.querySelector( '[data-static-site-importer-status]' );
+		const progress = root.querySelector( '[data-static-site-importer-progress]' );
 		if ( status ) {
 			status.hidden = false;
 		}
@@ -72,7 +74,7 @@
 		}
 	};
 
-	var hasSource = function ( source ) {
+	const hasSource = function ( source ) {
 		return Boolean(
 			( source.files && source.files.length > 0 ) ||
 			( source.html && source.html.trim() ) ||
@@ -81,19 +83,17 @@
 	};
 
 	roots.forEach( function ( root ) {
-		var submit = root.querySelector( '[data-static-site-importer-submit]' );
+		const submit = root.querySelector( '[data-static-site-importer-submit]' );
 		if ( ! submit ) {
 			return;
 		}
 
 		submit.addEventListener( 'click', async function () {
-			var sourceUrl = root.querySelector( '[data-static-site-importer-source-url]' );
-			var html = root.querySelector( '[data-static-site-importer-source-html]' );
-			var files = root.querySelector( '[data-static-site-importer-source-files]' );
-			var restUrl = root.getAttribute( 'data-static-site-importer-rest-url' );
-			var nonce = root.getAttribute( 'data-static-site-importer-nonce' );
-			var provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
-			var source = {
+			const sourceUrl = root.querySelector( '[data-static-site-importer-source-url]' );
+			const html = root.querySelector( '[data-static-site-importer-source-html]' );
+			const files = root.querySelector( '[data-static-site-importer-source-files]' );
+			const provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
+			const source = {
 				url: sourceUrl ? sourceUrl.value : '',
 				html: html ? html.value : '',
 				files: await buildFiles( files ),
@@ -108,20 +108,22 @@
 			submit.disabled = true;
 
 			try {
-				var response = await fetch( restUrl, {
+				const restUrl = root.getAttribute( 'data-static-site-importer-rest-url' );
+				const nonce = root.getAttribute( 'data-static-site-importer-nonce' );
+				const response = await fetch( restUrl, {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
 						'X-WP-Nonce': nonce,
 					},
 					body: JSON.stringify( {
-						provider: provider,
-						source: source,
+						provider,
+						source,
 						activate: true,
 						overwrite: true,
 					} ),
 				} );
-				var report = await response.json();
+				const report = await response.json();
 				setReport( root, report );
 				showStatus( root, response.ok && report.success ? 'Import complete.' : 'Import failed.' );
 			} catch ( error ) {


### PR DESCRIPTION
## Summary
- Replace legacy var/function property syntax in the importer block scripts with lint-compliant declarations.
- Move REST request attributes closer to use so early returns do not trip block lint rules.

## Testing
- php tests/smoke-importer-block.php
- php tests/smoke-url-import-runtime.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Cleaning release-blocking importer block JavaScript lint and running targeted smoke verification.