### PR TITLE
Fix document metadata diagnostic bucket

### DIFF
--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -462,6 +462,9 @@ class Static_Site_Importer_Diagnostic_Contract {
 		if ( '' !== $explicit ) {
 			return sanitize_key( $explicit );
 		}
+		if ( 'document_metadata_routed' === $type ) {
+			return 'static_site_import_quality';
+		}
 
 		$haystack = strtolower( implode( ' ', array( $type, $reason_code, self::first_scalar( $row, array( 'message', 'reason', 'detail' ), '' ) ) ) );
 		if ( str_contains( $haystack, 'runtime_dependency' ) || str_contains( $haystack, 'dom_target' ) || str_contains( $haystack, 'runtime_target' ) || str_contains( $haystack, 'canvas' ) || str_contains( $haystack, 'animation' ) ) {

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -476,6 +476,12 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 					),
 					'diagnostics'   => array(
 						array(
+							'type'        => 'document_metadata_routed',
+							'source_path' => 'website/index.html',
+							'severity'    => 'info',
+							'message'     => 'Full-document metadata/assets were routed through the generated_theme.document_metadata contract instead of generated page block content.',
+						),
+						array(
 							'type'        => 'dropped_image_asset',
 							'source_path' => 'assets/hero.jpg',
 							'message'     => 'Dropped image asset.',
@@ -509,14 +515,16 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 'static-site-importer/import-diagnostics/v1', $diagnostics['schema'] ?? '' );
-		$this->assertSame( 4, $diagnostics['diagnostic_summary']['total'] ?? 0 );
+		$this->assertSame( 5, $diagnostics['diagnostic_summary']['total'] ?? 0 );
 		$this->assertSame( 1, $diagnostics['diagnostic_summary']['repair_bucket']['dropped_images'] ?? 0 );
+		$this->assertSame( 1, $diagnostics['diagnostic_summary']['repair_bucket']['static_site_import_quality'] ?? 0 );
 		$this->assertSame( 1, $diagnostics['diagnostic_summary']['repair_bucket']['invalid_block_content'] ?? 0 );
 		$this->assertSame( 1, $diagnostics['diagnostic_summary']['repair_bucket']['runtime_target_gap'] ?? 0 );
 		$this->assertSame( 1, $diagnostics['diagnostic_summary']['repair_bucket']['semantic_parity'] ?? 0 );
-		$this->assertSame( 1, $diagnostics['diagnostic_summary']['parser_owner']['static-site-importer'] ?? 0 );
+		$this->assertSame( 2, $diagnostics['diagnostic_summary']['parser_owner']['static-site-importer'] ?? 0 );
 		$this->assertSame( 3, $diagnostics['diagnostic_summary']['parser_owner']['blocks-engine'] ?? 0 );
 		$this->assertSame( 'static-site-importer', $diagnostics['by_repair_bucket']['dropped_images'][0]['parser_owner'] ?? '' );
+		$this->assertSame( 'document_metadata_routed', $diagnostics['by_repair_bucket']['static_site_import_quality'][0]['type'] ?? '' );
 		$this->assertSame( 'blocks-engine', $diagnostics['by_repair_bucket']['runtime_target_gap'][0]['parser_owner'] ?? '' );
 		$this->assertSame( '#canvas', $diagnostics['runtime_dependency_target_gaps'][0]['selector'] ?? '' );
 		$this->assertSame( 'header nav', $diagnostics['by_repair_bucket']['semantic_parity'][0]['selector'] ?? '' );

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -43,6 +43,12 @@ $diagnostics = Static_Site_Importer_Diagnostic_Contract::build(
 			),
 			'diagnostics'   => array(
 				array(
+					'type'        => 'document_metadata_routed',
+					'source_path' => 'website/index.html',
+					'severity'    => 'info',
+					'message'     => 'Full-document metadata/assets were routed through the generated_theme.document_metadata contract instead of generated page block content.',
+				),
+				array(
 					'type'        => 'dropped_image_asset',
 					'source_path' => 'assets/hero.jpg',
 					'message'     => 'Dropped image asset.',
@@ -76,12 +82,14 @@ $diagnostics = Static_Site_Importer_Diagnostic_Contract::build(
 );
 
 $assert( 'static-site-importer/import-diagnostics/v1' === ( $diagnostics['schema'] ?? '' ), 'schema' );
-$assert( 4 === ( $diagnostics['diagnostic_summary']['total'] ?? 0 ), 'total-count' );
+$assert( 5 === ( $diagnostics['diagnostic_summary']['total'] ?? 0 ), 'total-count' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['dropped_images'] ?? 0 ), 'dropped-images-bucket' );
+$assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['static_site_import_quality'] ?? 0 ), 'document-metadata-import-quality-bucket' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['invalid_block_content'] ?? 0 ), 'invalid-block-bucket' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['runtime_target_gap'] ?? 0 ), 'runtime-target-bucket' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['semantic_parity'] ?? 0 ), 'semantic-parity-bucket' );
 $assert( 'static-site-importer' === ( $diagnostics['by_repair_bucket']['dropped_images'][0]['parser_owner'] ?? '' ), 'dropped-images-owner' );
+$assert( 'document_metadata_routed' === ( $diagnostics['by_repair_bucket']['static_site_import_quality'][0]['type'] ?? '' ), 'document-metadata-type' );
 $assert( 'blocks-engine' === ( $diagnostics['by_repair_bucket']['runtime_target_gap'][0]['parser_owner'] ?? '' ), 'runtime-target-owner' );
 $assert( '#canvas' === ( $diagnostics['runtime_dependency_target_gaps'][0]['selector'] ?? '' ), 'runtime-target-selector' );
 $assert( 'header nav' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['selector'] ?? '' ), 'semantic-selector' );


### PR DESCRIPTION
## Summary
- Classifies document_metadata_routed as import quality instead of dropped_images.
- Keeps real dropped image asset diagnostics in dropped_images.
- Adds focused smoke/PHPUnit contract coverage for the bucket split.

## Verification
- php tests/smoke-import-diagnostic-contract.php
- composer validate --no-check-publish
- php -l includes/class-static-site-importer-diagnostic-contract.php
- php -l tests/smoke-import-diagnostic-contract.php
- php -l tests/StaticSiteImporterFallbackDiagnosticsTest.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Investigating matrix diagnostic packets, implementing the diagnostic bucket fix, and drafting tests/PR text.