### PR TITLE
Document release lint warning exceptions

### DIFF
--- a/includes/class-static-site-importer-codebox-validation.php
+++ b/includes/class-static-site-importer-codebox-validation.php
@@ -40,7 +40,7 @@ class Static_Site_Importer_Codebox_Validation {
 			return $result;
 		}
 
-		$delegation_request = self::host_delegation_request( $request, $input );
+		$delegation_request       = self::host_delegation_request( $request, $input );
 		$host_delegation_callback = array( 'WP_Codebox_Abilities', 'request_host_delegation' );
 		if ( is_callable( $host_delegation_callback ) ) {
 			$delegation_result = call_user_func( $host_delegation_callback, $delegation_request );

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -397,7 +397,8 @@ class Static_Site_Importer_Theme_Materializer {
 				return new WP_Error( 'static_site_importer_materialization_plan_asset_content_invalid', sprintf( 'Blocks Engine materialization_plan.assets content_base64 must be scalar: %s', $relative ) );
 			}
 
-			$base64  = preg_replace( '/\s+/', '', (string) $asset['content_base64'] ) ?? '';
+			$base64 = preg_replace( '/\s+/', '', (string) $asset['content_base64'] ) ?? '';
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes declared artifact payload content, not executable code.
 			$decoded = base64_decode( $base64, true );
 			if ( false === $decoded ) {
 				return new WP_Error( 'static_site_importer_materialization_plan_asset_base64_invalid', sprintf( 'Blocks Engine materialization_plan.assets content_base64 is not valid base64: %s', $relative ) );
@@ -681,16 +682,20 @@ class Static_Site_Importer_Theme_Materializer {
 				continue;
 			}
 
-			$handle        = sanitize_key( $theme_slug . '-asset-' . preg_replace( '/\.[^.]+$/', '', str_replace( '/', '-', $theme_path ) ) );
-			$in_footer     = 'head' !== (string) ( $script['placement'] ?? '' );
+			$handle    = sanitize_key( $theme_slug . '-asset-' . preg_replace( '/\.[^.]+$/', '', str_replace( '/', '-', $theme_path ) ) );
+			$in_footer = 'head' !== (string) ( $script['placement'] ?? '' );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generates quoted PHP string literals for functions.php.
 			$script_lines .= "\twp_enqueue_script( " . var_export( $handle, true ) . ', get_template_directory_uri() . ' . var_export( '/' . $theme_path, true ) . ", array(), wp_get_theme()->get( 'Version' ), " . ( $in_footer ? 'true' : 'false' ) . " );\n";
 			if ( ! empty( $script['defer'] ) ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generates quoted PHP string literals for functions.php.
 				$script_lines .= "\twp_script_add_data( " . var_export( $handle, true ) . ", 'defer', true );\n";
 			}
 			if ( ! empty( $script['async'] ) ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generates quoted PHP string literals for functions.php.
 				$script_lines .= "\twp_script_add_data( " . var_export( $handle, true ) . ", 'async', true );\n";
 			}
 			if ( isset( $script['type'] ) && 'module' === strtolower( (string) $script['type'] ) ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generates quoted PHP string literals for functions.php.
 				$script_lines .= "\twp_script_add_data( " . var_export( $handle, true ) . ", 'type', 'module' );\n";
 			}
 		}

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -654,6 +654,7 @@ function static_site_importer_rest_preview_file_summary( array $artifact ): arra
 		if ( isset( $file['content'] ) ) {
 			$bytes = strlen( (string) $file['content'] );
 		} elseif ( isset( $file['content_base64'] ) ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes artifact payload content for size accounting.
 			$decoded = base64_decode( (string) $file['content_base64'], true );
 			$bytes   = false === $decoded ? 0 : strlen( $decoded );
 		}
@@ -834,6 +835,7 @@ function static_site_importer_rest_source_artifact( array $source ) {
 			}
 
 			if ( isset( $file['content_base64'] ) ) {
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes uploaded artifact payload content.
 				$content = base64_decode( (string) $file['content_base64'], true );
 				if ( false === $content ) {
 					return new WP_Error( 'static_site_importer_invalid_file_content', __( 'Uploaded file content could not be decoded.', 'static-site-importer' ), array( 'status' => 400 ) );
@@ -884,6 +886,7 @@ function static_site_importer_rest_archive_files( array $archive ) {
 		return new WP_Error( 'static_site_importer_zip_unavailable', __( 'ZIP archive extraction is unavailable on this server.', 'static-site-importer' ), array( 'status' => 500 ) );
 	}
 
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes uploaded ZIP archive payload content.
 	$content = isset( $archive['content_base64'] ) ? base64_decode( (string) $archive['content_base64'], true ) : false;
 	if ( false === $content ) {
 		return new WP_Error( 'static_site_importer_invalid_archive_content', __( 'Uploaded ZIP archive content could not be decoded.', 'static-site-importer' ), array( 'status' => 400 ) );


### PR DESCRIPTION
## Summary
- Add targeted PHPCS justifications for base64 artifact payload decoding.
- Add targeted PHPCS justifications for var_export usage when generating quoted PHP string literals.
- Fix the remaining assignment alignment warning that blocked release lint.

## Testing
- `homeboy lint static-site-importer --path /Users/chubes/Developer/static-site-importer@main --runner homeboy-lab --summary`
- `homeboy test static-site-importer --path /Users/chubes/Developer/static-site-importer@main --skip-lint --runner homeboy-lab`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigating release lint warnings, applying targeted PHPCS justifications, and running validation.