### PR TITLE
Materialize <form> via a configurable form_plugin provider (default Jetpack Forms)

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -92,6 +92,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'overwrite'                    => array( 'type' => 'boolean' ),
 						'fail_on_quality'              => array( 'type' => 'boolean' ),
 						'allow_missing_woocommerce'    => array( 'type' => 'boolean' ),
+						'allow_missing_jetpack'        => array( 'type' => 'boolean' ),
 						'report'                       => array( 'type' => 'string' ),
 						'asset_materialization_policy' => array(
 							'type' => 'string',
@@ -130,6 +131,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'overwrite'                    => array( 'type' => 'boolean' ),
 						'fail_on_quality'              => array( 'type' => 'boolean' ),
 						'allow_missing_woocommerce'    => array( 'type' => 'boolean' ),
+						'allow_missing_jetpack'        => array( 'type' => 'boolean' ),
 						'report'                       => array( 'type' => 'string' ),
 						'asset_materialization_policy' => array(
 							'type' => 'string',
@@ -169,6 +171,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'overwrite'                 => array( 'type' => 'boolean' ),
 						'fail_on_quality'           => array( 'type' => 'boolean' ),
 						'allow_missing_woocommerce' => array( 'type' => 'boolean' ),
+						'allow_missing_jetpack'     => array( 'type' => 'boolean' ),
 						'compiler_options'          => array( 'type' => 'object' ),
 						'transform_options'         => array( 'type' => 'object' ),
 						'validation'                => array( 'type' => 'object' ),
@@ -201,6 +204,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'overwrite'                    => array( 'type' => 'boolean' ),
 						'fail_on_quality'              => array( 'type' => 'boolean' ),
 						'allow_missing_woocommerce'    => array( 'type' => 'boolean' ),
+						'allow_missing_jetpack'        => array( 'type' => 'boolean' ),
 						'asset_materialization_policy' => array(
 							'type' => 'string',
 							'enum' => array( 'copy_to_theme', 'use_map' ),
@@ -338,6 +342,7 @@ if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' )
 			'overwrite'                    => ! empty( $input['overwrite'] ),
 			'fail_on_quality'              => ! empty( $input['fail_on_quality'] ),
 			'allow_missing_woocommerce'    => ! empty( $input['allow_missing_woocommerce'] ),
+			'allow_missing_jetpack'        => ! empty( $input['allow_missing_jetpack'] ),
 			'materialize_dependencies'     => array_key_exists( 'materialize_dependencies', $input ) ? (bool) $input['materialize_dependencies'] : true,
 			'report'                       => isset( $input['report'] ) ? (string) $input['report'] : '',
 			'asset_materialization_policy' => isset( $input['asset_materialization_policy'] ) ? (string) $input['asset_materialization_policy'] : '',

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -222,10 +222,20 @@ class Static_Site_Importer_Diagnostic_Contract {
 				$diagnostic['source_diagnostic'] = $source_diagnostic;
 			}
 
-			foreach ( array( 'message', 'reason', 'excerpt', 'source_snippet', 'source_html_preview', 'emitted_block_preview', 'observed_output', 'html_excerpt', 'block_name', 'block_path', 'script_path', 'element', 'tag_name', 'tag', 'src', 'href', 'expected', 'observed', 'suggested_primitive' ) as $field ) {
+			foreach ( array( 'message', 'reason', 'excerpt', 'source_snippet', 'source_html_preview', 'emitted_block_preview', 'observed_output', 'html_excerpt', 'block_name', 'block_path', 'script_path', 'element', 'tag_name', 'tag', 'src', 'href', 'expected', 'observed', 'suggested_primitive', 'diagnostic_code', 'mapped_provider' ) as $field ) {
 				$value = self::first_scalar( $row, array( $field ), '' );
 				if ( '' !== $value ) {
 					$diagnostic[ $field ] = $value;
+				}
+			}
+
+			// Preserve the runtime-mapping signal a real provider sets when it
+			// materializes a preserved island (e.g. a <form> mapped to working
+			// form-provider blocks). The honest fixture gate treats a preserved
+			// runtime island as acceptable only when this signal is truthy.
+			foreach ( array( 'runtime_mapped', 'runtime_carried' ) as $signal ) {
+				if ( ! empty( $row[ $signal ] ) ) {
+					$diagnostic[ $signal ] = true;
 				}
 			}
 

--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -15,12 +15,121 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Static_Site_Importer_Entity_Materializer_Registry {
 
 	/**
-	 * Return the first adapter that handles product rows.
+	 * Per-capability provider selection contract.
+	 *
+	 * Each capability declares a default provider, the core setting/option that
+	 * overrides it, and the capability-scoped filter consumers use to register or
+	 * route to a different adapter (Gravity Forms, CF7, EDD, and so on). The
+	 * registry sits behind this so a capability resolves to exactly one adapter.
+	 *
+	 * @return array<string,array<string,string>>
+	 */
+	public static function capabilities(): array {
+		return array(
+			'form' => array(
+				'default_provider' => 'jetpack',
+				'option'           => 'static_site_importer_form_plugin',
+				'filter'           => 'ssi_form_plugin',
+			),
+			'shop' => array(
+				'default_provider' => 'woocommerce',
+				'option'           => 'static_site_importer_shop_plugin',
+				'filter'           => 'ssi_shop_plugin',
+			),
+		);
+	}
+
+	/**
+	 * Resolve the selected provider id for a capability.
+	 *
+	 * Resolution order: capability default, core setting/option override, the
+	 * capability-scoped filter, then the cross-capability provider filter.
+	 *
+	 * @param string $capability Capability key.
+	 * @return string
+	 */
+	public static function provider_for( string $capability ): string {
+		$capabilities = self::capabilities();
+		$config       = $capabilities[ $capability ] ?? array();
+		$provider     = (string) ( $config['default_provider'] ?? '' );
+
+		$option_key = (string) ( $config['option'] ?? '' );
+		if ( '' !== $option_key && function_exists( 'get_option' ) ) {
+			$stored = get_option( $option_key, '' );
+			if ( is_string( $stored ) && '' !== trim( $stored ) ) {
+				$provider = trim( $stored );
+			}
+		}
+
+		$capability_filter = (string) ( $config['filter'] ?? '' );
+		if ( '' !== $capability_filter && function_exists( 'apply_filters' ) ) {
+			/**
+			 * Filters the provider selected for a single materializer capability.
+			 *
+			 * @param string $provider   Selected provider id.
+			 * @param string $capability Capability key.
+			 */
+			$provider = (string) apply_filters( $capability_filter, $provider, $capability );
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			/**
+			 * Filters the provider selected for any materializer capability.
+			 *
+			 * @param string $provider   Selected provider id.
+			 * @param string $capability Capability key.
+			 */
+			$provider = (string) apply_filters( 'ssi_entity_materializer_provider', $provider, $capability );
+		}
+
+		return $provider;
+	}
+
+	/**
+	 * Resolve the registered adapter that serves a capability's selected provider.
+	 *
+	 * @param string $capability Capability key.
+	 * @return array<string,mixed>
+	 */
+	public static function adapter_for_capability( string $capability ): array {
+		$adapters = self::adapters();
+		$provider = self::provider_for( $capability );
+
+		$capability_adapters = array();
+		foreach ( $adapters as $adapter ) {
+			if ( ! is_array( $adapter ) || $capability !== (string) ( $adapter['capability'] ?? '' ) ) {
+				continue;
+			}
+
+			$capability_adapters[] = $adapter;
+			if ( $provider === (string) ( $adapter['provider'] ?? '' ) ) {
+				return $adapter;
+			}
+		}
+
+		// No adapter matched the selected provider; fall back to the first
+		// adapter registered for the capability so a misconfigured provider does
+		// not silently drop materialization.
+		return $capability_adapters[0] ?? array();
+	}
+
+	/**
+	 * Return the adapter that materializes detected forms.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function form_adapter(): array {
+		return self::adapter_for_capability( 'form' );
+	}
+
+	/**
+	 * Return the adapter that handles product rows.
 	 *
 	 * @return array<string,mixed>
 	 */
 	public static function product_adapter(): array {
-		return self::adapter( 'woocommerce_simple_product' );
+		$adapter = self::adapter_for_capability( 'shop' );
+		return ! empty( $adapter ) ? $adapter : self::adapter( 'woocommerce_simple_product' );
 	}
 
 	/**
@@ -56,6 +165,36 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 		return array(
 			'products' => array(),
 			'errors'   => array(
+				array(
+					'path'    => '$',
+					'message' => 'Entity materializer validator is unavailable.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Validate an entity manifest and return the validator's native result shape.
+	 *
+	 * Unlike validate_manifest(), this does not coerce the result to the product
+	 * contract, so capability adapters (forms, and future entity types) keep their
+	 * own validated keys (e.g. `forms`).
+	 *
+	 * @param array<string,mixed> $adapter Adapter definition.
+	 * @param mixed               $data    Manifest data.
+	 * @return array<string,mixed>
+	 */
+	public static function validate_manifest_generic( array $adapter, mixed $data ): array {
+		$validator = $adapter['validator'] ?? null;
+		if ( is_callable( $validator ) ) {
+			$result = call_user_func( $validator, $data );
+			if ( is_array( $result ) ) {
+				return $result;
+			}
+		}
+
+		return array(
+			'errors' => array(
 				array(
 					'path'    => '$',
 					'message' => 'Entity materializer validator is unavailable.',
@@ -205,6 +344,8 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 			'woocommerce_simple_product' => array(
 				'id'              => 'woocommerce_simple_product',
 				'entity_type'     => 'product',
+				'capability'      => 'shop',
+				'provider'        => 'woocommerce',
 				'label'           => 'WooCommerce simple product',
 				'report_key'      => 'product_seeding',
 				'waiver_arg'      => 'allow_missing_woocommerce',
@@ -218,6 +359,27 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 						'plugin_file'           => 'woocommerce/woocommerce.php',
 						'availability_callback' => array( 'Static_Site_Importer_Woo_Product_Seeder', 'woocommerce_available' ),
 						'missing_apis'          => array( 'WC_Product_Simple', 'product_post_type', 'product_cat_taxonomy' ),
+					),
+				),
+			),
+			'jetpack_contact_form'       => array(
+				'id'              => 'jetpack_contact_form',
+				'entity_type'     => 'form',
+				'capability'      => 'form',
+				'provider'        => 'jetpack',
+				'label'           => 'Jetpack contact form',
+				'report_key'      => 'form_seeding',
+				'waiver_arg'      => 'allow_missing_jetpack',
+				'validator'       => array( self::class, 'validate_forms_manifest' ),
+				'materializer'    => array( 'Static_Site_Importer_Form_Seeder', 'seed' ),
+				'report_callback' => array( 'Static_Site_Importer_Form_Seeder', 'new_report' ),
+				'dependencies'    => array(
+					array(
+						'type'                  => 'wp_org_plugin',
+						'slug'                  => 'jetpack',
+						'plugin_file'           => 'jetpack/jetpack.php',
+						'availability_callback' => array( 'Static_Site_Importer_Form_Seeder', 'jetpack_forms_available' ),
+						'missing_apis'          => array( 'Automattic\\Jetpack\\Forms\\ContactForm\\Contact_Form', 'jetpack/contact-form', 'jetpack/field-text' ),
 					),
 				),
 			),
@@ -362,6 +524,85 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 		return array(
 			'products' => empty( $errors ) ? $products : array(),
 			'errors'   => $errors,
+		);
+	}
+
+	/**
+	 * Validate detected form runtime islands into a normalized forms manifest.
+	 *
+	 * Each form carries the preserved <form> fallback metadata (action/method
+	 * form attributes plus the source control list). A form is only seedable when
+	 * it exposes at least one control the provider can map; submit-only forms are
+	 * rejected because they cannot reach feature parity.
+	 *
+	 * @param mixed $data Forms manifest data.
+	 * @return array{forms:array<int,array<string,mixed>>,errors:array<int,array<string,string>>}
+	 */
+	public static function validate_forms_manifest( mixed $data ): array {
+		$forms  = array();
+		$errors = array();
+
+		if ( ! is_array( $data ) ) {
+			return array(
+				'forms'  => array(),
+				'errors' => array(
+					array(
+						'path'    => '$',
+						'message' => 'forms_manifest must be an object or array of forms.',
+					),
+				),
+			);
+		}
+
+		$rows = isset( $data['forms'] ) && is_array( $data['forms'] ) ? $data['forms'] : $data;
+		if ( ! is_array( $rows ) ) {
+			$rows = array();
+		}
+
+		$index = 0;
+		foreach ( $rows as $form ) {
+			$path_prefix = '$.forms[' . $index . ']';
+			++$index;
+			if ( ! is_array( $form ) ) {
+				$errors[] = array(
+					'path'    => $path_prefix,
+					'message' => 'Form must be an object.',
+				);
+				continue;
+			}
+
+			$controls = isset( $form['controls'] ) && is_array( $form['controls'] ) ? array_values( array_filter( $form['controls'], 'is_array' ) ) : array();
+			$mappable = array_filter(
+				$controls,
+				static function ( array $control ): bool {
+					$type = strtolower( trim( (string) ( $control['type'] ?? '' ) ) );
+					$tag  = strtolower( trim( (string) ( $control['tag'] ?? '' ) ) );
+					return ! in_array( $type, array( 'submit', 'hidden', 'reset', 'image', 'file', 'button' ), true ) && '' !== ( $type . $tag );
+				}
+			);
+
+			if ( empty( $mappable ) ) {
+				$errors[] = array(
+					'path'    => $path_prefix . '.controls',
+					'message' => 'Form must declare at least one mappable input control.',
+				);
+				continue;
+			}
+
+			$forms[] = array(
+				'selector'    => isset( $form['selector'] ) && is_scalar( $form['selector'] ) ? (string) $form['selector'] : '',
+				'source_path' => isset( $form['source_path'] ) && is_scalar( $form['source_path'] ) ? (string) $form['source_path'] : '',
+				'form'        => isset( $form['form'] ) && is_array( $form['form'] ) ? $form['form'] : array(),
+				'controls'    => $controls,
+			);
+		}
+
+		// Forms validate per row: a single unmappable form (for example a
+		// submit-only search form) is rejected without discarding the other
+		// mappable forms, so partial feature parity is still materialized.
+		return array(
+			'forms'  => $forms,
+			'errors' => $errors,
 		);
 	}
 

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -1,0 +1,396 @@
+<?php
+/**
+ * Jetpack contact-form materialization for preserved form runtime islands.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Turns preserved <form> fallback metadata into working Jetpack Form blocks.
+ *
+ * Mirrors Static_Site_Importer_Woo_Product_Seeder: the registry owns the manifest
+ * contract; this provider seeder only consumes the normalized shape after the
+ * adapter validator has succeeded and emits real form-provider block markup so a
+ * detected form gains submission handling, email notifications, and spam control
+ * instead of staying a dead html_form_fallback runtime island.
+ */
+class Static_Site_Importer_Form_Seeder {
+
+	/**
+	 * Provider id this seeder materializes for.
+	 */
+	public const PROVIDER_ID = 'jetpack';
+
+	/**
+	 * Map a source control type to a Jetpack field block name.
+	 *
+	 * @return array<string,string>
+	 */
+	private static function field_block_map(): array {
+		return array(
+			'text'     => 'jetpack/field-text',
+			'search'   => 'jetpack/field-text',
+			'password' => 'jetpack/field-text',
+			'number'   => 'jetpack/field-text',
+			'email'    => 'jetpack/field-email',
+			'tel'      => 'jetpack/field-telephone',
+			'url'      => 'jetpack/field-url',
+			'date'     => 'jetpack/field-date',
+			'textarea' => 'jetpack/field-textarea',
+			'select'   => 'jetpack/field-select',
+			'checkbox' => 'jetpack/field-checkbox',
+			'radio'    => 'jetpack/field-radio',
+		);
+	}
+
+	/**
+	 * Materialize Jetpack contact forms from a validated forms manifest.
+	 *
+	 * @param array<string, mixed> $manifest Validated forms manifest.
+	 * @return array<string, mixed>
+	 */
+	public static function seed( array $manifest ): array {
+		$forms  = self::manifest_forms( $manifest );
+		$report = self::new_report( 'not_run' );
+
+		if ( empty( $forms ) ) {
+			$report['status'] = 'skipped';
+			$report['reason'] = 'empty_validated_manifest';
+			return $report;
+		}
+
+		$available             = self::jetpack_forms_available();
+		$report['provider']    = self::PROVIDER_ID;
+		$report['available']   = $available;
+		$report['status']      = 'completed';
+
+		foreach ( $forms as $form ) {
+			$row                = self::seed_form( $form, $available );
+			$report['forms'][]  = $row;
+
+			$status = $row['status'] ?? 'error';
+			if ( isset( $report['counts'][ $status ] ) ) {
+				++$report['counts'][ $status ];
+			} else {
+				++$report['counts']['error'];
+			}
+		}
+
+		return $report;
+	}
+
+	/**
+	 * Build an initial report shape.
+	 *
+	 * @param string $status Report status.
+	 * @return array<string, mixed>
+	 */
+	public static function new_report( string $status = 'skipped' ): array {
+		return array(
+			'status'    => $status,
+			'reason'    => '',
+			'provider'  => self::PROVIDER_ID,
+			'available' => self::jetpack_forms_available(),
+			'counts'    => array(
+				'mapped'  => 0,
+				'skipped' => 0,
+				'error'   => 0,
+			),
+			'forms'     => array(),
+		);
+	}
+
+	/**
+	 * Determine whether the Jetpack Forms runtime is available to host seeded forms.
+	 *
+	 * Public so the registry availability callback and the dependency gate can run
+	 * before forms are materialized into a runtime that can carry submissions.
+	 *
+	 * @return bool
+	 */
+	public static function jetpack_forms_available(): bool {
+		if ( class_exists( 'Automattic\\Jetpack\\Forms\\ContactForm\\Contact_Form' ) ) {
+			return true;
+		}
+		if ( class_exists( 'Grunion_Contact_Form' ) || class_exists( 'Contact_Form' ) ) {
+			return true;
+		}
+
+		return function_exists( 'is_plugin_active' ) && is_plugin_active( 'jetpack/jetpack.php' );
+	}
+
+	/**
+	 * Extract the validator-owned forms list from a manifest.
+	 *
+	 * @param array<string, mixed> $manifest Validated forms manifest.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function manifest_forms( array $manifest ): array {
+		$forms = isset( $manifest['forms'] ) && is_array( $manifest['forms'] ) ? $manifest['forms'] : $manifest;
+
+		return array_values(
+			array_filter(
+				$forms,
+				static fn ( $form ): bool => is_array( $form )
+			)
+		);
+	}
+
+	/**
+	 * Map one source form into Jetpack contact-form block markup.
+	 *
+	 * @param array<string, mixed> $form      Validated form row.
+	 * @param bool                 $available Whether the Jetpack runtime is active.
+	 * @return array<string, mixed>
+	 */
+	private static function seed_form( array $form, bool $available ): array {
+		$controls = isset( $form['controls'] ) && is_array( $form['controls'] ) ? $form['controls'] : array();
+		$selector = isset( $form['selector'] ) && is_scalar( $form['selector'] ) ? (string) $form['selector'] : '';
+
+		$field_blocks = array();
+		$mapped_types = array();
+		$submit_text  = 'Submit';
+		$skipped      = array();
+
+		foreach ( $controls as $control ) {
+			if ( ! is_array( $control ) ) {
+				continue;
+			}
+
+			$type = strtolower( trim( (string) ( $control['type'] ?? '' ) ) );
+			$tag  = strtolower( trim( (string) ( $control['tag'] ?? '' ) ) );
+
+			if ( 'submit' === $type || ( 'button' === $tag && 'submit' === $type ) ) {
+				$text        = self::control_text( $control );
+				$submit_text = '' !== $text ? $text : $submit_text;
+				continue;
+			}
+
+			$field_block = self::field_block_from_control( $tag, $type, $control );
+			if ( null === $field_block ) {
+				$skipped[] = '' !== $type ? $type : $tag;
+				continue;
+			}
+
+			$field_blocks[] = $field_block;
+			$mapped_types[] = $field_block['name'];
+		}
+
+		if ( empty( $field_blocks ) ) {
+			return array(
+				'selector'      => $selector,
+				'provider'      => self::PROVIDER_ID,
+				'block_name'    => 'jetpack/contact-form',
+				'status'        => 'skipped',
+				'reason'        => 'no_mappable_form_fields',
+				'runtime_mapped' => false,
+				'skipped_types' => array_values( array_unique( array_filter( $skipped ) ) ),
+			);
+		}
+
+		$inner_blocks   = $field_blocks;
+		$inner_blocks[] = self::submit_button_block( $submit_text );
+		$form_attrs     = self::contact_form_attributes( $form );
+		$markup         = self::serialize_block( 'jetpack/contact-form', $form_attrs, $inner_blocks );
+
+		return array(
+			'selector'       => $selector,
+			'provider'       => self::PROVIDER_ID,
+			'block_name'     => 'jetpack/contact-form',
+			'status'         => 'mapped',
+			'field_count'    => count( $field_blocks ),
+			'field_blocks'   => $mapped_types,
+			'skipped_types'  => array_values( array_unique( array_filter( $skipped ) ) ),
+			'submit_text'    => $submit_text,
+			'runtime_mapped' => true,
+			'runtime_carried' => $available,
+			'block_markup'   => $markup,
+		);
+	}
+
+	/**
+	 * Build a Jetpack field block definition from a source control.
+	 *
+	 * @param string               $tag     Source control tag.
+	 * @param string               $type    Source control type.
+	 * @param array<string, mixed> $control Source control metadata.
+	 * @return array<string, mixed>|null
+	 */
+	private static function field_block_from_control( string $tag, string $type, array $control ): ?array {
+		$map = self::field_block_map();
+
+		$lookup = 'textarea' === $tag ? 'textarea' : ( 'select' === $tag ? 'select' : $type );
+		if ( 'select-multiple' === $type ) {
+			$lookup = 'select';
+		}
+
+		if ( ! isset( $map[ $lookup ] ) ) {
+			return null;
+		}
+
+		$attrs = array();
+		$label = self::control_text( $control );
+		if ( '' !== $label ) {
+			$attrs['label'] = $label;
+		}
+		if ( ! empty( $control['required'] ) ) {
+			$attrs['required'] = true;
+		}
+		$placeholder = isset( $control['placeholder'] ) && is_scalar( $control['placeholder'] ) ? trim( (string) $control['placeholder'] ) : '';
+		if ( '' !== $placeholder ) {
+			$attrs['placeholder'] = $placeholder;
+		}
+
+		if ( in_array( $lookup, array( 'select', 'radio', 'checkbox' ), true ) ) {
+			$options = self::option_labels( $control );
+			if ( ! empty( $options ) ) {
+				$attrs['options'] = $options;
+			}
+		}
+
+		return array(
+			'name'  => $map[ $lookup ],
+			'attrs' => $attrs,
+		);
+	}
+
+	/**
+	 * Build the Jetpack submit button block.
+	 *
+	 * @param string $text Submit button label.
+	 * @return array<string, mixed>
+	 */
+	private static function submit_button_block( string $text ): array {
+		return array(
+			'name'  => 'jetpack/button',
+			'attrs' => array(
+				'element' => 'button',
+				'text'    => '' !== trim( $text ) ? trim( $text ) : 'Submit',
+				'lock'    => array(
+					'remove' => true,
+					'move'   => false,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Resolve the contact-form block attributes from source form metadata.
+	 *
+	 * @param array<string, mixed> $form Validated form row.
+	 * @return array<string, mixed>
+	 */
+	private static function contact_form_attributes( array $form ): array {
+		$attrs    = array();
+		$metadata = isset( $form['form'] ) && is_array( $form['form'] ) ? $form['form'] : array();
+		$action   = isset( $metadata['action'] ) && is_scalar( $metadata['action'] ) ? trim( (string) $metadata['action'] ) : '';
+
+		if ( '' !== $action && 0 === stripos( $action, 'mailto:' ) ) {
+			$recipient = trim( substr( $action, 7 ) );
+			$recipient = explode( '?', $recipient, 2 )[0];
+			if ( '' !== $recipient && self::is_email( $recipient ) ) {
+				$attrs['to'] = $recipient;
+			}
+		}
+
+		return $attrs;
+	}
+
+	/**
+	 * Read a control label/text value.
+	 *
+	 * @param array<string, mixed> $control Source control metadata.
+	 * @return string
+	 */
+	private static function control_text( array $control ): string {
+		foreach ( array( 'label', 'value', 'placeholder', 'name' ) as $key ) {
+			if ( isset( $control[ $key ] ) && is_scalar( $control[ $key ] ) && '' !== trim( (string) $control[ $key ] ) ) {
+				return trim( (string) $control[ $key ] );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract option labels from a select/radio/checkbox control.
+	 *
+	 * @param array<string, mixed> $control Source control metadata.
+	 * @return array<int, string>
+	 */
+	private static function option_labels( array $control ): array {
+		$options = isset( $control['options'] ) && is_array( $control['options'] ) ? $control['options'] : array();
+		$labels  = array();
+
+		foreach ( $options as $option ) {
+			if ( is_array( $option ) ) {
+				$label = isset( $option['label'] ) && is_scalar( $option['label'] ) ? trim( (string) $option['label'] ) : '';
+				if ( '' === $label && isset( $option['value'] ) && is_scalar( $option['value'] ) ) {
+					$label = trim( (string) $option['value'] );
+				}
+			} else {
+				$label = is_scalar( $option ) ? trim( (string) $option ) : '';
+			}
+
+			if ( '' !== $label ) {
+				$labels[] = $label;
+			}
+		}
+
+		return $labels;
+	}
+
+	/**
+	 * Serialize a block tree to WordPress block-comment markup.
+	 *
+	 * @param string                          $name        Block name.
+	 * @param array<string, mixed>            $attrs       Block attributes.
+	 * @param array<int, array<string,mixed>> $inner_blocks Child block definitions.
+	 * @return string
+	 */
+	private static function serialize_block( string $name, array $attrs, array $inner_blocks = array() ): string {
+		$attr_json = '';
+		if ( ! empty( $attrs ) ) {
+			$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $attrs ) : json_encode( $attrs ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+			if ( is_string( $encoded ) && '' !== $encoded && '[]' !== $encoded ) {
+				$attr_json = ' ' . $encoded;
+			}
+		}
+
+		if ( empty( $inner_blocks ) ) {
+			return '<!-- wp:' . $name . $attr_json . ' /-->';
+		}
+
+		$inner = array();
+		foreach ( $inner_blocks as $block ) {
+			if ( ! is_array( $block ) || empty( $block['name'] ) ) {
+				continue;
+			}
+			$inner[] = self::serialize_block(
+				(string) $block['name'],
+				isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array(),
+				isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : array()
+			);
+		}
+
+		return '<!-- wp:' . $name . $attr_json . ' -->' . "\n" . implode( "\n", $inner ) . "\n" . '<!-- /wp:' . $name . ' -->';
+	}
+
+	/**
+	 * Validate a candidate recipient email without requiring WordPress helpers.
+	 *
+	 * @param string $email Candidate email.
+	 * @return bool
+	 */
+	private static function is_email( string $email ): bool {
+		if ( function_exists( 'is_email' ) ) {
+			return (bool) is_email( $email );
+		}
+
+		return false !== filter_var( $email, FILTER_VALIDATE_EMAIL );
+	}
+}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -18,6 +18,12 @@ if ( ! class_exists( 'Static_Site_Importer_Product_Handoff_Contract' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Diagnostic_Loss_Classes' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-diagnostic-loss-classes.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Form_Seeder' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-form-seeder.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Entity_Materializer_Registry' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-entity-materializer-registry.php';
+}
 
 /**
  * Builds SSI import reports and normalizes diagnostics for repair loops.
@@ -1023,6 +1029,125 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
+	 * Materialize preserved <form> runtime islands through the configured provider.
+	 *
+	 * Collects preserved form findings, runs them through the form-capability
+	 * adapter, and stamps the runtime-mapped signal plus mapped-block evidence onto
+	 * each finding that a real provider could map. The form_seeding report records
+	 * provider, dependency availability, and per-form mapping outcomes. Forms with
+	 * no mappable controls keep no signal and stay an unacceptable parity loss.
+	 *
+	 * @param array<string,mixed> $report Import report (mutated in place).
+	 * @param array<string,mixed> $args   Import args.
+	 * @return array<string,mixed> The recorded form_seeding report.
+	 */
+	public static function materialize_form_findings( array &$report, array $args = array() ): array {
+		$adapter = Static_Site_Importer_Entity_Materializer_Registry::form_adapter();
+
+		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
+		$indexes     = array();
+		foreach ( $diagnostics as $index => $diagnostic ) {
+			if ( is_array( $diagnostic ) && 'html_form_fallback' === (string) ( $diagnostic['diagnostic_code'] ?? '' ) ) {
+				$indexes[] = (int) $index;
+			}
+		}
+
+		if ( empty( $indexes ) ) {
+			$seeding           = Static_Site_Importer_Entity_Materializer_Registry::new_entity_report( $adapter );
+			$seeding['status'] = 'skipped';
+			$seeding['reason'] = 'no_form_findings';
+			$report['form_seeding'] = $seeding;
+			return $seeding;
+		}
+
+		$manifest_forms = array();
+		foreach ( $indexes as $index ) {
+			$diagnostic       = $report['diagnostics'][ $index ];
+			$manifest_forms[] = array(
+				'selector'    => isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '',
+				'source_path' => isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : ( isset( $diagnostic['source'] ) && is_scalar( $diagnostic['source'] ) ? (string) $diagnostic['source'] : '' ),
+				'form'        => isset( $diagnostic['form'] ) && is_array( $diagnostic['form'] ) ? $diagnostic['form'] : array(),
+				'controls'    => isset( $diagnostic['controls'] ) && is_array( $diagnostic['controls'] ) ? $diagnostic['controls'] : array(),
+			);
+		}
+
+		$validation = Static_Site_Importer_Entity_Materializer_Registry::validate_manifest_generic( $adapter, array( 'forms' => $manifest_forms ) );
+		$seeding    = Static_Site_Importer_Entity_Materializer_Registry::materialize( $adapter, array( 'forms' => isset( $validation['forms'] ) && is_array( $validation['forms'] ) ? $validation['forms'] : array() ) );
+
+		$seeding['provider']     = Static_Site_Importer_Entity_Materializer_Registry::provider_for( 'form' );
+		$seeding['form_count']   = count( $manifest_forms );
+		$seeding['mapped_count'] = 0;
+		$seeding['waived']       = ! empty( $args[ (string) ( $adapter['waiver_arg'] ?? 'allow_missing_jetpack' ) ] );
+		if ( ! empty( $validation['errors'] ) ) {
+			$seeding['validation_errors'] = $validation['errors'];
+		}
+
+		$pending = $indexes;
+		$rows    = isset( $seeding['forms'] ) && is_array( $seeding['forms'] ) ? $seeding['forms'] : array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) || empty( $row['runtime_mapped'] ) ) {
+				continue;
+			}
+
+			++$seeding['mapped_count'];
+			$selector = isset( $row['selector'] ) && is_scalar( $row['selector'] ) ? (string) $row['selector'] : '';
+			$index    = self::form_finding_index_for_selector( $report['diagnostics'], $pending, $selector );
+			if ( null === $index ) {
+				continue;
+			}
+
+			$report['diagnostics'][ $index ] = self::mark_form_finding_mapped( $report['diagnostics'][ $index ], $row, $seeding['provider'] );
+			$pending                         = array_values( array_diff( $pending, array( $index ) ) );
+		}
+
+		$report['form_seeding'] = $seeding;
+		return $seeding;
+	}
+
+	/**
+	 * Resolve which pending form finding a materialized row maps onto.
+	 *
+	 * @param array<int,array<string,mixed>> $diagnostics Report diagnostics.
+	 * @param array<int,int>                 $pending     Pending diagnostic indexes.
+	 * @param string                         $selector    Materialized form selector.
+	 * @return int|null
+	 */
+	private static function form_finding_index_for_selector( array $diagnostics, array $pending, string $selector ): ?int {
+		if ( '' !== $selector ) {
+			foreach ( $pending as $index ) {
+				$diagnostic = $diagnostics[ $index ] ?? array();
+				if ( is_array( $diagnostic ) && $selector === (string) ( $diagnostic['selector'] ?? '' ) ) {
+					return $index;
+				}
+			}
+		}
+
+		return $pending[0] ?? null;
+	}
+
+	/**
+	 * Stamp the runtime-mapped signal and mapped-block evidence onto a finding.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic to mark.
+	 * @param array<string,mixed> $row        Materialized form row.
+	 * @param string              $provider   Resolved form provider id.
+	 * @return array<string,mixed>
+	 */
+	private static function mark_form_finding_mapped( array $diagnostic, array $row, string $provider ): array {
+		$diagnostic['runtime_mapped']  = true;
+		$diagnostic['runtime_carried'] = ! empty( $row['runtime_carried'] );
+		$diagnostic['mapped_provider'] = isset( $row['provider'] ) && is_scalar( $row['provider'] ) && '' !== (string) $row['provider'] ? (string) $row['provider'] : $provider;
+		$diagnostic['acceptability']   = 'acceptable_preservation';
+		$diagnostic['block_name']      = isset( $row['block_name'] ) && is_scalar( $row['block_name'] ) ? (string) $row['block_name'] : 'jetpack/contact-form';
+
+		if ( isset( $row['block_markup'] ) && is_scalar( $row['block_markup'] ) ) {
+			$diagnostic['emitted_block_preview'] = self::diagnostic_excerpt( (string) $row['block_markup'] );
+		}
+
+		return $diagnostic;
+	}
+
+	/**
 	 * Build a compact diagnostic excerpt.
 	 *
 	 * @param string $html Source HTML.
@@ -1583,6 +1708,46 @@ class Static_Site_Importer_Report_Diagnostics {
 			if ( isset( $fallback[ $field ] ) && is_scalar( $fallback[ $field ] ) && '' !== trim( (string) $fallback[ $field ] ) ) {
 				$diagnostic[ $field ] = (string) $fallback[ $field ];
 			}
+		}
+
+		$diagnostic_code = self::first_scalar( $fallback, array( 'diagnostic_code' ) );
+		if ( 'html_form_fallback' === $diagnostic_code ) {
+			$diagnostic = self::enrich_form_fallback_diagnostic( $diagnostic, $fallback, $diagnostic_code );
+		}
+
+		return $diagnostic;
+	}
+
+	/**
+	 * Carry preserved <form> runtime island metadata onto its SSI diagnostic.
+	 *
+	 * Keeps the native diagnostic_code, classifies the finding as a preserved
+	 * runtime island, and forwards the form attributes and source control list so
+	 * the configured form provider can materialize it and close the gate loop.
+	 *
+	 * @param array<string,mixed> $diagnostic      Base diagnostic.
+	 * @param array<string,mixed> $fallback        Native fallback row.
+	 * @param string              $diagnostic_code Native diagnostic code.
+	 * @return array<string,mixed>
+	 */
+	private static function enrich_form_fallback_diagnostic( array $diagnostic, array $fallback, string $diagnostic_code ): array {
+		$diagnostic['diagnostic_code'] = $diagnostic_code;
+		$diagnostic['loss_class']      = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
+		$diagnostic['diagnostic_class'] = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
+		$diagnostic['tag']             = 'form';
+		$diagnostic['tag_name']        = isset( $diagnostic['tag_name'] ) && '' !== $diagnostic['tag_name'] ? $diagnostic['tag_name'] : 'form';
+		$diagnostic['element']         = 'form';
+		$diagnostic['suggested_primitive'] = 'form';
+		$diagnostic['runtime_requirement'] = self::first_scalar( $fallback, array( 'runtime_requirement' ) );
+
+		if ( isset( $fallback['form'] ) && is_array( $fallback['form'] ) ) {
+			$diagnostic['form'] = $fallback['form'];
+		}
+		if ( isset( $fallback['controls'] ) && is_array( $fallback['controls'] ) ) {
+			$diagnostic['controls'] = array_values( array_filter( $fallback['controls'], 'is_array' ) );
+		}
+		if ( isset( $fallback['control_count'] ) && is_numeric( $fallback['control_count'] ) ) {
+			$diagnostic['control_count'] = (int) $fallback['control_count'];
 		}
 
 		return $diagnostic;
@@ -2291,6 +2456,10 @@ class Static_Site_Importer_Report_Diagnostics {
 			'element',
 			'html_excerpt',
 			'context',
+			'diagnostic_code',
+			'runtime_mapped',
+			'runtime_carried',
+			'mapped_provider',
 		);
 
 		$compact = array();

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -190,6 +190,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::materialize_required_plugins( $args );
 		self::record_product_seeding_report( $args );
 		self::record_commerce_dependency_check( $args );
+		self::record_form_materialization( $args );
 		$source_of_truth_manifest                    = self::source_of_truth_manifest( $import_run_id, $source_artifact_reference, $theme_dir, $theme_slug, $page_targets, $page_ids, $permalinks, $writes, $materialized );
 		self::$conversion_report['source_of_truth'] = $source_of_truth_manifest;
 		$quality                                    = Static_Site_Importer_Report_Diagnostics::finalize_report( self::$conversion_report, $args );
@@ -3006,6 +3007,23 @@ class Static_Site_Importer_Theme_Generator {
 		if ( isset( self::$conversion_report['product_seeding'] ) && is_array( self::$conversion_report['product_seeding'] ) ) {
 			self::$conversion_report['product_seeding']['reason'] = 'woocommerce_required_but_missing';
 		}
+	}
+
+	/**
+	 * Materialize detected form runtime islands through the configured provider.
+	 *
+	 * Mirrors the commerce path: preserved <form> findings carry the source form
+	 * metadata, the configured form provider maps them into working form-provider
+	 * blocks, and successfully mapped findings receive the runtime-mapped signal so
+	 * the honest fixture gate counts them as acceptable preservation instead of a
+	 * dead, unacceptable feature-parity loss. Forms that cannot be mapped keep no
+	 * signal and stay unacceptable.
+	 *
+	 * @param array<string, mixed> $args Import args.
+	 * @return void
+	 */
+	private static function record_form_materialization( array $args ): void {
+		Static_Site_Importer_Report_Diagnostics::materialize_form_findings( self::$conversion_report, $args );
 	}
 
 	/**

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -46,6 +46,7 @@ class Static_Site_Importer_Validation_Runtime {
 			'overwrite'                 => array_key_exists( 'overwrite', $input ) ? (bool) $input['overwrite'] : true,
 			'fail_on_quality'           => ! empty( $input['fail_on_quality'] ),
 			'allow_missing_woocommerce' => ! empty( $input['allow_missing_woocommerce'] ),
+			'allow_missing_jetpack'     => ! empty( $input['allow_missing_jetpack'] ),
 			'report'                    => $report_path,
 			'source_metadata'           => array_merge(
 				isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -58,6 +58,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-pa
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-stylesheet-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-form-seeder.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-product-handoff-contract.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-diagnostic-loss-classes.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-diagnostic-contract.php';

--- a/tests/smoke-form-materializer.php
+++ b/tests/smoke-form-materializer.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Smoke coverage for the configurable form provider layer and Jetpack form adapter.
+ *
+ * Run from the repository root:
+ * php tests/smoke-form-materializer.php
+ *
+ * @package StaticSiteImporter
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $key ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.keyFound
+			$key = strtolower( (string) $key );
+			return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+		}
+	}
+
+	$GLOBALS['ssi_test_hooks'] = array();
+
+	if ( ! function_exists( 'add_filter' ) ) {
+		function add_filter( string $hook, callable $callback ): void {
+			$GLOBALS['ssi_test_hooks'][ $hook ][] = $callback;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value, ...$args ) {
+			foreach ( $GLOBALS['ssi_test_hooks'][ $hook ] ?? array() as $callback ) {
+				$value = $callback( $value, ...$args );
+			}
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( $name, $default = false ) {
+			unset( $name );
+			return $default;
+		}
+	}
+
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-woo-product-seeder.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-form-seeder.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-loss-classes.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-transformer-adapter.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
+
+	$failures   = array();
+	$assertions = 0;
+	$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+		}
+	};
+
+	// --- Default provider selection -----------------------------------------
+	$assert( 'jetpack' === Static_Site_Importer_Entity_Materializer_Registry::provider_for( 'form' ), 'form-default-provider-jetpack' );
+	$assert( 'woocommerce' === Static_Site_Importer_Entity_Materializer_Registry::provider_for( 'shop' ), 'shop-default-provider-woocommerce' );
+
+	$form_adapter = Static_Site_Importer_Entity_Materializer_Registry::form_adapter();
+	$assert( 'jetpack_contact_form' === ( $form_adapter['id'] ?? '' ), 'form-adapter-resolves-jetpack' );
+	$assert( 'form' === ( $form_adapter['capability'] ?? '' ), 'form-adapter-capability' );
+	$assert( 'allow_missing_jetpack' === ( $form_adapter['waiver_arg'] ?? '' ), 'form-adapter-waiver' );
+
+	// --- Woo path unaffected -------------------------------------------------
+	$product_adapter = Static_Site_Importer_Entity_Materializer_Registry::product_adapter();
+	$assert( 'woocommerce_simple_product' === ( $product_adapter['id'] ?? '' ), 'product-adapter-unchanged' );
+	$assert( 'shop' === ( $product_adapter['capability'] ?? '' ), 'product-adapter-capability-shop' );
+	$assert( 'allow_missing_woocommerce' === ( $product_adapter['waiver_arg'] ?? '' ), 'product-adapter-waiver-unchanged' );
+
+	// --- Forms manifest validation rejects submit-only forms ----------------
+	$submit_only = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest(
+		array( 'forms' => array( array( 'selector' => 'form#x', 'controls' => array( array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ) ) ) )
+	);
+	$assert( array() === $submit_only['forms'], 'submit-only-form-rejected' );
+	$assert( ! empty( $submit_only['errors'] ), 'submit-only-form-error-recorded' );
+
+	// --- Jetpack form seeder maps controls to contact-form blocks -----------
+	$forms_manifest = array(
+		'forms' => array(
+			array(
+				'selector' => 'form.contact',
+				'form'     => array( 'action' => 'mailto:hello@example.com', 'method' => 'post' ),
+				'controls' => array(
+					array( 'tag' => 'input', 'type' => 'text', 'name' => 'name', 'label' => 'Your name', 'required' => true ),
+					array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email', 'required' => true ),
+					array( 'tag' => 'input', 'type' => 'tel', 'name' => 'phone', 'label' => 'Phone' ),
+					array( 'tag' => 'select', 'type' => 'select', 'name' => 'topic', 'label' => 'Topic', 'options' => array( array( 'label' => 'Sales' ), array( 'label' => 'Support' ) ) ),
+					array( 'tag' => 'textarea', 'type' => 'textarea', 'name' => 'message', 'label' => 'Message' ),
+					array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send message' ),
+				),
+			),
+		),
+	);
+	$seed = Static_Site_Importer_Form_Seeder::seed( $forms_manifest );
+	$assert( 'completed' === ( $seed['status'] ?? '' ), 'seed-status-completed' );
+	$assert( 1 === ( $seed['counts']['mapped'] ?? 0 ), 'seed-one-form-mapped' );
+	$row    = $seed['forms'][0] ?? array();
+	$markup = (string) ( $row['block_markup'] ?? '' );
+	$assert( true === ( $row['runtime_mapped'] ?? false ), 'seed-form-runtime-mapped' );
+	$assert( 5 === ( $row['field_count'] ?? 0 ), 'seed-five-fields-mapped' );
+	$assert( str_contains( $markup, 'wp:jetpack/contact-form' ), 'markup-contact-form' );
+	$assert( str_contains( $markup, 'wp:jetpack/field-text' ), 'markup-field-text' );
+	$assert( str_contains( $markup, 'wp:jetpack/field-email' ), 'markup-field-email' );
+	$assert( str_contains( $markup, 'wp:jetpack/field-telephone' ), 'markup-field-telephone' );
+	$assert( str_contains( $markup, 'wp:jetpack/field-select' ), 'markup-field-select' );
+	$assert( str_contains( $markup, 'wp:jetpack/field-textarea' ), 'markup-field-textarea' );
+	$assert( str_contains( $markup, 'wp:jetpack/button' ), 'markup-submit-button' );
+	$assert( str_contains( $markup, 'hello@example.com' ), 'markup-mailto-recipient' );
+	$assert( str_contains( $markup, '"options":["Sales","Support"]' ), 'markup-select-options' );
+
+	// --- Native html_form_fallback row is enriched into a form finding -------
+	$enrich   = new ReflectionMethod( 'Static_Site_Importer_Report_Diagnostics', 'diagnostic_from_conversion_report_fallback' );
+	$enriched = $enrich->invoke(
+		null,
+		array(
+			'diagnostic_code' => 'html_form_fallback',
+			'reason'          => 'form_requires_runtime',
+			'source_path'     => 'website/index.html',
+			'selector'        => 'form.contact',
+			'tag'             => 'form',
+			'form'            => array( 'action' => 'mailto:hello@example.com', 'method' => 'post' ),
+			'controls'        => array(
+				array( 'tag' => 'input', 'type' => 'email', 'label' => 'Email' ),
+			),
+			'control_count'   => 1,
+		)
+	);
+	$assert( 'html_form_fallback' === ( $enriched['diagnostic_code'] ?? '' ), 'enrich-carries-diagnostic-code' );
+	$assert( Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND === ( $enriched['loss_class'] ?? '' ), 'enrich-loss-class-preserved-runtime-island' );
+	$assert( isset( $enriched['form']['action'] ) && 'mailto:hello@example.com' === $enriched['form']['action'], 'enrich-carries-form-metadata' );
+	$assert( isset( $enriched['controls'][0]['type'] ) && 'email' === $enriched['controls'][0]['type'], 'enrich-carries-controls' );
+	$assert( 'form' === ( $enriched['tag'] ?? '' ), 'enrich-tag-form' );
+
+	// --- Gate loop: a mapped form finding receives the runtime-mapped signal --
+	$report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
+	$report['diagnostics'][] = array(
+		'type'            => 'unsupported_html_fallback',
+		'diagnostic_code' => 'html_form_fallback',
+		'loss_class'      => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path'     => 'website/index.html',
+		'selector'        => 'form.contact',
+		'tag'             => 'form',
+		'form'            => array( 'action' => 'mailto:hello@example.com', 'method' => 'post' ),
+		'controls'        => array(
+			array( 'tag' => 'input', 'type' => 'text', 'label' => 'Your name', 'required' => true ),
+			array( 'tag' => 'input', 'type' => 'email', 'label' => 'Email' ),
+			array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ),
+		),
+	);
+	// A second form with no mappable controls must stay unmapped (unacceptable loss).
+	$report['diagnostics'][] = array(
+		'type'            => 'unsupported_html_fallback',
+		'diagnostic_code' => 'html_form_fallback',
+		'loss_class'      => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path'     => 'website/index.html',
+		'selector'        => 'form.search-only',
+		'tag'             => 'form',
+		'controls'        => array(
+			array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Go' ),
+		),
+	);
+
+	$seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $report, array() );
+	$assert( 'jetpack' === ( $seeding['provider'] ?? '' ), 'materialize-provider-jetpack' );
+	$assert( 2 === ( $seeding['form_count'] ?? 0 ), 'materialize-counts-two-form-findings' );
+	$assert( 1 === ( $seeding['mapped_count'] ?? 0 ), 'materialize-one-form-mapped' );
+
+	$mapped   = $report['diagnostics'][0];
+	$unmapped = $report['diagnostics'][1];
+	$assert( true === ( $mapped['runtime_mapped'] ?? false ), 'finding-runtime-mapped-set' );
+	$assert( 'jetpack' === ( $mapped['mapped_provider'] ?? '' ), 'finding-mapped-provider' );
+	$assert( 'jetpack/contact-form' === ( $mapped['block_name'] ?? '' ), 'finding-block-name' );
+	$assert( 'acceptable_preservation' === ( $mapped['acceptability'] ?? '' ), 'finding-acceptable-preservation' );
+	$assert( Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND === Static_Site_Importer_Diagnostic_Loss_Classes::classify( $mapped ), 'finding-stays-preserved-runtime-island' );
+	$assert( empty( $unmapped['runtime_mapped'] ), 'unmappable-form-stays-unsignaled' );
+
+	// --- Provider override routes to a different registered adapter ----------
+	add_filter(
+		'static_site_importer_entity_materializers',
+		static function ( array $adapters ): array {
+			$adapters['gravity_forms_adapter'] = array(
+				'id'         => 'gravity_forms_adapter',
+				'capability' => 'form',
+				'provider'   => 'gravity_forms',
+				'waiver_arg' => 'allow_missing_gravity_forms',
+			);
+			return $adapters;
+		}
+	);
+	add_filter( 'ssi_form_plugin', static fn ( string $provider ): string => 'gravity_forms' );
+
+	$assert( 'gravity_forms' === Static_Site_Importer_Entity_Materializer_Registry::provider_for( 'form' ), 'form-provider-override' );
+	$overridden = Static_Site_Importer_Entity_Materializer_Registry::form_adapter();
+	$assert( 'gravity_forms_adapter' === ( $overridden['id'] ?? '' ), 'form-adapter-routes-to-override' );
+	// Shop capability stays on the default provider despite the form override.
+	$assert( 'woocommerce' === Static_Site_Importer_Entity_Materializer_Registry::provider_for( 'shop' ), 'shop-provider-unaffected-by-form-override' );
+
+	if ( empty( $failures ) ) {
+		echo 'PASS smoke-form-materializer.php (' . $assertions . " assertions)\n";
+		exit( 0 );
+	}
+
+	echo 'FAILURES (' . count( $failures ) . ' of ' . $assertions . " assertions):\n";
+	echo implode( "\n", $failures ) . "\n";
+	exit( 1 );
+}


### PR DESCRIPTION
Closes #487

## Summary
Turns a detected source `<form>` from a dead `html_form_fallback` runtime island into a working WordPress form, mirroring the existing detect-store → add-WooCommerce path, and behind a configurable per-capability provider layer.

## Configurable provider layer
- Adds `form` (default `jetpack`) and `shop` (default `woocommerce`) capabilities to the entity materializer registry. Each resolves to exactly one adapter via: core option override (`static_site_importer_form_plugin` / `static_site_importer_shop_plugin`), the capability filter (`ssi_form_plugin` / `ssi_shop_plugin`), then the cross-capability `ssi_entity_materializer_provider` filter.
- The existing `static_site_importer_entity_materializers` filter stays the adapter registration hook, so consumers can register and route to their own adapters (Gravity Forms, CF7, EDD, …).
- The WooCommerce adapter now declares `capability=shop`/`provider=woocommerce` for symmetry; `product_adapter()` resolves through the layer with a safe fallback, so the commerce path is unchanged.

## Jetpack form adapter (`jetpack_contact_form`)
- Declares Jetpack as the required plugin (`slug: jetpack`, `plugin_file: jetpack/jetpack.php`, `availability_callback` checking Jetpack Forms availability), matching the WooCommerce dependency shape.
- Maps the preserved `html_form_fallback` metadata (form attributes + source controls — already carried by the transformer conversion report; no transformer-side manifest needed) into `jetpack/contact-form` containing `jetpack/field-*` blocks (text/email/telephone/url/date/textarea/select/checkbox/radio carrying labels, required, placeholder, options) plus a `jetpack/button` submit. `mailto:` actions seed the contact-form recipient.

## Gate-loop closure
- The `html_form_fallback` finding is carried with its `form`/`controls` metadata and classified as a `preserved_runtime_island`. When a real provider maps it, the finding receives `runtime_mapped`/`runtime_carried` (preserved through the validation-result and compact diagnostics that the honest fixture gate reads), so the gate counts it as acceptable preservation. A form with no mappable controls keeps no signal and stays an unacceptable feature-parity loss.
- Adds the `allow_missing_jetpack` waiver, plumbed through the import/validate abilities and the validation runtime alongside `allow_missing_woocommerce`.

## Tests
- New standalone `tests/smoke-form-materializer.php` (40 assertions): default provider selection, Jetpack adapter field mapping (incl. select options + mailto recipient + submit), native fallback → enriched form finding, the runtime-mapped signal on a mapped finding (and no signal on an unmappable submit-only form), an `ssi_form_plugin` filter override routing to a registered provider, and the unchanged WooCommerce path.
- Full standalone PHP smoke suite green (18 pass; the 3 `wp eval-file`-only fixtures are pre-existing and unrelated). No new PHPStan type errors.

Do not merge — for review.