### PR TITLE
Route preserved island JS to the companion plugin, not the theme (#488)

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -90,15 +90,23 @@ class Static_Site_Importer_Companion_Plugin {
 		);
 
 		$descriptor = array(
-			'schema'      => self::PAYLOAD_SCHEMA,
-			'slug'        => $plugin_slug,
-			'namespace'   => $block_namespace,
-			'site_slug'   => $site_slug,
-			'plugin_file' => $main_file,
-			'mu_plugin'   => $mu_plugin,
-			'block_names' => $block_names,
-			'loader_file' => '',
-			'files'       => $files,
+			'schema'         => self::PAYLOAD_SCHEMA,
+			'slug'           => $plugin_slug,
+			'namespace'      => $block_namespace,
+			'site_slug'      => $site_slug,
+			'plugin_file'    => $main_file,
+			'mu_plugin'      => $mu_plugin,
+			'block_names'    => $block_names,
+			// Handles of preserved island scripts the plugin carries + enqueues
+			// scoped. Exposed so the gate/diagnostics can account for preserved
+			// island JS as companion-plugin-carried (theme-independent) rather
+			// than theme-coupled.
+			'island_handles' => array_map(
+				static fn ( array $island ): string => (string) $island['handle'],
+				$preserved
+			),
+			'loader_file'    => '',
+			'files'          => $files,
 		);
 
 		if ( $mu_plugin ) {

--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -367,23 +367,31 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 	public static function companion_dependency_row( array $dependency, bool $waived ): array {
 		$active = self::companion_plugin_available( $dependency );
 
-		$block_names = array();
-		$payload     = isset( $dependency['payload'] ) && is_array( $dependency['payload'] ) ? $dependency['payload'] : array();
-		$scaffold    = empty( $payload ) ? null : Static_Site_Importer_Companion_Plugin::scaffold( $payload );
+		$block_names    = array();
+		$island_handles = array();
+		$payload        = isset( $dependency['payload'] ) && is_array( $dependency['payload'] ) ? $dependency['payload'] : array();
+		$scaffold       = empty( $payload ) ? null : Static_Site_Importer_Companion_Plugin::scaffold( $payload );
 		if ( is_array( $scaffold ) && isset( $scaffold['block_names'] ) && is_array( $scaffold['block_names'] ) ) {
 			$block_names = array_values( array_map( 'strval', $scaffold['block_names'] ) );
 		}
+		if ( is_array( $scaffold ) && isset( $scaffold['island_handles'] ) && is_array( $scaffold['island_handles'] ) ) {
+			$island_handles = array_values( array_map( 'strval', $scaffold['island_handles'] ) );
+		}
 
 		return array(
-			'type'        => 'companion_plugin',
-			'source'      => 'generated',
-			'slug'        => (string) ( $dependency['slug'] ?? '' ),
-			'plugin_file' => (string) ( $dependency['plugin_file'] ?? '' ),
-			'mu_plugin'   => ! empty( $dependency['mu_plugin'] ),
-			'required'    => true,
-			'active'      => $active,
-			'waived'      => $waived,
-			'block_names' => $block_names,
+			'type'           => 'companion_plugin',
+			'source'         => 'generated',
+			'slug'           => (string) ( $dependency['slug'] ?? '' ),
+			'plugin_file'    => (string) ( $dependency['plugin_file'] ?? '' ),
+			'mu_plugin'      => ! empty( $dependency['mu_plugin'] ),
+			'required'       => true,
+			'active'         => $active,
+			'waived'         => $waived,
+			'block_names'    => $block_names,
+			// Preserved island JS handles this companion carries + enqueues
+			// scoped; lets the gate/diagnostics treat preserved island JS as
+			// companion-plugin-carried instead of theme-coupled.
+			'island_handles' => $island_handles,
 		);
 	}
 

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -567,14 +567,24 @@ class Static_Site_Importer_Report_Diagnostics {
 		$source = 'companion_plugins.dependencies.' . $slug;
 
 		if ( ! empty( $row['active'] ) ) {
-			$report['diagnostics'][] = array(
-				'code'        => 'companion_plugin_present',
-				'severity'    => 'info',
-				'source'      => $source,
-				'message'     => sprintf( 'Companion plugin %s is active; generated blocks are available theme-independently.', $slug ),
-				'slug'        => $slug,
-				'block_names' => $row['block_names'] ?? array(),
+			$island_handles = isset( $row['island_handles'] ) && is_array( $row['island_handles'] ) ? $row['island_handles'] : array();
+			$present        = array(
+				'code'           => 'companion_plugin_present',
+				'severity'       => 'info',
+				'source'         => $source,
+				'message'        => sprintf( 'Companion plugin %s is active; generated blocks are available theme-independently.', $slug ),
+				'slug'           => $slug,
+				'block_names'    => $row['block_names'] ?? array(),
+				'island_handles' => $island_handles,
 			);
+			// Preserved island JS that rides the active companion plugin is
+			// carried theme-independently; flag the runtime-carried signal the
+			// honest gate looks for so this JS is not counted as lost.
+			if ( ! empty( $island_handles ) ) {
+				$present['runtime_carried'] = true;
+				$present['message']         = sprintf( 'Companion plugin %s is active; generated blocks and preserved island JS are carried theme-independently.', $slug );
+			}
+			$report['diagnostics'][] = $present;
 			return;
 		}
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -181,9 +181,11 @@ class Static_Site_Importer_Theme_Generator {
 			$writes[ $theme_dir . '/templates/page-' . $slug . '.html' ] = Static_Site_Importer_Theme_Materializer::content_template( '', $has_header_part, $has_footer_part );
 		}
 
-		if ( '' !== trim( $materialized['js'] ) ) {
-			$writes[ $theme_dir . '/assets/site.js' ] = $materialized['js'];
-		}
+		// Preserved island JS is theme-independent: it rides the generated
+		// companion plugin (scoped, enqueued from the plugin), never the theme.
+		// The theme deliberately no longer materializes an `assets/site.js`
+		// blob — that anti-pattern dies on theme switch. Legitimate per-asset
+		// site scripts still ride the theme via $materialized['scripts'].
 
 		self::analyze_generated_theme_block_documents( $writes, $theme_dir );
 		self::$conversion_report['theme_slug'] = $theme_slug;

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -809,7 +809,6 @@ class Static_Site_Importer_Theme_Materializer {
 	private static function functions_php( string $theme_slug, array $scripts = array(), array $stylesheets = array() ): string {
 		$style_handle     = sanitize_key( $theme_slug ) . '-style';
 		$editor_handle    = sanitize_key( $theme_slug ) . '-editor-style';
-		$script_handle    = sanitize_key( $theme_slug ) . '-site';
 		$script_lines     = '';
 		$stylesheet_lines = '';
 		$stylesheet_deps  = array();
@@ -874,9 +873,6 @@ class Static_Site_Importer_Theme_Materializer {
 			"add_action( 'wp_enqueue_scripts', static function (): void {\n" .
 			$stylesheet_lines .
 			"\twp_enqueue_style( '" . $style_handle . "', get_stylesheet_uri(), " . $stylesheet_dependencies . ", wp_get_theme()->get( 'Version' ) );\n" .
-			"\tif ( file_exists( get_template_directory() . '/assets/site.js' ) ) {\n" .
-			"\t\twp_enqueue_script( '" . $script_handle . "', get_template_directory_uri() . '/assets/site.js', array(), wp_get_theme()->get( 'Version' ), true );\n" .
-			"\t}\n" .
 			$script_lines .
 			"} );\n\n" .
 			"add_action( 'enqueue_block_editor_assets', static function (): void {\n" .

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Smoke coverage for the preserved-island-JS consumption seam (issue #488 SSI side).
+ *
+ * Proves that preserved custom JS rides the generated companion plugin
+ * (scoped, enqueued from the plugin, theme-independent) and NOT the generated
+ * theme. The blocks-engine producer that populates companion_plugin_payload's
+ * preserved_js slot is a separate later task, so the seam is exercised
+ * synthetically: a payload whose preserved_js carries one island.
+ *
+ * Run from the repository root:
+ * php tests/smoke-companion-plugin-js.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code, private string $message ) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		$title = strtolower( trim( $title ) );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title ) ?? '';
+		return trim( $title, '-' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.keyFound
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-companion-plugin.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+// Unique island marker so we can prove the same JS is NOT duplicated into the
+// theme. Generic; no fixture-specific strings.
+$island_body = 'window.__ssiIslandMarker=function(){return 42;};';
+$payload     = array(
+	'schema'       => Static_Site_Importer_Companion_Plugin::PAYLOAD_SCHEMA,
+	'site_slug'    => 'Example Site',
+	'site_name'    => 'Example Site',
+	'blocks'       => array(
+		array(
+			'name'       => 'Custom Hero',
+			'block_json' => array(
+				'title'    => 'Custom Hero',
+				'category' => 'design',
+			),
+			'render'     => '<div class="ssi-hero"><?php echo esc_html( $attributes["heading"] ?? "" ); ?></div>',
+		),
+	),
+	'preserved_js' => array(
+		array(
+			'handle'  => 'hero-island',
+			'content' => $island_body,
+			'block'   => 'ssi-example-site/custom-hero',
+		),
+	),
+);
+
+// 1. Companion plugin consumes preserved_js: scoped enqueue + island file +
+//    descriptor carriage. This is the payload -> scaffold() pass-through.
+$descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $payload );
+$assert( is_array( $descriptor ), 'scaffold-returns-descriptor', is_array( $descriptor ) ? '' : 'WP_Error returned' );
+
+if ( is_array( $descriptor ) ) {
+	$assert( array( 'hero-island' ) === ( $descriptor['island_handles'] ?? null ), 'descriptor-exposes-island-handles' );
+
+	$files = $descriptor['files'];
+	$main  = $files['ssi-example-site/ssi-example-site.php'] ?? '';
+	$assert( str_contains( $main, "add_filter( 'render_block'" ), 'companion-scopes-island-to-owning-block' );
+	$assert( str_contains( $main, 'wp_enqueue_script' ), 'companion-enqueues-island-js' );
+	$assert( str_contains( $main, "'block' => 'ssi-example-site/custom-hero'" ), 'companion-island-bound-to-block' );
+
+	$island_files = array_filter(
+		$files,
+		static fn ( string $content, string $path ): bool => str_contains( $path, '/islands/' ) && str_ends_with( $path, '.js' ),
+		ARRAY_FILTER_USE_BOTH
+	);
+	$assert( 1 === count( $island_files ), 'companion-emits-one-island-js-file' );
+	$assert( in_array( $island_body, array_values( $island_files ), true ), 'companion-island-file-carries-js-body' );
+}
+
+// 2. Theme decoupling: the generated theme functions.php no longer enqueues a
+//    theme-coupled site.js, and the preserved island JS body never lands in the
+//    theme. A legitimate per-asset script still rides the theme (path intact).
+$theme_dir   = '/tmp/ssi-theme';
+$legit_asset = 'assets/materialized/app.js';
+$writes      = Static_Site_Importer_Theme_Materializer::base_theme_writes(
+	$theme_dir,
+	'example-site',
+	'Example Site',
+	'body { color: #000; }',
+	false,
+	false,
+	array(
+		array(
+			'theme_path' => $legit_asset,
+			'placement'  => 'body',
+		),
+	),
+	array()
+);
+
+$functions_php = $writes[ $theme_dir . '/functions.php' ] ?? '';
+$assert( '' !== $functions_php, 'theme-functions-php-generated' );
+$assert( ! str_contains( $functions_php, 'site.js' ), 'theme-no-longer-enqueues-site-js' );
+$assert( ! str_contains( $functions_php, $island_body ), 'theme-does-not-carry-preserved-island-js' );
+$assert( ! isset( $writes[ $theme_dir . '/assets/site.js' ] ), 'theme-writes-omit-site-js-asset' );
+$write_blob = implode( "\n", array_values( $writes ) );
+$assert( ! str_contains( $write_blob, $island_body ), 'no-theme-write-carries-preserved-island-js' );
+// Theme path otherwise intact: legitimate per-asset scripts still enqueue.
+$assert( str_contains( $functions_php, $legit_asset ), 'theme-still-enqueues-legitimate-asset-scripts' );
+
+// 3. Gate/diagnostics account for the JS as companion-plugin-carried.
+$GLOBALS['ssi_companion_js_active'] = false;
+if ( ! function_exists( 'is_plugin_active' ) ) {
+	function is_plugin_active( string $plugin_file ): bool {
+		return ! empty( $GLOBALS['ssi_companion_js_active'] );
+	}
+}
+
+$dependency = Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_dependency( $payload );
+$row        = Static_Site_Importer_Entity_Materializer_Registry::companion_dependency_row( $dependency, false );
+$assert( array( 'hero-island' ) === ( $row['island_handles'] ?? null ), 'dependency-row-carries-island-handles' );
+
+// Active companion: present diagnostic flags JS as runtime-carried theme-independently.
+$GLOBALS['ssi_companion_js_active'] = true;
+$report                            = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( $report, $dependency, false );
+$present = array_values( array_filter( $report['diagnostics'] ?? array(), static fn ( array $d ): bool => 'companion_plugin_present' === ( $d['code'] ?? '' ) ) );
+$assert( 1 === count( $present ), 'present-diagnostic-emitted-when-active' );
+$assert( array( 'hero-island' ) === ( $present[0]['island_handles'] ?? null ), 'present-diagnostic-carries-island-handles' );
+$assert( true === ( $present[0]['runtime_carried'] ?? false ), 'present-diagnostic-flags-runtime-carried' );
+$stored = $report['companion_plugins']['dependencies']['ssi-example-site']['island_handles'] ?? null;
+$assert( array( 'hero-island' ) === $stored, 'report-stores-companion-island-handles' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: companion plugin JS consumption seam smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
Closes #488 (SSI side).

## What
Preserved custom JS now rides the generated **companion plugin** (scoped, enqueued from the plugin via a `render_block` filter keyed on the owning block) instead of the generated **theme**. The theme-coupled `assets/site.js` mechanism died on theme switch — the same anti-pattern SSI already rejects for custom blocks.

## Changes
- **Theme decoupling** (`theme-materializer.php`, `theme-generator.php`): the generated `functions.php` no longer enqueues a theme-coupled `assets/site.js`, and the theme no longer materializes that JS blob. Legitimate per-asset site scripts (`$materialized['scripts']`) still ride the theme — that path is untouched.
- **Consumption seam** (`companion-plugin.php`): the payload → `scaffold()` `preserved_js` pass-through already enqueues scoped; `scaffold()` now also exposes carried preserved-island handles (`island_handles`) in its descriptor so the carriage is observable.
- **Diagnostics accounting** (`entity-materializer-registry.php`, `report-diagnostics.php`): `companion_dependency_row()` reports `island_handles`, and the `companion_plugin_present` diagnostic flags `runtime_carried` so the honest gate counts preserved island JS as companion-plugin-carried (theme-independent) rather than lost.
- **Test** (`tests/smoke-companion-plugin-js.php`): synthetic payload with one `preserved_js` island → asserts it lands enqueued + scoped to its owning block in the scaffolded plugin and is absent from every generated theme write, while a legitimate per-asset theme script still enqueues (theme path intact). Mirrors how slice-1 was proven synthetically.

## Scope / reality
The `preserved_js` slot is empty until the **blocks-engine producer** populates it — that population is a **separate later blocks-engine task** (not touched here). This PR is the SSI consumption seam only, proven synthetically.

## Tests
All standalone PHP smoke tests pass (`php tests/smoke-*.php`), including the new seam test and the existing `smoke-companion-plugin.php`. The 3 pre-existing failures (`smoke-import-source-of-truth-manifest`, `smoke-static-interactive-artifact`, `smoke-website-artifact-document-metadata`) are the known `wp eval-file` ABSPATH baseline failures — they `exit(1)` without a WordPress runtime and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)