### PR TITLE
Wire generated block.json render file in companion-plugin scaffold

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -188,15 +188,17 @@ class Static_Site_Importer_Companion_Plugin {
 			);
 		}
 
-		$block_json = self::block_json( $block, $block_namespace . '/' . $name );
+		$render     = isset( $block['render'] ) && is_scalar( $block['render'] ) ? (string) $block['render'] : '';
+		$has_render = '' !== $render;
+
+		$block_json = self::block_json( $block, $block_namespace . '/' . $name, $has_render );
 		if ( is_wp_error( $block_json ) ) {
 			return $block_json;
 		}
 
 		$files = array( 'block.json' => $block_json );
 
-		$render = isset( $block['render'] ) && is_scalar( $block['render'] ) ? (string) $block['render'] : '';
-		if ( '' !== $render ) {
+		if ( $has_render ) {
 			$files['render.php'] = self::normalize_render( $render );
 		}
 
@@ -226,9 +228,10 @@ class Static_Site_Importer_Companion_Plugin {
 	 *
 	 * @param array<string,mixed> $block      Block payload entry.
 	 * @param string              $block_name Fully-qualified block name.
+	 * @param bool                $has_render Whether build_block writes a render.php for this block.
 	 * @return string|WP_Error
 	 */
-	private static function block_json( array $block, string $block_name ) {
+	private static function block_json( array $block, string $block_name, bool $has_render = false ) {
 		$raw = $block['block_json'] ?? null;
 		if ( is_string( $raw ) ) {
 			$decoded = json_decode( $raw, true );
@@ -253,6 +256,13 @@ class Static_Site_Importer_Companion_Plugin {
 		}
 		if ( ! isset( $decoded['apiVersion'] ) ) {
 			$decoded['apiVersion'] = 3;
+		}
+
+		// Wire the generated render.php so register_block_type() picks up the
+		// server-render callback. Respect any render value the upstream payload
+		// already declared, and never point a static block at a missing file.
+		if ( $has_render && ! isset( $decoded['render'] ) ) {
+			$decoded['render'] = 'file:./render.php';
 		}
 
 		return self::encode_json( $decoded );

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -153,9 +153,57 @@ if ( is_array( $descriptor ) ) {
 
 	$render = $files['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
 	$assert( str_starts_with( ltrim( $render ), '<?php' ), 'render-php-opens-with-php-tag' );
+	// A block with render content must wire block.json -> render.php so
+	// register_block_type() actually invokes the generated render callback.
+	$assert( '' !== $render, 'render-block-emits-render-php' );
+	$assert( is_array( $block_json ) && 'file:./render.php' === ( $block_json['render'] ?? '' ), 'block-json-wires-render-file', is_array( $block_json ) && isset( $block_json['render'] ) ? (string) $block_json['render'] : '(absent)' );
 
 	$island_files = array_filter( array_keys( $files ), static fn ( string $path ): bool => str_contains( $path, '/islands/' ) && str_ends_with( $path, '.js' ) );
 	$assert( 1 === count( $island_files ), 'preserved-island-js-file-emitted' );
+}
+
+// A static block (no render content) must not get a render key pointing at a
+// render.php that build_block never writes, and an upstream-declared render
+// value must be preserved verbatim rather than clobbered to file:./render.php.
+$render_variants = Static_Site_Importer_Companion_Plugin::scaffold(
+	array(
+		'schema'    => Static_Site_Importer_Companion_Plugin::PAYLOAD_SCHEMA,
+		'site_slug' => 'render-variants',
+		'site_name' => 'Render Variants',
+		'blocks'    => array(
+			array(
+				'name'       => 'Static Card',
+				'block_json' => array(
+					'title'    => 'Static Card',
+					'category' => 'design',
+				),
+			),
+			array(
+				'name'       => 'Declared Render',
+				'block_json' => array(
+					'title'    => 'Declared Render',
+					'category' => 'design',
+					'render'   => 'file:./custom-render.php',
+				),
+				'render'     => '<div class="ssi-declared"></div>',
+			),
+		),
+	)
+);
+$assert( is_array( $render_variants ), 'render-variants-scaffold-returns-descriptor', is_array( $render_variants ) ? '' : 'WP_Error returned' );
+
+if ( is_array( $render_variants ) ) {
+	$variant_files = $render_variants['files'];
+
+	$static_json_raw = $variant_files['ssi-render-variants/blocks/static-card/block.json'] ?? '';
+	$static_json     = json_decode( $static_json_raw, true );
+	$assert( is_array( $static_json ) && ! isset( $static_json['render'] ), 'static-block-json-omits-render-key', is_array( $static_json ) && isset( $static_json['render'] ) ? (string) $static_json['render'] : '(absent)' );
+	$assert( ! isset( $variant_files['ssi-render-variants/blocks/static-card/render.php'] ), 'static-block-emits-no-render-php' );
+
+	$declared_json_raw = $variant_files['ssi-render-variants/blocks/declared-render/block.json'] ?? '';
+	$declared_json     = json_decode( $declared_json_raw, true );
+	$assert( is_array( $declared_json ) && 'file:./custom-render.php' === ( $declared_json['render'] ?? '' ), 'block-json-preserves-upstream-render', is_array( $declared_json ) && isset( $declared_json['render'] ) ? (string) $declared_json['render'] : '(absent)' );
+	$assert( isset( $variant_files['ssi-render-variants/blocks/declared-render/render.php'] ), 'declared-render-block-emits-render-php' );
 }
 
 // mu-plugin variant materializes a root loader stub.


### PR DESCRIPTION
## What
Fixes a latent bug in the companion-plugin scaffold (from #492): `build_block()` writes a `render.php` whenever a block has render content, but `block_json()` never declared `"render": "file:./render.php"`. So `register_block_type()` read a block.json with no render callback and silently ignored the generated `render.php` — dynamic/server-rendered companion blocks would not render. This is dormant today (no payload producer yet) but would bite as soon as slice 2 lands, so fixing it now.

## Change (`includes/class-static-site-importer-companion-plugin.php`)
- `build_block()` computes render presence once and passes it to `block_json()`.
- `block_json()` injects `"render": "file:./render.php"` **only** when the block actually has render content, and **only if** the upstream payload's block.json hasn't already declared a `render` value (so a payload-declared `file:./custom-render.php` is preserved). Static blocks get no render key.

## Verification
- `php tests/smoke-companion-plugin.php` → **OK: 58 assertions** (was 51). New assertions: render block wires `render: file:./render.php` + emits render.php; static block omits render key + emits no render.php; upstream-declared render value is preserved.
- `php -l` clean on both files. Smoke test is pure (stubs WP), runs standalone.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosing and fixing the bug + tests under human review.
