### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: Extra-Chill/homeboy-action@v2
+      - uses: Extra-Chill/homeboy-action@42636bb42a936a11339ba8424c6589ea542a76e1  # v2.8.2
         with:
           commands: test
           php-version: ${{ matrix.php-version }}


### PR DESCRIPTION
Pins the third-party action in `.github/workflows/test.yml` to a commit SHA.

`Extra-Chill/homeboy-action@v2` -> `42636bb42a936a11339ba8424c6589ea542a76e1` (v2.8.2), the commit `@v2` currently resolves to. `actions/checkout` is GitHub-owned, out of scope for this third-party pass.

Verify:

    gh api repos/Extra-Chill/homeboy-action/commits/v2 --jq .sha
    # => 42636bb42a936a11339ba8424c6589ea542a76e1

Tracking: DEVPROD-1072.
