### PR TITLE
Make importer block preview-oriented

### DIFF
--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -169,7 +169,7 @@
 				if ( response.ok && previewUrl( report ) ) {
 					showStatus( root, 'Preview ready.' );
 				} else if ( response.ok && report.preview && report.preview.status === 'unavailable' ) {
-					showStatus( root, report.preview.message || 'Preview unavailable: no preview provider is configured.' );
+					showStatus( root, report.preview.message || 'Preview unavailable: WP Codebox did not return a preview URL or Playground blueprint URL.' );
 				} else {
 					showStatus( root, response.ok && report.success ? 'Preview request complete.' : 'Preview request failed.' );
 				}

--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -55,6 +55,21 @@
 		} ) );
 	};
 
+	const buildArchive = async function ( input ) {
+		const file = input && input.files && input.files.length ? input.files[ 0 ] : null;
+		if ( ! file || ! /\.zip$/i.test( file.name || '' ) ) {
+			return null;
+		}
+
+		return {
+			path: file.name || 'website.zip',
+			name: file.name || 'website.zip',
+			type: file.type || 'application/zip',
+			size: file.size || 0,
+			content_base64: await fileToBase64( file ),
+		};
+	};
+
 	const setReport = function ( root, report ) {
 		const reportEl = root.querySelector( '[data-static-site-importer-report]' );
 		if ( reportEl ) {
@@ -74,9 +89,34 @@
 		}
 	};
 
+	const previewUrl = function ( report ) {
+		const preview = report && report.preview && typeof report.preview === 'object' ? report.preview : {};
+		const playground = preview.playground && typeof preview.playground === 'object' ? preview.playground : {};
+		return preview.url || playground.blueprint_url || '';
+	};
+
+	const setPreviewLink = function ( root, report ) {
+		const wrap = root.querySelector( '[data-static-site-importer-preview-link-wrap]' );
+		const link = root.querySelector( '[data-static-site-importer-preview-link]' );
+		const url = previewUrl( report );
+
+		if ( ! wrap || ! link ) {
+			return;
+		}
+
+		if ( url ) {
+			link.href = url;
+			wrap.hidden = false;
+		} else {
+			link.removeAttribute( 'href' );
+			wrap.hidden = true;
+		}
+	};
+
 	const hasSource = function ( source ) {
 		return Boolean(
 			( source.files && source.files.length > 0 ) ||
+			( source.archive && source.archive.content_base64 ) ||
 			( source.html && source.html.trim() ) ||
 			( source.url && source.url.trim() )
 		);
@@ -92,19 +132,21 @@
 			const sourceUrl = root.querySelector( '[data-static-site-importer-source-url]' );
 			const html = root.querySelector( '[data-static-site-importer-source-html]' );
 			const files = root.querySelector( '[data-static-site-importer-source-files]' );
+			const archive = root.querySelector( '[data-static-site-importer-source-archive]' );
 			const provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
 			const source = {
 				url: sourceUrl ? sourceUrl.value : '',
 				html: html ? html.value : '',
 				files: await buildFiles( files ),
+				archive: await buildArchive( archive ),
 			};
 
 			if ( ! hasSource( source ) ) {
-				showStatus( root, 'Add a website URL, site files, or raw HTML to start.' );
+				showStatus( root, 'Add a website URL, site directory, ZIP archive, or raw HTML to start.' );
 				return;
 			}
 
-			showStatus( root, 'Importing site into WordPress...' );
+			showStatus( root, 'Creating WordPress preview...' );
 			submit.disabled = true;
 
 			try {
@@ -119,16 +161,22 @@
 					body: JSON.stringify( {
 						provider,
 						source,
-						activate: true,
-						overwrite: true,
 					} ),
 				} );
 				const report = await response.json();
 				setReport( root, report );
-				showStatus( root, response.ok && report.success ? 'Import complete.' : 'Import failed.' );
+				setPreviewLink( root, report );
+				if ( response.ok && previewUrl( report ) ) {
+					showStatus( root, 'Preview ready.' );
+				} else if ( response.ok && report.preview && report.preview.status === 'unavailable' ) {
+					showStatus( root, report.preview.message || 'Preview unavailable: no preview provider is configured.' );
+				} else {
+					showStatus( root, response.ok && report.success ? 'Preview request complete.' : 'Preview request failed.' );
+				}
 			} catch ( error ) {
 				setReport( root, { success: false, error: { message: error.message } } );
-				showStatus( root, 'Import request failed.' );
+				setPreviewLink( root, null );
+				showStatus( root, 'Preview request failed.' );
 			} finally {
 				submit.disabled = false;
 			}

--- a/includes/block.php
+++ b/includes/block.php
@@ -50,8 +50,13 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 				</label>
 
 				<label class="ssi-importer__field">
-					<span class="ssi-importer__label"><?php esc_html_e( 'Site files', 'static-site-importer' ); ?></span>
-					<input type="file" name="ssi_static_template[]" multiple data-static-site-importer-source-files>
+					<span class="ssi-importer__label"><?php esc_html_e( 'Site directory', 'static-site-importer' ); ?></span>
+					<input type="file" name="ssi_static_template[]" multiple webkitdirectory data-static-site-importer-source-files>
+				</label>
+
+				<label class="ssi-importer__field">
+					<span class="ssi-importer__label"><?php esc_html_e( 'ZIP archive', 'static-site-importer' ); ?></span>
+					<input type="file" name="ssi_static_archive" accept=".zip,application/zip" data-static-site-importer-source-archive>
 				</label>
 
 				<label class="ssi-importer__field">
@@ -59,13 +64,14 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 					<textarea name="ssi_html" rows="6" data-static-site-importer-source-html></textarea>
 				</label>
 
-				<button type="button" class="ssi-importer__submit" data-static-site-importer-submit><?php esc_html_e( 'Start import', 'static-site-importer' ); ?></button>
+				<button type="button" class="ssi-importer__submit" data-static-site-importer-submit><?php esc_html_e( 'Create preview', 'static-site-importer' ); ?></button>
 			</form>
 		</section>
 
 		<section class="ssi-importer__report" aria-live="polite" hidden data-static-site-importer-status>
 			<p class="ssi-importer__label"><?php esc_html_e( 'Import status', 'static-site-importer' ); ?></p>
 			<p data-static-site-importer-progress></p>
