### PR TITLE
Track SSI import source of truth

### DIFF
--- a/docs/product-handoff-contract.md
+++ b/docs/product-handoff-contract.md
@@ -6,16 +6,22 @@ Static Site Importer's product handoff uses four machine-readable envelopes. The
 
 1. Product caller provides an input artifact with schema `blocks-engine/php-transformer/site-artifact/v1`.
 2. Blocks Engine compiles it and returns `blocks-engine/php-transformer/result/v1` with `source_reports.materialization_plan` using `blocks-engine/php-transformer/materialization-plan/v1`.
-3. SSI consumes the materialization plan, writes WordPress pages/theme/assets, and returns an import report with nested `blocks-engine/import-validation-result/v1` and `blocks-engine/finding-packets/v1` artifacts.
+3. SSI consumes the materialization plan, writes WordPress pages/theme/assets, records source-of-truth provenance, and returns an import report with nested `blocks-engine/import-validation-result/v1` and `blocks-engine/finding-packets/v1` artifacts.
 4. Codebox may validate the WordPress result and return `wp-codebox/validation-artifact-envelope/v1` with artifact references for rendered output, visual comparison, WordPress state, import report, and diagnostics.
 
 ## Ownership
 
 - Blocks Engine owns static artifact compilation and the materialization plan.
-- SSI owns WordPress writes and the import report.
+- SSI owns WordPress writes, page provenance post meta, the generated theme `static-site-importer-manifest.json`, and the import report.
 - Codebox owns optional WordPress validation and artifact references.
 - WPSG, Data Machine, and Studio Native consume these outputs directly; they should not depend on legacy SSI wrapper history.
 
 ## Boundary
 
 Blocks Engine stays out of Codebox details. If a caller wants Codebox validation, it asks Codebox after SSI materializes WordPress and passes SSI output or runtime references through the Codebox-owned envelope.
