### PR TITLE
Fix Playground current runtime generation

### DIFF
--- a/blocks/importer/block.json
+++ b/blocks/importer/block.json
@@ -25,6 +25,10 @@
     "applyToCurrentSite": {
       "type": "boolean",
       "default": false
+    },
+    "generateInCurrentRuntime": {
+      "type": "boolean",
+      "default": false
     }
   },
   "editorScript": "file:./editor.js",

--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -256,6 +256,8 @@
 			const uploadInputs = root.querySelectorAll( '[data-static-site-importer-source-files], [data-static-site-importer-source-directory]' );
 			const provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
 			const applyToCurrentSite = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
+			const generateInCurrentRuntime = root.getAttribute( 'data-static-site-importer-generate-in-current-runtime' ) === '1';
+			const shouldApplyToCurrentSite = applyToCurrentSite || generateInCurrentRuntime;
 			const source = {
 				url: form ? form.getAttribute( 'data-static-site-importer-default-url' ) || '' : '',
 				html: html ? html.value : '',
@@ -269,7 +271,7 @@
 				return;
 			}
 
-			showStatus( root, applyToCurrentSite ? 'Importing to this site...' : 'Creating WordPress preview...' );
+			showStatus( root, applyToCurrentSite ? 'Importing to this site...' : 'Generating WordPress website...' );
 			submit.disabled = true;
 
 			try {
@@ -284,16 +286,17 @@
 					body: JSON.stringify( {
 						provider,
 						source,
-						apply_to_current_site: applyToCurrentSite,
-						activate: applyToCurrentSite,
-						overwrite: applyToCurrentSite,
+						apply_to_current_site: shouldApplyToCurrentSite,
+						activate: shouldApplyToCurrentSite,
+						overwrite: shouldApplyToCurrentSite,
+						generate_in_current_runtime: generateInCurrentRuntime,
 					} ),
 				} );
 				const report = await response.json();
 				setReport( root, report );
 				setPreviewLink( root, report );
-				if ( response.ok && applyToCurrentSite && report.success ) {
-					showStatus( root, 'Import complete.' );
+				if ( response.ok && shouldApplyToCurrentSite && report.success ) {
+					showStatus( root, applyToCurrentSite ? 'Import complete.' : 'WordPress website generated.' );
 				} else if ( response.ok && previewUrl( report ) ) {
 					showStatus( root, 'Preview ready.' );
 				} else if ( response.ok && report.preview && report.preview.status === 'unavailable' ) {

--- a/docs/playground/blueprint.json
+++ b/docs/playground/blueprint.json
@@ -25,7 +25,7 @@
     },
     {
       "step": "runPHP",
-    "code": "<?php require_once '/wordpress/wp-load.php';\n$page = get_page_by_path( 'import', OBJECT, 'page' );\n$content = '<!-- wp:static-site-importer/importer {\"title\":\"Import HTML to WordPress\",\"intro\":\"Upload a website or paste HTML. Static Site Importer will generate your new WordPress website.\",\"applyToCurrentSite\":false} /-->';\n$post = array(\n    'post_title' => 'Import Static Site',\n    'post_name' => 'import',\n    'post_type' => 'page',\n    'post_status' => 'publish',\n    'post_content' => $content,\n    'comment_status' => 'closed',\n    'ping_status' => 'closed',\n);\nif ( $page instanceof WP_Post ) {\n    $post['ID'] = $page->ID;\n    wp_update_post( $post );\n} else {\n    wp_insert_post( $post );\n}\nupdate_option( 'static_site_importer_protected_pages', array( 'import' ), false );\n?>"
+    "code": "<?php require_once '/wordpress/wp-load.php';\n$page = get_page_by_path( 'import', OBJECT, 'page' );\n$content = '<!-- wp:static-site-importer/importer {\"title\":\"Import HTML to WordPress\",\"intro\":\"Upload a website or paste HTML. Static Site Importer will generate your new WordPress website.\",\"applyToCurrentSite\":false,\"generateInCurrentRuntime\":true} /-->';\n$post = array(\n    'post_title' => 'Import Static Site',\n    'post_name' => 'import',\n    'post_type' => 'page',\n    'post_status' => 'publish',\n    'post_content' => $content,\n    'comment_status' => 'closed',\n    'ping_status' => 'closed',\n);\nif ( $page instanceof WP_Post ) {\n    $post['ID'] = $page->ID;\n    wp_update_post( $post );\n} else {\n    wp_insert_post( $post );\n}\nupdate_option( 'static_site_importer_protected_pages', array( 'import' ), false );\n?>"
     }
   ]
 }

