### PR TITLE
Centralize site-identity derivation into one primitive (#501)

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -31,6 +31,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Site_Identity' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-site-identity.php';
+}
+
 /**
  * Scaffolds a one-per-site companion plugin from a generated block payload.
  */
@@ -174,13 +178,30 @@ class Static_Site_Importer_Companion_Plugin {
 	/**
 	 * Human-readable site name for plugin headers.
 	 *
+	 * The display name follows the shared site-identity priority (site_name ->
+	 * name -> site_title) so the companion plugin header matches the theme name
+	 * derived from the same source. A payload that carries only a slug keeps the
+	 * slug as its display name rather than the generic identity constant.
+	 *
 	 * @param array<string,mixed> $payload   Generated companion-plugin payload.
 	 * @param string              $site_slug Sanitized site slug.
 	 * @return string
 	 */
 	private static function site_name( array $payload, string $site_slug ): string {
-		$raw = isset( $payload['site_name'] ) && is_scalar( $payload['site_name'] ) ? trim( (string) $payload['site_name'] ) : '';
-		return '' !== $raw ? $raw : $site_slug;
+		$identity = Static_Site_Importer_Site_Identity::resolve(
+			array(
+				'site_title' => isset( $payload['site_name'] ) && is_scalar( $payload['site_name'] ) ? (string) $payload['site_name'] : '',
+				'name'       => isset( $payload['name'] ) && is_scalar( $payload['name'] ) ? (string) $payload['name'] : '',
+				'title'      => isset( $payload['site_title'] ) && is_scalar( $payload['site_title'] ) ? (string) $payload['site_title'] : '',
+			)
+		);
+
+		$name = $identity['name'];
+		if ( Static_Site_Importer_Site_Identity::DEFAULT_NAME === $name || Static_Site_Importer_Site_Identity::default_name() === $name ) {
+			return $site_slug;
+		}
+
+		return $name;
 	}
 
 	/**

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Site_Identity' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-site-identity.php';
+}
+
 /**
  * Creates, updates, and describes WordPress pages from source pages.
  */
@@ -239,9 +243,9 @@ class Static_Site_Importer_Page_Materializer {
 			return 'Home';
 		}
 
-		$title = preg_replace( '/\s+(?:\x{2014}|-)\s+.+$/u', '', $page->document()->title() );
-		if ( '' !== trim( (string) $title ) ) {
-			return trim( (string) $title );
+		$title = Static_Site_Importer_Site_Identity::strip_title_suffix( $page->document()->title() );
+		if ( '' !== trim( $title ) ) {
+			return trim( $title );
 		}
 
 		return ucwords( str_replace( '-', ' ', self::page_slug( $filename, $page ) ) );

--- a/includes/class-static-site-importer-site-identity.php
+++ b/includes/class-static-site-importer-site-identity.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * Site-identity primitive.
+ *
+ * Single source of truth for deriving a site's { name, slug, title } from an
+ * import source. Every consumer (REST playground fallback, theme generator,
+ * companion plugin, page materializer) resolves identity through this class so
+ * the human-facing name, the theme/plugin slug, and the extracted document
+ * title stay consistent instead of drifting toward a generic constant.
+ *
+ * Deterministic priority:
+ * - name/title: explicit site_title/name arg -> source document <title>
+ *   (extracted + suffix-stripped) -> source URL host -> generic constant.
+ * - slug: explicit slug arg -> sanitize_title(name) -> host -> generic constant.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolves a canonical { name, slug, title } identity from an import source.
+ */
+class Static_Site_Importer_Site_Identity {
+
+	/**
+	 * Last-resort slug when no usable name, document title, or host is available.
+	 */
+	public const DEFAULT_SLUG = 'generated-wordpress-website';
+
+	/**
+	 * Last-resort human-readable name (untranslated) when nothing else is usable.
+	 */
+	public const DEFAULT_NAME = 'Generated WordPress Website';
+
+	/**
+	 * Resolve a canonical site identity from an import context.
+	 *
+	 * Recognized context keys (all optional):
+	 * - site_title / name / title: explicit, highest-priority human name.
+	 * - slug: explicit slug override.
+	 * - document_title: a pre-extracted raw document title (suffix-stripped here).
+	 * - html: raw HTML to extract a <title> from.
+	 * - artifact: a website artifact bundle whose entrypoint <title> is used.
+	 * - url / source_url: the source URL, used for the host fallback.
+	 *
+	 * @param array<string,mixed> $context Identity resolution context.
+	 * @return array{name:string,slug:string,title:string}
+	 */
+	public static function resolve( array $context ): array {
+		$name = self::resolve_name( $context );
+		$slug = self::resolve_slug( $context, $name );
+
+		return array(
+			'name'  => $name,
+			'slug'  => $slug,
+			'title' => $name,
+		);
+	}
+
+	/**
+	 * Resolve the human-readable site name following the canonical priority.
+	 *
+	 * @param array<string,mixed> $context Identity resolution context.
+	 * @return string
+	 */
+	private static function resolve_name( array $context ): string {
+		foreach ( array( 'site_title', 'name', 'title' ) as $key ) {
+			if ( isset( $context[ $key ] ) && is_scalar( $context[ $key ] ) ) {
+				$explicit = self::sanitize_name( (string) $context[ $key ] );
+				if ( '' !== $explicit ) {
+					return $explicit;
+				}
+			}
+		}
+
+		$document_title = self::document_title_from_context( $context );
+		if ( '' !== $document_title ) {
+			return $document_title;
+		}
+
+		$host = self::host_name_from_context( $context );
+		if ( '' !== $host ) {
+			return $host;
+		}
+
+		return self::default_name();
+	}
+
+	/**
+	 * Resolve the slug following the canonical priority.
+	 *
+	 * @param array<string,mixed> $context Identity resolution context.
+	 * @param string              $name    Resolved site name.
+	 * @return string
+	 */
+	private static function resolve_slug( array $context, string $name ): string {
+		if ( isset( $context['slug'] ) && is_scalar( $context['slug'] ) ) {
+			$explicit = self::sanitize_slug( (string) $context['slug'] );
+			if ( '' !== $explicit ) {
+				return $explicit;
+			}
+		}
+
+		$from_name = self::sanitize_slug( $name );
+		if ( '' !== $from_name ) {
+			return $from_name;
+		}
+
+		$from_host = self::sanitize_slug( self::host_name_from_context( $context ) );
+		if ( '' !== $from_host ) {
+			return $from_host;
+		}
+
+		return self::DEFAULT_SLUG;
+	}
+
+	/**
+	 * Produce a collision-free slug by appending -2, -3, ... when taken.
+	 *
+	 * @param string                $desired  Desired slug.
+	 * @param callable(string):bool $is_taken Returns true when a slug is already in use.
+	 * @return string
+	 */
+	public static function unique_slug( string $desired, callable $is_taken ): string {
+		$desired = self::sanitize_slug( $desired );
+		if ( '' === $desired ) {
+			$desired = self::DEFAULT_SLUG;
+		}
+
+		if ( ! $is_taken( $desired ) ) {
+			return $desired;
+		}
+
+		$suffix = 2;
+		do {
+			$candidate = $desired . '-' . $suffix;
+			++$suffix;
+		} while ( $is_taken( $candidate ) );
+
+		return $candidate;
+	}
+
+	/**
+	 * Strip a trailing " — suffix" / " | suffix" / " - suffix" from a title.
+	 *
+	 * Shared so page titles, theme names, and the REST fallback all collapse
+	 * "Maya & Devon — Home" to "Maya & Devon" identically.
+	 *
+	 * @param string $title Raw title.
+	 * @return string
+	 */
+	public static function strip_title_suffix( string $title ): string {
+		$title = trim( $title );
+		if ( '' === $title ) {
+			return '';
+		}
+
+		$parts = preg_split( '/\s+(?:\||\x{2014}|\x{2013}|-)\s+/u', $title );
+		$first = is_array( $parts ) && isset( $parts[0] ) ? trim( (string) $parts[0] ) : $title;
+
+		return '' !== $first ? $first : $title;
+	}
+
+	/**
+	 * Extract a cleaned, suffix-stripped title from a raw HTML document.
+	 *
+	 * @param string $html HTML document.
+	 * @return string
+	 */
+	public static function title_from_html( string $html ): string {
+		if ( '' === trim( $html ) || ! preg_match( '/<title[^>]*>(.*?)<\/title>/is', $html, $matches ) ) {
+			return '';
+		}
+
+		return self::clean_title( (string) $matches[1] );
+	}
+
+	/**
+	 * Extract the entrypoint document title from a website artifact bundle.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @return string
+	 */
+	public static function title_from_website_artifact( array $artifact ): string {
+		$entrypoint = isset( $artifact['entrypoint'] ) && is_scalar( $artifact['entrypoint'] ) ? self::normalize_route_path( (string) $artifact['entrypoint'] ) : '';
+		$files      = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
+
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$path = isset( $file['path'] ) && is_scalar( $file['path'] ) ? self::normalize_route_path( (string) $file['path'] ) : '';
+			if ( '' === $path || ( '' !== $entrypoint && $path !== $entrypoint ) ) {
+				continue;
+			}
+
+			$content = isset( $file['content'] ) && is_scalar( $file['content'] ) ? (string) $file['content'] : '';
+			$title   = self::title_from_html( $content );
+			if ( '' !== $title ) {
+				return $title;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Resolve the bare host (minus a leading www.) from a source URL.
+	 *
+	 * @param string $url Source URL.
+	 * @return string
+	 */
+	public static function host_from_url( string $url ): string {
+		$url = trim( $url );
+		if ( '' === $url ) {
+			return '';
+		}
+
+		if ( function_exists( 'wp_parse_url' ) ) {
+			$host = wp_parse_url( $url, PHP_URL_HOST );
+		} else {
+			$parsed = parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- WordPress wp_parse_url is unavailable in this runtime-free path.
+			$host   = is_array( $parsed ) && isset( $parsed['host'] ) ? $parsed['host'] : '';
+		}
+		$host = is_string( $host ) ? strtolower( trim( $host ) ) : '';
+		if ( '' === $host ) {
+			return '';
+		}
+
+		if ( str_starts_with( $host, 'www.' ) ) {
+			$host = substr( $host, 4 );
+		}
+
+		return $host;
+	}
+
+	/**
+	 * The translated last-resort site name.
+	 *
+	 * @return string
+	 */
+	public static function default_name(): string {
+		return function_exists( '__' ) ? __( 'Generated WordPress Website', 'static-site-importer' ) : self::DEFAULT_NAME;
+	}
+
+	/**
+	 * Resolve a document title from the context's document/html/artifact inputs.
+	 *
+	 * @param array<string,mixed> $context Identity resolution context.
+	 * @return string
+	 */
+	private static function document_title_from_context( array $context ): string {
+		if ( isset( $context['document_title'] ) && is_scalar( $context['document_title'] ) ) {
+			$title = self::clean_title( (string) $context['document_title'] );
+			if ( '' !== $title ) {
+				return $title;
+			}
+		}
+
+		if ( isset( $context['html'] ) && is_scalar( $context['html'] ) ) {
+			$title = self::title_from_html( (string) $context['html'] );
+			if ( '' !== $title ) {
+				return $title;
+			}
+		}
+
+		if ( isset( $context['artifact'] ) && is_array( $context['artifact'] ) ) {
+			$title = self::title_from_website_artifact( $context['artifact'] );
+			if ( '' !== $title ) {
+				return $title;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Resolve the host fallback name from the context's URL inputs.
+	 *
+	 * @param array<string,mixed> $context Identity resolution context.
+	 * @return string
+	 */
+	private static function host_name_from_context( array $context ): string {
+		foreach ( array( 'url', 'source_url' ) as $key ) {
+			if ( isset( $context[ $key ] ) && is_scalar( $context[ $key ] ) ) {
+				$host = self::host_from_url( (string) $context[ $key ] );
+				if ( '' !== $host ) {
+					return $host;
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Decode, tag-strip, suffix-strip, and sanitize a raw title fragment.
+	 *
+	 * @param string $raw Raw title fragment.
+	 * @return string
+	 */
+	private static function clean_title( string $raw ): string {
+		$title = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $raw ) : preg_replace( '/<[^>]*>/', '', $raw );
+		$title = html_entity_decode( trim( (string) $title ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$title = self::strip_title_suffix( $title );
+
+		return self::sanitize_name( $title );
+	}
+
+	/**
+	 * Sanitize a human-readable name.
+	 *
+	 * @param string $name Raw name.
+	 * @return string
+	 */
+	private static function sanitize_name( string $name ): string {
+		$name = trim( $name );
+		if ( '' === $name ) {
+			return '';
+		}
+
+		return function_exists( 'sanitize_text_field' ) ? sanitize_text_field( $name ) : trim( (string) preg_replace( '/<[^>]*>/', '', $name ) );
+	}
+
+	/**
+	 * Sanitize a slug, with a runtime-independent fallback.
+	 *
+	 * @param string $value Raw slug source.
+	 * @return string
+	 */
+	private static function sanitize_slug( string $value ): string {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			return '';
+		}
+
+		if ( function_exists( 'sanitize_title' ) ) {
+			$sanitized = sanitize_title( $value );
+			if ( '' !== $sanitized ) {
+				return $sanitized;
+			}
+		}
+
+		$value = strtolower( $value );
+		$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+
+		return trim( (string) $value, '-' );
+	}
+
+	/**
+	 * Normalize an artifact route path for entrypoint matching.
+	 *
+	 * @param string $path Raw path.
+	 * @return string
+	 */
+	private static function normalize_route_path( string $path ): string {
+		$path_without_query = strtok( $path, '?' );
+		$path               = str_replace( '\\', '/', false === $path_without_query ? $path : $path_without_query );
+		$path               = ltrim( $path, '/' );
+		$segments           = array();
+		foreach ( explode( '/', $path ) as $segment ) {
+			if ( '' === $segment || '.' === $segment ) {
+				continue;
+			}
+
+			if ( '..' === $segment ) {
+				array_pop( $segments );
+				continue;
+			}
+
+			$segments[] = $segment;
+		}
+
+		return implode( '/', $segments );
+	}
+}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -15,6 +15,10 @@ if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-transformer-adapter.php';
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Site_Identity' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-site-identity.php';
+}
+
 /**
  * Generates a block theme from a static HTML document.
  */
@@ -52,11 +56,29 @@ class Static_Site_Importer_Theme_Generator {
 		if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
 			return new WP_Error( 'static_site_importer_missing_transformer_adapter', 'Static Site Importer transformer adapter is required to import a website artifact.' );
 		}
+		// site_title (blogname) intentionally stays restricted to an explicit arg
+		// or a real extracted document title; it never falls back to the host or
+		// generic constant the way the theme name/slug do.
 		if ( empty( $args['site_title'] ) ) {
-			$site_title = self::site_title_from_website_artifact( $artifact );
+			$site_title = Static_Site_Importer_Site_Identity::title_from_website_artifact( $artifact );
 			if ( '' !== $site_title ) {
 				$args['site_title'] = $site_title;
 			}
+		}
+		$identity = Static_Site_Importer_Site_Identity::resolve(
+			array(
+				'site_title' => isset( $args['site_title'] ) ? (string) $args['site_title'] : '',
+				'name'       => isset( $args['name'] ) ? (string) $args['name'] : '',
+				'slug'       => isset( $args['slug'] ) ? (string) $args['slug'] : '',
+				'artifact'   => $artifact,
+				'url'        => isset( $args['url'] ) ? (string) $args['url'] : '',
+			)
+		);
+		if ( empty( $args['name'] ) ) {
+			$args['name'] = $identity['name'];
+		}
+		if ( empty( $args['slug'] ) ) {
+			$args['slug'] = $identity['slug'];
 		}
 		if ( empty( $args['source_artifact_reference'] ) ) {
 			$args['source_artifact_reference'] = self::source_artifact_reference_from_artifact( $artifact, $args );
@@ -88,12 +110,16 @@ class Static_Site_Importer_Theme_Generator {
 	 */
 	private static function import_compiled_website_artifact( array $compiled, array $args = array() ) {
 		$artifacts    = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
-		$theme_name   = isset( $args['name'] ) && '' !== trim( (string) $args['name'] ) ? sanitize_text_field( (string) $args['name'] ) : 'Imported Website Artifact';
-		$theme_slug   = isset( $args['slug'] ) && '' !== trim( (string) $args['slug'] ) ? sanitize_title( (string) $args['slug'] ) : sanitize_title( $theme_name );
+		$identity     = Static_Site_Importer_Site_Identity::resolve(
+			array(
+				'site_title' => isset( $args['site_title'] ) ? (string) $args['site_title'] : '',
+				'name'       => isset( $args['name'] ) ? (string) $args['name'] : '',
+				'slug'       => isset( $args['slug'] ) ? (string) $args['slug'] : '',
+			)
+		);
+		$theme_name   = $identity['name'];
+		$theme_slug   = $identity['slug'];
 		$site_title   = isset( $args['site_title'] ) && '' !== trim( (string) $args['site_title'] ) ? sanitize_text_field( (string) $args['site_title'] ) : '';
-		if ( '' === $theme_slug ) {
-			$theme_slug = 'imported-website-artifact';
-		}
 
 		$theme_root = get_theme_root();
 		$theme_dir  = trailingslashit( $theme_root ) . $theme_slug;
@@ -1415,37 +1441,6 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return $refs;
-	}
-
-	/**
-	 * Infer a WordPress site title from the source artifact entrypoint.
-	 *
-	 * @param array<string,mixed> $artifact Website artifact bundle.
-	 * @return string
-	 */
-	private static function site_title_from_website_artifact( array $artifact ): string {
-		$entrypoint = isset( $artifact['entrypoint'] ) && is_scalar( $artifact['entrypoint'] ) ? self::normalize_route_path( (string) $artifact['entrypoint'] ) : '';
-		$files      = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
-		foreach ( $files as $file ) {
-			if ( ! is_array( $file ) ) {
-				continue;
-			}
-			$path = isset( $file['path'] ) && is_scalar( $file['path'] ) ? self::normalize_route_path( (string) $file['path'] ) : '';
-			if ( '' === $path || ( '' !== $entrypoint && $path !== $entrypoint ) ) {
-				continue;
-			}
-			$content = isset( $file['content'] ) && is_scalar( $file['content'] ) ? (string) $file['content'] : '';
-			if ( '' === trim( $content ) || ! preg_match( '/<title[^>]*>(.*?)<\/title>/is', $content, $matches ) ) {
-				continue;
-			}
-
-			$title = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( (string) $matches[1] ) : preg_replace( '/<[^>]*>/', '', (string) $matches[1] );
-			$title = html_entity_decode( trim( $title ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
-			$title = preg_split( '/\s+(?:\||\x{2014}|\x{2013}|-)\s+/u', $title )[0] ?? $title;
-			return function_exists( 'sanitize_text_field' ) ? sanitize_text_field( trim( $title ) ) : trim( preg_replace( '/<[^>]*>/', '', $title ) );
-		}
-
-		return '';
 	}
 
 	/**

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Site_Identity' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-site-identity.php';
+}
+
 /**
  * Register Static Site Importer REST routes.
  *
@@ -471,18 +475,28 @@ function static_site_importer_rest_should_apply_to_current_site( array $params )
 function static_site_importer_rest_open_in_playground( array $source, array $input ) {
 	$input['activate']  = true;
 	$input['overwrite'] = true;
-	if ( empty( $input['slug'] ) ) {
-		$input['slug'] = 'generated-wordpress-website';
-	}
-	if ( empty( $input['name'] ) ) {
-		$input['name'] = __( 'Generated WordPress Website', 'static-site-importer' );
-	}
 
 	$artifact = static_site_importer_rest_source_artifact( $source );
 	if ( is_wp_error( $artifact ) ) {
 		return $artifact;
 	}
 	$input['artifact'] = $artifact;
+
+	$identity = Static_Site_Importer_Site_Identity::resolve(
+		array(
+			'site_title' => isset( $input['site_title'] ) ? (string) $input['site_title'] : '',
+			'name'       => isset( $input['name'] ) ? (string) $input['name'] : '',
+			'slug'       => isset( $input['slug'] ) ? (string) $input['slug'] : '',
+			'artifact'   => $artifact,
+			'url'        => isset( $source['url'] ) ? (string) $source['url'] : '',
+		)
+	);
+	if ( empty( $input['name'] ) ) {
+		$input['name'] = $identity['name'];
+	}
+	if ( empty( $input['slug'] ) ) {
+		$input['slug'] = $identity['slug'];
+	}
 
 	$result = static_site_importer_rest_create_playground_open( $artifact, $input, isset( $source['figma_file'] ) ? 'figma_file' : 'upload' );
 	if ( is_wp_error( $result ) ) {

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -46,6 +46,7 @@ foreach ( $static_site_importer_figma_transformers as $static_site_importer_figm
 	require_once $static_site_importer_figma_transformer;
 }
 
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-site-identity.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-source-page.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-fetcher.php';

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -30,6 +30,11 @@ const importFixture = skipImport ? fixture : prepareImportFixture( fixture );
 
 const steps = [
   {
+    name: 'Site identity smoke',
+    command: 'php',
+    args: [ path.join( repoRoot, 'tests/smoke-site-identity.php' ) ],
+  },
+  {
     name: 'Transformer adapter smoke',
     command: 'php',
     args: [ path.join( repoRoot, 'tests/smoke-transformer-adapter.php' ) ],

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -748,10 +748,32 @@ $assert( 'https://github.com/Automattic/static-site-importer/releases/latest/dow
 $assert( str_contains( (string) $playground_blueprint_code, 'static_site_importer_ability_import_website_artifact' ), 'rest-playground-open-blueprint-runs-import-ability' );
 $assert( str_contains( (string) $playground_blueprint_code, "'activate' => true" ), 'rest-playground-open-blueprint-activates-generated-site' );
 $assert( str_contains( (string) $playground_blueprint_code, "'overwrite' => true" ), 'rest-playground-open-blueprint-overwrites-generated-site' );
+// Sourceless HTML (no <title>, no URL) still falls back to the generic identity constant.
 $assert( str_contains( (string) $playground_blueprint_code, "'slug' => 'generated-wordpress-website'" ), 'rest-playground-open-blueprint-uses-non-legacy-generated-theme-slug' );
 $assert( str_contains( (string) $playground_blueprint_code, "'name' => 'Generated WordPress Website'" ), 'rest-playground-open-blueprint-uses-generated-theme-name' );
 $assert( ! str_contains( (string) $playground_blueprint_code, 'imported-website-artifact' ), 'rest-playground-open-blueprint-omits-legacy-theme-slug' );
 $assert( ! str_contains( (string) $playground_blueprint_code, 'Codebox' ), 'rest-playground-open-blueprint-does-not-introduce-codebox' );
+
+// A real source document title now names the generated theme/site via the
+// site-identity primitive instead of collapsing to the generic constant.
+Static_Site_Importer_Theme_Generator::$last_args = array();
+$titled_playground_response = static_site_importer_rest_create_import(
+	new WP_REST_Request(
+		array(
+			'apply_to_current_site' => false,
+			'open_in_playground'    => true,
+			'source'                => array(
+				'html' => '<!doctype html><html><head><title>Maya &amp; Devon &#8212; Home</title></head><body><main>Generate</main></body></html>',
+			),
+		)
+	)
+);
+$titled_blueprint_json = rawurldecode( substr( (string) ( $titled_playground_response['preview']['playground']['blueprint_url'] ?? '' ), strlen( 'https://playground.wordpress.net/#' ) ) );
+$titled_blueprint      = json_decode( $titled_blueprint_json, true );
+$titled_blueprint_code = wp_json_encode( is_array( $titled_blueprint ) ? $titled_blueprint : array() );
+$assert( str_contains( (string) $titled_blueprint_code, "'name' => 'Maya & Devon'" ), 'rest-playground-open-derives-name-from-source-document-title' );
+$assert( str_contains( (string) $titled_blueprint_code, "'slug' => 'maya-devon'" ), 'rest-playground-open-derives-slug-from-source-document-title' );
+$assert( ! str_contains( (string) $titled_blueprint_code, 'generated-wordpress-website' ), 'rest-playground-open-titled-source-omits-generic-constant' );
 
 $figma_upload_artifact = Static_Site_Importer_Figma_Import::website_artifact_from_input(
 	array(

--- a/tests/smoke-site-identity.php
+++ b/tests/smoke-site-identity.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Smoke test: site-identity primitive priority chain.
+ *
+ * Run from the repository root:
+ * php tests/smoke-site-identity.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = '' ): string {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $text ): string {
+		return trim( strip_tags( $text ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		return trim( (string) preg_replace( '/[^a-z0-9\-]+/', '-', strtolower( $title ) ), '-' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( string $text ): string {
+		return trim( strip_tags( $text ) );
+	}
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( string $url, int $component = -1 ) {
+		return parse_url( $url, $component );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-site-identity.php';
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+// 1. Explicit site_title wins over everything.
+$identity = Static_Site_Importer_Site_Identity::resolve(
+	array(
+		'site_title' => 'Explicit Brand',
+		'html'       => '<title>Document Title</title>',
+		'url'        => 'https://maya-devon.example/',
+	)
+);
+$assert( 'Explicit Brand' === $identity['name'], 'explicit-site-title-wins-name', $identity['name'] );
+$assert( 'explicit-brand' === $identity['slug'], 'explicit-site-title-derives-slug', $identity['slug'] );
+$assert( $identity['title'] === $identity['name'], 'title-mirrors-name' );
+
+// 2. Document title (suffix stripped) used when no explicit name.
+$identity = Static_Site_Importer_Site_Identity::resolve(
+	array(
+		'html' => '<!doctype html><head><title>Maya &amp; Devon &#8212; Home</title></head>',
+		'url'  => 'https://fallback.example/',
+	)
+);
+$assert( 'Maya & Devon' === $identity['name'], 'document-title-strips-suffix-and-decodes', $identity['name'] );
+$assert( 'maya-devon' === $identity['slug'], 'document-title-derives-slug', $identity['slug'] );
+
+// 3. Website-artifact entrypoint title resolves identically to raw HTML.
+$identity = Static_Site_Importer_Site_Identity::resolve(
+	array(
+		'artifact' => array(
+			'entrypoint' => 'website/index.html',
+			'files'      => array(
+				array(
+					'path'    => 'website/index.html',
+					'content' => '<html><head><title>Northline Plumbing | Grand Rapids</title></head></html>',
+				),
+			),
+		),
+	)
+);
+$assert( 'Northline Plumbing' === $identity['name'], 'artifact-entrypoint-title-strips-pipe-suffix', $identity['name'] );
+
+// 4. URL host fallback (minus www.) when no title is available.
+$identity = Static_Site_Importer_Site_Identity::resolve(
+	array(
+		'url' => 'https://www.Acme-Co.example/path?x=1',
+	)
+);
+$assert( 'acme-co.example' === $identity['name'], 'host-fallback-drops-www-and-lowercases', $identity['name'] );
+
+// 5. Generic constant only as a last resort.
+$identity = Static_Site_Importer_Site_Identity::resolve( array( 'html' => '<main>No title here</main>' ) );
+$assert( Static_Site_Importer_Site_Identity::DEFAULT_NAME === $identity['name'], 'constant-last-resort-name', $identity['name'] );
+$assert( Static_Site_Importer_Site_Identity::DEFAULT_SLUG === $identity['slug'], 'constant-last-resort-slug', $identity['slug'] );
+
+// 6. Explicit slug override wins over the name-derived slug.
+$identity = Static_Site_Importer_Site_Identity::resolve(
+	array(
+		'name' => 'Maya & Devon',
+		'slug' => 'Custom Slug Override',
+	)
+);
+$assert( 'custom-slug-override' === $identity['slug'], 'explicit-slug-override-wins', $identity['slug'] );
+$assert( 'Maya & Devon' === $identity['name'], 'explicit-name-preserved-with-slug-override', $identity['name'] );
+
+// 7. Shared suffix-strip handles em-dash, en-dash, pipe, and hyphen separators.
+$assert( 'Maya & Devon' === Static_Site_Importer_Site_Identity::strip_title_suffix( 'Maya & Devon — Home' ), 'strip-em-dash' );
+$assert( 'Maya & Devon' === Static_Site_Importer_Site_Identity::strip_title_suffix( 'Maya & Devon – Home' ), 'strip-en-dash' );
+$assert( 'Maya & Devon' === Static_Site_Importer_Site_Identity::strip_title_suffix( 'Maya & Devon | Home' ), 'strip-pipe' );
+$assert( 'Maya & Devon' === Static_Site_Importer_Site_Identity::strip_title_suffix( 'Maya & Devon - Home' ), 'strip-hyphen' );
+$assert( 'Single' === Static_Site_Importer_Site_Identity::strip_title_suffix( 'Single' ), 'strip-no-separator-keeps-title' );
+$assert( 'co-op' === Static_Site_Importer_Site_Identity::strip_title_suffix( 'co-op' ), 'strip-keeps-intra-word-hyphen' );
+
+// 8. Uniqueness suffix appends -2, -3, ... against a taken-check.
+$taken     = array( 'maya-devon' => true, 'maya-devon-2' => true );
+$is_taken  = static fn ( string $slug ): bool => isset( $taken[ $slug ] );
+$assert( 'maya-devon-3' === Static_Site_Importer_Site_Identity::unique_slug( 'maya-devon', $is_taken ), 'unique-slug-appends-next-free-suffix' );
+$assert( 'fresh-slug' === Static_Site_Importer_Site_Identity::unique_slug( 'fresh-slug', $is_taken ), 'unique-slug-returns-desired-when-free' );
+$assert( Static_Site_Importer_Site_Identity::DEFAULT_SLUG === Static_Site_Importer_Site_Identity::unique_slug( '', static fn ( string $slug ): bool => false ), 'unique-slug-falls-back-to-constant-when-empty' );
+
+if ( empty( $failures ) ) {
+	echo 'OK: site identity smoke passed (' . (int) $assertions . " assertions)\n";
+	exit( 0 );
+}
+
+echo "FAIL: site identity smoke\n";
+foreach ( $failures as $failure ) {
+	echo $failure . "\n";
+}
+exit( 1 );

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -373,9 +373,7 @@ $assert( $target_route_page instanceof Static_Site_Importer_Source_Page && 'home
 $assert( $target_route_page instanceof Static_Site_Importer_Source_Page && '1' === $target_route_page->metadata_value( 'entrypoint' ), 'materialization-plan-target-root-route-preserves-entrypoint' );
 $assert( $target_route_page instanceof Static_Site_Importer_Source_Page && str_contains( $target_route_page->body(), 'Nested home' ), 'materialization-plan-target-route-page-body-is-preserved' );
 
-$site_title_from_artifact = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'site_title_from_website_artifact' );
-$site_title               = $site_title_from_artifact->invoke(
-	null,
+$site_title = Static_Site_Importer_Site_Identity::title_from_website_artifact(
 	array(
 		'entrypoint' => 'website/nested/index.html',
 		'files'      => array(


### PR DESCRIPTION
Closes #501

## Problem
"Site identity" (name / slug / title) was derived inconsistently across ~6 places with no source of truth. The **real** document title was extracted for page titles, but the generated **theme** and **companion plugin** fell back to a generic constant, so every import produced theme `generated-wordpress-website` + plugin `ssi-generated-wordpress-website` — which collide at multi-site / website-generation scale.

## The primitive
New `Static_Site_Importer_Site_Identity` (`includes/class-static-site-importer-site-identity.php`) is the single source of truth.

`resolve( array $context ): { name, slug, title }` with one deterministic priority:

- **name/title:** explicit `site_title`/`name` arg → source document `<title>` (extracted + suffix-stripped) → source URL host (`wp_parse_url(... HOST)`, minus leading `www.`) → constant `Generated WordPress Website` (last resort only).
- **slug:** explicit `slug` → `sanitize_title(name)` → host → constant `generated-wordpress-website`.

Plus:
- `strip_title_suffix()` — the shared suffix-strip (pipe / em-dash / en-dash / hyphen), **moved out of** page-materializer so there is no duplicated regex.
- `title_from_html()` / `title_from_website_artifact()` — the shared document-`<title>` extractor.
- `unique_slug( $desired, $is_taken )` — appends `-2`, `-3`, … against a "taken?" check for install-time theme-dir / plugin-slug collisions.

## Consumers consolidated
- **`rest.php` `open_in_playground`** — drops the hardcoded `'generated-wordpress-website'` / `'Generated WordPress Website'` fallback; derives name/slug from the source artifact document title (and URL host) via the primitive.
- **theme-generator** — derives `theme_name`/`theme_slug` via the primitive; removes the `'Imported Website Artifact'` / `'imported-website-artifact'` constants and the duplicate `site_title_from_website_artifact()` extractor. `site_title` (blogname) intentionally stays restricted to an explicit arg or a real extracted title.
- **companion-plugin** — `site_name` follows the shared identity priority (slug-only payloads still keep the slug as display name; the non-empty `site_slug` guard is preserved).
- **page-materializer** — calls the primitive's shared suffix-strip instead of its inline regex.

## Behavior change (intended / positive)
A real titled import now names the theme/plugin after the source:

| | before | after |
|---|---|---|
| theme slug | `generated-wordpress-website` (or `imported-website-artifact`) | `maya-devon` |
| companion plugin | `ssi-generated-wordpress-website` | `ssi-maya-devon` |

(e.g. `"Maya & Devon — Home"` → `Maya & Devon` → `maya-devon`.) Sourceless input with no `<title>` and no URL still falls back to the generic constant.

## Left in place (documented)
The Figma `display_title` derivation (`site_title → title → name → artifact metadata title → source name`) has a different priority than the document-`<title>` chain and is not a clean fit; left unchanged to avoid regressing the Figma path.

## Tests
- `tests/smoke-site-identity.php` (new): priority chain, slug sanitization, shared suffix-strip across all separators, uniqueness suffix; wired into the validation harness.
- `tests/smoke-importer-block.php`: added an assertion proving the REST playground blueprint now derives `name => 'Maya & Devon'` / `slug => 'maya-devon'` from a titled source (kept the constant-fallback assertions for the sourceless case).
- `tests/smoke-visual-repair-css.php`: repointed the artifact-title assertion at the primitive's public `title_from_website_artifact()`.

All standalone PHP smokes pass; `php -l` clean. The 3 `wp eval-file` ABSPATH-guarded smokes and the pre-existing `progress-event-saved-state` environmental assertion in the document-metadata smoke fail identically on `main` (verified) and are unrelated baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)