### PR TITLE
Materialize product-grid fallbacks into WooCommerce products (#510)

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1241,6 +1241,318 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
+	 * Materialize detected product-grid fallbacks through the configured shop provider.
+	 *
+	 * Collects every `html_product_grid_fallback` finding, normalizes each detected
+	 * product into a `products-manifest/v1` row (deriving a slug, normalizing the
+	 * currency price text into a decimal string, and forwarding description, image,
+	 * and source selectors), runs the rows through the shop adapter's manifest
+	 * validator + seeder, and stamps the runtime-mapped / acceptable-preservation
+	 * signal onto each finding whose products were actually seeded. Findings whose
+	 * products could not be seeded (for example because WooCommerce is unavailable)
+	 * keep no signal and stay an unacceptable parity loss, which lets the existing
+	 * commerce dependency gate report the missing runtime.
+	 *
+	 * @param array<string,mixed> $report Import report (mutated in place).
+	 * @param array<string,mixed> $args   Import args.
+	 * @return array<string,mixed> The recorded product_finding_seeding report.
+	 */
+	public static function materialize_product_findings( array &$report, array $args = array() ): array {
+		$adapter = Static_Site_Importer_Entity_Materializer_Registry::product_adapter();
+
+		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
+		$indexes     = self::product_grid_finding_indexes( $diagnostics );
+
+		if ( empty( $indexes ) ) {
+			$seeding                           = Static_Site_Importer_Entity_Materializer_Registry::new_entity_report( $adapter );
+			$seeding['status']                 = 'skipped';
+			$seeding['reason']                 = 'no_product_findings';
+			$report['product_finding_seeding'] = $seeding;
+			return $seeding;
+		}
+
+		$manifest_products = array();
+		$finding_slugs     = array();
+		foreach ( $indexes as $index ) {
+			$diagnostic = $report['diagnostics'][ $index ];
+			$products   = isset( $diagnostic['products'] ) && is_array( $diagnostic['products'] ) ? $diagnostic['products'] : array();
+			$container  = isset( $diagnostic['container_selector'] ) && is_scalar( $diagnostic['container_selector'] )
+				? (string) $diagnostic['container_selector']
+				: ( isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '' );
+
+			foreach ( $products as $product ) {
+				if ( ! is_array( $product ) ) {
+					continue;
+				}
+
+				$row = self::product_finding_manifest_row( $product, $container );
+				if ( null === $row ) {
+					continue;
+				}
+
+				$manifest_products[]       = $row;
+				$finding_slugs[ $index ][] = $row['slug'];
+			}
+		}
+
+		$manifest   = array(
+			'schema_version' => 1,
+			'products'       => $manifest_products,
+		);
+		$validation = Static_Site_Importer_Entity_Materializer_Registry::validate_manifest( $adapter, $manifest );
+		$validated  = isset( $validation['products'] ) && is_array( $validation['products'] ) ? $validation['products'] : array();
+
+		$seeding = Static_Site_Importer_Entity_Materializer_Registry::materialize( $adapter, array( 'products' => $validated ) );
+
+		$seeding['provider']      = Static_Site_Importer_Entity_Materializer_Registry::provider_for( 'shop' );
+		$seeding['finding_count'] = count( $indexes );
+		$seeding['product_count'] = count( $manifest_products );
+		$seeding['mapped_count']  = 0;
+		$seeding['waived']        = ! empty( $args[ (string) ( $adapter['waiver_arg'] ?? 'allow_missing_woocommerce' ) ] );
+		$seeding['manifest']      = $manifest;
+		if ( ! empty( $validation['errors'] ) ) {
+			$seeding['validation_errors'] = $validation['errors'];
+		}
+
+		$seeded_slugs = array();
+		foreach ( ( isset( $seeding['products'] ) && is_array( $seeding['products'] ) ? $seeding['products'] : array() ) as $product_row ) {
+			if ( ! is_array( $product_row ) ) {
+				continue;
+			}
+			if ( in_array( (string) ( $product_row['status'] ?? '' ), array( 'created', 'updated' ), true ) ) {
+				$seeded_slugs[ (string) ( $product_row['slug'] ?? '' ) ] = true;
+			}
+		}
+
+		foreach ( $indexes as $index ) {
+			$slugs = $finding_slugs[ $index ] ?? array();
+			foreach ( $slugs as $slug ) {
+				if ( isset( $seeded_slugs[ $slug ] ) ) {
+					++$seeding['mapped_count'];
+					$report['diagnostics'][ $index ] = self::mark_product_finding_mapped( $report['diagnostics'][ $index ], $seeding['provider'] );
+					break;
+				}
+			}
+		}
+
+		$report['product_finding_seeding'] = $seeding;
+		return $seeding;
+	}
+
+	/**
+	 * Return diagnostic indexes for every detected product-grid fallback finding.
+	 *
+	 * @param array<int,mixed> $diagnostics Report diagnostics.
+	 * @return array<int,int>
+	 */
+	public static function product_grid_finding_indexes( array $diagnostics ): array {
+		$indexes = array();
+		foreach ( $diagnostics as $index => $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+
+			$code = (string) ( $diagnostic['diagnostic_code'] ?? '' );
+			if ( '' === $code ) {
+				$code = (string) ( $diagnostic['kind'] ?? '' );
+			}
+
+			if ( 'html_product_grid_fallback' === $code ) {
+				$indexes[] = (int) $index;
+			}
+		}
+
+		return $indexes;
+	}
+
+	/**
+	 * Normalize one detected product into a products-manifest/v1 row.
+	 *
+	 * @param array<string,mixed> $product           Detected product entry.
+	 * @param string              $container_selector Owning grid container selector.
+	 * @return array<string,mixed>|null
+	 */
+	private static function product_finding_manifest_row( array $product, string $container_selector ): ?array {
+		$name = isset( $product['name'] ) && is_scalar( $product['name'] ) ? trim( (string) $product['name'] ) : '';
+		if ( '' === $name ) {
+			return null;
+		}
+
+		$slug_source = isset( $product['slug'] ) && is_scalar( $product['slug'] ) && '' !== trim( (string) $product['slug'] )
+			? (string) $product['slug']
+			: $name;
+		$slug        = self::product_slug( $slug_source );
+		if ( '' === $slug ) {
+			return null;
+		}
+
+		$row = array(
+			'name'          => $name,
+			'slug'          => $slug,
+			'regular_price' => self::normalize_product_price( isset( $product['price'] ) && is_scalar( $product['price'] ) ? (string) $product['price'] : '' ),
+		);
+
+		$sale_price = self::normalize_product_price( isset( $product['sale_price'] ) && is_scalar( $product['sale_price'] ) ? (string) $product['sale_price'] : '' );
+		if ( '' !== $sale_price ) {
+			$row['sale_price'] = $sale_price;
+		}
+
+		if ( isset( $product['description'] ) && is_scalar( $product['description'] ) && '' !== trim( (string) $product['description'] ) ) {
+			$row['description'] = (string) $product['description'];
+		}
+
+		$image = self::product_image_src( $product['image'] ?? null );
+		if ( '' !== $image ) {
+			$row['image'] = $image;
+		}
+
+		$selectors = array();
+		if ( isset( $product['source_selector'] ) && is_scalar( $product['source_selector'] ) && '' !== trim( (string) $product['source_selector'] ) ) {
+			$selectors[] = trim( (string) $product['source_selector'] );
+		}
+		if ( '' !== $container_selector ) {
+			$selectors[] = $container_selector;
+		}
+		$selectors = array_values( array_unique( $selectors ) );
+		if ( ! empty( $selectors ) ) {
+			$row['source_selectors'] = $selectors;
+		}
+
+		return $row;
+	}
+
+	/**
+	 * Derive a lowercase URL slug for a product.
+	 *
+	 * @param string $text Slug source text.
+	 * @return string
+	 */
+	private static function product_slug( string $text ): string {
+		if ( function_exists( 'sanitize_title' ) ) {
+			return sanitize_title( $text );
+		}
+
+		$slug = strtolower( trim( $text ) );
+		$slug = preg_replace( '/[^a-z0-9]+/', '-', $slug );
+		return trim( is_string( $slug ) ? $slug : '', '-' );
+	}
+
+	/**
+	 * Resolve the product image source from a string or {src, alt} object.
+	 *
+	 * @param mixed $image Detected product image.
+	 * @return string
+	 */
+	private static function product_image_src( mixed $image ): string {
+		if ( is_string( $image ) ) {
+			return trim( $image );
+		}
+
+		if ( is_array( $image ) ) {
+			$src = $image['src'] ?? '';
+			return is_scalar( $src ) ? trim( (string) $src ) : '';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Normalize a human-readable currency price into a decimal manifest string.
+	 *
+	 * Generic and locale-tolerant: strips currency symbols, whitespace, and other
+	 * non-numeric characters, then resolves the decimal separator from the digit
+	 * grouping itself rather than any site or locale setting. Handles US grouping
+	 * ("$1,299.00" => "1299.00"), European grouping ("1.299,00 €" => "1299.00"),
+	 * symbol-only integers ("$24" => "24", "€18" => "18"), and bare decimals
+	 * ("18.00" => "18.00"). The fractional part is normalized to exactly two
+	 * decimals; integers stay integers so the manifest validator accepts both.
+	 *
+	 * @param string $price Raw price text.
+	 * @return string Decimal price string, or '' when no digits are present.
+	 */
+	public static function normalize_product_price( string $price ): string {
+		$clean = preg_replace( '/[^0-9.,]/', '', trim( $price ) );
+		$clean = is_string( $clean ) ? $clean : '';
+		if ( '' === $clean ) {
+			return '';
+		}
+
+		$comma_count = substr_count( $clean, ',' );
+		$dot_count   = substr_count( $clean, '.' );
+
+		$decimal_sep = '';
+		if ( $comma_count > 0 && $dot_count > 0 ) {
+			// When both separators appear, the rightmost one is the decimal point.
+			$decimal_sep = ( (int) strrpos( $clean, ',' ) > (int) strrpos( $clean, '.' ) ) ? ',' : '.';
+		} elseif ( 1 === $comma_count && 0 === $dot_count ) {
+			$decimal_sep = self::is_decimal_tail( $clean, ',' ) ? ',' : '';
+		} elseif ( 1 === $dot_count && 0 === $comma_count ) {
+			$decimal_sep = self::is_decimal_tail( $clean, '.' ) ? '.' : '';
+		}
+		// Repeated single separators (e.g. "1,234,567") are digit grouping only.
+
+		if ( '' !== $decimal_sep ) {
+			$parts    = explode( $decimal_sep, $clean );
+			$fraction = (string) array_pop( $parts );
+			$integer  = (string) preg_replace( '/[^0-9]/', '', implode( '', $parts ) );
+			$fraction = (string) preg_replace( '/[^0-9]/', '', $fraction );
+		} else {
+			$integer  = (string) preg_replace( '/[^0-9]/', '', $clean );
+			$fraction = '';
+		}
+
+		$integer = ltrim( $integer, '0' );
+		if ( '' === $integer ) {
+			$integer = '0';
+		}
+
+		if ( '' === $fraction ) {
+			return $integer;
+		}
+
+		if ( strlen( $fraction ) > 2 ) {
+			return number_format( (float) ( $integer . '.' . $fraction ), 2, '.', '' );
+		}
+
+		return $integer . '.' . str_pad( $fraction, 2, '0' );
+	}
+
+	/**
+	 * Decide whether a single separator's trailing digits read as a decimal part.
+	 *
+	 * @param string $clean Digit-and-separator string.
+	 * @param string $sep   Candidate decimal separator.
+	 * @return bool
+	 */
+	private static function is_decimal_tail( string $clean, string $sep ): bool {
+		$pos = strrpos( $clean, $sep );
+		if ( false === $pos ) {
+			return false;
+		}
+
+		$length = strlen( substr( $clean, $pos + 1 ) );
+		return $length >= 1 && $length <= 2;
+	}
+
+	/**
+	 * Stamp the runtime-mapped / acceptable-preservation signal onto a product finding.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic to mark.
+	 * @param string              $provider   Resolved shop provider id.
+	 * @return array<string,mixed>
+	 */
+	private static function mark_product_finding_mapped( array $diagnostic, string $provider ): array {
+		$diagnostic['runtime_mapped']  = true;
+		$diagnostic['mapped_provider'] = '' !== $provider ? $provider : 'woocommerce';
+		$diagnostic['acceptability']   = 'acceptable_preservation';
+		$diagnostic['block_name']      = isset( $diagnostic['block_name'] ) && is_scalar( $diagnostic['block_name'] ) && '' !== (string) $diagnostic['block_name']
+			? (string) $diagnostic['block_name']
+			: 'woocommerce/product-collection';
+
+		return $diagnostic;
+	}
+
+	/**
 	 * Build a compact diagnostic excerpt.
 	 *
 	 * @param string $html Source HTML.
@@ -1808,6 +2120,13 @@ class Static_Site_Importer_Report_Diagnostics {
 			$diagnostic = self::enrich_form_fallback_diagnostic( $diagnostic, $fallback, $diagnostic_code );
 		}
 
+		// The product-grid fallback may carry its code under `kind` (Blocks Engine
+		// product-grid contract) or `diagnostic_code` (normalized fallbacks).
+		$kind = self::first_scalar( $fallback, array( 'kind' ) );
+		if ( 'html_product_grid_fallback' === $diagnostic_code || 'html_product_grid_fallback' === $kind ) {
+			$diagnostic = self::enrich_product_grid_fallback_diagnostic( $diagnostic, $fallback );
+		}
+
 		return $diagnostic;
 	}
 
@@ -1841,6 +2160,43 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 		if ( isset( $fallback['control_count'] ) && is_numeric( $fallback['control_count'] ) ) {
 			$diagnostic['control_count'] = (int) $fallback['control_count'];
+		}
+
+		return $diagnostic;
+	}
+
+	/**
+	 * Carry preserved product-grid metadata onto its SSI diagnostic.
+	 *
+	 * Mirrors the form-fallback enrichment: keeps a stable diagnostic_code,
+	 * classifies the finding as a preserved runtime island, and forwards the
+	 * container selector plus the detected product list so the configured shop
+	 * provider can materialize the products and close the gate loop.
+	 *
+	 * @param array<string,mixed> $diagnostic Base diagnostic.
+	 * @param array<string,mixed> $fallback   Native fallback row.
+	 * @return array<string,mixed>
+	 */
+	private static function enrich_product_grid_fallback_diagnostic( array $diagnostic, array $fallback ): array {
+		$diagnostic['diagnostic_code']     = 'html_product_grid_fallback';
+		$diagnostic['loss_class']          = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
+		$diagnostic['diagnostic_class']    = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
+		$diagnostic['tag']                 = 'product-grid';
+		$diagnostic['element']             = 'product-grid';
+		$diagnostic['suggested_primitive'] = 'product';
+
+		$container = self::first_scalar( $fallback, array( 'container_selector', 'selector' ) );
+		if ( '' !== $container ) {
+			$diagnostic['container_selector'] = $container;
+			if ( empty( $diagnostic['selector'] ) ) {
+				$diagnostic['selector'] = $container;
+			}
+		}
+
+		if ( isset( $fallback['products'] ) && is_array( $fallback['products'] ) ) {
+			$products                    = array_values( array_filter( $fallback['products'], 'is_array' ) );
+			$diagnostic['products']      = $products;
+			$diagnostic['product_count'] = count( $products );
 		}
 
 		return $diagnostic;

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -223,6 +223,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::record_product_seeding_report( $args );
 		self::record_commerce_dependency_check( $args );
 		self::record_form_materialization( $args );
+		self::record_product_materialization( $args );
 		$source_of_truth_manifest                    = self::source_of_truth_manifest( $import_run_id, $source_artifact_reference, $theme_dir, $theme_slug, $page_targets, $page_ids, $permalinks, $writes, $materialized );
 		self::$conversion_report['source_of_truth'] = $source_of_truth_manifest;
 		$quality                                    = Static_Site_Importer_Report_Diagnostics::finalize_report( self::$conversion_report, $args );
@@ -3028,6 +3029,25 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Materialize detected product-grid fallbacks through the configured shop provider.
+	 *
+	 * Mirrors the form path: preserved `html_product_grid_fallback` findings carry
+	 * the detected product list, the shop provider seeds them into real WooCommerce
+	 * products, and successfully seeded findings receive the runtime-mapped signal so
+	 * the honest fixture gate counts them as acceptable preservation instead of a
+	 * dead, unacceptable feature-parity loss. Commerce intent detection picks up the
+	 * same findings so the WooCommerce auto-install and dependency gate fire ahead of
+	 * this seeding step. Products that cannot be seeded keep no signal and stay
+	 * unacceptable.
+	 *
+	 * @param array<string, mixed> $args Import args.
+	 * @return void
+	 */
+	private static function record_product_materialization( array $args ): void {
+		Static_Site_Importer_Report_Diagnostics::materialize_product_findings( self::$conversion_report, $args );
+	}
+
+	/**
 	 * Collapse dependency reports to the legacy plugin materialization status.
 	 *
 	 * @param array<string,array<string,mixed>> $reports Dependency reports keyed by plugin slug.
@@ -3074,6 +3094,25 @@ class Static_Site_Importer_Theme_Generator {
 				}
 				if ( $context_count > $product_count ) {
 					$product_count = $context_count;
+				}
+			}
+		}
+
+		$diagnostics     = isset( self::$conversion_report['diagnostics'] ) && is_array( self::$conversion_report['diagnostics'] ) ? self::$conversion_report['diagnostics'] : array();
+		$finding_indexes = Static_Site_Importer_Report_Diagnostics::product_grid_finding_indexes( $diagnostics );
+		if ( ! empty( $finding_indexes ) ) {
+			$finding_product_count = 0;
+			foreach ( $finding_indexes as $index ) {
+				$diagnostic             = $diagnostics[ $index ] ?? array();
+				$products               = is_array( $diagnostic ) && isset( $diagnostic['products'] ) && is_array( $diagnostic['products'] ) ? $diagnostic['products'] : array();
+				$finding_product_count += count( $products );
+			}
+			if ( $finding_product_count > 0 ) {
+				if ( ! in_array( 'html_product_grid_fallback', $sources, true ) ) {
+					$sources[] = 'html_product_grid_fallback';
+				}
+				if ( $finding_product_count > $product_count ) {
+					$product_count = $finding_product_count;
 				}
 			}
 		}

--- a/tests/smoke-product-materializer.php
+++ b/tests/smoke-product-materializer.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Smoke coverage for the product-grid fallback materialization path.
+ *
+ * Consumes the Blocks Engine `html_product_grid_fallback` finding, normalizes it
+ * into a products-manifest/v1, validates + seeds it through the WooCommerce shop
+ * adapter, and confirms the gate-closure signal is stamped onto seeded findings.
+ *
+ * Run from the repository root:
+ * php tests/smoke-product-materializer.php
+ *
+ * @package StaticSiteImporter
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	}
+	if ( ! defined( 'OBJECT' ) ) {
+		define( 'OBJECT', 'OBJECT' );
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $key ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.keyFound
+			$key = strtolower( (string) $key );
+			return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_title' ) ) {
+		function sanitize_title( $title ) {
+			$title = strtolower( trim( (string) $title ) );
+			$title = preg_replace( '/[^a-z0-9]+/', '-', $title );
+			return trim( (string) $title, '-' );
+		}
+	}
+
+	if ( ! function_exists( 'wp_kses_post' ) ) {
+		function wp_kses_post( $value ) {
+			return (string) $value;
+		}
+	}
+
+	$GLOBALS['ssi_test_hooks'] = array();
+
+	if ( ! function_exists( 'add_filter' ) ) {
+		function add_filter( string $hook, callable $callback ): void {
+			$GLOBALS['ssi_test_hooks'][ $hook ][] = $callback;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value, ...$args ) {
+			foreach ( $GLOBALS['ssi_test_hooks'][ $hook ] ?? array() as $callback ) {
+				$value = $callback( $value, ...$args );
+			}
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( $name, $default = false ) {
+			unset( $name );
+			return $default;
+		}
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data ) {
+			return json_encode( $data );
+		}
+	}
+
+	// --- WooCommerce runtime mock ------------------------------------------------
+	// Captures the seeded simple products so the smoke test can assert the prices
+	// the seeder wrote without a live WooCommerce install.
+	$GLOBALS['ssi_seeded_products'] = array();
+	$GLOBALS['ssi_next_product_id'] = 1000;
+
+	if ( ! function_exists( 'post_type_exists' ) ) {
+		function post_type_exists( $type ) {
+			return 'product' === $type;
+		}
+	}
+	if ( ! function_exists( 'taxonomy_exists' ) ) {
+		function taxonomy_exists( $taxonomy ) {
+			return 'product_cat' === $taxonomy;
+		}
+	}
+	if ( ! function_exists( 'get_page_by_path' ) ) {
+		function get_page_by_path( $path, $output = OBJECT, $post_type = 'post' ) {
+			unset( $path, $output, $post_type );
+			return null;
+		}
+	}
+
+	if ( ! class_exists( 'WC_Product_Simple' ) ) {
+		class WC_Product_Simple {
+			/** @var array<string,mixed> */
+			public $data = array();
+			public function set_name( $value ) {
+				$this->data['name'] = $value; }
+			public function set_slug( $value ) {
+				$this->data['slug'] = $value; }
+			public function set_status( $value ) {
+				$this->data['status'] = $value; }
+			public function set_description( $value ) {
+				$this->data['description'] = $value; }
+			public function set_short_description( $value ) {
+				$this->data['short_description'] = $value; }
+			public function set_regular_price( $value ) {
+				$this->data['regular_price'] = $value; }
+			public function set_sale_price( $value ) {
+				$this->data['sale_price'] = $value; }
+			public function set_stock_status( $value ) {
+				$this->data['stock_status'] = $value; }
+			public function set_manage_stock( $value ) {
+				$this->data['manage_stock'] = $value; }
+			public function set_stock_quantity( $value ) {
+				$this->data['stock_quantity'] = $value; }
+			public function save() {
+				$id                                          = $GLOBALS['ssi_next_product_id']++;
+				$this->data['id']                            = $id;
+				$GLOBALS['ssi_seeded_products'][ (string) ( $this->data['slug'] ?? '' ) ] = $this->data;
+				return $id;
+			}
+		}
+	}
+
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-woo-product-seeder.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-form-seeder.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-loss-classes.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-transformer-adapter.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
+
+	$failures   = array();
+	$assertions = 0;
+	$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+		}
+	};
+
+	// --- Price normalization is generic and locale-tolerant -----------------
+	$price_cases = array(
+		'$24'         => '24',
+		'$1,299.00'   => '1299.00',
+		'€18'         => '18',
+		'18.00'       => '18.00',
+		'18'          => '18',
+		'€18,50'      => '18.50',
+		'1,299'       => '1299',
+		'1.299,00 €'  => '1299.00',
+		'$1,234,567'  => '1234567',
+		'  $0.99 '    => '0.99',
+		'12.5'        => '12.50',
+		'1,234.567'   => '1234.57',
+		'49.999'      => '49999',
+		''            => '',
+		'free'        => '',
+	);
+	foreach ( $price_cases as $input => $expected ) {
+		$actual = Static_Site_Importer_Report_Diagnostics::normalize_product_price( (string) $input );
+		$assert( $expected === $actual, 'price-normalize-' . sanitize_key( (string) $input ), 'input "' . $input . '" => "' . $actual . '" expected "' . $expected . '"' );
+	}
+
+	// --- Native html_product_grid_fallback row enriches into a product finding
+	$enrich   = new ReflectionMethod( 'Static_Site_Importer_Report_Diagnostics', 'diagnostic_from_conversion_report_fallback' );
+	$enriched = $enrich->invoke(
+		null,
+		array(
+			'kind'               => 'html_product_grid_fallback',
+			'reason'             => 'commerce_requires_runtime',
+			'source_path'        => 'website/shop.html',
+			'container_selector' => 'ul.products',
+			'products'           => array(
+				array(
+					'name'             => 'Aero Mug',
+					'price'            => '$24',
+					'sale_price'       => null,
+					'description'      => 'Double-walled travel mug.',
+					'image'            => array( 'src' => 'https://cdn.example.com/mug.jpg', 'alt' => 'Aero Mug' ),
+					'has_cart_control' => true,
+					'source_selector'  => 'ul.products li:nth-child(1)',
+				),
+			),
+		)
+	);
+	$assert( 'html_product_grid_fallback' === ( $enriched['diagnostic_code'] ?? '' ), 'enrich-carries-diagnostic-code' );
+	$assert( Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND === ( $enriched['loss_class'] ?? '' ), 'enrich-loss-class-preserved-runtime-island' );
+	$assert( 'ul.products' === ( $enriched['container_selector'] ?? '' ), 'enrich-carries-container-selector' );
+	$assert( isset( $enriched['products'][0]['name'] ) && 'Aero Mug' === $enriched['products'][0]['name'], 'enrich-carries-products' );
+	$assert( 1 === ( $enriched['product_count'] ?? 0 ), 'enrich-product-count' );
+
+	// --- materialize_product_findings: manifest + seeding + gate-closure -----
+	$report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/shop.html' );
+	$report['diagnostics'][] = array(
+		'type'               => 'unsupported_html_fallback',
+		'diagnostic_code'    => 'html_product_grid_fallback',
+		'loss_class'         => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path'        => 'website/shop.html',
+		'container_selector' => 'ul.products',
+		'selector'           => 'ul.products',
+		'products'           => array(
+			array(
+				'name'             => 'Aero Mug',
+				'price'            => '$24',
+				'sale_price'       => null,
+				'description'      => 'Double-walled travel mug.',
+				'image'            => array( 'src' => 'https://cdn.example.com/mug.jpg', 'alt' => 'Aero Mug' ),
+				'has_cart_control' => true,
+				'source_selector'  => 'ul.products li:nth-child(1)',
+			),
+			array(
+				'name'             => 'Trail Pack',
+				'price'            => '$1,299.00',
+				'sale_price'       => '$999.00',
+				'description'      => null,
+				'image'            => null,
+				'has_cart_control' => true,
+				'source_selector'  => 'ul.products li:nth-child(2)',
+			),
+		),
+	);
+
+	$seeding = Static_Site_Importer_Report_Diagnostics::materialize_product_findings( $report, array() );
+	$assert( 'woocommerce' === ( $seeding['provider'] ?? '' ), 'materialize-provider-woocommerce' );
+	$assert( 1 === ( $seeding['finding_count'] ?? 0 ), 'materialize-one-finding' );
+	$assert( 2 === ( $seeding['product_count'] ?? 0 ), 'materialize-two-products' );
+	$assert( 'completed' === ( $seeding['status'] ?? '' ), 'materialize-status-completed' );
+	$assert( empty( $seeding['validation_errors'] ), 'materialize-manifest-valid', (string) wp_json_encode( $seeding['validation_errors'] ?? array() ) );
+
+	// Manifest shape is products-manifest/v1.
+	$manifest = $seeding['manifest'] ?? array();
+	$assert( 1 === ( $manifest['schema_version'] ?? 0 ), 'manifest-schema-version-1' );
+	$rows = $manifest['products'] ?? array();
+	$assert( 2 === count( $rows ), 'manifest-two-rows' );
+	$assert( 'Aero Mug' === ( $rows[0]['name'] ?? '' ), 'manifest-row0-name' );
+	$assert( 'aero-mug' === ( $rows[0]['slug'] ?? '' ), 'manifest-row0-slug' );
+	$assert( '24' === ( $rows[0]['regular_price'] ?? '' ), 'manifest-row0-regular-price' );
+	$assert( ! isset( $rows[0]['sale_price'] ), 'manifest-row0-no-sale-price' );
+	$assert( 'https://cdn.example.com/mug.jpg' === ( $rows[0]['image'] ?? '' ), 'manifest-row0-image-src' );
+	$assert( in_array( 'ul.products li:nth-child(1)', $rows[0]['source_selectors'] ?? array(), true ), 'manifest-row0-source-selectors' );
+	$assert( '1299.00' === ( $rows[1]['regular_price'] ?? '' ), 'manifest-row1-regular-price' );
+	$assert( '999.00' === ( $rows[1]['sale_price'] ?? '' ), 'manifest-row1-sale-price' );
+
+	// Seeder created real (mocked) products with the normalized prices.
+	$assert( 2 === ( $seeding['counts']['created'] ?? 0 ), 'seeder-created-two' );
+	$assert( isset( $GLOBALS['ssi_seeded_products']['aero-mug'] ), 'seeder-product-aero-mug' );
+	$assert( '24' === ( $GLOBALS['ssi_seeded_products']['aero-mug']['regular_price'] ?? '' ), 'seeder-aero-mug-price' );
+	$assert( isset( $GLOBALS['ssi_seeded_products']['trail-pack'] ), 'seeder-product-trail-pack' );
+	$assert( '1299.00' === ( $GLOBALS['ssi_seeded_products']['trail-pack']['regular_price'] ?? '' ), 'seeder-trail-pack-price' );
+	$assert( '999.00' === ( $GLOBALS['ssi_seeded_products']['trail-pack']['sale_price'] ?? '' ), 'seeder-trail-pack-sale-price' );
+
+	// Gate-closure: the seeded finding receives the runtime-mapped signal.
+	$assert( 1 === ( $seeding['mapped_count'] ?? 0 ), 'materialize-finding-mapped-count' );
+	$finding = $report['diagnostics'][0];
+	$assert( true === ( $finding['runtime_mapped'] ?? false ), 'finding-runtime-mapped' );
+	$assert( 'woocommerce' === ( $finding['mapped_provider'] ?? '' ), 'finding-mapped-provider' );
+	$assert( 'acceptable_preservation' === ( $finding['acceptability'] ?? '' ), 'finding-acceptable-preservation' );
+	$assert( Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND === Static_Site_Importer_Diagnostic_Loss_Classes::classify( $finding ), 'finding-stays-preserved-runtime-island' );
+	$assert( is_array( $report['product_finding_seeding'] ?? null ), 'report-records-product-finding-seeding' );
+
+	// --- No product findings => skipped report ------------------------------
+	$empty_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/about.html' );
+	$empty_seed   = Static_Site_Importer_Report_Diagnostics::materialize_product_findings( $empty_report, array() );
+	$assert( 'skipped' === ( $empty_seed['status'] ?? '' ), 'no-findings-skipped' );
+	$assert( 'no_product_findings' === ( $empty_seed['reason'] ?? '' ), 'no-findings-reason' );
+
+	// --- product_grid_finding_indexes detects both `kind` and `diagnostic_code`
+	$indexes = Static_Site_Importer_Report_Diagnostics::product_grid_finding_indexes(
+		array(
+			array( 'diagnostic_code' => 'html_form_fallback' ),
+			array( 'kind' => 'html_product_grid_fallback' ),
+			array( 'diagnostic_code' => 'html_product_grid_fallback' ),
+		)
+	);
+	$assert( array( 1, 2 ) === $indexes, 'finding-indexes-detect-kind-and-code' );
+
+	if ( empty( $failures ) ) {
+		echo 'PASS smoke-product-materializer.php (' . $assertions . " assertions)\n";
+		exit( 0 );
+	}
+
+	echo 'FAILURES (' . count( $failures ) . ' of ' . $assertions . " assertions):\n";
+	echo implode( "\n", $failures ) . "\n";
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary

