### PR TITLE
Consume font materialization plans

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -160,7 +160,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		$writes = array_merge(
 			$stylesheet_writes,
-			Static_Site_Importer_Theme_Materializer::base_theme_writes( $theme_dir, $theme_slug, $theme_name, $materialized['css'], $has_header_part, $has_footer_part, $materialized['scripts'] )
+			Static_Site_Importer_Theme_Materializer::base_theme_writes( $theme_dir, $theme_slug, $theme_name, $materialized['css'], $has_header_part, $has_footer_part, $materialized['scripts'], $materialized['stylesheets'] )
 		);
 		$writes = array_merge( $writes, $template_part_writes );
 		$result         = Static_Site_Importer_Page_Materializer::write_page_contents( $document_pages, $page_ids, $page_artifacts['contents'] );
@@ -1409,7 +1409,7 @@ class Static_Site_Importer_Theme_Generator {
 	 *
 	 * @param string              $theme_dir Theme directory.
 	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
-	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>}|WP_Error
+	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>,stylesheets:array<int,array<string,mixed>>}|WP_Error
 	 */
 	private static function materialize_website_artifact_files_to_theme( string $theme_dir, array $artifacts ) {
 		$result = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files( $theme_dir, self::$active_theme_uri, $artifacts );
@@ -1421,10 +1421,11 @@ class Static_Site_Importer_Theme_Generator {
 			self::$conversion_report['diagnostics'][] = $diagnostic;
 		}
 		return array(
-			'css'     => $result['css'],
-			'js'      => $result['js'],
-			'assets'  => $result['assets'],
-			'scripts' => $result['scripts'],
+			'css'         => $result['css'],
+			'js'          => $result['js'],
+			'assets'      => $result['assets'],
+			'scripts'     => isset( $result['scripts'] ) && is_array( $result['scripts'] ) ? $result['scripts'] : array(),
+			'stylesheets' => isset( $result['stylesheets'] ) && is_array( $result['stylesheets'] ) ? $result['stylesheets'] : array(),
 		);
 	}
 

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -23,12 +23,13 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @param string $css             Source CSS.
 	 * @param bool   $has_header_part Whether a header template part exists.
 	 * @param bool   $has_footer_part Whether a footer template part exists.
-	 * @param array<int,array<string,mixed>> $scripts Materialized script asset rows.
+	 * @param array<int,array<string,mixed>> $scripts     Materialized script asset rows.
+	 * @param array<int,array<string,mixed>> $stylesheets Materialized stylesheet asset rows.
 	 * @return array<string,string> Absolute write paths mapped to file contents.
 	 */