--- a/includes/block.php
+++ b/includes/block.php
@@ -35,11 +35,12 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 	$provider    = isset( $attributes['provider'] ) ? sanitize_key( (string) $attributes['provider'] ) : '';
 	$default_url = isset( $attributes['defaultUrl'] ) ? esc_url_raw( (string) $attributes['defaultUrl'] ) : '';
 	$apply       = ! empty( $attributes['applyToCurrentSite'] );
+	$runtime     = ! empty( $attributes['generateInCurrentRuntime'] );
 	$button_text = $apply ? __( 'Import to this site', 'static-site-importer' ) : __( 'Generate WordPress website', 'static-site-importer' );
 
 	ob_start();
 	?>
-	<div class="ssi-importer" data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>" data-static-site-importer-apply-to-current-site="<?php echo $apply ? '1' : '0'; ?>">
+	<div class="ssi-importer" data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>" data-static-site-importer-apply-to-current-site="<?php echo $apply ? '1' : '0'; ?>" data-static-site-importer-generate-in-current-runtime="<?php echo $runtime ? '1' : '0'; ?>">
 		<section class="ssi-importer__panel" aria-labelledby="ssi-importer-title">
 			<p class="ssi-importer__eyebrow"><?php esc_html_e( 'Static Site Importer', 'static-site-importer' ); ?></p>
 			<h1 id="ssi-importer-title" class="ssi-importer__title"><?php echo esc_html( $title ); ?></h1>

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -361,6 +361,7 @@ $assert( 'static-site-importer/importer' === ( $metadata['name'] ?? '' ), 'block
 $assert( 'Static Site Importer' === ( $metadata['title'] ?? '' ), 'block-title-is-product-name' );
 $assert( isset( $metadata['viewScript'] ), 'block-has-frontend-script' );
 $assert( false === ( $metadata['attributes']['applyToCurrentSite']['default'] ?? null ), 'block-defaults-to-preview-mode' );
+$assert( false === ( $metadata['attributes']['generateInCurrentRuntime']['default'] ?? null ), 'block-defaults-current-runtime-generation-off' );
 
 static_site_importer_register_block();
 
@@ -383,6 +384,7 @@ $assert( str_contains( $html, 'data-static-site-importer' ), 'render-has-root-ho
 $assert( str_contains( $html, 'data-static-site-importer-rest-url="https://example.test/wp-json/static-site-importer/v1/imports"' ), 'render-exposes-import-rest-route' );
 $assert( str_contains( $html, 'data-static-site-importer-provider="privateprovider"' ), 'render-sanitizes-provider' );
 $assert( str_contains( $html, 'data-static-site-importer-apply-to-current-site="1"' ), 'render-exposes-current-site-apply-flag' );
+$assert( str_contains( $html, 'data-static-site-importer-generate-in-current-runtime="0"' ), 'render-exposes-current-runtime-generation-flag' );
 $assert( ! str_contains( $html, 'data-static-site-importer-source-url' ), 'render-omits-url-input-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-default-url="https://example.com/source"' ), 'render-preserves-default-url-for-programmatic-use' );
 $assert( str_contains( $html, 'data-static-site-importer-source-files' ), 'render-has-file-input-hook' );
@@ -404,6 +406,7 @@ $assert( ! str_contains( $html, 'Import status' ), 'render-omits-import-status-s
 $assert( str_contains( $html, 'Import your site' ), 'render-uses-custom-title' );
 $assert( str_contains( $html, 'https://example.com/source' ), 'render-uses-default-url' );
 $assert( str_contains( static_site_importer_render_block(), 'Generate WordPress website' ), 'render-preview-mode-button-generates-wordpress-website' );
+$assert( str_contains( static_site_importer_render_block( array( 'generateInCurrentRuntime' => true ) ), 'data-static-site-importer-generate-in-current-runtime="1"' ), 'render-can-target-current-runtime-with-generate-label' );
 
 $view_js = file_get_contents( dirname( __DIR__ ) . '/blocks/importer/view.js' );
 $assert( is_string( $view_js ), 'view-js-readable' );
@@ -411,9 +414,10 @@ $assert( str_contains( $view_js, 'webkitRelativePath' ), 'view-preserves-directo
 $assert( str_contains( $view_js, 'data-static-site-importer-source-directory' ), 'view-reads-directory-upload-input' );
 $assert( str_contains( $view_js, 'webkitGetAsEntry' ), 'view-supports-dropped-directory-entries' );
 $assert( str_contains( $view_js, 'archive: await buildArchive( uploadInputs, root )' ), 'view-sends-zip-from-combined-upload-as-archive-payload' );
-$assert( str_contains( $view_js, 'apply_to_current_site: applyToCurrentSite' ), 'view-sends-current-site-apply-flag' );
-$assert( str_contains( $view_js, 'activate: applyToCurrentSite' ), 'view-activates-current-site-imports' );
-$assert( str_contains( $view_js, 'overwrite: applyToCurrentSite' ), 'view-overwrites-current-site-imports' );
+$assert( str_contains( $view_js, 'apply_to_current_site: shouldApplyToCurrentSite' ), 'view-sends-current-runtime-apply-flag' );
+$assert( str_contains( $view_js, 'activate: shouldApplyToCurrentSite' ), 'view-activates-current-runtime-generation' );
+$assert( str_contains( $view_js, 'overwrite: shouldApplyToCurrentSite' ), 'view-overwrites-current-runtime-generation' );
+$assert( str_contains( $view_js, 'generate_in_current_runtime: generateInCurrentRuntime' ), 'view-sends-current-runtime-generation-flag' );
 $generic_preview_message = implode( ' ', array( 'no', 'preview', 'provider', 'is', 'configured' ) );
 $assert( ! str_contains( $view_js, $generic_preview_message ), 'view-does-not-reference-generic-preview-message' );
 $assert( str_contains( $view_js, 'Open WordPress preview' ) || str_contains( $html, 'Open WordPress preview' ), 'view-or-render-has-preview-link-label' );
@@ -576,6 +580,7 @@ $assert( str_contains( $blueprint_code, 'static-site-importer/importer' ), 'play
 $assert( str_contains( $blueprint_code, '"title":"Import HTML to WordPress"' ), 'playground-blueprint-uses-import-html-title' );
 $assert( str_contains( $blueprint_code, '"intro":"Upload a website or paste HTML. Static Site Importer will generate your new WordPress website."' ), 'playground-blueprint-uses-generate-website-copy' );
 $assert( str_contains( $blueprint_code, '"applyToCurrentSite":false' ), 'playground-blueprint-generates-wordpress-website' );
+$assert( str_contains( $blueprint_code, '"generateInCurrentRuntime":true' ), 'playground-blueprint-targets-current-runtime-generation' );
 $assert( str_contains( $blueprint_code, 'static_site_importer_protected_pages' ), 'playground-blueprint-protects-import-page' );
 $plugin_step = $blueprint['steps'][1] ?? array();
 $assert( 'https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip' === ( $plugin_step['pluginData']['url'] ?? '' ), 'playground-blueprint-installs-packaged-release' );


### PR DESCRIPTION
## Summary
- add a block flag for generating inside the current disposable Playground runtime
- keep the public Playground CTA as `Generate WordPress website` while sending current-site generation flags under the hood
- update the README Playground blueprint and smoke coverage for the runtime flag

## Testing
- `php tests/smoke-importer-block.php`
- `node --check blocks/importer/view.js`
- `php -l includes/block.php`
- `php -r '$json = json_decode(file_get_contents("docs/playground/blueprint.json"), true); if (JSON_ERROR_NONE !== json_last_error()) { fwrite(STDERR, json_last_error_msg() . PHP_EOL); exit(1); } echo "blueprint json ok\n";'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the current-runtime generation flag, updating tests, and running focused verification.