### PR TITLE
Align canonical artifact export envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,18 +206,19 @@ Important behavior:
 
 ## Website Artifact Export
 
-`static-site-importer/export-theme` exports an imported or active block theme as a Blocks Engine website artifact. SSI owns the WordPress import/export/materialization path; Blocks Engine PHP transformer owns generic website artifact compilation. Studio Web, WP Codebox, and other products should consume the exported `website_artifact` object rather than SSI-specific static-site wrappers.
+`static-site-importer/export-theme` exports an imported or active block theme as the canonical Studio Native handoff bundle. SSI owns the WordPress import/export/materialization path; Blocks Engine PHP transformer owns generic website artifact compilation inside SSI. Studio Native, WP Codebox, and other product callers should consume `result.artifact_bundle` instead of reading an SSI-private or Blocks Engine-specific wrapper.
 
 The export envelope includes:
 
-- `schema: "blocks-engine/php-transformer/site-artifact/v1"`, `artifact_type: "website"`, `version`, `id`, `generated_at`, `root`, and `entrypoint`.
+- `result.schema: "static-site-importer/export-theme-result/v1"`.
+- `result.artifact_bundle.schema: "studio-native/website-artifact-bundle/v1"`, `root`, and `entrypoint`.
 - `files[]` entries with safe artifact-relative paths, `role`, `kind`, `mime_type`, `encoding`, `bytes`, `sha256`, and inline `content`.
 - UTF-8 text content by default; binary content is transported as Base64 with `encoding: "base64"`.
 - source/materialization provenance under `provenance`.
 - import/validation summaries and `reports[]` references for repair loops.
 - `import-report.json` and `source-documents.json` metadata files when the exported theme has SSI import provenance.
 
-The default root is `website` with `entrypoint: "website/index.html"`. Callers can pass any safe single-segment root with a matching entrypoint, such as `root: "artifact"` and `entrypoint: "artifact/index.html"`.
+The default root is `website` with `entrypoint: "website/index.html"`. Callers can pass any safe single-segment root with a matching entrypoint, such as `root: "artifact"` and `entrypoint: "artifact/index.html"`. The import ability accepts the same canonical bundle through `artifact_bundle`; the lower-level `artifact` input remains available for direct Blocks Engine website artifacts.
 
 ## Product Handoff Contract
 

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -86,6 +86,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 					'type'       => 'object',
 					'properties' => array(
 						'artifact'                     => array( 'type' => 'object' ),
+						'artifact_bundle'              => array( 'type' => 'object' ),
 						'slug'                         => array( 'type' => 'string' ),
 						'name'                         => array( 'type' => 'string' ),
 						'activate'                     => array( 'type' => 'boolean' ),
@@ -102,7 +103,6 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'source_metadata'              => array( 'type' => 'object' ),
 						'validation_artifacts'         => array( 'type' => 'object' ),
 					),
-					'required'   => array( 'artifact' ),
 				),
 				'output_schema'       => array( 'type' => 'object' ),
 				'execute_callback'    => 'static_site_importer_ability_import_website_artifact',
