### PR TITLE
Expose reusable Playground import-blueprint primitive

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -231,12 +231,29 @@ function static_site_importer_rest_create_playground_open( array $artifact, arra
 }
 
 /**
- * Build the WPSG-style self-contained Playground blueprint that runs the import.
+ * Build the Playground blueprint steps that import a website artifact on boot.
  *
- * @param array<string,mixed> $input Import ability input.
- * @return array<string,mixed>
+ * Public, reusable primitive: consumers (for example, a host shell or a site
+ * forge) can build the "import-on-boot" steps without reaching into the
+ * REST-internal blueprint builder. The steps are byte-identical to the ones
+ * {@see static_site_importer_rest_playground_blueprint()} ships today.
+ *
+ * The returned steps are:
+ * - login
+ * - installPlugin (SSI from GitHub releases) — omitted when $options['install'] is false
+ * - runPHP — runs static_site_importer_ability_import_website_artifact( $input )
+ *
+ * Pass `'install' => false` for hosts/runtimes where SSI is already present
+ * (for example, shipped as a mu-plugin in a sandbox runtime) so the blueprint
+ * skips the GitHub release install step and imports against the bundled plugin.
+ *
+ * @param array<string,mixed> $input   Import ability input.
+ * @param array<string,mixed> $options Optional. { install: bool (default true) }.
+ * @return array<int,array<string,mixed>>
  */