+			<p hidden data-static-site-importer-preview-link-wrap><a href="#" target="_blank" rel="noopener noreferrer" data-static-site-importer-preview-link><?php esc_html_e( 'Open WordPress preview', 'static-site-importer' ); ?></a></p>
 			<textarea rows="10" readonly hidden data-static-site-importer-report></textarea>
 		</section>
 	</div>

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -27,6 +27,15 @@ function static_site_importer_register_rest_routes(): void {
 }
 
 /**
+ * Register default preview providers.
+ *
+ * @return void
+ */
+function static_site_importer_register_preview_providers(): void {
+	add_filter( 'static_site_importer_preview_result', 'static_site_importer_rest_codebox_preview_result', 10, 3 );
+}
+
+/**
  * Require a site operator for import mutations.
  *
  * @return true|WP_Error
@@ -229,6 +238,283 @@ function static_site_importer_rest_normalize_preview_result( array $result ): ar
 }
 
 /**
+ * Create a preview through WP Codebox's disposable browser Playground session API.
+ *
+ * @param array<string,mixed>|WP_Error|null $result  Existing provider result.
+ * @param array<string,mixed>               $request Preview request.
+ * @param array<string,mixed>               $params  Raw REST params.
+ * @return array<string,mixed>|WP_Error|null
+ */
+function static_site_importer_rest_codebox_preview_result( $result, array $request, array $params ) {
+	if ( null !== $result ) {
+		return $result;
+	}
+
+	if ( ! class_exists( 'WP_Codebox_Abilities' ) || ! method_exists( 'WP_Codebox_Abilities', 'create_browser_playground_session' ) ) {
+		return null;
+	}
+
+	$codebox_input = static_site_importer_rest_codebox_preview_input( $request, $params );
+	if ( is_wp_error( $codebox_input ) ) {
+		return $codebox_input;
+	}
+
+	$session = WP_Codebox_Abilities::create_browser_playground_session( $codebox_input );
+	if ( is_wp_error( $session ) ) {
+		return $session;
+	}
+
+	if ( ! is_array( $session ) ) {
+		return new WP_Error( 'static_site_importer_codebox_preview_result_invalid', __( 'WP Codebox preview returned an invalid session response.', 'static-site-importer' ), array( 'status' => 500 ) );
+	}
+
+	return static_site_importer_rest_codebox_preview_from_session( $session, $request );
+}
+
+/**
+ * Build WP Codebox browser Playground input from an SSI preview request.
+ *
+ * @param array<string,mixed> $request Preview request.
+ * @param array<string,mixed> $params  Raw REST params.
+ * @return array<string,mixed>|WP_Error
+ */
+function static_site_importer_rest_codebox_preview_input( array $request, array $params ) {
+	$source      = isset( $request['source'] ) && is_array( $request['source'] ) ? $request['source'] : array();
+	$artifact    = isset( $source['artifact'] ) && is_array( $source['artifact'] ) ? $source['artifact'] : array();
+	$import_args = isset( $request['import_args'] ) && is_array( $request['import_args'] ) ? $request['import_args'] : array();
+
+	$input = array(
+		'goal'               => __( 'Create a disposable WordPress preview for a Static Site Importer request.', 'static-site-importer' ),
+		'target'             => array(
+			'kind' => 'static-site-importer-preview',
+			'ref'  => 'static-site-importer/importer',
+		),
+		'expected_artifacts' => array( 'preview', 'static-site-importer-report' ),
+		'context'            => array(
+			'product'        => 'static-site-importer',
+			'request_schema' => (string) ( $request['schema'] ?? 'static-site-importer/preview-request/v1' ),
+			'source_url'     => isset( $source['url'] ) ? (string) $source['url'] : '',
+		),
+		'artifact_files'     => static_site_importer_rest_codebox_artifact_files( $artifact ),
+		'browser_runner'     => array(
+			'task_path'   => '/tmp/static-site-importer-preview-request.json',
+			'result_path' => '/tmp/static-site-importer-preview-result.json',
+			'invocation'  => array(
+				'type'  => 'ability',
+				'name'  => ! empty( $artifact ) ? 'static-site-importer/import-website-artifact' : 'static-site-importer/import-url',
+				'input' => array_filter(
+					array(
+						'artifact' => $artifact,
+						'url'      => isset( $source['url'] ) ? (string) $source['url'] : '',
+					) + $import_args
+				),
+			),
+			'capture_paths' => array(
+				array(
+					'path'      => '/tmp/static-site-importer-preview-result.json',
+					'name'      => 'static-site-importer-preview-result',
+					'kind'      => 'json',
+					'mime_type' => 'application/json',
+				),
+			),
+		),
+		'orchestrator'       => array(
+			'type' => 'static-site-importer-preview',
+			'id'   => 'static-site-importer/importer',
+		),
+	);
+
+	/**
+	 * Filters the WP Codebox browser Playground input for SSI previews.
+	 *
+	 * Deployments may add generic WP Codebox runtime packages, browser plugins, or
+	 * Playground options here. SSI intentionally does not hardcode environment paths.
+	 *
+	 * @param array<string,mixed> $input   WP Codebox browser session input.
+	 * @param array<string,mixed> $request SSI preview request.
+	 * @param array<string,mixed> $params  Raw REST params.
+	 */
+	$input = apply_filters( 'static_site_importer_codebox_preview_input', $input, $request, $params );
+	if ( ! is_array( $input ) ) {
+		return new WP_Error( 'static_site_importer_codebox_preview_input_invalid', __( 'WP Codebox preview input filters must return an array.', 'static-site-importer' ), array( 'status' => 500 ) );
+	}
+
+	return $input;
+}
+
+/**
+ * Convert SSI website artifact files to WP Codebox browser artifact files.
+ *
+ * @param array<string,mixed> $artifact Website artifact.
+ * @return array<int,array<string,mixed>>
+ */
+function static_site_importer_rest_codebox_artifact_files( array $artifact ): array {
+	$artifact_files = array();
+	$files          = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
+
+	foreach ( $files as $file ) {
+		if ( ! is_array( $file ) ) {
+			continue;
+		}
+
+		$path = isset( $file['path'] ) ? (string) $file['path'] : '';
+		$path = preg_replace( '#^website/#', '', $path );
+		$path = static_site_importer_rest_codebox_artifact_path( (string) $path );
+		if ( '' === $path ) {
+			continue;
+		}
+
+		$artifact_file = array(
+			'path' => $path,
+			'kind' => preg_match( '/\.html?$/i', $path ) ? 'html' : 'asset',
+		);
+
+		if ( isset( $file['content_base64'] ) ) {
+			$artifact_file['encoding']       = 'base64';
+			$artifact_file['content_base64'] = (string) $file['content_base64'];
+		} else {
+			$artifact_file['encoding'] = 'utf-8';
+			$artifact_file['content']  = isset( $file['content'] ) ? (string) $file['content'] : '';
+		}
+
+		$artifact_files[] = $artifact_file;
+	}
+
+	return $artifact_files;
+}
+
+/**
+ * Normalize a path for WP Codebox browser artifact files.
+ *
+ * @param string $path Artifact path.
+ * @return string
+ */
+function static_site_importer_rest_codebox_artifact_path( string $path ): string {
+	$path = str_replace( '\\', '/', $path );
+	$path = preg_replace( '#(^|/)\.(?=/|$)#', '', $path );
+	$path = preg_replace( '#(^|/)\.\.(?=/|$)#', '', $path );
+	$path = preg_replace( '#[^A-Za-z0-9_./-]#', '-', $path );
+	$path = preg_replace( '#/+#', '/', (string) $path );
+	$path = trim( (string) $path, '/' );
+
+	return '' !== $path ? $path : '';
+}
+
+/**
+ * Normalize a WP Codebox browser session into SSI's preview response shape.
+ *
+ * @param array<string,mixed> $session WP Codebox browser session.
+ * @param array<string,mixed> $request SSI preview request.
+ * @return array<string,mixed>
+ */
+function static_site_importer_rest_codebox_preview_from_session( array $session, array $request ): array {
+	$playground    = isset( $session['playground'] ) && is_array( $session['playground'] ) ? $session['playground'] : array();
+	$artifacts     = isset( $session['artifacts'] ) && is_array( $session['artifacts'] ) ? $session['artifacts'] : array();
+	$preview_url   = static_site_importer_rest_codebox_preview_url( $playground, $artifacts );
+	$blueprint_url = static_site_importer_rest_codebox_blueprint_url( $session );
+
+	if ( '' === $preview_url && '' === $blueprint_url ) {
+		return array(
+			'success' => false,
+			'preview' => array(
+				'status'  => 'unavailable',
+				'message' => __( 'Preview unavailable: WP Codebox did not return a preview URL or Playground blueprint URL.', 'static-site-importer' ),
+			),
+			'provider' => 'wp-codebox/create-browser-playground-session',
+			'codebox'  => array(
+				'session' => static_site_importer_rest_codebox_session_summary( $session ),
+			),
+			'request'  => $request,
+		);
+	}
+
+	return array(
+		'success' => true,
+		'preview' => array_filter(
+			array(
+				'status'     => 'ready',
+				'url'        => $preview_url,
+				'playground' => array_filter(
+					array(
+						'blueprint_url' => $blueprint_url,
+						'preview_url'   => isset( $playground['preview_url'] ) ? (string) $playground['preview_url'] : '',
+						'scope'         => isset( $playground['scope'] ) ? (string) $playground['scope'] : '',
+					)
+				),
+			)
+		),
+		'provider' => 'wp-codebox/create-browser-playground-session',
+		'codebox'  => array(
+			'session' => static_site_importer_rest_codebox_session_summary( $session ),
+		),
+	);
+}
+
+/**
+ * Extract the best reviewer-facing preview URL from a WP Codebox session.
+ *
+ * @param array<string,mixed> $playground Playground contract.
+ * @param array<string,mixed> $artifacts  Artifact contract.
+ * @return string
+ */
+function static_site_importer_rest_codebox_preview_url( array $playground, array $artifacts ): string {
+	foreach ( array( $playground['preview_public_url'] ?? '', $playground['site_url'] ?? '', $playground['preview_url'] ?? '', $artifacts['preview_url'] ?? '' ) as $candidate ) {
+		$candidate = esc_url_raw( (string) $candidate );
+		if ( preg_match( '#^https?://#i', $candidate ) ) {
+			return $candidate;
+		}
+	}
+
+	return '';
+}
+
+/**
+ * Build a Playground blueprint URL from a WP Codebox executable blueprint ref.
+ *
+ * @param array<string,mixed> $session WP Codebox browser session.
+ * @return string
+ */
+function static_site_importer_rest_codebox_blueprint_url( array $session ): string {
+	if ( ! class_exists( 'WP_Codebox_Browser_Task_Builder' ) || ! method_exists( 'WP_Codebox_Browser_Task_Builder', 'executable_blueprint_ref' ) ) {
+		return '';
+	}
+
+	$blueprint_ref = WP_Codebox_Browser_Task_Builder::executable_blueprint_ref( $session );
+	if ( ! is_array( $blueprint_ref ) ) {
+		return '';
+	}
+
+	$endpoint = isset( $blueprint_ref['hydration_endpoint'] ) ? (string) $blueprint_ref['hydration_endpoint'] : ( isset( $blueprint_ref['endpoint'] ) ? (string) $blueprint_ref['endpoint'] : '' );
+	if ( '' === $endpoint ) {
+		return '';
+	}
+
+	$blueprint_endpoint = str_starts_with( $endpoint, 'http://' ) || str_starts_with( $endpoint, 'https://' ) ? $endpoint : rest_url( ltrim( $endpoint, '/' ) );
+
+	return esc_url_raw( 'https://playground.wordpress.net/?blueprint-url=' . rawurlencode( $blueprint_endpoint ) );
+}
+
+/**
+ * Create a compact Codebox session summary for diagnostics.
+ *
+ * @param array<string,mixed> $session WP Codebox browser session.
+ * @return array<string,mixed>
+ */
+function static_site_importer_rest_codebox_session_summary( array $session ): array {
+	$session_envelope = isset( $session['session'] ) && is_array( $session['session'] ) ? $session['session'] : array();
+
+	return array_filter(
+		array(
+			'schema'          => isset( $session['schema'] ) ? (string) $session['schema'] : '',
+			'execution'       => isset( $session['execution'] ) ? (string) $session['execution'] : '',
+			'execution_scope' => isset( $session['execution_scope'] ) ? (string) $session['execution_scope'] : '',
+			'session_id'      => isset( $session_envelope['id'] ) ? (string) $session_envelope['id'] : '',
+			'status'          => isset( $session_envelope['status'] ) ? (string) $session_envelope['status'] : '',
+		)
+	);
+}
+
+/**
  * Build import args from REST input.
  *
  * @param array<string,mixed> $params Request params.
@@ -422,4 +708,8 @@ function static_site_importer_rest_entrypoint( array $files ): string {
 	}
 
 	return 'website/index.html';
+}
+
+if ( function_exists( 'add_filter' ) ) {
+	static_site_importer_register_preview_providers();
 }

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -27,15 +27,6 @@ function static_site_importer_register_rest_routes(): void {
 }
 
 /**
- * Register default preview providers.
- *
- * @return void
- */
-function static_site_importer_register_preview_providers(): void {
-	add_filter( 'static_site_importer_preview_result', 'static_site_importer_rest_codebox_preview_result', 10, 3 );
-}
-
-/**
  * Require a site operator for import mutations.
  *
  * @return true|WP_Error
@@ -160,27 +151,13 @@ function static_site_importer_rest_create_preview( array $source, array $input, 
 		'provider'    => isset( $params['provider'] ) ? sanitize_key( (string) $params['provider'] ) : '',
 	);
 
-	/**
-	 * Creates a standalone WordPress preview for an SSI import request.
-	 *
-	 * Providers should return an array containing `preview.url` and/or
-	 * `preview.playground.blueprint_url`. Return null when no provider is available.
-	 *
-	 * @param array<string,mixed>|WP_Error|null $result  Provider result.
-	 * @param array<string,mixed>               $request Preview request.
-	 * @param array<string,mixed>               $params  Raw REST params.
-	 */
-	$result = apply_filters( 'static_site_importer_preview_result', null, $request, $params );
+	$result = static_site_importer_rest_codebox_preview_result( $request, $params );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
 
