### PR TITLE
Surface Blocks Engine conversion reports

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -52,6 +52,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'svg_materialization_failure_count'  => 0,
 				'svg_sprite_reference_failure_count' => 0,
 				'commerce_dependency_failures'       => 0,
+				'interaction_candidate_count'        => 0,
 				'failure_reasons'                    => array(),
 			),
 			'source_documents'        => array(
@@ -172,6 +173,12 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 		if ( 'blocks-engine/php-transformer/materialization-plan/v1' === (string) ( $site['schema'] ?? '' ) ) {
 			$report['blocks_engine']['materialization_plan'] = self::compiled_site_report_payload( $site );
+		}
+
+		$conversion_report = isset( $compiled['conversion_report'] ) && is_array( $compiled['conversion_report'] ) ? $compiled['conversion_report'] : array();
+		if ( ! empty( $conversion_report ) ) {
+			$report['blocks_engine']['conversion_report'] = self::conversion_report_payload( $conversion_report );
+			self::record_conversion_report_quality_metadata( $report, $conversion_report );
 		}
 	}
 
@@ -317,6 +324,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'svg_materialization_failures'  => (int) ( $quality['svg_materialization_failure_count'] ?? 0 ),
 				'svg_sprite_reference_failures' => (int) ( $quality['svg_sprite_reference_failure_count'] ?? 0 ),
 				'commerce_dependency_failures'  => (int) ( $quality['commerce_dependency_failures'] ?? 0 ),
+				'interaction_candidates'        => (int) ( $quality['interaction_candidate_count'] ?? 0 ),
 			),
 			'quality_gates'        => array(
 				'fallback_blocks'              => self::validation_gate( 'fallback_blocks', (int) ( $quality['fallback_count'] ?? 0 ), $quality ),
@@ -324,6 +332,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'generated_fallback_blocks'    => self::validation_gate( 'generated_fallback_blocks', (int) ( $quality['core_html_block_count'] ?? 0 ) + (int) ( $quality['freeform_block_count'] ?? 0 ), $quality ),
 				'asset_materialization'        => self::validation_gate( 'asset_materialization', (int) ( $quality['svg_materialization_failure_count'] ?? 0 ) + (int) ( $quality['svg_sprite_reference_failure_count'] ?? 0 ), $quality ),
 				'commerce_dependencies'        => self::validation_gate( 'commerce_dependencies', (int) ( $quality['commerce_dependency_failures'] ?? 0 ), $quality ),
+				'interaction_candidates'       => self::validation_gate( 'interaction_candidates', (int) ( $quality['interaction_candidate_count'] ?? 0 ), $quality ),
 				'visual_fidelity'             => array(
 					'status' => (string) ( $report['visual_fidelity']['status'] ?? 'requires_external_render_check' ),
 					'owner'  => (string) ( $report['visual_fidelity']['gate_owner'] ?? 'benchmark_harness' ),
@@ -467,6 +476,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'freeform_block_count'         => (int) ( $quality['freeform_block_count'] ?? 0 ),
 			'invalid_block_count'          => (int) ( $quality['invalid_block_count'] ?? 0 ),
 			'invalid_block_document_count' => (int) ( $quality['invalid_block_document_count'] ?? 0 ),
+			'interaction_candidate_count'  => (int) ( $quality['interaction_candidate_count'] ?? 0 ),
 			'source_document_count'        => (int) ( $source_documents['total_count'] ?? 0 ),
 			'unresolved_link_count'        => (int) ( $source_documents['unresolved_link_count'] ?? 0 ),
 			'commerce'                     => $commerce,
@@ -497,6 +507,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'generated_fallback_blocks' => 'core_html_block_count',
 			'asset_materialization'     => 'svg_materialization_failure_count',
 			'commerce_dependencies'     => 'commerce_dependency_failures',
+			'interaction_candidates'    => 'interaction_candidate_count',
 		);
 		$ref_key  = $ref_keys[ $name ] ?? $name;
 
@@ -777,6 +788,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'svg_sprite_reference_failure',
 				'commerce_dependency_failure',
 				'commerce_product_inference_unmatched',
+				'interaction_candidate',
 			),
 			true
 		);
