### PR TITLE
Enforce import quality gates before materialization

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -370,6 +370,8 @@ if ( ! function_exists( 'static_site_importer_ability_error' ) ) {
 	 * @return array<string, mixed>
 	 */
 	function static_site_importer_ability_error( string $code, string $message, $data = null ): array {
+		$import_report_summary = is_array( $data ) && isset( $data['import_report_summary'] ) && is_array( $data['import_report_summary'] ) ? $data['import_report_summary'] : static_site_importer_failure_report_summary( $code, $message );
+
 		return array(
 			'success'               => false,
 			'error'                 => array(
@@ -377,7 +379,7 @@ if ( ! function_exists( 'static_site_importer_ability_error' ) ) {
 				'message' => $message,
 				'data'    => $data,
 			),
-			'import_report_summary' => static_site_importer_failure_report_summary( $code, $message ),
+			'import_report_summary' => $import_report_summary,
 		);
 	}
 }

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -98,11 +98,6 @@ class Static_Site_Importer_Theme_Generator {
 			return new WP_Error( 'static_site_importer_theme_exists', sprintf( 'Theme already exists: %s', $theme_slug ) );
 		}
 
-		$result = Static_Site_Importer_Theme_Materializer::ensure_dirs( $theme_dir );
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
 		$source_metadata           = isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array();
 		$source_metadata['source'] = 'website_artifact';
 		$html_path                 = (string) ( $compiled['provenance']['source'] ?? ( $compiled['input']['entry_path'] ?? 'website_artifact' ) );
@@ -129,7 +124,7 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		$permalinks     = Static_Site_Importer_Page_Materializer::page_permalinks( $page_ids );
-		$materialized = self::materialize_website_artifact_files_to_theme( $theme_dir, $artifacts );
+		$materialized = self::materialize_website_artifact_files_to_theme( $theme_dir, $artifacts, false );
 		if ( is_wp_error( $materialized ) ) {
 			return $materialized;
 		}
@@ -163,10 +158,6 @@ class Static_Site_Importer_Theme_Generator {
 			Static_Site_Importer_Theme_Materializer::base_theme_writes( $theme_dir, $theme_slug, $theme_name, $materialized['css'], $has_header_part, $has_footer_part, $materialized['scripts'], $materialized['stylesheets'] )
 		);
 		$writes = array_merge( $writes, $template_part_writes );
-		$result         = Static_Site_Importer_Page_Materializer::write_page_contents( $document_pages, $page_ids, $page_artifacts['contents'] );
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
 		self::analyze_imported_page_content_documents( $document_pages, $page_artifacts['contents'] );
 
 		self::record_source_documents_summary( $artifacts['documents'] ?? array(), $document_pages, $page_ids, $permalinks );
@@ -203,6 +194,37 @@ class Static_Site_Importer_Theme_Generator {
 		}
 		if ( false === $finding_packets_json ) {
 			return new WP_Error( 'static_site_importer_finding_packets_encode_failed', 'Failed to encode finding packets JSON.' );
+		}
+		if ( ! empty( $quality['fail_import'] ) ) {
+			return new WP_Error(
+				'static_site_importer_quality_gate_failed',
+				'Import failed quality gates; materialization was not completed.',
+				array(
+					'status'                   => 422,
+					'theme_slug'               => $theme_slug,
+					'theme_name'               => $theme_name,
+					'quality'                  => $quality,
+					'import_report_summary'    => self::$conversion_report['compact_summary'] ?? array(),
+					'import_validation_result' => $validation_result,
+					'finding_packets'          => $finding_packets,
+					'source_documents'         => self::$conversion_report['source_documents'] ?? array(),
+				)
+			);
+		}
+
+		$result = Static_Site_Importer_Theme_Materializer::ensure_dirs( $theme_dir );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$materialized_write = self::materialize_website_artifact_files_to_theme( $theme_dir, $artifacts, true, false );
+		if ( is_wp_error( $materialized_write ) ) {
+			return $materialized_write;
+		}
+
+		$result = Static_Site_Importer_Page_Materializer::write_page_contents( $document_pages, $page_ids, $page_artifacts['contents'] );
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
 		$writes[ $theme_dir . '/import-report.json' ]            = $report_json . "\n";
@@ -1414,20 +1436,24 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
-	 * Write compiler-emitted files that can be consumed without re-importing HTML.
+	 * Prepare or write compiler-emitted files that can be consumed without re-importing HTML.
 	 *
-	 * @param string              $theme_dir Theme directory.
-	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
+	 * @param string              $theme_dir          Theme directory.
+	 * @param array<string,mixed> $artifacts          WordPress artifacts from Blocks Engine.
+	 * @param bool                $write_files        Whether to write materialized asset files.
+	 * @param bool                $record_diagnostics Whether to append materialization diagnostics to the report.
 	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>,stylesheets:array<int,array<string,mixed>>}|WP_Error
 	 */
