### PR TITLE
Companion-plugin scaffold + install path + declared dependency (slice 1 of #491)

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -1,0 +1,559 @@
+<?php
+/**
+ * Companion-plugin scaffolder.
+ *
+ * Generates a standalone, theme-independent WordPress plugin that houses a
+ * site's generated custom blocks (registered from their own block.json) and any
+ * preserved island JS, scoped to where it is used. The compiled artifact owns
+ * the block.json + render + assets payload; this class is the deterministic
+ * destination that turns that payload into an installable plugin file set.
+ *
+ * The file-set builder is pure and side-effect free so it is testable without a
+ * full WordPress runtime. The install/activate side effects live in
+ * Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin().
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Scaffolds a one-per-site companion plugin from a generated block payload.
+ */
+class Static_Site_Importer_Companion_Plugin {
+
+	/**
+	 * Payload schema identifier consumed by the scaffolder.
+	 */
+	public const PAYLOAD_SCHEMA = 'static-site-importer/companion-plugin/v1';
+
+	/**
+	 * Build the standalone plugin scaffold from a generated payload.
+	 *
+	 * The returned descriptor carries the namespaced slug, the plugin basename
+	 * used as a satisfied-dependency key, the fully-qualified block names, and
+	 * the relative-path => file-content map that the install path materializes.
+	 *
+	 * @param array<string,mixed> $payload Generated companion-plugin payload.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function scaffold( array $payload ) {
+		$site_slug = self::site_slug( $payload );
+		if ( '' === $site_slug ) {
+			return new WP_Error(
+				'static_site_importer_companion_plugin_site_slug_missing',
+				'Companion-plugin payload must declare a non-empty site_slug.'
+			);
+		}
+
+		$blocks = self::payload_blocks( $payload );
+		if ( empty( $blocks ) ) {
+			return new WP_Error(
+				'static_site_importer_companion_plugin_blocks_missing',
+				'Companion-plugin payload must declare at least one block with a name and block.json.'
+			);
+		}
+
+		$plugin_slug     = 'ssi-' . $site_slug;
+		$block_namespace = $plugin_slug;
+		$mu_plugin       = ! empty( $payload['mu_plugin'] );
+		$site_name       = self::site_name( $payload, $site_slug );
+
+		$files       = array();
+		$block_names = array();
+		$preserved   = self::preserved_js( $payload, $block_namespace );
+
+		foreach ( $blocks as $block ) {
+			$built = self::build_block( $block, $block_namespace );
+			if ( is_wp_error( $built ) ) {
+				return $built;
+			}
+
+			$block_names[] = $built['block_name'];
+			foreach ( $built['files'] as $relative => $content ) {
+				$files[ $plugin_slug . '/blocks/' . $built['dir'] . '/' . $relative ] = $content;
+			}
+		}
+
+		foreach ( $preserved as $island ) {
+			$files[ $plugin_slug . '/' . $island['relative_src'] ] = $island['content'];
+		}
+
+		$main_file = $plugin_slug . '/' . $plugin_slug . '.php';
+		$files     = array_merge(
+			array(
+				$main_file => self::main_plugin_file( $plugin_slug, $block_namespace, $site_name, $block_names, $preserved ),
+			),
+			$files
+		);
+
+		$descriptor = array(
+			'schema'      => self::PAYLOAD_SCHEMA,
+			'slug'        => $plugin_slug,
+			'namespace'   => $block_namespace,
+			'site_slug'   => $site_slug,
+			'plugin_file' => $main_file,
+			'mu_plugin'   => $mu_plugin,
+			'block_names' => $block_names,
+			'loader_file' => '',
+			'files'       => $files,
+		);
+
+		if ( $mu_plugin ) {
+			// mu-plugins only auto-load PHP files at the mu-plugins root, never
+			// subdirectory files. Emit a root loader stub that requires the real
+			// plugin file so the same directory layout works in both modes.
+			$loader                    = $plugin_slug . '.php';
+			$descriptor['loader_file'] = $loader;
+			$descriptor['files']       = array_merge(
+				array( $loader => self::mu_loader_file( $plugin_slug, $main_file, $site_name ) ),
+				$descriptor['files']
+			);
+		}
+
+		return $descriptor;
+	}
+
+	/**
+	 * Namespaced plugin slug, e.g. ssi-acme, for a payload.
+	 *
+	 * @param array<string,mixed> $payload Generated companion-plugin payload.
+	 * @return string
+	 */
+	public static function plugin_slug( array $payload ): string {
+		$site_slug = self::site_slug( $payload );
+		return '' === $site_slug ? '' : 'ssi-' . $site_slug;
+	}
+
+	/**
+	 * Plugin basename used as the satisfied-dependency key.
+	 *
+	 * @param array<string,mixed> $payload Generated companion-plugin payload.
+	 * @return string
+	 */
+	public static function plugin_file( array $payload ): string {
+		$slug = self::plugin_slug( $payload );
+		return '' === $slug ? '' : $slug . '/' . $slug . '.php';
+	}
+
+	/**
+	 * Sanitized site slug from the payload.
+	 *
+	 * @param array<string,mixed> $payload Generated companion-plugin payload.
+	 * @return string
+	 */
+	private static function site_slug( array $payload ): string {
+		$raw = isset( $payload['site_slug'] ) && is_scalar( $payload['site_slug'] ) ? (string) $payload['site_slug'] : '';
+		return self::sanitize_slug( $raw );
+	}
+
+	/**
+	 * Human-readable site name for plugin headers.
+	 *
+	 * @param array<string,mixed> $payload   Generated companion-plugin payload.
+	 * @param string              $site_slug Sanitized site slug.
+	 * @return string
+	 */
+	private static function site_name( array $payload, string $site_slug ): string {
+		$raw = isset( $payload['site_name'] ) && is_scalar( $payload['site_name'] ) ? trim( (string) $payload['site_name'] ) : '';
+		return '' !== $raw ? $raw : $site_slug;
+	}
+
+	/**
+	 * Normalize the block list from the payload.
+	 *
+	 * @param array<string,mixed> $payload Generated companion-plugin payload.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function payload_blocks( array $payload ): array {
+		$blocks = isset( $payload['blocks'] ) && is_array( $payload['blocks'] ) ? $payload['blocks'] : array();
+		return array_values( array_filter( $blocks, 'is_array' ) );
+	}
+
+	/**
+	 * Build one block's file set and fully-qualified name.
+	 *
+	 * @param array<string,mixed> $block     Block payload entry.
+	 * @param string              $block_namespace Plugin block namespace.
+	 * @return array{block_name:string,dir:string,files:array<string,string>}|WP_Error
+	 */
+	private static function build_block( array $block, string $block_namespace ) {
+		$name = isset( $block['name'] ) && is_scalar( $block['name'] ) ? self::sanitize_slug( (string) $block['name'] ) : '';
+		if ( '' === $name ) {
+			return new WP_Error(
+				'static_site_importer_companion_plugin_block_name_missing',
+				'Each companion-plugin block must declare a sanitizable name.'
+			);
+		}
+
+		$block_json = self::block_json( $block, $block_namespace . '/' . $name );
+		if ( is_wp_error( $block_json ) ) {
+			return $block_json;
+		}
+
+		$files = array( 'block.json' => $block_json );
+
+		$render = isset( $block['render'] ) && is_scalar( $block['render'] ) ? (string) $block['render'] : '';
+		if ( '' !== $render ) {
+			$files['render.php'] = self::normalize_render( $render );
+		}
+
+		$view_js = isset( $block['view_js'] ) && is_scalar( $block['view_js'] ) ? (string) $block['view_js'] : '';
+		if ( '' !== $view_js ) {
+			$files['view.js'] = $view_js;
+		}
+
+		$assets = isset( $block['assets'] ) && is_array( $block['assets'] ) ? $block['assets'] : array();
+		foreach ( $assets as $relative => $content ) {
+			$relative = self::sanitize_relative_path( (string) $relative );
+			if ( '' === $relative || ! is_scalar( $content ) ) {
+				continue;
+			}
+			$files[ $relative ] = (string) $content;
+		}
+
+		return array(
+			'block_name' => $block_namespace . '/' . $name,
+			'dir'        => $name,
+			'files'      => $files,
+		);
+	}
+
+	/**
+	 * Resolve a block.json string, forcing the namespaced block name.
+	 *
+	 * @param array<string,mixed> $block      Block payload entry.
+	 * @param string              $block_name Fully-qualified block name.
+	 * @return string|WP_Error
+	 */
+	private static function block_json( array $block, string $block_name ) {
+		$raw = $block['block_json'] ?? null;
+		if ( is_string( $raw ) ) {
+			$decoded = json_decode( $raw, true );
+		} elseif ( is_array( $raw ) ) {
+			$decoded = $raw;
+		} else {
+			$decoded = null;
+		}
+
+		if ( ! is_array( $decoded ) ) {
+			return new WP_Error(
+				'static_site_importer_companion_plugin_block_json_invalid',
+				sprintf( 'Block %s must declare block_json as a JSON object or string.', $block_name )
+			);
+		}
+
+		// The companion plugin owns the namespace, so the generated block.json is
+		// authoritative for the block name regardless of what the payload carried.
+		$decoded['name'] = $block_name;
+		if ( ! isset( $decoded['$schema'] ) ) {
+			$decoded = array( '$schema' => 'https://schemas.wp.org/trunk/block.json' ) + $decoded;
+		}
+		if ( ! isset( $decoded['apiVersion'] ) ) {
+			$decoded['apiVersion'] = 3;
+		}
+
+		return self::encode_json( $decoded );
+	}
+
+	/**
+	 * Normalize preserved island JS entries into a scoped descriptor list.
+	 *
+	 * @param array<string,mixed> $payload   Generated companion-plugin payload.
+	 * @param string              $block_namespace Plugin block namespace.
+	 * @return array<int,array<string,string>>
+	 */
+	private static function preserved_js( array $payload, string $block_namespace ): array {
+		$entries = isset( $payload['preserved_js'] ) && is_array( $payload['preserved_js'] ) ? $payload['preserved_js'] : array();
+		$islands = array();
+		$index   = 0;
+
+		foreach ( $entries as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$content = isset( $entry['content'] ) && is_scalar( $entry['content'] ) ? (string) $entry['content'] : '';
+			if ( '' === $content ) {
+				continue;
+			}
+
+			++$index;
+			$handle_raw   = isset( $entry['handle'] ) && is_scalar( $entry['handle'] ) ? self::sanitize_slug( (string) $entry['handle'] ) : '';
+			$handle       = '' !== $handle_raw ? $handle_raw : $block_namespace . '-island-' . $index;
+			$relative_raw = isset( $entry['src'] ) && is_scalar( $entry['src'] ) ? self::sanitize_relative_path( (string) $entry['src'] ) : '';
+			$relative     = '' !== $relative_raw ? $relative_raw : 'islands/' . $handle . '.js';
+			$block        = isset( $entry['block'] ) && is_scalar( $entry['block'] ) ? (string) $entry['block'] : '';
+
+			$islands[] = array(
+				'handle'       => $handle,
+				'relative_src' => $relative,
+				'content'      => $content,
+				// Scope: enqueue only when this block renders. Empty block means
+				// the island is unscoped, but slice 1 only emits scoped islands.
+				'block'        => $block,
+			);
+		}
+
+		return $islands;
+	}
+
+	/**
+	 * Render the main plugin PHP file.
+	 *
+	 * @param string                          $plugin_slug Plugin slug.
+	 * @param string                          $block_namespace   Block namespace.
+	 * @param string                          $site_name   Human-readable site name.
+	 * @param array<int,string>               $block_names Fully-qualified block names.
+	 * @param array<int,array<string,string>> $preserved   Preserved island descriptors.
+	 * @return string
+	 */
+	private static function main_plugin_file(
+		string $plugin_slug,
+		string $block_namespace,
+		string $site_name,
+		array $block_names,
+		array $preserved
+	): string {
+		$header_name = sprintf( 'SSI Companion: %s', $site_name );
+		$fn_prefix   = str_replace( '-', '_', $plugin_slug );
+		$islands_php = self::export_islands_php( $preserved );
+
+		$lines   = array();
+		$lines[] = '<?php';
+		$lines[] = '/**';
+		$lines[] = ' * Plugin Name: ' . $header_name;
+		$lines[] = ' * Description: Generated companion plugin housing custom blocks and preserved island JS for ' . $site_name . '. Generated by Static Site Importer.';
+		$lines[] = ' * Version: 1.0.0';
+		$lines[] = ' * Requires at least: 6.9';
+		$lines[] = ' * Requires PHP: 8.1';
+		$lines[] = ' * Text Domain: ' . $plugin_slug;
+		$lines[] = ' *';
+		$lines[] = ' * @package StaticSiteImporterCompanion';
+		$lines[] = ' */';
+		$lines[] = '';
+		$lines[] = "if ( ! defined( 'ABSPATH' ) ) {";
+		$lines[] = "\texit;";
+		$lines[] = '}';
+		$lines[] = '';
+		$lines[] = sprintf( "define( '%s_DIR', plugin_dir_path( __FILE__ ) );", strtoupper( $fn_prefix ) );
+		$lines[] = sprintf( "define( '%s_URL', plugin_dir_url( __FILE__ ) );", strtoupper( $fn_prefix ) );
+		$lines[] = '';
+		$lines[] = '/**';
+		$lines[] = ' * Register the generated custom blocks from their own block.json.';
+		$lines[] = ' */';
+		$lines[] = sprintf( 'function %s_register_blocks() {', $fn_prefix );
+		$lines[] = sprintf( "\t\$blocks_dir = %s_DIR . 'blocks';", strtoupper( $fn_prefix ) );
+		$lines[] = "\tif ( ! is_dir( \$blocks_dir ) || ! function_exists( 'register_block_type' ) ) {";
+		$lines[] = "\t\treturn;";
+		$lines[] = "\t}";
+		$lines[] = '';
+		$lines[] = sprintf( "\tforeach ( %s as \$block_dir ) {", self::export_block_dirs_php( $block_names ) );
+		$lines[] = "\t\t\$path = \$blocks_dir . '/' . \$block_dir;";
+		$lines[] = "\t\tif ( is_dir( \$path ) ) {";
+		$lines[] = "\t\t\tregister_block_type( \$path );";
+		$lines[] = "\t\t}";
+		$lines[] = "\t}";
+		$lines[] = '}';
+		$lines[] = sprintf( "add_action( 'init', '%s_register_blocks' );", $fn_prefix );
+		$lines[] = '';
+		$lines[] = '/**';
+		$lines[] = ' * Preserved island scripts, scoped to the block they belong to.';
+		$lines[] = ' *';
+		$lines[] = ' * @return array<int,array<string,string>>';
+		$lines[] = ' */';
+		$lines[] = sprintf( 'function %s_islands() {', $fn_prefix );
+		$lines[] = "\treturn " . $islands_php . ';';
+		$lines[] = '}';
+		$lines[] = '';
+		$lines[] = '/**';
+		$lines[] = ' * Enqueue preserved island JS only when its owning block renders.';
+		$lines[] = ' *';
+		$lines[] = ' * @param string              $content Rendered block HTML.';
+		$lines[] = ' * @param array<string,mixed> $block   Parsed block.';
+		$lines[] = ' * @return string';
+		$lines[] = ' */';
+		$lines[] = sprintf( 'function %s_enqueue_islands( $content, $block ) {', $fn_prefix );
+		$lines[] = "\t\$name = is_array( \$block ) && isset( \$block['blockName'] ) ? (string) \$block['blockName'] : '';";
+		$lines[] = "\tif ( '' === \$name || ! function_exists( 'wp_enqueue_script' ) ) {";
+		$lines[] = "\t\treturn \$content;";
+		$lines[] = "\t}";
+		$lines[] = '';
+		$lines[] = sprintf( "\tforeach ( %s_islands() as \$island ) {", $fn_prefix );
+		$lines[] = "\t\tif ( ( \$island['block'] ?? '' ) !== \$name || '' === ( \$island['src'] ?? '' ) ) {";
+		$lines[] = "\t\t\tcontinue;";
+		$lines[] = "\t\t}";
+		$lines[] = sprintf( "\t\twp_enqueue_script( \$island['handle'], %s_URL . \$island['src'], array(), '1.0.0', true );", strtoupper( $fn_prefix ) );
+		$lines[] = "\t}";
+		$lines[] = '';
+		$lines[] = "\treturn \$content;";
+		$lines[] = '}';
+		$lines[] = sprintf( "add_filter( 'render_block', '%s_enqueue_islands', 10, 2 );", $fn_prefix );
+		$lines[] = '';
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Render the mu-plugin root loader stub.
+	 *
+	 * @param string $plugin_slug Plugin slug.
+	 * @param string $main_file   Main plugin file relative to plugins dir.
+	 * @param string $site_name   Human-readable site name.
+	 * @return string
+	 */
+	private static function mu_loader_file( string $plugin_slug, string $main_file, string $site_name ): string {
+		$lines   = array();
+		$lines[] = '<?php';
+		$lines[] = '/**';
+		$lines[] = ' * Plugin Name: SSI Companion Loader: ' . $site_name;
+		$lines[] = ' * Description: Must-use loader that requires the ' . $plugin_slug . ' companion plugin. Generated by Static Site Importer.';
+		$lines[] = ' *';
+		$lines[] = ' * @package StaticSiteImporterCompanion';
+		$lines[] = ' */';
+		$lines[] = '';
+		$lines[] = "if ( ! defined( 'ABSPATH' ) ) {";
+		$lines[] = "\texit;";
+		$lines[] = '}';
+		$lines[] = '';
+		$lines[] = sprintf( "\$ssi_companion_main = __DIR__ . '/%s';", $main_file );
+		$lines[] = 'if ( is_readable( $ssi_companion_main ) ) {';
+		$lines[] = "\trequire_once \$ssi_companion_main;";
+		$lines[] = '}';
+		$lines[] = '';
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Export island descriptors as a PHP array literal for the generated file.
+	 *
+	 * @param array<int,array<string,string>> $preserved Preserved island descriptors.
+	 * @return string
+	 */
+	private static function export_islands_php( array $preserved ): string {
+		if ( empty( $preserved ) ) {
+			return 'array()';
+		}
+
+		$rows = array();
+		foreach ( $preserved as $island ) {
+			$rows[] = sprintf(
+				"\t\tarray( 'handle' => '%s', 'src' => '%s', 'block' => '%s' ),",
+				self::php_single_quote( $island['handle'] ),
+				self::php_single_quote( $island['relative_src'] ),
+				self::php_single_quote( $island['block'] )
+			);
+		}
+
+		return "array(\n" . implode( "\n", $rows ) . "\n\t)";
+	}
+
+	/**
+	 * Export the block directory list as a PHP array literal.
+	 *
+	 * @param array<int,string> $block_names Fully-qualified block names.
+	 * @return string
+	 */
+	private static function export_block_dirs_php( array $block_names ): string {
+		$dirs = array();
+		foreach ( $block_names as $block_name ) {
+			$parts  = explode( '/', $block_name );
+			$dirs[] = "'" . self::php_single_quote( (string) end( $parts ) ) . "'";
+		}
+
+		return 'array( ' . implode( ', ', $dirs ) . ' )';
+	}
+
+	/**
+	 * Ensure the render markup opens with a PHP tag so register_block_type can use it.
+	 *
+	 * @param string $render Render markup or PHP.
+	 * @return string
+	 */
+	private static function normalize_render( string $render ): string {
+		$trimmed = ltrim( $render );
+		if ( str_starts_with( $trimmed, '<?php' ) || str_starts_with( $trimmed, '<?=' ) ) {
+			return $render;
+		}
+
+		return "<?php\n/**\n * Generated companion block render.\n *\n * @package StaticSiteImporterCompanion\n */\n?>\n" . $render;
+	}
+
+	/**
+	 * JSON-encode a value with stable formatting, guarded for non-WP runtimes.
+	 *
+	 * @param array<string,mixed> $value Value to encode.
+	 * @return string
+	 */
+	private static function encode_json( array $value ): string {
+		$flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+		if ( function_exists( 'wp_json_encode' ) ) {
+			$encoded = wp_json_encode( $value, $flags );
+		} else {
+			$encoded = json_encode( $value, $flags ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Generated outside a WP runtime in tests; wp_json_encode used when available.
+		}
+
+		return false === $encoded ? '{}' : $encoded . "\n";
+	}
+
+	/**
+	 * Sanitize a slug, falling back to a portable regex when WP is unavailable.
+	 *
+	 * @param string $value Raw slug.
+	 * @return string
+	 */
+	private static function sanitize_slug( string $value ): string {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			return '';
+		}
+
+		if ( function_exists( 'sanitize_title' ) ) {
+			$sanitized = sanitize_title( $value );
+			if ( '' !== $sanitized ) {
+				return $sanitized;
+			}
+		}
+
+		$value = strtolower( $value );
+		$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+		return trim( (string) $value, '-' );
+	}
+
+	/**
+	 * Sanitize a relative file path, rejecting traversal and absolute paths.
+	 *
+	 * @param string $value Raw relative path.
+	 * @return string
+	 */
+	private static function sanitize_relative_path( string $value ): string {
+		$value = str_replace( '\\', '/', trim( $value ) );
+		$value = ltrim( $value, '/' );
+		if ( '' === $value || str_contains( $value, '../' ) || str_contains( $value, './' ) ) {
+			return '';
+		}
+
+		$segments = array();
+		foreach ( explode( '/', $value ) as $segment ) {
+			$segment = preg_replace( '/[^A-Za-z0-9._-]/', '', $segment );
+			if ( '' === $segment || '..' === $segment ) {
+				continue;
+			}
+			$segments[] = $segment;
+		}
+
+		return implode( '/', $segments );
+	}
+
+	/**
+	 * Escape a value for embedding inside single-quoted generated PHP.
+	 *
+	 * @param string $value Raw value.
+	 * @return string
+	 */
+	private static function php_single_quote( string $value ): string {
+		return str_replace( array( '\\', "'" ), array( '\\\\', "\\'" ), $value );
+	}
+}

--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -273,7 +273,118 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 			);
 		}
 
+		foreach ( self::companion_dependencies( $adapter ) as $dependency ) {
+			$slug = (string) ( $dependency['slug'] ?? '' );
+			if ( '' === $slug ) {
+				continue;
+			}
+
+			$reports[ $slug ] = self::materialize_companion_dependency( $dependency );
+		}
+
 		return $reports;
+	}
+
+	/**
+	 * Build a generated companion-plugin dependency definition from a payload.
+	 *
+	 * Companion plugins are per-site and generated at import time, so they are not
+	 * static adapter entries like the WooCommerce/Jetpack directory slugs. This
+	 * builder produces a dependency definition of type `companion_plugin` that the
+	 * install path and diagnostics treat as a first-class declared dependency,
+	 * distinct from directory slugs.
+	 *
+	 * @param array<string,mixed> $payload Generated companion-plugin payload.
+	 * @return array<string,mixed>
+	 */
+	public static function companion_plugin_dependency( array $payload ): array {
+		$slug        = Static_Site_Importer_Companion_Plugin::plugin_slug( $payload );
+		$plugin_file = Static_Site_Importer_Companion_Plugin::plugin_file( $payload );
+		$mu_plugin   = ! empty( $payload['mu_plugin'] );
+
+		$dependency = array(
+			'type'        => 'companion_plugin',
+			'slug'        => $slug,
+			'plugin_file' => $plugin_file,
+			'mu_plugin'   => $mu_plugin,
+			'payload'     => $payload,
+		);
+
+		$dependency['availability_callback'] = static function () use ( $dependency ): bool {
+			return self::companion_plugin_available( $dependency );
+		};
+
+		return $dependency;
+	}
+
+	/**
+	 * Determine whether a generated companion plugin is installed and active.
+	 *
+	 * @param array<string,mixed> $dependency Companion dependency definition.
+	 * @return bool
+	 */
+	public static function companion_plugin_available( array $dependency ): bool {
+		$plugin_file = (string) ( $dependency['plugin_file'] ?? '' );
+		if ( '' === $plugin_file ) {
+			return false;
+		}
+
+		if ( ! empty( $dependency['mu_plugin'] ) ) {
+			if ( ! defined( 'WPMU_PLUGIN_DIR' ) ) {
+				return false;
+			}
+			return file_exists( rtrim( (string) WPMU_PLUGIN_DIR, '/' ) . '/' . $plugin_file );
+		}
+
+		return function_exists( 'is_plugin_active' ) && is_plugin_active( $plugin_file );
+	}
+
+	/**
+	 * Materialize a generated companion-plugin dependency.
+	 *
+	 * @param array<string,mixed> $dependency Companion dependency definition.
+	 * @return array<string,mixed>
+	 */
+	public static function materialize_companion_dependency( array $dependency ): array {
+		$payload = isset( $dependency['payload'] ) && is_array( $dependency['payload'] ) ? $dependency['payload'] : array();
+		return Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin(
+			$payload,
+			$dependency['availability_callback'] ?? null
+		);
+	}
+
+	/**
+	 * Build the dependency report row for a generated companion plugin.
+	 *
+	 * Mirrors the directory-plugin dependency row shape so the gate/diagnostics
+	 * surface a companion the same way they surface WooCommerce/Jetpack, but keys
+	 * it by the namespaced companion slug and flags its `generated` source.
+	 *
+	 * @param array<string,mixed> $dependency Companion dependency definition.
+	 * @param bool                $waived     Whether enforcement is waived.
+	 * @return array<string,mixed>
+	 */
+	public static function companion_dependency_row( array $dependency, bool $waived ): array {
+		$active = self::companion_plugin_available( $dependency );
+
+		$block_names = array();
+		$payload     = isset( $dependency['payload'] ) && is_array( $dependency['payload'] ) ? $dependency['payload'] : array();
+		$scaffold    = empty( $payload ) ? null : Static_Site_Importer_Companion_Plugin::scaffold( $payload );
+		if ( is_array( $scaffold ) && isset( $scaffold['block_names'] ) && is_array( $scaffold['block_names'] ) ) {
+			$block_names = array_values( array_map( 'strval', $scaffold['block_names'] ) );
+		}
+
+		return array(
+			'type'        => 'companion_plugin',
+			'source'      => 'generated',
+			'slug'        => (string) ( $dependency['slug'] ?? '' ),
+			'plugin_file' => (string) ( $dependency['plugin_file'] ?? '' ),
+			'mu_plugin'   => ! empty( $dependency['mu_plugin'] ),
+			'required'    => true,
+			'active'      => $active,
+			'waived'      => $waived,
+			'block_names' => $block_names,
+		);
 	}
 
 	/**
@@ -618,6 +729,22 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 			array_filter(
 				$dependencies,
 				static fn ( mixed $dependency ): bool => is_array( $dependency ) && 'wp_org_plugin' === (string) ( $dependency['type'] ?? '' )
+			)
+		);
+	}
+
+	/**
+	 * Return generated companion-plugin dependency definitions for an adapter.
+	 *
+	 * @param array<string,mixed> $adapter Adapter definition.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function companion_dependencies( array $adapter ): array {
+		$dependencies = isset( $adapter['dependencies'] ) && is_array( $adapter['dependencies'] ) ? $adapter['dependencies'] : array();
+		return array_values(
+			array_filter(
+				$dependencies,
+				static fn ( mixed $dependency ): bool => is_array( $dependency ) && 'companion_plugin' === (string) ( $dependency['type'] ?? '' )
 			)
 		);
 	}

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -84,6 +84,206 @@ class Static_Site_Importer_Plugin_Materializer {
 	}
 
 	/**
+	 * Ensure a generated companion plugin is materialized on disk and active.
+	 *
+	 * Mirrors ensure_wp_org_plugin() for a payload SSI produced itself instead of
+	 * a WordPress.org directory slug: it scaffolds the plugin file set, writes the
+	 * files into the plugins (or mu-plugins) directory, activates it (mu-plugins
+	 * are always active), and treats it as a satisfied dependency. All WordPress
+	 * calls are guarded so the deterministic plan is testable without a runtime.
+	 *
+	 * @param array<string, mixed> $payload            Generated companion-plugin payload.
+	 * @param callable|null        $availability_check Optional callback that returns true when the plugin is available.
+	 * @return array<string, mixed>
+	 */
+	public static function ensure_generated_plugin(
+		array $payload,
+		?callable $availability_check = null
+	): array {
+		$descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $payload );
+		if ( is_wp_error( $descriptor ) ) {
+			$report = self::new_generated_report( '', '' );
+			return self::failed_report( $report, $descriptor );
+		}
+
+		$report                = self::new_generated_report( (string) $descriptor['slug'], (string) $descriptor['plugin_file'] );
+		$report['mu_plugin']   = (bool) $descriptor['mu_plugin'];
+		$report['block_names'] = $descriptor['block_names'];
+
+		$plan = self::generated_install_plan( $descriptor );
+		if ( is_wp_error( $plan ) ) {
+			return self::failed_report( $report, $plan );
+		}
+
+		$report['files'] = array_keys( $plan['files'] );
+
+		if ( self::available( $availability_check ) ) {
+			$report['status']    = 'already_available';
+			$report['installed'] = true;
+			$report['active']    = true;
+			return $report;
+		}
+
+		$report['attempted'] = true;
+
+		$written = self::write_generated_files( $plan );
+		if ( is_wp_error( $written ) ) {
+			return self::failed_report( $report, $written );
+		}
+		$report['installed'] = true;
+		$report['actions'][] = 'installed';
+
+		if ( false === $plan['activate'] ) {
+			// mu-plugins are always active; no activation call is required.
+			$report['active'] = true;
+			$report['status'] = 'installed_activated';
+			return $report;
+		}
+
+		$plugin_file = (string) $descriptor['plugin_file'];
+		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( $plugin_file ) ) {
+			$report['active'] = true;
+		} elseif ( function_exists( 'activate_plugin' ) ) {
+			$activate = activate_plugin( $plugin_file );
+			if ( is_wp_error( $activate ) ) {
+				return self::failed_report( $report, $activate );
+			}
+			$report['active']    = true;
+			$report['actions'][] = 'activated';
+		} else {
+			return self::failed_report(
+				$report,
+				new WP_Error(
+					'static_site_importer_companion_activate_unavailable',
+					'WordPress plugin activation API is unavailable.'
+				)
+			);
+		}
+
+		if ( null !== $availability_check && ! self::available( $availability_check ) ) {
+			return self::failed_report(
+				$report,
+				new WP_Error(
+					'static_site_importer_companion_plugin_unavailable',
+					sprintf( 'Companion plugin %s was installed/activated but is still unavailable.', (string) $descriptor['slug'] )
+				)
+			);
+		}
+
+		$report['status'] = 'installed_activated';
+		return $report;
+	}
+
+	/**
+	 * Build a deterministic install plan for a scaffolded companion plugin.
+	 *
+	 * Resolves the destination directory and the absolute file paths without
+	 * touching the filesystem, so the file set and activation intent can be
+	 * asserted in isolation. WordPress directory constants are read when defined
+	 * and may be overridden for tests.
+	 *
+	 * @param array<string, mixed> $descriptor Scaffolder descriptor.
+	 * @param string|null          $base_dir   Optional destination override.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function generated_install_plan( array $descriptor, ?string $base_dir = null ) {
+		$files = isset( $descriptor['files'] ) && is_array( $descriptor['files'] ) ? $descriptor['files'] : array();
+		if ( empty( $files ) ) {
+			return new WP_Error(
+				'static_site_importer_companion_plugin_empty',
+				'Companion-plugin scaffold produced no files to install.'
+			);
+		}
+
+		$mu_plugin = ! empty( $descriptor['mu_plugin'] );
+
+		if ( null === $base_dir ) {
+			if ( $mu_plugin && defined( 'WPMU_PLUGIN_DIR' ) ) {
+				$base_dir = (string) WPMU_PLUGIN_DIR;
+			} elseif ( ! $mu_plugin && defined( 'WP_PLUGIN_DIR' ) ) {
+				$base_dir = (string) WP_PLUGIN_DIR;
+			} else {
+				$base_dir = '';
+			}
+		}
+
+		$absolute = array();
+		if ( '' !== $base_dir ) {
+			$prefix = rtrim( $base_dir, '/' ) . '/';
+			foreach ( $files as $relative => $content ) {
+				$absolute[ $prefix . $relative ] = $content;
+			}
+		}
+
+		return array(
+			'slug'           => (string) ( $descriptor['slug'] ?? '' ),
+			'plugin_file'    => (string) ( $descriptor['plugin_file'] ?? '' ),
+			'mu_plugin'      => $mu_plugin,
+			'destination'    => $mu_plugin ? 'mu_plugin' : 'plugin',
+			'base_dir'       => $base_dir,
+			'files'          => $files,
+			'absolute_files' => $absolute,
+			// mu-plugins do not require an activation call; regular plugins do.
+			'activate'       => ! $mu_plugin,
+		);
+	}
+
+	/**
+	 * Write a generated install plan's files to disk.
+	 *
+	 * @param array<string, mixed> $plan Install plan from generated_install_plan().
+	 * @return true|WP_Error
+	 */
+	private static function write_generated_files( array $plan ) {
+		$absolute = isset( $plan['absolute_files'] ) && is_array( $plan['absolute_files'] ) ? $plan['absolute_files'] : array();
+		if ( empty( $absolute ) ) {
+			return new WP_Error(
+				'static_site_importer_companion_plugin_dir_unresolved',
+				'Companion-plugin destination directory could not be resolved.'
+			);
+		}
+
+		foreach ( $absolute as $path => $content ) {
+			$dir = dirname( (string) $path );
+			if ( ! is_dir( $dir ) ) {
+				$created = function_exists( 'wp_mkdir_p' ) ? wp_mkdir_p( $dir ) : false;
+				if ( ! $created ) {
+					return new WP_Error(
+						'static_site_importer_companion_plugin_mkdir_failed',
+						sprintf( 'Failed to create companion-plugin directory: %s', $dir )
+					);
+				}
+			}
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writes the generated companion plugin into the plugins directory.
+			if ( false === file_put_contents( (string) $path, (string) $content ) ) {
+				return new WP_Error(
+					'static_site_importer_companion_plugin_write_failed',
+					sprintf( 'Failed to write companion-plugin file: %s', $path )
+				);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Build an initial generated-plugin materialization report.
+	 *
+	 * @param string $slug        Companion plugin slug.
+	 * @param string $plugin_file Plugin basename.
+	 * @return array<string, mixed>
+	 */
+	private static function new_generated_report( string $slug, string $plugin_file ): array {
+		$report                = self::new_report( $slug, $plugin_file );
+		$report['source']      = 'generated';
+		$report['mu_plugin']   = false;
+		$report['block_names'] = array();
+		$report['files']       = array();
+		return $report;
+	}
+
+	/**
 	 * Build an initial materialization report.
 	 *
 	 * @param string $slug        WordPress.org plugin slug.

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -61,6 +61,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'svg_materialization_failure_count'     => 0,
 				'svg_sprite_reference_failure_count'    => 0,
 				'commerce_dependency_failures'          => 0,
+				'companion_plugin_dependency_failures'  => 0,
 				'interaction_candidate_count'           => 0,
 				'runtime_dependency_parity_issue_count' => 0,
 				'semantic_parity_failure_count'         => 0,
@@ -494,6 +495,9 @@ class Static_Site_Importer_Report_Diagnostics {
 		if ( ( $quality['commerce_dependency_failures'] ?? 0 ) > 0 ) {
 			$reasons[] = 'woocommerce_missing';
 		}
+		if ( ( $quality['companion_plugin_dependency_failures'] ?? 0 ) > 0 ) {
+			$reasons[] = 'companion_plugin_missing';
+		}
 		if ( ( $quality['runtime_dependency_parity_issue_count'] ?? 0 ) > 0 ) {
 			$reasons[] = 'runtime_dependency_parity';
 		}
@@ -513,6 +517,9 @@ class Static_Site_Importer_Report_Diagnostics {
 		if ( in_array( 'woocommerce_missing', $reasons, true ) ) {
 			$quality['fail_import'] = true;
 		}
+		if ( in_array( 'companion_plugin_missing', $reasons, true ) ) {
+			$quality['fail_import'] = true;
+		}
 
 		$quality['diagnostic_refs'] = self::quality_diagnostic_refs( $report['diagnostics'] ?? array() );
 		$report['quality']          = $quality;
@@ -520,6 +527,82 @@ class Static_Site_Importer_Report_Diagnostics {
 		$report['artifact_diagnostics'] = Static_Site_Importer_Artifact_Diagnostics_Adapter::build_for_import_report( $report );
 
 		return $quality;
+	}
+
+	/**
+	 * Record a generated companion-plugin dependency into a conversion report.
+	 *
+	 * Mirrors the WooCommerce/Jetpack directory-dependency surface so the gate and
+	 * diagnostics treat a generated companion as a first-class declared dependency:
+	 * a present companion emits an info diagnostic, a waived-but-missing one emits a
+	 * warning, and a required-but-missing one increments the dependency-failure
+	 * quality counter (which fails the import) and emits an error diagnostic. The
+	 * declared dependency row is stored under `companion_plugins.dependencies` keyed
+	 * by the namespaced companion slug, distinct from `commerce.dependencies`.
+	 *
+	 * @param array<string, mixed> $report     Conversion report (mutated in place).
+	 * @param array<string, mixed> $dependency Companion dependency definition.
+	 * @param bool                 $waived     Whether enforcement is waived.
+	 * @return void
+	 */
+	public static function record_companion_plugin_dependency( array &$report, array $dependency, bool $waived ): void {
+		$row  = Static_Site_Importer_Entity_Materializer_Registry::companion_dependency_row( $dependency, $waived );
+		$slug = (string) ( $row['slug'] ?? '' );
+		if ( '' === $slug ) {
+			return;
+		}
+
+		if ( ! isset( $report['companion_plugins'] ) || ! is_array( $report['companion_plugins'] ) ) {
+			$report['companion_plugins'] = array( 'dependencies' => array() );
+		}
+		if ( ! isset( $report['companion_plugins']['dependencies'] ) || ! is_array( $report['companion_plugins']['dependencies'] ) ) {
+			$report['companion_plugins']['dependencies'] = array();
+		}
+		$report['companion_plugins']['dependencies'][ $slug ] = $row;
+
+		if ( ! isset( $report['diagnostics'] ) || ! is_array( $report['diagnostics'] ) ) {
+			$report['diagnostics'] = array();
+		}
+
+		$source = 'companion_plugins.dependencies.' . $slug;
+
+		if ( ! empty( $row['active'] ) ) {
+			$report['diagnostics'][] = array(
+				'code'        => 'companion_plugin_present',
+				'severity'    => 'info',
+				'source'      => $source,
+				'message'     => sprintf( 'Companion plugin %s is active; generated blocks are available theme-independently.', $slug ),
+				'slug'        => $slug,
+				'block_names' => $row['block_names'] ?? array(),
+			);
+			return;
+		}
+
+		if ( $waived ) {
+			$report['diagnostics'][] = array(
+				'code'        => 'companion_plugin_waived',
+				'severity'    => 'warning',
+				'source'      => $source,
+				'message'     => sprintf( 'Companion plugin %s requirement was waived; generated blocks were not installed.', $slug ),
+				'slug'        => $slug,
+				'block_names' => $row['block_names'] ?? array(),
+			);
+			return;
+		}
+
+		if ( ! isset( $report['quality'] ) || ! is_array( $report['quality'] ) ) {
+			$report['quality'] = array();
+		}
+		$report['quality']['companion_plugin_dependency_failures'] = (int) ( $report['quality']['companion_plugin_dependency_failures'] ?? 0 ) + 1;
+
+		$report['diagnostics'][] = array(
+			'code'        => 'companion_plugin_missing',
+			'severity'    => 'error',
+			'source'      => $source,
+			'message'     => sprintf( 'Companion plugin %s is required to house generated blocks but is not installed/active.', $slug ),
+			'slug'        => $slug,
+			'block_names' => $row['block_names'] ?? array(),
+		);
 	}
 
 	/**

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -50,6 +50,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-do
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-source-page.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-fetcher.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-import-runtime.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-companion-plugin.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-plugin-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-entity-materializer-registry.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-asset-reporter.php';

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Smoke coverage for the companion-plugin scaffolder, install/activate path, and
+ * declared-dependency wiring (issue #491 slice 1).
+ *
+ * Run from the repository root:
+ * php tests/smoke-companion-plugin.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$ssi_companion_tmp = sys_get_temp_dir() . '/ssi-companion-smoke-' . getmypid();
+if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+	define( 'WP_PLUGIN_DIR', $ssi_companion_tmp . '/plugins' );
+}
+if ( ! defined( 'WPMU_PLUGIN_DIR' ) ) {
+	define( 'WPMU_PLUGIN_DIR', $ssi_companion_tmp . '/mu-plugins' );
+}
+
+// Controllable plugin-activation stubs so the install path is exercised without
+// a WordPress runtime. is_plugin_active reports inactive until activate_plugin
+// records the activation intent.
+$GLOBALS['ssi_companion_active']    = array();
+$GLOBALS['ssi_companion_activated'] = array();
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code, private string $message ) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		$title = strtolower( trim( $title ) );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title ) ?? '';
+		return trim( $title, '-' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.keyFound
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( string $path ): bool {
+		return is_dir( $path ) || mkdir( $path, 0777, true );
+	}
+}
+
+if ( ! function_exists( 'is_plugin_active' ) ) {
+	function is_plugin_active( string $plugin_file ): bool {
+		return in_array( $plugin_file, $GLOBALS['ssi_companion_active'], true );
+	}
+}
+
+if ( ! function_exists( 'activate_plugin' ) ) {
+	function activate_plugin( string $plugin_file ) {
+		$GLOBALS['ssi_companion_active'][]    = $plugin_file;
+		$GLOBALS['ssi_companion_activated'][] = $plugin_file;
+		return null;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-companion-plugin.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-plugin-materializer.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+// Synthetic minimal payload: one block (block.json + render) plus a preserved
+// island scoped to that block. Generic; no fixture-specific strings.
+$payload = array(
+	'schema'       => Static_Site_Importer_Companion_Plugin::PAYLOAD_SCHEMA,
+	'site_slug'    => 'Example Site',
+	'site_name'    => 'Example Site',
+	'blocks'       => array(
+		array(
+			'name'       => 'Custom Hero',
+			'block_json' => array(
+				'title'    => 'Custom Hero',
+				'category' => 'design',
+			),
+			'render'     => '<div class="ssi-hero"><?php echo esc_html( $attributes["heading"] ?? "" ); ?></div>',
+		),
+	),
+	'preserved_js' => array(
+		array(
+			'handle'  => 'hero-island',
+			'content' => 'document.addEventListener("DOMContentLoaded",function(){});',
+			'block'   => 'ssi-example-site/custom-hero',
+		),
+	),
+);
+
+// 1. Scaffolder emits a valid plugin file set.
+$descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $payload );
+$assert( is_array( $descriptor ), 'scaffold-returns-descriptor', is_array( $descriptor ) ? '' : 'WP_Error returned' );
+
+if ( is_array( $descriptor ) ) {
+	$assert( 'ssi-example-site' === $descriptor['slug'], 'scaffold-namespaces-slug', (string) $descriptor['slug'] );
+	$assert( 'ssi-example-site/ssi-example-site.php' === $descriptor['plugin_file'], 'scaffold-plugin-file-path', (string) $descriptor['plugin_file'] );
+	$assert( array( 'ssi-example-site/custom-hero' ) === $descriptor['block_names'], 'scaffold-namespaces-block-name' );
+	$assert( false === $descriptor['mu_plugin'], 'scaffold-regular-plugin-by-default' );
+
+	$files = $descriptor['files'];
+	$main  = $files['ssi-example-site/ssi-example-site.php'] ?? '';
+	$assert( str_contains( $main, 'Plugin Name:' ), 'main-file-has-plugin-header' );
+	$assert( str_contains( $main, 'register_block_type' ), 'main-file-registers-blocks' );
+	$assert( str_contains( $main, "add_filter( 'render_block'" ), 'main-file-scopes-island-enqueue' );
+	$assert( str_contains( $main, 'wp_enqueue_script' ), 'main-file-enqueues-island-js' );
+
+	$block_json_raw = $files['ssi-example-site/blocks/custom-hero/block.json'] ?? '';
+	$block_json     = json_decode( $block_json_raw, true );
+	$assert( is_array( $block_json ) && 'ssi-example-site/custom-hero' === ( $block_json['name'] ?? '' ), 'block-json-forces-namespaced-name' );
+	$assert( is_array( $block_json ) && 3 === ( $block_json['apiVersion'] ?? 0 ), 'block-json-has-api-version' );
+
+	$render = $files['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
+	$assert( str_starts_with( ltrim( $render ), '<?php' ), 'render-php-opens-with-php-tag' );
+
+	$island_files = array_filter( array_keys( $files ), static fn ( string $path ): bool => str_contains( $path, '/islands/' ) && str_ends_with( $path, '.js' ) );
+	$assert( 1 === count( $island_files ), 'preserved-island-js-file-emitted' );
+}
+
+// mu-plugin variant materializes a root loader stub.
+$mu_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( array_merge( $payload, array( 'mu_plugin' => true ) ) );
+$assert( is_array( $mu_descriptor ) && true === $mu_descriptor['mu_plugin'], 'scaffold-honors-mu-plugin-option' );
+$assert( is_array( $mu_descriptor ) && 'ssi-example-site.php' === $mu_descriptor['loader_file'], 'mu-plugin-emits-root-loader' );
+$assert( is_array( $mu_descriptor ) && isset( $mu_descriptor['files']['ssi-example-site.php'] ), 'mu-plugin-loader-file-present' );
+
+// Invalid payloads are rejected.
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::scaffold( array( 'site_slug' => '' ) ) ), 'scaffold-rejects-missing-site-slug' );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::scaffold( array( 'site_slug' => 'x', 'blocks' => array() ) ) ), 'scaffold-rejects-missing-blocks' );
+
+// 2. Install plan resolves the file set + activation intent (pure / no writes).
+if ( is_array( $descriptor ) ) {
+	$plan = Static_Site_Importer_Plugin_Materializer::generated_install_plan( $descriptor, '/var/plugins' );
+	$assert( is_array( $plan ), 'install-plan-built' );
+	if ( is_array( $plan ) ) {
+		$assert( 'plugin' === $plan['destination'], 'install-plan-regular-destination' );
+		$assert( true === $plan['activate'], 'install-plan-regular-requires-activation' );
+		$assert( isset( $plan['absolute_files']['/var/plugins/ssi-example-site/ssi-example-site.php'] ), 'install-plan-absolute-paths-prefixed' );
+	}
+
+	$mu_plan = Static_Site_Importer_Plugin_Materializer::generated_install_plan( $mu_descriptor, '/var/mu-plugins' );
+	$assert( is_array( $mu_plan ) && 'mu_plugin' === $mu_plan['destination'], 'install-plan-mu-destination' );
+	$assert( is_array( $mu_plan ) && false === $mu_plan['activate'], 'install-plan-mu-no-activation' );
+}
+
+// 3. Full install/activate path writes the file set and activates it.
+$report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $payload );
+$assert( 'installed_activated' === ( $report['status'] ?? '' ), 'install-status-installed-activated', (string) ( $report['status'] ?? '' ) );
+$assert( true === ( $report['installed'] ?? false ), 'install-reports-installed' );
+$assert( true === ( $report['active'] ?? false ), 'install-reports-active' );
+$assert( in_array( 'installed', $report['actions'] ?? array(), true ), 'install-records-installed-action' );
+$assert( in_array( 'activated', $report['actions'] ?? array(), true ), 'install-records-activated-action' );
+$assert( in_array( 'ssi-example-site/ssi-example-site.php', $GLOBALS['ssi_companion_activated'], true ), 'install-activates-companion-plugin' );
+$assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ), 'install-writes-main-file-to-disk' );
+$assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/block.json' ), 'install-writes-block-json-to-disk' );
+$written_main = file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) ? (string) file_get_contents( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) : '';
+$assert( str_contains( $written_main, 'register_block_type' ), 'written-main-file-registers-blocks' );
+
+// mu-plugin install writes the root loader and needs no activation call.
+$mu_report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( array_merge( $payload, array( 'mu_plugin' => true ) ) );
+$assert( 'installed_activated' === ( $mu_report['status'] ?? '' ), 'mu-install-status', (string) ( $mu_report['status'] ?? '' ) );
+$assert( true === ( $mu_report['mu_plugin'] ?? false ), 'mu-install-reports-mu-plugin' );
+$assert( ! in_array( 'activated', $mu_report['actions'] ?? array(), true ), 'mu-install-skips-activation' );
+$assert( file_exists( WPMU_PLUGIN_DIR . '/ssi-example-site.php' ), 'mu-install-writes-root-loader' );
+
+// 4. Declared-dependency wiring: distinct generated/companion dependency entry.
+$dependency = Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_dependency( $payload );
+$assert( 'companion_plugin' === ( $dependency['type'] ?? '' ), 'dependency-type-is-companion-plugin' );
+$assert( 'ssi-example-site' === ( $dependency['slug'] ?? '' ), 'dependency-slug-namespaced' );
+$assert( is_callable( $dependency['availability_callback'] ?? null ), 'dependency-has-availability-callback' );
+
+// The earlier install marked the regular companion active via the stub, so the
+// dependency row reflects a satisfied dependency.
+$active_row = Static_Site_Importer_Entity_Materializer_Registry::companion_dependency_row( $dependency, false );
+$assert( 'generated' === ( $active_row['source'] ?? '' ), 'dependency-row-source-generated' );
+$assert( true === ( $active_row['active'] ?? false ), 'dependency-row-active-when-installed' );
+$assert( array( 'ssi-example-site/custom-hero' ) === ( $active_row['block_names'] ?? array() ), 'dependency-row-carries-block-names' );
+
+// A not-yet-installed companion surfaces as a gate-visible failure.
+$missing_payload    = array_merge( $payload, array( 'site_slug' => 'second-site' ) );
+$missing_dependency = Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_dependency( $missing_payload );
+$assert( false === Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_available( $missing_dependency ), 'missing-companion-not-available' );
+
+$gate_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( $gate_report, $missing_dependency, false );
+$assert( 1 === (int) ( $gate_report['quality']['companion_plugin_dependency_failures'] ?? 0 ), 'missing-companion-increments-quality-counter' );
+$assert( isset( $gate_report['companion_plugins']['dependencies']['ssi-second-site'] ), 'companion-dependency-declared-in-report' );
+$missing_diag = array_values( array_filter( $gate_report['diagnostics'] ?? array(), static fn ( array $d ): bool => 'companion_plugin_missing' === ( $d['code'] ?? '' ) ) );
+$assert( 1 === count( $missing_diag ), 'missing-companion-emits-diagnostic' );
+
+$quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $gate_report, array( 'fail_on_quality' => true ) );
+$assert( in_array( 'companion_plugin_missing', $quality['failure_reasons'] ?? array(), true ), 'gate-sees-companion-plugin-missing' );
+$assert( true === ( $quality['fail_import'] ?? false ), 'gate-fails-import-on-missing-companion' );
+
+// Waived missing companion warns but does not fail the gate.
+$waived_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( $waived_report, $missing_dependency, true );
+$assert( 0 === (int) ( $waived_report['quality']['companion_plugin_dependency_failures'] ?? 0 ), 'waived-companion-no-quality-failure' );
+$waived_diag = array_values( array_filter( $waived_report['diagnostics'] ?? array(), static fn ( array $d ): bool => 'companion_plugin_waived' === ( $d['code'] ?? '' ) ) );
+$assert( 1 === count( $waived_diag ), 'waived-companion-emits-warning' );
+
+// Cleanup generated fixtures.
+$cleanup = static function ( string $dir ) use ( &$cleanup ): void {
+	if ( ! is_dir( $dir ) ) {
+		return;
+	}
+	$items = scandir( $dir );
+	foreach ( is_array( $items ) ? $items : array() as $item ) {
+		if ( '.' === $item || '..' === $item ) {
+			continue;
+		}
+		$path = $dir . '/' . $item;
+		is_dir( $path ) ? $cleanup( $path ) : unlink( $path );
+	}
+	rmdir( $dir );
+};
+$cleanup( $ssi_companion_tmp );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: companion plugin smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
Refs #491 — **slice 1 of N** of the companion-plugin / plugin-materialization keystone.

## In scope (this PR)
The SSI side of the keystone: a companion-plugin **scaffolder**, an **install/activate path** that accepts a *generated* plugin payload, and **declared-dependency wiring** so the gate/diagnostics see it. Proven end to end with a synthetic minimal one-block payload (no fixture-specific strings).

## Deferred (separate slices — NOT in this PR)
- **Slice 2 (blocks-engine):** artifact-pipeline packaging that bundles `block.json` + render + assets + preserved JS into the payload this path consumes.
- **Slice 3 (wire-ups, after 1+2):** JS→plugin (#488), preserve-vs-rebuild (#224), recognizer-registration hook.
- Mapping/routing is unchanged: `core/html` stays the safe last-resort fallback. This PR only builds the destination + install path.

## What this adds
**1. Scaffolder — `includes/class-static-site-importer-companion-plugin.php`**
Given a payload (block definitions: `block.json` + render/markup + optional assets/view JS, plus optional preserved island JS), generates a standalone plugin file set:
- One companion plugin per site, namespaced `ssi-<site-slug>/…`; block names `ssi-<site>/<block>`, registered via `register_block_type` from each block's own `block.json` (the scaffold forces the namespaced name + apiVersion).
- Preserved island JS enqueued **scoped** (via a `render_block` filter keyed on the owning block), not globally.
- **Regular plugin by default**; `mu_plugin` option (default off) emits an mu-plugins **root loader stub** that requires the real plugin (mu-plugins only auto-load root-level files).
- The file-set builder is pure/side-effect-free and guarded (`function_exists`/`defined`) so it is testable without a WP runtime; generated PHP is itself `php -l` clean.

**2. Install/activate path — `Plugin_Materializer::ensure_generated_plugin()` + `generated_install_plan()`**
Mirrors the existing directory-plugin dependency path (`plugin_file` + `availability_callback`): resolves the destination (`WP_PLUGIN_DIR`/`WPMU_PLUGIN_DIR`), writes the generated files, activates regular plugins (mu-plugins are always active), and treats it as a satisfied dependency. `generated_install_plan()` is a pure seam exposing the file set + activation intent without touching disk; all WP calls are guarded.

**3. Declared-dependency wiring**
- `Entity_Materializer_Registry`: a new `companion_plugin` dependency type (`companion_plugin_dependency()` builder, `companion_plugin_available()`, `companion_dependency_row()`, `materialize_companion_dependency()`), distinct from directory slugs; `materialize_plugin_dependencies()` now materializes both wp_org and companion deps.
- `Report_Diagnostics::record_companion_plugin_dependency()` mirrors the WooCommerce/Jetpack surface: `companion_plugin_present`/`companion_plugin_waived`/`companion_plugin_missing` diagnostics, a `companion_plugin_dependency_failures` quality counter, and a `companion_plugin_missing` gate reason (fails the import) so the gate/diagnostics see the generated dependency.

## Tests
- New `tests/smoke-companion-plugin.php` — 51 assertions over scaffold (regular + mu, namespacing, header, `register_block_type`, scoped island enqueue, invalid-payload rejection), install/activate (plan + full write + activation intent, regular + mu), and the declared-dependency/gate surface.
- Full standalone smoke suite stays green; the existing directory-plugin (Woo/Jetpack) path is unchanged. The only suite failures are the 3 pre-existing `wp eval-file`-only fixtures that require ABSPATH/a WP runtime (unrelated).

**DO NOT MERGE** — opening for review; depends on slice 2 for a real payload producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)