### PR TITLE
Preserve materialized asset metadata

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -152,7 +152,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		$writes = array_merge(
 			$stylesheet_writes,
-			Static_Site_Importer_Theme_Materializer::base_theme_writes( $theme_dir, $theme_slug, $theme_name, $materialized['css'], $has_footer_part )
+			Static_Site_Importer_Theme_Materializer::base_theme_writes( $theme_dir, $theme_slug, $theme_name, $materialized['css'], $has_footer_part, $materialized['scripts'] )
 		);
 		$writes = array_merge( $writes, $template_part_writes );
 		$result         = Static_Site_Importer_Page_Materializer::write_page_contents( $document_pages, $page_ids, $page_artifacts['contents'] );
@@ -1349,7 +1349,7 @@ class Static_Site_Importer_Theme_Generator {
 	 *
 	 * @param string              $theme_dir Theme directory.
 	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
-	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>}|WP_Error
+	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>}|WP_Error
 	 */
 	private static function materialize_website_artifact_files_to_theme( string $theme_dir, array $artifacts ) {
 		$result = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files( $theme_dir, self::$active_theme_uri, $artifacts );
@@ -1361,9 +1361,10 @@ class Static_Site_Importer_Theme_Generator {
 			self::$conversion_report['diagnostics'][] = $diagnostic;
 		}
 		return array(
-			'css'    => $result['css'],
-			'js'     => $result['js'],
-			'assets' => $result['assets'],
+			'css'     => $result['css'],
+			'js'      => $result['js'],
+			'assets'  => $result['assets'],
+			'scripts' => isset( $result['scripts'] ) && is_array( $result['scripts'] ) ? $result['scripts'] : array(),
 		);
 	}
 

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -22,11 +22,12 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @param string $theme_name      Theme name.
 	 * @param string $css             Source CSS.
 	 * @param bool   $has_footer_part Whether a footer template part exists.
+	 * @param array<int,array<string,mixed>> $scripts Materialized script asset rows.
 	 * @return array<string,string> Absolute write paths mapped to file contents.
 	 */
