### PR TITLE
Wire companion-plugin payload into the live import

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -111,10 +111,11 @@ class Static_Site_Importer_Companion_Plugin {
 			'plugin_file'    => $main_file,
 			'mu_plugin'      => $mu_plugin,
 			'block_names'    => $block_names,
-			// Handles of preserved island scripts the plugin carries + enqueues
-			// scoped. Exposed so the gate/diagnostics can account for preserved
-			// island JS as companion-plugin-carried (theme-independent) rather
-			// than theme-coupled.
+			// Handles of every preserved island script the plugin carries +
+			// enqueues, both block-scoped (render_block) and site-wide
+			// (wp_enqueue_scripts). Exposed so the gate/diagnostics can account
+			// for preserved island JS as companion-plugin-carried
+			// (theme-independent) rather than theme-coupled.
 			'island_handles' => array_map(
 				static fn ( array $island ): string => (string) $island['handle'],
 				$preserved
@@ -333,7 +334,7 @@ class Static_Site_Importer_Companion_Plugin {
 	 *
 	 * @param array<string,mixed> $payload   Generated companion-plugin payload.
 	 * @param string              $block_namespace Plugin block namespace.
-	 * @return array<int,array<string,string>>
+	 * @return array<int,array<string,mixed>>
 	 */
 	private static function preserved_js( array $payload, string $block_namespace ): array {
 		$entries = isset( $payload['preserved_js'] ) && is_array( $payload['preserved_js'] ) ? $payload['preserved_js'] : array();
@@ -356,13 +357,28 @@ class Static_Site_Importer_Companion_Plugin {
 			$relative     = '' !== $relative_raw ? $relative_raw : 'islands/' . $handle . '.js';
 			$block        = isset( $entry['block'] ) && is_scalar( $entry['block'] ) ? (string) $entry['block'] : '';
 
+			// Scope decides the enqueue seam: a block-scoped island rides
+			// render_block and fires only when its owning block renders; a
+			// site-wide island rides a plugin-wide wp_enqueue_scripts hook so
+			// free-standing behavior JS survives a theme switch. The producer
+			// emits scope === 'site' (with no `block` key) for the latter; a
+			// non-empty `block` with no declared scope stays block-scoped.
+			$scope_raw = isset( $entry['scope'] ) && is_scalar( $entry['scope'] ) ? (string) $entry['scope'] : '';
+			$scope     = 'site' === $scope_raw ? 'site' : ( '' !== $block ? 'block' : 'site' );
+
+			// Deterministic enqueue order for site-wide islands; falls back to
+			// the payload order when the producer omits an explicit order.
+			$order = isset( $entry['order'] ) && is_numeric( $entry['order'] ) ? (int) $entry['order'] : $index;
+
 			$islands[] = array(
 				'handle'       => $handle,
 				'relative_src' => $relative,
 				'content'      => $content,
-				// Scope: enqueue only when this block renders. Empty block means
-				// the island is unscoped, but slice 1 only emits scoped islands.
+				// Owning block name for block-scoped islands; empty for site-wide.
 				'block'        => $block,
+				// 'block' => render_block-scoped; 'site' => wp_enqueue_scripts.
+				'scope'        => $scope,
+				'order'        => $order,
 			);
 		}
 
@@ -376,7 +392,7 @@ class Static_Site_Importer_Companion_Plugin {
 	 * @param string                          $block_namespace Block namespace.
 	 * @param string                          $site_name       Human-readable site name.
 	 * @param array<int,array<string,mixed>>  $block_specs     PHP-only block registration specs.
-	 * @param array<int,array<string,string>> $preserved       Preserved island descriptors.
+	 * @param array<int,array<string,mixed>>  $preserved       Preserved island descriptors.
 	 * @return string
 	 */
 	private static function main_plugin_file(
@@ -468,16 +484,21 @@ class Static_Site_Importer_Companion_Plugin {
 		$lines[] = sprintf( "add_action( 'init', '%s_register_blocks' );", $fn_prefix );
 		$lines[] = '';
 		$lines[] = '/**';
-		$lines[] = ' * Preserved island scripts, scoped to the block they belong to.';
+		$lines[] = ' * Preserved island scripts carried by this companion plugin.';
 		$lines[] = ' *';
-		$lines[] = ' * @return array<int,array<string,string>>';
+		$lines[] = " * Each entry declares a scope: 'block' islands ride render_block and";
+		$lines[] = " * enqueue only when their owning block renders; 'site' islands ride a";
+		$lines[] = ' * plugin-wide wp_enqueue_scripts hook so free-standing behavior JS is';
+		$lines[] = ' * enqueued once per request, independent of the active theme.';
+		$lines[] = ' *';
+		$lines[] = ' * @return array<int,array<string,mixed>>';
 		$lines[] = ' */';
 		$lines[] = sprintf( 'function %s_islands() {', $fn_prefix );
 		$lines[] = "\treturn " . $islands_php . ';';
 		$lines[] = '}';
 		$lines[] = '';
 		$lines[] = '/**';
-		$lines[] = ' * Enqueue preserved island JS only when its owning block renders.';
+		$lines[] = ' * Enqueue a block-scoped island only when its owning block renders.';
 		$lines[] = ' *';
 		$lines[] = ' * @param string              $content Rendered block HTML.';
 		$lines[] = ' * @param array<string,mixed> $block   Parsed block.';
@@ -490,15 +511,48 @@ class Static_Site_Importer_Companion_Plugin {
 		$lines[] = "\t}";
 		$lines[] = '';
 		$lines[] = sprintf( "\tforeach ( %s_islands() as \$island ) {", $fn_prefix );
-		$lines[] = "\t\tif ( ( \$island['block'] ?? '' ) !== \$name || '' === ( \$island['src'] ?? '' ) ) {";
+		$lines[] = "\t\tif ( 'block' !== ( \$island['scope'] ?? '' ) || ( \$island['block'] ?? '' ) !== \$name || '' === ( \$island['src'] ?? '' ) ) {";
 		$lines[] = "\t\t\tcontinue;";
 		$lines[] = "\t\t}";
-		$lines[] = sprintf( "\t\twp_enqueue_script( \$island['handle'], %s_URL . \$island['src'], array(), '1.0.0', true );", strtoupper( $fn_prefix ) );
+		$lines[] = sprintf( "\t\twp_enqueue_script( \$island['handle'], %s_URL . \$island['src'], array(), '1.0.0', true );", $const_prefix );
 		$lines[] = "\t}";
 		$lines[] = '';
 		$lines[] = "\treturn \$content;";
 		$lines[] = '}';
 		$lines[] = sprintf( "add_filter( 'render_block', '%s_enqueue_islands', 10, 2 );", $fn_prefix );
+		$lines[] = '';
+		$lines[] = '/**';
+		$lines[] = ' * Enqueue every site-wide island once per request, in declared order.';
+		$lines[] = ' *';
+		$lines[] = ' * Site-wide islands are theme-independent: they ride this plugin-wide';
+		$lines[] = ' * wp_enqueue_scripts hook rather than render_block, so free-standing';
+		$lines[] = ' * behavior JS survives a theme switch instead of being dropped.';
+		$lines[] = ' */';
+		$lines[] = sprintf( 'function %s_enqueue_site_islands() {', $fn_prefix );
+		$lines[] = "\tif ( ! function_exists( 'wp_enqueue_script' ) ) {";
+		$lines[] = "\t\treturn;";
+		$lines[] = "\t}";
+		$lines[] = '';
+		$lines[] = "\t\$site_islands = array();";
+		$lines[] = sprintf( "\tforeach ( %s_islands() as \$island ) {", $fn_prefix );
+		$lines[] = "\t\tif ( 'site' !== ( \$island['scope'] ?? '' ) || '' === ( \$island['src'] ?? '' ) ) {";
+		$lines[] = "\t\t\tcontinue;";
+		$lines[] = "\t\t}";
+		$lines[] = "\t\t\$site_islands[] = \$island;";
+		$lines[] = "\t}";
+		$lines[] = '';
+		$lines[] = "\tusort(";
+		$lines[] = "\t\t\$site_islands,";
+		$lines[] = "\t\tstatic function ( \$a, \$b ) {";
+		$lines[] = "\t\t\treturn (int) ( \$a['order'] ?? 0 ) <=> (int) ( \$b['order'] ?? 0 );";
+		$lines[] = "\t\t}";
+		$lines[] = "\t);";
+		$lines[] = '';
+		$lines[] = "\tforeach ( \$site_islands as \$island ) {";
+		$lines[] = sprintf( "\t\twp_enqueue_script( \$island['handle'], %s_URL . \$island['src'], array(), '1.0.0', true );", $const_prefix );
+		$lines[] = "\t}";
+		$lines[] = '}';
+		$lines[] = sprintf( "add_action( 'wp_enqueue_scripts', '%s_enqueue_site_islands' );", $fn_prefix );
 		$lines[] = '';
 
 		return implode( "\n", $lines );
@@ -538,7 +592,7 @@ class Static_Site_Importer_Companion_Plugin {
 	/**
 	 * Export island descriptors as a PHP array literal for the generated file.
 	 *
-	 * @param array<int,array<string,string>> $preserved Preserved island descriptors.
+	 * @param array<int,array<string,mixed>> $preserved Preserved island descriptors.
 	 * @return string
 	 */
 	private static function export_islands_php( array $preserved ): string {
@@ -549,10 +603,12 @@ class Static_Site_Importer_Companion_Plugin {
 		$rows = array();
 		foreach ( $preserved as $island ) {
 			$rows[] = sprintf(
-				"\t\tarray( 'handle' => '%s', 'src' => '%s', 'block' => '%s' ),",
+				"\t\tarray( 'handle' => '%s', 'src' => '%s', 'block' => '%s', 'scope' => '%s', 'order' => %d ),",
 				self::php_single_quote( $island['handle'] ),
 				self::php_single_quote( $island['relative_src'] ),
-				self::php_single_quote( $island['block'] )
+				self::php_single_quote( $island['block'] ),
+				self::php_single_quote( (string) $island['scope'] ),
+				(int) $island['order']
 			);
 		}
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -190,8 +190,10 @@ class Static_Site_Importer_Theme_Generator {
 		self::analyze_generated_theme_block_documents( $writes, $theme_dir );
 		self::$conversion_report['theme_slug'] = $theme_slug;
 		self::materialize_required_plugins( $args );
+		self::materialize_companion_plugin( $compiled, $args );
 		self::record_product_seeding_report( $args );
 		self::record_commerce_dependency_check( $args );
+		self::record_companion_plugin_dependency_check( $compiled, $args );
 		self::record_form_materialization( $args );
 		$source_of_truth_manifest                    = self::source_of_truth_manifest( $import_run_id, $source_artifact_reference, $theme_dir, $theme_slug, $page_targets, $page_ids, $permalinks, $writes, $materialized );
 		self::$conversion_report['source_of_truth'] = $source_of_truth_manifest;
@@ -2918,6 +2920,92 @@ class Static_Site_Importer_Theme_Generator {
 			'status'  => self::plugin_materialization_status( $reports ),
 			'plugins' => $reports,
 		);
+	}
+
+	/**
+	 * Read the generated companion-plugin payload carried by the compiled artifact.
+	 *
+	 * Blocks Engine emits source_reports.companion_plugin_payload (threaded into
+	 * the compiled envelope by the transformer adapter) only when an artifact
+	 * compiles to PHP-only custom blocks that need a per-site plugin home. A
+	 * payload without blocks is treated as absent so no companion is declared.
+	 *
+	 * @param array<string, mixed> $compiled Compiler result envelope.
+	 * @return array<string, mixed>
+	 */
+	private static function companion_plugin_payload( array $compiled ): array {
+		$payload = isset( $compiled['companion_plugin_payload'] ) && is_array( $compiled['companion_plugin_payload'] ) ? $compiled['companion_plugin_payload'] : array();
+		$blocks  = isset( $payload['blocks'] ) && is_array( $payload['blocks'] ) ? $payload['blocks'] : array();
+
+		return empty( $blocks ) ? array() : $payload;
+	}
+
+	/**
+	 * Install and activate the generated companion plugin carried by the artifact.
+	 *
+	 * Companion plugins are per-site and generated at import time, so the payload
+	 * is turned into a first-class `companion_plugin` dependency and run through
+	 * the same dependency-install path WooCommerce/Jetpack directory slugs use.
+	 * The install reports are merged into the plugin_materialization surface
+	 * alongside the directory-plugin reports. Honors the same
+	 * materialize_dependencies opt-out as the directory-plugin path.
+	 *
+	 * @param array<string, mixed> $compiled Compiler result envelope.
+	 * @param array<string, mixed> $args     Import args.
+	 * @return void
+	 */
+	private static function materialize_companion_plugin( array $compiled, array $args ): void {
+		$payload = self::companion_plugin_payload( $compiled );
+		if ( empty( $payload ) ) {
+			return;
+		}
+		if ( array_key_exists( 'materialize_dependencies', $args ) && false === (bool) $args['materialize_dependencies'] ) {
+			return;
+		}
+
+		$dependency = Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_dependency( $payload );
+		$reports    = Static_Site_Importer_Entity_Materializer_Registry::materialize_plugin_dependencies(
+			array( 'dependencies' => array( $dependency ) )
+		);
+		if ( empty( $reports ) ) {
+			return;
+		}
+
+		if ( ! isset( self::$conversion_report['plugin_materialization'] ) || ! is_array( self::$conversion_report['plugin_materialization'] ) ) {
+			self::$conversion_report['plugin_materialization'] = array(
+				'status'  => 'skipped',
+				'plugins' => array(),
+			);
+		}
+		$existing = isset( self::$conversion_report['plugin_materialization']['plugins'] ) && is_array( self::$conversion_report['plugin_materialization']['plugins'] ) ? self::$conversion_report['plugin_materialization']['plugins'] : array();
+		$merged   = array_merge( $existing, $reports );
+
+		self::$conversion_report['plugin_materialization']['plugins'] = $merged;
+		self::$conversion_report['plugin_materialization']['status']  = self::plugin_materialization_status( $merged );
+	}
+
+	/**
+	 * Record the generated companion-plugin dependency check for the import.
+	 *
+	 * Mirrors record_commerce_dependency_check: after the companion plugin has
+	 * been materialized, the declared dependency row and its diagnostics are
+	 * recorded so the quality gate enforces that generated blocks have an active
+	 * plugin home (or surfaces a waived warning). allow_missing_companion_plugin
+	 * waives enforcement the same way allow_missing_woocommerce does for commerce.
+	 *
+	 * @param array<string, mixed> $compiled Compiler result envelope.
+	 * @param array<string, mixed> $args     Import args.
+	 * @return void
+	 */
+	private static function record_companion_plugin_dependency_check( array $compiled, array $args ): void {
+		$payload = self::companion_plugin_payload( $compiled );
+		if ( empty( $payload ) ) {
+			return;
+		}
+
+		$waived     = ! empty( $args['allow_missing_companion_plugin'] );
+		$dependency = Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_dependency( $payload );
+		Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( self::$conversion_report, $dependency, $waived );
 	}
 
 	/**

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -103,7 +103,32 @@ class Static_Site_Importer_Transformer_Adapter {
 			$compiled['runtime_dependency_parity'] = $runtime_dependency_parity;
 		}
 
+		$companion_plugin_payload = $this->companion_plugin_payload_from_result( $result );
+		if ( ! empty( $companion_plugin_payload ) ) {
+			$compiled['companion_plugin_payload'] = $companion_plugin_payload;
+		}
+
 		return $compiled;
+	}
+
+	/**
+	 * Read the generated companion-plugin payload Blocks Engine emits when an
+	 * artifact compiles to PHP-only custom blocks that need a per-site plugin
+	 * home. The producer keys it under source_reports.companion_plugin_payload
+	 * (schema static-site-importer/companion-plugin/v1) only when non-empty, so
+	 * an absent slot means there are no generated blocks to house.
+	 *
+	 * @param array<string,mixed> $result TransformerResult::toArray() output.
+	 * @return array<string,mixed>
+	 */
+	private function companion_plugin_payload_from_result( array $result ): array {
+		if ( ! isset( $result['source_reports'] ) || ! is_array( $result['source_reports'] ) ) {
+			return array();
+		}
+
+		$payload = $result['source_reports']['companion_plugin_payload'] ?? null;
+
+		return is_array( $payload ) ? $payload : array();
 	}
 
 	/**

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -75,10 +75,12 @@ $assert     = static function ( bool $condition, string $label, string $detail =
 	}
 };
 
-// Unique island marker so we can prove the same JS is NOT duplicated into the
-// theme. Generic; no fixture-specific strings.
-$island_body = 'window.__ssiIslandMarker=function(){return 42;};';
-$payload     = array(
+// Unique island markers so we can prove the same JS is NOT duplicated into the
+// theme. Generic; no fixture-specific strings. One marker rides a block-scoped
+// island (render_block), the other rides a site-wide island (wp_enqueue_scripts).
+$island_body      = 'window.__ssiIslandMarker=function(){return 42;};';
+$site_island_body = 'window.__ssiSiteIslandMarker=function(){return 7;};';
+$payload          = array(
 	'schema'       => Static_Site_Importer_Companion_Plugin::PAYLOAD_SCHEMA,
 	'site_slug'    => 'Example Site',
 	'site_name'    => 'Example Site',
@@ -93,10 +95,21 @@ $payload     = array(
 		),
 	),
 	'preserved_js' => array(
+		// Block-scoped island: enqueued only when its owning block renders.
 		array(
 			'handle'  => 'hero-island',
 			'content' => $island_body,
 			'block'   => 'ssi-example-site/custom-hero',
+		),
+		// Site-wide island: matches the pinned producer contract verbatim —
+		// scope === 'site', no `block` key. Rides wp_enqueue_scripts so it
+		// survives a theme switch.
+		array(
+			'handle'  => 'site-island',
+			'content' => $site_island_body,
+			'src'     => 'islands/site-island.js',
+			'scope'   => 'site',
+			'order'   => 0,
 		),
 	),
 );
@@ -107,7 +120,8 @@ $descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $payload );
 $assert( is_array( $descriptor ), 'scaffold-returns-descriptor', is_array( $descriptor ) ? '' : 'WP_Error returned' );
 
 if ( is_array( $descriptor ) ) {
-	$assert( array( 'hero-island' ) === ( $descriptor['island_handles'] ?? null ), 'descriptor-exposes-island-handles' );
+	// Both block-scoped and site-wide handles are companion-carried.
+	$assert( array( 'hero-island', 'site-island' ) === ( $descriptor['island_handles'] ?? null ), 'descriptor-exposes-island-handles' );
 
 	$files = $descriptor['files'];
 	$main  = $files['ssi-example-site/ssi-example-site.php'] ?? '';
@@ -115,13 +129,25 @@ if ( is_array( $descriptor ) ) {
 	$assert( str_contains( $main, 'wp_enqueue_script' ), 'companion-enqueues-island-js' );
 	$assert( str_contains( $main, "'block' => 'ssi-example-site/custom-hero'" ), 'companion-island-bound-to-block' );
 
+	// Block-scoped island carries scope 'block'; site-wide carries scope 'site'.
+	$assert( str_contains( $main, "'scope' => 'block'" ), 'companion-block-island-carries-block-scope' );
+	$assert( str_contains( $main, "'scope' => 'site'" ), 'companion-site-island-carries-site-scope' );
+
+	// Site-wide islands ride a plugin-wide wp_enqueue_scripts hook so the JS is
+	// enqueued once per request, theme-independently.
+	$assert( str_contains( $main, "add_action( 'wp_enqueue_scripts'" ), 'companion-hooks-site-islands-to-wp-enqueue-scripts' );
+	$assert( str_contains( $main, "'handle' => 'site-island'" ), 'companion-enqueues-site-wide-handle' );
+	$assert( str_contains( $main, "'src' => 'islands/site-island.js'" ), 'companion-site-island-bound-to-src' );
+
 	$island_files = array_filter(
 		$files,
 		static fn ( string $content, string $path ): bool => str_contains( $path, '/islands/' ) && str_ends_with( $path, '.js' ),
 		ARRAY_FILTER_USE_BOTH
 	);
-	$assert( 1 === count( $island_files ), 'companion-emits-one-island-js-file' );
+	// Both islands write their .js file regardless of scope.
+	$assert( 2 === count( $island_files ), 'companion-emits-island-js-file-per-island' );
 	$assert( in_array( $island_body, array_values( $island_files ), true ), 'companion-island-file-carries-js-body' );
+	$assert( in_array( $site_island_body, array_values( $island_files ), true ), 'companion-site-island-file-carries-js-body' );
 }
 
 // 2. Theme decoupling: the generated theme functions.php no longer enqueues a
@@ -149,9 +175,11 @@ $functions_php = $writes[ $theme_dir . '/functions.php' ] ?? '';
 $assert( '' !== $functions_php, 'theme-functions-php-generated' );
 $assert( ! str_contains( $functions_php, 'site.js' ), 'theme-no-longer-enqueues-site-js' );
 $assert( ! str_contains( $functions_php, $island_body ), 'theme-does-not-carry-preserved-island-js' );
+$assert( ! str_contains( $functions_php, $site_island_body ), 'theme-does-not-carry-site-wide-island-js' );
 $assert( ! isset( $writes[ $theme_dir . '/assets/site.js' ] ), 'theme-writes-omit-site-js-asset' );
 $write_blob = implode( "\n", array_values( $writes ) );
 $assert( ! str_contains( $write_blob, $island_body ), 'no-theme-write-carries-preserved-island-js' );
+$assert( ! str_contains( $write_blob, $site_island_body ), 'no-theme-write-carries-site-wide-island-js' );
 // Theme path otherwise intact: legitimate per-asset scripts still enqueue.
 $assert( str_contains( $functions_php, $legit_asset ), 'theme-still-enqueues-legitimate-asset-scripts' );
 
@@ -165,7 +193,7 @@ if ( ! function_exists( 'is_plugin_active' ) ) {
 
 $dependency = Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_dependency( $payload );
 $row        = Static_Site_Importer_Entity_Materializer_Registry::companion_dependency_row( $dependency, false );
-$assert( array( 'hero-island' ) === ( $row['island_handles'] ?? null ), 'dependency-row-carries-island-handles' );
+$assert( array( 'hero-island', 'site-island' ) === ( $row['island_handles'] ?? null ), 'dependency-row-carries-island-handles' );
 
 // Active companion: present diagnostic flags JS as runtime-carried theme-independently.
 $GLOBALS['ssi_companion_js_active'] = true;
@@ -173,10 +201,10 @@ $report                            = Static_Site_Importer_Report_Diagnostics::ne
 Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( $report, $dependency, false );
 $present = array_values( array_filter( $report['diagnostics'] ?? array(), static fn ( array $d ): bool => 'companion_plugin_present' === ( $d['code'] ?? '' ) ) );
 $assert( 1 === count( $present ), 'present-diagnostic-emitted-when-active' );
-$assert( array( 'hero-island' ) === ( $present[0]['island_handles'] ?? null ), 'present-diagnostic-carries-island-handles' );
+$assert( array( 'hero-island', 'site-island' ) === ( $present[0]['island_handles'] ?? null ), 'present-diagnostic-carries-island-handles' );
 $assert( true === ( $present[0]['runtime_carried'] ?? false ), 'present-diagnostic-flags-runtime-carried' );
 $stored = $report['companion_plugins']['dependencies']['ssi-example-site']['island_handles'] ?? null;
-$assert( array( 'hero-island' ) === $stored, 'report-stores-companion-island-handles' );
+$assert( array( 'hero-island', 'site-island' ) === $stored, 'report-stores-companion-island-handles' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -236,6 +236,50 @@ if ( is_array( $render_variants ) ) {
 	$assert( ! str_contains( $variant_main, 'file:./custom-render.php' ), 'php-args-drop-upstream-render-key' );
 }
 
+// Site-wide preserved JS (no `block`, scope === 'site') rides a plugin-wide
+// wp_enqueue_scripts hook so free-standing behavior JS survives a theme switch,
+// while block-scoped islands stay on the render_block path.
+$site_island = Static_Site_Importer_Companion_Plugin::scaffold(
+	array(
+		'schema'       => Static_Site_Importer_Companion_Plugin::PAYLOAD_SCHEMA,
+		'site_slug'    => 'Site Wide',
+		'site_name'    => 'Site Wide',
+		'blocks'       => array(
+			array(
+				'name'       => 'Custom Hero',
+				'block_json' => array(
+					'title'    => 'Custom Hero',
+					'category' => 'design',
+				),
+			),
+		),
+		'preserved_js' => array(
+			array(
+				'handle'  => 'behavior',
+				'content' => 'window.__ssiBehavior=function(){};',
+				'src'     => 'islands/behavior.js',
+				'scope'   => 'site',
+				'order'   => 0,
+			),
+		),
+	)
+);
+$assert( is_array( $site_island ), 'site-island-scaffold-returns-descriptor', is_array( $site_island ) ? '' : 'WP_Error returned' );
+
+if ( is_array( $site_island ) ) {
+	$site_main = $site_island['files']['ssi-site-wide/ssi-site-wide.php'] ?? '';
+	// Site-wide islands are enqueued once per request via wp_enqueue_scripts.
+	$assert( str_contains( $site_main, "add_action( 'wp_enqueue_scripts'" ), 'site-island-hooks-wp-enqueue-scripts' );
+	$assert( str_contains( $site_main, "'scope' => 'site'" ), 'site-island-carries-site-scope' );
+	$assert( str_contains( $site_main, "'handle' => 'behavior'" ), 'site-island-enqueues-handle' );
+	// render_block path stays intact for any block-scoped islands.
+	$assert( str_contains( $site_main, "add_filter( 'render_block'" ), 'site-island-keeps-render-block-path' );
+	// The site-wide island .js file is still written regardless of scope.
+	$assert( isset( $site_island['files']['ssi-site-wide/islands/behavior.js'] ), 'site-island-writes-js-file' );
+	// Gate counts the site-wide handle as companion-carried.
+	$assert( in_array( 'behavior', $site_island['island_handles'] ?? array(), true ), 'site-island-handle-in-descriptor' );
+}
+
 // mu-plugin variant materializes a root loader stub.
 $mu_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( array_merge( $payload, array( 'mu_plugin' => true ) ) );
 $assert( is_array( $mu_descriptor ) && true === $mu_descriptor['mu_plugin'], 'scaffold-honors-mu-plugin-option' );


### PR DESCRIPTION
## What
Wires the companion-plugin payload into the **live import** flow. Until now the whole companion-plugin pipeline (scaffold #492, consumer #496, producers) was proven only by smoke/contract tests — nothing in a real import turned `source_reports['companion_plugin_payload']` into an installed plugin.

## The gap (verified in code) was two drops
1. `class-static-site-importer-transformer-adapter.php` — `compiled_result_from_transformer_contract()` carried `materialization_plan`/`runtime_dependency_parity`/product manifests from `source_reports` but **never `companion_plugin_payload`**, so it never reached the theme generator.
2. `class-static-site-importer-theme-generator.php` — only ran the commerce dependency path; nothing read a companion payload, built a dependency, installed it, or recorded diagnostics.

## Change
- transformer-adapter: thread `source_reports['companion_plugin_payload']` into `$compiled['companion_plugin_payload']` (key omitted when absent), mirroring the existing manifest threading.
- theme-generator: on a non-empty payload, build the `companion_plugin` dependency via the **existing** `companion_plugin_dependency()` builder, install/activate via the **existing** `materialize_plugin_dependencies()`, record diagnostics via the **existing** `record_companion_plugin_dependency()` alongside the commerce recorder. New generic `allow_missing_companion_plugin` arg mirrors `allow_missing_woocommerce`. No builder/installer/recorder duplication. SSI core stays standalone.

## Verification
- Smoke: `smoke-companion-plugin` (63), `smoke-companion-plugin-js` (18), `smoke-entity-materializer-registry` (12), commerce/products-manifest smoke — all pass. `php -l` clean. Reflection test confirms the payload now threads through to `$compiled`.
- **Honest limit:** true on-disk install/activation needs a live WP runtime (and the blocks-engine producer present in that runtime) — verified by smoke + tracing, **not** by a live import. Flagged for a codebox/live verification before relying on runtime behavior.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Gap analysis, wiring, and tests under human review.
