### PR TITLE
Open Playground only after blueprint is ready

### DIFF
--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -199,29 +199,13 @@
 		return playground.blueprint_url || preview.url || '';
 	};
 
-	const openPendingPreviewWindow = function () {
-		const openedWindow = window.open( 'about:blank', '_blank' );
-		if ( openedWindow ) {
-			openedWindow.opener = null;
-		}
-
-		return openedWindow;
-	};
-
-	const openPreview = function ( report, openedWindow ) {
+	const openPreview = function ( report ) {
 		const url = previewUrl( report );
 		if ( ! url ) {
-			if ( openedWindow ) {
-				openedWindow.close();
-			}
 			return false;
 		}
 
-		if ( openedWindow ) {
-			openedWindow.location.href = url;
-		} else {
-			window.open( url, '_blank', 'noopener,noreferrer' );
-		}
+		window.open( url, '_blank', 'noopener,noreferrer' );
 
 		return true;
 	};
@@ -282,7 +266,6 @@
 		const restUrl = root.getAttribute( 'data-static-site-importer-figma-rest-url' );
 		const nonce = root.getAttribute( 'data-static-site-importer-nonce' );
 		const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
-		const playgroundWindow = isCurrentSiteImport ? null : openPendingPreviewWindow();
 		const formData = new FormData();
 		formData.append( 'figma_file', file );
 		formData.append( 'apply_to_current_site', isCurrentSiteImport ? '1' : '0' );
@@ -304,19 +287,13 @@
 			if ( response.ok && isCurrentSiteImport && report.success ) {
 				showStatus( root, 'Figma import complete.' );
 			} else if ( response.ok && report.success && previewUrl( report ) ) {
-				openPreview( report, playgroundWindow );
+				openPreview( report );
 				showStatus( root, 'WordPress Playground opened.' );
 			} else {
-				if ( playgroundWindow ) {
-					playgroundWindow.close();
-				}
 				showStatus( root, response.ok ? 'Figma import request complete.' : 'Figma import request failed.' );
 			}
 		} catch ( error ) {
 			setReport( root, { success: false, error: { message: error.message } } );
-			if ( playgroundWindow ) {
-				playgroundWindow.close();
-			}
 			showStatus( root, 'Figma import request failed.' );
 		}
 	};
@@ -351,7 +328,6 @@
 			const uploadInputs = root.querySelectorAll( '[data-static-site-importer-source-files], [data-static-site-importer-source-directory]' );
 			const provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
 			const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
-			const playgroundWindow = isCurrentSiteImport ? null : openPendingPreviewWindow();
 			const source = {
 				url: form ? form.getAttribute( 'data-static-site-importer-default-url' ) || '' : '',
 				html: html ? html.value : '',
@@ -360,9 +336,6 @@
 			};
 
 			if ( ! hasSource( source ) ) {
-				if ( playgroundWindow ) {
-					playgroundWindow.close();
-				}
 				setReport( root, { success: false, error: { message: 'Upload a website or paste HTML to start.' } } );
 				showStatus( root, 'Upload a website or paste HTML to start.' );
 				return;
@@ -393,27 +366,18 @@
 				if ( response.ok && isCurrentSiteImport && report.success ) {
 					showStatus( root, 'Import complete.' );
 				} else if ( response.ok && report.success && previewUrl( report ) ) {
-					openPreview( report, playgroundWindow );
+					openPreview( report );
 					showStatus( root, 'WordPress Playground opened.' );
 				} else if ( response.ok && previewUrl( report ) ) {
-					openPreview( report, playgroundWindow );
+					openPreview( report );
 					showStatus( root, 'Preview opened.' );
 				} else if ( response.ok && report.preview && report.preview.status === 'unavailable' ) {
-					if ( playgroundWindow ) {
-						playgroundWindow.close();
-					}
 					showStatus( root, report.preview.message || 'Preview unavailable: WP Codebox did not return a preview URL or Playground blueprint URL.' );
 				} else {
-					if ( playgroundWindow ) {
-						playgroundWindow.close();
-					}
 					showStatus( root, response.ok && report.success ? 'Preview request complete.' : 'Preview request failed.' );
 				}
 			} catch ( error ) {
 				setReport( root, { success: false, error: { message: error.message } } );
-				if ( playgroundWindow ) {
-					playgroundWindow.close();
-				}
 				showStatus( root, 'Preview request failed.' );
 			} finally {
 				submit.disabled = false;

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -553,10 +553,9 @@ $assert( str_contains( $view_js, 'isCurrentSiteImport' ), 'view-names-current-si
 $assert( str_contains( $view_js, 'apply_to_current_site: isCurrentSiteImport' ), 'view-sends-current-site-apply-flag-only-from-apply-mode' );
 $assert( str_contains( $view_js, 'activate: isCurrentSiteImport' ), 'view-activates-only-current-site-imports' );
 $assert( str_contains( $view_js, 'overwrite: isCurrentSiteImport' ), 'view-overwrites-only-current-site-imports' );
-$assert( str_contains( $view_js, "window.open( 'about:blank', '_blank' )" ), 'view-opens-controllable-playground-window-from-click' );
-$assert( ! str_contains( $view_js, "window.open( 'about:blank', '_blank', 'noopener,noreferrer' )" ), 'view-does-not-open-uncontrollable-about-blank-window' );
-$assert( str_contains( $view_js, 'openedWindow.opener = null' ), 'view-clears-playground-window-opener' );
-$assert( str_contains( $view_js, 'openPreview( report, playgroundWindow )' ), 'view-navigates-opened-window-to-playground-url' );
+$assert( ! str_contains( $view_js, 'about:blank' ), 'view-does-not-open-window-before-preview-url-is-ready' );
+$assert( ! str_contains( $view_js, 'openPendingPreviewWindow' ), 'view-has-no-pending-preview-window-helper' );
+$assert( str_contains( $view_js, 'openPreview( report )' ), 'view-opens-preview-only-after-report-is-ready' );
 $assert( str_contains( $view_js, 'playground.blueprint_url || preview.url' ), 'view-opens-playground-blueprint-for-generated-site' );
 $generic_preview_message = implode( ' ', array( 'no', 'preview', 'provider', 'is', 'configured' ) );
 $assert( ! str_contains( $view_js, $generic_preview_message ), 'view-does-not-reference-generic-preview-message' );


### PR DESCRIPTION
## Summary
- Remove all pre-opened `about:blank` placeholder windows from the Generate WordPress Website flow.
- Wait for the REST response to return the generated Playground URL, then open that URL once.
- Keep the generated Playground URL selection from the old preview link path while leaving the redundant link removed.

## Testing
- `php tests/smoke-importer-block.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Restoring the prepare-then-open flow, updating assertions, and running focused verification.
