### PR TITLE
Update PHP transformer to 0.1.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.10",
+        "version": "0.1.11",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "7c154bb6b362556e930425148c2ed3661766f9c0"
+          "reference": "8a6bbebc826dd140b36bf8f16b7008f6a27c2980"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.10.zip",
-          "reference": "7c154bb6b362556e930425148c2ed3661766f9c0"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.11.zip",
+          "reference": "8a6bbebc826dd140b36bf8f16b7008f6a27c2980"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.1.10",
+    "automattic/blocks-engine-php-transformer": "^0.1.11",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89fd80fb073476945347f6d6df907b41",
+    "content-hash": "18865f24323b0d657da43dcc2051950b",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.10",
+            "version": "0.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "7c154bb6b362556e930425148c2ed3661766f9c0"
+                "reference": "8a6bbebc826dd140b36bf8f16b7008f6a27c2980"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.10.zip",
-                "reference": "7c154bb6b362556e930425148c2ed3661766f9c0"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.11.zip",
+                "reference": "8a6bbebc826dd140b36bf8f16b7008f6a27c2980"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Update the vendored Blocks Engine PHP transformer package to v0.1.11.
- Pull in raw HTML conversion fixes and navigation dedupe serialization cleanup.

## Verification
- composer update automattic/blocks-engine-php-transformer --with-dependencies
- php tests/smoke-transformer-adapter.php
- php tests/smoke-materialized-block-content-validation.php
- php tests/smoke-website-artifact-commerce-detection.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updating dependency metadata and running targeted verification.