@@ -326,8 +326,15 @@ if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' )
 	 */
 	function static_site_importer_ability_import_website_artifact( array $input ): array {
 		$artifact = isset( $input['artifact'] ) && is_array( $input['artifact'] ) ? $input['artifact'] : array();
+		if ( empty( $artifact ) && isset( $input['artifact_bundle'] ) && is_array( $input['artifact_bundle'] ) ) {
+			$artifact = Static_Site_Importer_Artifact_Envelope::website_artifact_from_bundle( $input['artifact_bundle'] );
+			if ( is_wp_error( $artifact ) ) {
+				/** @var WP_Error $artifact */
+				return static_site_importer_ability_error( (string) $artifact->get_error_code(), $artifact->get_error_message(), $artifact->get_error_data() );
+			}
+		}
 		if ( empty( $artifact ) ) {
-			return static_site_importer_ability_error( 'static_site_importer_missing_website_artifact', 'The artifact input is required.' );
+			return static_site_importer_ability_error( 'static_site_importer_missing_website_artifact', 'The artifact or artifact_bundle input is required.' );
 		}
 
 		$args = array(

--- a/includes/class-static-site-importer-artifact-envelope.php
+++ b/includes/class-static-site-importer-artifact-envelope.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Studio Native artifact envelope contract.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Normalizes the Studio Native <-> SSI artifact handoff.
+ */
+class Static_Site_Importer_Artifact_Envelope {
+	public const WEBSITE_ARTIFACT_BUNDLE_SCHEMA = 'studio-native/website-artifact-bundle/v1';
+	public const EXPORT_RESULT_SCHEMA           = 'static-site-importer/export-theme-result/v1';
+
+	/**
+	 * Build the canonical export result envelope consumed by Studio Native.
+	 *
+	 * @param array<string,mixed> $website_artifact Blocks Engine website artifact.
+	 * @return array<string,mixed>
+	 */
+	public static function export_result_from_website_artifact( array $website_artifact ): array {
+		return array(
+			'schema'          => self::EXPORT_RESULT_SCHEMA,
+			'artifact_bundle' => self::bundle_from_website_artifact( $website_artifact ),
+		);
+	}
+
+	/**
+	 * Convert a Blocks Engine website artifact into the Studio Native bundle shape.
+	 *
+	 * @param array<string,mixed> $website_artifact Blocks Engine website artifact.
+	 * @return array<string,mixed>
+	 */
+	public static function bundle_from_website_artifact( array $website_artifact ): array {
+		$files = isset( $website_artifact['files'] ) && is_array( $website_artifact['files'] ) ? $website_artifact['files'] : array();
+
+		return array_filter(
+			array(
+				'schema'       => self::WEBSITE_ARTIFACT_BUNDLE_SCHEMA,
+				'root'         => isset( $website_artifact['root'] ) ? (string) $website_artifact['root'] : 'website',
+				'entrypoint'   => isset( $website_artifact['entrypoint'] ) ? (string) $website_artifact['entrypoint'] : 'website/index.html',
+				'files'        => array_values( array_map( array( self::class, 'bundle_file_from_website_artifact_file' ), $files ) ),
+				'provenance'   => isset( $website_artifact['provenance'] ) && is_array( $website_artifact['provenance'] ) ? $website_artifact['provenance'] : array(),
+				'report'       => isset( $website_artifact['report'] ) && is_array( $website_artifact['report'] ) ? $website_artifact['report'] : array(),
+				'validation'   => isset( $website_artifact['validation'] ) && is_array( $website_artifact['validation'] ) ? $website_artifact['validation'] : array(),
+				'import'       => isset( $website_artifact['import'] ) && is_array( $website_artifact['import'] ) ? $website_artifact['import'] : array(),
+				'reports'      => isset( $website_artifact['reports'] ) && is_array( $website_artifact['reports'] ) ? $website_artifact['reports'] : array(),
+			),
+			static fn ( $value ): bool => array() !== $value && null !== $value && '' !== $value
+		);
+	}
+
+	/**
+	 * Convert the canonical Studio Native bundle into a Blocks Engine website artifact.
+	 *
+	 * @param array<string,mixed> $bundle Studio Native artifact bundle.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function website_artifact_from_bundle( array $bundle ) {
+		if ( ( $bundle['schema'] ?? '' ) !== self::WEBSITE_ARTIFACT_BUNDLE_SCHEMA ) {
+			return new WP_Error( 'static_site_importer_artifact_bundle_schema_invalid', 'The artifact_bundle input must use schema studio-native/website-artifact-bundle/v1.', array( 'status' => 400 ) );
+		}
+
+		$files = isset( $bundle['files'] ) && is_array( $bundle['files'] ) ? $bundle['files'] : array();
+		if ( empty( $files ) ) {
+			return new WP_Error( 'static_site_importer_artifact_bundle_empty', 'The artifact_bundle input must contain files.', array( 'status' => 400 ) );
+		}
+
+		return array(
+			'schema'        => Static_Site_Importer_Transformer_Adapter::WEBSITE_ARTIFACT_SCHEMA,
+			'artifact_type' => 'website',
+			'root'          => isset( $bundle['root'] ) ? (string) $bundle['root'] : 'website',
+			'entrypoint'    => isset( $bundle['entrypoint'] ) ? (string) $bundle['entrypoint'] : 'website/index.html',
+			'files'         => array_values( array_map( array( self::class, 'website_artifact_file_from_bundle_file' ), $files ) ),
+			'provenance'    => isset( $bundle['provenance'] ) && is_array( $bundle['provenance'] ) ? $bundle['provenance'] : array( 'producer' => 'studio-native' ),
+		);
+	}
+
+	/**
+	 * Convert one website artifact file into a bundle file.
+	 *
+	 * @param mixed $file File entry.
+	 * @return array<string,mixed>
+	 */
+	private static function bundle_file_from_website_artifact_file( $file ): array {
+		$file = is_array( $file ) ? $file : array();
+
+		return array_filter(
+			array(
+				'path'           => isset( $file['path'] ) ? (string) $file['path'] : '',
+				'role'           => isset( $file['role'] ) ? (string) $file['role'] : '',
+				'kind'           => isset( $file['kind'] ) ? (string) $file['kind'] : '',
+				'mime_type'      => isset( $file['mime_type'] ) ? (string) $file['mime_type'] : '',
+				'encoding'       => isset( $file['encoding'] ) ? (string) $file['encoding'] : 'utf-8',
+				'content'        => isset( $file['content'] ) ? (string) $file['content'] : null,
+				'content_base64' => isset( $file['content_base64'] ) ? (string) $file['content_base64'] : null,
+				'sha256'         => isset( $file['sha256'] ) ? (string) $file['sha256'] : '',
+				'bytes'          => isset( $file['bytes'] ) ? (int) $file['bytes'] : null,
+				'size'           => isset( $file['size'] ) ? (int) $file['size'] : null,
+				'entrypoint'     => ! empty( $file['entrypoint'] ),
+				'provenance'     => isset( $file['provenance'] ) && is_array( $file['provenance'] ) ? $file['provenance'] : array(),
+			),
+			static fn ( $value ): bool => null !== $value && array() !== $value && '' !== $value
+		);
+	}
+
+	/**
+	 * Convert one bundle file into a website artifact file.
+	 *
+	 * @param mixed $file File entry.
+	 * @return array<string,mixed>
+	 */
+	private static function website_artifact_file_from_bundle_file( $file ): array {
+		$file = is_array( $file ) ? $file : array();
+		$entrypoint = ! empty( $file['entrypoint'] ) || 'entrypoint' === ( $file['role'] ?? '' );
+
+		return array_filter(
+			array(
+				'path'           => isset( $file['path'] ) ? (string) $file['path'] : '',
+				'kind'           => isset( $file['kind'] ) ? (string) $file['kind'] : '',
+				'role'           => isset( $file['role'] ) ? (string) $file['role'] : '',
+				'mime_type'      => isset( $file['mime_type'] ) ? (string) $file['mime_type'] : '',
+				'encoding'       => isset( $file['encoding'] ) ? (string) $file['encoding'] : 'utf-8',
+				'entrypoint'     => $entrypoint,
+				'content'        => isset( $file['content'] ) ? (string) $file['content'] : null,
+				'content_base64' => isset( $file['content_base64'] ) ? (string) $file['content_base64'] : null,
+				'provenance'     => isset( $file['provenance'] ) && is_array( $file['provenance'] ) ? $file['provenance'] : array(),
+			),
+			static fn ( $value ): bool => null !== $value && array() !== $value && '' !== $value
+		);
+	}
+}

--- a/includes/class-static-site-importer-theme-exporter.php
+++ b/includes/class-static-site-importer-theme-exporter.php
@@ -12,9 +12,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-transformer-adapter.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Artifact_Envelope' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-artifact-envelope.php';
+}
 
 /**
- * Exports WordPress block themes to Blocks Engine website artifacts.
+ * Exports WordPress block themes to canonical Studio Native artifact bundles.
  */
 class Static_Site_Importer_Theme_Exporter {
 
@@ -22,7 +25,7 @@ class Static_Site_Importer_Theme_Exporter {
 	 * Export an imported or active block theme as a website artifact.
 	 *
 	 * @param array $args Export args.
-	 * @return array{website_artifact:array<string,mixed>}|WP_Error
+	 * @return array{result:array<string,mixed>}|WP_Error
 	 */
 	public static function export_theme( array $args = array() ) {
 		$transformer = new Static_Site_Importer_Transformer_Adapter();
@@ -140,7 +143,7 @@ class Static_Site_Importer_Theme_Exporter {
 		$website_artifact = self::export_website_artifact( $theme_slug, $root, $entrypoint, $files, $report, $source_metadata );
 
 		return array(
-			'website_artifact' => $website_artifact,
+			'result' => Static_Site_Importer_Artifact_Envelope::export_result_from_website_artifact( $website_artifact ),
 		);
 	}
 

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -61,6 +61,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-wo
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-product-handoff-contract.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-diagnostic-contract.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-diagnostics-adapter.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-envelope.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-codebox-validation.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-transformer-adapter.php';

--- a/tests/smoke-export-theme-ability.php
+++ b/tests/smoke-export-theme-ability.php
@@ -175,7 +175,25 @@ if ( ! function_exists( 'add_action' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-exporter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-envelope.php';
 require_once dirname( __DIR__ ) . '/includes/abilities.php';
+
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator' ) ) {
+	class Static_Site_Importer_Theme_Generator {
+		public static array $last_artifact = array();
+
+		public static function import_website_artifact( array $artifact, array $args = array() ): array {
+			unset( $args );
+			self::$last_artifact = $artifact;
+
+			return array(
+				'theme_slug' => 'fixture-theme',
+				'report'     => array(),
+			);
+		}
+	}
+}
+
 $result = static_site_importer_ability_export_theme(
 	array(
 		'theme_slug'      => 'fixture-theme',
@@ -196,13 +214,13 @@ $assert     = static function ( bool $condition, string $label, string $detail =
 
 $assert( ! is_wp_error( $result ), 'export-succeeds', is_wp_error( $result ) ? $result->get_error_message() : '' );
 $assert( true === ( $result['success'] ?? false ), 'ability-success' );
-$artifact = $result['website_artifact'] ?? array();
+$export_result = $result['result'] ?? array();
+$artifact       = $export_result['artifact_bundle'] ?? array();
 $assert( ! isset( $result['artifact_set'] ), 'artifact-set-wrapper-removed' );
 $assert( ! isset( $result['files'] ), 'top-level-files-wrapper-removed' );
 $assert( ! isset( $result['report'] ), 'top-level-report-wrapper-removed' );
-$assert( 'blocks-engine/php-transformer/site-artifact/v1' === ( $artifact['schema'] ?? '' ), 'website-artifact-schema' );
-$assert( 'website' === ( $artifact['artifact_type'] ?? '' ), 'artifact-type' );
-$assert( 1 === ( $artifact['version'] ?? 0 ), 'artifact-version' );
+$assert( 'static-site-importer/export-theme-result/v1' === ( $export_result['schema'] ?? '' ), 'export-result-schema' );
+$assert( 'studio-native/website-artifact-bundle/v1' === ( $artifact['schema'] ?? '' ), 'website-artifact-bundle-schema' );
 $assert( 'website' === ( $artifact['root'] ?? '' ), 'artifact-root' );
 $assert( 'website/index.html' === ( $artifact['entrypoint'] ?? '' ), 'entrypoint' );
 $assert( 6 === count( $artifact['files'] ?? array() ), 'exports-entrypoint-assets-and-metadata' );
@@ -232,6 +250,21 @@ $assert( 'smoke' === ( $artifact['provenance']['source_metadata']['source'] ?? '
 $assert( 'website/import-report.json' === ( $artifact['reports'][0]['path'] ?? '' ), 'report-ref' );
 $assert( 'smoke' === ( $artifact['report']['source_metadata']['source'] ?? '' ), 'source-metadata-preserved' );
 $assert( 'completed' === ( $artifact['report']['import_report']['status'] ?? '' ), 'import-report-preserved' );
+$normalized_artifact = Static_Site_Importer_Artifact_Envelope::website_artifact_from_bundle( $artifact );
+$assert( ! is_wp_error( $normalized_artifact ), 'bundle-normalizes-to-website-artifact' );
+$assert( 'blocks-engine/php-transformer/site-artifact/v1' === ( $normalized_artifact['schema'] ?? '' ), 'normalized-website-artifact-schema' );
+$assert( 'website/index.html' === ( $normalized_artifact['entrypoint'] ?? '' ), 'normalized-entrypoint' );
+$assert( 6 === count( $normalized_artifact['files'] ?? array() ), 'normalized-file-count' );
+$import_result = static_site_importer_ability_import_website_artifact(
+	array(
+		'artifact_bundle' => $artifact,
+		'slug'            => 'fixture-theme',
+		'name'            => 'Fixture Theme',
+	)
+);
+$assert( true === ( $import_result['success'] ?? false ), 'ability-imports-artifact-bundle' );
+$assert( 'blocks-engine/php-transformer/site-artifact/v1' === ( Static_Site_Importer_Theme_Generator::$last_artifact['schema'] ?? '' ), 'ability-import-normalizes-bundle-schema' );
+$assert( 'website/index.html' === ( Static_Site_Importer_Theme_Generator::$last_artifact['entrypoint'] ?? '' ), 'ability-import-normalizes-bundle-entrypoint' );
 $export_format_conversion_calls = array_filter(
 	$GLOBALS['ssi_export_format_conversion_calls'],
 	static fn ( array $call ): bool => 'blocks' === $call[0] && 'html' === $call[1]


### PR DESCRIPTION
## Summary
- Export SSI theme captures as `result.artifact_bundle` using `studio-native/website-artifact-bundle/v1`.
- Add a focused SSI artifact envelope helper for export and import normalization.
- Allow `import-website-artifact` to consume the canonical `artifact_bundle` while keeping direct Blocks Engine `artifact` input available.
- Update focused contract docs and smoke coverage.

## Tests
- `php -l includes/class-static-site-importer-artifact-envelope.php && php -l includes/class-static-site-importer-theme-exporter.php && php -l includes/abilities.php`
- `php tests/smoke-export-theme-ability.php`
- `php tests/smoke-importer-block.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the artifact envelope contract, updating tests/docs, and running targeted verification.