### PR TITLE
Propagate Figma transform diagnostics

### DIFF
--- a/includes/class-static-site-importer-figma-import.php
+++ b/includes/class-static-site-importer-figma-import.php
@@ -56,7 +56,13 @@ class Static_Site_Importer_Figma_Import {
 		if ( ! empty( $validation_artifacts ) ) {
 			$import_input['validation_artifacts'] = $validation_artifacts;
 		}
-		return static_site_importer_ability_import_website_artifact( $import_input );
+		$result                  = static_site_importer_ability_import_website_artifact( $import_input );
+		$figma_transform_report = self::figma_transform_report_from_metadata( isset( $import_input['source_metadata'] ) && is_array( $import_input['source_metadata'] ) ? $import_input['source_metadata'] : array() );
+		if ( ! empty( $figma_transform_report ) ) {
+			$result['figma_transform_report'] = $figma_transform_report;
+		}
+
+		return $result;
 	}
 
 	/**
@@ -72,24 +78,17 @@ class Static_Site_Importer_Figma_Import {
 		}
 
 		$import_input = self::import_input( $input, $artifact );
-		$scenegraph   = self::scenegraph_from_input( $input );
 
-		$transform_diagnostics = array();
-		if ( ! empty( $scenegraph ) && function_exists( 'blocks_engine_figma_transformer_transform_scenegraph' ) ) {
-			$transform = blocks_engine_figma_transformer_transform_scenegraph( $scenegraph, self::transform_options( $input ) );
-			if ( is_object( $transform ) && is_callable( array( $transform, 'toArray' ) ) ) {
-				$transform = $transform->toArray();
-			}
-			if ( is_array( $transform ) ) {
-				$transform_diagnostics = $transform['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
-			}
-		}
+		$source_metadata        = isset( $import_input['source_metadata'] ) && is_array( $import_input['source_metadata'] ) ? $import_input['source_metadata'] : array();
+		$figma_transform_report = self::figma_transform_report_from_metadata( $source_metadata );
+		$transform_diagnostics  = self::transform_diagnostics_from_report( $figma_transform_report );
 
 		return array(
 			'schema'                  => 'static-site-importer/figma-diagnostics/v1',
 			'success'                 => true,
 			'request'                 => self::diagnostics_request_summary( $input ),
 			'artifact'                => self::diagnostics_artifact_summary( $artifact ),
+			'figma_transform_report'  => $figma_transform_report,
 			'transform_diagnostics'   => is_array( $transform_diagnostics ) ? $transform_diagnostics : array(),
 			'production_import_input' => array(
 				'slug'      => (string) ( $import_input['slug'] ?? '' ),
@@ -357,12 +356,40 @@ class Static_Site_Importer_Figma_Import {
 			return new WP_Error( 'static_site_importer_figma_transform_empty', self::empty_transform_message( $diagnostic ), $data );
 		}
 
+		$provenance = self::provenance( $input ) + array( 'transform' => 'blocks-engine/figma-transformer' );
+		$report     = self::figma_transform_report_from_transform( $transform );
+		if ( ! empty( $report ) ) {
+			$provenance['figma_transform_report'] = $report;
+		}
+
 		return array(
 			'schema'     => Static_Site_Importer_Transformer_Adapter::WEBSITE_ARTIFACT_SCHEMA,
 			'root'       => 'website',
 			'entrypoint' => self::entrypoint( 'website/index.html', $files ),
 			'files'      => $files,
-			'provenance' => self::provenance( $input ) + array( 'transform' => 'blocks-engine/figma-transformer' ),
+			'provenance' => $provenance,
+		);
+	}
+
+	/**
+	 * Extract durable Figma transform diagnostics from a Blocks Engine result.
+	 *
+	 * @param array<string,mixed> $transform Blocks Engine Figma transform result.
+	 * @return array<string,mixed>
+	 */
+	private static function figma_transform_report_from_transform( array $transform ): array {
+		$source_reports = isset( $transform['source_reports'] ) && is_array( $transform['source_reports'] ) ? $transform['source_reports'] : array();
+		$figma_report   = isset( $source_reports['figma'] ) && is_array( $source_reports['figma'] ) ? $source_reports['figma'] : array();
+		if ( empty( $figma_report ) ) {
+			return array();
+		}
+
+		return array(
+			'schema'         => 'static-site-importer/figma-transform-report/v1',
+			'source'         => 'blocks-engine/figma-transformer',
+			'source_reports' => array(
+				'figma' => $figma_report,
+			),
 		);
 	}
 
