### PR TITLE
Fix preview button readiness

### DIFF
--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -195,26 +195,7 @@
 
 	const previewUrl = function ( report ) {
 		const preview = report && report.preview && typeof report.preview === 'object' ? report.preview : {};
-		const playground = preview.playground && typeof preview.playground === 'object' ? preview.playground : {};
-		return preview.url || playground.blueprint_url || '';
-	};
-
-	const setPreviewLink = function ( root, report ) {
-		const wrap = root.querySelector( '[data-static-site-importer-preview-link-wrap]' );
-		const link = root.querySelector( '[data-static-site-importer-preview-link]' );
-
-		if ( ! wrap || ! link ) {
-			return;
-		}
-
-		const url = previewUrl( report );
-		if ( url ) {
-			link.href = url;
-			wrap.hidden = false;
-		} else {
-			link.removeAttribute( 'href' );
-			wrap.hidden = true;
-		}
+		return preview.url || '';
 	};
 
 	const openPreview = function ( report, openedWindow ) {
@@ -298,7 +279,7 @@
 		formData.append( 'activate', isCurrentSiteImport ? '1' : '0' );
 		formData.append( 'overwrite', isCurrentSiteImport ? '1' : '0' );
 
-		showStatus( root, isCurrentSiteImport ? 'Importing Figma file to this site...' : 'Preparing Figma file for WordPress Playground...' );
+		showStatus( root, isCurrentSiteImport ? 'Importing Figma file to this site...' : 'Preparing Figma file for WordPress preview...' );
 
 		try {
 			const response = await fetch( restUrl, {
@@ -310,12 +291,11 @@
 			} );
 			const report = await response.json();
 			setReport( root, report );
-			setPreviewLink( root, report );
 			if ( response.ok && isCurrentSiteImport && report.success ) {
 				showStatus( root, 'Figma import complete.' );
 			} else if ( response.ok && report.success && previewUrl( report ) ) {
 				openPreview( report, playgroundWindow );
-				showStatus( root, 'WordPress Playground opened.' );
+				showStatus( root, 'WordPress preview opened.' );
 			} else {
 				if ( playgroundWindow ) {
 					playgroundWindow.close();
@@ -324,7 +304,6 @@
 			}
 		} catch ( error ) {
 			setReport( root, { success: false, error: { message: error.message } } );
-			setPreviewLink( root, null );
 			if ( playgroundWindow ) {
 				playgroundWindow.close();
 			}
@@ -379,7 +358,7 @@
 				return;
 			}
 
-			showStatus( root, isCurrentSiteImport ? 'Importing to this site...' : 'Opening WordPress Playground...' );
+			showStatus( root, isCurrentSiteImport ? 'Importing to this site...' : 'Preparing WordPress preview...' );
 			submit.disabled = true;
 
 			try {
@@ -401,12 +380,11 @@
 				} );
 				const report = await response.json();
 				setReport( root, report );
-				setPreviewLink( root, report );
 				if ( response.ok && isCurrentSiteImport && report.success ) {
 					showStatus( root, 'Import complete.' );
 				} else if ( response.ok && report.success && previewUrl( report ) ) {
 					openPreview( report, playgroundWindow );
-					showStatus( root, 'WordPress Playground opened.' );
+					showStatus( root, 'WordPress preview opened.' );
 				} else if ( response.ok && previewUrl( report ) ) {
 					openPreview( report, playgroundWindow );
 					showStatus( root, 'Preview opened.' );
@@ -423,7 +401,6 @@
 				}
 			} catch ( error ) {
 				setReport( root, { success: false, error: { message: error.message } } );
-				setPreviewLink( root, null );
 				if ( playgroundWindow ) {
 					playgroundWindow.close();
 				}

--- a/includes/block.php
+++ b/includes/block.php
@@ -75,7 +75,6 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 
 		<section class="ssi-importer__report" aria-live="polite" hidden data-static-site-importer-status>
 			<p hidden data-static-site-importer-progress></p>
-			<p hidden data-static-site-importer-preview-link-wrap><a href="#" target="_blank" rel="noopener noreferrer" data-static-site-importer-preview-link><?php esc_html_e( 'Open WordPress preview', 'static-site-importer' ); ?></a></p>
 			<textarea rows="10" readonly hidden data-static-site-importer-report></textarea>
 		</section>
 	</div>

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -519,7 +519,7 @@ $assert( str_contains( $html, 'data-static-site-importer-source-html' ), 'render
 $assert( str_contains( $html, '<summary class="ssi-importer__label">Paste HTML</summary>' ), 'render-collapses-paste-html-by-default' );
 $assert( str_contains( $html, 'data-static-site-importer-submit' ), 'render-has-submit-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-progress' ), 'render-has-progress-hook' );
-$assert( str_contains( $html, 'data-static-site-importer-preview-link' ), 'render-has-preview-link-hook' );
+$assert( ! str_contains( $html, 'data-static-site-importer-preview-link' ), 'render-omits-redundant-preview-link-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-report' ), 'render-has-report-hook' );
 $assert( ! str_contains( $html, 'Import status' ), 'render-omits-import-status-section-copy' );
 $assert( str_contains( $html, 'Import your site' ), 'render-uses-custom-title' );
@@ -555,9 +555,10 @@ $assert( str_contains( $view_js, 'activate: isCurrentSiteImport' ), 'view-activa
 $assert( str_contains( $view_js, 'overwrite: isCurrentSiteImport' ), 'view-overwrites-only-current-site-imports' );
 $assert( str_contains( $view_js, "window.open( 'about:blank'" ), 'view-opens-playground-window-from-click' );
 $assert( str_contains( $view_js, 'openPreview( report, playgroundWindow )' ), 'view-navigates-opened-window-to-playground-url' );
+$assert( ! str_contains( $view_js, 'playground.blueprint_url' ), 'view-does-not-open-playground-blueprint-before-preview-is-ready' );
 $generic_preview_message = implode( ' ', array( 'no', 'preview', 'provider', 'is', 'configured' ) );
 $assert( ! str_contains( $view_js, $generic_preview_message ), 'view-does-not-reference-generic-preview-message' );
-$assert( str_contains( $view_js, 'Open WordPress preview' ) || str_contains( $html, 'Open WordPress preview' ), 'view-or-render-has-preview-link-label' );
+$assert( ! str_contains( $view_js, 'Open WordPress preview' ) && ! str_contains( $html, 'Open WordPress preview' ), 'view-and-render-omit-redundant-preview-link-label' );
 
 WP_Codebox_Abilities::$next_session = array(
 	'success'         => true,


### PR DESCRIPTION
## Summary
- Open generated WordPress previews only after the ready preview URL is returned.
- Remove the redundant Open WordPress preview link from the importer block output.
- Update importer block smoke assertions for the single-button flow.

## Testing
- php tests/smoke-importer-block.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the preview button flow, editing the block UI behavior, updating smoke assertions, and running verification.