### PR TITLE
Resolve CSS var() for theme.json body font-family

### DIFF
--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -932,6 +932,8 @@ class Static_Site_Importer_Theme_Materializer {
 			return null;
 		}
 
+		$custom_properties = self::css_custom_properties( $css );
+
 		foreach ( $rule_matches as $rule_match ) {
 			$selectors = array_map( 'trim', explode( ',', strtolower( $rule_match[1] ) ) );
 			if ( ! in_array( 'body', $selectors, true ) ) {
@@ -943,12 +945,78 @@ class Static_Site_Importer_Theme_Materializer {
 			}
 
 			$value = trim( preg_replace( '/\s*!important\s*$/i', '', $property_match[1] ) );
+
+			// Source typography is commonly applied through CSS custom properties
+			// (`body { font-family: var(--font-body) }`). Resolve the reference to
+			// the concrete typeface stack so theme.json carries a font-family that
+			// actually applies, rather than an undefined `var(--font-body)` that
+			// silently falls back to the default theme font.
+			$value = self::resolve_css_variables( $value, $custom_properties );
+
 			if ( self::is_safe_font_family_value( $value ) ) {
 				return $value;
 			}
 		}
 
 		return null;
+	}
+
+	/**
+	 * Collect `--name: value` custom-property declarations from CSS.
+	 *
+	 * @param string $css Source CSS.
+	 * @return array<string,string> Map of property name to declared value.
+	 */
+	private static function css_custom_properties( string $css ): array {
+		if ( ! preg_match_all( '/(--[A-Za-z0-9_-]+)\s*:\s*([^;{}]+)/', $css, $matches, PREG_SET_ORDER ) ) {
+			return array();
+		}
+
+		$properties = array();
+		foreach ( $matches as $match ) {
+			$properties[ (string) $match[1] ] = trim( (string) $match[2] );
+		}
+
+		return $properties;
+	}
+
+	/**
+	 * Expand `var(--name[, fallback])` references using custom-property definitions.
+	 *
+	 * Bounded recursive passes resolve variables whose values reference other
+	 * variables. Unresolved references are left intact so the caller's safety
+	 * validation rejects them.
+	 *
+	 * @param string                $value      CSS value possibly containing var() references.
+	 * @param array<string,string>  $properties Custom-property map.
+	 * @return string
+	 */
+	private static function resolve_css_variables( string $value, array $properties ): string {
+		if ( false === strpos( $value, 'var(' ) ) {
+			return $value;
+		}
+
+		for ( $pass = 0; $pass < 5; $pass++ ) {
+			$expanded = preg_replace_callback(
+				'/var\(\s*(--[A-Za-z0-9_-]+)\s*(?:,\s*([^()]*))?\)/',
+				static function ( array $match ) use ( $properties ): string {
+					$name = (string) $match[1];
+					if ( isset( $properties[ $name ] ) && '' !== $properties[ $name ] ) {
+						return $properties[ $name ];
+					}
+
+					return ( isset( $match[2] ) && '' !== trim( (string) $match[2] ) ) ? trim( (string) $match[2] ) : (string) $match[0];
+				},
+				$value
+			);
+
+			if ( ! is_string( $expanded ) || $expanded === $value ) {
+				break;
+			}
+			$value = $expanded;
+		}
+
+		return trim( $value );
 	}
 
 	/**
@@ -967,7 +1035,14 @@ class Static_Site_Importer_Theme_Materializer {
 			return false;
 		}
 
-		return (bool) preg_match( '/^[A-Za-z0-9_\-\s,"\'().]+$/', $value );
+		// A real font-family stack never contains CSS function syntax. Reject any
+		// leftover parentheses (e.g. an unresolved `var(--font-body)`) so a dead
+		// custom-property reference is never written into theme.json.
+		if ( false !== strpos( $value, '(' ) || false !== strpos( $value, ')' ) ) {
+			return false;
+		}
+
+		return (bool) preg_match( '/^[A-Za-z0-9_\-\s,"\']+$/', $value );
 	}
 
 	/**

--- a/tests/smoke-theme-materializer-dry-run.php
+++ b/tests/smoke-theme-materializer-dry-run.php
@@ -56,6 +56,13 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		$title = strtolower( trim( $title ) );
+		return preg_replace( '/[^a-z0-9_\-]+/', '-', $title ) ?? '';
+	}
+}
+
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
 
 $failures   = array();
@@ -160,6 +167,38 @@ $unsafe_theme_writes = Static_Site_Importer_Theme_Materializer::base_theme_write
 );
 $unsafe_theme_json   = json_decode( $unsafe_theme_writes[ $theme_dir . '/theme.json' ] ?? '', true );
 $assert( ! isset( $unsafe_theme_json['styles']['typography']['fontFamily'] ), 'unsafe-body-font-family-is-not-materialized' );
+
+// Sources commonly apply the body face through a CSS custom property
+// (`body { font-family: var(--font-body) }` defined in :root). theme.json must
+// carry the resolved typeface stack so the body font actually applies, instead
+// of an undefined `var(--font-body)` that silently falls back to the default.
+$var_font_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes(
+	$theme_dir,
+	'imported-theme',
+	'Imported Theme',
+	":root { --font-body: 'Lora', Georgia, serif; } body { font-family: var(--font-body); }",
+	false,
+	false
+);
+$var_font_json   = json_decode( $var_font_writes[ $theme_dir . '/theme.json' ] ?? '', true );
+$assert(
+	"'Lora', Georgia, serif" === ( $var_font_json['styles']['typography']['fontFamily'] ?? '' ),
+	'var-body-font-family-resolves-to-concrete-typeface-in-theme-json',
+	(string) ( $var_font_json['styles']['typography']['fontFamily'] ?? '' )
+);
+
+// An unresolvable var() (no definition, no fallback) must never be written into
+// theme.json as a dead reference.
+$unresolved_var_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes(
+	$theme_dir,
+	'imported-theme',
+	'Imported Theme',
+	'body { font-family: var(--font-missing); }',
+	false,
+	false
+);
+$unresolved_var_json   = json_decode( $unresolved_var_writes[ $theme_dir . '/theme.json' ] ?? '', true );
+$assert( ! isset( $unresolved_var_json['styles']['typography']['fontFamily'] ), 'unresolved-var-body-font-family-is-not-materialized' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## What
Companion to the blocks-engine font var()-resolution PR. SSI was writing a dead `var(--font-body)` into the generated `theme.json` (`styles.typography.fontFamily`), an undefined custom property → body font fell back to the default theme font.

## Change (`includes/class-static-site-importer-theme-materializer.php`)
- `body_font_family_from_css()` resolves `var()` via new `css_custom_properties()`/`resolve_css_variables()` helpers; `is_safe_font_family_value()` rejects leftover parens so a dead var() never reaches theme.json.

## Verification
- theme.json `var(--font-body)` → `'Lora', Georgia, serif`; effective computed body font-family now the source font. SSI smoke suites pass (added cases for var() resolution + unresolvable-var drop).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosis, fix, and verification under human review.