-	if ( null === $result ) {
-		return static_site_importer_rest_preview_unavailable_result( $request );
-	}
-
 	if ( ! is_array( $result ) ) {
-		return new WP_Error( 'static_site_importer_preview_result_invalid', __( 'Preview providers must return an array result, WP_Error, or null.', 'static-site-importer' ), array( 'status' => 500 ) );
+		return new WP_Error( 'static_site_importer_codebox_preview_result_invalid', __( 'WP Codebox preview must return an array result or WP_Error.', 'static-site-importer' ), array( 'status' => 500 ) );
 	}
 
 	return static_site_importer_rest_normalize_preview_result( $result );
@@ -197,16 +174,17 @@ function static_site_importer_rest_preview_unavailable_result( array $request ):
 		'success' => false,
 		'preview' => array(
 			'status'  => 'unavailable',
-			'message' => __( 'Preview unavailable: no Static Site Importer preview provider is configured for standalone WordPress previews.', 'static-site-importer' ),
+			'message' => __( 'Preview unavailable: WP Codebox is unavailable, not installed, or does not provide the required browser Playground session API.', 'static-site-importer' ),
 		),
+		'provider' => 'wp-codebox/create-browser-playground-session',
 		'request' => $request,
 	);
 }
 
 /**
- * Normalize provider output to the REST preview contract.
+ * Normalize preview output to the REST preview contract.
  *
- * @param array<string,mixed> $result Provider result.
+ * @param array<string,mixed> $result Preview result.
  * @return array<string,mixed>
  */
 function static_site_importer_rest_normalize_preview_result( array $result ): array {
@@ -240,18 +218,13 @@ function static_site_importer_rest_normalize_preview_result( array $result ): ar
 /**
  * Create a preview through WP Codebox's disposable browser Playground session API.
  *
- * @param array<string,mixed>|WP_Error|null $result  Existing provider result.
- * @param array<string,mixed>               $request Preview request.
- * @param array<string,mixed>               $params  Raw REST params.
- * @return array<string,mixed>|WP_Error|null
+ * @param array<string,mixed> $request Preview request.
+ * @param array<string,mixed> $params  Raw REST params.
+ * @return array<string,mixed>|WP_Error
  */
-function static_site_importer_rest_codebox_preview_result( $result, array $request, array $params ) {
-	if ( null !== $result ) {
-		return $result;
-	}
-
+function static_site_importer_rest_codebox_preview_result( array $request, array $params ) {
 	if ( ! class_exists( 'WP_Codebox_Abilities' ) || ! method_exists( 'WP_Codebox_Abilities', 'create_browser_playground_session' ) ) {
-		return null;
+		return static_site_importer_rest_preview_unavailable_result( $request );
 	}
 
 	$codebox_input = static_site_importer_rest_codebox_preview_input( $request, $params );
@@ -708,8 +681,4 @@ function static_site_importer_rest_entrypoint( array $files ): string {
 	}
 
 	return 'website/index.html';
-}
-
-if ( function_exists( 'add_filter' ) ) {
-	static_site_importer_register_preview_providers();
 }

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -58,25 +58,16 @@ function static_site_importer_rest_create_import( WP_REST_Request $request ) {
 	$source = isset( $params['source'] ) && is_array( $params['source'] ) ? $params['source'] : array();
 	$input  = static_site_importer_rest_import_args( $params );
 
-	if ( isset( $source['url'] ) && '' !== trim( (string) $source['url'] ) ) {
-		$input['url'] = esc_url_raw( (string) $source['url'] );
-		if ( isset( $params['provider'] ) ) {
-			$input['provider'] = sanitize_key( (string) $params['provider'] );
-		}
-		if ( isset( $params['provider_args'] ) && is_array( $params['provider_args'] ) ) {
-			$input['provider_args'] = $params['provider_args'];
+	if ( ! static_site_importer_rest_should_apply_to_current_site( $params ) ) {
+		$result = static_site_importer_rest_create_preview( $source, $input, $params );
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
-		$result = Static_Site_Importer_URL_Import_Runtime::import_url( $input );
-	} else {
-		$artifact = static_site_importer_rest_source_artifact( $source );
-		if ( is_wp_error( $artifact ) ) {
-			return $artifact;
-		}
-
-		$result = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $input );
+		return rest_ensure_response( $result );
 	}
 
+	$result = static_site_importer_rest_apply_to_current_site( $source, $input, $params );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -86,6 +77,153 @@ function static_site_importer_rest_create_import( WP_REST_Request $request ) {
 			'success'               => true,
 			'result'                => $result,
 			'import_report_summary' => isset( $result['import_report_summary'] ) && is_array( $result['import_report_summary'] ) ? $result['import_report_summary'] : array(),
+		)
+	);
+}
+
+/**
+ * Determine whether the request explicitly targets the current WordPress site.
+ *
+ * @param array<string,mixed> $params Request params.
+ * @return bool
+ */
+function static_site_importer_rest_should_apply_to_current_site( array $params ): bool {
+	return ! empty( $params['apply_to_current_site'] );
+}
+
+/**
+ * Apply an import to the installed WordPress site.
+ *
+ * @param array<string,mixed> $source Source payload.
+ * @param array<string,mixed> $input  Import args.
+ * @param array<string,mixed> $params Request params.
+ * @return array<string,mixed>|WP_Error
+ */
+function static_site_importer_rest_apply_to_current_site( array $source, array $input, array $params ) {
+	if ( isset( $source['url'] ) && '' !== trim( (string) $source['url'] ) ) {
+		$input['url'] = esc_url_raw( (string) $source['url'] );
+		if ( isset( $params['provider'] ) ) {
+			$input['provider'] = sanitize_key( (string) $params['provider'] );
+		}
+		if ( isset( $params['provider_args'] ) && is_array( $params['provider_args'] ) ) {
+			$input['provider_args'] = $params['provider_args'];
+		}
+
+		return Static_Site_Importer_URL_Import_Runtime::import_url( $input );
+	} else {
+		$artifact = static_site_importer_rest_source_artifact( $source );
+		if ( is_wp_error( $artifact ) ) {
+			return $artifact;
+		}
+
+		return Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $input );
+	}
+}
+
+/**
+ * Create a standalone preview request without mutating the current site.
+ *
+ * @param array<string,mixed> $source Source payload.
+ * @param array<string,mixed> $input  Import args.
+ * @param array<string,mixed> $params Request params.
+ * @return array<string,mixed>|WP_Error
+ */
+function static_site_importer_rest_create_preview( array $source, array $input, array $params ) {
+	$source_url = isset( $source['url'] ) ? esc_url_raw( (string) $source['url'] ) : '';
+	$artifact   = array();
+
+	if ( '' === trim( $source_url ) || isset( $source['html'] ) || isset( $source['files'] ) || isset( $source['archive'] ) ) {
+		$artifact = static_site_importer_rest_source_artifact( $source );
+		if ( is_wp_error( $artifact ) ) {
+			return $artifact;
+		}
+	}
+
+	$request = array(
+		'schema'      => 'static-site-importer/preview-request/v1',
+		'source'      => array_filter(
+			array(
+				'url'      => $source_url,
+				'artifact' => $artifact,
+			)
+		),
+		'import_args' => $input,
+		'provider'    => isset( $params['provider'] ) ? sanitize_key( (string) $params['provider'] ) : '',
+	);
+
+	/**
+	 * Creates a standalone WordPress preview for an SSI import request.
+	 *
+	 * Providers should return an array containing `preview.url` and/or
+	 * `preview.playground.blueprint_url`. Return null when no provider is available.
+	 *
+	 * @param array<string,mixed>|WP_Error|null $result  Provider result.
+	 * @param array<string,mixed>               $request Preview request.
+	 * @param array<string,mixed>               $params  Raw REST params.
+	 */
+	$result = apply_filters( 'static_site_importer_preview_result', null, $request, $params );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	if ( null === $result ) {
+		return static_site_importer_rest_preview_unavailable_result( $request );
+	}
+
+	if ( ! is_array( $result ) ) {
+		return new WP_Error( 'static_site_importer_preview_result_invalid', __( 'Preview providers must return an array result, WP_Error, or null.', 'static-site-importer' ), array( 'status' => 500 ) );
+	}
+
+	return static_site_importer_rest_normalize_preview_result( $result );
+}
+
+/**
+ * Build a precise preview-unavailable response.
+ *
+ * @param array<string,mixed> $request Preview request.
+ * @return array<string,mixed>
+ */
+function static_site_importer_rest_preview_unavailable_result( array $request ): array {
+	return array(
+		'success' => false,
+		'preview' => array(
+			'status'  => 'unavailable',
+			'message' => __( 'Preview unavailable: no Static Site Importer preview provider is configured for standalone WordPress previews.', 'static-site-importer' ),
+		),
+		'request' => $request,
+	);
+}
+
+/**
+ * Normalize provider output to the REST preview contract.
+ *
+ * @param array<string,mixed> $result Provider result.
+ * @return array<string,mixed>
+ */
+function static_site_importer_rest_normalize_preview_result( array $result ): array {
+	$preview = isset( $result['preview'] ) && is_array( $result['preview'] ) ? $result['preview'] : $result;
+	$url     = isset( $preview['url'] ) ? esc_url_raw( (string) $preview['url'] ) : '';
+	$playground = isset( $preview['playground'] ) && is_array( $preview['playground'] ) ? $preview['playground'] : array();
+	if ( isset( $playground['blueprint_url'] ) ) {
+		$playground['blueprint_url'] = esc_url_raw( (string) $playground['blueprint_url'] );
+	}
+
+	$preview = array_filter(
+		array_merge(
+			$preview,
+			array(
+				'status'     => isset( $preview['status'] ) ? sanitize_key( (string) $preview['status'] ) : 'ready',
+				'url'        => $url,
+				'playground' => $playground,
+			)
+		)
+	);
+
+	return array_merge(
+		$result,
+		array(
+			'success' => array_key_exists( 'success', $result ) ? (bool) $result['success'] : ( ! empty( $url ) || ! empty( $playground['blueprint_url'] ) ),
+			'preview' => $preview,
 		)
 	);
 }
@@ -159,6 +297,15 @@ function static_site_importer_rest_source_artifact( array $source ) {
 		}
 	}
 
