### PR TITLE
Update Blocks Engine PHP transformer to 0.1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.6",
+        "version": "0.1.7",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "13c1cf9867f6cec06ae4328d641f183ac3f3b465"
+          "reference": "6f4eb7b97307f2f4f104bae8471093cd905cd7f4"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.6.zip",
-          "reference": "13c1cf9867f6cec06ae4328d641f183ac3f3b465"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.7.zip",
+          "reference": "6f4eb7b97307f2f4f104bae8471093cd905cd7f4"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.0",
-    "automattic/blocks-engine-php-transformer": "^0.1.6",
+    "automattic/blocks-engine-php-transformer": "^0.1.7",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "660f969956d914626815e7d1b0735945",
+    "content-hash": "831520d117ff5d9555fa4bfdccba9340",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.6",
+            "version": "0.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "13c1cf9867f6cec06ae4328d641f183ac3f3b465"
+                "reference": "6f4eb7b97307f2f4f104bae8471093cd905cd7f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.6.zip",
-                "reference": "13c1cf9867f6cec06ae4328d641f183ac3f3b465"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.7.zip",
+                "reference": "6f4eb7b97307f2f4f104bae8471093cd905cd7f4"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Update the bundled Blocks Engine PHP transformer package metadata from 0.1.6 to 0.1.7.
- Pull in block validity diagnostics plus the latest button, navigation, visual probe comparison, and CSS style-signal conversion fixes.

## Testing
- php tests/smoke-transformer-adapter.php
- php tests/smoke-materialized-block-content-validation.php
- php tests/smoke-codebox-validation-contract.php
- php tests/smoke-product-handoff-contract.php
- php tests/smoke-importer-block.php
- php tests/smoke-visual-repair-css.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updating dependency metadata, running smoke tests, and preparing this PR description.