### PR TITLE
Fix release lint blockers

### DIFF
--- a/includes/class-static-site-importer-artifact-envelope.php
+++ b/includes/class-static-site-importer-artifact-envelope.php
@@ -40,17 +40,17 @@ class Static_Site_Importer_Artifact_Envelope {
 
 		return array_filter(
 			array(
-				'schema'       => self::WEBSITE_ARTIFACT_BUNDLE_SCHEMA,
-				'root'         => isset( $website_artifact['root'] ) ? (string) $website_artifact['root'] : 'website',
-				'entrypoint'   => isset( $website_artifact['entrypoint'] ) ? (string) $website_artifact['entrypoint'] : 'website/index.html',
-				'files'        => array_values( array_map( array( self::class, 'bundle_file_from_website_artifact_file' ), $files ) ),
-				'provenance'   => isset( $website_artifact['provenance'] ) && is_array( $website_artifact['provenance'] ) ? $website_artifact['provenance'] : array(),
-				'report'       => isset( $website_artifact['report'] ) && is_array( $website_artifact['report'] ) ? $website_artifact['report'] : array(),
-				'validation'   => isset( $website_artifact['validation'] ) && is_array( $website_artifact['validation'] ) ? $website_artifact['validation'] : array(),
-				'import'       => isset( $website_artifact['import'] ) && is_array( $website_artifact['import'] ) ? $website_artifact['import'] : array(),
-				'reports'      => isset( $website_artifact['reports'] ) && is_array( $website_artifact['reports'] ) ? $website_artifact['reports'] : array(),
+				'schema'     => self::WEBSITE_ARTIFACT_BUNDLE_SCHEMA,
+				'root'       => isset( $website_artifact['root'] ) ? (string) $website_artifact['root'] : 'website',
+				'entrypoint' => isset( $website_artifact['entrypoint'] ) ? (string) $website_artifact['entrypoint'] : 'website/index.html',
+				'files'      => array_values( array_map( array( self::class, 'bundle_file_from_website_artifact_file' ), $files ) ),
+				'provenance' => isset( $website_artifact['provenance'] ) && is_array( $website_artifact['provenance'] ) ? $website_artifact['provenance'] : array(),
+				'report'     => isset( $website_artifact['report'] ) && is_array( $website_artifact['report'] ) ? $website_artifact['report'] : array(),
+				'validation' => isset( $website_artifact['validation'] ) && is_array( $website_artifact['validation'] ) ? $website_artifact['validation'] : array(),
+				'import'     => isset( $website_artifact['import'] ) && is_array( $website_artifact['import'] ) ? $website_artifact['import'] : array(),
+				'reports'    => isset( $website_artifact['reports'] ) && is_array( $website_artifact['reports'] ) ? $website_artifact['reports'] : array(),
 			),
-			static fn ( $value ): bool => array() !== $value && null !== $value && '' !== $value
+			static fn ( $value ): bool => array() !== $value && '' !== $value
 		);
 	}
 
@@ -115,7 +115,7 @@ class Static_Site_Importer_Artifact_Envelope {
 	 * @return array<string,mixed>
 	 */
 	private static function website_artifact_file_from_bundle_file( $file ): array {
-		$file = is_array( $file ) ? $file : array();
+		$file       = is_array( $file ) ? $file : array();
 		$entrypoint = ! empty( $file['entrypoint'] ) || 'entrypoint' === ( $file['role'] ?? '' );
 
 		return array_filter(

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -347,10 +347,10 @@ class Static_Site_Importer_Theme_Generator {
 		$quality_passed    = empty( $quality['fail_import'] );
 		$review_pending    = ! $quality_passed || $diagnostic_count > 0;
 		$common            = array(
-			'schema'    => 'wp-codebox/live-progress-event/v1',
-			'run_id'    => $import_run_id,
+			'schema'        => 'wp-codebox/live-progress-event/v1',
+			'run_id'        => $import_run_id,
 			'source_schema' => 'static-site-importer/materialization-progress/v1',
-			'timestamp' => $now,
+			'timestamp'     => $now,
 		);
 
 		return array(
@@ -392,7 +392,10 @@ class Static_Site_Importer_Theme_Generator {
 					'label'     => $review_pending ? 'Review pending' : 'Saved to WordPress',
 					'artifacts' => array_filter(
 						array(
-							'import_report' => '' !== $report_path ? array( 'path' => $report_path, 'kind' => 'json' ) : null,
+							'import_report' => '' !== $report_path ? array(
+								'path' => $report_path,
+								'kind' => 'json',
+							) : null,
 						)
 					),
 				)

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -90,7 +90,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			$root = realpath( dirname( $entry ) );
 			if ( false === $root ) {
 				WP_CLI::error( 'Could not resolve the source directory.' );
+				return;
 			}
+			$root = (string) $root;
 
 			$files    = array();
 			$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $root, FilesystemIterator::SKIP_DOTS ) );
@@ -108,11 +110,12 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				$content = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- CLI reads operator-provided source files.
 				if ( false === $content ) {
 					WP_CLI::error( sprintf( 'Could not read source file: %s', $path ) );
+					return;
 				}
 
 				$files[] = array(
 					'path'           => $relative,
-					'content_base64' => base64_encode( $content ),
+					'content_base64' => base64_encode( $content ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encodes declared artifact payload bytes, including binary assets.
 				);
 			}
 


### PR DESCRIPTION
## Summary
- Fix PHPStan type issues in the restored CLI import wrapper.
- Add the base64 payload-encoding PHPCS rationale for local artifact files.
- Clean up existing release lint formatting/static-analysis blockers in artifact/progress report code.

## Testing
- `php -l static-site-importer.php`
- `php -l includes/class-static-site-importer-artifact-envelope.php`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `homeboy lint static-site-importer --path /Users/chubes/Developer/static-site-importer@release-v1.1.40`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing Homeboy release lint blockers, applying lint/static-analysis fixes, and running verification.