-function static_site_importer_rest_playground_blueprint( array $input ): array {
+function static_site_importer_playground_import_steps( array $input, array $options = array() ): array {
+	$install = ! array_key_exists( 'install', $options ) || ! empty( $options['install'] );
+
 	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generates self-contained Playground import code.
 	$input_literal = var_export( $input, true );
 	$import_code   = '<?php
@@ -255,6 +272,47 @@ if ( ! is_array( $result ) || empty( $result["success"] ) ) {
 update_option( "static_site_importer_playground_preview_result", $result, false );
 ?>';
 
+	$steps = array(
+		array(
+			'step' => 'login',
+		),
+	);
+
+	if ( $install ) {
+		$steps[] = array(
+			'step'       => 'installPlugin',
+			'pluginData' => array(
+				'resource' => 'url',
+				'url'      => 'https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip',
+			),
+			'options'    => array(
+				'activate'         => true,
+				'targetFolderName' => 'static-site-importer',
+			),
+		);
+	}
+
+	$steps[] = array(
+		'step' => 'runPHP',
+		'code' => $import_code,
+	);
+
+	return $steps;
+}
+
+/**
+ * Build the full Playground blueprint that imports a website artifact on boot.
+ *
+ * Public, reusable primitive that wraps {@see static_site_importer_playground_import_steps()}
+ * into a complete blueprint ($schema, landingPage, preferredVersions, features,
+ * steps). The blueprint shape is identical to what
+ * {@see static_site_importer_rest_playground_blueprint()} returns today.
+ *
+ * @param array<string,mixed> $input   Import ability input.
+ * @param array<string,mixed> $options Optional. { install: bool (default true) }.
+ * @return array<string,mixed>
+ */
+function static_site_importer_playground_import_blueprint( array $input, array $options = array() ): array {
 	return array(
 		'$schema'           => 'https://playground.wordpress.net/blueprint-schema.json',
 		'landingPage'       => '/',
@@ -265,27 +323,22 @@ update_option( "static_site_importer_playground_preview_result", $result, false 
 		'features'          => array(
 			'networking' => true,
 		),
-		'steps'             => array(
-			array(
-				'step' => 'login',
-			),
-			array(
-				'step'       => 'installPlugin',
-				'pluginData' => array(
-					'resource' => 'url',
-					'url'      => 'https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip',
-				),
-				'options'    => array(
-					'activate'         => true,
-					'targetFolderName' => 'static-site-importer',
-				),
-			),
-			array(
-				'step' => 'runPHP',
-				'code' => $import_code,
-			),
-		),
+		'steps'             => static_site_importer_playground_import_steps( $input, $options ),
 	);
+}
+
+/**
+ * Build the WPSG-style self-contained Playground blueprint that runs the import.
+ *
+ * Thin REST-internal wrapper retained for backward compatibility. Delegates to
+ * the public {@see static_site_importer_playground_import_blueprint()} primitive
+ * with the install step enabled so the public /import preview URL is unchanged.
+ *
+ * @param array<string,mixed> $input Import ability input.
+ * @return array<string,mixed>
+ */
+function static_site_importer_rest_playground_blueprint( array $input ): array {
+	return static_site_importer_playground_import_blueprint( $input );
 }
 
 /**

--- a/tests/smoke-playground-import-primitive.php
+++ b/tests/smoke-playground-import-primitive.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Smoke test: public Playground import-on-boot primitive.
+ *
+ * Proves the reusable primitives that build the "import-on-boot" Playground
+ * blueprint:
+ *  - static_site_importer_playground_import_steps() includes the installPlugin
+ *    step by default and always includes login + runPHP;
+ *  - passing [ 'install' => false ] omits the installPlugin step (for runtimes
+ *    where SSI is already present) while keeping login + runPHP;
+ *  - the runPHP code runs the proven import entrypoint;
+ *  - static_site_importer_playground_import_blueprint() produces the same step
+ *    set as the legacy static_site_importer_rest_playground_blueprint(), proving
+ *    the legacy function delegates to the public primitive.
+ *
+ * Run from the repository root:
+ * php tests/smoke-playground-import-primitive.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! defined( 'STATIC_SITE_IMPORTER_PATH' ) ) {
+	define( 'STATIC_SITE_IMPORTER_PATH', dirname( __DIR__ ) . '/' );
+}
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = '' ): string {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( string $url ): string {
+		return $url;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $options = 0, int $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/rest.php';
+
+/**
+ * Return the step identifiers in a blueprint steps array.
+ *
+ * @param array<int,array<string,mixed>> $steps Blueprint steps.
+ * @return array<int,string>
+ */
+$step_names = static function ( array $steps ): array {
+	return array_values(
+		array_map(
+			static function ( $step ): string {
+				return is_array( $step ) && isset( $step['step'] ) ? (string) $step['step'] : '';
+			},
+			$steps
+		)
+	);
+};
+
+$assert(
+	function_exists( 'static_site_importer_playground_import_steps' ),
+	'steps-function-exists',
+	'public steps primitive is defined'
+);
+$assert(
+	function_exists( 'static_site_importer_playground_import_blueprint' ),
+	'blueprint-function-exists',
+	'public blueprint primitive is defined'
+);
+
+$input = array(
+	'name'     => 'Primitive Demo',
+	'slug'     => 'primitive-demo',
+	'activate' => true,
+	'artifact' => array(
+		'schema'     => 'static-site-importer/website-artifact/v1',
+		'entrypoint' => 'website/index.html',
+		'files'      => array(
+			array(
+				'path'    => 'website/index.html',
+				'content' => '<!doctype html><title>Primitive</title><h1>Hi</h1>',
+			),
+		),
+	),
+);
+
+// --- Case 1: default steps include installPlugin + runPHP (+ login). ---
+$default_steps = static_site_importer_playground_import_steps( $input );
+$default_names = $step_names( $default_steps );
+
+$assert( is_array( $default_steps ), 'default-array', 'default steps is an array' );
+$assert(
+	in_array( 'login', $default_names, true ),
+	'default-login',
+	'default steps include login'
+);
+$assert(
+	in_array( 'installPlugin', $default_names, true ),
+	'default-install',
+	'default steps include installPlugin'
+);
+$assert(
+	in_array( 'runPHP', $default_names, true ),
+	'default-runphp',
+	'default steps include runPHP'
+);
+
+// --- Case 2: install=false omits installPlugin but keeps login + runPHP. ---
+$no_install_steps = static_site_importer_playground_import_steps( $input, array( 'install' => false ) );
+$no_install_names = $step_names( $no_install_steps );
+
+$assert(
+	! in_array( 'installPlugin', $no_install_names, true ),
+	'no-install-omits-install',
+	'install=false omits the installPlugin step'
+);
+$assert(
+	in_array( 'login', $no_install_names, true ),
+	'no-install-keeps-login',
+	'install=false keeps the login step'
+);
+$assert(
+	in_array( 'runPHP', $no_install_names, true ),
+	'no-install-keeps-runphp',
+	'install=false keeps the runPHP step'
+);
+
+// --- Case 3: runPHP code runs the proven import entrypoint. ---
+$run_php_code = '';
+foreach ( $no_install_steps as $step ) {
+	if ( is_array( $step ) && isset( $step['step'] ) && 'runPHP' === $step['step'] ) {
+		$run_php_code = (string) ( $step['code'] ?? '' );
+		break;
+	}
+}
+
+$assert(
+	false !== strpos( $run_php_code, 'static_site_importer_ability_import_website_artifact' ),
+	'runphp-entrypoint',
+	'runPHP code calls the import website artifact ability'
+);
+$assert(
+	false !== strpos( $run_php_code, 'website/index.html' ),
+	'runphp-embedded-artifact',
+	'runPHP code embeds the artifact entrypoint via var_export'
+);
+$assert(
+	false !== strpos( $run_php_code, 'static_site_importer_playground_preview_result' ),
+	'runphp-preview-result',
+	'runPHP code persists the preview result option'
+);
+
+// --- Case 4: blueprint primitive matches the legacy REST blueprint (delegation parity). ---
+$primitive_blueprint = static_site_importer_playground_import_blueprint( $input );
+$legacy_blueprint    = static_site_importer_rest_playground_blueprint( $input );
+
+$assert(
+	$primitive_blueprint === $legacy_blueprint,
+	'delegation-parity',
+	'public blueprint is byte-identical to the legacy REST blueprint'
+);
+$assert(
+	isset( $primitive_blueprint['steps'] ) && $primitive_blueprint['steps'] === $default_steps,
+	'blueprint-steps-parity',
+	'public blueprint embeds the public default steps'
+);
+
+// --- Report. ---
+if ( empty( $failures ) ) {
+	echo 'PASS: smoke-playground-import-primitive (' . (int) $assertions . " assertions)\n";
+	exit( 0 );
+}
+
+echo 'FAILURES (' . count( $failures ) . ' of ' . (int) $assertions . " assertions):\n";
+foreach ( $failures as $failure ) {
+	echo ' - ' . $failure . "\n";
+}
+exit( 1 );


### PR DESCRIPTION
## What
Consumers (Studio Native's in-page preview, Site Forge) need to orchestrate the same import-on-boot blueprint the `/import` live preview uses — including a variant **without** the `installPlugin` step for runtimes where SSI is already present (e.g. shipped as a sandbox mu-plugin).

New public primitives in `includes/rest.php`:
- `static_site_importer_playground_import_steps( $input, $options )` — the blueprint steps (`login` + `installPlugin` + `runPHP` import). `$options['install'] = false` omits `installPlugin` while keeping `login` + `runPHP`.
- `static_site_importer_playground_import_blueprint( $input, $options )` — wraps the steps into a full blueprint.

The legacy `static_site_importer_rest_playground_blueprint()` now **delegates** to the primitive (install defaults true), so the public `/import` preview blueprint is **byte-identical** (asserted with strict `===`).

## Why
Same upstream-seam pattern as the disposition filter (#505): SSI stays the generic engine and exposes a reusable primitive; products orchestrate it. This is what lets Studio Native materialize a project by importing its artifact into the in-page Playground on load, instead of reaching into a `_rest_` internal and stripping steps.

## Tests
`tests/smoke-playground-import-primitive.php` (14 assertions): default includes `installPlugin`; `install=>false` omits it but keeps `login`+`runPHP`; runPHP body calls the import ability with the embedded artifact; and delegation parity vs the legacy function. Existing `smoke-import-disposition.php` still passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Extracting the reusable primitive and the smoke test.