### PR TITLE
Improve raw HTML import diagnostics

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1007,6 +1007,18 @@ class Static_Site_Importer_Report_Diagnostics {
 			'interaction_candidate_count' => count( $interaction_candidates ),
 		);
 
+		foreach ( array( 'asset_reference_count', 'presentation_gap_count' ) as $count_field ) {
+			if ( isset( $conversion_report[ $count_field ] ) && is_numeric( $conversion_report[ $count_field ] ) ) {
+				$payload[ $count_field ] = (int) $conversion_report[ $count_field ];
+			}
+		}
+
+		foreach ( array( 'source_selector_summaries', 'block_type_counts', 'asset_references', 'presentation_gaps', 'page_metrics' ) as $field ) {
+			if ( isset( $conversion_report[ $field ] ) && is_array( $conversion_report[ $field ] ) ) {
+				$payload[ $field ] = self::compact_native_report_value( $conversion_report[ $field ] );
+			}
+		}
+
 		if ( ! empty( $diagnostics ) ) {
 			$payload['diagnostics'] = self::compact_native_report_rows( $diagnostics );
 		}
@@ -1141,7 +1153,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return array<int,array<string,mixed>>
 	 */
 	private static function compact_native_report_rows( array $rows ): array {
-		$fields  = array( 'type', 'kind', 'code', 'severity', 'source', 'source_path', 'path', 'selector', 'tag_name', 'block_name', 'block_path', 'reason', 'reason_code', 'message', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt' );
+		$fields  = array( 'type', 'kind', 'code', 'severity', 'source', 'source_path', 'path', 'selector', 'tag_name', 'block_name', 'block_path', 'attribute_path', 'reason', 'reason_code', 'message', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt' );
 		$compact = array();
 		foreach ( array_slice( $rows, 0, 50 ) as $row ) {
 			if ( ! is_array( $row ) ) {
@@ -1157,6 +1169,28 @@ class Static_Site_Importer_Report_Diagnostics {
 
 			if ( ! empty( $entry ) ) {
 				$compact[] = $entry;
+			}
+		}
+
+		return $compact;
+	}
+
+	/**
+	 * Compact nested native report values while preserving scalar metrics.
+	 *
+	 * @param mixed $value Native report value.
+	 * @return mixed
+	 */
+	private static function compact_native_report_value( mixed $value ): mixed {
+		if ( ! is_array( $value ) ) {
+			return is_scalar( $value ) || null === $value ? $value : null;
+		}
+
+		$compact = array();
+		foreach ( array_slice( $value, 0, 50, true ) as $key => $item ) {
+			$compacted = self::compact_native_report_value( $item );
+			if ( null !== $compacted ) {
+				$compact[ $key ] = $compacted;
 			}
 		}
 

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -241,7 +241,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		$emitted = '';
-		if ( function_exists( 'serialize_blocks' ) ) {
+		if ( function_exists( 'serialize_blocks' ) && self::is_serializable_parsed_block( $block ) ) {
 			// @phpstan-ignore-next-line argument.type -- Parsed block shape comes from WordPress parse_blocks() or transformer diagnostics.
 			$emitted = serialize_blocks( array( $block ) );
 		}
@@ -274,6 +274,34 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		return $entry;
+	}
+
+	/**
+	 * Check whether a diagnostic block has the parsed-block fields WordPress serialization requires.
+	 *
+	 * @param array<string,mixed> $block Generated or parsed block.
+	 * @return bool
+	 */
+	private static function is_serializable_parsed_block( array $block ): bool {
+		if ( ! array_key_exists( 'blockName', $block ) || ! isset( $block['attrs'], $block['innerBlocks'], $block['innerContent'] ) ) {
+			return false;
+		}
+
+		if ( null !== $block['blockName'] && ! is_string( $block['blockName'] ) ) {
+			return false;
+		}
+
+		if ( ! is_array( $block['attrs'] ) || ! is_array( $block['innerBlocks'] ) || ! is_array( $block['innerContent'] ) ) {
+			return false;
+		}
+
+		foreach ( $block['innerBlocks'] as $inner_block ) {
+			if ( ! is_array( $inner_block ) || ! self::is_serializable_parsed_block( $inner_block ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -2039,10 +2039,39 @@ class Static_Site_Importer_Theme_Generator {
 			array(
 				'source'                       => 'blocks_engine',
 				'total_count'                  => count( $records ),
+				'counts_by_format'             => self::source_document_counts_by_format( $records ),
 				'blocks_engine_documents'      => $records,
 				'blocks_engine_document_count' => count( $records ),
 			)
 		);
+	}
+
+	/**
+	 * Count materialized source documents by source-path format.
+	 *
+	 * @param array<int,array<string,mixed>> $records Source document records.
+	 * @return array<string,int>
+	 */
+	private static function source_document_counts_by_format( array $records ): array {
+		$counts = array(
+			'html'     => 0,
+			'markdown' => 0,
+			'mdx'      => 0,
+		);
+
+		foreach ( $records as $record ) {
+			$source_path = isset( $record['source_path'] ) && is_scalar( $record['source_path'] ) ? strtolower( (string) $record['source_path'] ) : '';
+			$extension   = strtolower( pathinfo( $source_path, PATHINFO_EXTENSION ) );
+			if ( 'mdx' === $extension ) {
+				++$counts['mdx'];
+			} elseif ( in_array( $extension, array( 'md', 'markdown' ), true ) ) {
+				++$counts['markdown'];
+			} else {
+				++$counts['html'];
+			}
+		}
+
+		return $counts;
 	}
 
 	/**
@@ -2389,15 +2418,18 @@ class Static_Site_Importer_Theme_Generator {
 		$core_html_count = 0;
 		$freeform_count  = 0;
 		$invalid_count   = 0;
+		$invalid_blocks  = array();
 
 		/** @var array<int, array<string, mixed>> $analyzed_blocks */
 		$analyzed_blocks = $blocks;
-		self::analyze_generated_block_list( $analyzed_blocks, $block_count, $core_html_count, $freeform_count, $invalid_count, $relative_path );
+		self::analyze_generated_block_list( $analyzed_blocks, $block_count, $core_html_count, $freeform_count, $invalid_count, $invalid_blocks, $relative_path );
 
 		$serialized             = serialize_blocks( $blocks );
-		$serialization_mismatch = self::normalize_block_document_for_report( $block_markup ) !== self::normalize_block_document_for_report( $serialized );
+		$serialization_mismatch = self::block_documents_differ_for_report( $block_markup, $serialized );
+		$first_differing_token  = array();
 		if ( $serialization_mismatch ) {
 			++$invalid_count;
+			$first_differing_token = self::first_differing_block_document_token( $block_markup, $serialized );
 		}
 
 		self::$conversion_report['quality']['core_html_block_count'] += $core_html_count;
@@ -2405,7 +2437,9 @@ class Static_Site_Importer_Theme_Generator {
 		self::$conversion_report['quality']['invalid_block_count']   += $invalid_count;
 		if ( $invalid_count > 0 ) {
 			++self::$conversion_report['quality']['invalid_block_document_count'];
-			self::$conversion_report['diagnostics'][] = array(
+			$first_invalid_block = $invalid_blocks[0] ?? self::first_parsed_block_summary( $analyzed_blocks );
+			$validation_message  = $serialization_mismatch ? 'Serialized block document differs from generated block markup.' : 'Generated block document contains parser-exposed invalid block markup.';
+			$diagnostic          = array(
 				'type'                   => 'invalid_block_document',
 				'source'                 => $relative_path,
 				'block_count'            => $block_count,
@@ -2413,9 +2447,22 @@ class Static_Site_Importer_Theme_Generator {
 				'freeform_block_count'   => $freeform_count,
 				'invalid_block_count'    => $invalid_count,
 				'serialization_mismatch' => $serialization_mismatch,
+				'validation_message'     => $validation_message,
+				'parser_validation_message' => $validation_message,
 				'original_excerpt'       => Static_Site_Importer_Report_Diagnostics::diagnostic_excerpt( $block_markup ),
 				'serialized_excerpt'     => Static_Site_Importer_Report_Diagnostics::diagnostic_excerpt( $serialized ),
 			);
+			if ( ! empty( $first_invalid_block ) ) {
+				$diagnostic['block_name']     = $first_invalid_block['block_name'];
+				$diagnostic['block_path']     = $first_invalid_block['block_path'];
+				$diagnostic['attribute_path'] = $first_invalid_block['attribute_path'];
+				$diagnostic['invalid_blocks'] = $invalid_blocks;
+			}
+			if ( ! empty( $first_differing_token ) ) {
+				$diagnostic['first_differing_token'] = $first_differing_token;
+			}
+
+			self::$conversion_report['diagnostics'][] = $diagnostic;
 		}
 
 		return array(
@@ -2442,29 +2489,67 @@ class Static_Site_Importer_Theme_Generator {
 	 * @param array<int,int>                $path            Parsed block path.
 	 * @return void
 	 */
-	private static function analyze_generated_block_list( array $blocks, int &$block_count, int &$core_html_count, int &$freeform_count, int &$invalid_count, string $source = '', array $path = array() ): void {
+	private static function analyze_generated_block_list( array $blocks, int &$block_count, int &$core_html_count, int &$freeform_count, int &$invalid_count, array &$invalid_blocks, string $source = '', array $path = array() ): void {
 		foreach ( $blocks as $index => $block ) {
+			$block_path = array_merge( $path, array( $index ) );
 			$name = isset( $block['blockName'] ) ? $block['blockName'] : null;
 			if ( is_string( $name ) && '' !== $name ) {
 				++$block_count;
 				if ( 'core/html' === $name ) {
 					++$core_html_count;
-					self::record_generated_core_html_block( $source, array_merge( $path, array( $index ) ), $block );
+					self::record_generated_core_html_block( $source, $block_path, $block );
 				}
 				if ( 'core/freeform' === $name ) {
 					++$freeform_count;
-					self::record_generated_freeform_block( $source, array_merge( $path, array( $index ) ), $block, false );
+					self::record_generated_freeform_block( $source, $block_path, $block, false );
 				}
 			} elseif ( '' !== trim( isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ? $block['innerHTML'] : '' ) ) {
 				++$freeform_count;
 				++$invalid_count;
-				self::record_generated_freeform_block( $source, array_merge( $path, array( $index ) ), $block, true );
+				$invalid_blocks[] = array(
+					'block_name'     => 'unparsed_html',
+					'block_path'     => implode( '.', $block_path ),
+					'attribute_path' => 'innerHTML',
+					'reason'         => 'parser_exposed_unparsed_html',
+					'html_excerpt'   => Static_Site_Importer_Report_Diagnostics::diagnostic_excerpt( (string) $block['innerHTML'] ),
+				);
+				self::record_generated_freeform_block( $source, $block_path, $block, true );
 			}
 
 			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
-				self::analyze_generated_block_list( $block['innerBlocks'], $block_count, $core_html_count, $freeform_count, $invalid_count, $source, array_merge( $path, array( $index ) ) );
+				self::analyze_generated_block_list( $block['innerBlocks'], $block_count, $core_html_count, $freeform_count, $invalid_count, $invalid_blocks, $source, $block_path );
 			}
 		}
+	}
+
+	/**
+	 * Return the first named parsed block as context for document-level mismatches.
+	 *
+	 * @param array<int,array<string,mixed>> $blocks Parsed blocks.
+	 * @param array<int,int>                 $path   Current block path.
+	 * @return array<string,string>
+	 */
+	private static function first_parsed_block_summary( array $blocks, array $path = array() ): array {
+		foreach ( $blocks as $index => $block ) {
+			$block_path = array_merge( $path, array( $index ) );
+			$name       = isset( $block['blockName'] ) && is_string( $block['blockName'] ) && '' !== $block['blockName'] ? $block['blockName'] : '';
+			if ( '' !== $name ) {
+				return array(
+					'block_name'     => $name,
+					'block_path'     => implode( '.', $block_path ),
+					'attribute_path' => 'document',
+				);
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$summary = self::first_parsed_block_summary( $block['innerBlocks'], $block_path );
+				if ( ! empty( $summary ) ) {
+					return $summary;
+				}
+			}
+		}
+
+		return array();
 	}
 
 	/**
@@ -2550,5 +2635,93 @@ class Static_Site_Importer_Theme_Generator {
 		$markup = preg_replace( '/\s+/', ' ', is_string( $markup ) ? $markup : '' );
 
 		return is_string( $markup ) ? trim( $markup ) : '';
+	}
+
+	/**
+	 * Determine whether two block documents differ semantically for report purposes.
+	 *
+	 * @param string $original   Original generated markup.
+	 * @param string $serialized WordPress-serialized markup.
+	 * @return bool
+	 */
+	private static function block_documents_differ_for_report( string $original, string $serialized ): bool {
+		if ( self::normalize_block_document_for_report( $original ) === self::normalize_block_document_for_report( $serialized ) ) {
+			return false;
+		}
+
+		$original_blocks   = self::canonical_parsed_block_document_for_report( $original );
+		$serialized_blocks = self::canonical_parsed_block_document_for_report( $serialized );
+		if ( array() !== $original_blocks || array() !== $serialized_blocks ) {
+			return $original_blocks !== $serialized_blocks;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Parse a block document into a canonical shape for semantic report comparison.
+	 *
+	 * @param string $markup Block document markup.
+	 * @return array<int,mixed>
+	 */
+	private static function canonical_parsed_block_document_for_report( string $markup ): array {
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			return array();
+		}
+
+		$blocks = parse_blocks( $markup );
+		return self::canonicalize_parsed_block_values_for_report( is_array( $blocks ) ? $blocks : array() );
+	}
+
+	/**
+	 * Normalize parsed block values so harmless serializer escaping does not fail reports.
+	 *
+	 * @param mixed $value Parsed block value.
+	 * @return mixed
+	 */
+	private static function canonicalize_parsed_block_values_for_report( mixed $value ): mixed {
+		if ( is_string( $value ) ) {
+			$decoded = json_decode( '"' . str_replace( '"', '\\"', $value ) . '"' );
+			return is_string( $decoded ) ? $decoded : $value;
+		}
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$normalized = array();
+		foreach ( $value as $key => $item ) {
+			$normalized[ $key ] = self::canonicalize_parsed_block_values_for_report( $item );
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Report the first token that differs between generated and serialized block documents.
+	 *
+	 * @param string $original   Original generated markup.
+	 * @param string $serialized WordPress-serialized markup.
+	 * @return array<string,mixed>
+	 */
+	private static function first_differing_block_document_token( string $original, string $serialized ): array {
+		$original_tokens   = preg_split( '/(<!--\s*\/?wp:[^>]+-->|<[^>]+>|\s+)/', self::normalize_block_document_for_report( $original ), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
+		$serialized_tokens = preg_split( '/(<!--\s*\/?wp:[^>]+-->|<[^>]+>|\s+)/', self::normalize_block_document_for_report( $serialized ), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
+		$original_tokens   = is_array( $original_tokens ) ? array_values( $original_tokens ) : array();
+		$serialized_tokens = is_array( $serialized_tokens ) ? array_values( $serialized_tokens ) : array();
+		$limit             = max( count( $original_tokens ), count( $serialized_tokens ) );
+
+		for ( $index = 0; $index < $limit; ++$index ) {
+			$original_token   = $original_tokens[ $index ] ?? null;
+			$serialized_token = $serialized_tokens[ $index ] ?? null;
+			if ( $original_token !== $serialized_token ) {
+				return array(
+					'index'      => $index,
+					'original'   => null === $original_token ? null : Static_Site_Importer_Report_Diagnostics::diagnostic_excerpt( (string) $original_token ),
+					'serialized' => null === $serialized_token ? null : Static_Site_Importer_Report_Diagnostics::diagnostic_excerpt( (string) $serialized_token ),
+				);
+			}
+		}
+
+		return array();
 	}
 }

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -51,7 +51,7 @@ class Static_Site_Importer_Transformer_Adapter {
 		$options = $this->normalize_compile_options( $options );
 		$result  = blocks_engine_php_transformer_compile_artifact( $artifact, $options );
 
-		return $this->compiled_result_from_transformer_contract( $result );
+		return $this->compiled_result_from_transformer_contract( $result, $artifact );
 	}
 
 	/**
@@ -60,7 +60,7 @@ class Static_Site_Importer_Transformer_Adapter {
 	 * @param array<string,mixed> $result TransformerResult::toArray() output.
 	 * @return array<string,mixed>|WP_Error
 	 */
-	private function compiled_result_from_transformer_contract( array $result ) {
+	private function compiled_result_from_transformer_contract( array $result, array $artifact = array() ) {
 		$view     = $this->materialization_view_from_result( $result );
 		$compiled = ! empty( $view ) ? $this->compiled_result_from_materialization_view( $view ) : $this->compiled_result_from_native_transformer_contract( $result );
 		if ( is_wp_error( $compiled ) ) {
@@ -72,7 +72,10 @@ class Static_Site_Importer_Transformer_Adapter {
 			$source_reports       = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
 			$materialization_plan = isset( $source_reports['materialization_plan'] ) && is_array( $source_reports['materialization_plan'] ) ? $source_reports['materialization_plan'] : array();
 		}
-		$products  = $this->products_manifest_from_transformer_reports( $result, $materialization_plan );
+		$products  = $this->merge_product_manifests(
+			$this->products_manifest_from_transformer_reports( $result, $materialization_plan ),
+			$this->products_manifest_from_raw_artifact_html( $artifact )
+		);
 		$artifacts = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
 		$blocks    = isset( $artifacts['blocks'] ) && is_array( $artifacts['blocks'] ) ? $artifacts['blocks'] : array();
 
@@ -289,6 +292,293 @@ class Static_Site_Importer_Transformer_Adapter {
 		}
 
 		return $products;
+	}
+
+	/**
+	 * Infer product rows from raw HTML carried by a website artifact.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function products_manifest_from_raw_artifact_html( array $artifact ): array {
+		$products = array();
+		foreach ( $this->html_documents_from_artifact( $artifact ) as $document ) {
+			$products = array_merge( $products, $this->products_from_json_ld_html( $document['html'], $document['path'] ) );
+			$products = array_merge( $products, $this->products_from_product_card_html( $document['html'], $document['path'] ) );
+		}
+
+		return $this->merge_product_manifests( array(), $products );
+	}
+
+	/**
+	 * Return HTML file payloads from a website artifact.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @return array<int,array{path:string,html:string}>
+	 */
+	private function html_documents_from_artifact( array $artifact ): array {
+		$documents = array();
+		$files     = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$path = isset( $file['path'] ) && is_scalar( $file['path'] ) ? (string) $file['path'] : '';
+			$kind = isset( $file['kind'] ) && is_scalar( $file['kind'] ) ? strtolower( (string) $file['kind'] ) : '';
+			$mime = isset( $file['mime_type'] ) && is_scalar( $file['mime_type'] ) ? strtolower( (string) $file['mime_type'] ) : '';
+			if ( 'html' !== $kind && 'text/html' !== $mime && ! str_ends_with( strtolower( $path ), '.html' ) && ! str_ends_with( strtolower( $path ), '.htm' ) ) {
+				continue;
+			}
+
+			$html = '';
+			if ( isset( $file['content'] ) && is_scalar( $file['content'] ) ) {
+				$html = (string) $file['content'];
+			} elseif ( isset( $file['content_base64'] ) && is_scalar( $file['content_base64'] ) ) {
+				$decoded = base64_decode( (string) $file['content_base64'], true );
+				$html    = false !== $decoded ? $decoded : '';
+			}
+
+			if ( '' !== trim( $html ) ) {
+				$documents[] = array(
+					'path' => $path,
+					'html' => $html,
+				);
+			}
+		}
+
+		return $documents;
+	}
+
+	/**
+	 * Extract products from JSON-LD Product nodes.
+	 *
+	 * @param string $html        HTML document.
+	 * @param string $source_path Artifact source path.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function products_from_json_ld_html( string $html, string $source_path ): array {
+		$dom      = $this->load_html_document( $html );
+		$products = array();
+		foreach ( $dom->getElementsByTagName( 'script' ) as $script ) {
+			$type = strtolower( trim( $script->getAttribute( 'type' ) ) );
+			if ( ! str_contains( $type, 'ld+json' ) ) {
+				continue;
+			}
+
+			$data = json_decode( trim( (string) $script->textContent ), true );
+			if ( ! is_array( $data ) ) {
+				continue;
+			}
+
+			foreach ( $this->json_ld_product_nodes( $data ) as $node ) {
+				$product = $this->normalize_product_report_row( $this->product_row_from_json_ld_node( $node, $source_path ) );
+				if ( ! empty( $product ) ) {
+					$products[] = $product;
+				}
+			}
+		}
+
+		return $products;
+	}
+
+	/**
+	 * Extract products from visible product cards.
+	 *
+	 * @param string $html        HTML document.
+	 * @param string $source_path Artifact source path.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function products_from_product_card_html( string $html, string $source_path ): array {
+		$dom      = $this->load_html_document( $html );
+		$xpath    = new DOMXPath( $dom );
+		$products = array();
+		$cards    = $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' product-card ')]" );
+		if ( false === $cards ) {
+			return array();
+		}
+
+		foreach ( $cards as $card ) {
+			if ( ! $card instanceof DOMElement ) {
+				continue;
+			}
+			$name  = $this->first_xpath_text( $xpath, './/*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]', $card );
+			$price = $this->price_from_text( $this->first_xpath_text( $xpath, ".//*[contains(concat(' ', normalize-space(@class), ' '), ' price ')]", $card ) );
+			if ( '' === $price ) {
+				$price = $this->price_from_text( (string) $card->textContent );
+			}
+
+			$product = $this->normalize_product_report_row(
+				array(
+					'kind'             => 'product',
+					'name'             => $name,
+					'slug'             => $this->sanitize_slug( $name ),
+					'regular_price'    => $price,
+					'source_selectors' => array( '.product-card' ),
+					'source_path'      => $source_path,
+				)
+			);
+			if ( ! empty( $product ) ) {
+				$products[] = $product;
+			}
+		}
+
+		return $products;
+	}
+
+	/**
+	 * Merge product manifests by slug while preserving earlier sources.
+	 *
+	 * @param array<int,array<string,mixed>> $primary   Primary product rows.
+	 * @param array<int,array<string,mixed>> $secondary Secondary product rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function merge_product_manifests( array $primary, array $secondary ): array {
+		$products = array();
+		$seen     = array();
+		foreach ( array_merge( $primary, $secondary ) as $product ) {
+			if ( ! is_array( $product ) || empty( $product['slug'] ) || isset( $seen[ $product['slug'] ] ) ) {
+				continue;
+			}
+			$seen[ $product['slug'] ] = true;
+			$products[]              = $product;
+		}
+
+		return $products;
+	}
+
+	/**
+	 * Load an HTML document while suppressing parser warnings for arbitrary source HTML.
+	 *
+	 * @param string $html HTML document.
+	 * @return DOMDocument
+	 */
+	private function load_html_document( string $html ): DOMDocument {
+		$dom      = new DOMDocument();
+		$previous = libxml_use_internal_errors( true );
+		$dom->loadHTML( $html );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+
+		return $dom;
+	}
+
+	/**
+	 * Recursively return JSON-LD nodes whose @type includes Product.
+	 *
+	 * @param array<string|int,mixed> $data JSON-LD data.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function json_ld_product_nodes( array $data ): array {
+		$nodes = array();
+		$type  = $data['@type'] ?? null;
+		if ( is_string( $type ) && $this->json_ld_type_is_product( $type ) ) {
+			$nodes[] = $data;
+		} elseif ( is_array( $type ) ) {
+			foreach ( $type as $type_entry ) {
+				if ( is_scalar( $type_entry ) && $this->json_ld_type_is_product( (string) $type_entry ) ) {
+					$nodes[] = $data;
+					break;
+				}
+			}
+		}
+
+		foreach ( array( '@graph', 'itemListElement' ) as $key ) {
+			if ( isset( $data[ $key ] ) && is_array( $data[ $key ] ) ) {
+				foreach ( $data[ $key ] as $child ) {
+					if ( is_array( $child ) ) {
+						$nodes = array_merge( $nodes, $this->json_ld_product_nodes( $child ) );
+					}
+				}
+			}
+		}
+
+		return $nodes;
+	}
+
+	/**
+	 * Check whether one JSON-LD @type token represents a Product.
+	 *
+	 * @param string $type JSON-LD type token.
+	 * @return bool
+	 */
+	private function json_ld_type_is_product( string $type ): bool {
+		$type = strtolower( trim( $type ) );
+		return 'product' === $type || str_ends_with( $type, ':product' );
+	}
+
+	/**
+	 * Convert a JSON-LD Product node into a generic product row.
+	 *
+	 * @param array<string,mixed> $node        JSON-LD Product node.
+	 * @param string              $source_path Artifact source path.
+	 * @return array<string,mixed>
+	 */
+	private function product_row_from_json_ld_node( array $node, string $source_path ): array {
+		$name   = isset( $node['name'] ) && is_scalar( $node['name'] ) ? trim( (string) $node['name'] ) : '';
+		$url    = isset( $node['url'] ) && is_scalar( $node['url'] ) ? trim( (string) $node['url'] ) : '';
+		$offers = isset( $node['offers'] ) && is_array( $node['offers'] ) ? $node['offers'] : array();
+		if ( isset( $offers[0] ) && is_array( $offers[0] ) ) {
+			$offers = $offers[0];
+		}
+
+		$price = '';
+		if ( isset( $offers['price'] ) && is_scalar( $offers['price'] ) ) {
+			$price = $this->price_from_text( (string) $offers['price'] );
+		} elseif ( isset( $node['price'] ) && is_scalar( $node['price'] ) ) {
+			$price = $this->price_from_text( (string) $node['price'] );
+		}
+
+		$slug = '';
+		if ( '' !== $url ) {
+			$path = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url, PHP_URL_PATH ) : parse_url( $url, PHP_URL_PATH );
+			$path = trim( is_string( $path ) ? $path : '', '/' );
+			$slug = '' !== $path ? basename( $path ) : '';
+		}
+		if ( '' === $slug ) {
+			$slug = $this->sanitize_slug( $name );
+		}
+
+		return array(
+			'kind'             => 'product',
+			'name'             => $name,
+			'slug'             => $slug,
+			'regular_price'    => $price,
+			'description'      => isset( $node['description'] ) && is_scalar( $node['description'] ) ? trim( (string) $node['description'] ) : '',
+			'source_selectors' => array( 'script[type="application/ld+json"]' ),
+			'source_path'      => $source_path,
+		);
+	}
+
+	/**
+	 * Return first XPath text match under an optional context node.
+	 *
+	 * @param DOMXPath        $xpath XPath helper.
+	 * @param string          $query XPath query.
+	 * @param DOMElement|null $context Context node.
+	 * @return string
+	 */
+	private function first_xpath_text( DOMXPath $xpath, string $query, ?DOMElement $context = null ): string {
+		$nodes = $xpath->query( $query, $context );
+		if ( false === $nodes || 0 === $nodes->length ) {
+			return '';
+		}
+
+		return trim( (string) $nodes->item( 0 )->textContent );
+	}
+
+	/**
+	 * Extract a decimal price string from visible text.
+	 *
+	 * @param string $text Source text.
+	 * @return string
+	 */
+	private function price_from_text( string $text ): string {
+		if ( preg_match( '/(?:[$€£]\s*)?([0-9]+(?:[,.][0-9]{1,2})?)/', $text, $matches ) ) {
+			return str_replace( ',', '.', $matches[1] );
+		}
+
+		return '';
 	}
 
 	/**

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -86,6 +86,40 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Incomplete diagnostic blocks fall back to HTML previews instead of calling serialize_blocks().
+	 */
+	public function test_fallback_diagnostic_entry_handles_incomplete_block_shape(): void {
+		$warnings = array();
+		set_error_handler(
+			static function ( int $errno, string $errstr ) use ( &$warnings ): bool {
+				$warnings[] = $errstr;
+				return true;
+			}
+		);
+
+		try {
+			$entry = Static_Site_Importer_Report_Diagnostics::fallback_diagnostic_entry(
+				'freeform_block',
+				'generated:templates/front-page.html',
+				'<p>Unparsed HTML</p>',
+				array(
+					'reason' => 'generated_document_contains_malformed_freeform_html',
+					'stage'  => 'generated_theme_block_analysis',
+				),
+				array(
+					'innerHTML' => '<p>Unparsed HTML</p>',
+				)
+			);
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( array(), $warnings );
+		$this->assertStringContainsString( 'Unparsed HTML', $entry['emitted_block_preview'] ?? '' );
+		$this->assertNull( $entry['block_name'] ?? null );
+	}
+
+	/**
 	 * Import validation and finding packet artifacts expose repair-loop contracts.
 	 */
 	public function test_import_validation_result_and_finding_packets_are_machine_readable(): void {

--- a/tests/smoke-materialized-block-content-validation.php
+++ b/tests/smoke-materialized-block-content-validation.php
@@ -54,6 +54,12 @@ if ( ! function_exists( 'esc_html' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( string $value ): string {
+		return strip_tags( $value );
+	}
+}
+
 if ( ! function_exists( 'get_post_type_object' ) ) {
 	function get_post_type_object( string $post_type ): ?object {
 		return 'page' === $post_type ? (object) array( 'name' => 'page' ) : null;
@@ -140,6 +146,39 @@ $assert( 'wordpress_parse_blocks_serialize_blocks' === ( $materialized['validati
 $assert( 1 === ( $materialized['block_count'] ?? 0 ), 'block-count' );
 $assert( 0 === ( $materialized['invalid_block_count'] ?? -1 ), 'valid-content-has-no-invalid-blocks' );
 $assert( $materialized === $generated, 'legacy-generated-theme-bucket-preserved' );
+
+$report_property->setValue( null, Static_Site_Importer_Report_Diagnostics::new_conversion_report( '/tmp/source/index.html' ) );
+$analyze->invoke(
+	null,
+	array( 'index.html' => $page ),
+	array( 'index.html' => '<p>Loose unparsed HTML</p>' )
+);
+
+$invalid_report      = $report_property->getValue();
+$invalid_diagnostic = array();
+foreach ( $invalid_report['diagnostics'] ?? array() as $diagnostic ) {
+	if ( is_array( $diagnostic ) && 'invalid_block_document' === ( $diagnostic['type'] ?? '' ) ) {
+		$invalid_diagnostic = $diagnostic;
+		break;
+	}
+}
+
+$assert( 'invalid_block_document' === ( $invalid_diagnostic['type'] ?? '' ), 'invalid-document-diagnostic-type' );
+$assert( 'posts/page-home.post_content' === ( $invalid_diagnostic['source'] ?? '' ), 'invalid-document-source' );
+$assert( 'unparsed_html' === ( $invalid_diagnostic['block_name'] ?? '' ), 'invalid-document-block-name' );
+$assert( '0' === ( $invalid_diagnostic['block_path'] ?? '' ), 'invalid-document-block-path' );
+$assert( 'innerHTML' === ( $invalid_diagnostic['attribute_path'] ?? '' ), 'invalid-document-attribute-path' );
+$assert( '' !== ( $invalid_diagnostic['validation_message'] ?? '' ), 'invalid-document-validation-message' );
+$assert( '' !== ( $invalid_diagnostic['parser_validation_message'] ?? '' ), 'invalid-document-parser-validation-message' );
+
+$report_property->setValue( null, Static_Site_Importer_Report_Diagnostics::new_conversion_report( '/tmp/source/index.html' ) );
+$analyze->invoke(
+	null,
+	array( 'index.html' => $page ),
+	array( 'index.html' => '<!-- wp:navigation-link {"label":"Home","url":"http:\\/\\/localhost:8881\\/","kind":"custom"} /-->' )
+);
+$slash_report = $report_property->getValue();
+$assert( 0 === ( $slash_report['quality']['invalid_block_count'] ?? -1 ), 'escaped-url-slashes-are-not-invalid-blocks' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -103,8 +103,28 @@ namespace {
 										'selector'              => 'iframe.booking-widget',
 										'reason_code'           => 'unsupported_interactive_embed',
 										'block_name'            => 'core/html',
+										'attribute_path'        => 'attrs.content',
 										'source_html_preview'   => '<iframe class="booking-widget"></iframe>',
 										'emitted_block_preview' => '<!-- wp:html --><iframe class="booking-widget"></iframe><!-- /wp:html -->',
+									),
+								),
+								'asset_reference_count'   => 2,
+								'presentation_gap_count'  => 1,
+								'block_type_counts'       => array(
+									'core/paragraph' => 2,
+									'core/html'      => 1,
+								),
+								'source_selector_summaries' => array(
+									array(
+										'source_path' => 'website/index.html',
+										'selector'    => 'main',
+										'block_count' => 3,
+									),
+								),
+								'page_metrics'           => array(
+									array(
+										'source_path' => 'website/index.html',
+										'block_count' => 3,
 									),
 								),
 								'interaction_candidates' => array(
@@ -288,6 +308,11 @@ namespace {
 	$assert( 1 === ( $report['blocks_engine']['conversion_report']['fallback_count'] ?? 0 ), 'import-report-records-native-fallback-count' );
 	$assert( 1 === ( $report['blocks_engine']['conversion_report']['interaction_candidate_count'] ?? 0 ), 'import-report-records-native-interaction-candidate-count' );
 	$assert( 'button.reserve' === ( $report['blocks_engine']['conversion_report']['interaction_candidates'][0]['selector'] ?? '' ), 'import-report-records-native-interaction-candidates' );
+	$assert( 2 === ( $report['blocks_engine']['conversion_report']['asset_reference_count'] ?? 0 ), 'import-report-records-native-asset-reference-count' );
+	$assert( 1 === ( $report['blocks_engine']['conversion_report']['presentation_gap_count'] ?? 0 ), 'import-report-records-native-presentation-gap-count' );
+	$assert( 1 === ( $report['blocks_engine']['conversion_report']['block_type_counts']['core/html'] ?? 0 ), 'import-report-records-native-block-type-counts' );
+	$assert( 'main' === ( $report['blocks_engine']['conversion_report']['source_selector_summaries'][0]['selector'] ?? '' ), 'import-report-records-native-selector-summaries' );
+	$assert( 3 === ( $report['blocks_engine']['conversion_report']['page_metrics'][0]['block_count'] ?? 0 ), 'import-report-records-native-page-metrics' );
 	$assert( 1 === ( $report['quality']['interaction_candidate_count'] ?? 0 ), 'quality-records-interaction-candidate-count' );
 	$assert( 'reported' === ( $report['import_validation_result']['quality_gates']['interaction_candidates']['status'] ?? '' ), 'validation-gate-reports-interaction-candidates' );
 	$assert( 'unsupported_html_fallback' === ( $report['diagnostics'][0]['type'] ?? '' ), 'native-fallback-becomes-normalized-diagnostic' );

--- a/tests/smoke-website-artifact-commerce-detection.php
+++ b/tests/smoke-website-artifact-commerce-detection.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Smoke coverage for commerce inference from raw website artifact HTML.
+ *
+ * Run from the repository root:
+ * php tests/smoke-website-artifact-commerce-detection.php
+ *
+ * @package StaticSiteImporter
+ */
+
+namespace {
+	function blocks_engine_php_transformer_compile_artifact( array $artifact, array $options = array() ): array {
+		return array(
+			'schema'         => 'blocks-engine/php-transformer/result/v1',
+			'status'         => 'success',
+			'source_reports' => array(
+				'artifact'              => array(
+					'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+					'entry_path' => 'website/index.html',
+				),
+				'materialization_plan' => array(
+					'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+					'pages'  => array(
+						array(
+							'source_path'  => 'website/index.html',
+							'post_type'    => 'page',
+							'slug'         => 'home',
+							'title'        => 'Storefront',
+							'block_markup' => '<!-- wp:paragraph --><p>Storefront</p><!-- /wp:paragraph -->',
+						),
+					),
+				),
+			),
+		);
+	}
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $code;
+			private string $message;
+
+			public function __construct( string $code, string $message ) {
+				$this->code    = $code;
+				$this->message = $message;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( mixed $thing ): bool {
+			return $thing instanceof WP_Error;
+		}
+	}
+
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-transformer-adapter.php';
+
+	$failures   = array();
+	$assertions = 0;
+	$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+		}
+	};
+
+	$artifact = array(
+		'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+		'entrypoint' => 'website/index.html',
+		'files'      => array(
+			array(
+				'path'      => 'website/index.html',
+				'kind'      => 'html',
+				'mime_type' => 'text/html',
+				'content'   => '<!doctype html><html><head><script type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Signal Hoodie","url":"/shop/signal-hoodie","offers":{"@type":"Offer","price":"64"}}</script></head><body><article class="product-card"><h2>Field Mug</h2><p class="price">$18.50</p></article></body></html>',
+			),
+		),
+	);
+
+	$compiled = ( new Static_Site_Importer_Transformer_Adapter() )->compile_website_artifact( $artifact );
+	$products = is_array( $compiled ) ? ( $compiled['products_manifest'] ?? array() ) : array();
+
+	$assert( ! is_wp_error( $compiled ), 'compile-succeeds', is_wp_error( $compiled ) ? $compiled->get_error_message() : '' );
+	$assert( 2 === count( $products ), 'detects-json-ld-and-product-card-products' );
+	$assert( 'signal-hoodie' === ( $products[0]['slug'] ?? '' ), 'json-ld-product-slug-from-url' );
+	$assert( 'Signal Hoodie' === ( $products[0]['name'] ?? '' ), 'json-ld-product-name' );
+	$assert( '64.00' === ( $products[0]['regular_price'] ?? '' ), 'json-ld-product-price-normalized' );
+	$assert( 'field-mug' === ( $products[1]['slug'] ?? '' ), 'product-card-slug-from-heading' );
+	$assert( '18.50' === ( $products[1]['regular_price'] ?? '' ), 'product-card-price-normalized' );
+
+	$validation = Static_Site_Importer_Entity_Materializer_Registry::validate_manifest(
+		Static_Site_Importer_Entity_Materializer_Registry::product_adapter(),
+		array(
+			'schema_version' => 1,
+			'products'       => $products,
+		)
+	);
+	$assert( array() === ( $validation['errors'] ?? array() ), 'validated-products-are-seedable' );
+	$assert( 2 === count( $validation['products'] ?? array() ), 'validator-preserves-detected-product-count' );
+
+	if ( $failures ) {
+		fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+		exit( 1 );
+	}
+
+	echo 'OK: website artifact commerce detection smoke passed (' . $assertions . " assertions)\n";
+}

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -350,6 +350,9 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 	}
 
 	$assert( 3 === ( $source_docs['blocks_engine_document_count'] ?? null ), 'multi-page-blocks-engine-document-count' );
+	$assert( 3 === ( $source_docs['counts_by_format']['html'] ?? null ), 'multi-page-html-source-document-count' );
+	$assert( 0 === ( $source_docs['counts_by_format']['markdown'] ?? null ), 'multi-page-markdown-source-document-count' );
+	$assert( 0 === ( $source_docs['counts_by_format']['mdx'] ?? null ), 'multi-page-mdx-source-document-count' );
 	$assert( 'blocks_engine' === ( $source_docs['source'] ?? '' ), 'multi-page-source-is-blocks-engine' );
 	$assert( 'home' === ( $documents_by_source['website/index.html']['slug'] ?? '' ), 'entry-index-materializes-as-home' );
 	$assert( str_ends_with( (string) ( $documents_by_source['website/index.html']['permalink'] ?? '' ), '/' ), 'entry-index-has-front-page-permalink' );


### PR DESCRIPTION
## Summary
- Add richer invalid block diagnostics and semantic block-document comparison so harmless serializer escaping does not count as invalid.
- Fix website-artifact source document format counts.
- Surface broader Blocks Engine conversion report metrics in SSI reports.
- Infer product intent from raw website artifact HTML using JSON-LD Product data and visible `.product-card` cards.

## Matrix evidence
Combined local raw HTML matrix with SSI integration + Blocks Engine integration:
- 41/41 imports succeeded
- hard failures: 1 -> 0
- fallbacks: 45 -> 15
- core/html blocks: 0 -> 0
- freeform blocks: 0 -> 0
- invalid block documents: 202 -> 0
- product intent detected for product/catalog fixtures, including `19-product-catalog` and `20-switchback-woocommerce-extra-hard`
- summary: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/raw-html-combined-matrix-v2/summary.json`

## Testing
- `php -l includes/class-static-site-importer-report-diagnostics.php`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l includes/class-static-site-importer-transformer-adapter.php`
- `php tests/smoke-materialized-block-content-validation.php`
- `php tests/smoke-website-artifact-commerce-detection.php`
- Combined local raw HTML matrix with Blocks Engine integration package preloaded

Known: `php tests/smoke-transformer-adapter.php` still reports two pre-existing materialization-view assertion failures unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosis, implementation, fanout integration, and local verification.