### PR TITLE
Fix SSI version baseline

### DIFF
--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'STATIC_SITE_IMPORTER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'STATIC_SITE_IMPORTER_URL', plugin_dir_url( __FILE__ ) );
-define( 'STATIC_SITE_IMPORTER_VERSION', '1.1.5' );
+define( 'STATIC_SITE_IMPORTER_VERSION', '1.1.4' );
 
 $static_site_importer_autoload = STATIC_SITE_IMPORTER_PATH . 'vendor/autoload.php';
 if ( is_readable( $static_site_importer_autoload ) ) {


### PR DESCRIPTION
## Summary
- Restore STATIC_SITE_IMPORTER_VERSION to the canonical 1.1.4 baseline on main.
- Allow the next Homeboy release to bump the plugin header and runtime constant together.

## Testing
- Homeboy release preflight identified this exact mismatch before release mutation: Version mismatch in static-site-importer.php: found 1.1.5, expected 1.1.4.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the release baseline mismatch and drafting the one-line fix.