### PR TITLE
Wire Figma zstd decoder for uploads

### DIFF
--- a/includes/class-static-site-importer-figma-import.php
+++ b/includes/class-static-site-importer-figma-import.php
@@ -14,6 +14,31 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Static_Site_Importer_Figma_Import {
 	/**
+	 * Register the default local Zstandard decoder for .fig uploads.
+	 */
+	public static function register_default_zstd_decoder(): void {
+		if ( ! function_exists( 'add_filter' ) ) {
+			return;
+		}
+
+		add_filter(
+			'blocks_engine_figma_transformer_zstd_decoder',
+			static function ( $decoder ) {
+				if ( is_callable( $decoder ) || ! class_exists( '\Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCommandDecoder' ) ) {
+					return $decoder;
+				}
+
+				$command = self::zstd_command();
+				if ( empty( $command ) ) {
+					return $decoder;
+				}
+
+				return new \Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCommandDecoder( $command );
+			}
+		);
+	}
+
+	/**
 	 * Import a Figma request through the existing website artifact import ability.
 	 *
 	 * @param array<string,mixed> $input Figma import input.
@@ -320,10 +345,16 @@ class Static_Site_Importer_Figma_Import {
 
 		$files = self::normalize_files( isset( $transform['files'] ) && is_array( $transform['files'] ) ? $transform['files'] : array(), 'website/' );
 		if ( empty( $files ) ) {
-			return new WP_Error( 'static_site_importer_figma_transform_empty', 'Blocks Engine Figma transformer did not produce importable files.', array(
+			$diagnostic = self::first_transform_diagnostic( $transform );
+			$data       = array(
 				'status'    => 500,
 				'transform' => $transform,
-			) );
+			);
+			if ( ! empty( $diagnostic ) ) {
+				$data['diagnostic'] = $diagnostic;
+			}
+
+			return new WP_Error( 'static_site_importer_figma_transform_empty', self::empty_transform_message( $diagnostic ), $data );
 		}
 
 		return array(
@@ -333,6 +364,61 @@ class Static_Site_Importer_Figma_Import {
 			'files'      => $files,
 			'provenance' => self::provenance( $input ) + array( 'transform' => 'blocks-engine/figma-transformer' ),
 		);
+	}
+
+	/**
+	 * Return the first useful transformer diagnostic for an empty Figma result.
+	 *
+	 * @param array<string,mixed> $transform Transform result.
+	 * @return array<string,mixed>
+	 */
+	private static function first_transform_diagnostic( array $transform ): array {
+		$diagnostics = isset( $transform['diagnostics'] ) && is_array( $transform['diagnostics'] ) ? $transform['diagnostics'] : array();
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( is_array( $diagnostic ) ) {
+				return $diagnostic;
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Build a concise empty-transform error message with transformer context.
+	 *
+	 * @param array<string,mixed> $diagnostic First transformer diagnostic.
+	 */
+	private static function empty_transform_message( array $diagnostic ): string {
+		$message = 'Blocks Engine Figma transformer did not produce importable files.';
+		if ( ! empty( $diagnostic['message'] ) && is_scalar( $diagnostic['message'] ) ) {
+			$message .= ' ' . (string) $diagnostic['message'];
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Resolve an available zstd command for decoding compressed Figma chunks.
+	 *
+	 * @return array<int,string>
+	 */
+	private static function zstd_command(): array {
+		$configured = defined( 'STATIC_SITE_IMPORTER_FIGMA_ZSTD_COMMAND' ) ? (string) STATIC_SITE_IMPORTER_FIGMA_ZSTD_COMMAND : '';
+		if ( '' === $configured ) {
+			$configured = (string) getenv( 'STATIC_SITE_IMPORTER_FIGMA_ZSTD_COMMAND' );
+		}
+
+		if ( '' !== $configured ) {
+			return array( $configured, '-dc' );
+		}
+
+		foreach ( array( '/opt/homebrew/bin/zstd', '/usr/local/bin/zstd', '/usr/bin/zstd' ) as $candidate ) {
+			if ( is_executable( $candidate ) ) {
+				return array( $candidate, '-dc' );
+			}
+		}
+
+		return array();
 	}
 
 	/**

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -59,6 +59,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/block.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/rest.php';
 
 Static_Site_Importer_Codebox_Validation::register_default_provider();
+Static_Site_Importer_Figma_Import::register_default_zstd_decoder();
 
 add_action( 'init', 'static_site_importer_register_block' );
 add_action( 'rest_api_init', 'static_site_importer_register_rest_routes' );

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -29,6 +29,7 @@ $assert = static function ( bool $condition, string $label, string $detail = '' 
 $GLOBALS['ssi_registered_block'] = null;
 $GLOBALS['ssi_options']          = array();
 $GLOBALS['ssi_test_options']     = array();
+$GLOBALS['ssi_filters']          = array();
 $GLOBALS['ssi_home_url']         = 'https://example.test/';
 $GLOBALS['ssi_uuid_count']       = 0;
 $GLOBALS['ssi_transients']       = array();
@@ -135,7 +136,26 @@ if ( ! function_exists( 'blocks_engine_php_transformer_convert_format' ) ) {
 
 if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( string $hook, $value, ...$args ) {
+		foreach ( $GLOBALS['ssi_filters'][ $hook ] ?? array() as $callback ) {
+			$value = $callback( $value, ...$args );
+		}
+
 		return $value;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+		unset( $priority, $accepted_args );
+		$GLOBALS['ssi_filters'][ $hook ][] = $callback;
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'has_filter' ) ) {
+	function has_filter( string $hook ) {
+		return empty( $GLOBALS['ssi_filters'][ $hook ] ) ? false : true;
 	}
 }
 
@@ -396,6 +416,7 @@ if ( is_readable( $figma_transformer_bootstrap ) ) {
 	require_once $figma_transformer_bootstrap;
 }
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-figma-import.php';
+Static_Site_Importer_Figma_Import::register_default_zstd_decoder();
 require_once dirname( __DIR__ ) . '/includes/abilities.php';
 require_once dirname( __DIR__ ) . '/includes/rest.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document.php';
@@ -408,6 +429,14 @@ $assert( is_string( $plugin_source ), 'plugin-source-readable' );
 $assert( ! str_contains( $plugin_source, 'Requires Plugins: blocks-engine-php-transformer' ), 'transformer-is-not-a-required-wordpress-plugin' );
 $assert( str_contains( $plugin_source, "vendor/autoload.php" ), 'loads-composer-autoloader' );
 $assert( str_contains( $plugin_source, "vendor/automattic/blocks-engine-php-transformer/php-transformer/php-transformer.php" ), 'loads-composer-transformer-bootstrap' );
+$assert( str_contains( $plugin_source, 'Static_Site_Importer_Figma_Import::register_default_zstd_decoder();' ), 'plugin-registers-figma-zstd-decoder' );
+
+$known_zstd_command = false;
+foreach ( array( '/opt/homebrew/bin/zstd', '/usr/local/bin/zstd', '/usr/bin/zstd' ) as $known_zstd_path ) {
+	$known_zstd_command = $known_zstd_command || is_executable( $known_zstd_path );
+}
+$figma_zstd_decoder = apply_filters( 'blocks_engine_figma_transformer_zstd_decoder', null );
+$assert( ! $known_zstd_command || is_callable( $figma_zstd_decoder ), 'figma-zstd-decoder-registers-when-command-exists' );
 
 $rest_source = file_get_contents( dirname( __DIR__ ) . '/includes/rest.php' );
 $assert( is_string( $rest_source ), 'rest-source-readable' );
@@ -701,6 +730,11 @@ $figma_upload_artifact = Static_Site_Importer_Figma_Import::website_artifact_fro
 	)
 );
 $assert( is_wp_error( $figma_upload_artifact ) || is_array( $figma_upload_artifact ), 'figma-file-source-routes-through-transformer' );
+if ( is_wp_error( $figma_upload_artifact ) && 'static_site_importer_figma_transform_empty' === $figma_upload_artifact->get_error_code() ) {
+	$figma_upload_error_data = $figma_upload_artifact->get_error_data();
+	$assert( isset( $figma_upload_error_data['diagnostic'] ) && is_array( $figma_upload_error_data['diagnostic'] ), 'figma-empty-transform-error-exposes-diagnostic' );
+	$assert( 'Blocks Engine Figma transformer did not produce importable files.' !== $figma_upload_artifact->get_error_message(), 'figma-empty-transform-error-message-includes-diagnostic' );
+}
 $generic_fig_artifact = static_site_importer_rest_source_artifact(
 	array(
 		'files' => array(


### PR DESCRIPTION
## Summary
- register SSI's default Figma zstd decoder against Blocks Engine's decoder filter
- use an available local zstd command for compressed .fig chunks, with env/constant override support
- surface the first transformer diagnostic when a Figma transform returns no importable files

## Testing
- php tests/smoke-importer-block.php
- php -l includes/class-static-site-importer-figma-import.php
- php -l static-site-importer.php
- Verified /Users/chubes/Downloads/Fisiostetic.fig through Static_Site_Importer_Figma_Import::website_artifact_from_input() produced 24 artifact files, including website/index.html and website/style.css

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnose the Figma upload failure, implement the zstd decoder registration and diagnostic handling, add smoke coverage, and run local verification.