### PR TITLE
Fix stabilization release lint

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -41,7 +41,6 @@ function static_site_importer_register_rest_routes(): void {
 			),
 		)
 	);
-
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove the blank line that failed PHPCS release lint after the Playground stabilization cleanup.

## Testing
- php tests/smoke-importer-block.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Applying and verifying the lint-only follow-up fix.