### PR TITLE
Expose quality gate diagnostics to fixture matrix

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -371,8 +371,18 @@ if ( ! function_exists( 'static_site_importer_ability_error' ) ) {
 	 */
 	function static_site_importer_ability_error( string $code, string $message, $data = null ): array {
 		$import_report_summary = is_array( $data ) && isset( $data['import_report_summary'] ) && is_array( $data['import_report_summary'] ) ? $data['import_report_summary'] : static_site_importer_failure_report_summary( $code, $message );
+		$diagnostics           = static_site_importer_error_diagnostics( $code, $message, $data, $import_report_summary );
+		$fixture_diagnostics   = class_exists( 'Static_Site_Importer_Diagnostic_Contract' ) ? Static_Site_Importer_Diagnostic_Contract::build(
+			array(
+				'success'                  => false,
+				'status'                   => 'failed',
+				'diagnostics'              => $diagnostics,
+				'import_validation_result' => is_array( $data ) && isset( $data['import_validation_result'] ) && is_array( $data['import_validation_result'] ) ? $data['import_validation_result'] : array(),
+				'import_report'            => is_array( $data ) && isset( $data['import_report'] ) && is_array( $data['import_report'] ) ? $data['import_report'] : array(),
+			)
+		) : array( 'diagnostics' => $diagnostics );
 
-		return array(
+		$payload = array(
 			'success'               => false,
 			'error'                 => array(
 				'code'    => $code,
@@ -380,6 +390,57 @@ if ( ! function_exists( 'static_site_importer_ability_error' ) ) {
 				'data'    => $data,
 			),
 			'import_report_summary' => $import_report_summary,
+			'diagnostics'           => $diagnostics,
+			'errors'                => $diagnostics,
+			'fixture_diagnostics'   => $fixture_diagnostics,
+		);
+
+		if ( is_array( $data ) && isset( $data['import_validation_result'] ) && is_array( $data['import_validation_result'] ) ) {
+			$payload['import_validation_result'] = $data['import_validation_result'];
+		}
+		if ( is_array( $data ) && isset( $data['finding_packets'] ) && is_array( $data['finding_packets'] ) ) {
+			$payload['finding_packets'] = $data['finding_packets'];
+		}
+
+		return $payload;
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_error_diagnostics' ) ) {
+	/**
+	 * Promote nested validation diagnostics to top-level ability fields.
+	 *
+	 * @param string              $code                  Error code.
+	 * @param string              $message               Error message.
+	 * @param mixed               $data                  Optional error data.
+	 * @param array<string,mixed> $import_report_summary Import report summary.
+	 * @return array<int,array<string,mixed>>
+	 */
+	function static_site_importer_error_diagnostics( string $code, string $message, $data, array $import_report_summary ): array {
+		$candidates = array(
+			is_array( $data ) && isset( $data['import_validation_result']['diagnostics'] ) && is_array( $data['import_validation_result']['diagnostics'] ) ? $data['import_validation_result']['diagnostics'] : array(),
+			isset( $import_report_summary['diagnostics'] ) && is_array( $import_report_summary['diagnostics'] ) ? $import_report_summary['diagnostics'] : array(),
+		);
+
+		foreach ( $candidates as $candidate ) {
+			$diagnostics = array_values( array_filter( $candidate, 'is_array' ) );
+			if ( ! empty( $diagnostics ) ) {
+				return $diagnostics;
+			}
+		}
+
+		return array(
+			array(
+				'type'        => 'validation_error',
+				'kind'        => 'validation_error',
+				'severity'    => 'error',
+				'code'        => $code,
+				'reason_code' => $code,
+				'reason'      => $code,
+				'message'     => $message,
+				'stage'       => 'validation',
+				'owner'       => 'static-site-importer',
+			)
 		);
 	}
 }

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2105,8 +2105,11 @@ class Static_Site_Importer_Report_Diagnostics {
 			'selector',
 			'script_path',
 			'excerpt',
+			'source_snippet',
 			'source_html_preview',
+			'observed_output',
 			'emitted_block_preview',
+			'observed_block_name',
 			'block_name',
 			'block_path',
 			'engine',
@@ -2121,6 +2124,7 @@ class Static_Site_Importer_Report_Diagnostics {
 
 		$compact = array();
 		foreach ( array_slice( $diagnostics, 0, 50 ) as $diagnostic ) {
+			$diagnostic = self::with_matrix_diagnostic_aliases( $diagnostic );
 			$row = array();
 			foreach ( $fields as $field ) {
 				if ( ! array_key_exists( $field, $diagnostic ) || null === $diagnostic[ $field ] || '' === $diagnostic[ $field ] || array() === $diagnostic[ $field ] ) {
@@ -2136,6 +2140,31 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		return $compact;
+	}
+
+	/**
+	 * Add generic aliases consumed by fixture-matrix grouping without changing source ownership.
+	 *
+	 * @param array<string,mixed> $diagnostic Normalized diagnostic.
+	 * @return array<string,mixed>
+	 */
+	private static function with_matrix_diagnostic_aliases( array $diagnostic ): array {
+		if ( empty( $diagnostic['source_snippet'] ) ) {
+			foreach ( array( 'source_html_preview', 'html_excerpt', 'excerpt' ) as $field ) {
+				if ( isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) && '' !== trim( (string) $diagnostic[ $field ] ) ) {
+					$diagnostic['source_snippet'] = (string) $diagnostic[ $field ];
+					break;
+				}
+			}
+		}
+		if ( empty( $diagnostic['observed_output'] ) && isset( $diagnostic['emitted_block_preview'] ) && is_scalar( $diagnostic['emitted_block_preview'] ) ) {
+			$diagnostic['observed_output'] = (string) $diagnostic['emitted_block_preview'];
+		}
+		if ( empty( $diagnostic['observed_block_name'] ) && isset( $diagnostic['block_name'] ) && is_scalar( $diagnostic['block_name'] ) ) {
+			$diagnostic['observed_block_name'] = (string) $diagnostic['block_name'];
+		}
+
+		return $diagnostic;
 	}
 
 	/**

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -207,6 +207,11 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<iframe', $packet['source']['snippet'] ?? '' );
 		$this->assertStringContainsString( '<!-- wp:html -->', $packet['observed']['output'] ?? '' );
 		$this->assertStringContainsString( 'without fallback', $packet['expected']['outcome'] ?? '' );
+
+		$validation_diagnostic = $report['import_validation_result']['diagnostics'][0] ?? array();
+		$this->assertStringContainsString( '<iframe', $validation_diagnostic['source_snippet'] ?? '' );
+		$this->assertStringContainsString( '<!-- wp:html -->', $validation_diagnostic['observed_output'] ?? '' );
+		$this->assertSame( 'core/html', $validation_diagnostic['observed_block_name'] ?? '' );
 	}
 
 	/**

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -20,7 +20,26 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook_name = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook_name ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook_name, $callback ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return true;
+	}
+}
+
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
+require_once dirname( __DIR__ ) . '/includes/abilities.php';
 
 $failures   = array();
 $assertions = 0;
@@ -101,6 +120,40 @@ $assert( 'blocks-engine' === ( $diagnostics['by_repair_bucket']['runtime_target_
 $assert( '#canvas' === ( $diagnostics['runtime_dependency_target_gaps'][0]['selector'] ?? '' ), 'runtime-target-selector' );
 $assert( 'header nav' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['selector'] ?? '' ), 'semantic-selector' );
 $assert( array() === ( $diagnostics['artifact_refs'] ?? null ), 'no-runtime-artifact-requirement' );
+
+$quality_gate_error = static_site_importer_ability_error(
+	'static_site_importer_quality_gate_failed',
+	'Import failed quality gates; materialization was not completed.',
+	array(
+		'import_validation_result' => array(
+			'diagnostics' => array(
+				array(
+					'id'                  => 'diag-001-core-html',
+					'type'                => 'core_html_block',
+					'kind'                => 'core_html_block',
+					'severity'            => 'warning',
+					'reason_code'         => 'generated_document_contains_core_html',
+					'reason'              => 'generated_document_contains_core_html',
+					'source_path'         => 'posts/page-home.post_content',
+					'selector'            => 'iframe#map',
+					'source_html_preview' => '<iframe id="map"></iframe>',
+					'observed_output'     => '<!-- wp:html --><iframe id="map"></iframe><!-- /wp:html -->',
+					'observed_block_name' => 'core/html',
+				)
+			),
+		),
+		'quality'                  => array(
+			'core_html_block_count' => 1,
+			'failure_reasons'      => array( 'core_html_block' ),
+		),
+	)
+);
+
+$assert( 'core_html_block' === ( $quality_gate_error['diagnostics'][0]['type'] ?? '' ), 'ability-error-promotes-validation-diagnostic-type' );
+$assert( 'iframe#map' === ( $quality_gate_error['diagnostics'][0]['selector'] ?? '' ), 'ability-error-promotes-validation-selector' );
+$assert( is_array( $quality_gate_error['errors'][0] ?? null ), 'ability-error-errors-are-structured' );
+$assert( 'core_html_block' === ( $quality_gate_error['errors'][0]['kind'] ?? '' ), 'ability-error-prevents-numeric-generic-errors' );
+$assert( 'fallback_block' === ( $quality_gate_error['fixture_diagnostics']['diagnostics'][0]['repair_bucket'] ?? '' ), 'ability-error-fixture-diagnostics-classified' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-semantic-parity-diagnostics.php
+++ b/tests/smoke-semantic-parity-diagnostics.php
@@ -109,6 +109,21 @@ Static_Site_Importer_Report_Diagnostics::record_blocks_engine_result( $fail_repo
 $fail_quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $fail_report, array( 'fail_on_quality' => true ) );
 $assert( true === ( $fail_quality['fail_import'] ?? false ), 'fail-on-quality-fails' );
 
+$context_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+$context_report['diagnostics'][] = array(
+	'type'                  => 'core_html_block',
+	'source'                => 'generated:posts/page-home.post_content',
+	'source_html_preview'   => '<iframe id="map"></iframe>',
+	'emitted_block_preview' => '<!-- wp:html --><iframe id="map"></iframe><!-- /wp:html -->',
+	'block_name'            => 'core/html',
+	'reason'                => 'generated_document_contains_core_html',
+);
+Static_Site_Importer_Report_Diagnostics::finalize_report( $context_report, array() );
+$context_diagnostic = $context_report['import_validation_result']['diagnostics'][0] ?? array();
+$assert( '<iframe id="map"></iframe>' === ( $context_diagnostic['source_snippet'] ?? '' ), 'validation-diagnostic-source-snippet-alias' );
+$assert( '<!-- wp:html --><iframe id="map"></iframe><!-- /wp:html -->' === ( $context_diagnostic['observed_output'] ?? '' ), 'validation-diagnostic-observed-output-alias' );
+$assert( 'core/html' === ( $context_diagnostic['observed_block_name'] ?? '' ), 'validation-diagnostic-observed-block-name-alias' );
+
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
 	exit( 1 );


### PR DESCRIPTION
## Summary
- promote nested validation diagnostics onto ability error payloads
- preserve source snippets, observed output, and observed block names in compact validation diagnostics
- make SSI matrix findings more actionable instead of numeric generic fixture diagnostics

## Testing
- php -l includes/abilities.php
- php -l includes/class-static-site-importer-report-diagnostics.php
- php tests/smoke-import-diagnostic-contract.php
- php tests/smoke-semantic-parity-diagnostics.php

## Notes
- Broader php tests/smoke-transformer-adapter.php still has existing materialization-view assertion failures unrelated to this diagnostics change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode general subagents
- **Used for:** r14 matrix diagnostic analysis, diagnostics propagation patch drafting, and smoke tests