### PR TITLE
Fix SSI release version targets

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -38,6 +38,10 @@
     {
       "file": "static-site-importer.php",
       "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
+    },
+    {
+      "file": "static-site-importer.php",
+      "pattern": "define\\(\\s*'STATIC_SITE_IMPORTER_VERSION',\\s*'([0-9.]+)'\\s*\\)"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Restore the Static Site Importer runtime constant as a Homeboy release version target.
- Keep future release bumps synchronized between the plugin header and STATIC_SITE_IMPORTER_VERSION.

## Testing
- php -r "json_decode(file_get_contents('homeboy.json'), true, 512, JSON_THROW_ON_ERROR); echo 'json ok'.PHP_EOL;"

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the release-target mismatch and drafting the small configuration fix.