### PR TITLE
Fix Codebox preview URL extraction

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -490,20 +490,21 @@ function static_site_importer_rest_codebox_preview_input( array $request, array 
 	$import_args = isset( $request['import_args'] ) && is_array( $request['import_args'] ) ? $request['import_args'] : array();
 
 	$input = array(
-		'goal'               => __( 'Create a disposable WordPress preview for a Static Site Importer request.', 'static-site-importer' ),
-		'target'             => array(
+		'goal'                        => __( 'Create a disposable WordPress preview for a Static Site Importer request.', 'static-site-importer' ),
+		'include_raw_browser_session' => true,
+		'target'                      => array(
 			'kind' => 'static-site-importer-preview',
 			'ref'  => 'static-site-importer/importer',
 		),
-		'expected_artifacts' => array( 'preview', 'static-site-importer-report' ),
-		'context'            => array(
+		'expected_artifacts'          => array( 'preview', 'static-site-importer-report' ),
+		'context'                     => array(
 			'product'        => 'static-site-importer',
 			'request_schema' => (string) ( $request['schema'] ?? 'static-site-importer/preview-request/v1' ),
 			'request_id'     => (string) ( $request['request_id'] ?? '' ),
 			'source_url'     => isset( $source['url'] ) ? (string) $source['url'] : '',
 		),
-		'artifact_files'     => static_site_importer_rest_codebox_artifact_files( $artifact ),
-		'browser_runner'     => array(
+		'artifact_files'              => static_site_importer_rest_codebox_artifact_files( $artifact ),
+		'browser_runner'              => array(
 			'task_path'     => '/tmp/static-site-importer-preview-request.json',
 			'result_path'   => '/tmp/static-site-importer-preview-result.json',
 			'invocation'    => array(
@@ -525,7 +526,7 @@ function static_site_importer_rest_codebox_preview_input( array $request, array 
 				),
 			),
 		),
-		'orchestrator'       => array(
+		'orchestrator'                => array(
 			'type' => 'static-site-importer-preview',
 			'id'   => 'static-site-importer/importer',
 		),

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -459,6 +459,7 @@ $assert( true === ( $preview_response['success'] ?? null ), 'rest-preview-codebo
 $assert( 'https://preview.example.test/ssi' === ( $preview_response['preview']['url'] ?? '' ), 'rest-preview-contract-exposes-codebox-preview-url' );
 $assert( isset( $preview_response['preview']['playground']['blueprint_url'] ), 'rest-preview-contract-exposes-playground-blueprint-url' );
 $assert( 'static-site-importer/import-website-artifact' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['name'] ?? '' ), 'rest-preview-codebox-invokes-ssi-import-ability' );
+$assert( true === ( WP_Codebox_Abilities::$last_input['include_raw_browser_session'] ?? null ), 'rest-preview-codebox-requests-raw-session-for-blueprint-extraction' );
 $assert( isset( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact'] ), 'rest-preview-codebox-request-includes-artifact' );
 $assert( 'website/uploaded/site/index.html' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact']['files'][0]['path'] ?? '' ), 'rest-directory-path-is-normalized' );
 $assert( 'uploaded/site/index.html' === ( WP_Codebox_Abilities::$last_input['artifact_files'][0]['path'] ?? '' ), 'rest-preview-codebox-strips-website-prefix-for-browser-artifacts' );


### PR DESCRIPTION
## Summary
- request the raw WP Codebox browser session for SSI previews so SSI can extract preview and Playground blueprint URLs
- add smoke coverage asserting the preview request asks Codebox for the raw session contract

## Testing
- php tests/smoke-importer-block.php
- composer validate
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Figma runner/Codebox preview contract mismatch, drafting the patch, and running verification.