### PR TITLE
Surface runtime dependency parity reports

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -53,6 +53,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'svg_sprite_reference_failure_count' => 0,
 				'commerce_dependency_failures'       => 0,
 				'interaction_candidate_count'        => 0,
+				'runtime_dependency_parity_issue_count' => 0,
 				'failure_reasons'                    => array(),
 			),
 			'source_documents'        => array(
@@ -182,6 +183,12 @@ class Static_Site_Importer_Report_Diagnostics {
 		if ( ! empty( $conversion_report ) ) {
 			$report['blocks_engine']['conversion_report'] = self::conversion_report_payload( $conversion_report );
 			self::record_conversion_report_quality_metadata( $report, $conversion_report );
+		}
+
+		$runtime_dependency_parity = isset( $compiled['runtime_dependency_parity'] ) && is_array( $compiled['runtime_dependency_parity'] ) ? $compiled['runtime_dependency_parity'] : array();
+		if ( ! empty( $runtime_dependency_parity ) ) {
+			$report['blocks_engine']['runtime_dependency_parity'] = self::runtime_dependency_parity_payload( $runtime_dependency_parity );
+			self::record_runtime_dependency_parity_quality_metadata( $report, $runtime_dependency_parity );
 		}
 	}
 
@@ -356,6 +363,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'svg_sprite_reference_failures' => (int) ( $quality['svg_sprite_reference_failure_count'] ?? 0 ),
 				'commerce_dependency_failures'  => (int) ( $quality['commerce_dependency_failures'] ?? 0 ),
 				'interaction_candidates'        => (int) ( $quality['interaction_candidate_count'] ?? 0 ),
+				'runtime_dependency_parity'     => (int) ( $quality['runtime_dependency_parity_issue_count'] ?? 0 ),
 			),
 			'quality_gates'           => array(
 				'fallback_blocks'           => self::validation_gate( 'fallback_blocks', (int) ( $quality['fallback_count'] ?? 0 ), $quality ),
@@ -364,6 +372,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'asset_materialization'     => self::validation_gate( 'asset_materialization', (int) ( $quality['svg_materialization_failure_count'] ?? 0 ) + (int) ( $quality['svg_sprite_reference_failure_count'] ?? 0 ), $quality ),
 				'commerce_dependencies'     => self::validation_gate( 'commerce_dependencies', (int) ( $quality['commerce_dependency_failures'] ?? 0 ), $quality ),
 				'interaction_candidates'    => self::validation_gate( 'interaction_candidates', (int) ( $quality['interaction_candidate_count'] ?? 0 ), $quality ),
+				'runtime_dependency_parity' => self::validation_gate( 'runtime_dependency_parity', (int) ( $quality['runtime_dependency_parity_issue_count'] ?? 0 ), $quality ),
 				'visual_fidelity'           => array(
 					'status' => (string) ( $report['visual_fidelity']['status'] ?? 'requires_external_render_check' ),
 					'owner'  => (string) ( $report['visual_fidelity']['gate_owner'] ?? 'benchmark_harness' ),
@@ -452,6 +461,9 @@ class Static_Site_Importer_Report_Diagnostics {
 		if ( ( $quality['commerce_dependency_failures'] ?? 0 ) > 0 ) {
 			$reasons[] = 'woocommerce_missing';
 		}
+		if ( ( $quality['runtime_dependency_parity_issue_count'] ?? 0 ) > 0 ) {
+			$reasons[] = 'runtime_dependency_parity';
+		}
 
 		$quality['pass']            = empty( $reasons );
 		$quality['failure_reasons'] = $reasons;
@@ -508,6 +520,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'invalid_block_count'          => (int) ( $quality['invalid_block_count'] ?? 0 ),
 			'invalid_block_document_count' => (int) ( $quality['invalid_block_document_count'] ?? 0 ),
 			'interaction_candidate_count'  => (int) ( $quality['interaction_candidate_count'] ?? 0 ),
+			'runtime_dependency_parity_issue_count' => (int) ( $quality['runtime_dependency_parity_issue_count'] ?? 0 ),
 			'source_document_count'        => (int) ( $source_documents['total_count'] ?? 0 ),
 			'unresolved_link_count'        => (int) ( $source_documents['unresolved_link_count'] ?? 0 ),
 			'commerce'                     => $commerce,
@@ -539,6 +552,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'asset_materialization'     => 'svg_materialization_failure_count',
 			'commerce_dependencies'     => 'commerce_dependency_failures',
 			'interaction_candidates'    => 'interaction_candidate_count',
+			'runtime_dependency_parity' => 'runtime_dependency_parity_issue_count',
 		);
 		$ref_key  = $ref_keys[ $name ] ?? $name;
 
@@ -853,6 +867,9 @@ class Static_Site_Importer_Report_Diagnostics {
 				'commerce_dependency_failure',
 				'commerce_product_inference_unmatched',
 				'interaction_candidate',
+				'runtime_dependency_missing_dom_target',
+				'runtime_dependency_unsupported_element_reference',
+				'runtime_dependency_parity_issue',
 			),
 			true
 		);
@@ -947,6 +964,9 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 		if ( in_array( $type, array( 'content_loss_abort', 'empty_conversion', 'invalid_block_document' ), true ) ) {
 			return 'Convert the source content into valid non-empty WordPress block markup without losing source content.';
+		}
+		if ( in_array( $type, array( 'runtime_dependency_missing_dom_target', 'runtime_dependency_unsupported_element_reference', 'runtime_dependency_parity_issue' ), true ) ) {
+			return 'Runtime scripts should be preserved only with DOM targets and browser elements that exist in the imported WordPress page.';
 		}
 
 		return 'Import should complete without this diagnostic being reported.';
@@ -1099,6 +1119,178 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
+	 * Preserve optional Blocks Engine runtime dependency parity evidence compactly.
+	 *
+	 * @param array<string,mixed> $runtime_dependency_parity Native runtime dependency parity report.
+	 * @return array<string,mixed>
+	 */
+	private static function runtime_dependency_parity_payload( array $runtime_dependency_parity ): array {
+		$scripts  = self::runtime_dependency_parity_scripts( $runtime_dependency_parity );
+		$findings = self::runtime_dependency_parity_findings( $runtime_dependency_parity );
+
+		$payload = array(
+			'schema'                            => isset( $runtime_dependency_parity['schema'] ) && is_scalar( $runtime_dependency_parity['schema'] ) ? (string) $runtime_dependency_parity['schema'] : 'blocks-engine/runtime-dependency-parity/v1',
+			'status'                            => isset( $runtime_dependency_parity['status'] ) && is_scalar( $runtime_dependency_parity['status'] ) ? (string) $runtime_dependency_parity['status'] : '',
+			'script_count'                      => count( $scripts ),
+			'finding_count'                     => count( $findings ),
+			'missing_dom_target_count'          => count( array_filter( $findings, static fn ( array $finding ): bool => 'runtime_dependency_missing_dom_target' === ( $finding['type'] ?? '' ) ) ),
+			'unsupported_element_reference_count' => count( array_filter( $findings, static fn ( array $finding ): bool => 'runtime_dependency_unsupported_element_reference' === ( $finding['type'] ?? '' ) ) ),
+			'vendor_telemetry_script_count'     => count( array_filter( $findings, static fn ( array $finding ): bool => 'runtime_dependency_vendor_telemetry_script' === ( $finding['type'] ?? '' ) ) ),
+		);
+
+		if ( ! empty( $scripts ) ) {
+			$payload['scripts'] = self::compact_native_report_rows( $scripts );
+		}
+		if ( ! empty( $findings ) ) {
+			$payload['findings'] = self::compact_native_report_rows( $findings );
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Reflect runtime dependency parity findings into report quality metadata.
+	 *
+	 * @param array<string,mixed> $report                    Import report.
+	 * @param array<string,mixed> $runtime_dependency_parity Native runtime dependency parity report.
+	 * @return void
+	 */
+	private static function record_runtime_dependency_parity_quality_metadata( array &$report, array $runtime_dependency_parity ): void {
+		$issue_count = 0;
+		foreach ( self::runtime_dependency_parity_findings( $runtime_dependency_parity ) as $finding ) {
+			$diagnostic = self::diagnostic_from_runtime_dependency_parity_finding( $finding );
+			if ( empty( $diagnostic ) ) {
+				continue;
+			}
+
+			if ( 'runtime_dependency_vendor_telemetry_script' !== ( $diagnostic['type'] ?? '' ) ) {
+				++$issue_count;
+			}
+			$report['diagnostics'][] = $diagnostic;
+		}
+
+		$report['quality']['runtime_dependency_parity_issue_count'] = (int) ( $report['quality']['runtime_dependency_parity_issue_count'] ?? 0 ) + $issue_count;
+	}
+
+	/**
+	 * Return script rows from plausible runtime dependency parity fields.
+	 *
+	 * @param array<string,mixed> $runtime_dependency_parity Native runtime dependency parity report.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function runtime_dependency_parity_scripts( array $runtime_dependency_parity ): array {
+		foreach ( array( 'scripts', 'script_assets', 'assets' ) as $field ) {
+			$rows = self::array_values_if_list( $runtime_dependency_parity[ $field ] ?? array() );
+			if ( ! empty( $rows ) ) {
+				return array_values( array_filter( $rows, 'is_array' ) );
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Return normalized finding rows from plausible runtime dependency parity fields.
+	 *
+	 * @param array<string,mixed> $runtime_dependency_parity Native runtime dependency parity report.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function runtime_dependency_parity_findings( array $runtime_dependency_parity ): array {
+		$findings = array();
+		foreach ( self::array_values_if_list( $runtime_dependency_parity['findings'] ?? array() ) as $finding ) {
+			if ( is_array( $finding ) ) {
+				$findings[] = self::normalize_runtime_dependency_parity_finding( $finding );
+			}
+		}
+
+		foreach ( self::array_values_if_list( $runtime_dependency_parity['missing_dom_targets'] ?? array() ) as $target ) {
+			if ( is_array( $target ) ) {
+				$findings[] = self::normalize_runtime_dependency_parity_finding( array_merge( array( 'type' => 'missing_dom_target' ), $target ) );
+			}
+		}
+
+		foreach ( self::array_values_if_list( $runtime_dependency_parity['unsupported_elements'] ?? array() ) as $element ) {
+			if ( is_array( $element ) ) {
+				$findings[] = self::normalize_runtime_dependency_parity_finding( array_merge( array( 'type' => 'unsupported_element_reference' ), $element ) );
+			}
+		}
+
+		foreach ( self::array_values_if_list( $runtime_dependency_parity['vendor_telemetry_scripts'] ?? array() ) as $script ) {
+			if ( is_array( $script ) ) {
+				$findings[] = self::normalize_runtime_dependency_parity_finding( array_merge( array( 'type' => 'vendor_telemetry_script' ), $script ) );
+			}
+		}
+
+		return $findings;
+	}
+
+	/**
+	 * Normalize one runtime dependency parity row into SSI diagnostic-compatible fields.
+	 *
+	 * @param array<string,mixed> $finding Runtime dependency parity finding row.
+	 * @return array<string,mixed>
+	 */
+	private static function normalize_runtime_dependency_parity_finding( array $finding ): array {
+		$type = self::first_scalar( $finding, array( 'type', 'kind', 'code' ) );
+		$type = sanitize_key( $type );
+		if ( str_contains( $type, 'missing' ) && ( str_contains( $type, 'target' ) || str_contains( $type, 'dom' ) || str_contains( $type, 'selector' ) ) ) {
+			$type = 'runtime_dependency_missing_dom_target';
+		} elseif ( str_contains( $type, 'unsupported' ) && ( str_contains( $type, 'element' ) || str_contains( $type, 'dom' ) ) ) {
+			$type = 'runtime_dependency_unsupported_element_reference';
+		} elseif ( str_contains( $type, 'telemetry' ) || ! empty( $finding['telemetry'] ) ) {
+			$type = 'runtime_dependency_vendor_telemetry_script';
+		} elseif ( ! str_starts_with( $type, 'runtime_dependency_' ) ) {
+			$type = 'runtime_dependency_parity_issue';
+		}
+
+		$finding['type'] = $type;
+		return $finding;
+	}
+
+	/**
+	 * Normalize runtime dependency parity rows into SSI diagnostics.
+	 *
+	 * @param array<string,mixed> $finding Normalized runtime dependency parity finding row.
+	 * @return array<string,mixed>
+	 */
+	private static function diagnostic_from_runtime_dependency_parity_finding( array $finding ): array {
+		$type        = isset( $finding['type'] ) && is_scalar( $finding['type'] ) ? (string) $finding['type'] : 'runtime_dependency_parity_issue';
+		$source      = self::first_scalar( $finding, array( 'source_path', 'source', 'document_path', 'path' ) );
+		$script_path = self::first_scalar( $finding, array( 'script_path', 'script', 'asset_path', 'asset' ) );
+		$selector    = self::first_scalar( $finding, array( 'selector', 'target_selector', 'target', 'dom_target' ) );
+
+		if ( '' === $source && '' === $script_path && '' === $selector ) {
+			return array();
+		}
+
+		$diagnostic = array(
+			'type'        => $type,
+			'source'      => '' !== $source ? $source : $script_path,
+			'reason'      => self::first_scalar( $finding, array( 'reason_code', 'reason', 'message' ) ),
+			'engine'      => 'blocks-engine/php-transformer',
+			'stage'       => 'runtime_dependency_parity',
+			'converter'   => 'blocks-engine/php-transformer',
+			'severity'    => 'runtime_dependency_vendor_telemetry_script' === $type ? 'notice' : 'warning',
+			'script_path' => $script_path,
+		);
+
+		if ( '' !== $selector ) {
+			$diagnostic['selector'] = $selector;
+		}
+		if ( '' === $diagnostic['reason'] ) {
+			$diagnostic['reason'] = $type;
+		}
+
+		foreach ( array( 'source_path', 'message', 'excerpt', 'source_html_preview', 'html_excerpt', 'tag_name', 'element', 'handle', 'src' ) as $field ) {
+			if ( isset( $finding[ $field ] ) && is_scalar( $finding[ $field ] ) && '' !== trim( (string) $finding[ $field ] ) ) {
+				$diagnostic[ $field ] = (string) $finding[ $field ];
+			}
+		}
+
+		return $diagnostic;
+	}
+
+	/**
 	 * Return fallback rows from old and canonical Blocks Engine conversion-report fields.
 	 *
 	 * @param array<string,mixed> $conversion_report Native conversion report.
@@ -1181,7 +1373,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return array<int,array<string,mixed>>
 	 */
 	private static function compact_native_report_rows( array $rows ): array {
-		$fields  = array( 'type', 'kind', 'code', 'severity', 'source', 'source_path', 'path', 'selector', 'tag_name', 'block_name', 'block_path', 'attribute_path', 'reason', 'reason_code', 'message', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt' );
+		$fields  = array( 'type', 'kind', 'code', 'severity', 'source', 'source_path', 'path', 'script_path', 'selector', 'target_selector', 'target', 'dom_target', 'tag_name', 'element', 'block_name', 'block_path', 'attribute_path', 'reason', 'reason_code', 'message', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt', 'handle', 'src', 'role', 'discovered', 'materialized', 'enqueued', 'telemetry', 'vendor' );
 		$compact = array();
 		foreach ( array_slice( $rows, 0, 50 ) as $row ) {
 			if ( ! is_array( $row ) ) {
@@ -1191,7 +1383,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			$entry = array();
 			foreach ( $fields as $field ) {
 				if ( isset( $row[ $field ] ) && is_scalar( $row[ $field ] ) && '' !== trim( (string) $row[ $field ] ) ) {
-					$entry[ $field ] = (string) $row[ $field ];
+					$entry[ $field ] = is_bool( $row[ $field ] ) || is_numeric( $row[ $field ] ) ? $row[ $field ] : (string) $row[ $field ];
 				}
 			}
 
@@ -1326,6 +1518,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'svg_sprite_reference_failure_count' => array( 'svg_sprite_reference_failure' ),
 			'commerce_dependency_failures'       => array( 'commerce_dependency_failure' ),
 			'interaction_candidate_count'        => array( 'interaction_candidate' ),
+			'runtime_dependency_parity_issue_count' => array( 'runtime_dependency_missing_dom_target', 'runtime_dependency_unsupported_element_reference', 'runtime_dependency_parity_issue' ),
 		);
 
 		$refs = array();
@@ -1464,6 +1657,10 @@ class Static_Site_Importer_Report_Diagnostics {
 			'commerce_dependency_failure'          => 'conversion_quality',
 			'commerce_product_inference_unmatched' => 'conversion_quality',
 			'interaction_candidate'                => 'source_interaction',
+			'runtime_dependency_missing_dom_target' => 'runtime_dependency_parity',
+			'runtime_dependency_unsupported_element_reference' => 'runtime_dependency_parity',
+			'runtime_dependency_vendor_telemetry_script' => 'runtime_dependency_parity',
+			'runtime_dependency_parity_issue'      => 'runtime_dependency_parity',
 		);
 
 		return $categories[ $type ] ?? 'import_quality';
@@ -1493,6 +1690,10 @@ class Static_Site_Importer_Report_Diagnostics {
 			'commerce_dependency_failure'          => 'install_or_configure_dependency',
 			'commerce_product_inference_unmatched' => 'provide_structured_product_data',
 			'interaction_candidate'                => 'inspect_interactive_behavior',
+			'runtime_dependency_missing_dom_target' => 'restore_or_remove_runtime_dom_dependency',
+			'runtime_dependency_unsupported_element_reference' => 'replace_unsupported_runtime_element',
+			'runtime_dependency_vendor_telemetry_script' => 'review_vendor_telemetry_script',
+			'runtime_dependency_parity_issue'      => 'inspect_runtime_dependency_parity',
 		);
 
 		return $classes[ $type ] ?? 'inspect_import_diagnostic';
@@ -1506,7 +1707,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	private static function diagnostic_context( array $diagnostic ): array {
 		$context = array();
-		foreach ( array( 'href', 'tag', 'tag_name', 'block_name', 'block_path', 'excerpt', 'html_excerpt', 'source_html_preview', 'error_message', 'kind' ) as $key ) {
+		foreach ( array( 'href', 'tag', 'tag_name', 'block_name', 'block_path', 'excerpt', 'html_excerpt', 'source_html_preview', 'error_message', 'kind', 'script_path', 'element', 'handle', 'src' ) as $key ) {
 			if ( array_key_exists( $key, $diagnostic ) && null !== $diagnostic[ $key ] && '' !== $diagnostic[ $key ] ) {
 				$context[ $key ] = $diagnostic[ $key ];
 			}
@@ -1654,6 +1855,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'source_path',
 			'source',
 			'selector',
+			'script_path',
 			'excerpt',
 			'source_html_preview',
 			'emitted_block_preview',
@@ -1664,6 +1866,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'reason',
 			'message',
 			'tag_name',
+			'element',
 			'html_excerpt',
 			'context',
 		);

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -98,7 +98,39 @@ class Static_Site_Importer_Transformer_Adapter {
 			$compiled['products_manifest'] = $products;
 		}
 
+		$runtime_dependency_parity = $this->runtime_dependency_parity_report_from_result( $result, $view );
+		if ( ! empty( $runtime_dependency_parity ) ) {
+			$compiled['runtime_dependency_parity'] = $runtime_dependency_parity;
+		}
+
 		return $compiled;
+	}
+
+	/**
+	 * Read optional Blocks Engine runtime dependency parity reports from known envelopes.
+	 *
+	 * @param array<string,mixed> $result TransformerResult::toArray() output.
+	 * @param array<string,mixed> $view   Optional MaterializationView projection.
+	 * @return array<string,mixed>
+	 */
+	private function runtime_dependency_parity_report_from_result( array $result, array $view = array() ): array {
+		$candidates = array();
+		if ( isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ) {
+			$source_reports = $result['source_reports'];
+			$candidates[]   = $source_reports['runtime_dependency_parity'] ?? null;
+			$candidates[]   = isset( $source_reports['conversion_report'] ) && is_array( $source_reports['conversion_report'] ) ? ( $source_reports['conversion_report']['runtime_dependency_parity'] ?? null ) : null;
+		}
+		$candidates[] = isset( $result['conversion_report'] ) && is_array( $result['conversion_report'] ) ? ( $result['conversion_report']['runtime_dependency_parity'] ?? null ) : null;
+		$candidates[] = isset( $result['reports'] ) && is_array( $result['reports'] ) ? ( $result['reports']['runtime_dependency_parity'] ?? null ) : null;
+		$candidates[] = isset( $view['runtime_dependency_parity'] ) ? $view['runtime_dependency_parity'] : null;
+
+		foreach ( $candidates as $candidate ) {
+			if ( is_array( $candidate ) && ! empty( $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		return array();
 	}
 
 	/**

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -321,6 +321,131 @@ namespace {
 	$assert( 'interaction_candidate' === ( $report['diagnostics'][1]['type'] ?? '' ), 'interaction-candidate-becomes-report-diagnostic' );
 	$assert( 2 === ( $report['finding_packets']['count'] ?? 0 ), 'native-report-diagnostics-create-finding-packets' );
 
+	$runtime_dependency_parity = array(
+		'schema'                   => 'blocks-engine/runtime-dependency-parity/v1',
+		'status'                   => 'reported',
+		'scripts'                  => array(
+			array(
+				'path'         => 'assets/script.js',
+				'role'         => 'script',
+				'discovered'   => true,
+				'materialized' => true,
+				'enqueued'     => true,
+			),
+			array(
+				'path'         => 'assets/rum.js',
+				'role'         => 'script',
+				'discovered'   => true,
+				'materialized' => true,
+				'enqueued'     => true,
+				'telemetry'    => true,
+				'vendor'       => 'rum',
+			),
+		),
+		'missing_dom_targets'      => array(
+			array(
+				'source_path' => 'website/index.html',
+				'script_path' => 'assets/script.js',
+				'selector'    => '#canvas',
+				'message'     => 'script.js references #canvas, but the imported page does not contain that DOM target.',
+			),
+		),
+		'unsupported_elements'     => array(
+			array(
+				'source_path' => 'website/index.html',
+				'script_path' => 'assets/script.js',
+				'element'     => 'canvas',
+				'selector'    => 'canvas',
+			),
+		),
+		'vendor_telemetry_scripts' => array(
+			array(
+				'source_path' => 'website/index.html',
+				'script_path' => 'assets/rum.js',
+				'vendor'      => 'rum',
+				'telemetry'   => true,
+			),
+		),
+	);
+
+	$GLOBALS['ssi_transformer_adapter_result_override'] = array(
+		'schema'         => 'blocks-engine/php-transformer/result/v1',
+		'status'         => 'success',
+		'source_reports' => array(
+			'artifact'                  => array( 'entry_path' => 'website/index.html' ),
+			'materialization_plan'      => array(
+				'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+				'pages'  => array(),
+			),
+			'runtime_dependency_parity' => $runtime_dependency_parity,
+		),
+	);
+	$runtime_parity_compiled = $adapter->compile_website_artifact( array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ) );
+	unset( $GLOBALS['ssi_transformer_adapter_result_override'] );
+	$assert( ! is_wp_error( $runtime_parity_compiled ), 'runtime-parity-compile-succeeds' );
+	$assert( 'blocks-engine/runtime-dependency-parity/v1' === ( $runtime_parity_compiled['runtime_dependency_parity']['schema'] ?? '' ), 'source-report-runtime-parity-preserved' );
+
+	$runtime_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
+	Static_Site_Importer_Report_Diagnostics::record_blocks_engine_result( $runtime_report, $runtime_parity_compiled );
+	Static_Site_Importer_Report_Diagnostics::finalize_report( $runtime_report, array() );
+	$runtime_payload = $runtime_report['blocks_engine']['runtime_dependency_parity'] ?? array();
+	$runtime_gate    = $runtime_report['import_validation_result']['quality_gates']['runtime_dependency_parity'] ?? array();
+	$assert( 2 === ( $runtime_payload['script_count'] ?? 0 ), 'runtime-parity-records-script-count' );
+	$assert( 'assets/script.js' === ( $runtime_payload['scripts'][0]['path'] ?? '' ), 'runtime-parity-preserves-script-path' );
+	$assert( true === ( $runtime_payload['scripts'][0]['materialized'] ?? false ), 'runtime-parity-preserves-script-materialized-state' );
+	$assert( true === ( $runtime_payload['scripts'][0]['enqueued'] ?? false ), 'runtime-parity-preserves-script-enqueued-state' );
+	$assert( 1 === ( $runtime_payload['missing_dom_target_count'] ?? 0 ), 'runtime-parity-counts-missing-dom-targets' );
+	$assert( 1 === ( $runtime_payload['unsupported_element_reference_count'] ?? 0 ), 'runtime-parity-counts-unsupported-elements' );
+	$assert( 1 === ( $runtime_payload['vendor_telemetry_script_count'] ?? 0 ), 'runtime-parity-counts-vendor-telemetry-scripts' );
+	$assert( 2 === ( $runtime_report['quality']['runtime_dependency_parity_issue_count'] ?? 0 ), 'runtime-parity-quality-count-excludes-telemetry-notice' );
+	$assert( 'reported' === ( $runtime_gate['status'] ?? '' ), 'runtime-parity-gate-reports-issues' );
+	$assert( 2 === ( $runtime_gate['count'] ?? 0 ), 'runtime-parity-gate-counts-actionable-issues' );
+	$assert( 2 === count( $runtime_gate['diagnostic_refs'] ?? array() ), 'runtime-parity-gate-has-diagnostic-refs' );
+	$assert( 'runtime_dependency_missing_dom_target' === ( $runtime_report['diagnostics'][0]['type'] ?? '' ), 'runtime-parity-missing-target-becomes-diagnostic' );
+	$assert( '#canvas' === ( $runtime_report['diagnostics'][0]['selector'] ?? '' ), 'runtime-parity-diagnostic-preserves-selector' );
+	$assert( 'assets/script.js' === ( $runtime_report['diagnostics'][0]['script_path'] ?? '' ), 'runtime-parity-diagnostic-preserves-script-path' );
+	$assert( 'runtime_dependency_vendor_telemetry_script' === ( $runtime_report['diagnostics'][2]['type'] ?? '' ), 'runtime-parity-telemetry-becomes-low-severity-diagnostic' );
+	$assert( 'notice' === ( $runtime_report['diagnostics'][2]['severity'] ?? '' ), 'runtime-parity-telemetry-is-notice' );
+	$assert( 2 === ( $runtime_report['finding_packets']['count'] ?? 0 ), 'runtime-parity-actionable-diagnostics-create-finding-packets' );
+	$assert( 'failed' === ( Static_Site_Importer_Report_Diagnostics::import_validation_result( $runtime_report, Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $runtime_report, array( 'fail_on_quality' => true ) ) )['status'] ?? '' ), 'runtime-parity-fail-on-quality-can-fail' );
+
+	$runtime_parity_locations = array(
+		'source_reports.conversion_report.runtime_dependency_parity' => array(
+			'source_reports' => array(
+				'artifact'             => array( 'entry_path' => 'website/index.html' ),
+				'materialization_plan' => array( 'schema' => 'blocks-engine/php-transformer/materialization-plan/v1' ),
+				'conversion_report'    => array( 'runtime_dependency_parity' => $runtime_dependency_parity ),
+			),
+		),
+		'conversion_report.runtime_dependency_parity' => array(
+			'source_reports'    => array(
+				'artifact'             => array( 'entry_path' => 'website/index.html' ),
+				'materialization_plan' => array( 'schema' => 'blocks-engine/php-transformer/materialization-plan/v1' ),
+			),
+			'conversion_report' => array( 'runtime_dependency_parity' => $runtime_dependency_parity ),
+		),
+		'reports.runtime_dependency_parity' => array(
+			'source_reports' => array(
+				'artifact'             => array( 'entry_path' => 'website/index.html' ),
+				'materialization_plan' => array( 'schema' => 'blocks-engine/php-transformer/materialization-plan/v1' ),
+			),
+			'reports'        => array( 'runtime_dependency_parity' => $runtime_dependency_parity ),
+		),
+	);
+	foreach ( $runtime_parity_locations as $label => $payload ) {
+		$GLOBALS['ssi_transformer_adapter_result_override'] = array_merge(
+			array(
+				'schema' => 'blocks-engine/php-transformer/result/v1',
+				'status' => 'success',
+			),
+			$payload
+		);
+		$location_compiled = $adapter->compile_website_artifact( array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ) );
+		unset( $GLOBALS['ssi_transformer_adapter_result_override'] );
+		$assert( ! is_wp_error( $location_compiled ), 'runtime-parity-location-compile-' . $label );
+		$assert( 'blocks-engine/runtime-dependency-parity/v1' === ( $location_compiled['runtime_dependency_parity']['schema'] ?? '' ), 'runtime-parity-location-consumed-' . $label );
+	}
+
 	$GLOBALS['ssi_transformer_adapter_result_override'] = array(
 		'schema'            => 'blocks-engine/php-transformer/result/v1',
 		'status'            => 'success',


### PR DESCRIPTION
## Summary
- consume optional Blocks Engine runtime dependency parity reports from tolerant envelope locations before the Blocks Engine release lands
- preserve compact parity evidence under blocks_engine.runtime_dependency_parity, including discovered/materialized/enqueued script rows
- emit SSI diagnostics, finding packets, diagnostic refs, and a runtime_dependency_parity quality gate for actionable missing DOM target / unsupported element findings while keeping telemetry notices lower severity

## Testing
- php -l includes/class-static-site-importer-transformer-adapter.php
- php -l includes/class-static-site-importer-report-diagnostics.php
- php -l tests/smoke-transformer-adapter.php
- php tests/smoke-transformer-adapter.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing the report ingestion, diagnostics/gate plumbing, synthetic smoke coverage, and PR description.