### PR TITLE
Fix release gate blockers

### DIFF
--- a/includes/class-static-site-importer-codebox-validation.php
+++ b/includes/class-static-site-importer-codebox-validation.php
@@ -18,9 +18,9 @@ if ( ! class_exists( 'Static_Site_Importer_Diagnostic_Contract' ) ) {
  */
 class Static_Site_Importer_Codebox_Validation {
 
-	private const REQUEST_SCHEMA             = 'static-site-importer/codebox-validation-request/v1';
-	private const RESULT_SCHEMA              = 'static-site-importer/codebox-validation-result/v1';
-	private const ARTIFACT_SCHEMA            = 'static-site-importer/codebox-validation-artifacts/v1';
+	private const REQUEST_SCHEMA  = 'static-site-importer/codebox-validation-request/v1';
+	private const RESULT_SCHEMA   = 'static-site-importer/codebox-validation-result/v1';
+	private const ARTIFACT_SCHEMA = 'static-site-importer/codebox-validation-artifacts/v1';
 
 	/**
 	 * Register the default WP Codebox host-delegation bridge.
@@ -51,7 +51,7 @@ class Static_Site_Importer_Codebox_Validation {
 			return null;
 		}
 
-		$source = isset( $request['source'] ) && is_array( $request['source'] ) ? $request['source'] : array();
+		$source   = isset( $request['source'] ) && is_array( $request['source'] ) ? $request['source'] : array();
 		$artifact = isset( $source['artifact'] ) && is_array( $source['artifact'] ) ? $source['artifact'] : array();
 		if ( empty( $artifact ) ) {
 			return null;
@@ -386,11 +386,9 @@ class Static_Site_Importer_Codebox_Validation {
 				),
 				'import_report'           => self::local_file_artifact_ref( $report_path, 'blocks-engine/import-report' ),
 				'block_validation_result' => self::local_file_artifact_ref( $validation_result_path, 'blocks-engine/import-validation-result' ),
-				'raw'                     => array_values(
-					array_filter(
-						array(
-							self::local_file_artifact_ref( $finding_packets_path, 'blocks-engine/finding-packets' ),
-						)
+				'raw'                     => array_filter(
+					array(
+						self::local_file_artifact_ref( $finding_packets_path, 'blocks-engine/finding-packets' ),
 					)
 				),
 			),
@@ -405,10 +403,11 @@ class Static_Site_Importer_Codebox_Validation {
 	 */
 	private static function local_validation_artifact_dir( string $slug ) {
 		$upload_dir = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
-		$base_dir   = isset( $upload_dir['basedir'] ) && is_string( $upload_dir['basedir'] ) ? $upload_dir['basedir'] : sys_get_temp_dir();
+		$base_dir   = isset( $upload_dir['basedir'] ) ? (string) $upload_dir['basedir'] : sys_get_temp_dir();
 		$run_id     = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : uniqid( 'validation-', true );
 		$directory  = trailingslashit( $base_dir ) . 'static-site-importer/codebox-validation-' . sanitize_title( $slug ) . '-' . sanitize_key( $run_id );
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- Standalone smoke-test fallback when WordPress filesystem helpers are unavailable.
 		$created = function_exists( 'wp_mkdir_p' ) ? wp_mkdir_p( $directory ) : ( is_dir( $directory ) || mkdir( $directory, 0777, true ) );
 		if ( ! $created ) {
 			return new WP_Error( 'static_site_importer_codebox_validation_artifact_dir_failed', 'Could not create Codebox validation artifact directory.' );
@@ -593,22 +592,6 @@ class Static_Site_Importer_Codebox_Validation {
 	}
 
 	/**
-	 * Extract an import report from common provider result slots.
-	 *
-	 * @param array<string,mixed> $result Provider result.
-	 * @return array<string,mixed>
-	 */
-	private static function provider_import_report( array $result ): array {
-		foreach ( array( $result['import_report'] ?? null, $result['summary']['import_report'] ?? null, $result['artifacts']['import_report'] ?? null ) as $candidate ) {
-			if ( is_array( $candidate ) && ( isset( $candidate['quality'] ) || isset( $candidate['diagnostics'] ) || isset( $candidate['blocks_engine'] ) ) ) {
-				return $candidate;
-			}
-		}
-
-		return array();
-	}
-
-	/**
 	 * Build a request summary from raw input when request creation failed.
 	 *
 	 * @param array<string,mixed> $input Raw caller input.
@@ -630,318 +613,6 @@ class Static_Site_Importer_Codebox_Validation {
 			),
 			'required_artifacts'  => self::required_artifacts(),
 		);
-	}
-
-	/**
-	 * Read provider-level diagnostic rows.
-	 *
-	 * @param array<string,mixed> $result Provider result.
-	 * @return array<int,array<string,mixed>>
-	 */
-	private static function diagnostic_rows_from_result( array $result ): array {
-		$rows = array();
-		foreach ( array( $result['diagnostics'] ?? array(), $result['artifact_diagnostics']['diagnostics'] ?? array(), $result['import_validation_result']['diagnostics'] ?? array() ) as $candidate ) {
-			if ( is_array( $candidate ) ) {
-				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $candidate ) );
-			}
-		}
-
-		return $rows;
-	}
-
-	/**
-	 * Read import-report diagnostic rows.
-	 *
-	 * @param array<string,mixed> $import_report Import report.
-	 * @return array<int,array<string,mixed>>
-	 */
-	private static function diagnostic_rows_from_import_report( array $import_report ): array {
-		$rows = self::normalize_diagnostic_rows( isset( $import_report['diagnostics'] ) && is_array( $import_report['diagnostics'] ) ? $import_report['diagnostics'] : array() );
-		if ( isset( $import_report['artifact_diagnostics']['diagnostics'] ) && is_array( $import_report['artifact_diagnostics']['diagnostics'] ) ) {
-			$rows = array_merge( $rows, self::normalize_diagnostic_rows( $import_report['artifact_diagnostics']['diagnostics'] ) );
-		}
-
-		return $rows;
-	}
-
-	/**
-	 * Extract Blocks Engine conversion-report diagnostics and fallback rows.
-	 *
-	 * @param array<string,mixed> $import_report Import report.
-	 * @return array<int,array<string,mixed>>
-	 */
-	private static function blocks_engine_conversion_diagnostics( array $import_report ): array {
-		$conversion_report = isset( $import_report['blocks_engine']['conversion_report'] ) && is_array( $import_report['blocks_engine']['conversion_report'] ) ? $import_report['blocks_engine']['conversion_report'] : array();
-		$rows              = array();
-		foreach ( array( 'diagnostics', 'fallback_diagnostics', 'fallbacks', 'presentation_gaps', 'interaction_candidates' ) as $field ) {
-			if ( isset( $conversion_report[ $field ] ) && is_array( $conversion_report[ $field ] ) ) {
-				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $conversion_report[ $field ], 'blocks_engine_conversion_report' ) );
-			}
-		}
-
-		return $rows;
-	}
-
-	/**
-	 * Extract runtime dependency parity target gaps.
-	 *
-	 * @param array<string,mixed> $import_report Import report.
-	 * @return array<int,array<string,mixed>>
-	 */
-	private static function runtime_dependency_target_gaps( array $import_report ): array {
-		$runtime_dependency_parity = isset( $import_report['blocks_engine']['runtime_dependency_parity'] ) && is_array( $import_report['blocks_engine']['runtime_dependency_parity'] ) ? $import_report['blocks_engine']['runtime_dependency_parity'] : array();
-		$rows                      = array();
-		foreach ( array( 'findings', 'missing_dom_targets', 'unsupported_elements' ) as $field ) {
-			if ( isset( $runtime_dependency_parity[ $field ] ) && is_array( $runtime_dependency_parity[ $field ] ) ) {
-				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $runtime_dependency_parity[ $field ], 'runtime_dependency_parity' ) );
-			}
-		}
-
-		return $rows;
-	}
-
-	/**
-	 * Normalize diagnostic rows to a stable consumer-facing subset.
-	 *
-	 * @param array<int|string,mixed> $rows          Raw diagnostic rows.
-	 * @param string                  $default_stage Default stage.
-	 * @return array<int,array<string,mixed>>
-	 */
-	private static function normalize_diagnostic_rows( array $rows, string $default_stage = '' ): array {
-		$normalized = array();
-		foreach ( array_values( $rows ) as $index => $row ) {
-			if ( ! is_array( $row ) ) {
-				continue;
-			}
-
-			$type        = self::first_scalar( $row, array( 'type', 'kind', 'code', 'reason_code' ), 'diagnostic' );
-			$reason_code = self::first_scalar( $row, array( 'reason_code', 'code', 'reason', 'kind', 'type' ), $type );
-			$source_path = self::first_scalar( $row, array( 'source_path', 'path', 'source', 'file', 'script_path' ), '' );
-			$diagnostic  = array(
-				'id'          => self::first_scalar( $row, array( 'id' ), sprintf( 'diag-%03d-%s', $index + 1, sanitize_key( $type . '-' . $reason_code . '-' . $source_path ) ) ),
-				'type'        => sanitize_key( $type ),
-				'severity'    => self::first_scalar( $row, array( 'severity', 'level' ), self::default_diagnostic_severity( $type ) ),
-				'category'    => self::diagnostic_category( $type ),
-				'reason_code' => sanitize_key( $reason_code ),
-				'source_path' => $source_path,
-				'selector'    => self::first_scalar( $row, array( 'selector', 'target_selector', 'css_selector' ), '' ),
-				'code'        => self::first_scalar( $row, array( 'code', 'error_code' ), sanitize_key( $reason_code ) ),
-				'stage'       => self::first_scalar( $row, array( 'stage' ), $default_stage ),
-				'owner'       => self::first_scalar( $row, array( 'owner', 'engine', 'converter' ), '' ),
-			);
-
-			foreach ( array( 'message', 'reason', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt', 'block_name', 'block_path', 'script_path', 'element', 'tag_name', 'src', 'href', 'expected', 'observed' ) as $field ) {
-				$value = self::first_scalar( $row, array( $field ), '' );
-				if ( '' !== $value ) {
-					$diagnostic[ $field ] = $value;
-				}
-			}
-
-			$normalized[] = array_filter(
-				$diagnostic,
-				static fn ( mixed $value ): bool => '' !== $value
-			);
-		}
-
-		return $normalized;
-	}
-
-	/**
-	 * Return quality counts from import report first, then compact summaries.
-	 *
-	 * @param array<string,mixed> $import_report Import report.
-	 * @param array<string,mixed> $summary Provider summary.
-	 * @return array<string,int>
-	 */
-	private static function quality_counts( array $import_report, array $summary ): array {
-		$quality = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
-		$keys    = array( 'fallback_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
-
-		$counts = array();
-		foreach ( $keys as $key ) {
-			$counts[ $key ] = isset( $quality[ $key ] ) && is_numeric( $quality[ $key ] ) ? (int) $quality[ $key ] : 0;
-		}
-
-		return $counts;
-	}
-
-	/**
-	 * Summarize Blocks Engine import-report details.
-	 *
-	 * @param array<string,mixed> $import_report Import report.
-	 * @return array<string,mixed>
-	 */
-	private static function blocks_engine_summary( array $import_report ): array {
-		$blocks_engine = isset( $import_report['blocks_engine'] ) && is_array( $import_report['blocks_engine'] ) ? $import_report['blocks_engine'] : array();
-
-		$summary = array();
-		foreach ( array( 'website_artifact', 'conversion_report', 'runtime_dependency_parity', 'semantic_parity' ) as $field ) {
-			if ( isset( $blocks_engine[ $field ] ) && is_array( $blocks_engine[ $field ] ) && ! empty( $blocks_engine[ $field ] ) ) {
-				$summary[ $field ] = $blocks_engine[ $field ];
-			}
-		}
-
-		return $summary;
-	}
-
-	/**
-	 * Build diagnostic counts by severity and category.
-	 *
-	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
-	 * @return array<string,mixed>
-	 */
-	private static function diagnostic_summary( array $diagnostics ): array {
-		$summary = array(
-			'total'    => count( $diagnostics ),
-			'severity' => array(),
-			'category' => array(),
-			'type'     => array(),
-		);
-		foreach ( $diagnostics as $diagnostic ) {
-			foreach ( array( 'severity', 'category', 'type' ) as $field ) {
-				$value                       = isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) ? (string) $diagnostic[ $field ] : 'unknown';
-				$summary[ $field ][ $value ] = ( $summary[ $field ][ $value ] ?? 0 ) + 1;
-			}
-		}
-
-		return $summary;
-	}
-
-	/**
-	 * Group diagnostics by category.
-	 *
-	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
-	 * @return array<string,array<int,array<string,mixed>>>
-	 */
-	private static function diagnostics_by_category( array $diagnostics ): array {
-		$grouped = array();
-		foreach ( $diagnostics as $diagnostic ) {
-			$category               = isset( $diagnostic['category'] ) && is_scalar( $diagnostic['category'] ) ? (string) $diagnostic['category'] : 'uncategorized';
-			$grouped[ $category ][] = $diagnostic;
-		}
-
-		return $grouped;
-	}
-
-	/**
-	 * Select diagnostics matching types or type fragments.
-	 *
-	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
-	 * @param array<int,string>              $needles     Type needles.
-	 * @return array<int,array<string,mixed>>
-	 */
-	private static function diagnostics_matching_types( array $diagnostics, array $needles ): array {
-		return array_values(
-			array_filter(
-				$diagnostics,
-				static function ( array $diagnostic ) use ( $needles ): bool {
-					$type     = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : '';
-					$category = isset( $diagnostic['category'] ) && is_scalar( $diagnostic['category'] ) ? (string) $diagnostic['category'] : '';
-					foreach ( $needles as $needle ) {
-						if ( $needle === $type || str_contains( $type, $needle ) || str_contains( $category, $needle ) ) {
-							return true;
-						}
-					}
-
-					return false;
-				}
-			)
-		);
-	}
-
-	/**
-	 * Stable artifact references for validation output.
-	 *
-	 * @param array<string,mixed> $artifacts     Validation artifacts.
-	 * @param array<string,mixed> $import_report Import report.
-	 * @return array<string,mixed>
-	 */
-	private static function fixture_artifact_refs( array $artifacts, array $import_report ): array {
-		$refs = $artifacts;
-		if ( isset( $import_report['import_validation_result']['artifacts'] ) && is_array( $import_report['import_validation_result']['artifacts'] ) ) {
-			$refs['import_validation_artifacts'] = $import_report['import_validation_result']['artifacts'];
-		}
-		if ( isset( $import_report['visual_parity_artifacts'] ) && is_array( $import_report['visual_parity_artifacts'] ) ) {
-			$refs['visual_parity_artifacts'] = $import_report['visual_parity_artifacts'];
-		}
-
-		return $refs;
-	}
-
-	/**
-	 * Remove duplicate diagnostics by id/type/source/selector/code.
-	 *
-	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
-	 * @return array<int,array<string,mixed>>
-	 */
-	private static function dedupe_diagnostics( array $diagnostics ): array {
-		$seen   = array();
-		$unique = array();
-		foreach ( $diagnostics as $diagnostic ) {
-			$key = implode( '|', array_map( 'strval', array( $diagnostic['id'] ?? '', $diagnostic['type'] ?? '', $diagnostic['source_path'] ?? '', $diagnostic['selector'] ?? '', $diagnostic['code'] ?? '' ) ) );
-			if ( isset( $seen[ $key ] ) ) {
-				continue;
-			}
-
-			$seen[ $key ] = true;
-			$unique[]     = $diagnostic;
-		}
-
-		return $unique;
-	}
-
-	/**
-	 * Resolve a scalar value from candidate fields.
-	 *
-	 * @param array<string,mixed> $row      Source row.
-	 * @param array<int,string>   $fields   Candidate fields.
-	 * @param string              $fallback Fallback value.
-	 * @return string
-	 */
-	private static function first_scalar( array $row, array $fields, string $fallback = '' ): string {
-		foreach ( $fields as $field ) {
-			if ( isset( $row[ $field ] ) && is_scalar( $row[ $field ] ) && '' !== trim( (string) $row[ $field ] ) ) {
-				return (string) $row[ $field ];
-			}
-		}
-
-		return $fallback;
-	}
-
-	/**
-	 * Classify diagnostics by generic category.
-	 *
-	 * @param string $type Diagnostic type.
-	 * @return string
-	 */
-	private static function diagnostic_category( string $type ): string {
-		if ( str_contains( $type, 'svg' ) ) {
-			return 'svg';
-		}
-		if ( str_contains( $type, 'asset' ) || str_contains( $type, 'image' ) ) {
-			return 'asset';
-		}
-		if ( str_contains( $type, 'runtime_dependency' ) || str_contains( $type, 'dom_target' ) ) {
-			return 'runtime_dependency_parity';
-		}
-		if ( str_contains( $type, 'core_html' ) || str_contains( $type, 'freeform' ) || str_contains( $type, 'fallback' ) ) {
-			return 'fallback_block';
-		}
-		if ( str_contains( $type, 'button' ) || str_contains( $type, 'style' ) || str_contains( $type, 'presentation' ) ) {
-			return 'style_loss_hint';
-		}
-
-		return 'import_quality';
-	}
-
-	/**
-	 * Default diagnostic severity.
-	 *
-	 * @param string $type Diagnostic type.
-	 * @return string
-	 */
-	private static function default_diagnostic_severity( string $type ): string {
-		return str_contains( $type, 'missing' ) || str_contains( $type, 'invalid' ) || str_contains( $type, 'error' ) ? 'error' : 'warning';
 	}
 
 	/**

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -277,7 +277,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 		);
 		foreach ( $diagnostics as $diagnostic ) {
 			foreach ( array( 'severity', 'category', 'type', 'parser_owner', 'repair_bucket' ) as $field ) {
-				$value                         = isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) ? (string) $diagnostic[ $field ] : 'unknown';
+				$value                       = isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) ? (string) $diagnostic[ $field ] : 'unknown';
 				$summary[ $field ][ $value ] = ( $summary[ $field ][ $value ] ?? 0 ) + 1;
 			}
 		}
@@ -295,7 +295,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 	private static function diagnostics_by_field( array $diagnostics, string $field ): array {
 		$grouped = array();
 		foreach ( $diagnostics as $diagnostic ) {
-			$key             = isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) ? (string) $diagnostic[ $field ] : 'uncategorized';
+			$key               = isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) ? (string) $diagnostic[ $field ] : 'uncategorized';
 			$grouped[ $key ][] = $diagnostic;
 		}
 
@@ -355,7 +355,19 @@ class Static_Site_Importer_Diagnostic_Contract {
 		$values = array_values( $buckets );
 		usort(
 			$values,
-			static fn ( array $left, array $right ): int => ( $right['count'] <=> $left['count'] ) ?: strcmp( (string) $left['parser_owner'], (string) $right['parser_owner'] ) ?: strcmp( (string) $left['repair_bucket'], (string) $right['repair_bucket'] )
+			static function ( array $left, array $right ): int {
+				$count_compare = $right['count'] <=> $left['count'];
+				if ( 0 !== $count_compare ) {
+					return $count_compare;
+				}
+
+				$owner_compare = strcmp( (string) $left['parser_owner'], (string) $right['parser_owner'] );
+				if ( 0 !== $owner_compare ) {
+					return $owner_compare;
+				}
+
+				return strcmp( (string) $left['repair_bucket'], (string) $right['repair_bucket'] );
+			}
 		);
 
 		return $values;
@@ -544,13 +556,13 @@ class Static_Site_Importer_Diagnostic_Contract {
 	 */
 	private static function repair_mode( string $repair_bucket ): string {
 		$modes = array(
-			'button_style_loss'         => 'transformer-style-parity',
-			'broken_svg'                => 'svg-transformer-parity',
-			'dropped_images'            => 'asset-materialization',
-			'invalid_block_content'     => 'block-validation-parity',
-			'runtime_target_gap'        => 'runtime-dom-target-parity',
-			'semantic_parity'           => 'semantic-parity',
-			'fallback_block'            => 'fallback-block-replacement',
+			'button_style_loss'          => 'transformer-style-parity',
+			'broken_svg'                 => 'svg-transformer-parity',
+			'dropped_images'             => 'asset-materialization',
+			'invalid_block_content'      => 'block-validation-parity',
+			'runtime_target_gap'         => 'runtime-dom-target-parity',
+			'semantic_parity'            => 'semantic-parity',
+			'fallback_block'             => 'fallback-block-replacement',
 			'static_site_import_quality' => 'import-validation',
 		);
 

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -69,15 +69,15 @@ class Static_Site_Importer_Page_Materializer {
 			$type     = self::page_post_type( $page );
 			$existing = get_page_by_path( $slug, OBJECT, $type );
 			$row      = array(
-				'source_path'       => $page->source_key(),
-				'target_type'       => 'wordpress_post',
-				'post_type'         => $type,
-				'slug'              => $slug,
-				'title'             => self::page_title( $filename, $page ),
-				'status'            => self::page_status( $page ),
-				'existing_post_id'  => 0,
-				'existing_status'   => '',
-				'protected'         => false,
+				'source_path'          => $page->source_key(),
+				'target_type'          => 'wordpress_post',
+				'post_type'            => $type,
+				'slug'                 => $slug,
+				'title'                => self::page_title( $filename, $page ),
+				'status'               => self::page_status( $page ),
+				'existing_post_id'     => 0,
+				'existing_status'      => '',
+				'protected'            => false,
 				'materialized_post_id' => 0,
 			);
 
@@ -174,7 +174,7 @@ class Static_Site_Importer_Page_Materializer {
 				continue;
 			}
 
-			$target     = isset( $page_targets[ $filename ] ) && is_array( $page_targets[ $filename ] ) ? $page_targets[ $filename ] : array();
+			$target     = $page_targets[ $filename ] ?? array();
 			$provenance = array(
 				'schema'        => 'static-site-importer/page-provenance/v1',
 				'import_run_id' => (string) ( $manifest['import_run_id'] ?? '' ),

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -378,7 +378,7 @@ class Static_Site_Importer_Theme_Generator {
 			return $cleanup;
 		}
 
-		$previous_manifest_json = file_get_contents( $previous_manifest_path );
+		$previous_manifest_json = file_get_contents( $previous_manifest_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads an importer-owned local manifest file.
 		if ( false === $previous_manifest_json ) {
 			return new WP_Error( 'static_site_importer_previous_manifest_read_failed', 'Failed to read the previous Static Site Importer manifest.' );
 		}
@@ -425,7 +425,7 @@ class Static_Site_Importer_Theme_Generator {
 				continue;
 			}
 
-			if ( ! unlink( $path ) ) {
+			if ( ! wp_delete_file( $path ) ) {
 				return new WP_Error( 'static_site_importer_stale_generated_file_delete_failed', sprintf( 'Failed to delete stale generated theme file: %s', $relative ) );
 			}
 
@@ -1530,7 +1530,11 @@ class Static_Site_Importer_Theme_Generator {
 		$provenance = isset( $compiled['provenance'] ) && is_array( $compiled['provenance'] ) ? $compiled['provenance'] : array();
 		$input      = isset( $compiled['input'] ) && is_array( $compiled['input'] ) ? $compiled['input'] : array();
 
-		foreach ( array( 'id' => array( 'artifact_id', 'id', 'run_id' ), 'hash' => array( 'artifact_hash', 'hash', 'sha256' ), 'hash_algo' => array( 'artifact_hash_algo', 'hash_algo' ) ) as $target => $keys ) {
+		foreach ( array(
+			'id'        => array( 'artifact_id', 'id', 'run_id' ),
+			'hash'      => array( 'artifact_hash', 'hash', 'sha256' ),
+			'hash_algo' => array( 'artifact_hash_algo', 'hash_algo' ),
+		) as $target => $keys ) {
 			if ( isset( $reference[ $target ] ) && is_scalar( $reference[ $target ] ) && '' !== trim( (string) $reference[ $target ] ) ) {
 				continue;
 			}

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -117,7 +117,7 @@ class Static_Site_Importer_Theme_Materializer {
 				continue;
 			}
 
-			$relative = self::normalize_artifact_materialization_path( isset( $file['path'] ) ? (string) $file['path'] : '' );
+			$relative  = self::normalize_artifact_materialization_path( isset( $file['path'] ) ? (string) $file['path'] : '' );
 			$retention = self::source_retention_policy( $file, $relative, 'website_artifact:files' );
 			if ( '' === $relative ) {
 				$diagnostics[] = array(
@@ -163,13 +163,13 @@ class Static_Site_Importer_Theme_Materializer {
 			}
 
 			$assets[ $relative ] = array(
-				'source'     => $relative,
-				'path'       => $relative,
-				'url'        => trailingslashit( $theme_uri ) . $target_relative,
-				'final_url'  => trailingslashit( $theme_uri ) . $target_relative,
-				'mime_type'  => self::mime_type( $target ),
-				'theme_path' => $target_relative,
-				'policy'     => 'theme',
+				'source'           => $relative,
+				'path'             => $relative,
+				'url'              => trailingslashit( $theme_uri ) . $target_relative,
+				'final_url'        => trailingslashit( $theme_uri ) . $target_relative,
+				'mime_type'        => self::mime_type( $target ),
+				'theme_path'       => $target_relative,
+				'policy'           => 'theme',
 				'source_role'      => $retention['source_role'],
 				'keep_source'      => $retention['keep_source'],
 				'deletion_allowed' => $retention['deletion_allowed'],
@@ -221,7 +221,7 @@ class Static_Site_Importer_Theme_Materializer {
 				return new WP_Error( 'static_site_importer_materialization_plan_asset_invalid', 'Blocks Engine materialization_plan.assets entries must be arrays.' );
 			}
 
-			$relative = self::normalize_artifact_materialization_path( isset( $asset['path'] ) && is_scalar( $asset['path'] ) ? (string) $asset['path'] : '' );
+			$relative  = self::normalize_artifact_materialization_path( isset( $asset['path'] ) && is_scalar( $asset['path'] ) ? (string) $asset['path'] : '' );
 			$retention = self::source_retention_policy( $asset, $relative, 'materialization_plan.assets' );
 			if ( '' === $relative ) {
 				return new WP_Error( 'static_site_importer_materialization_plan_asset_path_invalid', 'Blocks Engine materialization_plan.assets entries must include safe relative paths.' );
@@ -381,16 +381,16 @@ class Static_Site_Importer_Theme_Materializer {
 		if ( empty( $retention ) ) {
 			$retention = self::source_retention_policy( $asset, $relative, $origin );
 		}
-		$report    = array(
-			'source'     => $relative,
-			'path'       => $relative,
-			'url'        => $url,
-			'final_url'  => $url,
-			'mime_type'  => $mime_type,
-			'theme_path' => $target_relative,
-			'policy'     => 'theme',
-			'origin'     => $origin,
-			'order'      => $order,
+		$report = array(
+			'source'           => $relative,
+			'path'             => $relative,
+			'url'              => $url,
+			'final_url'        => $url,
+			'mime_type'        => $mime_type,
+			'theme_path'       => $target_relative,
+			'policy'           => 'theme',
+			'origin'           => $origin,
+			'order'            => $order,
 			'source_role'      => $retention['source_role'],
 			'keep_source'      => $retention['keep_source'],
 			'deletion_allowed' => $retention['deletion_allowed'],


### PR DESCRIPTION
## Summary
- Remove obsolete duplicate Codebox diagnostic helpers now delegated to Static_Site_Importer_Diagnostic_Contract.
- Apply PHPCS formatting fixes from the release gate.
- Resolve PHPStan findings without suppressing dead-code diagnostics.

## Verification
- php -l includes/class-static-site-importer-codebox-validation.php
- php -l includes/class-static-site-importer-diagnostic-contract.php
- php -l includes/class-static-site-importer-page-materializer.php
- php -l includes/class-static-site-importer-theme-generator.php
- php -l includes/class-static-site-importer-theme-materializer.php
- homeboy lint static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-single-upload-playground-flow
- php tests/smoke-codebox-validation-contract.php
- php tests/smoke-import-diagnostic-contract.php
- php tests/smoke-theme-materializer-dry-run.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosed release-gate failures, removed dead duplicate helpers, applied lint/PHPStan fixes, and ran targeted verification.