### PR TITLE
fix: load transformer path repository layout

### DIFF
--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -24,13 +24,25 @@ if ( is_readable( $static_site_importer_autoload ) ) {
 	require_once $static_site_importer_autoload;
 }
 
-$static_site_importer_transformer = STATIC_SITE_IMPORTER_PATH . 'vendor/automattic/blocks-engine-php-transformer/php-transformer/php-transformer.php';
-if ( ! function_exists( 'blocks_engine_php_transformer_compile_artifact' ) && is_readable( $static_site_importer_transformer ) ) {
+$static_site_importer_transformers = array(
+	STATIC_SITE_IMPORTER_PATH . 'vendor/automattic/blocks-engine-php-transformer/php-transformer/php-transformer.php',
+	STATIC_SITE_IMPORTER_PATH . 'vendor/automattic/blocks-engine-php-transformer/php-transformer.php',
+);
+foreach ( $static_site_importer_transformers as $static_site_importer_transformer ) {
+	if ( function_exists( 'blocks_engine_php_transformer_compile_artifact' ) || ! is_readable( $static_site_importer_transformer ) ) {
+		continue;
+	}
 	require_once $static_site_importer_transformer;
 }
 
-$static_site_importer_figma_transformer = STATIC_SITE_IMPORTER_PATH . 'vendor/automattic/blocks-engine-figma-transformer/figma-transformer/figma-transformer.php';
-if ( ( ! function_exists( 'blocks_engine_figma_transformer_transform_scenegraph' ) || ! function_exists( 'blocks_engine_figma_transformer_transform_file' ) ) && is_readable( $static_site_importer_figma_transformer ) ) {
+$static_site_importer_figma_transformers = array(
+	STATIC_SITE_IMPORTER_PATH . 'vendor/automattic/blocks-engine-figma-transformer/figma-transformer/figma-transformer.php',
+	STATIC_SITE_IMPORTER_PATH . 'vendor/automattic/blocks-engine-figma-transformer/figma-transformer.php',
+);
+foreach ( $static_site_importer_figma_transformers as $static_site_importer_figma_transformer ) {
+	if ( ( function_exists( 'blocks_engine_figma_transformer_transform_scenegraph' ) && function_exists( 'blocks_engine_figma_transformer_transform_file' ) ) || ! is_readable( $static_site_importer_figma_transformer ) ) {
+		continue;
+	}
 	require_once $static_site_importer_figma_transformer;
 }
 

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -429,6 +429,7 @@ $assert( is_string( $plugin_source ), 'plugin-source-readable' );
 $assert( ! str_contains( $plugin_source, 'Requires Plugins: blocks-engine-php-transformer' ), 'transformer-is-not-a-required-wordpress-plugin' );
 $assert( str_contains( $plugin_source, "vendor/autoload.php" ), 'loads-composer-autoloader' );
 $assert( str_contains( $plugin_source, "vendor/automattic/blocks-engine-php-transformer/php-transformer/php-transformer.php" ), 'loads-composer-transformer-bootstrap' );
+$assert( str_contains( $plugin_source, "vendor/automattic/blocks-engine-php-transformer/php-transformer.php" ), 'loads-composer-path-transformer-bootstrap' );
 $assert( str_contains( $plugin_source, 'Static_Site_Importer_Figma_Import::register_default_zstd_decoder();' ), 'plugin-registers-figma-zstd-decoder' );
 
 $known_zstd_command = false;


### PR DESCRIPTION
## Summary
- Load Blocks Engine transformer bootstraps from both release archive and Composer path repository layouts.
- Apply the same layout fallback to the Figma transformer bootstrap.
- Extend the importer block smoke contract to cover the path repository bootstrap path.

## Context
The SSI fixture matrix can now override Blocks Engine php-transformer via a Composer path repository. Composer installs that path package at vendor/automattic/blocks-engine-php-transformer/php-transformer.php, while release archives expose vendor/automattic/blocks-engine-php-transformer/php-transformer/php-transformer.php. SSI only checked the release archive layout, causing every matrix fixture to fail with static_site_importer_missing_transformer.

## Verification
- composer install --no-interaction --prefer-dist --no-progress
- php tests/smoke-importer-block.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Debugging the SSI matrix bootstrap failure, implementing the Composer path layout fallback, adding smoke coverage, and drafting this PR description.