### PR TITLE
Clean up diagnostic loss signals

### DIFF
--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -181,7 +181,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 			if ( ! is_array( $row ) ) {
 				continue;
 			}
-			if ( self::is_report_only_diagnostic( $row ) ) {
+			if ( self::is_report_only_diagnostic( $row ) || self::is_count_only_diagnostic( $row ) ) {
 				continue;
 			}
 
@@ -214,7 +214,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 			$diagnostic['loss_class']       = Static_Site_Importer_Diagnostic_Loss_Classes::classify( array_merge( $row, $diagnostic ) );
 			$diagnostic['diagnostic_class'] = $diagnostic['loss_class'];
 
-			foreach ( array( 'message', 'reason', 'excerpt', 'source_html_preview', 'emitted_block_preview', 'html_excerpt', 'block_name', 'block_path', 'script_path', 'element', 'tag_name', 'tag', 'src', 'href', 'expected', 'observed', 'suggested_primitive' ) as $field ) {
+			foreach ( array( 'message', 'reason', 'excerpt', 'source_snippet', 'source_html_preview', 'emitted_block_preview', 'observed_output', 'html_excerpt', 'block_name', 'block_path', 'script_path', 'element', 'tag_name', 'tag', 'src', 'href', 'expected', 'observed', 'suggested_primitive' ) as $field ) {
 				$value = self::first_scalar( $row, array( $field ), '' );
 				if ( '' !== $value ) {
 					$diagnostic[ $field ] = $value;
@@ -402,7 +402,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 	}
 
 	/**
-	 * Remove duplicate diagnostics by id/type/source/selector/code.
+	 * Remove duplicate diagnostics by stable source context and reason.
 	 *
 	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics.
 	 * @return array<int,array<string,mixed>>
@@ -411,16 +411,53 @@ class Static_Site_Importer_Diagnostic_Contract {
 		$seen   = array();
 		$unique = array();
 		foreach ( $diagnostics as $diagnostic ) {
-			$key = implode( '|', array_map( 'strval', array( $diagnostic['id'] ?? '', $diagnostic['type'] ?? '', $diagnostic['source_path'] ?? '', $diagnostic['selector'] ?? '', $diagnostic['code'] ?? '' ) ) );
+			$key = self::diagnostic_dedupe_key( $diagnostic );
 			if ( isset( $seen[ $key ] ) ) {
+				$unique[ $seen[ $key ] ] = self::merge_diagnostic_context( $unique[ $seen[ $key ] ], $diagnostic );
 				continue;
 			}
 
-			$seen[ $key ] = true;
+			$seen[ $key ] = count( $unique );
 			$unique[]     = $diagnostic;
 		}
 
 		return $unique;
+	}
+
+	/**
+	 * Build a dedupe key that can collapse SSI and Blocks Engine echoes of the same finding.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic row.
+	 * @return string
+	 */
+	private static function diagnostic_dedupe_key( array $diagnostic ): string {
+		$source_path = isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : '';
+		$selector    = isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '';
+		$reason      = self::first_scalar( $diagnostic, array( 'reason_code', 'code', 'reason' ), '' );
+		$loss_class  = isset( $diagnostic['loss_class'] ) && is_scalar( $diagnostic['loss_class'] ) ? (string) $diagnostic['loss_class'] : '';
+
+		if ( '' !== $source_path && '' !== $selector && '' !== $reason ) {
+			return implode( '|', array( 'context', $source_path, $selector, sanitize_key( $reason ), $loss_class ) );
+		}
+
+		return implode( '|', array_map( 'strval', array( 'identity', $diagnostic['id'] ?? '', $diagnostic['type'] ?? '', $source_path, $selector, $diagnostic['code'] ?? '' ) ) );
+	}
+
+	/**
+	 * Merge duplicate diagnostics without discarding source evidence from either producer.
+	 *
+	 * @param array<string,mixed> $primary   First diagnostic row.
+	 * @param array<string,mixed> $duplicate Duplicate diagnostic row.
+	 * @return array<string,mixed>
+	 */
+	private static function merge_diagnostic_context( array $primary, array $duplicate ): array {
+		foreach ( $duplicate as $field => $value ) {
+			if ( ! array_key_exists( $field, $primary ) || '' === $primary[ $field ] || null === $primary[ $field ] || array() === $primary[ $field ] ) {
+				$primary[ $field ] = $value;
+			}
+		}
+
+		return $primary;
 	}
 
 	/**
@@ -486,6 +523,45 @@ class Static_Site_Importer_Diagnostic_Contract {
 		$constraints = strtolower( self::first_scalar( $row, array( 'constraints', 'constraint' ), '' ) );
 
 		return in_array( $constraints, array( 'report_only', 'report-only' ), true );
+	}
+
+	/**
+	 * Check whether a diagnostic is only a count/index placeholder.
+	 *
+	 * @param array<string,mixed> $row Source row.
+	 * @return bool
+	 */
+	private static function is_count_only_diagnostic( array $row ): bool {
+		$type   = sanitize_key( self::first_scalar( $row, array( 'type', 'kind', 'code' ), '' ) );
+		$reason = self::first_scalar( $row, array( 'reason_code', 'reason', 'error_code', 'message' ), '' );
+
+		if ( ! self::is_placeholder_scalar( $type ) && ! in_array( $type, array( 'diagnostic', 'import_diagnostic', 'static_site_fixture_diagnostic', 'static_site_importer_diagnostic' ), true ) ) {
+			return false;
+		}
+
+		if ( '' !== $reason && ! self::is_placeholder_scalar( $reason ) ) {
+			return false;
+		}
+
+		foreach ( array( 'selector', 'source_snippet', 'source_html_preview', 'emitted_block_preview', 'observed_output', 'html_excerpt', 'excerpt', 'script_path', 'src', 'href', 'expected', 'observed' ) as $field ) {
+			if ( isset( $row[ $field ] ) && is_scalar( $row[ $field ] ) && ! self::is_placeholder_scalar( (string) $row[ $field ] ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a scalar is a placeholder rather than source evidence.
+	 *
+	 * @param string $value Value.
+	 * @return bool
+	 */
+	private static function is_placeholder_scalar( string $value ): bool {
+		$value = trim( strtolower( $value ) );
+
+		return '' === $value || '(none)' === $value || 'none' === $value || self::is_numeric_only_string( $value );
 	}
 
 	/**

--- a/includes/class-static-site-importer-diagnostic-loss-classes.php
+++ b/includes/class-static-site-importer-diagnostic-loss-classes.php
@@ -38,13 +38,16 @@ class Static_Site_Importer_Diagnostic_Loss_Classes {
 		$reason      = sanitize_key( self::scalar( $diagnostic, array( 'reason_code', 'reason', 'error_code' ) ) );
 		$stage       = sanitize_key( self::scalar( $diagnostic, array( 'stage' ) ) );
 		$block_name  = self::scalar( $diagnostic, array( 'block_name', 'observed_block_name' ) );
-		$haystack    = strtolower( implode( ' ', array( $type, $category, $repair, $reason, $stage, $block_name ) ) );
+		$element     = self::scalar( $diagnostic, array( 'element', 'tag_name', 'tag' ) );
+		$selector    = self::scalar( $diagnostic, array( 'selector', 'target_selector', 'runtime_target_selector' ) );
+		$haystack    = strtolower( implode( ' ', array( $type, $category, $repair, $reason, $stage, $block_name, $element, $selector ) ) );
 
 		if (
 			self::contains_any(
 				$haystack,
 				array( 'runtime_dependency_vendor_telemetry_script', 'interaction_candidate', 'runtime_island', 'preserved_runtime' )
 			)
+			|| self::is_preserved_runtime_element( $element, $selector )
 		) {
 			return self::PRESERVED_RUNTIME_ISLAND;
 		}
@@ -174,5 +177,21 @@ class Static_Site_Importer_Diagnostic_Loss_Classes {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Determine whether a fallback row preserves a runtime-only element.
+	 *
+	 * @param string $element  Element or tag field.
+	 * @param string $selector Selector field.
+	 * @return bool
+	 */
+	private static function is_preserved_runtime_element( string $element, string $selector ): bool {
+		$element = strtolower( trim( $element ) );
+		if ( in_array( $element, array( 'canvas', 'script' ), true ) ) {
+			return true;
+		}
+
+		return 1 === preg_match( '/^(?:canvas|script)(?:$|[\s.#:[>+~])/', strtolower( trim( $selector ) ) );
 	}
 }

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1702,8 +1702,12 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		$normalized = array();
+		$seen       = array();
 		foreach ( array_values( $report['diagnostics'] ) as $index => $diagnostic ) {
 			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+			if ( self::is_count_only_diagnostic( $diagnostic ) ) {
 				continue;
 			}
 
@@ -1741,10 +1745,92 @@ class Static_Site_Importer_Report_Diagnostics {
 				$machine['context'] = $context;
 			}
 
-			$normalized[] = array_merge( $machine, $diagnostic );
+			$row = array_merge( $machine, $diagnostic );
+			$key = self::diagnostic_dedupe_key( $row );
+			if ( isset( $seen[ $key ] ) ) {
+				$normalized[ $seen[ $key ] ] = self::merge_diagnostic_context( $normalized[ $seen[ $key ] ], $row );
+				continue;
+			}
+
+			$seen[ $key ] = count( $normalized );
+			$normalized[] = $row;
 		}
 
 		$report['diagnostics'] = $normalized;
+	}
+
+	/**
+	 * Check whether a diagnostic is only a count/index placeholder.
+	 *
+	 * @param array<string,mixed> $diagnostic Candidate diagnostic.
+	 * @return bool
+	 */
+	private static function is_count_only_diagnostic( array $diagnostic ): bool {
+		$type   = sanitize_key( self::first_scalar( $diagnostic, array( 'type', 'kind', 'code' ) ) );
+		$reason = self::first_scalar( $diagnostic, array( 'reason_code', 'reason', 'error_code', 'message' ) );
+
+		if ( ! self::is_placeholder_scalar( $type ) && ! in_array( $type, array( 'diagnostic', 'import_diagnostic', 'static_site_fixture_diagnostic', 'static_site_importer_diagnostic' ), true ) ) {
+			return false;
+		}
+		if ( '' !== $reason && ! self::is_placeholder_scalar( $reason ) ) {
+			return false;
+		}
+
+		foreach ( array( 'selector', 'source_snippet', 'source_html_preview', 'emitted_block_preview', 'observed_output', 'html_excerpt', 'excerpt', 'script_path', 'src', 'href', 'expected', 'observed' ) as $field ) {
+			if ( isset( $diagnostic[ $field ] ) && is_scalar( $diagnostic[ $field ] ) && ! self::is_placeholder_scalar( (string) $diagnostic[ $field ] ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a scalar is a placeholder rather than source evidence.
+	 *
+	 * @param string $value Value.
+	 * @return bool
+	 */
+	private static function is_placeholder_scalar( string $value ): bool {
+		$value = trim( strtolower( $value ) );
+
+		return '' === $value || '(none)' === $value || 'none' === $value || 1 === preg_match( '/^\d+$/', $value );
+	}
+
+	/**
+	 * Build a dedupe key that can collapse SSI and Blocks Engine echoes of the same finding.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic row.
+	 * @return string
+	 */
+	private static function diagnostic_dedupe_key( array $diagnostic ): string {
+		$source_path = isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : '';
+		$selector    = isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '';
+		$reason      = self::first_scalar( $diagnostic, array( 'reason_code', 'reason', 'error_code' ) );
+		$loss_class  = isset( $diagnostic['loss_class'] ) && is_scalar( $diagnostic['loss_class'] ) ? (string) $diagnostic['loss_class'] : '';
+
+		if ( '' !== $source_path && '' !== $selector && '' !== $reason ) {
+			return implode( '|', array( 'context', $source_path, $selector, sanitize_key( $reason ), $loss_class ) );
+		}
+
+		return implode( '|', array_map( 'strval', array( 'identity', $diagnostic['id'] ?? '', $diagnostic['type'] ?? '', $source_path, $selector, $diagnostic['reason_code'] ?? '' ) ) );
+	}
+
+	/**
+	 * Merge duplicate diagnostics without discarding source evidence from either producer.
+	 *
+	 * @param array<string,mixed> $primary   First diagnostic row.
+	 * @param array<string,mixed> $duplicate Duplicate diagnostic row.
+	 * @return array<string,mixed>
+	 */
+	private static function merge_diagnostic_context( array $primary, array $duplicate ): array {
+		foreach ( $duplicate as $field => $value ) {
+			if ( ! array_key_exists( $field, $primary ) || '' === $primary[ $field ] || null === $primary[ $field ] || array() === $primary[ $field ] ) {
+				$primary[ $field ] = $value;
+			}
+		}
+
+		return $primary;
 	}
 
 	/**

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -82,6 +82,20 @@ $diagnostics = Static_Site_Importer_Diagnostic_Contract::build(
 					'type'        => 'invalid_block_content',
 					'source_path' => 'templates/front-page.html',
 				),
+				array(
+					'id'          => 'ssi-canvas-fallback',
+					'type'        => 'unsupported_html_fallback',
+					'source_path' => 'templates/front-page.html',
+					'selector'    => 'canvas#hero',
+					'code'        => 'unsupported_html_fallback',
+				),
+				array(
+					'id'          => 'blocks-engine-canvas-fallback',
+					'type'        => 'unsupported_html_fallback',
+					'source_path' => 'templates/front-page.html',
+					'selector'    => 'canvas#hero',
+					'code'        => 'unsupported_html_fallback',
+				),
 			),
 			'blocks_engine' => array(
 				'runtime_dependency_parity' => array(
@@ -107,12 +121,13 @@ $diagnostics = Static_Site_Importer_Diagnostic_Contract::build(
 );
 
 $assert( 'static-site-importer/import-diagnostics/v1' === ( $diagnostics['schema'] ?? '' ), 'schema' );
-$assert( 4 === ( $diagnostics['diagnostic_summary']['total'] ?? 0 ), 'total-count' );
+$assert( 5 === ( $diagnostics['diagnostic_summary']['total'] ?? 0 ), 'total-count' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['dropped_images'] ?? 0 ), 'dropped-images-bucket' );
 $assert( ! isset( $diagnostics['diagnostic_summary']['repair_bucket']['static_site_import_quality'] ), 'report-only-metadata-bucket-excluded' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['invalid_block_content'] ?? 0 ), 'invalid-block-bucket' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['runtime_target_gap'] ?? 0 ), 'runtime-target-bucket' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['semantic_parity'] ?? 0 ), 'semantic-parity-bucket' );
+$assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['fallback_block'] ?? 0 ), 'deduped-fallback-bucket' );
 $assert( ! isset( $diagnostics['diagnostic_summary']['type']['website_artifact_materialization_contract_note'] ), 'report-only-contract-note-excluded' );
 $assert( ! isset( $diagnostics['diagnostic_summary']['type']['document_metadata_routed'] ), 'report-only-metadata-note-excluded' );
 $assert( 'static-site-importer' === ( $diagnostics['by_repair_bucket']['dropped_images'][0]['parser_owner'] ?? '' ), 'dropped-images-owner' );
@@ -120,8 +135,10 @@ $assert( 'blocks-engine' === ( $diagnostics['by_repair_bucket']['runtime_target_
 $assert( 'unsupported_loss' === ( $diagnostics['by_repair_bucket']['dropped_images'][0]['loss_class'] ?? '' ), 'dropped-images-loss-class' );
 $assert( 'importer_materialization_bug' === ( $diagnostics['by_repair_bucket']['invalid_block_content'][0]['loss_class'] ?? '' ), 'invalid-block-loss-class' );
 $assert( 'editable_approximation' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['loss_class'] ?? '' ), 'semantic-parity-loss-class' );
+$assert( 'preserved_runtime_island' === ( $diagnostics['by_repair_bucket']['fallback_block'][0]['loss_class'] ?? '' ), 'canvas-fallback-loss-class' );
 $assert( 1 === ( $diagnostics['loss_class_summary']['unsupported_loss'] ?? 0 ), 'loss-class-summary-unsupported' );
 $assert( 2 === ( $diagnostics['loss_class_summary']['importer_materialization_bug'] ?? 0 ), 'loss-class-summary-importer' );
+$assert( 1 === ( $diagnostics['loss_class_summary']['preserved_runtime_island'] ?? 0 ), 'loss-class-summary-preserved-runtime' );
 $assert( '#canvas' === ( $diagnostics['runtime_dependency_target_gaps'][0]['selector'] ?? '' ), 'runtime-target-selector' );
 $assert( 'header nav' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['selector'] ?? '' ), 'semantic-selector' );
 $assert( array() === ( $diagnostics['artifact_refs'] ?? null ), 'no-runtime-artifact-requirement' );
@@ -177,9 +194,44 @@ $numeric_contract = Static_Site_Importer_Diagnostic_Contract::build(
 );
 $numeric_diagnostic = $numeric_contract['diagnostics'][0] ?? array();
 $numeric_only       = static fn ( $value ): bool => is_scalar( $value ) && 1 === preg_match( '/^\d+$/', (string) $value );
+$assert( 0 === ( $numeric_contract['diagnostic_summary']['total'] ?? -1 ), 'contract-drops-count-only-diagnostic' );
 $assert( ! $numeric_only( $numeric_diagnostic['type'] ?? '' ), 'contract-type-not-numeric-only' );
 $assert( ! $numeric_only( $numeric_diagnostic['kind'] ?? '' ), 'contract-kind-not-numeric-only' );
 $assert( ! $numeric_only( $numeric_diagnostic['reason_code'] ?? '' ), 'contract-reason-code-not-numeric-only' );
+
+$deduped_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'status'        => 'failed',
+		'success'       => false,
+		'import_report' => array(
+			'diagnostics'   => array(
+				array(
+					'type'           => 'core_html_block',
+					'source_path'    => 'posts/page-home.post_content',
+					'selector'       => 'iframe#map',
+					'reason_code'    => 'generated_document_contains_core_html',
+					'source_snippet' => '<iframe id="map"></iframe>',
+				),
+			),
+			'blocks_engine' => array(
+				'conversion_report' => array(
+					'diagnostics' => array(
+						array(
+							'type'                  => 'unsupported_html_fallback',
+							'source_path'           => 'posts/page-home.post_content',
+							'selector'              => 'iframe#map',
+							'reason_code'           => 'generated_document_contains_core_html',
+							'emitted_block_preview' => '<!-- wp:html --><iframe id="map"></iframe><!-- /wp:html -->',
+						),
+					),
+				),
+			),
+		),
+	)
+);
+$assert( 1 === ( $deduped_contract['diagnostic_summary']['total'] ?? 0 ), 'contract-dedupes-context-equivalent-diagnostics' );
+$assert( '<iframe id="map"></iframe>' === ( $deduped_contract['diagnostics'][0]['source_snippet'] ?? '' ), 'contract-preserves-source-snippet' );
+$assert( '<!-- wp:html --><iframe id="map"></iframe><!-- /wp:html -->' === ( $deduped_contract['diagnostics'][0]['emitted_block_preview'] ?? '' ), 'contract-merges-duplicate-output-preview' );
 
 $numeric_quality_gate_error = static_site_importer_ability_error(
 	'static_site_importer_quality_gate_failed',

--- a/tests/smoke-report-diagnostic-loss-classes.php
+++ b/tests/smoke-report-diagnostic-loss-classes.php
@@ -64,6 +64,42 @@ $assert( 'editable_approximation' === ( $report['import_validation_result']['dia
 $assert( 'editable_approximation' === ( $report['finding_packets']['packets'][0]['loss_class'] ?? '' ), 'finding-packet-loss-class' );
 $assert( 'editable_approximation' === ( $report['finding_packets']['packets'][0]['routing']['loss_class'] ?? '' ), 'finding-packet-routing-loss-class' );
 
+$runtime_only_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
+$runtime_only_report['diagnostics'][] = array(
+	'type'        => 'interaction_candidate',
+	'source_path' => 'website/index.html',
+	'selector'    => '.map iframe',
+);
+$runtime_only_report['quality']['interaction_candidate_count'] = 1;
+$runtime_only_quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $runtime_only_report, array() );
+$assert( true === ( $runtime_only_quality['pass'] ?? false ), 'preserved-runtime-island-does-not-fail-quality' );
+$assert( array() === ( $runtime_only_quality['failure_reasons'] ?? null ), 'preserved-runtime-island-not-failure-reason' );
+
+$cleanup_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
+$cleanup_report['diagnostics'][] = array(
+	'type'        => 'static_site_fixture_diagnostic',
+	'reason'      => '2',
+	'source_path' => 'website/index.html',
+);
+$cleanup_report['diagnostics'][] = array(
+	'type'                => 'core_html_block',
+	'source_path'         => 'posts/page-home.post_content',
+	'selector'            => 'iframe#map',
+	'reason_code'         => 'generated_document_contains_core_html',
+	'source_html_preview' => '<iframe id="map"></iframe>',
+);
+$cleanup_report['diagnostics'][] = array(
+	'type'                  => 'unsupported_html_fallback',
+	'source_path'           => 'posts/page-home.post_content',
+	'selector'              => 'iframe#map',
+	'reason_code'           => 'generated_document_contains_core_html',
+	'emitted_block_preview' => '<!-- wp:html --><iframe id="map"></iframe><!-- /wp:html -->',
+);
+Static_Site_Importer_Report_Diagnostics::finalize_report( $cleanup_report, array() );
+$assert( 1 === count( $cleanup_report['diagnostics'] ?? array() ), 'report-drops-count-only-and-dedupes' );
+$assert( '<iframe id="map"></iframe>' === ( $cleanup_report['import_validation_result']['diagnostics'][0]['source_snippet'] ?? '' ), 'report-preserves-source-snippet' );
+$assert( '<!-- wp:html --><iframe id="map"></iframe><!-- /wp:html -->' === ( $cleanup_report['import_validation_result']['diagnostics'][0]['observed_output'] ?? '' ), 'report-merges-observed-output' );
+
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
 	exit( 1 );


### PR DESCRIPTION
## Summary
- Drop count/index-only diagnostics before matrix normalization.
- Deduplicate SSI and Blocks Engine diagnostics by stable source context.
- Classify canvas/script fallbacks as preserved runtime islands when appropriate.

## Tests
- php tests/smoke-validation-runtime-diagnostics.php
- php tests/smoke-semantic-parity-diagnostics.php
- php tests/smoke-import-diagnostic-contract.php
- php tests/smoke-diagnostic-loss-classes.php
- php tests/smoke-report-diagnostic-loss-classes.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing diagnostic cleanup, dedupe behavior, runtime-island classification, and smoke test updates.