### PR TITLE
Add importer diagnostic contract

### DIFF
--- a/includes/class-static-site-importer-codebox-validation.php
+++ b/includes/class-static-site-importer-codebox-validation.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Diagnostic_Contract' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-diagnostic-contract.php';
+}
+
 /**
  * Builds and dispatches SSI validation requests for disposable Codebox runtimes.
  */
@@ -17,7 +21,6 @@ class Static_Site_Importer_Codebox_Validation {
 	private const REQUEST_SCHEMA             = 'static-site-importer/codebox-validation-request/v1';
 	private const RESULT_SCHEMA              = 'static-site-importer/codebox-validation-result/v1';
 	private const ARTIFACT_SCHEMA            = 'static-site-importer/codebox-validation-artifacts/v1';
-	private const FIXTURE_DIAGNOSTICS_SCHEMA = 'static-site-importer/codebox-fixture-diagnostics/v1';
 
 	/**
 	 * Register the default WP Codebox host-delegation bridge.
@@ -88,7 +91,7 @@ class Static_Site_Importer_Codebox_Validation {
 	}
 
 	/**
-	 * Delegate SSI validation requests to WP Codebox/Homeboy host providers.
+	 * Delegate SSI validation requests to WP Codebox host providers.
 	 *
 	 * @param mixed               $result  Existing provider result.
 	 * @param array<string,mixed> $request SSI validation request.
@@ -133,7 +136,7 @@ class Static_Site_Importer_Codebox_Validation {
 		/**
 		 * Filters the SSI Codebox validation request before runtime dispatch.
 		 *
-		 * WP Codebox/Homeboy integrations may attach orchestration metadata here, but
+		 * WP Codebox integrations may attach orchestration metadata here, but
 		 * should not execute the run. Execution belongs to
 		 * `static_site_importer_codebox_validation_result`.
 		 *
@@ -533,7 +536,7 @@ class Static_Site_Importer_Codebox_Validation {
 			'request'       => self::request_summary( $request ),
 			'artifacts'     => self::artifact_contract( $request, array() ),
 			'runtime'       => array(
-				'provider' => 'wp-codebox/homeboy',
+				'provider' => 'wp-codebox',
 				'status'   => 'missing_provider',
 			),
 			'summary'       => array(
@@ -546,7 +549,7 @@ class Static_Site_Importer_Codebox_Validation {
 			),
 			'upstream_gaps' => array(
 				array(
-					'owner'        => 'wp-codebox/homeboy',
+					'owner'        => 'wp-codebox',
 					'capability'   => 'static-site-importer Codebox validation provider',
 					'missing'      => 'No provider is registered on static_site_importer_codebox_validation_result to run the SSI import, block validation, browser render capture, screenshot capture, and visual diff capture inside a disposable WP Codebox runtime.',
 					'needed_shape' => 'Accept static-site-importer/codebox-validation-request/v1 and return static-site-importer/codebox-validation-result/v1 with durable artifact references for generated theme/archive, import report, block validation result, browser/render evidence metadata, screenshots, and diffs.',
@@ -570,7 +573,7 @@ class Static_Site_Importer_Codebox_Validation {
 						'reason_code' => 'missing_provider',
 						'message'     => 'No Codebox validation provider is registered.',
 						'stage'       => 'runtime_dispatch',
-						'owner'       => 'wp-codebox/homeboy',
+						'owner'       => 'wp-codebox',
 					),
 				),
 			)
@@ -580,48 +583,13 @@ class Static_Site_Importer_Codebox_Validation {
 	}
 
 	/**
-	 * Build the fixture-level diagnostics envelope consumed by matrix runners.
+	 * Build the importer-owned diagnostics envelope.
 	 *
 	 * @param array<string,mixed> $result Provider or synthesized result.
 	 * @return array<string,mixed>
 	 */
 	private static function fixture_diagnostics( array $result ): array {
-		$request       = isset( $result['request'] ) && is_array( $result['request'] ) ? $result['request'] : array();
-		$import_args   = isset( $request['import_args'] ) && is_array( $request['import_args'] ) ? $request['import_args'] : array();
-		$import_report = self::provider_import_report( $result );
-		$summary       = isset( $result['summary'] ) && is_array( $result['summary'] ) ? $result['summary'] : array();
-		$artifacts     = isset( $result['artifacts'] ) && is_array( $result['artifacts'] ) ? $result['artifacts'] : array();
-
-		$diagnostics = array_merge(
-			self::diagnostic_rows_from_result( $result ),
-			self::diagnostic_rows_from_import_report( $import_report ),
-			self::blocks_engine_conversion_diagnostics( $import_report ),
-			self::runtime_dependency_target_gaps( $import_report )
-		);
-		$diagnostics = self::dedupe_diagnostics( $diagnostics );
-
-		$quality_counts = self::quality_counts( $import_report, $summary );
-
-		return array(
-			'schema'                         => self::FIXTURE_DIAGNOSTICS_SCHEMA,
-			'fixture'                        => array(
-				'slug' => isset( $result['slug'] ) && is_scalar( $result['slug'] ) ? (string) $result['slug'] : ( isset( $import_args['slug'] ) ? (string) $import_args['slug'] : '' ),
-				'name' => isset( $result['name'] ) && is_scalar( $result['name'] ) ? (string) $result['name'] : ( isset( $import_args['name'] ) ? (string) $import_args['name'] : '' ),
-			),
-			'status'                         => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : '',
-			'success'                        => ! empty( $result['success'] ),
-			'quality_counts'                 => $quality_counts,
-			'import_report_quality_counts'   => $quality_counts,
-			'diagnostic_summary'             => self::diagnostic_summary( $diagnostics ),
-			'diagnostics'                    => $diagnostics,
-			'by_category'                    => self::diagnostics_by_category( $diagnostics ),
-			'blocks_engine'                  => self::blocks_engine_summary( $import_report ),
-			'runtime_dependency_target_gaps' => self::runtime_dependency_target_gaps( $import_report ),
-			'asset_diagnostics'              => self::diagnostics_matching_types( $diagnostics, array( 'asset', 'image', 'local_asset_not_materialized', 'missing_asset', 'dropped_image' ) ),
-			'svg_diagnostics'                => self::diagnostics_matching_types( $diagnostics, array( 'svg', 'unsafe_inline_svg', 'svg_materialization_failure', 'svg_sprite_reference_failure' ) ),
-			'button_style_loss_hints'        => self::diagnostics_matching_types( $diagnostics, array( 'button', 'style_loss', 'presentation_gap' ) ),
-			'artifact_refs'                  => self::fixture_artifact_refs( $artifacts, $import_report ),
-		);
+		return Static_Site_Importer_Diagnostic_Contract::build( $result );
 	}
 
 	/**
@@ -733,7 +701,7 @@ class Static_Site_Importer_Codebox_Validation {
 	}
 
 	/**
-	 * Normalize diagnostic rows to a stable matrix-consumable subset.
+	 * Normalize diagnostic rows to a stable consumer-facing subset.
 	 *
 	 * @param array<int|string,mixed> $rows          Raw diagnostic rows.
 	 * @param string                  $default_stage Default stage.
@@ -882,7 +850,7 @@ class Static_Site_Importer_Codebox_Validation {
 	}
 
 	/**
-	 * Stable artifact references for matrix output.
+	 * Stable artifact references for validation output.
 	 *
 	 * @param array<string,mixed> $artifacts     Validation artifacts.
 	 * @param array<string,mixed> $import_report Import report.

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -1,0 +1,561 @@
+<?php
+/**
+ * Static Site Importer diagnostic contract.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Normalizes importer-owned diagnostics for validation and repair loops.
+ */
+class Static_Site_Importer_Diagnostic_Contract {
+
+	public const IMPORT_DIAGNOSTICS_SCHEMA = 'static-site-importer/import-diagnostics/v1';
+
+	/**
+	 * Build an importer-owned diagnostics envelope from a validation/import result.
+	 *
+	 * @param array<string,mixed> $result Validation provider or synthesized result.
+	 * @return array<string,mixed>
+	 */
+	public static function build( array $result ): array {
+		$request       = isset( $result['request'] ) && is_array( $result['request'] ) ? $result['request'] : array();
+		$import_args   = isset( $request['import_args'] ) && is_array( $request['import_args'] ) ? $request['import_args'] : array();
+		$import_report = self::provider_import_report( $result );
+		$summary       = isset( $result['summary'] ) && is_array( $result['summary'] ) ? $result['summary'] : array();
+		$artifacts     = isset( $result['artifacts'] ) && is_array( $result['artifacts'] ) ? $result['artifacts'] : array();
+
+		$diagnostics = array_merge(
+			self::diagnostic_rows_from_result( $result ),
+			self::diagnostic_rows_from_import_report( $import_report ),
+			self::blocks_engine_conversion_diagnostics( $import_report ),
+			self::runtime_dependency_target_gaps( $import_report ),
+			self::semantic_parity_diagnostics( $import_report )
+		);
+		$diagnostics = self::dedupe_diagnostics( $diagnostics );
+
+		$quality_counts = self::quality_counts( $import_report, $summary );
+
+		return array(
+			'schema'                         => self::IMPORT_DIAGNOSTICS_SCHEMA,
+			'fixture'                        => array(
+				'slug' => isset( $result['slug'] ) && is_scalar( $result['slug'] ) ? (string) $result['slug'] : ( isset( $import_args['slug'] ) ? (string) $import_args['slug'] : '' ),
+				'name' => isset( $result['name'] ) && is_scalar( $result['name'] ) ? (string) $result['name'] : ( isset( $import_args['name'] ) ? (string) $import_args['name'] : '' ),
+			),
+			'status'                         => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : '',
+			'success'                        => ! empty( $result['success'] ),
+			'quality_counts'                 => $quality_counts,
+			'import_report_quality_counts'   => $quality_counts,
+			'diagnostic_summary'             => self::diagnostic_summary( $diagnostics ),
+			'diagnostics'                    => $diagnostics,
+			'by_repair_bucket'               => self::diagnostics_by_field( $diagnostics, 'repair_bucket' ),
+			'by_parser_owner'                => self::diagnostics_by_field( $diagnostics, 'parser_owner' ),
+			'by_category'                    => self::diagnostics_by_field( $diagnostics, 'category' ),
+			'top_parser_buckets'             => self::top_parser_buckets( $diagnostics ),
+			'blocks_engine'                  => self::blocks_engine_summary( $import_report ),
+			'runtime_dependency_target_gaps' => self::runtime_dependency_target_gaps( $import_report ),
+			'asset_diagnostics'              => self::diagnostics_matching_types( $diagnostics, array( 'asset', 'image', 'local_asset_not_materialized', 'missing_asset', 'dropped_image' ) ),
+			'svg_diagnostics'                => self::diagnostics_matching_types( $diagnostics, array( 'svg', 'unsafe_inline_svg', 'svg_materialization_failure', 'svg_sprite_reference_failure' ) ),
+			'button_style_loss_hints'        => self::diagnostics_matching_types( $diagnostics, array( 'button', 'style_loss', 'presentation_gap' ) ),
+			'artifact_refs'                  => self::artifact_refs( $artifacts, $import_report ),
+		);
+	}
+
+	/**
+	 * Extract an import report from common provider result slots.
+	 *
+	 * @param array<string,mixed> $result Provider result.
+	 * @return array<string,mixed>
+	 */
+	private static function provider_import_report( array $result ): array {
+		foreach ( array( $result['import_report'] ?? null, $result['summary']['import_report'] ?? null, $result['artifacts']['import_report'] ?? null ) as $candidate ) {
+			if ( is_array( $candidate ) && ( isset( $candidate['quality'] ) || isset( $candidate['diagnostics'] ) || isset( $candidate['blocks_engine'] ) ) ) {
+				return $candidate;
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Read provider-level diagnostic rows.
+	 *
+	 * @param array<string,mixed> $result Provider result.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function diagnostic_rows_from_result( array $result ): array {
+		$rows = array();
+		foreach ( array( $result['diagnostics'] ?? array(), $result['artifact_diagnostics']['diagnostics'] ?? array(), $result['import_validation_result']['diagnostics'] ?? array() ) as $candidate ) {
+			if ( is_array( $candidate ) ) {
+				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $candidate ) );
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Read import-report diagnostic rows.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function diagnostic_rows_from_import_report( array $import_report ): array {
+		$rows = self::normalize_diagnostic_rows( isset( $import_report['diagnostics'] ) && is_array( $import_report['diagnostics'] ) ? $import_report['diagnostics'] : array() );
+		if ( isset( $import_report['artifact_diagnostics']['diagnostics'] ) && is_array( $import_report['artifact_diagnostics']['diagnostics'] ) ) {
+			$rows = array_merge( $rows, self::normalize_diagnostic_rows( $import_report['artifact_diagnostics']['diagnostics'] ) );
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Extract Blocks Engine conversion-report diagnostics and fallback rows.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function blocks_engine_conversion_diagnostics( array $import_report ): array {
+		$conversion_report = isset( $import_report['blocks_engine']['conversion_report'] ) && is_array( $import_report['blocks_engine']['conversion_report'] ) ? $import_report['blocks_engine']['conversion_report'] : array();
+		$rows              = array();
+		foreach ( array( 'diagnostics', 'fallback_diagnostics', 'fallbacks', 'presentation_gaps', 'interaction_candidates' ) as $field ) {
+			if ( isset( $conversion_report[ $field ] ) && is_array( $conversion_report[ $field ] ) ) {
+				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $conversion_report[ $field ], 'blocks_engine_conversion_report' ) );
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Extract runtime dependency parity target gaps.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function runtime_dependency_target_gaps( array $import_report ): array {
+		$runtime_dependency_parity = isset( $import_report['blocks_engine']['runtime_dependency_parity'] ) && is_array( $import_report['blocks_engine']['runtime_dependency_parity'] ) ? $import_report['blocks_engine']['runtime_dependency_parity'] : array();
+		$rows                      = array();
+		foreach ( array( 'findings', 'missing_dom_targets', 'unsupported_elements' ) as $field ) {
+			if ( isset( $runtime_dependency_parity[ $field ] ) && is_array( $runtime_dependency_parity[ $field ] ) ) {
+				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $runtime_dependency_parity[ $field ], 'runtime_dependency_parity' ) );
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Extract semantic parity findings.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function semantic_parity_diagnostics( array $import_report ): array {
+		$semantic_parity = isset( $import_report['blocks_engine']['semantic_parity'] ) && is_array( $import_report['blocks_engine']['semantic_parity'] ) ? $import_report['blocks_engine']['semantic_parity'] : array();
+		$findings        = isset( $semantic_parity['findings'] ) && is_array( $semantic_parity['findings'] ) ? $semantic_parity['findings'] : array();
+
+		return self::normalize_diagnostic_rows( $findings, 'semantic_parity' );
+	}
+
+	/**
+	 * Normalize diagnostic rows to a stable consumer-facing subset.
+	 *
+	 * @param array<int|string,mixed> $rows          Raw diagnostic rows.
+	 * @param string                  $default_stage Default stage.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function normalize_diagnostic_rows( array $rows, string $default_stage = '' ): array {
+		$normalized = array();
+		foreach ( array_values( $rows ) as $index => $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$type          = self::first_scalar( $row, array( 'type', 'kind', 'code', 'reason_code' ), 'diagnostic' );
+			$reason_code   = self::first_scalar( $row, array( 'reason_code', 'code', 'reason', 'kind', 'type' ), $type );
+			$source_path   = self::first_scalar( $row, array( 'source_path', 'path', 'source', 'file', 'script_path' ), '' );
+			$repair_bucket = self::repair_bucket( $type, $reason_code, $row );
+			$parser_owner  = self::parser_owner( $type, $repair_bucket, $row );
+			$diagnostic    = array(
+				'id'                      => self::first_scalar( $row, array( 'id' ), sprintf( 'diag-%03d-%s', $index + 1, sanitize_key( $type . '-' . $reason_code . '-' . $source_path ) ) ),
+				'type'                    => sanitize_key( $type ),
+				'kind'                    => sanitize_key( self::first_scalar( $row, array( 'kind', 'code', 'type' ), $type ) ),
+				'severity'                => self::first_scalar( $row, array( 'severity', 'level' ), self::default_diagnostic_severity( $type ) ),
+				'category'                => self::diagnostic_category( $type ),
+				'group_key'               => $repair_bucket,
+				'repair_bucket'           => $repair_bucket,
+				'parser_owner'            => $parser_owner,
+				'candidate_repo'          => $parser_owner,
+				'repair_mode'             => self::repair_mode( $repair_bucket ),
+				'reason_code'             => sanitize_key( $reason_code ),
+				'source_path'             => $source_path,
+				'path'                    => $source_path,
+				'selector'                => self::first_scalar( $row, array( 'selector', 'target_selector', 'css_selector' ), '' ),
+				'code'                    => self::first_scalar( $row, array( 'code', 'error_code' ), sanitize_key( $reason_code ) ),
+				'stage'                   => self::first_scalar( $row, array( 'stage' ), $default_stage ),
+				'owner'                   => self::first_scalar( $row, array( 'owner', 'engine', 'converter' ), $parser_owner ),
+				'runtime_target_selector' => self::first_scalar( $row, array( 'runtime_target_selector', 'target_selector', 'target', 'selector' ), '' ),
+				'missing_asset_path'      => self::missing_asset_path( $row ),
+			);
+
+			foreach ( array( 'message', 'reason', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt', 'block_name', 'block_path', 'script_path', 'element', 'tag_name', 'tag', 'src', 'href', 'expected', 'observed', 'suggested_primitive' ) as $field ) {
+				$value = self::first_scalar( $row, array( $field ), '' );
+				if ( '' !== $value ) {
+					$diagnostic[ $field ] = $value;
+				}
+			}
+
+			$normalized[] = array_filter(
+				$diagnostic,
+				static fn ( mixed $value ): bool => '' !== $value
+			);
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Return quality counts from import report first, then compact summaries.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @param array<string,mixed> $summary Provider summary.
+	 * @return array<string,int>
+	 */
+	private static function quality_counts( array $import_report, array $summary ): array {
+		$quality = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
+		$keys    = array( 'fallback_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
+
+		$counts = array();
+		foreach ( $keys as $key ) {
+			$counts[ $key ] = isset( $quality[ $key ] ) && is_numeric( $quality[ $key ] ) ? (int) $quality[ $key ] : 0;
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Summarize Blocks Engine import-report details.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<string,mixed>
+	 */
+	private static function blocks_engine_summary( array $import_report ): array {
+		$blocks_engine = isset( $import_report['blocks_engine'] ) && is_array( $import_report['blocks_engine'] ) ? $import_report['blocks_engine'] : array();
+
+		$summary = array();
+		foreach ( array( 'website_artifact', 'conversion_report', 'runtime_dependency_parity', 'semantic_parity' ) as $field ) {
+			if ( isset( $blocks_engine[ $field ] ) && is_array( $blocks_engine[ $field ] ) && ! empty( $blocks_engine[ $field ] ) ) {
+				$summary[ $field ] = $blocks_engine[ $field ];
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Build diagnostic counts by severity, category, type, owner, and bucket.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @return array<string,mixed>
+	 */
+	private static function diagnostic_summary( array $diagnostics ): array {
+		$summary = array(
+			'total'         => count( $diagnostics ),
+			'severity'      => array(),
+			'category'      => array(),
+			'type'          => array(),
+			'parser_owner'  => array(),
+			'repair_bucket' => array(),
+		);
+		foreach ( $diagnostics as $diagnostic ) {
+			foreach ( array( 'severity', 'category', 'type', 'parser_owner', 'repair_bucket' ) as $field ) {
+				$value                         = isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) ? (string) $diagnostic[ $field ] : 'unknown';
+				$summary[ $field ][ $value ] = ( $summary[ $field ][ $value ] ?? 0 ) + 1;
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Group diagnostics by a field.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @param string                         $field       Field name.
+	 * @return array<string,array<int,array<string,mixed>>>
+	 */
+	private static function diagnostics_by_field( array $diagnostics, string $field ): array {
+		$grouped = array();
+		foreach ( $diagnostics as $diagnostic ) {
+			$key             = isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) ? (string) $diagnostic[ $field ] : 'uncategorized';
+			$grouped[ $key ][] = $diagnostic;
+		}
+
+		return $grouped;
+	}
+
+	/**
+	 * Select diagnostics matching types or type fragments.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @param array<int,string>              $needles     Type needles.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function diagnostics_matching_types( array $diagnostics, array $needles ): array {
+		return array_values(
+			array_filter(
+				$diagnostics,
+				static function ( array $diagnostic ) use ( $needles ): bool {
+					$type     = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : '';
+					$category = isset( $diagnostic['category'] ) && is_scalar( $diagnostic['category'] ) ? (string) $diagnostic['category'] : '';
+					$bucket   = isset( $diagnostic['repair_bucket'] ) && is_scalar( $diagnostic['repair_bucket'] ) ? (string) $diagnostic['repair_bucket'] : '';
+					foreach ( $needles as $needle ) {
+						if ( $needle === $type || str_contains( $type, $needle ) || str_contains( $category, $needle ) || str_contains( $bucket, $needle ) ) {
+							return true;
+						}
+					}
+
+					return false;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Build the top parser-owner/repair-bucket counts.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function top_parser_buckets( array $diagnostics ): array {
+		$buckets = array();
+		foreach ( $diagnostics as $diagnostic ) {
+			$parser_owner  = isset( $diagnostic['parser_owner'] ) && is_scalar( $diagnostic['parser_owner'] ) ? (string) $diagnostic['parser_owner'] : 'static-site-importer';
+			$repair_bucket = isset( $diagnostic['repair_bucket'] ) && is_scalar( $diagnostic['repair_bucket'] ) ? (string) $diagnostic['repair_bucket'] : 'static_site_import_quality';
+			$key           = $parser_owner . ':' . $repair_bucket;
+			if ( ! isset( $buckets[ $key ] ) ) {
+				$buckets[ $key ] = array(
+					'parser_owner'  => $parser_owner,
+					'repair_bucket' => $repair_bucket,
+					'count'         => 0,
+				);
+			}
+
+			++$buckets[ $key ]['count'];
+		}
+
+		$values = array_values( $buckets );
+		usort(
+			$values,
+			static fn ( array $left, array $right ): int => ( $right['count'] <=> $left['count'] ) ?: strcmp( (string) $left['parser_owner'], (string) $right['parser_owner'] ) ?: strcmp( (string) $left['repair_bucket'], (string) $right['repair_bucket'] )
+		);
+
+		return $values;
+	}
+
+	/**
+	 * Stable artifact references from validation/import output.
+	 *
+	 * @param array<string,mixed> $artifacts     Validation artifacts.
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<string,mixed>
+	 */
+	private static function artifact_refs( array $artifacts, array $import_report ): array {
+		$refs = $artifacts;
+		if ( isset( $import_report['import_validation_result']['artifacts'] ) && is_array( $import_report['import_validation_result']['artifacts'] ) ) {
+			$refs['import_validation_artifacts'] = $import_report['import_validation_result']['artifacts'];
+		}
+		if ( isset( $import_report['visual_parity_artifacts'] ) && is_array( $import_report['visual_parity_artifacts'] ) ) {
+			$refs['visual_parity_artifacts'] = $import_report['visual_parity_artifacts'];
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * Remove duplicate diagnostics by id/type/source/selector/code.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function dedupe_diagnostics( array $diagnostics ): array {
+		$seen   = array();
+		$unique = array();
+		foreach ( $diagnostics as $diagnostic ) {
+			$key = implode( '|', array_map( 'strval', array( $diagnostic['id'] ?? '', $diagnostic['type'] ?? '', $diagnostic['source_path'] ?? '', $diagnostic['selector'] ?? '', $diagnostic['code'] ?? '' ) ) );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+
+			$seen[ $key ] = true;
+			$unique[]     = $diagnostic;
+		}
+
+		return $unique;
+	}
+
+	/**
+	 * Resolve a scalar value from candidate fields.
+	 *
+	 * @param array<string,mixed> $row      Source row.
+	 * @param array<int,string>   $fields   Candidate fields.
+	 * @param string              $fallback Fallback value.
+	 * @return string
+	 */
+	private static function first_scalar( array $row, array $fields, string $fallback = '' ): string {
+		foreach ( $fields as $field ) {
+			if ( isset( $row[ $field ] ) && is_scalar( $row[ $field ] ) && '' !== trim( (string) $row[ $field ] ) ) {
+				return (string) $row[ $field ];
+			}
+		}
+
+		return $fallback;
+	}
+
+	/**
+	 * Classify diagnostics by generic category.
+	 *
+	 * @param string $type Diagnostic type.
+	 * @return string
+	 */
+	private static function diagnostic_category( string $type ): string {
+		if ( str_contains( $type, 'svg' ) ) {
+			return 'svg';
+		}
+		if ( str_contains( $type, 'asset' ) || str_contains( $type, 'image' ) ) {
+			return 'asset';
+		}
+		if ( str_contains( $type, 'runtime_dependency' ) || str_contains( $type, 'dom_target' ) || str_contains( $type, 'runtime_target' ) ) {
+			return 'runtime_dependency_parity';
+		}
+		if ( str_contains( $type, 'semantic_parity' ) || str_contains( $type, 'navigation_' ) || str_contains( $type, 'landmark_' ) ) {
+			return 'semantic_parity';
+		}
+		if ( str_contains( $type, 'core_html' ) || str_contains( $type, 'freeform' ) || str_contains( $type, 'fallback' ) ) {
+			return 'fallback_block';
+		}
+		if ( str_contains( $type, 'invalid_block' ) || str_contains( $type, 'block_validation' ) ) {
+			return 'block_validity';
+		}
+		if ( str_contains( $type, 'button' ) || str_contains( $type, 'style' ) || str_contains( $type, 'presentation' ) ) {
+			return 'style_loss_hint';
+		}
+
+		return 'import_quality';
+	}
+
+	/**
+	 * Determine repair bucket.
+	 *
+	 * @param string              $type        Diagnostic type.
+	 * @param string              $reason_code Reason code.
+	 * @param array<string,mixed> $row         Source row.
+	 * @return string
+	 */
+	private static function repair_bucket( string $type, string $reason_code, array $row ): string {
+		$explicit = self::first_scalar( $row, array( 'repair_bucket', 'group_key' ), '' );
+		if ( '' !== $explicit ) {
+			return sanitize_key( $explicit );
+		}
+
+		$haystack = strtolower( implode( ' ', array( $type, $reason_code, self::first_scalar( $row, array( 'message', 'reason', 'detail' ), '' ) ) ) );
+		if ( str_contains( $haystack, 'runtime_dependency' ) || str_contains( $haystack, 'dom_target' ) || str_contains( $haystack, 'runtime_target' ) || str_contains( $haystack, 'canvas' ) || str_contains( $haystack, 'animation' ) ) {
+			return 'runtime_target_gap';
+		}
+		if ( str_contains( $haystack, 'invalid_block' ) || str_contains( $haystack, 'block_validation' ) || str_contains( $haystack, 'invalid content' ) ) {
+			return 'invalid_block_content';
+		}
+		if ( str_contains( $haystack, 'svg' ) ) {
+			return 'broken_svg';
+		}
+		if ( str_contains( $haystack, 'asset' ) || str_contains( $haystack, 'image' ) || self::missing_asset_path( $row ) ) {
+			return 'dropped_images';
+		}
+		if ( str_contains( $haystack, 'button' ) || str_contains( $haystack, 'style' ) || str_contains( $haystack, 'presentation' ) ) {
+			return 'button_style_loss';
+		}
+		if ( str_contains( $haystack, 'semantic_parity' ) || str_contains( $haystack, 'navigation_' ) || str_contains( $haystack, 'landmark_' ) ) {
+			return 'semantic_parity';
+		}
+		if ( str_contains( $haystack, 'core_html' ) || str_contains( $haystack, 'freeform' ) || str_contains( $haystack, 'fallback' ) ) {
+			return 'fallback_block';
+		}
+
+		return 'static_site_import_quality';
+	}
+
+	/**
+	 * Determine likely product owner for the parser/repair bucket.
+	 *
+	 * @param string              $type          Diagnostic type.
+	 * @param string              $repair_bucket Repair bucket.
+	 * @param array<string,mixed> $row           Source row.
+	 * @return string
+	 */
+	private static function parser_owner( string $type, string $repair_bucket, array $row ): string {
+		$explicit = self::first_scalar( $row, array( 'parser_owner', 'owner' ), '' );
+		if ( in_array( $explicit, array( 'blocks-engine', 'static-site-importer' ), true ) ) {
+			return $explicit;
+		}
+
+		$engine = self::first_scalar( $row, array( 'engine', 'converter', 'candidate_repo' ), '' );
+		if ( str_contains( $engine, 'blocks-engine' ) ) {
+			return 'blocks-engine';
+		}
+		if ( str_contains( $engine, 'static-site-importer' ) ) {
+			return 'static-site-importer';
+		}
+
+		if ( in_array( $repair_bucket, array( 'dropped_images', 'static_site_import_quality' ), true ) || str_contains( $type, 'asset' ) || str_contains( $type, 'image' ) ) {
+			return 'static-site-importer';
+		}
+
+		return 'blocks-engine';
+	}
+
+	/**
+	 * Repair mode for a bucket.
+	 *
+	 * @param string $repair_bucket Repair bucket.
+	 * @return string
+	 */
+	private static function repair_mode( string $repair_bucket ): string {
+		$modes = array(
+			'button_style_loss'         => 'transformer-style-parity',
+			'broken_svg'                => 'svg-transformer-parity',
+			'dropped_images'            => 'asset-materialization',
+			'invalid_block_content'     => 'block-validation-parity',
+			'runtime_target_gap'        => 'runtime-dom-target-parity',
+			'semantic_parity'           => 'semantic-parity',
+			'fallback_block'            => 'fallback-block-replacement',
+			'static_site_import_quality' => 'import-validation',
+		);
+
+		return $modes[ $repair_bucket ] ?? 'import-validation';
+	}
+
+	/**
+	 * Default diagnostic severity.
+	 *
+	 * @param string $type Diagnostic type.
+	 * @return string
+	 */
+	private static function default_diagnostic_severity( string $type ): string {
+		return str_contains( $type, 'missing' ) || str_contains( $type, 'invalid' ) || str_contains( $type, 'error' ) ? 'error' : 'warning';
+	}
+
+	/**
+	 * Extract a missing asset path.
+	 *
+	 * @param array<string,mixed> $row Diagnostic row.
+	 * @return string
+	 */
+	private static function missing_asset_path( array $row ): string {
+		return self::first_scalar( $row, array( 'missing_asset_path', 'asset_path', 'src', 'href' ), '' );
+	}
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -47,6 +47,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-th
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-stylesheet-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-product-handoff-contract.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-diagnostic-contract.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-codebox-validation.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -319,9 +319,9 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Codebox validation output exposes fixture diagnostics for matrix grouping.
+	 * Codebox validation output exposes importer diagnostics for repair grouping.
 	 */
-	public function test_codebox_validation_result_includes_fixture_matrix_diagnostics(): void {
+	public function test_codebox_validation_result_includes_importer_diagnostics(): void {
 		$provider = static function (): array {
 			$import_report = array(
 				'quality'                  => array(
@@ -425,15 +425,19 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 
 		$this->assertIsArray( $result );
 		$fixture = $result['fixture_diagnostics'] ?? array();
-		$this->assertSame( 'static-site-importer/codebox-fixture-diagnostics/v1', $fixture['schema'] ?? '' );
+		$this->assertSame( 'static-site-importer/import-diagnostics/v1', $fixture['schema'] ?? '' );
 		$this->assertSame( 'fixture-one', $fixture['fixture']['slug'] ?? '' );
 		$this->assertSame( 'Fixture One', $fixture['fixture']['name'] ?? '' );
 		$this->assertSame( 1, $fixture['quality_counts']['core_html_block_count'] ?? 0 );
 		$this->assertSame( 1, $fixture['import_report_quality_counts']['runtime_dependency_parity_issue_count'] ?? 0 );
 		$this->assertSame( 1, $fixture['diagnostic_summary']['type']['core_html_block'] ?? 0 );
+		$this->assertSame( 1, $fixture['diagnostic_summary']['repair_bucket']['fallback_block'] ?? 0 );
+		$this->assertSame( 1, $fixture['diagnostic_summary']['parser_owner']['blocks-engine'] ?? 0 );
 		$this->assertSame( 'templates/front-page.html', $fixture['diagnostics'][0]['source_path'] ?? '' );
 		$this->assertSame( 'a.wp-block-button__link', $fixture['diagnostics'][0]['selector'] ?? '' );
 		$this->assertSame( 'generated_document_contains_core_html', $fixture['diagnostics'][0]['code'] ?? '' );
+		$this->assertSame( 'fallback_block', $fixture['diagnostics'][0]['repair_bucket'] ?? '' );
+		$this->assertSame( 'blocks-engine', $fixture['diagnostics'][0]['parser_owner'] ?? '' );
 		$this->assertCount( 1, $fixture['runtime_dependency_target_gaps'] ?? array() );
 		$this->assertSame( '#cart-drawer', $fixture['runtime_dependency_target_gaps'][0]['selector'] ?? '' );
 		$this->assertCount( 1, $fixture['asset_diagnostics'] ?? array() );
@@ -442,8 +446,78 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 'assets/icon.svg', $fixture['svg_diagnostics'][0]['source_path'] ?? '' );
 		$this->assertCount( 1, $fixture['button_style_loss_hints'] ?? array() );
 		$this->assertSame( 'button.cta', $fixture['button_style_loss_hints'][0]['selector'] ?? '' );
+		$this->assertContains(
+			array(
+				'parser_owner'  => 'blocks-engine',
+				'repair_bucket' => 'fallback_block',
+				'count'         => 1,
+			),
+			$fixture['top_parser_buckets'] ?? array()
+		);
 		$this->assertSame( 'run-123/import-report.json', $fixture['artifact_refs']['import_report']['artifact_id'] ?? '' );
 		$this->assertArrayNotHasKey( 'path', $fixture['artifact_refs']['import_report'] ?? array() );
+	}
+
+	/**
+	 * Import diagnostics are product-owned and do not require Codebox runtime fields.
+	 */
+	public function test_import_diagnostic_contract_normalizes_parser_repair_buckets_without_codebox(): void {
+		$diagnostics = Static_Site_Importer_Diagnostic_Contract::build(
+			array(
+				'status'        => 'failed',
+				'success'       => false,
+				'import_report' => array(
+					'quality'       => array(
+						'invalid_block_count'                => 1,
+						'semantic_parity_failure_count'      => 1,
+						'runtime_dependency_parity_issue_count' => 1,
+					),
+					'diagnostics'   => array(
+						array(
+							'type'        => 'dropped_image_asset',
+							'source_path' => 'assets/hero.jpg',
+							'message'     => 'Dropped image asset.',
+						),
+						array(
+							'type'        => 'invalid_block_content',
+							'source_path' => 'templates/front-page.html',
+						),
+					),
+					'blocks_engine' => array(
+						'runtime_dependency_parity' => array(
+							'missing_dom_targets' => array(
+								array(
+									'type'     => 'runtime_dependency_target_missing',
+									'selector' => '#canvas',
+								),
+							),
+						),
+						'semantic_parity'           => array(
+							'findings' => array(
+								array(
+									'type'        => 'navigation_missing',
+									'source_path' => 'index.html',
+									'selector'    => 'header nav',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 'static-site-importer/import-diagnostics/v1', $diagnostics['schema'] ?? '' );
+		$this->assertSame( 4, $diagnostics['diagnostic_summary']['total'] ?? 0 );
+		$this->assertSame( 1, $diagnostics['diagnostic_summary']['repair_bucket']['dropped_images'] ?? 0 );
+		$this->assertSame( 1, $diagnostics['diagnostic_summary']['repair_bucket']['invalid_block_content'] ?? 0 );
+		$this->assertSame( 1, $diagnostics['diagnostic_summary']['repair_bucket']['runtime_target_gap'] ?? 0 );
+		$this->assertSame( 1, $diagnostics['diagnostic_summary']['repair_bucket']['semantic_parity'] ?? 0 );
+		$this->assertSame( 1, $diagnostics['diagnostic_summary']['parser_owner']['static-site-importer'] ?? 0 );
+		$this->assertSame( 3, $diagnostics['diagnostic_summary']['parser_owner']['blocks-engine'] ?? 0 );
+		$this->assertSame( 'static-site-importer', $diagnostics['by_repair_bucket']['dropped_images'][0]['parser_owner'] ?? '' );
+		$this->assertSame( 'blocks-engine', $diagnostics['by_repair_bucket']['runtime_target_gap'][0]['parser_owner'] ?? '' );
+		$this->assertSame( '#canvas', $diagnostics['runtime_dependency_target_gaps'][0]['selector'] ?? '' );
+		$this->assertSame( 'header nav', $diagnostics['by_repair_bucket']['semantic_parity'][0]['selector'] ?? '' );
 	}
 
 	/**

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -431,13 +431,15 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $fixture['quality_counts']['core_html_block_count'] ?? 0 );
 		$this->assertSame( 1, $fixture['import_report_quality_counts']['runtime_dependency_parity_issue_count'] ?? 0 );
 		$this->assertSame( 1, $fixture['diagnostic_summary']['type']['core_html_block'] ?? 0 );
-		$this->assertSame( 1, $fixture['diagnostic_summary']['repair_bucket']['fallback_block'] ?? 0 );
-		$this->assertSame( 1, $fixture['diagnostic_summary']['parser_owner']['blocks-engine'] ?? 0 );
+		$this->assertSame( 2, $fixture['diagnostic_summary']['repair_bucket']['fallback_block'] ?? 0 );
+		$this->assertSame( 2, $fixture['diagnostic_summary']['parser_owner']['blocks-engine'] ?? 0 );
 		$this->assertSame( 'templates/front-page.html', $fixture['diagnostics'][0]['source_path'] ?? '' );
 		$this->assertSame( 'a.wp-block-button__link', $fixture['diagnostics'][0]['selector'] ?? '' );
 		$this->assertSame( 'generated_document_contains_core_html', $fixture['diagnostics'][0]['code'] ?? '' );
 		$this->assertSame( 'fallback_block', $fixture['diagnostics'][0]['repair_bucket'] ?? '' );
 		$this->assertSame( 'blocks-engine', $fixture['diagnostics'][0]['parser_owner'] ?? '' );
+		$this->assertSame( 'unsupported_html_fallback', $fixture['diagnostics'][4]['type'] ?? '' );
+		$this->assertSame( 'fallback_block', $fixture['diagnostics'][4]['repair_bucket'] ?? '' );
 		$this->assertCount( 1, $fixture['runtime_dependency_target_gaps'] ?? array() );
 		$this->assertSame( '#cart-drawer', $fixture['runtime_dependency_target_gaps'][0]['selector'] ?? '' );
 		$this->assertCount( 1, $fixture['asset_diagnostics'] ?? array() );
@@ -450,7 +452,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 			array(
 				'parser_owner'  => 'blocks-engine',
 				'repair_bucket' => 'fallback_block',
-				'count'         => 1,
+				'count'         => 2,
 			),
 			$fixture['top_parser_buckets'] ?? array()
 		);

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -432,7 +432,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $fixture['import_report_quality_counts']['runtime_dependency_parity_issue_count'] ?? 0 );
 		$this->assertSame( 1, $fixture['diagnostic_summary']['type']['core_html_block'] ?? 0 );
 		$this->assertSame( 2, $fixture['diagnostic_summary']['repair_bucket']['fallback_block'] ?? 0 );
-		$this->assertSame( 2, $fixture['diagnostic_summary']['parser_owner']['blocks-engine'] ?? 0 );
+		$this->assertSame( 5, $fixture['diagnostic_summary']['parser_owner']['blocks-engine'] ?? 0 );
 		$this->assertSame( 'templates/front-page.html', $fixture['diagnostics'][0]['source_path'] ?? '' );
 		$this->assertSame( 'a.wp-block-button__link', $fixture['diagnostics'][0]['selector'] ?? '' );
 		$this->assertSame( 'generated_document_contains_core_html', $fixture['diagnostics'][0]['code'] ?? '' );

--- a/tests/smoke-codebox-validation-contract.php
+++ b/tests/smoke-codebox-validation-contract.php
@@ -95,6 +95,7 @@ namespace {
 		}
 	}
 
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
 	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-codebox-validation.php';
 	Static_Site_Importer_Codebox_Validation::register_default_provider();
 
@@ -119,7 +120,7 @@ namespace {
 	$assert( 'blocked' === ( $blocked['status'] ?? '' ), 'blocked-status' );
 	$assert( 'static-site-importer/codebox-validation-result/v1' === ( $blocked['schema'] ?? '' ), 'result-schema' );
 	$assert( 'static-site-importer/codebox-validation-artifacts/v1' === ( $blocked['artifacts']['schema'] ?? '' ), 'artifact-schema' );
-	$assert( 'static-site-importer/codebox-fixture-diagnostics/v1' === ( $blocked['fixture_diagnostics']['schema'] ?? '' ), 'blocked-fixture-diagnostics-schema' );
+	$assert( 'static-site-importer/import-diagnostics/v1' === ( $blocked['fixture_diagnostics']['schema'] ?? '' ), 'blocked-fixture-diagnostics-schema' );
 	$assert( 'fixture-import' === ( $blocked['fixture_diagnostics']['fixture']['slug'] ?? '' ), 'blocked-fixture-slug' );
 	$assert( 'runtime_provider_unavailable' === ( $blocked['fixture_diagnostics']['diagnostics'][0]['type'] ?? '' ), 'blocked-fixture-diagnostic-type' );
 	$assert( ! empty( $blocked['upstream_gaps'][0]['needed_shape'] ), 'upstream-gap-is-concrete' );
@@ -134,13 +135,13 @@ namespace {
 				'schema'     => 'wp-codebox/host-delegation-result/v1',
 				'status'     => 'completed',
 				'request_id' => (string) ( $request['request_id'] ?? '' ),
-				'provider'   => 'test-homeboy',
+				'provider'   => 'test-host-provider',
 				'result'     => array(
 					'summary'   => array( 'quality_pass' => true ),
 					'artifacts' => array(
-						'import_report'           => array( 'artifact_ref' => 'hb-run://456/import-report.json' ),
-						'block_validation_result' => array( 'artifact_ref' => 'hb-run://456/block-validation.json' ),
-						'browser_render_evidence' => array( 'artifact_ref' => 'hb-run://456/browser-render.json' ),
+						'import_report'           => array( 'artifact_ref' => 'artifact://delegated/import-report.json' ),
+						'block_validation_result' => array( 'artifact_ref' => 'artifact://delegated/block-validation.json' ),
+						'browser_render_evidence' => array( 'artifact_ref' => 'artifact://delegated/browser-render.json' ),
 					),
 				),
 			);
@@ -158,9 +159,9 @@ namespace {
 
 	$assert( true === ( $delegated['success'] ?? false ), 'delegated-provider-success' );
 	$assert( 'succeeded' === ( $delegated['status'] ?? '' ), 'delegated-provider-status' );
-	$assert( 'test-homeboy' === ( $delegated['runtime']['provider'] ?? '' ), 'delegated-runtime-provider' );
+	$assert( 'test-host-provider' === ( $delegated['runtime']['provider'] ?? '' ), 'delegated-runtime-provider' );
 	$assert( 'completed' === ( $delegated['runtime']['host_delegation_status'] ?? '' ), 'delegated-host-status' );
-	$assert( 'hb-run://456/import-report.json' === ( $delegated['artifacts']['import_report']['artifact_ref'] ?? '' ), 'delegated-import-report-ref' );
+	$assert( 'artifact://delegated/import-report.json' === ( $delegated['artifacts']['import_report']['artifact_ref'] ?? '' ), 'delegated-import-report-ref' );
 
 	add_filter(
 		'static_site_importer_codebox_validation_result',
@@ -224,13 +225,13 @@ namespace {
 					),
 				),
 				'artifacts' => array(
-					'generated_theme'         => array( 'artifact_ref' => 'hb-run://123/theme', 'path' => '/Users/local/theme' ),
+					'generated_theme'         => array( 'artifact_ref' => 'artifact://validation/theme', 'path' => '/Users/local/theme' ),
 					'theme_archive'           => array( 'url' => 'https://artifacts.example/theme.zip', 'sha256' => 'abc' ),
-					'import_report'           => array( 'artifact_ref' => 'hb-run://123/import-report.json' ),
-					'block_validation_result' => array( 'artifact_ref' => 'hb-run://123/block-validation.json' ),
-					'browser_render_evidence' => array( 'artifact_ref' => 'hb-run://123/browser-render.json' ),
-					'screenshots'             => array( array( 'artifact_ref' => 'hb-run://123/home.png' ) ),
-					'diffs'                   => array( array( 'artifact_ref' => 'hb-run://123/home.diff.png' ) ),
+					'import_report'           => array( 'artifact_ref' => 'artifact://validation/import-report.json' ),
+					'block_validation_result' => array( 'artifact_ref' => 'artifact://validation/block-validation.json' ),
+					'browser_render_evidence' => array( 'artifact_ref' => 'artifact://validation/browser-render.json' ),
+					'screenshots'             => array( array( 'artifact_ref' => 'artifact://validation/home.png' ) ),
+					'diffs'                   => array( array( 'artifact_ref' => 'artifact://validation/home.diff.png' ) ),
 				),
 			);
 		}
@@ -246,18 +247,22 @@ namespace {
 	$assert( true === ( $provided['success'] ?? false ), 'provider-success' );
 	$assert( 'succeeded' === ( $provided['status'] ?? '' ), 'provider-status' );
 	$assert( 'test-codebox' === ( $provided['runtime']['provider'] ?? '' ), 'runtime-provider' );
-	$assert( 'hb-run://123/theme' === ( $provided['artifacts']['generated_theme']['artifact_ref'] ?? '' ), 'generated-theme-ref' );
+	$assert( 'artifact://validation/theme' === ( $provided['artifacts']['generated_theme']['artifact_ref'] ?? '' ), 'generated-theme-ref' );
 	$assert( ! isset( $provided['artifacts']['generated_theme']['path'] ), 'local-path-removed-from-reviewer-artifact' );
-	$assert( 'hb-run://123/import-report.json' === ( $provided['artifacts']['import_report']['artifact_ref'] ?? '' ), 'import-report-ref' );
-	$assert( 'hb-run://123/block-validation.json' === ( $provided['artifacts']['block_validation_result']['artifact_ref'] ?? '' ), 'block-validation-ref' );
-	$assert( 'hb-run://123/browser-render.json' === ( $provided['artifacts']['browser_render_evidence']['artifact_ref'] ?? '' ), 'browser-render-ref' );
+	$assert( 'artifact://validation/import-report.json' === ( $provided['artifacts']['import_report']['artifact_ref'] ?? '' ), 'import-report-ref' );
+	$assert( 'artifact://validation/block-validation.json' === ( $provided['artifacts']['block_validation_result']['artifact_ref'] ?? '' ), 'block-validation-ref' );
+	$assert( 'artifact://validation/browser-render.json' === ( $provided['artifacts']['browser_render_evidence']['artifact_ref'] ?? '' ), 'browser-render-ref' );
 	$assert( 1 === count( $provided['artifacts']['screenshots'] ?? array() ), 'screenshot-ref-count' );
 	$assert( 1 === count( $provided['artifacts']['diffs'] ?? array() ), 'diff-ref-count' );
-	$assert( 'static-site-importer/codebox-fixture-diagnostics/v1' === ( $provided['fixture_diagnostics']['schema'] ?? '' ), 'provided-fixture-diagnostics-schema' );
+	$assert( 'static-site-importer/import-diagnostics/v1' === ( $provided['fixture_diagnostics']['schema'] ?? '' ), 'provided-fixture-diagnostics-schema' );
 	$assert( 1 === ( $provided['fixture_diagnostics']['quality_counts']['core_html_block_count'] ?? 0 ), 'provided-quality-core-html-count' );
 	$assert( 1 === ( $provided['fixture_diagnostics']['diagnostic_summary']['type']['core_html_block'] ?? 0 ), 'provided-diagnostic-summary-core-html' );
+	$assert( 1 === ( $provided['fixture_diagnostics']['diagnostic_summary']['repair_bucket']['fallback_block'] ?? 0 ), 'provided-diagnostic-summary-repair-bucket' );
+	$assert( 1 <= ( $provided['fixture_diagnostics']['diagnostic_summary']['parser_owner']['blocks-engine'] ?? 0 ), 'provided-diagnostic-summary-parser-owner' );
 	$assert( 'templates/front-page.html' === ( $provided['fixture_diagnostics']['diagnostics'][0]['source_path'] ?? '' ), 'provided-diagnostic-source-path' );
 	$assert( 'a.wp-block-button__link' === ( $provided['fixture_diagnostics']['diagnostics'][0]['selector'] ?? '' ), 'provided-diagnostic-selector' );
+	$assert( 'fallback_block' === ( $provided['fixture_diagnostics']['diagnostics'][0]['repair_bucket'] ?? '' ), 'provided-diagnostic-repair-bucket' );
+	$assert( 'blocks-engine' === ( $provided['fixture_diagnostics']['diagnostics'][0]['parser_owner'] ?? '' ), 'provided-diagnostic-parser-owner' );
 	$assert( '#cart-drawer' === ( $provided['fixture_diagnostics']['runtime_dependency_target_gaps'][0]['selector'] ?? '' ), 'provided-runtime-target-gap-selector' );
 	$assert( 'assets/hero.jpg' === ( $provided['fixture_diagnostics']['asset_diagnostics'][0]['source_path'] ?? '' ), 'provided-asset-diagnostic-source' );
 	$assert( 'assets/icon.svg' === ( $provided['fixture_diagnostics']['svg_diagnostics'][0]['source_path'] ?? '' ), 'provided-svg-diagnostic-source' );

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Smoke coverage for the SSI-owned import diagnostic contract.
+ *
+ * Run from the repository root:
+ * php tests/smoke-import-diagnostic-contract.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.keyFound
+		$key = strtolower( (string) $key );
+
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$diagnostics = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'status'        => 'failed',
+		'success'       => false,
+		'import_report' => array(
+			'quality'       => array(
+				'invalid_block_count'                   => 1,
+				'runtime_dependency_parity_issue_count' => 1,
+				'semantic_parity_failure_count'         => 1,
+			),
+			'diagnostics'   => array(
+				array(
+					'type'        => 'dropped_image_asset',
+					'source_path' => 'assets/hero.jpg',
+					'message'     => 'Dropped image asset.',
+				),
+				array(
+					'type'        => 'invalid_block_content',
+					'source_path' => 'templates/front-page.html',
+				),
+			),
+			'blocks_engine' => array(
+				'runtime_dependency_parity' => array(
+					'missing_dom_targets' => array(
+						array(
+							'type'     => 'runtime_dependency_target_missing',
+							'selector' => '#canvas',
+						),
+					),
+				),
+				'semantic_parity'           => array(
+					'findings' => array(
+						array(
+							'type'        => 'navigation_missing',
+							'source_path' => 'index.html',
+							'selector'    => 'header nav',
+						),
+					),
+				),
+			),
+		),
+	)
+);
+
+$assert( 'static-site-importer/import-diagnostics/v1' === ( $diagnostics['schema'] ?? '' ), 'schema' );
+$assert( 4 === ( $diagnostics['diagnostic_summary']['total'] ?? 0 ), 'total-count' );
+$assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['dropped_images'] ?? 0 ), 'dropped-images-bucket' );
+$assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['invalid_block_content'] ?? 0 ), 'invalid-block-bucket' );
+$assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['runtime_target_gap'] ?? 0 ), 'runtime-target-bucket' );
+$assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['semantic_parity'] ?? 0 ), 'semantic-parity-bucket' );
+$assert( 'static-site-importer' === ( $diagnostics['by_repair_bucket']['dropped_images'][0]['parser_owner'] ?? '' ), 'dropped-images-owner' );
+$assert( 'blocks-engine' === ( $diagnostics['by_repair_bucket']['runtime_target_gap'][0]['parser_owner'] ?? '' ), 'runtime-target-owner' );
+$assert( '#canvas' === ( $diagnostics['runtime_dependency_target_gaps'][0]['selector'] ?? '' ), 'runtime-target-selector' );
+$assert( 'header nav' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['selector'] ?? '' ), 'semantic-selector' );
+$assert( array() === ( $diagnostics['artifact_refs'] ?? null ), 'no-runtime-artifact-requirement' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: import diagnostic contract smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Adds an SSI-owned `static-site-importer/import-diagnostics/v1` diagnostic envelope.
- Normalizes importer and Blocks Engine validation data into product-owned diagnostic summaries, repair buckets, parser owners, runtime target gaps, semantic parity findings, and artifact refs.
- Routes Codebox validation output through the SSI diagnostic contract without introducing Homeboy run IDs, matrix orchestration, or Lab routing into SSI.

This rehomes the useful parser/import diagnostic parts from the closed Homeboy Extensions SSI PRs into Static Site Importer, where the product knowledge belongs.

## Testing
- `git diff --check`
- `php tests/smoke-import-diagnostic-contract.php`
- `php tests/smoke-codebox-validation-contract.php`
- `php tests/smoke-semantic-parity-diagnostics.php`

## Boundary
- SSI owns import validation semantics and diagnostic contracts.
- SSI does not own Homeboy matrix orchestration, run IDs, Lab routing, or Homeboy artifact refs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting, refactoring, and verifying the diagnostic contract.