### PR TITLE
Clean up numeric fixture diagnostics

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -423,7 +423,7 @@ if ( ! function_exists( 'static_site_importer_error_diagnostics' ) ) {
 		);
 
 		foreach ( $candidates as $candidate ) {
-			$diagnostics = array_values( array_filter( $candidate, 'is_array' ) );
+			$diagnostics = array_values( array_filter( $candidate, 'static_site_importer_is_actionable_error_diagnostic' ) );
 			if ( ! empty( $diagnostics ) ) {
 				return $diagnostics;
 			}
@@ -442,6 +442,33 @@ if ( ! function_exists( 'static_site_importer_error_diagnostics' ) ) {
 				'owner'       => 'static-site-importer',
 			)
 		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_is_actionable_error_diagnostic' ) ) {
+	/**
+	 * Check whether an error diagnostic has machine-actionable identity or source context.
+	 *
+	 * @param mixed $diagnostic Candidate diagnostic.
+	 * @return bool
+	 */
+	function static_site_importer_is_actionable_error_diagnostic( $diagnostic ): bool {
+		if ( ! is_array( $diagnostic ) ) {
+			return false;
+		}
+
+		foreach ( array( 'type', 'kind', 'code', 'reason_code', 'reason', 'error_code', 'source_path', 'path', 'source', 'selector' ) as $field ) {
+			if ( ! isset( $diagnostic[ $field ] ) || ! is_scalar( $diagnostic[ $field ] ) ) {
+				continue;
+			}
+
+			$value = trim( (string) $diagnostic[ $field ] );
+			if ( '' !== $value && ! preg_match( '/^\d+$/', $value ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }
 

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -185,15 +185,15 @@ class Static_Site_Importer_Diagnostic_Contract {
 				continue;
 			}
 
-			$type          = self::first_scalar( $row, array( 'type', 'kind', 'code', 'reason_code' ), 'diagnostic' );
-			$reason_code   = self::first_scalar( $row, array( 'reason_code', 'code', 'reason', 'kind', 'type' ), $type );
+			$type          = self::first_identifier( $row, array( 'type', 'kind', 'code', 'reason_code' ), 'diagnostic' );
+			$reason_code   = self::first_identifier( $row, array( 'reason_code', 'code', 'reason', 'kind', 'type' ), $type );
 			$source_path   = self::first_scalar( $row, array( 'source_path', 'path', 'source', 'file', 'script_path' ), '' );
 			$repair_bucket = self::repair_bucket( $type, $reason_code, $row );
 			$parser_owner  = self::parser_owner( $type, $repair_bucket, $row );
 			$diagnostic    = array(
 				'id'                      => self::first_scalar( $row, array( 'id' ), sprintf( 'diag-%03d-%s', $index + 1, sanitize_key( $type . '-' . $reason_code . '-' . $source_path ) ) ),
 				'type'                    => sanitize_key( $type ),
-				'kind'                    => sanitize_key( self::first_scalar( $row, array( 'kind', 'code', 'type' ), $type ) ),
+				'kind'                    => sanitize_key( self::first_identifier( $row, array( 'kind', 'code', 'type' ), $type ) ),
 				'severity'                => self::first_scalar( $row, array( 'severity', 'level' ), self::default_diagnostic_severity( $type ) ),
 				'category'                => self::diagnostic_category( $type ),
 				'group_key'               => $repair_bucket,
@@ -439,6 +439,41 @@ class Static_Site_Importer_Diagnostic_Contract {
 		}
 
 		return $fallback;
+	}
+
+	/**
+	 * Resolve a diagnostic identity value without treating counts/indexes as codes.
+	 *
+	 * @param array<string,mixed> $row      Source row.
+	 * @param array<int,string>   $fields   Candidate fields.
+	 * @param string              $fallback Fallback value.
+	 * @return string
+	 */
+	private static function first_identifier( array $row, array $fields, string $fallback = '' ): string {
+		foreach ( $fields as $field ) {
+			if ( ! isset( $row[ $field ] ) || ! is_scalar( $row[ $field ] ) ) {
+				continue;
+			}
+
+			$value = trim( (string) $row[ $field ] );
+			if ( '' === $value || self::is_numeric_only_string( $value ) ) {
+				continue;
+			}
+
+			return $value;
+		}
+
+		return $fallback;
+	}
+
+	/**
+	 * Check whether a string is only a numeric count/index.
+	 *
+	 * @param string $value Value.
+	 * @return bool
+	 */
+	private static function is_numeric_only_string( string $value ): bool {
+		return 1 === preg_match( '/^\d+$/', trim( $value ) );
 	}
 
 	/**

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1860,8 +1860,13 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	private static function diagnostic_reason_code( string $type, array $diagnostic ): string {
 		foreach ( array( 'reason_code', 'reason', 'error_code' ) as $key ) {
-			if ( isset( $diagnostic[ $key ] ) && is_scalar( $diagnostic[ $key ] ) && '' !== trim( (string) $diagnostic[ $key ] ) ) {
-				return sanitize_key( (string) $diagnostic[ $key ] );
+			if ( ! isset( $diagnostic[ $key ] ) || ! is_scalar( $diagnostic[ $key ] ) ) {
+				continue;
+			}
+
+			$value = trim( (string) $diagnostic[ $key ] );
+			if ( '' !== $value && ! preg_match( '/^\d+$/', $value ) ) {
+				return sanitize_key( $value );
 			}
 		}
 

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -161,6 +161,44 @@ $assert( 'core_html_block' === ( $quality_gate_error['errors'][0]['kind'] ?? '' 
 $assert( 'fallback_block' === ( $quality_gate_error['fixture_diagnostics']['diagnostics'][0]['repair_bucket'] ?? '' ), 'ability-error-fixture-diagnostics-classified' );
 $assert( 'editable_approximation' === ( $quality_gate_error['fixture_diagnostics']['diagnostics'][0]['loss_class'] ?? '' ), 'ability-error-fixture-loss-classified' );
 
+$numeric_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'status'      => 'failed',
+		'success'     => false,
+		'diagnostics' => array(
+			array(
+				'type'        => '2',
+				'kind'        => '8',
+				'reason'      => '3',
+				'source_path' => 'website/index.html',
+			),
+		),
+	)
+);
+$numeric_diagnostic = $numeric_contract['diagnostics'][0] ?? array();
+$numeric_only       = static fn ( $value ): bool => is_scalar( $value ) && 1 === preg_match( '/^\d+$/', (string) $value );
+$assert( ! $numeric_only( $numeric_diagnostic['type'] ?? '' ), 'contract-type-not-numeric-only' );
+$assert( ! $numeric_only( $numeric_diagnostic['kind'] ?? '' ), 'contract-kind-not-numeric-only' );
+$assert( ! $numeric_only( $numeric_diagnostic['reason_code'] ?? '' ), 'contract-reason-code-not-numeric-only' );
+
+$numeric_quality_gate_error = static_site_importer_ability_error(
+	'static_site_importer_quality_gate_failed',
+	'Import failed quality gates; materialization was not completed.',
+	array(
+		'import_validation_result' => array(
+			'diagnostics' => array(
+				array(
+					'message' => '2',
+				),
+			),
+		),
+	)
+);
+$assert( 'validation_error' === ( $numeric_quality_gate_error['errors'][0]['kind'] ?? '' ), 'ability-error-rejects-numeric-message-diagnostic' );
+$assert( ! $numeric_only( $numeric_quality_gate_error['errors'][0]['reason'] ?? '' ), 'ability-error-reason-not-numeric-only' );
+$assert( ! $numeric_only( $numeric_quality_gate_error['fixture_diagnostics']['diagnostics'][0]['kind'] ?? '' ), 'fixture-diagnostic-kind-not-numeric-only' );
+$assert( ! $numeric_only( $numeric_quality_gate_error['fixture_diagnostics']['diagnostics'][0]['reason_code'] ?? '' ), 'fixture-diagnostic-reason-code-not-numeric-only' );
+
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
 	exit( 1 );


### PR DESCRIPTION
## Summary
- reject numeric-only flattened diagnostic rows in ability error promotion
- prevent numeric counts/indexes from becoming diagnostic type, kind, or reason code
- preserve real diagnostic type/reason/source context for matrix routing

## Testing
- php tests/smoke-import-diagnostic-contract.php
- php tests/smoke-validation-runtime-diagnostics.php
- php tests/smoke-report-diagnostic-loss-classes.php
- php tests/smoke-diagnostic-loss-classes.php
- php -l on edited PHP files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode general subagents
- **Used for:** diagnostic root-cause analysis, implementation, and tests