### PR TITLE
Bump bundled php-transformer pin to v0.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.1.18",
+        "version": "0.2.0",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "ee4377732f79712c8defa10980d0c7df9d8d8015"
+          "reference": "b1ea8f43e827a0bb040f3b013aabb7c3880edd97"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.18.zip",
-          "reference": "ee4377732f79712c8defa10980d0c7df9d8d8015"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.0.zip",
+          "reference": "b1ea8f43e827a0bb040f3b013aabb7c3880edd97"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.1.18",
+    "automattic/blocks-engine-php-transformer": "^0.2.0",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eeda082acbbd2f1660dcaae6fc0888e2",
+    "content-hash": "301494b0160f7661523a4a4c80674268",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.18",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "ee4377732f79712c8defa10980d0c7df9d8d8015"
+                "reference": "b1ea8f43e827a0bb040f3b013aabb7c3880edd97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.1.18.zip",
-                "reference": "ee4377732f79712c8defa10980d0c7df9d8d8015"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.0.zip",
+                "reference": "b1ea8f43e827a0bb040f3b013aabb7c3880edd97"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
Bump bundled php-transformer pin to v0.2.0 (composer.json + lock). Dependency bump only — no release.

## Changes
- `composer.json`: custom `automattic/blocks-engine-php-transformer` package pin updated
  - `version`: `0.1.18` → `0.2.0`
  - `dist.url` → `.../php-transformer-v0.2.0.zip`
  - `source.reference` / `dist.reference` → `b1ea8f43e827a0bb040f3b013aabb7c3880edd97` (tag `php-transformer-v0.2.0`)
  - `require` constraint `^0.1.18` → `^0.2.0`
- `composer.lock`: regenerated via `composer update automattic/blocks-engine-php-transformer --no-install` (locked version/dist/reference now point at v0.2.0). Lock hash is composer-regenerated — no manual `composer update` needed on merge.

`composer validate` passes; both JSON files validate.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (Claude Code)
- **Used for:** Editing composer.json/lock, regenerating the lock, and opening this PR.