### PR TITLE
Materialize imported body font family

### DIFF
--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -916,7 +916,62 @@ class Static_Site_Importer_Theme_Materializer {
 			$data['styles']['color'] = $design_tokens['styles'];
 		}
 
+		$body_font_family = self::body_font_family_from_css( $css );
+		if ( null !== $body_font_family ) {
+			$data['styles']['typography']['fontFamily'] = $body_font_family;
+		}
+
 		return wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";
+	}
+
+	/**
+	 * Extract a safe body font-family declaration from source CSS.
+	 *
+	 * @param string $css Source CSS.
+	 * @return string|null
+	 */
+	private static function body_font_family_from_css( string $css ): ?string {
+		$css = trim( (string) preg_replace( '/\/\*.*?\*\//s', '', $css ) );
+		if ( '' === $css || ! preg_match_all( '/([^{}]+)\{([^{}]*)\}/', $css, $rule_matches, PREG_SET_ORDER ) ) {
+			return null;
+		}
+
+		foreach ( $rule_matches as $rule_match ) {
+			$selectors = array_map( 'trim', explode( ',', strtolower( $rule_match[1] ) ) );
+			if ( ! in_array( 'body', $selectors, true ) ) {
+				continue;
+			}
+
+			if ( ! preg_match( '/(?:^|;)\s*font-family\s*:\s*([^;{}]+)/i', $rule_match[2], $property_match ) ) {
+				continue;
+			}
+
+			$value = trim( preg_replace( '/\s*!important\s*$/i', '', $property_match[1] ) );
+			if ( self::is_safe_font_family_value( $value ) ) {
+				return $value;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check whether a CSS font-family value is safe to expose in theme.json.
+	 *
+	 * @param string $value CSS font-family value.
+	 * @return bool
+	 */
+	private static function is_safe_font_family_value( string $value ): bool {
+		$value = trim( $value );
+		if ( '' === $value || strlen( $value ) > 300 ) {
+			return false;
+		}
+
+		if ( preg_match( '/[<>;{}]/', $value ) || preg_match( '/\b(?:expression|url|import)\s*\(/i', $value ) ) {
+			return false;
+		}
+
+		return (bool) preg_match( '/^[A-Za-z0-9_\-\s,"\'().]+$/', $value );
 	}
 
 	/**

--- a/tests/smoke-theme-materializer-dry-run.php
+++ b/tests/smoke-theme-materializer-dry-run.php
@@ -44,6 +44,18 @@ if ( ! function_exists( 'is_wp_error' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key ) ?? '' );
+	}
+}
+
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
 
 $failures   = array();
@@ -121,6 +133,33 @@ $assert( 'ephemeral' === ( $ephemeral['assets']['images/tmp.svg']['source_role']
 $assert( false === ( $ephemeral['assets']['images/tmp.svg']['keep_source'] ?? true ), 'ephemeral-source-can-opt-out-of-retention' );
 $assert( true === ( $ephemeral['assets']['images/tmp.svg']['deletion_allowed'] ?? false ), 'ephemeral-source-allows-deletion-semantics' );
 $assert( array() === ( $ephemeral['diagnostics'] ?? array() ), 'ephemeral-source-does-not-warn' );
+
+$theme_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes(
+	$theme_dir,
+	'imported-theme',
+	'Imported Theme',
+	'html, body { margin: 0; } body { font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif !important; color: #111; }',
+	false,
+	false
+);
+$theme_json   = json_decode( $theme_writes[ $theme_dir . '/theme.json' ] ?? '', true );
+$assert( is_array( $theme_json ), 'generated-theme-json-decodes' );
+$assert(
+	'"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif' === ( $theme_json['styles']['typography']['fontFamily'] ?? '' ),
+	'body-font-family-is-materialized-in-theme-json',
+	(string) ( $theme_json['styles']['typography']['fontFamily'] ?? '' )
+);
+
+$unsafe_theme_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes(
+	$theme_dir,
+	'imported-theme',
+	'Imported Theme',
+	'body { font-family: url("https://example.test/font"); }',
+	false,
+	false
+);
+$unsafe_theme_json   = json_decode( $unsafe_theme_writes[ $theme_dir . '/theme.json' ] ?? '', true );
+$assert( ! isset( $unsafe_theme_json['styles']['typography']['fontFamily'] ), 'unsafe-body-font-family-is-not-materialized' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- Promotes safe source CSS `body { font-family: ... }` declarations into generated `theme.json` global typography styles.
- Preserves body font-family stacks including CSS variable references like `var(--font-body)`, while ignoring unsafe function-based values.
- Adds focused smoke coverage for generated theme output.

## Evidence
- Bench run: https://homeboy-artifacts-tunnel.dev.chubes.net/10cc02d8-e07d-4595-8e5a-170c2ed1bab0
- Supplied top family: `static_site_import_quality:html_semantic_parity_typography_font_family_dropped:body`, count 5.
- Implicated fixtures declare body font-family values in source CSS: `12-portfolio`, `14-restaurant`, `15-saas`, `2-onepager-coffee`, `21-studio-web-seafood-popup`.

## Tests
- `php -l includes/class-static-site-importer-theme-materializer.php`
- `php tests/smoke-theme-materializer-dry-run.php`
- `php tests/smoke-visual-repair-css.php`
- `composer validate --no-check-publish`

## Expected matrix impact
- Expected to remove the top `html_semantic_parity_typography_font_family_dropped:body` family for fixtures whose source body font-family is a safe CSS stack or CSS variable reference.
- No local benchmark was run per project rules.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigating benchmark evidence, implementing the focused materializer change, and drafting tests/PR text.