### PR TITLE
Expose import diagnostics on success, not just failure

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -358,10 +358,76 @@ if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' )
 			return static_site_importer_ability_error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
 		}
 
+		return static_site_importer_ability_import_success( is_array( $result ) ? $result : array(), $input );
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_import_success' ) ) {
+	/**
+	 * Build the success envelope for a completed website artifact import.
+	 *
+	 * Mirrors the failure envelope (`static_site_importer_ability_error`) so consumers
+	 * can read the same `static-site-importer/import-diagnostics/v1` contract whether an
+	 * import succeeded or failed: warnings, quality counts, blocks-engine conversion stats,
+	 * semantic parity, and runtime-dependency gaps are all surfaced on success too.
+	 *
+	 * @param array<string,mixed> $result Import result from Static_Site_Importer_Theme_Generator::import_website_artifact().
+	 * @param array<string,mixed> $input  Original ability input.
+	 * @return array<string,mixed>
+	 */
+	function static_site_importer_ability_import_success( array $result, array $input ): array {
+		$contract = static_site_importer_success_diagnostics_contract( $result );
+
+		/**
+		 * Fires after a website artifact import completes successfully, once the
+		 * import-diagnostics contract has been built. Consumers can read the contract
+		 * without reconstructing it from the raw result.
+		 *
+		 * @param array<string,mixed> $contract The static-site-importer/import-diagnostics/v1 contract.
+		 * @param array<string,mixed> $result   The raw import result.
+		 * @param array<string,mixed> $input    The original ability input.
+		 */
+		do_action( 'static_site_importer_import_completed', $contract, $result, $input );
+
 		return array(
-			'success' => true,
-			'result'  => $result,
+			'success'             => true,
+			'result'              => $result,
+			'diagnostics'         => isset( $contract['diagnostics'] ) && is_array( $contract['diagnostics'] ) ? $contract['diagnostics'] : array(),
+			'fixture_diagnostics' => $contract,
 		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_success_diagnostics_contract' ) ) {
+	/**
+	 * Build the import-diagnostics contract from a successful import result.
+	 *
+	 * Maps the success result shape returned by
+	 * Static_Site_Importer_Theme_Generator::import_website_artifact() into the keys the
+	 * diagnostic contract reads. Fields the contract needs but the result does not carry
+	 * are mapped from what the import returns rather than fabricated.
+	 *
+	 * @param array<string,mixed> $result Import result.
+	 * @return array<string,mixed>
+	 */
+	function static_site_importer_success_diagnostics_contract( array $result ): array {
+		$import_validation_result = isset( $result['import_validation_result'] ) && is_array( $result['import_validation_result'] ) ? $result['import_validation_result'] : array();
+		$quality                  = isset( $result['quality'] ) && is_array( $result['quality'] ) ? $result['quality'] : array();
+		$validation_diagnostics   = isset( $import_validation_result['diagnostics'] ) && is_array( $import_validation_result['diagnostics'] ) ? $import_validation_result['diagnostics'] : array();
+
+		$contract_input = array(
+			'success'                  => true,
+			'status'                   => isset( $result['import_report_summary']['status'] ) && is_scalar( $result['import_report_summary']['status'] ) ? (string) $result['import_report_summary']['status'] : 'completed',
+			'slug'                     => isset( $result['theme_slug'] ) ? (string) $result['theme_slug'] : '',
+			'name'                     => isset( $result['theme_name'] ) ? (string) $result['theme_name'] : '',
+			'import_validation_result' => $import_validation_result,
+			'import_report'            => array(
+				'quality'     => $quality,
+				'diagnostics' => $validation_diagnostics,
+			),
+		);
+
+		return class_exists( 'Static_Site_Importer_Diagnostic_Contract' ) ? Static_Site_Importer_Diagnostic_Contract::build( $contract_input ) : array( 'diagnostics' => $validation_diagnostics );
 	}
 }
 

--- a/tests/smoke-ability-import-success-diagnostics.php
+++ b/tests/smoke-ability-import-success-diagnostics.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Smoke coverage for the import-website-artifact success envelope carrying the
+ * static-site-importer/import-diagnostics/v1 contract and firing the completion hook.
+ *
+ * Run from the repository root:
+ * php tests/smoke-ability-import-success-diagnostics.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text ): string {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) );
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( string $hook_name ): bool {
+		unset( $hook_name );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook_name ): int {
+		unset( $hook_name );
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook_name, string $callback ): void {
+		unset( $hook_name, $callback );
+	}
+}
+
+$GLOBALS['ssi_smoke_fired_hooks'] = array();
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook_name, ...$args ): void {
+		$GLOBALS['ssi_smoke_fired_hooks'][] = array(
+			'hook' => $hook_name,
+			'args' => $args,
+		);
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
+require_once dirname( __DIR__ ) . '/includes/abilities.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+// A representative success result shaped like
+// Static_Site_Importer_Theme_Generator::import_website_artifact() returns.
+$result = array(
+	'theme_slug'               => 'acme-co',
+	'theme_name'               => 'Acme Co',
+	'quality'                  => array(
+		'fallback_count'                        => 2,
+		'core_html_block_count'                 => 1,
+		'runtime_dependency_parity_issue_count' => 1,
+	),
+	'import_report_summary'    => array(
+		'status' => 'completed',
+	),
+	'import_validation_result' => array(
+		'schema'      => 'blocks-engine/import-validation-result/v1',
+		'status'      => 'reported',
+		'diagnostics' => array(
+			array(
+				'type'        => 'core_html_block',
+				'reason_code' => 'unconverted_markup',
+				'severity'    => 'warning',
+				'source_path' => 'website/index.html',
+				'selector'    => 'div.hero',
+				'message'     => 'Fell back to a core/html block.',
+			),
+		),
+	),
+);
+
+$input    = array( 'slug' => 'acme-co' );
+$envelope = static_site_importer_ability_import_success( $result, $input );
+
+$assert( true === ( $envelope['success'] ?? false ), 'envelope-success-true' );
+$assert( $result === ( $envelope['result'] ?? null ), 'envelope-preserves-raw-result' );
+$assert( is_array( $envelope['fixture_diagnostics'] ?? null ), 'envelope-has-fixture-diagnostics' );
+
+$contract = $envelope['fixture_diagnostics'];
+$assert(
+	Static_Site_Importer_Diagnostic_Contract::IMPORT_DIAGNOSTICS_SCHEMA === ( $contract['schema'] ?? '' ),
+	'contract-schema-v1',
+	(string) ( $contract['schema'] ?? '' )
+);
+$assert( true === ( $contract['success'] ?? false ), 'contract-success-true' );
+$assert( 'acme-co' === ( $contract['fixture']['slug'] ?? '' ), 'contract-carries-slug' );
+$assert( 2 === ( $contract['quality_counts']['fallback_count'] ?? -1 ), 'contract-quality-counts-from-result' );
+$assert( 1 === ( $contract['quality_counts']['runtime_dependency_parity_issue_count'] ?? -1 ), 'contract-runtime-quality-count' );
+$assert( ! empty( $contract['diagnostics'] ), 'contract-has-diagnostic-rows' );
+$assert(
+	is_array( $envelope['diagnostics'] ?? null ) && count( $envelope['diagnostics'] ) === count( $contract['diagnostics'] ),
+	'envelope-diagnostics-match-contract'
+);
+
+$fired = array_values(
+	array_filter(
+		$GLOBALS['ssi_smoke_fired_hooks'],
+		static fn ( array $entry ): bool => 'static_site_importer_import_completed' === $entry['hook']
+	)
+);
+$assert( 1 === count( $fired ), 'completion-hook-fired-once', (string) count( $fired ) );
+$assert( ( $fired[0]['args'][0] ?? null ) === $contract, 'hook-arg-contract' );
+$assert( ( $fired[0]['args'][1] ?? null ) === $result, 'hook-arg-result' );
+$assert( ( $fired[0]['args'][2] ?? null ) === $input, 'hook-arg-input' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: ability import success diagnostics smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## What

`static_site_importer_ability_import_website_artifact()` returned the full `static-site-importer/import-diagnostics/v1` contract on **failure** (via `static_site_importer_ability_error` → `Static_Site_Importer_Diagnostic_Contract::build()`), but on **success** it returned only `array( 'success' => true, 'result' => $result )`. Consumers had no structured way to see *how a successful import went* — warnings, quality counts, blocks-engine conversion stats, semantic parity, and runtime-dependency gaps were all computed but never surfaced.

## Change

- Success path now builds the diagnostics contract from the import result and returns it for symmetry with the failure envelope. The return adds `diagnostics` (the rows) and `fixture_diagnostics` (the full `import-diagnostics/v1` contract), alongside the existing `success` / `result`.
- Mapping is honest: `static_site_importer_success_diagnostics_contract()` maps the import result's `import_validation_result`, `quality`, `theme_slug`/`theme_name`, and summary `status` into the keys the contract reads. Nothing is fabricated — fields the result does not carry (e.g. blocks-engine conversion detail, which is written to the report file, not returned) are simply absent.
- New composability hook so consumers don't reconstruct the contract: `do_action( 'static_site_importer_import_completed', $contract, $result, $input )`, fired right before the success return. Naming follows existing `static_site_importer_*` hooks.
- SSI stays generic — no consumer/product specifics; it just exposes what it already computes.

## Tests

- New focused smoke test `tests/smoke-ability-import-success-diagnostics.php` asserts the success envelope now carries the `import-diagnostics/v1` contract (schema, slug, quality counts mapped from the result, diagnostic rows) and that the completion action fires once with `(contract, result, input)`. 14 assertions, passing.
- `php -l` clean on touched files; no conflict markers; existing `smoke-ability-error-report-summary.php` still passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Reading the contract/import code to map the success result, implementing the success-path envelope + `static_site_importer_import_completed` hook, and writing the smoke test.
