### PR TITLE
Add Figma file upload support

### DIFF
--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -128,7 +128,7 @@
 		const selectedFiles = selectedInputFiles( inputs, root );
 		const files = selectedFiles.filter( function ( record ) {
 			const path = record.path || uploadedFilePath( record.file );
-			return ! /\.zip$/i.test( record.file.name || path || '' ) && shouldIncludeSiteFile( path );
+			return ! /\.(fig|zip)$/i.test( record.file.name || path || '' ) && shouldIncludeSiteFile( path );
 		} );
 		return Promise.all( files.map( async function ( upload ) {
 			const file = upload.file;
@@ -164,6 +164,20 @@
 			path: archive.path || file.name || 'website.zip',
 			name: file.name || 'website.zip',
 			type: file.type || 'application/zip',
+			size: file.size || 0,
+			content_base64: await fileToBase64( file ),
+		};
+	};
+
+	const buildFigmaFile = async function ( input ) {
+		const file = input && input.files && input.files[ 0 ] ? input.files[ 0 ] : null;
+		if ( ! file ) {
+			return null;
+		}
+
+		return {
+			name: file.name || 'design.fig',
+			type: file.type || 'application/octet-stream',
 			size: file.size || 0,
 			content_base64: await fileToBase64( file ),
 		};
@@ -220,6 +234,7 @@
 		return Boolean(
 			( source.files && source.files.length > 0 ) ||
 			( source.archive && source.archive.content_base64 ) ||
+			( source.figma_file && source.figma_file.content_base64 ) ||
 			( source.html && source.html.trim() ) ||
 			( source.url && source.url.trim() )
 		);
@@ -266,6 +281,7 @@
 		submit.addEventListener( 'click', async function () {
 			const form = root.querySelector( '[data-static-site-importer-form]' );
 			const html = root.querySelector( '[data-static-site-importer-source-html]' );
+			const figmaFile = root.querySelector( '[data-static-site-importer-source-figma-file]' );
 			const uploadInputs = root.querySelectorAll( '[data-static-site-importer-source-files], [data-static-site-importer-source-directory]' );
 			const provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
 			const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
@@ -274,6 +290,7 @@
 				html: html ? html.value : '',
 				files: await buildFiles( uploadInputs, root ),
 				archive: await buildArchive( uploadInputs, root ),
+				figma_file: await buildFigmaFile( figmaFile ),
 			};
 
 			if ( ! hasSource( source ) ) {

--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.8",
+        "version": "0.1.10",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "1f12991b1d23c66de1c36e325490ad0056c0d75d"
+          "reference": "7c154bb6b362556e930425148c2ed3661766f9c0"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.8.zip",
-          "reference": "1f12991b1d23c66de1c36e325490ad0056c0d75d"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.10.zip",
+          "reference": "7c154bb6b362556e930425148c2ed3661766f9c0"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.1.8",
+    "automattic/blocks-engine-php-transformer": "^0.1.10",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a6ea432c5e6249bc231d916152e174a1",
+    "content-hash": "89fd80fb073476945347f6d6df907b41",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.8",
+            "version": "0.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "1f12991b1d23c66de1c36e325490ad0056c0d75d"
+                "reference": "7c154bb6b362556e930425148c2ed3661766f9c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.8.zip",
-                "reference": "1f12991b1d23c66de1c36e325490ad0056c0d75d"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.10.zip",
+                "reference": "7c154bb6b362556e930425148c2ed3661766f9c0"
             },
             "require": {
                 "league/commonmark": "^2.5",

--- a/includes/block.php
+++ b/includes/block.php
@@ -60,6 +60,15 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 					</label>
 				</fieldset>
 
+				<fieldset class="ssi-importer__field">
+					<legend class="ssi-importer__label"><?php esc_html_e( 'Upload Figma file', 'static-site-importer' ); ?></legend>
+					<p class="ssi-importer__upload-copy"><?php esc_html_e( 'Choose a .fig file exported from Figma.', 'static-site-importer' ); ?></p>
+					<label class="ssi-importer__upload-option">
+						<span><?php esc_html_e( 'Choose .fig file', 'static-site-importer' ); ?></span>
+						<input type="file" name="ssi_figma_file" accept=".fig" data-static-site-importer-source-figma-file>
+					</label>
+				</fieldset>
+
 				<details class="ssi-importer__field">
 					<summary class="ssi-importer__label"><?php esc_html_e( 'Paste HTML', 'static-site-importer' ); ?></summary>
 					<textarea name="ssi_html" rows="6" data-static-site-importer-source-html></textarea>

--- a/includes/class-static-site-importer-figma-import.php
+++ b/includes/class-static-site-importer-figma-import.php
@@ -198,6 +198,11 @@ class Static_Site_Importer_Figma_Import {
 	 * @return array<string,mixed>|WP_Error
 	 */
 	public static function website_artifact_from_input( array $input ) {
+		$figma_file = self::figma_file_from_input( $input );
+		if ( ! empty( $figma_file ) ) {
+			return self::website_artifact_from_figma_file( $figma_file, $input );
+		}
+
 		$scenegraph = self::scenegraph_from_input( $input );
 		if ( ! empty( $scenegraph ) ) {
 			$artifact = self::website_artifact_from_scenegraph( $scenegraph, $input );
@@ -248,6 +253,58 @@ class Static_Site_Importer_Figma_Import {
 		}
 
 		$transform = blocks_engine_figma_transformer_transform_scenegraph( $scenegraph, self::transform_options( $input ) );
+
+		return self::website_artifact_from_transform( $transform, $input );
+	}
+
+	/**
+	 * Transform an uploaded .fig file into a website artifact.
+	 *
+	 * @param array<string,mixed> $figma_file Uploaded .fig source payload.
+	 * @param array<string,mixed> $input      Full request input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function website_artifact_from_figma_file( array $figma_file, array $input ) {
+		if ( ! function_exists( 'blocks_engine_figma_transformer_transform_file' ) ) {
+			return new WP_Error( 'static_site_importer_figma_transformer_unavailable', 'Blocks Engine Figma transformer is not available.', array( 'status' => 501 ) );
+		}
+
+		$name = isset( $figma_file['name'] ) ? (string) $figma_file['name'] : '';
+		if ( ! preg_match( '/\.fig$/i', $name ) ) {
+			return new WP_Error( 'static_site_importer_figma_file_type_invalid', 'Figma file uploads must use a .fig file.', array( 'status' => 400 ) );
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes uploaded .fig payload content.
+		$content = isset( $figma_file['content_base64'] ) ? base64_decode( (string) $figma_file['content_base64'], true ) : false;
+		if ( false === $content ) {
+			return new WP_Error( 'static_site_importer_figma_file_content_invalid', 'Uploaded .fig content could not be decoded.', array( 'status' => 400 ) );
+		}
+
+		$tmp = tempnam( sys_get_temp_dir(), 'ssi-fig-' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Transformer requires a local file path for .fig archive inspection.
+		if ( false === $tmp || false === file_put_contents( $tmp, $content ) ) {
+			return new WP_Error( 'static_site_importer_figma_file_tempfile_failed', 'Uploaded .fig file could not be staged for transformation.', array( 'status' => 500 ) );
+		}
+
+		try {
+			$transform = blocks_engine_figma_transformer_transform_file( $tmp, self::transform_options( $input ) );
+		} finally {
+			if ( file_exists( $tmp ) ) {
+				wp_delete_file( $tmp );
+			}
+		}
+
+		return self::website_artifact_from_transform( $transform, $input );
+	}
+
+	/**
+	 * Convert a Blocks Engine Figma transform result into SSI's website artifact shape.
+	 *
+	 * @param mixed               $transform Transform result.
+	 * @param array<string,mixed> $input     Full request input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function website_artifact_from_transform( $transform, array $input ) {
 		if ( is_object( $transform ) && is_callable( array( $transform, 'toArray' ) ) ) {
 			$transform = $transform->toArray();
 		}
@@ -276,6 +333,25 @@ class Static_Site_Importer_Figma_Import {
 			'files'      => $files,
 			'provenance' => self::provenance( $input ) + array( 'transform' => 'blocks-engine/figma-transformer' ),
 		);
+	}
+
+	/**
+	 * Extract the uploaded .fig file payload from supported request shapes.
+	 *
+	 * @param array<string,mixed> $input Figma import input.
+	 * @return array<string,mixed>
+	 */
+	private static function figma_file_from_input( array $input ): array {
+		if ( isset( $input['figma_file'] ) && is_array( $input['figma_file'] ) ) {
+			return $input['figma_file'];
+		}
+
+		$source = isset( $input['source'] ) && is_array( $input['source'] ) ? $input['source'] : array();
+		if ( isset( $source['figma_file'] ) && is_array( $source['figma_file'] ) ) {
+			return $source['figma_file'];
+		}
+
+		return array();
 	}
 
 	/**

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -420,7 +420,7 @@ function static_site_importer_rest_open_in_playground( array $source, array $inp
 	}
 	$input['artifact'] = $artifact;
 
-	$result = static_site_importer_rest_create_playground_open( $artifact, $input, 'upload' );
+	$result = static_site_importer_rest_create_playground_open( $artifact, $input, isset( $source['figma_file'] ) ? 'figma_file' : 'upload' );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -456,7 +456,7 @@ function static_site_importer_rest_apply_to_current_site( array $source, array $
 		return $result;
 	};
 
-	if ( isset( $source['url'] ) && '' !== trim( (string) $source['url'] ) ) {
+	if ( ! isset( $source['figma_file'] ) && isset( $source['url'] ) && '' !== trim( (string) $source['url'] ) ) {
 		$input['url'] = esc_url_raw( (string) $source['url'] );
 		if ( isset( $params['provider'] ) ) {
 			$input['provider'] = sanitize_key( (string) $params['provider'] );
@@ -1038,6 +1038,9 @@ function static_site_importer_rest_preview_source_summary( array $source, array 
 	if ( isset( $source['archive'] ) && is_array( $source['archive'] ) && ! empty( $source['archive'] ) ) {
 		$types[] = 'archive';
 	}
+	if ( isset( $source['figma_file'] ) && is_array( $source['figma_file'] ) && ! empty( $source['figma_file'] ) ) {
+		$types[] = 'figma_file';
+	}
 
 	return array_merge(
 		array( 'type' => 1 === count( $types ) ? $types[0] : ( empty( $types ) ? 'unknown' : 'mixed' ) ),
@@ -1219,6 +1222,10 @@ function static_site_importer_rest_import_args( array $params ): array {
 function static_site_importer_rest_source_artifact( array $source ) {
 	if ( isset( $source['artifact'] ) && is_array( $source['artifact'] ) ) {
 		return $source['artifact'];
+	}
+
+	if ( isset( $source['figma_file'] ) && is_array( $source['figma_file'] ) ) {
+		return Static_Site_Importer_Figma_Import::website_artifact_from_input( array( 'source' => $source ) );
 	}
 
 	$files = array();
@@ -1409,6 +1416,10 @@ function static_site_importer_rest_should_include_artifact_file( string $path ):
 	}
 
 	if ( '.DS_Store' === $name ) {
+		return false;
+	}
+
+	if ( preg_match( '/\.fig$/i', (string) $name ) ) {
 		return false;
 	}
 

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -30,7 +30,7 @@ if ( ! function_exists( 'blocks_engine_php_transformer_compile_artifact' ) && is
 }
 
 $static_site_importer_figma_transformer = STATIC_SITE_IMPORTER_PATH . 'vendor/automattic/blocks-engine-figma-transformer/figma-transformer/figma-transformer.php';
-if ( ! function_exists( 'blocks_engine_figma_transformer_transform_scenegraph' ) && is_readable( $static_site_importer_figma_transformer ) ) {
+if ( ( ! function_exists( 'blocks_engine_figma_transformer_transform_scenegraph' ) || ! function_exists( 'blocks_engine_figma_transformer_transform_file' ) ) && is_readable( $static_site_importer_figma_transformer ) ) {
 	require_once $static_site_importer_figma_transformer;
 }
 

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -390,6 +390,7 @@ if ( ! function_exists( 'get_page_uri' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/includes/block.php';
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 $figma_transformer_bootstrap = dirname( __DIR__ ) . '/vendor/automattic/blocks-engine-figma-transformer/figma-transformer/figma-transformer.php';
 if ( is_readable( $figma_transformer_bootstrap ) ) {
 	require_once $figma_transformer_bootstrap;
@@ -456,6 +457,9 @@ $assert( str_contains( $html, 'Choose files or ZIP' ), 'render-has-file-or-zip-u
 $assert( str_contains( $html, 'Choose folder' ), 'render-has-folder-upload-affordance' );
 $assert( str_contains( $html, 'data-static-site-importer-source-directory' ), 'render-has-directory-upload-hook' );
 $assert( str_contains( $html, 'webkitdirectory' ), 'render-preserves-directory-upload-affordance' );
+$assert( str_contains( $html, 'Upload Figma file' ), 'render-has-separate-figma-upload-label' );
+$assert( str_contains( $html, 'data-static-site-importer-source-figma-file' ), 'render-has-separate-figma-upload-hook' );
+$assert( str_contains( $html, 'accept=&quot;.fig&quot;' ) || str_contains( $html, 'accept=".fig"' ), 'render-figma-upload-accepts-fig-only' );
 $assert( ! str_contains( $html, 'data-static-site-importer-source-archive' ), 'render-omits-separate-zip-upload-hook' );
 $assert( str_contains( $html, 'accept=&quot;.zip,application/zip' ) || str_contains( $html, 'accept=".zip,application/zip' ), 'render-accepts-zip-in-combined-upload' );
 $assert( str_contains( $html, 'data-static-site-importer-source-html' ), 'render-has-html-input-hook' );
@@ -479,6 +483,9 @@ $assert( str_contains( $view_js, 'webkitRelativePath' ), 'view-preserves-directo
 $assert( str_contains( $view_js, 'data-static-site-importer-source-directory' ), 'view-reads-directory-upload-input' );
 $assert( str_contains( $view_js, 'webkitGetAsEntry' ), 'view-supports-dropped-directory-entries' );
 $assert( str_contains( $view_js, 'archive: await buildArchive( uploadInputs, root )' ), 'view-sends-zip-from-combined-upload-as-archive-payload' );
+$assert( str_contains( $view_js, 'figma_file: await buildFigmaFile( figmaFile )' ), 'view-sends-distinct-figma-source-shape' );
+$assert( str_contains( $view_js, '/\\.(fig|zip)$/i' ), 'view-excludes-fig-files-from-generic-static-upload' );
+$assert( str_contains( $view_js, 'data-static-site-importer-source-figma-file' ), 'view-reads-separate-figma-file-input' );
 $assert( str_contains( $view_js, 'shouldIncludeSiteFile' ), 'view-skips-known-non-site-upload-files-before-reading' );
 $assert( ! str_contains( $view_js, 'CurrentRuntime' ), 'view-does-not-reference-current-runtime-mode' );
 $assert( ! str_contains( $view_js, 'generate_in_current_runtime' ), 'view-does-not-send-current-runtime-flag' );
@@ -680,6 +687,95 @@ $assert( str_contains( (string) $playground_blueprint_code, "'overwrite' => true
 $assert( str_contains( (string) $playground_blueprint_code, "'slug' => 'generated-wordpress-website'" ), 'rest-playground-open-blueprint-uses-non-legacy-generated-theme-slug' );
 $assert( str_contains( (string) $playground_blueprint_code, "'name' => 'Generated WordPress Website'" ), 'rest-playground-open-blueprint-uses-generated-theme-name' );
 $assert( ! str_contains( (string) $playground_blueprint_code, 'imported-website-artifact' ), 'rest-playground-open-blueprint-omits-legacy-theme-slug' );
+$assert( ! str_contains( (string) $playground_blueprint_code, 'Codebox' ), 'rest-playground-open-blueprint-does-not-introduce-codebox' );
+
+$figma_upload_artifact = Static_Site_Importer_Figma_Import::website_artifact_from_input(
+	array(
+		'source' => array(
+			'figma_file' => array(
+				'name'           => 'design.fig',
+				'type'           => 'application/octet-stream',
+				'content_base64' => base64_encode( 'not-a-zip' ),
+			),
+		),
+	)
+);
+$assert( is_wp_error( $figma_upload_artifact ) || is_array( $figma_upload_artifact ), 'figma-file-source-routes-through-transformer' );
+$generic_fig_artifact = static_site_importer_rest_source_artifact(
+	array(
+		'files' => array(
+			array(
+				'path'           => 'design.fig',
+				'content_base64' => base64_encode( 'not-a-site' ),
+			),
+		),
+	)
+);
+$assert( is_wp_error( $generic_fig_artifact ), 'rest-generic-static-upload-ignores-fig-file' );
+
+if ( class_exists( 'ZipArchive' ) ) {
+	$fig_payload = array(
+		'name'         => 'Public Import Fixture',
+		'NODE_CHANGES' => array(
+			'4:1' => array(
+				'node' => array(
+					'id'       => '4:1',
+					'type'     => 'FRAME',
+					'name'     => 'Landing',
+					'children' => array(
+						array(
+							'id'         => '4:2',
+							'type'       => 'TEXT',
+							'name'       => 'Heading',
+							'characters' => 'Synthetic FIG Upload',
+						),
+					),
+				),
+			),
+		),
+	);
+	$fig_json    = wp_json_encode( $fig_payload );
+	$fig_chunk   = gzdeflate( (string) $fig_json );
+	$fig_canvas  = 'fig-kiwi' . pack( 'V', 106 ) . pack( 'V', strlen( $fig_chunk ) ) . $fig_chunk;
+	$fig_path    = tempnam( sys_get_temp_dir(), 'ssi-fig-smoke-' );
+	$fig_archive = new ZipArchive();
+	$fig_archive->open( $fig_path, ZipArchive::OVERWRITE );
+	$fig_archive->addFromString( 'canvas.fig', $fig_canvas );
+	$fig_archive->addFromString( 'meta.json', '{"name":"Public Import Fixture"}' );
+	$fig_archive->close();
+
+	Static_Site_Importer_Theme_Generator::$last_artifact = array();
+	Static_Site_Importer_Theme_Generator::$last_args     = array();
+	WP_Codebox_Abilities::$last_input = array();
+	$fig_upload_response = static_site_importer_rest_create_import(
+		new WP_REST_Request(
+			array(
+				'apply_to_current_site' => false,
+				'source'                => array(
+					'figma_file' => array(
+						'name'           => 'design.fig',
+						'type'           => 'application/octet-stream',
+						'content_base64' => base64_encode( file_get_contents( $fig_path ) ),
+					),
+				),
+			)
+		)
+	);
+	@unlink( $fig_path );
+	$assert( ! is_wp_error( $fig_upload_response ), 'rest-fig-upload-playground-does-not-error', is_wp_error( $fig_upload_response ) ? $fig_upload_response->get_error_code() . ': ' . $fig_upload_response->get_error_message() : '' );
+	if ( is_wp_error( $fig_upload_response ) ) {
+		$fig_upload_response = array();
+	}
+	$assert( true === ( $fig_upload_response['success'] ?? null ), 'rest-fig-upload-playground-succeeds' );
+	$assert( 'playground' === ( $fig_upload_response['mode'] ?? '' ), 'rest-fig-upload-uses-playground-mode' );
+	$assert( str_starts_with( $fig_upload_response['preview']['url'] ?? '', 'https://playground.wordpress.net/#' ), 'rest-fig-upload-returns-direct-playground-blueprint-url' );
+	$assert( 'figma_file' === ( $fig_upload_response['request']['source'] ?? '' ), 'rest-fig-upload-records-distinct-source' );
+	$assert( array() === Static_Site_Importer_Theme_Generator::$last_args, 'rest-fig-upload-playground-does-not-import-current-site' );
+	$assert( array() === WP_Codebox_Abilities::$last_input, 'rest-fig-upload-playground-does-not-use-codebox' );
+	$fig_upload_blueprint_json = rawurldecode( substr( (string) ( $fig_upload_response['preview']['playground']['blueprint_url'] ?? '' ), strlen( 'https://playground.wordpress.net/#' ) ) );
+	$assert( str_contains( $fig_upload_blueprint_json, 'Synthetic FIG Upload' ), 'rest-fig-upload-blueprint-contains-transformed-artifact' );
+	$assert( ! str_contains( $fig_upload_blueprint_json, 'content_base64' ), 'rest-fig-upload-blueprint-does-not-carry-raw-fig-source' );
+}
 
 $blueprint = json_decode( file_get_contents( dirname( __DIR__ ) . '/docs/playground/blueprint.json' ), true );
 $assert( is_array( $blueprint ), 'playground-blueprint-decodes' );


### PR DESCRIPTION
## Summary
- Add a separate Figma file upload affordance to the importer block.
- Send Figma uploads as a distinct source.figma_file payload, separate from generic static-site files.
- Transform uploaded Figma files into the existing SSI website artifact shape, then reuse the same current-site vs direct Playground URL contract.
- Update transformer dependencies to include the latest PHP transformer improvements.

## Testing
- php tests/smoke-importer-block.php
- git diff --check

## Notes
- The browser Playground URL still imports a generated SSI website artifact. Raw Figma transform happens before the Playground URL is generated, avoiding reliance on browser Playground zstd/ZipArchive support.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode and subagent
- **Used for:** Implementing Figma file upload support, transformer dependency update, regression coverage, and verification.