### PR TITLE
Enrich Codebox fixture diagnostics

### DIFF
--- a/includes/class-static-site-importer-codebox-validation.php
+++ b/includes/class-static-site-importer-codebox-validation.php
@@ -14,9 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Static_Site_Importer_Codebox_Validation {
 
-	private const REQUEST_SCHEMA  = 'static-site-importer/codebox-validation-request/v1';
-	private const RESULT_SCHEMA   = 'static-site-importer/codebox-validation-result/v1';
-	private const ARTIFACT_SCHEMA = 'static-site-importer/codebox-validation-artifacts/v1';
+	private const REQUEST_SCHEMA             = 'static-site-importer/codebox-validation-request/v1';
+	private const RESULT_SCHEMA              = 'static-site-importer/codebox-validation-result/v1';
+	private const ARTIFACT_SCHEMA            = 'static-site-importer/codebox-validation-artifacts/v1';
+	private const FIXTURE_DIAGNOSTICS_SCHEMA = 'static-site-importer/codebox-fixture-diagnostics/v1';
 
 	/**
 	 * Register the default WP Codebox host-delegation bridge.
@@ -43,7 +44,7 @@ class Static_Site_Importer_Codebox_Validation {
 		$delegation_request       = self::host_delegation_request( $request, $input );
 		$host_delegation_callback = array( 'WP_Codebox_Abilities', 'request_host_delegation' );
 		$host_delegation_methods  = class_exists( 'WP_Codebox_Abilities' ) ? get_class_methods( 'WP_Codebox_Abilities' ) : array();
-		if ( in_array( 'request_host_delegation', $host_delegation_methods, true ) ) {
+		if ( in_array( 'request_host_delegation', $host_delegation_methods, true ) && is_callable( $host_delegation_callback ) ) {
 			$delegation_result = call_user_func( $host_delegation_callback, $delegation_request );
 		} elseif ( function_exists( 'has_filter' ) && has_filter( 'wp_codebox_host_delegation_request' ) ) {
 			$delegation_result = apply_filters( 'wp_codebox_host_delegation_request', null, $delegation_request );
@@ -104,6 +105,57 @@ class Static_Site_Importer_Codebox_Validation {
 		}
 
 		return self::normalize_provider_result( $request, $result );
+	}
+
+	/**
+	 * Build a structured validation result for failures that happen before provider output exists.
+	 *
+	 * @param WP_Error            $error Validation error.
+	 * @param array<string,mixed> $input Raw caller input.
+	 * @return array<string,mixed>
+	 */
+	public static function error_result_from_wp_error( WP_Error $error, array $input = array() ): array {
+		$request = self::build_error_request_summary( $input );
+		$status  = 'static_site_importer_codebox_validation_source_missing' === $error->get_error_code() ? 'blocked' : 'failed';
+
+		$result = array(
+			'success'       => false,
+			'schema'        => self::RESULT_SCHEMA,
+			'status'        => $status,
+			'product_path'  => 'static-site-importer/validate-in-codebox',
+			'request'       => $request,
+			'artifacts'     => self::artifact_contract( array( 'source' => array() ), array() ),
+			'runtime'       => array(),
+			'summary'       => array(
+				'quality_pass' => false,
+				'error_code'   => $error->get_error_code(),
+			),
+			'upstream_gaps' => array(),
+		);
+
+		$result['fixture_diagnostics'] = self::fixture_diagnostics(
+			array(
+				'slug'        => isset( $request['import_args']['slug'] ) ? (string) $request['import_args']['slug'] : '',
+				'name'        => isset( $request['import_args']['name'] ) ? (string) $request['import_args']['name'] : '',
+				'request'     => $request,
+				'status'      => $status,
+				'success'     => false,
+				'artifacts'   => $result['artifacts'],
+				'diagnostics' => array(
+					array(
+						'type'        => 'validation_request_error',
+						'severity'    => 'error',
+						'code'        => $error->get_error_code(),
+						'reason_code' => $error->get_error_code(),
+						'message'     => $error->get_error_message(),
+						'stage'       => 'request_validation',
+						'owner'       => 'static-site-importer',
+					),
+				),
+			)
+		);
+
+		return $result;
 	}
 
 	/**
@@ -274,8 +326,7 @@ class Static_Site_Importer_Codebox_Validation {
 	private static function normalize_provider_result( array $request, array $result ): array {
 		$status    = isset( $result['status'] ) ? sanitize_key( (string) $result['status'] ) : ( ! empty( $result['success'] ) ? 'succeeded' : 'failed' );
 		$artifacts = self::artifact_contract( $request, isset( $result['artifacts'] ) && is_array( $result['artifacts'] ) ? $result['artifacts'] : array() );
-
-		return array(
+		$output    = array(
 			'success'       => 'succeeded' === $status,
 			'schema'        => self::RESULT_SCHEMA,
 			'status'        => $status,
@@ -286,6 +337,20 @@ class Static_Site_Importer_Codebox_Validation {
 			'summary'       => isset( $result['summary'] ) && is_array( $result['summary'] ) ? $result['summary'] : array(),
 			'upstream_gaps' => isset( $result['upstream_gaps'] ) && is_array( $result['upstream_gaps'] ) ? array_values( $result['upstream_gaps'] ) : array(),
 		);
+
+		$output['fixture_diagnostics'] = self::fixture_diagnostics(
+			array_merge(
+				$result,
+				array(
+					'status'    => $status,
+					'success'   => $output['success'],
+					'request'   => $output['request'],
+					'artifacts' => $artifacts,
+				)
+			)
+		);
+
+		return $output;
 	}
 
 	/**
@@ -295,7 +360,7 @@ class Static_Site_Importer_Codebox_Validation {
 	 * @return array<string,mixed>
 	 */
 	private static function provider_unavailable_result( array $request ): array {
-		return array(
+		$result = array(
 			'success'       => false,
 			'schema'        => self::RESULT_SCHEMA,
 			'status'        => 'blocked',
@@ -323,6 +388,427 @@ class Static_Site_Importer_Codebox_Validation {
 				),
 			),
 		);
+
+		$result['fixture_diagnostics'] = self::fixture_diagnostics(
+			array(
+				'status'        => 'blocked',
+				'success'       => false,
+				'request'       => $result['request'],
+				'artifacts'     => $result['artifacts'],
+				'summary'       => $result['summary'],
+				'upstream_gaps' => $result['upstream_gaps'],
+				'diagnostics'   => array(
+					array(
+						'type'        => 'runtime_provider_unavailable',
+						'severity'    => 'error',
+						'code'        => 'missing_provider',
+						'reason_code' => 'missing_provider',
+						'message'     => 'No Codebox validation provider is registered.',
+						'stage'       => 'runtime_dispatch',
+						'owner'       => 'wp-codebox/homeboy',
+					),
+				),
+			)
+		);
+
+		return $result;
+	}
+
+	/**
+	 * Build the fixture-level diagnostics envelope consumed by matrix runners.
+	 *
+	 * @param array<string,mixed> $result Provider or synthesized result.
+	 * @return array<string,mixed>
+	 */
+	private static function fixture_diagnostics( array $result ): array {
+		$request       = isset( $result['request'] ) && is_array( $result['request'] ) ? $result['request'] : array();
+		$import_args   = isset( $request['import_args'] ) && is_array( $request['import_args'] ) ? $request['import_args'] : array();
+		$import_report = self::provider_import_report( $result );
+		$summary       = isset( $result['summary'] ) && is_array( $result['summary'] ) ? $result['summary'] : array();
+		$artifacts     = isset( $result['artifacts'] ) && is_array( $result['artifacts'] ) ? $result['artifacts'] : array();
+
+		$diagnostics = array_merge(
+			self::diagnostic_rows_from_result( $result ),
+			self::diagnostic_rows_from_import_report( $import_report ),
+			self::blocks_engine_conversion_diagnostics( $import_report ),
+			self::runtime_dependency_target_gaps( $import_report )
+		);
+		$diagnostics = self::dedupe_diagnostics( $diagnostics );
+
+		$quality_counts = self::quality_counts( $import_report, $summary );
+
+		return array(
+			'schema'                         => self::FIXTURE_DIAGNOSTICS_SCHEMA,
+			'fixture'                        => array(
+				'slug' => isset( $result['slug'] ) && is_scalar( $result['slug'] ) ? (string) $result['slug'] : ( isset( $import_args['slug'] ) ? (string) $import_args['slug'] : '' ),
+				'name' => isset( $result['name'] ) && is_scalar( $result['name'] ) ? (string) $result['name'] : ( isset( $import_args['name'] ) ? (string) $import_args['name'] : '' ),
+			),
+			'status'                         => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : '',
+			'success'                        => ! empty( $result['success'] ),
+			'quality_counts'                 => $quality_counts,
+			'import_report_quality_counts'   => $quality_counts,
+			'diagnostic_summary'             => self::diagnostic_summary( $diagnostics ),
+			'diagnostics'                    => $diagnostics,
+			'by_category'                    => self::diagnostics_by_category( $diagnostics ),
+			'blocks_engine'                  => self::blocks_engine_summary( $import_report ),
+			'runtime_dependency_target_gaps' => self::runtime_dependency_target_gaps( $import_report ),
+			'asset_diagnostics'              => self::diagnostics_matching_types( $diagnostics, array( 'asset', 'image', 'local_asset_not_materialized', 'missing_asset', 'dropped_image' ) ),
+			'svg_diagnostics'                => self::diagnostics_matching_types( $diagnostics, array( 'svg', 'unsafe_inline_svg', 'svg_materialization_failure', 'svg_sprite_reference_failure' ) ),
+			'button_style_loss_hints'        => self::diagnostics_matching_types( $diagnostics, array( 'button', 'style_loss', 'presentation_gap' ) ),
+			'artifact_refs'                  => self::fixture_artifact_refs( $artifacts, $import_report ),
+		);
+	}
+
+	/**
+	 * Extract an import report from common provider result slots.
+	 *
+	 * @param array<string,mixed> $result Provider result.
+	 * @return array<string,mixed>
+	 */
+	private static function provider_import_report( array $result ): array {
+		foreach ( array( $result['import_report'] ?? null, $result['summary']['import_report'] ?? null, $result['artifacts']['import_report'] ?? null ) as $candidate ) {
+			if ( is_array( $candidate ) && ( isset( $candidate['quality'] ) || isset( $candidate['diagnostics'] ) || isset( $candidate['blocks_engine'] ) ) ) {
+				return $candidate;
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Build a request summary from raw input when request creation failed.
+	 *
+	 * @param array<string,mixed> $input Raw caller input.
+	 * @return array<string,mixed>
+	 */
+	private static function build_error_request_summary( array $input ): array {
+		return array(
+			'schema'              => self::REQUEST_SCHEMA,
+			'product_path'        => 'static-site-importer/validate-in-codebox',
+			'execution_scope'     => 'disposable-wp-codebox-runtime',
+			'has_inline_artifact' => isset( $input['artifact'] ) && is_array( $input['artifact'] ) && ! empty( $input['artifact'] ),
+			'artifact_schema'     => isset( $input['artifact']['schema'] ) && is_scalar( $input['artifact']['schema'] ) ? (string) $input['artifact']['schema'] : '',
+			'import_args'         => array_filter(
+				array(
+					'slug' => isset( $input['slug'] ) ? sanitize_title( (string) $input['slug'] ) : '',
+					'name' => isset( $input['name'] ) ? sanitize_text_field( (string) $input['name'] ) : '',
+				),
+				static fn ( string $value ): bool => '' !== $value
+			),
+			'required_artifacts'  => self::required_artifacts(),
+		);
+	}
+
+	/**
+	 * Read provider-level diagnostic rows.
+	 *
+	 * @param array<string,mixed> $result Provider result.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function diagnostic_rows_from_result( array $result ): array {
+		$rows = array();
+		foreach ( array( $result['diagnostics'] ?? array(), $result['artifact_diagnostics']['diagnostics'] ?? array(), $result['import_validation_result']['diagnostics'] ?? array() ) as $candidate ) {
+			if ( is_array( $candidate ) ) {
+				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $candidate ) );
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Read import-report diagnostic rows.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function diagnostic_rows_from_import_report( array $import_report ): array {
+		$rows = self::normalize_diagnostic_rows( isset( $import_report['diagnostics'] ) && is_array( $import_report['diagnostics'] ) ? $import_report['diagnostics'] : array() );
+		if ( isset( $import_report['artifact_diagnostics']['diagnostics'] ) && is_array( $import_report['artifact_diagnostics']['diagnostics'] ) ) {
+			$rows = array_merge( $rows, self::normalize_diagnostic_rows( $import_report['artifact_diagnostics']['diagnostics'] ) );
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Extract Blocks Engine conversion-report diagnostics and fallback rows.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function blocks_engine_conversion_diagnostics( array $import_report ): array {
+		$conversion_report = isset( $import_report['blocks_engine']['conversion_report'] ) && is_array( $import_report['blocks_engine']['conversion_report'] ) ? $import_report['blocks_engine']['conversion_report'] : array();
+		$rows              = array();
+		foreach ( array( 'diagnostics', 'fallback_diagnostics', 'fallbacks', 'presentation_gaps', 'interaction_candidates' ) as $field ) {
+			if ( isset( $conversion_report[ $field ] ) && is_array( $conversion_report[ $field ] ) ) {
+				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $conversion_report[ $field ], 'blocks_engine_conversion_report' ) );
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Extract runtime dependency parity target gaps.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function runtime_dependency_target_gaps( array $import_report ): array {
+		$runtime_dependency_parity = isset( $import_report['blocks_engine']['runtime_dependency_parity'] ) && is_array( $import_report['blocks_engine']['runtime_dependency_parity'] ) ? $import_report['blocks_engine']['runtime_dependency_parity'] : array();
+		$rows                      = array();
+		foreach ( array( 'findings', 'missing_dom_targets', 'unsupported_elements' ) as $field ) {
+			if ( isset( $runtime_dependency_parity[ $field ] ) && is_array( $runtime_dependency_parity[ $field ] ) ) {
+				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $runtime_dependency_parity[ $field ], 'runtime_dependency_parity' ) );
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Normalize diagnostic rows to a stable matrix-consumable subset.
+	 *
+	 * @param array<int|string,mixed> $rows          Raw diagnostic rows.
+	 * @param string                  $default_stage Default stage.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function normalize_diagnostic_rows( array $rows, string $default_stage = '' ): array {
+		$normalized = array();
+		foreach ( array_values( $rows ) as $index => $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$type        = self::first_scalar( $row, array( 'type', 'kind', 'code', 'reason_code' ), 'diagnostic' );
+			$reason_code = self::first_scalar( $row, array( 'reason_code', 'code', 'reason', 'kind', 'type' ), $type );
+			$source_path = self::first_scalar( $row, array( 'source_path', 'path', 'source', 'file', 'script_path' ), '' );
+			$diagnostic  = array(
+				'id'          => self::first_scalar( $row, array( 'id' ), sprintf( 'diag-%03d-%s', $index + 1, sanitize_key( $type . '-' . $reason_code . '-' . $source_path ) ) ),
+				'type'        => sanitize_key( $type ),
+				'severity'    => self::first_scalar( $row, array( 'severity', 'level' ), self::default_diagnostic_severity( $type ) ),
+				'category'    => self::diagnostic_category( $type ),
+				'reason_code' => sanitize_key( $reason_code ),
+				'source_path' => $source_path,
+				'selector'    => self::first_scalar( $row, array( 'selector', 'target_selector', 'css_selector' ), '' ),
+				'code'        => self::first_scalar( $row, array( 'code', 'error_code' ), sanitize_key( $reason_code ) ),
+				'stage'       => self::first_scalar( $row, array( 'stage' ), $default_stage ),
+				'owner'       => self::first_scalar( $row, array( 'owner', 'engine', 'converter' ), '' ),
+			);
+
+			foreach ( array( 'message', 'reason', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt', 'block_name', 'block_path', 'script_path', 'element', 'tag_name', 'src', 'href', 'expected', 'observed' ) as $field ) {
+				$value = self::first_scalar( $row, array( $field ), '' );
+				if ( '' !== $value ) {
+					$diagnostic[ $field ] = $value;
+				}
+			}
+
+			$normalized[] = array_filter(
+				$diagnostic,
+				static fn ( mixed $value ): bool => '' !== $value
+			);
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Return quality counts from import report first, then compact summaries.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @param array<string,mixed> $summary Provider summary.
+	 * @return array<string,int>
+	 */
+	private static function quality_counts( array $import_report, array $summary ): array {
+		$quality = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
+		$keys    = array( 'fallback_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
+
+		$counts = array();
+		foreach ( $keys as $key ) {
+			$counts[ $key ] = isset( $quality[ $key ] ) && is_numeric( $quality[ $key ] ) ? (int) $quality[ $key ] : 0;
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Summarize Blocks Engine import-report details.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<string,mixed>
+	 */
+	private static function blocks_engine_summary( array $import_report ): array {
+		$blocks_engine = isset( $import_report['blocks_engine'] ) && is_array( $import_report['blocks_engine'] ) ? $import_report['blocks_engine'] : array();
+
+		$summary = array();
+		foreach ( array( 'website_artifact', 'conversion_report', 'runtime_dependency_parity', 'semantic_parity' ) as $field ) {
+			if ( isset( $blocks_engine[ $field ] ) && is_array( $blocks_engine[ $field ] ) && ! empty( $blocks_engine[ $field ] ) ) {
+				$summary[ $field ] = $blocks_engine[ $field ];
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Build diagnostic counts by severity and category.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @return array<string,mixed>
+	 */
+	private static function diagnostic_summary( array $diagnostics ): array {
+		$summary = array(
+			'total'    => count( $diagnostics ),
+			'severity' => array(),
+			'category' => array(),
+			'type'     => array(),
+		);
+		foreach ( $diagnostics as $diagnostic ) {
+			foreach ( array( 'severity', 'category', 'type' ) as $field ) {
+				$value                       = isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) ? (string) $diagnostic[ $field ] : 'unknown';
+				$summary[ $field ][ $value ] = ( $summary[ $field ][ $value ] ?? 0 ) + 1;
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Group diagnostics by category.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @return array<string,array<int,array<string,mixed>>>
+	 */
+	private static function diagnostics_by_category( array $diagnostics ): array {
+		$grouped = array();
+		foreach ( $diagnostics as $diagnostic ) {
+			$category               = isset( $diagnostic['category'] ) && is_scalar( $diagnostic['category'] ) ? (string) $diagnostic['category'] : 'uncategorized';
+			$grouped[ $category ][] = $diagnostic;
+		}
+
+		return $grouped;
+	}
+
+	/**
+	 * Select diagnostics matching types or type fragments.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @param array<int,string>              $needles     Type needles.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function diagnostics_matching_types( array $diagnostics, array $needles ): array {
+		return array_values(
+			array_filter(
+				$diagnostics,
+				static function ( array $diagnostic ) use ( $needles ): bool {
+					$type     = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : '';
+					$category = isset( $diagnostic['category'] ) && is_scalar( $diagnostic['category'] ) ? (string) $diagnostic['category'] : '';
+					foreach ( $needles as $needle ) {
+						if ( $needle === $type || str_contains( $type, $needle ) || str_contains( $category, $needle ) ) {
+							return true;
+						}
+					}
+
+					return false;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Stable artifact references for matrix output.
+	 *
+	 * @param array<string,mixed> $artifacts     Validation artifacts.
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<string,mixed>
+	 */
+	private static function fixture_artifact_refs( array $artifacts, array $import_report ): array {
+		$refs = $artifacts;
+		if ( isset( $import_report['import_validation_result']['artifacts'] ) && is_array( $import_report['import_validation_result']['artifacts'] ) ) {
+			$refs['import_validation_artifacts'] = $import_report['import_validation_result']['artifacts'];
+		}
+		if ( isset( $import_report['visual_parity_artifacts'] ) && is_array( $import_report['visual_parity_artifacts'] ) ) {
+			$refs['visual_parity_artifacts'] = $import_report['visual_parity_artifacts'];
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * Remove duplicate diagnostics by id/type/source/selector/code.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function dedupe_diagnostics( array $diagnostics ): array {
+		$seen   = array();
+		$unique = array();
+		foreach ( $diagnostics as $diagnostic ) {
+			$key = implode( '|', array_map( 'strval', array( $diagnostic['id'] ?? '', $diagnostic['type'] ?? '', $diagnostic['source_path'] ?? '', $diagnostic['selector'] ?? '', $diagnostic['code'] ?? '' ) ) );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+
+			$seen[ $key ] = true;
+			$unique[]     = $diagnostic;
+		}
+
+		return $unique;
+	}
+
+	/**
+	 * Resolve a scalar value from candidate fields.
+	 *
+	 * @param array<string,mixed> $row      Source row.
+	 * @param array<int,string>   $fields   Candidate fields.
+	 * @param string              $fallback Fallback value.
+	 * @return string
+	 */
+	private static function first_scalar( array $row, array $fields, string $fallback = '' ): string {
+		foreach ( $fields as $field ) {
+			if ( isset( $row[ $field ] ) && is_scalar( $row[ $field ] ) && '' !== trim( (string) $row[ $field ] ) ) {
+				return (string) $row[ $field ];
+			}
+		}
+
+		return $fallback;
+	}
+
+	/**
+	 * Classify diagnostics by generic category.
+	 *
+	 * @param string $type Diagnostic type.
+	 * @return string
+	 */
+	private static function diagnostic_category( string $type ): string {
+		if ( str_contains( $type, 'svg' ) ) {
+			return 'svg';
+		}
+		if ( str_contains( $type, 'asset' ) || str_contains( $type, 'image' ) ) {
+			return 'asset';
+		}
+		if ( str_contains( $type, 'runtime_dependency' ) || str_contains( $type, 'dom_target' ) ) {
+			return 'runtime_dependency_parity';
+		}
+		if ( str_contains( $type, 'core_html' ) || str_contains( $type, 'freeform' ) || str_contains( $type, 'fallback' ) ) {
+			return 'fallback_block';
+		}
+		if ( str_contains( $type, 'button' ) || str_contains( $type, 'style' ) || str_contains( $type, 'presentation' ) ) {
+			return 'style_loss_hint';
+		}
+
+		return 'import_quality';
+	}
+
+	/**
+	 * Default diagnostic severity.
+	 *
+	 * @param string $type Diagnostic type.
+	 * @return string
+	 */
+	private static function default_diagnostic_severity( string $type ): string {
+		return str_contains( $type, 'missing' ) || str_contains( $type, 'invalid' ) || str_contains( $type, 'error' ) ? 'error' : 'warning';
 	}
 
 	/**

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -332,7 +332,6 @@ class Static_Site_Importer_Page_Materializer {
 		}
 
 		$result = call_user_func( 'blocks_engine_php_transformer_convert_format', $body, 'html', 'blocks' );
-		$result = is_array( $result ) ? $result : array();
 
 		foreach ( isset( $result['diagnostics'] ) && is_array( $result['diagnostics'] ) ? $result['diagnostics'] : array() as $diagnostic ) {
 			if ( is_array( $diagnostic ) ) {

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -50,7 +50,6 @@ class Static_Site_Importer_Transformer_Adapter {
 
 		$options = $this->normalize_compile_options( $options );
 		$result  = call_user_func( 'blocks_engine_php_transformer_compile_artifact', $artifact, $options );
-		$result  = is_array( $result ) ? $result : array();
 
 		return $this->compiled_result_from_transformer_contract( $result, $artifact );
 	}
@@ -967,7 +966,6 @@ class Static_Site_Importer_Transformer_Adapter {
 	public function blocks_to_html( string $block_markup, array $options = array() ): string {
 		if ( $this->supports_blocks_to_html() ) {
 			$result = call_user_func( 'blocks_engine_php_transformer_convert_format', $block_markup, 'blocks', 'html', $options );
-			$result = is_array( $result ) ? $result : array();
 			if ( isset( $result['documents'][0]['content'] ) && is_scalar( $result['documents'][0]['content'] ) ) {
 				return (string) $result['documents'][0]['content'];
 			}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -99,8 +99,14 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 
 			$result = Static_Site_Importer_Codebox_Validation::validate( $input );
 			if ( is_wp_error( $result ) ) {
-				WP_CLI::error( $result->get_error_message() );
-				return;
+				$error_result = Static_Site_Importer_Codebox_Validation::error_result_from_wp_error( $result, $input );
+				$json         = wp_json_encode( $error_result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+				if ( false === $json ) {
+					WP_CLI::error( $result->get_error_message() );
+				}
+
+				WP_CLI::line( (string) $json );
+				WP_CLI::halt( 1 );
 			}
 
 			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -319,6 +319,161 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Codebox validation output exposes fixture diagnostics for matrix grouping.
+	 */
+	public function test_codebox_validation_result_includes_fixture_matrix_diagnostics(): void {
+		$provider = static function (): array {
+			$import_report = array(
+				'quality'                  => array(
+					'fallback_count'                        => 1,
+					'core_html_block_count'                 => 1,
+					'freeform_block_count'                  => 1,
+					'invalid_block_count'                   => 1,
+					'invalid_block_document_count'          => 1,
+					'svg_materialization_failure_count'     => 1,
+					'runtime_dependency_parity_issue_count' => 1,
+				),
+				'diagnostics'              => array(
+					array(
+						'id'          => 'diag-core-html',
+						'type'        => 'core_html_block',
+						'severity'    => 'warning',
+						'reason_code' => 'generated_document_contains_core_html',
+						'source_path' => 'templates/front-page.html',
+						'selector'    => 'a.wp-block-button__link',
+						'block_name'  => 'core/html',
+					),
+					array(
+						'id'          => 'diag-svg',
+						'type'        => 'svg_materialization_failure',
+						'code'        => 'svg_missing_payload',
+						'source_path' => 'assets/icon.svg',
+					),
+					array(
+						'id'          => 'diag-image',
+						'type'        => 'dropped_image_asset',
+						'code'        => 'image_missing',
+						'source_path' => 'assets/hero.jpg',
+					),
+				),
+				'blocks_engine'           => array(
+					'conversion_report'         => array(
+						'diagnostic_count'  => 1,
+						'diagnostics'       => array(
+							array(
+								'id'          => 'be-button-style',
+								'type'        => 'button_style_loss',
+								'code'        => 'button_radius_dropped',
+								'source_path' => 'index.html',
+								'selector'    => 'button.cta',
+							),
+						),
+						'fallbacks'         => array(
+							array(
+								'id'          => 'be-fallback',
+								'type'        => 'unsupported_html_fallback',
+								'source_path' => 'index.html',
+								'selector'    => 'iframe.map',
+							),
+						),
+					),
+					'runtime_dependency_parity' => array(
+						'finding_count'       => 1,
+						'missing_dom_targets' => array(
+							array(
+								'id'          => 'runtime-missing-target',
+								'type'        => 'runtime_dependency_missing_dom_target',
+								'code'        => 'missing_dom_target',
+								'source_path' => 'scripts/app.js',
+								'selector'    => '#cart-drawer',
+							),
+						),
+					),
+				),
+				'import_validation_result' => array(
+					'artifacts' => array(
+						'import_report' => array( 'path' => 'import-report.json' ),
+					),
+				),
+			);
+
+			return array(
+				'success'       => false,
+				'status'        => 'failed',
+				'import_report' => $import_report,
+				'artifacts'     => array(
+					'import_report' => array(
+						'artifact_id' => 'run-123/import-report.json',
+						'path'        => '/tmp/local/import-report.json',
+					),
+				),
+			);
+		};
+
+		add_filter( 'static_site_importer_codebox_validation_result', $provider, 1 );
+		try {
+			$result = Static_Site_Importer_Codebox_Validation::validate(
+				array(
+					'artifact' => array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1' ),
+					'slug'     => 'fixture-one',
+					'name'     => 'Fixture One',
+				)
+			);
+		} finally {
+			remove_filter( 'static_site_importer_codebox_validation_result', $provider, 1 );
+		}
+
+		$this->assertIsArray( $result );
+		$fixture = $result['fixture_diagnostics'] ?? array();
+		$this->assertSame( 'static-site-importer/codebox-fixture-diagnostics/v1', $fixture['schema'] ?? '' );
+		$this->assertSame( 'fixture-one', $fixture['fixture']['slug'] ?? '' );
+		$this->assertSame( 'Fixture One', $fixture['fixture']['name'] ?? '' );
+		$this->assertSame( 1, $fixture['quality_counts']['core_html_block_count'] ?? 0 );
+		$this->assertSame( 1, $fixture['import_report_quality_counts']['runtime_dependency_parity_issue_count'] ?? 0 );
+		$this->assertSame( 1, $fixture['diagnostic_summary']['type']['core_html_block'] ?? 0 );
+		$this->assertSame( 'templates/front-page.html', $fixture['diagnostics'][0]['source_path'] ?? '' );
+		$this->assertSame( 'a.wp-block-button__link', $fixture['diagnostics'][0]['selector'] ?? '' );
+		$this->assertSame( 'generated_document_contains_core_html', $fixture['diagnostics'][0]['code'] ?? '' );
+		$this->assertCount( 1, $fixture['runtime_dependency_target_gaps'] ?? array() );
+		$this->assertSame( '#cart-drawer', $fixture['runtime_dependency_target_gaps'][0]['selector'] ?? '' );
+		$this->assertCount( 1, $fixture['asset_diagnostics'] ?? array() );
+		$this->assertSame( 'assets/hero.jpg', $fixture['asset_diagnostics'][0]['source_path'] ?? '' );
+		$this->assertCount( 1, $fixture['svg_diagnostics'] ?? array() );
+		$this->assertSame( 'assets/icon.svg', $fixture['svg_diagnostics'][0]['source_path'] ?? '' );
+		$this->assertCount( 1, $fixture['button_style_loss_hints'] ?? array() );
+		$this->assertSame( 'button.cta', $fixture['button_style_loss_hints'][0]['selector'] ?? '' );
+		$this->assertSame( 'run-123/import-report.json', $fixture['artifact_refs']['import_report']['artifact_id'] ?? '' );
+		$this->assertArrayNotHasKey( 'path', $fixture['artifact_refs']['import_report'] ?? array() );
+	}
+
+	/**
+	 * Pre-dispatch validation errors can still be consumed as structured JSON.
+	 */
+	public function test_codebox_validation_error_result_is_structured(): void {
+		$error = Static_Site_Importer_Codebox_Validation::validate(
+			array(
+				'slug' => 'missing-artifact',
+				'name' => 'Missing Artifact',
+			)
+		);
+
+		$this->assertWPError( $error );
+		$result = Static_Site_Importer_Codebox_Validation::error_result_from_wp_error(
+			$error,
+			array(
+				'slug' => 'missing-artifact',
+				'name' => 'Missing Artifact',
+			)
+		);
+
+		$this->assertSame( 'static-site-importer/codebox-validation-result/v1', $result['schema'] ?? '' );
+		$this->assertFalse( $result['success'] ?? true );
+		$this->assertSame( 'missing-artifact', $result['fixture_diagnostics']['fixture']['slug'] ?? '' );
+		$this->assertSame( 'validation_request_error', $result['fixture_diagnostics']['diagnostics'][0]['type'] ?? '' );
+		$this->assertSame( 'static_site_importer_codebox_validation_source_missing', $result['fixture_diagnostics']['diagnostics'][0]['code'] ?? '' );
+	}
+
+	/**
 	 * Assert that a report value does not expose local filesystem paths.
 	 *
 	 * @param mixed $value Report value.

--- a/tests/smoke-codebox-validation-contract.php
+++ b/tests/smoke-codebox-validation-contract.php
@@ -101,6 +101,9 @@ namespace {
 	$assert( 'blocked' === ( $blocked['status'] ?? '' ), 'blocked-status' );
 	$assert( 'static-site-importer/codebox-validation-result/v1' === ( $blocked['schema'] ?? '' ), 'result-schema' );
 	$assert( 'static-site-importer/codebox-validation-artifacts/v1' === ( $blocked['artifacts']['schema'] ?? '' ), 'artifact-schema' );
+	$assert( 'static-site-importer/codebox-fixture-diagnostics/v1' === ( $blocked['fixture_diagnostics']['schema'] ?? '' ), 'blocked-fixture-diagnostics-schema' );
+	$assert( 'fixture-import' === ( $blocked['fixture_diagnostics']['fixture']['slug'] ?? '' ), 'blocked-fixture-slug' );
+	$assert( 'runtime_provider_unavailable' === ( $blocked['fixture_diagnostics']['diagnostics'][0]['type'] ?? '' ), 'blocked-fixture-diagnostic-type' );
 	$assert( ! empty( $blocked['upstream_gaps'][0]['needed_shape'] ), 'upstream-gap-is-concrete' );
 
 	add_filter(
@@ -150,6 +153,58 @@ namespace {
 				'success'   => true,
 				'summary'   => array( 'quality_pass' => true ),
 				'runtime'   => array( 'provider' => 'test-codebox' ),
+				'import_report' => array(
+					'quality'       => array(
+						'core_html_block_count'                 => 1,
+						'svg_materialization_failure_count'     => 1,
+						'runtime_dependency_parity_issue_count' => 1,
+					),
+					'diagnostics'   => array(
+						array(
+							'id'          => 'diag-core-html',
+							'type'        => 'core_html_block',
+							'reason_code' => 'generated_document_contains_core_html',
+							'source_path' => 'templates/front-page.html',
+							'selector'    => 'a.wp-block-button__link',
+						),
+						array(
+							'id'          => 'diag-svg',
+							'type'        => 'svg_materialization_failure',
+							'code'        => 'svg_missing_payload',
+							'source_path' => 'assets/icon.svg',
+						),
+						array(
+							'id'          => 'diag-image',
+							'type'        => 'dropped_image_asset',
+							'code'        => 'image_missing',
+							'source_path' => 'assets/hero.jpg',
+						),
+					),
+					'blocks_engine' => array(
+						'conversion_report'         => array(
+							'diagnostics' => array(
+								array(
+									'id'          => 'be-button-style',
+									'type'        => 'button_style_loss',
+									'code'        => 'button_radius_dropped',
+									'source_path' => 'index.html',
+									'selector'    => 'button.cta',
+								),
+							),
+						),
+						'runtime_dependency_parity' => array(
+							'missing_dom_targets' => array(
+								array(
+									'id'          => 'runtime-missing-target',
+									'type'        => 'runtime_dependency_missing_dom_target',
+									'code'        => 'missing_dom_target',
+									'source_path' => 'scripts/app.js',
+									'selector'    => '#cart-drawer',
+								),
+							),
+						),
+					),
+				),
 				'artifacts' => array(
 					'generated_theme'         => array( 'artifact_ref' => 'hb-run://123/theme', 'path' => '/Users/local/theme' ),
 					'theme_archive'           => array( 'url' => 'https://artifacts.example/theme.zip', 'sha256' => 'abc' ),
@@ -180,6 +235,15 @@ namespace {
 	$assert( 'hb-run://123/browser-render.json' === ( $provided['artifacts']['browser_render_evidence']['artifact_ref'] ?? '' ), 'browser-render-ref' );
 	$assert( 1 === count( $provided['artifacts']['screenshots'] ?? array() ), 'screenshot-ref-count' );
 	$assert( 1 === count( $provided['artifacts']['diffs'] ?? array() ), 'diff-ref-count' );
+	$assert( 'static-site-importer/codebox-fixture-diagnostics/v1' === ( $provided['fixture_diagnostics']['schema'] ?? '' ), 'provided-fixture-diagnostics-schema' );
+	$assert( 1 === ( $provided['fixture_diagnostics']['quality_counts']['core_html_block_count'] ?? 0 ), 'provided-quality-core-html-count' );
+	$assert( 1 === ( $provided['fixture_diagnostics']['diagnostic_summary']['type']['core_html_block'] ?? 0 ), 'provided-diagnostic-summary-core-html' );
+	$assert( 'templates/front-page.html' === ( $provided['fixture_diagnostics']['diagnostics'][0]['source_path'] ?? '' ), 'provided-diagnostic-source-path' );
+	$assert( 'a.wp-block-button__link' === ( $provided['fixture_diagnostics']['diagnostics'][0]['selector'] ?? '' ), 'provided-diagnostic-selector' );
+	$assert( '#cart-drawer' === ( $provided['fixture_diagnostics']['runtime_dependency_target_gaps'][0]['selector'] ?? '' ), 'provided-runtime-target-gap-selector' );
+	$assert( 'assets/hero.jpg' === ( $provided['fixture_diagnostics']['asset_diagnostics'][0]['source_path'] ?? '' ), 'provided-asset-diagnostic-source' );
+	$assert( 'assets/icon.svg' === ( $provided['fixture_diagnostics']['svg_diagnostics'][0]['source_path'] ?? '' ), 'provided-svg-diagnostic-source' );
+	$assert( 'button.cta' === ( $provided['fixture_diagnostics']['button_style_loss_hints'][0]['selector'] ?? '' ), 'provided-button-style-loss-selector' );
 
 	if ( $failures ) {
 		fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- Adds an additive `fixture_diagnostics` envelope to `validate-in-codebox` results for fixture matrix grouping.
- Normalizes import report quality counts, SSI diagnostics, Blocks Engine conversion diagnostics, runtime dependency target gaps, asset/image/SVG diagnostics, button/style-loss hints, and artifact refs.
- Emits structured JSON for pre-dispatch WP_Error validation failures in the CLI path so matrix runs can retain partial results.
- Adds focused smoke and WP unit coverage for the new output shape.

## Tests
- `php tests/smoke-codebox-validation-contract.php`
- `homeboy lint static-site-importer`
- `php -l includes/class-static-site-importer-codebox-validation.php && php -l includes/class-static-site-importer-page-materializer.php && php -l includes/class-static-site-importer-transformer-adapter.php && php -l static-site-importer.php`

## Notes
- `homeboy test static-site-importer` is blocked before SSI tests run because the remote Homeboy runner's `wordpress` extension has no sourceUrl/source-url metadata.
- `npm run test:validation` currently fails in the existing Website artifact document metadata smoke step.
- `npm run test:js-block-validation` cannot start locally because `jsdom` is missing from `node_modules`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing and testing richer Static Site Importer validation diagnostics for fixture matrix runs.