### PR TITLE
Add block Figma upload path

### DIFF
--- a/blocks/importer/editor.js
+++ b/blocks/importer/editor.js
@@ -16,7 +16,7 @@
 				{ className: 'ssi-importer ssi-importer--editor' },
 				el( 'p', { className: 'ssi-importer__eyebrow' }, 'Static Site Importer' ),
 				el( 'h2', { className: 'ssi-importer__title' }, 'Bring a site into WordPress' ),
-				el( 'p', { className: 'ssi-importer__copy' }, 'Visitors upload a static site, ZIP, folder, or paste HTML. The block imports through Static Site Importer.' ),
+				el( 'p', { className: 'ssi-importer__copy' }, 'Visitors upload a static site, ZIP, folder, Figma file, or paste HTML. The block imports through Static Site Importer.' ),
 				components && components.Notice
 					? el( components.Notice, { status: 'info', isDismissible: false }, 'URL imports use the generic Static Site Importer provider hook before falling back to the built-in public URL fetcher.' )
 					: null,

--- a/blocks/importer/editor.js
+++ b/blocks/importer/editor.js
@@ -16,7 +16,7 @@
 				{ className: 'ssi-importer ssi-importer--editor' },
 				el( 'p', { className: 'ssi-importer__eyebrow' }, 'Static Site Importer' ),
 				el( 'h2', { className: 'ssi-importer__title' }, 'Bring a site into WordPress' ),
-				el( 'p', { className: 'ssi-importer__copy' }, 'Visitors upload a static site, ZIP, or Figma export, or paste HTML. The block imports through Static Site Importer.' ),
+				el( 'p', { className: 'ssi-importer__copy' }, 'Visitors upload a static site, ZIP, folder, or paste HTML. The block imports through Static Site Importer.' ),
 				components && components.Notice
 					? el( components.Notice, { status: 'info', isDismissible: false }, 'URL imports use the generic Static Site Importer provider hook before falling back to the built-in public URL fetcher.' )
 					: null,

--- a/blocks/importer/style.css
+++ b/blocks/importer/style.css
@@ -82,13 +82,14 @@
 }
 
 .ssi-importer__upload-row {
-	display: grid;
-	grid-template-columns: minmax(0, 1fr) auto;
+	display: flex;
+	flex-wrap: wrap;
 	gap: 10px;
 	align-items: center;
 }
 
 .ssi-importer__upload-button {
+	min-width: 96px;
 	border: 0;
 	border-radius: 999px;
 	padding: 10px 16px;
@@ -119,6 +120,10 @@
 	display: none;
 }
 
+.ssi-importer__report p {
+	margin: 0;
+}
+
 .ssi-importer__field textarea {
 	min-height: 128px;
 	resize: vertical;
@@ -145,7 +150,7 @@
 		width: auto;
 	}
 
-	.ssi-importer__upload-row {
-		grid-template-columns: 1fr;
+	.ssi-importer__upload-button {
+		flex: 1 1 100%;
 	}
 }

--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -128,7 +128,7 @@
 		const selectedFiles = selectedInputFiles( inputs, root );
 		const files = selectedFiles.filter( function ( record ) {
 			const path = record.path || uploadedFilePath( record.file );
-			return ! /\.(fig|zip)$/i.test( record.file.name || path || '' ) && shouldIncludeSiteFile( path );
+			return ! /\.zip$/i.test( record.file.name || path || '' ) && shouldIncludeSiteFile( path );
 		} );
 		return Promise.all( files.map( async function ( upload ) {
 			const file = upload.file;
@@ -164,24 +164,6 @@
 			path: archive.path || file.name || 'website.zip',
 			name: file.name || 'website.zip',
 			type: file.type || 'application/zip',
-			size: file.size || 0,
-			content_base64: await fileToBase64( file ),
-		};
-	};
-
-	const buildFigmaFile = async function ( inputs, root ) {
-		const selectedFiles = selectedInputFiles( inputs, root );
-		const upload = selectedFiles.find( function ( record ) {
-			return /\.fig$/i.test( record.file.name || record.path || '' );
-		} );
-		if ( ! upload ) {
-			return null;
-		}
-		const file = upload.file;
-
-		return {
-			name: file.name || 'design.fig',
-			type: file.type || 'application/octet-stream',
 			size: file.size || 0,
 			content_base64: await fileToBase64( file ),
 		};
@@ -256,7 +238,6 @@
 		return Boolean(
 			( source.files && source.files.length > 0 ) ||
 			( source.archive && source.archive.content_base64 ) ||
-			( source.figma_file && source.figma_file.content_base64 ) ||
 			( source.html && source.html.trim() ) ||
 			( source.url && source.url.trim() )
 		);
@@ -329,7 +310,6 @@
 				html: html ? html.value : '',
 				files: await buildFiles( uploadInputs, root ),
 				archive: await buildArchive( uploadInputs, root ),
-				figma_file: await buildFigmaFile( uploadInputs, root ),
 			};
 
 			if ( ! hasSource( source ) ) {

--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -188,6 +188,7 @@
 			status.hidden = false;
 		}
 		if ( progress ) {
+			progress.hidden = false;
 			progress.textContent = message;
 		}
 	};
@@ -268,30 +269,87 @@
 		} );
 	};
 
