### PR TITLE
Use direct Playground blueprints for Figma previews

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -41,6 +41,16 @@ function static_site_importer_register_rest_routes(): void {
 			),
 		)
 	);
+
+	register_rest_route(
+		'static-site-importer/v1',
+		'/figma-preview-blueprint/(?P<ref>[a-f0-9]{64})',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'static_site_importer_rest_figma_preview_blueprint',
+			'permission_callback' => '__return_true',
+		)
+	);
 }
 
 /**
@@ -96,7 +106,7 @@ function static_site_importer_rest_import_figma( WP_REST_Request $request ) {
 			'overwrite' => array_key_exists( 'overwrite', $input ) ? ! empty( $input['overwrite'] ) : true,
 		)
 	);
-	$result = static_site_importer_rest_create_preview( array( 'artifact' => $artifact ), Static_Site_Importer_Figma_Import::import_input( $params, $artifact ), $params );
+	$result = static_site_importer_rest_create_figma_playground_preview( $artifact, Static_Site_Importer_Figma_Import::import_input( $params, $artifact ) );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -105,6 +115,135 @@ function static_site_importer_rest_import_figma( WP_REST_Request $request ) {
 	static_site_importer_rest_add_figma_cors_headers( $response, $request );
 
 	return $response;
+}
+
+/**
+ * Return a prepared Figma import Playground blueprint.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function static_site_importer_rest_figma_preview_blueprint( WP_REST_Request $request ) {
+	$ref = strtolower( trim( (string) $request->get_param( 'ref' ) ) );
+	if ( ! preg_match( '/^[a-f0-9]{64}$/', $ref ) ) {
+		return new WP_Error( 'static_site_importer_figma_blueprint_ref_invalid', __( 'Figma preview blueprint ref is invalid.', 'static-site-importer' ), array( 'status' => 400 ) );
+	}
+
+	$blueprint = get_transient( static_site_importer_rest_figma_blueprint_transient_key( $ref ) );
+	if ( ! is_array( $blueprint ) ) {
+		return new WP_Error( 'static_site_importer_figma_blueprint_not_found', __( 'Figma preview blueprint expired. Create a new Figma preview.', 'static-site-importer' ), array( 'status' => 404 ) );
+	}
+
+	return rest_ensure_response( $blueprint );
+}
+
+/**
+ * Create a plain Playground preview for Figma imports.
+ *
+ * @param array<string,mixed> $artifact Website artifact.
+ * @param array<string,mixed> $input    Import ability input.
+ * @return array<string,mixed>|WP_Error
+ */
+function static_site_importer_rest_create_figma_playground_preview( array $artifact, array $input ) {
+	$blueprint = static_site_importer_rest_figma_playground_blueprint( $input );
+	$ref       = hash( 'sha256', wp_json_encode( $blueprint ) ?: serialize( $blueprint ) );
+	$stored    = set_transient( static_site_importer_rest_figma_blueprint_transient_key( $ref ), $blueprint, WEEK_IN_SECONDS );
+	if ( ! $stored ) {
+		return new WP_Error( 'static_site_importer_figma_blueprint_store_failed', __( 'Could not store the Figma preview blueprint.', 'static-site-importer' ), array( 'status' => 500 ) );
+	}
+
+	$endpoint      = rest_url( 'static-site-importer/v1/figma-preview-blueprint/' . $ref );
+	$blueprint_url = 'https://playground.wordpress.net/?blueprint-url=' . rawurlencode( $endpoint ) . '&url=%2F';
+
+	return array(
+		'success' => true,
+		'preview' => array(
+			'status'     => 'ready',
+			'playground' => array(
+				'blueprint_url' => esc_url_raw( $blueprint_url ),
+				'preview_url'   => '/',
+				'ref'           => $ref,
+			),
+		),
+		'provider' => 'static-site-importer/figma-direct-playground-blueprint',
+		'request'  => array(
+			'schema'     => 'static-site-importer/figma-preview-request/v1',
+			'artifact'   => array(
+				'entrypoint' => (string) ( $artifact['entrypoint'] ?? '' ),
+				'file_count'  => isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? count( $artifact['files'] ) : 0,
+			),
+			'blueprint' => array(
+				'ref' => $ref,
+			),
+		),
+	);
+}
+
+/**
+ * Build a self-contained Playground blueprint that imports the Figma artifact.
+ *
+ * @param array<string,mixed> $input Import ability input.
+ * @return array<string,mixed>
+ */
+function static_site_importer_rest_figma_playground_blueprint( array $input ): array {
+	$import_code = '<?php
+require_once "/wordpress/wp-load.php";
+
+if ( ! function_exists( "static_site_importer_ability_import_website_artifact" ) ) {
+	throw new RuntimeException( "Static Site Importer import function is unavailable." );
+}
+
+$input = ' . var_export( $input, true ) . ';
+$result = static_site_importer_ability_import_website_artifact( $input );
+
+if ( ! is_array( $result ) || empty( $result["success"] ) ) {
+	throw new RuntimeException( "Static Site Importer Figma import failed: " . wp_json_encode( $result ) );
+}
+
+update_option( "static_site_importer_figma_preview_result", $result, false );
+?>';
+
+	return array(
+		'$schema'           => 'https://playground.wordpress.net/blueprint-schema.json',
+		'landingPage'       => '/',
+		'preferredVersions' => array(
+			'php' => '8.2',
+			'wp'  => 'latest',
+		),
+		'features'          => array(
+			'networking' => true,
+		),
+		'steps'             => array(
+			array(
+				'step' => 'login',
+			),
+			array(
+				'step'       => 'installPlugin',
+				'pluginData' => array(
+					'resource' => 'url',
+					'url'      => 'https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip',
+				),
+				'options'    => array(
+					'activate'         => true,
+					'targetFolderName' => 'static-site-importer',
+				),
+			),
+			array(
+				'step' => 'runPHP',
+				'code' => $import_code,
+			),
+		),
+	);
+}
+
+/**
+ * Build the transient key for prepared Figma preview blueprints.
+ *
+ * @param string $ref Blueprint ref hash.
+ * @return string
+ */
+function static_site_importer_rest_figma_blueprint_transient_key( string $ref ): string {
+	return 'static_site_importer_figma_blueprint_' . substr( $ref, 0, 32 );
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -31,6 +31,9 @@ $GLOBALS['ssi_options']          = array();
 $GLOBALS['ssi_test_options']     = array();
 $GLOBALS['ssi_home_url']         = 'https://example.test/';
 $GLOBALS['ssi_uuid_count']       = 0;
+$GLOBALS['ssi_transients']       = array();
+
+defined( 'WEEK_IN_SECONDS' ) || define( 'WEEK_IN_SECONDS', 7 * 24 * 60 * 60 );
 
 if ( ! function_exists( 'register_block_type' ) ) {
 	function register_block_type( string $path, array $args = array() ): bool {
@@ -171,6 +174,20 @@ if ( ! function_exists( 'update_option' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( string $name ) {
+		return $GLOBALS['ssi_transients'][ $name ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( string $name, $value, int $expiration = 0 ): bool {
+		$GLOBALS['ssi_transients'][ $name ] = $value;
+
+		return true;
+	}
+}
+
 if ( ! function_exists( 'wp_generate_uuid4' ) ) {
 	function wp_generate_uuid4(): string {
 		++$GLOBALS['ssi_uuid_count'];
@@ -233,6 +250,10 @@ if ( ! class_exists( 'WP_REST_Request' ) ) {
 
 		public function get_json_params(): array {
 			return $this->params;
+		}
+
+		public function get_param( string $name ) {
+			return $this->params[ $name ] ?? null;
 		}
 
 		public function get_header( string $name ): string {
@@ -629,6 +650,7 @@ if ( ! is_wp_error( $html_source_page ) ) {
 
 Static_Site_Importer_Theme_Generator::$last_artifact = array();
 Static_Site_Importer_Theme_Generator::$last_args     = array();
+WP_Codebox_Abilities::$last_input = array();
 WP_Codebox_Abilities::$next_session = array(
 	'success'         => true,
 	'schema'          => 'wp-codebox/browser-playground-session/v1',
@@ -692,15 +714,23 @@ $assert( 'created' === ( $figma_response['status'] ?? '' ), 'figma-rest-response
 $assert( str_starts_with( $figma_response['open_url'] ?? '', 'https://playground.wordpress.net/?blueprint-url=' ), 'figma-rest-response-open-url-is-playground-blueprint' );
 $assert( isset( $figma_response['preview_session']['playground']['blueprint_url'] ), 'figma-rest-response-exposes-playground-blueprint-url' );
 $assert( array() === Static_Site_Importer_Theme_Generator::$last_artifact, 'figma-rest-preview-does-not-apply-to-current-site' );
-$assert( 'function' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['type'] ?? '' ), 'figma-rest-preview-invokes-ssi-import-function-type' );
-$assert( 'static_site_importer_ability_import_website_artifact' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['name'] ?? '' ), 'figma-rest-preview-invokes-ssi-import-function' );
-$assert( 'website/index.html' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact']['entrypoint'] ?? '' ), 'figma-artifact-entrypoint-normalized' );
-$assert( 'website/assets/styles.css' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact']['files'][1]['path'] ?? '' ), 'figma-artifact-file-path-normalized' );
-$assert( true === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['activate'] ?? null ), 'figma-preview-defaults-to-activate-in-playground' );
-$assert( true === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['overwrite'] ?? null ), 'figma-preview-defaults-to-overwrite-in-playground' );
-$assert( 'Fisiostetic' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['name'] ?? null ), 'figma-import-name-derived-from-metadata' );
-$assert( 'Fisiostetic' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['site_title'] ?? null ), 'figma-import-site-title-derived-from-metadata' );
-$assert( 'figma-to-wordpress' === ( WP_Codebox_Abilities::$last_input['browser_runner']['invocation']['input']['artifact']['provenance']['source'] ?? '' ), 'figma-artifact-provenance-source' );
+$assert( array() === WP_Codebox_Abilities::$last_input, 'figma-rest-preview-does-not-use-codebox-runner' );
+$figma_open_url_parts = wp_parse_url( (string) $figma_response['open_url'] );
+parse_str( (string) ( $figma_open_url_parts['query'] ?? '' ), $figma_open_url_query );
+$assert( '/' === ( $figma_open_url_query['url'] ?? '' ), 'figma-playground-opens-imported-wordpress-front-page' );
+$figma_blueprint_ref = (string) ( $figma_response['preview_session']['playground']['ref'] ?? '' );
+$assert( preg_match( '/^[a-f0-9]{64}$/', $figma_blueprint_ref ) === 1, 'figma-preview-exposes-blueprint-ref' );
+$figma_blueprint_response = static_site_importer_rest_figma_preview_blueprint( new WP_REST_Request( array( 'ref' => $figma_blueprint_ref ) ) );
+$assert( is_array( $figma_blueprint_response ), 'figma-blueprint-hydrates' );
+$figma_blueprint_code = wp_json_encode( $figma_blueprint_response );
+$assert( str_contains( (string) $figma_blueprint_code, 'static_site_importer_ability_import_website_artifact' ), 'figma-blueprint-invokes-ssi-import-function' );
+$assert( str_contains( (string) $figma_blueprint_code, 'website/index.html' ) || str_contains( (string) $figma_blueprint_code, 'website\/index.html' ), 'figma-artifact-entrypoint-normalized' );
+$assert( str_contains( (string) $figma_blueprint_code, 'website/assets/styles.css' ) || str_contains( (string) $figma_blueprint_code, 'website\/assets\/styles.css' ), 'figma-artifact-file-path-normalized' );
+$assert( str_contains( (string) $figma_blueprint_code, "'activate' => true" ), 'figma-preview-defaults-to-activate-in-playground' );
+$assert( str_contains( (string) $figma_blueprint_code, "'overwrite' => true" ), 'figma-preview-defaults-to-overwrite-in-playground' );
+$assert( str_contains( (string) $figma_blueprint_code, "'name' => 'Fisiostetic'" ), 'figma-import-name-derived-from-metadata' );
+$assert( str_contains( (string) $figma_blueprint_code, "'site_title' => 'Fisiostetic'" ), 'figma-import-site-title-derived-from-metadata' );
+$assert( str_contains( (string) $figma_blueprint_code, "'source' => 'figma-to-wordpress'" ), 'figma-artifact-provenance-source' );
 
 if ( class_exists( 'ZipArchive' ) ) {
 	$zip_path = tempnam( sys_get_temp_dir(), 'ssi-test-' );


### PR DESCRIPTION
## Summary
- Route `/import-figma` previews through a plain Static Site Importer Playground blueprint instead of the WP Codebox browser runner.
- Add a transient-backed SSI blueprint hydration endpoint for prepared Figma preview blueprints.
- Build the blueprint to install SSI, call `static_site_importer_ability_import_website_artifact()` directly, and open `/` after import.
- Update smoke coverage to assert Figma previews do not invoke the Codebox runner and hydrate a direct SSI blueprint.

## Verification
- `php -l includes/rest.php`
- `php -l tests/smoke-importer-block.php`
- `php tests/smoke-importer-block.php`
- Installed the patched plugin on `wordpress-importer-test` (`http://localhost:8882`).
- Posted the saved Fisiostetic Figma artifact bundle to `/wp-json/static-site-importer/v1/import-figma`.
- Verified the returned `open_url` uses `/wp-json/static-site-importer/v1/figma-preview-blueprint/<ref>` with `url=/` and no `wp-codebox` blueprint ref.
- Hydrated the blueprint and confirmed it has 3 steps, `landingPage=/`, no Codebox, and direct `static_site_importer_ability_import_website_artifact()` invocation.
- Ran the direct blueprint successfully with `npx --yes @wp-playground/cli run-blueprint`.
- Ran a diagnostic variant proving the imported Playground had `theme=fisiostetic`, `show_on_front=page`, `page_on_front=4`, front page content length `113328`, and `import_result_success=true`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the mismatch between importer-block and Figma preview orchestration, implementing the direct Playground blueprint route, adding smoke coverage, and running local Playground verification.