### PR TITLE
Fix Playground blueprint opening

### DIFF
--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -195,7 +195,17 @@
 
 	const previewUrl = function ( report ) {
 		const preview = report && report.preview && typeof report.preview === 'object' ? report.preview : {};
-		return preview.url || '';
+		const playground = preview.playground && typeof preview.playground === 'object' ? preview.playground : {};
+		return playground.blueprint_url || preview.url || '';
+	};
+
+	const openPendingPreviewWindow = function () {
+		const openedWindow = window.open( 'about:blank', '_blank' );
+		if ( openedWindow ) {
+			openedWindow.opener = null;
+		}
+
+		return openedWindow;
 	};
 
 	const openPreview = function ( report, openedWindow ) {
@@ -272,7 +282,7 @@
 		const restUrl = root.getAttribute( 'data-static-site-importer-figma-rest-url' );
 		const nonce = root.getAttribute( 'data-static-site-importer-nonce' );
 		const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
-		const playgroundWindow = isCurrentSiteImport ? null : window.open( 'about:blank', '_blank', 'noopener,noreferrer' );
+		const playgroundWindow = isCurrentSiteImport ? null : openPendingPreviewWindow();
 		const formData = new FormData();
 		formData.append( 'figma_file', file );
 		formData.append( 'apply_to_current_site', isCurrentSiteImport ? '1' : '0' );
@@ -295,7 +305,7 @@
 				showStatus( root, 'Figma import complete.' );
 			} else if ( response.ok && report.success && previewUrl( report ) ) {
 				openPreview( report, playgroundWindow );
-				showStatus( root, 'WordPress preview opened.' );
+				showStatus( root, 'WordPress Playground opened.' );
 			} else {
 				if ( playgroundWindow ) {
 					playgroundWindow.close();
@@ -341,7 +351,7 @@
 			const uploadInputs = root.querySelectorAll( '[data-static-site-importer-source-files], [data-static-site-importer-source-directory]' );
 			const provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
 			const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
-			const playgroundWindow = isCurrentSiteImport ? null : window.open( 'about:blank', '_blank', 'noopener,noreferrer' );
+			const playgroundWindow = isCurrentSiteImport ? null : openPendingPreviewWindow();
 			const source = {
 				url: form ? form.getAttribute( 'data-static-site-importer-default-url' ) || '' : '',
 				html: html ? html.value : '',
@@ -384,7 +394,7 @@
 					showStatus( root, 'Import complete.' );
 				} else if ( response.ok && report.success && previewUrl( report ) ) {
 					openPreview( report, playgroundWindow );
-					showStatus( root, 'WordPress preview opened.' );
+					showStatus( root, 'WordPress Playground opened.' );
 				} else if ( response.ok && previewUrl( report ) ) {
 					openPreview( report, playgroundWindow );
 					showStatus( root, 'Preview opened.' );

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -553,9 +553,11 @@ $assert( str_contains( $view_js, 'isCurrentSiteImport' ), 'view-names-current-si
 $assert( str_contains( $view_js, 'apply_to_current_site: isCurrentSiteImport' ), 'view-sends-current-site-apply-flag-only-from-apply-mode' );
 $assert( str_contains( $view_js, 'activate: isCurrentSiteImport' ), 'view-activates-only-current-site-imports' );
 $assert( str_contains( $view_js, 'overwrite: isCurrentSiteImport' ), 'view-overwrites-only-current-site-imports' );
-$assert( str_contains( $view_js, "window.open( 'about:blank'" ), 'view-opens-playground-window-from-click' );
+$assert( str_contains( $view_js, "window.open( 'about:blank', '_blank' )" ), 'view-opens-controllable-playground-window-from-click' );
+$assert( ! str_contains( $view_js, "window.open( 'about:blank', '_blank', 'noopener,noreferrer' )" ), 'view-does-not-open-uncontrollable-about-blank-window' );
+$assert( str_contains( $view_js, 'openedWindow.opener = null' ), 'view-clears-playground-window-opener' );
 $assert( str_contains( $view_js, 'openPreview( report, playgroundWindow )' ), 'view-navigates-opened-window-to-playground-url' );
-$assert( ! str_contains( $view_js, 'playground.blueprint_url' ), 'view-does-not-open-playground-blueprint-before-preview-is-ready' );
+$assert( str_contains( $view_js, 'playground.blueprint_url || preview.url' ), 'view-opens-playground-blueprint-for-generated-site' );
 $generic_preview_message = implode( ' ', array( 'no', 'preview', 'provider', 'is', 'configured' ) );
 $assert( ! str_contains( $view_js, $generic_preview_message ), 'view-does-not-reference-generic-preview-message' );
 $assert( ! str_contains( $view_js, 'Open WordPress preview' ) && ! str_contains( $html, 'Open WordPress preview' ), 'view-and-render-omit-redundant-preview-link-label' );


### PR DESCRIPTION
## Summary
- Open the generated Playground blueprint URL for the Generate WordPress Website flow.
- Keep the click-created placeholder tab controllable so it can be navigated or closed instead of leaving a dead `about:blank` tab.
- Preserve the no-second-preview-link UI while opening the imported Playground site directly.

## Testing
- `php tests/smoke-importer-block.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the dead `about:blank` browser behavior, patching the importer block open flow, updating smoke assertions, and running verification.
