### PR TITLE
Add current-site importer block mode

### DIFF
--- a/blocks/importer/block.json
+++ b/blocks/importer/block.json
@@ -21,6 +21,10 @@
     "defaultUrl": {
       "type": "string",
       "default": ""
+    },
+    "applyToCurrentSite": {
+      "type": "boolean",
+      "default": false
     }
   },
   "editorScript": "file:./editor.js",

--- a/blocks/importer/editor.js
+++ b/blocks/importer/editor.js
@@ -6,7 +6,11 @@
 	const el = element.createElement;
 
 	blocks.registerBlockType( 'static-site-importer/importer', {
-		edit() {
+		edit( props ) {
+			const attributes = props.attributes || {};
+			const applyToCurrentSite = Boolean( attributes.applyToCurrentSite );
+			const setAttributes = typeof props.setAttributes === 'function' ? props.setAttributes : function () {};
+
 			return el(
 				'div',
 				{ className: 'ssi-importer ssi-importer--editor' },
@@ -15,6 +19,16 @@
 				el( 'p', { className: 'ssi-importer__copy' }, 'Visitors paste a URL, upload site files, or add HTML. The block imports through Static Site Importer.' ),
 				components && components.Notice
 					? el( components.Notice, { status: 'info', isDismissible: false }, 'URL imports use the generic Static Site Importer provider hook before falling back to the built-in public URL fetcher.' )
+					: null,
+				components && components.ToggleControl
+					? el( components.ToggleControl, {
+						label: 'Apply imports to this site',
+						help: applyToCurrentSite ? 'Imports mutate this WordPress site.' : 'Imports create a preview when possible.',
+						checked: applyToCurrentSite,
+						onChange: function ( value ) {
+							setAttributes( { applyToCurrentSite: Boolean( value ) } );
+						},
+					} )
 					: null
 			);
 		},

--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -134,6 +134,7 @@
 			const files = root.querySelector( '[data-static-site-importer-source-files]' );
 			const archive = root.querySelector( '[data-static-site-importer-source-archive]' );
 			const provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
+			const applyToCurrentSite = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
 			const source = {
 				url: sourceUrl ? sourceUrl.value : '',
 				html: html ? html.value : '',
@@ -146,7 +147,7 @@
 				return;
 			}
 
-			showStatus( root, 'Creating WordPress preview...' );
+			showStatus( root, applyToCurrentSite ? 'Importing to this site...' : 'Creating WordPress preview...' );
 			submit.disabled = true;
 
 			try {
@@ -161,12 +162,17 @@
 					body: JSON.stringify( {
 						provider,
 						source,
+						apply_to_current_site: applyToCurrentSite,
+						activate: applyToCurrentSite,
+						overwrite: applyToCurrentSite,
 					} ),
 				} );
 				const report = await response.json();
 				setReport( root, report );
 				setPreviewLink( root, report );
-				if ( response.ok && previewUrl( report ) ) {
+				if ( response.ok && applyToCurrentSite && report.success ) {
+					showStatus( root, 'Import complete.' );
+				} else if ( response.ok && previewUrl( report ) ) {
 					showStatus( root, 'Preview ready.' );
 				} else if ( response.ok && report.preview && report.preview.status === 'unavailable' ) {
 					showStatus( root, report.preview.message || 'Preview unavailable: WP Codebox did not return a preview URL or Playground blueprint URL.' );

--- a/includes/block.php
+++ b/includes/block.php
@@ -34,10 +34,12 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 	$intro       = isset( $attributes['intro'] ) && '' !== trim( (string) $attributes['intro'] ) ? (string) $attributes['intro'] : __( 'Paste a URL, upload site files, or add HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' );
 	$provider    = isset( $attributes['provider'] ) ? sanitize_key( (string) $attributes['provider'] ) : '';
 	$default_url = isset( $attributes['defaultUrl'] ) ? esc_url_raw( (string) $attributes['defaultUrl'] ) : '';
+	$apply       = ! empty( $attributes['applyToCurrentSite'] );
+	$button_text = $apply ? __( 'Import to this site', 'static-site-importer' ) : __( 'Create preview', 'static-site-importer' );
 
 	ob_start();
 	?>
-	<div class="ssi-importer" data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>">
+	<div class="ssi-importer" data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>" data-static-site-importer-apply-to-current-site="<?php echo $apply ? '1' : '0'; ?>">
 		<section class="ssi-importer__panel" aria-labelledby="ssi-importer-title">
 			<p class="ssi-importer__eyebrow"><?php esc_html_e( 'Static Site Importer', 'static-site-importer' ); ?></p>
 			<h1 id="ssi-importer-title" class="ssi-importer__title"><?php echo esc_html( $title ); ?></h1>
@@ -64,7 +66,7 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 					<textarea name="ssi_html" rows="6" data-static-site-importer-source-html></textarea>
 				</label>
 
-				<button type="button" class="ssi-importer__submit" data-static-site-importer-submit><?php esc_html_e( 'Create preview', 'static-site-importer' ); ?></button>
+				<button type="button" class="ssi-importer__submit" data-static-site-importer-submit><?php echo esc_html( $button_text ); ?></button>
 			</form>
 		</section>
 

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -28,6 +28,11 @@ class Static_Site_Importer_Page_Materializer {
 			$type   = self::page_post_type( $page );
 
 			$existing = get_page_by_path( $slug, OBJECT, $type );
+			if ( $existing instanceof WP_Post && self::is_protected_page( $existing ) ) {
+				$page_ids[ $filename ] = (int) $existing->ID;
+				continue;
+			}
+
 			$postarr  = array(
 				'post_title'   => $title,
 				'post_name'    => $slug,
@@ -94,6 +99,10 @@ class Static_Site_Importer_Page_Materializer {
 	public static function write_page_contents( array $pages, array $page_ids, array $contents ) {
 		foreach ( array_keys( $pages ) as $filename ) {
 			$page_id = $page_ids[ $filename ] ?? 0;
+			$post    = $page_id ? get_post( $page_id ) : null;
+			if ( $post instanceof WP_Post && self::is_protected_page( $post ) ) {
+				continue;
+			}
 
 			$result = wp_update_post(
 				array(
@@ -216,6 +225,43 @@ class Static_Site_Importer_Page_Materializer {
 
 		$post_type_object = get_post_type_object( $post_type );
 		return $post_type_object instanceof WP_Post_Type ? $post_type : 'page';
+	}
+
+	/**
+	 * Determine whether an existing page is protected from importer writes.
+	 *
+	 * The `static_site_importer_protected_pages` option accepts slugs, paths, or
+	 * numeric post IDs. The filter lets host products inject their own policy.
+	 *
+	 * @param WP_Post $post Existing WordPress post.
+	 * @return bool
+	 */
+	public static function is_protected_page( WP_Post $post ): bool {
+		$protected = get_option( 'static_site_importer_protected_pages', array() );
+		if ( is_string( $protected ) ) {
+			$protected = preg_split( '/[\s,]+/', $protected );
+		}
+		if ( ! is_array( $protected ) ) {
+			$protected = array();
+		}
+
+		$tokens = array_filter(
+			array_map(
+				static function ( $value ): string {
+					return is_scalar( $value ) ? trim( (string) $value ) : '';
+				},
+				$protected
+			),
+			static fn( string $value ): bool => '' !== $value
+		);
+
+		$path = trim( (string) get_page_uri( $post ), '/' );
+		$slug = (string) $post->post_name;
+		$id   = (string) $post->ID;
+
+		$is_protected = in_array( $id, $tokens, true ) || in_array( $slug, $tokens, true ) || in_array( $path, $tokens, true ) || in_array( '/' . $path, $tokens, true );
+
+		return (bool) apply_filters( 'static_site_importer_is_protected_page', $is_protected, $post, $tokens );
 	}
 
 	/**

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -51,6 +51,9 @@ function static_site_importer_rest_manage_permission() {
  */
 function static_site_importer_rest_create_import( WP_REST_Request $request ) {
 	$params = $request->get_json_params();
+	if ( ! is_array( $params ) ) {
+		$params = $request->get_params();
+	}
 
 	$source = isset( $params['source'] ) && is_array( $params['source'] ) ? $params['source'] : array();
 	$input  = static_site_importer_rest_import_args( $params );
@@ -69,13 +72,7 @@ function static_site_importer_rest_create_import( WP_REST_Request $request ) {
 		return $result;
 	}
 
-	return rest_ensure_response(
-		array(
-			'success'               => true,
-			'result'                => $result,
-			'import_report_summary' => isset( $result['import_report_summary'] ) && is_array( $result['import_report_summary'] ) ? $result['import_report_summary'] : array(),
-		)
-	);
+	return rest_ensure_response( $result );
 }
 
 /**
@@ -106,15 +103,42 @@ function static_site_importer_rest_apply_to_current_site( array $source, array $
 			$input['provider_args'] = $params['provider_args'];
 		}
 
-		return Static_Site_Importer_URL_Import_Runtime::import_url( $input );
+		return static_site_importer_rest_execute_import_ability( 'static-site-importer/import-url', $input, 'static_site_importer_ability_import_url' );
 	} else {
 		$artifact = static_site_importer_rest_source_artifact( $source );
 		if ( is_wp_error( $artifact ) ) {
 			return $artifact;
 		}
 
-		return Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $input );
+		$input['artifact'] = $artifact;
+
+		return static_site_importer_rest_execute_import_ability( 'static-site-importer/import-website-artifact', $input, 'static_site_importer_ability_import_website_artifact' );
 	}
+}
+
+/**
+ * Execute a mutating SSI import through the shared ability boundary.
+ *
+ * @param string $ability_name Ability name.
+ * @param array<string,mixed> $input Ability input.
+ * @param callable-string $fallback_callback Local callback for non-Abilities test/runtime contexts.
+ * @return array<string,mixed>|WP_Error
+ */
+function static_site_importer_rest_execute_import_ability( string $ability_name, array $input, string $fallback_callback ) {
+	if ( function_exists( 'wp_get_ability' ) ) {
+		$ability = wp_get_ability( $ability_name );
+		if ( is_object( $ability ) && is_callable( array( $ability, 'execute' ) ) ) {
+			$result = $ability->execute( $input );
+
+			return $result;
+		}
+	}
+
+	if ( is_callable( $fallback_callback ) ) {
+		return call_user_func( $fallback_callback, $input );
+	}
+
+	return new WP_Error( 'static_site_importer_ability_unavailable', sprintf( 'Static Site Importer ability is unavailable: %s.', $ability_name ), array( 'status' => 500 ) );
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -111,6 +111,24 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( ?string $hook = null ): bool {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook ): int {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable|string|array $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+		return true;
+	}
+}
+
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		private string $code;
@@ -147,6 +165,18 @@ if ( ! class_exists( 'WP_REST_Request' ) ) {
 
 		public function get_json_params(): array {
 			return $this->params;
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_Post' ) ) {
+	class WP_Post {
+		public int $ID;
+		public string $post_name;
+
+		public function __construct( int $id, string $post_name ) {
+			$this->ID        = $id;
+			$this->post_name = $post_name;
 		}
 	}
 }
@@ -214,8 +244,22 @@ if ( ! function_exists( 'wp_create_nonce' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $name, $default = false ) {
+		return $GLOBALS['ssi_test_options'][ $name ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'get_page_uri' ) ) {
+	function get_page_uri( WP_Post $post ): string {
+		return 'tools/' . $post->post_name;
+	}
+}
+
 require_once dirname( __DIR__ ) . '/includes/block.php';
+require_once dirname( __DIR__ ) . '/includes/abilities.php';
 require_once dirname( __DIR__ ) . '/includes/rest.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-page-materializer.php';
 
 $plugin_source = file_get_contents( dirname( __DIR__ ) . '/static-site-importer.php' );
 $assert( is_string( $plugin_source ), 'plugin-source-readable' );
@@ -228,6 +272,7 @@ $assert( is_array( $metadata ), 'block-json-decodes' );
 $assert( 'static-site-importer/importer' === ( $metadata['name'] ?? '' ), 'block-name-is-product-importer' );
 $assert( 'Static Site Importer' === ( $metadata['title'] ?? '' ), 'block-title-is-product-name' );
 $assert( isset( $metadata['viewScript'] ), 'block-has-frontend-script' );
+$assert( false === ( $metadata['attributes']['applyToCurrentSite']['default'] ?? null ), 'block-defaults-to-preview-mode' );
 
 static_site_importer_register_block();
 
@@ -238,16 +283,18 @@ $assert( 'static_site_importer_render_block' === ( $registered['args']['render_c
 
 $html = static_site_importer_render_block(
 	array(
-		'title'      => 'Import your site',
-		'intro'      => 'Upload files, paste HTML, or start from a URL.',
-		'provider'   => 'Private Provider!',
-		'defaultUrl' => 'https://example.com/source',
+		'title'              => 'Import your site',
+		'intro'              => 'Upload files, paste HTML, or start from a URL.',
+		'provider'           => 'Private Provider!',
+		'defaultUrl'         => 'https://example.com/source',
+		'applyToCurrentSite' => true,
 	)
 );
 
 $assert( str_contains( $html, 'data-static-site-importer' ), 'render-has-root-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-rest-url="https://example.test/wp-json/static-site-importer/v1/imports"' ), 'render-exposes-import-rest-route' );
 $assert( str_contains( $html, 'data-static-site-importer-provider="privateprovider"' ), 'render-sanitizes-provider' );
+$assert( str_contains( $html, 'data-static-site-importer-apply-to-current-site="1"' ), 'render-exposes-current-site-apply-flag' );
 $assert( str_contains( $html, 'data-static-site-importer-source-url' ), 'render-has-url-input-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-source-files' ), 'render-has-file-input-hook' );
 $assert( str_contains( $html, 'webkitdirectory' ), 'render-has-directory-upload-affordance' );
@@ -264,8 +311,9 @@ $view_js = file_get_contents( dirname( __DIR__ ) . '/blocks/importer/view.js' );
 $assert( is_string( $view_js ), 'view-js-readable' );
 $assert( str_contains( $view_js, 'webkitRelativePath' ), 'view-preserves-directory-relative-paths' );
 $assert( str_contains( $view_js, 'archive: await buildArchive' ), 'view-sends-zip-as-archive-payload' );
-$assert( ! str_contains( $view_js, 'activate: true' ), 'view-does-not-activate-current-site' );
-$assert( ! str_contains( $view_js, 'overwrite: true' ), 'view-does-not-overwrite-current-site' );
+$assert( str_contains( $view_js, 'apply_to_current_site: applyToCurrentSite' ), 'view-sends-current-site-apply-flag' );
+$assert( str_contains( $view_js, 'activate: applyToCurrentSite' ), 'view-activates-current-site-imports' );
+$assert( str_contains( $view_js, 'overwrite: applyToCurrentSite' ), 'view-overwrites-current-site-imports' );
 $generic_preview_message = implode( ' ', array( 'no', 'preview', 'provider', 'is', 'configured' ) );
 $assert( ! str_contains( $view_js, $generic_preview_message ), 'view-does-not-reference-generic-preview-message' );
 $assert( str_contains( $view_js, 'Open WordPress preview' ) || str_contains( $html, 'Open WordPress preview' ), 'view-or-render-has-preview-link-label' );
@@ -357,6 +405,13 @@ $apply_response = static_site_importer_rest_create_import(
 );
 $assert( true === ( $apply_response['success'] ?? null ), 'rest-current-site-apply-is-explicitly-available' );
 $assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['activate'] ?? null ), 'rest-current-site-apply-preserves-activate' );
+$assert( isset( $apply_response['result'] ), 'rest-current-site-apply-returns-ability-envelope' );
+
+$GLOBALS['ssi_test_options']['static_site_importer_protected_pages'] = array( 'import', 'tools/settings', '42' );
+$assert( Static_Site_Importer_Page_Materializer::is_protected_page( new WP_Post( 7, 'import' ) ), 'protected-page-matches-slug' );
+$assert( Static_Site_Importer_Page_Materializer::is_protected_page( new WP_Post( 8, 'settings' ) ), 'protected-page-matches-path' );
+$assert( Static_Site_Importer_Page_Materializer::is_protected_page( new WP_Post( 42, 'other' ) ), 'protected-page-matches-id' );
+$assert( ! Static_Site_Importer_Page_Materializer::is_protected_page( new WP_Post( 9, 'ordinary' ) ), 'ordinary-page-is-not-protected' );
 
 if ( class_exists( 'ZipArchive' ) ) {
 	$zip_path = tempnam( sys_get_temp_dir(), 'ssi-test-' );


### PR DESCRIPTION
## Summary
- Add an importer block setting for applying imports directly to the current site.
- Route current-site REST imports through the existing SSI import abilities so block and ability behavior share the same boundary.
- Add protected-page support via `static_site_importer_protected_pages` so pages such as `/import` are not overwritten by repeated imports.

## Testing
- `php -l includes/rest.php && php -l includes/class-static-site-importer-page-materializer.php && php tests/smoke-importer-block.php`
- Verified on local `wordpress-importer-test`: REST current-site import activates/materializes the imported theme while preserving protected `/import` content.
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting implementation, local verification, and PR preparation.
