### PR TITLE
Expose validation diagnostics in matrix results

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -406,6 +406,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				),
 			),
 			'diagnostic_summary'      => $summary['diagnostic_summary'] ?? array(),
+			'diagnostics'             => self::compact_import_report_diagnostics( $diagnostics ),
 			'diagnostic_refs'         => isset( $quality['diagnostic_refs'] ) && is_array( $quality['diagnostic_refs'] ) ? $quality['diagnostic_refs'] : array(),
 			'artifacts'               => self::validation_artifact_refs(),
 			'visual_parity_artifacts' => isset( $report['visual_parity_artifacts'] ) && is_array( $report['visual_parity_artifacts'] ) ? $report['visual_parity_artifacts'] : self::visual_parity_artifact_contract(),

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -102,6 +102,8 @@ class Static_Site_Importer_Validation_Runtime {
 			'import_report' => array(),
 		);
 		$result['fixture_diagnostics'] = Static_Site_Importer_Diagnostic_Contract::build( $result );
+		$result['diagnostics']         = isset( $result['fixture_diagnostics']['diagnostics'] ) && is_array( $result['fixture_diagnostics']['diagnostics'] ) ? $result['fixture_diagnostics']['diagnostics'] : array();
+		$result['diagnostic_summary']  = isset( $result['fixture_diagnostics']['diagnostic_summary'] ) && is_array( $result['fixture_diagnostics']['diagnostic_summary'] ) ? $result['fixture_diagnostics']['diagnostic_summary'] : array();
 
 		return $result;
 	}
@@ -152,6 +154,8 @@ class Static_Site_Importer_Validation_Runtime {
 			),
 		);
 		$result['fixture_diagnostics'] = Static_Site_Importer_Diagnostic_Contract::build( $result );
+		$result['diagnostics']         = isset( $result['fixture_diagnostics']['diagnostics'] ) && is_array( $result['fixture_diagnostics']['diagnostics'] ) ? $result['fixture_diagnostics']['diagnostics'] : array();
+		$result['diagnostic_summary']  = isset( $result['fixture_diagnostics']['diagnostic_summary'] ) && is_array( $result['fixture_diagnostics']['diagnostic_summary'] ) ? $result['fixture_diagnostics']['diagnostic_summary'] : array();
 
 		return $result;
 	}

--- a/tests/smoke-semantic-parity-diagnostics.php
+++ b/tests/smoke-semantic-parity-diagnostics.php
@@ -90,6 +90,9 @@ $validation = $report['import_validation_result'] ?? array();
 $assert( 'reported' === ( $validation['quality_gates']['semantic_parity']['status'] ?? '' ), 'validation-gate-reported' );
 $assert( 3 === ( $validation['quality_gates']['semantic_parity']['count'] ?? 0 ), 'validation-gate-count' );
 $assert( 3 === count( $validation['quality_gates']['semantic_parity']['diagnostic_refs'] ?? array() ), 'validation-gate-diagnostic-refs' );
