### PR TITLE
Update Blocks Engine transformer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.1",
+        "version": "0.1.2",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "310ba6f23096e2ac93485f9ed0377531dcbe74d5"
+          "reference": "706b0e0c4b071ca971c1d7b1b6afc82b53140ffa"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.1.zip",
-          "reference": "310ba6f23096e2ac93485f9ed0377531dcbe74d5"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.2.zip",
+          "reference": "706b0e0c4b071ca971c1d7b1b6afc82b53140ffa"
         },
         "autoload": {
           "psr-4": {
@@ -36,7 +36,7 @@
     }
   ],
   "require": {
-    "automattic/blocks-engine-php-transformer": "^0.1.1",
+    "automattic/blocks-engine-php-transformer": "^0.1.2",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2798f76ed506dbd3ccf2afa20b129b60",
+    "content-hash": "9c97ff9fcef6400f53189be768bf9934",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "310ba6f23096e2ac93485f9ed0377531dcbe74d5"
+                "reference": "706b0e0c4b071ca971c1d7b1b6afc82b53140ffa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.1.zip",
-                "reference": "310ba6f23096e2ac93485f9ed0377531dcbe74d5"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.2.zip",
+                "reference": "706b0e0c4b071ca971c1d7b1b6afc82b53140ffa"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Updates the bundled Blocks Engine PHP transformer package from 0.1.1 to 0.1.2.
- Pulls in the latest merged HTML conversion improvements for multi-page artifacts, search forms, inline SVG fallback reduction, and logo/nav/button classification.

## Testing
- `php tests/smoke-visual-repair-css.php`
- `php tests/smoke-importer-block.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updating the Composer dependency metadata, running verification, and drafting this PR description.