### PR TITLE
Clarify SSI matrix diagnostic contract

### DIFF
--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -213,6 +213,12 @@ class Static_Site_Importer_Diagnostic_Contract {
 			);
 			$diagnostic['loss_class']       = Static_Site_Importer_Diagnostic_Loss_Classes::classify( array_merge( $row, $diagnostic ) );
 			$diagnostic['diagnostic_class'] = $diagnostic['loss_class'];
+			$diagnostic['repair_class']     = $diagnostic['repair_mode'];
+			$diagnostic['acceptability']    = self::diagnostic_acceptability( $diagnostic['loss_class'] );
+			$source_diagnostic              = self::source_diagnostic_identity( $row, $diagnostic );
+			if ( ! empty( $source_diagnostic ) ) {
+				$diagnostic['source_diagnostic'] = $source_diagnostic;
+			}
 
 			foreach ( array( 'message', 'reason', 'excerpt', 'source_snippet', 'source_html_preview', 'emitted_block_preview', 'observed_output', 'html_excerpt', 'block_name', 'block_path', 'script_path', 'element', 'tag_name', 'tag', 'src', 'href', 'expected', 'observed', 'suggested_primitive' ) as $field ) {
 				$value = self::first_scalar( $row, array( $field ), '' );
@@ -687,6 +693,45 @@ class Static_Site_Importer_Diagnostic_Contract {
 		);
 
 		return $modes[ $repair_bucket ] ?? 'import-validation';
+	}
+
+	/**
+	 * Classify whether a diagnostic represents acceptable preservation or an imported-output defect.
+	 *
+	 * @param string $loss_class Normalized loss class.
+	 * @return string
+	 */
+	private static function diagnostic_acceptability( string $loss_class ): string {
+		if ( Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND === $loss_class ) {
+			return 'acceptable_preservation';
+		}
+		if ( in_array( $loss_class, array( Static_Site_Importer_Diagnostic_Loss_Classes::NATIVE_CONVERSION, Static_Site_Importer_Diagnostic_Loss_Classes::EDITABLE_APPROXIMATION ), true ) ) {
+			return 'acceptable_conversion';
+		}
+
+		return 'unacceptable_imported_output_defect';
+	}
+
+	/**
+	 * Preserve exact source diagnostic identity for matrix and repair-loop consumers.
+	 *
+	 * @param array<string,mixed> $row        Raw diagnostic row.
+	 * @param array<string,mixed> $diagnostic Normalized diagnostic row.
+	 * @return array<string,string>
+	 */
+	private static function source_diagnostic_identity( array $row, array $diagnostic ): array {
+		$identity = array();
+		foreach ( array( 'id', 'type', 'kind', 'code', 'reason_code', 'reason', 'message', 'source_path', 'selector', 'stage', 'engine' ) as $field ) {
+			$value = self::first_scalar( $row, array( $field ), '' );
+			if ( '' === $value ) {
+				$value = self::first_scalar( $diagnostic, array( $field ), '' );
+			}
+			if ( '' !== $value ) {
+				$identity[ $field ] = $value;
+			}
+		}
+
+		return $identity;
 	}
 
 	/**

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -936,12 +936,17 @@ class Static_Site_Importer_Report_Diagnostics {
 			'category'             => isset( $diagnostic['category'] ) && is_scalar( $diagnostic['category'] ) ? (string) $diagnostic['category'] : self::diagnostic_category( $type ),
 			'loss_class'           => isset( $diagnostic['loss_class'] ) && is_scalar( $diagnostic['loss_class'] ) ? (string) $diagnostic['loss_class'] : Static_Site_Importer_Diagnostic_Loss_Classes::classify( $diagnostic ),
 			'diagnostic_class'     => isset( $diagnostic['diagnostic_class'] ) && is_scalar( $diagnostic['diagnostic_class'] ) ? (string) $diagnostic['diagnostic_class'] : Static_Site_Importer_Diagnostic_Loss_Classes::classify( $diagnostic ),
+			'repair_class'         => isset( $diagnostic['repair_class'] ) && is_scalar( $diagnostic['repair_class'] ) ? (string) $diagnostic['repair_class'] : self::diagnostic_repair_class( $type ),
+			'acceptability'        => isset( $diagnostic['acceptability'] ) && is_scalar( $diagnostic['acceptability'] ) ? (string) $diagnostic['acceptability'] : self::diagnostic_acceptability( Static_Site_Importer_Diagnostic_Loss_Classes::classify( $diagnostic ) ),
+			'source_diagnostic'    => isset( $diagnostic['source_diagnostic'] ) && is_array( $diagnostic['source_diagnostic'] ) ? $diagnostic['source_diagnostic'] : self::source_diagnostic_identity( $diagnostic, $diagnostic ),
 			'owner'                => self::finding_owner( $diagnostic ),
 			'routing'              => array(
 				'component'              => self::finding_owner( $diagnostic ),
 				'stage'                  => isset( $diagnostic['stage'] ) && is_scalar( $diagnostic['stage'] ) ? (string) $diagnostic['stage'] : 'import',
 				'suggested_repair_class' => isset( $diagnostic['suggested_repair_class'] ) && is_scalar( $diagnostic['suggested_repair_class'] ) ? (string) $diagnostic['suggested_repair_class'] : self::diagnostic_repair_class( $type ),
+				'repair_class'           => isset( $diagnostic['repair_class'] ) && is_scalar( $diagnostic['repair_class'] ) ? (string) $diagnostic['repair_class'] : self::diagnostic_repair_class( $type ),
 				'loss_class'             => isset( $diagnostic['loss_class'] ) && is_scalar( $diagnostic['loss_class'] ) ? (string) $diagnostic['loss_class'] : Static_Site_Importer_Diagnostic_Loss_Classes::classify( $diagnostic ),
+				'acceptability'          => isset( $diagnostic['acceptability'] ) && is_scalar( $diagnostic['acceptability'] ) ? (string) $diagnostic['acceptability'] : self::diagnostic_acceptability( Static_Site_Importer_Diagnostic_Loss_Classes::classify( $diagnostic ) ),
 			),
 			'provenance'           => self::validation_provenance( $report ),
 			'reproduction_context' => array_merge(
@@ -1722,10 +1727,16 @@ class Static_Site_Importer_Report_Diagnostics {
 				'category'               => self::diagnostic_category( $type ),
 				'reason_code'            => $reason_code,
 				'suggested_repair_class' => self::diagnostic_repair_class( $type ),
+				'repair_class'           => self::diagnostic_repair_class( $type ),
 				'source_path'            => $source_path,
 			);
 			$machine['loss_class']       = Static_Site_Importer_Diagnostic_Loss_Classes::classify( array_merge( $diagnostic, $machine ) );
 			$machine['diagnostic_class'] = $machine['loss_class'];
+			$machine['acceptability']    = self::diagnostic_acceptability( $machine['loss_class'] );
+			$source_diagnostic           = self::source_diagnostic_identity( $diagnostic, $machine );
+			if ( ! empty( $source_diagnostic ) ) {
+				$machine['source_diagnostic'] = $source_diagnostic;
+			}
 
 			$selector = isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? trim( (string) $diagnostic['selector'] ) : '';
 			if ( '' !== $selector ) {
@@ -2048,6 +2059,45 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
+	 * Classify whether a diagnostic is acceptable preservation/conversion or an imported-output defect.
+	 *
+	 * @param string $loss_class Normalized loss class.
+	 * @return string
+	 */
+	private static function diagnostic_acceptability( string $loss_class ): string {
+		if ( Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND === $loss_class ) {
+			return 'acceptable_preservation';
+		}
+		if ( in_array( $loss_class, array( Static_Site_Importer_Diagnostic_Loss_Classes::NATIVE_CONVERSION, Static_Site_Importer_Diagnostic_Loss_Classes::EDITABLE_APPROXIMATION ), true ) ) {
+			return 'acceptable_conversion';
+		}
+
+		return 'unacceptable_imported_output_defect';
+	}
+
+	/**
+	 * Preserve source diagnostic identity fields alongside the normalized row.
+	 *
+	 * @param array<string,mixed> $diagnostic Raw diagnostic row.
+	 * @param array<string,mixed> $machine    Normalized diagnostic row.
+	 * @return array<string,string>
+	 */
+	private static function source_diagnostic_identity( array $diagnostic, array $machine ): array {
+		$identity = array();
+		foreach ( array( 'id', 'type', 'kind', 'code', 'reason_code', 'reason', 'message', 'source_path', 'selector', 'stage', 'engine' ) as $field ) {
+			$value = self::first_scalar( $diagnostic, array( $field ) );
+			if ( '' === $value ) {
+				$value = self::first_scalar( $machine, array( $field ) );
+			}
+			if ( '' !== $value ) {
+				$identity[ $field ] = $value;
+			}
+		}
+
+		return $identity;
+	}
+
+	/**
 	 * Extract concise diagnostic context for repair prompts.
 	 *
 	 * @param array<string,mixed> $diagnostic Diagnostic record.
@@ -2202,8 +2252,11 @@ class Static_Site_Importer_Report_Diagnostics {
 			'category',
 			'loss_class',
 			'diagnostic_class',
+			'acceptability',
 			'reason_code',
 			'suggested_repair_class',
+			'repair_class',
+			'source_diagnostic',
 			'source_path',
 			'source',
 			'selector',

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -136,6 +136,9 @@ $assert( 'unsupported_loss' === ( $diagnostics['by_repair_bucket']['dropped_imag
 $assert( 'importer_materialization_bug' === ( $diagnostics['by_repair_bucket']['invalid_block_content'][0]['loss_class'] ?? '' ), 'invalid-block-loss-class' );
 $assert( 'editable_approximation' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['loss_class'] ?? '' ), 'semantic-parity-loss-class' );
 $assert( 'preserved_runtime_island' === ( $diagnostics['by_repair_bucket']['fallback_block'][0]['loss_class'] ?? '' ), 'canvas-fallback-loss-class' );
+$assert( 'acceptable_preservation' === ( $diagnostics['by_repair_bucket']['fallback_block'][0]['acceptability'] ?? '' ), 'canvas-fallback-acceptable-preservation' );
+$assert( 'fallback-block-replacement' === ( $diagnostics['by_repair_bucket']['fallback_block'][0]['repair_class'] ?? '' ), 'canvas-fallback-repair-class' );
+$assert( 'unsupported_html_fallback' === ( $diagnostics['by_repair_bucket']['fallback_block'][0]['source_diagnostic']['type'] ?? '' ), 'canvas-fallback-source-diagnostic-type' );
 $assert( 1 === ( $diagnostics['loss_class_summary']['unsupported_loss'] ?? 0 ), 'loss-class-summary-unsupported' );
 $assert( 2 === ( $diagnostics['loss_class_summary']['importer_materialization_bug'] ?? 0 ), 'loss-class-summary-importer' );
 $assert( 1 === ( $diagnostics['loss_class_summary']['preserved_runtime_island'] ?? 0 ), 'loss-class-summary-preserved-runtime' );
@@ -177,6 +180,7 @@ $assert( is_array( $quality_gate_error['errors'][0] ?? null ), 'ability-error-er
 $assert( 'core_html_block' === ( $quality_gate_error['errors'][0]['kind'] ?? '' ), 'ability-error-prevents-numeric-generic-errors' );
 $assert( 'fallback_block' === ( $quality_gate_error['fixture_diagnostics']['diagnostics'][0]['repair_bucket'] ?? '' ), 'ability-error-fixture-diagnostics-classified' );
 $assert( 'editable_approximation' === ( $quality_gate_error['fixture_diagnostics']['diagnostics'][0]['loss_class'] ?? '' ), 'ability-error-fixture-loss-classified' );
+$assert( 'acceptable_conversion' === ( $quality_gate_error['fixture_diagnostics']['diagnostics'][0]['acceptability'] ?? '' ), 'ability-error-fixture-acceptability-classified' );
 
 $numeric_contract = Static_Site_Importer_Diagnostic_Contract::build(
 	array(

--- a/tests/smoke-report-diagnostic-loss-classes.php
+++ b/tests/smoke-report-diagnostic-loss-classes.php
@@ -61,8 +61,14 @@ $assert( 'importer_materialization_bug' === ( $report['diagnostics'][2]['loss_cl
 $assert( 1 === ( $report['compact_summary']['loss_class_summary']['editable_approximation'] ?? 0 ), 'compact-summary-editable-count' );
 $assert( 1 === ( $report['import_validation_result']['diagnostic_summary']['loss_class']['preserved_runtime_island'] ?? 0 ), 'validation-summary-runtime-count' );
 $assert( 'editable_approximation' === ( $report['import_validation_result']['diagnostics'][0]['loss_class'] ?? '' ), 'validation-diagnostic-loss-class' );
+$assert( 'acceptable_conversion' === ( $report['import_validation_result']['diagnostics'][0]['acceptability'] ?? '' ), 'validation-diagnostic-acceptability' );
+$assert( 'replace_fallback_block' === ( $report['import_validation_result']['diagnostics'][0]['repair_class'] ?? '' ), 'validation-diagnostic-repair-class' );
+$assert( 'core_html_block' === ( $report['import_validation_result']['diagnostics'][0]['source_diagnostic']['type'] ?? '' ), 'validation-diagnostic-source-diagnostic-type' );
 $assert( 'editable_approximation' === ( $report['finding_packets']['packets'][0]['loss_class'] ?? '' ), 'finding-packet-loss-class' );
 $assert( 'editable_approximation' === ( $report['finding_packets']['packets'][0]['routing']['loss_class'] ?? '' ), 'finding-packet-routing-loss-class' );
+$assert( 'acceptable_conversion' === ( $report['finding_packets']['packets'][0]['acceptability'] ?? '' ), 'finding-packet-acceptability' );
+$assert( 'replace_fallback_block' === ( $report['finding_packets']['packets'][0]['routing']['repair_class'] ?? '' ), 'finding-packet-routing-repair-class' );
+$assert( 'core_html_block' === ( $report['finding_packets']['packets'][0]['source_diagnostic']['type'] ?? '' ), 'finding-packet-source-diagnostic-type' );
 
 $runtime_only_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
 $runtime_only_report['diagnostics'][] = array(
@@ -74,6 +80,7 @@ $runtime_only_report['quality']['interaction_candidate_count'] = 1;
 $runtime_only_quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $runtime_only_report, array() );
 $assert( true === ( $runtime_only_quality['pass'] ?? false ), 'preserved-runtime-island-does-not-fail-quality' );
 $assert( array() === ( $runtime_only_quality['failure_reasons'] ?? null ), 'preserved-runtime-island-not-failure-reason' );
+$assert( 'acceptable_preservation' === ( $runtime_only_report['import_validation_result']['diagnostics'][0]['acceptability'] ?? '' ), 'preserved-runtime-island-acceptability' );
 
 $cleanup_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
 $cleanup_report['diagnostics'][] = array(


### PR DESCRIPTION
## Summary
- Preserve exact source diagnostic identity on normalized SSI diagnostics via `source_diagnostic`.
- Add explicit `repair_class` and `acceptability` fields to import diagnostics, validation diagnostics, and finding packets.
- Keep preserved runtime islands classified separately from imported-output defects without duplicating PR #484 fixture filtering/classification work.

## Evidence
Latest matrix evidence reported 72 failed fixtures with diagnostic blind spots around generic families and missing source context:

- Result artifact: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/49834b40-a58d-4836-a3cf-29bfce38c0ac-static-site-fixture-matrix-result.json
- Matrix artifact: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e/8e954bd5-b29e-41e1-b77a-2d081d33a355-matrix.json
- Artifact base: https://homeboy-artifacts-tunnel.dev.chubes.net/a592d1ca-14fa-4a22-b6c1-0a81599f922e

Expected matrix effect: transformer/runtime-island/materialization findings should explain their source diagnostic, loss class, repair class, and acceptability. Preserved runtime islands should show as acceptable preservation, while importer materialization and unsupported-loss rows remain unacceptable imported-output defects for repair routing. This improves blind-spot/actionability signals rather than changing fixture pass/fail thresholds.

## Tests
- `php -l includes/class-static-site-importer-diagnostic-contract.php`
- `php -l includes/class-static-site-importer-report-diagnostics.php`
- `php tests/smoke-import-diagnostic-contract.php`
- `php tests/smoke-report-diagnostic-loss-classes.php`
- `php tests/smoke-diagnostic-loss-classes.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Evidence review, diagnostic contract implementation, focused smoke test updates, and PR drafting.
