### PR TITLE
Preserve imported home route and site title

### DIFF
--- a/includes/class-static-site-importer-source-page.php
+++ b/includes/class-static-site-importer-source-page.php
@@ -155,8 +155,9 @@ class Static_Site_Importer_Source_Page {
 		}
 		if ( isset( $page['metadata'] ) && is_array( $page['metadata'] ) ) {
 			foreach ( $page['metadata'] as $key => $value ) {
-				if ( is_string( $key ) && is_scalar( $value ) ) {
-					$metadata[ strtolower( str_replace( '-', '_', $key ) ) ] = (string) $value;
+				$metadata_key = is_string( $key ) ? strtolower( str_replace( '-', '_', $key ) ) : '';
+				if ( '' !== $metadata_key && is_scalar( $value ) && ! array_key_exists( $metadata_key, $metadata ) ) {
+					$metadata[ $metadata_key ] = (string) $value;
 				}
 			}
 		}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -52,6 +52,12 @@ class Static_Site_Importer_Theme_Generator {
 		if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
 			return new WP_Error( 'static_site_importer_missing_transformer_adapter', 'Static Site Importer transformer adapter is required to import a website artifact.' );
 		}
+		if ( empty( $args['site_title'] ) ) {
+			$site_title = self::site_title_from_website_artifact( $artifact );
+			if ( '' !== $site_title ) {
+				$args['site_title'] = $site_title;
+			}
+		}
 
 		$compiler_options = isset( $args['compiler_options'] ) && is_array( $args['compiler_options'] ) ? $args['compiler_options'] : array();
 		$compiled         = ( new Static_Site_Importer_Transformer_Adapter() )->compile_website_artifact( $artifact, array_merge( array( 'include_conversion_report' => true ), $compiler_options ) );
@@ -236,6 +242,9 @@ class Static_Site_Importer_Theme_Generator {
 			}
 
 			switch_theme( $theme_slug );
+			if ( isset( $args['site_title'] ) && '' !== trim( (string) $args['site_title'] ) ) {
+				update_option( 'blogname', sanitize_text_field( (string) $args['site_title'] ) );
+			}
 			if ( 0 !== $front_page_id ) {
 				update_option( 'show_on_front', 'page' );
 				update_option( 'page_on_front', $front_page_id );
@@ -941,6 +950,37 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return $refs;
+	}
+
+	/**
+	 * Infer a WordPress site title from the source artifact entrypoint.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @return string
+	 */
+	private static function site_title_from_website_artifact( array $artifact ): string {
+		$entrypoint = isset( $artifact['entrypoint'] ) && is_scalar( $artifact['entrypoint'] ) ? self::normalize_route_path( (string) $artifact['entrypoint'] ) : '';
+		$files      = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+			$path = isset( $file['path'] ) && is_scalar( $file['path'] ) ? self::normalize_route_path( (string) $file['path'] ) : '';
+			if ( '' === $path || ( '' !== $entrypoint && $path !== $entrypoint ) ) {
+				continue;
+			}
+			$content = isset( $file['content'] ) && is_scalar( $file['content'] ) ? (string) $file['content'] : '';
+			if ( '' === trim( $content ) || ! preg_match( '/<title[^>]*>(.*?)<\/title>/is', $content, $matches ) ) {
+				continue;
+			}
+
+			$title = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( (string) $matches[1] ) : strip_tags( (string) $matches[1] );
+			$title = html_entity_decode( trim( $title ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+			$title = preg_split( '/\s+(?:\||\x{2014}|\x{2013}|-)\s+/u', $title )[0] ?? $title;
+			return function_exists( 'sanitize_text_field' ) ? sanitize_text_field( trim( $title ) ) : trim( strip_tags( $title ) );
+		}
+
+		return '';
 	}
 
 	/**

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -297,6 +297,9 @@ $target_route_pages = $source_pages->invoke(
 						'title'        => 'Nested Home',
 						'entrypoint'   => true,
 						'block_markup' => '<!-- wp:paragraph --><p>Nested home</p><!-- /wp:paragraph -->',
+						'metadata'     => array(
+							'slug' => 'index',
+						),
 					),
 				),
 				'routes' => array(
@@ -318,6 +321,21 @@ $assert( $target_route_page instanceof Static_Site_Importer_Source_Page, 'materi
 $assert( $target_route_page instanceof Static_Site_Importer_Source_Page && 'home' === $target_route_page->metadata_value( 'slug' ), 'materialization-plan-target-root-route-normalizes-home-slug' );
 $assert( $target_route_page instanceof Static_Site_Importer_Source_Page && '1' === $target_route_page->metadata_value( 'entrypoint' ), 'materialization-plan-target-root-route-preserves-entrypoint' );
 $assert( $target_route_page instanceof Static_Site_Importer_Source_Page && str_contains( $target_route_page->body(), 'Nested home' ), 'materialization-plan-target-route-page-body-is-preserved' );
+
+$site_title_from_artifact = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'site_title_from_website_artifact' );
+$site_title               = $site_title_from_artifact->invoke(
+	null,
+	array(
+		'entrypoint' => 'website/nested/index.html',
+		'files'      => array(
+			array(
+				'path'    => 'website/nested/index.html',
+				'content' => '<!doctype html><html><head><title>Northline Plumbing &amp; Heating | Grand Rapids, MI</title></head><body></body></html>',
+			),
+		),
+	)
+);
+$assert( 'Northline Plumbing & Heating' === $site_title, 'website-artifact-entrypoint-title-infers-site-title' );
 
 $malformed_routes = $source_pages->invoke(
 	null,


### PR DESCRIPTION
## Summary
- Keep top-level materialization-plan route metadata authoritative over nested page metadata so root routes stay normalized to `home`.
- Infer an imported site title from the source artifact entrypoint `<title>` and set `blogname` when activating the generated theme.
- Add smoke coverage for nested metadata overriding root-route slugs and source-title inference.

## Testing
- `php tests/smoke-visual-repair-css.php`
- `php tests/smoke-importer-block.php`
- `php -l includes/class-static-site-importer-theme-generator.php && php -l includes/class-static-site-importer-source-page.php && php -l tests/smoke-visual-repair-css.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugging the local fixture import regression, drafting the route/title fix, adding regression coverage, and running targeted verification.