-	public static function base_theme_writes( string $theme_dir, string $theme_slug, string $theme_name, string $css, bool $has_footer_part ): array {
+	public static function base_theme_writes( string $theme_dir, string $theme_slug, string $theme_name, string $css, bool $has_footer_part, array $scripts = array() ): array {
 		return array(
-			$theme_dir . '/functions.php'             => self::functions_php( $theme_slug ),
+			$theme_dir . '/functions.php'             => self::functions_php( $theme_slug, $scripts ),
 			$theme_dir . '/theme.json'                => self::theme_json( $theme_name, $css ),
 			$theme_dir . '/templates/front-page.html' => self::content_template( '', $has_footer_part ),
 			$theme_dir . '/templates/page.html'       => self::content_template( '', $has_footer_part ),
@@ -93,7 +94,7 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @param string              $theme_dir Theme directory.
 	 * @param string              $theme_uri Theme URI.
 	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
-	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|WP_Error
+	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|WP_Error
 	 */
 	public static function materialize_website_artifact_files( string $theme_dir, string $theme_uri, array $artifacts ) {
 		$native_plan = self::materialize_materialization_plan_assets( $theme_dir, $theme_uri, $artifacts );
@@ -163,6 +164,7 @@ class Static_Site_Importer_Theme_Materializer {
 			'css'         => trim( implode( "\n\n", array_filter( $css ) ) ),
 			'js'          => trim( implode( "\n", array_filter( $js ) ) ),
 			'assets'      => $assets,
+			'scripts'     => array(),
 			'diagnostics' => $diagnostics,
 		);
 	}
@@ -173,7 +175,7 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @param string              $theme_dir Theme directory.
 	 * @param string              $theme_uri Theme URI.
 	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
-	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|null|WP_Error
+	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|null|WP_Error
 	 */
 	private static function materialize_materialization_plan_assets( string $theme_dir, string $theme_uri, array $artifacts ) {
 		$site = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
@@ -192,7 +194,9 @@ class Static_Site_Importer_Theme_Materializer {
 		$css         = array();
 		$js          = array();
 		$assets      = array();
+		$scripts     = array();
 		$diagnostics = array();
+		$order       = 0;
 
 		foreach ( $site['assets'] as $asset ) {
 			if ( ! is_array( $asset ) ) {
@@ -212,14 +216,7 @@ class Static_Site_Importer_Theme_Materializer {
 			$kind  = isset( $asset['kind'] ) && is_scalar( $asset['kind'] ) ? (string) $asset['kind'] : '';
 			$role  = isset( $asset['role'] ) && is_scalar( $asset['role'] ) ? (string) $asset['role'] : '';
 			$lower = strtolower( $relative );
-			if ( 'css' === $kind || 'stylesheet' === $role || str_ends_with( $lower, '.css' ) ) {
-				$css[] = trim( $content );
-				continue;
-			}
-			if ( 'js' === $kind || 'script' === $role || str_ends_with( $lower, '.js' ) ) {
-				$js[] = trim( $content );
-				continue;
-			}
+			++$order;
 
 			$target_relative = 'assets/materialized/' . $relative;
 			$target          = trailingslashit( $theme_dir ) . $target_relative;
@@ -233,25 +230,144 @@ class Static_Site_Importer_Theme_Materializer {
 				return $result;
 			}
 
-			$mime_type = isset( $asset['mime_type'] ) && is_scalar( $asset['mime_type'] ) && '' !== (string) $asset['mime_type'] ? (string) $asset['mime_type'] : self::mime_type( $target );
-			$assets[ $relative ] = array(
-				'source'     => $relative,
-				'path'       => $relative,
-				'url'        => trailingslashit( $theme_uri ) . $target_relative,
-				'final_url'  => trailingslashit( $theme_uri ) . $target_relative,
-				'mime_type'  => $mime_type,
-				'theme_path' => $target_relative,
-				'policy'     => 'theme',
-				'origin'     => 'materialization_plan.assets',
-			);
+			$assets[ $relative ] = self::materialization_plan_asset_report( $asset, $relative, trailingslashit( $theme_uri ) . $target_relative, $target_relative, self::mime_type( $target ), $order );
+
+			if ( 'css' === $kind || 'stylesheet' === $role || str_ends_with( $lower, '.css' ) ) {
+				$css[] = array(
+					'path'    => $relative,
+					'content' => trim( $content ),
+				);
+				continue;
+			}
+			if ( 'js' === $kind || 'script' === $role || str_ends_with( $lower, '.js' ) ) {
+				$scripts[] = $assets[ $relative ];
+				continue;
+			}
 		}
 
 		return array(
-			'css'         => trim( implode( "\n\n", array_filter( $css ) ) ),
+			'css'         => trim( implode( "\n\n", array_filter( self::rewrite_materialized_css_chunks( $css, $assets ) ) ) ),
 			'js'          => trim( implode( "\n", array_filter( $js ) ) ),
 			'assets'      => $assets,
+			'scripts'     => $scripts,
 			'diagnostics' => $diagnostics,
 		);
+	}
+
+	/**
+	 * Build an SSI asset report row while preserving native Blocks Engine metadata.
+	 *
+	 * @param array<string,mixed> $asset           Blocks Engine asset row.
+	 * @param string              $relative        Safe source-relative path.
+	 * @param string              $url             Materialized theme URL.
+	 * @param string              $target_relative Materialized theme-relative path.
+	 * @param string              $fallback_mime   MIME type inferred from written path.
+	 * @param int                 $order           Native asset order.
+	 * @return array<string,mixed>
+	 */
+	private static function materialization_plan_asset_report( array $asset, string $relative, string $url, string $target_relative, string $fallback_mime, int $order ): array {
+		$mime_type = isset( $asset['mime_type'] ) && is_scalar( $asset['mime_type'] ) && '' !== (string) $asset['mime_type'] ? (string) $asset['mime_type'] : $fallback_mime;
+		$report    = array(
+			'source'     => $relative,
+			'path'       => $relative,
+			'url'        => $url,
+			'final_url'  => $url,
+			'mime_type'  => $mime_type,
+			'theme_path' => $target_relative,
+			'policy'     => 'theme',
+			'origin'     => 'materialization_plan.assets',
+			'order'      => $order,
+		);
+
+		foreach ( array( 'role', 'kind', 'type', 'media', 'as', 'crossorigin', 'integrity', 'placement', 'source_hash' ) as $key ) {
+			if ( isset( $asset[ $key ] ) && is_scalar( $asset[ $key ] ) && '' !== (string) $asset[ $key ] ) {
+				$report[ $key ] = (string) $asset[ $key ];
+			}
+		}
+
+		foreach ( array( 'defer', 'async' ) as $key ) {
+			if ( array_key_exists( $key, $asset ) ) {
+				$report[ $key ] = (bool) $asset[ $key ];
+			}
+		}
+
+		return $report;
+	}
+
+	/**
+	 * Rewrite CSS url(...) references to materialized theme URLs.
+	 *
+	 * @param array<int,array{path:string,content:string}> $chunks CSS chunks and their source paths.
+	 * @param array<string,array<string,mixed>>             $assets Materialized asset rows keyed by source path.
+	 * @return array<int,string>
+	 */
+	private static function rewrite_materialized_css_chunks( array $chunks, array $assets ): array {
+		$rewritten = array();
+		foreach ( $chunks as $chunk ) {
+			$rewritten[] = self::rewrite_materialized_css_urls( $chunk['content'], $chunk['path'], $assets );
+		}
+
+		return $rewritten;
+	}
+
+	/**
+	 * Rewrite one CSS payload's relative url(...) references.
+	 *
+	 * @param string                            $css             CSS payload.
+	 * @param string                            $stylesheet_path Source-relative stylesheet path.
+	 * @param array<string,array<string,mixed>> $assets          Materialized asset rows keyed by source path.
+	 * @return string
+	 */
+	private static function rewrite_materialized_css_urls( string $css, string $stylesheet_path, array $assets ): string {
+		if ( '' === trim( $css ) || empty( $assets ) ) {
+			return $css;
+		}
+
+		$stylesheet_dir = dirname( $stylesheet_path );
+		return preg_replace_callback(
+			'/url\(\s*(["\']?)([^)"\']+)\1\s*\)/i',
+			static function ( array $matches ) use ( $assets, $stylesheet_dir ): string {
+				$url = trim( (string) $matches[2] );
+				if ( '' === $url || str_starts_with( $url, '#' ) || str_starts_with( strtolower( $url ), 'data:' ) || preg_match( '#^[a-z][a-z0-9+.-]*:#i', $url ) || str_starts_with( $url, '/' ) ) {
+					return $matches[0];
+				}
+
+				$candidate = self::resolve_materialized_relative_url( $stylesheet_dir, $url );
+				if ( '' === $candidate || ! isset( $assets[ $candidate ]['final_url'] ) || ! is_scalar( $assets[ $candidate ]['final_url'] ) ) {
+					return $matches[0];
+				}
+
+				return 'url(' . $matches[1] . (string) $assets[ $candidate ]['final_url'] . $matches[1] . ')';
+			},
+			$css
+		) ?? $css;
+	}
+
+	/**
+	 * Resolve a relative asset URL against a source stylesheet path.
+	 *
+	 * @param string $base_dir Source stylesheet directory.
+	 * @param string $url      Relative CSS URL.
+	 * @return string Safe source-relative path, or empty string when it escapes the artifact root.
+	 */
+	private static function resolve_materialized_relative_url( string $base_dir, string $url ): string {
+		$path     = ( '.' === $base_dir ? '' : trim( $base_dir, '/' ) . '/' ) . strtok( $url, '?#' );
+		$segments = array();
+		foreach ( explode( '/', str_replace( '\\', '/', $path ) ) as $segment ) {
+			if ( '' === $segment || '.' === $segment ) {
+				continue;
+			}
+			if ( '..' === $segment ) {
+				if ( empty( $segments ) ) {
+					return '';
+				}
+				array_pop( $segments );
+				continue;
+			}
+			$segments[] = $segment;
+		}
+
+		return self::normalize_artifact_materialization_path( implode( '/', $segments ) );
 	}
 
 	/**
@@ -548,12 +664,38 @@ class Static_Site_Importer_Theme_Materializer {
 	 * Build functions.php.
 	 *
 	 * @param string $theme_slug Theme slug.
+	 * @param array<int,array<string,mixed>> $scripts Materialized script asset rows.
 	 * @return string
 	 */
-	private static function functions_php( string $theme_slug ): string {
+	private static function functions_php( string $theme_slug, array $scripts = array() ): string {
 		$style_handle  = sanitize_key( $theme_slug ) . '-style';
 		$editor_handle = sanitize_key( $theme_slug ) . '-editor-style';
 		$script_handle = sanitize_key( $theme_slug ) . '-site';
+		$script_lines  = '';
+
+		foreach ( $scripts as $script ) {
+			if ( ! is_array( $script ) || ! isset( $script['theme_path'] ) || ! is_scalar( $script['theme_path'] ) ) {
+				continue;
+			}
+
+			$theme_path = self::normalize_artifact_materialization_path( (string) $script['theme_path'] );
+			if ( '' === $theme_path ) {
+				continue;
+			}
+
+			$handle     = sanitize_key( $theme_slug . '-asset-' . preg_replace( '/\.[^.]+$/', '', str_replace( '/', '-', $theme_path ) ) );
+			$in_footer  = 'head' !== (string) ( $script['placement'] ?? '' );
+			$script_lines .= "\twp_enqueue_script( " . var_export( $handle, true ) . ", get_template_directory_uri() . " . var_export( '/' . $theme_path, true ) . ", array(), wp_get_theme()->get( 'Version' ), " . ( $in_footer ? 'true' : 'false' ) . " );\n";
+			if ( ! empty( $script['defer'] ) ) {
+				$script_lines .= "\twp_script_add_data( " . var_export( $handle, true ) . ", 'defer', true );\n";
+			}
+			if ( ! empty( $script['async'] ) ) {
+				$script_lines .= "\twp_script_add_data( " . var_export( $handle, true ) . ", 'async', true );\n";
+			}
+			if ( isset( $script['type'] ) && 'module' === strtolower( (string) $script['type'] ) ) {
+				$script_lines .= "\twp_script_add_data( " . var_export( $handle, true ) . ", 'type', 'module' );\n";
+			}
+		}
 
 		return "<?php\n" .
 			"/**\n" .
@@ -568,6 +710,7 @@ class Static_Site_Importer_Theme_Materializer {
 			"\tif ( file_exists( get_template_directory() . '/assets/site.js' ) ) {\n" .
 			"\t\twp_enqueue_script( '" . $script_handle . "', get_template_directory_uri() . '/assets/site.js', array(), wp_get_theme()->get( 'Version' ), true );\n" .
 			"\t}\n" .
+			$script_lines .
 			"} );\n\n" .
 			"add_action( 'enqueue_block_editor_assets', static function (): void {\n" .
 			"\twp_enqueue_style( '" . $editor_handle . "', get_template_directory_uri() . '/assets/css/editor-style.css', array(), wp_get_theme()->get( 'Version' ) );\n" .

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -68,6 +68,12 @@ if ( ! function_exists( 'wp_mkdir_p' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( mixed $value, int $flags = 0 ): string|false {
+		return json_encode( $value, $flags );
+	}
+}
+
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-stylesheet-materializer.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-source-page.php';
@@ -328,7 +334,30 @@ $asset_result    = Static_Site_Importer_Theme_Materializer::materialize_website_
 				array(
 					'path'    => 'assets/site.css',
 					'role'    => 'stylesheet',
-					'content' => '.native-plan{color:green}',
+					'media'   => 'screen',
+					'content' => '@font-face{font-family:NativePlan;src:url("../fonts/native.woff2") format("woff2")}.native-plan{color:green}',
+				),
+				array(
+					'path'      => 'assets/app.js',
+					'role'      => 'script',
+					'kind'      => 'js',
+					'type'      => 'module',
+					'placement' => 'head',
+					'defer'     => true,
+					'content'   => 'window.nativePlanOrder = ["app"];',
+				),
+				array(
+					'path'    => 'assets/vendor.js',
+					'role'    => 'script',
+					'kind'    => 'js',
+					'async'   => true,
+					'content' => 'window.nativePlanOrder.push("vendor");',
+				),
+				array(
+					'path'           => 'fonts/native.woff2',
+					'role'           => 'font',
+					'mime_type'      => 'font/woff2',
+					'content_base64' => base64_encode( 'font-data' ),
 				),
 				array(
 					'path'           => 'assets/logo.png',
@@ -348,12 +377,32 @@ $asset_result    = Static_Site_Importer_Theme_Materializer::materialize_website_
 	)
 );
 $assert( is_array( $asset_result ), 'materialization-plan-assets-succeed' );
-$asset_result = is_array( $asset_result ) ? $asset_result : array( 'css' => '', 'assets' => array() );
+$asset_result = is_array( $asset_result ) ? $asset_result : array( 'css' => '', 'assets' => array(), 'scripts' => array() );
 $assert( str_contains( (string) $asset_result['css'], '.native-plan' ), 'materialization-plan-asset-css-wins' );
+$assert( str_contains( (string) $asset_result['css'], 'assets/materialized/fonts/native.woff2' ), 'materialization-plan-css-font-url-is-rewritten' );
 $assert( ! str_contains( (string) $asset_result['css'], '.top-level-artifact' ), 'top-level-css-is-ignored-when-native-plan-assets-have-payloads' );
 $assert( file_exists( $asset_theme_dir . '/assets/materialized/assets/logo.png' ), 'materialization-plan-binary-asset-is-written' );
+$assert( file_exists( $asset_theme_dir . '/assets/materialized/assets/app.js' ), 'materialization-plan-script-asset-is-written' );
+$assert( file_exists( $asset_theme_dir . '/assets/materialized/assets/vendor.js' ), 'materialization-plan-second-script-asset-is-written' );
+$assert( file_exists( $asset_theme_dir . '/assets/materialized/fonts/native.woff2' ), 'materialization-plan-font-asset-is-written' );
 $assert( 'materialization_plan.assets' === ( $asset_result['assets']['assets/logo.png']['origin'] ?? '' ), 'materialization-plan-asset-origin-is-reported' );
 $assert( str_ends_with( (string) ( $asset_result['assets']['assets/logo.png']['final_url'] ?? '' ), '/assets/materialized/assets/logo.png' ), 'materialization-plan-asset-final-url-shape' );
+$assert( 'screen' === ( $asset_result['assets']['assets/site.css']['media'] ?? '' ), 'materialization-plan-style-metadata-is-preserved' );
+$assert( 'font' === ( $asset_result['assets']['fonts/native.woff2']['role'] ?? '' ), 'materialization-plan-font-role-is-preserved' );
+$assert( 'font/woff2' === ( $asset_result['assets']['fonts/native.woff2']['mime_type'] ?? '' ), 'materialization-plan-font-mime-is-preserved' );
+$assert( '' === (string) ( $asset_result['js'] ?? '' ), 'materialization-plan-scripts-are-not-concatenated' );
+$assert( 2 === count( $asset_result['scripts'] ?? array() ), 'materialization-plan-script-rows-are-preserved' );
+$assert( 'assets/app.js' === ( $asset_result['scripts'][0]['path'] ?? '' ), 'materialization-plan-script-order-first' );
+$assert( 'assets/vendor.js' === ( $asset_result['scripts'][1]['path'] ?? '' ), 'materialization-plan-script-order-second' );
+$assert( true === ( $asset_result['scripts'][0]['defer'] ?? false ), 'materialization-plan-script-defer-is-preserved' );
+$assert( 'module' === ( $asset_result['scripts'][0]['type'] ?? '' ), 'materialization-plan-script-type-is-preserved' );
+$assert( true === ( $asset_result['scripts'][1]['async'] ?? false ), 'materialization-plan-script-async-is-preserved' );
+$base_writes   = Static_Site_Importer_Theme_Materializer::base_theme_writes( $asset_theme_dir, 'fixture-theme', 'Fixture Theme', (string) $asset_result['css'], false, $asset_result['scripts'] );
+$functions_php = (string) ( $base_writes[ $asset_theme_dir . '/functions.php' ] ?? '' );
+$assert( str_contains( $functions_php, '/assets/materialized/assets/app.js' ), 'materialization-plan-script-is-enqueued' );
+$assert( str_contains( $functions_php, "wp_script_add_data( 'fixture-theme-asset-assets-materialized-assets-app', 'defer', true );" ), 'materialization-plan-script-defer-is-enqueued' );
+$assert( str_contains( $functions_php, "wp_script_add_data( 'fixture-theme-asset-assets-materialized-assets-app', 'type', 'module' );" ), 'materialization-plan-script-type-is-enqueued' );
+$assert( str_contains( $functions_php, "wp_script_add_data( 'fixture-theme-asset-assets-materialized-assets-vendor', 'async', true );" ), 'materialization-plan-script-async-is-enqueued' );
 
 $metadata_only = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files(
 	sys_get_temp_dir() . '/ssi-materialization-plan-assets-metadata-only-' . uniqid( '', true ),


### PR DESCRIPTION
## Summary
- Preserve separate materialization-plan JS/CSS/font asset rows.
- Enqueue ordered scripts with basic metadata such as async/defer/module and placement.
- Materialize fonts and conservatively rewrite CSS url(...) references.

## Verification
- php tests/smoke-visual-repair-css.php
- php tests/smoke-transformer-adapter.php
- php tests/smoke-export-theme-ability.php
- php tests/smoke-website-artifact-products-manifest.php
- php tests/smoke-url-import-runtime.php
- php tests/smoke-importer-block.php
- php tests/smoke-product-handoff-contract.php
- php tests/smoke-codebox-validation-contract.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing the code/test changes.