### PR TITLE
Fix public runtime preview link target

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -530,12 +530,25 @@ function static_site_importer_rest_generate_in_current_runtime( array $source, a
 		return $result;
 	}
 
-	$preview           = isset( $result['preview'] ) && is_array( $result['preview'] ) ? $result['preview'] : array();
-	$preview['status'] = isset( $preview['status'] ) ? $preview['status'] : 'ready';
+	$preview                   = isset( $result['preview'] ) && is_array( $result['preview'] ) ? $result['preview'] : array();
+	$preview['status']         = isset( $preview['status'] ) ? $preview['status'] : 'ready';
+	$preview['url']            = static_site_importer_rest_current_runtime_preview_url();
+	$playground                = isset( $preview['playground'] ) && is_array( $preview['playground'] ) ? $preview['playground'] : array();
+	$playground['preview_url'] = $preview['url'];
+	$preview['playground']     = $playground;
 	$result['preview'] = $preview;
 	$result['mode']    = 'generated_in_current_runtime';
 
 	return $result;
+}
+
+/**
+ * Return the active runtime front page URL for public Playground generation.
+ *
+ * @return string
+ */
+function static_site_importer_rest_current_runtime_preview_url(): string {
+	return '/';
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -664,7 +664,8 @@ $assert( 'generated_in_current_runtime' === ( $runtime_response['mode'] ?? '' ),
 $assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['activate'] ?? null ), 'rest-current-runtime-generation-activates-generated-site' );
 $assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['overwrite'] ?? null ), 'rest-current-runtime-generation-overwrites-generated-site' );
 $assert( array() === WP_Codebox_Abilities::$last_input, 'rest-current-runtime-generation-does-not-use-codebox-preview' );
-$assert( 'https://example.test/' === ( $runtime_response['preview']['url'] ?? '' ), 'rest-current-runtime-generation-returns-runtime-preview-url' );
+$assert( '/' === ( $runtime_response['preview']['url'] ?? '' ), 'rest-current-runtime-generation-returns-active-runtime-front-page-url' );
+$assert( '/' === ( $runtime_response['preview']['playground']['preview_url'] ?? '' ), 'rest-current-runtime-generation-records-playground-preview-path' );
 
 $blueprint = json_decode( file_get_contents( dirname( __DIR__ ) . '/docs/playground/blueprint.json' ), true );
 $assert( is_array( $blueprint ), 'playground-blueprint-decodes' );


### PR DESCRIPTION
## Summary
- Return the active runtime front-page path for public Playground runtime generation previews.
- Record the same path under `preview.playground.preview_url`.
- Keep explicit current-site import using its existing absolute `home_url('/')` behavior.

## Testing
- `php tests/smoke-importer-block.php`

## Regression fixed
After the public runtime mode refactor, runtime generation succeeded but reused the current-site import preview decorator. That set the Gutenberg block's "Open WordPress preview" link to a generic `home_url('/')`, which is brittle in public Playground. Public runtime generation now returns `/` so the link opens the generated site in the active runtime.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Tracing the preview URL regression, restoring the current-runtime URL contract, and adding regression coverage.