### PR TITLE
Add Playground import page blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ At runtime, SSI loads the transformer package from `vendor/` and calls `blocks_e
 
 The admin path always overwrites an existing generated theme with the same slug. Pasted HTML, fetched URL HTML, and direct HTML uploads are copied into a generated upload work directory as `index.html` and imported as a single-page site. ZIP uploads are for multi-page static sites or bundled source-site exports; they are extracted to an upload work directory, the selected `index.html` is used as the entry file, sibling HTML files from that extracted site directory are imported, and nested `.md` / `.markdown` files are imported as content pages. The importer does not require the original source model to be a single `index.html`; it needs one selected HTML entry file for shared shell/chrome and imports the source content documents it can read.
 
+## Browser Playground Demo
+
+Open Static Site Importer in a disposable WordPress Playground site:
+
+https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/static-site-importer/main/docs/playground/blueprint.json
+
+The blueprint installs and activates the packaged Static Site Importer release, logs the visitor in, and opens `/import/` with the `static-site-importer/importer` block configured for `applyToCurrentSite`. Testers can upload a ZIP, choose a local site directory, paste HTML, or enter one public URL. The import runs inside the browser Playground site and activates the generated WordPress block theme there, so the imported result can be inspected without installing anything locally.
+
 URL intake rules:
 
 - Fetches one URL only; this is not a crawler and does not execute JavaScript.

--- a/docs/playground/blueprint.json
+++ b/docs/playground/blueprint.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "landingPage": "/import/",
+  "preferredVersions": {
+    "php": "8.2",
+    "wp": "latest"
+  },
+  "features": {
+    "networking": true
+  },
+  "steps": [
+    {
+      "step": "login"
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "url",
+        "url": "https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip"
+      },
+      "options": {
+        "activate": true,
+        "targetFolderName": "static-site-importer"
+      }
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php require_once '/wordpress/wp-load.php';\n$page = get_page_by_path( 'import', OBJECT, 'page' );\n$content = '<!-- wp:static-site-importer/importer {\"title\":\"Import a static site in your browser\",\"intro\":\"Upload a ZIP, choose a local site directory, paste raw HTML, or enter a public URL. Static Site Importer will convert it into this disposable WordPress Playground site.\",\"applyToCurrentSite\":true} /-->';\n$post = array(\n    'post_title' => 'Import Static Site',\n    'post_name' => 'import',\n    'post_type' => 'page',\n    'post_status' => 'publish',\n    'post_content' => $content,\n    'comment_status' => 'closed',\n    'ping_status' => 'closed',\n);\nif ( $page instanceof WP_Post ) {\n    $post['ID'] = $page->ID;\n    wp_update_post( $post );\n} else {\n    wp_insert_post( $post );\n}\nupdate_option( 'static_site_importer_protected_pages', array( 'import' ), false );\n?>"
+    }
+  ]
+}

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -95,6 +95,23 @@ function static_site_importer_rest_should_apply_to_current_site( array $params )
  * @return array<string,mixed>|WP_Error
  */
 function static_site_importer_rest_apply_to_current_site( array $source, array $input, array $params ) {
+	$decorate_current_site_preview = static function ( $result ) {
+		if ( ! is_array( $result ) ) {
+			return $result;
+		}
+
+		$preview_url = function_exists( 'home_url' ) ? home_url( '/' ) : '';
+		$preview     = isset( $result['preview'] ) && is_array( $result['preview'] ) ? $result['preview'] : array();
+		if ( '' !== $preview_url ) {
+			$preview['url'] = $preview_url;
+		}
+		$preview['status'] = isset( $preview['status'] ) ? $preview['status'] : 'ready';
+
+		$result['preview'] = $preview;
+
+		return $result;
+	};
+
 	if ( isset( $source['url'] ) && '' !== trim( (string) $source['url'] ) ) {
 		$input['url'] = esc_url_raw( (string) $source['url'] );
 		if ( isset( $params['provider'] ) ) {
@@ -104,7 +121,7 @@ function static_site_importer_rest_apply_to_current_site( array $source, array $
 			$input['provider_args'] = $params['provider_args'];
 		}
 
-		return static_site_importer_rest_execute_import_ability( 'static-site-importer/import-url', $input, 'static_site_importer_ability_import_url' );
+		return $decorate_current_site_preview( static_site_importer_rest_execute_import_ability( 'static-site-importer/import-url', $input, 'static_site_importer_ability_import_url' ) );
 	} else {
 		$artifact = static_site_importer_rest_source_artifact( $source );
 		if ( is_wp_error( $artifact ) ) {
@@ -113,7 +130,7 @@ function static_site_importer_rest_apply_to_current_site( array $source, array $
 
 		$input['artifact'] = $artifact;
 
-		return static_site_importer_rest_execute_import_ability( 'static-site-importer/import-website-artifact', $input, 'static_site_importer_ability_import_website_artifact' );
+		return $decorate_current_site_preview( static_site_importer_rest_execute_import_ability( 'static-site-importer/import-website-artifact', $input, 'static_site_importer_ability_import_website_artifact' ) );
 	}
 }
 

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -164,6 +164,12 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_delete_file' ) ) {
+	function wp_delete_file( string $file ): bool {
+		return file_exists( $file ) ? unlink( $file ) : true;
+	}
+}
+
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		private string $code;
@@ -274,6 +280,12 @@ if ( ! class_exists( 'WP_Codebox_Browser_Task_Builder' ) ) {
 if ( ! function_exists( 'rest_url' ) ) {
 	function rest_url( string $path = '' ): string {
 		return 'https://example.test/wp-json/' . ltrim( $path, '/' );
+	}
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( string $path = '' ): string {
+		return 'https://example.test/' . ltrim( $path, '/' );
 	}
 }
 
@@ -493,6 +505,17 @@ $apply_response = static_site_importer_rest_create_import(
 $assert( true === ( $apply_response['success'] ?? null ), 'rest-current-site-apply-is-explicitly-available' );
 $assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['activate'] ?? null ), 'rest-current-site-apply-preserves-activate' );
 $assert( isset( $apply_response['result'] ), 'rest-current-site-apply-returns-ability-envelope' );
+$assert( 'https://example.test/' === ( $apply_response['preview']['url'] ?? '' ), 'rest-current-site-apply-returns-site-preview-url' );
+
+$blueprint = json_decode( file_get_contents( dirname( __DIR__ ) . '/docs/playground/blueprint.json' ), true );
+$assert( is_array( $blueprint ), 'playground-blueprint-decodes' );
+$assert( '/import/' === ( $blueprint['landingPage'] ?? '' ), 'playground-blueprint-lands-on-import-page' );
+$blueprint_code = implode( "\n", array_map( static fn( array $step ): string => isset( $step['code'] ) ? (string) $step['code'] : '', $blueprint['steps'] ?? array() ) );
+$assert( str_contains( $blueprint_code, 'static-site-importer/importer' ), 'playground-blueprint-creates-importer-block-page' );
+$assert( str_contains( $blueprint_code, 'applyToCurrentSite' ), 'playground-blueprint-applies-imports-to-current-site' );
+$assert( str_contains( $blueprint_code, 'static_site_importer_protected_pages' ), 'playground-blueprint-protects-import-page' );
+$plugin_step = $blueprint['steps'][1] ?? array();
+$assert( 'https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip' === ( $plugin_step['pluginData']['url'] ?? '' ), 'playground-blueprint-installs-packaged-release' );
 
 $GLOBALS['ssi_test_options']['static_site_importer_protected_pages'] = array( 'import', 'tools/settings', '42' );
 $assert( Static_Site_Importer_Page_Materializer::is_protected_page( new WP_Post( 7, 'import' ) ), 'protected-page-matches-slug' );


### PR DESCRIPTION
## Summary
- Add a WordPress Playground blueprint that opens Static Site Importer at /import/.
- Configure the importer block to apply uploads directly to the browser Playground site.
- Return the current site URL from current-site imports so testers get an obvious preview link.
- Document the shareable Playground URL.

## Testing
- php -r 'json_decode(file_get_contents("docs/playground/blueprint.json"), true, 512, JSON_THROW_ON_ERROR); echo "blueprint json ok" . PHP_EOL;'
- php -l includes/rest.php && php -l tests/smoke-importer-block.php
- php tests/smoke-importer-block.php
- Manual: inline Playground blueprint loaded /import/ successfully; import path reached SSI and confirmed the UI works. Follow-up fixed missing transformer by installing the packaged release ZIP.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the Playground blueprint, REST preview URL change, documentation, and smoke test updates.