### PR TITLE
Update Blocks Engine transformer to 0.1.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.13",
+        "version": "0.1.14",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "46a6d684729055b15911f60a2074985e3b6f9c41"
+          "reference": "9d69e02914942ba4d5d675b1c9807f57da34e59c"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.13.zip",
-          "reference": "46a6d684729055b15911f60a2074985e3b6f9c41"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.14.zip",
+          "reference": "9d69e02914942ba4d5d675b1c9807f57da34e59c"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.1.13",
+    "automattic/blocks-engine-php-transformer": "^0.1.14",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e3e18f180da6cf41df243057290afbe",
+    "content-hash": "3a81024117839538fa9f7e30bf286fc7",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.13",
+            "version": "0.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "46a6d684729055b15911f60a2074985e3b6f9c41"
+                "reference": "9d69e02914942ba4d5d675b1c9807f57da34e59c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.13.zip",
-                "reference": "46a6d684729055b15911f60a2074985e3b6f9c41"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.14.zip",
+                "reference": "9d69e02914942ba4d5d675b1c9807f57da34e59c"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Bump `automattic/blocks-engine-php-transformer` from `0.1.13` to `0.1.14`.
- Pulls in the merged generic parity fixes for runtime targets, canvas, image assets, inline SVG assets, button controls/styles, and valid button label markup.

## Testing
- `php tests/smoke-codebox-validation-contract.php`
- `php tests/smoke-visual-repair-css.php`
- `php tests/smoke-transformer-adapter.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updated dependency metadata/lockfile and ran verification; Chris reviews and owns the change.