-	const bindUploadTrigger = function ( root ) {
-		const trigger = root.querySelector( '[data-static-site-importer-upload-trigger]' );
-		const sourceType = root.querySelector( '[data-static-site-importer-source-type]' );
-		if ( ! trigger || ! sourceType ) {
+	const clickInput = function ( root, triggerSelector, inputSelector ) {
+		const trigger = root.querySelector( triggerSelector );
+		const input = root.querySelector( inputSelector );
+		if ( ! trigger || ! input ) {
 			return;
 		}
 
 		trigger.addEventListener( 'click', function () {
-			const selector = sourceType.value === 'folder' ? '[data-static-site-importer-source-directory]' : '[data-static-site-importer-source-files]';
-			const input = root.querySelector( selector );
-			if ( input ) {
-				input.click();
-			}
+			input.click();
 		} );
+	};
+
+	const bindUploadTriggers = function ( root ) {
+		clickInput( root, '[data-static-site-importer-upload-files]', '[data-static-site-importer-source-files]' );
+		clickInput( root, '[data-static-site-importer-upload-folder]', '[data-static-site-importer-source-directory]' );
+		clickInput( root, '[data-static-site-importer-upload-figma]', '[data-static-site-importer-source-figma-file]' );
+	};
+
+	const submitFigmaFile = async function ( root, file ) {
+		const restUrl = root.getAttribute( 'data-static-site-importer-figma-rest-url' );
+		const nonce = root.getAttribute( 'data-static-site-importer-nonce' );
+		const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
+		const playgroundWindow = isCurrentSiteImport ? null : window.open( 'about:blank', '_blank', 'noopener,noreferrer' );
+		const formData = new FormData();
+		formData.append( 'figma_file', file );
+		formData.append( 'apply_to_current_site', isCurrentSiteImport ? '1' : '0' );
+		formData.append( 'activate', isCurrentSiteImport ? '1' : '0' );
+		formData.append( 'overwrite', isCurrentSiteImport ? '1' : '0' );
+
+		showStatus( root, isCurrentSiteImport ? 'Importing Figma file to this site...' : 'Preparing Figma file for WordPress Playground...' );
+
+		try {
+			const response = await fetch( restUrl, {
+				method: 'POST',
+				headers: {
+					'X-WP-Nonce': nonce,
+				},
+				body: formData,
+			} );
+			const report = await response.json();
+			setReport( root, report );
+			setPreviewLink( root, report );
+			if ( response.ok && isCurrentSiteImport && report.success ) {
+				showStatus( root, 'Figma import complete.' );
+			} else if ( response.ok && report.success && previewUrl( report ) ) {
+				openPreview( report, playgroundWindow );
+				showStatus( root, 'WordPress Playground opened.' );
+			} else {
+				if ( playgroundWindow ) {
+					playgroundWindow.close();
+				}
+				showStatus( root, response.ok ? 'Figma import request complete.' : 'Figma import request failed.' );
+			}
+		} catch ( error ) {
+			setReport( root, { success: false, error: { message: error.message } } );
+			setPreviewLink( root, null );
+			if ( playgroundWindow ) {
+				playgroundWindow.close();
+			}
+			showStatus( root, 'Figma import request failed.' );
+		}
 	};
 
 	roots.forEach( function ( root ) {
 		bindDropzone( root );
-		bindUploadTrigger( root );
+		bindUploadTriggers( root );
 		root.querySelectorAll( '[data-static-site-importer-source-files], [data-static-site-importer-source-directory]' ).forEach( function ( input ) {
 			input.addEventListener( 'change', function () {
 				setDroppedFiles( root, [] );
 			} );
 		} );
+
+		const figmaInput = root.querySelector( '[data-static-site-importer-source-figma-file]' );
+		if ( figmaInput ) {
+			figmaInput.addEventListener( 'change', function () {
+				const file = figmaInput.files && figmaInput.files.length ? figmaInput.files[ 0 ] : null;
+				if ( file ) {
+					submitFigmaFile( root, file );
+				}
+			} );
+		}
 
 		const submit = root.querySelector( '[data-static-site-importer-submit]' );
 		if ( ! submit ) {

--- a/includes/block.php
+++ b/includes/block.php
@@ -31,7 +31,7 @@ function static_site_importer_register_block(): void {
  */
 function static_site_importer_render_block( array $attributes = array() ): string {
 	$title       = isset( $attributes['title'] ) && '' !== trim( (string) $attributes['title'] ) ? (string) $attributes['title'] : __( 'Bring a site into WordPress.', 'static-site-importer' );
-	$intro       = isset( $attributes['intro'] ) && '' !== trim( (string) $attributes['intro'] ) ? (string) $attributes['intro'] : __( 'Upload a static site, ZIP, folder, or paste HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' );
+	$intro       = isset( $attributes['intro'] ) && '' !== trim( (string) $attributes['intro'] ) ? (string) $attributes['intro'] : __( 'Upload a static site, ZIP, folder, Figma file, or paste HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' );
 	$provider    = isset( $attributes['provider'] ) ? sanitize_key( (string) $attributes['provider'] ) : '';
 	$default_url = isset( $attributes['defaultUrl'] ) ? esc_url_raw( (string) $attributes['defaultUrl'] ) : '';
 	$apply       = ! empty( $attributes['applyToCurrentSite'] );
@@ -40,7 +40,7 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 
 	ob_start();
 	?>
-	<div class="ssi-importer" data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>" data-static-site-importer-apply-to-current-site="<?php echo $apply ? '1' : '0'; ?>" data-static-site-importer-open-in-playground="<?php echo $playground ? '1' : '0'; ?>">
+	<div class="ssi-importer" data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-figma-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/import-figma-file' ) ); ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>" data-static-site-importer-apply-to-current-site="<?php echo $apply ? '1' : '0'; ?>" data-static-site-importer-open-in-playground="<?php echo $playground ? '1' : '0'; ?>">
 		<section class="ssi-importer__panel" aria-labelledby="ssi-importer-title">
 			<p class="ssi-importer__eyebrow"><?php esc_html_e( 'Static Site Importer', 'static-site-importer' ); ?></p>
 			<h1 id="ssi-importer-title" class="ssi-importer__title"><?php echo esc_html( $title ); ?></h1>
@@ -54,14 +54,13 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 
 				<fieldset class="ssi-importer__field ssi-importer__upload-controls">
 					<legend class="ssi-importer__label"><?php esc_html_e( 'Choose website source', 'static-site-importer' ); ?></legend>
-					<div class="ssi-importer__upload-row">
-						<select class="ssi-importer__source-select" aria-label="<?php echo esc_attr( __( 'Source type', 'static-site-importer' ) ); ?>" data-static-site-importer-source-type>
-							<option value="files"><?php esc_html_e( 'Files or ZIP', 'static-site-importer' ); ?></option>
-							<option value="folder"><?php esc_html_e( 'Folder', 'static-site-importer' ); ?></option>
-						</select>
-						<button type="button" class="ssi-importer__upload-button" data-static-site-importer-upload-trigger><?php esc_html_e( 'Upload source', 'static-site-importer' ); ?></button>
+					<div class="ssi-importer__upload-row" role="group" aria-label="<?php echo esc_attr( __( 'Upload source type', 'static-site-importer' ) ); ?>">
+						<button type="button" class="ssi-importer__upload-button" data-static-site-importer-upload-files><?php esc_html_e( 'File(s)', 'static-site-importer' ); ?></button>
+						<button type="button" class="ssi-importer__upload-button" data-static-site-importer-upload-folder><?php esc_html_e( 'Folder', 'static-site-importer' ); ?></button>
+						<button type="button" class="ssi-importer__upload-button" data-static-site-importer-upload-figma><?php esc_html_e( 'Figma', 'static-site-importer' ); ?></button>
 						<input type="file" name="ssi_static_upload[]" accept=".zip,application/zip,.html,.htm,text/html,text/css,text/javascript,application/javascript,application/json,application/xml,text/xml,image/*,font/*" multiple hidden data-static-site-importer-source-files>
 						<input type="file" name="ssi_static_directory[]" multiple webkitdirectory hidden data-static-site-importer-source-directory>
+						<input type="file" name="ssi_figma_file" accept=".fig" hidden data-static-site-importer-source-figma-file>
 					</div>
 				</fieldset>
 
@@ -75,6 +74,7 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 		</section>
 
 		<section class="ssi-importer__report" aria-live="polite" hidden data-static-site-importer-status>
+			<p hidden data-static-site-importer-progress></p>
 			<p hidden data-static-site-importer-preview-link-wrap><a href="#" target="_blank" rel="noopener noreferrer" data-static-site-importer-preview-link><?php esc_html_e( 'Open WordPress preview', 'static-site-importer' ); ?></a></p>
 			<textarea rows="10" readonly hidden data-static-site-importer-report></textarea>
 		</section>

--- a/includes/block.php
+++ b/includes/block.php
@@ -31,7 +31,7 @@ function static_site_importer_register_block(): void {
  */
 function static_site_importer_render_block( array $attributes = array() ): string {
 	$title       = isset( $attributes['title'] ) && '' !== trim( (string) $attributes['title'] ) ? (string) $attributes['title'] : __( 'Bring a site into WordPress.', 'static-site-importer' );
-	$intro       = isset( $attributes['intro'] ) && '' !== trim( (string) $attributes['intro'] ) ? (string) $attributes['intro'] : __( 'Upload a static site, ZIP, or Figma export, or paste HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' );
+	$intro       = isset( $attributes['intro'] ) && '' !== trim( (string) $attributes['intro'] ) ? (string) $attributes['intro'] : __( 'Upload a static site, ZIP, folder, or paste HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' );
 	$provider    = isset( $attributes['provider'] ) ? sanitize_key( (string) $attributes['provider'] ) : '';
 	$default_url = isset( $attributes['defaultUrl'] ) ? esc_url_raw( (string) $attributes['defaultUrl'] ) : '';
 	$apply       = ! empty( $attributes['applyToCurrentSite'] );
@@ -49,18 +49,18 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 			<form class="ssi-importer__form" data-static-site-importer-form data-static-site-importer-default-url="<?php echo esc_attr( $default_url ); ?>">
 				<fieldset class="ssi-importer__field ssi-importer__dropzone" data-static-site-importer-dropzone>
 					<legend class="ssi-importer__label"><?php esc_html_e( 'Drop website source', 'static-site-importer' ); ?></legend>
-					<p class="ssi-importer__upload-copy"><?php esc_html_e( 'Drag a folder, ZIP, Figma export, or static site files here.', 'static-site-importer' ); ?></p>
+					<p class="ssi-importer__upload-copy"><?php esc_html_e( 'Drag a folder, ZIP, or static site files here.', 'static-site-importer' ); ?></p>
 				</fieldset>
 
 				<fieldset class="ssi-importer__field ssi-importer__upload-controls">
 					<legend class="ssi-importer__label"><?php esc_html_e( 'Choose website source', 'static-site-importer' ); ?></legend>
 					<div class="ssi-importer__upload-row">
 						<select class="ssi-importer__source-select" aria-label="<?php echo esc_attr( __( 'Source type', 'static-site-importer' ) ); ?>" data-static-site-importer-source-type>
-							<option value="files"><?php esc_html_e( 'Files, ZIP, or FIG', 'static-site-importer' ); ?></option>
+							<option value="files"><?php esc_html_e( 'Files or ZIP', 'static-site-importer' ); ?></option>
 							<option value="folder"><?php esc_html_e( 'Folder', 'static-site-importer' ); ?></option>
 						</select>
 						<button type="button" class="ssi-importer__upload-button" data-static-site-importer-upload-trigger><?php esc_html_e( 'Upload source', 'static-site-importer' ); ?></button>
-						<input type="file" name="ssi_static_upload[]" accept=".fig,.zip,application/zip,.html,.htm,text/html,text/css,text/javascript,application/javascript,application/json,application/xml,text/xml,image/*,font/*" multiple hidden data-static-site-importer-source-files>
+						<input type="file" name="ssi_static_upload[]" accept=".zip,application/zip,.html,.htm,text/html,text/css,text/javascript,application/javascript,application/json,application/xml,text/xml,image/*,font/*" multiple hidden data-static-site-importer-source-files>
 						<input type="file" name="ssi_static_directory[]" multiple webkitdirectory hidden data-static-site-importer-source-directory>
 					</div>
 				</fieldset>

--- a/includes/class-static-site-importer-figma-import.php
+++ b/includes/class-static-site-importer-figma-import.php
@@ -244,6 +244,18 @@ class Static_Site_Importer_Figma_Import {
 	}
 
 	/**
+	 * Transform a server-side uploaded .fig temp file into a website artifact.
+	 *
+	 * @param string              $path  Uploaded temp file path.
+	 * @param string              $name  Original uploaded file name.
+	 * @param array<string,mixed> $input Full request input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function website_artifact_from_figma_upload( string $path, string $name, array $input ) {
+		return self::website_artifact_from_figma_file_path( $path, $name, $input );
+	}
+
+	/**
 	 * Convert the current Figma plugin artifact bundle into a website artifact.
 	 *
 	 * @param array<string,mixed> $bundle Figma plugin artifact bundle.
@@ -290,14 +302,7 @@ class Static_Site_Importer_Figma_Import {
 	 * @return array<string,mixed>|WP_Error
 	 */
 	private static function website_artifact_from_figma_file( array $figma_file, array $input ) {
-		if ( ! function_exists( 'blocks_engine_figma_transformer_transform_file' ) ) {
-			return new WP_Error( 'static_site_importer_figma_transformer_unavailable', 'Blocks Engine Figma transformer is not available.', array( 'status' => 501 ) );
-		}
-
 		$name = isset( $figma_file['name'] ) ? (string) $figma_file['name'] : '';
-		if ( ! preg_match( '/\.fig$/i', $name ) ) {
-			return new WP_Error( 'static_site_importer_figma_file_type_invalid', 'Figma file uploads must use a .fig file.', array( 'status' => 400 ) );
-		}
 
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes uploaded .fig payload content.
 		$content = isset( $figma_file['content_base64'] ) ? base64_decode( (string) $figma_file['content_base64'], true ) : false;
@@ -312,12 +317,36 @@ class Static_Site_Importer_Figma_Import {
 		}
 
 		try {
-			$transform = blocks_engine_figma_transformer_transform_file( $tmp, self::transform_options( $input ) );
+			return self::website_artifact_from_figma_file_path( $tmp, $name, $input );
 		} finally {
 			if ( file_exists( $tmp ) ) {
 				wp_delete_file( $tmp );
 			}
 		}
+	}
+
+	/**
+	 * Transform a local .fig file path into a website artifact.
+	 *
+	 * @param string              $path  Local .fig file path.
+	 * @param string              $name  Original file name.
+	 * @param array<string,mixed> $input Full request input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function website_artifact_from_figma_file_path( string $path, string $name, array $input ) {
+		if ( ! function_exists( 'blocks_engine_figma_transformer_transform_file' ) ) {
+			return new WP_Error( 'static_site_importer_figma_transformer_unavailable', 'Blocks Engine Figma transformer is not available.', array( 'status' => 501 ) );
+		}
+
+		if ( ! preg_match( '/\.fig$/i', $name ) ) {
+			return new WP_Error( 'static_site_importer_figma_file_type_invalid', 'Figma file uploads must use a .fig file.', array( 'status' => 400 ) );
+		}
+
+		if ( '' === $path || ! is_readable( $path ) ) {
+			return new WP_Error( 'static_site_importer_figma_file_unreadable', 'Uploaded .fig file could not be read.', array( 'status' => 400 ) );
+		}
+
+		$transform = blocks_engine_figma_transformer_transform_file( $path, self::transform_options( $input ) );
 
 		return self::website_artifact_from_transform( $transform, $input );
 	}

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -41,6 +41,16 @@ function static_site_importer_register_rest_routes(): void {
 			),
 		)
 	);
+
+	register_rest_route(
+		'static-site-importer/v1',
+		'/import-figma-file',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'static_site_importer_rest_import_figma_file',
+			'permission_callback' => 'static_site_importer_rest_manage_permission',
+		)
+	);
 }
 
 /**
@@ -116,6 +126,60 @@ function static_site_importer_rest_import_figma( WP_REST_Request $request ) {
  */
 function static_site_importer_rest_create_figma_playground_preview( array $artifact, array $input ) {
 	return static_site_importer_rest_create_playground_open( $artifact, $input, 'figma' );
+}
+
+/**
+ * Import a multipart .fig upload from the block UI.
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return WP_REST_Response|WP_Error
+ */
+function static_site_importer_rest_import_figma_file( WP_REST_Request $request ) {
+	$files = $request->get_file_params();
+	$file  = isset( $files['figma_file'] ) && is_array( $files['figma_file'] ) ? $files['figma_file'] : array();
+	$name  = isset( $file['name'] ) ? (string) $file['name'] : '';
+	$tmp   = isset( $file['tmp_name'] ) ? (string) $file['tmp_name'] : '';
+
+	if ( '' === $name || '' === $tmp || ! empty( $file['error'] ) ) {
+		return new WP_Error( 'static_site_importer_figma_file_missing', __( 'Upload a Figma .fig file to start.', 'static-site-importer' ), array( 'status' => 400 ) );
+	}
+
+	$input = static_site_importer_rest_import_args( $request->get_params() );
+	if ( empty( $input['slug'] ) ) {
+		$input['slug'] = sanitize_title( preg_replace( '/\.fig$/i', '', $name ) );
+	}
+	if ( empty( $input['name'] ) ) {
+		$input['name'] = preg_replace( '/\.fig$/i', '', $name );
+	}
+
+	$artifact = Static_Site_Importer_Figma_Import::website_artifact_from_figma_upload( $tmp, $name, $input );
+	if ( is_wp_error( $artifact ) ) {
+		return $artifact;
+	}
+
+	$input['artifact'] = $artifact;
+
+	if ( static_site_importer_rest_should_apply_to_current_site( $request->get_params() ) ) {
+		$input['activate']  = ! empty( $request->get_param( 'activate' ) );
+		$input['overwrite'] = ! empty( $request->get_param( 'overwrite' ) );
+		$result             = static_site_importer_rest_execute_import_ability( 'static-site-importer/import-website-artifact', $input, 'static_site_importer_ability_import_website_artifact' );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	$input['activate']  = true;
+	$input['overwrite'] = true;
+	$result             = static_site_importer_rest_create_playground_open( $artifact, $input, 'figma_file' );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	$result['mode'] = 'playground';
+
+	return rest_ensure_response( $result );
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -481,14 +481,15 @@ $assert( ! str_contains( $html, 'data-static-site-importer-source-url' ), 'rende
 $assert( str_contains( $html, 'data-static-site-importer-default-url="https://example.com/source"' ), 'render-preserves-default-url-for-programmatic-use' );
 $assert( str_contains( $html, 'data-static-site-importer-source-files' ), 'render-has-file-input-hook' );
 $assert( str_contains( $html, 'Drop website source' ), 'render-has-decoupled-dropzone-label' );
-$assert( str_contains( $html, 'Drag a folder, ZIP, Figma export, or static site files here.' ), 'render-has-upload-dropzone-copy' );
+$assert( str_contains( $html, 'Drag a folder, ZIP, or static site files here.' ), 'render-has-upload-dropzone-copy' );
 $assert( str_contains( $html, 'data-static-site-importer-dropzone' ), 'render-has-upload-dropzone-hook' );
 $assert( str_contains( $html, 'Choose website source' ), 'render-has-decoupled-source-picker-label' );
 $assert( str_contains( $html, 'data-static-site-importer-source-type' ), 'render-has-source-type-dropdown-hook' );
 $assert( str_contains( $html, '<select' ), 'render-has-source-type-dropdown' );
 $assert( str_contains( $html, 'data-static-site-importer-upload-trigger' ), 'render-has-single-upload-trigger-hook' );
 $assert( str_contains( $html, 'Upload source' ), 'render-has-single-visible-upload-affordance' );
-$assert( str_contains( $html, 'Files, ZIP, or FIG' ), 'render-preserves-file-zip-fig-upload-choice' );
+$assert( str_contains( $html, 'Files or ZIP' ), 'render-preserves-file-zip-upload-choice' );
+$assert( ! str_contains( $html, 'FIG' ), 'render-omits-fig-upload-choice' );
 $assert( str_contains( $html, 'Folder' ), 'render-preserves-folder-upload-choice' );
 $assert( str_contains( $html, 'data-static-site-importer-source-directory' ), 'render-preserves-directory-upload-hook' );
 $assert( str_contains( $html, 'webkitdirectory' ), 'render-preserves-directory-picker' );
@@ -498,7 +499,7 @@ $assert( ! str_contains( $html, '<details class="ssi-importer__upload-picker"' )
 $assert( ! str_contains( $html, '<summary class="ssi-importer__upload-button"' ), 'render-omits-upload-summary-button' );
 $assert( ! str_contains( $html, 'Upload Figma file' ), 'render-omits-separate-figma-upload-label' );
 $assert( ! str_contains( $html, 'data-static-site-importer-source-figma-file' ), 'render-omits-separate-figma-upload-hook' );
-$assert( str_contains( $html, 'accept=&quot;.fig,.zip,application/zip' ) || str_contains( $html, 'accept=".fig,.zip,application/zip' ), 'render-figma-upload-accepts-fig-in-combined-upload' );
+$assert( ! str_contains( $html, '.fig' ), 'render-omits-fig-from-combined-upload-accept' );
 $assert( ! str_contains( $html, 'data-static-site-importer-source-archive' ), 'render-omits-separate-zip-upload-hook' );
 $assert( str_contains( $html, '.zip,application/zip' ), 'render-accepts-zip-in-combined-upload' );
 $assert( str_contains( $html, 'data-static-site-importer-source-html' ), 'render-has-html-input-hook' );
@@ -526,8 +527,9 @@ $assert( str_contains( $view_js, "sourceType.value === 'folder'" ), 'view-routes
 $assert( str_contains( $view_js, 'input.click()' ), 'view-opens-selected-hidden-input' );
 $assert( str_contains( $view_js, 'webkitGetAsEntry' ), 'view-supports-dropped-directory-entries' );
 $assert( str_contains( $view_js, 'archive: await buildArchive( uploadInputs, root )' ), 'view-sends-zip-from-combined-upload-as-archive-payload' );
-$assert( str_contains( $view_js, 'figma_file: await buildFigmaFile( uploadInputs, root )' ), 'view-sends-distinct-figma-source-shape-from-combined-upload' );
-$assert( str_contains( $view_js, '/\\.(fig|zip)$/i' ), 'view-excludes-fig-files-from-generic-static-upload' );
+$assert( ! str_contains( $view_js, 'figma_file' ), 'view-does-not-send-figma-source-shape-from-block' );
+$assert( ! str_contains( $view_js, 'buildFigmaFile' ), 'view-does-not-build-figma-file-payload' );
+$assert( str_contains( $view_js, '/\\.zip$/i' ), 'view-excludes-zip-files-from-generic-static-upload' );
 $assert( ! str_contains( $view_js, 'data-static-site-importer-source-figma-file' ), 'view-omits-separate-figma-file-input' );
 $assert( str_contains( $view_js, 'shouldIncludeSiteFile' ), 'view-skips-known-non-site-upload-files-before-reading' );
 $assert( ! str_contains( $view_js, 'CurrentRuntime' ), 'view-does-not-reference-current-runtime-mode' );

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -291,13 +291,23 @@ if ( ! class_exists( 'WP_Error' ) ) {
 if ( ! class_exists( 'WP_REST_Request' ) ) {
 	class WP_REST_Request {
 		private array $params;
+		private array $files;
 
-		public function __construct( array $params ) {
+		public function __construct( array $params, array $files = array() ) {
 			$this->params = $params;
+			$this->files  = $files;
 		}
 
 		public function get_json_params(): array {
 			return $this->params;
+		}
+
+		public function get_params(): array {
+			return $this->params;
+		}
+
+		public function get_file_params(): array {
+			return $this->files;
 		}
 
 		public function get_param( string $name ) {
@@ -474,6 +484,7 @@ $html = static_site_importer_render_block(
 
 $assert( str_contains( $html, 'data-static-site-importer' ), 'render-has-root-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-rest-url="https://example.test/wp-json/static-site-importer/v1/imports"' ), 'render-exposes-import-rest-route' );
+$assert( str_contains( $html, 'data-static-site-importer-figma-rest-url="https://example.test/wp-json/static-site-importer/v1/import-figma-file"' ), 'render-exposes-figma-file-rest-route' );
 $assert( str_contains( $html, 'data-static-site-importer-provider="privateprovider"' ), 'render-sanitizes-provider' );
 $assert( str_contains( $html, 'data-static-site-importer-apply-to-current-site="1"' ), 'render-exposes-current-site-apply-flag' );
 $assert( str_contains( $html, 'data-static-site-importer-open-in-playground="0"' ), 'render-exposes-open-in-playground-flag' );
@@ -484,27 +495,30 @@ $assert( str_contains( $html, 'Drop website source' ), 'render-has-decoupled-dro
 $assert( str_contains( $html, 'Drag a folder, ZIP, or static site files here.' ), 'render-has-upload-dropzone-copy' );
 $assert( str_contains( $html, 'data-static-site-importer-dropzone' ), 'render-has-upload-dropzone-hook' );
 $assert( str_contains( $html, 'Choose website source' ), 'render-has-decoupled-source-picker-label' );
-$assert( str_contains( $html, 'data-static-site-importer-source-type' ), 'render-has-source-type-dropdown-hook' );
-$assert( str_contains( $html, '<select' ), 'render-has-source-type-dropdown' );
-$assert( str_contains( $html, 'data-static-site-importer-upload-trigger' ), 'render-has-single-upload-trigger-hook' );
-$assert( str_contains( $html, 'Upload source' ), 'render-has-single-visible-upload-affordance' );
-$assert( str_contains( $html, 'Files or ZIP' ), 'render-preserves-file-zip-upload-choice' );
-$assert( ! str_contains( $html, 'FIG' ), 'render-omits-fig-upload-choice' );
+$assert( ! str_contains( $html, 'data-static-site-importer-source-type' ), 'render-omits-source-type-dropdown-hook' );
+$assert( ! str_contains( $html, '<select' ), 'render-omits-source-type-dropdown' );
+$assert( str_contains( $html, 'data-static-site-importer-upload-files' ), 'render-has-files-upload-button-hook' );
+$assert( str_contains( $html, 'data-static-site-importer-upload-folder' ), 'render-has-folder-upload-button-hook' );
+$assert( str_contains( $html, 'data-static-site-importer-upload-figma' ), 'render-has-figma-upload-button-hook' );
+$assert( str_contains( $html, 'File(s)' ), 'render-has-files-visible-upload-affordance' );
+$assert( str_contains( $html, 'Figma' ), 'render-has-figma-upload-choice' );
 $assert( str_contains( $html, 'Folder' ), 'render-preserves-folder-upload-choice' );
 $assert( str_contains( $html, 'data-static-site-importer-source-directory' ), 'render-preserves-directory-upload-hook' );
+$assert( str_contains( $html, 'data-static-site-importer-source-figma-file' ), 'render-has-separate-figma-upload-hook' );
 $assert( str_contains( $html, 'webkitdirectory' ), 'render-preserves-directory-picker' );
 $assert( str_contains( $html, 'hidden data-static-site-importer-source-files' ) || str_contains( $html, 'data-static-site-importer-source-files hidden' ), 'render-hides-file-input-behind-trigger' );
 $assert( str_contains( $html, 'hidden data-static-site-importer-source-directory' ) || str_contains( $html, 'data-static-site-importer-source-directory hidden' ), 'render-hides-directory-input-behind-trigger' );
+$assert( str_contains( $html, 'hidden data-static-site-importer-source-figma-file' ) || str_contains( $html, 'data-static-site-importer-source-figma-file hidden' ), 'render-hides-figma-input-behind-trigger' );
 $assert( ! str_contains( $html, '<details class="ssi-importer__upload-picker"' ), 'render-omits-upload-expander' );
 $assert( ! str_contains( $html, '<summary class="ssi-importer__upload-button"' ), 'render-omits-upload-summary-button' );
 $assert( ! str_contains( $html, 'Upload Figma file' ), 'render-omits-separate-figma-upload-label' );
-$assert( ! str_contains( $html, 'data-static-site-importer-source-figma-file' ), 'render-omits-separate-figma-upload-hook' );
-$assert( ! str_contains( $html, '.fig' ), 'render-omits-fig-from-combined-upload-accept' );
+$assert( str_contains( $html, 'accept=".fig" hidden data-static-site-importer-source-figma-file' ) || str_contains( $html, 'accept=".fig" data-static-site-importer-source-figma-file hidden' ), 'render-accepts-fig-only-on-dedicated-input' );
 $assert( ! str_contains( $html, 'data-static-site-importer-source-archive' ), 'render-omits-separate-zip-upload-hook' );
 $assert( str_contains( $html, '.zip,application/zip' ), 'render-accepts-zip-in-combined-upload' );
 $assert( str_contains( $html, 'data-static-site-importer-source-html' ), 'render-has-html-input-hook' );
 $assert( str_contains( $html, '<summary class="ssi-importer__label">Paste HTML</summary>' ), 'render-collapses-paste-html-by-default' );
 $assert( str_contains( $html, 'data-static-site-importer-submit' ), 'render-has-submit-hook' );
+$assert( str_contains( $html, 'data-static-site-importer-progress' ), 'render-has-progress-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-preview-link' ), 'render-has-preview-link-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-report' ), 'render-has-report-hook' );
 $assert( ! str_contains( $html, 'Import status' ), 'render-omits-import-status-section-copy' );
@@ -521,16 +535,17 @@ $view_js = file_get_contents( dirname( __DIR__ ) . '/blocks/importer/view.js' );
 $assert( is_string( $view_js ), 'view-js-readable' );
 $assert( str_contains( $view_js, 'webkitRelativePath' ), 'view-preserves-directory-relative-paths' );
 $assert( str_contains( $view_js, 'data-static-site-importer-source-directory' ), 'view-reads-directory-upload-input' );
-$assert( str_contains( $view_js, 'data-static-site-importer-source-type' ), 'view-reads-source-type-dropdown' );
-$assert( str_contains( $view_js, 'data-static-site-importer-upload-trigger' ), 'view-binds-single-upload-trigger' );
-$assert( str_contains( $view_js, "sourceType.value === 'folder'" ), 'view-routes-upload-trigger-from-dropdown' );
+$assert( ! str_contains( $view_js, 'data-static-site-importer-source-type' ), 'view-omits-source-type-dropdown' );
+$assert( str_contains( $view_js, 'data-static-site-importer-upload-files' ), 'view-binds-files-upload-button' );
+$assert( str_contains( $view_js, 'data-static-site-importer-upload-folder' ), 'view-binds-folder-upload-button' );
+$assert( str_contains( $view_js, 'data-static-site-importer-upload-figma' ), 'view-binds-figma-upload-button' );
 $assert( str_contains( $view_js, 'input.click()' ), 'view-opens-selected-hidden-input' );
 $assert( str_contains( $view_js, 'webkitGetAsEntry' ), 'view-supports-dropped-directory-entries' );
 $assert( str_contains( $view_js, 'archive: await buildArchive( uploadInputs, root )' ), 'view-sends-zip-from-combined-upload-as-archive-payload' );
-$assert( ! str_contains( $view_js, 'figma_file' ), 'view-does-not-send-figma-source-shape-from-block' );
+$assert( str_contains( $view_js, "formData.append( 'figma_file', file )" ), 'view-sends-figma-file-as-multipart-upload' );
 $assert( ! str_contains( $view_js, 'buildFigmaFile' ), 'view-does-not-build-figma-file-payload' );
 $assert( str_contains( $view_js, '/\\.zip$/i' ), 'view-excludes-zip-files-from-generic-static-upload' );
-$assert( ! str_contains( $view_js, 'data-static-site-importer-source-figma-file' ), 'view-omits-separate-figma-file-input' );
+$assert( str_contains( $view_js, 'data-static-site-importer-source-figma-file' ), 'view-reads-separate-figma-file-input' );
 $assert( str_contains( $view_js, 'shouldIncludeSiteFile' ), 'view-skips-known-non-site-upload-files-before-reading' );
 $assert( ! str_contains( $view_js, 'CurrentRuntime' ), 'view-does-not-reference-current-runtime-mode' );
 $assert( ! str_contains( $view_js, 'generate_in_current_runtime' ), 'view-does-not-send-current-runtime-flag' );
@@ -813,7 +828,6 @@ if ( class_exists( 'ZipArchive' ) ) {
 			)
 		)
 	);
-	@unlink( $fig_path );
 	$assert( ! is_wp_error( $fig_upload_response ), 'rest-fig-upload-playground-does-not-error', is_wp_error( $fig_upload_response ) ? $fig_upload_response->get_error_code() . ': ' . $fig_upload_response->get_error_message() : '' );
 	if ( is_wp_error( $fig_upload_response ) ) {
 		$fig_upload_response = array();
@@ -827,6 +841,34 @@ if ( class_exists( 'ZipArchive' ) ) {
 	$fig_upload_blueprint_json = rawurldecode( substr( (string) ( $fig_upload_response['preview']['playground']['blueprint_url'] ?? '' ), strlen( 'https://playground.wordpress.net/#' ) ) );
 	$assert( str_contains( $fig_upload_blueprint_json, 'Synthetic FIG Upload' ), 'rest-fig-upload-blueprint-contains-transformed-artifact' );
 	$assert( ! str_contains( $fig_upload_blueprint_json, 'content_base64' ), 'rest-fig-upload-blueprint-does-not-carry-raw-fig-source' );
+
+	$fig_multipart_response = static_site_importer_rest_import_figma_file(
+		new WP_REST_Request(
+			array(
+				'apply_to_current_site' => false,
+			),
+			array(
+				'figma_file' => array(
+					'name'     => 'design.fig',
+					'type'     => 'application/octet-stream',
+					'tmp_name' => $fig_path,
+					'error'    => 0,
+					'size'     => filesize( $fig_path ),
+				),
+			)
+		)
+	);
+	@unlink( $fig_path );
+	$assert( ! is_wp_error( $fig_multipart_response ), 'rest-fig-multipart-playground-does-not-error', is_wp_error( $fig_multipart_response ) ? $fig_multipart_response->get_error_code() . ': ' . $fig_multipart_response->get_error_message() : '' );
+	if ( is_wp_error( $fig_multipart_response ) ) {
+		$fig_multipart_response = array();
+	}
+	$assert( true === ( $fig_multipart_response['success'] ?? null ), 'rest-fig-multipart-playground-succeeds' );
+	$assert( 'playground' === ( $fig_multipart_response['mode'] ?? '' ), 'rest-fig-multipart-uses-playground-mode' );
+	$assert( str_starts_with( $fig_multipart_response['preview']['url'] ?? '', 'https://playground.wordpress.net/#' ), 'rest-fig-multipart-returns-direct-playground-blueprint-url' );
+	$fig_multipart_blueprint_json = rawurldecode( substr( (string) ( $fig_multipart_response['preview']['playground']['blueprint_url'] ?? '' ), strlen( 'https://playground.wordpress.net/#' ) ) );
+	$assert( str_contains( $fig_multipart_blueprint_json, 'Synthetic FIG Upload' ), 'rest-fig-multipart-blueprint-contains-transformed-artifact' );
+	$assert( ! str_contains( $fig_multipart_blueprint_json, 'content_base64' ), 'rest-fig-multipart-blueprint-does-not-carry-raw-fig-source' );
 }
 
 $blueprint = json_decode( file_get_contents( dirname( __DIR__ ) . '/docs/playground/blueprint.json' ), true );


### PR DESCRIPTION
## Summary
- replace the importer block source dropdown with File(s), Folder, and Figma buttons
- add a multipart Figma upload endpoint for the block UI
- transform .fig uploads server-side before opening the generated WordPress site in Playground
- keep the existing JSON Figma runner endpoint intact

## Testing
- php -l includes/block.php
- php -l includes/rest.php
- php -l includes/class-static-site-importer-figma-import.php
- node --check blocks/importer/view.js
- node --check blocks/importer/editor.js
- php tests/smoke-importer-block.php
- homeboy lint static-site-importer --path "/Users/chubes/Developer/static-site-importer@fix-single-upload-playground-flow"

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the block UI, multipart Figma upload route, tests, and verification.