### PR TITLE
Ignore PHPUnit result cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 vendor/
 build/
 .homeboy/
+.phpunit.result.cache


### PR DESCRIPTION
## Summary
- Ignore PHPUnit's generated .phpunit.result.cache file so release test runs do not leave the worktree dirty.

## Testing
- homeboy release static-site-importer --path /Users/chubes/Developer/static-site-importer@release-ssi-1-1-5 --apply --skip-checks=lint --git-identity "Chris Huber <chubes@extrachill.com>" reached the post-test dirty check and identified only .phpunit.result.cache.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the release-blocking transient PHPUnit cache and adding the ignore entry.