### PR TITLE
Fix importer preview release lint

### DIFF
--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -98,12 +98,12 @@
 	const setPreviewLink = function ( root, report ) {
 		const wrap = root.querySelector( '[data-static-site-importer-preview-link-wrap]' );
 		const link = root.querySelector( '[data-static-site-importer-preview-link]' );
-		const url = previewUrl( report );
 
 		if ( ! wrap || ! link ) {
 			return;
 		}
 
+		const url = previewUrl( report );
 		if ( url ) {
 			link.href = url;
 			wrap.hidden = false;

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -538,19 +538,45 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	private static function visual_parity_artifact_contract( array $provided = array() ): array {
 		$slots = array(
-			'browser_render'           => array( 'kind' => 'browser_render_evidence', 'aliases' => array( 'browser-html', 'browser-artifact', 'artifact-bundle' ), 'reason' => 'Codebox/runtime browser render evidence was not provided.' ),
-			'source_screenshot'        => array( 'kind' => 'source_screenshot', 'reason' => 'Source screenshot was not captured by the runtime.' ),
-			'imported_screenshot'      => array( 'kind' => 'imported_screenshot', 'reason' => 'Imported WordPress screenshot was not captured by the runtime.' ),
-			'visual_diff'              => array( 'kind' => 'visual_diff', 'aliases' => array( 'visual_parity_artifact' ), 'reason' => 'Visual diff output was not captured by the runtime.' ),
-			'import_report'            => array( 'kind' => 'static-site-importer/import-report', 'artifact_name' => 'import-report.json' ),
-			'import_validation_result' => array( 'kind' => 'static-site-importer/import-validation-result', 'artifact_name' => 'import-validation-result.json' ),
-			'finding_packets'          => array( 'kind' => 'static-site-importer/finding-packets', 'artifact_name' => 'finding-packets.json' ),
-			'block_validation'         => array( 'kind' => 'gutenberg_block_validation', 'reason' => 'Block validation artifact was not provided by the runtime.' ),
+			'browser_render'           => array(
+				'kind'    => 'browser_render_evidence',
+				'aliases' => array( 'browser-html', 'browser-artifact', 'artifact-bundle' ),
+				'reason'  => 'Codebox/runtime browser render evidence was not provided.',
+			),
+			'source_screenshot'        => array(
+				'kind'   => 'source_screenshot',
+				'reason' => 'Source screenshot was not captured by the runtime.',
+			),
+			'imported_screenshot'      => array(
+				'kind'   => 'imported_screenshot',
+				'reason' => 'Imported WordPress screenshot was not captured by the runtime.',
+			),
+			'visual_diff'              => array(
+				'kind'    => 'visual_diff',
+				'aliases' => array( 'visual_parity_artifact' ),
+				'reason'  => 'Visual diff output was not captured by the runtime.',
+			),
+			'import_report'            => array(
+				'kind'          => 'static-site-importer/import-report',
+				'artifact_name' => 'import-report.json',
+			),
+			'import_validation_result' => array(
+				'kind'          => 'static-site-importer/import-validation-result',
+				'artifact_name' => 'import-validation-result.json',
+			),
+			'finding_packets'          => array(
+				'kind'          => 'static-site-importer/finding-packets',
+				'artifact_name' => 'finding-packets.json',
+			),
+			'block_validation'         => array(
+				'kind'   => 'gutenberg_block_validation',
+				'reason' => 'Block validation artifact was not provided by the runtime.',
+			),
 		);
 
 		$artifacts = array();
 		foreach ( $slots as $name => $slot ) {
-			$aliases = isset( $slot['aliases'] ) && is_array( $slot['aliases'] ) ? array_values( $slot['aliases'] ) : array();
+			$aliases = isset( $slot['aliases'] ) ? $slot['aliases'] : array();
 			$ref     = self::durable_artifact_ref( self::provided_visual_parity_artifact_ref( $provided, $name, (string) $slot['kind'], $aliases ) );
 			if ( empty( $ref ) && isset( $slot['artifact_name'] ) ) {
 				$ref = array(
@@ -567,18 +593,16 @@ class Static_Site_Importer_Report_Diagnostics {
 				empty( $ref )
 					? array(
 						'capture_state' => 'not_captured',
-						'reason'        => (string) ( $slot['reason'] ?? 'Artifact was not provided by the runtime.' ),
+						'reason'        => isset( $slot['reason'] ) ? (string) $slot['reason'] : 'Artifact was not provided by the runtime.',
 					)
 					: array( 'ref' => $ref )
 			);
 		}
 
-		$missing = array_values(
-			array_keys(
-				array_filter(
-					$artifacts,
-					static fn ( array $artifact ): bool => 'captured' !== ( $artifact['status'] ?? '' )
-				)
+		$missing = array_keys(
+			array_filter(
+				$artifacts,
+				static fn ( array $artifact ): bool => 'captured' !== $artifact['status']
 			)
 		);
 
@@ -1224,10 +1248,6 @@ class Static_Site_Importer_Report_Diagnostics {
 		);
 
 		foreach ( $diagnostics as $diagnostic ) {
-			if ( ! is_array( $diagnostic ) ) {
-				continue;
-			}
-
 			++$summary['total'];
 			$severity = isset( $diagnostic['severity'] ) && is_scalar( $diagnostic['severity'] ) ? (string) $diagnostic['severity'] : 'warning';
 			if ( ! array_key_exists( $severity, $summary ) ) {

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -51,9 +51,6 @@ function static_site_importer_rest_manage_permission() {
  */
 function static_site_importer_rest_create_import( WP_REST_Request $request ) {
 	$params = $request->get_json_params();
-	if ( ! is_array( $params ) ) {
-		$params = array();
-	}
 
 	$source = isset( $params['source'] ) && is_array( $params['source'] ) ? $params['source'] : array();
 	$input  = static_site_importer_rest_import_args( $params );
@@ -171,13 +168,13 @@ function static_site_importer_rest_create_preview( array $source, array $input, 
  */
 function static_site_importer_rest_preview_unavailable_result( array $request ): array {
 	return array(
-		'success' => false,
-		'preview' => array(
+		'success'  => false,
+		'preview'  => array(
 			'status'  => 'unavailable',
 			'message' => __( 'Preview unavailable: WP Codebox is unavailable, not installed, or does not provide the required browser Playground session API.', 'static-site-importer' ),
 		),
 		'provider' => 'wp-codebox/create-browser-playground-session',
-		'request' => $request,
+		'request'  => $request,
 	);
 }
 
@@ -188,8 +185,8 @@ function static_site_importer_rest_preview_unavailable_result( array $request ):
  * @return array<string,mixed>
  */
 function static_site_importer_rest_normalize_preview_result( array $result ): array {
-	$preview = isset( $result['preview'] ) && is_array( $result['preview'] ) ? $result['preview'] : $result;
-	$url     = isset( $preview['url'] ) ? esc_url_raw( (string) $preview['url'] ) : '';
+	$preview    = isset( $result['preview'] ) && is_array( $result['preview'] ) ? $result['preview'] : $result;
+	$url        = isset( $preview['url'] ) ? esc_url_raw( (string) $preview['url'] ) : '';
 	$playground = isset( $preview['playground'] ) && is_array( $preview['playground'] ) ? $preview['playground'] : array();
 	if ( isset( $playground['blueprint_url'] ) ) {
 		$playground['blueprint_url'] = esc_url_raw( (string) $playground['blueprint_url'] );
@@ -223,7 +220,8 @@ function static_site_importer_rest_normalize_preview_result( array $result ): ar
  * @return array<string,mixed>|WP_Error
  */
 function static_site_importer_rest_codebox_preview_result( array $request, array $params ) {
-	if ( ! class_exists( 'WP_Codebox_Abilities' ) || ! method_exists( 'WP_Codebox_Abilities', 'create_browser_playground_session' ) ) {
+	$create_session = array( 'WP_Codebox_Abilities', 'create_browser_playground_session' );
+	if ( ! is_callable( $create_session ) ) {
 		return static_site_importer_rest_preview_unavailable_result( $request );
 	}
 
@@ -232,7 +230,7 @@ function static_site_importer_rest_codebox_preview_result( array $request, array
 		return $codebox_input;
 	}
 
-	$session = WP_Codebox_Abilities::create_browser_playground_session( $codebox_input );
+	$session = call_user_func( $create_session, $codebox_input );
 	if ( is_wp_error( $session ) ) {
 		return $session;
 	}
@@ -307,12 +305,12 @@ function static_site_importer_rest_codebox_preview_input( array $request, array 
 	 * @param array<string,mixed> $request SSI preview request.
 	 * @param array<string,mixed> $params  Raw REST params.
 	 */
-	$input = apply_filters( 'static_site_importer_codebox_preview_input', $input, $request, $params );
-	if ( ! is_array( $input ) ) {
+	$filtered_input = apply_filters( 'static_site_importer_codebox_preview_input', $input, $request, $params );
+	if ( ! is_array( $filtered_input ) ) {
 		return new WP_Error( 'static_site_importer_codebox_preview_input_invalid', __( 'WP Codebox preview input filters must return an array.', 'static-site-importer' ), array( 'status' => 500 ) );
 	}
 
-	return $input;
+	return $filtered_input;
 }
 
 /**
@@ -388,8 +386,8 @@ function static_site_importer_rest_codebox_preview_from_session( array $session,
 
 	if ( '' === $preview_url && '' === $blueprint_url ) {
 		return array(
-			'success' => false,
-			'preview' => array(
+			'success'  => false,
+			'preview'  => array(
 				'status'  => 'unavailable',
 				'message' => __( 'Preview unavailable: WP Codebox did not return a preview URL or Playground blueprint URL.', 'static-site-importer' ),
 			),
@@ -402,8 +400,8 @@ function static_site_importer_rest_codebox_preview_from_session( array $session,
 	}
 
 	return array(
-		'success' => true,
-		'preview' => array_filter(
+		'success'  => true,
+		'preview'  => array_filter(
 			array(
 				'status'     => 'ready',
 				'url'        => $preview_url,
@@ -448,11 +446,12 @@ function static_site_importer_rest_codebox_preview_url( array $playground, array
  * @return string
  */
 function static_site_importer_rest_codebox_blueprint_url( array $session ): string {
-	if ( ! class_exists( 'WP_Codebox_Browser_Task_Builder' ) || ! method_exists( 'WP_Codebox_Browser_Task_Builder', 'executable_blueprint_ref' ) ) {
+	$executable_blueprint_ref = array( 'WP_Codebox_Browser_Task_Builder', 'executable_blueprint_ref' );
+	if ( ! is_callable( $executable_blueprint_ref ) ) {
 		return '';
 	}
 
-	$blueprint_ref = WP_Codebox_Browser_Task_Builder::executable_blueprint_ref( $session );
+	$blueprint_ref = call_user_func( $executable_blueprint_ref, $session );
 	if ( ! is_array( $blueprint_ref ) ) {
 		return '';
 	}


### PR DESCRIPTION
## Summary
- Fix release lint findings in the importer preview workflow changes.
- Keep the WP Codebox preview behavior unchanged.

## Testing
- php -l includes/rest.php && php -l includes/class-static-site-importer-report-diagnostics.php && php -l tests/smoke-importer-block.php
- for test in tests/smoke-*.php; do php "" || exit 1; done
- git diff --check
- homeboy lint static-site-importer --file blocks/importer/view.js --summary

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Release-blocking lint cleanup and verification.