### PR TITLE
Update Blocks Engine transformer to 0.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "2d33407b1c9924bf07d1135208672aafd5b140ea"
+          "reference": "f998a596650bf9c4ae0a8480d80a4e51161ab169"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/2d33407b1c9924bf07d1135208672aafd5b140ea.zip",
-          "reference": "2d33407b1c9924bf07d1135208672aafd5b140ea"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.3.zip",
+          "reference": "f998a596650bf9c4ae0a8480d80a4e51161ab169"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.0",
-    "automattic/blocks-engine-php-transformer": "^0.1.2",
+    "automattic/blocks-engine-php-transformer": "^0.1.3",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16cd8b055d400efca8f321152a5ac80d",
+    "content-hash": "53fe3861879514ca0eb9dea2b544aa3d",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "2d33407b1c9924bf07d1135208672aafd5b140ea"
+                "reference": "f998a596650bf9c4ae0a8480d80a4e51161ab169"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/2d33407b1c9924bf07d1135208672aafd5b140ea.zip",
-                "reference": "2d33407b1c9924bf07d1135208672aafd5b140ea"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.3.zip",
+                "reference": "f998a596650bf9c4ae0a8480d80a4e51161ab169"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Updates the bundled Blocks Engine PHP transformer package from 0.1.2 to 0.1.3.
- Pulls in the latest raw HTML parity improvements from Blocks Engine PRs #58, #59, #60, and #61.
- Uses the released tag archive `php-transformer-v0.1.3` instead of a trunk commit zip for the php-transformer dependency.

## Corpus profile
Measured against /Users/chubes/Downloads/raw-html on merged Blocks Engine trunk:
- fixtures: 23
- statuses: 22 success_with_warnings, 1 success
- fallbacks: 191 -> 45
- html_asset_rows: 88 -> 0
- remaining fallback buckets: html_script_fallback 24, html_unsupported_element 20, html_form_fallback 1

Profile artifact: /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/raw-html-profile-blocks-trunk-wave2.json

## Testing
- `php tests/smoke-visual-repair-css.php`
- `php tests/smoke-importer-block.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Profiling raw HTML fixture parity, coordinating upstream transformer PRs, updating dependency metadata, running verification, and drafting this PR description.
