### PR TITLE
Bump bundled php-transformer pin to v0.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.2.1",
+        "version": "0.2.2",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "17dbc8693bcad18c1a7e4196d6003056f7d3eec1"
+          "reference": "4fcc9de3c6dfa2c6334b95d865709fd12fdb7d63"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.1.zip",
-          "reference": "17dbc8693bcad18c1a7e4196d6003056f7d3eec1"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.2.zip",
+          "reference": "4fcc9de3c6dfa2c6334b95d865709fd12fdb7d63"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.2.1",
+    "automattic/blocks-engine-php-transformer": "^0.2.2",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc9f7a3b0427433e70ecb16b2d8fc390",
+    "content-hash": "16948bcf72c28856a918a5eda84953b0",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "17dbc8693bcad18c1a7e4196d6003056f7d3eec1"
+                "reference": "4fcc9de3c6dfa2c6334b95d865709fd12fdb7d63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.1.zip",
-                "reference": "17dbc8693bcad18c1a7e4196d6003056f7d3eec1"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.2.zip",
+                "reference": "4fcc9de3c6dfa2c6334b95d865709fd12fdb7d63"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
Bump bundled php-transformer pin to v0.2.2 (the merged transformer batch). Dependency bump only — no release.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (Claude Code)
- **Used for:** Editing composer.json/composer.lock and opening this PR.