### PR TITLE
Fix release lint blockers

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1424,8 +1424,8 @@ class Static_Site_Importer_Theme_Generator {
 			'css'         => $result['css'],
 			'js'          => $result['js'],
 			'assets'      => $result['assets'],
-			'scripts'     => isset( $result['scripts'] ) && is_array( $result['scripts'] ) ? $result['scripts'] : array(),
-			'stylesheets' => isset( $result['stylesheets'] ) && is_array( $result['stylesheets'] ) ? $result['stylesheets'] : array(),
+			'scripts'     => $result['scripts'],
+			'stylesheets' => $result['stylesheets'],
 		);
 	}
 

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -326,7 +326,7 @@ class Static_Site_Importer_Theme_Materializer {
 			}
 
 			++$order;
-			$asset = array_merge(
+			$asset               = array_merge(
 				$row,
 				array(
 					'path'   => $relative,
@@ -745,7 +745,7 @@ class Static_Site_Importer_Theme_Materializer {
 		$stylesheet_deps  = array();
 
 		foreach ( $stylesheets as $stylesheet ) {
-			if ( ! is_array( $stylesheet ) || ! isset( $stylesheet['theme_path'] ) || ! is_scalar( $stylesheet['theme_path'] ) ) {
+			if ( ! isset( $stylesheet['theme_path'] ) || ! is_scalar( $stylesheet['theme_path'] ) ) {
 				continue;
 			}
 
@@ -754,12 +754,15 @@ class Static_Site_Importer_Theme_Materializer {
 				continue;
 			}
 
-			$handle             = sanitize_key( $theme_slug . '-asset-' . preg_replace( '/\.[^.]+$/', '', str_replace( '/', '-', $theme_path ) ) );
-			$stylesheet_deps[]  = $handle;
-			$stylesheet_lines  .= "\twp_enqueue_style( " . var_export( $handle, true ) . ", get_template_directory_uri() . " . var_export( '/' . $theme_path, true ) . ", array(), wp_get_theme()->get( 'Version' )";
-			$media              = isset( $stylesheet['media'] ) && is_scalar( $stylesheet['media'] ) && '' !== (string) $stylesheet['media'] ? (string) $stylesheet['media'] : '';
-			$stylesheet_lines  .= '' !== $media ? ', ' . var_export( $media, true ) . " );\n" : " );\n";
+			$handle            = sanitize_key( $theme_slug . '-asset-' . preg_replace( '/\.[^.]+$/', '', str_replace( '/', '-', $theme_path ) ) );
+			$stylesheet_deps[] = $handle;
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generates quoted PHP string literals for functions.php.
+			$stylesheet_lines .= "\twp_enqueue_style( " . var_export( $handle, true ) . ', get_template_directory_uri() . ' . var_export( '/' . $theme_path, true ) . ", array(), wp_get_theme()->get( 'Version' )";
+			$media             = isset( $stylesheet['media'] ) && is_scalar( $stylesheet['media'] ) && '' !== (string) $stylesheet['media'] ? (string) $stylesheet['media'] : '';
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generates quoted PHP string literals for functions.php.
+			$stylesheet_lines .= '' !== $media ? ', ' . var_export( $media, true ) . " );\n" : " );\n";
 		}
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generates quoted PHP array literals for functions.php.
 		$stylesheet_dependencies = empty( $stylesheet_deps ) ? 'array()' : var_export( $stylesheet_deps, true );
 
 		foreach ( $scripts as $script ) {

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1196,7 +1196,14 @@ function static_site_importer_rest_should_include_artifact_file( string $path ):
 	$path  = str_replace( '\\', '/', $path );
 	$path  = preg_replace( '#/+#', '/', $path );
 	$path  = preg_replace( '#^website/#', '', ltrim( (string) $path, '/' ) );
-	$parts = array_values( array_filter( explode( '/', (string) $path ), 'strlen' ) );
+	$parts = array_values(
+		array_filter(
+			explode( '/', (string) $path ),
+			static function ( string $part ): bool {
+				return '' !== $part;
+			}
+		)
+	);
 	$name  = end( $parts );
 
 	if ( false === $name ) {


### PR DESCRIPTION
## Summary
- clean up release lint findings introduced by the latest SSI changes
- use the now-exact materializer return shape instead of redundant guards
- annotate generated PHP string-literal exports used while building `functions.php`
- make uploaded artifact path filtering acceptable to PHPStan

## Testing
- `php tests/smoke-importer-block.php`
- `php tests/smoke-visual-repair-css.php`
- `php -l includes/rest.php && php -l includes/class-static-site-importer-theme-generator.php && php -l includes/class-static-site-importer-theme-materializer.php`
- `homeboy lint static-site-importer`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing and fixing release lint blockers after the SSI release preflight failed.
