### PR TITLE
Filter report-only import diagnostics

### DIFF
--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -175,6 +175,9 @@ class Static_Site_Importer_Diagnostic_Contract {
 			if ( ! is_array( $row ) ) {
 				continue;
 			}
+			if ( self::is_report_only_diagnostic( $row ) ) {
+				continue;
+			}
 
 			$type          = self::first_scalar( $row, array( 'type', 'kind', 'code', 'reason_code' ), 'diagnostic' );
 			$reason_code   = self::first_scalar( $row, array( 'reason_code', 'code', 'reason', 'kind', 'type' ), $type );
@@ -415,6 +418,18 @@ class Static_Site_Importer_Diagnostic_Contract {
 		}
 
 		return $fallback;
+	}
+
+	/**
+	 * Check whether a diagnostic row is report evidence rather than repair work.
+	 *
+	 * @param array<string,mixed> $row Source row.
+	 * @return bool
+	 */
+	private static function is_report_only_diagnostic( array $row ): bool {
+		$constraints = strtolower( self::first_scalar( $row, array( 'constraints', 'constraint' ), '' ) );
+
+		return in_array( $constraints, array( 'report_only', 'report-only' ), true );
 	}
 
 	/**

--- a/includes/class-static-site-importer-document-metadata-reporter.php
+++ b/includes/class-static-site-importer-document-metadata-reporter.php
@@ -43,6 +43,7 @@ class Static_Site_Importer_Document_Metadata_Reporter {
 			'source'       => $normalized['source_path'],
 			'severity'     => 'info',
 			'stage'        => 'website_artifact_materialization',
+			'constraints'  => 'report_only',
 			'message'      => 'Full-document metadata/assets were routed through the generated_theme.document_metadata contract instead of generated page block content.',
 			'meta_count'   => count( $normalized['meta'] ),
 			'link_count'   => count( $normalized['links'] ),

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -43,6 +43,18 @@ $diagnostics = Static_Site_Importer_Diagnostic_Contract::build(
 			),
 			'diagnostics'   => array(
 				array(
+					'type'        => 'website_artifact_materialization_contract_note',
+					'source_path' => 'website/index.html',
+					'constraints' => 'report_only',
+					'message'     => 'Direct materialization contract note.',
+				),
+				array(
+					'type'        => 'document_metadata_routed',
+					'source_path' => 'website/index.html',
+					'constraints' => 'report_only',
+					'message'     => 'Document metadata routing note.',
+				),
+				array(
 					'type'        => 'dropped_image_asset',
 					'source_path' => 'assets/hero.jpg',
 					'message'     => 'Dropped image asset.',
@@ -81,6 +93,8 @@ $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['dropped_im
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['invalid_block_content'] ?? 0 ), 'invalid-block-bucket' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['runtime_target_gap'] ?? 0 ), 'runtime-target-bucket' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['semantic_parity'] ?? 0 ), 'semantic-parity-bucket' );
+$assert( ! isset( $diagnostics['diagnostic_summary']['type']['website_artifact_materialization_contract_note'] ), 'report-only-contract-note-excluded' );
+$assert( ! isset( $diagnostics['diagnostic_summary']['type']['document_metadata_routed'] ), 'report-only-metadata-note-excluded' );
 $assert( 'static-site-importer' === ( $diagnostics['by_repair_bucket']['dropped_images'][0]['parser_owner'] ?? '' ), 'dropped-images-owner' );
 $assert( 'blocks-engine' === ( $diagnostics['by_repair_bucket']['runtime_target_gap'][0]['parser_owner'] ?? '' ), 'runtime-target-owner' );
 $assert( '#canvas' === ( $diagnostics['runtime_dependency_target_gaps'][0]['selector'] ?? '' ), 'runtime-target-selector' );


### PR DESCRIPTION
## Summary
- Exclude diagnostics marked constraints: report_only from the repair-loop diagnostic contract.
- Mark document metadata routing notes as report-only, matching the existing website artifact materialization contract note behavior.
- Cover the filtering path in the import diagnostic contract smoke test.

## Verification
- php tests/smoke-import-diagnostic-contract.php
- php -l includes/class-static-site-importer-diagnostic-contract.php && php -l includes/class-static-site-importer-document-metadata-reporter.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finding clustering, root-cause analysis, code/test edits, and verification.