### PR TITLE
Skip non-site metadata during uploads

### DIFF
--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -34,6 +34,18 @@
 		return file.webkitRelativePath || file.name || 'upload';
 	};
 
+	const shouldIncludeSiteFile = function ( path ) {
+		const normalized = String( path || '' ).replace( /\\/g, '/' ).replace( /^\/+/, '' );
+		const parts = normalized.split( '/' ).filter( Boolean );
+		const name = parts.length ? parts[ parts.length - 1 ] : '';
+
+		if ( name === '.DS_Store' ) {
+			return false;
+		}
+
+		return ! ( name.toLowerCase() === 'result.json' && ! parts.includes( 'assets' ) );
+	};
+
 	const droppedFilesByRoot = new WeakMap();
 
 	const selectedInputFiles = function ( inputs, root ) {
@@ -115,7 +127,8 @@
 	const buildFiles = async function ( inputs, root ) {
 		const selectedFiles = selectedInputFiles( inputs, root );
 		const files = selectedFiles.filter( function ( record ) {
-			return ! /\.zip$/i.test( record.file.name || record.path || '' );
+			const path = record.path || uploadedFilePath( record.file );
+			return ! /\.zip$/i.test( record.file.name || path || '' ) && shouldIncludeSiteFile( path );
 		} );
 		return Promise.all( files.map( async function ( upload ) {
 			const file = upload.file;

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1034,6 +1034,10 @@ function static_site_importer_rest_source_artifact( array $source ) {
 				continue;
 			}
 
+			if ( ! static_site_importer_rest_should_include_artifact_file( $path ) ) {
+				continue;
+			}
+
 			if ( isset( $file['content'] ) ) {
 				$files[] = array(
 					'path'    => $path,
@@ -1126,6 +1130,10 @@ function static_site_importer_rest_archive_files( array $archive ) {
 			continue;
 		}
 
+		if ( ! static_site_importer_rest_should_include_artifact_file( $path ) ) {
+			continue;
+		}
+
 		$file_content = $zip->getFromIndex( $i );
 		if ( false === $file_content ) {
 			$zip->close();
@@ -1167,6 +1175,30 @@ function static_site_importer_rest_artifact_path( string $path ): string {
 	}
 
 	return str_starts_with( $path, 'website/' ) ? $path : 'website/' . $path;
+}
+
+/**
+ * Determine whether an uploaded artifact file belongs to the static site.
+ *
+ * @param string $path Normalized artifact path.
+ * @return bool
+ */
+function static_site_importer_rest_should_include_artifact_file( string $path ): bool {
+	$path  = str_replace( '\\', '/', $path );
+	$path  = preg_replace( '#/+#', '/', $path );
+	$path  = preg_replace( '#^website/#', '', ltrim( (string) $path, '/' ) );
+	$parts = array_values( array_filter( explode( '/', (string) $path ), 'strlen' ) );
+	$name  = end( $parts );
+
+	if ( false === $name ) {
+		return false;
+	}
+
+	if ( '.DS_Store' === $name ) {
+		return false;
+	}
+
+	return ! ( 'result.json' === strtolower( (string) $name ) && ! in_array( 'assets', $parts, true ) );
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -414,6 +414,7 @@ $assert( str_contains( $view_js, 'webkitRelativePath' ), 'view-preserves-directo
 $assert( str_contains( $view_js, 'data-static-site-importer-source-directory' ), 'view-reads-directory-upload-input' );
 $assert( str_contains( $view_js, 'webkitGetAsEntry' ), 'view-supports-dropped-directory-entries' );
 $assert( str_contains( $view_js, 'archive: await buildArchive( uploadInputs, root )' ), 'view-sends-zip-from-combined-upload-as-archive-payload' );
+$assert( str_contains( $view_js, 'shouldIncludeSiteFile' ), 'view-skips-known-non-site-upload-files-before-reading' );
 $assert( str_contains( $view_js, 'apply_to_current_site: shouldApplyToCurrentSite' ), 'view-sends-current-runtime-apply-flag' );
 $assert( str_contains( $view_js, 'activate: shouldApplyToCurrentSite' ), 'view-activates-current-runtime-generation' );
 $assert( str_contains( $view_js, 'overwrite: shouldApplyToCurrentSite' ), 'view-overwrites-current-runtime-generation' );
@@ -716,6 +717,40 @@ if ( class_exists( 'ZipArchive' ) ) {
 	$assert( in_array( 'website/site/index.html', $paths, true ), 'rest-zip-extracts-normalized-entry' );
 	$assert( in_array( 'website/escape.html', $paths, true ), 'rest-zip-strips-traversal-entry' );
 }
+
+$artifact = static_site_importer_rest_source_artifact(
+	array(
+		'files' => array(
+			array(
+				'path'    => 'index.html',
+				'content' => '<main>Site</main>',
+			),
+			array(
+				'path'    => 'result.json',
+				'content' => '{"figma":"metadata"}',
+			),
+			array(
+				'path'    => 'figma-export/result.json',
+				'content' => '{"figma":"metadata"}',
+			),
+			array(
+				'path'    => '.DS_Store',
+				'content' => 'macos',
+			),
+			array(
+				'path'    => 'assets/data.json',
+				'content' => '{"site":"data"}',
+			),
+		),
+	)
+);
+$assert( is_array( $artifact ), 'rest-artifact-skips-non-site-metadata-builds' );
+$paths = array_column( $artifact['files'] ?? array(), 'path' );
+$assert( in_array( 'website/index.html', $paths, true ), 'rest-artifact-keeps-html-file' );
+$assert( in_array( 'website/assets/data.json', $paths, true ), 'rest-artifact-keeps-site-json-asset' );
+$assert( ! in_array( 'website/result.json', $paths, true ), 'rest-artifact-skips-root-figma-result-json' );
+$assert( ! in_array( 'website/figma-export/result.json', $paths, true ), 'rest-artifact-skips-nested-figma-result-json' );
+$assert( ! in_array( 'website/.DS_Store', $paths, true ), 'rest-artifact-skips-macos-metadata-file' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( PHP_EOL, $failures ) . PHP_EOL );


### PR DESCRIPTION
## Summary
- skip known non-site metadata files before the importer reads/uploads dropped folders
- apply the same filtering when REST builds artifacts from direct file and ZIP payloads
- preserve normal site JSON assets under `assets/`

## Testing
- `php tests/smoke-importer-block.php`
- `php tests/smoke-visual-repair-css.php`
- `php -l includes/rest.php && php -l tests/smoke-importer-block.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Figma upload crash path, drafting the metadata filtering change, and adding smoke coverage.
