### PR TITLE
Return canonical import progress events

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -323,6 +323,80 @@ class Static_Site_Importer_Theme_Generator {
 			'pages'                           => $page_ids,
 			'quality'                         => $quality,
 			'source_documents'                => self::$conversion_report['source_documents'],
+			'progress_events'                 => self::import_progress_events( $import_run_id, $theme_slug, $page_ids, $writes, $quality, $validation_result, $external_report_path ),
+		);
+	}
+
+	/**
+	 * Build the canonical progress timeline returned to host chat/Codebox callers.
+	 *
+	 * @param string              $import_run_id Import run id.
+	 * @param string              $theme_slug    Theme slug.
+	 * @param array<string,int>   $page_ids      Materialized page IDs.
+	 * @param array<string,string> $writes        Theme file writes.
+	 * @param array<string,mixed>  $quality       Quality summary.
+	 * @param array<string,mixed>  $validation    Validation result.
+	 * @param string              $report_path   External report path.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function import_progress_events( string $import_run_id, string $theme_slug, array $page_ids, array $writes, array $quality, array $validation, string $report_path ): array {
+		$now               = gmdate( 'c' );
+		$page_count        = count( $page_ids );
+		$file_count        = count( $writes );
+		$diagnostic_count  = isset( $validation['diagnostics'] ) && is_array( $validation['diagnostics'] ) ? count( $validation['diagnostics'] ) : 0;
+		$quality_passed    = empty( $quality['fail_import'] );
+		$review_pending    = ! $quality_passed || $diagnostic_count > 0;
+		$common            = array(
+			'schema'    => 'wp-codebox/live-progress-event/v1',
+			'run_id'    => $import_run_id,
+			'source_schema' => 'static-site-importer/materialization-progress/v1',
+			'timestamp' => $now,
+		);
+
+		return array(
+			array_merge(
+				$common,
+				array(
+					'phase'    => 'ssi.materialization.completed',
+					'status'   => 'succeeded',
+					'label'    => 'Materialized WordPress content',
+					'progress' => array(
+						'current'   => $page_count,
+						'completed' => $page_count,
+						'total'     => $page_count,
+						'percent'   => 100,
+						'unit'      => 'pages',
+					),
+					'detail'   => array(
+						'theme_slug' => $theme_slug,
+						'file_count' => $file_count,
+					),
+				)
+			),
+			array_merge(
+				$common,
+				array(
+					'phase'       => 'ssi.validation.completed',
+					'status'      => $quality_passed ? 'succeeded' : 'failed',
+					'label'       => $quality_passed ? 'Validation passed' : 'Validation needs review',
+					'diagnostics' => array(
+						'count' => $diagnostic_count,
+					),
+				)
+			),
+			array_merge(
+				$common,
+				array(
+					'phase'     => $review_pending ? 'ssi.review.pending' : 'ssi.saved.completed',
+					'status'    => $review_pending ? 'running' : 'succeeded',
+					'label'     => $review_pending ? 'Review pending' : 'Saved to WordPress',
+					'artifacts' => array_filter(
+						array(
+							'import_report' => '' !== $report_path ? array( 'path' => $report_path, 'kind' => 'json' ) : null,
+						)
+					),
+				)
+			),
 		);
 	}
 

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -211,6 +211,7 @@ if ( ! is_wp_error( $result ) ) {
 	$finding_packets   = json_decode( $read( $result['finding_packets_path'] ?? '' ), true );
 	$page_ids  = array_values( $result['pages'] ?? array() );
 	$page_id   = (int) ( $page_ids[0] ?? 0 );
+	$progress_events = isset( $result['progress_events'] ) && is_array( $result['progress_events'] ) ? $result['progress_events'] : array();
 	$page      = $page_id > 0 ? get_post( $page_id ) : null;
 	$content   = $page instanceof WP_Post ? $page->post_content : '';
 	$documents = array();
@@ -245,6 +246,10 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( 'ssi-smoke-run-001' === ( $report['import_run_id'] ?? '' ), 'report-includes-import-run-id' );
 	$assert( 'sha256:ember-rye-smoke' === ( $report['source_artifact']['hash'] ?? '' ), 'report-includes-source-artifact-hash' );
 	$assert( 'static-site-importer/source-of-truth-manifest/v1' === ( $report['source_of_truth']['schema'] ?? '' ), 'report-includes-source-of-truth-schema' );
+	$assert( 'wp-codebox/live-progress-event/v1' === ( $progress_events[0]['schema'] ?? '' ), 'progress-event-uses-canonical-schema' );
+	$assert( 'ssi.materialization.completed' === ( $progress_events[0]['phase'] ?? '' ), 'progress-event-materialization-phase' );
+	$assert( 100 === (int) ( $progress_events[0]['progress']['percent'] ?? 0 ), 'progress-event-materialization-complete-percent' );
+	$assert( 'ssi.saved.completed' === ( $progress_events[2]['phase'] ?? '' ), 'progress-event-saved-state' );
 	$assert( 'ssi-smoke-run-001' === ( $manifest['import_run_id'] ?? '' ), 'manifest-includes-import-run-id' );
 	$assert( 'sha256:ember-rye-smoke' === ( $manifest['artifact']['hash'] ?? '' ), 'manifest-includes-source-artifact-hash' );
 	$assert( 'index.html' === ( $manifest['desired']['pages'][0]['source_path'] ?? '' ), 'manifest-includes-desired-page-source' );


### PR DESCRIPTION
## Summary
- Return a canonical progress_events timeline from website artifact imports.
- Bridge materialization, validation, and saved/review-pending states through the shared wp-codebox live progress schema.
- Cover the returned progress contract in the existing website artifact smoke test.

## Testing
- php tests/smoke-website-artifact-document-metadata.php
- php -l includes/class-static-site-importer-theme-generator.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the import progress event bridge, added focused smoke coverage, and ran targeted verification.