### PR TITLE
Restore import validation release gates

### DIFF
--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -598,6 +598,9 @@ class Static_Site_Importer_Theme_Materializer {
 		if ( null === $template_parts ) {
 			$template_parts = isset( $artifacts['template_parts'] ) && is_array( $artifacts['template_parts'] ) ? $artifacts['template_parts'] : array();
 		}
+		if ( empty( $template_parts ) ) {
+			$template_parts = array( self::default_header_template_part() );
+		}
 
 		$writes  = array();
 		$reports = array();
@@ -627,6 +630,21 @@ class Static_Site_Importer_Theme_Materializer {
 		return array(
 			'writes'  => $writes,
 			'reports' => $reports,
+		);
+	}
+
+	/**
+	 * Build SSI's default header template part when the compiler has no chrome contract.
+	 *
+	 * @return array<string,mixed> Template part artifact.
+	 */
+	private static function default_header_template_part(): array {
+		return array(
+			'slug'         => 'header',
+			'area'         => 'header',
+			'title'        => 'Header',
+			'generated'    => true,
+			'block_markup' => '<!-- wp:group {"tagName":"header","layout":{"type":"constrained"}} --><header class="wp-block-group"><!-- wp:site-title /--><!-- wp:navigation /--></header><!-- /wp:group -->',
 		);
 	}
 

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -80,6 +80,72 @@ add_action( 'rest_api_init', 'static_site_importer_register_rest_routes' );
 
 if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 	WP_CLI::add_command(
+		'static-site-importer import-theme',
+		static function ( array $args, array $assoc_args ): void {
+			$entry = isset( $args[0] ) ? (string) $args[0] : '';
+			if ( '' === $entry || ! is_readable( $entry ) || ! is_file( $entry ) ) {
+				WP_CLI::error( 'Provide a readable source HTML file.' );
+			}
+
+			$root = realpath( dirname( $entry ) );
+			if ( false === $root ) {
+				WP_CLI::error( 'Could not resolve the source directory.' );
+			}
+
+			$files    = array();
+			$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $root, FilesystemIterator::SKIP_DOTS ) );
+			foreach ( $iterator as $file ) {
+				if ( ! $file instanceof SplFileInfo || ! $file->isFile() || ! $file->isReadable() ) {
+					continue;
+				}
+
+				$path     = $file->getPathname();
+				$relative = ltrim( str_replace( '\\', '/', substr( $path, strlen( $root ) ) ), '/' );
+				if ( '' === $relative ) {
+					continue;
+				}
+
+				$content = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- CLI reads operator-provided source files.
+				if ( false === $content ) {
+					WP_CLI::error( sprintf( 'Could not read source file: %s', $path ) );
+				}
+
+				$files[] = array(
+					'path'           => $relative,
+					'content_base64' => base64_encode( $content ),
+				);
+			}
+
+			$entry_realpath = realpath( $entry );
+			$entrypoint     = false !== $entry_realpath ? ltrim( str_replace( '\\', '/', substr( $entry_realpath, strlen( $root ) ) ), '/' ) : basename( $entry );
+			$input          = array(
+				'artifact'                     => array(
+					'schema'     => Static_Site_Importer_Transformer_Adapter::WEBSITE_ARTIFACT_SCHEMA,
+					'entrypoint' => $entrypoint,
+					'files'      => $files,
+				),
+				'slug'                         => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
+				'name'                         => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
+				'activate'                     => isset( $assoc_args['activate'] ),
+				'overwrite'                    => isset( $assoc_args['overwrite'] ),
+				'fail_on_quality'              => isset( $assoc_args['fail-on-quality'] ),
+				'allow_missing_woocommerce'    => isset( $assoc_args['allow-missing-woocommerce'] ),
+				'materialize_dependencies'     => ! isset( $assoc_args['skip-dependency-materialization'] ),
+				'report'                       => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
+				'asset_materialization_policy' => isset( $assoc_args['asset-materialization-policy'] ) ? (string) $assoc_args['asset-materialization-policy'] : '',
+			);
+
+			$result = static_site_importer_ability_import_website_artifact( $input );
+			if ( empty( $result['success'] ) ) {
+				$error = isset( $result['error'] ) && is_array( $result['error'] ) ? $result['error'] : array();
+				WP_CLI::error( (string) ( $error['message'] ?? 'Static site import failed.' ) );
+			}
+
+			WP_CLI::success( sprintf( 'Imported %s.', (string) ( $result['result']['theme_slug'] ?? $input['slug'] ) ) );
+		}
+	);
+
+	WP_CLI::add_command(
 		'static-site-importer validate-in-codebox',
 		static function ( array $args, array $assoc_args ): void {
 			unset( $args );


### PR DESCRIPTION
## Summary
- Restore the `wp static-site-importer import-theme` CLI command used by the validation harness.
- Add an SSI-generated default header template part when Blocks Engine does not provide template part or navigation rows.
- Keep local static-source imports on the website artifact materialization path.

## Testing
- `php -l static-site-importer.php`
- `php -l includes/class-static-site-importer-theme-materializer.php`
- `STATIC_SITE_IMPORTER_WP_CLI="studio wp --path /Users/chubes/Studio/intelligence-chubes4 --skip-plugins=static-site-importer --require=/Users/chubes/Developer/static-site-importer@fix-import-validation-release-gates/static-site-importer.php" npm run test:validation`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing release-blocking import validation failures, restoring the CLI import path, adding generated header fallback behavior, and running validation.
