### PR TITLE
Consume php-transformer 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ When a generated artifact contains full-document HTML, Static Site Importer rout
 - Composer dependencies installed with `composer install`.
 - Node dependencies installed only when running the JavaScript block-validation smoke tests.
 
-SSI requires `automattic/blocks-engine-php-transformer:^0.1.0` in Composer to align installed dependencies with the tagged Blocks Engine PHP transformer release. Until the package is published on Packagist, `composer.json` includes an explicit package repository for the `php-transformer-v0.1.0` tag at `ac92ddb` with autoloading rooted at the Blocks Engine monorepo archive's `php-transformer/src/` directory. Remove that repository override once Packagist serves the package metadata.
+SSI requires `automattic/blocks-engine-php-transformer:^0.1.1` in Composer to align installed dependencies with the tagged Blocks Engine PHP transformer release. Until the package is published on Packagist, `composer.json` includes an explicit package repository for the `php-transformer-v0.1.1` tag at `310ba6f` with autoloading rooted at the Blocks Engine monorepo archive's `php-transformer/src/` directory. Remove that repository override once Packagist serves the package metadata.
 
 At runtime, SSI loads the transformer package from `vendor/` and calls `blocks_engine_php_transformer_compile_artifact()` and `blocks_engine_php_transformer_convert_format()` directly.
 

