### PR TITLE
Classify preserved runtime islands separately

### DIFF
--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -189,6 +189,8 @@ class Static_Site_Importer_Diagnostic_Contract {
 			$reason_code   = self::first_identifier( $row, array( 'reason_code', 'code', 'reason', 'kind', 'type' ), $type );
 			$source_path   = self::first_scalar( $row, array( 'source_path', 'path', 'source', 'file', 'script_path' ), '' );
 			$repair_bucket = self::repair_bucket( $type, $reason_code, $row );
+			$loss_class    = Static_Site_Importer_Diagnostic_Loss_Classes::classify( array_merge( $row, array( 'repair_bucket' => $repair_bucket ) ) );
+			$repair_bucket = self::repair_bucket_for_loss_class( $repair_bucket, $loss_class );
 			$parser_owner  = self::parser_owner( $type, $repair_bucket, $row );
 			$diagnostic    = array(
 				'id'                      => self::first_scalar( $row, array( 'id' ), sprintf( 'diag-%03d-%s', $index + 1, sanitize_key( $type . '-' . $reason_code . '-' . $source_path ) ) ),
@@ -211,7 +213,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 				'runtime_target_selector' => self::first_scalar( $row, array( 'runtime_target_selector', 'target_selector', 'target', 'selector' ), '' ),
 				'missing_asset_path'      => self::missing_asset_path( $row ),
 			);
-			$diagnostic['loss_class']       = Static_Site_Importer_Diagnostic_Loss_Classes::classify( array_merge( $row, $diagnostic ) );
+			$diagnostic['loss_class']       = $loss_class;
 			$diagnostic['diagnostic_class'] = $diagnostic['loss_class'];
 
 			foreach ( array( 'message', 'reason', 'excerpt', 'source_snippet', 'source_html_preview', 'emitted_block_preview', 'observed_output', 'html_excerpt', 'block_name', 'block_path', 'script_path', 'element', 'tag_name', 'tag', 'src', 'href', 'expected', 'observed', 'suggested_primitive' ) as $field ) {
@@ -640,6 +642,21 @@ class Static_Site_Importer_Diagnostic_Contract {
 	}
 
 	/**
+	 * Keep acceptable runtime islands out of actionable importer-quality buckets.
+	 *
+	 * @param string $repair_bucket Current repair bucket.
+	 * @param string $loss_class    Product-facing loss class.
+	 * @return string
+	 */
+	private static function repair_bucket_for_loss_class( string $repair_bucket, string $loss_class ): string {
+		if ( Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND !== $loss_class ) {
+			return $repair_bucket;
+		}
+
+		return in_array( $repair_bucket, array( 'static_site_import_quality', 'import_quality' ), true ) ? Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND : $repair_bucket;
+	}
+
+	/**
 	 * Determine likely product owner for the parser/repair bucket.
 	 *
 	 * @param string              $type          Diagnostic type.
@@ -680,6 +697,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 			'broken_svg'                 => 'svg-transformer-parity',
 			'dropped_images'             => 'asset-materialization',
 			'invalid_block_content'      => 'block-validation-parity',
+			'preserved_runtime_island'   => 'accepted-runtime-preservation',
 			'runtime_target_gap'         => 'runtime-dom-target-parity',
 			'semantic_parity'            => 'semantic-parity',
 			'fallback_block'             => 'fallback-block-replacement',

--- a/includes/class-static-site-importer-diagnostic-loss-classes.php
+++ b/includes/class-static-site-importer-diagnostic-loss-classes.php
@@ -45,7 +45,7 @@ class Static_Site_Importer_Diagnostic_Loss_Classes {
 		if (
 			self::contains_any(
 				$haystack,
-				array( 'runtime_dependency_vendor_telemetry_script', 'interaction_candidate', 'runtime_island', 'preserved_runtime' )
+				array( 'runtime_dependency_vendor_telemetry_script', 'interaction_candidate', 'runtime_island', 'runtimeisland', 'preserved_runtime', 'preservedasaboundedruntimeisland' )
 			)
 			|| self::is_preserved_runtime_element( $element, $selector )
 		) {

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -941,6 +941,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'component'              => self::finding_owner( $diagnostic ),
 				'stage'                  => isset( $diagnostic['stage'] ) && is_scalar( $diagnostic['stage'] ) ? (string) $diagnostic['stage'] : 'import',
 				'suggested_repair_class' => isset( $diagnostic['suggested_repair_class'] ) && is_scalar( $diagnostic['suggested_repair_class'] ) ? (string) $diagnostic['suggested_repair_class'] : self::diagnostic_repair_class( $type ),
+				'repair_bucket'          => isset( $diagnostic['repair_bucket'] ) && is_scalar( $diagnostic['repair_bucket'] ) ? (string) $diagnostic['repair_bucket'] : '',
 				'loss_class'             => isset( $diagnostic['loss_class'] ) && is_scalar( $diagnostic['loss_class'] ) ? (string) $diagnostic['loss_class'] : Static_Site_Importer_Diagnostic_Loss_Classes::classify( $diagnostic ),
 			),
 			'provenance'           => self::validation_provenance( $report ),
@@ -1726,6 +1727,10 @@ class Static_Site_Importer_Report_Diagnostics {
 			);
 			$machine['loss_class']       = Static_Site_Importer_Diagnostic_Loss_Classes::classify( array_merge( $diagnostic, $machine ) );
 			$machine['diagnostic_class'] = $machine['loss_class'];
+			if ( Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND === $machine['loss_class'] ) {
+				$machine['repair_bucket'] = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
+				$machine['group_key']     = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
+			}
 
 			$selector = isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? trim( (string) $diagnostic['selector'] ) : '';
 			if ( '' !== $selector ) {
@@ -1746,6 +1751,13 @@ class Static_Site_Importer_Report_Diagnostics {
 			}
 
 			$row = array_merge( $machine, $diagnostic );
+			if ( Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND === $machine['loss_class'] ) {
+				$repair_bucket = isset( $row['repair_bucket'] ) && is_scalar( $row['repair_bucket'] ) ? (string) $row['repair_bucket'] : '';
+				if ( '' === $repair_bucket || in_array( $repair_bucket, array( 'static_site_import_quality', 'import_quality' ), true ) ) {
+					$row['repair_bucket'] = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
+					$row['group_key']     = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
+				}
+			}
 			$key = self::diagnostic_dedupe_key( $row );
 			if ( isset( $seen[ $key ] ) ) {
 				$normalized[ $seen[ $key ] ] = self::merge_diagnostic_context( $normalized[ $seen[ $key ] ], $row );
@@ -2204,6 +2216,8 @@ class Static_Site_Importer_Report_Diagnostics {
 			'diagnostic_class',
 			'reason_code',
 			'suggested_repair_class',
+			'repair_bucket',
+			'group_key',
 			'source_path',
 			'source',
 			'selector',

--- a/tests/smoke-diagnostic-loss-classes.php
+++ b/tests/smoke-diagnostic-loss-classes.php
@@ -53,6 +53,13 @@ $fixtures = array(
 		),
 		'expected'   => 'preserved_runtime_island',
 	),
+	'runtime-reason-phrase' => array(
+		'diagnostic' => array(
+			'type'   => 'dom',
+			'reason' => 'Runtime-dependent source markup was preserved as a bounded runtime island.',
+		),
+		'expected'   => 'preserved_runtime_island',
+	),
 	'unsupported' => array(
 		'diagnostic' => array(
 			'type' => 'content_loss_abort',
@@ -77,7 +84,7 @@ foreach ( $fixtures as $label => $fixture ) {
 $counts = Static_Site_Importer_Diagnostic_Loss_Classes::counts( array_column( $fixtures, 'diagnostic' ) );
 $assert( 1 === ( $counts['native_conversion'] ?? 0 ), 'counts-native' );
 $assert( 1 === ( $counts['editable_approximation'] ?? 0 ), 'counts-editable' );
-$assert( 1 === ( $counts['preserved_runtime_island'] ?? 0 ), 'counts-runtime' );
+$assert( 2 === ( $counts['preserved_runtime_island'] ?? 0 ), 'counts-runtime' );
 $assert( 1 === ( $counts['unsupported_loss'] ?? 0 ), 'counts-unsupported' );
 $assert( 1 === ( $counts['importer_materialization_bug'] ?? 0 ), 'counts-importer' );
 

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -83,6 +83,13 @@ $diagnostics = Static_Site_Importer_Diagnostic_Contract::build(
 					'source_path' => 'templates/front-page.html',
 				),
 				array(
+					'type'          => 'dom',
+					'source_path'   => 'templates/front-page.html',
+					'selector'      => '.site-header',
+					'reason'        => 'Runtime-dependent source markup was preserved as a bounded runtime island.',
+					'repair_bucket' => 'static_site_import_quality',
+				),
+				array(
 					'id'          => 'ssi-canvas-fallback',
 					'type'        => 'unsupported_html_fallback',
 					'source_path' => 'templates/front-page.html',
@@ -121,12 +128,13 @@ $diagnostics = Static_Site_Importer_Diagnostic_Contract::build(
 );
 
 $assert( 'static-site-importer/import-diagnostics/v1' === ( $diagnostics['schema'] ?? '' ), 'schema' );
-$assert( 5 === ( $diagnostics['diagnostic_summary']['total'] ?? 0 ), 'total-count' );
+$assert( 6 === ( $diagnostics['diagnostic_summary']['total'] ?? 0 ), 'total-count' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['dropped_images'] ?? 0 ), 'dropped-images-bucket' );
 $assert( ! isset( $diagnostics['diagnostic_summary']['repair_bucket']['static_site_import_quality'] ), 'report-only-metadata-bucket-excluded' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['invalid_block_content'] ?? 0 ), 'invalid-block-bucket' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['runtime_target_gap'] ?? 0 ), 'runtime-target-bucket' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['semantic_parity'] ?? 0 ), 'semantic-parity-bucket' );
+$assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['preserved_runtime_island'] ?? 0 ), 'preserved-runtime-bucket' );
 $assert( 1 === ( $diagnostics['diagnostic_summary']['repair_bucket']['fallback_block'] ?? 0 ), 'deduped-fallback-bucket' );
 $assert( ! isset( $diagnostics['diagnostic_summary']['type']['website_artifact_materialization_contract_note'] ), 'report-only-contract-note-excluded' );
 $assert( ! isset( $diagnostics['diagnostic_summary']['type']['document_metadata_routed'] ), 'report-only-metadata-note-excluded' );
@@ -135,10 +143,12 @@ $assert( 'blocks-engine' === ( $diagnostics['by_repair_bucket']['runtime_target_
 $assert( 'unsupported_loss' === ( $diagnostics['by_repair_bucket']['dropped_images'][0]['loss_class'] ?? '' ), 'dropped-images-loss-class' );
 $assert( 'importer_materialization_bug' === ( $diagnostics['by_repair_bucket']['invalid_block_content'][0]['loss_class'] ?? '' ), 'invalid-block-loss-class' );
 $assert( 'editable_approximation' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['loss_class'] ?? '' ), 'semantic-parity-loss-class' );
+$assert( 'preserved_runtime_island' === ( $diagnostics['by_repair_bucket']['preserved_runtime_island'][0]['loss_class'] ?? '' ), 'preserved-runtime-loss-class' );
+$assert( 'accepted-runtime-preservation' === ( $diagnostics['by_repair_bucket']['preserved_runtime_island'][0]['repair_mode'] ?? '' ), 'preserved-runtime-repair-mode' );
 $assert( 'preserved_runtime_island' === ( $diagnostics['by_repair_bucket']['fallback_block'][0]['loss_class'] ?? '' ), 'canvas-fallback-loss-class' );
 $assert( 1 === ( $diagnostics['loss_class_summary']['unsupported_loss'] ?? 0 ), 'loss-class-summary-unsupported' );
 $assert( 2 === ( $diagnostics['loss_class_summary']['importer_materialization_bug'] ?? 0 ), 'loss-class-summary-importer' );
-$assert( 1 === ( $diagnostics['loss_class_summary']['preserved_runtime_island'] ?? 0 ), 'loss-class-summary-preserved-runtime' );
+$assert( 2 === ( $diagnostics['loss_class_summary']['preserved_runtime_island'] ?? 0 ), 'loss-class-summary-preserved-runtime' );
 $assert( '#canvas' === ( $diagnostics['runtime_dependency_target_gaps'][0]['selector'] ?? '' ), 'runtime-target-selector' );
 $assert( 'header nav' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['selector'] ?? '' ), 'semantic-selector' );
 $assert( array() === ( $diagnostics['artifact_refs'] ?? null ), 'no-runtime-artifact-requirement' );

--- a/tests/smoke-report-diagnostic-loss-classes.php
+++ b/tests/smoke-report-diagnostic-loss-classes.php
@@ -41,9 +41,10 @@ $report['diagnostics'][] = array(
 	'block_name'  => 'core/html',
 );
 $report['diagnostics'][] = array(
-	'type'        => 'interaction_candidate',
-	'source_path' => 'website/index.html',
-	'selector'    => '.map iframe',
+	'type'          => 'interaction_candidate',
+	'source_path'   => 'website/index.html',
+	'selector'      => '.map iframe',
+	'repair_bucket' => 'static_site_import_quality',
 );
 $report['diagnostics'][] = array(
 	'type'        => 'svg_materialization_failure',
@@ -57,12 +58,15 @@ Static_Site_Importer_Report_Diagnostics::finalize_report( $report, array() );
 
 $assert( 'editable_approximation' === ( $report['diagnostics'][0]['loss_class'] ?? '' ), 'report-diagnostic-editable-loss-class' );
 $assert( 'preserved_runtime_island' === ( $report['diagnostics'][1]['loss_class'] ?? '' ), 'report-diagnostic-runtime-loss-class' );
+$assert( 'preserved_runtime_island' === ( $report['diagnostics'][1]['repair_bucket'] ?? '' ), 'report-diagnostic-runtime-repair-bucket' );
 $assert( 'importer_materialization_bug' === ( $report['diagnostics'][2]['loss_class'] ?? '' ), 'report-diagnostic-importer-loss-class' );
 $assert( 1 === ( $report['compact_summary']['loss_class_summary']['editable_approximation'] ?? 0 ), 'compact-summary-editable-count' );
 $assert( 1 === ( $report['import_validation_result']['diagnostic_summary']['loss_class']['preserved_runtime_island'] ?? 0 ), 'validation-summary-runtime-count' );
 $assert( 'editable_approximation' === ( $report['import_validation_result']['diagnostics'][0]['loss_class'] ?? '' ), 'validation-diagnostic-loss-class' );
+$assert( 'preserved_runtime_island' === ( $report['import_validation_result']['diagnostics'][1]['repair_bucket'] ?? '' ), 'validation-runtime-repair-bucket' );
 $assert( 'editable_approximation' === ( $report['finding_packets']['packets'][0]['loss_class'] ?? '' ), 'finding-packet-loss-class' );
 $assert( 'editable_approximation' === ( $report['finding_packets']['packets'][0]['routing']['loss_class'] ?? '' ), 'finding-packet-routing-loss-class' );
+$assert( 'preserved_runtime_island' === ( $report['finding_packets']['packets'][1]['routing']['repair_bucket'] ?? '' ), 'finding-packet-runtime-routing-repair-bucket' );
 
 $runtime_only_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
 $runtime_only_report['diagnostics'][] = array(


### PR DESCRIPTION
## Summary
- Recognize the fixture-matrix preserved-runtime wording as `preserved_runtime_island`.
- Route preserved runtime islands out of generic `static_site_import_quality` / `import_quality` buckets into `preserved_runtime_island`.
- Expose the accepted runtime bucket through import validation diagnostics and finding-packet routing without changing true materialization or unsupported-loss buckets.

## Evidence
Latest matrix after #196/#526/#6739 reported 72/72 failed fixtures with 977 findings, including 441 `preserved_runtime_island` findings that still surfaced under generic SSI quality families.

- Result artifact: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/49834b40-a58d-4836-a3cf-29bfce38c0ac-static-site-fixture-matrix-result.json
- Matrix artifact: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/8e954bd5-b29e-41e1-b77a-2d081d33a355-matrix.json

Expected matrix impact: preserved runtime selectors such as `.site-header`, `.site-nav`, `.reveal`, and `#mobile-nav` should no longer inflate actionable `static_site_import_quality` families when SSI has intentionally preserved them as bounded runtime islands. Real `importer_materialization_bug`, `unsupported_loss`, `runtime_target_gap`, and fallback-block findings remain routed to their existing buckets.

## Tests
- `php tests/smoke-diagnostic-loss-classes.php`
- `php tests/smoke-report-diagnostic-loss-classes.php`
- `php tests/smoke-import-diagnostic-contract.php`
- `php -l includes/class-static-site-importer-diagnostic-loss-classes.php && php -l includes/class-static-site-importer-diagnostic-contract.php && php -l includes/class-static-site-importer-report-diagnostics.php && php -l tests/smoke-diagnostic-loss-classes.php && php -l tests/smoke-report-diagnostic-loss-classes.php && php -l tests/smoke-import-diagnostic-contract.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Evidence review, diagnostic normalization changes, focused smoke test updates, and PR drafting.
