### PR TITLE
Open Playground previews at artifact URL

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -755,7 +755,40 @@ function static_site_importer_rest_codebox_blueprint_url( array $session ): stri
 
 	$blueprint_endpoint = str_starts_with( $endpoint, 'http://' ) || str_starts_with( $endpoint, 'https://' ) ? $endpoint : rest_url( ltrim( $endpoint, '/' ) );
 
-	return esc_url_raw( 'https://playground.wordpress.net/?blueprint-url=' . rawurlencode( $blueprint_endpoint ) );
+	$playground = isset( $session['playground'] ) && is_array( $session['playground'] ) ? $session['playground'] : array();
+	$artifacts  = isset( $session['artifacts'] ) && is_array( $session['artifacts'] ) ? $session['artifacts'] : array();
+	$preview_url = static_site_importer_rest_codebox_relative_preview_path( (string) ( $playground['preview_url'] ?? $artifacts['preview_url'] ?? '' ) );
+	$url = 'https://playground.wordpress.net/?blueprint-url=' . rawurlencode( $blueprint_endpoint );
+	if ( '' !== $preview_url ) {
+		$url .= '&url=' . rawurlencode( $preview_url );
+	}
+
+	return esc_url_raw( $url );
+}
+
+/**
+ * Extract a Playground-local preview path for launch URLs.
+ *
+ * @param string $preview_url Preview URL from WP Codebox.
+ * @return string
+ */
+function static_site_importer_rest_codebox_relative_preview_path( string $preview_url ): string {
+	$preview_url = trim( $preview_url );
+	if ( '' === $preview_url ) {
+		return '';
+	}
+
+	if ( str_starts_with( $preview_url, '/' ) && ! str_starts_with( $preview_url, '//' ) ) {
+		return $preview_url;
+	}
+
+	$path = wp_parse_url( $preview_url, PHP_URL_PATH );
+	if ( ! is_string( $path ) || '' === $path ) {
+		return '';
+	}
+
+	$query = wp_parse_url( $preview_url, PHP_URL_QUERY );
+	return $path . ( is_string( $query ) && '' !== $query ? '?' . $query : '' );
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -463,6 +463,9 @@ $preview_response = static_site_importer_rest_create_import(
 $assert( true === ( $preview_response['success'] ?? null ), 'rest-preview-codebox-result-succeeds' );
 $assert( 'https://preview.example.test/ssi' === ( $preview_response['preview']['url'] ?? '' ), 'rest-preview-contract-exposes-codebox-preview-url' );
 $assert( isset( $preview_response['preview']['playground']['blueprint_url'] ), 'rest-preview-contract-exposes-playground-blueprint-url' );
+$preview_blueprint_url_parts = wp_parse_url( (string) $preview_response['preview']['playground']['blueprint_url'] );
+parse_str( (string) ( $preview_blueprint_url_parts['query'] ?? '' ), $preview_blueprint_url_query );
+$assert( '/?preview=1' === ( $preview_blueprint_url_query['url'] ?? '' ), 'rest-preview-playground-url-lands-on-relative-preview-path' );
 $assert( 'function' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['type'] ?? '' ), 'rest-preview-codebox-invokes-ssi-import-function-type' );
 $assert( 'static_site_importer_ability_import_website_artifact' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['name'] ?? '' ), 'rest-preview-codebox-invokes-ssi-import-function' );
 $assert( true === ( WP_Codebox_Abilities::$last_input['include_raw_browser_session'] ?? null ), 'rest-preview-codebox-requests-raw-session-for-blueprint-extraction' );


### PR DESCRIPTION
## Summary
- Append Playground’s `url` launch parameter when WP Codebox returns a relative preview artifact path.
- Preserve the existing encoded `blueprint-url` setup parameter while sending users directly to the generated artifact page.
- Add smoke coverage so relative preview paths are exposed in the Playground launch URL.

## Verification
- `php -l includes/rest.php`
- `php tests/smoke-importer-block.php`
- Installed the patched plugin on the local `wordpress-importer-test` Studio site.
- Posted the saved Fisiostetic Figma artifact bundle to `http://localhost:8882/wp-json/static-site-importer/v1/import-figma`.
- Verified the returned `open_url` has exactly outer query params `blueprint-url,url`, retains `_wpnonce` inside the decoded blueprint URL, and uses `url=/wp-content/uploads/wp-codebox/artifacts/index.html`.
- Hydrated and ran the returned Playground blueprint successfully with `npx --yes @wp-playground/cli run-blueprint`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Figma preview opening the default WordPress homepage, implementing the Playground launch URL fix, adding smoke coverage, and running local verification.