### PR TITLE
Install SSI in Codebox previews

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -501,6 +501,15 @@ function static_site_importer_rest_codebox_preview_input( array $request, array 
 		),
 		'artifact_files'              => static_site_importer_rest_codebox_artifact_files( $artifact ),
 		'runtime'                     => array(
+			'plugins'          => array(
+				array_filter(
+					array(
+						'slug'     => 'static-site-importer',
+						'path'     => defined( 'STATIC_SITE_IMPORTER_PATH' ) ? STATIC_SITE_IMPORTER_PATH : '',
+						'activate' => true,
+					)
+				),
+			),
 			'prepared_runtime' => array(
 				'enabled'   => true,
 				'cache_key' => 'static-site-importer-preview',

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -466,6 +466,8 @@ $assert( 'static-site-importer/import-website-artifact' === ( WP_Codebox_Abiliti
 $assert( true === ( WP_Codebox_Abilities::$last_input['include_raw_browser_session'] ?? null ), 'rest-preview-codebox-requests-raw-session-for-blueprint-extraction' );
 $assert( true === ( WP_Codebox_Abilities::$last_input['runtime']['prepared_runtime']['enabled'] ?? null ), 'rest-preview-codebox-enables-prepared-runtime-for-blueprint-ref' );
 $assert( 'static-site-importer-preview' === ( WP_Codebox_Abilities::$last_input['runtime']['prepared_runtime']['cache_key'] ?? '' ), 'rest-preview-codebox-uses-stable-prepared-runtime-cache-key' );
+$assert( 'static-site-importer' === ( WP_Codebox_Abilities::$last_input['runtime']['plugins'][0]['slug'] ?? '' ), 'rest-preview-codebox-installs-ssi-runtime-plugin' );
+$assert( true === ( WP_Codebox_Abilities::$last_input['runtime']['plugins'][0]['activate'] ?? null ), 'rest-preview-codebox-activates-ssi-runtime-plugin' );
 $assert( isset( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact'] ), 'rest-preview-codebox-request-includes-artifact' );
 $assert( 'website/uploaded/site/index.html' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact']['files'][0]['path'] ?? '' ), 'rest-directory-path-is-normalized' );
 $assert( 'uploaded/site/index.html' === ( WP_Codebox_Abilities::$last_input['artifact_files'][0]['path'] ?? '' ), 'rest-preview-codebox-strips-website-prefix-for-browser-artifacts' );


### PR DESCRIPTION
## Summary
- include Static Site Importer itself in the WP Codebox runtime plugin list for previews
- activate the plugin inside the Playground before the browser runner invokes SSI import abilities
- add smoke coverage for the runtime plugin request contract

## Why
Figma previews were opening Playground successfully, but the imported site did not materialize. The hydrated Blueprint had the Codebox runner step, but the Playground site did not have Static Site Importer installed, so the `static-site-importer/import-website-artifact` ability was unavailable inside the runtime.

## Testing
- php tests/smoke-importer-block.php
- composer validate
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing Playground import dependency, drafting the runtime plugin request fix, and running verification.
