### PR TITLE
Clarify public Playground runtime generation mode

### DIFF
--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -268,8 +268,8 @@
 			const html = root.querySelector( '[data-static-site-importer-source-html]' );
 			const uploadInputs = root.querySelectorAll( '[data-static-site-importer-source-files], [data-static-site-importer-source-directory]' );
 			const provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
-			const applyToCurrentSite = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
-			const generateInCurrentRuntime = root.getAttribute( 'data-static-site-importer-generate-in-current-runtime' ) === '1';
+			const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
+			const isCurrentRuntimeGeneration = root.getAttribute( 'data-static-site-importer-generate-in-current-runtime' ) === '1';
 			const source = {
 				url: form ? form.getAttribute( 'data-static-site-importer-default-url' ) || '' : '',
 				html: html ? html.value : '',
@@ -283,7 +283,7 @@
 				return;
 			}
 
-			showStatus( root, applyToCurrentSite ? 'Importing to this site...' : 'Generating WordPress website...' );
+			showStatus( root, isCurrentSiteImport ? 'Importing to this site...' : 'Generating WordPress website...' );
 			submit.disabled = true;
 
 			try {
@@ -298,17 +298,19 @@
 					body: JSON.stringify( {
 						provider,
 						source,
-						apply_to_current_site: applyToCurrentSite,
-						activate: applyToCurrentSite,
-						overwrite: applyToCurrentSite,
-						generate_in_current_runtime: generateInCurrentRuntime,
+						apply_to_current_site: isCurrentSiteImport,
+						activate: isCurrentSiteImport,
+						overwrite: isCurrentSiteImport,
+						generate_in_current_runtime: isCurrentRuntimeGeneration,
 					} ),
 				} );
 				const report = await response.json();
 				setReport( root, report );
 				setPreviewLink( root, report );