+
+## Source Of Truth
+
+Every SSI import run has an `import_run_id`. When callers or compiler results provide artifact identity, SSI carries the artifact id/hash into the import report, page provenance meta, and generated theme manifest.
+
+The source-of-truth manifest uses schema `static-site-importer/source-of-truth-manifest/v1` and records desired pages, files, and assets plus existing matched page targets when available. On overwrite/re-import, SSI may remove prior SSI-generated theme files/assets that appeared in the previous manifest and are absent from the current desired manifest. Unknown user files survive, and WordPress page deletion remains disabled until a later reviewed page reconciliation policy is added.

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -57,6 +57,43 @@ class Static_Site_Importer_Page_Materializer {
 	}
 
 	/**
+	 * Describe the intended WordPress targets before materialization writes.
+	 *
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages Pages.
+	 * @return array<string,array<string,mixed>> Target rows keyed by source filename.
+	 */
+	public static function page_targets( array $pages ): array {
+		$targets = array();
+		foreach ( $pages as $filename => $page ) {
+			$slug     = self::page_slug( $filename, $page );
+			$type     = self::page_post_type( $page );
+			$existing = get_page_by_path( $slug, OBJECT, $type );
+			$row      = array(
+				'source_path'       => $page->source_key(),
+				'target_type'       => 'wordpress_post',
+				'post_type'         => $type,
+				'slug'              => $slug,
+				'title'             => self::page_title( $filename, $page ),
+				'status'            => self::page_status( $page ),
+				'existing_post_id'  => 0,
+				'existing_status'   => '',
+				'protected'         => false,
+				'materialized_post_id' => 0,
+			);
+
+			if ( $existing instanceof WP_Post ) {
+				$row['existing_post_id'] = (int) $existing->ID;
+				$row['existing_status']  = (string) $existing->post_status;
+				$row['protected']        = self::is_protected_page( $existing );
+			}
+
+			$targets[ $filename ] = $row;
+		}
+
+		return $targets;
+	}
+
+	/**
 	 * Build page-specific template and pattern artifacts.
 	 *
 	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Pages.
@@ -115,6 +152,49 @@ class Static_Site_Importer_Page_Materializer {
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Persist import provenance on pages owned by Static Site Importer.
+	 *
+	 * @param array<string, Static_Site_Importer_Source_Page> $pages          Pages.
+	 * @param array<string,int>                               $page_ids       Page IDs keyed by filename.
+	 * @param array<string,array<string,mixed>>                $page_targets   Target rows keyed by filename.
+	 * @param array<string,mixed>                              $manifest       Source-of-truth manifest.
+	 * @return true|WP_Error
+	 */
+	public static function record_page_provenance( array $pages, array $page_ids, array $page_targets, array $manifest ) {
+		foreach ( array_keys( $pages ) as $filename ) {
+			$page_id = (int) ( $page_ids[ $filename ] ?? 0 );
+			$post    = $page_id > 0 ? get_post( $page_id ) : null;
+			if ( ! $post instanceof WP_Post || self::is_protected_page( $post ) ) {
+				continue;
+			}
+
+			$target     = isset( $page_targets[ $filename ] ) && is_array( $page_targets[ $filename ] ) ? $page_targets[ $filename ] : array();
+			$provenance = array(
+				'schema'        => 'static-site-importer/page-provenance/v1',
+				'import_run_id' => (string) ( $manifest['import_run_id'] ?? '' ),
+				'artifact'      => isset( $manifest['artifact'] ) && is_array( $manifest['artifact'] ) ? $manifest['artifact'] : array(),
+				'source_path'   => (string) ( $target['source_path'] ?? $filename ),
+				'target'        => array(
+					'post_id'   => $page_id,
+					'post_type' => (string) ( $target['post_type'] ?? $post->post_type ),
+					'slug'      => (string) ( $target['slug'] ?? $post->post_name ),
+				),
+			);
+
+			$json = wp_json_encode( $provenance, JSON_UNESCAPED_SLASHES );
+			if ( false === $json ) {
+				return new WP_Error( 'static_site_importer_page_provenance_encode_failed', 'Failed to encode page provenance metadata.' );
+			}
+
+			update_post_meta( $page_id, '_static_site_importer_provenance', wp_slash( $json ) );
+			update_post_meta( $page_id, '_static_site_importer_import_run_id', (string) ( $manifest['import_run_id'] ?? '' ) );
+			update_post_meta( $page_id, '_static_site_importer_source_path', (string) ( $target['source_path'] ?? $filename ) );
 		}
 
 		return true;

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -105,6 +105,20 @@ class Static_Site_Importer_Report_Diagnostics {
 				'svg_sprites'  => array(),
 				'local'        => array(),
 			),
+			'source_of_truth'         => array(
+				'schema'           => 'static-site-importer/source-of-truth-manifest/v1',
+				'import_run_id'    => '',
+				'artifact'         => array(),
+				'desired'          => array(
+					'pages'  => array(),
+					'files'  => array(),
+					'assets' => array(),
+				),
+				'existing_matches' => array(
+					'pages' => array(),
+				),
+				'manifest_path'    => '',
+			),
 			'asset_map'               => array(
 				'supplied'         => false,
 				'entry_count'      => 0,

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -58,6 +58,9 @@ class Static_Site_Importer_Theme_Generator {
 				$args['site_title'] = $site_title;
 			}
 		}
+		if ( empty( $args['source_artifact_reference'] ) ) {
+			$args['source_artifact_reference'] = self::source_artifact_reference_from_artifact( $artifact, $args );
+		}
 
 		$compiler_options = isset( $args['compiler_options'] ) && is_array( $args['compiler_options'] ) ? $args['compiler_options'] : array();
 		$compiled         = ( new Static_Site_Importer_Transformer_Adapter() )->compile_website_artifact( $artifact, array_merge( array( 'include_conversion_report' => true ), $compiler_options ) );
@@ -98,10 +101,16 @@ class Static_Site_Importer_Theme_Generator {
 			return new WP_Error( 'static_site_importer_theme_exists', sprintf( 'Theme already exists: %s', $theme_slug ) );
 		}
 
+		$import_run_id             = self::import_run_id( $args );
+		$source_artifact_reference = self::source_artifact_reference_from_compiled( $compiled, $args );
 		$source_metadata           = isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array();
 		$source_metadata['source'] = 'website_artifact';
 		$html_path                 = (string) ( $compiled['provenance']['source'] ?? ( $compiled['input']['entry_path'] ?? 'website_artifact' ) );
 		self::$conversion_report   = Static_Site_Importer_Report_Diagnostics::new_conversion_report( $html_path, $source_metadata );
+		self::$conversion_report['import_run_id']            = $import_run_id;
+		self::$conversion_report['source_artifact']           = $source_artifact_reference;
+		self::$conversion_report['source_of_truth']['import_run_id'] = $import_run_id;
+		self::$conversion_report['source_of_truth']['artifact']      = $source_artifact_reference;
 		Static_Site_Importer_Report_Diagnostics::record_blocks_engine_result( self::$conversion_report, $compiled );
 		Static_Site_Importer_Report_Diagnostics::record_direct_website_artifact_source_summary( self::$conversion_report, $compiled );
 		self::record_products_manifest_from_import_args( $args, $compiled );
@@ -118,7 +127,8 @@ class Static_Site_Importer_Theme_Generator {
 			return $document_pages;
 		}
 
-		$page_ids = Static_Site_Importer_Page_Materializer::create_page_shells( $document_pages );
+		$page_targets = Static_Site_Importer_Page_Materializer::page_targets( $document_pages );
+		$page_ids     = Static_Site_Importer_Page_Materializer::create_page_shells( $document_pages );
 		if ( is_wp_error( $page_ids ) ) {
 			return $page_ids;
 		}
@@ -180,21 +190,11 @@ class Static_Site_Importer_Theme_Generator {
 		self::materialize_required_plugins( $args );
 		self::record_product_seeding_report( $args );
 		self::record_commerce_dependency_check( $args );
-		$quality                = Static_Site_Importer_Report_Diagnostics::finalize_report( self::$conversion_report, $args );
+		$source_of_truth_manifest                    = self::source_of_truth_manifest( $import_run_id, $source_artifact_reference, $theme_dir, $theme_slug, $page_targets, $page_ids, $permalinks, $writes, $materialized );
+		self::$conversion_report['source_of_truth'] = $source_of_truth_manifest;
+		$quality                                    = Static_Site_Importer_Report_Diagnostics::finalize_report( self::$conversion_report, $args );
 		$validation_result      = self::$conversion_report['import_validation_result'] ?? array();
 		$finding_packets        = self::$conversion_report['finding_packets'] ?? array();
-		$report_json            = wp_json_encode( self::$conversion_report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
-		$validation_result_json = wp_json_encode( $validation_result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
-		$finding_packets_json   = wp_json_encode( $finding_packets, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
-		if ( false === $report_json ) {
-			return new WP_Error( 'static_site_importer_report_encode_failed', 'Failed to encode import report JSON.' );
-		}
-		if ( false === $validation_result_json ) {
-			return new WP_Error( 'static_site_importer_validation_result_encode_failed', 'Failed to encode import validation result JSON.' );
-		}
-		if ( false === $finding_packets_json ) {
-			return new WP_Error( 'static_site_importer_finding_packets_encode_failed', 'Failed to encode finding packets JSON.' );
-		}
 		if ( ! empty( $quality['fail_import'] ) ) {
 			return new WP_Error(
 				'static_site_importer_quality_gate_failed',
@@ -212,6 +212,26 @@ class Static_Site_Importer_Theme_Generator {
 			);
 		}
 
+		$cleanup = self::cleanup_stale_generated_theme_files( $theme_dir, $source_of_truth_manifest, $args );
+		if ( is_wp_error( $cleanup ) ) {
+			return $cleanup;
+		}
+		$source_of_truth_manifest['cleanup']       = $cleanup;
+		self::$conversion_report['source_of_truth'] = $source_of_truth_manifest;
+
+		$report_json            = wp_json_encode( self::$conversion_report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		$validation_result_json = wp_json_encode( $validation_result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		$finding_packets_json   = wp_json_encode( $finding_packets, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		if ( false === $report_json ) {
+			return new WP_Error( 'static_site_importer_report_encode_failed', 'Failed to encode import report JSON.' );
+		}
+		if ( false === $validation_result_json ) {
+			return new WP_Error( 'static_site_importer_validation_result_encode_failed', 'Failed to encode import validation result JSON.' );
+		}
+		if ( false === $finding_packets_json ) {
+			return new WP_Error( 'static_site_importer_finding_packets_encode_failed', 'Failed to encode finding packets JSON.' );
+		}
+
 		$result = Static_Site_Importer_Theme_Materializer::ensure_dirs( $theme_dir );
 		if ( is_wp_error( $result ) ) {
 			return $result;
@@ -226,7 +246,16 @@ class Static_Site_Importer_Theme_Generator {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
+		$result = Static_Site_Importer_Page_Materializer::record_page_provenance( $document_pages, $page_ids, $page_targets, $source_of_truth_manifest );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 
+		$manifest_json = wp_json_encode( $source_of_truth_manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		if ( false === $manifest_json ) {
+			return new WP_Error( 'static_site_importer_manifest_encode_failed', 'Failed to encode source-of-truth manifest JSON.' );
+		}
+		$writes[ $theme_dir . '/static-site-importer-manifest.json' ] = $manifest_json . "\n";
 		$writes[ $theme_dir . '/import-report.json' ]            = $report_json . "\n";
 		$writes[ $theme_dir . '/import-validation-result.json' ] = $validation_result_json . "\n";
 		$writes[ $theme_dir . '/finding-packets.json' ]          = $finding_packets_json . "\n";
@@ -283,16 +312,347 @@ class Static_Site_Importer_Theme_Generator {
 			'report_path'                     => $theme_dir . '/import-report.json',
 			'validation_result_path'          => $theme_dir . '/import-validation-result.json',
 			'finding_packets_path'            => $theme_dir . '/finding-packets.json',
+			'manifest_path'                   => $theme_dir . '/static-site-importer-manifest.json',
 			'external_report_path'            => $external_report_path,
 			'external_validation_result_path' => $external_validation_result_path,
 			'external_finding_packets_path'   => $external_finding_packets_path,
 			'import_report_summary'           => self::$conversion_report['compact_summary'],
 			'import_validation_result'        => $validation_result,
 			'finding_packets'                 => $finding_packets,
+			'source_of_truth'                 => $source_of_truth_manifest,
 			'pages'                           => $page_ids,
 			'quality'                         => $quality,
 			'source_documents'                => self::$conversion_report['source_documents'],
 		);
+	}
+
+	/**
+	 * Remove generated theme files from the previous SSI manifest when absent from the new desired manifest.
+	 *
+	 * @param string              $theme_dir        Theme directory.
+	 * @param array<string,mixed> $current_manifest Current source-of-truth manifest.
+	 * @param array<string,mixed> $args             Import args.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function cleanup_stale_generated_theme_files( string $theme_dir, array $current_manifest, array $args = array() ) {
+		$previous_manifest_path = trailingslashit( $theme_dir ) . 'static-site-importer-manifest.json';
+		$cleanup                = array(
+			'enabled'                => true,
+			'policy'                 => 'previous_manifest_file_targets_only',
+			'previous_manifest_path' => 'static-site-importer-manifest.json',
+			'deleted'                => array(),
+			'skipped'                => array(),
+			'pages'                  => array(
+				'enabled'     => true,
+				'policy'      => 'previous_manifest_provenance_report_first',
+				'action'      => self::stale_page_action( $args ),
+				'stale_pages' => array(),
+				'skipped'     => array(),
+				'counts'      => array(
+					'stale_pages'   => 0,
+					'pages_drafted' => 0,
+					'pages_deleted' => 0,
+					'skipped'       => 0,
+				),
+				'notes'       => array( 'Stale SSI-owned pages are reported by default. Drafting requires explicit stale_page_action=draft; deletion is not supported here.' ),
+			),
+			'counts'                 => array(
+				'deleted'       => 0,
+				'skipped'       => 0,
+				'pages_drafted' => 0,
+				'pages_deleted' => 0,
+			),
+			'protected'              => array(
+				'pages_deleted' => 0,
+				'pages_drafted' => 0,
+				'notes'         => array( 'Page deletion is intentionally disabled; this cleanup only removes prior SSI-generated theme files and assets.' ),
+			),
+		);
+
+		if ( ! is_file( $previous_manifest_path ) ) {
+			$cleanup['skipped'][] = array(
+				'path'   => 'static-site-importer-manifest.json',
+				'reason' => 'previous_manifest_missing',
+			);
+			$cleanup['counts']['skipped'] = count( $cleanup['skipped'] );
+			return $cleanup;
+		}
+
+		$previous_manifest_json = file_get_contents( $previous_manifest_path );
+		if ( false === $previous_manifest_json ) {
+			return new WP_Error( 'static_site_importer_previous_manifest_read_failed', 'Failed to read the previous Static Site Importer manifest.' );
+		}
+
+		$previous_manifest = json_decode( $previous_manifest_json, true );
+		if ( ! is_array( $previous_manifest ) || 'static-site-importer/source-of-truth-manifest/v1' !== (string) ( $previous_manifest['schema'] ?? '' ) ) {
+			$cleanup['skipped'][] = array(
+				'path'   => 'static-site-importer-manifest.json',
+				'reason' => 'previous_manifest_invalid',
+			);
+			$cleanup['counts']['skipped'] = count( $cleanup['skipped'] );
+			return $cleanup;
+		}
+
+		$page_reconciliation = self::reconcile_stale_manifest_pages( $previous_manifest, $current_manifest, $cleanup['pages']['action'] );
+		if ( is_wp_error( $page_reconciliation ) ) {
+			return $page_reconciliation;
+		}
+		$cleanup['pages']                         = $page_reconciliation;
+		$cleanup['protected']['pages_deleted']    = (int) ( $page_reconciliation['counts']['pages_deleted'] ?? 0 );
+		$cleanup['protected']['pages_drafted']    = (int) ( $page_reconciliation['counts']['pages_drafted'] ?? 0 );
+		$cleanup['counts']['pages_deleted']       = (int) ( $page_reconciliation['counts']['pages_deleted'] ?? 0 );
+		$cleanup['counts']['pages_drafted']       = (int) ( $page_reconciliation['counts']['pages_drafted'] ?? 0 );
+
+		$current_paths  = self::manifest_theme_file_paths( $current_manifest );
+		$previous_paths = self::manifest_theme_file_paths( $previous_manifest );
+		$stale_paths    = array_values( array_diff( array_keys( $previous_paths ), array_keys( $current_paths ) ) );
+
+		foreach ( $stale_paths as $relative ) {
+			$path = trailingslashit( $theme_dir ) . $relative;
+			if ( ! file_exists( $path ) ) {
+				$cleanup['skipped'][] = array(
+					'path'   => $relative,
+					'reason' => 'already_missing',
+				);
+				continue;
+			}
+
+			if ( ! is_file( $path ) ) {
+				$cleanup['skipped'][] = array(
+					'path'   => $relative,
+					'reason' => 'not_a_file',
+				);
+				continue;
+			}
+
+			if ( ! unlink( $path ) ) {
+				return new WP_Error( 'static_site_importer_stale_generated_file_delete_failed', sprintf( 'Failed to delete stale generated theme file: %s', $relative ) );
+			}
+
+			$cleanup['deleted'][] = array(
+				'path'   => $relative,
+				'reason' => 'absent_from_current_manifest',
+			);
+		}
+
+		$cleanup['counts']['deleted'] = count( $cleanup['deleted'] );
+		$cleanup['counts']['skipped'] = count( $cleanup['skipped'] );
+
+		return $cleanup;
+	}
+
+	/**
+	 * Resolve the explicitly requested stale page action.
+	 *
+	 * @param array<string,mixed> $args Import args.
+	 * @return string
+	 */
+	private static function stale_page_action( array $args ): string {
+		$action = isset( $args['stale_page_action'] ) && is_scalar( $args['stale_page_action'] ) ? sanitize_key( (string) $args['stale_page_action'] ) : '';
+		if ( '' === $action ) {
+			$option = get_option( 'static_site_importer_stale_page_action', '' );
+			$action = is_scalar( $option ) ? sanitize_key( (string) $option ) : '';
+		}
+
+		return 'draft' === $action ? 'draft' : 'report_only';
+	}
+
+	/**
+	 * Report or draft SSI-owned pages present in the previous manifest but absent from the current desired pages.
+	 *
+	 * @param array<string,mixed> $previous_manifest Previous source-of-truth manifest.
+	 * @param array<string,mixed> $current_manifest  Current source-of-truth manifest.
+	 * @param string              $action            Reconciliation action.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function reconcile_stale_manifest_pages( array $previous_manifest, array $current_manifest, string $action ) {
+		$reconciliation = array(
+			'enabled'     => true,
+			'policy'      => 'previous_manifest_provenance_report_first',
+			'action'      => 'draft' === $action ? 'draft' : 'report_only',
+			'stale_pages' => array(),
+			'skipped'     => array(),
+			'counts'      => array(
+				'stale_pages'   => 0,
+				'pages_drafted' => 0,
+				'pages_deleted' => 0,
+				'skipped'       => 0,
+			),
+			'notes'       => array( 'Only pages with valid Static Site Importer provenance meta are eligible. Protected pages and pages without SSI provenance are never mutated.' ),
+		);
+
+		$current_sources = array();
+		$current_posts   = array();
+		foreach ( self::manifest_pages( $current_manifest ) as $page ) {
+			$source_path = isset( $page['source_path'] ) && is_scalar( $page['source_path'] ) ? (string) $page['source_path'] : '';
+			$post_id     = (int) ( $page['materialized_post_id'] ?? 0 );
+			if ( '' !== $source_path ) {
+				$current_sources[ $source_path ] = true;
+			}
+			if ( $post_id > 0 ) {
+				$current_posts[ $post_id ] = true;
+			}
+		}
+
+		foreach ( self::manifest_pages( $previous_manifest ) as $page ) {
+			$source_path = isset( $page['source_path'] ) && is_scalar( $page['source_path'] ) ? (string) $page['source_path'] : '';
+			$post_id     = (int) ( $page['materialized_post_id'] ?? 0 );
+			if ( '' !== $source_path && isset( $current_sources[ $source_path ] ) ) {
+				continue;
+			}
+			if ( $post_id <= 0 || isset( $current_posts[ $post_id ] ) ) {
+				continue;
+			}
+
+			$post = get_post( $post_id );
+			if ( ! $post instanceof WP_Post ) {
+				$reconciliation['skipped'][] = array(
+					'post_id'     => $post_id,
+					'source_path' => $source_path,
+					'reason'      => 'post_missing',
+				);
+				continue;
+			}
+
+			if ( Static_Site_Importer_Page_Materializer::is_protected_page( $post ) ) {
+				$reconciliation['skipped'][] = array(
+					'post_id'     => $post_id,
+					'source_path' => $source_path,
+					'slug'        => (string) $post->post_name,
+					'reason'      => 'protected_page',
+				);
+				continue;
+			}
+
+			$provenance = self::page_provenance( $post_id );
+			if ( empty( $provenance ) ) {
+				$reconciliation['skipped'][] = array(
+					'post_id'     => $post_id,
+					'source_path' => $source_path,
+					'slug'        => (string) $post->post_name,
+					'reason'      => 'missing_static_site_importer_provenance',
+				);
+				continue;
+			}
+
+			$row = array(
+				'post_id'         => $post_id,
+				'post_type'       => (string) $post->post_type,
+				'slug'            => (string) $post->post_name,
+				'source_path'     => $source_path,
+				'previous_status' => (string) $post->post_status,
+				'action'          => 'report_only',
+			);
+
+			if ( 'draft' === $reconciliation['action'] ) {
+				if ( 'draft' !== $post->post_status ) {
+					$result = wp_update_post(
+						array(
+							'ID'          => $post_id,
+							'post_status' => 'draft',
+						),
+						true
+					);
+					if ( is_wp_error( $result ) ) {
+						return $result;
+					}
+					++$reconciliation['counts']['pages_drafted'];
+				}
+				$row['action']     = 'drafted';
+				$row['new_status'] = 'draft';
+			}
+
+			$reconciliation['stale_pages'][] = $row;
+		}
+
+		$reconciliation['counts']['stale_pages'] = count( $reconciliation['stale_pages'] );
+		$reconciliation['counts']['skipped']     = count( $reconciliation['skipped'] );
+
+		return $reconciliation;
+	}
+
+	/**
+	 * Extract desired pages from a manifest.
+	 *
+	 * @param array<string,mixed> $manifest Source-of-truth manifest.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function manifest_pages( array $manifest ): array {
+		$desired = isset( $manifest['desired'] ) && is_array( $manifest['desired'] ) ? $manifest['desired'] : array();
+		$pages   = isset( $desired['pages'] ) && is_array( $desired['pages'] ) ? $desired['pages'] : array();
+
+		return array_values( array_filter( $pages, 'is_array' ) );
+	}
+
+	/**
+	 * Read valid Static Site Importer page provenance meta.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array<string,mixed>
+	 */
+	private static function page_provenance( int $post_id ): array {
+		$raw = (string) get_post_meta( $post_id, '_static_site_importer_provenance', true );
+		if ( '' === trim( $raw ) ) {
+			return array();
+		}
+
+		$provenance = json_decode( $raw, true );
+		if ( ! is_array( $provenance ) || 'static-site-importer/page-provenance/v1' !== (string) ( $provenance['schema'] ?? '' ) ) {
+			return array();
+		}
+
+		return $provenance;
+	}
+
+	/**
+	 * Extract safe theme-relative file paths from a source-of-truth manifest.
+	 *
+	 * @param array<string,mixed> $manifest Source-of-truth manifest.
+	 * @return array<string,true>
+	 */
+	private static function manifest_theme_file_paths( array $manifest ): array {
+		$desired = isset( $manifest['desired'] ) && is_array( $manifest['desired'] ) ? $manifest['desired'] : array();
+		$paths   = array();
+
+		foreach ( $desired['files'] ?? array() as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$relative = self::normalize_manifest_theme_relative_path( isset( $file['path'] ) && is_scalar( $file['path'] ) ? (string) $file['path'] : '' );
+			if ( '' !== $relative ) {
+				$paths[ $relative ] = true;
+			}
+		}
+
+		foreach ( $desired['assets'] ?? array() as $asset ) {
+			if ( ! is_array( $asset ) ) {
+				continue;
+			}
+
+			$relative = self::normalize_manifest_theme_relative_path( isset( $asset['theme_path'] ) && is_scalar( $asset['theme_path'] ) ? (string) $asset['theme_path'] : '' );
+			if ( '' !== $relative ) {
+				$paths[ $relative ] = true;
+			}
+		}
+
+		return $paths;
+	}
+
+	/**
+	 * Normalize a manifest theme-relative path for safe file cleanup.
+	 *
+	 * @param string $path Manifest path.
+	 * @return string
+	 */
+	private static function normalize_manifest_theme_relative_path( string $path ): string {
+		$path = str_replace( '\\', '/', trim( $path ) );
+		$path = ltrim( $path, '/' );
+		if ( '' === $path || str_contains( $path, "\0" ) || str_starts_with( $path, '../' ) || str_contains( $path, '/../' ) || preg_match( '#^[a-z][a-z0-9+.-]*:#i', $path ) ) {
+			return '';
+		}
+
+		return $path;
 	}
 
 	/**
@@ -1086,6 +1446,220 @@ class Static_Site_Importer_Theme_Generator {
 
 		$decoded = json_decode( $report, true );
 		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/**
+	 * Build a stable import run id for report and provenance joins.
+	 *
+	 * @param array<string,mixed> $args Import args.
+	 * @return string
+	 */
+	private static function import_run_id( array $args ): string {
+		if ( isset( $args['import_run_id'] ) && is_scalar( $args['import_run_id'] ) && '' !== trim( (string) $args['import_run_id'] ) ) {
+			return sanitize_key( (string) $args['import_run_id'] );
+		}
+
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return 'ssi-' . wp_generate_uuid4();
+		}
+
+		return 'ssi-' . gmdate( 'YmdHis' ) . '-' . bin2hex( random_bytes( 4 ) );
+	}
+
+	/**
+	 * Extract artifact identity fields supplied with a source artifact.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @param array<string,mixed> $args     Import args.
+	 * @return array<string,mixed>
+	 */
+	private static function source_artifact_reference_from_artifact( array $artifact, array $args = array() ): array {
+		$reference = array(
+			'schema'     => isset( $artifact['schema'] ) && is_scalar( $artifact['schema'] ) ? (string) $artifact['schema'] : '',
+			'id'         => '',
+			'hash'       => '',
+			'hash_algo'  => '',
+			'entrypoint' => isset( $artifact['entrypoint'] ) && is_scalar( $artifact['entrypoint'] ) ? (string) $artifact['entrypoint'] : '',
+		);
+
+		foreach ( array( 'artifact_id', 'id', 'run_id' ) as $key ) {
+			if ( isset( $args[ $key ] ) && is_scalar( $args[ $key ] ) && '' !== trim( (string) $args[ $key ] ) ) {
+				$reference['id'] = (string) $args[ $key ];
+				break;
+			}
+			if ( isset( $artifact[ $key ] ) && is_scalar( $artifact[ $key ] ) && '' !== trim( (string) $artifact[ $key ] ) ) {
+				$reference['id'] = (string) $artifact[ $key ];
+				break;
+			}
+		}
+
+		foreach ( array( 'artifact_hash', 'hash', 'sha256' ) as $key ) {
+			if ( isset( $args[ $key ] ) && is_scalar( $args[ $key ] ) && '' !== trim( (string) $args[ $key ] ) ) {
+				$reference['hash'] = (string) $args[ $key ];
+				break;
+			}
+			if ( isset( $artifact[ $key ] ) && is_scalar( $artifact[ $key ] ) && '' !== trim( (string) $artifact[ $key ] ) ) {
+				$reference['hash'] = (string) $artifact[ $key ];
+				break;
+			}
+		}
+
+		if ( isset( $args['artifact_hash_algo'] ) && is_scalar( $args['artifact_hash_algo'] ) ) {
+			$reference['hash_algo'] = (string) $args['artifact_hash_algo'];
+		} elseif ( isset( $artifact['hash_algo'] ) && is_scalar( $artifact['hash_algo'] ) ) {
+			$reference['hash_algo'] = (string) $artifact['hash_algo'];
+		} elseif ( isset( $artifact['sha256'] ) || isset( $args['sha256'] ) ) {
+			$reference['hash_algo'] = 'sha256';
+		}
+
+		return array_filter(
+			$reference,
+			static fn ( $value ): bool => '' !== $value
+		);
+	}
+
+	/**
+	 * Extract artifact identity fields from the compiled result and import args.
+	 *
+	 * @param array<string,mixed> $compiled Compiler result envelope.
+	 * @param array<string,mixed> $args     Import args.
+	 * @return array<string,mixed>
+	 */
+	private static function source_artifact_reference_from_compiled( array $compiled, array $args = array() ): array {
+		$reference  = isset( $args['source_artifact_reference'] ) && is_array( $args['source_artifact_reference'] ) ? $args['source_artifact_reference'] : array();
+		$provenance = isset( $compiled['provenance'] ) && is_array( $compiled['provenance'] ) ? $compiled['provenance'] : array();
+		$input      = isset( $compiled['input'] ) && is_array( $compiled['input'] ) ? $compiled['input'] : array();
+
+		foreach ( array( 'id' => array( 'artifact_id', 'id', 'run_id' ), 'hash' => array( 'artifact_hash', 'hash', 'sha256' ), 'hash_algo' => array( 'artifact_hash_algo', 'hash_algo' ) ) as $target => $keys ) {
+			if ( isset( $reference[ $target ] ) && is_scalar( $reference[ $target ] ) && '' !== trim( (string) $reference[ $target ] ) ) {
+				continue;
+			}
+			foreach ( $keys as $key ) {
+				foreach ( array( $args, $provenance, $input ) as $source ) {
+					if ( isset( $source[ $key ] ) && is_scalar( $source[ $key ] ) && '' !== trim( (string) $source[ $key ] ) ) {
+						$reference[ $target ] = (string) $source[ $key ];
+						break 2;
+					}
+				}
+			}
+		}
+
+		if ( ! isset( $reference['entrypoint'] ) && isset( $input['entry_path'] ) && is_scalar( $input['entry_path'] ) ) {
+			$reference['entrypoint'] = (string) $input['entry_path'];
+		}
+
+		return array_filter(
+			$reference,
+			static fn ( $value ): bool => is_scalar( $value ) ? '' !== trim( (string) $value ) : ! empty( $value )
+		);
+	}
+
+	/**
+	 * Build the source-of-truth manifest embedded in reports and written to disk.
+	 *
+	 * @param string                       $import_run_id Import run id.
+	 * @param array<string,mixed>          $artifact      Source artifact reference.
+	 * @param string                       $theme_dir     Theme directory.
+	 * @param string                       $theme_slug    Theme slug.
+	 * @param array<string,array<string,mixed>> $page_targets Page target rows.
+	 * @param array<string,int>            $page_ids      Page IDs keyed by source path.
+	 * @param array<string,string>         $permalinks    Permalinks keyed by source path.
+	 * @param array<string,string>         $writes        Theme writes.
+	 * @param array<string,mixed>          $materialized  Materialized asset summary.
+	 * @return array<string,mixed>
+	 */
+	private static function source_of_truth_manifest( string $import_run_id, array $artifact, string $theme_dir, string $theme_slug, array $page_targets, array $page_ids, array $permalinks, array $writes, array $materialized ): array {
+		$pages           = array();
+		$existing_pages  = array();
+		foreach ( $page_targets as $filename => $target ) {
+			if ( ! is_array( $target ) ) {
+				continue;
+			}
+			$post_id                         = (int) ( $page_ids[ $filename ] ?? 0 );
+			$target['materialized_post_id']   = $post_id;
+			$target['permalink']              = $permalinks[ $filename ] ?? '';
+			$target['provenance_meta_key']    = ! empty( $target['protected'] ) ? '' : '_static_site_importer_provenance';
+			$pages[]                          = $target;
+			if ( ! empty( $target['existing_post_id'] ) ) {
+				$existing_pages[] = array(
+					'source_path' => (string) ( $target['source_path'] ?? $filename ),
+					'post_id'     => (int) $target['existing_post_id'],
+					'post_type'   => (string) ( $target['post_type'] ?? 'page' ),
+					'slug'        => (string) ( $target['slug'] ?? '' ),
+					'protected'   => ! empty( $target['protected'] ),
+				);
+			}
+		}
+
+		$files = array();
+		foreach ( array_keys( $writes ) as $path ) {
+			$relative = self::theme_relative_path( (string) $path, $theme_dir );
+			if ( '' !== $relative ) {
+				$files[] = array(
+					'target_type' => 'theme_file',
+					'path'        => $relative,
+				);
+			}
+		}
+		foreach ( array( 'static-site-importer-manifest.json', 'import-report.json', 'import-validation-result.json', 'finding-packets.json' ) as $path ) {
+			$files[] = array(
+				'target_type' => 'theme_file',
+				'path'        => $path,
+			);
+		}
+
+		$assets = array();
+		foreach ( $materialized['assets'] ?? array() as $source => $asset ) {
+			if ( ! is_array( $asset ) ) {
+				continue;
+			}
+			$assets[] = array(
+				'source_path' => is_string( $source ) ? $source : (string) ( $asset['source'] ?? '' ),
+				'target_type' => 'theme_asset',
+				'theme_path'  => (string) ( $asset['theme_path'] ?? '' ),
+				'url'         => (string) ( $asset['final_url'] ?? ( $asset['url'] ?? '' ) ),
+				'policy'      => (string) ( $asset['policy'] ?? 'theme' ),
+			);
+		}
+
+		return array(
+			'schema'           => 'static-site-importer/source-of-truth-manifest/v1',
+			'version'          => 1,
+			'import_run_id'    => $import_run_id,
+			'artifact'         => $artifact,
+			'generated_theme'  => array(
+				'slug' => $theme_slug,
+			),
+			'desired'          => array(
+				'pages'  => $pages,
+				'files'  => $files,
+				'assets' => $assets,
+			),
+			'existing_matches' => array(
+				'pages' => $existing_pages,
+			),
+			'manifest_path'    => 'static-site-importer-manifest.json',
+			'cleanup'          => array(
+				'enabled' => false,
+				'notes'   => array( 'Stale cleanup/deletion is intentionally not part of this foundation layer.' ),
+			),
+		);
+	}
+
+	/**
+	 * Convert an absolute generated theme file path to a theme-relative path.
+	 *
+	 * @param string $path      Absolute path.
+	 * @param string $theme_dir Theme directory.
+	 * @return string
+	 */
+	private static function theme_relative_path( string $path, string $theme_dir ): string {
+		$prefix = trailingslashit( $theme_dir );
+		if ( ! str_starts_with( $path, $prefix ) ) {
+			return '';
+		}
+
+		return ltrim( substr( $path, strlen( $prefix ) ), '/\\' );
 	}
 
 	/**

--- a/tests/fixtures/product-handoff-contract/v1.json
+++ b/tests/fixtures/product-handoff-contract/v1.json
@@ -31,7 +31,7 @@
       "owner": "static_site_importer",
       "consumer": "product_caller",
       "schema": "static-site-importer/import-report/v1",
-      "required_fields": ["version", "theme_slug", "source", "blocks_engine", "generated_theme", "quality", "diagnostics", "import_validation_result", "finding_packets"],
+      "required_fields": ["version", "theme_slug", "import_run_id", "source", "source_of_truth", "blocks_engine", "generated_theme", "quality", "diagnostics", "import_validation_result", "finding_packets"],
       "nested_artifacts": {
         "import_validation_result": "blocks-engine/import-validation-result/v1",
         "finding_packets": "blocks-engine/finding-packets/v1",
@@ -106,9 +106,60 @@
       "version": 1,
       "schema": "static-site-importer/import-report/v1",
       "theme_slug": "atlas-bakery",
+      "import_run_id": "ssi-run-123",
       "source": {
         "type": "website_artifact",
         "source": "artifact.json"
+      },
+      "source_artifact": {
+        "id": "artifact-123",
+        "hash": "sha256:abc123",
+        "hash_algo": "sha256",
+        "entrypoint": "website/index.html"
+      },
+      "source_of_truth": {
+        "schema": "static-site-importer/source-of-truth-manifest/v1",
+        "version": 1,
+        "import_run_id": "ssi-run-123",
+        "artifact": {
+          "id": "artifact-123",
+          "hash": "sha256:abc123",
+          "hash_algo": "sha256",
+          "entrypoint": "website/index.html"
+        },
+        "generated_theme": {
+          "slug": "atlas-bakery"
+        },
+        "desired": {
+          "pages": [
+            {
+              "source_path": "website/index.html",
+              "target_type": "wordpress_post",
+              "post_type": "page",
+              "slug": "home",
+              "title": "Atlas Bakery",
+              "status": "publish",
+              "existing_post_id": 0,
+              "protected": false,
+              "materialized_post_id": 42,
+              "provenance_meta_key": "_static_site_importer_provenance"
+            }
+          ],
+          "files": [
+            { "target_type": "theme_file", "path": "style.css" },
+            { "target_type": "theme_file", "path": "templates/front-page.html" },
+            { "target_type": "theme_file", "path": "static-site-importer-manifest.json" },
+            { "target_type": "theme_file", "path": "import-report.json" }
+          ],
+          "assets": []
+        },
+        "existing_matches": {
+          "pages": []
+        },
+        "manifest_path": "static-site-importer-manifest.json",
+        "cleanup": {
+          "enabled": false
+        }
       },
       "blocks_engine": {
         "available": true,

--- a/tests/smoke-import-source-of-truth-manifest.php
+++ b/tests/smoke-import-source-of-truth-manifest.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Smoke test: website artifact imports write non-destructive source-of-truth provenance.
+ *
+ * Run inside a WordPress site:
+ * wp eval-file tests/smoke-import-source-of-truth-manifest.php --skip-plugins
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+$plugin_root = dirname( __DIR__ );
+
+if ( ! function_exists( 'blocks_engine_php_transformer_compile_artifact' ) ) {
+	function blocks_engine_php_transformer_compile_artifact( array $artifact, array $options = array() ): array {
+		unset( $options );
+		$files      = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
+		$entry_path = isset( $artifact['entrypoint'] ) && is_scalar( $artifact['entrypoint'] ) ? (string) $artifact['entrypoint'] : '';
+		$pages      = array();
+		$assets     = array();
+
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) || empty( $file['path'] ) || ! is_scalar( $file['path'] ) ) {
+				continue;
+			}
+
+			$path = (string) $file['path'];
+			if ( str_ends_with( $path, '.css' ) ) {
+				$assets[] = array(
+					'path'    => $path,
+					'role'    => 'stylesheet',
+					'kind'    => 'css',
+					'content' => isset( $file['content'] ) && is_scalar( $file['content'] ) ? (string) $file['content'] : '',
+				);
+				continue;
+			}
+			if ( ! str_ends_with( $path, '.html' ) ) {
+				$assets[] = array(
+					'path'    => $path,
+					'content' => isset( $file['content'] ) && is_scalar( $file['content'] ) ? (string) $file['content'] : '',
+				);
+				continue;
+			}
+
+			$is_entry = '' === $entry_path || $path === $entry_path;
+			$basename = basename( $path );
+			if ( 'protected.html' === $basename ) {
+				$slug  = 'ssi-protected-source-of-truth';
+				$title = 'Protected Source Of Truth';
+			} elseif ( 'old.html' === $basename ) {
+				$slug  = 'ssi-stale-source-of-truth';
+				$title = 'Stale Source Of Truth';
+			} else {
+				$slug  = 'ssi-source-of-truth-home';
+				$title = 'Source Of Truth Home';
+			}
+			$pages[]  = array(
+				'source_path'  => $path,
+				'entrypoint'   => $is_entry,
+				'post_type'    => 'page',
+				'slug'         => $slug,
+				'title'        => $title,
+				'block_markup' => '<!-- wp:paragraph --><p>Imported ' . esc_html( $title ) . '</p><!-- /wp:paragraph -->',
+			);
+		}
+
+		return array(
+			'schema'         => 'blocks-engine/php-transformer/result/v1',
+			'status'         => 'success',
+			'provenance'     => array(
+				'source' => '' !== $entry_path ? $entry_path : 'artifact.json',
+				'hash'   => isset( $artifact['hash'] ) && is_scalar( $artifact['hash'] ) ? (string) $artifact['hash'] : '',
+			),
+			'input'          => array( 'entry_path' => $entry_path ),
+			'source_reports' => array(
+				'materialization_plan' => array(
+					'schema'     => 'blocks-engine/php-transformer/materialization-plan/v1',
+					'entry_path' => $entry_path,
+					'pages'      => $pages,
+					'assets'     => $assets,
+				),
+			),
+			'diagnostics'    => array(),
+		);
+	}
+}
+
+if ( is_readable( $plugin_root . '/static-site-importer.php' ) ) {
+	require_once $plugin_root . '/static-site-importer.php';
+}
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+$read       = static function ( string $path ): string {
+	$contents = file_get_contents( $path );
+	return false === $contents ? '' : $contents;
+};
+
+$protected_page = get_page_by_path( 'ssi-protected-source-of-truth', OBJECT, 'page' );
+$protected_id   = wp_insert_post(
+	array_filter(
+		array(
+			'ID'           => $protected_page instanceof WP_Post ? $protected_page->ID : 0,
+			'post_title'   => 'Protected Source Of Truth',
+			'post_name'    => 'ssi-protected-source-of-truth',
+			'post_status'  => 'publish',
+			'post_type'    => 'page',
+			'post_content' => '<!-- wp:paragraph --><p>Protected original content.</p><!-- /wp:paragraph -->',
+		),
+		static fn ( $value ): bool => 0 !== $value
+	),
+	true
+);
+$assert( ! is_wp_error( $protected_id ), 'protected-page-created', is_wp_error( $protected_id ) ? $protected_id->get_error_message() : '' );
+update_option( 'static_site_importer_protected_pages', array( 'ssi-protected-source-of-truth', (string) $protected_id ) );
+
+$user_page = get_page_by_path( 'ssi-user-source-of-truth', OBJECT, 'page' );
+$user_id   = wp_insert_post(
+	array_filter(
+		array(
+			'ID'           => $user_page instanceof WP_Post ? $user_page->ID : 0,
+			'post_title'   => 'User Source Of Truth',
+			'post_name'    => 'ssi-user-source-of-truth',
+			'post_status'  => 'publish',
+			'post_type'    => 'page',
+			'post_content' => '<!-- wp:paragraph --><p>User original content.</p><!-- /wp:paragraph -->',
+		),
+		static fn ( $value ): bool => 0 !== $value
+	),
+	true
+);
+$assert( ! is_wp_error( $user_id ), 'user-page-created', is_wp_error( $user_id ) ? $user_id->get_error_message() : '' );
+
+$result = Static_Site_Importer_Theme_Generator::import_website_artifact(
+	array(
+		'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+		'id'         => 'artifact-source-of-truth-smoke',
+		'hash'       => 'sha256:source-of-truth-smoke',
+		'hash_algo'  => 'sha256',
+		'entrypoint' => 'index.html',
+		'files'      => array(
+			array( 'path' => 'index.html', 'content' => '<main><h1>Source Of Truth Home</h1></main>' ),
+			array( 'path' => 'protected.html', 'content' => '<main><h1>Protected Replacement</h1></main>' ),
+			array( 'path' => 'old.html', 'content' => '<main><h1>Stale Source Of Truth</h1></main>' ),
+			array( 'path' => 'assets/site.css', 'content' => 'body{color:#111}' ),
+			array( 'path' => 'assets/old-image.txt', 'content' => 'old generated asset' ),
+		),
+	),
+	array(
+		'name'          => 'Source Of Truth Smoke',
+		'slug'          => 'source-of-truth-smoke-theme',
+		'overwrite'     => true,
+		'activate'      => false,
+		'import_run_id' => 'ssi-source-of-truth-smoke-run',
+	)
+);
+
+$assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+if ( ! is_wp_error( $result ) ) {
+	$report    = json_decode( $read( $result['report_path'] ), true );
+	$manifest  = json_decode( $read( $result['manifest_path'] ), true );
+	$page_ids  = $result['pages'] ?? array();
+	$home_id   = (int) ( $page_ids['index.html'] ?? 0 );
+	$protected = get_post( (int) $protected_id );
+	$home_meta = json_decode( (string) get_post_meta( $home_id, '_static_site_importer_provenance', true ), true );
+	$stale_id  = (int) ( $page_ids['old.html'] ?? 0 );
+	$theme_dir = (string) $result['theme_dir'];
+	$stale_template_path = $theme_dir . '/templates/page-ssi-protected-source-of-truth.html';
+	$stale_page_template_path = $theme_dir . '/templates/page-ssi-stale-source-of-truth.html';
+	$stale_asset_path    = $theme_dir . '/assets/materialized/assets/old-image.txt';
+	$unknown_file_path   = $theme_dir . '/templates/user-added.html';
+	$unknown_file_result = file_put_contents( $unknown_file_path, '<!-- user file -->' );
+
+	$assert( is_file( $result['manifest_path'] ), 'manifest-file-written' );
+	$assert( is_file( $stale_template_path ), 'first-import-generated-protected-template' );
+	$assert( $stale_id > 0, 'first-import-created-stale-candidate-page' );
+	$assert( is_file( $stale_page_template_path ), 'first-import-generated-stale-page-template' );
+	$assert( is_file( $stale_asset_path ), 'first-import-generated-old-asset' );
+	$assert( false !== $unknown_file_result, 'unknown-file-created' );
+	$assert( 'ssi-source-of-truth-smoke-run' === ( $report['import_run_id'] ?? '' ), 'report-has-import-run-id' );
+	$assert( 'sha256:source-of-truth-smoke' === ( $report['source_artifact']['hash'] ?? '' ), 'report-has-artifact-hash' );
+	$assert( 'static-site-importer/source-of-truth-manifest/v1' === ( $report['source_of_truth']['schema'] ?? '' ), 'report-has-source-of-truth-schema' );
+	$assert( $manifest === ( $report['source_of_truth'] ?? array() ), 'report-embeds-written-manifest' );
+	$assert( 'ssi-source-of-truth-smoke-run' === ( $home_meta['import_run_id'] ?? '' ), 'owned-page-has-provenance-meta' );
+	$assert( '' === (string) get_post_meta( (int) $protected_id, '_static_site_importer_provenance', true ), 'protected-page-has-no-provenance-meta' );
+	$assert( $protected instanceof WP_Post && str_contains( $protected->post_content, 'Protected original content.' ), 'protected-page-content-unchanged' );
+	$assert( ! empty( $manifest['desired']['pages'] ), 'manifest-has-desired-pages' );
+	$assert( in_array( 'static-site-importer-manifest.json', array_column( $manifest['desired']['files'] ?? array(), 'path' ), true ), 'manifest-has-generated-manifest-file-target' );
+	$assert( ! empty( $manifest['desired']['assets'] ), 'manifest-has-desired-assets' );
+	$assert( in_array( true, array_column( $manifest['existing_matches']['pages'] ?? array(), 'protected' ), true ), 'manifest-reports-protected-existing-match' );
+	$assert( true === ( $manifest['cleanup']['enabled'] ?? false ), 'manifest-cleanup-enabled' );
+
+	$reimport = Static_Site_Importer_Theme_Generator::import_website_artifact(
+		array(
+			'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+			'id'         => 'artifact-source-of-truth-smoke',
+			'hash'       => 'sha256:source-of-truth-smoke-reimport',
+			'hash_algo'  => 'sha256',
+			'entrypoint' => 'index.html',
+			'files'      => array(
+				array( 'path' => 'index.html', 'content' => '<main><h1>Source Of Truth Home Updated</h1></main>' ),
+				array( 'path' => 'assets/site.css', 'content' => 'body{color:#222}' ),
+			),
+		),
+		array(
+			'name'          => 'Source Of Truth Smoke',
+			'slug'          => 'source-of-truth-smoke-theme',
+			'overwrite'     => true,
+			'activate'      => false,
+			'import_run_id' => 'ssi-source-of-truth-smoke-reimport-run',
+		)
+	);
+
+	$assert( ! is_wp_error( $reimport ), 'reimport-succeeds', is_wp_error( $reimport ) ? $reimport->get_error_message() : '' );
+	if ( ! is_wp_error( $reimport ) ) {
+		$reimport_report   = json_decode( $read( $reimport['report_path'] ), true );
+		$reimport_manifest = json_decode( $read( $reimport['manifest_path'] ), true );
+		$deleted_paths     = array_column( $reimport_manifest['cleanup']['deleted'] ?? array(), 'path' );
+		$protected_after   = get_post( (int) $protected_id );
+		$user_after        = get_post( (int) $user_id );
+		$stale_after       = get_post( $stale_id );
+		$stale_pages       = $reimport_manifest['cleanup']['pages']['stale_pages'] ?? array();
+		$stale_page_ids    = array_map( 'intval', array_column( is_array( $stale_pages ) ? $stale_pages : array(), 'post_id' ) );
+
+		$assert( ! is_file( $stale_template_path ), 'reimport-removes-stale-generated-template' );
+		$assert( ! is_file( $stale_page_template_path ), 'reimport-removes-stale-generated-page-template' );
+		$assert( ! is_file( $stale_asset_path ), 'reimport-removes-stale-generated-asset' );
+		$assert( is_file( $unknown_file_path ), 'reimport-preserves-unknown-user-file' );
+		$assert( in_array( 'templates/page-ssi-protected-source-of-truth.html', $deleted_paths, true ), 'cleanup-records-stale-template-delete' );
+		$assert( in_array( 'templates/page-ssi-stale-source-of-truth.html', $deleted_paths, true ), 'cleanup-records-stale-page-template-delete' );
+		$assert( in_array( 'assets/materialized/assets/old-image.txt', $deleted_paths, true ), 'cleanup-records-stale-asset-delete' );
+		$assert( 'report_only' === ( $reimport_manifest['cleanup']['pages']['action'] ?? '' ), 'stale-page-default-action-report-only' );
+		$assert( in_array( $stale_id, $stale_page_ids, true ), 'stale-page-detected' );
+		$assert( 1 === (int) ( $reimport_manifest['cleanup']['pages']['counts']['stale_pages'] ?? 0 ), 'stale-page-count-recorded' );
+		$assert( 0 === (int) ( $reimport_manifest['cleanup']['pages']['counts']['pages_drafted'] ?? -1 ), 'stale-page-default-does-not-draft' );
+		$assert( 0 === (int) ( $reimport_manifest['cleanup']['pages']['counts']['pages_deleted'] ?? -1 ), 'stale-page-default-does-not-delete' );
+		$assert( 0 === (int) ( $reimport_manifest['cleanup']['counts']['pages_drafted'] ?? -1 ), 'cleanup-counts-record-no-page-drafting' );
+		$assert( 0 === (int) ( $reimport_manifest['cleanup']['counts']['pages_deleted'] ?? -1 ), 'cleanup-counts-record-no-page-deletion' );
+		$assert( 0 === (int) ( $reimport_manifest['cleanup']['protected']['pages_deleted'] ?? -1 ), 'cleanup-records-no-page-deletion' );
+		$assert( $reimport_manifest === ( $reimport_report['source_of_truth'] ?? array() ), 'reimport-report-embeds-cleanup-manifest' );
+		$assert( $protected_after instanceof WP_Post && str_contains( $protected_after->post_content, 'Protected original content.' ), 'reimport-protected-page-content-unchanged' );
+		$assert( $user_after instanceof WP_Post && 'publish' === $user_after->post_status && str_contains( $user_after->post_content, 'User original content.' ), 'reimport-user-page-unchanged' );
+		$assert( $stale_after instanceof WP_Post && 'publish' === $stale_after->post_status, 'reimport-stale-page-remains-published-in-report-only-mode' );
+	}
+}
+
+update_option( 'static_site_importer_protected_pages', array() );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: import source-of-truth manifest smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -196,6 +196,8 @@ $result = Static_Site_Importer_Theme_Generator::import_website_artifact(
 		'slug'        => 'ember-rye-document-metadata-smoke',
 		'overwrite'   => true,
 		'activate'    => false,
+		'import_run_id' => 'ssi-smoke-run-001',
+		'artifact_hash' => 'sha256:ember-rye-smoke',
 	)
 );
 
@@ -204,6 +206,7 @@ $assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $
 if ( ! is_wp_error( $result ) ) {
 	$theme_dir = $result['theme_dir'];
 	$report    = json_decode( $read( $result['report_path'] ), true );
+	$manifest  = json_decode( $read( $result['manifest_path'] ?? '' ), true );
 	$validation_result = json_decode( $read( $result['validation_result_path'] ?? '' ), true );
 	$finding_packets   = json_decode( $read( $result['finding_packets_path'] ?? '' ), true );
 	$page_ids  = array_values( $result['pages'] ?? array() );
@@ -238,6 +241,20 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( 0 === ( $report['quality']['core_html_block_count'] ?? null ), 'quality-core-html-count-is-zero' );
 	$assert( is_file( $result['validation_result_path'] ?? '' ), 'validation-result-artifact-is-written' );
 	$assert( is_file( $result['finding_packets_path'] ?? '' ), 'finding-packets-artifact-is-written' );
+	$assert( is_file( $result['manifest_path'] ?? '' ), 'source-of-truth-manifest-is-written' );
+	$assert( 'ssi-smoke-run-001' === ( $report['import_run_id'] ?? '' ), 'report-includes-import-run-id' );
+	$assert( 'sha256:ember-rye-smoke' === ( $report['source_artifact']['hash'] ?? '' ), 'report-includes-source-artifact-hash' );
+	$assert( 'static-site-importer/source-of-truth-manifest/v1' === ( $report['source_of_truth']['schema'] ?? '' ), 'report-includes-source-of-truth-schema' );
+	$assert( 'ssi-smoke-run-001' === ( $manifest['import_run_id'] ?? '' ), 'manifest-includes-import-run-id' );
+	$assert( 'sha256:ember-rye-smoke' === ( $manifest['artifact']['hash'] ?? '' ), 'manifest-includes-source-artifact-hash' );
+	$assert( 'index.html' === ( $manifest['desired']['pages'][0]['source_path'] ?? '' ), 'manifest-includes-desired-page-source' );
+	$assert( $page_id === (int) ( $manifest['desired']['pages'][0]['materialized_post_id'] ?? 0 ), 'manifest-includes-materialized-page-id' );
+	$assert( 'static-site-importer-manifest.json' === ( $manifest['manifest_path'] ?? '' ), 'manifest-reports-relative-manifest-path' );
+	$assert( in_array( 'import-report.json', array_column( $manifest['desired']['files'] ?? array(), 'path' ), true ), 'manifest-includes-report-file-target' );
+	$assert( '_static_site_importer_provenance' === ( $manifest['desired']['pages'][0]['provenance_meta_key'] ?? '' ), 'manifest-identifies-page-provenance-meta-key' );
+	$provenance = json_decode( (string) get_post_meta( $page_id, '_static_site_importer_provenance', true ), true );
+	$assert( 'ssi-smoke-run-001' === ( $provenance['import_run_id'] ?? '' ), 'page-provenance-meta-includes-import-run-id' );
+	$assert( 'index.html' === ( $provenance['source_path'] ?? '' ), 'page-provenance-meta-includes-source-path' );
 	$assert( 'blocks-engine/import-validation-result/v1' === ( $validation_result['schema'] ?? '' ), 'validation-result-schema' );
 	$assert( 'ImportValidationResult' === ( $validation_result['artifact_type'] ?? '' ), 'validation-result-artifact-type' );
 	$assert( 'passed' === ( $validation_result['status'] ?? '' ), 'validation-result-status-passed' );


### PR DESCRIPTION
## Summary
- Add import run/source artifact provenance and write a static-site-importer-manifest.json into generated themes.
- Record desired generated pages/files/assets and cleanup actions in the import report.
- Clean stale SSI-generated theme files/assets on overwrite and report stale SSI-owned pages without mutating them by default.

## Verification
- php -l includes/class-static-site-importer-theme-generator.php
- php -l includes/class-static-site-importer-page-materializer.php
- php -l includes/class-static-site-importer-report-diagnostics.php
- php -l tests/smoke-import-source-of-truth-manifest.php
- php tests/smoke-product-handoff-contract.php
- studio wp eval-file /Users/chubes/Developer/static-site-importer@fix-import-provenance-manifest-clean/tests/smoke-import-source-of-truth-manifest.php --skip-plugins
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Designing and implementing provenance/manifest reconciliation, adding targeted smokes, and drafting this PR description.