### PR TITLE
Update Blocks Engine transformer to 0.1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.4",
+        "version": "0.1.6",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "9f9aa2b54ea80be05dda67b79b94e2074d24586a"
+          "reference": "13c1cf9867f6cec06ae4328d641f183ac3f3b465"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.4.zip",
-          "reference": "9f9aa2b54ea80be05dda67b79b94e2074d24586a"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.6.zip",
+          "reference": "13c1cf9867f6cec06ae4328d641f183ac3f3b465"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.0",
-    "automattic/blocks-engine-php-transformer": "^0.1.4",
+    "automattic/blocks-engine-php-transformer": "^0.1.6",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df47d6bf5569fabca58c91f19365423c",
+    "content-hash": "660f969956d914626815e7d1b0735945",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.4",
+            "version": "0.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "9f9aa2b54ea80be05dda67b79b94e2074d24586a"
+                "reference": "13c1cf9867f6cec06ae4328d641f183ac3f3b465"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.4.zip",
-                "reference": "9f9aa2b54ea80be05dda67b79b94e2074d24586a"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.6.zip",
+                "reference": "13c1cf9867f6cec06ae4328d641f183ac3f3b465"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Update the packaged Blocks Engine PHP transformer dependency from 0.1.4 to 0.1.6.
- Pull in the latest raw HTML conversion improvements and visual parity probe guardrails.

## Testing
- php tests/smoke-importer-block.php
- php tests/smoke-visual-repair-css.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updating dependency metadata, running verification, and preparing this PR description.