+	if ( isset( $source['archive'] ) && is_array( $source['archive'] ) ) {
+		$archive_files = static_site_importer_rest_archive_files( $source['archive'] );
+		if ( is_wp_error( $archive_files ) ) {
+			return $archive_files;
+		}
+
+		$files = array_merge( $files, $archive_files );
+	}
+
 	if ( empty( $files ) ) {
 		return new WP_Error( 'static_site_importer_missing_source', __( 'Add a website URL, site files, or raw HTML to start.', 'static-site-importer' ), array( 'status' => 400 ) );
 	}
@@ -168,6 +315,69 @@ function static_site_importer_rest_source_artifact( array $source ) {
 		'entrypoint' => static_site_importer_rest_entrypoint( $files ),
 		'files'      => $files,
 	);
+}
+
+/**
+ * Extract a ZIP archive payload into normalized website artifact files.
+ *
+ * @param array<string,mixed> $archive Archive payload.
+ * @return array<int,array<string,mixed>>|WP_Error
+ */
+function static_site_importer_rest_archive_files( array $archive ) {
+	$name = isset( $archive['name'] ) ? (string) $archive['name'] : ( isset( $archive['path'] ) ? (string) $archive['path'] : '' );
+	if ( ! preg_match( '/\.zip$/i', $name ) ) {
+		return new WP_Error( 'static_site_importer_invalid_archive_type', __( 'ZIP uploads must use a .zip file.', 'static-site-importer' ), array( 'status' => 400 ) );
+	}
+
+	if ( ! class_exists( 'ZipArchive' ) ) {
+		return new WP_Error( 'static_site_importer_zip_unavailable', __( 'ZIP archive extraction is unavailable on this server.', 'static-site-importer' ), array( 'status' => 500 ) );
+	}
+
+	$content = isset( $archive['content_base64'] ) ? base64_decode( (string) $archive['content_base64'], true ) : false;
+	if ( false === $content ) {
+		return new WP_Error( 'static_site_importer_invalid_archive_content', __( 'Uploaded ZIP archive content could not be decoded.', 'static-site-importer' ), array( 'status' => 400 ) );
+	}
+
+	$tmp = tempnam( sys_get_temp_dir(), 'ssi-zip-' );
+	if ( false === $tmp || false === file_put_contents( $tmp, $content ) ) {
+		return new WP_Error( 'static_site_importer_archive_tempfile_failed', __( 'Uploaded ZIP archive could not be staged for extraction.', 'static-site-importer' ), array( 'status' => 500 ) );
+	}
+
+	$zip = new ZipArchive();
+	if ( true !== $zip->open( $tmp ) ) {
+		@unlink( $tmp );
+		return new WP_Error( 'static_site_importer_archive_open_failed', __( 'Uploaded ZIP archive could not be opened.', 'static-site-importer' ), array( 'status' => 400 ) );
+	}
+
+	$files = array();
+	for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+		$entry = $zip->getNameIndex( $i );
+		if ( false === $entry || str_ends_with( $entry, '/' ) || str_starts_with( $entry, '__MACOSX/' ) ) {
+			continue;
+		}
+
+		$path = static_site_importer_rest_artifact_path( $entry );
+		if ( '' === $path ) {
+			continue;
+		}
+
+		$file_content = $zip->getFromIndex( $i );
+		if ( false === $file_content ) {
+			$zip->close();
+			@unlink( $tmp );
+			return new WP_Error( 'static_site_importer_archive_entry_read_failed', __( 'A ZIP archive entry could not be read.', 'static-site-importer' ), array( 'status' => 400 ) );
+		}
+
+		$files[] = array(
+			'path'           => $path,
+			'content_base64' => base64_encode( $file_content ),
+		);
+	}
+
+	$zip->close();
+	@unlink( $tmp );
+
+	return $files;
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -175,6 +175,37 @@ if ( ! class_exists( 'Static_Site_Importer_Theme_Generator' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_Codebox_Abilities' ) ) {
+	class WP_Codebox_Abilities {
+		public static array $last_input = array();
+		public static array $next_session = array();
+
+		public static function create_browser_playground_session( array $input ): array {
+			self::$last_input = $input;
+
+			return self::$next_session;
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_Codebox_Browser_Task_Builder' ) ) {
+	class WP_Codebox_Browser_Task_Builder {
+		public static function executable_blueprint_ref( array $session ): array {
+			$playground = isset( $session['playground'] ) && is_array( $session['playground'] ) ? $session['playground'] : array();
+			$prepared   = isset( $playground['prepared_runtime'] ) && is_array( $playground['prepared_runtime'] ) ? $playground['prepared_runtime'] : array();
+			if ( empty( $prepared['cache_key'] ) || empty( $prepared['input_hash'] ) ) {
+				return array();
+			}
+
+			return array(
+				'schema'             => 'wp-codebox/browser-blueprint-ref/v1',
+				'ref'                => 'prepared:' . $prepared['cache_key'] . ':' . $prepared['input_hash'],
+				'hydration_endpoint' => '/wp-codebox/v1/browser-blueprint-ref?ref=prepared%3A' . rawurlencode( $prepared['cache_key'] ) . '%3A' . rawurlencode( $prepared['input_hash'] ),
+			);
+		}
+	}
+}
+
 if ( ! function_exists( 'rest_url' ) ) {
 	function rest_url( string $path = '' ): string {
 		return 'https://example.test/wp-json/' . ltrim( $path, '/' );
@@ -302,6 +333,55 @@ $apply_response = static_site_importer_rest_create_import(
 );
 $assert( true === ( $apply_response['success'] ?? null ), 'rest-current-site-apply-is-explicitly-available' );
 $assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['activate'] ?? null ), 'rest-current-site-apply-preserves-activate' );
+
+WP_Codebox_Abilities::$next_session = array(
+	'success'         => true,
+	'schema'          => 'wp-codebox/browser-playground-session/v1',
+	'execution'       => 'browser-playground',
+	'execution_scope' => 'disposable-playground',
+	'session'         => array(
+		'id'     => 'ssi-preview-session',
+		'status' => 'ready',
+	),
+	'playground'      => array(
+		'preview_public_url' => 'https://preview.example.test/ssi',
+		'preview_url'        => '/?preview=1',
+		'scope'              => 'ssi-preview-session',
+		'prepared_runtime'   => array(
+			'cache_key'  => 'ssi-preview-cache',
+			'input_hash' => str_repeat( 'a', 64 ),
+		),
+	),
+	'artifacts'       => array(
+		'preview_url' => '/?preview=1',
+	),
+);
+$codebox_preview = static_site_importer_rest_codebox_preview_result(
+	null,
+	$GLOBALS['ssi_preview_request'],
+	array()
+);
+$assert( true === ( $codebox_preview['success'] ?? null ), 'rest-codebox-preview-provider-succeeds' );
+$assert( 'https://preview.example.test/ssi' === ( $codebox_preview['preview']['url'] ?? '' ), 'rest-codebox-preview-provider-exposes-preview-url' );
+$assert( isset( $codebox_preview['preview']['playground']['blueprint_url'] ), 'rest-codebox-preview-provider-exposes-blueprint-url' );
+$assert( 'wp-codebox/create-browser-playground-session' === ( $codebox_preview['provider'] ?? '' ), 'rest-codebox-preview-provider-identified' );
+$assert( 'static-site-importer/import-website-artifact' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['name'] ?? '' ), 'rest-codebox-preview-invokes-ssi-import-ability' );
+$assert( 'uploaded/site/index.html' === ( WP_Codebox_Abilities::$last_input['artifact_files'][0]['path'] ?? '' ), 'rest-codebox-preview-strips-website-prefix-for-browser-artifacts' );
+
+WP_Codebox_Abilities::$next_session = array(
+	'success'    => true,
+	'schema'     => 'wp-codebox/browser-playground-session/v1',
+	'session'    => array( 'id' => 'ssi-preview-session-no-url' ),
+	'playground' => array(),
+	'artifacts'  => array(),
+);
+$codebox_unavailable = static_site_importer_rest_codebox_preview_result(
+	null,
+	$GLOBALS['ssi_preview_request'],
+	array()
+);
+$assert( false === ( $codebox_unavailable['success'] ?? null ), 'rest-codebox-preview-without-url-does-not-pretend-success' );
+$assert( 'unavailable' === ( $codebox_unavailable['preview']['status'] ?? '' ), 'rest-codebox-preview-without-url-reports-unavailable' );
 
 if ( class_exists( 'ZipArchive' ) ) {
 	$zip_path = tempnam( sys_get_temp_dir(), 'ssi-test-' );

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -81,6 +81,100 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		return trim( preg_replace( '/[^a-z0-9\-]+/', '-', strtolower( $title ) ), '-' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $text ): string {
+		return trim( strip_tags( $text ) );
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'rest_ensure_response' ) ) {
+	function rest_ensure_response( $response ) {
+		return $response;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( 'static_site_importer_preview_result' === $hook && ! empty( $GLOBALS['ssi_preview_provider'] ) && is_callable( $GLOBALS['ssi_preview_provider'] ) ) {
+			return $GLOBALS['ssi_preview_provider']( $value, ...$args );
+		}
+
+		return $value;
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private $data;
+
+		public function __construct( string $code, string $message, $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		private array $params;
+
+		public function __construct( array $params ) {
+			$this->params = $params;
+		}
+
+		public function get_json_params(): array {
+			return $this->params;
+		}
+	}
+}
+
+if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
+	class Static_Site_Importer_Transformer_Adapter {
+		public const WEBSITE_ARTIFACT_SCHEMA = 'blocks-engine/website-artifact/v1';
+	}
+}
+
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator' ) ) {
+	class Static_Site_Importer_Theme_Generator {
+		public static array $last_artifact = array();
+		public static array $last_args     = array();
+
+		public static function import_website_artifact( array $artifact, array $args ): array {
+			self::$last_artifact = $artifact;
+			self::$last_args     = $args;
+
+			return array( 'import_report_summary' => array( 'status' => 'passed' ) );
+		}
+	}
+}
+
 if ( ! function_exists( 'rest_url' ) ) {
 	function rest_url( string $path = '' ): string {
 		return 'https://example.test/wp-json/' . ltrim( $path, '/' );
@@ -94,6 +188,7 @@ if ( ! function_exists( 'wp_create_nonce' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/includes/block.php';
+require_once dirname( __DIR__ ) . '/includes/rest.php';
 
 $plugin_source = file_get_contents( dirname( __DIR__ ) . '/static-site-importer.php' );
 $assert( is_string( $plugin_source ), 'plugin-source-readable' );
@@ -128,11 +223,108 @@ $assert( str_contains( $html, 'data-static-site-importer-rest-url="https://examp
 $assert( str_contains( $html, 'data-static-site-importer-provider="privateprovider"' ), 'render-sanitizes-provider' );
 $assert( str_contains( $html, 'data-static-site-importer-source-url' ), 'render-has-url-input-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-source-files' ), 'render-has-file-input-hook' );
+$assert( str_contains( $html, 'webkitdirectory' ), 'render-has-directory-upload-affordance' );
+$assert( str_contains( $html, 'data-static-site-importer-source-archive' ), 'render-has-zip-upload-hook' );
+$assert( str_contains( $html, 'accept=&quot;.zip,application/zip&quot;' ) || str_contains( $html, 'accept=".zip,application/zip"' ), 'render-limits-archive-input-to-zip' );
 $assert( str_contains( $html, 'data-static-site-importer-source-html' ), 'render-has-html-input-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-submit' ), 'render-has-submit-hook' );
+$assert( str_contains( $html, 'data-static-site-importer-preview-link' ), 'render-has-preview-link-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-report' ), 'render-has-report-hook' );
 $assert( str_contains( $html, 'Import your site' ), 'render-uses-custom-title' );
 $assert( str_contains( $html, 'https://example.com/source' ), 'render-uses-default-url' );
+
+$view_js = file_get_contents( dirname( __DIR__ ) . '/blocks/importer/view.js' );
+$assert( is_string( $view_js ), 'view-js-readable' );
+$assert( str_contains( $view_js, 'webkitRelativePath' ), 'view-preserves-directory-relative-paths' );
+$assert( str_contains( $view_js, 'archive: await buildArchive' ), 'view-sends-zip-as-archive-payload' );
+$assert( ! str_contains( $view_js, 'activate: true' ), 'view-does-not-activate-current-site' );
+$assert( ! str_contains( $view_js, 'overwrite: true' ), 'view-does-not-overwrite-current-site' );
+$assert( str_contains( $view_js, 'Open WordPress preview' ) || str_contains( $html, 'Open WordPress preview' ), 'view-or-render-has-preview-link-label' );
+
+$GLOBALS['ssi_preview_provider'] = static function ( $result, array $request ): array {
+	$GLOBALS['ssi_preview_request'] = $request;
+
+	return array(
+		'success' => true,
+		'preview' => array(
+			'playground' => array(
+				'blueprint_url' => 'https://playground.wordpress.net/?blueprint-url=https://example.test/blueprint.json',
+			),
+		),
+	);
+};
+
+$preview_response = static_site_importer_rest_create_import(
+	new WP_REST_Request(
+		array(
+			'source' => array(
+				'files' => array(
+					array(
+						'path'    => 'uploaded/site/index.html',
+						'content' => '<main>Hello</main>',
+					),
+				),
+			),
+		)
+	)
+);
+$assert( true === ( $preview_response['success'] ?? null ), 'rest-preview-provider-result-succeeds' );
+$assert( isset( $preview_response['preview']['playground']['blueprint_url'] ), 'rest-preview-contract-exposes-playground-blueprint-url' );
+$assert( 'static-site-importer/preview-request/v1' === ( $GLOBALS['ssi_preview_request']['schema'] ?? '' ), 'rest-preview-request-has-schema' );
+$assert( isset( $GLOBALS['ssi_preview_request']['source']['artifact'] ), 'rest-preview-request-includes-artifact' );
+$assert( 'website/uploaded/site/index.html' === ( $GLOBALS['ssi_preview_request']['source']['artifact']['files'][0]['path'] ?? '' ), 'rest-directory-path-is-normalized' );
+
+$GLOBALS['ssi_preview_provider'] = null;
+$unavailable_response = static_site_importer_rest_create_import(
+	new WP_REST_Request(
+		array(
+			'source' => array(
+				'html' => '<main>No provider</main>',
+			),
+		)
+	)
+);
+$assert( false === ( $unavailable_response['success'] ?? null ), 'rest-preview-default-does-not-pretend-success' );
+$assert( 'unavailable' === ( $unavailable_response['preview']['status'] ?? '' ), 'rest-preview-default-reports-unavailable' );
+
+Static_Site_Importer_Theme_Generator::$last_artifact = array();
+$apply_response = static_site_importer_rest_create_import(
+	new WP_REST_Request(
+		array(
+			'apply_to_current_site' => true,
+			'activate'              => true,
+			'overwrite'             => true,
+			'source'                => array(
+				'html' => '<main>Apply</main>',
+			),
+		)
+	)
+);
+$assert( true === ( $apply_response['success'] ?? null ), 'rest-current-site-apply-is-explicitly-available' );
+$assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['activate'] ?? null ), 'rest-current-site-apply-preserves-activate' );
+
+if ( class_exists( 'ZipArchive' ) ) {
+	$zip_path = tempnam( sys_get_temp_dir(), 'ssi-test-' );
+	$zip      = new ZipArchive();
+	$zip->open( $zip_path, ZipArchive::OVERWRITE );
+	$zip->addFromString( 'site/index.html', '<main>ZIP</main>' );
+	$zip->addFromString( '../escape.html', '<main>Escape</main>' );
+	$zip->close();
+
+	$artifact = static_site_importer_rest_source_artifact(
+		array(
+			'archive' => array(
+				'name'           => 'site.zip',
+				'content_base64' => base64_encode( file_get_contents( $zip_path ) ),
+			),
+		)
+	);
+	@unlink( $zip_path );
+	$assert( is_array( $artifact ), 'rest-zip-artifact-builds' );
+	$paths = array_column( $artifact['files'] ?? array(), 'path' );
+	$assert( in_array( 'website/site/index.html', $paths, true ), 'rest-zip-extracts-normalized-entry' );
+	$assert( in_array( 'website/escape.html', $paths, true ), 'rest-zip-strips-traversal-entry' );
+}
 
 if ( $failures ) {
 	fwrite( STDERR, implode( PHP_EOL, $failures ) . PHP_EOL );

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -107,10 +107,6 @@ if ( ! function_exists( 'rest_ensure_response' ) ) {
 
 if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( string $hook, $value, ...$args ) {
-		if ( 'static_site_importer_preview_result' === $hook && ! empty( $GLOBALS['ssi_preview_provider'] ) && is_callable( $GLOBALS['ssi_preview_provider'] ) ) {
-			return $GLOBALS['ssi_preview_provider']( $value, ...$args );
-		}
-
 		return $value;
 	}
 }
@@ -270,69 +266,9 @@ $assert( str_contains( $view_js, 'webkitRelativePath' ), 'view-preserves-directo
 $assert( str_contains( $view_js, 'archive: await buildArchive' ), 'view-sends-zip-as-archive-payload' );
 $assert( ! str_contains( $view_js, 'activate: true' ), 'view-does-not-activate-current-site' );
 $assert( ! str_contains( $view_js, 'overwrite: true' ), 'view-does-not-overwrite-current-site' );
+$generic_preview_message = implode( ' ', array( 'no', 'preview', 'provider', 'is', 'configured' ) );
+$assert( ! str_contains( $view_js, $generic_preview_message ), 'view-does-not-reference-generic-preview-message' );
 $assert( str_contains( $view_js, 'Open WordPress preview' ) || str_contains( $html, 'Open WordPress preview' ), 'view-or-render-has-preview-link-label' );
-
-$GLOBALS['ssi_preview_provider'] = static function ( $result, array $request ): array {
-	$GLOBALS['ssi_preview_request'] = $request;
-
-	return array(
-		'success' => true,
-		'preview' => array(
-			'playground' => array(
-				'blueprint_url' => 'https://playground.wordpress.net/?blueprint-url=https://example.test/blueprint.json',
-			),
-		),
-	);
-};
-
-$preview_response = static_site_importer_rest_create_import(
-	new WP_REST_Request(
-		array(
-			'source' => array(
-				'files' => array(
-					array(
-						'path'    => 'uploaded/site/index.html',
-						'content' => '<main>Hello</main>',
-					),
-				),
-			),
-		)
-	)
-);
-$assert( true === ( $preview_response['success'] ?? null ), 'rest-preview-provider-result-succeeds' );
-$assert( isset( $preview_response['preview']['playground']['blueprint_url'] ), 'rest-preview-contract-exposes-playground-blueprint-url' );
-$assert( 'static-site-importer/preview-request/v1' === ( $GLOBALS['ssi_preview_request']['schema'] ?? '' ), 'rest-preview-request-has-schema' );
-$assert( isset( $GLOBALS['ssi_preview_request']['source']['artifact'] ), 'rest-preview-request-includes-artifact' );
-$assert( 'website/uploaded/site/index.html' === ( $GLOBALS['ssi_preview_request']['source']['artifact']['files'][0]['path'] ?? '' ), 'rest-directory-path-is-normalized' );
-
-$GLOBALS['ssi_preview_provider'] = null;
-$unavailable_response = static_site_importer_rest_create_import(
-	new WP_REST_Request(
-		array(
-			'source' => array(
-				'html' => '<main>No provider</main>',
-			),
-		)
-	)
-);
-$assert( false === ( $unavailable_response['success'] ?? null ), 'rest-preview-default-does-not-pretend-success' );
-$assert( 'unavailable' === ( $unavailable_response['preview']['status'] ?? '' ), 'rest-preview-default-reports-unavailable' );
-
-Static_Site_Importer_Theme_Generator::$last_artifact = array();
-$apply_response = static_site_importer_rest_create_import(
-	new WP_REST_Request(
-		array(
-			'apply_to_current_site' => true,
-			'activate'              => true,
-			'overwrite'             => true,
-			'source'                => array(
-				'html' => '<main>Apply</main>',
-			),
-		)
-	)
-);
-$assert( true === ( $apply_response['success'] ?? null ), 'rest-current-site-apply-is-explicitly-available' );
-$assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['activate'] ?? null ), 'rest-current-site-apply-preserves-activate' );
 
 WP_Codebox_Abilities::$next_session = array(
 	'success'         => true,
@@ -356,18 +292,30 @@ WP_Codebox_Abilities::$next_session = array(
 		'preview_url' => '/?preview=1',
 	),
 );
-$codebox_preview = static_site_importer_rest_codebox_preview_result(
-	null,
-	$GLOBALS['ssi_preview_request'],
-	array()
-);
-$assert( true === ( $codebox_preview['success'] ?? null ), 'rest-codebox-preview-provider-succeeds' );
-$assert( 'https://preview.example.test/ssi' === ( $codebox_preview['preview']['url'] ?? '' ), 'rest-codebox-preview-provider-exposes-preview-url' );
-$assert( isset( $codebox_preview['preview']['playground']['blueprint_url'] ), 'rest-codebox-preview-provider-exposes-blueprint-url' );
-$assert( 'wp-codebox/create-browser-playground-session' === ( $codebox_preview['provider'] ?? '' ), 'rest-codebox-preview-provider-identified' );
-$assert( 'static-site-importer/import-website-artifact' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['name'] ?? '' ), 'rest-codebox-preview-invokes-ssi-import-ability' );
-$assert( 'uploaded/site/index.html' === ( WP_Codebox_Abilities::$last_input['artifact_files'][0]['path'] ?? '' ), 'rest-codebox-preview-strips-website-prefix-for-browser-artifacts' );
 
+$preview_response = static_site_importer_rest_create_import(
+	new WP_REST_Request(
+		array(
+			'source' => array(
+				'files' => array(
+					array(
+						'path'    => 'uploaded/site/index.html',
+						'content' => '<main>Hello</main>',
+					),
+				),
+			),
+		)
+	)
+);
+$assert( true === ( $preview_response['success'] ?? null ), 'rest-preview-codebox-result-succeeds' );
+$assert( 'https://preview.example.test/ssi' === ( $preview_response['preview']['url'] ?? '' ), 'rest-preview-contract-exposes-codebox-preview-url' );
+$assert( isset( $preview_response['preview']['playground']['blueprint_url'] ), 'rest-preview-contract-exposes-playground-blueprint-url' );
+$assert( 'static-site-importer/import-website-artifact' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['name'] ?? '' ), 'rest-preview-codebox-invokes-ssi-import-ability' );
+$assert( isset( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact'] ), 'rest-preview-codebox-request-includes-artifact' );
+$assert( 'website/uploaded/site/index.html' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact']['files'][0]['path'] ?? '' ), 'rest-directory-path-is-normalized' );
+$assert( 'uploaded/site/index.html' === ( WP_Codebox_Abilities::$last_input['artifact_files'][0]['path'] ?? '' ), 'rest-preview-codebox-strips-website-prefix-for-browser-artifacts' );
+
+Static_Site_Importer_Theme_Generator::$last_artifact = array();
 WP_Codebox_Abilities::$next_session = array(
 	'success'    => true,
 	'schema'     => 'wp-codebox/browser-playground-session/v1',
@@ -375,13 +323,40 @@ WP_Codebox_Abilities::$next_session = array(
 	'playground' => array(),
 	'artifacts'  => array(),
 );
-$codebox_unavailable = static_site_importer_rest_codebox_preview_result(
-	null,
-	$GLOBALS['ssi_preview_request'],
-	array()
+$unavailable_response = static_site_importer_rest_create_import(
+	new WP_REST_Request(
+		array(
+			'source' => array(
+				'html' => '<main>No provider</main>',
+			),
+		)
+	)
 );
-$assert( false === ( $codebox_unavailable['success'] ?? null ), 'rest-codebox-preview-without-url-does-not-pretend-success' );
-$assert( 'unavailable' === ( $codebox_unavailable['preview']['status'] ?? '' ), 'rest-codebox-preview-without-url-reports-unavailable' );
+$assert( false === ( $unavailable_response['success'] ?? null ), 'rest-preview-default-does-not-pretend-success' );
+$assert( 'unavailable' === ( $unavailable_response['preview']['status'] ?? '' ), 'rest-preview-default-reports-unavailable' );
+$assert( str_contains( $unavailable_response['preview']['message'] ?? '', 'WP Codebox did not return a preview URL or Playground blueprint URL' ), 'rest-preview-default-codebox-no-url-diagnostic' );
+$assert( array() === Static_Site_Importer_Theme_Generator::$last_artifact, 'rest-preview-default-does-not-apply-to-current-site' );
+
+$codebox_missing = static_site_importer_rest_preview_unavailable_result( array( 'schema' => 'static-site-importer/preview-request/v1' ) );
+$assert( false === ( $codebox_missing['success'] ?? null ), 'rest-codebox-unavailable-does-not-pretend-success' );
+$assert( 'wp-codebox/create-browser-playground-session' === ( $codebox_missing['provider'] ?? '' ), 'rest-codebox-unavailable-identifies-required-api' );
+$assert( str_contains( $codebox_missing['preview']['message'] ?? '', 'WP Codebox is unavailable, not installed, or does not provide the required browser Playground session API' ), 'rest-codebox-unavailable-diagnostic-wording' );
+
+Static_Site_Importer_Theme_Generator::$last_artifact = array();
+$apply_response = static_site_importer_rest_create_import(
+	new WP_REST_Request(
+		array(
+			'apply_to_current_site' => true,
+			'activate'              => true,
+			'overwrite'             => true,
+			'source'                => array(
+				'html' => '<main>Apply</main>',
+			),
+		)
+	)
+);
+$assert( true === ( $apply_response['success'] ?? null ), 'rest-current-site-apply-is-explicitly-available' );
+$assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['activate'] ?? null ), 'rest-current-site-apply-preserves-activate' );
 
 if ( class_exists( 'ZipArchive' ) ) {
 	$zip_path = tempnam( sys_get_temp_dir(), 'ssi-test-' );


### PR DESCRIPTION
## Summary
- Make the frontend importer block default to standalone preview requests instead of current-site activation/overwrite.
- Add directory and ZIP upload affordances, with directory relative paths and server-side ZIP normalization.
- Add a preview provider REST contract that returns preview URLs or a precise unavailable diagnostic, while keeping current-site apply behind an explicit flag.
- Extend importer block smoke coverage for rendering, JS payload shape, REST preview contract, explicit apply, and ZIP normalization.

## Tests
- php -l includes/rest.php
- php -l tests/smoke-importer-block.php
- php tests/smoke-importer-block.php
- for test in tests/smoke-*.php; do php "$test" || exit 1; done
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the preview-oriented importer block workflow, REST provider contract, ZIP normalization, and focused smoke tests.