### PR TITLE
Clarify direct Blocks Engine transformer usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Import a static site or generated website artifact into WordPress pages and a companion block theme.
 
-Static Site Importer is a WordPress plugin. It requires the [Blocks Engine PHP transformer](https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer) plugin and calls that plugin's canonical helper functions for generic artifact compilation and format conversion.
+Static Site Importer is a WordPress plugin. It requires the [Blocks Engine PHP transformer](https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer) Composer package and calls that package's canonical helper functions for generic artifact compilation and format conversion.
 
 ## Architecture Stack
 
@@ -25,7 +25,7 @@ When a generated artifact contains full-document HTML, Static Site Importer rout
 - Allows ZIP/CLI source-site imports to include nested `.md` / `.markdown` content documents; `.mdx` is skipped with explicit diagnostics because MDX runtime components are not supported.
 - Provides a WP-CLI importer for a local HTML entry file or one public HTML URL; the local source file does not need to be named `index.html` unless you want automatic front-page assignment.
 - Discovers readable sibling `*.html` files beside the selected entry file and recursive Markdown content documents under the source tree, then imports them as WordPress pages.
-- Compiles static HTML fragments and Markdown content through the Blocks Engine PHP transformer plugin helpers.
+- Compiles static HTML fragments and Markdown content through the Blocks Engine PHP transformer package helpers.
 - Stores converted page bodies on the imported WordPress pages as `post_content`.
 - Generates a block theme with shared header/footer template parts, `core/post-content` templates, page patterns for reusable/reference artifacts, `theme.json`, `style.css`, and optional `assets/site.js`.
 - Rewrites local `.html` links to the imported WordPress page permalinks.
@@ -37,12 +37,12 @@ When a generated artifact contains full-document HTML, Static Site Importer rout
 
 - WordPress 6.6 or later.
 - PHP 8.1 or later.
-- Blocks Engine PHP transformer plugin installed and active.
+- Composer dependencies installed with `composer install`.
 - Node dependencies installed only when running the JavaScript block-validation smoke tests.
 
 SSI requires `automattic/blocks-engine-php-transformer:^0.1.0` in Composer to align installed dependencies with the tagged Blocks Engine PHP transformer release. Until the package is published on Packagist, `composer.json` includes an explicit package repository for the `php-transformer-v0.1.0` tag at `ac92ddb` with autoloading rooted at the Blocks Engine monorepo archive's `php-transformer/src/` directory. Remove that repository override once Packagist serves the package metadata.
 
-At runtime, WordPress still loads the transformer plugin, and SSI calls `blocks_engine_php_transformer_compile_artifact()` and `blocks_engine_php_transformer_convert_format()`.
+At runtime, SSI loads the transformer package from `vendor/` and calls `blocks_engine_php_transformer_compile_artifact()` and `blocks_engine_php_transformer_convert_format()` directly.
 
 ## Admin Usage
 
@@ -284,7 +284,7 @@ npm run test:validation -- --json
 
 ### PHP Smokes
 
-PHP smokes run inside WordPress with the Blocks Engine PHP transformer plugin loaded through the plugin runtime:
+PHP smokes run inside WordPress with SSI's Composer dependencies installed:
 
 ```bash
 wp eval-file tests/smoke-admin-import-html-entry.php

--- a/homeboy.json
+++ b/homeboy.json
@@ -19,16 +19,7 @@
             ]
           }
         ],
-        "validation_dependencies": [
-          {
-            "type": "github",
-            "repo": "Automattic/blocks-engine",
-            "ref": "trunk",
-            "plugin_slug": "blocks-engine-php-transformer",
-            "package_path": "php-transformer",
-            "activate": true
-          }
-        ]
+        "validation_dependencies": []
       }
     }
   },

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -250,7 +250,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'tag_name'              => isset( $context['tag_name'] ) ? (string) $context['tag_name'] : self::diagnostic_tag_name_from_html( $element_html ),
 			'block_name'            => isset( $block['blockName'] ) ? (string) $block['blockName'] : null,
 			'engine'                => 'blocks-engine/php-transformer',
-			'stage'                 => isset( $context['stage'] ) ? (string) $context['stage'] : 'html_to_blocks',
+			'stage'                 => isset( $context['stage'] ) ? (string) $context['stage'] : 'block_conversion',
 			'html_length'           => strlen( $element_html ),
 			'html_excerpt'          => self::diagnostic_excerpt( $element_html ),
 		);


### PR DESCRIPTION
## Summary

- Clarifies that Static Site Importer uses the Blocks Engine PHP Transformer Composer package directly.
- Removes validation-time plugin activation for the transformer now that SSI owns the Composer dependency path.
- Updates fallback diagnostics to use a neutral `block_conversion` stage instead of the legacy `html_to_blocks` label.

## Verification

```sh
composer validate --no-check-publish
php tests/smoke-transformer-adapter.php
php tests/smoke-importer-block.php
```

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Repository inspection, dependency-chain cleanup, focused edits, and verification command selection.