@@ -941,6 +953,192 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
+	 * Preserve optional Blocks Engine conversion-report fields for import-report consumers.
+	 *
+	 * @param array<string,mixed> $conversion_report Native conversion report.
+	 * @return array<string,mixed>
+	 */
+	private static function conversion_report_payload( array $conversion_report ): array {
+		$diagnostics            = self::array_values_if_list( $conversion_report['diagnostics'] ?? array() );
+		$fallbacks              = self::array_values_if_list( $conversion_report['fallbacks'] ?? array() );
+		$interaction_candidates = self::array_values_if_list( $conversion_report['interaction_candidates'] ?? array() );
+
+		$payload = array(
+			'schema'                      => isset( $conversion_report['schema'] ) && is_scalar( $conversion_report['schema'] ) ? (string) $conversion_report['schema'] : 'blocks-engine/php-transformer/conversion-report/v1',
+			'status'                      => isset( $conversion_report['status'] ) && is_scalar( $conversion_report['status'] ) ? (string) $conversion_report['status'] : '',
+			'diagnostic_count'            => count( $diagnostics ),
+			'fallback_count'              => count( $fallbacks ),
+			'interaction_candidate_count' => count( $interaction_candidates ),
+		);
+
+		if ( ! empty( $diagnostics ) ) {
+			$payload['diagnostics'] = self::compact_native_report_rows( $diagnostics );
+		}
+		if ( ! empty( $fallbacks ) ) {
+			$payload['fallbacks'] = self::compact_native_report_rows( $fallbacks );
+		}
+		if ( ! empty( $interaction_candidates ) ) {
+			$payload['interaction_candidates'] = self::compact_native_report_rows( $interaction_candidates );
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Reflect optional native conversion-report quality metadata without changing import behavior.
+	 *
+	 * @param array<string,mixed> $report            Import report.
+	 * @param array<string,mixed> $conversion_report Native conversion report.
+	 * @return void
+	 */
+	private static function record_conversion_report_quality_metadata( array &$report, array $conversion_report ): void {
+		$fallbacks              = self::array_values_if_list( $conversion_report['fallbacks'] ?? array() );
+		$interaction_candidates = self::array_values_if_list( $conversion_report['interaction_candidates'] ?? array() );
+
+		$report['quality']['interaction_candidate_count'] = (int) ( $report['quality']['interaction_candidate_count'] ?? 0 ) + count( $interaction_candidates );
+		$report['quality']['fallback_count']              = (int) ( $report['quality']['fallback_count'] ?? 0 ) + count( $fallbacks );
+
+		foreach ( $fallbacks as $fallback ) {
+			if ( ! is_array( $fallback ) ) {
+				continue;
+			}
+
+			$diagnostic = self::diagnostic_from_conversion_report_fallback( $fallback );
+			if ( ! empty( $diagnostic ) ) {
+				$report['diagnostics'][] = $diagnostic;
+			}
+		}
+
+		foreach ( $interaction_candidates as $candidate ) {
+			if ( ! is_array( $candidate ) ) {
+				continue;
+			}
+
+			$diagnostic = self::diagnostic_from_interaction_candidate( $candidate );
+			if ( ! empty( $diagnostic ) ) {
+				$report['diagnostics'][] = $diagnostic;
+			}
+		}
+	}
+
+	/**
+	 * Normalize a native fallback row into SSI's diagnostic shape when useful fields exist.
+	 *
+	 * @param array<string,mixed> $fallback Native fallback row.
+	 * @return array<string,mixed>
+	 */
+	private static function diagnostic_from_conversion_report_fallback( array $fallback ): array {
+		$source = self::first_scalar( $fallback, array( 'source_path', 'source', 'path' ) );
+		$reason = self::first_scalar( $fallback, array( 'reason_code', 'reason', 'code' ) );
+		if ( '' === $source && '' === $reason ) {
+			return array();
+		}
+
+		$diagnostic = array(
+			'type'      => 'unsupported_html_fallback',
+			'source'    => $source,
+			'reason'    => '' !== $reason ? $reason : 'native_conversion_report_fallback',
+			'engine'    => 'blocks-engine/php-transformer',
+			'stage'     => 'block_conversion',
+			'converter' => 'blocks-engine/php-transformer',
+		);
+
+		foreach ( array( 'source_path', 'selector', 'tag_name', 'block_name', 'block_path', 'message', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt' ) as $field ) {
+			if ( isset( $fallback[ $field ] ) && is_scalar( $fallback[ $field ] ) && '' !== trim( (string) $fallback[ $field ] ) ) {
+				$diagnostic[ $field ] = (string) $fallback[ $field ];
+			}
+		}
+
+		return $diagnostic;
+	}
+
+	/**
+	 * Normalize a native interaction candidate into a report-only diagnostic.
+	 *
+	 * @param array<string,mixed> $candidate Native interaction candidate row.
+	 * @return array<string,mixed>
+	 */
+	private static function diagnostic_from_interaction_candidate( array $candidate ): array {
+		$source = self::first_scalar( $candidate, array( 'source_path', 'source', 'path' ) );
+		if ( '' === $source && '' === self::first_scalar( $candidate, array( 'selector', 'kind', 'type' ) ) ) {
+			return array();
+		}
+
+		$diagnostic = array(
+			'type'      => 'interaction_candidate',
+			'source'    => $source,
+			'reason'    => 'native_conversion_report_interaction_candidate',
+			'engine'    => 'blocks-engine/php-transformer',
+			'stage'     => 'interaction_detection',
+			'converter' => 'blocks-engine/php-transformer',
+		);
+
+		foreach ( array( 'source_path', 'selector', 'tag_name', 'message', 'excerpt', 'source_html_preview', 'html_excerpt', 'kind' ) as $field ) {
+			if ( isset( $candidate[ $field ] ) && is_scalar( $candidate[ $field ] ) && '' !== trim( (string) $candidate[ $field ] ) ) {
+				$diagnostic[ $field ] = (string) $candidate[ $field ];
+			}
+		}
+
+		return $diagnostic;
+	}
+
+	/**
+	 * Compact native report rows while preserving scalar diagnostic metadata.
+	 *
+	 * @param array<int,mixed> $rows Native report rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function compact_native_report_rows( array $rows ): array {
+		$fields  = array( 'type', 'kind', 'code', 'severity', 'source', 'source_path', 'path', 'selector', 'tag_name', 'block_name', 'block_path', 'reason', 'reason_code', 'message', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt' );
+		$compact = array();
+		foreach ( array_slice( $rows, 0, 50 ) as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$entry = array();
+			foreach ( $fields as $field ) {
+				if ( isset( $row[ $field ] ) && is_scalar( $row[ $field ] ) && '' !== trim( (string) $row[ $field ] ) ) {
+					$entry[ $field ] = (string) $row[ $field ];
+				}
+			}
+
+			if ( ! empty( $entry ) ) {
+				$compact[] = $entry;
+			}
+		}
+
+		return $compact;
+	}
+
+	/**
+	 * Return array values only for list-like report rows.
+	 *
+	 * @param mixed $value Candidate list.
+	 * @return array<int,mixed>
+	 */
+	private static function array_values_if_list( mixed $value ): array {
+		return is_array( $value ) ? array_values( $value ) : array();
+	}
+
+	/**
+	 * Return the first non-empty scalar from a row.
+	 *
+	 * @param array<string,mixed> $row  Source row.
+	 * @param array<int,string>   $keys Candidate keys.
+	 * @return string
+	 */
+	private static function first_scalar( array $row, array $keys ): string {
+		foreach ( $keys as $key ) {
+			if ( isset( $row[ $key ] ) && is_scalar( $row[ $key ] ) && '' !== trim( (string) $row[ $key ] ) ) {
+				return (string) $row[ $key ];
+			}
+		}
+
+		return '';
+	}
+
+	/**
 	 * Normalize import diagnostics into a stable, machine-actionable shape.
 	 *
 	 * @param array<string,mixed> $report Import report.
@@ -1013,6 +1211,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'svg_materialization_failure_count'  => array( 'svg_materialization_failure' ),
 			'svg_sprite_reference_failure_count' => array( 'svg_sprite_reference_failure' ),
 			'commerce_dependency_failures'       => array( 'commerce_dependency_failure' ),
+			'interaction_candidate_count'        => array( 'interaction_candidate' ),
 		);
 
 		$refs = array();
@@ -1150,6 +1349,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'source_region_unassigned'             => 'source_region',
 			'commerce_dependency_failure'          => 'conversion_quality',
 			'commerce_product_inference_unmatched' => 'conversion_quality',
+			'interaction_candidate'                => 'source_interaction',
 		);
 
 		return $categories[ $type ] ?? 'import_quality';
@@ -1178,6 +1378,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'source_region_unassigned'             => 'assign_or_ignore_source_region',
 			'commerce_dependency_failure'          => 'install_or_configure_dependency',
 			'commerce_product_inference_unmatched' => 'provide_structured_product_data',
+			'interaction_candidate'                => 'inspect_interactive_behavior',
 		);
 
 		return $classes[ $type ] ?? 'inspect_import_diagnostic';
@@ -1191,7 +1392,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	private static function diagnostic_context( array $diagnostic ): array {
 		$context = array();
-		foreach ( array( 'href', 'tag', 'tag_name', 'block_name', 'block_path', 'excerpt', 'html_excerpt', 'source_html_preview', 'error_message' ) as $key ) {
+		foreach ( array( 'href', 'tag', 'tag_name', 'block_name', 'block_path', 'excerpt', 'html_excerpt', 'source_html_preview', 'error_message', 'kind' ) as $key ) {
 			if ( array_key_exists( $key, $diagnostic ) && null !== $diagnostic[ $key ] && '' !== $diagnostic[ $key ] ) {
 				$context[ $key ] = $diagnostic[ $key ];
 			}

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -129,8 +129,12 @@ class Static_Site_Importer_Transformer_Adapter {
 			'diagnostics'         => isset( $result['diagnostics'] ) && is_array( $result['diagnostics'] ) ? $result['diagnostics'] : array(),
 			'provenance'          => isset( $result['provenance'] ) && is_array( $result['provenance'] ) ? $result['provenance'] : array(),
 		);
-		if ( isset( $result['conversion_report'] ) && is_array( $result['conversion_report'] ) ) {
-			$compiled['conversion_report'] = $result['conversion_report'];
+		$conversion_report = isset( $source_reports['conversion_report'] ) && is_array( $source_reports['conversion_report'] ) ? $source_reports['conversion_report'] : array();
+		if ( empty( $conversion_report ) && isset( $result['conversion_report'] ) && is_array( $result['conversion_report'] ) ) {
+			$conversion_report = $result['conversion_report'];
+		}
+		if ( ! empty( $conversion_report ) ) {
+			$compiled['conversion_report'] = $conversion_report;
 		}
 
 		return $compiled;

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -87,6 +87,35 @@ namespace {
 									'stylesheets' => array( 'assets/site.css' ),
 								),
 							),
+							'conversion_report' => array(
+								'schema'                 => 'blocks-engine/php-transformer/conversion-report/v1',
+								'status'                 => 'success',
+								'serialized_blocks'      => '<!-- wp:paragraph --><p>Source report Home</p><!-- /wp:paragraph -->',
+								'diagnostics'            => array(
+									array(
+										'code'    => 'source_report_diagnostic',
+										'message' => 'Source report diagnostic.',
+									),
+								),
+								'fallbacks'              => array(
+									array(
+										'source_path'           => 'website/index.html',
+										'selector'              => 'iframe.booking-widget',
+										'reason_code'           => 'unsupported_interactive_embed',
+										'block_name'            => 'core/html',
+										'source_html_preview'   => '<iframe class="booking-widget"></iframe>',
+										'emitted_block_preview' => '<!-- wp:html --><iframe class="booking-widget"></iframe><!-- /wp:html -->',
+									),
+								),
+								'interaction_candidates' => array(
+									array(
+										'source_path'         => 'website/index.html',
+										'selector'            => 'button.reserve',
+										'kind'                => 'button',
+										'source_html_preview' => '<button class="reserve">Reserve</button>',
+									),
+								),
+							),
 						),
 						'blocks'            => array(
 							array( 'blockName' => 'core/paragraph', 'innerBlocks' => array() ),
@@ -184,7 +213,16 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( string $key ): string {
+			$key = strtolower( $key );
+			return (string) preg_replace( '/[^a-z0-9_\-]/', '', $key );
+		}
+	}
+
 	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-transformer-adapter.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
 
 	$failures   = array();
 	$assertions = 0;
@@ -214,9 +252,10 @@ namespace {
 	$assert( true === ( $GLOBALS['ssi_transformer_adapter_compile_calls'][0][1]['include_conversion_report'] ?? false ), 'compile-options-forwarded-as-native-report-request' );
 	$assert( 'blocks-engine/php-transformer/result/v1' === ( $compiled['schema'] ?? '' ), 'native-result-schema-is-preserved' );
 	$assert( 'success' === ( $compiled['conversion_report']['status'] ?? '' ), 'conversion-report-shape-preserved' );
-	$assert( '<!-- wp:paragraph --><p>Native report Home</p><!-- /wp:paragraph -->' === ( $compiled['conversion_report']['serialized_blocks'] ?? '' ), 'conversion-report-uses-native-serialized-blocks' );
-	$assert( 'native_report_diagnostic' === ( $compiled['conversion_report']['diagnostics'][0]['code'] ?? '' ), 'conversion-report-uses-native-diagnostics' );
-	$assert( 'native-conversion-report' === ( $compiled['conversion_report']['fallbacks'][0]['source'] ?? '' ), 'conversion-report-uses-native-fallbacks' );
+	$assert( '<!-- wp:paragraph --><p>Source report Home</p><!-- /wp:paragraph -->' === ( $compiled['conversion_report']['serialized_blocks'] ?? '' ), 'conversion-report-prefers-source-report-serialized-blocks' );
+	$assert( 'source_report_diagnostic' === ( $compiled['conversion_report']['diagnostics'][0]['code'] ?? '' ), 'conversion-report-prefers-source-report-diagnostics' );
+	$assert( 'website/index.html' === ( $compiled['conversion_report']['fallbacks'][0]['source_path'] ?? '' ), 'conversion-report-prefers-source-report-fallbacks' );
+	$assert( 'button.reserve' === ( $compiled['conversion_report']['interaction_candidates'][0]['selector'] ?? '' ), 'conversion-report-preserves-interaction-candidates' );
 	$assert( 'top_level_diagnostic' !== ( $compiled['conversion_report']['diagnostics'][0]['code'] ?? '' ), 'conversion-report-ignores-top-level-diagnostics' );
 	$assert( 'top-level' !== ( $compiled['conversion_report']['fallbacks'][0]['source'] ?? '' ), 'conversion-report-ignores-top-level-fallbacks' );
 	$assert( 'website/index.html' === ( $compiled['input']['entry_path'] ?? '' ), 'native-artifact-report-preserved-as-input' );
@@ -239,6 +278,45 @@ namespace {
 	$assert( 2 === count( $GLOBALS['ssi_transformer_adapter_compile_calls'] ), 'plugin-compile-helper-called-for-native-report' );
 	$assert( true === ( $GLOBALS['ssi_transformer_adapter_compile_calls'][1][1]['include_conversion_report'] ?? false ), 'native-report-option-forwarded' );
 	$assert( isset( $native_report_compiled['conversion_report'] ) && is_array( $native_report_compiled['conversion_report'] ), 'native-report-request-exposes-conversion-report' );
+
+	$report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
+	Static_Site_Importer_Report_Diagnostics::record_blocks_engine_result( $report, $compiled );
+	Static_Site_Importer_Report_Diagnostics::finalize_report( $report, array() );
+	$assert( 1 === ( $report['blocks_engine']['conversion_report']['fallback_count'] ?? 0 ), 'import-report-records-native-fallback-count' );
+	$assert( 1 === ( $report['blocks_engine']['conversion_report']['interaction_candidate_count'] ?? 0 ), 'import-report-records-native-interaction-candidate-count' );
+	$assert( 'button.reserve' === ( $report['blocks_engine']['conversion_report']['interaction_candidates'][0]['selector'] ?? '' ), 'import-report-records-native-interaction-candidates' );
+	$assert( 1 === ( $report['quality']['interaction_candidate_count'] ?? 0 ), 'quality-records-interaction-candidate-count' );
+	$assert( 'reported' === ( $report['import_validation_result']['quality_gates']['interaction_candidates']['status'] ?? '' ), 'validation-gate-reports-interaction-candidates' );
+	$assert( 'unsupported_html_fallback' === ( $report['diagnostics'][0]['type'] ?? '' ), 'native-fallback-becomes-normalized-diagnostic' );
+	$assert( 'unsupported_interactive_embed' === ( $report['diagnostics'][0]['reason_code'] ?? '' ), 'native-fallback-preserves-reason-code' );
+	$assert( 'replace_unsupported_html' === ( $report['diagnostics'][0]['suggested_repair_class'] ?? '' ), 'native-fallback-gets-repair-class' );
+	$assert( 'interaction_candidate' === ( $report['diagnostics'][1]['type'] ?? '' ), 'interaction-candidate-becomes-report-diagnostic' );
+	$assert( 2 === ( $report['finding_packets']['count'] ?? 0 ), 'native-report-diagnostics-create-finding-packets' );
+
+	$GLOBALS['ssi_transformer_adapter_result_override'] = array(
+		'schema'            => 'blocks-engine/php-transformer/result/v1',
+		'status'            => 'success',
+		'source_reports'    => array(
+			'artifact'              => array( 'entry_path' => 'website/index.html' ),
+			'materialization_plan' => array(
+				'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+				'pages'  => array(),
+			),
+		),
+		'serialized_blocks' => '<!-- wp:paragraph --><p>Top level</p><!-- /wp:paragraph -->',
+		'conversion_report' => array(
+			'schema'            => 'blocks-engine/php-transformer/conversion-report/v1',
+			'serialized_blocks' => '<!-- wp:paragraph --><p>Tagged dependency report</p><!-- /wp:paragraph -->',
+			'fallbacks'         => array(
+				array( 'source' => 'tagged-dependency-top-level' ),
+			),
+		),
+	);
+	$tagged_dependency_compiled = $adapter->compile_website_artifact( array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ) );
+	unset( $GLOBALS['ssi_transformer_adapter_result_override'] );
+	$assert( ! is_wp_error( $tagged_dependency_compiled ), 'tagged-dependency-report-compile-succeeds' );
+	$assert( '<!-- wp:paragraph --><p>Tagged dependency report</p><!-- /wp:paragraph -->' === ( $tagged_dependency_compiled['conversion_report']['serialized_blocks'] ?? '' ), 'top-level-conversion-report-remains-compatible' );
+	$assert( 'tagged-dependency-top-level' === ( $tagged_dependency_compiled['conversion_report']['fallbacks'][0]['source'] ?? '' ), 'top-level-conversion-report-fallbacks-preserved' );
 
 	$GLOBALS['ssi_transformer_adapter_result_override'] = array(
 		'schema' => 'blocks-engine/php-transformer/result/v1',


### PR DESCRIPTION
## Summary
- Prefer source_reports.conversion_report when present while keeping current tagged dependency compatibility.
- Surface fallback diagnostics and interaction candidates in import reports.
- Add quality/report metadata for interaction candidates.

## Verification
- php tests/smoke-transformer-adapter.php
- npm run test:validation

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing the code/test changes.