### PR TITLE
Update PHP transformer to 0.1.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.11",
+        "version": "0.1.12",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "8a6bbebc826dd140b36bf8f16b7008f6a27c2980"
+          "reference": "e708340b946ebe2c1d9fb316df2764cec9d95ad9"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.11.zip",
-          "reference": "8a6bbebc826dd140b36bf8f16b7008f6a27c2980"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.12.zip",
+          "reference": "e708340b946ebe2c1d9fb316df2764cec9d95ad9"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.1.11",
+    "automattic/blocks-engine-php-transformer": "^0.1.12",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18865f24323b0d657da43dcc2051950b",
+    "content-hash": "0dea3f1c330ed1b33363399b31c9623f",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.11",
+            "version": "0.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "8a6bbebc826dd140b36bf8f16b7008f6a27c2980"
+                "reference": "e708340b946ebe2c1d9fb316df2764cec9d95ad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.11.zip",
-                "reference": "8a6bbebc826dd140b36bf8f16b7008f6a27c2980"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.12.zip",
+                "reference": "e708340b946ebe2c1d9fb316df2764cec9d95ad9"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- update automattic/blocks-engine-php-transformer to 0.1.12
- brings in semantic parity diagnostics, runtime dependency parity diagnostics, sharper canvas fallback diagnostics, and linked CSS flex layout improvements

## Testing
- php tests/smoke-transformer-adapter.php
- php tests/smoke-semantic-parity-diagnostics.php
- php tests/smoke-importer-block.php
- php -r 'require "vendor/automattic/blocks-engine-php-transformer/php-transformer/php-transformer.php"; echo blocks_engine_php_transformer_version(), "\n";' returned 0.1.12

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Update the Blocks Engine PHP transformer package pin, refresh Composer lock state, and run targeted verification.