### PR TITLE
Retire stale block-artifact-compiler schema identifiers

### DIFF
--- a/includes/class-static-site-importer-document-metadata-reporter.php
+++ b/includes/class-static-site-importer-document-metadata-reporter.php
@@ -22,7 +22,7 @@ class Static_Site_Importer_Document_Metadata_Reporter {
 	 */
 	public static function record( array &$report, array $artifacts ): void {
 		$metadata = isset( $artifacts['document_metadata'] ) && is_array( $artifacts['document_metadata'] ) ? $artifacts['document_metadata'] : array();
-		if ( 'block-artifact-compiler/document-metadata/v1' !== (string) ( $metadata['schema'] ?? '' ) ) {
+		if ( 'blocks-engine/php-transformer/document-metadata/v1' !== (string) ( $metadata['schema'] ?? '' ) ) {
 			return;
 		}
 

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -759,7 +759,7 @@ class Static_Site_Importer_Transformer_Adapter {
 		}
 
 		$metadata                = $this->html_document_metadata( $html );
-		$metadata['schema']      = 'block-artifact-compiler/document-metadata/v1';
+		$metadata['schema']      = 'blocks-engine/php-transformer/document-metadata/v1';
 		$metadata['source_path'] = isset( $page['source_path'] ) && is_scalar( $page['source_path'] ) ? (string) $page['source_path'] : '';
 
 		return $metadata;

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -105,17 +105,17 @@ $assert = static function ( bool $condition, string $label, string $detail = '' 
 
 $artifacts = array(
 	'visual_repair' => array(
-		'schema' => 'block-artifact-compiler/visual-repair-artifacts/v1',
+		'schema' => 'blocks-engine/php-transformer/visual-repair-artifacts/v1',
 		'css'    => '.compiled-site-repair { display: block; }',
 		'styles' => array(
 			array(
-				'schema'  => 'block-artifact-compiler/visual-repair-css/v1',
+				'schema'  => 'blocks-engine/php-transformer/visual-repair-css/v1',
 				'target'  => 'frontend',
 				'path'    => 'assets/css/visual-repair.css',
 				'content' => "/* Blocks Engine: visual repair artifacts. */\n.wp-block-group.hero-shell { gap: 0; }",
 			),
 			array(
-				'schema'  => 'block-artifact-compiler/visual-repair-css/v1',
+				'schema'  => 'blocks-engine/php-transformer/visual-repair-css/v1',
 				'target'  => 'editor',
 				'path'    => 'assets/css/visual-repair-editor.css',
 				'content' => "/* Blocks Engine: editor visual repair artifacts. */\n.editor-styles-wrapper .glow-orb { opacity: 1 !important; }",


### PR DESCRIPTION
## What
The retired packages `block-format-bridge` (bfb) and `block-artifact-compiler` (bac) no longer exist; SSI now depends only on `automattic/blocks-engine-php-transformer`. SSI still carried three stale schema-string **literals** naming the retired `block-artifact-compiler`. This renames them into the `blocks-engine/php-transformer/*` family SSI already uses everywhere else, so SSI no longer references the retired packages at all.

## Changes
- `includes/class-static-site-importer-transformer-adapter.php` + `class-static-site-importer-document-metadata-reporter.php`: `block-artifact-compiler/document-metadata/v1` → `blocks-engine/php-transformer/document-metadata/v1` (setter + matcher kept in sync).
- `tests/smoke-visual-repair-css.php`: `block-artifact-compiler/visual-repair-*/v1` → `blocks-engine/php-transformer/visual-repair-*/v1`.

## Why it's safe
- Cross-repo grep (blocks-engine, homeboy-rigs, homeboy-extensions) found **zero external consumers** of these exact strings — they are SSI-internal handshakes SSI both sets and matches.
- The current php-transformer engine does **not** emit these schemas (verified in `ArtifactCompiler`); SSI fabricates the document-metadata schema itself.

## Verification
- `php tests/smoke-visual-repair-css.php` → OK (87 assertions); `php -l` clean; zero remaining `block-artifact-compiler`/`block-format-bridge`/`bfb_`/`bac_` references on re-grep.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Drafting the implementation and verification under human review.