+$assert( 3 === count( $validation['diagnostics'] ?? array() ), 'validation-artifact-exposes-diagnostics' );
+$assert( 'semantic_parity_navigation_missing' === ( $validation['diagnostics'][0]['type'] ?? '' ), 'validation-artifact-preserves-diagnostic-type' );
+$assert( 'header nav' === ( $validation['diagnostics'][0]['selector'] ?? '' ), 'validation-artifact-preserves-selector' );
 $assert( 3 === ( $report['finding_packets']['count'] ?? 0 ), 'finding-packets-created' );
 $assert( 'blocks-engine/php-transformer' === ( $validation['quality_gates']['semantic_fidelity']['owner'] ?? '' ), 'semantic-fidelity-owner' );
 

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -401,6 +401,8 @@ namespace {
 	$assert( 'reported' === ( $runtime_gate['status'] ?? '' ), 'runtime-parity-gate-reports-issues' );
 	$assert( 2 === ( $runtime_gate['count'] ?? 0 ), 'runtime-parity-gate-counts-actionable-issues' );
 	$assert( 2 === count( $runtime_gate['diagnostic_refs'] ?? array() ), 'runtime-parity-gate-has-diagnostic-refs' );
+	$assert( 3 === count( $runtime_report['import_validation_result']['diagnostics'] ?? array() ), 'runtime-parity-validation-artifact-exposes-diagnostics' );
+	$assert( '#canvas' === ( $runtime_report['import_validation_result']['diagnostics'][0]['selector'] ?? '' ), 'runtime-parity-validation-artifact-preserves-selector' );
 	$assert( 'runtime_dependency_missing_dom_target' === ( $runtime_report['diagnostics'][0]['type'] ?? '' ), 'runtime-parity-missing-target-becomes-diagnostic' );
 	$assert( '#canvas' === ( $runtime_report['diagnostics'][0]['selector'] ?? '' ), 'runtime-parity-diagnostic-preserves-selector' );
 	$assert( 'assets/script.js' === ( $runtime_report['diagnostics'][0]['script_path'] ?? '' ), 'runtime-parity-diagnostic-preserves-script-path' );

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Smoke coverage for validation-runtime diagnostic propagation.
+ *
+ * Run from the repository root:
+ * php tests/smoke-validation-runtime-diagnostics.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.keyFound
+		$key = strtolower( (string) $key );
+
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( (string) $title );
+		$title = preg_replace( '/[^a-z0-9_\-]+/', '-', $title );
+
+		return trim( is_string( $title ) ? $title : '', '-' );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-validation-runtime.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$artifact_dir = sys_get_temp_dir() . '/ssi-validation-runtime-diagnostics-' . uniqid( '', true );
+mkdir( $artifact_dir, 0777, true );
+$report_path = $artifact_dir . '/import-report.json';
+
+file_put_contents(
+	$report_path,
+	json_encode(
+		array(
+			'quality'     => array(
+				'semantic_parity_failure_count' => 1,
+			),
+			'diagnostics' => array(
+				array(
+					'type'        => 'semantic_parity_navigation_missing',
+					'severity'    => 'warning',
+					'source_path' => 'website/index.html',
+					'selector'    => 'footer nav',
+					'reason'      => 'Source navigation menu was not represented as a core/navigation block.',
+				),
+			),
+		),
+		JSON_PRETTY_PRINT
+	)
+);
+
+$method = new ReflectionMethod( Static_Site_Importer_Validation_Runtime::class, 'result_from_import' );
+$result = $method->invoke(
+	null,
+	array(
+		'external_report_path' => $report_path,
+		'quality'              => array( 'pass' => false ),
+		'theme_slug'           => 'ssi-fixture-theme',
+	),
+	$artifact_dir,
+	array(
+		'slug' => 'fixture-22',
+		'name' => 'Fixture 22',
+	)
+);
+
+$assert( false === ( $result['success'] ?? true ), 'quality-failure-reflected' );
+$assert( isset( $result['fixture_diagnostics']['diagnostics'] ), 'nested-fixture-diagnostics-present' );
+$assert( 1 === count( $result['diagnostics'] ?? array() ), 'top-level-diagnostics-present' );
+$assert( 'semantic_parity_navigation_missing' === ( $result['diagnostics'][0]['type'] ?? '' ), 'top-level-diagnostic-type-preserved' );
+$assert( 'footer nav' === ( $result['diagnostics'][0]['selector'] ?? '' ), 'top-level-diagnostic-selector-preserved' );
+$assert( 1 === ( $result['diagnostic_summary']['total'] ?? 0 ), 'top-level-diagnostic-summary-present' );
+
+unlink( $report_path );
+rmdir( $artifact_dir );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: validation runtime diagnostics smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- expose compact validation diagnostics directly on import validation result envelopes
- propagate validation runtime diagnostics and summaries to top-level result fields
- add smoke coverage for matrix diagnostics consumers

## Testing
- php tests/smoke-validation-runtime-diagnostics.php
- php tests/smoke-semantic-parity-diagnostics.php
- php tests/smoke-transformer-adapter.php
- php tests/smoke-import-diagnostic-contract.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode general subagents
- **Used for:** r10 matrix diagnostic analysis, diagnostics propagation patch drafting, and smoke test updates