--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.0",
+        "version": "0.1.1",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "ac92ddb"
+          "reference": "310ba6f23096e2ac93485f9ed0377531dcbe74d5"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.0.zip",
-          "reference": "ac92ddb"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.1.zip",
+          "reference": "310ba6f23096e2ac93485f9ed0377531dcbe74d5"
         },
         "autoload": {
           "psr-4": {
@@ -36,7 +36,7 @@
     }
   ],
   "require": {
-    "automattic/blocks-engine-php-transformer": "^0.1.0",
+    "automattic/blocks-engine-php-transformer": "^0.1.1",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60bedbd6c84f8d1f48783537f878730a",
+    "content-hash": "2798f76ed506dbd3ccf2afa20b129b60",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "ac92ddb"
+                "reference": "310ba6f23096e2ac93485f9ed0377531dcbe74d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.0.zip",
-                "reference": "ac92ddb"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.1.zip",
+                "reference": "310ba6f23096e2ac93485f9ed0377531dcbe74d5"
             },
             "require": {
                 "league/commonmark": "^2.5",

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -73,7 +73,7 @@ class Static_Site_Importer_Page_Materializer {
 		foreach ( $pages as $filename => $page ) {
 			$slug         = self::page_slug( $filename, $page );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
-			$content      = self::rewrite_materialized_asset_references( self::source_page_content_blocks( $page, $diagnostics ), $assets );
+			$content      = self::rewrite_materialized_asset_references( self::source_page_content_blocks( $page, $diagnostics ), $assets, $page->source_key() );
 
 			$patterns[ $filename ] = $pattern_slug;
 			$files[ $filename ]    = Static_Site_Importer_Theme_Materializer::pattern_file( self::page_title( $filename, $page ), $pattern_slug, $content );
@@ -292,9 +292,10 @@ class Static_Site_Importer_Page_Materializer {
 	 *
 	 * @param string                              $markup Serialized block markup.
 	 * @param array<string,array<string,mixed>>   $assets Materialized assets keyed by source path.
+	 * @param string                              $source_path Source page path for resolving page-relative URLs.
 	 * @return string Updated markup.
 	 */
-	private static function rewrite_materialized_asset_references( string $markup, array $assets ): string {
+	private static function rewrite_materialized_asset_references( string $markup, array $assets, string $source_path = '' ): string {
 		if ( '' === trim( $markup ) || empty( $assets ) ) {
 			return $markup;
 		}
@@ -315,16 +316,27 @@ class Static_Site_Importer_Page_Materializer {
 			return $markup;
 		}
 
+		$source_dir = dirname( self::normalize_route_path( $source_path ) );
+
 		return preg_replace_callback(
 			'/\b(src|href)=([' . "'\"" . '])([^' . "'\"" . ']*)\2/i',
-			static function ( array $matches ) use ( $replacements ): string {
+			static function ( array $matches ) use ( $replacements, $source_dir ): string {
 				$url        = html_entity_decode( (string) $matches[3], ENT_QUOTES | ENT_HTML5 );
 				$normalized = self::normalize_route_path( $url );
-				if ( '' === $normalized || ! isset( $replacements[ $normalized ] ) ) {
+				if ( '' !== $normalized && isset( $replacements[ $normalized ] ) ) {
+					return $matches[1] . '=' . $matches[2] . esc_url( $replacements[ $normalized ] ) . $matches[2];
+				}
+
+				if ( '' === $normalized || '' === $source_dir || '.' === $source_dir || str_starts_with( $url, '/' ) || preg_match( '#^[a-z][a-z0-9+.-]*:#i', $url ) ) {
 					return $matches[0];
 				}
 
-				return $matches[1] . '=' . $matches[2] . esc_url( $replacements[ $normalized ] ) . $matches[2];
+				$resolved = self::normalize_route_path( $source_dir . '/' . $url );
+				if ( '' === $resolved || ! isset( $replacements[ $resolved ] ) ) {
+					return $matches[0];
+				}
+
+				return $matches[1] . '=' . $matches[2] . esc_url( $replacements[ $resolved ] ) . $matches[2];
 			},
 			$markup
 		) ?? $markup;

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -960,7 +960,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	private static function conversion_report_payload( array $conversion_report ): array {
 		$diagnostics            = self::array_values_if_list( $conversion_report['diagnostics'] ?? array() );
-		$fallbacks              = self::array_values_if_list( $conversion_report['fallbacks'] ?? array() );
+		$fallbacks              = self::conversion_report_fallback_rows( $conversion_report );
 		$interaction_candidates = self::array_values_if_list( $conversion_report['interaction_candidates'] ?? array() );
 
 		$payload = array(
@@ -975,7 +975,8 @@ class Static_Site_Importer_Report_Diagnostics {
 			$payload['diagnostics'] = self::compact_native_report_rows( $diagnostics );
 		}
 		if ( ! empty( $fallbacks ) ) {
-			$payload['fallbacks'] = self::compact_native_report_rows( $fallbacks );
+			$payload['fallbacks']             = self::compact_native_report_rows( $fallbacks );
+			$payload['fallback_diagnostics'] = self::compact_native_report_rows( $fallbacks );
 		}
 		if ( ! empty( $interaction_candidates ) ) {
 			$payload['interaction_candidates'] = self::compact_native_report_rows( $interaction_candidates );
@@ -992,7 +993,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return void
 	 */
 	private static function record_conversion_report_quality_metadata( array &$report, array $conversion_report ): void {
-		$fallbacks              = self::array_values_if_list( $conversion_report['fallbacks'] ?? array() );
+		$fallbacks              = self::conversion_report_fallback_rows( $conversion_report );
 		$interaction_candidates = self::array_values_if_list( $conversion_report['interaction_candidates'] ?? array() );
 
 		$report['quality']['interaction_candidate_count'] = (int) ( $report['quality']['interaction_candidate_count'] ?? 0 ) + count( $interaction_candidates );
@@ -1019,6 +1020,21 @@ class Static_Site_Importer_Report_Diagnostics {
 				$report['diagnostics'][] = $diagnostic;
 			}
 		}
+	}
+
+	/**
+	 * Return fallback rows from old and canonical Blocks Engine conversion-report fields.
+	 *
+	 * @param array<string,mixed> $conversion_report Native conversion report.
+	 * @return array<int,mixed>
+	 */
+	private static function conversion_report_fallback_rows( array $conversion_report ): array {
+		$fallbacks = self::array_values_if_list( $conversion_report['fallbacks'] ?? array() );
+		if ( ! empty( $fallbacks ) ) {
+			return $fallbacks;
+		}
+
+		return self::array_values_if_list( $conversion_report['fallback_diagnostics'] ?? array() );
 	}
 
 	/**

--- a/includes/class-static-site-importer-source-page.php
+++ b/includes/class-static-site-importer-source-page.php
@@ -162,7 +162,7 @@ class Static_Site_Importer_Source_Page {
 		}
 
 		$title       = $metadata['title'] ?? '';
-		$body_format = isset( $metadata['body_format'] ) && '' !== $metadata['body_format'] ? $metadata['body_format'] : 'blocks';
+		$body_format = 'blocks';
 		$document    = new Static_Site_Importer_Document( '<!doctype html><html><head><title>' . esc_html( $title ) . '</title></head><body><main>' . $content . '</main></body></html>' );
 
 		return new self( $source_key, $source_key, 'materialization_plan_page', $document, $content, $body_format, $metadata );

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -65,13 +65,17 @@ class Static_Site_Importer_Transformer_Adapter {
 	 * @return array<string,mixed>|WP_Error
 	 */
 	private function compiled_result_from_transformer_contract( array $result ) {
-		$compiled = $this->compiled_result_from_native_transformer_contract( $result );
+		$view     = $this->materialization_view_from_result( $result );
+		$compiled = ! empty( $view ) ? $this->compiled_result_from_materialization_view( $view ) : $this->compiled_result_from_native_transformer_contract( $result );
 		if ( is_wp_error( $compiled ) ) {
 			return $compiled;
 		}
 
-		$source_reports       = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
-		$materialization_plan = isset( $source_reports['materialization_plan'] ) && is_array( $source_reports['materialization_plan'] ) ? $source_reports['materialization_plan'] : array();
+		$materialization_plan = ! empty( $view['materialization_plan'] ) && is_array( $view['materialization_plan'] ) ? $view['materialization_plan'] : array();
+		if ( empty( $materialization_plan ) ) {
+			$source_reports       = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
+			$materialization_plan = isset( $source_reports['materialization_plan'] ) && is_array( $source_reports['materialization_plan'] ) ? $source_reports['materialization_plan'] : array();
+		}
 		$products             = $this->products_manifest_from_transformer_reports( $result, $materialization_plan );
 		$artifacts            = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
 		$blocks               = isset( $artifacts['blocks'] ) && is_array( $artifacts['blocks'] ) ? $artifacts['blocks'] : array();
@@ -80,10 +84,12 @@ class Static_Site_Importer_Transformer_Adapter {
 			$artifacts['block_tree'] = $this->block_tree_report( $blocks );
 		}
 
-		$artifacts['document_metadata'] = $this->document_metadata_from_compiled_site( $materialization_plan );
-		$artifacts['documents']         = isset( $result['documents'] ) && is_array( $result['documents'] ) ? $result['documents'] : array();
-		$artifacts['files']             = $this->artifact_files_from_site_report( $materialization_plan, $result );
+		$compiled_site_metadata_source  = ! empty( $view['compiled_site'] ) && is_array( $view['compiled_site'] ) ? $view['compiled_site'] : $materialization_plan;
+		$artifacts['document_metadata'] = $this->document_metadata_from_compiled_site( $compiled_site_metadata_source );
+		$artifacts['documents']         = ! empty( $view['documents'] ) && is_array( $view['documents'] ) ? $view['documents'] : ( isset( $result['documents'] ) && is_array( $result['documents'] ) ? $result['documents'] : array() );
+		$artifacts['files']             = $this->artifact_files_from_site_report( $materialization_plan, ! empty( $view ) ? $view : $result );
 		$artifacts['site']              = $materialization_plan;
+		$artifacts['compiled_site']     = ! empty( $view['compiled_site'] ) && is_array( $view['compiled_site'] ) ? $view['compiled_site'] : array();
 		$artifacts['template_parts']    = isset( $materialization_plan['template_parts'] ) && is_array( $materialization_plan['template_parts'] ) ? $materialization_plan['template_parts'] : array();
 		$artifacts['visual_repair']     = isset( $materialization_plan['visual_repair'] ) && is_array( $materialization_plan['visual_repair'] ) ? $materialization_plan['visual_repair'] : array();
 
@@ -91,6 +97,63 @@ class Static_Site_Importer_Transformer_Adapter {
 
 		if ( ! empty( $products ) ) {
 			$compiled['products_manifest'] = $products;
+		}
+
+		return $compiled;
+	}
+
+	/**
+	 * Project a v0.1.1 canonical transformer result through Blocks Engine's materialization view.
+	 *
+	 * @param array<string,mixed> $result TransformerResult::toArray() output.
+	 * @return array<string,mixed>
+	 */
+	private function materialization_view_from_result( array $result ): array {
+		$class = 'Automattic\\BlocksEngine\\PhpTransformer\\StaticSite\\MaterializationView';
+		if ( ! class_exists( $class ) ) {
+			return array();
+		}
+
+		try {
+			$view = ( new $class() )->fromResult( $result );
+		} catch ( Throwable ) {
+			return array();
+		}
+
+		return is_array( $view ) ? $view : array();
+	}
+
+	/**
+	 * Build SSI's compiler envelope from Blocks Engine's materialization view.
+	 *
+	 * @param array<string,mixed> $view MaterializationView::fromResult() output.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private function compiled_result_from_materialization_view( array $view ) {
+		$materialization_plan = isset( $view['materialization_plan'] ) && is_array( $view['materialization_plan'] ) ? $view['materialization_plan'] : array();
+		if ( 'blocks-engine/php-transformer/materialization-plan/v1' !== (string) ( $materialization_plan['schema'] ?? '' ) ) {
+			return new WP_Error( 'static_site_importer_transformer_missing_materialization_plan', 'Blocks Engine php-transformer compile results must include source_reports.materialization_plan.' );
+		}
+
+		$compiled = array(
+			'schema'              => isset( $view['result_schema'] ) && is_scalar( $view['result_schema'] ) ? (string) $view['result_schema'] : self::TRANSFORMER_RESULT_SCHEMA,
+			'status'              => isset( $view['status'] ) && is_scalar( $view['status'] ) ? (string) $view['status'] : '',
+			'input'               => isset( $view['artifact_summary'] ) && is_array( $view['artifact_summary'] ) ? $view['artifact_summary'] : array(),
+			'artifact_summary'    => isset( $view['artifact_summary'] ) && is_array( $view['artifact_summary'] ) ? $view['artifact_summary'] : array(),
+			'artifacts'           => array(
+				'block_markup'  => isset( $view['block_markup'] ) && is_scalar( $view['block_markup'] ) ? (string) $view['block_markup'] : '',
+				'blocks'        => isset( $view['blocks'] ) && is_array( $view['blocks'] ) ? $view['blocks'] : array(),
+				'block_types'   => isset( $view['block_types'] ) && is_array( $view['block_types'] ) ? $view['block_types'] : array(),
+				'components'    => isset( $view['components'] ) && is_array( $view['components'] ) ? $view['components'] : array(),
+				'files'         => isset( $view['assets'] ) && is_array( $view['assets'] ) ? $view['assets'] : array(),
+				'compiled_site' => isset( $view['compiled_site'] ) && is_array( $view['compiled_site'] ) ? $view['compiled_site'] : array(),
+			),
+			'diagnostics'         => isset( $view['diagnostics'] ) && is_array( $view['diagnostics'] ) ? $view['diagnostics'] : array(),
+			'provenance'          => isset( $view['provenance'] ) && is_array( $view['provenance'] ) ? $view['provenance'] : array(),
+		);
+
+		if ( isset( $view['conversion_report'] ) && is_array( $view['conversion_report'] ) && ! empty( $view['conversion_report'] ) ) {
+			$compiled['conversion_report'] = $view['conversion_report'];
 		}
 
 		return $compiled;

--- a/tests/smoke-static-interactive-artifact.php
+++ b/tests/smoke-static-interactive-artifact.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Smoke test: website artifact import preserves static interactive diagnostics and assets.
+ *
+ * Run inside a WordPress site with Static Site Importer available:
+ * wp eval-file tests/smoke-static-interactive-artifact.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+if ( ! defined( 'STATIC_SITE_IMPORTER_PATH' ) && is_readable( $plugin_root . '/static-site-importer.php' ) ) {
+	require_once $plugin_root . '/static-site-importer.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator', false ) ) {
+	require_once $plugin_root . '/includes/class-static-site-importer-theme-generator.php';
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$read = static function ( string $path ): string {
+	$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Smoke test reads generated artifacts.
+	return false === $contents ? '' : $contents;
+};
+
+$assert( class_exists( 'Automattic\\BlocksEngine\\PhpTransformer\\StaticSite\\MaterializationView' ), 'materialization-view-class-available' );
+
+$artifact = array(
+	'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+	'entrypoint' => 'website/index.html',
+	'files'      => array(
+		array(
+			'path'    => 'website/index.html',
+			'content' => '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Static Interactive Kitchen</title><link rel="stylesheet" href="assets/site.css"><script type="module" src="assets/app.js" defer></script><script src="assets/analytics.js" async></script></head><body><main><section class="accordion"><button aria-expanded="false">Open pantry notes</button><div hidden><p>Fermentation schedule.</p></div></section><section class="tabs" role="tablist"><button role="tab" aria-selected="true">Bake</button><button role="tab">Serve</button></section><dialog><p>Reservation dialog fallback.</p></dialog><section class="carousel"><button class="prev">Prev</button><img src="assets/images/photo.svg" alt="Loaf carousel"><button class="next">Next</button></section><form action="/newsletter" method="post"><label>Email<input name="email" type="email"></label><button>Send</button></form></main></body></html>',
+		),
+		array(
+			'path'    => 'website/assets/site.css',
+			'content' => '@import url("theme.css");@font-face{font-family:"Kitchen Local";src:url("fonts/kitchen.woff2") format("woff2");font-weight:400}.accordion{border:1px solid #332}.carousel img{width:100%;height:auto}',
+		),
+		array(
+			'path'    => 'website/assets/theme.css',
+			'content' => '.tabs{display:flex;gap:0.5rem}.prev,.next{border-radius:999px}',
+		),
+		array(
+			'path'    => 'website/assets/app.js',
+			'content' => 'export function bootStaticKitchen(){document.documentElement.dataset.staticKitchen="ready";}',
+		),
+		array(
+			'path'    => 'website/assets/analytics.js',
+			'content' => 'window.staticKitchenAnalytics=true;',
+		),
+		array(
+			'path'     => 'website/assets/fonts/kitchen.woff2',
+			'encoding' => 'base64',
+			'content'  => base64_encode( 'fake-font-fixture' ),
+		),
+		array(
+			'path'    => 'website/assets/images/photo.svg',
+			'content' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><rect width="16" height="16" fill="#d2691e"/><circle cx="8" cy="8" r="4" fill="#fff4d6"/></svg>',
+		),
+	),
+);
+
+$result = Static_Site_Importer_Theme_Generator::import_website_artifact(
+	$artifact,
+	array(
+		'name'      => 'Static Interactive Fixture',
+		'slug'      => 'static-interactive-fixture-smoke',
+		'overwrite' => true,
+		'activate'  => false,
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+if ( ! is_wp_error( $result ) ) {
+	$theme_dir = $result['theme_dir'];
+	$report    = json_decode( $read( $result['report_path'] ), true );
+	$style     = $read( $theme_dir . '/style.css' );
+	$metadata  = $report['generated_theme']['document_metadata'] ?? array();
+	$scripts   = isset( $metadata['scripts'] ) && is_array( $metadata['scripts'] ) ? $metadata['scripts'] : array();
+	$page_ids  = array_values( $result['pages'] ?? array() );
+	$page      = ! empty( $page_ids[0] ) ? get_post( (int) $page_ids[0] ) : null;
+	$content   = $page instanceof WP_Post ? $page->post_content : '';
+	$be_report = $report['blocks_engine']['conversion_report'] ?? array();
+	$gate      = $report['import_validation_result']['quality_gates']['interaction_candidates'] ?? array();
+
+	$assert( 'blocks-engine/php-transformer/conversion-report/v1' === ( $be_report['schema'] ?? '' ), 'conversion-report-schema-recorded' );
+	$assert( 2 <= (int) ( $be_report['fallback_count'] ?? 0 ), 'fallback-diagnostics-counted' );
+	$assert( 2 <= count( $be_report['fallback_diagnostics'] ?? array() ), 'fallback-diagnostics-exposed' );
+	$assert( array_key_exists( 'interaction_candidate_count', $be_report ), 'interaction-candidate-count-exposed' );
+	$assert( array_key_exists( 'interaction_candidate_count', $report['quality'] ?? array() ), 'interaction-candidate-quality-count-exposed' );
+	$assert( isset( $gate['status'] ), 'interaction-candidate-gate-recorded' );
+	$assert( 'static-site-importer/document-metadata/v1' === ( $metadata['schema'] ?? '' ), 'document-metadata-recorded' );
+	$assert( 'module' === ( $scripts[0]['type'] ?? '' ), 'module-script-type-preserved' );
+	$assert( true === ( $scripts[0]['defer'] ?? false ), 'defer-script-metadata-preserved' );
+	$assert( true === ( $scripts[1]['async'] ?? false ), 'async-script-metadata-preserved' );
+	$assert( str_contains( $style, '@font-face' ), 'style-preserves-font-face' );
+	$assert( str_contains( $style, '.tabs' ), 'style-includes-imported-css' );
+	$assert( is_file( $theme_dir . '/assets/materialized/website/assets/site.css' ), 'site-css-materialized' );
+	$assert( is_file( $theme_dir . '/assets/materialized/website/assets/theme.css' ), 'imported-css-materialized' );
+	$assert( is_file( $theme_dir . '/assets/materialized/website/assets/app.js' ), 'module-js-materialized' );
+	$assert( is_file( $theme_dir . '/assets/materialized/website/assets/analytics.js' ), 'async-js-materialized' );
+	$assert( is_file( $theme_dir . '/assets/materialized/website/assets/fonts/kitchen.woff2' ), 'font-asset-materialized' );
+	$assert( is_file( $theme_dir . '/assets/materialized/website/assets/images/photo.svg' ), 'image-asset-materialized' );
+	$assert( str_contains( $content, 'assets/materialized/website/assets/images/photo.svg' ), 'page-content-rewrites-local-image' );
+	$assert( ! str_contains( $content, 'src="assets/images/photo.svg"' ), 'page-content-removes-source-image-path' );
+}
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: static interactive artifact smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -220,6 +220,9 @@ namespace {
 		}
 	}
 
+	if ( is_readable( dirname( __DIR__ ) . '/vendor/autoload.php' ) ) {
+		require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+	}
 	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-transformer-adapter.php';
 	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
@@ -317,6 +320,92 @@ namespace {
 	$assert( ! is_wp_error( $tagged_dependency_compiled ), 'tagged-dependency-report-compile-succeeds' );
 	$assert( '<!-- wp:paragraph --><p>Tagged dependency report</p><!-- /wp:paragraph -->' === ( $tagged_dependency_compiled['conversion_report']['serialized_blocks'] ?? '' ), 'top-level-conversion-report-remains-compatible' );
 	$assert( 'tagged-dependency-top-level' === ( $tagged_dependency_compiled['conversion_report']['fallbacks'][0]['source'] ?? '' ), 'top-level-conversion-report-fallbacks-preserved' );
+
+	$GLOBALS['ssi_transformer_adapter_result_override'] = array(
+		'schema'            => 'blocks-engine/php-transformer/result/v1',
+		'status'            => 'success',
+		'components'        => array( array( 'name' => 'accordion' ) ),
+		'block_types'       => array( array( 'name' => 'core/details' ) ),
+		'source_reports'    => array(
+			'artifact'              => array(
+				'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+				'entry_path' => 'website/index.html',
+			),
+			'compiled_site'        => array(
+				'schema'     => 'blocks-engine/php-transformer/compiled-site/v1',
+				'entry_path' => 'website/index.html',
+			),
+			'materialization_plan' => array(
+				'schema'                   => 'blocks-engine/php-transformer/materialization-plan/v1',
+				'entry_path'               => 'website/index.html',
+				'pages'                    => array(
+					array(
+						'source_path'  => 'website/index.html',
+						'slug'         => 'home-view',
+						'title'        => 'Home View',
+						'post_type'    => 'page',
+						'entrypoint'   => true,
+						'block_markup' => '<!-- wp:details --><details class="wp-block-details"><summary>Question</summary><p>Answer</p></details><!-- /wp:details -->',
+					),
+				),
+				'routes'                   => array(),
+				'navigation_links'         => array(),
+				'menus'                    => array(),
+				'template_parts'           => array(),
+				'template_part_writes'     => array(),
+				'assets'                   => array(
+					array(
+						'path'    => 'assets/view.css',
+						'role'    => 'stylesheet',
+						'kind'    => 'css',
+						'content' => '.view{display:block}',
+					),
+				),
+				'theme'                    => array(),
+				'asset_rewrite_candidates' => array(),
+				'rewrite_candidates'       => array(),
+				'totals'                   => array(),
+			),
+			'conversion_report'    => array(
+				'schema'                 => 'blocks-engine/php-transformer/conversion-report/v1',
+				'source_format'          => 'artifact',
+				'source_summary'         => array(),
+				'selector_summary'       => array(),
+				'fallback_diagnostics'   => array(),
+				'asset_refs'             => array(),
+				'navigation_candidates'  => array(),
+				'interaction_candidates' => array(
+					array(
+						'source_path' => 'website/index.html',
+						'selector'    => '.accordion button',
+						'kind'        => 'accordion',
+					),
+				),
+				'presentation_gaps'      => array(),
+				'metrics'                => array(),
+			),
+		),
+		'blocks'            => array( array( 'blockName' => 'core/details', 'innerBlocks' => array() ) ),
+		'serialized_blocks' => '<!-- wp:details --><details class="wp-block-details"><summary>Question</summary><p>Answer</p></details><!-- /wp:details -->',
+		'documents'         => array( array( 'source_path' => 'website/index.html', 'block_markup' => '<!-- wp:details /-->' ) ),
+		'assets'            => array( array( 'path' => 'assets/top-level-view.css', 'role' => 'stylesheet', 'kind' => 'css', 'content' => '.top{}' ) ),
+		'diagnostics'       => array( array( 'code' => 'view_diagnostic' ) ),
+		'fallbacks'         => array(),
+		'provenance'        => array( array( 'source' => 'canonical-view' ) ),
+		'coverage'          => array(),
+		'context'           => array(),
+		'metrics'           => array(),
+	);
+	$view_compiled = $adapter->compile_website_artifact( array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ) );
+	unset( $GLOBALS['ssi_transformer_adapter_result_override'] );
+	$assert( ! is_wp_error( $view_compiled ), 'materialization-view-compile-succeeds', is_wp_error( $view_compiled ) ? $view_compiled->get_error_message() : '' );
+	$assert( 'website/index.html' === ( $view_compiled['artifact_summary']['entry_path'] ?? '' ), 'materialization-view-exposes-artifact-summary' );
+	$assert( 'website/index.html' === ( $view_compiled['input']['entry_path'] ?? '' ), 'materialization-view-artifact-summary-drives-input' );
+	$assert( 'blocks-engine/php-transformer/compiled-site/v1' === ( $view_compiled['artifacts']['compiled_site']['schema'] ?? '' ), 'materialization-view-exposes-compiled-site' );
+	$assert( 'home-view' === ( $view_compiled['artifacts']['site']['pages'][0]['slug'] ?? '' ), 'materialization-view-materialization-plan-drives-site' );
+	$assert( 'assets/view.css' === ( $view_compiled['artifacts']['files'][0]['path'] ?? '' ), 'materialization-view-materialization-plan-assets-drive-files' );
+	$assert( 'view_diagnostic' === ( $view_compiled['diagnostics'][0]['code'] ?? '' ), 'materialization-view-exposes-diagnostics' );
+	$assert( '.accordion button' === ( $view_compiled['conversion_report']['interaction_candidates'][0]['selector'] ?? '' ), 'materialization-view-exposes-conversion-report' );
 
 	$GLOBALS['ssi_transformer_adapter_result_override'] = array(
 		'schema' => 'blocks-engine/php-transformer/result/v1',


### PR DESCRIPTION
## Summary
- Update the Blocks Engine PHP Transformer package override to php-transformer-v0.1.1.
- Consume the released MaterializationView projection when available while preserving fallback compatibility.
- Add static-interactive artifact smoke coverage for CSS imports, fonts, script metadata, static interaction markup, fallback diagnostics, and asset materialization.

## Verification
- composer update automattic/blocks-engine-php-transformer
- composer validate
- php tests/smoke-transformer-adapter.php
- studio wp eval-file tests/smoke-static-interactive-artifact.php --skip-plugins
- studio wp eval-file tests/smoke-website-artifact-document-metadata.php --skip-plugins
- npm run test:validation

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing the dependency update, adapter changes, and smoke coverage.