-	public static function base_theme_writes( string $theme_dir, string $theme_slug, string $theme_name, string $css, bool $has_header_part, bool $has_footer_part, array $scripts = array() ): array {
+	public static function base_theme_writes( string $theme_dir, string $theme_slug, string $theme_name, string $css, bool $has_header_part, bool $has_footer_part, array $scripts = array(), array $stylesheets = array() ): array {
 		return array(
-			$theme_dir . '/functions.php'             => self::functions_php( $theme_slug, $scripts ),
+			$theme_dir . '/functions.php'             => self::functions_php( $theme_slug, $scripts, $stylesheets ),
 			$theme_dir . '/theme.json'                => self::theme_json( $theme_name, $css ),
 			$theme_dir . '/templates/front-page.html' => self::content_template( '', $has_header_part, $has_footer_part ),
 			$theme_dir . '/templates/page.html'       => self::content_template( '', $has_header_part, $has_footer_part ),
@@ -97,7 +98,7 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @param string              $theme_dir Theme directory.
 	 * @param string              $theme_uri Theme URI.
 	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
-	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|WP_Error
+	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>,stylesheets:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|WP_Error
 	 */
 	public static function materialize_website_artifact_files( string $theme_dir, string $theme_uri, array $artifacts ) {
 		$native_plan = self::materialize_materialization_plan_assets( $theme_dir, $theme_uri, $artifacts );
@@ -170,6 +171,7 @@ class Static_Site_Importer_Theme_Materializer {
 			'js'          => '',
 			'assets'      => $assets,
 			'scripts'     => array(),
+			'stylesheets' => array(),
 			'diagnostics' => $diagnostics,
 		);
 	}
@@ -180,7 +182,7 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @param string              $theme_dir Theme directory.
 	 * @param string              $theme_uri Theme URI.
 	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
-	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|null|WP_Error
+	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>,stylesheets:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|null|WP_Error
 	 */
 	private static function materialize_materialization_plan_assets( string $theme_dir, string $theme_uri, array $artifacts ) {
 		$site = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
@@ -199,6 +201,7 @@ class Static_Site_Importer_Theme_Materializer {
 		$css         = array();
 		$assets      = array();
 		$scripts     = array();
+		$stylesheets = array();
 		$diagnostics = array();
 		$order       = 0;
 
@@ -252,13 +255,91 @@ class Static_Site_Importer_Theme_Materializer {
 			}
 		}
 
+		$font_stylesheets = self::materialize_font_materialization_stylesheets( $theme_dir, $theme_uri, $site, $assets, $order );
+		if ( is_wp_error( $font_stylesheets ) ) {
+			return $font_stylesheets;
+		}
+		$stylesheets = array_merge( $stylesheets, $font_stylesheets );
+
 		return array(
 			'css'         => trim( implode( "\n\n", array_filter( self::rewrite_materialized_css_chunks( $css, $assets ) ) ) ),
 			'js'          => '',
 			'assets'      => $assets,
 			'scripts'     => $scripts,
+			'stylesheets' => $stylesheets,
 			'diagnostics' => $diagnostics,
 		);
+	}
+
+	/**
+	 * Write theme font materialization stylesheet rows declared by Blocks Engine.
+	 *
+	 * @param string                            $theme_dir Theme directory.
+	 * @param string                            $theme_uri Theme URI.
+	 * @param array<string,mixed>               $site      Materialization plan site artifact.
+	 * @param array<string,array<string,mixed>> $assets    Materialized asset rows keyed by source path.
+	 * @param int                               $order     Current materialization order.
+	 * @return array<int,array<string,mixed>>|WP_Error
+	 */
+	private static function materialize_font_materialization_stylesheets( string $theme_dir, string $theme_uri, array $site, array &$assets, int &$order ) {
+		$theme = isset( $site['theme'] ) && is_array( $site['theme'] ) ? $site['theme'] : array();
+		$plan  = isset( $theme['font_materialization'] ) && is_array( $theme['font_materialization'] ) ? $theme['font_materialization'] : array();
+		if ( 'blocks-engine/php-transformer/font-materialization-plan/v1' !== (string) ( $plan['schema'] ?? '' ) ) {
+			return array();
+		}
+
+		$rows = isset( $plan['stylesheets'] ) && is_array( $plan['stylesheets'] ) ? $plan['stylesheets'] : array();
+		if ( empty( $rows ) && isset( $plan['css'] ) && is_scalar( $plan['css'] ) && '' !== trim( (string) $plan['css'] ) ) {
+			$rows[] = array(
+				'path'      => 'assets/css/fonts.css',
+				'role'      => 'stylesheet',
+				'mime_type' => 'text/css',
+				'content'   => trim( (string) $plan['css'] ) . "\n",
+			);
+		}
+
+		$stylesheets = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				return new WP_Error( 'static_site_importer_font_materialization_stylesheet_invalid', 'Blocks Engine font_materialization.stylesheets entries must be arrays.' );
+			}
+
+			$relative = self::normalize_artifact_materialization_path( isset( $row['path'] ) && is_scalar( $row['path'] ) ? (string) $row['path'] : '' );
+			if ( '' === $relative ) {
+				return new WP_Error( 'static_site_importer_font_materialization_stylesheet_path_invalid', 'Blocks Engine font_materialization.stylesheets entries must include safe relative paths.' );
+			}
+
+			$content = isset( $row['content'] ) && is_scalar( $row['content'] ) ? (string) $row['content'] : '';
+			if ( '' === trim( $content ) ) {
+				continue;
+			}
+
+			$target = trailingslashit( $theme_dir ) . $relative;
+			$dir    = dirname( $target );
+			if ( ! wp_mkdir_p( $dir ) ) {
+				return new WP_Error( 'static_site_importer_font_materialization_stylesheet_mkdir_failed', sprintf( 'Failed to create font materialization stylesheet directory: %s', $dir ) );
+			}
+
+			$result = self::write_file( $target, $content );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			++$order;
+			$asset = array_merge(
+				$row,
+				array(
+					'path'   => $relative,
+					'role'   => isset( $row['role'] ) && is_scalar( $row['role'] ) ? (string) $row['role'] : 'stylesheet',
+					'kind'   => isset( $row['kind'] ) && is_scalar( $row['kind'] ) ? (string) $row['kind'] : 'css',
+					'origin' => 'theme.font_materialization',
+				)
+			);
+			$assets[ $relative ] = self::materialization_plan_asset_report( $asset, $relative, trailingslashit( $theme_uri ) . $relative, $relative, self::mime_type( $target ), $order );
+			$stylesheets[]       = $assets[ $relative ];
+		}
+
+		return $stylesheets;
 	}
 
 	/**
@@ -274,6 +355,7 @@ class Static_Site_Importer_Theme_Materializer {
 	 */
 	private static function materialization_plan_asset_report( array $asset, string $relative, string $url, string $target_relative, string $fallback_mime, int $order ): array {
 		$mime_type = isset( $asset['mime_type'] ) && is_scalar( $asset['mime_type'] ) && '' !== (string) $asset['mime_type'] ? (string) $asset['mime_type'] : $fallback_mime;
+		$origin    = isset( $asset['origin'] ) && is_scalar( $asset['origin'] ) && '' !== (string) $asset['origin'] ? (string) $asset['origin'] : 'materialization_plan.assets';
 		$report    = array(
 			'source'     => $relative,
 			'path'       => $relative,
@@ -282,7 +364,7 @@ class Static_Site_Importer_Theme_Materializer {
 			'mime_type'  => $mime_type,
 			'theme_path' => $target_relative,
 			'policy'     => 'theme',
-			'origin'     => 'materialization_plan.assets',
+			'origin'     => $origin,
 			'order'      => $order,
 		);
 
@@ -650,14 +732,35 @@ class Static_Site_Importer_Theme_Materializer {
 	 * Build functions.php.
 	 *
 	 * @param string $theme_slug Theme slug.
-	 * @param array<int,array<string,mixed>> $scripts Materialized script asset rows.
+	 * @param array<int,array<string,mixed>> $scripts     Materialized script asset rows.
+	 * @param array<int,array<string,mixed>> $stylesheets Materialized stylesheet asset rows.
 	 * @return string
 	 */
-	private static function functions_php( string $theme_slug, array $scripts = array() ): string {
-		$style_handle  = sanitize_key( $theme_slug ) . '-style';
-		$editor_handle = sanitize_key( $theme_slug ) . '-editor-style';
-		$script_handle = sanitize_key( $theme_slug ) . '-site';
-		$script_lines  = '';
+	private static function functions_php( string $theme_slug, array $scripts = array(), array $stylesheets = array() ): string {
+		$style_handle     = sanitize_key( $theme_slug ) . '-style';
+		$editor_handle    = sanitize_key( $theme_slug ) . '-editor-style';
+		$script_handle    = sanitize_key( $theme_slug ) . '-site';
+		$script_lines     = '';
+		$stylesheet_lines = '';
+		$stylesheet_deps  = array();
+
+		foreach ( $stylesheets as $stylesheet ) {
+			if ( ! is_array( $stylesheet ) || ! isset( $stylesheet['theme_path'] ) || ! is_scalar( $stylesheet['theme_path'] ) ) {
+				continue;
+			}
+
+			$theme_path = self::normalize_artifact_materialization_path( (string) $stylesheet['theme_path'] );
+			if ( '' === $theme_path ) {
+				continue;
+			}
+
+			$handle             = sanitize_key( $theme_slug . '-asset-' . preg_replace( '/\.[^.]+$/', '', str_replace( '/', '-', $theme_path ) ) );
+			$stylesheet_deps[]  = $handle;
+			$stylesheet_lines  .= "\twp_enqueue_style( " . var_export( $handle, true ) . ", get_template_directory_uri() . " . var_export( '/' . $theme_path, true ) . ", array(), wp_get_theme()->get( 'Version' )";
+			$media              = isset( $stylesheet['media'] ) && is_scalar( $stylesheet['media'] ) && '' !== (string) $stylesheet['media'] ? (string) $stylesheet['media'] : '';
+			$stylesheet_lines  .= '' !== $media ? ', ' . var_export( $media, true ) . " );\n" : " );\n";
+		}
+		$stylesheet_dependencies = empty( $stylesheet_deps ) ? 'array()' : var_export( $stylesheet_deps, true );
 
 		foreach ( $scripts as $script ) {
 			if ( ! isset( $script['theme_path'] ) || ! is_scalar( $script['theme_path'] ) ) {
@@ -696,14 +799,16 @@ class Static_Site_Importer_Theme_Materializer {
 			"\tadd_editor_style( 'assets/css/editor-style.css' );\n" .
 			"} );\n\n" .
 			"add_action( 'wp_enqueue_scripts', static function (): void {\n" .
-			"\twp_enqueue_style( '" . $style_handle . "', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );\n" .
+			$stylesheet_lines .
+			"\twp_enqueue_style( '" . $style_handle . "', get_stylesheet_uri(), " . $stylesheet_dependencies . ", wp_get_theme()->get( 'Version' ) );\n" .
 			"\tif ( file_exists( get_template_directory() . '/assets/site.js' ) ) {\n" .
 			"\t\twp_enqueue_script( '" . $script_handle . "', get_template_directory_uri() . '/assets/site.js', array(), wp_get_theme()->get( 'Version' ), true );\n" .
 			"\t}\n" .
 			$script_lines .
 			"} );\n\n" .
 			"add_action( 'enqueue_block_editor_assets', static function (): void {\n" .
-			"\twp_enqueue_style( '" . $editor_handle . "', get_template_directory_uri() . '/assets/css/editor-style.css', array(), wp_get_theme()->get( 'Version' ) );\n" .
+			$stylesheet_lines .
+			"\twp_enqueue_style( '" . $editor_handle . "', get_template_directory_uri() . '/assets/css/editor-style.css', " . $stylesheet_dependencies . ", wp_get_theme()->get( 'Version' ) );\n" .
 			"} );\n";
 	}
 

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -397,6 +397,20 @@ $asset_result    = Static_Site_Importer_Theme_Materializer::materialize_website_
 	array(
 		'site'  => array(
 			'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'theme'  => array(
+				'font_materialization' => array(
+					'schema'      => 'blocks-engine/php-transformer/font-materialization-plan/v1',
+					'provider'    => 'google_fonts',
+					'stylesheets' => array(
+						array(
+							'path'      => 'assets/css/fonts.css',
+							'role'      => 'stylesheet',
+							'mime_type' => 'text/css',
+							'content'   => '@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap");' . "\n",
+						),
+					),
+				),
+			),
 			'assets' => array(
 				array(
 					'path'    => 'assets/site.css',
@@ -461,12 +475,18 @@ $assert( file_exists( $asset_theme_dir . '/assets/materialized/fonts/native.woff
 $assert( ! file_exists( $asset_theme_dir . '/assets/materialized/website/3-artist-music/merch.html' ), 'materialization-plan-html-document-is-not-written-as-asset' );
 $assert( 'materialization_plan.assets' === ( $asset_result['assets']['assets/logo.png']['origin'] ?? '' ), 'materialization-plan-asset-origin-is-reported' );
 $assert( ! isset( $asset_result['assets']['website/3-artist-music/merch.html'] ), 'materialization-plan-html-document-is-not-reported-as-asset' );
+$assert( file_exists( $asset_theme_dir . '/assets/css/fonts.css' ), 'font-materialization-stylesheet-is-written' );
+$assert( str_contains( (string) file_get_contents( $asset_theme_dir . '/assets/css/fonts.css' ), 'fonts.googleapis.com/css2?family=Open+Sans' ), 'font-materialization-preserves-google-font-import' );
+$assert( 'theme.font_materialization' === ( $asset_result['assets']['assets/css/fonts.css']['origin'] ?? '' ), 'font-materialization-origin-is-reported' );
+$assert( 'assets/css/fonts.css' === ( $asset_result['assets']['assets/css/fonts.css']['theme_path'] ?? '' ), 'font-materialization-theme-path-is-not-nested' );
 $assert( str_ends_with( (string) ( $asset_result['assets']['assets/logo.png']['final_url'] ?? '' ), '/assets/materialized/assets/logo.png' ), 'materialization-plan-asset-final-url-shape' );
+$assert( str_ends_with( (string) ( $asset_result['assets']['assets/css/fonts.css']['final_url'] ?? '' ), '/assets/css/fonts.css' ), 'font-materialization-final-url-shape' );
 $assert( 'screen' === ( $asset_result['assets']['assets/site.css']['media'] ?? '' ), 'materialization-plan-style-metadata-is-preserved' );
 $assert( 'font' === ( $asset_result['assets']['fonts/native.woff2']['role'] ?? '' ), 'materialization-plan-font-role-is-preserved' );
 $assert( 'font/woff2' === ( $asset_result['assets']['fonts/native.woff2']['mime_type'] ?? '' ), 'materialization-plan-font-mime-is-preserved' );
 $assert( '' === (string) ( $asset_result['js'] ?? '' ), 'materialization-plan-scripts-are-not-concatenated' );
 $assert( 2 === count( $asset_result['scripts'] ?? array() ), 'materialization-plan-script-rows-are-preserved' );
+$assert( 1 === count( $asset_result['stylesheets'] ?? array() ), 'font-materialization-stylesheet-row-is-preserved' );
 $assert( 'assets/app.js' === ( $asset_result['scripts'][0]['path'] ?? '' ), 'materialization-plan-script-order-first' );
 $assert( 'assets/vendor.js' === ( $asset_result['scripts'][1]['path'] ?? '' ), 'materialization-plan-script-order-second' );
 $assert( true === ( $asset_result['scripts'][0]['defer'] ?? false ), 'materialization-plan-script-defer-is-preserved' );
@@ -499,8 +519,11 @@ $assert( str_contains( $rewritten_content, 'href="https://example.test/merch/"' 
 $assert( ! str_contains( $rewritten_content, 'href="https://example.test/wp-content/themes/generated/assets/materialized/website/3-artist-music/merch.html"' ), 'html-page-link-does-not-rewrite-to-materialized-html-asset' );
 $assert( str_contains( $rewritten_content, 'src="https://example.test/wp-content/themes/generated/assets/materialized/website/3-artist-music/assets/logo.png"' ), 'non-html-asset-link-still-rewrites-to-materialized-asset' );
 
-$base_writes   = Static_Site_Importer_Theme_Materializer::base_theme_writes( $asset_theme_dir, 'fixture-theme', 'Fixture Theme', (string) $asset_result['css'], false, false, $asset_result['scripts'] );
+$base_writes   = Static_Site_Importer_Theme_Materializer::base_theme_writes( $asset_theme_dir, 'fixture-theme', 'Fixture Theme', (string) $asset_result['css'], false, false, $asset_result['scripts'], $asset_result['stylesheets'] );
 $functions_php = (string) ( $base_writes[ $asset_theme_dir . '/functions.php' ] ?? '' );
+$assert( str_contains( $functions_php, '/assets/css/fonts.css' ), 'font-materialization-stylesheet-is-enqueued' );
+$assert( str_contains( $functions_php, "wp_enqueue_style( 'fixture-theme-style', get_stylesheet_uri(), array (\n  0 => 'fixture-theme-asset-assets-css-fonts',\n), wp_get_theme()->get( 'Version' ) );" ), 'theme-style-depends-on-font-materialization-stylesheet' );
+$assert( str_contains( $functions_php, "wp_enqueue_style( 'fixture-theme-editor-style', get_template_directory_uri() . '/assets/css/editor-style.css', array (\n  0 => 'fixture-theme-asset-assets-css-fonts',\n), wp_get_theme()->get( 'Version' ) );" ), 'editor-style-depends-on-font-materialization-stylesheet' );
 $assert( str_contains( $functions_php, '/assets/materialized/assets/app.js' ), 'materialization-plan-script-is-enqueued' );
 $assert( str_contains( $functions_php, "wp_script_add_data( 'fixture-theme-asset-assets-materialized-assets-app', 'defer', true );" ), 'materialization-plan-script-defer-is-enqueued' );
 $assert( str_contains( $functions_php, "wp_script_add_data( 'fixture-theme-asset-assets-materialized-assets-app', 'type', 'module' );" ), 'materialization-plan-script-type-is-enqueued' );


### PR DESCRIPTION
## Summary
- consume Blocks Engine theme.font_materialization plans in generated themes
- write and report assets/css/fonts.css from font materialization stylesheets
- enqueue materialized font CSS before frontend and editor styles

## Testing
- php tests/smoke-visual-repair-css.php
- php -l includes/class-static-site-importer-theme-materializer.php
- php -l includes/class-static-site-importer-theme-generator.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implemented the font materialization consumption path and smoke test coverage.