### PR TITLE
Enable Codebox prepared previews

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -500,6 +500,12 @@ function static_site_importer_rest_codebox_preview_input( array $request, array 
 			'source_url'     => isset( $source['url'] ) ? (string) $source['url'] : '',
 		),
 		'artifact_files'              => static_site_importer_rest_codebox_artifact_files( $artifact ),
+		'runtime'                     => array(
+			'prepared_runtime' => array(
+				'enabled'   => true,
+				'cache_key' => 'static-site-importer-preview',
+			),
+		),
 		'browser_runner'              => array(
 			'task_path'     => '/tmp/static-site-importer-preview-request.json',
 			'result_path'   => '/tmp/static-site-importer-preview-result.json',

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -460,6 +460,8 @@ $assert( 'https://preview.example.test/ssi' === ( $preview_response['preview']['
 $assert( isset( $preview_response['preview']['playground']['blueprint_url'] ), 'rest-preview-contract-exposes-playground-blueprint-url' );
 $assert( 'static-site-importer/import-website-artifact' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['name'] ?? '' ), 'rest-preview-codebox-invokes-ssi-import-ability' );
 $assert( true === ( WP_Codebox_Abilities::$last_input['include_raw_browser_session'] ?? null ), 'rest-preview-codebox-requests-raw-session-for-blueprint-extraction' );
+$assert( true === ( WP_Codebox_Abilities::$last_input['runtime']['prepared_runtime']['enabled'] ?? null ), 'rest-preview-codebox-enables-prepared-runtime-for-blueprint-ref' );
+$assert( 'static-site-importer-preview' === ( WP_Codebox_Abilities::$last_input['runtime']['prepared_runtime']['cache_key'] ?? '' ), 'rest-preview-codebox-uses-stable-prepared-runtime-cache-key' );
 $assert( isset( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact'] ), 'rest-preview-codebox-request-includes-artifact' );
 $assert( 'website/uploaded/site/index.html' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact']['files'][0]['path'] ?? '' ), 'rest-directory-path-is-normalized' );
 $assert( 'uploaded/site/index.html' === ( WP_Codebox_Abilities::$last_input['artifact_files'][0]['path'] ?? '' ), 'rest-preview-codebox-strips-website-prefix-for-browser-artifacts' );


### PR DESCRIPTION
## Summary
- opt SSI Codebox previews into prepared runtime generation so WP Codebox can return a blueprint hydration ref
- keep the stable SSI preview cache key explicit in the Codebox request
- add smoke coverage for the prepared-runtime request contract

## Testing
- php tests/smoke-importer-block.php
- composer validate
- git diff --check
- verified locally via WP-CLI that enabling prepared runtime makes WP Codebox produce a Playground blueprint URL for SSI previews

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the remaining Codebox prepared-runtime contract gap, drafting the patch, and running verification.