### PR TITLE
Consume Figma transformer diagnostics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,19 +38,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-figma-transformer",
-        "version": "0.1.1",
+        "version": "0.1.2",
         "description": "PHP primitives for transforming Figma designs into static HTML website artifacts.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "e3a2c49c808d7cbc23bc63dcaca733697278d0dc"
+          "reference": "467f9f6647f41bfa9a64984b40007a8d97f1a072"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/figma-transformer-v0.1.1.zip",
-          "reference": "e3a2c49c808d7cbc23bc63dcaca733697278d0dc"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/figma-transformer-v0.1.2.zip",
+          "reference": "467f9f6647f41bfa9a64984b40007a8d97f1a072"
         },
         "autoload": {
           "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e5c5bb2fc41969c7b9395ce43cade1c",
+    "content-hash": "a6ea432c5e6249bc231d916152e174a1",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "e3a2c49c808d7cbc23bc63dcaca733697278d0dc"
+                "reference": "467f9f6647f41bfa9a64984b40007a8d97f1a072"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/figma-transformer-v0.1.1.zip",
-                "reference": "e3a2c49c808d7cbc23bc63dcaca733697278d0dc"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/figma-transformer-v0.1.2.zip",
+                "reference": "467f9f6647f41bfa9a64984b40007a8d97f1a072"
             },
             "require": {
                 "php": ">=8.1"

--- a/includes/class-static-site-importer-figma-import.php
+++ b/includes/class-static-site-importer-figma-import.php
@@ -35,6 +35,101 @@ class Static_Site_Importer_Figma_Import {
 	}
 
 	/**
+	 * Diagnose a Figma runner request through the production transform boundary.
+	 *
+	 * @param array<string,mixed> $input Figma import input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function diagnostics_report( array $input ) {
+		$artifact = self::website_artifact_from_input( $input );
+		if ( is_wp_error( $artifact ) ) {
+			return $artifact;
+		}
+
+		$import_input = self::import_input( $input, $artifact );
+		$scenegraph   = self::scenegraph_from_input( $input );
+
+		$transform_diagnostics = array();
+		if ( ! empty( $scenegraph ) && function_exists( 'blocks_engine_figma_transformer_transform_scenegraph' ) ) {
+			$transform = blocks_engine_figma_transformer_transform_scenegraph( $scenegraph, self::transform_options( $input ) );
+			if ( is_object( $transform ) && is_callable( array( $transform, 'toArray' ) ) ) {
+				$transform = $transform->toArray();
+			}
+			if ( is_array( $transform ) ) {
+				$transform_diagnostics = $transform['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+			}
+		}
+
+		return array(
+			'schema'                  => 'static-site-importer/figma-diagnostics/v1',
+			'success'                 => true,
+			'request'                 => self::diagnostics_request_summary( $input ),
+			'artifact'                => self::diagnostics_artifact_summary( $artifact ),
+			'transform_diagnostics'   => is_array( $transform_diagnostics ) ? $transform_diagnostics : array(),
+			'production_import_input' => array(
+				'slug'      => (string) ( $import_input['slug'] ?? '' ),
+				'name'      => (string) ( $import_input['name'] ?? '' ),
+				'activate'  => (bool) ( $import_input['activate'] ?? false ),
+				'overwrite' => (bool) ( $import_input['overwrite'] ?? false ),
+			),
+		);
+	}
+
+	/**
+	 * Summarize the Figma request without echoing the full design payload.
+	 *
+	 * @param array<string,mixed> $input Figma import input.
+	 * @return array<string,mixed>
+	 */
+	private static function diagnostics_request_summary( array $input ): array {
+		$scenegraph = self::scenegraph_from_input( $input );
+		$source     = isset( $input['source'] ) && is_array( $input['source'] ) ? $input['source'] : array();
+
+		return array_filter(
+			array(
+				'has_scenegraph'  => ! empty( $scenegraph ),
+				'has_bundle'      => isset( $input['artifact_bundle'] ) && is_array( $input['artifact_bundle'] ),
+				'frame_id'        => isset( $input['frame_id'] ) ? (string) $input['frame_id'] : '',
+				'source_file_key' => isset( $source['fileKey'] ) ? (string) $source['fileKey'] : '',
+				'node_ids'        => isset( $source['nodeIds'] ) && is_array( $source['nodeIds'] ) ? array_values( array_map( 'strval', $source['nodeIds'] ) ) : array(),
+			)
+		);
+	}
+
+	/**
+	 * Summarize the generated website artifact boundary.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact.
+	 * @return array<string,mixed>
+	 */
+	private static function diagnostics_artifact_summary( array $artifact ): array {
+		$files       = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
+		$paths       = array();
+		$asset_paths = array();
+
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) || ! isset( $file['path'] ) || ! is_scalar( $file['path'] ) ) {
+				continue;
+			}
+
+			$path    = (string) $file['path'];
+			$paths[] = $path;
+			if ( str_contains( $path, '/assets/' ) ) {
+				$asset_paths[] = $path;
+			}
+		}
+
+		return array(
+			'schema'      => (string) ( $artifact['schema'] ?? '' ),
+			'root'        => (string) ( $artifact['root'] ?? '' ),
+			'entrypoint'  => (string) ( $artifact['entrypoint'] ?? '' ),
+			'file_count'  => count( $paths ),
+			'asset_count' => count( $asset_paths ),
+			'asset_paths' => $asset_paths,
+		);
+	}
+
+	/**
 	 * Build a Figma plugin runner response for browser clients.
 	 *
 	 * @param array<string,mixed> $ability_result Ability result.

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -114,4 +114,37 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			}
 		}
 	);
+
+	WP_CLI::add_command(
+		'static-site-importer figma-diagnostics',
+		static function ( array $args, array $assoc_args ): void {
+			unset( $args );
+
+			if ( empty( $assoc_args['input'] ) ) {
+				WP_CLI::error( 'Provide a Figma request JSON file with --input=<path>.' );
+				return;
+			}
+
+			$input_json = file_get_contents( (string) $assoc_args['input'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- CLI reads an operator-provided request file.
+			$input      = json_decode( false === $input_json ? '' : $input_json, true );
+			if ( ! is_array( $input ) ) {
+				WP_CLI::error( 'The --input file must contain a JSON object.' );
+				return;
+			}
+
+			$result = Static_Site_Importer_Figma_Import::diagnostics_report( $input );
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::error( $result->get_error_message() );
+				return;
+			}
+
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			if ( false === $json ) {
+				WP_CLI::error( 'Failed to encode Figma diagnostics result.' );
+				return;
+			}
+
+			WP_CLI::line( $json );
+		}
+	);
 }

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -390,6 +390,10 @@ if ( ! function_exists( 'get_page_uri' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/includes/block.php';
+$figma_transformer_bootstrap = dirname( __DIR__ ) . '/vendor/automattic/blocks-engine-figma-transformer/figma-transformer/figma-transformer.php';
+if ( is_readable( $figma_transformer_bootstrap ) ) {
+	require_once $figma_transformer_bootstrap;
+}
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-figma-import.php';
 require_once dirname( __DIR__ ) . '/includes/abilities.php';
 require_once dirname( __DIR__ ) . '/includes/rest.php';
@@ -806,6 +810,46 @@ $assert( str_contains( (string) $figma_blueprint_code, "'overwrite' => true" ), 
 $assert( str_contains( (string) $figma_blueprint_code, "'name' => 'Fisiostetic'" ), 'figma-import-name-derived-from-metadata' );
 $assert( str_contains( (string) $figma_blueprint_code, "'site_title' => 'Fisiostetic'" ), 'figma-import-site-title-derived-from-metadata' );
 $assert( str_contains( (string) $figma_blueprint_code, "'source' => 'figma-to-wordpress'" ), 'figma-artifact-provenance-source' );
+
+$figma_diagnostics = Static_Site_Importer_Figma_Import::diagnostics_report(
+	array(
+		'schema'     => 'figma-to-wordpress/runner-request/v1',
+		'source'     => array(
+			'fileKey' => 'fixture-file-key',
+			'nodeIds' => array( '1:1' ),
+		),
+		'slug'       => 'figma-diagnostics',
+		'name'       => 'Figma Diagnostics',
+		'scenegraph' => array(
+			'name'  => 'Diagnostics Fixture',
+			'nodes' => array(
+				array(
+					'id'       => '1:1',
+					'type'     => 'FRAME',
+					'name'     => 'Landing Page',
+					'width'    => 640,
+					'height'   => 360,
+					'children' => array(
+						array(
+							'id'       => '1:2',
+							'type'     => 'TEXT',
+							'name'     => 'Heading',
+							'text'     => 'Hello diagnostics',
+							'fontSize' => 32,
+						),
+					),
+				),
+			),
+		),
+	)
+);
+$assert( is_array( $figma_diagnostics ), 'figma-diagnostics-builds-report' );
+$assert( true === ( $figma_diagnostics['success'] ?? null ), 'figma-diagnostics-succeeds' );
+$assert( 'static-site-importer/figma-diagnostics/v1' === ( $figma_diagnostics['schema'] ?? '' ), 'figma-diagnostics-uses-schema' );
+$assert( true === ( $figma_diagnostics['request']['has_scenegraph'] ?? null ), 'figma-diagnostics-summarizes-scenegraph-request' );
+$assert( 'website/index.html' === ( $figma_diagnostics['artifact']['entrypoint'] ?? '' ), 'figma-diagnostics-summarizes-artifact-entrypoint' );
+$assert( isset( $figma_diagnostics['transform_diagnostics']['diagnostic_codes'] ), 'figma-diagnostics-exposes-transform-diagnostics' );
+$assert( 'figma-diagnostics' === ( $figma_diagnostics['production_import_input']['slug'] ?? '' ), 'figma-diagnostics-summarizes-production-import-input' );
 
 if ( class_exists( 'ZipArchive' ) ) {
 	$zip_path = tempnam( sys_get_temp_dir(), 'ssi-test-' );


### PR DESCRIPTION
## Summary
- Bump the bundled Blocks Engine Figma transformer to `0.1.2`.
- Add a WP-CLI Figma diagnostics surface that reuses the production transform path without mutating the site.
- Cover the diagnostics envelope in the importer smoke test.

## Verification
- `homeboy lint static-site-importer --path "/Users/chubes/Developer/static-site-importer@consume-figma-transformer-0-1-2" --runner homeboy-lab --summary`
- `homeboy test static-site-importer --path "/Users/chubes/Developer/static-site-importer@consume-figma-transformer-0-1-2"`
- `homeboy build static-site-importer --path "/Users/chubes/Developer/static-site-importer@consume-figma-transformer-0-1-2"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Dependency update, diagnostics command implementation, test coverage, and Homeboy verification.