### PR TITLE
Extract products from bundle data files (preferred source over DOM detection)

### DIFF
--- a/includes/class-static-site-importer-bundle-data-source.php
+++ b/includes/class-static-site-importer-bundle-data-source.php
@@ -1,0 +1,992 @@
+<?php
+/**
+ * Bundle-aware structured-data source.
+ *
+ * Many static site bundles render their catalog client-side from a static data
+ * file (for example `js/products.js` exporting an array of product objects).
+ * The rendered HTML for those pages imports empty because the content only
+ * exists in the data file. This source reads those `.js`/`.json` data files
+ * directly — without executing JavaScript — and recognizes entity-shaped arrays
+ * by DATA SHAPE alone (a name-like field plus a price-like field), never by
+ * variable names or site-specific keys.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Extracts product candidates from static data files carried in a website artifact.
+ */
+class Static_Site_Importer_Bundle_Data_Source {
+
+	/**
+	 * Name-like field synonyms (normalized: lowercased, alphanumerics only).
+	 *
+	 * @var array<int,string>
+	 */
+	private const NAME_KEYS = array( 'name', 'title', 'productname', 'producttitle', 'label' );
+
+	/**
+	 * Price-like field synonyms.
+	 *
+	 * @var array<int,string>
+	 */
+	private const PRICE_KEYS = array( 'price', 'amount', 'cost', 'regularprice', 'baseprice', 'unitprice' );
+
+	/**
+	 * Sale-price field synonyms.
+	 *
+	 * @var array<int,string>
+	 */
+	private const SALE_PRICE_KEYS = array( 'saleprice', 'discountprice', 'specialprice' );
+
+	/**
+	 * Description field synonyms.
+	 *
+	 * @var array<int,string>
+	 */
+	private const DESCRIPTION_KEYS = array( 'description', 'desc', 'body', 'summary', 'details', 'notes', 'about', 'blurb' );
+
+	/**
+	 * Image field synonyms.
+	 *
+	 * @var array<int,string>
+	 */
+	private const IMAGE_KEYS = array( 'image', 'img', 'src', 'thumbnail', 'thumb', 'photo', 'picture', 'imageurl' );
+
+	/**
+	 * Category field synonyms.
+	 *
+	 * @var array<int,string>
+	 */
+	private const CATEGORY_KEYS = array( 'category', 'categories', 'type', 'collection', 'department', 'tags' );
+
+	/**
+	 * Explicit URL-slug field synonyms used to derive a stable slug.
+	 *
+	 * Internal identifiers (id/sku) are intentionally excluded: they are rarely
+	 * URL slugs, and slugging from the name keeps the row dedupe-compatible with
+	 * the DOM product detector, which slugs from the product name/URL.
+	 *
+	 * @var array<int,string>
+	 */
+	private const SLUG_KEYS = array( 'slug', 'handle', 'permalink', 'seoslug', 'urlkey' );
+
+	/**
+	 * Minimum fraction of array elements that must be product-shaped for the
+	 * array to be treated as a product catalog.
+	 */
+	private const PRODUCT_SHAPE_RATIO = 0.6;
+
+	/**
+	 * Build generic product report rows from the data files in a website artifact.
+	 *
+	 * Rows use the canonical keys consumed by the transformer adapter's
+	 * `normalize_product_report_row()` so the existing products-manifest/v1 path
+	 * and WooCommerce seeder are reused.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function product_rows_from_artifact( array $artifact ): array {
+		$rows = array();
+		foreach ( self::data_files_from_artifact( $artifact ) as $file ) {
+			foreach ( self::object_arrays_from_source( $file['source'], $file['ext'] ) as $object_array ) {
+				if ( ! self::is_product_shaped_array( $object_array ) ) {
+					continue;
+				}
+				foreach ( $object_array as $object ) {
+					$row = self::product_row_from_object( $object, $file['path'] );
+					if ( array() !== $row ) {
+						$rows[] = $row;
+					}
+				}
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Return decoded `.js`/`.json` data files from a website artifact.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @return array<int,array{path:string,ext:string,source:string}>
+	 */
+	private static function data_files_from_artifact( array $artifact ): array {
+		$files  = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
+		$result = array();
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$path = isset( $file['path'] ) && is_scalar( $file['path'] ) ? (string) $file['path'] : '';
+			$ext  = self::data_extension( $path, $file );
+			if ( '' === $ext ) {
+				continue;
+			}
+
+			$source = self::file_content( $file );
+			if ( '' === trim( $source ) ) {
+				continue;
+			}
+
+			$result[] = array(
+				'path'   => $path,
+				'ext'    => $ext,
+				'source' => $source,
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Resolve a data-file extension (`js` or `json`) from path or declared type.
+	 *
+	 * @param string              $path Artifact path.
+	 * @param array<string,mixed> $file Artifact file entry.
+	 * @return string Empty string when the file is not a data file.
+	 */
+	private static function data_extension( string $path, array $file ): string {
+		$lower = strtolower( $path );
+		if ( str_ends_with( $lower, '.json' ) ) {
+			return 'json';
+		}
+		if ( str_ends_with( $lower, '.mjs' ) || str_ends_with( $lower, '.cjs' ) || str_ends_with( $lower, '.js' ) ) {
+			return 'js';
+		}
+
+		$kind = isset( $file['kind'] ) && is_scalar( $file['kind'] ) ? strtolower( (string) $file['kind'] ) : '';
+		$mime = isset( $file['mime_type'] ) && is_scalar( $file['mime_type'] ) ? strtolower( (string) $file['mime_type'] ) : '';
+		if ( 'json' === $kind || str_contains( $mime, 'json' ) ) {
+			return 'json';
+		}
+		if ( 'js' === $kind || 'javascript' === $kind || str_contains( $mime, 'javascript' ) || str_contains( $mime, 'ecmascript' ) ) {
+			return 'js';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Decode a website artifact file payload to text.
+	 *
+	 * @param array<string,mixed> $file Artifact file entry.
+	 * @return string
+	 */
+	private static function file_content( array $file ): string {
+		if ( isset( $file['content'] ) && is_scalar( $file['content'] ) ) {
+			return (string) $file['content'];
+		}
+		if ( isset( $file['content_base64'] ) && is_scalar( $file['content_base64'] ) ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Website artifacts may carry trusted data payloads as base64.
+			$decoded = base64_decode( (string) $file['content_base64'], true );
+			return false !== $decoded ? $decoded : '';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract every array-of-objects literal from a data source.
+	 *
+	 * For `.json` the document is decoded strictly first; for `.js` (or invalid
+	 * JSON) the lenient literal parser is used. The decoded structure is walked
+	 * to collect any nested list whose elements are objects.
+	 *
+	 * @param string $source Raw file source.
+	 * @param string $ext    Data extension (`js` or `json`).
+	 * @return array<int,array<int,array<string,mixed>>>
+	 */
+	private static function object_arrays_from_source( string $source, string $ext ): array {
+		$collected = array();
+
+		if ( 'json' === $ext ) {
+			$decoded = json_decode( $source, true );
+			if ( null !== $decoded ) {
+				self::collect_object_arrays( $decoded, $collected );
+				return $collected;
+			}
+		}
+
+		foreach ( self::literals_from_js( $source ) as $value ) {
+			self::collect_object_arrays( $value, $collected );
+		}
+
+		return $collected;
+	}
+
+	/**
+	 * Recursively collect lists whose elements are associative arrays.
+	 *
+	 * @param mixed                                       $value     Decoded value.
+	 * @param array<int,array<int,array<string,mixed>>> &$collected Accumulator.
+	 * @return void
+	 */
+	private static function collect_object_arrays( mixed $value, array &$collected ): void {
+		if ( ! is_array( $value ) ) {
+			return;
+		}
+
+		if ( self::is_object_list( $value ) ) {
+			$objects = array();
+			foreach ( $value as $entry ) {
+				if ( is_array( $entry ) && ! array_is_list( $entry ) ) {
+					$objects[] = $entry;
+				}
+			}
+			if ( array() !== $objects ) {
+				$collected[] = $objects;
+			}
+		}
+
+		foreach ( $value as $child ) {
+			self::collect_object_arrays( $child, $collected );
+		}
+	}
+
+	/**
+	 * Check whether a value is a non-empty list containing object entries.
+	 *
+	 * @param array<int|string,mixed> $value Decoded value.
+	 * @return bool
+	 */
+	private static function is_object_list( array $value ): bool {
+		if ( array() === $value || ! array_is_list( $value ) ) {
+			return false;
+		}
+
+		foreach ( $value as $entry ) {
+			if ( is_array( $entry ) && ! array_is_list( $entry ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Parse object/array literals out of arbitrary JavaScript source.
+	 *
+	 * Comments are stripped first; the scanner then skips string literals and
+	 * attempts to parse a value at each top-level `{`/`[`, discarding fragments
+	 * that do not parse as data literals (for example function bodies).
+	 *
+	 * @param string $source JavaScript source.
+	 * @return array<int,mixed>
+	 */
+	private static function literals_from_js( string $source ): array {
+		$source = self::strip_js_comments( $source );
+		$length = strlen( $source );
+		$values = array();
+		$index  = 0;
+
+		while ( $index < $length ) {
+			$char = $source[ $index ];
+
+			if ( '"' === $char || "'" === $char || '`' === $char ) {
+				$index = self::skip_string( $source, $index );
+				continue;
+			}
+
+			if ( '{' === $char || '[' === $char ) {
+				$cursor = $index;
+				$value  = self::parse_value( $source, $cursor );
+				if ( self::PARSE_FAILED !== $value ) {
+					$values[] = $value;
+					$index    = $cursor;
+					continue;
+				}
+			}
+
+			++$index;
+		}
+
+		return $values;
+	}
+
+	/**
+	 * Sentinel returned when a literal fails to parse.
+	 */
+	private const PARSE_FAILED = "\0__ssi_parse_failed__\0";
+
+	/**
+	 * Recursive-descent parse of one JavaScript data value.
+	 *
+	 * @param string $source JavaScript source (comment-stripped).
+	 * @param int   &$index  Cursor; advanced past the parsed value on success.
+	 * @return mixed Parsed value, or self::PARSE_FAILED.
+	 */
+	private static function parse_value( string $source, int &$index ): mixed {
+		self::skip_whitespace( $source, $index );
+		if ( $index >= strlen( $source ) ) {
+			return self::PARSE_FAILED;
+		}
+
+		$char = $source[ $index ];
+		if ( '{' === $char ) {
+			return self::parse_object( $source, $index );
+		}
+		if ( '[' === $char ) {
+			return self::parse_array( $source, $index );
+		}
+		if ( '"' === $char || "'" === $char || '`' === $char ) {
+			return self::parse_string( $source, $index );
+		}
+		if ( '-' === $char || '+' === $char || '.' === $char || ctype_digit( $char ) ) {
+			return self::parse_number( $source, $index );
+		}
+
+		return self::parse_keyword_or_reference( $source, $index );
+	}
+
+	/**
+	 * Parse a JavaScript object literal into an associative array.
+	 *
+	 * @param string $source JavaScript source.
+	 * @param int   &$index  Cursor positioned at `{`.
+	 * @return mixed Associative array, or self::PARSE_FAILED.
+	 */
+	private static function parse_object( string $source, int &$index ): mixed {
+		$length = strlen( $source );
+		++$index; // Consume '{'.
+		$object = array();
+
+		while ( $index < $length ) {
+			self::skip_whitespace( $source, $index );
+			if ( $index >= $length ) {
+				return self::PARSE_FAILED;
+			}
+			if ( '}' === $source[ $index ] ) {
+				++$index;
+				return $object;
+			}
+
+			$key = self::parse_key( $source, $index );
+			if ( self::PARSE_FAILED === $key ) {
+				return self::PARSE_FAILED;
+			}
+
+			self::skip_whitespace( $source, $index );
+			if ( $index >= $length || ':' !== $source[ $index ] ) {
+				return self::PARSE_FAILED;
+			}
+			++$index; // Consume ':'.
+
+			$value = self::parse_value( $source, $index );
+			if ( self::PARSE_FAILED === $value ) {
+				return self::PARSE_FAILED;
+			}
+			$object[ $key ] = $value;
+
+			self::skip_whitespace( $source, $index );
+			if ( $index < $length && ',' === $source[ $index ] ) {
+				++$index;
+				continue;
+			}
+			if ( $index < $length && '}' === $source[ $index ] ) {
+				++$index;
+				return $object;
+			}
+
+			return self::PARSE_FAILED;
+		}
+
+		return self::PARSE_FAILED;
+	}
+
+	/**
+	 * Parse a JavaScript array literal into a list.
+	 *
+	 * @param string $source JavaScript source.
+	 * @param int   &$index  Cursor positioned at `[`.
+	 * @return mixed List array, or self::PARSE_FAILED.
+	 */
+	private static function parse_array( string $source, int &$index ): mixed {
+		$length = strlen( $source );
+		++$index; // Consume '['.
+		$list = array();
+
+		while ( $index < $length ) {
+			self::skip_whitespace( $source, $index );
+			if ( $index >= $length ) {
+				return self::PARSE_FAILED;
+			}
+			if ( ']' === $source[ $index ] ) {
+				++$index;
+				return $list;
+			}
+
+			$value = self::parse_value( $source, $index );
+			if ( self::PARSE_FAILED === $value ) {
+				return self::PARSE_FAILED;
+			}
+			$list[] = $value;
+
+			self::skip_whitespace( $source, $index );
+			if ( $index < $length && ',' === $source[ $index ] ) {
+				++$index;
+				continue;
+			}
+			if ( $index < $length && ']' === $source[ $index ] ) {
+				++$index;
+				return $list;
+			}
+
+			return self::PARSE_FAILED;
+		}
+
+		return self::PARSE_FAILED;
+	}
+
+	/**
+	 * Parse an object key (quoted string or bareword identifier).
+	 *
+	 * @param string $source JavaScript source.
+	 * @param int   &$index  Cursor.
+	 * @return string|mixed Key string, or self::PARSE_FAILED.
+	 */
+	private static function parse_key( string $source, int &$index ): mixed {
+		$char = $source[ $index ] ?? '';
+		if ( '"' === $char || "'" === $char || '`' === $char ) {
+			return self::parse_string( $source, $index );
+		}
+
+		$length = strlen( $source );
+		$start  = $index;
+		while ( $index < $length ) {
+			$current = $source[ $index ];
+			if ( ctype_alnum( $current ) || '_' === $current || '$' === $current ) {
+				++$index;
+				continue;
+			}
+			break;
+		}
+
+		if ( $index === $start ) {
+			return self::PARSE_FAILED;
+		}
+
+		return substr( $source, $start, $index - $start );
+	}
+
+	/**
+	 * Parse a quoted string literal (single, double, or backtick quotes).
+	 *
+	 * @param string $source JavaScript source.
+	 * @param int   &$index  Cursor positioned at the opening quote.
+	 * @return string
+	 */
+	private static function parse_string( string $source, int &$index ): string {
+		$length = strlen( $source );
+		$quote  = $source[ $index ];
+		++$index; // Consume opening quote.
+		$value = '';
+
+		while ( $index < $length ) {
+			$char = $source[ $index ];
+			if ( '\\' === $char && $index + 1 < $length ) {
+				$value .= self::unescape_sequence( $source[ $index + 1 ] );
+				$index += 2;
+				continue;
+			}
+			if ( $char === $quote ) {
+				++$index; // Consume closing quote.
+				break;
+			}
+			$value .= $char;
+			++$index;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Translate a backslash escape sequence into its literal character.
+	 *
+	 * @param string $escaped Character following the backslash.
+	 * @return string
+	 */
+	private static function unescape_sequence( string $escaped ): string {
+		return match ( $escaped ) {
+			'n'     => "\n",
+			't'     => "\t",
+			'r'     => "\r",
+			default => $escaped,
+		};
+	}
+
+	/**
+	 * Parse a numeric literal into an int or float.
+	 *
+	 * @param string $source JavaScript source.
+	 * @param int   &$index  Cursor.
+	 * @return mixed Number, or self::PARSE_FAILED.
+	 */
+	private static function parse_number( string $source, int &$index ): mixed {
+		$length = strlen( $source );
+		$start  = $index;
+		if ( '-' === $source[ $index ] || '+' === $source[ $index ] ) {
+			++$index;
+		}
+		$has_digit = false;
+		while ( $index < $length ) {
+			$char = $source[ $index ];
+			if ( ctype_digit( $char ) ) {
+				$has_digit = true;
+				++$index;
+				continue;
+			}
+			if ( '.' === $char || 'e' === $char || 'E' === $char || '+' === $char || '-' === $char ) {
+				++$index;
+				continue;
+			}
+			break;
+		}
+
+		if ( ! $has_digit ) {
+			return self::PARSE_FAILED;
+		}
+
+		$raw = substr( $source, $start, $index - $start );
+		if ( ! is_numeric( $raw ) ) {
+			return self::PARSE_FAILED;
+		}
+
+		return ( (float) $raw === floor( (float) $raw ) && ! str_contains( $raw, '.' ) && ! str_contains( strtolower( $raw ), 'e' ) )
+			? (int) $raw
+			: (float) $raw;
+	}
+
+	/**
+	 * Parse `true`/`false`/`null`, or skip an unresolvable reference/expression.
+	 *
+	 * Variable references, member expressions, and calls cannot be resolved
+	 * without executing JavaScript; they are consumed and treated as null so the
+	 * surrounding literal still parses.
+	 *
+	 * @param string $source JavaScript source.
+	 * @param int   &$index  Cursor.
+	 * @return mixed Boolean, null, or self::PARSE_FAILED.
+	 */
+	private static function parse_keyword_or_reference( string $source, int &$index ): mixed {
+		$length = strlen( $source );
+		$start  = $index;
+		while ( $index < $length ) {
+			$char = $source[ $index ];
+			if ( ctype_alnum( $char ) || '_' === $char || '$' === $char ) {
+				++$index;
+				continue;
+			}
+			break;
+		}
+
+		if ( $index === $start ) {
+			return self::PARSE_FAILED;
+		}
+
+		$word = strtolower( substr( $source, $start, $index - $start ) );
+		if ( 'true' === $word ) {
+			$resolved = true;
+		} elseif ( 'false' === $word ) {
+			$resolved = false;
+		} else {
+			$resolved = null; // null, undefined, NaN, or an unresolvable reference.
+		}
+
+		// Consume any member access, subscript, or call chain on the reference.
+		self::skip_reference_chain( $source, $index );
+
+		return $resolved;
+	}
+
+	/**
+	 * Skip a trailing `.member`, `[...]`, or `(...)` chain after a reference.
+	 *
+	 * @param string $source JavaScript source.
+	 * @param int   &$index  Cursor.
+	 * @return void
+	 */
+	private static function skip_reference_chain( string $source, int &$index ): void {
+		$length = strlen( $source );
+		while ( $index < $length ) {
+			self::skip_whitespace( $source, $index );
+			$char = $source[ $index ] ?? '';
+			if ( '.' === $char ) {
+				++$index;
+				while ( $index < $length ) {
+					$current = $source[ $index ];
+					if ( ctype_alnum( $current ) || '_' === $current || '$' === $current ) {
+						++$index;
+						continue;
+					}
+					break;
+				}
+				continue;
+			}
+			if ( '[' === $char || '(' === $char ) {
+				self::skip_balanced( $source, $index );
+				continue;
+			}
+			break;
+		}
+	}
+
+	/**
+	 * Skip a balanced bracket/paren group, respecting nested strings.
+	 *
+	 * @param string $source JavaScript source.
+	 * @param int   &$index  Cursor positioned at the opening bracket.
+	 * @return void
+	 */
+	private static function skip_balanced( string $source, int &$index ): void {
+		$length = strlen( $source );
+		$open   = $source[ $index ];
+		$close  = '[' === $open ? ']' : ')';
+		$depth  = 0;
+		while ( $index < $length ) {
+			$char = $source[ $index ];
+			if ( '"' === $char || "'" === $char || '`' === $char ) {
+				$index = self::skip_string( $source, $index );
+				continue;
+			}
+			if ( $char === $open ) {
+				++$depth;
+			} elseif ( $char === $close ) {
+				--$depth;
+				if ( 0 === $depth ) {
+					++$index;
+					return;
+				}
+			}
+			++$index;
+		}
+	}
+
+	/**
+	 * Advance past a string literal starting at the opening quote.
+	 *
+	 * @param string $source Source text.
+	 * @param int    $index  Cursor positioned at the opening quote.
+	 * @return int Index just past the closing quote.
+	 */
+	private static function skip_string( string $source, int $index ): int {
+		$length = strlen( $source );
+		$quote  = $source[ $index ];
+		++$index;
+		while ( $index < $length ) {
+			$char = $source[ $index ];
+			if ( '\\' === $char ) {
+				$index += 2;
+				continue;
+			}
+			++$index;
+			if ( $char === $quote ) {
+				break;
+			}
+		}
+
+		return $index;
+	}
+
+	/**
+	 * Advance the cursor past whitespace.
+	 *
+	 * @param string $source Source text.
+	 * @param int   &$index  Cursor.
+	 * @return void
+	 */
+	private static function skip_whitespace( string $source, int &$index ): void {
+		$length = strlen( $source );
+		while ( $index < $length && ctype_space( $source[ $index ] ) ) {
+			++$index;
+		}
+	}
+
+	/**
+	 * Remove `//` line and block comments while preserving string contents.
+	 *
+	 * @param string $source JavaScript source.
+	 * @return string
+	 */
+	private static function strip_js_comments( string $source ): string {
+		$length = strlen( $source );
+		$out    = '';
+		$index  = 0;
+		while ( $index < $length ) {
+			$char = $source[ $index ];
+			$next = $index + 1 < $length ? $source[ $index + 1 ] : '';
+
+			if ( '"' === $char || "'" === $char || '`' === $char ) {
+				$end  = self::skip_string( $source, $index );
+				$out .= substr( $source, $index, $end - $index );
+				$index = $end;
+				continue;
+			}
+
+			if ( '/' === $char && '/' === $next ) {
+				$index += 2;
+				while ( $index < $length && "\n" !== $source[ $index ] ) {
+					++$index;
+				}
+				continue;
+			}
+
+			if ( '/' === $char && '*' === $next ) {
+				$index += 2;
+				while ( $index + 1 < $length && ! ( '*' === $source[ $index ] && '/' === $source[ $index + 1 ] ) ) {
+					++$index;
+				}
+				$index += 2;
+				continue;
+			}
+
+			$out .= $char;
+			++$index;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Determine whether a list of objects is product-shaped.
+	 *
+	 * An object is product-shaped when it has a name-like field plus a
+	 * price-like field. The list qualifies when a strong majority of its
+	 * objects are product-shaped, which rejects config maps and navigation
+	 * arrays that lack a price signal.
+	 *
+	 * @param array<int,array<string,mixed>> $objects Object list.
+	 * @return bool
+	 */
+	private static function is_product_shaped_array( array $objects ): bool {
+		$total = count( $objects );
+		if ( 0 === $total ) {
+			return false;
+		}
+
+		$matches = 0;
+		foreach ( $objects as $object ) {
+			if ( is_array( $object ) && self::is_product_shaped_object( $object ) ) {
+				++$matches;
+			}
+		}
+
+		return $matches > 0 && ( $matches / $total ) >= self::PRODUCT_SHAPE_RATIO;
+	}
+
+	/**
+	 * Determine whether a single object carries product-shaped fields.
+	 *
+	 * @param array<string,mixed> $object Object.
+	 * @return bool
+	 */
+	private static function is_product_shaped_object( array $object ): bool {
+		$normalized = self::normalized_keys( $object );
+		$name       = self::first_key_value( $object, $normalized, self::NAME_KEYS );
+		$price      = self::first_key_value( $object, $normalized, self::PRICE_KEYS );
+
+		return '' !== self::scalar_text( $name ) && '' !== self::price_to_decimal( $price );
+	}
+
+	/**
+	 * Map a product-shaped object to a generic product report row.
+	 *
+	 * @param array<string,mixed> $object      Source object.
+	 * @param string              $source_path Artifact source path.
+	 * @return array<string,mixed>
+	 */
+	private static function product_row_from_object( array $object, string $source_path ): array {
+		$normalized = self::normalized_keys( $object );
+
+		$name  = self::scalar_text( self::first_key_value( $object, $normalized, self::NAME_KEYS ) );
+		$price = self::price_to_decimal( self::first_key_value( $object, $normalized, self::PRICE_KEYS ) );
+		if ( '' === $name || '' === $price ) {
+			return array();
+		}
+
+		$row = array(
+			'kind'             => 'product',
+			'name'             => $name,
+			'slug'             => self::slug_from_object( $object, $normalized, $name ),
+			'regular_price'    => $price,
+			'source_path'      => $source_path,
+			'source_selectors' => array( 'bundle-data:' . self::basename_path( $source_path ) ),
+		);
+
+		$sale = self::price_to_decimal( self::first_key_value( $object, $normalized, self::SALE_PRICE_KEYS ) );
+		if ( '' !== $sale ) {
+			$row['sale_price'] = $sale;
+		}
+
+		$description = self::scalar_text( self::first_key_value( $object, $normalized, self::DESCRIPTION_KEYS ) );
+		if ( '' !== $description ) {
+			$row['description'] = $description;
+		}
+
+		$image = self::scalar_text( self::first_key_value( $object, $normalized, self::IMAGE_KEYS ) );
+		if ( '' !== $image ) {
+			$row['image'] = $image;
+		}
+
+		$categories = self::string_collection( self::first_key_value( $object, $normalized, self::CATEGORY_KEYS ) );
+		if ( array() !== $categories ) {
+			$row['categories'] = $categories;
+		}
+
+		return $row;
+	}
+
+	/**
+	 * Derive a slug from an identifier-like field, falling back to the name.
+	 *
+	 * @param array<string,mixed>   $object     Source object.
+	 * @param array<string,string>  $normalized Normalized-key map.
+	 * @param string                $name       Resolved product name.
+	 * @return string
+	 */
+	private static function slug_from_object( array $object, array $normalized, string $name ): string {
+		$candidate = self::scalar_text( self::first_key_value( $object, $normalized, self::SLUG_KEYS ) );
+		$source    = '' !== $candidate ? $candidate : $name;
+
+		return self::slugify( $source );
+	}
+
+	/**
+	 * Build a lowercase URL slug.
+	 *
+	 * @param string $value Source text.
+	 * @return string
+	 */
+	private static function slugify( string $value ): string {
+		if ( function_exists( 'sanitize_title' ) ) {
+			return sanitize_title( $value );
+		}
+
+		return trim( strtolower( (string) preg_replace( '/[^a-z0-9]+/i', '-', $value ) ), '-' );
+	}
+
+	/**
+	 * Map an object's keys to their normalized forms (lowercase alphanumerics).
+	 *
+	 * @param array<string,mixed> $object Source object.
+	 * @return array<string,string> Normalized key => original key.
+	 */
+	private static function normalized_keys( array $object ): array {
+		$map = array();
+		foreach ( array_keys( $object ) as $key ) {
+			$map[ self::normalize_key( (string) $key ) ] = (string) $key;
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Normalize a field name to lowercase alphanumerics for synonym matching.
+	 *
+	 * @param string $key Field name.
+	 * @return string
+	 */
+	private static function normalize_key( string $key ): string {
+		return strtolower( (string) preg_replace( '/[^a-z0-9]/i', '', $key ) );
+	}
+
+	/**
+	 * Return the first value whose normalized key matches a synonym.
+	 *
+	 * @param array<string,mixed>  $object     Source object.
+	 * @param array<string,string> $normalized Normalized-key map.
+	 * @param array<int,string>    $synonyms   Normalized synonym list.
+	 * @return mixed
+	 */
+	private static function first_key_value( array $object, array $normalized, array $synonyms ): mixed {
+		foreach ( $synonyms as $synonym ) {
+			if ( isset( $normalized[ $synonym ] ) ) {
+				$original = $normalized[ $synonym ];
+				if ( array_key_exists( $original, $object ) ) {
+					return $object[ $original ];
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Return a trimmed scalar string, or an empty string for non-scalars.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @return string
+	 */
+	private static function scalar_text( mixed $value ): string {
+		if ( is_bool( $value ) || null === $value || is_array( $value ) ) {
+			return '';
+		}
+
+		return is_scalar( $value ) ? trim( (string) $value ) : '';
+	}
+
+	/**
+	 * Convert a numeric or currency-formatted price into a plain decimal string.
+	 *
+	 * @param mixed $value Candidate price.
+	 * @return string Empty string when no price can be extracted.
+	 */
+	private static function price_to_decimal( mixed $value ): string {
+		if ( is_int( $value ) || is_float( $value ) ) {
+			return (string) $value;
+		}
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+
+		$text = str_replace( ',', '', $value );
+		if ( preg_match( '/-?\d+(?:\.\d+)?/', $text, $matches ) ) {
+			return $matches[0];
+		}
+
+		return '';
+	}
+
+	/**
+	 * Normalize a category-like value into a list of non-empty strings.
+	 *
+	 * @param mixed $value Category value (string or list).
+	 * @return array<int,string>
+	 */
+	private static function string_collection( mixed $value ): array {
+		$values = array();
+		if ( is_array( $value ) ) {
+			foreach ( $value as $entry ) {
+				$text = self::scalar_text( $entry );
+				if ( '' !== $text ) {
+					$values[] = $text;
+				}
+			}
+		} else {
+			$text = self::scalar_text( $value );
+			if ( '' !== $text ) {
+				$values[] = $text;
+			}
+		}
+
+		return array_values( array_unique( $values ) );
+	}
+
+	/**
+	 * Return the file basename for provenance labelling.
+	 *
+	 * @param string $path Artifact path.
+	 * @return string
+	 */
+	private static function basename_path( string $path ): string {
+		$base = basename( $path );
+
+		return '' !== $base ? $base : $path;
+	}
+}

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Bundle_Data_Source' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-bundle-data-source.php';
+}
+
 /**
  * Keeps SSI workflows insulated from transformer package implementation details.
  */
@@ -73,8 +77,11 @@ class Static_Site_Importer_Transformer_Adapter {
 			$materialization_plan = isset( $source_reports['materialization_plan'] ) && is_array( $source_reports['materialization_plan'] ) ? $source_reports['materialization_plan'] : array();
 		}
 		$products  = $this->merge_product_manifests(
-			$this->products_manifest_from_transformer_reports( $result, $materialization_plan ),
-			$this->products_manifest_from_raw_artifact_html( $artifact )
+			$this->products_manifest_from_artifact_data_files( $artifact ),
+			$this->merge_product_manifests(
+				$this->products_manifest_from_transformer_reports( $result, $materialization_plan ),
+				$this->products_manifest_from_raw_artifact_html( $artifact )
+			)
 		);
 		$artifacts = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
 		$blocks    = isset( $artifacts['blocks'] ) && is_array( $artifacts['blocks'] ) ? $artifacts['blocks'] : array();
@@ -278,6 +285,29 @@ class Static_Site_Importer_Transformer_Adapter {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Extract commerce products from static bundle data files.
+	 *
+	 * Bundles often render their catalog client-side from a static `.js`/`.json`
+	 * data file, so the rendered HTML imports empty. This reads those data files
+	 * directly (without executing JavaScript), recognizing product-shaped arrays
+	 * by data shape, and is the preferred product source ahead of DOM detection.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function products_manifest_from_artifact_data_files( array $artifact ): array {
+		$products = array();
+		foreach ( Static_Site_Importer_Bundle_Data_Source::product_rows_from_artifact( $artifact ) as $row ) {
+			$product = $this->normalize_product_report_row( $row );
+			if ( ! empty( $product ) ) {
+				$products[] = $product;
+			}
+		}
+
+		return $this->merge_product_manifests( array(), $products );
 	}
 
 	/**

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -67,6 +67,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-di
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-validation-runtime.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-bundle-data-source.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-transformer-adapter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-figma-import.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-exporter.php';

--- a/tests/smoke-website-artifact-bundle-data-products.php
+++ b/tests/smoke-website-artifact-bundle-data-products.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Smoke coverage for bundle-aware structured-data product extraction.
+ *
+ * Proves a site bundle that renders its catalog client-side from a static
+ * `js/products.js` (or `.json`) data file materializes products through the
+ * existing products-manifest/v1 path and WooCommerce seeder adapter, keying off
+ * data shape rather than variable names or site-specific keys.
+ *
+ * Run from the repository root:
+ * php tests/smoke-website-artifact-bundle-data-products.php
+ *
+ * @package StaticSiteImporter
+ */
+
+namespace {
+	function blocks_engine_php_transformer_compile_artifact( array $artifact, array $options = array() ): array {
+		return array(
+			'schema'         => 'blocks-engine/php-transformer/result/v1',
+			'status'         => 'success',
+			'source_reports' => array(
+				'artifact'              => array(
+					'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+					'entry_path' => 'website/index.html',
+				),
+				'materialization_plan' => array(
+					'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+					'pages'  => array(
+						array(
+							'source_path'  => 'website/index.html',
+							'post_type'    => 'page',
+							'slug'         => 'shop',
+							'title'        => 'Shop',
+							'block_markup' => '<!-- wp:paragraph --><p>Shop</p><!-- /wp:paragraph -->',
+						),
+					),
+				),
+			),
+		);
+	}
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $code;
+			private string $message;
+
+			public function __construct( string $code, string $message ) {
+				$this->code    = $code;
+				$this->message = $message;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( mixed $thing ): bool {
+			return $thing instanceof WP_Error;
+		}
+	}
+
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-bundle-data-source.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-transformer-adapter.php';
+
+	$failures   = array();
+	$assertions = 0;
+	$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+		}
+	};
+
+	// A client-rendered catalog data file shaped like the shop fixtures:
+	// unquoted keys, single quotes, comments, integer prices, a trailing comma,
+	// a nested object, and an unresolvable variable reference value.
+	$products_js = <<<'JS'
+/* Studio — product catalog data. Rendered client-side into #featuredGrid. */
+
+// Glaze swatch tokens -> hex. A config map, not a product list.
+const GLAZES = {
+  Oatmeal: '#e3d8c5',
+  Sage:    '#a7b09a',
+  Charcoal:'#3f3f3c'
+};
+
+const PRODUCTS = [
+  {
+    id: 'tf-01',
+    name: 'Oatmeal Dinner Plate',
+    category: 'Tableware',
+    price: 48,
+    featured: true,
+    glaze: GLAZES.Oatmeal,
+    description: "A hand-thrown dinner plate finished in a soft matte oatmeal glaze. It's lead-free.",
+    variants: { label: 'Glaze', options: ['Oatmeal', 'Sage', 'Charcoal'] }
+  },
+  {
+    id: 'tf-02',
+    name: 'Sage Breakfast Bowl',
+    category: 'Bowls',
+    price: 36.5,
+    featured: true,
+    description: 'A deep everyday bowl glazed in dusty sage.',
+    variants: { label: 'Glaze', options: ['Sage', 'Oatmeal'] }
+  },
+  {
+    id: 'tf-03',
+    name: 'Stoneware Tumbler',
+    category: 'Mugs & Cups',
+    price: 28,
+    featured: false,
+    description: 'A handleless tumbler with a gently tapered waist.',
+  },
+];
+
+if (typeof window !== 'undefined') { window.PRODUCTS = PRODUCTS; }
+JS;
+
+	// Non-product arrays/objects that must not be misdetected: navigation links
+	// (label + href, no price) and a settings object.
+	$config_js = <<<'JS'
+const NAV = [
+  { label: 'Home', href: '/' },
+  { label: 'Shop', href: '/shop' },
+  { label: 'Contact', href: '/contact' }
+];
+
+const SETTINGS = { currency: 'USD', perPage: 12, theme: 'light' };
+JS;
+
+	// A JSON data file using alternate field synonyms (title/amount/desc/type).
+	$catalog_json = <<<'JSON'
+{
+  "items": [
+    {
+      "sku": "cat-01",
+      "title": "Pour-Over Dripper",
+      "type": "Gear",
+      "amount": "24.00",
+      "desc": "A ceramic pour-over cone for single cups."
+    }
+  ]
+}
+JSON;
+
+	// Rendered HTML carries a product card for a product that also exists in the
+	// bundle data, with a different price, to prove bundle-data wins on dedupe.
+	$index_html = '<!doctype html><html><body>'
+		. '<article class="product-card"><h2>Oatmeal Dinner Plate</h2><p class="price">$99.00</p></article>'
+		. '<div id="featuredGrid" class="grid"></div>'
+		. '</body></html>';
+
+	$artifact = array(
+		'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+		'entrypoint' => 'website/index.html',
+		'files'      => array(
+			array(
+				'path'      => 'website/index.html',
+				'kind'      => 'html',
+				'mime_type' => 'text/html',
+				'content'   => $index_html,
+			),
+			array(
+				'path'    => 'website/js/products.js',
+				'content' => $products_js,
+			),
+			array(
+				'path'    => 'website/js/config.js',
+				'content' => $config_js,
+			),
+			array(
+				'path'    => 'website/data/catalog.json',
+				'content' => $catalog_json,
+			),
+		),
+	);
+
+	$compiled = ( new Static_Site_Importer_Transformer_Adapter() )->compile_website_artifact( $artifact );
+	$products = is_array( $compiled ) ? ( $compiled['products_manifest'] ?? array() ) : array();
+	$by_slug  = array();
+	foreach ( $products as $product ) {
+		$by_slug[ $product['slug'] ?? '' ] = $product;
+	}
+
+	$assert( ! is_wp_error( $compiled ), 'compile-succeeds', is_wp_error( $compiled ) ? $compiled->get_error_message() : '' );
+	$assert( 4 === count( $products ), 'extracts-three-js-and-one-json-product', 'count=' . count( $products ) );
+
+	// js/products.js products materialize with name/price/category/description.
+	$plate = $by_slug['oatmeal-dinner-plate'] ?? array();
+	$assert( 'Oatmeal Dinner Plate' === ( $plate['name'] ?? '' ), 'js-product-name' );
+	$assert( '48.00' === ( $plate['regular_price'] ?? '' ), 'js-integer-price-normalized', 'price=' . ( $plate['regular_price'] ?? '' ) );
+	$assert( array( 'Tableware' ) === ( $plate['categories'] ?? array() ), 'js-single-category-to-list' );
+	$assert( str_contains( (string) ( $plate['description'] ?? '' ), 'oatmeal glaze' ), 'js-description-with-escaped-quote' );
+	$assert( str_starts_with( (string) ( ( $plate['source_selectors'][0] ?? '' ) ), 'bundle-data:products.js' ), 'js-product-source-provenance' );
+
+	$bowl = $by_slug['sage-breakfast-bowl'] ?? array();
+	$assert( '36.50' === ( $bowl['regular_price'] ?? '' ), 'js-decimal-price-normalized' );
+
+	$assert( isset( $by_slug['stoneware-tumbler'] ), 'js-product-after-trailing-comma' );
+
+	// JSON data file with title/amount/desc/type synonyms.
+	$dripper = $by_slug['pour-over-dripper'] ?? array();
+	$assert( 'Pour-Over Dripper' === ( $dripper['name'] ?? '' ), 'json-title-synonym-to-name' );
+	$assert( '24.00' === ( $dripper['regular_price'] ?? '' ), 'json-amount-synonym-to-price' );
+	$assert( array( 'Gear' ) === ( $dripper['categories'] ?? array() ), 'json-type-synonym-to-category' );
+	$assert( str_contains( (string) ( $dripper['description'] ?? '' ), 'pour-over cone' ), 'json-desc-synonym-to-description' );
+
+	// Non-product arrays are not misdetected.
+	$assert( ! isset( $by_slug['home'] ) && ! isset( $by_slug['shop'] ) && ! isset( $by_slug['contact'] ), 'navigation-array-not-detected' );
+
+	// Bundle data is preferred over DOM detection on dedupe (price stays 48, not 99).
+	$assert( '48.00' === ( $plate['regular_price'] ?? '' ), 'bundle-data-preferred-over-dom-card' );
+
+	// The full set is seedable through the existing WooCommerce product adapter.
+	$validation = Static_Site_Importer_Entity_Materializer_Registry::validate_manifest(
+		Static_Site_Importer_Entity_Materializer_Registry::product_adapter(),
+		array(
+			'schema_version' => 1,
+			'products'       => $products,
+		)
+	);
+	$assert( array() === ( $validation['errors'] ?? array() ), 'woo-adapter-validator-accepts-bundle-products', implode( '; ', array_map( static fn ( $e ) => ( $e['path'] ?? '' ) . ' ' . ( $e['message'] ?? '' ), $validation['errors'] ?? array() ) ) );
+	$assert( 4 === count( $validation['products'] ?? array() ), 'woo-adapter-validator-preserves-product-count' );
+	$assert( 'Oatmeal Dinner Plate' === ( $validation['products'][0]['name'] ?? ( $by_slug['oatmeal-dinner-plate']['name'] ?? '' ) ), 'woo-adapter-validator-preserves-name' );
+
+	if ( $failures ) {
+		fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+		exit( 1 );
+	}
+
+	echo 'OK: website artifact bundle data products smoke passed (' . $assertions . " assertions)\n";
+}


### PR DESCRIPTION
## Summary

Static site bundles frequently render their catalog client-side from a static data file (for example `js/products.js` exporting an array of product objects). The rendered HTML for those pages imports **empty** -- e.g. `<div id="featuredGrid" class="grid"></div>` -- because the content only exists in the data array. But that array ships in the bundle, so render-then-import is not needed: the source data can be read directly.

This adds **bundle-aware structured-data extraction** as the *preferred* product source, composing with the DOM-based detection from #512 (now the fallback).

## What changed

- **New `Static_Site_Importer_Bundle_Data_Source`** reads the `.js`/`.json` files already carried in a website artifact (the directory-upload path packs all bundle files into `artifact['files']`) and extracts product candidates **without executing JavaScript**:
  - a tolerant recursive-descent parser pulls static array/object literals out of JavaScript, handling unquoted keys, single/backtick quotes, trailing commas, `//` and `/* */` comments, and unresolvable variable references (consumed as `null`); `.json` is decoded directly.
  - detection keys off **data shape only** -- an object is product-shaped when it has a name-like field **and** a price-like field, and an array qualifies when a strong majority of its elements match. Field detection generalizes across `name|title`, `price|amount|cost`, `description|desc|body`, `image|img|src`, `category|type`. No hardcoding of `PRODUCTS`/`price`/site specifics.
- **Reuses the existing pipeline**: extracted rows flow through `normalize_product_report_row()` into the same `products-manifest/v1` shape consumed by `Static_Site_Importer_Woo_Product_Seeder`. Bundle data is merged ahead of transformer-report and raw-HTML product sources, deduped by name-derived slug (so it composes cleanly with #512's DOM detection -- bundle wins, DOM fills gaps).

## Layered strategy

bundle-data extraction (preferred) -> DOM detection (#512, fallback) -> render (future last resort, out of scope).

## Verification

- New smoke `tests/smoke-website-artifact-bundle-data-products.php` (18 assertions): a `js/products.js`-shaped data file materializes products with name/price/category/description; a `.json` file with `title`/`amount`/`desc`/`type` synonyms also works; navigation/config arrays are **not** misdetected; bundle data wins over a conflicting DOM product card; and the full set passes the WooCommerce product adapter validator (the seedable contract the seeder consumes).
- Ran the extractor against the real blocks-engine shop fixtures -- products extract from their actual JS data files with zero false positives from heavy SVG/function code:
  - terra-ceramics: 13, lumen-coffee: 12, inkwell-books: 14, sole-society: 14, fernwood-plants: 19.
- `php -l` clean on all changed files; existing smoke suite green.

## Scope / follow-ups (not in this PR)

This is the contained product slice. Deliberately deferred:
- **Variants -> WooCommerce variable products.** The shop fixtures carry `variants`/`options`, but `products-manifest/v1` and the seeder only model simple products. Materializing variants needs variable-product type + attributes + variations in both the manifest schema and the seeder -- a separate, larger change.
- **Other bundle entity types** (posts/listings/team/etc.) via the same shape-based reader and the entity-materializer registry.
- **Computed/external data** (values assembled at runtime or fetched) remain out of reach for static reading by design.

Refs #514, #510, #489.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Investigating the import pipeline, designing the generic shape-based extractor + JS literal parser, implementing the source/adapter wiring, and writing tests.