@@ -419,6 +446,30 @@ class Static_Site_Importer_Figma_Import {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Read the durable Figma transform report from generic SSI metadata.
+	 *
+	 * @param array<string,mixed> $metadata SSI source metadata/provenance.
+	 * @return array<string,mixed>
+	 */
+	private static function figma_transform_report_from_metadata( array $metadata ): array {
+		$report = isset( $metadata['figma_transform_report'] ) && is_array( $metadata['figma_transform_report'] ) ? $metadata['figma_transform_report'] : array();
+
+		return $report;
+	}
+
+	/**
+	 * Extract the existing compact diagnostics bucket from the transform report.
+	 *
+	 * @param array<string,mixed> $report Durable Figma transform report.
+	 * @return array<string,mixed>
+	 */
+	private static function transform_diagnostics_from_report( array $report ): array {
+		$diagnostics = $report['source_reports']['figma']['html']['transform_diagnostics'] ?? array();
+
+		return is_array( $diagnostics ) ? $diagnostics : array();
 	}
 
 	/**
@@ -611,6 +662,8 @@ class Static_Site_Importer_Figma_Import {
 	public static function import_input( array $input, array $artifact ): array {
 		$title = self::display_title( $input, $artifact );
 
+		$source_metadata = isset( $artifact['provenance'] ) && is_array( $artifact['provenance'] ) ? $artifact['provenance'] : self::provenance( $input );
+
 		return array(
 			'artifact'                  => $artifact,
 			'slug'                      => isset( $input['slug'] ) ? (string) $input['slug'] : '',
@@ -621,7 +674,7 @@ class Static_Site_Importer_Figma_Import {
 			'fail_on_quality'           => ! empty( $input['fail_on_quality'] ),
 			'allow_missing_woocommerce' => ! empty( $input['allow_missing_woocommerce'] ),
 			'compiler_options'          => isset( $input['compiler_options'] ) && is_array( $input['compiler_options'] ) ? $input['compiler_options'] : array(),
-			'source_metadata'           => self::provenance( $input ),
+			'source_metadata'           => $source_metadata,
 		);
 	}
 

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -957,45 +957,55 @@ $assert( str_contains( (string) $figma_blueprint_code, "'name' => 'Fisiostetic'"
 $assert( str_contains( (string) $figma_blueprint_code, "'site_title' => 'Fisiostetic'" ), 'figma-import-site-title-derived-from-metadata' );
 $assert( str_contains( (string) $figma_blueprint_code, "'source' => 'figma-to-wordpress'" ), 'figma-artifact-provenance-source' );
 
-$figma_diagnostics = Static_Site_Importer_Figma_Import::diagnostics_report(
-	array(
-		'schema'     => 'figma-to-wordpress/runner-request/v1',
-		'source'     => array(
-			'fileKey' => 'fixture-file-key',
-			'nodeIds' => array( '1:1' ),
-		),
-		'slug'       => 'figma-diagnostics',
-		'name'       => 'Figma Diagnostics',
-		'scenegraph' => array(
-			'name'  => 'Diagnostics Fixture',
-			'nodes' => array(
-				array(
-					'id'       => '1:1',
-					'type'     => 'FRAME',
-					'name'     => 'Landing Page',
-					'width'    => 640,
-					'height'   => 360,
-					'children' => array(
-						array(
-							'id'       => '1:2',
-							'type'     => 'TEXT',
-							'name'     => 'Heading',
-							'text'     => 'Hello diagnostics',
-							'fontSize' => 32,
-						),
+$figma_diagnostics_input = array(
+	'schema'     => 'figma-to-wordpress/runner-request/v1',
+	'source'     => array(
+		'fileKey' => 'fixture-file-key',
+		'nodeIds' => array( '1:1' ),
+	),
+	'slug'       => 'figma-diagnostics',
+	'name'       => 'Figma Diagnostics',
+	'scenegraph' => array(
+		'name'  => 'Diagnostics Fixture',
+		'nodes' => array(
+			array(
+				'id'       => '1:1',
+				'type'     => 'FRAME',
+				'name'     => 'Landing Page',
+				'width'    => 640,
+				'height'   => 360,
+				'children' => array(
+					array(
+						'id'       => '1:2',
+						'type'     => 'TEXT',
+						'name'     => 'Heading',
+						'text'     => 'Hello diagnostics',
+						'fontSize' => 32,
 					),
 				),
 			),
 		),
-	)
+	),
+);
+$figma_diagnostics       = Static_Site_Importer_Figma_Import::diagnostics_report(
+	$figma_diagnostics_input
 );
 $assert( is_array( $figma_diagnostics ), 'figma-diagnostics-builds-report' );
 $assert( true === ( $figma_diagnostics['success'] ?? null ), 'figma-diagnostics-succeeds' );
 $assert( 'static-site-importer/figma-diagnostics/v1' === ( $figma_diagnostics['schema'] ?? '' ), 'figma-diagnostics-uses-schema' );
 $assert( true === ( $figma_diagnostics['request']['has_scenegraph'] ?? null ), 'figma-diagnostics-summarizes-scenegraph-request' );
 $assert( 'website/index.html' === ( $figma_diagnostics['artifact']['entrypoint'] ?? '' ), 'figma-diagnostics-summarizes-artifact-entrypoint' );
+$assert( 'static-site-importer/figma-transform-report/v1' === ( $figma_diagnostics['figma_transform_report']['schema'] ?? '' ), 'figma-diagnostics-exposes-durable-transform-report' );
 $assert( isset( $figma_diagnostics['transform_diagnostics']['diagnostic_codes'] ), 'figma-diagnostics-exposes-transform-diagnostics' );
 $assert( 'figma-diagnostics' === ( $figma_diagnostics['production_import_input']['slug'] ?? '' ), 'figma-diagnostics-summarizes-production-import-input' );
+
+Static_Site_Importer_Theme_Generator::$last_artifact = array();
+Static_Site_Importer_Theme_Generator::$last_args     = array();
+$figma_import_result = Static_Site_Importer_Figma_Import::import( $figma_diagnostics_input );
+$assert( true === ( $figma_import_result['success'] ?? null ), 'figma-import-scenegraph-succeeds' );
+$assert( 'static-site-importer/figma-transform-report/v1' === ( $figma_import_result['figma_transform_report']['schema'] ?? '' ), 'figma-import-result-exposes-durable-transform-report' );
+$assert( 'static-site-importer/figma-transform-report/v1' === ( Static_Site_Importer_Theme_Generator::$last_artifact['provenance']['figma_transform_report']['schema'] ?? '' ), 'figma-artifact-provenance-preserves-transform-report' );
+$assert( 'static-site-importer/figma-transform-report/v1' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['figma_transform_report']['schema'] ?? '' ), 'figma-import-source-metadata-preserves-transform-report' );
 
 if ( class_exists( 'ZipArchive' ) ) {
 	$zip_path = tempnam( sys_get_temp_dir(), 'ssi-test-' );


### PR DESCRIPTION
## Summary
- Captures Blocks Engine Figma transform reports as generic SSI metadata.
- Propagates the Figma transform report through artifact provenance, import source metadata, import results, and diagnostics reports.
- Keeps the Figma import contract generic: no Studio-specific schema handling.
- Expands smoke coverage for diagnostics propagation through the Figma adapter path.

## Testing
- `php -l includes/class-static-site-importer-figma-import.php`
- `php -l tests/smoke-importer-block.php`
- `php tests/smoke-importer-block.php`
- `php tests/smoke-transformer-adapter.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the Figma adapter diagnostics flow, implementing generic diagnostics propagation, resolving the branch refresh conflict, updating smoke tests, and running verification.
