### PR TITLE
Store Figma preview blueprints in uploads

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -131,6 +131,9 @@ function static_site_importer_rest_figma_preview_blueprint( WP_REST_Request $req
 
 	$blueprint = get_transient( static_site_importer_rest_figma_blueprint_transient_key( $ref ) );
 	if ( ! is_array( $blueprint ) ) {
+		$blueprint = static_site_importer_rest_read_figma_blueprint( $ref );
+	}
+	if ( ! is_array( $blueprint ) ) {
 		return new WP_Error( 'static_site_importer_figma_blueprint_not_found', __( 'Figma preview blueprint expired. Create a new Figma preview.', 'static-site-importer' ), array( 'status' => 404 ) );
 	}
 
@@ -147,7 +150,7 @@ function static_site_importer_rest_figma_preview_blueprint( WP_REST_Request $req
 function static_site_importer_rest_create_figma_playground_preview( array $artifact, array $input ) {
 	$blueprint = static_site_importer_rest_figma_playground_blueprint( $input );
 	$ref       = hash( 'sha256', wp_json_encode( $blueprint ) ?: serialize( $blueprint ) );
-	$stored    = set_transient( static_site_importer_rest_figma_blueprint_transient_key( $ref ), $blueprint, WEEK_IN_SECONDS );
+	$stored    = static_site_importer_rest_store_figma_blueprint( $ref, $blueprint );
 	if ( ! $stored ) {
 		return new WP_Error( 'static_site_importer_figma_blueprint_store_failed', __( 'Could not store the Figma preview blueprint.', 'static-site-importer' ), array( 'status' => 500 ) );
 	}
@@ -244,6 +247,73 @@ update_option( "static_site_importer_figma_preview_result", $result, false );
  */
 function static_site_importer_rest_figma_blueprint_transient_key( string $ref ): string {
 	return 'static_site_importer_figma_blueprint_' . substr( $ref, 0, 32 );
+}
+
+/**
+ * Store a prepared Figma preview blueprint.
+ *
+ * @param string              $ref       Blueprint ref hash.
+ * @param array<string,mixed> $blueprint Playground blueprint.
+ * @return bool
+ */
+function static_site_importer_rest_store_figma_blueprint( string $ref, array $blueprint ): bool {
+	if ( function_exists( 'set_transient' ) && set_transient( static_site_importer_rest_figma_blueprint_transient_key( $ref ), $blueprint, WEEK_IN_SECONDS ) ) {
+		return true;
+	}
+
+	$path = static_site_importer_rest_figma_blueprint_path( $ref );
+	if ( '' === $path ) {
+		return false;
+	}
+
+	$dir = dirname( $path );
+	if ( ! is_dir( $dir ) && ! wp_mkdir_p( $dir ) ) {
+		return false;
+	}
+
+	$json = wp_json_encode( $blueprint );
+	return false !== $json && false !== file_put_contents( $path, $json . "\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Stores an importer-owned prepared Playground blueprint.
+}
+
+/**
+ * Read a prepared Figma preview blueprint from uploads storage.
+ *
+ * @param string $ref Blueprint ref hash.
+ * @return array<string,mixed>|null
+ */
+function static_site_importer_rest_read_figma_blueprint( string $ref ): ?array {
+	$path = static_site_importer_rest_figma_blueprint_path( $ref );
+	if ( '' === $path || ! is_readable( $path ) ) {
+		return null;
+	}
+
+	$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads an importer-owned prepared Playground blueprint.
+	if ( ! is_string( $contents ) || '' === $contents ) {
+		return null;
+	}
+
+	$blueprint = json_decode( $contents, true );
+	return is_array( $blueprint ) ? $blueprint : null;
+}
+
+/**
+ * Resolve a prepared Figma preview blueprint path under uploads.
+ *
+ * @param string $ref Blueprint ref hash.
+ * @return string
+ */
+function static_site_importer_rest_figma_blueprint_path( string $ref ): string {
+	if ( ! preg_match( '/^[a-f0-9]{64}$/', $ref ) ) {
+		return '';
+	}
+
+	$uploads = wp_upload_dir( null, false );
+	$base_dir = isset( $uploads['basedir'] ) ? (string) $uploads['basedir'] : '';
+	if ( '' === $base_dir ) {
+		return '';
+	}
+
+	return trailingslashit( $base_dir ) . 'static-site-importer/figma-blueprints/' . $ref . '.json';
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -32,6 +32,7 @@ $GLOBALS['ssi_test_options']     = array();
 $GLOBALS['ssi_home_url']         = 'https://example.test/';
 $GLOBALS['ssi_uuid_count']       = 0;
 $GLOBALS['ssi_transients']       = array();
+$GLOBALS['ssi_upload_dir']       = sys_get_temp_dir() . '/ssi-smoke-uploads-' . getmypid();
 
 defined( 'WEEK_IN_SECONDS' ) || define( 'WEEK_IN_SECONDS', 7 * 24 * 60 * 60 );
 
@@ -182,9 +183,40 @@ if ( ! function_exists( 'get_transient' ) ) {
 
 if ( ! function_exists( 'set_transient' ) ) {
 	function set_transient( string $name, $value, int $expiration = 0 ): bool {
+		if ( str_starts_with( $name, 'static_site_importer_figma_blueprint_' ) ) {
+			return false;
+		}
+
 		$GLOBALS['ssi_transients'][ $name ] = $value;
 
 		return true;
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $path ): string {
+		return rtrim( $path, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( string $path ): bool {
+		return is_dir( $path ) || mkdir( $path, 0777, true );
+	}
+}
+
+if ( ! function_exists( 'wp_upload_dir' ) ) {
+	function wp_upload_dir( $time = null, bool $create_dir = true ): array {
+		unset( $time );
+		if ( $create_dir && ! is_dir( $GLOBALS['ssi_upload_dir'] ) ) {
+			wp_mkdir_p( $GLOBALS['ssi_upload_dir'] );
+		}
+
+		return array(
+			'basedir' => $GLOBALS['ssi_upload_dir'],
+			'baseurl' => 'https://example.test/uploads',
+			'error'   => false,
+		);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fall back from transients to an uploads-backed JSON store for prepared Figma preview blueprints.
- Hydrate Figma preview blueprints from uploads when transient storage is unavailable or too large.
- Cover the fallback in the importer smoke harness by simulating transient failure for Figma blueprint entries.

## Verification
- `php -l includes/rest.php`
- `php -l tests/smoke-importer-block.php`
- `php tests/smoke-importer-block.php`
- Installed the patch on `wordpress-importer-test` and confirmed `/import-figma` returns a direct SSI blueprint URL that hydrates with HTTP 200.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing transient storage failure on large prepared Figma blueprints, implementing uploads-backed storage fallback, and verifying local hydration.