PR2 of the static-product-grid -> WooCommerce capability (#510, epic #489). This consumes the Blocks Engine product-grid finding and materializes WooCommerce products through the **existing** simple-product seeder, mirroring the form-fallback materialization path that already shipped.

It builds against blocks-engine PR1's `html_product_grid_fallback` finding contract:

```
kind: "html_product_grid_fallback"
container_selector: "<css selector>"
products: [
  { name, price ("$24"), sale_price (or null), description (or null),
    image: {src, alt}|null, has_cart_control, source_selector }, ...
]
```

## What it does

1. **`materialize_product_findings()`** (`includes/class-static-site-importer-report-diagnostics.php`) mirrors `materialize_form_findings()`: scans diagnostics for `html_product_grid_fallback`, normalizes each detected product into a `products-manifest/v1` row, validates through the existing `validate_woo_products_manifest()`, seeds through `Static_Site_Importer_Woo_Product_Seeder::seed()`, and stamps the runtime-mapped / `acceptable_preservation` gate-closure signal onto each finding whose products were actually seeded. Findings that cannot be seeded (e.g. WooCommerce absent) keep no signal and stay an unacceptable parity loss, so the existing dependency gate still reports the missing runtime.
2. **Fallback enrichment**: native `html_product_grid_fallback` rows (carried under `kind` or `diagnostic_code`) are enriched into SSI diagnostics that retain the container selector and detected product list, classified as a preserved runtime island.
3. **Wiring** (`includes/class-static-site-importer-theme-generator.php`): `record_product_materialization()` is added next to `record_form_materialization()`, and `commerce_dependency_intent()` now detects product-grid findings — so the already-built WooCommerce auto-install (`materialize_required_plugins`) and dependency gate (`record_commerce_dependency_check`) fire from detected products ahead of seeding.

### How findings map to `products-manifest/v1`

| finding field | manifest row field | notes |
|---|---|---|
| `name` | `name` | required; row dropped if empty |
| `name` (or explicit `slug`) | `slug` | derived via `sanitize_title` |
| `price` | `regular_price` | decimal-normalized (see below); required by validator |
| `sale_price` | `sale_price` | normalized; omitted when null/empty |
| `description` | `description` | omitted when null/empty |
| `image.src` (or string image) | `image` | validator requires a string, so the `{src, alt}` object collapses to `src` |
| `source_selector` + `container_selector` | `source_selectors` | de-duplicated string array |

### Price normalization

Generic and locale-tolerant — no site/locale hardcoding. It strips currency symbols and whitespace, then resolves the decimal separator from the digit grouping itself rather than any locale setting:

- both `,` and `.` present -> the rightmost separator is the decimal point (`$1,299.00` -> `1299.00`, `1.299,00 EUR` -> `1299.00`)
- a single separator with 1-2 trailing digits -> decimal (`18.00` -> `18.00`, `18,50` -> `18.50`)
- a single separator with 3+ trailing digits, or repeated separators -> digit grouping only (`1,299` -> `1299`, `1,234,567` -> `1234567`)
- symbol-only integers stay integers (`$24` -> `24`, `EUR18` -> `18`); fractions normalize to exactly two decimals (`12.5` -> `12.50`, `1,234.567` -> `1234.57`)

## Boundary

Scoped to the product/diagnostics materialization path. The CSS/theme-style materialization path is untouched; the only theme-generator change is the adjacent `record_product_materialization()` call plus the finding-aware branch in `commerce_dependency_intent()` — no restructuring of the CSS code.

## Tests

`tests/smoke-product-materializer.php` (50 assertions) covers price normalization, fallback enrichment, `products-manifest/v1` shaping, seeding with a mocked WooCommerce runtime (asserting created products carry the normalized prices), gate-closure signalling, and the no-findings path.

- `php tests/smoke-product-materializer.php` -> PASS (50 assertions)
- `php tests/smoke-form-materializer.php` and the other diagnostics/commerce smoke tests stay green.
- `php -l` clean on both modified files.
- Three pre-existing suite tests (`smoke-import-source-of-truth-manifest`, `smoke-static-interactive-artifact`, `smoke-website-artifact-document-metadata`) fail identically on `origin/main` (they need a live WP runtime) and are unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Implementing the product-finding materializer, price normalization, theme-generator wiring, and the smoke test, following the existing form-materialization pattern.