### PR TITLE
Rewrite HTML links to imported pages

### DIFF
--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -62,9 +62,10 @@ class Static_Site_Importer_Page_Materializer {
 	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Pages.
 	 * @param string                                          $theme_slug Theme slug.
 	 * @param array<string,array<string,mixed>>                 $assets     Materialized assets keyed by source path.
+	 * @param array<string,string>                              $permalinks Imported page permalinks keyed by source path.
 	 * @return array{patterns:array<string,string>,files:array<string,string>,contents:array<string,string>,diagnostics:array<int,array<string,mixed>>}
 	 */
-	public static function page_artifacts( array $pages, string $theme_slug, array $assets = array() ): array {
+	public static function page_artifacts( array $pages, string $theme_slug, array $assets = array(), array $permalinks = array() ): array {
 		$patterns    = array();
 		$files       = array();
 		$contents    = array();
@@ -73,7 +74,7 @@ class Static_Site_Importer_Page_Materializer {
 		foreach ( $pages as $filename => $page ) {
 			$slug         = self::page_slug( $filename, $page );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
-			$content      = self::rewrite_materialized_asset_references( self::source_page_content_blocks( $page, $diagnostics ), $assets, $page->source_key() );
+			$content      = self::rewrite_materialized_asset_references( self::source_page_content_blocks( $page, $diagnostics ), $assets, $page->source_key(), $permalinks );
 
 			$patterns[ $filename ] = $pattern_slug;
 			$files[ $filename ]    = Static_Site_Importer_Theme_Materializer::pattern_file( self::page_title( $filename, $page ), $pattern_slug, $content );
@@ -293,21 +294,28 @@ class Static_Site_Importer_Page_Materializer {
 	 * @param string                              $markup Serialized block markup.
 	 * @param array<string,array<string,mixed>>   $assets Materialized assets keyed by source path.
 	 * @param string                              $source_path Source page path for resolving page-relative URLs.
+	 * @param array<string,string>                $permalinks Imported page permalinks keyed by source path.
 	 * @return string Updated markup.
 	 */
-	private static function rewrite_materialized_asset_references( string $markup, array $assets, string $source_path = '' ): string {
-		if ( '' === trim( $markup ) || empty( $assets ) ) {
+	private static function rewrite_materialized_asset_references( string $markup, array $assets, string $source_path = '', array $permalinks = array() ): string {
+		if ( '' === trim( $markup ) || ( empty( $assets ) && empty( $permalinks ) ) ) {
 			return $markup;
 		}
 
 		$replacements = array();
+		foreach ( $permalinks as $source => $permalink ) {
+			$normalized_source = self::normalize_route_path( $source );
+			if ( '' !== $normalized_source && '' !== trim( (string) $permalink ) ) {
+				$replacements[ $normalized_source ] = (string) $permalink;
+			}
+		}
 		foreach ( $assets as $source => $asset ) {
 			if ( ! isset( $asset['final_url'] ) || ! is_scalar( $asset['final_url'] ) ) {
 				continue;
 			}
 
 			$normalized_source = self::normalize_route_path( $source );
-			if ( '' !== $normalized_source ) {
+			if ( '' !== $normalized_source && ! isset( $replacements[ $normalized_source ] ) ) {
 				$replacements[ $normalized_source ] = (string) $asset['final_url'];
 			}
 		}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -133,7 +133,7 @@ class Static_Site_Importer_Theme_Generator {
 			return $materialized;
 		}
 
-		$page_artifacts = Static_Site_Importer_Page_Materializer::page_artifacts( $document_pages, $theme_slug, $materialized['assets'] );
+		$page_artifacts = Static_Site_Importer_Page_Materializer::page_artifacts( $document_pages, $theme_slug, $materialized['assets'], $permalinks );
 		foreach ( $page_artifacts['diagnostics'] as $diagnostic ) {
 			self::$conversion_report['diagnostics'][] = $diagnostic;
 		}

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -214,6 +214,9 @@ class Static_Site_Importer_Theme_Materializer {
 			$kind  = isset( $asset['kind'] ) && is_scalar( $asset['kind'] ) ? (string) $asset['kind'] : '';
 			$role  = isset( $asset['role'] ) && is_scalar( $asset['role'] ) ? (string) $asset['role'] : '';
 			$lower = strtolower( $relative );
+			if ( 'html' === $kind || str_ends_with( $lower, '.html' ) || str_ends_with( $lower, '.htm' ) ) {
+				continue;
+			}
 			++$order;
 
 			$target_relative = 'assets/materialized/' . $relative;

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -50,9 +50,21 @@ if ( ! function_exists( 'sanitize_title' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $text ): string {
+		return trim( preg_replace( '/[\r\n\t ]+/', ' ', html_entity_decode( $text, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ) );
+	}
+}
+
 if ( ! function_exists( 'esc_html' ) ) {
 	function esc_html( string $text ): string {
 		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( string $url ): string {
+		return htmlspecialchars( $url, ENT_QUOTES, 'UTF-8' );
 	}
 }
 
@@ -77,6 +89,7 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-stylesheet-materializer.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-source-page.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-page-materializer.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php';
 
@@ -419,6 +432,12 @@ $asset_result    = Static_Site_Importer_Theme_Materializer::materialize_website_
 					'mime_type'      => 'image/png',
 					'content_base64' => base64_encode( "\x89PNG\r\n\x1a\n" ),
 				),
+				array(
+					'path'    => 'website/3-artist-music/merch.html',
+					'kind'    => 'html',
+					'role'    => 'document',
+					'content' => '<!doctype html><html><body><main><h1>Merch</h1></main></body></html>',
+				),
 			),
 		),
 		'files' => array(
@@ -439,7 +458,9 @@ $assert( file_exists( $asset_theme_dir . '/assets/materialized/assets/logo.png' 
 $assert( file_exists( $asset_theme_dir . '/assets/materialized/assets/app.js' ), 'materialization-plan-script-asset-is-written' );
 $assert( file_exists( $asset_theme_dir . '/assets/materialized/assets/vendor.js' ), 'materialization-plan-second-script-asset-is-written' );
 $assert( file_exists( $asset_theme_dir . '/assets/materialized/fonts/native.woff2' ), 'materialization-plan-font-asset-is-written' );
+$assert( ! file_exists( $asset_theme_dir . '/assets/materialized/website/3-artist-music/merch.html' ), 'materialization-plan-html-document-is-not-written-as-asset' );
 $assert( 'materialization_plan.assets' === ( $asset_result['assets']['assets/logo.png']['origin'] ?? '' ), 'materialization-plan-asset-origin-is-reported' );
+$assert( ! isset( $asset_result['assets']['website/3-artist-music/merch.html'] ), 'materialization-plan-html-document-is-not-reported-as-asset' );
 $assert( str_ends_with( (string) ( $asset_result['assets']['assets/logo.png']['final_url'] ?? '' ), '/assets/materialized/assets/logo.png' ), 'materialization-plan-asset-final-url-shape' );
 $assert( 'screen' === ( $asset_result['assets']['assets/site.css']['media'] ?? '' ), 'materialization-plan-style-metadata-is-preserved' );
 $assert( 'font' === ( $asset_result['assets']['fonts/native.woff2']['role'] ?? '' ), 'materialization-plan-font-role-is-preserved' );
@@ -451,6 +472,33 @@ $assert( 'assets/vendor.js' === ( $asset_result['scripts'][1]['path'] ?? '' ), '
 $assert( true === ( $asset_result['scripts'][0]['defer'] ?? false ), 'materialization-plan-script-defer-is-preserved' );
 $assert( 'module' === ( $asset_result['scripts'][0]['type'] ?? '' ), 'materialization-plan-script-type-is-preserved' );
 $assert( true === ( $asset_result['scripts'][1]['async'] ?? false ), 'materialization-plan-script-async-is-preserved' );
+
+$source_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'website/3-artist-music/index.html',
+		'slug'         => 'home',
+		'title'        => 'Home',
+		'block_markup' => '<!-- wp:paragraph --><p><a href="merch.html">Merch</a><img src="assets/logo.png" alt="Logo"></p><!-- /wp:paragraph -->',
+	)
+);
+$assert( $source_page instanceof Static_Site_Importer_Source_Page, 'source-page-for-link-rewrite-is-created' );
+$page_artifacts = $source_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'website/3-artist-music/index.html' => $source_page ),
+	'fixture-theme',
+	array(
+		'website/3-artist-music/merch.html' => array( 'final_url' => 'https://example.test/wp-content/themes/generated/assets/materialized/website/3-artist-music/merch.html' ),
+		'website/3-artist-music/assets/logo.png' => array( 'final_url' => 'https://example.test/wp-content/themes/generated/assets/materialized/website/3-artist-music/assets/logo.png' ),
+	),
+	array(
+		'website/3-artist-music/merch.html' => 'https://example.test/merch/',
+		'merch.html'                       => 'https://example.test/merch/',
+	)
+) : array( 'contents' => array() );
+$rewritten_content = (string) ( $page_artifacts['contents']['website/3-artist-music/index.html'] ?? '' );
+$assert( str_contains( $rewritten_content, 'href="https://example.test/merch/"' ), 'html-page-link-rewrites-to-imported-page-permalink' );
+$assert( ! str_contains( $rewritten_content, 'href="https://example.test/wp-content/themes/generated/assets/materialized/website/3-artist-music/merch.html"' ), 'html-page-link-does-not-rewrite-to-materialized-html-asset' );
+$assert( str_contains( $rewritten_content, 'src="https://example.test/wp-content/themes/generated/assets/materialized/website/3-artist-music/assets/logo.png"' ), 'non-html-asset-link-still-rewrites-to-materialized-asset' );
+
 $base_writes   = Static_Site_Importer_Theme_Materializer::base_theme_writes( $asset_theme_dir, 'fixture-theme', 'Fixture Theme', (string) $asset_result['css'], false, $asset_result['scripts'] );
 $functions_php = (string) ( $base_writes[ $asset_theme_dir . '/functions.php' ] ?? '' );
 $assert( str_contains( $functions_php, '/assets/materialized/assets/app.js' ), 'materialization-plan-script-is-enqueued' );


### PR DESCRIPTION
## Summary
- Pass imported page permalinks into page artifact rewriting so `.html` document links resolve to WordPress pages.
- Keep page permalink rewrites authoritative over materialized asset URLs.
- Skip materializing HTML document assets into generated theme assets.
- Add smoke coverage for `merch.html` rewriting to an imported page permalink instead of `assets/materialized/.../merch.html`.

## Testing
- `php tests/smoke-visual-repair-css.php`
- `php tests/smoke-importer-block.php`
- `php -l includes/class-static-site-importer-page-materializer.php && php -l includes/class-static-site-importer-theme-generator.php && php -l includes/class-static-site-importer-theme-materializer.php && php -l tests/smoke-visual-repair-css.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugging imported HTML document link rewriting, implementing the SSI fix, and adding regression coverage.