### PR TITLE
Normalize materialization-plan root routes

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1137,12 +1137,30 @@ class Static_Site_Importer_Theme_Generator {
 					$normalized[ $key ] = (string) $route[ $key ];
 				}
 			}
+			if ( ! isset( $normalized['slug'] ) && isset( $route['target_slug'] ) && is_scalar( $route['target_slug'] ) && '' !== trim( (string) $route['target_slug'] ) ) {
+				$normalized['slug'] = (string) $route['target_slug'];
+			}
+			if ( ! isset( $normalized['title'] ) && isset( $route['target_title'] ) && is_scalar( $route['target_title'] ) && '' !== trim( (string) $route['target_title'] ) ) {
+				$normalized['title'] = (string) $route['target_title'];
+			}
 
 			if ( isset( $route['route_key'] ) && is_scalar( $route['route_key'] ) && '' !== trim( (string) $route['route_key'] ) ) {
 				$normalized['route_key'] = (string) $route['route_key'];
 			}
+			$route_path = '';
 			if ( isset( $route['path'] ) && is_scalar( $route['path'] ) && '' !== trim( (string) $route['path'] ) ) {
-				$normalized['route_path'] = self::normalize_route_path( (string) $route['path'] );
+				$route_path = (string) $route['path'];
+			} elseif ( isset( $route['target_path'] ) && is_scalar( $route['target_path'] ) && '' !== trim( (string) $route['target_path'] ) ) {
+				$route_path = (string) $route['target_path'];
+			}
+			if ( '' !== $route_path ) {
+				$normalized['route_path'] = self::normalize_route_path( $route_path );
+				if ( '' === $normalized['route_path'] && ! empty( $route['source_relation'] ) && 'entrypoint' === (string) $route['source_relation'] ) {
+					$normalized['entrypoint'] = '1';
+				}
+				if ( '' === $normalized['route_path'] && isset( $normalized['slug'] ) && in_array( sanitize_title( $normalized['slug'] ), array( 'index', 'home' ), true ) ) {
+					$normalized['slug'] = 'home';
+				}
 			}
 
 			if ( isset( $route['metadata'] ) && is_array( $route['metadata'] ) ) {

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -283,6 +283,42 @@ $assert( $native_page instanceof Static_Site_Importer_Source_Page && 'Home Canon
 $assert( $native_page instanceof Static_Site_Importer_Source_Page && 'home-route' === $native_page->metadata_value( 'route_key' ), 'materialization-plan-route-key-is-preserved' );
 $assert( $native_page instanceof Static_Site_Importer_Source_Page && str_contains( $native_page->body(), 'Native page' ), 'materialization-plan-page-body-wins-over-compiled-site-document' );
 
+$target_route_pages = $source_pages->invoke(
+	null,
+	array(
+		'artifacts' => array(
+			'site' => array(
+				'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+				'pages'  => array(
+					array(
+						'source_path'  => 'website/nested/index.html',
+						'post_type'    => 'page',
+						'slug'         => 'index',
+						'title'        => 'Nested Home',
+						'entrypoint'   => true,
+						'block_markup' => '<!-- wp:paragraph --><p>Nested home</p><!-- /wp:paragraph -->',
+					),
+				),
+				'routes' => array(
+					array(
+						'kind'            => 'route',
+						'source_path'     => 'website/nested/index.html',
+						'target_path'     => '/',
+						'target_slug'     => 'index',
+						'title'           => 'Nested Home Route',
+						'source_relation' => 'entrypoint',
+					),
+				),
+			),
+		),
+	)
+);
+$target_route_page = is_array( $target_route_pages ) ? ( $target_route_pages['website/nested/index.html'] ?? null ) : null;
+$assert( $target_route_page instanceof Static_Site_Importer_Source_Page, 'materialization-plan-target-route-page-source-key-is-used' );
+$assert( $target_route_page instanceof Static_Site_Importer_Source_Page && 'home' === $target_route_page->metadata_value( 'slug' ), 'materialization-plan-target-root-route-normalizes-home-slug' );
+$assert( $target_route_page instanceof Static_Site_Importer_Source_Page && '1' === $target_route_page->metadata_value( 'entrypoint' ), 'materialization-plan-target-root-route-preserves-entrypoint' );
+$assert( $target_route_page instanceof Static_Site_Importer_Source_Page && str_contains( $target_route_page->body(), 'Nested home' ), 'materialization-plan-target-route-page-body-is-preserved' );
+
 $malformed_routes = $source_pages->invoke(
 	null,
 	array(


### PR DESCRIPTION
## Summary
- Accept Blocks Engine materialization-plan route fields `target_path`, `target_slug`, and `target_title` when normalizing source pages.
- Normalize entrypoint root routes like `target_path: /` + `target_slug: index` to the WordPress home page slug.
- Add smoke coverage for nested `index.html` root-route materialization.

## Testing
- `php tests/smoke-visual-repair-css.php`
- `php tests/smoke-importer-block.php`
- `php -l includes/class-static-site-importer-theme-generator.php && php -l tests/smoke-visual-repair-css.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugging the Playground import route-materialization issue, drafting the code change, adding regression coverage, and running targeted verification.