### PR TITLE
Add consumer-defined import disposition seam

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -498,14 +498,87 @@ function static_site_importer_rest_open_in_playground( array $source, array $inp
 		$input['slug'] = $identity['slug'];
 	}
 
-	$result = static_site_importer_rest_create_playground_open( $artifact, $input, isset( $source['figma_file'] ) ? 'figma_file' : 'upload' );
-	if ( is_wp_error( $result ) ) {
-		return $result;
+	$preview_source = isset( $source['figma_file'] ) ? 'figma_file' : 'upload';
+
+	return static_site_importer_import_website_artifact_with_disposition(
+		$artifact,
+		$input,
+		array(
+			'source'         => $source,
+			'mode'           => 'playground',
+			'preview_source' => $preview_source,
+		)
+	);
+}
+
+/**
+ * Run a normalized website artifact through the consumer-defined import disposition.
+ *
+ * This is the shared seam used by both the REST import endpoint and direct
+ * server-side callers (for example, a generator that produces an artifact
+ * in-process). By the time execution reaches this function the artifact and
+ * import args are already normalized, so a consumer decides only *what happens
+ * to the import* — not how the artifact is built.
+ *
+ * Consumers register on the {@see 'static_site_importer_import_disposition'}
+ * filter: return null to defer (to other consumers, then the built-in preview),
+ * or return a response array / WP_Error to claim the import and define its
+ * outcome. A claiming consumer owns any persistence it performs and the preview
+ * it returns; it may call {@see static_site_importer_build_playground_preview()}
+ * to reuse the built-in, non-destructive Playground preview.
+ *
+ * @param array<string,mixed> $artifact Normalized website artifact ({ schema, entrypoint, files }).
+ * @param array<string,mixed> $input    Normalized import args (artifact, name, slug, activate, overwrite, ...).
+ * @param array<string,mixed> $context  Optional context: { source, params, mode, preview_source }.
+ * @return array<string,mixed>|WP_Error
+ */
+function static_site_importer_import_website_artifact_with_disposition( array $artifact, array $input = array(), array $context = array() ) {
+	/**
+	 * Filter what happens to a normalized website-artifact import.
+	 *
+	 * Static Site Importer stays generic: it normalizes the artifact and then
+	 * lets a consumer (a product/bridge layer) define the import's disposition.
+	 * Return null to defer to the built-in Playground preview; return a response
+	 * array or WP_Error to claim the import.
+	 *
+	 * @param array<string,mixed>|WP_Error|null $disposition Null to defer; array/WP_Error to claim.
+	 * @param array<string,mixed>               $artifact    Normalized website artifact.
+	 * @param array<string,mixed>               $input       Normalized import args.
+	 * @param array<string,mixed>               $context     { source, params, mode, preview_source }.
+	 */
+	$disposition = apply_filters( 'static_site_importer_import_disposition', null, $artifact, $input, $context );
+	if ( null !== $disposition ) {
+		return $disposition;
 	}
 
-	$result['mode'] = 'playground';
+	$preview_source = isset( $context['preview_source'] ) ? (string) $context['preview_source'] : 'upload';
+	$result         = static_site_importer_build_playground_preview( $artifact, $input, $preview_source );
+	if ( is_array( $result ) ) {
+		$result['mode'] = 'playground';
+	}
 
 	return $result;
+}
+
+/**
+ * Build a non-destructive, self-contained Playground preview for a website artifact.
+ *
+ * Stable, consumer-facing wrapper around the built-in Playground preview builder.
+ * Disposition handlers that persist an artifact elsewhere (for example, into a
+ * host product's project store) can call this to return a working preview URL
+ * without reaching into REST-internal helpers.
+ *
+ * @param array<string,mixed> $artifact Normalized website artifact.
+ * @param array<string,mixed> $input    Normalized import args.
+ * @param string              $source   Preview source label.
+ * @return array<string,mixed>|WP_Error
+ */
+function static_site_importer_build_playground_preview( array $artifact, array $input = array(), string $source = 'consumer' ) {
+	if ( ! isset( $input['artifact'] ) ) {
+		$input['artifact'] = $artifact;
+	}
+
+	return static_site_importer_rest_create_playground_open( $artifact, $input, $source );
 }
 
 /**

--- a/tests/smoke-import-disposition.php
+++ b/tests/smoke-import-disposition.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Smoke test: consumer-defined import disposition seam.
+ *
+ * Proves the actual extension behavior of
+ * static_site_importer_import_website_artifact_with_disposition():
+ *  - with no consumer registered, it falls back to the built-in, non-destructive
+ *    Playground preview (a real blueprint URL);
+ *  - a consumer registered on the 'static_site_importer_import_disposition'
+ *    filter receives the normalized artifact + context and can claim the import,
+ *    fully defining its outcome.
+ *
+ * Run from the repository root:
+ * php tests/smoke-import-disposition.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! defined( 'STATIC_SITE_IMPORTER_PATH' ) ) {
+	define( 'STATIC_SITE_IMPORTER_PATH', dirname( __DIR__ ) . '/' );
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+// Minimal WordPress hook registry so add_filter()/apply_filters() behave for real.
+$GLOBALS['ssi_filters'] = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+		$GLOBALS['ssi_filters'][ $hook ][ $priority ][] = array(
+			'callback'      => $callback,
+			'accepted_args' => $accepted_args,
+		);
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['ssi_filters'][ $hook ] ) ) {
+			return $value;
+		}
+
+		$registered = $GLOBALS['ssi_filters'][ $hook ];
+		ksort( $registered );
+
+		foreach ( $registered as $callbacks ) {
+			foreach ( $callbacks as $entry ) {
+				$passed = array_slice( array_merge( array( $value ), $args ), 0, $entry['accepted_args'] );
+				$value  = call_user_func_array( $entry['callback'], $passed );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = '' ): string {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( string $url ): string {
+		return $url;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $options = 0, int $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/rest.php';
+
+$assert(
+	function_exists( 'static_site_importer_import_website_artifact_with_disposition' ),
+	'function-exists',
+	'disposition dispatcher is defined'
+);
+
+$artifact = array(
+	'schema'     => 'static-site-importer/website-artifact/v1',
+	'entrypoint' => 'website/index.html',
+	'files'      => array(
+		array(
+			'path'    => 'website/index.html',
+			'content' => '<!doctype html><title>Disposition</title><h1>Hi</h1>',
+		),
+	),
+);
+
+// --- Case 1: no consumer registered -> built-in Playground preview fallback. ---
+$fallback = static_site_importer_import_website_artifact_with_disposition(
+	$artifact,
+	array( 'name' => 'Disposition Demo', 'slug' => 'disposition-demo' ),
+	array( 'mode' => 'playground', 'preview_source' => 'upload' )
+);
+
+$assert( is_array( $fallback ), 'fallback-array', 'fallback returns an array' );
+$assert( ! empty( $fallback['success'] ), 'fallback-success', 'fallback marks success' );
+$assert(
+	isset( $fallback['preview']['playground']['blueprint_url'] )
+		&& 0 === strpos( (string) $fallback['preview']['playground']['blueprint_url'], 'https://playground.wordpress.net/#' ),
+	'fallback-blueprint-url',
+	'fallback yields a self-contained Playground blueprint URL'
+);
+$assert(
+	isset( $fallback['mode'] ) && 'playground' === $fallback['mode'],
+	'fallback-mode',
+	'fallback is tagged as the built-in playground disposition'
+);
+
+// --- Case 2: a consumer claims the import and defines its own outcome. ---
+$GLOBALS['ssi_seen'] = array();
+
+add_filter(
+	'static_site_importer_import_disposition',
+	static function ( $disposition, $seen_artifact, $seen_input, $seen_context ) {
+		// Defer cooperatively if a prior consumer already claimed it.
+		if ( null !== $disposition ) {
+			return $disposition;
+		}
+
+		$GLOBALS['ssi_seen'] = array(
+			'artifact_entrypoint' => $seen_artifact['entrypoint'] ?? null,
+			'context_mode'        => $seen_context['mode'] ?? null,
+			'input_slug'          => $seen_input['slug'] ?? null,
+		);
+
+		// A real consumer would persist the artifact here, then return a preview.
+		$preview = static_site_importer_build_playground_preview( $seen_artifact, $seen_input, 'project' );
+
+		return array(
+			'success' => true,
+			'mode'    => 'project',
+			'project' => array( 'id' => 4242 ),
+			'preview' => $preview['preview'] ?? array(),
+		);
+	},
+	10,
+	4
+);
+
+$claimed = static_site_importer_import_website_artifact_with_disposition(
+	$artifact,
+	array( 'name' => 'Disposition Demo', 'slug' => 'disposition-demo' ),
+	array( 'mode' => 'playground', 'preview_source' => 'upload' )
+);
+
+$assert( is_array( $claimed ), 'claimed-array', 'claimed disposition returns an array' );
+$assert(
+	isset( $claimed['mode'] ) && 'project' === $claimed['mode'],
+	'claimed-mode',
+	'consumer outcome replaces the built-in playground mode'
+);
+$assert(
+	isset( $claimed['project']['id'] ) && 4242 === $claimed['project']['id'],
+	'claimed-project',
+	'consumer-defined disposition payload is returned verbatim'
+);
+$assert(
+	isset( $claimed['preview']['playground']['blueprint_url'] ),
+	'claimed-preview',
+	'consumer can reuse the built-in Playground preview helper'
+);
+$assert(
+	'website/index.html' === ( $GLOBALS['ssi_seen']['artifact_entrypoint'] ?? null ),
+	'consumer-received-artifact',
+	'consumer receives the normalized artifact'
+);
+$assert(
+	'playground' === ( $GLOBALS['ssi_seen']['context_mode'] ?? null )
+		&& 'disposition-demo' === ( $GLOBALS['ssi_seen']['input_slug'] ?? null ),
+	'consumer-received-context',
+	'consumer receives the import context and normalized input'
+);
+
+// --- Report. ---
+if ( empty( $failures ) ) {
+	echo 'PASS: smoke-import-disposition (' . (int) $assertions . " assertions)\n";
+	exit( 0);
+}
+
+echo 'FAILURES (' . count( $failures ) . ' of ' . (int) $assertions . " assertions):\n";
+foreach ( $failures as $failure ) {
+	echo ' - ' . $failure . "\n";
+}
+exit( 1 );


### PR DESCRIPTION
## What

Static Site Importer normalizes a website artifact and then lets a **consumer define what happens to the import**, instead of hardcoding the outcome. This is the generic foundation for routing any artifact-producing path (uploads, raw HTML, generated sites) into a host product without SSI growing knowledge of that product.

### Contract

New filter `static_site_importer_import_disposition`:

```php
apply_filters(
    'static_site_importer_import_disposition',
    null,        // return null to defer; array/WP_Error to claim
    $artifact,   // normalized website artifact { schema, entrypoint, files[] }
    $input,      // normalized import args { artifact, name, slug, activate, overwrite, ... }
    $context     // { source, params, mode, preview_source }
);
```

- Return `null` → defer to the built-in **non-destructive Playground preview** (`playground.wordpress.net/#<blueprint>`).
- Return an array / `WP_Error` → the consumer **claims** the import and owns the outcome (persistence + response shape, including its own `preview`).

Shared dispatcher `static_site_importer_import_website_artifact_with_disposition( $artifact, $input, $context )` is reachable from **both** the REST import endpoint (the default `/import` playground path now routes through it) and **direct server-side callers**. A consumer-facing helper `static_site_importer_build_playground_preview( $artifact, $input, $source )` lets disposition handlers reuse the built-in Playground preview without touching REST internals.

## Why

SSI must stay a generic, standalone product and not grow per-consumer (Studio Native / Studio Web / etc.) semantics. This seam keeps the engine generic — product semantics like "store as a host project" live entirely in the registering consumer. It's the foundation for a unified flow where import, generate, and (later) other entrypoints all land as host projects through one extension point.

## Compatibility

Backward compatible: with no consumer registered, output is identical to before (`mode: playground` + the same blueprint URL). Non-destructive by default — unclaimed imports never mutate the host site.

## Tests

`tests/smoke-import-disposition.php` (11 assertions) covers both the built-in fallback and a consumer claiming the import (and asserts the consumer receives the normalized artifact + context). Existing rest/import smoke tests (`smoke-importer-block`, `smoke-transformer-adapter`) still pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Codebase investigation, designing the disposition seam against existing SSI conventions, drafting the implementation and smoke test.