### PR TITLE
Add diagnostic loss classes

### DIFF
--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Diagnostic_Loss_Classes' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-diagnostic-loss-classes.php';
+}
+
 /**
  * Normalizes importer-owned diagnostics for validation and repair loops.
  */
@@ -52,7 +56,9 @@ class Static_Site_Importer_Diagnostic_Contract {
 			'import_report_quality_counts'   => $quality_counts,
 			'diagnostic_summary'             => self::diagnostic_summary( $diagnostics ),
 			'diagnostics'                    => $diagnostics,
+			'loss_class_summary'             => Static_Site_Importer_Diagnostic_Loss_Classes::counts( $diagnostics ),
 			'by_repair_bucket'               => self::diagnostics_by_field( $diagnostics, 'repair_bucket' ),
+			'by_loss_class'                  => self::diagnostics_by_field( $diagnostics, 'loss_class' ),
 			'by_parser_owner'                => self::diagnostics_by_field( $diagnostics, 'parser_owner' ),
 			'by_category'                    => self::diagnostics_by_field( $diagnostics, 'category' ),
 			'top_parser_buckets'             => self::top_parser_buckets( $diagnostics ),
@@ -205,6 +211,8 @@ class Static_Site_Importer_Diagnostic_Contract {
 				'runtime_target_selector' => self::first_scalar( $row, array( 'runtime_target_selector', 'target_selector', 'target', 'selector' ), '' ),
 				'missing_asset_path'      => self::missing_asset_path( $row ),
 			);
+			$diagnostic['loss_class']       = Static_Site_Importer_Diagnostic_Loss_Classes::classify( array_merge( $row, $diagnostic ) );
+			$diagnostic['diagnostic_class'] = $diagnostic['loss_class'];
 
 			foreach ( array( 'message', 'reason', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt', 'block_name', 'block_path', 'script_path', 'element', 'tag_name', 'tag', 'src', 'href', 'expected', 'observed', 'suggested_primitive' ) as $field ) {
 				$value = self::first_scalar( $row, array( $field ), '' );
@@ -271,6 +279,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 			'total'         => count( $diagnostics ),
 			'severity'      => array(),
 			'category'      => array(),
+			'loss_class'    => Static_Site_Importer_Diagnostic_Loss_Classes::counts( $diagnostics ),
 			'type'          => array(),
 			'parser_owner'  => array(),
 			'repair_bucket' => array(),

--- a/includes/class-static-site-importer-diagnostic-loss-classes.php
+++ b/includes/class-static-site-importer-diagnostic-loss-classes.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Product-facing diagnostic loss classes.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Classifies existing diagnostics into stable product readiness buckets.
+ */
+class Static_Site_Importer_Diagnostic_Loss_Classes {
+
+	public const NATIVE_CONVERSION            = 'native_conversion';
+	public const EDITABLE_APPROXIMATION       = 'editable_approximation';
+	public const PRESERVED_RUNTIME_ISLAND     = 'preserved_runtime_island';
+	public const UNSUPPORTED_LOSS             = 'unsupported_loss';
+	public const IMPORTER_MATERIALIZATION_BUG = 'importer_materialization_bug';
+
+	/**
+	 * Return the stable product-facing loss class for an existing diagnostic row.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic row.
+	 * @return string
+	 */
+	public static function classify( array $diagnostic ): string {
+		$explicit = self::scalar( $diagnostic, array( 'loss_class', 'diagnostic_class' ) );
+		if ( in_array( $explicit, self::classes(), true ) ) {
+			return $explicit;
+		}
+
+		$type        = sanitize_key( self::scalar( $diagnostic, array( 'type', 'kind', 'code' ) ) );
+		$category    = sanitize_key( self::scalar( $diagnostic, array( 'category' ) ) );
+		$repair      = sanitize_key( self::scalar( $diagnostic, array( 'suggested_repair_class', 'repair_bucket', 'group_key' ) ) );
+		$reason      = sanitize_key( self::scalar( $diagnostic, array( 'reason_code', 'reason', 'error_code' ) ) );
+		$stage       = sanitize_key( self::scalar( $diagnostic, array( 'stage' ) ) );
+		$block_name  = self::scalar( $diagnostic, array( 'block_name', 'observed_block_name' ) );
+		$haystack    = strtolower( implode( ' ', array( $type, $category, $repair, $reason, $stage, $block_name ) ) );
+
+		if (
+			self::contains_any(
+				$haystack,
+				array( 'runtime_dependency_vendor_telemetry_script', 'interaction_candidate', 'runtime_island', 'preserved_runtime' )
+			)
+		) {
+			return self::PRESERVED_RUNTIME_ISLAND;
+		}
+
+		if (
+			self::contains_any(
+				$haystack,
+				array(
+					'local_asset_not_materialized',
+					'materialization_failure',
+					'sprite_reference_failure',
+					'invalid_block',
+					'block_validation',
+					'missing_dom_target',
+					'runtime_dependency_target',
+					'runtime_dependency_parity_issue',
+					'commerce_dependency_failure',
+				)
+			)
+		) {
+			return self::IMPORTER_MATERIALIZATION_BUG;
+		}
+
+		if (
+			self::contains_any(
+				$haystack,
+				array(
+					'content_loss',
+					'empty_conversion',
+					'unsupported_source_document',
+					'unsafe_inline_svg',
+					'unsupported_element_reference',
+					'dropped_image',
+					'missing_asset',
+				)
+			)
+		) {
+			return self::UNSUPPORTED_LOSS;
+		}
+
+		if (
+			self::contains_any(
+				$haystack,
+				array(
+					'unsupported_html_fallback',
+					'core_html',
+					'freeform',
+					'fallback_block',
+					'presentation',
+					'style_loss',
+					'semantic_parity',
+					'navigation_',
+					'landmark_',
+				)
+			)
+		) {
+			return self::EDITABLE_APPROXIMATION;
+		}
+
+		return self::NATIVE_CONVERSION;
+	}
+
+	/**
+	 * Count diagnostics by loss class, including zeroes for every stable class.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
+	 * @return array<string,int>
+	 */
+	public static function counts( array $diagnostics ): array {
+		$counts = array_fill_keys( self::classes(), 0 );
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+
+			$class            = self::classify( $diagnostic );
+			$counts[ $class ] = ( $counts[ $class ] ?? 0 ) + 1;
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Stable class names.
+	 *
+	 * @return array<int,string>
+	 */
+	public static function classes(): array {
+		return array(
+			self::NATIVE_CONVERSION,
+			self::EDITABLE_APPROXIMATION,
+			self::PRESERVED_RUNTIME_ISLAND,
+			self::UNSUPPORTED_LOSS,
+			self::IMPORTER_MATERIALIZATION_BUG,
+		);
+	}
+
+	/**
+	 * Return the first non-empty scalar value.
+	 *
+	 * @param array<string,mixed> $row    Source row.
+	 * @param array<int,string>   $fields Candidate fields.
+	 * @return string
+	 */
+	private static function scalar( array $row, array $fields ): string {
+		foreach ( $fields as $field ) {
+			if ( isset( $row[ $field ] ) && is_scalar( $row[ $field ] ) && '' !== trim( (string) $row[ $field ] ) ) {
+				return (string) $row[ $field ];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Determine whether a string contains any candidate fragment.
+	 *
+	 * @param string            $value   Value to inspect.
+	 * @param array<int,string> $needles Candidate fragments.
+	 * @return bool
+	 */
+	private static function contains_any( string $value, array $needles ): bool {
+		foreach ( $needles as $needle ) {
+			if ( str_contains( $value, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -15,6 +15,9 @@ if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Product_Handoff_Contract' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-product-handoff-contract.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Diagnostic_Loss_Classes' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-diagnostic-loss-classes.php';
+}
 
 /**
  * Builds SSI import reports and normalizes diagnostics for repair loops.
@@ -559,6 +562,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'semantic_parity'                       => self::compact_semantic_parity_summary( $report ),
 			'diagnostic_count'                      => count( $diagnostics ),
 			'diagnostic_summary'                    => self::compact_import_report_diagnostic_summary( $diagnostics ),
+			'loss_class_summary'                    => Static_Site_Importer_Diagnostic_Loss_Classes::counts( $diagnostics ),
 			'warning_summaries'                     => self::compact_import_report_diagnostic_summaries_by_severity( $diagnostics, 'warning' ),
 			'error_summaries'                       => self::compact_import_report_diagnostic_summaries_by_severity( $diagnostics, 'error' ),
 			'diagnostics'                           => self::compact_import_report_diagnostics( $diagnostics ),
@@ -930,11 +934,14 @@ class Static_Site_Importer_Report_Diagnostics {
 			'type'                 => $type,
 			'severity'             => $severity,
 			'category'             => isset( $diagnostic['category'] ) && is_scalar( $diagnostic['category'] ) ? (string) $diagnostic['category'] : self::diagnostic_category( $type ),
+			'loss_class'           => isset( $diagnostic['loss_class'] ) && is_scalar( $diagnostic['loss_class'] ) ? (string) $diagnostic['loss_class'] : Static_Site_Importer_Diagnostic_Loss_Classes::classify( $diagnostic ),
+			'diagnostic_class'     => isset( $diagnostic['diagnostic_class'] ) && is_scalar( $diagnostic['diagnostic_class'] ) ? (string) $diagnostic['diagnostic_class'] : Static_Site_Importer_Diagnostic_Loss_Classes::classify( $diagnostic ),
 			'owner'                => self::finding_owner( $diagnostic ),
 			'routing'              => array(
 				'component'              => self::finding_owner( $diagnostic ),
 				'stage'                  => isset( $diagnostic['stage'] ) && is_scalar( $diagnostic['stage'] ) ? (string) $diagnostic['stage'] : 'import',
 				'suggested_repair_class' => isset( $diagnostic['suggested_repair_class'] ) && is_scalar( $diagnostic['suggested_repair_class'] ) ? (string) $diagnostic['suggested_repair_class'] : self::diagnostic_repair_class( $type ),
+				'loss_class'             => isset( $diagnostic['loss_class'] ) && is_scalar( $diagnostic['loss_class'] ) ? (string) $diagnostic['loss_class'] : Static_Site_Importer_Diagnostic_Loss_Classes::classify( $diagnostic ),
 			),
 			'provenance'           => self::validation_provenance( $report ),
 			'reproduction_context' => array_merge(
@@ -1713,6 +1720,8 @@ class Static_Site_Importer_Report_Diagnostics {
 				'suggested_repair_class' => self::diagnostic_repair_class( $type ),
 				'source_path'            => $source_path,
 			);
+			$machine['loss_class']       = Static_Site_Importer_Diagnostic_Loss_Classes::classify( array_merge( $diagnostic, $machine ) );
+			$machine['diagnostic_class'] = $machine['loss_class'];
 
 			$selector = isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? trim( (string) $diagnostic['selector'] ) : '';
 			if ( '' !== $selector ) {
@@ -2009,6 +2018,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'warning' => 0,
 			'notice'  => 0,
 			'info'    => 0,
+			'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::counts( $diagnostics ),
 		);
 
 		foreach ( $diagnostics as $diagnostic ) {
@@ -2042,6 +2052,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			$summaries[] = array(
 				'id'      => isset( $diagnostic['id'] ) && is_scalar( $diagnostic['id'] ) ? (string) $diagnostic['id'] : '',
 				'type'    => isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : 'static_site_importer_diagnostic',
+				'loss_class' => isset( $diagnostic['loss_class'] ) && is_scalar( $diagnostic['loss_class'] ) ? (string) $diagnostic['loss_class'] : Static_Site_Importer_Diagnostic_Loss_Classes::classify( $diagnostic ),
 				'source'  => self::diagnostic_summary_source( $diagnostic ),
 				'message' => self::diagnostic_summary_message( $diagnostic ),
 			);
@@ -2098,6 +2109,8 @@ class Static_Site_Importer_Report_Diagnostics {
 			'type',
 			'severity',
 			'category',
+			'loss_class',
+			'diagnostic_class',
 			'reason_code',
 			'suggested_repair_class',
 			'source_path',

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -59,6 +59,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-th
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-stylesheet-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-product-handoff-contract.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-diagnostic-loss-classes.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-diagnostic-contract.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-validation-runtime.php';

--- a/tests/smoke-diagnostic-loss-classes.php
+++ b/tests/smoke-diagnostic-loss-classes.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Smoke coverage for product-facing diagnostic loss classes.
+ *
+ * Run from the repository root:
+ * php tests/smoke-diagnostic-loss-classes.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.keyFound
+		$key = strtolower( (string) $key );
+
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-loss-classes.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$fixtures = array(
+	'native'      => array(
+		'diagnostic' => array(
+			'type'        => 'document_metadata_routed',
+			'source_path' => 'website/index.html',
+		),
+		'expected'   => 'native_conversion',
+	),
+	'editable'    => array(
+		'diagnostic' => array(
+			'type'       => 'core_html_block',
+			'block_name' => 'core/html',
+		),
+		'expected'   => 'editable_approximation',
+	),
+	'runtime'     => array(
+		'diagnostic' => array(
+			'type'   => 'interaction_candidate',
+			'reason' => 'native_conversion_report_interaction_candidate',
+		),
+		'expected'   => 'preserved_runtime_island',
+	),
+	'unsupported' => array(
+		'diagnostic' => array(
+			'type' => 'content_loss_abort',
+		),
+		'expected'   => 'unsupported_loss',
+	),
+	'importer'    => array(
+		'diagnostic' => array(
+			'type' => 'svg_materialization_failure',
+		),
+		'expected'   => 'importer_materialization_bug',
+	),
+);
+
+foreach ( $fixtures as $label => $fixture ) {
+	$assert(
+		$fixture['expected'] === Static_Site_Importer_Diagnostic_Loss_Classes::classify( $fixture['diagnostic'] ),
+		'loss-class-' . $label
+	);
+}
+
+$counts = Static_Site_Importer_Diagnostic_Loss_Classes::counts( array_column( $fixtures, 'diagnostic' ) );
+$assert( 1 === ( $counts['native_conversion'] ?? 0 ), 'counts-native' );
+$assert( 1 === ( $counts['editable_approximation'] ?? 0 ), 'counts-editable' );
+$assert( 1 === ( $counts['preserved_runtime_island'] ?? 0 ), 'counts-runtime' );
+$assert( 1 === ( $counts['unsupported_loss'] ?? 0 ), 'counts-unsupported' );
+$assert( 1 === ( $counts['importer_materialization_bug'] ?? 0 ), 'counts-importer' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: diagnostic loss classes smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -117,6 +117,11 @@ $assert( ! isset( $diagnostics['diagnostic_summary']['type']['website_artifact_m
 $assert( ! isset( $diagnostics['diagnostic_summary']['type']['document_metadata_routed'] ), 'report-only-metadata-note-excluded' );
 $assert( 'static-site-importer' === ( $diagnostics['by_repair_bucket']['dropped_images'][0]['parser_owner'] ?? '' ), 'dropped-images-owner' );
 $assert( 'blocks-engine' === ( $diagnostics['by_repair_bucket']['runtime_target_gap'][0]['parser_owner'] ?? '' ), 'runtime-target-owner' );
+$assert( 'unsupported_loss' === ( $diagnostics['by_repair_bucket']['dropped_images'][0]['loss_class'] ?? '' ), 'dropped-images-loss-class' );
+$assert( 'importer_materialization_bug' === ( $diagnostics['by_repair_bucket']['invalid_block_content'][0]['loss_class'] ?? '' ), 'invalid-block-loss-class' );
+$assert( 'editable_approximation' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['loss_class'] ?? '' ), 'semantic-parity-loss-class' );
+$assert( 1 === ( $diagnostics['loss_class_summary']['unsupported_loss'] ?? 0 ), 'loss-class-summary-unsupported' );
+$assert( 2 === ( $diagnostics['loss_class_summary']['importer_materialization_bug'] ?? 0 ), 'loss-class-summary-importer' );
 $assert( '#canvas' === ( $diagnostics['runtime_dependency_target_gaps'][0]['selector'] ?? '' ), 'runtime-target-selector' );
 $assert( 'header nav' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['selector'] ?? '' ), 'semantic-selector' );
 $assert( array() === ( $diagnostics['artifact_refs'] ?? null ), 'no-runtime-artifact-requirement' );
@@ -154,6 +159,7 @@ $assert( 'iframe#map' === ( $quality_gate_error['diagnostics'][0]['selector'] ??
 $assert( is_array( $quality_gate_error['errors'][0] ?? null ), 'ability-error-errors-are-structured' );
 $assert( 'core_html_block' === ( $quality_gate_error['errors'][0]['kind'] ?? '' ), 'ability-error-prevents-numeric-generic-errors' );
 $assert( 'fallback_block' === ( $quality_gate_error['fixture_diagnostics']['diagnostics'][0]['repair_bucket'] ?? '' ), 'ability-error-fixture-diagnostics-classified' );
+$assert( 'editable_approximation' === ( $quality_gate_error['fixture_diagnostics']['diagnostics'][0]['loss_class'] ?? '' ), 'ability-error-fixture-loss-classified' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-report-diagnostic-loss-classes.php
+++ b/tests/smoke-report-diagnostic-loss-classes.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Smoke coverage for loss classes in import reports, validation results, and finding packets.
+ *
+ * Run from the repository root:
+ * php tests/smoke-report-diagnostic-loss-classes.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.keyFound
+		$key = strtolower( (string) $key );
+
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-loss-classes.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
+$report['diagnostics'][] = array(
+	'type'        => 'core_html_block',
+	'source_path' => 'templates/front-page.html',
+	'block_name'  => 'core/html',
+);
+$report['diagnostics'][] = array(
+	'type'        => 'interaction_candidate',
+	'source_path' => 'website/index.html',
+	'selector'    => '.map iframe',
+);
+$report['diagnostics'][] = array(
+	'type'        => 'svg_materialization_failure',
+	'source_path' => 'assets/icon.svg',
+);
+$report['quality']['core_html_block_count']             = 1;
+$report['quality']['interaction_candidate_count']       = 1;
+$report['quality']['svg_materialization_failure_count'] = 1;
+
+Static_Site_Importer_Report_Diagnostics::finalize_report( $report, array() );
+
+$assert( 'editable_approximation' === ( $report['diagnostics'][0]['loss_class'] ?? '' ), 'report-diagnostic-editable-loss-class' );
+$assert( 'preserved_runtime_island' === ( $report['diagnostics'][1]['loss_class'] ?? '' ), 'report-diagnostic-runtime-loss-class' );
+$assert( 'importer_materialization_bug' === ( $report['diagnostics'][2]['loss_class'] ?? '' ), 'report-diagnostic-importer-loss-class' );
+$assert( 1 === ( $report['compact_summary']['loss_class_summary']['editable_approximation'] ?? 0 ), 'compact-summary-editable-count' );
+$assert( 1 === ( $report['import_validation_result']['diagnostic_summary']['loss_class']['preserved_runtime_island'] ?? 0 ), 'validation-summary-runtime-count' );
+$assert( 'editable_approximation' === ( $report['import_validation_result']['diagnostics'][0]['loss_class'] ?? '' ), 'validation-diagnostic-loss-class' );
+$assert( 'editable_approximation' === ( $report['finding_packets']['packets'][0]['loss_class'] ?? '' ), 'finding-packet-loss-class' );
+$assert( 'editable_approximation' === ( $report['finding_packets']['packets'][0]['routing']['loss_class'] ?? '' ), 'finding-packet-routing-loss-class' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: report diagnostic loss classes smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- add stable product-facing diagnostic/loss classes for SSI validation and matrix findings
- normalize existing SSI and Blocks Engine diagnostics into native conversion, editable approximation, preserved runtime island, unsupported loss, or importer materialization bug
- expose loss-class summaries in import diagnostic contracts, compact summaries, validation results, and finding packets

## Testing
- php -l on changed PHP files
- git diff --check
- php tests/smoke-diagnostic-loss-classes.php
- php tests/smoke-report-diagnostic-loss-classes.php
- php tests/smoke-import-diagnostic-contract.php
- php tests/smoke-validation-runtime-diagnostics.php
- php tests/smoke-transformer-adapter.php
- php tests/smoke-semantic-parity-diagnostics.php
- php tests/smoke-website-artifact-products-manifest.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode general subagents
- **Used for:** architecture refactor drafting, implementation, and smoke tests