### PR TITLE
Update Blocks Engine transformer to 0.1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.12",
+        "version": "0.1.13",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "e708340b946ebe2c1d9fb316df2764cec9d95ad9"
+          "reference": "46a6d684729055b15911f60a2074985e3b6f9c41"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.12.zip",
-          "reference": "e708340b946ebe2c1d9fb316df2764cec9d95ad9"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.13.zip",
+          "reference": "46a6d684729055b15911f60a2074985e3b6f9c41"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.1.12",
+    "automattic/blocks-engine-php-transformer": "^0.1.13",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0dea3f1c330ed1b33363399b31c9623f",
+    "content-hash": "3e3e18f180da6cf41df243057290afbe",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.12",
+            "version": "0.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "e708340b946ebe2c1d9fb316df2764cec9d95ad9"
+                "reference": "46a6d684729055b15911f60a2074985e3b6f9c41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.12.zip",
-                "reference": "e708340b946ebe2c1d9fb316df2764cec9d95ad9"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.13.zip",
+                "reference": "46a6d684729055b15911f60a2074985e3b6f9c41"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- update the bundled Blocks Engine PHP transformer package definition to `0.1.13`
- refresh `composer.lock` so SSI consumes runtime-control preservation and actionable runtime diagnostics

## Verification
- `php tests/smoke-codebox-validation-contract.php`
- `php tests/smoke-visual-repair-css.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** dependency update and verification.