### PR TITLE
Update Blocks Engine PHP transformer to 0.1.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.7",
+        "version": "0.1.8",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "6f4eb7b97307f2f4f104bae8471093cd905cd7f4"
+          "reference": "1f12991b1d23c66de1c36e325490ad0056c0d75d"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.7.zip",
-          "reference": "6f4eb7b97307f2f4f104bae8471093cd905cd7f4"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.8.zip",
+          "reference": "1f12991b1d23c66de1c36e325490ad0056c0d75d"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.0",
-    "automattic/blocks-engine-php-transformer": "^0.1.7",
+    "automattic/blocks-engine-php-transformer": "^0.1.8",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "831520d117ff5d9555fa4bfdccba9340",
+    "content-hash": "c3b5c0bb84878d6e8a9be86fa4217200",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.7",
+            "version": "0.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "6f4eb7b97307f2f4f104bae8471093cd905cd7f4"
+                "reference": "1f12991b1d23c66de1c36e325490ad0056c0d75d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.7.zip",
-                "reference": "6f4eb7b97307f2f4f104bae8471093cd905cd7f4"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.8.zip",
+                "reference": "1f12991b1d23c66de1c36e325490ad0056c0d75d"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Update the bundled Blocks Engine PHP transformer package metadata from 0.1.7 to 0.1.8.
- Pull in the flat menu regression fix so Common Table-style nav-menu headers stay as flat navigation lists instead of becoming dropdown submenus.

## Testing
- php tests/smoke-transformer-adapter.php
- php tests/smoke-importer-block.php
- php tests/smoke-visual-repair-css.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updating dependency metadata, running smoke tests, and preparing this PR description.