-	private static function materialize_website_artifact_files_to_theme( string $theme_dir, array $artifacts ) {
-		$result = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files( $theme_dir, self::$active_theme_uri, $artifacts );
+	private static function materialize_website_artifact_files_to_theme( string $theme_dir, array $artifacts, bool $write_files = true, bool $record_diagnostics = true ) {
+		$result = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files( $theme_dir, self::$active_theme_uri, $artifacts, $write_files );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
-		foreach ( $result['diagnostics'] as $diagnostic ) {
-			self::$conversion_report['diagnostics'][] = $diagnostic;
+		if ( $record_diagnostics ) {
+			foreach ( $result['diagnostics'] as $diagnostic ) {
+				self::$conversion_report['diagnostics'][] = $diagnostic;
+			}
 		}
 		return array(
 			'css'         => $result['css'],

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -98,10 +98,11 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @param string              $theme_dir Theme directory.
 	 * @param string              $theme_uri Theme URI.
 	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
+	 * @param bool                $write_files Whether to write materialized asset files.
 	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>,stylesheets:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|WP_Error
 	 */
-	public static function materialize_website_artifact_files( string $theme_dir, string $theme_uri, array $artifacts ) {
-		$native_plan = self::materialize_materialization_plan_assets( $theme_dir, $theme_uri, $artifacts );
+	public static function materialize_website_artifact_files( string $theme_dir, string $theme_uri, array $artifacts, bool $write_files = true ) {
+		$native_plan = self::materialize_materialization_plan_assets( $theme_dir, $theme_uri, $artifacts, $write_files );
 		if ( is_wp_error( $native_plan ) || null !== $native_plan ) {
 			return $native_plan;
 		}
@@ -145,14 +146,16 @@ class Static_Site_Importer_Theme_Materializer {
 
 			$target_relative = 'assets/materialized/' . $relative;
 			$target          = trailingslashit( $theme_dir ) . $target_relative;
-			$dir             = dirname( $target );
-			if ( ! wp_mkdir_p( $dir ) ) {
-				return new WP_Error( 'static_site_importer_artifact_asset_mkdir_failed', sprintf( 'Failed to create website artifact asset directory: %s', $dir ) );
-			}
+			if ( $write_files ) {
+				$dir = dirname( $target );
+				if ( ! wp_mkdir_p( $dir ) ) {
+					return new WP_Error( 'static_site_importer_artifact_asset_mkdir_failed', sprintf( 'Failed to create website artifact asset directory: %s', $dir ) );
+				}
 
-			$result = self::write_file( $target, $content );
-			if ( is_wp_error( $result ) ) {
-				return $result;
+				$result = self::write_file( $target, $content );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
 			}
 
 			$assets[ $relative ] = array(
@@ -182,9 +185,10 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @param string              $theme_dir Theme directory.
 	 * @param string              $theme_uri Theme URI.
 	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
+	 * @param bool                $write_files Whether to write materialized asset files.
 	 * @return array{css:string,js:string,assets:array<string,array<string,mixed>>,scripts:array<int,array<string,mixed>>,stylesheets:array<int,array<string,mixed>>,diagnostics:array<int,array<string,mixed>>}|null|WP_Error
 	 */
-	private static function materialize_materialization_plan_assets( string $theme_dir, string $theme_uri, array $artifacts ) {
+	private static function materialize_materialization_plan_assets( string $theme_dir, string $theme_uri, array $artifacts, bool $write_files = true ) {
 		$site = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
 		if ( 'blocks-engine/php-transformer/materialization-plan/v1' !== (string) ( $site['schema'] ?? '' ) || ! array_key_exists( 'assets', $site ) ) {
 			return null;
@@ -230,14 +234,16 @@ class Static_Site_Importer_Theme_Materializer {
 
 			$target_relative = 'assets/materialized/' . $relative;
 			$target          = trailingslashit( $theme_dir ) . $target_relative;
-			$dir             = dirname( $target );
-			if ( ! wp_mkdir_p( $dir ) ) {
-				return new WP_Error( 'static_site_importer_materialization_plan_asset_mkdir_failed', sprintf( 'Failed to create materialization-plan asset directory: %s', $dir ) );
-			}
+			if ( $write_files ) {
+				$dir = dirname( $target );
+				if ( ! wp_mkdir_p( $dir ) ) {
+					return new WP_Error( 'static_site_importer_materialization_plan_asset_mkdir_failed', sprintf( 'Failed to create materialization-plan asset directory: %s', $dir ) );
+				}
 
-			$result = self::write_file( $target, $content );
-			if ( is_wp_error( $result ) ) {
-				return $result;
+				$result = self::write_file( $target, $content );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
 			}
 
 			$assets[ $relative ] = self::materialization_plan_asset_report( $asset, $relative, trailingslashit( $theme_uri ) . $target_relative, $target_relative, self::mime_type( $target ), $order );
@@ -255,7 +261,7 @@ class Static_Site_Importer_Theme_Materializer {
 			}
 		}
 
-		$font_stylesheets = self::materialize_font_materialization_stylesheets( $theme_dir, $theme_uri, $site, $assets, $order );
+		$font_stylesheets = self::materialize_font_materialization_stylesheets( $theme_dir, $theme_uri, $site, $assets, $order, $write_files );
 		if ( is_wp_error( $font_stylesheets ) ) {
 			return $font_stylesheets;
 		}
@@ -279,9 +285,10 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @param array<string,mixed>               $site      Materialization plan site artifact.
 	 * @param array<string,array<string,mixed>> $assets    Materialized asset rows keyed by source path.
 	 * @param int                               $order     Current materialization order.
+	 * @param bool                               $write_files Whether to write materialized asset files.
 	 * @return array<int,array<string,mixed>>|WP_Error
 	 */
-	private static function materialize_font_materialization_stylesheets( string $theme_dir, string $theme_uri, array $site, array &$assets, int &$order ) {
+	private static function materialize_font_materialization_stylesheets( string $theme_dir, string $theme_uri, array $site, array &$assets, int &$order, bool $write_files = true ) {
 		$theme = isset( $site['theme'] ) && is_array( $site['theme'] ) ? $site['theme'] : array();
 		$plan  = isset( $theme['font_materialization'] ) && is_array( $theme['font_materialization'] ) ? $theme['font_materialization'] : array();
 		if ( 'blocks-engine/php-transformer/font-materialization-plan/v1' !== (string) ( $plan['schema'] ?? '' ) ) {
@@ -315,14 +322,16 @@ class Static_Site_Importer_Theme_Materializer {
 			}
 
 			$target = trailingslashit( $theme_dir ) . $relative;
-			$dir    = dirname( $target );
-			if ( ! wp_mkdir_p( $dir ) ) {
-				return new WP_Error( 'static_site_importer_font_materialization_stylesheet_mkdir_failed', sprintf( 'Failed to create font materialization stylesheet directory: %s', $dir ) );
-			}
+			if ( $write_files ) {
+				$dir = dirname( $target );
+				if ( ! wp_mkdir_p( $dir ) ) {
+					return new WP_Error( 'static_site_importer_font_materialization_stylesheet_mkdir_failed', sprintf( 'Failed to create font materialization stylesheet directory: %s', $dir ) );
+				}
 
-			$result = self::write_file( $target, $content );
-			if ( is_wp_error( $result ) ) {
-				return $result;
+				$result = self::write_file( $target, $content );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
 			}
 
 			++$order;

--- a/tests/smoke-ability-error-report-summary.php
+++ b/tests/smoke-ability-error-report-summary.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Smoke coverage for ability errors preserving import report summaries.
+ *
+ * Run from the repository root:
+ * php tests/smoke-ability-error-report-summary.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text ): string {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( string $hook_name ): bool {
+		unset( $hook_name );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook_name ): int {
+		unset( $hook_name );
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook_name, string $callback ): void {
+		unset( $hook_name, $callback );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/abilities.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$summary = array(
+	'status'                => 'failed',
+	'quality_pass'          => false,
+	'fail_import'           => true,
+	'failure_reasons'       => array( 'core_html_block' ),
+	'core_html_block_count' => 1,
+);
+
+$result = static_site_importer_ability_error(
+	'static_site_importer_quality_gate_failed',
+	'Import failed quality gates; materialization was not completed.',
+	array(
+		'import_report_summary' => $summary,
+		'quality'               => array( 'fail_import' => true ),
+	)
+);
+
+$assert( false === ( $result['success'] ?? true ), 'ability-error-fails' );
+$assert( $summary === ( $result['import_report_summary'] ?? array() ), 'preserves-import-report-summary' );
+$assert( 'core_html_block' === ( $result['import_report_summary']['failure_reasons'][0] ?? '' ), 'preserves-failure-reason' );
+$assert( true === ( $result['error']['data']['quality']['fail_import'] ?? false ), 'preserves-error-data' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: ability error report summary smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-theme-materializer-dry-run.php
+++ b/tests/smoke-theme-materializer-dry-run.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Smoke coverage for materializer dry-run mode.
+ *
+ * Run from the repository root:
+ * php tests/smoke-theme-materializer-dry-run.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $value ): string {
+		return rtrim( $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( string $path ): bool {
+		return is_dir( $path ) || mkdir( $path, 0777, true );
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code, private string $message ) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$theme_dir = sys_get_temp_dir() . '/ssi-dry-run-' . bin2hex( random_bytes( 6 ) );
+$result    = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files(
+	$theme_dir,
+	'https://example.test/wp-content/themes/imported',
+	array(
+		'files' => array(
+			array(
+				'path'    => 'images/logo.svg',
+				'kind'    => 'image',
+				'content' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>',
+			),
+		),
+	),
+	false
+);
+
+$assert( ! is_wp_error( $result ), 'dry-run-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+$assert( ! is_dir( $theme_dir ), 'dry-run-does-not-create-theme-dir' );
+$assert( 'assets/materialized/images/logo.svg' === ( $result['assets']['images/logo.svg']['theme_path'] ?? '' ), 'dry-run-reports-theme-path' );
+$assert( 'image/svg+xml' === ( $result['assets']['images/logo.svg']['mime_type'] ?? '' ), 'dry-run-reports-mime-type' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: theme materializer dry-run smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Stop completed materialization when import quality gates fail.
- Add dry-run asset materialization for preflight report generation.
- Preserve detailed import report summaries in ability error responses.

## Verification
- php -l on changed PHP files and new smoke tests
- php tests/smoke-theme-materializer-dry-run.php
- php tests/smoke-ability-error-report-summary.php
- php tests/smoke-materialized-block-content-validation.php
- php tests/smoke-website-artifact-products-manifest.php
- php tests/smoke-entity-materializer-registry.php
- php tests/smoke-static-interactive-artifact.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Auditing materialization gates, drafting implementation changes, and running targeted verification.