-				if ( response.ok && applyToCurrentSite && report.success ) {
-					showStatus( root, applyToCurrentSite ? 'Import complete.' : 'WordPress website generated.' );
+				if ( response.ok && isCurrentSiteImport && report.success ) {
+					showStatus( root, 'Import complete.' );
+				} else if ( response.ok && isCurrentRuntimeGeneration && report.success ) {
+					showStatus( root, 'WordPress website generated.' );
 				} else if ( response.ok && previewUrl( report ) ) {
 					showStatus( root, 'Preview ready.' );
 				} else if ( response.ok && report.preview && report.preview.status === 'unavailable' ) {

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -452,8 +452,18 @@ function static_site_importer_rest_create_import( WP_REST_Request $request ) {
 
 	$source = isset( $params['source'] ) && is_array( $params['source'] ) ? $params['source'] : array();
 	$input  = static_site_importer_rest_import_args( $params );
+	$mode   = static_site_importer_rest_import_mode( $params );
 
-	if ( ! static_site_importer_rest_should_apply_to_current_site( $params ) ) {
+	if ( 'current_runtime' === $mode ) {
+		$result = static_site_importer_rest_generate_in_current_runtime( $source, $input, $params );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	if ( 'preview' === $mode ) {
 		$result = static_site_importer_rest_create_preview( $source, $input, $params );
 		if ( is_wp_error( $result ) ) {
 			return $result;
@@ -471,13 +481,61 @@ function static_site_importer_rest_create_import( WP_REST_Request $request ) {
 }
 
 /**
+ * Resolve the import execution mode from REST flags.
+ *
+ * Modes are intentionally separate:
+ * - preview: non-mutating WP Codebox preview.
+ * - current_runtime: public Playground generation in the active disposable runtime.
+ * - current_site: explicit import into the installed WordPress site.
+ *
+ * @param array<string,mixed> $params Request params.
+ * @return 'preview'|'current_runtime'|'current_site'
+ */
+function static_site_importer_rest_import_mode( array $params ): string {
+	if ( ! empty( $params['apply_to_current_site'] ) ) {
+		return 'current_site';
+	}
+
+	if ( ! empty( $params['generate_in_current_runtime'] ) ) {
+		return 'current_runtime';
+	}
+
+	return 'preview';
+}
+
+/**
  * Determine whether the request explicitly targets the current WordPress site.
  *
  * @param array<string,mixed> $params Request params.
  * @return bool
  */
 function static_site_importer_rest_should_apply_to_current_site( array $params ): bool {
-	return ! empty( $params['apply_to_current_site'] );
+	return 'current_site' === static_site_importer_rest_import_mode( $params );
+}
+
+/**
+ * Generate a WordPress website in the active disposable runtime without WP Codebox.
+ *
+ * @param array<string,mixed> $source Source payload.
+ * @param array<string,mixed> $input  Import args.
+ * @param array<string,mixed> $params Request params.
+ * @return array<string,mixed>|WP_Error
+ */
+function static_site_importer_rest_generate_in_current_runtime( array $source, array $input, array $params ) {
+	$input['activate']  = array_key_exists( 'activate', $params ) ? ! empty( $params['activate'] ) : true;
+	$input['overwrite'] = array_key_exists( 'overwrite', $params ) ? ! empty( $params['overwrite'] ) : true;
+
+	$result = static_site_importer_rest_apply_to_current_site( $source, $input, $params );
+	if ( ! is_array( $result ) ) {
+		return $result;
+	}
+
+	$preview = isset( $result['preview'] ) && is_array( $result['preview'] ) ? $result['preview'] : array();
+	$preview['status'] = isset( $preview['status'] ) ? $preview['status'] : 'ready';
+	$result['preview'] = $preview;
+	$result['mode']    = 'generated_in_current_runtime';
+
+	return $result;
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -473,10 +473,12 @@ $assert( str_contains( $view_js, 'webkitGetAsEntry' ), 'view-supports-dropped-di
 $assert( str_contains( $view_js, 'archive: await buildArchive( uploadInputs, root )' ), 'view-sends-zip-from-combined-upload-as-archive-payload' );
 $assert( str_contains( $view_js, 'shouldIncludeSiteFile' ), 'view-skips-known-non-site-upload-files-before-reading' );
 $assert( ! str_contains( $view_js, 'applyToCurrentSite || generateInCurrentRuntime' ), 'view-does-not-treat-current-runtime-generation-as-current-site-import' );
-$assert( str_contains( $view_js, 'apply_to_current_site: applyToCurrentSite' ), 'view-sends-current-site-apply-flag-only-from-apply-mode' );
-$assert( str_contains( $view_js, 'activate: applyToCurrentSite' ), 'view-activates-only-current-site-imports' );
-$assert( str_contains( $view_js, 'overwrite: applyToCurrentSite' ), 'view-overwrites-only-current-site-imports' );
-$assert( str_contains( $view_js, 'generate_in_current_runtime: generateInCurrentRuntime' ), 'view-sends-current-runtime-generation-flag' );
+$assert( str_contains( $view_js, 'isCurrentSiteImport' ), 'view-names-current-site-import-mode-explicitly' );
+$assert( str_contains( $view_js, 'isCurrentRuntimeGeneration' ), 'view-names-current-runtime-generation-mode-explicitly' );
+$assert( str_contains( $view_js, 'apply_to_current_site: isCurrentSiteImport' ), 'view-sends-current-site-apply-flag-only-from-apply-mode' );
+$assert( str_contains( $view_js, 'activate: isCurrentSiteImport' ), 'view-activates-only-current-site-imports' );
+$assert( str_contains( $view_js, 'overwrite: isCurrentSiteImport' ), 'view-overwrites-only-current-site-imports' );
+$assert( str_contains( $view_js, 'generate_in_current_runtime: isCurrentRuntimeGeneration' ), 'view-sends-current-runtime-generation-flag' );
 $generic_preview_message = implode( ' ', array( 'no', 'preview', 'provider', 'is', 'configured' ) );
 $assert( ! str_contains( $view_js, $generic_preview_message ), 'view-does-not-reference-generic-preview-message' );
 $assert( str_contains( $view_js, 'Open WordPress preview' ) || str_contains( $html, 'Open WordPress preview' ), 'view-or-render-has-preview-link-label' );
@@ -621,6 +623,10 @@ $assert( false === ( $codebox_missing['success'] ?? null ), 'rest-codebox-unavai
 $assert( 'wp-codebox/create-browser-playground-session' === ( $codebox_missing['provider'] ?? '' ), 'rest-codebox-unavailable-identifies-required-api' );
 $assert( str_contains( $codebox_missing['preview']['message'] ?? '', 'WP Codebox is unavailable, not installed, or does not provide the required browser Playground session API' ), 'rest-codebox-unavailable-diagnostic-wording' );
 
+$assert( 'preview' === static_site_importer_rest_import_mode( array() ), 'rest-mode-defaults-to-codebox-preview' );
+$assert( 'current_runtime' === static_site_importer_rest_import_mode( array( 'generate_in_current_runtime' => true ) ), 'rest-mode-supports-current-runtime-generation' );
+$assert( 'current_site' === static_site_importer_rest_import_mode( array( 'apply_to_current_site' => true, 'generate_in_current_runtime' => true ) ), 'rest-mode-current-site-import-wins-when-explicit' );
+
 Static_Site_Importer_Theme_Generator::$last_artifact = array();
 $apply_response = static_site_importer_rest_create_import(
 	new WP_REST_Request(
@@ -638,6 +644,27 @@ $assert( true === ( $apply_response['success'] ?? null ), 'rest-current-site-app
 $assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['activate'] ?? null ), 'rest-current-site-apply-preserves-activate' );
 $assert( isset( $apply_response['result'] ), 'rest-current-site-apply-returns-ability-envelope' );
 $assert( 'https://example.test/' === ( $apply_response['preview']['url'] ?? '' ), 'rest-current-site-apply-returns-site-preview-url' );
+
+Static_Site_Importer_Theme_Generator::$last_artifact = array();
+Static_Site_Importer_Theme_Generator::$last_args     = array();
+WP_Codebox_Abilities::$last_input = array();
+$runtime_response = static_site_importer_rest_create_import(
+	new WP_REST_Request(
+		array(
+			'apply_to_current_site'      => false,
+			'generate_in_current_runtime' => true,
+			'source'                      => array(
+				'html' => '<main>Generate</main>',
+			),
+		)
+	)
+);
+$assert( true === ( $runtime_response['success'] ?? null ), 'rest-current-runtime-generation-succeeds-without-codebox' );
+$assert( 'generated_in_current_runtime' === ( $runtime_response['mode'] ?? '' ), 'rest-current-runtime-generation-reports-mode' );
+$assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['activate'] ?? null ), 'rest-current-runtime-generation-activates-generated-site' );
+$assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['overwrite'] ?? null ), 'rest-current-runtime-generation-overwrites-generated-site' );
+$assert( array() === WP_Codebox_Abilities::$last_input, 'rest-current-runtime-generation-does-not-use-codebox-preview' );
+$assert( 'https://example.test/' === ( $runtime_response['preview']['url'] ?? '' ), 'rest-current-runtime-generation-returns-runtime-preview-url' );
 
 $blueprint = json_decode( file_get_contents( dirname( __DIR__ ) . '/docs/playground/blueprint.json' ), true );
 $assert( is_array( $blueprint ), 'playground-blueprint-decodes' );


### PR DESCRIPTION
## Summary
- Add an explicit REST import mode resolver for three separate execution paths: Codebox preview, current-runtime generation, and current-site import.
- Route `generate_in_current_runtime:true` plus `apply_to_current_site:false` to runtime generation instead of WP Codebox preview.
- Rename frontend mode booleans so current-site import and current-runtime generation cannot be accidentally folded together again.
- Add regression coverage for the README/public Playground mode and the runtime path bypassing WP Codebox.

## Testing
- `php tests/smoke-importer-block.php`.

## Regression fixed
The README/public Playground block intentionally uses `applyToCurrentSite:false` with `generateInCurrentRuntime:true`: it should say "Generate WordPress website" and generate inside the active disposable Playground runtime. It should not say "Import to this site", should not set `apply_to_current_site`, and should not require WP Codebox.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Refactoring the mode routing, adding regression tests, and validating the public Playground runtime generation path.