### PR TITLE
Load Blocks Engine transformer from Composer

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -38,6 +38,10 @@
     {
       "file": "static-site-importer.php",
       "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
+    },
+    {
+      "file": "static-site-importer.php",
+      "pattern": "STATIC_SITE_IMPORTER_VERSION',\\s*'([0-9.]+)"
     }
   ]
 }

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -6,7 +6,6 @@
  * Author: Chris Huber
  * Requires at least: 6.9
  * Requires PHP: 8.1
- * Requires Plugins: blocks-engine-php-transformer
  * Text Domain: static-site-importer
  *
  * @package StaticSiteImporter
@@ -18,7 +17,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'STATIC_SITE_IMPORTER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'STATIC_SITE_IMPORTER_URL', plugin_dir_url( __FILE__ ) );
-define( 'STATIC_SITE_IMPORTER_VERSION', '1.1.4' );
+define( 'STATIC_SITE_IMPORTER_VERSION', '1.1.5' );
+
+$static_site_importer_autoload = STATIC_SITE_IMPORTER_PATH . 'vendor/autoload.php';
+if ( is_readable( $static_site_importer_autoload ) ) {
+	require_once $static_site_importer_autoload;
+}
+
+$static_site_importer_transformer = STATIC_SITE_IMPORTER_PATH . 'vendor/automattic/blocks-engine-php-transformer/php-transformer/php-transformer.php';
+if ( ! function_exists( 'blocks_engine_php_transformer_compile_artifact' ) && is_readable( $static_site_importer_transformer ) ) {
+	require_once $static_site_importer_transformer;
+}
 
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-source-page.php';

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -95,6 +95,12 @@ if ( ! function_exists( 'wp_create_nonce' ) ) {
 
 require_once dirname( __DIR__ ) . '/includes/block.php';
 
+$plugin_source = file_get_contents( dirname( __DIR__ ) . '/static-site-importer.php' );
+$assert( is_string( $plugin_source ), 'plugin-source-readable' );
+$assert( ! str_contains( $plugin_source, 'Requires Plugins: blocks-engine-php-transformer' ), 'transformer-is-not-a-required-wordpress-plugin' );
+$assert( str_contains( $plugin_source, "vendor/autoload.php" ), 'loads-composer-autoloader' );
+$assert( str_contains( $plugin_source, "vendor/automattic/blocks-engine-php-transformer/php-transformer/php-transformer.php" ), 'loads-composer-transformer-bootstrap' );
+
 $metadata = json_decode( file_get_contents( dirname( __DIR__ ) . '/blocks/importer/block.json' ), true );
 $assert( is_array( $metadata ), 'block-json-decodes' );
 $assert( 'static-site-importer/importer' === ( $metadata['name'] ?? '' ), 'block-name-is-product-importer' );


### PR DESCRIPTION
## Summary
- Remove the Blocks Engine PHP Transformer WordPress plugin requirement from Static Site Importer.
- Bootstrap the Composer-installed transformer package directly from vendor/ so SSI can activate as the host plugin that owns the importer block.
- Add smoke coverage that prevents the WordPress plugin dependency from coming back.

## Testing
- php tests/smoke-importer-block.php
- php tests/smoke-url-import-runtime.php
- php -l static-site-importer.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the runtime activation failure, correcting the Composer dependency bootstrap, and running targeted verification.