### PR TITLE
Stabilize public Playground runtime import contract

### DIFF
--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -270,6 +270,7 @@
 			const provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
 			const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
 			const isCurrentRuntimeGeneration = root.getAttribute( 'data-static-site-importer-generate-in-current-runtime' ) === '1';
+			const shouldWriteGeneratedSite = isCurrentSiteImport || isCurrentRuntimeGeneration;
 			const source = {
 				url: form ? form.getAttribute( 'data-static-site-importer-default-url' ) || '' : '',
 				html: html ? html.value : '',
@@ -299,8 +300,8 @@
 						provider,
 						source,
 						apply_to_current_site: isCurrentSiteImport,
-						activate: isCurrentSiteImport,
-						overwrite: isCurrentSiteImport,
+						activate: shouldWriteGeneratedSite,
+						overwrite: shouldWriteGeneratedSite,
 						generate_in_current_runtime: isCurrentRuntimeGeneration,
 					} ),
 				} );

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -522,8 +522,14 @@ function static_site_importer_rest_should_apply_to_current_site( array $params )
  * @return array<string,mixed>|WP_Error
  */
 function static_site_importer_rest_generate_in_current_runtime( array $source, array $input, array $params ) {
-	$input['activate']  = array_key_exists( 'activate', $params ) ? ! empty( $params['activate'] ) : true;
-	$input['overwrite'] = array_key_exists( 'overwrite', $params ) ? ! empty( $params['overwrite'] ) : true;
+	$input['activate']  = true;
+	$input['overwrite'] = true;
+	if ( empty( $input['slug'] ) ) {
+		$input['slug'] = 'generated-wordpress-website';
+	}
+	if ( empty( $input['name'] ) ) {
+		$input['name'] = __( 'Generated WordPress Website', 'static-site-importer' );
+	}
 
 	$result = static_site_importer_rest_apply_to_current_site( $source, $input, $params );
 	if ( ! is_array( $result ) ) {
@@ -534,7 +540,7 @@ function static_site_importer_rest_generate_in_current_runtime( array $source, a
 	$preview['status']         = isset( $preview['status'] ) ? $preview['status'] : 'ready';
 	$preview['url']            = static_site_importer_rest_current_runtime_preview_url();
 	$playground                = isset( $preview['playground'] ) && is_array( $preview['playground'] ) ? $preview['playground'] : array();
-	$playground['preview_url'] = $preview['url'];
+	$playground['preview_url'] = static_site_importer_rest_current_runtime_preview_path();
 	$preview['playground']     = $playground;
 	$result['preview']         = $preview;
 	$result['mode']            = 'generated_in_current_runtime';
@@ -548,6 +554,15 @@ function static_site_importer_rest_generate_in_current_runtime( array $source, a
  * @return string
  */
 function static_site_importer_rest_current_runtime_preview_url(): string {
+	return 'https://playground.wordpress.net/?url=%2F';
+}
+
+/**
+ * Return the active runtime front page path for public Playground generation.
+ *
+ * @return string
+ */
+function static_site_importer_rest_current_runtime_preview_path(): string {
 	return '/';
 }
 

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -475,9 +475,10 @@ $assert( str_contains( $view_js, 'shouldIncludeSiteFile' ), 'view-skips-known-no
 $assert( ! str_contains( $view_js, 'applyToCurrentSite || generateInCurrentRuntime' ), 'view-does-not-treat-current-runtime-generation-as-current-site-import' );
 $assert( str_contains( $view_js, 'isCurrentSiteImport' ), 'view-names-current-site-import-mode-explicitly' );
 $assert( str_contains( $view_js, 'isCurrentRuntimeGeneration' ), 'view-names-current-runtime-generation-mode-explicitly' );
+$assert( str_contains( $view_js, 'shouldWriteGeneratedSite = isCurrentSiteImport || isCurrentRuntimeGeneration' ), 'view-writes-generated-site-for-runtime-generation-without-marking-current-site-import' );
 $assert( str_contains( $view_js, 'apply_to_current_site: isCurrentSiteImport' ), 'view-sends-current-site-apply-flag-only-from-apply-mode' );
-$assert( str_contains( $view_js, 'activate: isCurrentSiteImport' ), 'view-activates-only-current-site-imports' );
-$assert( str_contains( $view_js, 'overwrite: isCurrentSiteImport' ), 'view-overwrites-only-current-site-imports' );
+$assert( str_contains( $view_js, 'activate: shouldWriteGeneratedSite' ), 'view-activates-current-site-and-runtime-generation' );
+$assert( str_contains( $view_js, 'overwrite: shouldWriteGeneratedSite' ), 'view-overwrites-current-site-and-runtime-generation' );
 $assert( str_contains( $view_js, 'generate_in_current_runtime: isCurrentRuntimeGeneration' ), 'view-sends-current-runtime-generation-flag' );
 $generic_preview_message = implode( ' ', array( 'no', 'preview', 'provider', 'is', 'configured' ) );
 $assert( ! str_contains( $view_js, $generic_preview_message ), 'view-does-not-reference-generic-preview-message' );
@@ -663,8 +664,10 @@ $assert( true === ( $runtime_response['success'] ?? null ), 'rest-current-runtim
 $assert( 'generated_in_current_runtime' === ( $runtime_response['mode'] ?? '' ), 'rest-current-runtime-generation-reports-mode' );
 $assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['activate'] ?? null ), 'rest-current-runtime-generation-activates-generated-site' );
 $assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['overwrite'] ?? null ), 'rest-current-runtime-generation-overwrites-generated-site' );
+$assert( 'generated-wordpress-website' === ( Static_Site_Importer_Theme_Generator::$last_args['slug'] ?? null ), 'rest-current-runtime-generation-uses-non-legacy-generated-theme-slug' );
+$assert( 'Generated WordPress Website' === ( Static_Site_Importer_Theme_Generator::$last_args['name'] ?? null ), 'rest-current-runtime-generation-uses-generated-theme-name' );
 $assert( array() === WP_Codebox_Abilities::$last_input, 'rest-current-runtime-generation-does-not-use-codebox-preview' );
-$assert( '/' === ( $runtime_response['preview']['url'] ?? '' ), 'rest-current-runtime-generation-returns-active-runtime-front-page-url' );
+$assert( 'https://playground.wordpress.net/?url=%2F' === ( $runtime_response['preview']['url'] ?? '' ), 'rest-current-runtime-generation-returns-playground-front-page-url' );
 $assert( '/' === ( $runtime_response['preview']['playground']['preview_url'] ?? '' ), 'rest-current-runtime-generation-records-playground-preview-path' );
 
 $blueprint = json_decode( file_get_contents( dirname( __DIR__ ) . '/docs/playground/blueprint.json' ), true );


### PR DESCRIPTION
## Summary
- Make public runtime generation write the generated site without marking the request as a current-site import.
- Force runtime generation to activate and overwrite the disposable generated theme on every run, preventing `static_site_importer_theme_exists` repeat-import failures.
- Use a generated-site slug/name for runtime generation instead of the legacy `imported-website-artifact` fallback.
- Return a real Playground open URL, `https://playground.wordpress.net/?url=%2F`, while keeping the runtime preview path as `/`.

## Testing
- `php tests/smoke-importer-block.php`
- `git diff --check`

## Regression fixed
The README/public Playground block must let the user upload HTML, generate the WordPress site inside the disposable Playground runtime, and open the generated site in the browser. It must not require Codebox, must not fail on repeated imports because a generated theme already exists, and must not expose the legacy `imported-website-artifact` fallback slug.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Tracing the public Playground runtime regressions, restoring a stable execution/open-url contract, and adding regression coverage.