### PR TITLE
Keep SSI release target to plugin header

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -38,10 +38,6 @@
     {
       "file": "static-site-importer.php",
       "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
-    },
-    {
-      "file": "static-site-importer.php",
-      "pattern": "STATIC_SITE_IMPORTER_VERSION',\\s*'([0-9.]+)"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Keep Homeboy's SSI release target scoped to the plugin header version.
- Avoid adding the stale STATIC_SITE_IMPORTER_VERSION constant as a release target during the 1.1.6 release path.

## Testing
- homeboy release static-site-importer --path /Users/chubes/Developer/static-site-importer@release-ssi-1-1-6 --apply --skip-checks=lint --bump 1.1.6 --git-identity "Chris Huber <chubes@extrachill.com>" exposed the version-target mismatch this fixes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the release-target mismatch and preparing the minimal release unblocker.