### PR TITLE
Update Blocks Engine transformer to 0.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.3",
+        "version": "0.1.4",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "f998a596650bf9c4ae0a8480d80a4e51161ab169"
+          "reference": "9f9aa2b54ea80be05dda67b79b94e2074d24586a"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.3.zip",
-          "reference": "f998a596650bf9c4ae0a8480d80a4e51161ab169"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.4.zip",
+          "reference": "9f9aa2b54ea80be05dda67b79b94e2074d24586a"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.0",
-    "automattic/blocks-engine-php-transformer": "^0.1.3",
+    "automattic/blocks-engine-php-transformer": "^0.1.4",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53fe3861879514ca0eb9dea2b544aa3d",
+    "content-hash": "df47d6bf5569fabca58c91f19365423c",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "f998a596650bf9c4ae0a8480d80a4e51161ab169"
+                "reference": "9f9aa2b54ea80be05dda67b79b94e2074d24586a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.3.zip",
-                "reference": "f998a596650bf9c4ae0a8480d80a4e51161ab169"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.4.zip",
+                "reference": "9f9aa2b54ea80be05dda67b79b94e2074d24586a"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Update the packaged Blocks Engine PHP transformer dependency from 0.1.3 to 0.1.4.
- Refresh composer.lock to point at the php-transformer-v0.1.4 release tag.

## Testing
- php tests/smoke-importer-block.php
- php tests/smoke-visual-repair-css.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updating dependency metadata, running verification, and drafting this PR description.