### PR TITLE
Move SSI fixture matrix rig into repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,20 @@ If no path is passed, the smoke uses `STATIC_SITE_IMPORTER_THEME_DIR`, then `WP_
 
 It validates `parts/header.html`, `parts/footer.html`, `patterns/*.php`, and `templates/*.html`, and reports invalid blocks with the file, nested block path, block name, validation reason, and failure summaries grouped by block name and file.
 
+### Fixture Matrix Rig
+
+The repo owns the Static Site Importer fixture matrix under `bench/`, `tools/`, `lib/fixture-matrix/`, `fixtures/`, and `rigs/static-site-importer-fixture-matrix/`. This is the product-level development gate for importer quality against generated static-site artifacts and the Blocks Engine fixture corpus.
+
+```bash
+npm run test:fixture-matrix
+node bench/static-site-fixture-matrix.bench.mjs \
+  --static-site-importer-path . \
+  --blocks-engine-php-transformer-path /path/to/blocks-engine/php-transformer \
+  --fixture-root /path/to/blocks-engine/fixtures/websites
+```
+
+See `docs/fixture-matrix.md` for the Homeboy/Lab/WP Codebox workflow, generated-artifact intake, visual parity, editor validation, and Blocks Engine corpus/override usage. SSI keeps only minimal matrix smoke fixtures under `tests/fixtures/fixture-matrix`; the canonical site corpus lives in Blocks Engine.
+
 ## Release Workflow
 
 This repo is Homeboy-managed:

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -1,0 +1,757 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runWpCodeboxRecipe, wpCodeboxCommand, wpCodeboxBin } from '../tools/wp-codebox/recipe.mjs';
+import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
+import {
+  buildFixtureMatrixRecipe,
+  collectFixtureMatrixRunResults,
+  createFixtureMatrix,
+  normalizeFixtureMatrixResult,
+  writeFixtureMatrixArtifacts,
+  writeFixtureMatrixResultArtifacts,
+} from '../lib/fixture-matrix.mjs';
+
+const DEFAULT_BATCH_SIZE = 10;
+// Each batch provisions its own WP Codebox sandbox, so batches are independent
+// and safe to fan out in parallel. A single live sandbox costs ~3.3GB host RSS,
+// but RSS grows superlinearly when several overlap (a measured `--concurrency 4`
+// run peaked near 65GB and OOM-pressured the host). Default to 2 so a plain run
+// still gets parallel speedup while staying within a few GB of headroom; the
+// hard cap bounds even an explicit override so a fat-fingered `--concurrency 500`
+// can not exhaust the host. Operators with RAM to spare can raise `--concurrency`
+// up to the cap.
+const DEFAULT_BATCH_CONCURRENCY = 2;
+const MAX_BATCH_CONCURRENCY = 16;
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+async function main() {
+  const options = { ...optionsFromEnv(), ...parseArgs(process.argv.slice(2)) };
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const { summary, runtimeError, runtime } = await runFixtureMatrix(options);
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  if (runtimeError) {
+    process.exitCode = runtime.exitCode || 1;
+  }
+}
+
+export default async function runFixtureMatrixBench() {
+  const options = { ...optionsFromEnv(), ...parseArgs(process.argv.slice(2)) };
+  // Per-fixture / per-batch failures (PHP OOM in collect_artifacts, capture
+  // failures, child timeouts) are already isolated inside `runFixtureMatrix`:
+  // each failing batch is recorded as failed fixtures and folded into the
+  // aggregate while sibling batches still run (see
+  // `runFixtureMatrixBatch`/`mapWithConcurrency`). Re-throwing `runtimeError`
+  // here would make the bench harness treat the entire lane as a hard
+  // assertion_failure and DISCARD the run -- losing the aggregate and every
+  // survivor from the batches that succeeded. Instead, always return the
+  // aggregated metrics so the lane records the partial result; the rig's
+  // `failed_fixture_count <= 0` result-gate then fails the run (because failed
+  // fixtures are counted) WITHOUT discarding it, and `summarizeBenchRun` emits
+  // the operator summary on that gate-FAIL. child_command_failures stay in
+  // metadata so the failing batch remains attributable. Genuine pre-aggregate
+  // setup failures (missing fixtures, composer install) still throw out of
+  // `runFixtureMatrix` and legitimately abort the lane.
+  const { summary } = await runFixtureMatrix(options);
+
+  const resultSummary = summary.result_summary || {};
+  return {
+    metrics: {
+      fixture_count: Number(summary.fixture_count || 0),
+      passed_fixture_count: Number(resultSummary.succeeded || 0),
+      failed_fixture_count: Number(resultSummary.failed || 0),
+      not_run_fixture_count: Number(resultSummary.not_run || 0),
+      finding_count: Number(resultSummary.finding_count || 0),
+    },
+    artifacts: {
+      cli_run: { path: path.join(summary.output_directory, 'cli-run.json') },
+      matrix: { path: path.join(summary.output_directory, 'matrix.json') },
+      result: { path: summary.result_file },
+      summary: { path: path.join(summary.output_directory, 'summary.json') },
+      finding_packets: { path: path.join(summary.output_directory, 'finding-packets.json') },
+    },
+    metadata: {
+      matrix_id: summary.matrix_id,
+      fixture_root: summary.fixture_root,
+      output_directory: summary.output_directory,
+      result_summary: summary.result_summary,
+      runtime: summary.runtime,
+      // Surface failing batches at the top level (also nested in runtime) so a
+      // gate-FAIL run stays attributable without re-reading the runtime block.
+      ...(summary.child_command_failures?.length ? { child_command_failures: summary.child_command_failures } : {}),
+    },
+  };
+}
+
+export async function runFixtureMatrix(options) {
+  const outputDirectory = path.resolve(options.outputDirectory || path.join(process.cwd(), 'artifacts', 'static-site-importer-fixture-matrix'));
+  const intake = options.artifactRoot
+    ? materializeGeneratedArtifactFixtures({
+      artifactRoot: path.resolve(options.artifactRoot),
+      fixtureRoot: path.resolve(options.fixtureRoot || path.join(outputDirectory, 'intake-fixtures')),
+      entrypoint: options.entrypoint || 'index.html',
+      maxDepth: options.maxDepth,
+    })
+    : null;
+  const fixtureRoot = path.resolve(intake?.fixture_root || options.fixtureRoot || path.join(packageRoot, 'tests', 'fixtures', 'fixture-matrix'));
+  const staticSiteImporterPath = options.staticSiteImporterPath || process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH || process.cwd();
+  const dependencyOverrides = prepareDependencyOverrides(options);
+  ensureComposerDependencies(staticSiteImporterPath, { dependencyOverrides });
+  const matrix = createFixtureMatrix({
+    id: options.id || `static-site-importer-fixture-matrix-${Date.now()}`,
+    fixture_root: fixtureRoot,
+    entrypoint: options.entrypoint || 'index.html',
+    maxDepth: options.maxDepth,
+    // Lane/tag selection: run "just the marketing/static lane" or only fixtures
+    // carrying a given manifest tag. Absent options leave the full matrix intact.
+    class: options.fixtureClass || options.class,
+    tag: options.tag,
+  });
+  const written = writeFixtureMatrixArtifacts({ outputDirectory, matrix });
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: outputDirectory,
+    playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
+    wordpressVersion: options.wordpressVersion,
+    staticSiteImporterPath,
+    staticSiteImporterPlugin: options.staticSiteImporterPlugin,
+    staticSiteImporterSlug: options.staticSiteImporterSlug,
+    dependencyOverrides,
+    ...editorValidationRecipeInput(options),
+    ...visualParityRecipeInput(options),
+    ...liveWpParityRecipeInput(options),
+  });
+  const recipeFile = path.join(outputDirectory, 'wp-codebox-static-site-fixture-matrix-recipe.json');
+  fs.writeFileSync(recipeFile, `${JSON.stringify(recipe, null, 2)}\n`);
+  const replay = wpCodeboxReplayCommand({
+    recipeFile,
+    artifactsDir: replayArtifactsDirectory(outputDirectory),
+    wpCodeboxBin: options.wpCodeboxBin,
+  });
+
+  let runtime = null;
+  let runtimeError = null;
+  let collectedResult = written.result;
+  if (options.run) {
+    const batchSize = positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE);
+    const concurrency = boundedConcurrency(options.concurrency, DEFAULT_BATCH_CONCURRENCY, MAX_BATCH_CONCURRENCY);
+    const batches = chunk(matrix.fixtures, batchSize);
+    // Each batch spins up its own isolated WP Codebox sandbox, so batches can run
+    // concurrently. `mapWithConcurrency` bounds how many sandboxes are live at
+    // once and returns outcomes in batch order, so the assembled batchRuns /
+    // batchResults / childCommandFailures stay deterministic regardless of which
+    // sandbox finishes first.
+    const batchOutcomes = await mapWithConcurrency(batches, concurrency, (fixtures, batchIndex) => runFixtureMatrixBatch({
+      fixtures,
+      batchIndex,
+      matrix,
+      outputDirectory,
+      staticSiteImporterPath,
+      options,
+    }));
+
+    const batchRuns = [];
+    const batchResults = [];
+    const childCommandFailures = [];
+    for (const outcome of batchOutcomes) {
+      batchRuns.push(outcome.batchRun);
+      batchResults.push(outcome.batchResult);
+      if (outcome.childCommandFailure) {
+        childCommandFailures.push(outcome.childCommandFailure);
+      }
+      // Preserve the original first-failure-by-batch-order semantics: the earliest
+      // batch that failed wins, independent of completion order.
+      if (outcome.error) {
+        runtimeError ||= outcome.error;
+      }
+    }
+    collectedResult = normalizeFixtureMatrixResult({
+      matrix,
+      results: batchResults.flatMap((result) => result.fixtures),
+      // Editor-quality scoring is always on; the native-rate gate is opt-in.
+      editorQuality: editorQualityGateInput(options),
+    });
+    runtime = {
+      exitCode: runtimeError ? (batchRuns.find((batch) => batch.exit_code)?.exit_code || 1) : 0,
+      batchSize,
+      concurrency,
+      batches: batchRuns,
+      childCommandFailures,
+    };
+    writeFixtureMatrixResultArtifacts({ outputDirectory, matrix, result: collectedResult });
+  }
+
+  const summary = {
+    schema: 'static-site-importer/fixture-matrix-cli-run/v1',
+    matrix_id: matrix.id,
+    fixture_root: matrix.fixture_root,
+    fixture_count: matrix.count,
+    intake,
+    dependency_overrides: dependencyOverrides,
+    recipe_dependency_overrides: recipe.metadata?.dependency_overrides || {},
+    output_directory: outputDirectory,
+    recipe_file: recipeFile,
+    replay,
+    artifact_refs: written.artifact_refs,
+    ...(runtime?.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
+    result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
+    result_summary: collectedResult.summary,
+    runtime: runtime ? runtimeSummary(runtime, runtimeError) : null,
+  };
+  fs.writeFileSync(path.join(outputDirectory, 'cli-run.json'), `${JSON.stringify(summary, null, 2)}\n`);
+  return { summary, runtimeError, runtime };
+}
+
+// Provision and reconcile a single batch in its own WP Codebox sandbox. Pure with
+// respect to other batches (it only writes batch-scoped recipe/output files and
+// per-fixture artifact subdirectories, all keyed by the unique batch suffix), so
+// many of these can run concurrently without colliding. Returns a stable outcome
+// the caller folds back together in batch order.
+export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outputDirectory, staticSiteImporterPath, options }) {
+  const batchNumber = batchIndex + 1;
+  const batchSuffix = String(batchNumber).padStart(3, '0');
+  const batchMatrix = createFixtureMatrix({
+    id: `${matrix.id}-batch-${batchSuffix}`,
+    fixture_root: matrix.fixture_root,
+    entrypoint: matrix.entrypoint,
+    fixtures,
+  });
+  const batchRecipe = buildFixtureMatrixRecipe({
+    matrix: batchMatrix,
+    artifactsDirectory: outputDirectory,
+    playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
+    wordpressVersion: options.wordpressVersion,
+    staticSiteImporterPath,
+    staticSiteImporterPlugin: options.staticSiteImporterPlugin,
+    staticSiteImporterSlug: options.staticSiteImporterSlug,
+    dependencyOverrides: prepareDependencyOverrides(options),
+    ...editorValidationRecipeInput(options),
+    ...visualParityRecipeInput(options),
+    ...liveWpParityRecipeInput(options),
+  });
+  const batchRecipeFile = path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`);
+  const outputFile = path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`);
+  const artifactRefs = batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile });
+  fs.writeFileSync(batchRecipeFile, `${JSON.stringify(batchRecipe, null, 2)}\n`);
+
+  let batchRuntime = null;
+  let batchError = null;
+  let childCommandFailure = null;
+  try {
+    batchRuntime = await runWpCodeboxRecipe({
+      recipeFile: batchRecipeFile,
+      artifactsDir: outputDirectory,
+      outputFile,
+      wpCodeboxBin: options.wpCodeboxBin,
+    });
+  } catch (error) {
+    batchError = error;
+    batchRuntime = {
+      exitCode: error?.code ?? 1,
+      outputFile,
+      json: parseJsonText(error?.stdout),
+    };
+    childCommandFailure = buildWpCodeboxChildCommandFailure({
+      error,
+      batchNumber,
+      batchSuffix,
+      batchRecipeFile,
+      outputFile,
+      artifactsDir: outputDirectory,
+      wpCodeboxBin: options.wpCodeboxBin,
+      artifactRefs,
+    });
+  }
+
+  const batchRun = fixtureMatrixBatchRunSummary({
+    batchNumber,
+    batchMatrix,
+    fixtures,
+    batchRecipeFile,
+    outputFile,
+    batchRuntime,
+    batchError,
+  });
+  const batchResult = collectFixtureMatrixRunResults({
+    matrix: batchMatrix,
+    outputDirectory,
+    outputFile,
+    codeboxOutput: batchRuntime?.json,
+    codeboxError: batchError,
+    visualParity: visualParityGateInput(options),
+    liveWpParity: liveWpParityCollectorInput(options),
+  });
+
+  return { batchRun, batchResult, error: batchError, childCommandFailure };
+}
+
+// Bounded-concurrency map that preserves input ordering. Spawns at most `limit`
+// workers, each pulling the next index off a shared cursor, so up to `limit`
+// async tasks are in flight at once while `results[i]` always corresponds to
+// `items[i]` regardless of completion order.
+export async function mapWithConcurrency(items, limit, worker) {
+  const results = new Array(items.length);
+  if (items.length === 0) {
+    return results;
+  }
+  const poolSize = Math.max(1, Math.min(limit, items.length));
+  let cursor = 0;
+  const runWorker = async () => {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await worker(items[index], index);
+    }
+  };
+  await Promise.all(Array.from({ length: poolSize }, () => runWorker()));
+  return results;
+}
+
+export function boundedConcurrency(value, fallback, max) {
+  const parsed = positiveInteger(value, fallback);
+  return Math.max(1, Math.min(parsed, max));
+}
+
+function ensureComposerDependencies(pluginPath, options = {}) {
+  const dependencyOverrides = options.dependencyOverrides || {};
+  const blocksEnginePhpTransformerPath = dependencyOverrides.blocks_engine_php_transformer?.path || '';
+  if (blocksEnginePhpTransformerPath) {
+    updateComposerPathRepository(pluginPath, blocksEnginePhpTransformerPath);
+    return;
+  }
+
+  if (fs.existsSync(path.join(pluginPath, 'vendor', 'autoload.php')) || !fs.existsSync(path.join(pluginPath, 'composer.json'))) {
+    return;
+  }
+
+  const result = spawnSync('composer', ['install', '--no-interaction', '--prefer-dist', '--no-progress'], {
+    cwd: pluginPath,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.status !== 0) {
+    throw new Error(`Composer dependency install failed for ${pluginPath}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+}
+
+function prepareDependencyOverrides(options) {
+  const blocksEnginePhpTransformerPath = resolveBlocksEnginePhpTransformerPath(options.blocksEnginePhpTransformerPath);
+  return {
+    ...(blocksEnginePhpTransformerPath
+      ? {
+        blocks_engine_php_transformer: {
+          package: 'automattic/blocks-engine-php-transformer',
+          path: blocksEnginePhpTransformerPath,
+        },
+      }
+      : {}),
+  };
+}
+
+export function resolveBlocksEnginePhpTransformerPath(input) {
+  if (!input) {
+    return '';
+  }
+
+  const candidate = path.resolve(input);
+  const packageComposer = path.join(candidate, 'composer.json');
+  if (composerPackageName(packageComposer) === 'automattic/blocks-engine-php-transformer') {
+    return candidate;
+  }
+
+  const nested = path.join(candidate, 'php-transformer');
+  if (composerPackageName(path.join(nested, 'composer.json')) === 'automattic/blocks-engine-php-transformer') {
+    return nested;
+  }
+
+  throw new Error(`Blocks Engine PHP transformer path must point to the package or Blocks Engine repo root: ${input}`);
+}
+
+function composerPackageName(composerFile) {
+  try {
+    const composer = JSON.parse(fs.readFileSync(composerFile, 'utf8'));
+    return typeof composer.name === 'string' ? composer.name : '';
+  } catch {
+    return '';
+  }
+}
+
+function updateComposerPathRepository(pluginPath, packagePath) {
+  const composerFile = path.join(pluginPath, 'composer.json');
+  const lockFile = path.join(pluginPath, 'composer.lock');
+  const composerJson = fs.readFileSync(composerFile, 'utf8');
+  const composerLock = fs.existsSync(lockFile) ? fs.readFileSync(lockFile, 'utf8') : null;
+  let result = null;
+  try {
+    configureComposerPathRepository(pluginPath, packagePath);
+    result = spawnSync('composer', ['update', 'automattic/blocks-engine-php-transformer', '--with-dependencies', '--no-interaction', '--prefer-source', '--no-progress'], {
+      cwd: pluginPath,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } finally {
+    fs.writeFileSync(composerFile, composerJson);
+    if (composerLock !== null) {
+      fs.writeFileSync(lockFile, composerLock);
+    }
+  }
+  if (result.status !== 0) {
+    throw new Error(`Composer dependency override failed for ${pluginPath}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+}
+
+function configureComposerPathRepository(pluginPath, packagePath) {
+  const composerFile = path.join(pluginPath, 'composer.json');
+  const composer = JSON.parse(fs.readFileSync(composerFile, 'utf8'));
+  composer.repositories = composer.repositories && typeof composer.repositories === 'object' && !Array.isArray(composer.repositories)
+    ? composer.repositories
+    : {};
+  composer.repositories['blocks-engine-php-transformer-dev'] = composerPathRepositoryConfig(composer, packagePath);
+  fs.writeFileSync(composerFile, `${JSON.stringify(composer, null, 2)}\n`);
+}
+
+export function composerPathRepositoryConfig(rootComposer, packagePath) {
+  return {
+    type: 'path',
+    url: packagePath,
+    canonical: true,
+    options: {
+      symlink: false,
+      versions: {
+        'automattic/blocks-engine-php-transformer': composerPathRepositoryVersion(rootComposer),
+      },
+    },
+  };
+}
+
+export function fixtureMatrixBatchRunSummary(input = {}) {
+  const batchError = input.batchError || null;
+  const batchRuntime = input.batchRuntime || null;
+  const fixtureIds = normalizeFixtureIds(input.fixtures);
+  return {
+    batch: input.batchNumber,
+    batch_id: input.batchMatrix?.id || '',
+    fixture_ids: fixtureIds,
+    fixture_count: fixtureIds.length,
+    recipe_file: input.batchRecipeFile || '',
+    output_file: input.outputFile || '',
+    exit_code: batchRuntime?.exitCode ?? 0,
+    error: batchError ? batchError.message : '',
+    stderr_tail: batchError ? textTail(batchError.stderr) : '',
+    stdout_tail: batchError ? textTail(batchError.stdout) : '',
+    parsed_output: Boolean(batchRuntime?.json),
+  };
+}
+
+function normalizeFixtureIds(fixtures) {
+  return Array.isArray(fixtures) ? fixtures.map((fixture) => fixture.id).filter(Boolean) : [];
+}
+
+function composerPathRepositoryVersion(rootComposer) {
+  const constraint = rootComposer?.require?.['automattic/blocks-engine-php-transformer'];
+  if (typeof constraint !== 'string') {
+    return '0.1.15';
+  }
+
+  const trimmed = constraint.trim();
+  const match = trimmed.match(/^\^?(\d+\.\d+\.\d+)$/);
+  return match ? match[1] : '0.1.15';
+}
+
+function runtimeSummary(runtime, runtimeError) {
+  return {
+    exit_code: runtime.exitCode,
+    ...(runtime.batchSize ? { batch_size: runtime.batchSize } : {}),
+    ...(runtime.concurrency ? { concurrency: runtime.concurrency } : {}),
+    ...(runtime.batches ? { batches: runtime.batches } : {}),
+    ...(runtime.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
+    error: runtimeError ? runtimeError.message : '',
+  };
+}
+
+function buildWpCodeboxChildCommandFailure({ error, batchNumber, batchSuffix, batchRecipeFile, outputFile, artifactsDir, wpCodeboxBin: bin, artifactRefs }) {
+  const command = wpCodeboxRecipeRunCommand({ recipeFile: batchRecipeFile, artifactsDir, outputFile, wpCodeboxBin: bin });
+  return {
+    schema: 'homeboy/child-command-failure/v1',
+    kind: 'child_command_failed',
+    label: `WP Codebox recipe-run batch ${batchSuffix}`,
+    batch: batchNumber,
+    batch_id: `batch-${batchSuffix}`,
+    command,
+    exit_status: exitStatus(error),
+    stdout_tail: tailText(error?.stdout),
+    stderr_tail: tailText(error?.stderr),
+    artifact_refs: artifactRefs,
+    message: error?.message || 'WP Codebox recipe-run failed',
+  };
+}
+
+function wpCodeboxRecipeRunCommand({ recipeFile, artifactsDir, outputFile, wpCodeboxBin: bin }) {
+  const base = wpCodeboxCommand(bin || wpCodeboxBin());
+  const argv = [
+    base.command,
+    ...(base.args || []),
+    'recipe-run',
+    recipeFile,
+    '--artifacts-dir', artifactsDir,
+    '--output', outputFile,
+  ];
+  return { argv };
+}
+
+function wpCodeboxReplayCommand({ recipeFile, artifactsDir, wpCodeboxBin: bin }) {
+  const base = safeWpCodeboxCommand(bin);
+  const argv = [
+    base.command,
+    ...(base.args || []),
+    'recipe-run',
+    '--recipe', recipeFile,
+    '--artifacts', artifactsDir,
+    '--json',
+  ];
+  return {
+    artifacts_directory: artifactsDir,
+    argv,
+    command: argv.map(shellArg).join(' '),
+  };
+}
+
+function safeWpCodeboxCommand(bin) {
+  return { command: bin || process.env.HOMEBOY_WP_CODEBOX_BIN || 'wp-codebox', args: [] };
+}
+
+function replayArtifactsDirectory(outputDirectory) {
+  const resolved = path.resolve(outputDirectory);
+  return path.join(path.dirname(resolved), `${path.basename(resolved)}-wp-codebox-replay-artifacts`);
+}
+
+function batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile }) {
+  return {
+    artifacts_directory: outputDirectory,
+    recipe_file: batchRecipeFile,
+    output_file: outputFile,
+    cli_run: path.join(outputDirectory, 'cli-run.json'),
+    matrix: path.join(outputDirectory, 'matrix.json'),
+    result: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
+    summary: path.join(outputDirectory, 'summary.json'),
+    finding_packets: path.join(outputDirectory, 'finding-packets.json'),
+    batch_recipe: path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`),
+    batch_output: path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`),
+  };
+}
+
+function exitStatus(error) {
+  const status = error?.status ?? error?.exitCode ?? error?.code;
+  return Number.isInteger(status) ? status : 1;
+}
+
+function tailText(value, maxLines = 40) {
+  if (!value) {
+    return '';
+  }
+  return String(value).split(/\r?\n/).slice(-maxLines).join('\n');
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg === '--run') {
+      options.run = true;
+      continue;
+    }
+    if (arg.startsWith('--no-')) {
+      options[camelCase(arg.slice(5))] = false;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      const [rawKey, rawValue] = arg.slice(2).split('=');
+      const key = camelCase(rawKey);
+      const value = rawValue === undefined ? args[index + 1] : rawValue;
+      if (rawValue === undefined) {
+        index += 1;
+      }
+      options[key] = value;
+      continue;
+    }
+    if (!options.fixtureRoot) {
+      options.fixtureRoot = arg;
+    }
+  }
+  return options;
+}
+
+function optionsFromEnv(env = process.env) {
+  const benchEnv = settingsBenchEnv(env);
+  return {
+    fixtureRoot: benchEnv.SSI_FIXTURE_MATRIX_FIXTURE_ROOT || env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT,
+    outputDirectory: benchEnv.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY || env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY || env.HOMEBOY_BENCH_ARTIFACTS_DIR,
+    staticSiteImporterPath: benchEnv.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH || env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH,
+    staticSiteImporterSlug: benchEnv.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_SLUG || env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_SLUG,
+    staticSiteImporterPlugin: benchEnv.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PLUGIN || env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PLUGIN,
+    entrypoint: benchEnv.SSI_FIXTURE_MATRIX_ENTRYPOINT || env.SSI_FIXTURE_MATRIX_ENTRYPOINT,
+    maxDepth: benchEnv.SSI_FIXTURE_MATRIX_MAX_DEPTH || env.SSI_FIXTURE_MATRIX_MAX_DEPTH,
+    // Lane/tag selection from the manifest classification: run a single class lane
+    // and/or only fixtures carrying a given manifest tag.
+    fixtureClass: benchEnv.SSI_FIXTURE_MATRIX_CLASS || env.SSI_FIXTURE_MATRIX_CLASS,
+    tag: benchEnv.SSI_FIXTURE_MATRIX_TAG || env.SSI_FIXTURE_MATRIX_TAG,
+    artifactRoot: benchEnv.SSI_FIXTURE_MATRIX_ARTIFACT_ROOT || env.SSI_FIXTURE_MATRIX_ARTIFACT_ROOT,
+    blocksEnginePhpTransformerPath: benchEnv.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH || env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH,
+    wordpressVersion: benchEnv.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION || env.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION,
+    batchSize: benchEnv.SSI_FIXTURE_MATRIX_BATCH_SIZE || env.SSI_FIXTURE_MATRIX_BATCH_SIZE,
+    concurrency: benchEnv.SSI_FIXTURE_MATRIX_CONCURRENCY || env.SSI_FIXTURE_MATRIX_CONCURRENCY,
+    run: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_RUN) || isTruthy(env.SSI_FIXTURE_MATRIX_RUN),
+    wpCodeboxBin: benchEnv.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN || env.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN,
+    editorValidation: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION ?? env.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION),
+    visualParity: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY),
+    visualParityGate: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE) || isTruthy(env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE),
+    // Opt-in live-WP parity capture + comparison. Off by default; mirrors the
+    // visual-parity-gate truthy env mapping. When on, the recipe appends the
+    // capture-html step and the result collector runs the live-wp-parity comparator.
+    liveWpParity: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_LIVE_WP_PARITY) || isTruthy(env.SSI_FIXTURE_MATRIX_LIVE_WP_PARITY),
+    pixelThreshold: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD,
+    visualParityCandidateUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_CANDIDATE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_CANDIDATE_URL,
+    visualParitySourceBaseUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL,
+    minNativeRate: benchEnv.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE || env.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE,
+  };
+}
+
+// Editor-validation recipe option. The wordpress.editor-validate-blocks step
+// launches a browser per imported site and is the slowest per-fixture step, so
+// --no-editor-validation (SSI_FIXTURE_MATRIX_EDITOR_VALIDATION=0) skips it while
+// leaving native-rate/loss-classes/findings intact. Enabled by default.
+function editorValidationRecipeInput(options) {
+  return {
+    editorValidation: options.editorValidation !== false,
+  };
+}
+
+// Visual-parity options shared by the recipe (capture step) and the result
+// collector (gating). Enable defaults on; gating defaults off (opt-in).
+function visualParityRecipeInput(options) {
+  return {
+    visualParity: options.visualParity !== false,
+    pixelThreshold: options.pixelThreshold,
+    visualParityCandidateUrl: options.visualParityCandidateUrl,
+    visualParitySourceBaseUrl: options.visualParitySourceBaseUrl,
+  };
+}
+
+function visualParityGateInput(options) {
+  return {
+    threshold: options.pixelThreshold,
+    gate: options.visualParityGate === true,
+  };
+}
+
+// Live-WP parity recipe option. Off by default; when on, `liveWpParityEnabled`
+// in the recipe builder appends the deterministic capture-html step per fixture.
+// `liveWpParity: false` is inert in the recipe builder (the capture step is only
+// added when truthy), so the OFF recipe is byte-identical to today.
+function liveWpParityRecipeInput(options) {
+  return {
+    liveWpParity: options.liveWpParity === true,
+  };
+}
+
+// Live-WP parity result-collector option. Off by default. When on, supplies the
+// comparator package path so the result collector can score each fixture's
+// captured rendered DOM against its staged source (with the render-free proxy
+// delta). Resolving the transformer path only when enabled avoids touching the
+// OFF path. A live-WP failure is isolated inside the collector (never sinks the lane).
+function liveWpParityCollectorInput(options) {
+  if (options.liveWpParity !== true) {
+    return { enabled: false };
+  }
+  return {
+    enabled: true,
+    blocksEnginePhpTransformerPath: resolveBlocksEnginePhpTransformerPath(options.blocksEnginePhpTransformerPath),
+    withProxy: true,
+  };
+}
+
+// Editor-quality gate options for the result collector. Scoring always runs;
+// `minNativeRate` defaults to absent (off) so gating is opt-in.
+function editorQualityGateInput(options) {
+  return {
+    minNativeRate: options.minNativeRate,
+  };
+}
+
+function settingsBenchEnv(env = process.env) {
+  try {
+    const settings = JSON.parse(env.HOMEBOY_SETTINGS_JSON || '{}');
+    return settings && typeof settings.bench_env === 'object' && !Array.isArray(settings.bench_env)
+      ? settings.bench_env
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function isTruthy(value) {
+  return value === true || value === '1' || value === 'true';
+}
+
+function isFalsy(value) {
+  return value === false || value === '0' || value === 'false' || value === 'no' || value === 'off';
+}
+
+function chunk(items, size) {
+  const chunks = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseJsonText(text) {
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch {
+    return null;
+  }
+}
+
+function textTail(value, maxLength = 4000) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return '';
+  }
+  return value.length > maxLength ? value.slice(value.length - maxLength) : value;
+}
+
+function camelCase(value) {
+  return value.replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase());
+}
+
+function shellArg(value) {
+  const text = String(value);
+  return /^[A-Za-z0-9_/:=.,+@%-]+$/.test(text) ? text : `'${text.replace(/'/g, `'\\''`)}'`;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: static-site-fixture-matrix [fixture-root] [options]\n\nOptions:\n  --fixture-root <path>              Static-site fixture root. Defaults to this package's fixtures directory.\n  --output-directory <path>          Artifact output directory.\n  --static-site-importer-path <path> Static Site Importer checkout/plugin directory.\n  --static-site-importer-slug <slug> Plugin slug. Defaults to static-site-importer.\n  --static-site-importer-plugin <p>  Plugin activation file. Defaults to static-site-importer/static-site-importer.php.\n  --artifact-root <path>             Generated artifact root to normalize into fixtures.\n  --blocks-engine-php-transformer-path <path>\n                                     Blocks Engine repo root or php-transformer package path for Composer.\n  --entrypoint <file>                Fixture entrypoint. Defaults to index.html.\n  --max-depth <n>                    Fixture discovery depth. Defaults to 2.\n  --wordpress-version <version>      WP Codebox WordPress version. Defaults to latest.\n  --batch-size <n>                   Fixtures per WP Codebox run when --run is used. Defaults to 10.\n  --concurrency <n>                  Batches (WP Codebox sandboxes) to run in parallel. Defaults to ${DEFAULT_BATCH_CONCURRENCY}, hard-capped at ${MAX_BATCH_CONCURRENCY}.\n  --no-editor-validation            Skip browser editor block validation.\n  --no-visual-parity                Skip wordpress.visual-compare recipe steps. Same as SSI_FIXTURE_MATRIX_VISUAL_PARITY=0.\n  --run                             Execute WP Codebox recipes. Omit locally to only materialize artifacts.\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/docs/fixture-matrix-orchestration-contract.md
+++ b/docs/fixture-matrix-orchestration-contract.md
@@ -1,0 +1,56 @@
+# SSI Fixture Matrix Orchestration Contract
+
+This rig does not require unmerged Static Site Importer support in Homeboy or
+Homeboy Extensions. It calls the current generic WP Codebox recipe execution
+surface and supplies all SSI policy from this package.
+
+## Required Current Interfaces
+
+- `${package.root}/tools/wp-codebox/recipe.mjs` must expose `runWpCodeboxRecipe(options)` as a pass-through to the upstream Homeboy Extensions helper.
+- `runWpCodeboxRecipe(options)` must accept `recipeFile`, `artifactsDir`,
+  `outputFile`, and optional `wpCodeboxBin` without adding Rigs-owned watchdog,
+  dedupe, CLI-discovery, or fallback artifact behavior.
+- WP Codebox recipes must accept schema `wp-codebox/workspace-recipe/v1`.
+- WP Codebox workflow steps must support `command: "wordpress.wp-cli"` with an
+  `args` entry containing a `command=...` WP-CLI string.
+- WP Codebox recipe inputs must support `extra_plugins` entries with `source`,
+  `slug`, and `activate`, plus `mounts` entries with `source`, `target`, and
+  `mode`.
+
+## SSI-Owned Inputs
+
+- Fixture root discovery starts at `--fixture-root`, defaults to an `index.html`
+  entrypoint, and descends two directory levels unless `--max-depth` is set.
+- Generated artifact intake starts at `--artifact-root` and materializes
+  structural candidates into a normal fixture root before matrix discovery.
+- The Static Site Importer plugin source is `--static-site-importer-path`.
+- The default plugin slug is `static-site-importer`.
+- The default activation file is
+  `static-site-importer/static-site-importer.php`.
+
+## SSI-Owned Artifacts
+
+- `matrix.json`: discovered fixture matrix.
+- `intake`: optional `cli-run.json` summary section describing generated
+  artifact roots materialized into matrix-compatible fixtures.
+- `<fixture-id>/artifact.json`: Blocks Engine site artifact input for SSI.
+- `wp-codebox-static-site-fixture-matrix-recipe.json`: full matrix recipe.
+- `wp-codebox-static-site-fixture-matrix-batch-NNN.json`: batch recipes when
+  `--run` is used.
+- `static-site-fixture-matrix-result.json`: normalized fixture results.
+- `summary.json`: aggregate pass/fail/finding counts.
+- `finding-packets.json`: grouped diagnostics for repair fanout.
+- `cli-run.json`: command summary and runtime metadata.
+
+## Diagnostic Interpretation
+
+The rig classifies SSI validation payloads into product repair groups here rather
+than in generic Homeboy layers:
+
+- `button_style_loss` maps to `blocks-engine` transformer style parity.
+- `broken_svg` maps to `blocks-engine` SVG transformer parity.
+- `dropped_images` maps to `static-site-importer` asset materialization.
+- `invalid_block_content` maps to `blocks-engine` block validation parity.
+- `runtime_target_gap` maps to `blocks-engine` runtime DOM target parity.
+- Unclassified findings remain `static_site_import_quality` for SSI import
+  validation.

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -1,0 +1,378 @@
+# Static Site Importer Rigs
+
+`static-site-importer-fixture-matrix` is a product-level fixture matrix for Static
+Site Importer quality checks. It keeps SSI-specific defaults, fixture discovery,
+expected artifact names, and diagnostic grouping in this package while invoking
+generic Homeboy/Homeboy Extensions primitives for WP Codebox recipe execution.
+
+```bash
+homeboy rig check static-site-importer-fixture-matrix
+node bench/static-site-fixture-matrix.bench.mjs \
+  --static-site-importer-path ~/Developer/static-site-importer \
+  --blocks-engine-php-transformer-path ~/Developer/blocks-engine \
+  --fixture-root ~/Developer/blocks-engine/fixtures/websites
+```
+
+Generated/static artifact roots can be normalized into matrix fixtures first:
+
+```bash
+node tools/artifact-intake.mjs \
+  --artifact-root /path/to/generated-artifacts \
+  --fixture-root /tmp/ssi-fixtures \
+  --manifest /tmp/ssi-fixtures/intake.json
+
+node bench/static-site-fixture-matrix.bench.mjs \
+  --artifact-root /path/to/generated-artifacts \
+  --output-directory /tmp/ssi-matrix \
+  --static-site-importer-path ~/Developer/static-site-importer
+```
+
+Add `--run` only in an approved non-local execution environment. The default
+command writes matrix, recipe, summary, result, and finding-packet artifacts
+without launching WP Codebox.
+
+Use `--blocks-engine-php-transformer-path` to test a local Blocks Engine checkout
+without cutting a PHP transformer release first. The bench installs SSI's
+Composer dependencies through a temporary path repository and records the
+override in `cli-run.json` under `dependency_overrides`. The path may point at
+either the Blocks Engine repo root or the `php-transformer/` package directory.
+
+## Canonical Blocks Engine Matrix
+
+Use the operator wrapper for the release-free development loop against the
+canonical Blocks Engine fixture corpus (`blocks-engine/fixtures/websites`, 72
+top-level fixtures):
+
+```bash
+node tools/run-fixture-matrix.mjs \
+  --runner homeboy-lab \
+  --static-site-importer ~/Developer/static-site-importer \
+  --blocks-engine ~/Developer/blocks-engine \
+  --lab-only
+```
+
+The wrapper composes the existing Homeboy surfaces rather than replacing the
+lower-level bench:
+
+- `homeboy rig install <this package> --id static-site-importer-fixture-matrix --reinstall`
+- `homeboy rig sync static-site-importer-fixture-matrix`
+- `homeboy bench --rig static-site-importer-fixture-matrix --profile fixture-matrix --iterations 1`
+
+It sets the SSI matrix bench environment for the canonical fixture root, Static
+Site Importer checkout, WP Codebox execution, shared state, and optional Blocks
+Engine PHP transformer override. By default, `--blocks-engine` also supplies the
+release-free transformer override path. Use `--blocks-engine-php-transformer-path`
+to point at a different repo/package, or run a final release/bump proof with
+`--mode release-proof` and the released SSI dependency installed.
+
+The fixture matrix is a deterministic transformer feedback gate, not a
+performance benchmark. The rig and wrapper run a single Homeboy bench iteration
+by default; use repeated runs only for explicitly separate performance work.
+
+Output is a JSON operator summary with the run ID, fixture count, pass/fail
+counts, finding count, top buckets/kinds when present in Homeboy output, artifact
+URLs, and the structured Homeboy bench output file. Pass `--dry-run` to inspect
+the composed commands without running Lab/WP Codebox. Arguments after `--` are
+forwarded to the lower-level bench, preserving the existing script options:
+
+### Code freshness guard
+
+Before running, the wrapper resolves the git freshness of the override/source
+checkouts (`--blocks-engine` / `--blocks-engine-php-transformer-path` and
+`--static-site-importer`) relative to their upstream. The plan and operator
+summary include a `code_freshness` block (per path: `branch`, `upstream`,
+`behind`, `ahead`, `dirty`, `commit`, `status`) plus the resolved
+`transformer_commit` so findings are attributable to the exact code under test.
+
+If any override is **behind or diverged** vs upstream, the wrapper warns loudly
+and **refuses to run** (exit non-zero) — a stale transformer produces
+semantic-parity findings that may already be fixed upstream (phantom findings).
+Refresh the checkout to upstream, or pass `--allow-stale-override` to proceed
+anyway. `--dry-run` always prints the resolved freshness and whether it *would*
+block, without running. Fresh/clean (or ahead-only) checkouts proceed with no
+new friction.
+
+```bash
+node tools/run-fixture-matrix.mjs \
+  --runner homeboy-lab \
+  --static-site-importer ~/Developer/static-site-importer \
+  --blocks-engine ~/Developer/blocks-engine \
+  --batch-size 5 \
+  --run-id ssi-matrix-dev-$(date +%Y%m%d) \
+  -- --wordpress-version latest
+```
+
+Compare two fixture-matrix finding-packet artifacts without requiring Homeboy run
+state:
+
+```bash
+node tools/compare-finding-packets.mjs \
+  --base /path/to/main/finding-packets.json \
+  --candidate /path/to/candidate/finding-packets.json \
+  --base-label current-main \
+  --candidate-label candidate \
+  --top 20
+```
+
+The comparison reports signed count deltas by repair bucket, `group_key`, kind,
+fixture, candidate repo, and selector family. Positive deltas mean the candidate
+has more findings in that group; negative deltas mean fewer findings.
+
+## Fixture Manifests (class / tags / complexity)
+
+Each fixture directory carries a `fixture.json` manifest authored alongside the
+fixture (owned by the corpus repo, `blocks-engine/fixtures/websites`). The
+manifest is the **sole source of truth** for a fixture's class — there is no
+runtime classification heuristic and no directory-name fallback.
+
+```json
+{
+  "class": "marketing/static",
+  "tags": ["restaurant", "has-form", "multipage"],
+  "complexity": 1
+}
+```
+
+- `class` — **required**. Must be one of the canonical `FIXTURE_CLASSES` values
+  verbatim: `marketing/static`, `docs/blog`, `ecommerce/catalog`,
+  `app/dashboard`, `canvas/webgl/audio/runtime-heavy`, `unknown`.
+- `tags` — optional free-form string array, used for lane/tag querying.
+- `complexity` — optional integer `1`–`5` (values out of range are clamped).
+
+Class resolution order: an explicit class injected by the runner/tests → the
+manifest `class` → `unknown`. A missing manifest or an invalid `class` value does
+**not** crash the run: that single fixture resolves to `unknown` and a loud
+warning naming the fixture is written to stderr. `tags` and `complexity` are
+carried through onto each fixture, the per-fixture result, and the
+`result_summary`, so runs can be filtered/queried by lane (class) and tag.
+
+Run a single lane or tag subset (matrix-wide, runner, or bench):
+
+```bash
+# Operator runner
+node tools/run-fixture-matrix.mjs \
+  --static-site-importer <path> --blocks-engine <path> \
+  --class marketing/static --tag restaurant
+
+# Bench directly (also via SSI_FIXTURE_MATRIX_CLASS / SSI_FIXTURE_MATRIX_TAG)
+node bench/static-site-fixture-matrix.bench.mjs \
+  --fixture-root <root> --class marketing/static --tag restaurant
+```
+
+`--class` selects a single class lane; `--tag` keeps only fixtures whose manifest
+tags include the tag; both together intersect.
+
+## Generic Invocation
+
+The workload composes these generic surfaces:
+
+- Homeboy rig package discovery and `bench_workloads.nodejs` registration.
+- Repo-level `tools/wp-codebox/recipe.mjs` as a pass-through to Homeboy Extensions WP Codebox recipe execution when `--run` is explicitly provided.
+- WP Codebox CLI availability and executable discovery are upstream runtime contract requirements, not rig-level fallback checks.
+- WP Codebox `workspace-recipe/v1` steps using generic `wordpress.wp-cli`
+  commands.
+- WP Codebox `wordpress.editor-validate-blocks` command (#1597) for the
+  editor-side block validity step (see below). Requires a wp-codebox build that
+  includes #1597; older builds reject the recipe at schema validation.
+- WP Codebox `wordpress.visual-compare` command for the pixel visual-parity step
+  (see below).
+
+SSI-specific behavior remains here: plugin slug/defaults, fixture artifact
+packing, `static-site-importer validate-artifact` command construction,
+artifact expectations, and diagnostic-to-repair grouping.
+
+## Editor Block Validity Gate
+
+The PHP `validate-artifact` step proves blocks *serialize* (PHP
+`parse_blocks`/`serialize_blocks` round-trip). It does **not** run the editor's
+JS save-comparison validation, which is what surfaces the "This block contains
+unexpected or invalid content" warning users actually see.
+
+After each fixture's import step, `buildFixtureMatrixRecipe` appends a
+`wordpress.editor-validate-blocks` step (#1597) that runs the editor's real
+`wp.blocks.validateBlock` pass (same WP Codebox sandbox) and emits per-block
+`{ name, isValid, issues }` results plus `total_blocks`/`valid_blocks`/
+`invalid_blocks`. This reuses the existing wp-codebox editor-validation command
+rather than rebuilding a validator.
+
+Live-wiring gap (verified by a real local recipe-run): the matrix currently
+passes only a bare `post-type=<type>` target. wp-codebox's
+`editorOpenTargetFromArgs` resolves a bare `post-type` to an EMPTY
+`post-new.php?post_type=<type>` editor, so the pass validates `total_blocks: 0`
+and proves nothing about the imported markup. To assert real imported-output
+block validity the step must receive a concrete target — most robustly the
+imported `post-id` surfaced out of the in-sandbox `validate-artifact` step (or
+an inline `content` snapshot of the imported post_content). See
+`lib/fixture-matrix/steps/editor-validation-step.mjs` for the target priority
+order and the remaining enablement.
+
+`collectEditorValidationDiagnostics` reads the probe's `selectorSummary`
+(invalid-warning matches) — and, when present, per-block `isValid`/`validateBlock`
+results — back into `editor_block_invalid` diagnostics. These classify into the
+Blocks Engine feature/visual-parity bucket (`candidate_repo: blocks-engine`,
+`repair_mode: editor-block-validation-parity`) with the unacceptable
+`editor_block_invalid` loss class, so the honest gate fails the fixture. Valid
+blocks emit nothing. Set `--no-editor-validation` /
+`SSI_FIXTURE_MATRIX_EDITOR_VALIDATION=0` / `editorValidation: false` to omit the
+step (the slowest per-site step, it launches a browser per fixture); the run
+still produces native-rate, loss-classes, pattern-families, and the rest of the
+findings — just no `validateBlock` editor-validity data.
+
+Live caveat: the `editor-validate-blocks` step runs locally in WP Codebox today
+(see "Running the matrix locally" below) — a real local recipe-run executed the
+step and returned `validation_method: wp.blocks.validateBlock`,
+`blockTypesRegistered: 109`. The wiring and the finding-parsing/gating logic are
+unit-tested in `tools/fixture-matrix.test.mjs`. The remaining enablement for a
+true imported-content assertion is targeting the imported post rather than a
+blank editor (gap documented above).
+
+## Pixel Visual Parity Gate
+
+Structural, feature, and editor-block validity all run *without ever rendering a
+browser*. After each fixture's import step, `buildFixtureMatrixRecipe` appends a
+`wordpress.visual-compare` step that renders the fixture's original static source
+vs the imported WordPress candidate in the same WP Codebox sandbox and emits
+`source.png`/`candidate.png`/`diff.png` plus `mismatch_pixels`/`total_pixels`
+(`wp-codebox/visual-compare/v1`). This is the exact recipe command the reusable
+`runVisualParityWorkload` helper composes in homeboy-extensions — the matrix
+emits it inline rather than spinning up a separate sandbox, so no new wp-codebox
+capability is introduced.
+
+`collectVisualParityDiagnostics` reads the comparison back out (from either the
+raw `wp-codebox/visual-compare/v1` diff or a normalized
+`homeboy/VisualParityArtifact/v1` artifact) and emits a `visual_parity_mismatch`
+diagnostic when `mismatch_pixels / total_pixels` exceeds the threshold (or a
+dimension mismatch is reported). Findings route to the visual-parity repair
+bucket (`candidate_repo: blocks-engine`, `repair_mode: visual-parity`). The
+screenshots, diff, and metrics are also captured into the SSI
+`visual_parity_artifacts` slot (`static-site-importer/visual-parity-artifacts/v1`)
+on the fixture result, even when the gate is off.
+
+Gating is **opt-in**, because pixel diffs can be flaky. By default a mismatch is
+captured but non-gating (the `visual_parity_mismatch` loss class resolves to
+`acceptable`). Pass `--visual-parity-gate` (run wrapper) /
+`SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=1` to make a mismatch-over-threshold a
+HARD gate (the loss class flips to the unacceptable, fixture-failing form, the
+same conditional-acceptance pattern as `preserved_runtime_island`). The mismatch
+threshold is configurable via `--pixel-threshold` /
+`SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD` (default `0.1`, also passed as
+the per-pixel `threshold=` arg so a higher value loosens the gate monotonically).
+Set `--no-visual-parity` / `visualParity: false` to omit the step entirely.
+
+Source/candidate wiring (verified by real local recipe-runs): the
+`wordpress.visual-compare` step renders and pixel-diffs locally in WP Codebox
+against the real two pages. `writeFixtureMatrixArtifacts` stages each fixture's
+ORIGINAL static source (index.html + css/js/images) into
+`<artifacts>/<id>/source/...`, and that artifacts directory is mounted into the
+sandbox at the WordPress uploads path, so the source is served by the same
+in-sandbox WordPress origin as the candidate. The step composes
+`source-url=/wp-content/uploads/static-site-importer-fixture-matrix/<id>/source/index.html`
+(served, HTTP 200) and `candidate-url=/`. Because each fixture's import step runs
+with `activate=true` — which sets `show_on_front=page` + `page_on_front` to the
+imported front page — and the recipe interleaves `[import, visual-compare]` per
+fixture, `/` resolves to THIS fixture's imported front page at capture time, the
+real imported WordPress output. A fixture can override `source_url`/`candidate_url`
+to target a specific staged page or imported permalink. The wiring,
+source-staging, finding-parsing, threshold, and gating logic are unit-tested in
+`tools/fixture-matrix.test.mjs`.
+
+Sandbox egress note: a captured page that references external resources (Google
+Fonts, CDNs) would otherwise hang an egress-free sandbox until the 120s browser
+timeout. `wordpress.visual-compare` aborts cross-origin requests during capture by
+default (`block-external-requests`, wp-codebox) so both source and candidate
+render deterministically (offline, system-font fallback) and the comparison
+completes fast. Real measured ratios (15-saas, 38-medical-clinic, default
+viewport): the imported candidate currently diverges sharply from the source
+(0.94 and 0.44 mismatch ratios with dimension drift) — dominated by oversized
+inline SVG icons that lose CSS sizing and a frontend theme stylesheet that is not
+applied to the rendered page. The gate is capture-only by default
+(`--visual-parity-gate` to enforce); at any reasonable `--pixel-threshold` these
+imports are nowhere near the 1:1 project gate.
+
+## Running the matrix locally
+
+`homeboy bench` auto-offloads to a connected default Lab runner whenever one is
+configured — even with no `--runner` flag. The offload translates
+component/checkout paths into the remote workspace but forwards
+`--shared-state`/`--artifact-root` verbatim, so local-only paths fail on the
+runner (`Permission denied`). To run the matrix on this machine against local
+checkouts, a local fixture root, and a local WP Codebox, pass `--local` to
+`tools/run-fixture-matrix.mjs` (it injects `--force-hot --allow-local-hot` into
+every routed Homeboy step):
+
+```
+node tools/run-fixture-matrix.mjs \
+  --local \
+  --static-site-importer <ssi-checkout> \
+  --blocks-engine <blocks-engine-checkout> \
+  --fixture-root <dir-of-fixture-subdirs> \
+  --wp-codebox-bin <wp-codebox>/packages/cli/dist/index.js
+```
+
+Notes:
+- The `editor-validate-blocks` step (#1597) requires a wp-codebox build that
+  includes #1597. The build homeboy materializes at
+  `~/.cache/homeboy/wp-codebox/source` can lag upstream `main`; if it predates
+  #1597 the recipe is rejected at schema validation
+  (`steps[N].command must be equal to one of the allowed values`). Point
+  `--wp-codebox-bin` at a current-`main` build to unblock it.
+- The rig `check` pipeline asserts the SSI checkout exists
+  (`<ssi>/static-site-importer.php`). If the checkout/worktree was removed (e.g.
+  by workspace hygiene), the bench fails with `rig.pipeline_failed` on the
+  `check` step — recreate the checkout before running.
+- Fixture roots must contain real fixture subdirectories. Symlinked fixture dirs
+  are skipped by discovery (`Dirent.isDirectory()` is false for symlinks), so the
+  matrix silently finds zero fixtures and the gate falsely "passes" with
+  `fixture_count: 0`. Copy fixtures in rather than symlinking.
+
+## Editor-Quality Metrics
+
+Beyond flagging editor-invalid blocks and losses, the matrix scores how *native
+and editable* each import is. `collectBlockComposition` surfaces the transformer's
+generic block-composition breakdown — the per-block-type counts / `detectBlockTypes`
+output already carried on the import artifact (including the copy SSI preserves at
+`import_report.blocks_engine.conversion_report.block_type_counts`) — and from that
+computes, per fixture and as a corpus aggregate:
+
+- `native_conversion_rate` = native core/Automattic blocks ÷ total blocks
+- `core_html_fallback_ratio` = `core/html` blocks ÷ total blocks
+- `editor_invalid_count` = reuse of the `editor_block_invalid` findings (above)
+
+A block is **native** when it lives in a core or known Automattic namespace
+(`core/*`, `jetpack/*`, `woocommerce/*`, `automattic/*`, `a8c/*`) and is not one
+of the non-native fallback wrappers (`core/html`, `core/freeform`). This namespace
+list is the *only* basis — there is **no per-fixture knowledge**, no hardcoded
+fixture ids or classes. When no per-block-type breakdown is present but SSI's
+quality report carries a total block count plus fallback counts, the composition
+is derived from those counts (native ≈ non-fallback remainder); when neither is
+available the fixture is left unscored rather than fabricating numbers.
+
+The per-fixture score lands on each fixture result as `editor_quality`, rolls up
+into `summary.editor_quality` (aggregate rates recomputed from summed totals, not
+an average of per-fixture rates), and into each `summary.classes[*].editor_quality`
+/ `summary.quality_budgets[*].editor_quality` class rollup.
+
+Scoring is always on and non-gating. An **opt-in** native-conversion gate (off by
+default, mirroring `--visual-parity-gate`) flips low-native fixtures to failing:
+pass `--min-native-rate <ratio>` (run wrapper) / `SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE`
+(accepts a `0–1` ratio or a percentage like `80`). Each scored fixture below the
+threshold earns an unacceptable `low_native_conversion` finding
+(`native_conversion_rate_below_min`, routed to `candidate_repo: blocks-engine`,
+`repair_mode: native-conversion-parity`) so it fails the same honest gate as other
+unacceptable losses. Default runs never emit it, so existing matrix behavior is
+unchanged.
+
+## Generated Artifact Intake Contract
+
+`--artifact-root` accepts any directory containing one or more generated static
+site artifacts. Discovery is structural, not fixture-specific:
+
+- A directory with `index.html` becomes one fixture.
+- A directory with `website/index.html` becomes one fixture from `website/`.
+- A directory with `artifact.json`, `website-artifact.json`, or
+  `static-site-candidate.json` containing `files[].path` entries under
+  `website/` becomes one materialized fixture.
+
+The bridge writes normal fixture directories under the requested fixture root,
+then the existing matrix path discovers them and writes `<fixture-id>/artifact.json`
+for SSI validation.

--- a/lib/artifact-intake.mjs
+++ b/lib/artifact-intake.mjs
@@ -1,0 +1,192 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_ENTRYPOINT = 'index.html';
+const DEFAULT_MAX_DEPTH = 3;
+
+export function materializeGeneratedArtifactFixtures(input = {}) {
+  const artifactRoot = requiredDirectory(input.artifactRoot || input.artifact_root, 'artifactRoot');
+  const fixtureRoot = path.resolve(requiredString(input.fixtureRoot || input.fixture_root, 'fixtureRoot'));
+  const entrypoint = input.entrypoint || DEFAULT_ENTRYPOINT;
+  const maxDepth = finiteNumber(input.maxDepth ?? input.max_depth, DEFAULT_MAX_DEPTH);
+  const candidates = discoverGeneratedArtifacts(artifactRoot, { entrypoint, maxDepth });
+  const fixtures = [];
+
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const [index, candidate] of candidates.entries()) {
+    const fixtureId = uniqueFixtureId(candidate.id || path.basename(candidate.source), fixtures, index + 1);
+    const fixtureDirectory = path.join(fixtureRoot, fixtureId);
+    fs.rmSync(fixtureDirectory, { recursive: true, force: true });
+    fs.mkdirSync(fixtureDirectory, { recursive: true });
+
+    if (candidate.kind === 'website_artifact') {
+      materializeWebsiteArtifact(candidate.payload, fixtureDirectory);
+    } else {
+      copyDirectory(candidate.source, fixtureDirectory);
+      const discoveredEntry = candidate.entrypoint || entrypoint;
+      if (discoveredEntry !== entrypoint && fs.existsSync(path.join(fixtureDirectory, discoveredEntry))) {
+        fs.copyFileSync(path.join(fixtureDirectory, discoveredEntry), path.join(fixtureDirectory, entrypoint));
+      }
+    }
+
+    fixtures.push({
+      id: fixtureId,
+      directory: fixtureDirectory,
+      fixture_path: fixtureDirectory,
+      fixture_root: fixtureRoot,
+      entrypoint,
+      source: candidate.source,
+      source_kind: candidate.kind,
+    });
+  }
+
+  return {
+    schema: 'static-site-importer/generated-artifact-intake/v1',
+    artifact_root: artifactRoot,
+    fixture_root: fixtureRoot,
+    entrypoint,
+    count: fixtures.length,
+    fixtures,
+  };
+}
+
+export function discoverGeneratedArtifacts(root, options = {}) {
+  const artifactRoot = requiredDirectory(root, 'artifactRoot');
+  const entrypoint = options.entrypoint || DEFAULT_ENTRYPOINT;
+  const maxDepth = finiteNumber(options.maxDepth ?? options.max_depth, DEFAULT_MAX_DEPTH);
+  const candidates = [];
+
+  visitDirectories(artifactRoot, 0, maxDepth, (directory) => {
+    const artifact = readWebsiteArtifact(directory);
+    if (artifact) {
+      candidates.push({
+        kind: 'website_artifact',
+        source: artifact.path,
+        payload: artifact.payload,
+        id: artifact.payload?.metadata?.site || path.basename(directory),
+      });
+      return false;
+    }
+
+    if (fs.existsSync(path.join(directory, entrypoint))) {
+      candidates.push({ kind: 'static_directory', source: directory, entrypoint, id: path.basename(directory) });
+      return false;
+    }
+
+    const websiteDirectory = path.join(directory, 'website');
+    if (fs.existsSync(path.join(websiteDirectory, entrypoint))) {
+      candidates.push({ kind: 'website_directory', source: websiteDirectory, entrypoint, id: path.basename(directory) });
+      return false;
+    }
+
+    return true;
+  });
+
+  return candidates.sort((left, right) => left.source.localeCompare(right.source));
+}
+
+function readWebsiteArtifact(directory) {
+  for (const name of ['artifact.json', 'website-artifact.json', 'static-site-candidate.json']) {
+    const filePath = path.join(directory, name);
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+      continue;
+    }
+    try {
+      const payload = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      if (Array.isArray(payload?.files) && payload.files.some((file) => file.path === 'website/index.html')) {
+        return { path: filePath, payload };
+      }
+    } catch {
+      // Non-JSON files with these names are not website artifact candidates.
+    }
+  }
+  return null;
+}
+
+function materializeWebsiteArtifact(artifact, fixtureDirectory) {
+  for (const file of artifact.files || []) {
+    if (!file?.path || !file.path.startsWith('website/')) {
+      continue;
+    }
+    const relativePath = file.path.slice('website/'.length);
+    if (!relativePath || relativePath.includes('..')) {
+      continue;
+    }
+    const destination = path.join(fixtureDirectory, relativePath);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    if (typeof file.content === 'string') {
+      fs.writeFileSync(destination, file.content);
+    } else if (typeof file.content_base64 === 'string') {
+      fs.writeFileSync(destination, Buffer.from(file.content_base64, 'base64'));
+    }
+  }
+}
+
+function copyDirectory(source, destination) {
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    if (entry.name === '.git' || entry.name === 'node_modules') {
+      continue;
+    }
+    const sourcePath = path.join(source, entry.name);
+    const destinationPath = path.join(destination, entry.name);
+    if (entry.isDirectory()) {
+      fs.mkdirSync(destinationPath, { recursive: true });
+      copyDirectory(sourcePath, destinationPath);
+    } else if (entry.isFile()) {
+      fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+      fs.copyFileSync(sourcePath, destinationPath);
+    }
+  }
+}
+
+function visitDirectories(directory, depth, maxDepth, callback) {
+  const shouldDescend = callback(directory) !== false;
+  if (!shouldDescend || depth >= maxDepth) {
+    return;
+  }
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name !== '.git' && entry.name !== 'node_modules') {
+      visitDirectories(path.join(directory, entry.name), depth + 1, maxDepth, callback);
+    }
+  }
+}
+
+function uniqueFixtureId(value, existingFixtures, fallback) {
+  const base = slug(value || `fixture-${fallback}`);
+  const existing = new Set(existingFixtures.map((fixture) => fixture.id));
+  if (!existing.has(base)) {
+    return base;
+  }
+  let suffix = 2;
+  while (existing.has(`${base}-${suffix}`)) {
+    suffix += 1;
+  }
+  return `${base}-${suffix}`;
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new TypeError(`${name} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function requiredDirectory(value, name) {
+  const directory = path.resolve(requiredString(value, name));
+  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+    throw new Error(`${name} must be an existing directory: ${directory}`);
+  }
+  return directory;
+}
+
+function finiteNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function slug(value) {
+  return String(value || 'fixture')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'fixture';
+}

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -1,0 +1,87 @@
+// Static Site Importer fixture matrix — thin composer.
+//
+// The accreted concerns (fixture discovery/taxonomy, recipe building, the
+// editor-validation #537 / visual-parity #538 / editor-quality #541 collectors,
+// finding classification + honest loss-acceptance #535, and the summary/aggregate
+// rollups) now live as composable modules under `./fixture-matrix/`. This file is
+// a behavior-preserving facade that re-exports the same public surface from the
+// same path, so `tools/`, `bench/`, and tests import it unchanged.
+//
+// Modularized as workstream 3 of the maintainability/parallel-safe-swarm epic
+// (Refs #242).
+
+export {
+  FIXTURE_MATRIX_SCHEMA,
+  FIXTURE_MATRIX_RESULT_SCHEMA,
+  WEBSITE_ARTIFACT_SCHEMA,
+  EDITOR_BLOCK_INVALID_KIND,
+  EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
+  EDITOR_INVALID_BLOCK_SELECTORS,
+  EDITOR_VALIDATE_BLOCKS_COMMAND,
+  EDITOR_VALIDATE_BLOCKS_SCHEMA,
+  EDITOR_VALIDATION_METHOD,
+  EDITOR_VALIDATION_PROVIDER,
+  DEFAULT_EDITOR_VALIDATION_POST_TYPE,
+  VISUAL_PARITY_MISMATCH_KIND,
+  LOW_NATIVE_CONVERSION_KIND,
+} from './fixture-matrix/shared/constants.mjs';
+
+export {
+  discoverFixtures,
+  createFixtureMatrix,
+  classifyFixture,
+} from './fixture-matrix/fixtures.mjs';
+
+export {
+  buildFixtureArtifact,
+  buildFixtureMatrixRecipe,
+  stageFixtureSource,
+  wordpressServedPath,
+  normalizeStaticSiteImporterPlugin,
+} from './fixture-matrix/steps/recipe-builder.mjs';
+
+export { editorBlockValidationStep } from './fixture-matrix/steps/editor-validation-step.mjs';
+
+export { visualParityCompareStep } from './fixture-matrix/steps/visual-parity-step.mjs';
+
+export {
+  liveWpParityCaptureStep,
+  liveWpParityEnabled,
+  normalizeLiveWpParityRecipeOptions,
+} from './fixture-matrix/steps/live-wp-parity-step.mjs';
+
+export {
+  normalizeFixtureMatrixResult,
+  writeFixtureMatrixArtifacts,
+  writeFixtureMatrixResultArtifacts,
+} from './fixture-matrix/result.mjs';
+
+export { collectFixtureMatrixRunResults } from './fixture-matrix/collectors/run-intake.mjs';
+
+export { classifyStaticSiteFinding, normalizeLossClass } from './fixture-matrix/findings.mjs';
+
+export {
+  collectBlockComposition,
+  collectBlockCompositionFromBlockDocuments,
+  collectBlockCompositionFromSerializedBlocks,
+  computeFixtureEditorQuality,
+  parseSerializedBlockNames,
+} from './fixture-matrix/collectors/quality-metrics.mjs';
+
+export {
+  collectEditorValidationDiagnostics,
+  collectEditorValidation,
+  isEditorValidateBlocksPayload,
+} from './fixture-matrix/collectors/editor-validation.mjs';
+
+export {
+  collectVisualParityDiagnostics,
+  normalizeVisualParityGateOptions,
+} from './fixture-matrix/collectors/visual-parity.mjs';
+
+export {
+  runLiveWpParity,
+  normalizeLiveWpParityReport,
+  collectLiveWpParity,
+  normalizeLiveWpParityCollectorOptions,
+} from './fixture-matrix/collectors/live-wp-parity.mjs';

--- a/lib/fixture-matrix/collectors/editor-validation.mjs
+++ b/lib/fixture-matrix/collectors/editor-validation.mjs
@@ -1,0 +1,207 @@
+// Editor-validation collector (#537): turns editor-canvas-probe / validateBlock
+// evidence into `editor_block_invalid` diagnostics for the Static Site Importer
+// fixture matrix.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242).
+
+import {
+  EDITOR_BLOCK_INVALID_KIND,
+  EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
+  EDITOR_INVALID_BLOCK_SELECTORS,
+  EDITOR_BLOCK_INVALID_DEFAULT_DETAIL,
+  EDITOR_VALIDATE_BLOCKS_SCHEMA,
+  EDITOR_VALIDATION_METHOD,
+  EDITOR_VALIDATION_PROVIDER,
+} from '../shared/constants.mjs';
+import {
+  normalizeArray,
+  numberValue,
+  firstNumber,
+  firstString,
+  compactObject,
+  objectValue,
+  diagnosticMessage,
+} from '../shared/utils.mjs';
+
+// Turn editor-validation evidence (either explicit per-block validity from a
+// `validateBlock`/getBlocks pass, or `wordpress.editor-canvas-probe`
+// invalid-block warning matches) into `editor_block_invalid` diagnostics. These
+// flow through `normalizeDiagnosticFinding` and gate via the
+// `editor_block_invalid` unacceptable loss class. Valid blocks emit nothing.
+export function collectEditorValidationDiagnostics(payload) {
+  const diagnostics = [];
+
+  for (const block of collectEditorValidatedBlocks(payload)) {
+    if (isInvalidEditorBlock(block)) {
+      diagnostics.push(editorInvalidBlockDiagnostic(block));
+    }
+  }
+
+  for (const group of collectEditorCanvasInvalidGroups(payload)) {
+    const count = numberValue(group.visible_count ?? group.visibleCount ?? group.count);
+    if (count <= 0) {
+      continue;
+    }
+    const detail = firstString([group.first_match?.text, group.firstMatch?.text, EDITOR_BLOCK_INVALID_DEFAULT_DETAIL]);
+    diagnostics.push({
+      kind: EDITOR_BLOCK_INVALID_KIND,
+      selector: group.selector || EDITOR_INVALID_BLOCK_SELECTORS[0],
+      source_path: group.source_path || group.sourcePath || '',
+      observed_output: detail,
+      message: `Editor rendered ${count} invalid-block warning${count === 1 ? '' : 's'} for the imported post (${detail}).`,
+    });
+  }
+
+  return diagnostics;
+}
+
+function collectEditorValidatedBlocks(payload) {
+  const blocks = [
+    ...normalizeArray(payload.editor_blocks || payload.editorBlocks),
+    ...normalizeArray(payload.editor_validation?.blocks || payload.editorValidation?.blocks),
+    ...normalizeArray(payload.editor_validation?.results || payload.editorValidation?.results),
+    ...normalizeArray(payload.editor_state?.blocks || payload.editorState?.blocks),
+  ];
+  // `wordpress.editor-validate-blocks` (wp.blocks.validateBlock) emits the
+  // per-block `{ name, isValid, issues }` set at the payload top level.
+  if (isEditorValidateBlocksPayload(payload)) {
+    blocks.push(...normalizeArray(payload.results));
+  }
+  return blocks;
+}
+
+// Recognize a `wordpress.editor-validate-blocks` payload (the real
+// `wp.blocks.validateBlock` editor-validation result). Matches either the
+// payload itself or a nested `editor_validation`/`editorValidation` slot.
+export function isEditorValidateBlocksPayload(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  if (value.schema === EDITOR_VALIDATE_BLOCKS_SCHEMA) {
+    return true;
+  }
+  if (value.validation_method === EDITOR_VALIDATION_METHOD || value.validationMethod === EDITOR_VALIDATION_METHOD) {
+    return true;
+  }
+  const hasCounts = ['total_blocks', 'totalBlocks', 'valid_blocks', 'validBlocks', 'invalid_blocks', 'invalidBlocks']
+    .some((key) => Object.hasOwn(value, key));
+  return hasCounts && Array.isArray(value.results);
+}
+
+function editorValidatePayload(payload) {
+  for (const candidate of [payload, payload?.editor_validation, payload?.editorValidation]) {
+    if (isEditorValidateBlocksPayload(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+// Normalize a `wordpress.editor-validate-blocks` payload into the headline
+// editor-validity metrics — `total_blocks` / `valid_blocks` / `invalid_blocks`
+// plus the `validation_method`/`validation_provider`. Counts come from the
+// command's own totals when present, otherwise they are recomputed from the
+// per-block `results`. Returns null when no validateBlock evidence is present
+// (never fabricated). These feed `result.editor_validation`, which the
+// editor-quality collector turns into `editor_valid_block_rate` /
+// `invalid_block_count` distinct from the PHP round-trip.
+export function collectEditorValidation(payload) {
+  const source = editorValidatePayload(objectValue(payload));
+  if (!source) {
+    return null;
+  }
+  const results = normalizeArray(source.results).filter((entry) => entry && typeof entry === 'object');
+  const totalFromResults = results.length;
+  const invalidFromResults = results.filter((block) => isInvalidEditorBlock(block)).length;
+  const total = pickCount(source.total_blocks ?? source.totalBlocks, totalFromResults);
+  const invalid = pickCount(source.invalid_blocks ?? source.invalidBlocks, invalidFromResults);
+  const valid = pickCount(source.valid_blocks ?? source.validBlocks, Math.max(0, total - invalid));
+  return compactObject({
+    validation_method: firstString([source.validation_method, source.validationMethod, EDITOR_VALIDATION_METHOD]),
+    validation_provider: firstString([source.validation_provider, source.validationProvider, EDITOR_VALIDATION_PROVIDER]),
+    total_blocks: total,
+    valid_blocks: valid,
+    invalid_blocks: invalid,
+  });
+}
+
+function pickCount(value, fallback) {
+  const number = firstNumber([value]);
+  return Number.isFinite(number) ? number : numberValue(fallback);
+}
+
+function isInvalidEditorBlock(block) {
+  if (!block || typeof block !== 'object') {
+    return false;
+  }
+  if (block.isValid === false || block.is_valid === false || block.valid === false) {
+    return true;
+  }
+  // A `validateBlock`-style result: [isValid, issues] or { isValid }.
+  if (Array.isArray(block.validation)) {
+    return block.validation[0] === false;
+  }
+  return false;
+}
+
+function editorInvalidBlockDiagnostic(block) {
+  const name = block.name || block.block_name || block.blockName || '';
+  const clientId = block.clientId || block.client_id || '';
+  const selector = block.selector || (clientId ? `[data-block="${clientId}"]` : '');
+  const detail = firstString([
+    Array.isArray(block.issues) ? block.issues.join('; ') : '',
+    Array.isArray(block.validationIssues) ? block.validationIssues.map((issue) => diagnosticMessage(issue)).filter(Boolean).join('; ') : '',
+    block.validity_detail || block.validityDetail,
+    block.reason,
+    EDITOR_BLOCK_INVALID_DEFAULT_DETAIL,
+  ]);
+  return {
+    kind: EDITOR_BLOCK_INVALID_KIND,
+    block_name: name,
+    observed_block_name: name,
+    selector,
+    source_path: block.source_path || block.source || '',
+    observed_output: firstString([block.originalContent, block.expectedContent, block.html_excerpt]),
+    message: `Editor reported block "${name || 'unknown'}" as invalid: ${detail}.`,
+  };
+}
+
+function collectEditorCanvasInvalidGroups(payload) {
+  const groups = [];
+  for (const summary of collectEditorCanvasSummaries(payload)) {
+    for (const group of normalizeArray(summary.selectorSummary?.groups || summary.selector_summary?.groups || summary.groups)) {
+      if (isEditorInvalidBlockGroup(group)) {
+        groups.push(group);
+      }
+    }
+  }
+  return groups;
+}
+
+function collectEditorCanvasSummaries(payload) {
+  const summaries = [];
+  for (const candidate of [
+    payload.summary,
+    payload.editor_canvas || payload.editorCanvas,
+    payload.editor_validation?.canvas || payload.editorValidation?.canvas,
+  ]) {
+    for (const value of normalizeArray(candidate)) {
+      if (value && typeof value === 'object' && (value.selectorSummary || value.selector_summary || value.groups)) {
+        summaries.push(value);
+      }
+    }
+  }
+  return summaries;
+}
+
+function isEditorInvalidBlockGroup(group) {
+  if (!group || typeof group !== 'object') {
+    return false;
+  }
+  const name = String(group.name || '').toLowerCase();
+  if (name === EDITOR_INVALID_BLOCK_SELECTOR_GROUP || /invalid|warning/.test(name)) {
+    return true;
+  }
+  return /block-editor-warning|is-invalid/.test(String(group.selector || ''));
+}

--- a/lib/fixture-matrix/collectors/live-wp-parity.mjs
+++ b/lib/fixture-matrix/collectors/live-wp-parity.mjs
@@ -1,0 +1,221 @@
+// Live-WP parity collector for the Static Site Importer fixture matrix.
+//
+// Host-side companion to ../steps/live-wp-parity-step.mjs. The capture step writes
+// the imported candidate's RENDERED DOM HTML to `files/browser/snapshot.html`
+// (via `wordpress.capture-html`). This module feeds that snapshot, together with
+// the staged fixture source, to the EXISTING blocks-engine deterministic comparator
+// through its CLI entry (`composer live-wp-parity` ->
+// php-transformer/tools/live-wp-parity/run.php), then normalizes the report into
+// the same parity-result shape the matrix already surfaces for the render-free gate.
+//
+// Determinism: the comparator is pure PHP (no browser/network/rasterization), and
+// the candidate (snapshot.html) was captured with external requests blocked, so
+// given a fixed snapshot the report is byte-identical run to run. With --with-proxy
+// the CLI also reports the render-free proxy score so callers can read the live-WP
+// vs proxy delta directly.
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { VISUAL_PARITY_SOURCE_SUBDIR } from '../shared/constants.mjs';
+import { objectValue, finiteNumber, compactObject, isTruthySignal } from '../shared/utils.mjs';
+
+// Run the blocks-engine live-wp-parity CLI against a captured rendered-DOM snapshot.
+//
+// @param {object} input
+//   - sourceHtmlPath: path to the fixture source HTML (required)
+//   - candidateHtmlPath: path to the captured rendered-DOM snapshot.html (required)
+//   - blocksEnginePhpTransformerPath: php-transformer package root (required;
+//       resolve via resolveBlocksEnginePhpTransformerPath)
+//   - sourceCssPath: optional explicit source CSS file; otherwise the CLI
+//       auto-extracts author CSS from the source's own <style>/linked stylesheets
+//   - candidateCssPath: optional extra CSS for the candidate side (default none —
+//       the rendered DOM carries its own WP-emitted styles)
+//   - withProxy: also compute the render-free proxy score + delta (default true)
+//   - exec: injectable command runner (defaults to spawnSync) for testing
+// @returns {object} normalized live-WP parity result (see normalizeLiveWpParityReport)
+export function runLiveWpParity(input = {}) {
+  const sourceHtmlPath = requirePath(input.sourceHtmlPath, 'sourceHtmlPath');
+  const candidateHtmlPath = requirePath(input.candidateHtmlPath, 'candidateHtmlPath');
+  const packagePath = requirePath(input.blocksEnginePhpTransformerPath, 'blocksEnginePhpTransformerPath');
+  const withProxy = input.withProxy !== false;
+  const exec = typeof input.exec === 'function' ? input.exec : defaultExec;
+
+  const runPhp = path.join(packagePath, 'tools', 'live-wp-parity', 'run.php');
+  const args = [
+    runPhp,
+    '--source', sourceHtmlPath,
+    '--candidate', candidateHtmlPath,
+    ...(input.sourceCssPath ? ['--source-css', input.sourceCssPath] : []),
+    ...(input.candidateCssPath ? ['--candidate-css', input.candidateCssPath] : []),
+    ...(withProxy ? ['--with-proxy'] : []),
+    '--json',
+  ];
+
+  const result = exec('php', args, { cwd: packagePath });
+  const status = finiteNumber(result?.status, result?.status === 0 ? 0 : 1);
+  const stdout = String(result?.stdout ?? '');
+  const stderr = String(result?.stderr ?? '');
+  if (status !== 0) {
+    throw new Error(`live-wp-parity CLI failed (status ${status}): ${stderr.trim() || stdout.trim()}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`live-wp-parity CLI emitted non-JSON output: ${error.message}`);
+  }
+
+  return normalizeLiveWpParityReport(parsed);
+}
+
+// Normalize the matrix-facing live-WP parity collector options into a stable
+// shape. `enabled` is the opt-in toggle (off by default), `blocksEnginePhpTransformerPath`
+// points at the comparator package, `withProxy` (default true) also computes the
+// render-free proxy score + delta, and `exec` is an injectable runner for tests.
+export function normalizeLiveWpParityCollectorOptions(options = {}) {
+  const source = objectValue(options);
+  return {
+    enabled: isTruthySignal(source.enabled ?? source.liveWpParity ?? source.live_wp_parity),
+    blocksEnginePhpTransformerPath: firstStringOption([
+      source.blocksEnginePhpTransformerPath,
+      source.blocks_engine_php_transformer_path,
+    ]),
+    withProxy: source.withProxy !== false && source.with_proxy !== false,
+    exec: typeof source.exec === 'function' ? source.exec : undefined,
+  };
+}
+
+// Per-fixture host-side live-WP parity collection. Resolves the captured rendered
+// DOM snapshot (files/browser/snapshot.html, written by the capture step) and the
+// staged fixture source, then runs the blocks-engine comparator via runLiveWpParity.
+//
+// Lane isolation: this is best-effort and NEVER throws. When the toggle is off,
+// the comparator package path is unknown, the snapshot/source artifacts are absent
+// (capture did not run), or the comparator itself fails, it returns null so a
+// live-WP miss can not sink the fixture lane. Returns the normalized
+// `static-site-importer/live-wp-parity-result/v1` result (live-WP score, proxy
+// score, and live-vs-proxy delta) when the comparison succeeds.
+export function collectLiveWpParity(input = {}) {
+  const options = normalizeLiveWpParityCollectorOptions(input.options || input);
+  if (!options.enabled || !options.blocksEnginePhpTransformerPath) {
+    return null;
+  }
+  const fixtureArtifactsDirectory = input.fixtureArtifactsDirectory || input.fixture_artifacts_directory;
+  if (typeof fixtureArtifactsDirectory !== 'string' || fixtureArtifactsDirectory.trim() === '') {
+    return null;
+  }
+  const entrypoint = input.entrypoint || input.fixture?.entrypoint || 'index.html';
+  const candidateHtmlPath = path.join(fixtureArtifactsDirectory, 'files', 'browser', 'snapshot.html');
+  const sourceHtmlPath = path.join(fixtureArtifactsDirectory, VISUAL_PARITY_SOURCE_SUBDIR, entrypoint);
+  // No capture/source on disk => the candidate render or source staging did not
+  // happen for this fixture. Skip silently rather than fail the lane.
+  if (!fs.existsSync(candidateHtmlPath) || !fs.existsSync(sourceHtmlPath)) {
+    return null;
+  }
+  try {
+    return runLiveWpParity({
+      sourceHtmlPath,
+      candidateHtmlPath,
+      blocksEnginePhpTransformerPath: options.blocksEnginePhpTransformerPath,
+      withProxy: options.withProxy,
+      exec: options.exec,
+    });
+  } catch {
+    // Lane isolation: a comparator failure is recorded as "no live-WP result"
+    // for this fixture, never an aborted lane.
+    return null;
+  }
+}
+
+function firstStringOption(values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value;
+    }
+  }
+  return '';
+}
+
+function defaultExec(command, args, options) {
+  // The full report carries every per-element / per-property delta, which for a
+  // large fixture exceeds spawnSync's default 1 MiB stdout buffer and would
+  // otherwise truncate the JSON. Raise the ceiling so the report is captured whole.
+  return spawnSync(command, args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...options });
+}
+
+// Normalize the CLI's `blocks-engine/php-transformer/live-wp-parity-report/v1`
+// payload into the matrix-facing live-WP parity result: the live-WP score + status,
+// a bounded per-property diff for evidence, and the render-free proxy comparison
+// when present. Keeps the same `parity`/`summary` vocabulary the render-free gate
+// already reports so both signals read side by side.
+export function normalizeLiveWpParityReport(report, options = {}) {
+  const payload = objectValue(report);
+  const live = objectValue(payload.live_wp);
+  const parity = objectValue(live.parity);
+  const summary = objectValue(live.summary);
+  const comparison = objectValue(payload.comparison);
+  const diffLimit = finiteNumber(options.diffLimit ?? options.diff_limit, 25);
+
+  return compactObject({
+    schema: 'static-site-importer/live-wp-parity-result/v1',
+    owner: 'codebox_runtime',
+    source: payload.source,
+    candidate: payload.candidate,
+    status: live.status,
+    score: finiteNumber(parity.score, 0),
+    property_parity: finiteNumber(parity.property_parity, 0),
+    coverage: finiteNumber(parity.coverage, 0),
+    matched_total: finiteNumber(summary.matched_total, 0),
+    source_total: finiteNumber(summary.source_total, 0),
+    finding_total: finiteNumber(summary.finding_total, 0),
+    property_diffs: collectPropertyDiffs(live, diffLimit),
+    comparison: Object.keys(comparison).length > 0
+      ? compactObject({
+          live_wp_score: finiteNumber(comparison.live_wp_score, 0),
+          proxy_score: finiteNumber(comparison.proxy_score, 0),
+          // Positive delta => the live WP render matched the source BETTER than the
+          // render-free proxy; negative => WP's render/global-styles diverged where
+          // the proxy did not (the layer the proxy cannot see).
+          delta: finiteNumber(comparison.delta, 0),
+        })
+      : undefined,
+  });
+}
+
+// Flatten the comparator's per-element style deltas into a bounded list naming the
+// exact diverged CSS property on the exact selector — the same per-property signal
+// the render-free gate surfaces, now for real WP output.
+function collectPropertyDiffs(liveReport, limit) {
+  const diffs = [];
+  for (const match of asArray(objectValue(liveReport).matches)) {
+    const record = objectValue(match);
+    for (const delta of asArray(record.style_deltas)) {
+      const entry = objectValue(delta);
+      diffs.push(compactObject({
+        source_selector: record.source_selector,
+        target_selector: record.target_selector,
+        property: entry.property,
+        source: entry.source,
+        target: entry.target,
+      }));
+      if (diffs.length >= limit) {
+        return diffs;
+      }
+    }
+  }
+  return diffs;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function requirePath(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`runLiveWpParity requires ${name}.`);
+  }
+  return value;
+}

--- a/lib/fixture-matrix/collectors/quality-metrics.mjs
+++ b/lib/fixture-matrix/collectors/quality-metrics.mjs
@@ -1,0 +1,503 @@
+// Editor-quality metrics (#541): block-composition extraction, per-fixture and
+// aggregate native-conversion scoring, and the opt-in native-rate gate for the
+// Static Site Importer fixture matrix.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242).
+
+import {
+  NATIVE_BLOCK_NAMESPACES,
+  CORE_HTML_BLOCK_NAME,
+  NON_NATIVE_FALLBACK_BLOCK_NAMES,
+  LOW_NATIVE_CONVERSION_KIND,
+  EDITOR_BLOCK_INVALID_KIND,
+  EDITOR_VALIDATION_METHOD,
+} from '../shared/constants.mjs';
+import {
+  objectValue,
+  numberValue,
+  firstNumber,
+  firstString,
+  compactObject,
+  qualityRatio,
+} from '../shared/utils.mjs';
+import { normalizeDiagnosticFinding } from '../findings.mjs';
+
+export function collectQualityMetrics(payload) {
+  return compactObject({
+    ...(payload.quality_metrics || payload.qualityMetrics || {}),
+    ...(payload.quality || {}),
+    ...(payload.import_report?.report?.quality || payload.importReport?.report?.quality || payload.report?.quality || {}),
+  });
+}
+
+// Surface the transformer's generic block-composition breakdown from whatever
+// import-artifact slot carries it. Returns a normalized
+// `{ block_total, native_block_count, core_html_block_count, block_type_counts,
+// source }` shape, or null when no block-composition data is present (never
+// fabricated). Sources are tried most-precise first:
+//   1. an explicit per-block-type breakdown (`block_type_counts` /
+//      `detectBlockTypes` map, or the nested native conversion-report copy);
+//   2. serialized block markup — the materialized `post_content` carries
+//      Gutenberg block comments (`<!-- wp:namespace/name ... -->`) that name each
+//      emitted block, so we parse those names directly;
+//   3. SSI's per-document analysis (`materialized_content` /
+//      `generated_theme` `block_documents[]`), which carries each document's total
+//      `block_count` plus its `core_html_block_count`/`freeform_block_count` —
+//      this is what real Lab/WP Codebox runs emit;
+//   4. the import report's aggregate quality counts.
+export function collectBlockComposition(payload) {
+  const breakdown = collectBlockTypeBreakdown(payload);
+  if (breakdown && breakdown.total > 0) {
+    return {
+      block_total: breakdown.total,
+      native_block_count: breakdown.native,
+      core_html_block_count: breakdown.core_html,
+      block_type_counts: breakdown.counts,
+      source: 'block_type_breakdown',
+    };
+  }
+  return collectBlockCompositionFromSerializedBlocks(payload)
+    || collectBlockCompositionFromBlockDocuments(payload)
+    || blockCompositionFromQualityCounts(payload);
+}
+
+function collectBlockTypeBreakdown(payload) {
+  for (const source of blockTypeBreakdownSources(payload)) {
+    const counts = normalizeBlockTypeCounts(source);
+    if (counts) {
+      return summarizeBlockTypeCounts(counts);
+    }
+  }
+  return null;
+}
+
+function blockTypeBreakdownSources(payload) {
+  const object = objectValue(payload);
+  const quality = collectQualityMetrics(object);
+  const importReport = objectValue(object.import_report || object.importReport || object.report);
+  const blocksEngine = objectValue(importReport.blocks_engine || importReport.blocksEngine || object.blocks_engine || object.blocksEngine);
+  const conversionReport = objectValue(blocksEngine.conversion_report || blocksEngine.conversionReport);
+  return [
+    object.block_type_counts,
+    object.blockTypeCounts,
+    object.block_types,
+    object.blockTypes,
+    object.detected_block_types,
+    object.detectedBlockTypes,
+    object.detect_block_types,
+    quality.block_type_counts,
+    quality.blockTypeCounts,
+    conversionReport.block_type_counts,
+    conversionReport.blockTypeCounts,
+    conversionReport.block_types,
+    conversionReport.blockTypes,
+  ];
+}
+
+// Normalize any block-type breakdown — a `{ name: count }` map, a list of block
+// names, or a list of `{ name, count }`-shaped rows — into a single
+// `{ name: count }` map. Returns null when nothing usable is present.
+function normalizeBlockTypeCounts(value) {
+  if (!value) {
+    return null;
+  }
+  const counts = {};
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (typeof entry === 'string') {
+        const name = normalizeBlockName(entry);
+        if (name) {
+          counts[name] = (counts[name] || 0) + 1;
+        }
+      } else if (entry && typeof entry === 'object') {
+        const name = normalizeBlockName(entry.name || entry.block || entry.block_name || entry.blockName || entry.type);
+        if (!name) {
+          continue;
+        }
+        const count = firstNumber([entry.count, entry.occurrences, entry.total, entry.instances, entry.value]);
+        counts[name] = (counts[name] || 0) + (Number.isFinite(count) ? count : 1);
+      }
+    }
+  } else if (typeof value === 'object') {
+    for (const [key, raw] of Object.entries(value)) {
+      const name = normalizeBlockName(key);
+      const count = Number(raw);
+      if (name && Number.isFinite(count)) {
+        counts[name] = (counts[name] || 0) + count;
+      }
+    }
+  }
+  return Object.keys(counts).length > 0 ? counts : null;
+}
+
+function summarizeBlockTypeCounts(counts) {
+  let total = 0;
+  let native = 0;
+  let coreHtml = 0;
+  for (const [name, value] of Object.entries(counts)) {
+    const count = numberValue(value);
+    total += count;
+    if (name === CORE_HTML_BLOCK_NAME) {
+      coreHtml += count;
+    }
+    if (isNativeBlockName(name)) {
+      native += count;
+    }
+  }
+  return { total, native, core_html: coreHtml, counts };
+}
+
+// Parse the block composition directly out of serialized Gutenberg block markup
+// (the materialized `post_content`). Every emitted block opens with a
+// `<!-- wp:namespace/name ... -->` comment — core blocks omit the namespace
+// (`<!-- wp:heading -->` is `core/heading`). Closing comments (`<!-- /wp:... -->`)
+// are skipped by the `\s+wp:` anchor, so each block is counted once. Returns the
+// normalized composition shape, or null when no serialized markup is present.
+export function collectBlockCompositionFromSerializedBlocks(payload) {
+  const counts = {};
+  let found = false;
+  for (const markup of serializedBlockSources(payload)) {
+    for (const name of parseSerializedBlockNames(markup)) {
+      counts[name] = (counts[name] || 0) + 1;
+      found = true;
+    }
+  }
+  if (!found) {
+    return null;
+  }
+  const summary = summarizeBlockTypeCounts(counts);
+  if (summary.total <= 0) {
+    return null;
+  }
+  return {
+    block_total: summary.total,
+    native_block_count: summary.native,
+    core_html_block_count: summary.core_html,
+    block_type_counts: summary.counts,
+    source: 'serialized_blocks',
+  };
+}
+
+// Extract the `wp:` block names from a single serialized-blocks string. Core
+// blocks (no namespace) are normalized to their `core/` form so they classify
+// against NATIVE_BLOCK_NAMESPACES consistently with explicit breakdowns.
+export function parseSerializedBlockNames(markup) {
+  if (typeof markup !== 'string' || !markup.includes('<!--')) {
+    return [];
+  }
+  const names = [];
+  const pattern = /<!--\s+wp:([a-z][a-z0-9-]*(?:\/[a-z][a-z0-9-]*)?)/g;
+  let match = pattern.exec(markup);
+  while (match) {
+    const name = normalizeBlockName(match[1]);
+    names.push(name.includes('/') ? name : `core/${name}`);
+    match = pattern.exec(markup);
+  }
+  return names;
+}
+
+// Collect every slot that may carry serialized block markup. SSI does not yet
+// persist raw `post_content` in its report, so this is opportunistic and
+// future-proof: it reads the obvious top-level/quality/import-report string slots
+// plus any per-document markup carried on a `block_documents[]` entry.
+function serializedBlockSources(payload) {
+  const object = objectValue(payload);
+  const quality = collectQualityMetrics(object);
+  const importReport = objectValue(object.import_report || object.importReport || object.report);
+  const strings = [
+    object.post_content,
+    object.postContent,
+    object.serialized_blocks,
+    object.serializedBlocks,
+    object.block_markup,
+    object.blockMarkup,
+    object.rendered_blocks,
+    object.renderedBlocks,
+    quality.post_content,
+    quality.serialized_blocks,
+    importReport.post_content,
+    importReport.serialized_blocks,
+  ];
+  for (const document of blockDocumentEntries(object)) {
+    strings.push(
+      document.post_content,
+      document.block_markup,
+      document.serialized_blocks,
+      document.serialized,
+      document.markup,
+    );
+  }
+  return strings.filter((value) => typeof value === 'string' && value.trim() !== '');
+}
+
+// Derive the composition from SSI's per-document block analysis. Each
+// `block_documents[]` entry records the materialized document's total
+// `block_count` plus the non-native `core_html_block_count`/`freeform_block_count`
+// fallbacks; native is the remainder. The materialized post-content documents are
+// preferred over the generated-theme documents (and never summed together, since
+// SSI records each materialized page in both arrays). Returns null when no
+// per-document totals are present.
+export function collectBlockCompositionFromBlockDocuments(payload) {
+  const documents = blockDocumentEntries(payload);
+  if (documents.length === 0) {
+    return null;
+  }
+  let total = 0;
+  let coreHtml = 0;
+  let freeform = 0;
+  for (const document of documents) {
+    total += numberValue(document.block_count ?? document.blockCount);
+    coreHtml += numberValue(document.core_html_block_count ?? document.coreHtmlBlockCount);
+    freeform += numberValue(document.freeform_block_count ?? document.freeformBlockCount);
+  }
+  if (total <= 0) {
+    return null;
+  }
+  return {
+    block_total: total,
+    native_block_count: Math.max(0, total - coreHtml - freeform),
+    core_html_block_count: coreHtml,
+    block_type_counts: null,
+    source: 'block_documents',
+  };
+}
+
+// The materialized post-content documents are the production-quality signal; fall
+// back to the generated-theme template documents only when no materialized pages
+// were recorded. The two arrays overlap (SSI pushes each materialized page into
+// both), so exactly one is chosen to avoid double counting.
+function blockDocumentEntries(payload) {
+  const object = objectValue(payload);
+  const importReport = objectValue(object.import_report || object.importReport || object.report);
+  const materialized = objectValue(importReport.materialized_content || importReport.materializedContent || object.materialized_content || object.materializedContent);
+  const generatedTheme = objectValue(importReport.generated_theme || importReport.generatedTheme || object.generated_theme || object.generatedTheme);
+  const materializedDocuments = blockDocumentList(materialized.block_documents || materialized.blockDocuments);
+  if (materializedDocuments.length > 0) {
+    return materializedDocuments;
+  }
+  const generatedDocuments = blockDocumentList(generatedTheme.block_documents || generatedTheme.blockDocuments);
+  if (generatedDocuments.length > 0) {
+    return generatedDocuments;
+  }
+  return blockDocumentList(object.block_documents || object.blockDocuments);
+}
+
+function blockDocumentList(value) {
+  return Array.isArray(value) ? value.filter((entry) => entry && typeof entry === 'object') : [];
+}
+
+// Best-effort fallback when no per-block-type breakdown exists but SSI's quality
+// report carries a total block count plus the fallback counts. Native blocks are
+// approximated as the non-fallback remainder (total minus core/html and
+// core/freeform). Returns null when no total block count is available.
+function blockCompositionFromQualityCounts(payload) {
+  const object = objectValue(payload);
+  const quality = collectQualityMetrics(object);
+  const importReport = objectValue(object.import_report || object.importReport || object.report);
+  const blocksEngine = objectValue(importReport.blocks_engine || importReport.blocksEngine || object.blocks_engine || object.blocksEngine);
+  const conversionReport = objectValue(blocksEngine.conversion_report || blocksEngine.conversionReport);
+  const total = firstNumber([
+    quality.block_count,
+    quality.total_block_count,
+    quality.blockCount,
+    object.block_count,
+    object.blockCount,
+    conversionReport.block_count,
+  ]);
+  if (!Number.isFinite(total) || total <= 0) {
+    return null;
+  }
+  const coreHtml = numberValue(quality.core_html_block_count ?? quality.coreHtmlBlockCount ?? object.core_html_block_count);
+  const freeform = numberValue(quality.freeform_block_count ?? quality.freeformBlockCount ?? object.freeform_block_count);
+  return {
+    block_total: total,
+    native_block_count: Math.max(0, total - coreHtml - freeform),
+    core_html_block_count: coreHtml,
+    block_type_counts: null,
+    source: 'quality_counts',
+  };
+}
+
+function normalizeBlockName(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+// Generic block-namespace classification: a block is native/editable when it
+// belongs to a core or known Automattic namespace and is not a non-native
+// fallback wrapper. No per-fixture knowledge is involved.
+function isNativeBlockName(name) {
+  const normalized = normalizeBlockName(name);
+  if (!normalized || NON_NATIVE_FALLBACK_BLOCK_NAMES.has(normalized)) {
+    return false;
+  }
+  const namespace = normalized.includes('/') ? normalized.split('/')[0] : '';
+  return NATIVE_BLOCK_NAMESPACES.includes(namespace);
+}
+
+// Per-fixture editor-quality score. `native_conversion_rate` and
+// `core_html_fallback_ratio` come from the generic block composition;
+// `editor_invalid_count` reuses the `editor_block_invalid` findings. When the
+// fixture carries a real `wp.blocks.validateBlock` result
+// (`result.editor_validation`, from the `wordpress.editor-validate-blocks`
+// command), the headline editor-validity is surfaced as `editor_valid_block_rate`
+// / `invalid_block_count` with the reported `validation_method` — distinct from
+// the PHP round-trip's structural counts.
+export function computeFixtureEditorQuality(result, findings) {
+  const composition = objectValue(result.block_composition);
+  const blockTotal = numberValue(composition.block_total);
+  const editorInvalidCount = findings.filter((finding) => finding.fixture_id === result.fixture_id
+    && (finding.loss_class === 'editor_block_invalid' || finding.kind === EDITOR_BLOCK_INVALID_KIND)).length;
+  const scored = blockTotal > 0;
+  const editorValidation = objectValue(result.editor_validation);
+  const hasEditorValidation = Object.keys(editorValidation).length > 0;
+  const editorValidatedTotal = numberValue(editorValidation.total_blocks);
+  const editorValidBlocks = numberValue(editorValidation.valid_blocks);
+  const editorInvalidBlocks = numberValue(editorValidation.invalid_blocks);
+  return compactObject({
+    scored,
+    source: result.block_composition ? (composition.source || 'unknown') : 'none',
+    block_total: blockTotal,
+    native_block_count: numberValue(composition.native_block_count),
+    core_html_block_count: numberValue(composition.core_html_block_count),
+    native_conversion_rate: scored ? qualityRatio(composition.native_block_count, blockTotal) : null,
+    core_html_fallback_ratio: scored ? qualityRatio(composition.core_html_block_count, blockTotal) : null,
+    editor_invalid_count: editorInvalidCount,
+    ...(hasEditorValidation
+      ? {
+        editor_validated: true,
+        validation_method: firstString([editorValidation.validation_method, EDITOR_VALIDATION_METHOD]),
+        editor_validated_block_total: editorValidatedTotal,
+        editor_valid_block_count: editorValidBlocks,
+        invalid_block_count: editorInvalidBlocks,
+        editor_valid_block_rate: editorValidatedTotal > 0 ? qualityRatio(editorValidBlocks, editorValidatedTotal) : null,
+      }
+      : {}),
+  });
+}
+
+export function attachFixtureEditorQuality(result, editorQuality) {
+  return { ...result, editor_quality: editorQuality || computeFixtureEditorQuality(result, []) };
+}
+
+// Roll the per-fixture editor-quality scores into one aggregate. Rates are
+// recomputed from summed block totals (not an average of per-fixture rates) so
+// the aggregate stays a true native/total ratio across the corpus.
+export function aggregateEditorQuality(editorQualityList, nativeRateGate = { minNativeRate: 0 }) {
+  let blockTotal = 0;
+  let native = 0;
+  let coreHtml = 0;
+  let editorInvalid = 0;
+  let scored = 0;
+  let editorValidatedTotal = 0;
+  let editorValidBlocks = 0;
+  let invalidBlockCount = 0;
+  let editorValidatedFixtures = 0;
+  for (const editorQuality of editorQualityList) {
+    blockTotal += numberValue(editorQuality.block_total);
+    native += numberValue(editorQuality.native_block_count);
+    coreHtml += numberValue(editorQuality.core_html_block_count);
+    editorInvalid += numberValue(editorQuality.editor_invalid_count);
+    editorValidatedTotal += numberValue(editorQuality.editor_validated_block_total);
+    editorValidBlocks += numberValue(editorQuality.editor_valid_block_count);
+    invalidBlockCount += numberValue(editorQuality.invalid_block_count);
+    if (editorQuality.scored) {
+      scored += 1;
+    }
+    if (editorQuality.editor_validated) {
+      editorValidatedFixtures += 1;
+    }
+  }
+  return {
+    scored_fixture_count: scored,
+    block_total: blockTotal,
+    native_block_count: native,
+    core_html_block_count: coreHtml,
+    editor_invalid_count: editorInvalid,
+    native_conversion_rate: qualityRatio(native, blockTotal),
+    core_html_fallback_ratio: qualityRatio(coreHtml, blockTotal),
+    // Real `wp.blocks.validateBlock` editor-validity headline, distinct from the
+    // PHP round-trip. `editor_valid_block_rate` is null until at least one
+    // fixture carries a validateBlock result.
+    validation_method: editorValidatedFixtures > 0 ? EDITOR_VALIDATION_METHOD : '',
+    editor_validated_fixture_count: editorValidatedFixtures,
+    editor_validated_block_total: editorValidatedTotal,
+    editor_valid_block_count: editorValidBlocks,
+    invalid_block_count: invalidBlockCount,
+    editor_valid_block_rate: editorValidatedTotal > 0 ? qualityRatio(editorValidBlocks, editorValidatedTotal) : null,
+    native_rate_gate: {
+      enabled: nativeRateGate.minNativeRate > 0,
+      min_native_rate: nativeRateGate.minNativeRate || 0,
+    },
+  };
+}
+
+export function normalizeNativeRateGateOptions(options) {
+  const source = objectValue(options);
+  let minNativeRate = firstNumber([source.minNativeRate, source.min_native_rate]);
+  if (!Number.isFinite(minNativeRate) || minNativeRate < 0) {
+    minNativeRate = 0;
+  }
+  // Allow the threshold to be expressed as a percentage (e.g. 80) or a ratio.
+  if (minNativeRate > 1) {
+    minNativeRate = minNativeRate / 100;
+  }
+  return { minNativeRate };
+}
+
+// Opt-in gate: when a positive minimum native-conversion rate is configured,
+// every scored fixture below it earns an unacceptable `low_native_conversion`
+// finding so it fails the same quality gate as other unacceptable losses.
+export function buildNativeRateGateFindings(fixtureResults, editorQualityByFixture, nativeRateGate) {
+  const findings = [];
+  for (const result of fixtureResults) {
+    const editorQuality = editorQualityByFixture.get(result.fixture_id);
+    if (!editorQuality || !editorQuality.scored || editorQuality.native_conversion_rate === null) {
+      continue;
+    }
+    if (editorQuality.native_conversion_rate >= nativeRateGate.minNativeRate) {
+      continue;
+    }
+    const ratePercent = (editorQuality.native_conversion_rate * 100).toFixed(1);
+    const minPercent = (nativeRateGate.minNativeRate * 100).toFixed(1);
+    findings.push(normalizeDiagnosticFinding({
+      kind: LOW_NATIVE_CONVERSION_KIND,
+      loss_class: 'low_native_conversion',
+      native_conversion_rate: editorQuality.native_conversion_rate,
+      min_native_rate: nativeRateGate.minNativeRate,
+      block_total: editorQuality.block_total,
+      native_block_count: editorQuality.native_block_count,
+      core_html_block_count: editorQuality.core_html_block_count,
+      message: `Native conversion rate ${ratePercent}% is below the ${minPercent}% minimum (${editorQuality.native_block_count}/${editorQuality.block_total} native blocks, ${editorQuality.core_html_block_count} core/html).`,
+    }, result, findings.length));
+  }
+  return findings;
+}
+
+export function accumulateEditorQuality(target, editorQuality) {
+  const source = objectValue(editorQuality);
+  target.block_total += numberValue(source.block_total);
+  target.native_block_count += numberValue(source.native_block_count);
+  target.core_html_block_count += numberValue(source.core_html_block_count);
+  target.editor_invalid_count += numberValue(source.editor_invalid_count);
+  target.editor_validated_block_total += numberValue(source.editor_validated_block_total);
+  target.editor_valid_block_count += numberValue(source.editor_valid_block_count);
+  target.invalid_block_count += numberValue(source.invalid_block_count);
+  if (source.scored) {
+    target.scored_fixture_count += 1;
+  }
+  if (source.editor_validated) {
+    target.editor_validated_fixture_count += 1;
+  }
+}
+
+export function finalizeEditorQuality(accumulator) {
+  const blockTotal = numberValue(accumulator.block_total);
+  const editorValidatedTotal = numberValue(accumulator.editor_validated_block_total);
+  return {
+    ...accumulator,
+    native_conversion_rate: qualityRatio(accumulator.native_block_count, blockTotal),
+    core_html_fallback_ratio: qualityRatio(accumulator.core_html_block_count, blockTotal),
+    editor_valid_block_rate: editorValidatedTotal > 0 ? qualityRatio(accumulator.editor_valid_block_count, editorValidatedTotal) : null,
+  };
+}

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -1,0 +1,310 @@
+// Run-result intake for the Static Site Importer fixture matrix: reads WP
+// Codebox runtime payloads + per-fixture artifact files back out, normalizes
+// them into fixture results, and threads the per-concern collectors together.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242).
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  normalizeArray,
+  objectValue,
+  numberValue,
+  firstString,
+  compactObject,
+  mergeObjects,
+  diagnosticMessage,
+  requiredString,
+  readJsonFileIfExists,
+  artifactRef,
+  parseJsonPayloadsFromText,
+} from '../shared/utils.mjs';
+import { createFixtureMatrix } from '../fixtures.mjs';
+import { dedupeDiagnostics } from '../findings.mjs';
+import { collectQualityMetrics, collectBlockComposition } from './quality-metrics.mjs';
+import { collectEditorValidationDiagnostics, collectEditorValidation } from './editor-validation.mjs';
+import {
+  collectVisualParityDiagnostics,
+  collectVisualParityArtifacts,
+  normalizeVisualParityGateOptions,
+} from './visual-parity.mjs';
+import {
+  collectLiveWpParity,
+  normalizeLiveWpParityCollectorOptions,
+} from './live-wp-parity.mjs';
+import { normalizeFixtureMatrixResult, normalizeFixtureResult } from '../result.mjs';
+
+export function collectFixtureMatrixRunResults(input = {}) {
+  const matrix = input.matrix || createFixtureMatrix(input);
+  const outputDirectory = requiredString(input.outputDirectory || input.output_directory, 'outputDirectory');
+  const codeboxOutput = input.codeboxOutput || input.codebox_output || readJsonFileIfExists(input.outputFile || input.output_file) || null;
+  const codeboxError = input.codeboxError || input.codebox_error || null;
+  const runtimePayloads = collectRuntimePayloads(codeboxOutput);
+  const visualParity = normalizeVisualParityGateOptions(input.visualParity || input.visual_parity || input);
+  // Opt-in live-WP parity collection. Off by default: when absent (or disabled),
+  // `enabled` is false and no live-WP comparison runs, so the per-fixture result
+  // is byte-identical to today. When on, each fixture's captured rendered DOM is
+  // scored against the staged source by the blocks-engine comparator.
+  const liveWpParity = normalizeLiveWpParityCollectorOptions(input.liveWpParity || input.live_wp_parity);
+  const results = matrix.fixtures.map((fixture) => {
+    const fixtureArtifactsDirectory = path.join(outputDirectory, fixture.id);
+    const payloads = [
+      ...runtimePayloads.filter((payload) => fixtureIdentity(payload) === fixture.id),
+      ...readFixturePayloadFiles(fixtureArtifactsDirectory),
+    ];
+    return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity });
+  });
+
+  return normalizeFixtureMatrixResult({ matrix, results });
+}
+
+function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity }) {
+  const merged = mergeObjects(payloads);
+  const diagnostics = collectFixtureDiagnostics(merged, { visualParity });
+  // Best-effort live-WP parity (opt-in). Returns null when disabled or when the
+  // capture/source/comparator is unavailable, keeping the lane isolated.
+  const liveWpParityResult = collectLiveWpParity({
+    fixtureArtifactsDirectory,
+    entrypoint: fixture.entrypoint,
+    options: liveWpParity,
+  });
+  const error = firstString([
+    merged.error,
+    merged.message && isFailurePayload(merged) ? merged.message : '',
+    codeboxError && payloads.length === 0 ? codeboxError.message || String(codeboxError) : '',
+  ]);
+  const success = inferFixtureSuccess(merged, diagnostics, error, payloads.length);
+  return normalizeFixtureResult({
+    fixture_id: fixture.id,
+    fixture_path: fixture.fixture_path,
+    status: fixtureStatus(payloads.length, error, success),
+    success,
+    error,
+    ssi_validation: merged.ssi_validation || merged.ssiValidation || merged.validation || merged.static_site_importer || null,
+    import_report: merged.import_report || merged.importReport || merged.report || null,
+    quality_metrics: collectQualityMetrics(merged),
+    block_composition: collectBlockComposition(merged),
+    // Real `wp.blocks.validateBlock` editor-validity from the
+    // `wordpress.editor-validate-blocks` command, distinct from the PHP
+    // round-trip's structural `invalid_block_counts`.
+    editor_validation: collectEditorValidation(merged),
+    blocks_engine_diagnostics: collectBlocksEngineDiagnostics(merged),
+    invalid_block_counts: collectInvalidBlockCounts(merged),
+    missing_assets: collectMissingAssets(merged),
+    runtime_target_gaps: collectRuntimeTargetGaps(merged),
+    diagnostics,
+    artifact_refs: collectFixtureArtifactRefs(merged, fixtureArtifactsDirectory),
+    artifacts: merged.artifacts || {},
+    visual_parity_artifacts: collectVisualParityArtifacts(merged),
+    live_wp_parity: liveWpParityResult,
+    raw: { payloads },
+  });
+}
+
+function collectFixtureDiagnostics(payload, options = {}) {
+  const diagnostics = [
+    ...normalizeArray(payload.diagnostics),
+    ...normalizeArray(payload.fixture_diagnostics?.diagnostics || payload.fixtureDiagnostics?.diagnostics),
+    ...normalizeArray(payload.findings),
+    ...collectFindingPacketDiagnostics(payload),
+    ...normalizeArray(payload.messages),
+    ...normalizeArray(payload.errors),
+    ...normalizeArray(payload.warnings),
+    ...normalizeArray(payload.upstream_gaps || payload.upstreamGaps).map((gap) => ({ kind: 'upstream_gap', ...objectValue(gap), message: diagnosticMessage(gap) || gap.missing || 'Upstream capability gap detected.' })),
+    ...collectBlocksEngineDiagnostics(payload),
+    ...collectRuntimeTargetGaps(payload).map((gap) => ({ kind: 'runtime_target_gap', ...objectValue(gap), message: diagnosticMessage(gap) || 'Runtime target gap detected.' })),
+    ...collectMissingAssets(payload).map((asset) => ({ kind: missingAssetKind(asset), ...objectValue(asset), message: diagnosticMessage(asset) || 'Missing imported asset.' })),
+    ...collectEditorValidationDiagnostics(payload),
+    ...collectVisualParityDiagnostics(payload, options.visualParity),
+  ];
+  const invalidBlockCount = Object.values(collectInvalidBlockCounts(payload)).reduce((sum, value) => sum + numberValue(value), 0);
+  if (invalidBlockCount > 0) {
+    diagnostics.push({ kind: 'invalid_block_content', message: `${invalidBlockCount} invalid block${invalidBlockCount === 1 ? '' : 's'} reported by SSI validation.` });
+  }
+  return dedupeDiagnostics(diagnostics);
+}
+
+function collectFindingPacketDiagnostics(payload) {
+  return [
+    ...normalizeArray(payload.finding_packets?.packets || payload.findingPackets?.packets),
+    ...normalizeArray(payload.import_report?.finding_packets?.packets || payload.importReport?.finding_packets?.packets),
+    ...normalizeArray(payload.report?.finding_packets?.packets),
+  ];
+}
+
+function collectFixtureArtifactRefs(payload, fixtureArtifactsDirectory) {
+  const refs = [...normalizeArray(payload.artifact_refs || payload.artifactRefs), ...normalizeArray(payload.artifacts?.refs)];
+  for (const [key, value] of Object.entries(payload.artifacts || {})) {
+    if (value && typeof value === 'object' && !Array.isArray(value) && (value.path || value.file || value.href)) {
+      refs.push({ artifact_id: key, kind: value.kind || key, ...value });
+    } else if (typeof value === 'string') {
+      refs.push({ artifact_id: key, kind: key, path: value });
+    }
+  }
+  for (const fileName of ['artifact.json', 'validation-result.json', 'import-report.json']) {
+    const filePath = path.join(fixtureArtifactsDirectory, fileName);
+    if (fs.existsSync(filePath)) {
+      refs.push(artifactRef(fileName.replace(/\.json$/, ''), filePath, fileName === 'artifact.json' ? 'input' : 'diagnostic'));
+    }
+  }
+  return refs;
+}
+
+function collectRuntimePayloads(value) {
+  const payloads = [];
+  visitRuntimePayloads(value, '', payloads, new Set());
+  return payloads;
+}
+
+function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen) {
+  if (!value || typeof value !== 'object' || seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+  const fixtureId = fixtureIdentity(value) || inheritedFixtureId;
+  if (fixtureId && hasPayloadData(value)) {
+    payloads.push({ fixture_id: fixtureId, ...value });
+  }
+  for (const key of ['stdout', 'stderr', 'output', 'result']) {
+    for (const parsed of parseJsonPayloadsFromText(value[key])) {
+      payloads.push({ fixture_id: fixtureId, ...parsed });
+    }
+  }
+  if (Array.isArray(value)) {
+    // Recipe steps run in per-fixture order ([import, editor-validate, ...]);
+    // the import step carries the fixture slug while the editor step does not.
+    // Thread the last-seen fixture id forward across sibling executions so the
+    // editor result inherits the fixture it validated. (`new Set()` per element
+    // is unnecessary; `seen` already guards re-entry.)
+    let carried = inheritedFixtureId;
+    for (const child of value) {
+      const childFixtureId = (child && typeof child === 'object') ? (fixtureIdentity(child) || carried) : carried;
+      visitRuntimePayloads(child, childFixtureId, payloads, seen);
+      if (childFixtureId) {
+        carried = childFixtureId;
+      }
+    }
+    return;
+  }
+  for (const child of Object.values(value)) {
+    visitRuntimePayloads(child, fixtureId, payloads, seen);
+  }
+}
+
+function hasPayloadData(value) {
+  return ['status', 'success', 'ok', 'passed', 'error', 'diagnostics', 'findings', 'summary', 'artifacts', 'upstream_gaps', 'runtime_target_gaps', 'blocks_engine', 'import_report']
+    .some((key) => Object.hasOwn(value, key));
+}
+
+function readFixturePayloadFiles(directory) {
+  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-validate-blocks.json', 'editor-canvas-summary.json', 'visual-compare.json', 'visual-diff.json', 'visual-parity.json']
+    .map((fileName) => readJsonFileIfExists(path.join(directory, fileName)))
+    .filter(Boolean);
+}
+
+function fixtureIdentity(payload) {
+  return payload?.fixture_id
+    || payload?.fixtureId
+    || payload?.fixture?.id
+    || payload?.fixture?.slug
+    || payload?.fixture_diagnostics?.fixture?.slug
+    || payload?.fixtureDiagnostics?.fixture?.slug
+    || payload?.request?.import_args?.slug
+    || payload?.request?.importArgs?.slug
+    || payload?.metadata?.fixture_id
+    || payload?.metadata?.fixtureId
+    || fixtureIdFromExecutionArgs(payload)
+    || '';
+}
+
+// Derive the fixture slug from a wp-codebox execution's args. The import step is
+// `wordpress.wp-cli command=static-site-importer validate-artifact --slug=<id>
+// --artifact=.../<id>/artifact.json`, so its slug is the only place the fixture
+// id appears on the (otherwise id-less) per-fixture executions. The
+// editor-validate-blocks step that follows carries no id of its own; surfacing
+// the slug here lets `visitRuntimePayloads` thread it forward to that step.
+function fixtureIdFromExecutionArgs(payload) {
+  const args = payload?.args;
+  if (!Array.isArray(args)) {
+    return '';
+  }
+  for (const arg of args) {
+    if (typeof arg !== 'string') {
+      continue;
+    }
+    const slug = arg.match(/--slug=([^\s]+)/);
+    if (slug) {
+      return slug[1];
+    }
+    const artifact = arg.match(/--artifact=\S*\/([^/\s]+)\/artifact\.json/);
+    if (artifact) {
+      return artifact[1];
+    }
+  }
+  return '';
+}
+
+function collectInvalidBlockCounts(payload) {
+  const quality = collectQualityMetrics(payload);
+  return compactObject({
+    invalid_block_count: payload.invalid_block_count || payload.invalidBlockCount || quality.invalid_block_count,
+    invalid_blocks: payload.invalid_blocks || payload.invalidBlocks || quality.invalid_blocks,
+    editor_invalid_blocks: payload.editor_invalid_blocks || payload.editorInvalidBlocks || quality.editor_invalid_blocks,
+  });
+}
+
+function collectMissingAssets(payload) {
+  return [
+    ...normalizeArray(payload.missing_assets || payload.missingAssets),
+    ...normalizeArray(payload.dropped_images || payload.droppedImages),
+    ...normalizeArray(payload.import_report?.missing_assets || payload.importReport?.missing_assets),
+    ...normalizeArray(payload.report?.missing_assets),
+  ];
+}
+
+function collectRuntimeTargetGaps(payload) {
+  return [
+    ...normalizeArray(payload.runtime_target_gaps || payload.runtimeTargetGaps),
+    ...normalizeArray(payload.runtime_targets_missing || payload.runtimeTargetsMissing),
+    ...normalizeArray(payload.blocks_engine?.runtime_target_gaps || payload.blocksEngine?.runtimeTargetGaps),
+  ];
+}
+
+function collectBlocksEngineDiagnostics(payload) {
+  return [
+    ...normalizeArray(payload.blocks_engine_diagnostics || payload.blocksEngineDiagnostics),
+    ...normalizeArray(payload.blocks_engine?.diagnostics || payload.blocksEngine?.diagnostics),
+    ...normalizeArray(payload.transformer_diagnostics || payload.transformerDiagnostics),
+  ];
+}
+
+function inferFixtureSuccess(payload, diagnostics, error, payloadCount) {
+  if (payload.success === true || payload.ok === true || payload.passed === true) {
+    return diagnostics.length === 0 && !error;
+  }
+  if (payload.success === false || payload.ok === false || payload.passed === false || payload.status === 'failed' || payload.status === 'error') {
+    return false;
+  }
+  if (payload.status === 'passed' || payload.status === 'success') {
+    return diagnostics.length === 0 && !error;
+  }
+  return payloadCount > 0 && diagnostics.length === 0 && !error;
+}
+
+function fixtureStatus(payloadCount, error, success) {
+  if (payloadCount === 0 && !error) {
+    return 'not_run';
+  }
+  return success ? 'passed' : 'failed';
+}
+
+function isFailurePayload(payload) {
+  return payload.success === false || payload.ok === false || payload.status === 'failed' || payload.status === 'error';
+}
+
+function missingAssetKind(value) {
+  const message = diagnosticMessage(value);
+  return /\.svg(?:\b|$)/i.test(message) ? 'broken_svg' : 'dropped_images';
+}

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -1,0 +1,218 @@
+// Visual-parity collector (#538): turns `wordpress.visual-compare` evidence into
+// `visual_parity_mismatch` diagnostics + the SSI visual-parity-artifacts slot,
+// and resolves the opt-in pixel gate for the Static Site Importer fixture matrix.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242).
+
+import {
+  VISUAL_PARITY_MISMATCH_KIND,
+  DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD,
+} from '../shared/constants.mjs';
+import {
+  normalizeArray,
+  objectValue,
+  firstNumber,
+  firstString,
+  finiteNumber,
+  compactObject,
+  clampRatio,
+  isTruthySignal,
+  artifactRef,
+} from '../shared/utils.mjs';
+
+// Turn `wordpress.visual-compare` evidence into `visual_parity_mismatch`
+// diagnostics, gated on the TRUSTWORTHY (dimension-fair) ratio.
+//
+// The legacy gate compared `mismatch_pixels/total_pixels` over the union canvas
+// (max width × max height of source vs candidate). When the two renders differ in
+// size — the common case, since the static source frequently lays out wider/taller
+// than the imported WordPress page — that raw ratio is dominated by the canvas-size
+// band (one side real content, the other transparent fill) and tells you almost
+// nothing about real visual fidelity. It also hard-failed on ANY dimension mismatch.
+//
+// The trustworthy gate instead compares the FAIR ratio: pixel mismatch over the
+// common overlap region only (`overlap_mismatch_pixels/overlap_pixels`, emitted by
+// wp-codebox). The dimension delta is reported as a SEPARATE signal rather than
+// smeared into the gate. A dimension mismatch only forces a finding when no overlap
+// signal is available (a degenerate/empty capture), where the fair ratio cannot be
+// computed. When the runtime predates overlap metrics, the fair ratio falls back to
+// the raw ratio so older evidence still gates as before. Matches at or under the
+// threshold emit nothing.
+export function collectVisualParityDiagnostics(payload, options = {}) {
+  const { threshold, gate } = normalizeVisualParityGateOptions(options);
+  const diagnostics = [];
+  for (const comparison of collectVisualParityComparisons(payload)) {
+    // Dimension mismatch is only a hard gate when we cannot measure a fair ratio
+    // (no overlap region — e.g. a zero-area/failed capture).
+    const dimensionForcesFinding = comparison.dimension_mismatch && !comparison.has_overlap_signal;
+    if (comparison.mismatch_ratio <= threshold && !dimensionForcesFinding) {
+      continue;
+    }
+    const percent = (comparison.mismatch_ratio * 100).toFixed(2);
+    const rawPercent = (comparison.raw_mismatch_ratio * 100).toFixed(2);
+    const thresholdPercent = (threshold * 100).toFixed(2);
+    const fairPixels = comparison.has_overlap_signal ? comparison.overlap_mismatch_pixels : comparison.mismatch_pixels;
+    const fairTotal = comparison.has_overlap_signal ? comparison.overlap_pixels : comparison.total_pixels;
+    diagnostics.push({
+      kind: VISUAL_PARITY_MISMATCH_KIND,
+      ...(gate ? { gate: true, visual_parity_gate: true } : {}),
+      source_path: comparison.source_path || '',
+      observed_output: `${percent}% pixels differ in overlap (${fairPixels}/${fairTotal})`,
+      mismatch_pixels: fairPixels,
+      total_pixels: fairTotal,
+      mismatch_ratio: comparison.mismatch_ratio,
+      raw_mismatch_pixels: comparison.mismatch_pixels,
+      raw_total_pixels: comparison.total_pixels,
+      raw_mismatch_ratio: comparison.raw_mismatch_ratio,
+      overlap_mismatch_pixels: comparison.overlap_mismatch_pixels,
+      overlap_pixels: comparison.overlap_pixels,
+      threshold,
+      dimension_mismatch: comparison.dimension_mismatch,
+      dimension_delta_pixels: comparison.dimension_delta_pixels,
+      artifact_refs: visualParityArtifactRefs(comparison),
+      message: dimensionForcesFinding
+        ? `Visual parity dimension mismatch between source and imported output with no measurable overlap region (raw ${comparison.mismatch_pixels}/${comparison.total_pixels} pixels, ${rawPercent}%).`
+        : `Pixel visual parity mismatch: ${fairPixels}/${fairTotal} overlap pixels (${percent}%) exceed the ${thresholdPercent}% threshold (raw full-page ${rawPercent}%, dimension delta ${comparison.dimension_delta_pixels} px).`,
+    });
+  }
+  return diagnostics;
+}
+
+export function normalizeVisualParityGateOptions(options = {}) {
+  const source = objectValue(options);
+  return {
+    threshold: clampRatio(finiteNumber(source.threshold ?? source.pixelThreshold ?? source.pixel_threshold ?? source.visualParityPixelThreshold ?? source.visual_parity_pixel_threshold, DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD)),
+    gate: isTruthySignal(source.gate ?? source.visualParityGate ?? source.visual_parity_gate),
+  };
+}
+
+// Collect candidate visual-compare records from either the normalized
+// `homeboy/VisualParityArtifact/v1` artifact (summary.*), the raw
+// `wp-codebox/visual-compare/v1` diff (comparison.*), or loosely-shaped payloads.
+function collectVisualParityComparisons(payload) {
+  const candidates = [
+    ...normalizeArray(payload.visual_parity || payload.visualParity),
+    ...normalizeArray(payload.visual_parity_artifacts || payload.visualParityArtifacts),
+    ...normalizeArray(payload.visual_compare || payload.visualCompare),
+    ...normalizeArray(payload.visual_diff || payload.visualDiff),
+    ...normalizeArray(payload.visual_parity?.comparisons || payload.visualParity?.comparisons),
+  ];
+  if (isVisualParityPayload(payload)) {
+    candidates.push(payload);
+  }
+  return candidates.map(normalizeVisualParityComparison).filter(Boolean);
+}
+
+function isVisualParityPayload(payload) {
+  const value = objectValue(payload);
+  if (typeof value.schema === 'string' && /visual.?compare|visualparityartifact/i.test(value.schema)) {
+    return true;
+  }
+  return Boolean(value.comparison && typeof value.comparison === 'object')
+    || (objectValue(value.summary).mismatch_pixels !== undefined)
+    || (objectValue(value.summary).total_pixels !== undefined);
+}
+
+function normalizeVisualParityComparison(value) {
+  const obj = objectValue(value);
+  const summary = objectValue(obj.summary);
+  const comparison = objectValue(obj.comparison);
+  const mismatchPixels = firstNumber([summary.mismatch_pixels, summary.mismatchPixels, comparison.mismatchPixels, comparison.mismatch_pixels, obj.mismatch_pixels, obj.mismatchPixels]);
+  const totalPixels = firstNumber([summary.total_pixels, summary.totalPixels, comparison.totalPixels, comparison.total_pixels, obj.total_pixels, obj.totalPixels]);
+  const explicitRatio = firstNumber([summary.mismatch_ratio, summary.mismatchRatio, comparison.mismatchRatio, comparison.mismatch_ratio, obj.mismatch_ratio, obj.mismatchRatio]);
+  // Dimension-fair (overlap-region) metrics emitted by wp-codebox's trustworthy
+  // visual-compare. When present these drive the gate; otherwise the fair ratio
+  // falls back to the raw union-canvas ratio for backward compatibility.
+  const overlapMismatchPixels = firstNumber([summary.overlap_mismatch_pixels, summary.overlapMismatchPixels, comparison.overlapMismatchPixels, comparison.overlap_mismatch_pixels, obj.overlap_mismatch_pixels, obj.overlapMismatchPixels]);
+  const overlapPixels = firstNumber([summary.overlap_pixels, summary.overlapPixels, comparison.overlapPixels, comparison.overlap_pixels, obj.overlap_pixels, obj.overlapPixels]);
+  const overlapRatio = firstNumber([summary.overlap_mismatch_ratio, summary.overlapMismatchRatio, comparison.overlapMismatchRatio, comparison.overlap_mismatch_ratio, obj.overlap_mismatch_ratio, obj.overlapMismatchRatio]);
+  const dimensionDeltaPixels = firstNumber([summary.dimension_delta_pixels, summary.dimensionDeltaPixels, comparison.dimensionDeltaPixels, comparison.dimension_delta_pixels, obj.dimension_delta_pixels, obj.dimensionDeltaPixels]);
+  const dimensionMismatch = Boolean(summary.dimension_mismatch ?? comparison.dimensionMismatch ?? comparison.dimension_mismatch ?? obj.dimension_mismatch);
+  const hasMetrics = [mismatchPixels, totalPixels, explicitRatio, overlapRatio, overlapMismatchPixels].some((metric) => Number.isFinite(metric));
+  if (!hasMetrics && !dimensionMismatch) {
+    return null;
+  }
+  const safeMismatch = Number.isFinite(mismatchPixels) ? mismatchPixels : 0;
+  const safeTotal = Number.isFinite(totalPixels) ? totalPixels : 0;
+  const rawRatio = safeTotal > 0 ? safeMismatch / safeTotal : (Number.isFinite(explicitRatio) ? explicitRatio : 0);
+  // The fair ratio is the overlap mismatch over the overlap area. Prefer explicit
+  // counts, then an explicit overlap ratio, then degrade to the raw ratio.
+  const safeOverlapPixels = Number.isFinite(overlapPixels) ? overlapPixels : 0;
+  const safeOverlapMismatch = Number.isFinite(overlapMismatchPixels) ? overlapMismatchPixels : 0;
+  const hasOverlapSignal = safeOverlapPixels > 0 || Number.isFinite(overlapRatio);
+  const fairRatio = safeOverlapPixels > 0
+    ? safeOverlapMismatch / safeOverlapPixels
+    : (Number.isFinite(overlapRatio) ? overlapRatio : rawRatio);
+  const safeDimensionDelta = Number.isFinite(dimensionDeltaPixels)
+    ? dimensionDeltaPixels
+    : (safeTotal > 0 && safeOverlapPixels > 0 ? safeTotal - safeOverlapPixels : 0);
+  const files = objectValue(obj.files);
+  const artifacts = objectValue(obj.artifacts);
+  const sourceObject = objectValue(obj.source);
+  return {
+    mismatch_pixels: safeMismatch,
+    total_pixels: safeTotal,
+    // `mismatch_ratio` is the GATING signal: the dimension-fair ratio.
+    mismatch_ratio: fairRatio,
+    raw_mismatch_ratio: rawRatio,
+    overlap_mismatch_pixels: safeOverlapMismatch,
+    overlap_pixels: safeOverlapPixels,
+    has_overlap_signal: hasOverlapSignal,
+    dimension_delta_pixels: safeDimensionDelta,
+    dimension_mismatch: dimensionMismatch,
+    source_path: firstString([sourceObject.path, sourceObject.url, obj.source_path, obj.sourcePath]),
+    source_screenshot: firstString([artifacts.source_screenshot, files.sourceScreenshot, obj.source_screenshot, obj.sourceScreenshot]),
+    candidate_screenshot: firstString([artifacts.candidate_screenshot, artifacts.imported_screenshot, files.candidateScreenshot, obj.candidate_screenshot, obj.candidateScreenshot]),
+    diff_screenshot: firstString([artifacts.diff_screenshot, files.diffScreenshot, obj.diff_screenshot, obj.diffScreenshot]),
+    visual_diff: firstString([artifacts.visual_diff, files.visualDiff, obj.visual_diff, obj.visualDiff]),
+  };
+}
+
+function visualParityArtifactRefs(comparison) {
+  return [
+    ['source_screenshot', comparison.source_screenshot],
+    ['candidate_screenshot', comparison.candidate_screenshot],
+    ['diff_screenshot', comparison.diff_screenshot],
+    ['visual_diff', comparison.visual_diff],
+  ]
+    .filter(([, ref]) => Boolean(ref))
+    .map(([id, ref]) => artifactRef(id, ref, 'visual-parity'));
+}
+
+// Capture visual-compare evidence into the SSI `visual_parity_artifacts` slot
+// shape so screenshots, the diff, and the mismatch metrics surface on the
+// fixture result even when gating is off. Returns null when no visual data was
+// produced (the runtime did not render).
+export function collectVisualParityArtifacts(payload) {
+  const comparisons = collectVisualParityComparisons(payload);
+  if (comparisons.length === 0) {
+    return null;
+  }
+  const comparison = comparisons[0];
+  const slot = (ref, kind, reason) => (ref
+    ? { status: 'captured', kind, ref: artifactRef(kind, ref, 'visual-parity') }
+    : { status: 'pending', kind, capture_state: 'not_captured', reason });
+  return {
+    schema: 'static-site-importer/visual-parity-artifacts/v1',
+    owner: 'codebox_runtime',
+    metrics: compactObject({
+      mismatch_pixels: comparison.mismatch_pixels,
+      total_pixels: comparison.total_pixels,
+      // `mismatch_ratio` is the dimension-fair (overlap) ratio — the trustworthy
+      // signal. Raw union-canvas figures are retained for evidence/diagnosis.
+      mismatch_ratio: comparison.mismatch_ratio,
+      raw_mismatch_ratio: comparison.raw_mismatch_ratio,
+      overlap_mismatch_pixels: comparison.overlap_mismatch_pixels,
+      overlap_pixels: comparison.overlap_pixels,
+      dimension_delta_pixels: comparison.dimension_delta_pixels,
+      dimension_mismatch: comparison.dimension_mismatch,
+    }),
+    artifacts: {
+      source_screenshot: slot(comparison.source_screenshot, 'source_screenshot', 'Source screenshot was not captured by the runtime.'),
+      imported_screenshot: slot(comparison.candidate_screenshot, 'imported_screenshot', 'Imported WordPress screenshot was not captured by the runtime.'),
+      diff_screenshot: slot(comparison.diff_screenshot, 'diff_screenshot', 'Diff screenshot was not captured by the runtime.'),
+      visual_diff: slot(comparison.visual_diff, 'visual_diff', 'Visual diff output was not captured by the runtime.'),
+    },
+  };
+}

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -1,0 +1,304 @@
+// Finding classification, loss-class derivation, and honest loss-acceptance
+// (#535) for the Static Site Importer fixture matrix.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242).
+
+import path from 'node:path';
+
+import {
+  DEFAULT_FINDING_GROUPS,
+  ACCEPTABLE_LOSS_CLASSES,
+  UNACCEPTABLE_LOSS_CLASSES,
+  RUNTIME_CARRIED_SIGNAL_KEYS,
+  VISUAL_PARITY_GATE_SIGNAL_KEYS,
+  LOW_NATIVE_CONVERSION_KIND,
+  VISUAL_PARITY_MISMATCH_KIND,
+  EDITOR_BLOCK_INVALID_KIND,
+} from './shared/constants.mjs';
+import {
+  normalizeArray,
+  objectValue,
+  isTruthySignal,
+} from './shared/utils.mjs';
+import { truncateString } from './shared/bounds.mjs';
+
+export function classifyStaticSiteFinding(input = {}) {
+  const haystack = [input.kind, input.type, input.code, input.category, input.repair_bucket, input.group_key, input.message, input.reason, input.detail]
+    .filter(Boolean)
+    .join(' ');
+  for (const [group_key, group] of Object.entries(DEFAULT_FINDING_GROUPS)) {
+    if (group.patterns.some((pattern) => pattern.test(haystack))) {
+      return { group_key, candidate_repo: group.candidate_repo, repair_mode: group.repair_mode };
+    }
+  }
+  return {
+    group_key: DEFAULT_FINDING_GROUPS[input.group_key] ? input.group_key : 'static_site_import_quality',
+    candidate_repo: input.candidate_repo || 'static-site-importer',
+    repair_mode: input.repair_mode || 'import-validation',
+  };
+}
+
+export function findingsForFixtureResult(result, context = {}) {
+  const diagnostics = normalizeArray(result.diagnostics || result.findings || result.messages);
+  const findings = diagnostics.map((diagnostic, index) => normalizeDiagnosticFinding(diagnostic, result, index));
+  if (result.status === 'failed' && findings.length === 0) {
+    findings.push(normalizeDiagnosticFinding({ kind: 'fixture_failed', message: result.error || 'Static-site fixture validation failed without a structured diagnostic.' }, result, 0));
+  }
+  if (context.executionRequested !== false && context.matrix?.fixtures?.some((fixture) => fixture.id === result.fixture_id) && result.status === 'not_run') {
+    findings.push(normalizeDiagnosticFinding({ kind: 'fixture_not_run', message: 'Static-site fixture was discovered but did not produce a validation result.' }, result, 0));
+  }
+  return findings;
+}
+
+export function normalizeDiagnosticFinding(diagnostic, result, index) {
+  const raw = diagnostic && typeof diagnostic === 'object' ? diagnostic : { message: String(diagnostic || '') };
+  const rawSource = objectValue(raw.source);
+  const rawObserved = objectValue(raw.observed);
+  const rawExpected = objectValue(raw.expected);
+  const rawReproduction = objectValue(raw.reproduction_context || raw.reproductionContext);
+  const message = raw.message || raw.reason || raw.detail || rawObserved.reason_code || rawExpected.outcome || raw.code || result.error || '';
+  const group = classifyStaticSiteFinding({ ...raw, message });
+  const kind = raw.kind || raw.code || raw.type || rawObserved.reason_code || 'static_site_fixture_diagnostic';
+  const selector = raw.selector || rawSource.selector || rawReproduction.selector || '';
+  const sourcePath = raw.source_path || raw.path || rawSource.path || rawReproduction.source_path || result.fixture_path || '';
+  const repairBucket = raw.repair_bucket || group.group_key;
+  const countOnlyDiagnostic = isCountOnlyStaticSiteFixtureDiagnostic({ raw, result, kind, message, selector });
+  const lossClass = countOnlyDiagnostic ? 'native_conversion' : classifyLossClass({ raw, kind, group_key: group.group_key, repair_bucket: repairBucket, message, result });
+  const lossAcceptance = resolveLossAcceptance(lossClass, raw);
+  return {
+    id: raw.id || `${result.fixture_id || 'fixture'}:${group.group_key}:${index + 1}`,
+    kind,
+    category: raw.category || group.group_key,
+    group_key: group.group_key,
+    repair_bucket: repairBucket,
+    severity: raw.severity || (result.status === 'failed' ? 'error' : 'warning'),
+    fixture_id: result.fixture_id || '',
+    fixture_class: result.fixture_class || result.taxonomy?.fixture_class || 'unknown',
+    path: sourcePath,
+    source_path: sourcePath,
+    selector,
+    selector_family: selectorFamily(selector),
+    pattern_family: patternFamily({ ...raw, kind, group_key: group.group_key, repair_bucket: repairBucket, selector }),
+    // Bound the free-text payload fields: a source snippet / observed block
+    // output can carry an entire serialized `post_content` body, which at lane
+    // scale balloons the aggregate past V8's per-string limit (#554). Truncate
+    // to a sane cap so per-finding size is bounded; classification/metrics above
+    // are derived from the full diagnostic before truncation.
+    reason: truncateString(message),
+    source_snippet: truncateString(raw.source_html_preview || raw.html_excerpt || rawSource.snippet || ''),
+    observed_output: truncateString(raw.emitted_block_preview || rawObserved.output || ''),
+    observed_block_name: raw.block_name || rawObserved.block_name || '',
+    repair_mode: raw.repair_mode || group.repair_mode,
+    candidate_repo: raw.candidate_repo || group.candidate_repo,
+    loss_class: lossClass,
+    loss_acceptance: lossAcceptance,
+    acceptable_loss: lossAcceptance === 'acceptable',
+    actionability: countOnlyDiagnostic ? 'count_only' : 'actionable',
+    actionable: !countOnlyDiagnostic,
+    artifact_refs: normalizeArray(raw.artifact_refs),
+    // The full raw diagnostic is intentionally NOT retained on the finding: it
+    // duplicates the (already-bounded) classified fields and can carry raw
+    // serialized markup. All classification above is computed from `raw` before
+    // this point; downstream consumers read the bounded top-level fields.
+  };
+}
+
+export function isActionableFinding(finding) {
+  return finding.actionable !== false;
+}
+
+function isCountOnlyStaticSiteFixtureDiagnostic({ raw, result, kind, message, selector }) {
+  if (kind !== 'static_site_fixture_diagnostic' || selector) {
+    return false;
+  }
+
+  const rawObject = raw && typeof raw === 'object' ? raw : {};
+  const sourcePath = rawObject.source_path || rawObject.path;
+  const sourceIsFixturePath = sourcePath && result?.fixture_path && path.resolve(String(sourcePath)) === path.resolve(String(result.fixture_path));
+  const hasActionableContext = Boolean(
+    rawObject.code
+    || rawObject.type
+    || rawObject.reason_code
+    || rawObject.detail
+    || (sourcePath && !sourceIsFixturePath)
+    || rawObject.source?.selector
+    || rawObject.source?.snippet
+    || rawObject.observed?.output
+  );
+  return !hasActionableContext && /^\d+(?:\.\d+)?$/.test(String(message || '').trim());
+}
+
+function classifyLossClass({ raw, kind, group_key, repair_bucket, message, result }) {
+  const explicit = normalizeLossClass(raw.loss_class || raw.lossClass || raw.classification?.loss_class || raw.classification?.lossClass || raw.acceptability || raw.quality_class || raw.qualityClass);
+  if (explicit) {
+    return explicit;
+  }
+
+  const haystack = [kind, group_key, repair_bucket, message, raw.reason, raw.detail].filter(Boolean).join(' ');
+  if (/preserved[_\s-]+runtime[_\s-]+island|runtime island preserved|runtime[_\s-]+island/i.test(haystack)) {
+    return 'preserved_runtime_island';
+  }
+  if (/native[_\s-]+conversion|converted natively|native block/i.test(haystack)) {
+    return 'native_conversion';
+  }
+  if (/editable[_\s-]+approximation|editable approximation|approximation/i.test(haystack)) {
+    return 'editable_approximation';
+  }
+  if (kind === 'fixture_not_run' || group_key === 'fixture_not_run') {
+    return 'fixture_not_run';
+  }
+  if (kind === 'fixture_failed' || group_key === 'fixture_failed') {
+    return 'fixture_failed';
+  }
+  if (group_key === 'low_native_conversion' || kind === LOW_NATIVE_CONVERSION_KIND || /native conversion rate .* below/i.test(haystack)) {
+    return 'low_native_conversion';
+  }
+  if (group_key === 'visual_parity_mismatch' || kind === VISUAL_PARITY_MISMATCH_KIND || /visual parity mismatch|pixel (?:diff|mismatch)/i.test(haystack)) {
+    return 'visual_parity_mismatch';
+  }
+  if (group_key === 'editor_block_invalid' || kind === EDITOR_BLOCK_INVALID_KIND || /editor block validation|block-editor-warning|this block contains unexpected or invalid content/i.test(haystack)) {
+    return 'editor_block_invalid';
+  }
+  if (group_key === 'invalid_block_content' || /invalid block|block validation/i.test(haystack)) {
+    return 'invalid_block_content';
+  }
+  if (group_key === 'dropped_images' || group_key === 'broken_svg' || /missing asset|dropped image|missing image|asset.*missing/i.test(haystack)) {
+    return 'missing_asset';
+  }
+  if (/missing output|output.*missing|empty output/i.test(haystack)) {
+    return 'missing_output';
+  }
+  if (/materialization/i.test(haystack)) {
+    return 'importer_materialization_bug';
+  }
+  if (result.status === 'failed') {
+    return 'unsupported_loss';
+  }
+  return 'native_conversion';
+}
+
+function resolveLossAcceptance(lossClass, raw) {
+  if (lossClass === 'preserved_runtime_island') {
+    // Feature parity: a preserved interactive island is only acceptable when the
+    // required runtime/behavior was actually carried or mapped. Absent that
+    // explicit positive signal, the behavior is dead and the gate must fail.
+    return hasRuntimeCarriedSignal(raw) ? 'acceptable' : 'unacceptable';
+  }
+  if (lossClass === 'visual_parity_mismatch') {
+    // Opt-in gate: a pixel mismatch is captured but non-gating by default
+    // (capture-only). It only becomes an unacceptable, gating finding when the
+    // run explicitly opted into gating (the parser stamps a gate signal).
+    return hasVisualParityGateSignal(raw) ? 'unacceptable' : 'acceptable';
+  }
+  return ACCEPTABLE_LOSS_CLASSES.has(lossClass) ? 'acceptable' : 'unacceptable';
+}
+
+function hasVisualParityGateSignal(raw) {
+  const rawObject = objectValue(raw);
+  const classification = objectValue(rawObject.classification);
+  return VISUAL_PARITY_GATE_SIGNAL_KEYS.some((key) => isTruthySignal(rawObject[key]) || isTruthySignal(classification[key]));
+}
+
+function hasRuntimeCarriedSignal(raw) {
+  const rawObject = objectValue(raw);
+  const classification = objectValue(rawObject.classification);
+  return RUNTIME_CARRIED_SIGNAL_KEYS.some((key) => isTruthySignal(rawObject[key]) || isTruthySignal(classification[key]));
+}
+
+export function patternFamily(finding) {
+  return [
+    finding.repair_bucket || finding.group_key || 'static_site_import_quality',
+    finding.kind || 'diagnostic',
+    selectorFamily(finding.selector),
+  ].join(':');
+}
+
+export function selectorFamily(selector) {
+  const value = String(selector || '').trim();
+  if (!value) {
+    return '(none)';
+  }
+
+  const firstToken = value.split(/\s+|\s*[>+~]\s*/).find(Boolean) || value;
+  if (firstToken.startsWith('#')) {
+    return `id:${firstToken.slice(1).split(/[:.#[\]]/)[0] || '(unknown)'}`;
+  }
+  if (firstToken.startsWith('.')) {
+    return `class:${firstToken.slice(1).split(/[:.#[\]]/)[0] || '(unknown)'}`;
+  }
+  if (firstToken.startsWith('[')) {
+    return `attr:${firstToken.slice(1).split(/[=\]]/)[0] || '(unknown)'}`;
+  }
+
+  return firstToken.split(/[:.#[\]]/)[0] || firstToken;
+}
+
+export function dedupeDiagnostics(diagnostics) {
+  const seen = new Set();
+  return diagnostics.filter((diagnostic) => {
+    const normalized = objectValue(diagnostic);
+    const key = [normalized.kind || normalized.code || normalized.type || normalized.reason_code, normalized.message || normalized.reason, normalized.path || normalized.source_path, normalized.selector]
+      .map((part) => String(part || ''))
+      .join('\u0000');
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+export function dedupeFindings(findings) {
+  const seen = new Set();
+  return findings.filter((finding) => {
+    const key = finding.selector || finding.source_snippet
+      ? [finding.fixture_id, finding.source_path, finding.selector || finding.selector_family, finding.source_snippet, finding.loss_class].join('\u0000')
+      : [finding.fixture_id, finding.loss_class, finding.kind, finding.group_key, finding.reason].join('\u0000');
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+export function normalizeLossClass(value) {
+  const normalized = String(value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  const aliases = {
+    acceptable: 'native_conversion',
+    native: 'native_conversion',
+    native_conversion: 'native_conversion',
+    editable: 'editable_approximation',
+    editable_approximation: 'editable_approximation',
+    preserved_runtime_island: 'preserved_runtime_island',
+    // The php-transformer emits the loss class as `runtime_island_preserved`
+    // (see blocks-engine php-transformer FallbackDiagnostic/HtmlTransformer). Alias
+    // it to the canonical `preserved_runtime_island` so the explicit-normalization
+    // path wins deterministically instead of relying on the wording regex below.
+    runtime_island_preserved: 'preserved_runtime_island',
+    runtime_island: 'preserved_runtime_island',
+    unsupported: 'unsupported_loss',
+    unsupported_loss: 'unsupported_loss',
+    materialization_bug: 'importer_materialization_bug',
+    importer_materialization_bug: 'importer_materialization_bug',
+    invalid_block: 'invalid_block_content',
+    invalid_block_output: 'invalid_block_output',
+    invalid_block_content: 'invalid_block_content',
+    editor_block_invalid: 'editor_block_invalid',
+    editor_invalid_block: 'editor_block_invalid',
+    low_native_conversion: 'low_native_conversion',
+    native_conversion_rate_below_min: 'low_native_conversion',
+    visual_parity_mismatch: 'visual_parity_mismatch',
+    visual_parity: 'visual_parity_mismatch',
+    pixel_mismatch: 'visual_parity_mismatch',
+    missing_asset: 'missing_asset',
+    missing_assets: 'missing_asset',
+    missing_output: 'missing_output',
+    fixture_not_run: 'fixture_not_run',
+    not_run: 'fixture_not_run',
+    fixture_failed: 'fixture_failed',
+  };
+  const lossClass = aliases[normalized] || normalized;
+  return ACCEPTABLE_LOSS_CLASSES.has(lossClass) || UNACCEPTABLE_LOSS_CLASSES.has(lossClass) ? lossClass : '';
+}

--- a/lib/fixture-matrix/fixtures.mjs
+++ b/lib/fixture-matrix/fixtures.mjs
@@ -1,0 +1,296 @@
+// Fixture discovery, normalization, and taxonomy classification for the
+// Static Site Importer fixture matrix.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242).
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  FIXTURE_MATRIX_SCHEMA,
+  FIXTURE_CLASSES,
+  FIXTURE_MANIFEST_FILENAME,
+  FIXTURE_COMPLEXITY_MIN,
+  FIXTURE_COMPLEXITY_MAX,
+} from './shared/constants.mjs';
+import {
+  normalizeArray,
+  finiteNumber,
+  requiredDirectory,
+  slug,
+  fileType,
+} from './shared/utils.mjs';
+
+export function discoverFixtures(root, options = {}) {
+  const fixtureRoot = requiredDirectory(root || options.fixtureRoot || options.fixture_root, 'fixtureRoot');
+  const entrypoint = options.entrypoint || 'index.html';
+  const maxDepth = finiteNumber(options.maxDepth ?? options.max_depth, 2);
+  const fixtures = [];
+
+  visitFixtureDirectory(fixtureRoot, 0, maxDepth, (directory) => {
+    const entryPath = path.join(directory, entrypoint);
+    if (!fs.existsSync(entryPath) || !fs.statSync(entryPath).isFile()) {
+      return;
+    }
+
+    fixtures.push(normalizeFixture({ root: fixtureRoot, directory, entrypoint }));
+  });
+
+  return fixtures.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export function createFixtureMatrix(input = {}) {
+  const normalized = normalizeArray(input.fixtures || discoverFixtures(input.fixture_root || input.fixtureRoot, input))
+    .map((fixture) => normalizeFixture(fixture));
+  const filter = normalizeFixtureFilter(input);
+  const fixtures = filter ? normalized.filter((fixture) => fixtureMatchesFilter(fixture, filter)) : normalized;
+  return {
+    schema: FIXTURE_MATRIX_SCHEMA,
+    id: input.id || input.run_id || input.runId || 'static-site-importer-fixture-matrix',
+    fixture_root: input.fixture_root || input.fixtureRoot || fixtures[0]?.fixture_root || normalized[0]?.fixture_root || '',
+    entrypoint: input.entrypoint || 'index.html',
+    ...(filter ? { filter } : {}),
+    count: fixtures.length,
+    fixtures,
+    artifacts: {
+      result: input.result_artifact || input.resultArtifact || 'static-site-fixture-matrix-result.json',
+      summary: input.summary_artifact || input.summaryArtifact || 'summary.json',
+      findings: input.findings_artifact || input.findingsArtifact || 'finding-packets.json',
+    },
+  };
+}
+
+// Classify a fixture. The per-fixture `fixture.json` manifest is the SOLE source
+// of truth for `class` — there is no heuristic fallback. Resolution order:
+//   1. An explicit class injected by tests / the runner / a carried result.
+//   2. The fixture's manifest `class` (must be a verbatim FIXTURE_CLASSES value).
+//   3. `unknown` — emitted with a loud warning naming the fixture.
+// A missing manifest or an invalid `class` value does NOT crash the run: the
+// single offending fixture resolves to `unknown` and is flagged.
+export function classifyFixture(input = {}) {
+  const explicit = normalizeFixtureClass(input.fixture_class || input.class);
+  if (explicit && explicit !== 'unknown') {
+    return { fixture_class: explicit, signals: ['explicit_metadata'], warning: null };
+  }
+
+  const fixtureName = fixtureLabelFor(input);
+  const manifest = input.manifest !== undefined
+    ? input.manifest
+    : readFixtureManifest(input.directory || input.path || input.fixture_path || input.fixturePath);
+
+  if (!manifest || typeof manifest !== 'object') {
+    const warning = `Fixture "${fixtureName}" has no ${FIXTURE_MANIFEST_FILENAME} manifest; classifying as "unknown".`;
+    warnFixtureClassification(warning);
+    return { fixture_class: 'unknown', signals: ['manifest_missing'], warning };
+  }
+
+  const rawClass = manifest.class ?? manifest.fixture_class;
+  if (typeof rawClass !== 'string' || !FIXTURE_CLASSES.includes(rawClass)) {
+    const warning = `Fixture "${fixtureName}" ${FIXTURE_MANIFEST_FILENAME} has invalid class ${JSON.stringify(rawClass)}; expected one of ${FIXTURE_CLASSES.join(', ')}. Classifying as "unknown".`;
+    warnFixtureClassification(warning);
+    return { fixture_class: 'unknown', signals: ['manifest_invalid_class'], warning };
+  }
+
+  return { fixture_class: rawClass, signals: ['manifest'], warning: null };
+}
+
+function fixtureLabelFor(input = {}) {
+  return input.id || input.slug || input.label || input.name || input.directory || input.path || input.fixture_path || 'unknown';
+}
+
+// Loud, single-line warning to stderr so a missing/invalid manifest is impossible
+// to miss in run logs. Exported as a no-arg-overridable hook so tests can capture
+// the emitted warnings deterministically.
+export function warnFixtureClassification(message) {
+  process.stderr.write(`[fixture-matrix] WARNING: ${message}\n`);
+}
+
+// Read `<fixture-dir>/fixture.json` if present. Returns the parsed object, or
+// null when the manifest is absent or unparseable (an unparseable manifest is
+// warned about and treated as missing — fail loud, do not guess).
+export function readFixtureManifest(directory) {
+  if (!directory) {
+    return null;
+  }
+  const manifestPath = path.join(directory, FIXTURE_MANIFEST_FILENAME);
+  if (!fs.existsSync(manifestPath) || !fs.statSync(manifestPath).isFile()) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (error) {
+    warnFixtureClassification(`Failed to parse ${manifestPath}: ${error.message}. Treating manifest as absent.`);
+    return null;
+  }
+}
+
+// Normalize a manifest `tags` value into a clean string array.
+export function normalizeManifestTags(value) {
+  return normalizeArray(value)
+    .map((tag) => String(tag || '').trim())
+    .filter(Boolean);
+}
+
+// Normalize a manifest `complexity` value into an integer within bounds, or null.
+export function normalizeManifestComplexity(value) {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+  const clamped = Math.min(FIXTURE_COMPLEXITY_MAX, Math.max(FIXTURE_COMPLEXITY_MIN, Math.round(number)));
+  return clamped;
+}
+
+// Build the active class/tag filter from runner/bench/test options, or null when
+// no filter is requested. Supports a single class and one-or-more tags.
+function normalizeFixtureFilter(input = {}) {
+  const classValue = normalizeFixtureClass(input.class || input.fixture_class || input.fixtureClass);
+  const fixtureClass = classValue && classValue !== 'unknown' ? classValue
+    : ((input.class || input.fixture_class || input.fixtureClass) ? 'unknown' : '');
+  const tags = normalizeManifestTags(input.tag || input.tags).map((tag) => tag.toLowerCase());
+  if (!fixtureClass && tags.length === 0) {
+    return null;
+  }
+  return { ...(fixtureClass ? { fixture_class: fixtureClass } : {}), ...(tags.length ? { tags } : {}) };
+}
+
+function fixtureMatchesFilter(fixture, filter) {
+  if (filter.fixture_class && fixture.fixture_class !== filter.fixture_class) {
+    return false;
+  }
+  if (filter.tags && filter.tags.length > 0) {
+    const fixtureTags = normalizeManifestTags(fixture.tags).map((tag) => tag.toLowerCase());
+    if (!filter.tags.every((tag) => fixtureTags.includes(tag))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function normalizeFixture(input) {
+  const directory = requiredDirectory(input.directory || input.path || input.fixture_path || input.fixturePath, 'fixture.directory');
+  const root = input.root || input.fixture_root || input.fixtureRoot || path.dirname(directory);
+  const relative = path.relative(path.resolve(root), path.resolve(directory));
+  const id = slug(input.id || input.slug || (relative && !relative.startsWith('..') ? relative : path.basename(directory)));
+  const files = input.files || input.fixture_files || input.fixtureFiles || collectFixtureFiles(directory, { maxFiles: input.maxFiles || input.max_files || 1000 });
+  const manifest = input.manifest !== undefined ? input.manifest : readFixtureManifest(directory);
+  const taxonomy = normalizeFixtureTaxonomy(input.taxonomy) || classifyFixture({ ...input, id, directory, root, files, manifest });
+  const tags = normalizeManifestTags(manifest?.tags ?? input.tags);
+  const complexity = normalizeManifestComplexity(manifest?.complexity ?? input.complexity);
+  return {
+    id,
+    label: input.label || input.name || id,
+    directory,
+    fixture_path: directory,
+    fixture_root: root,
+    entrypoint: input.entrypoint || 'index.html',
+    fixture_class: taxonomy.fixture_class,
+    tags,
+    complexity,
+    taxonomy: {
+      ...taxonomy,
+      tags,
+      complexity,
+    },
+  };
+}
+
+function normalizeFixtureTaxonomy(taxonomy) {
+  if (!taxonomy || typeof taxonomy !== 'object') {
+    return null;
+  }
+  const fixtureClassValue = taxonomy.fixture_class || taxonomy.fixtureClass;
+  if (!fixtureClassValue) {
+    return null;
+  }
+  return {
+    fixture_class: normalizeFixtureClass(fixtureClassValue) || 'unknown',
+    signals: normalizeArray(taxonomy.signals),
+    warning: taxonomy.warning || null,
+  };
+}
+
+export function collectFixtureFiles(directory, options = {}) {
+  const maxFiles = finiteNumber(options.maxFiles ?? options.max_files, 1000);
+  const files = [];
+  const visit = (current) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.name === '.git' || entry.name === 'node_modules') {
+        continue;
+      }
+      // The per-fixture manifest is matrix metadata, not website source — never
+      // pack it into the imported site artifact.
+      if (entry.isFile() && entry.name === FIXTURE_MANIFEST_FILENAME) {
+        continue;
+      }
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      const relativePath = path.relative(directory, entryPath).replace(/\\/g, '/');
+      const stat = fs.statSync(entryPath);
+      files.push({ relative_path: relativePath, absolute_path: entryPath, type: fileType(relativePath), bytes: stat.size });
+      if (files.length > maxFiles) {
+        throw new Error(`Fixture ${directory} has more than ${maxFiles} files.`);
+      }
+    }
+  };
+  visit(directory);
+  return files.sort((left, right) => left.relative_path.localeCompare(right.relative_path));
+}
+
+function visitFixtureDirectory(directory, depth, maxDepth, callback) {
+  callback(directory);
+  if (depth >= maxDepth) {
+    return;
+  }
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name !== '.git' && entry.name !== 'node_modules') {
+      visitFixtureDirectory(path.join(directory, entry.name), depth + 1, maxDepth, callback);
+    }
+  }
+}
+
+export function normalizeFixtureClass(value) {
+  const normalized = String(value || '').trim().toLowerCase().replace(/[_\s-]+/g, '/');
+  const aliases = {
+    marketing: 'marketing/static',
+    static: 'marketing/static',
+    marketingstatic: 'marketing/static',
+    'marketing/static': 'marketing/static',
+    docs: 'docs/blog',
+    documentation: 'docs/blog',
+    blog: 'docs/blog',
+    'docs/blog': 'docs/blog',
+    ecommerce: 'ecommerce/catalog',
+    commerce: 'ecommerce/catalog',
+    catalog: 'ecommerce/catalog',
+    shop: 'ecommerce/catalog',
+    'ecommerce/catalog': 'ecommerce/catalog',
+    app: 'app/dashboard',
+    dashboard: 'app/dashboard',
+    'app/dashboard': 'app/dashboard',
+    canvas: 'canvas/webgl/audio/runtime-heavy',
+    webgl: 'canvas/webgl/audio/runtime-heavy',
+    audio: 'canvas/webgl/audio/runtime-heavy',
+    runtime: 'canvas/webgl/audio/runtime-heavy',
+    'runtime/heavy': 'canvas/webgl/audio/runtime-heavy',
+    'canvas/webgl/audio/runtime/heavy': 'canvas/webgl/audio/runtime-heavy',
+    'canvas/webgl/audio/runtime-heavy': 'canvas/webgl/audio/runtime-heavy',
+  };
+  return aliases[normalized] || (FIXTURE_CLASSES.includes(normalized) ? normalized : 'unknown');
+}
+
+export function fixtureClassRank(value) {
+  const index = FIXTURE_CLASSES.indexOf(value);
+  return index >= 0 ? index : FIXTURE_CLASSES.length;
+}

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -1,0 +1,525 @@
+// Result normalization, quality gating, summary/aggregate rollups, and artifact
+// writing for the Static Site Importer fixture matrix.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242).
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  FIXTURE_MATRIX_RESULT_SCHEMA,
+  ACCEPTABLE_LOSS_CLASSES,
+  UNACCEPTABLE_LOSS_CLASSES,
+} from './shared/constants.mjs';
+import {
+  normalizeArray,
+  objectValue,
+  numberValue,
+  compactObject,
+  pushUnique,
+  countBy,
+  requiredString,
+  writeJsonFile,
+  artifactRef,
+} from './shared/utils.mjs';
+import { boundBlob } from './shared/bounds.mjs';
+import {
+  createFixtureMatrix,
+  classifyFixture,
+  normalizeFixtureClass,
+  fixtureClassRank,
+} from './fixtures.mjs';
+import {
+  findingsForFixtureResult,
+  dedupeFindings,
+  isActionableFinding,
+  selectorFamily,
+  patternFamily,
+} from './findings.mjs';
+import {
+  collectBlockComposition,
+  computeFixtureEditorQuality,
+  attachFixtureEditorQuality,
+  aggregateEditorQuality,
+  normalizeNativeRateGateOptions,
+  buildNativeRateGateFindings,
+  accumulateEditorQuality,
+  finalizeEditorQuality,
+} from './collectors/quality-metrics.mjs';
+import { buildFixtureArtifact, stageFixtureSource } from './steps/recipe-builder.mjs';
+
+export function normalizeFixtureMatrixResult(input = {}) {
+  const matrix = input.matrix || createFixtureMatrix(input);
+  const generationStatus = input.generationStatus || input.generation_status || 'succeeded';
+  const executionStatus = normalizeExecutionStatus(input);
+  const executionRequested = executionStatus !== 'not_requested';
+  const results = normalizeArray(input.results || input.fixture_results || input.fixtureResults).map(normalizeFixtureResult);
+  const resultByFixture = new Map(results.map((result) => [result.fixture_id, result]));
+  const fixtureResults = matrix.fixtures.map((fixture) => attachFixtureTaxonomy(
+    resultByFixture.get(fixture.id) || normalizeFixtureResult({ fixture_id: fixture.id, fixture_path: fixture.fixture_path, status: 'not_run' }),
+    fixture,
+  ));
+  const baseFindings = dedupeFindings(fixtureResults.flatMap((result) => findingsForFixtureResult(result, { matrix, executionRequested })));
+  // Editor-quality metrics are computed from generic block-composition data plus
+  // the #537 editor-invalid findings. Scoring always runs; gating is opt-in.
+  const nativeRateGate = normalizeNativeRateGateOptions(input.editorQuality || input.editor_quality || input);
+  const editorQualityByFixture = new Map(fixtureResults.map((result) => [result.fixture_id, computeFixtureEditorQuality(result, baseFindings)]));
+  const nativeRateGateFindings = nativeRateGate.minNativeRate > 0
+    ? buildNativeRateGateFindings(fixtureResults, editorQualityByFixture, nativeRateGate)
+    : [];
+  const findings = dedupeFindings([...baseFindings, ...nativeRateGateFindings]);
+  const actionableFindings = findings.filter(isActionableFinding);
+  const grouped = groupFindings(actionableFindings);
+  const acceptableActionableFindings = actionableFindings.filter((finding) => finding.loss_acceptance === 'acceptable');
+  const unacceptableActionableFindings = actionableFindings.filter((finding) => finding.loss_acceptance !== 'acceptable');
+  const gatedFixtureResults = fixtureResults.map((result) => attachFixtureEditorQuality(applyFixtureQualityGate(result, findings, { executionRequested }), editorQualityByFixture.get(result.fixture_id)));
+  const lossClassCounts = countBy(findings, (finding) => finding.loss_class || 'unsupported_loss');
+  const acceptanceCounts = countBy(findings, (finding) => finding.loss_acceptance || 'unacceptable');
+  const classRollups = fixtureClassRollups(gatedFixtureResults, findings);
+  const fanoutGroups = buildFanoutGroups(actionableFindings);
+
+  return {
+    schema: FIXTURE_MATRIX_RESULT_SCHEMA,
+    matrix_id: matrix.id,
+    fixture_root: matrix.fixture_root,
+    summary: {
+      generation_status: generationStatus,
+      execution_status: executionStatus,
+      fixture_count: matrix.fixtures.length,
+      succeeded: gatedFixtureResults.filter((result) => result.status === 'passed').length,
+      failed: gatedFixtureResults.filter((result) => result.status === 'failed').length,
+      not_run: gatedFixtureResults.filter((result) => result.raw_status === 'not_run').length,
+      finding_count: findings.length,
+      actionable_finding_count: actionableFindings.length,
+      non_actionable_finding_count: findings.length - actionableFindings.length,
+      acceptable_finding_count: acceptanceCounts.acceptable || 0,
+      unacceptable_finding_count: acceptanceCounts.unacceptable || 0,
+      loss_classes: lossClassCounts,
+      acceptable_loss_classes: Object.fromEntries(Object.entries(lossClassCounts).filter(([key]) => ACCEPTABLE_LOSS_CLASSES.has(key))),
+      unacceptable_loss_classes: Object.fromEntries(Object.entries(lossClassCounts).filter(([key]) => UNACCEPTABLE_LOSS_CLASSES.has(key))),
+      preserved_runtime_island_count: lossClassCounts.preserved_runtime_island || 0,
+      groups: Object.fromEntries(Object.entries(grouped).map(([key, items]) => [key, items.length])),
+      top_pattern_families: topPatternFamilies(actionableFindings),
+      top_acceptable_pattern_families: topPatternFamilies(acceptableActionableFindings),
+      top_unacceptable_pattern_families: topPatternFamilies(unacceptableActionableFindings),
+      unacceptable_candidate_repos: candidateRepoRollups(unacceptableActionableFindings),
+      fixture_exemplars: fixtureExemplars(actionableFindings),
+      diagnostic_blind_spots: diagnosticBlindSpots(actionableFindings),
+      fixture_classes: Object.fromEntries(Object.entries(classRollups).map(([key, row]) => [key, row.fixture_count])),
+      classes: classRollups,
+      quality_budgets: qualityBudgetSummaries(classRollups),
+      editor_quality: aggregateEditorQuality([...editorQualityByFixture.values()], nativeRateGate),
+    },
+    fixtures: gatedFixtureResults,
+    findings,
+    fanout_groups: fanoutGroups.map((group, index) => ({ ...group, index })),
+  };
+}
+
+function normalizeExecutionStatus(input = {}) {
+  const explicit = input.executionStatus || input.execution_status;
+  if (explicit) {
+    return String(explicit);
+  }
+  if (input.executionRequested === false || input.execution_requested === false || input.run === false) {
+    return 'not_requested';
+  }
+  return 'requested';
+}
+
+function applyFixtureQualityGate(result, findings, options = {}) {
+  if (options.executionRequested === false && result.status === 'not_run') {
+    return {
+      ...result,
+      raw_status: result.status,
+      success: false,
+      quality_gate: {
+        status: 'not_run',
+        acceptable_finding_count: 0,
+        unacceptable_finding_count: 0,
+        loss_classes: {},
+      },
+    };
+  }
+
+  const fixtureFindings = findings.filter((finding) => finding.fixture_id === result.fixture_id);
+  const unacceptableFindings = fixtureFindings.filter((finding) => finding.loss_acceptance === 'unacceptable');
+  const status = unacceptableFindings.length > 0 ? 'failed' : 'passed';
+  return {
+    ...result,
+    raw_status: result.status,
+    status,
+    success: status === 'passed',
+    quality_gate: {
+      status,
+      acceptable_finding_count: fixtureFindings.length - unacceptableFindings.length,
+      unacceptable_finding_count: unacceptableFindings.length,
+      loss_classes: countBy(fixtureFindings, (finding) => finding.loss_class || 'unsupported_loss'),
+    },
+  };
+}
+
+function attachFixtureTaxonomy(result, fixture) {
+  const taxonomy = fixture.taxonomy || classifyFixture(fixture);
+  const fixtureClass = normalizeFixtureClass(result.fixture_class) !== 'unknown' ? normalizeFixtureClass(result.fixture_class) : taxonomy.fixture_class;
+  const tags = result.tags?.length ? result.tags : (fixture.tags || []);
+  const complexity = result.complexity ?? fixture.complexity ?? null;
+  return {
+    ...result,
+    fixture_path: result.fixture_path || fixture.fixture_path,
+    fixture_class: fixtureClass,
+    tags,
+    complexity,
+    taxonomy: {
+      ...taxonomy,
+      ...result.taxonomy,
+      fixture_class: fixtureClass,
+      tags,
+      complexity,
+    },
+  };
+}
+
+export function normalizeFixtureResult(input) {
+  let status = input.status || 'not_run';
+  if (!input.status && input.success === true) {
+    status = 'passed';
+  } else if (!input.status && input.success === false) {
+    status = 'failed';
+  }
+  const liveWpParityResult = input.live_wp_parity || input.liveWpParity || null;
+  return {
+    fixture_id: input.fixture_id || input.fixtureId || input.id || '',
+    fixture_path: input.fixture_path || input.fixturePath || input.path || '',
+    fixture_class: normalizeFixtureClass(input.fixture_class || input.fixtureClass || input.taxonomy?.fixture_class) || 'unknown',
+    tags: normalizeArray(input.tags ?? input.taxonomy?.tags).map((tag) => String(tag || '').trim()).filter(Boolean),
+    complexity: input.complexity ?? input.taxonomy?.complexity ?? null,
+    taxonomy: input.taxonomy || {},
+    status,
+    success: status === 'passed',
+    error: input.error || input.message || '',
+    // Block composition is computed from the FULL input (which may carry
+    // serialized `post_content`/block markup) into bounded COUNTS first; the raw
+    // markup is then discarded by never retaining `input` and by bounding the
+    // report blobs below. See #554 / bounds.mjs.
+    block_composition: input.block_composition || input.blockComposition || collectBlockComposition(input),
+    // Real `wp.blocks.validateBlock` editor-validity (total/valid/invalid blocks
+    // + validation_method), distinct from the PHP round-trip. Round-trips through
+    // re-normalization so editor-quality scoring can read it.
+    editor_validation: input.editor_validation || input.editorValidation || null,
+    // Retained report blobs can carry raw serialized markup (e.g.
+    // `import_report.materialized_content.block_documents[].post_content`). Bound
+    // every retained string so the per-fixture result scales with #findings, not
+    // with raw content volume. Counts/metrics inside these blobs are untouched.
+    ssi_validation: boundBlob(input.ssi_validation || input.ssiValidation || null),
+    import_report: boundBlob(input.import_report || input.importReport || null),
+    quality_metrics: boundBlob(input.quality_metrics || input.qualityMetrics || {}),
+    blocks_engine_diagnostics: boundBlob(normalizeArray(input.blocks_engine_diagnostics || input.blocksEngineDiagnostics)),
+    invalid_block_counts: input.invalid_block_counts || input.invalidBlockCounts || {},
+    missing_assets: boundBlob(normalizeArray(input.missing_assets || input.missingAssets)),
+    runtime_target_gaps: boundBlob(normalizeArray(input.runtime_target_gaps || input.runtimeTargetGaps)),
+    diagnostics: boundBlob(normalizeArray(input.diagnostics || input.findings || input.messages)),
+    artifact_refs: normalizeArray(input.artifact_refs || input.artifactRefs),
+    artifacts: input.artifacts || {},
+    visual_parity_artifacts: input.visual_parity_artifacts || input.visualParityArtifacts || null,
+    // Opt-in live-WP parity result (live-WP score + render-free proxy score +
+    // delta). Only attached when the collector produced one; absent => the key is
+    // omitted entirely so a default (toggle-off) result is byte-identical to today.
+    ...(liveWpParityResult ? { live_wp_parity: liveWpParityResult } : {}),
+  };
+}
+
+export function writeFixtureMatrixArtifacts(input = {}) {
+  const outputDirectory = requiredString(input.outputDirectory || input.output_directory, 'outputDirectory');
+  const matrix = input.matrix || createFixtureMatrix(input);
+  const result = input.result || normalizeFixtureMatrixResult({ ...input, matrix, execution_status: input.execution_status || input.executionStatus || 'not_requested' });
+
+  fs.mkdirSync(outputDirectory, { recursive: true });
+  for (const fixture of matrix.fixtures) {
+    const fixtureDirectory = path.join(outputDirectory, fixture.id);
+    fs.mkdirSync(fixtureDirectory, { recursive: true });
+    writeJsonFile(path.join(fixtureDirectory, 'artifact.json'), buildFixtureArtifact(fixture, input));
+    // Stage the raw source site alongside artifact.json so the in-sandbox
+    // WordPress origin can serve it for the visual-parity `source-url`.
+    stageFixtureSource(fixture, fixtureDirectory, input);
+  }
+
+  writeJsonFile(path.join(outputDirectory, 'matrix.json'), matrix);
+  writeFixtureMatrixResultArtifacts({ outputDirectory, matrix, result });
+
+  return {
+    matrix,
+    result,
+    artifact_refs: [
+      artifactRef('matrix', path.join(outputDirectory, 'matrix.json'), 'matrix'),
+      artifactRef('result', path.join(outputDirectory, 'static-site-fixture-matrix-result.json'), 'diagnostic'),
+      artifactRef('summary', path.join(outputDirectory, 'summary.json'), 'summary'),
+      artifactRef('finding-packets', path.join(outputDirectory, 'finding-packets.json'), 'diagnostic'),
+    ],
+  };
+}
+
+export function writeFixtureMatrixResultArtifacts(input = {}) {
+  const outputDirectory = requiredString(input.outputDirectory || input.output_directory, 'outputDirectory');
+  const matrix = input.matrix || createFixtureMatrix(input);
+  const result = input.result || normalizeFixtureMatrixResult({ ...input, matrix });
+  writeJsonFile(path.join(outputDirectory, 'static-site-fixture-matrix-result.json'), result);
+  writeJsonFile(path.join(outputDirectory, 'summary.json'), result.summary);
+  writeJsonFile(path.join(outputDirectory, 'finding-packets.json'), result.findings);
+  return result;
+}
+
+function topPatternFamilies(findings, limit = 10) {
+  const families = new Map();
+  for (const finding of findings) {
+    const key = finding.pattern_family || patternFamily(finding);
+    const row = families.get(key) || {
+      key,
+      count: 0,
+      repair_bucket: finding.repair_bucket || finding.group_key || '',
+      kind: finding.kind || '',
+      candidate_repo: finding.candidate_repo || '',
+      fixture_ids: [],
+      selectors: [],
+      exemplars: [],
+    };
+    row.count += 1;
+    pushUnique(row.fixture_ids, finding.fixture_id, 5);
+    pushUnique(row.selectors, finding.selector, 5);
+    if (row.exemplars.length < 3) {
+      row.exemplars.push(fixtureExemplar(finding));
+    }
+    families.set(key, row);
+  }
+  return [...families.values()]
+    .sort((left, right) => right.count - left.count || left.key.localeCompare(right.key))
+    .slice(0, limit);
+}
+
+function fixtureExemplars(findings, limit = 10) {
+  const exemplars = [];
+  const seen = new Set();
+  for (const finding of findings) {
+    const exemplar = fixtureExemplar(finding);
+    const key = [exemplar.pattern_family, exemplar.fixture_id, exemplar.selector, exemplar.source_path].join('\u0000');
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    exemplars.push(exemplar);
+    if (exemplars.length >= limit) {
+      break;
+    }
+  }
+  return exemplars;
+}
+
+function fixtureExemplar(finding) {
+  return compactObject({
+    fixture_id: finding.fixture_id,
+    pattern_family: finding.pattern_family || patternFamily(finding),
+    repair_bucket: finding.repair_bucket || finding.group_key,
+    kind: finding.kind,
+    candidate_repo: finding.candidate_repo,
+    source_path: finding.source_path || finding.path,
+    selector: finding.selector,
+    selector_family: finding.selector_family || selectorFamily(finding.selector),
+    reason: finding.reason,
+    source_snippet: finding.source_snippet,
+    observed_block_name: finding.observed_block_name,
+    observed_output: finding.observed_output,
+  });
+}
+
+function diagnosticBlindSpots(findings) {
+  const spots = [];
+  const genericFindings = findings.filter((finding) => isGenericFinding(finding));
+  const missingSourceContext = findings.filter((finding) => !finding.selector && !finding.source_snippet && !finding.observed_output);
+  if (genericFindings.length > 0) {
+    spots.push(blindSpot('generic_finding_family', genericFindings, 'Findings need a specific type, repair bucket, or reason code before fanout.'));
+  }
+  if (missingSourceContext.length > 0) {
+    spots.push(blindSpot('missing_source_context', missingSourceContext, 'Findings need selector, source snippet, or observed block output for direct transformer repair.'));
+  }
+  return spots;
+}
+
+function blindSpot(kind, findings, recommendation) {
+  return {
+    kind,
+    count: findings.length,
+    recommendation,
+    exemplars: fixtureExemplars(findings, 5),
+  };
+}
+
+function isGenericFinding(finding) {
+  return ['static_site_fixture_diagnostic', 'import_diagnostic', 'diagnostic'].includes(finding.kind)
+    || ['static_site_import_quality'].includes(finding.group_key)
+    || !finding.reason;
+}
+
+function groupFindings(findings) {
+  return findings.reduce((groups, finding) => {
+    const key = finding.group_key || 'static_site_import_quality';
+    groups[key] = groups[key] || [];
+    groups[key].push(finding);
+    return groups;
+  }, {});
+}
+
+function buildFanoutGroups(findings) {
+  const groups = new Map();
+  for (const finding of findings) {
+    const acceptance = finding.loss_acceptance === 'acceptable' ? 'acceptable' : 'unacceptable';
+    const pattern = finding.pattern_family || patternFamily(finding);
+    const candidateRepo = finding.candidate_repo || 'unknown';
+    const key = `${acceptance}:${candidateRepo}:${pattern}`;
+    const row = groups.get(key) || {
+      group_key: key,
+      acceptance,
+      candidate_repo: candidateRepo,
+      pattern_family: pattern,
+      count: 0,
+      top_pattern_families: [],
+      fixture_exemplars: [],
+      findings: [],
+    };
+    row.count += 1;
+    row.findings.push(finding);
+    groups.set(key, row);
+  }
+
+  return [...groups.values()]
+    .map((group) => ({
+      ...group,
+      top_pattern_families: topPatternFamilies(group.findings, 5),
+      fixture_exemplars: fixtureExemplars(group.findings, 5),
+    }))
+    .sort(fanoutGroupSort);
+}
+
+function fanoutGroupSort(left, right) {
+  const acceptanceDelta = acceptanceRank(left.acceptance) - acceptanceRank(right.acceptance);
+  if (acceptanceDelta !== 0) {
+    return acceptanceDelta;
+  }
+  return right.count - left.count
+    || genericBucketRank(left) - genericBucketRank(right)
+    || left.candidate_repo.localeCompare(right.candidate_repo)
+    || left.pattern_family.localeCompare(right.pattern_family);
+}
+
+function acceptanceRank(value) {
+  return value === 'unacceptable' ? 0 : 1;
+}
+
+function genericBucketRank(group) {
+  return group.pattern_family === 'static_site_import_quality:static_site_fixture_diagnostic:(none)' ? 1 : 0;
+}
+
+function candidateRepoRollups(findings, limit = 10) {
+  const repos = new Map();
+  for (const finding of findings) {
+    const key = finding.candidate_repo || 'unknown';
+    const row = repos.get(key) || {
+      candidate_repo: key,
+      count: 0,
+      fixture_ids: [],
+      loss_classes: {},
+      repair_buckets: {},
+      top_pattern_families: [],
+      fixture_exemplars: [],
+      findings: [],
+    };
+    row.count += 1;
+    pushUnique(row.fixture_ids, finding.fixture_id, 10);
+    row.loss_classes[finding.loss_class || 'unsupported_loss'] = (row.loss_classes[finding.loss_class || 'unsupported_loss'] || 0) + 1;
+    row.repair_buckets[finding.repair_bucket || finding.group_key || 'static_site_import_quality'] = (row.repair_buckets[finding.repair_bucket || finding.group_key || 'static_site_import_quality'] || 0) + 1;
+    row.findings.push(finding);
+    row.top_pattern_families = topPatternFamilies(row.findings, 5);
+    row.fixture_exemplars = fixtureExemplars(row.findings, 5);
+    repos.set(key, row);
+  }
+
+  return [...repos.values()]
+    .map(({ findings: _findings, ...row }) => row)
+    .sort((left, right) => right.count - left.count || left.candidate_repo.localeCompare(right.candidate_repo))
+    .slice(0, limit);
+}
+
+function fixtureClassRollups(fixtureResults, findings) {
+  const byClass = {};
+  for (const result of fixtureResults) {
+    const key = normalizeFixtureClass(result.fixture_class) || 'unknown';
+    const row = byClass[key] || classRollup(key);
+    row.fixture_count += 1;
+    row[result.status] = (row[result.status] || 0) + 1;
+    if (result.raw_status === 'not_run' && result.status !== 'not_run') {
+      row.not_run += 1;
+    }
+    accumulateEditorQuality(row.editor_quality, result.editor_quality);
+    byClass[key] = row;
+  }
+
+  for (const finding of findings) {
+    const key = normalizeFixtureClass(finding.fixture_class) || 'unknown';
+    const row = byClass[key] || classRollup(key);
+    const bucket = finding.repair_bucket || finding.group_key || 'static_site_import_quality';
+    row.finding_count += 1;
+    row.loss_classes[finding.loss_class || 'unsupported_loss'] = (row.loss_classes[finding.loss_class || 'unsupported_loss'] || 0) + 1;
+    if (finding.loss_acceptance === 'acceptable') {
+      row.acceptable_finding_count += 1;
+    } else {
+      row.unacceptable_finding_count += 1;
+    }
+    row.repair_buckets[bucket] = (row.repair_buckets[bucket] || 0) + 1;
+    row.candidate_repos[finding.candidate_repo || 'unknown'] = (row.candidate_repos[finding.candidate_repo || 'unknown'] || 0) + 1;
+    byClass[key] = row;
+  }
+
+  return Object.fromEntries(Object.entries(byClass)
+    .map(([key, row]) => [key, { ...row, editor_quality: finalizeEditorQuality(row.editor_quality) }])
+    .sort(([left], [right]) => fixtureClassRank(left) - fixtureClassRank(right)));
+}
+
+function classRollup(key) {
+  return {
+    fixture_class: key,
+    fixture_count: 0,
+    passed: 0,
+    failed: 0,
+    not_run: 0,
+    finding_count: 0,
+    acceptable_finding_count: 0,
+    unacceptable_finding_count: 0,
+    loss_classes: {},
+    repair_buckets: {},
+    candidate_repos: {},
+    editor_quality: { scored_fixture_count: 0, block_total: 0, native_block_count: 0, core_html_block_count: 0, editor_invalid_count: 0, editor_validated_fixture_count: 0, editor_validated_block_total: 0, editor_valid_block_count: 0, invalid_block_count: 0 },
+  };
+}
+
+function qualityBudgetSummaries(classRollups) {
+  return Object.fromEntries(Object.entries(classRollups).map(([key, row]) => {
+    const dominantRepairBuckets = Object.entries(row.repair_buckets)
+      .map(([bucket, count]) => ({ bucket, count }))
+      .sort((left, right) => right.count - left.count || left.bucket.localeCompare(right.bucket));
+    return [key, {
+      fixture_class: key,
+      fixture_count: row.fixture_count,
+      passed: row.passed,
+      failed: row.failed,
+      not_run: row.not_run,
+      finding_count: row.finding_count,
+      acceptable_finding_count: row.acceptable_finding_count,
+      unacceptable_finding_count: row.unacceptable_finding_count,
+      loss_classes: row.loss_classes,
+      preserved_runtime_island_count: row.loss_classes.preserved_runtime_island || 0,
+      findings_per_fixture: row.fixture_count ? Number((row.finding_count / row.fixture_count).toFixed(2)) : 0,
+      dominant_repair_buckets: dominantRepairBuckets.slice(0, 5),
+      editor_quality: row.editor_quality,
+    }];
+  }));
+}

--- a/lib/fixture-matrix/shared/bounds.mjs
+++ b/lib/fixture-matrix/shared/bounds.mjs
@@ -1,0 +1,61 @@
+// Output-size bounding for the Static Site Importer fixture matrix (#554).
+//
+// The matrix assembles one aggregate result that is serialized with
+// JSON.stringify (per-fixture results + findings + result_summary). The
+// block-composition parsing added in #552 reads serialized `post_content` /
+// Gutenberg block markup; if that raw bulk is retained on each fixture result,
+// a lane-scale run (~30+ fixtures) serializes into a string that exceeds V8's
+// hard ~512MB per-string ceiling and throws `Invalid string length` (peak RSS
+// 11.2 GB observed at 30 fixtures).
+//
+// These helpers bound the RETAINED output independent of fixture count: raw
+// serialized markup is discarded after COUNTS are computed, and every retained
+// string field is truncated to a sane cap. Metrics (native_conversion_rate,
+// loss classes, finding counts, block counts, tags/complexity) are never
+// touched — this drops raw BULK, not metrics.
+
+// Per-string ceiling for any retained text field (source snippets, observed
+// output, reasons, and any deep string inside a retained report blob). Generous
+// enough to keep findings human-readable while orders of magnitude below V8's
+// per-string limit, so the aggregate scales with #fixtures/#patterns rather
+// than with raw content volume.
+export const MAX_RETAINED_STRING_LENGTH = 2048;
+
+// Depth guard for the recursive blob bounder. Retained report blobs are shallow
+// in practice; this only stops object/array recursion from running away on a
+// pathological structure. Strings are truncated at every depth regardless.
+const MAX_BOUND_DEPTH = 16;
+
+const TRUNCATION_NOTICE = '…[truncated]';
+
+// Truncate a single string to `max` characters, appending a visible notice so a
+// consumer can tell the value was clipped. Non-strings pass through untouched.
+export function truncateString(value, max = MAX_RETAINED_STRING_LENGTH) {
+  if (typeof value !== 'string' || value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max)}${TRUNCATION_NOTICE}`;
+}
+
+// Recursively truncate every string inside an arbitrary JSON-ish blob so a
+// single retained value (e.g. a serialized `post_content` body, or a
+// `block_documents[].post_content` carried on an import report) can not balloon
+// the aggregate output. Object/array shape, keys, and all non-string values
+// (counts, numbers, booleans) are preserved exactly — only string VALUES are
+// bounded. Returns the blob unchanged when there is nothing to bound.
+export function boundBlob(value, max = MAX_RETAINED_STRING_LENGTH, depth = 0) {
+  if (typeof value === 'string') {
+    return truncateString(value, max);
+  }
+  if (!value || typeof value !== 'object' || depth >= MAX_BOUND_DEPTH) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => boundBlob(entry, max, depth + 1));
+  }
+  const bounded = {};
+  for (const [key, entry] of Object.entries(value)) {
+    bounded[key] = boundBlob(entry, max, depth + 1);
+  }
+  return bounded;
+}

--- a/lib/fixture-matrix/shared/constants.mjs
+++ b/lib/fixture-matrix/shared/constants.mjs
@@ -1,0 +1,241 @@
+// Shared constants for the Static Site Importer fixture matrix.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242). Pure data only — no behavior.
+
+export const FIXTURE_MATRIX_SCHEMA = 'static-site-importer/fixture-matrix/v1';
+export const FIXTURE_MATRIX_RESULT_SCHEMA = 'static-site-importer/fixture-matrix-result/v1';
+export const WEBSITE_ARTIFACT_SCHEMA = 'blocks-engine/php-transformer/site-artifact/v1';
+
+export const DEFAULT_ENTRYPOINT = 'website/index.html';
+export const DEFAULT_IMPORTER_SLUG = 'static-site-importer';
+
+// Editor-side block validity (JS save-comparison) wiring. The imported post is
+// validated with the real block editor's `wp.blocks.validateBlock` pass inside
+// the same WP Codebox sandbox the matrix already spins up, via the
+// `wordpress.editor-validate-blocks` command (wp-codebox #1597). That command
+// emits a per-block `{ name, isValid, issues }` result set (schema
+// `wp-codebox/editor-validate-blocks/v1`) plus `total_blocks`/`valid_blocks`/
+// `invalid_blocks` and `validation_method: 'wp.blocks.validateBlock'`, which is
+// the authoritative editor-validity signal for whether stored markup still
+// matches each block type's `save()` output. `collectEditorValidation` /
+// `collectEditorValidationDiagnostics` read that shape back out.
+//
+// The legacy `wordpress.editor-canvas-probe` selector shape
+// (`.block-editor-warning` / `is-invalid` DOM warnings) is still parsed for
+// backward compatibility with older artifacts, but it is no longer produced by
+// the recipe — the canvas probe opened an EMPTY `post-new.php` and never
+// validated imported content.
+export const EDITOR_BLOCK_INVALID_KIND = 'editor_block_invalid';
+export const EDITOR_INVALID_BLOCK_SELECTOR_GROUP = 'editor_block_invalid';
+export const EDITOR_INVALID_BLOCK_SELECTORS = [
+  '.block-editor-warning',
+  '.block-editor-block-list__block.is-invalid',
+  '.wp-block[data-block].is-invalid',
+];
+// The real `wp.blocks.validateBlock` editor-validation command and its output
+// schema/method/provider. The recipe invokes the command against imported
+// content; the collector keys off the schema/method to read the result set.
+export const EDITOR_VALIDATE_BLOCKS_COMMAND = 'wordpress.editor-validate-blocks';
+export const EDITOR_VALIDATE_BLOCKS_SCHEMA = 'wp-codebox/editor-validate-blocks/v1';
+export const EDITOR_VALIDATION_METHOD = 'wp.blocks.validateBlock';
+export const EDITOR_VALIDATION_PROVIDER = 'wordpress-block-editor';
+// Default editor-validation target when a fixture carries no explicit
+// content/post target. `front-page` resolves, inside the WP Codebox sandbox at
+// runtime, to the site's static front page (`page_on_front`) — which SSI's
+// import points at the imported home page — and opens
+// `post.php?post=<id>&action=edit` so the command validates the REAL imported
+// front page's blocks. (A bare `post-type` resolved to an EMPTY
+// `post-new.php?post_type=<type>` editor, reporting `total_blocks: 0` and
+// proving nothing about imported markup — see wp-codebox `editorOpenTargetFromArgs`.)
+export const DEFAULT_EDITOR_VALIDATION_TARGET = 'front-page';
+// Retained for callers that still forward an explicit editor post type; the
+// default target no longer keys off it.
+export const DEFAULT_EDITOR_VALIDATION_POST_TYPE = 'page';
+// Legacy empty-post canvas-probe URL. Retained only so callers that still pass
+// an explicit editor URL keep working; the recipe no longer defaults to it.
+export const DEFAULT_EDITOR_VALIDATION_URL = '/wp-admin/post-new.php';
+export const EDITOR_BLOCK_INVALID_DEFAULT_DETAIL = 'This block contains unexpected or invalid content';
+
+// Pixel visual-parity wiring. After import, the same WP Codebox sandbox renders
+// the fixture's original static source vs the imported WordPress output via the
+// existing `wordpress.visual-compare` recipe command (the same command the
+// reusable `runVisualParityWorkload` helper composes in homeboy-extensions). The
+// command emits `source.png`/`candidate.png`/`diff.png` plus
+// `mismatch_pixels`/`total_pixels`, which `collectVisualParityDiagnostics` reads
+// back out. No new wp-codebox capability is introduced. Capture is on by
+// default; gating on mismatch-over-threshold is opt-in (pixel diffs can be
+// flaky) and is expressed as the conditional `visual_parity_mismatch` loss class.
+export const VISUAL_PARITY_MISMATCH_KIND = 'visual_parity_mismatch';
+
+// Editor-quality metrics wiring. The matrix already carries the transformer's
+// block-composition breakdown (block-type counts / `detectBlockTypes` output) on
+// each fixture's import artifact. From that generic, per-block-type data we score
+// how "native and editable" an import is — without any per-fixture knowledge:
+//   native_conversion_rate = native core/Automattic blocks / total blocks
+//   core_html_fallback_ratio = core/html blocks / total blocks
+//   editor_invalid_count = reuse of the #537 `editor_block_invalid` findings
+// A block is "native" when it lives in a core or known Automattic namespace
+// (core/*, jetpack/*, woocommerce/*, automattic/*, a8c/*) and is not one of the
+// non-native fallback wrappers (core/html, core/freeform). This list is the only
+// generic basis used; nothing keys off a fixture id or class.
+export const NATIVE_BLOCK_NAMESPACES = ['core', 'jetpack', 'woocommerce', 'automattic', 'a8c'];
+export const CORE_HTML_BLOCK_NAME = 'core/html';
+export const NON_NATIVE_FALLBACK_BLOCK_NAMES = new Set([CORE_HTML_BLOCK_NAME, 'core/freeform']);
+// Opt-in native-conversion gate. Like the visual-parity gate, scoring is always
+// captured but gating is off by default — it only fires when the run passes a
+// positive `--min-native-rate`/`minNativeRate` threshold.
+export const LOW_NATIVE_CONVERSION_KIND = 'native_conversion_rate_below_min';
+
+export const DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD = 0.1;
+// Candidate (imported WordPress output) URL. The per-fixture import step runs
+// with activate=true, which sets `show_on_front=page` + `page_on_front` to the
+// imported front page (see Static_Site_Importer_Theme_Generator::front_page_id).
+// Because the recipe interleaves [import, editor-validate, visual-compare] per
+// fixture, `/` resolves to THIS fixture's imported front page at the moment the
+// visual-compare runs — the real imported page, not an unrelated WP homepage. A
+// fixture can still override `candidate_url`/`candidate-url` to target a specific
+// imported permalink (e.g. `/?page_id=<id>` or a pretty permalink).
+export const DEFAULT_VISUAL_PARITY_CANDIDATE_URL = '/';
+// Base web path under which the fixture's ORIGINAL static source is staged and
+// served by the SAME in-sandbox WordPress origin the candidate uses. The matrix
+// copies each fixture's raw source files (index.html + css/js/images) into
+// `<artifacts>/<fixture-id>/<VISUAL_PARITY_SOURCE_SUBDIR>/...`, and that artifacts
+// directory is mounted into the sandbox at the WordPress uploads path below, so
+// the files are reachable at `<base>/<fixture-id>/<subdir>/index.html`. Serving
+// the source from the same origin (rather than a host 127.0.0.1 port, which the
+// in-sandbox browser cannot reach) is what lets `source-url` actually load
+// instead of hanging to the 120s capture timeout.
+export const DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL = '/wp-content/uploads/static-site-importer-fixture-matrix';
+// Subdirectory (under each fixture's artifacts dir) holding the staged raw source
+// site. Kept separate from the per-fixture `artifact.json` import payload so the
+// served source tree mirrors the fixture's own relative asset paths exactly.
+export const VISUAL_PARITY_SOURCE_SUBDIR = 'source';
+export const DEFAULT_VISUAL_PARITY_VIEWPORT = { width: 1280, height: 1600 };
+export const DEFAULT_VISUAL_PARITY_WAIT_FOR = 'domcontentloaded';
+// A finding only gates when it carries an explicit opt-in gate signal; absent
+// that, a mismatch is captured but non-gating (capture-only default).
+export const VISUAL_PARITY_GATE_SIGNAL_KEYS = ['gate', 'visual_parity_gate', 'visualParityGate'];
+
+export const DEFAULT_FINDING_GROUPS = {
+  // Low native-conversion-rate gate findings route to the transformer's
+  // native-conversion bucket. Listed first so the message ("native conversion
+  // rate ... below ... minimum") classifies here rather than matching the
+  // generic `native conversion` acceptable-loss text downstream.
+  low_native_conversion: {
+    patterns: [/native_conversion_rate_below_min/i, /native conversion rate .* below/i, /below the .* native (?:conversion )?(?:rate )?minimum/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'native-conversion-parity',
+  },
+  // Editor-side block invalidity routes to the Blocks Engine feature/visual
+  // parity bucket and must gate. Listed first so the `editor_block_invalid`
+  // kind classifies here instead of the structural PHP `invalid_block_content`
+  // group, even though both mention "invalid content".
+  editor_block_invalid: {
+    patterns: [/editor_block_invalid/i, /editor block validation/i, /block-editor-warning/i, /this block contains unexpected or invalid content/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'editor-block-validation-parity',
+  },
+  // Pixel visual-parity mismatches route to a dedicated visual-parity repair
+  // bucket. Listed early so the `visual_parity_mismatch` kind classifies here
+  // rather than falling into a generic group.
+  visual_parity_mismatch: {
+    patterns: [/visual_parity_mismatch/i, /visual parity/i, /pixel (?:diff|mismatch|parity)/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'visual-parity',
+  },
+  button_style_loss: {
+    patterns: [/default gray button/i, /button.*gray/i, /button.*style/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'transformer-style-parity',
+  },
+  broken_svg: {
+    patterns: [/broken svg/i, /svg.*broken/i, /svg.*missing/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'svg-transformer-parity',
+  },
+  dropped_images: {
+    patterns: [/dropped image/i, /missing image/i, /image.*missing/i, /asset.*missing/i],
+    candidate_repo: 'static-site-importer',
+    repair_mode: 'asset-materialization',
+  },
+  invalid_block_content: {
+    patterns: [/unexpected or invalid content/i, /invalid block/i, /block validation/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'block-validation-parity',
+  },
+  runtime_target_gap: {
+    patterns: [/runtime_dependency_target_missing/i, /html_canvas_runtime_fallback/i, /canvas/i, /animation/i, /script target/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'runtime-dom-target-parity',
+  },
+};
+
+export const ACCEPTABLE_LOSS_CLASSES = new Set([
+  'native_conversion',
+  'editable_approximation',
+  'preserved_runtime_island',
+  // Visual-parity mismatches are capture-only (acceptable) by default; they only
+  // become unacceptable when an explicit gate signal is present. See
+  // `resolveLossAcceptance`. This mirrors the conditional `preserved_runtime_island`.
+  'visual_parity_mismatch',
+]);
+
+export const UNACCEPTABLE_LOSS_CLASSES = new Set([
+  'unsupported_loss',
+  'importer_materialization_bug',
+  'invalid_block_output',
+  'invalid_block_content',
+  'editor_block_invalid',
+  'low_native_conversion',
+  'missing_asset',
+  'missing_output',
+  'fixture_not_run',
+  'fixture_failed',
+]);
+
+// Loss classes whose acceptability is conditional rather than automatic.
+// `preserved_runtime_island` only earns an acceptable verdict when the finding
+// carries an explicit signal that the interactive runtime/behavior was actually
+// carried or mapped into the WordPress site. "Markup preserved, behavior dead"
+// is a feature-parity failure, not an acceptable loss.
+export const RUNTIME_CARRIED_SIGNAL_KEYS = [
+  'runtime_carried',
+  'runtimeCarried',
+  'runtime_mapped',
+  'runtimeMapped',
+  'runtime_mapping',
+  'runtimeMapping',
+];
+
+// Canonical fixture-class vocabulary. A per-fixture `fixture.json` manifest is the
+// SOLE source of truth for a fixture's class — see the manifest schema below. The
+// manifest's `class` MUST be one of these values verbatim; anything else (or a
+// missing manifest) resolves to `unknown` with a loud warning rather than a
+// guess. Keep this vocabulary stable: fixtures (owned by blocks-engine) author
+// manifests against exactly these strings.
+export const FIXTURE_CLASSES = [
+  'marketing/static',
+  'docs/blog',
+  'ecommerce/catalog',
+  'app/dashboard',
+  'canvas/webgl/audio/runtime-heavy',
+  'unknown',
+];
+
+// Per-fixture manifest schema (`<fixture-dir>/fixture.json`):
+//
+//   {
+//     "class": "marketing/static",            // REQUIRED. One of FIXTURE_CLASSES, verbatim.
+//     "tags": ["restaurant", "has-form"],     // optional. Free-form string array for lane/tag querying.
+//     "complexity": 1                         // optional. Integer 1-5.
+//   }
+//
+// The manifest is authored in each fixture directory and owned by blocks-engine
+// (the corpus repo). The fixture matrix reads it at load time; class resolution
+// is manifest-only (no heuristic fallback). `tags` and `complexity` are carried
+// through onto each fixture, the per-fixture result, and the result summary so
+// runs can be filtered/queried by lane (class) and tag.
+export const FIXTURE_MANIFEST_FILENAME = 'fixture.json';
+export const FIXTURE_COMPLEXITY_MIN = 1;
+export const FIXTURE_COMPLEXITY_MAX = 5;

--- a/lib/fixture-matrix/shared/utils.mjs
+++ b/lib/fixture-matrix/shared/utils.mjs
@@ -1,0 +1,217 @@
+// Generic, domain-agnostic helpers for the Static Site Importer fixture matrix.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242). Pure utilities only — no behavior.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD } from './constants.mjs';
+
+export function pushUnique(values, value, limit) {
+  if (!value || values.includes(value) || values.length >= limit) {
+    return;
+  }
+  values.push(value);
+}
+
+export function countBy(values, keyCallback) {
+  return values.reduce((counts, value) => {
+    const key = keyCallback(value);
+    counts[key] = (counts[key] || 0) + 1;
+    return counts;
+  }, {});
+}
+
+export function clampRatio(value) {
+  if (!Number.isFinite(value) || value < 0) {
+    return DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD;
+  }
+  return value > 1 ? 1 : value;
+}
+
+export function qualityRatio(part, total) {
+  return total > 0 ? Number((numberValue(part) / total).toFixed(4)) : null;
+}
+
+export function isTruthySignal(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return !['', 'false', '0', 'no', 'none', 'null', 'undefined'].includes(normalized);
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value !== 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === 'object') {
+    return Object.keys(value).length > 0;
+  }
+  return Boolean(value);
+}
+
+export function fileType(filePath) {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === '.html' || extension === '.htm') return 'text/html';
+  if (extension === '.css') return 'text/css';
+  if (extension === '.js' || extension === '.mjs') return 'application/javascript';
+  if (extension === '.svg') return 'image/svg+xml';
+  if (extension === '.png') return 'image/png';
+  if (extension === '.jpg' || extension === '.jpeg') return 'image/jpeg';
+  if (extension === '.webp') return 'image/webp';
+  return 'application/octet-stream';
+}
+
+export function isImagePath(filePath) {
+  return /\.(png|jpe?g|gif|webp|svg)$/i.test(filePath);
+}
+
+export function isTextPayloadType(type) {
+  return typeof type === 'string' && (type.startsWith('text/') || type === 'application/javascript' || type === 'application/json' || type === 'image/svg+xml');
+}
+
+export function normalizeArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === undefined || value === null || value === '') return [];
+  return [value];
+}
+
+export function mergeObjects(values) {
+  return values.reduce((merged, value) => deepMerge(merged, value && typeof value === 'object' && !Array.isArray(value) ? value : {}), {});
+}
+
+export function deepMerge(left, right) {
+  const output = { ...left };
+  for (const [key, value] of Object.entries(right)) {
+    if (Array.isArray(value)) {
+      output[key] = [...normalizeArray(output[key]), ...value];
+    } else if (value && typeof value === 'object' && !Array.isArray(value) && output[key] && typeof output[key] === 'object' && !Array.isArray(output[key])) {
+      output[key] = deepMerge(output[key], value);
+    } else if (value !== undefined && value !== null && value !== '') {
+      output[key] = value;
+    }
+  }
+  return output;
+}
+
+export function compactObject(value) {
+  return Object.fromEntries(Object.entries(value || {}).filter(([, item]) => item !== undefined && item !== null && item !== ''));
+}
+
+export function objectValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+export function numberValue(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+export function firstNumber(values) {
+  for (const value of values) {
+    if (value === undefined || value === null || value === '') {
+      continue;
+    }
+    const number = Number(value);
+    if (Number.isFinite(number)) {
+      return number;
+    }
+  }
+  return NaN;
+}
+
+export function firstString(values) {
+  return values.map((value) => String(value || '').trim()).find(Boolean) || '';
+}
+
+export function diagnosticMessage(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return value?.message || value?.reason || value?.detail || value?.path || value?.target || value?.selector || '';
+}
+
+export function readJsonFileIfExists(filePath) {
+  if (!filePath || !fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    return {
+      status: 'failed',
+      error: `Unable to parse JSON artifact ${filePath}: ${error.message}`,
+      artifact_refs: [artifactRef('unparseable-json', filePath, 'diagnostic')],
+    };
+  }
+}
+
+export function parseJsonPayloadsFromText(text) {
+  if (typeof text !== 'string' || !text.trim()) {
+    return [];
+  }
+  const payloads = [];
+  const trimmed = text.trim();
+  const candidates = new Set([trimmed, ...text.split(/\r?\n/).map((line) => line.trim())]);
+  const firstObject = trimmed.indexOf('{');
+  const lastObject = trimmed.lastIndexOf('}');
+  if (firstObject >= 0 && lastObject > firstObject) {
+    candidates.add(trimmed.slice(firstObject, lastObject + 1));
+  }
+  for (const candidate of candidates) {
+    if (!candidate || !candidate.startsWith('{')) continue;
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        payloads.push(parsed);
+      }
+    } catch {
+      // WP-CLI output may mix human text and JSON; non-JSON lines are ignored.
+    }
+  }
+  return payloads;
+}
+
+export function requiredString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new TypeError(`${name} must be a non-empty string.`);
+  }
+  return value;
+}
+
+export function requiredDirectory(value, name) {
+  const directory = requiredString(value, name);
+  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+    throw new Error(`${name} must be an existing directory: ${directory}`);
+  }
+  return path.resolve(directory);
+}
+
+export function finiteNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+export function writeJsonFile(filePath, payload) {
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+export function artifactRef(artifact_id, filePath, kind) {
+  return { schema: 'homeboy/artifact-ref/v1', artifact_id, kind, path: filePath };
+}
+
+export function slug(value) {
+  return String(value || 'fixture')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'fixture';
+}
+
+export function shellToken(value) {
+  const text = String(value || '');
+  return /^[A-Za-z0-9_./:@=-]+$/.test(text) ? text : `'${text.replace(/'/g, "'\\''")}'`;
+}

--- a/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -1,0 +1,97 @@
+// Editor-validation recipe step for the Static Site Importer fixture matrix.
+//
+// Invokes the real `wp.blocks.validateBlock` editor-validation command
+// (`wordpress.editor-validate-blocks`, wp-codebox #1597) against each imported
+// fixture's content. This replaces the former `wordpress.editor-canvas-probe`
+// step, which opened an EMPTY `post-new.php` and therefore never validated
+// imported markup — it only reported whether the blank editor rendered any
+// invalid-block DOM warnings (always none).
+//
+// The command accepts `content`/`content-file` to validate inline/file markup,
+// or `target`/`post-id`/`url` to open a post. The matrix prefers the most
+// concrete imported-content target a fixture carries, in priority order:
+//   1. inline `content` (the imported post_content), if present;
+//   2. a `content-file` path;
+//   3. the imported `post-id`;
+//   4. an explicit editor `url` (e.g. `post.php?post=<id>&action=edit`);
+//   5. an explicit `target`;
+//   6. otherwise `target=front-page` (the default).
+//
+// IMPORTED-CONTENT TARGETING: the imported front page's post id is not known when
+// the recipe is built (the import runs later, inside the sandbox), so the default
+// resolves at runtime. SSI's `validate-artifact` import materializes the
+// fixture's pages and sets `page_on_front` to the imported home page; wp-codebox's
+// `editorOpenTargetFromArgs` + `resolveEditorOpenTarget` turn `target=front-page`
+// into `post.php?post=<page_on_front>&action=edit` by querying the running
+// WordPress, so the command validates the REAL imported front page's blocks.
+// (Previously the default emitted a bare `post-type`, which wp-codebox resolved to
+// an EMPTY `post-new.php?post_type=<type>` editor — `total_blocks: 0`, proving
+// nothing about imported markup. This is the wiring that closed that gap.)
+//
+// `wait-selector`/`wait-timeout` are forwarded when provided. The per-block
+// `{ name, isValid, issues }` results are read back out by
+// `collectEditorValidationDiagnostics` / `collectEditorValidation`.
+
+import {
+  EDITOR_VALIDATE_BLOCKS_COMMAND,
+  DEFAULT_EDITOR_VALIDATION_TARGET,
+} from '../shared/constants.mjs';
+
+function present(value) {
+  return value !== undefined && value !== null && String(value).trim() !== '';
+}
+
+export function editorBlockValidationStep(input = {}) {
+  const fixture = input.fixture || {};
+
+  const content = firstPresent([input.content, fixture.editor_content, fixture.editorContent, fixture.post_content, fixture.postContent, fixture.content]);
+  const contentFile = firstPresent([input.contentFile, input.content_file, fixture.editor_content_file, fixture.editorContentFile, fixture.content_file]);
+  const postId = firstPresent([input.postId, input.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
+  const url = firstPresent([input.url, input.editorValidationUrl, input.editor_validation_url, fixture.editor_url, fixture.editorUrl]);
+  const target = firstPresent([input.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
+
+  const args = [];
+  if (content !== undefined) {
+    args.push(`content=${content}`);
+  } else if (contentFile !== undefined) {
+    args.push(`content-file=${contentFile}`);
+  } else if (postId !== undefined) {
+    args.push(`post-id=${postId}`);
+  } else if (url !== undefined) {
+    args.push(`url=${url}`);
+  } else if (target !== undefined) {
+    args.push(`target=${target}`);
+  } else {
+    // Default to the site's static front page. SSI's import (`validate-artifact`)
+    // materializes the fixture's pages and points `page_on_front` at the imported
+    // home page, so `target=front-page` lets wp-codebox resolve that exact post id
+    // at runtime and open `post.php?post=<page_on_front>&action=edit`. That
+    // validates the REAL imported front page's blocks — not the empty
+    // `post-new.php?post_type=<type>` editor a bare `post-type` arg opens
+    // (total_blocks: 0, proving nothing about imported markup).
+    args.push(`target=${DEFAULT_EDITOR_VALIDATION_TARGET}`);
+  }
+
+  const waitSelector = firstPresent([input.waitSelector, input.wait_selector, fixture.editor_wait_selector, fixture.editorWaitSelector]);
+  if (waitSelector !== undefined) {
+    args.push(`wait-selector=${waitSelector}`);
+  }
+  const waitTimeout = firstPresent([input.waitTimeout, input.wait_timeout, fixture.editor_wait_timeout, fixture.editorWaitTimeout]);
+  if (waitTimeout !== undefined) {
+    args.push(`wait-timeout=${waitTimeout}`);
+  }
+
+  return {
+    command: EDITOR_VALIDATE_BLOCKS_COMMAND,
+    args,
+  };
+}
+
+function firstPresent(values) {
+  for (const value of values) {
+    if (present(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/lib/fixture-matrix/steps/live-wp-parity-step.mjs
+++ b/lib/fixture-matrix/steps/live-wp-parity-step.mjs
@@ -1,0 +1,71 @@
+// Live-WP parity capture step for the Static Site Importer fixture matrix.
+//
+// Companion to the render-free static-parity gate (blocks-engine php-transformer
+// `composer static-parity`), which is the PRIMARY parity signal but never
+// exercises WordPress's own block rendering + global-styles layer. This OPTIONAL
+// step (off by default) captures the imported candidate's RENDERED DOM HTML from a
+// real WordPress render so the same deterministic comparator can be run against
+// real WP output via blocks-engine `composer live-wp-parity`.
+//
+// It composes the EXISTING `wordpress.capture-html` command (Playwright
+// `page.content()` — the serialized rendered DOM, NOT a screenshot) so there is no
+// rasterization and no OOM risk. External requests are blocked (`network-policy=block`)
+// so the captured DOM is self-contained and deterministic: same import + same
+// render -> byte-identical snapshot.html -> byte-identical comparator report.
+//
+// The captured `files/browser/snapshot.html` artifact is fed host-side to the
+// blocks-engine live-wp-parity runner by `runLiveWpParity`
+// (see ../collectors/live-wp-parity.mjs), which surfaces the live-WP parity score
+// and per-property diff alongside the render-free proxy score.
+
+import {
+  DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
+  DEFAULT_VISUAL_PARITY_WAIT_FOR,
+} from '../shared/constants.mjs';
+import { isTruthySignal } from '../shared/utils.mjs';
+
+// Compose `wordpress.capture-html` for a fixture's imported candidate front page.
+// The candidate URL resolution mirrors the visual-parity step: it defaults to `/`,
+// which resolves to THIS fixture's imported front page (`page_on_front`) at capture
+// time because each import step activates with `activate=true` and the recipe
+// interleaves import -> capture per fixture. Per-fixture overrides are honored.
+export function liveWpParityCaptureStep(input = {}) {
+  const fixture = input.fixture || {};
+  const options = normalizeLiveWpParityRecipeOptions(input);
+  const candidateUrl = input.candidateUrl
+    || input.candidate_url
+    || fixture.candidate_url
+    || fixture.candidateUrl
+    || options.candidateUrl;
+  return {
+    command: 'wordpress.capture-html',
+    args: [
+      `url=${candidateUrl}`,
+      // DOM HTML only — deterministic, no screenshot, no rasterization.
+      'capture=html',
+      // Block external requests so the captured DOM is self-contained and stable.
+      'network-policy=block',
+      `wait-for=${options.waitFor}`,
+    ],
+  };
+}
+
+export function normalizeLiveWpParityRecipeOptions(input = {}) {
+  return {
+    candidateUrl: input.liveWpParityCandidateUrl
+      || input.live_wp_parity_candidate_url
+      || input.candidateUrl
+      || DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
+    waitFor: input.liveWpParityWaitFor
+      || input.live_wp_parity_wait_for
+      || input.waitFor
+      || DEFAULT_VISUAL_PARITY_WAIT_FOR,
+  };
+}
+
+// The live-WP capture is OPT-IN: the render-free static-parity gate remains the
+// primary, always-on signal, so the heavier real-render capture only runs when a
+// caller explicitly enables it. Default false.
+export function liveWpParityEnabled(input = {}) {
+  return isTruthySignal(input.liveWpParity ?? input.live_wp_parity);
+}

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -1,0 +1,331 @@
+// WP Codebox recipe building (import + editor-validation + visual-parity steps)
+// and fixture-artifact construction for the Static Site Importer fixture matrix.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242).
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  WEBSITE_ARTIFACT_SCHEMA,
+  DEFAULT_ENTRYPOINT,
+  DEFAULT_IMPORTER_SLUG,
+  VISUAL_PARITY_SOURCE_SUBDIR,
+} from '../shared/constants.mjs';
+import {
+  normalizeArray,
+  isImagePath,
+  requiredString,
+  shellToken,
+} from '../shared/utils.mjs';
+import { createFixtureMatrix, normalizeFixture, collectFixtureFiles } from '../fixtures.mjs';
+import { editorBlockValidationStep } from './editor-validation-step.mjs';
+import { visualParityCompareStep, normalizeVisualParityRecipeOptions } from './visual-parity-step.mjs';
+import { liveWpParityCaptureStep, liveWpParityEnabled } from './live-wp-parity-step.mjs';
+
+export function buildFixtureArtifact(fixture, options = {}) {
+  const normalized = normalizeFixture(fixture);
+  const files = collectFixtureFiles(normalized.directory, options);
+  // Encode EVERY file as `content_base64`, byte-for-byte matching the real
+  // product path. The SSI `import-theme` CLI (static-site-importer.php) reads
+  // each source file and emits `'content_base64' => base64_encode( $content )`
+  // unconditionally — there is no plain-`content` branch in the product. The
+  // matrix previously diverged here, base64-encoding only binary payloads and
+  // sending text (CSS/HTML/JS/JSON/SVG) as plain `content`. That divergence hid
+  // a catastrophic transformer bug: inline CSS was dropped only on the base64
+  // path, so a real import shipped an empty `style.css` (unstyled site) while
+  // the matrix's plain-content artifacts passed green. Mirroring the product's
+  // encoding exactly means the gate can never again exercise a payload shape the
+  // product does not actually produce.
+  const artifactFiles = files.map((file) => {
+    const payload = fs.readFileSync(file.absolute_path);
+    return {
+      path: `website/${file.relative_path}`,
+      source_path: file.absolute_path,
+      type: file.type,
+      bytes: file.bytes,
+      content_base64: payload.toString('base64'),
+    };
+  });
+
+  return {
+    schema: WEBSITE_ARTIFACT_SCHEMA,
+    entrypoint: DEFAULT_ENTRYPOINT,
+    entry_path: DEFAULT_ENTRYPOINT,
+    files: artifactFiles,
+    summary: {
+      file_count: artifactFiles.length,
+      entry_path: DEFAULT_ENTRYPOINT,
+      has_css: artifactFiles.some((file) => file.path.endsWith('.css')),
+      has_js: artifactFiles.some((file) => file.path.endsWith('.js')),
+      has_images: artifactFiles.some((file) => isImagePath(file.path)),
+    },
+    source_metadata: {
+      fixture_id: normalized.id,
+      fixture_path: normalized.directory,
+      fixture_entrypoint: normalized.entrypoint,
+      fixture_class: normalized.fixture_class,
+      fixture_tags: normalized.tags,
+      fixture_complexity: normalized.complexity,
+    },
+  };
+}
+
+// Stage a fixture's ORIGINAL static source (index.html + css/js/images) into the
+// matrix artifacts tree so the in-sandbox WordPress origin can serve it for the
+// visual-parity `source-url`. Files land at
+// `<fixtureDirectory>/<VISUAL_PARITY_SOURCE_SUBDIR>/<relative_path>`, preserving
+// each fixture's own relative asset layout so the served page resolves its CSS,
+// JS, and images exactly as the original did. The fixture's `artifact.json`
+// import payload is unchanged; this is a parallel, web-servable copy of the raw
+// source. Returns the list of staged relative paths. Without this, `source-url`
+// points at an unserved path and the visual-compare source capture hangs to the
+// 120s timeout (the #563 visual-parity gap).
+export function stageFixtureSource(fixture, fixtureDirectory, options = {}) {
+  const normalized = normalizeFixture(fixture);
+  const files = collectFixtureFiles(normalized.directory, options);
+  const sourceRoot = path.join(fixtureDirectory, VISUAL_PARITY_SOURCE_SUBDIR);
+  const staged = [];
+  for (const file of files) {
+    const destination = path.join(sourceRoot, file.relative_path);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(file.absolute_path, destination);
+    staged.push(file.relative_path);
+  }
+  return staged;
+}
+
+export function buildFixtureMatrixRecipe(input = {}) {
+  const matrix = input.matrix || createFixtureMatrix(input);
+  const artifactsDirectory = input.artifactsDirectory || input.artifacts_directory || '/artifacts/static-site-importer-fixture-matrix';
+  const playgroundArtifactsDirectory = input.playgroundArtifactsDirectory || input.playground_artifacts_directory;
+  const commandArtifactsDirectory = playgroundArtifactsDirectory || artifactsDirectory;
+  const importer = normalizeStaticSiteImporterPlugin(input);
+  const dependencyOverrideSetup = buildDependencyOverrideSetup(input, importer);
+  const mounts = normalizeArray(input.mounts);
+  const extraPlugins = [importer.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)];
+  const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
+  // Real-content validation options forwarded to the editor-validate-blocks step.
+  // No empty-post default: when nothing concrete is provided, the step targets
+  // `front-page`, which wp-codebox resolves to the imported static front page
+  // (`page_on_front`) at runtime so it validates real imported content.
+  const editorValidationOptions = {
+    url: input.editorValidationUrl || input.editor_validation_url,
+    postType: input.editorValidationPostType || input.editor_validation_post_type,
+    target: input.editorValidationTarget || input.editor_validation_target,
+    waitSelector: input.editorValidationWaitSelector || input.editor_validation_wait_selector,
+    waitTimeout: input.editorValidationWaitTimeout || input.editor_validation_wait_timeout,
+  };
+  const visualParityEnabled = input.visualParity !== false && input.visual_parity !== false;
+  // Keep the visual-parity `source-url` base aligned with where the staged source
+  // is actually served from. The staged source lives in the artifacts dir mounted
+  // into the sandbox at `playgroundArtifactsDirectory`; its WordPress-served web
+  // path is that target with the docroot (`/wordpress`) prefix stripped. When the
+  // operator hasn't pinned an explicit source base url, derive it from the mount
+  // target so a custom uploads path still resolves.
+  const derivedSourceBaseUrl = playgroundArtifactsDirectory
+    ? wordpressServedPath(playgroundArtifactsDirectory)
+    : '';
+  const visualParityRecipeOptions = normalizeVisualParityRecipeOptions({
+    ...(derivedSourceBaseUrl ? { sourceBaseUrl: derivedSourceBaseUrl } : {}),
+    ...input,
+  });
+  // Optional live-WP parity capture: off by default so the render-free static gate
+  // stays the primary, always-on signal. When enabled, append a deterministic
+  // `wordpress.capture-html` step (DOM HTML, external requests blocked, no
+  // screenshot) per fixture; the captured snapshot.html is fed host-side to the
+  // blocks-engine live-wp-parity runner (see collectors/live-wp-parity.mjs).
+  const liveWpParityCaptureEnabled = liveWpParityEnabled(input);
+
+  if (playgroundArtifactsDirectory) {
+    mounts.push({
+      source: artifactsDirectory,
+      target: playgroundArtifactsDirectory,
+      mode: 'readwrite',
+    });
+  }
+
+  return {
+    schema: 'wp-codebox/workspace-recipe/v1',
+    runtime: {
+      wp: input.wordpressVersion || input.wordpress_version || 'latest',
+      blueprint: input.blueprint || {},
+    },
+    inputs: {
+      mounts,
+      extra_plugins: extraPlugins,
+      ...(dependencyOverrideSetup.dependencyOverlays.length
+        ? { dependency_overlays: dependencyOverrideSetup.dependencyOverlays }
+        : {}),
+    },
+    ...(Object.keys(dependencyOverrideSetup.metadata).length
+      ? { metadata: { dependency_overrides: dependencyOverrideSetup.metadata } }
+      : {}),
+    workflow: {
+      steps: [
+        importer.activationStep,
+        ...matrix.fixtures.flatMap((fixture) => [
+          {
+            command: 'wordpress.wp-cli',
+            args: [
+              `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-missing-woocommerce --allow-failure`,
+            ],
+          },
+          ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, ...editorValidationOptions })] : []),
+          ...(visualParityEnabled ? [visualParityCompareStep({ fixture, ...visualParityRecipeOptions })] : []),
+          ...(liveWpParityCaptureEnabled ? [liveWpParityCaptureStep({ fixture, ...input })] : []),
+        ]),
+      ],
+    },
+    artifacts: {
+      directory: artifactsDirectory,
+    },
+  };
+}
+
+function buildDependencyOverrideSetup(input, importer) {
+  const overrides = input.dependencyOverrides || input.dependency_overrides || {};
+  const blocksEnginePhpTransformer = overrides.blocks_engine_php_transformer || overrides.blocksEnginePhpTransformer;
+  const rawPackagePath = blocksEnginePhpTransformer?.path || '';
+  if (!rawPackagePath) {
+    return { dependencyOverlays: [], metadata: {} };
+  }
+
+  const packagePath = path.resolve(rawPackagePath);
+  const packageName = blocksEnginePhpTransformer.package || 'automattic/blocks-engine-php-transformer';
+  if (packageName !== 'automattic/blocks-engine-php-transformer') {
+    throw new Error(`Unsupported SSI dependency override package: ${packageName}`);
+  }
+  const packageComposerFile = path.join(packagePath, 'composer.json');
+  if (!fs.existsSync(packageComposerFile)) {
+    throw new Error(`SSI dependency override package composer.json not found: ${packageComposerFile}`);
+  }
+  const packageComposer = JSON.parse(fs.readFileSync(packageComposerFile, 'utf8'));
+  if (packageComposer?.name !== packageName) {
+    throw new Error(`SSI dependency override path must contain ${packageName}: ${packagePath}`);
+  }
+
+  return {
+    dependencyOverlays: [
+      {
+        kind: 'composer-package',
+        package: packageName,
+        consumer: importer.slug,
+        source: packagePath,
+      },
+    ],
+    metadata: {
+      blocks_engine_php_transformer: {
+        package: packageName,
+        source_path: packagePath,
+        applied_by: 'wp_codebox_dependency_overlay',
+        consumer: importer.slug,
+      },
+    },
+  };
+}
+
+function dependencyOverrideComposerSetupPhp({ pluginPath, packagePath, packageName }) {
+  return `
+if (!defined('STDERR')) {
+    define('STDERR', fopen('php://stderr', 'wb'));
+}
+if (!defined('STDOUT')) {
+    define('STDOUT', fopen('php://stdout', 'wb'));
+}
+$pluginPath = ${phpString(pluginPath)};
+$packagePath = ${phpString(packagePath)};
+$packageName = ${phpString(packageName)};
+$composerFile = $pluginPath . '/composer.json';
+$packageComposerFile = $packagePath . '/composer.json';
+if (!file_exists($composerFile)) {
+    fwrite(STDERR, "Static Site Importer composer.json not found at $composerFile\\n");
+    exit(1);
+}
+if (!file_exists($packageComposerFile)) {
+    fwrite(STDERR, "Dependency override composer.json not found at $packageComposerFile\\n");
+    exit(1);
+}
+$packageComposer = json_decode(file_get_contents($packageComposerFile), true);
+if (!is_array($packageComposer) || ($packageComposer['name'] ?? '') !== $packageName) {
+    fwrite(STDERR, "Dependency override package mismatch at $packageComposerFile\\n");
+    exit(1);
+}
+$composer = json_decode(file_get_contents($composerFile), true);
+if (!is_array($composer)) {
+    fwrite(STDERR, "Static Site Importer composer.json is invalid JSON at $composerFile\\n");
+    exit(1);
+}
+$constraint = $composer['require'][$packageName] ?? '0.1.15';
+$version = preg_match('/^\\^?(\\d+\\.\\d+\\.\\d+)$/', trim((string) $constraint), $matches) ? $matches[1] : '0.1.15';
+$composer['repositories'] = isset($composer['repositories']) && is_array($composer['repositories']) ? $composer['repositories'] : [];
+$composer['repositories']['blocks-engine-php-transformer-dev'] = [
+    'type' => 'path',
+    'url' => $packagePath,
+    'canonical' => true,
+    'options' => [
+        'symlink' => false,
+        'versions' => [ $packageName => $version ],
+    ],
+];
+file_put_contents($composerFile, json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\\n");
+$descriptorSpec = [
+    0 => ['pipe', 'r'],
+    1 => ['pipe', 'w'],
+    2 => ['pipe', 'w'],
+];
+$process = proc_open(['composer', 'update', $packageName, '--with-dependencies', '--no-interaction', '--prefer-source', '--no-progress'], $descriptorSpec, $pipes, $pluginPath);
+if (!is_resource($process)) {
+    fwrite(STDERR, "Failed to start composer for SSI dependency override\\n");
+    exit(1);
+}
+fclose($pipes[0]);
+$stdout = stream_get_contents($pipes[1]);
+$stderr = stream_get_contents($pipes[2]);
+fclose($pipes[1]);
+fclose($pipes[2]);
+$exitCode = proc_close($process);
+if ($exitCode !== 0) {
+    fwrite(STDERR, "SSI dependency override composer update failed with exit $exitCode\\n" . $stderr . $stdout);
+    exit($exitCode ?: 1);
+}
+`;
+}
+
+function phpString(value) {
+  return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function wpCliDoubleQuotedToken(value) {
+  const text = String(value || '');
+  return `"${text.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+// Convert an in-sandbox WordPress filesystem path into its web-served path by
+// stripping the docroot prefix. WP Codebox installs WordPress at `/wordpress`, so
+// `/wordpress/wp-content/uploads/foo` is served at `/wp-content/uploads/foo`. A
+// path already rooted at `/wp-content` (no `/wordpress` prefix) is returned as-is.
+export function wordpressServedPath(filesystemPath, docroot = '/wordpress') {
+  const normalized = `/${String(filesystemPath).replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '')}`;
+  const prefix = `${docroot.replace(/\/+$/, '')}/`;
+  return normalized.startsWith(prefix) ? `/${normalized.slice(prefix.length)}` : normalized;
+}
+
+export function normalizeStaticSiteImporterPlugin(input = {}) {
+  const source = requiredString(input.staticSiteImporterPath || input.static_site_importer_path, 'staticSiteImporterPath');
+  const slugValue = input.staticSiteImporterSlug || input.static_site_importer_slug || DEFAULT_IMPORTER_SLUG;
+  const pluginFile = input.staticSiteImporterPlugin || input.static_site_importer_plugin || `${slugValue}/${slugValue}.php`;
+  return {
+    slug: slugValue,
+    extraPlugin: {
+      source,
+      slug: slugValue,
+      activate: true,
+    },
+    activationStep: {
+      command: 'wordpress.wp-cli',
+      args: [`command=plugin activate ${pluginFile}`],
+    },
+  };
+}

--- a/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -1,0 +1,96 @@
+// Visual-parity recipe step (#538) for the Static Site Importer fixture matrix.
+//
+// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
+// of the matrix modularization (Refs #242).
+//
+// PRIMARY PARITY SIGNAL: the deterministic, render-free static style parity gate
+// (blocks-engine php-transformer `composer static-parity`) is the primary parity
+// signal — same inputs yield a byte-identical 0..1 score plus a per-element /
+// per-property diff, with no rasterization, no dimension-sensitivity, and no OOM.
+// This full-page pixelmatch step is DEMOTED to optional visual EVIDENCE: it is
+// non-gating by default (see findings.mjs `resolveLossAcceptance`) and now also
+// captures a bounded viewport by default rather than a full-page screenshot,
+// because unbounded full-page capture OOM'd on tall (~6000px) pages. Full-page
+// capture remains available per-fixture via an explicit `full_page`/`fullPage`
+// opt-in.
+
+import {
+  DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD,
+  DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
+  DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL,
+  DEFAULT_VISUAL_PARITY_VIEWPORT,
+  DEFAULT_VISUAL_PARITY_WAIT_FOR,
+  VISUAL_PARITY_SOURCE_SUBDIR,
+} from '../shared/constants.mjs';
+import { objectValue, finiteNumber, isTruthySignal } from '../shared/utils.mjs';
+
+// Compose the existing `wordpress.visual-compare` recipe command into a
+// per-fixture visual-parity step. This is the same command the reusable
+// `runVisualParityWorkload` helper composes in homeboy-extensions; the matrix
+// emits it inline alongside the import/editor steps rather than spinning up a
+// separate sandbox. It renders the fixture's static source vs the imported
+// WordPress candidate and writes `source.png`/`candidate.png`/`diff.png` plus
+// the `mismatch_pixels`/`total_pixels` comparison that
+// `collectVisualParityDiagnostics` reads back out.
+//
+// SOURCE URL: the raw fixture source is staged into the matrix artifacts tree at
+// `<fixture-id>/<VISUAL_PARITY_SOURCE_SUBDIR>/...` (see `stageFixtureSource`),
+// and that tree is mounted into the sandbox at the WordPress uploads path, so the
+// default `source-url` resolves to `<base>/<fixture-id>/source/<entry>` served by
+// the SAME in-sandbox WordPress origin as the candidate. The previous default
+// pointed at an unstaged path, so source capture hung to the 120s timeout.
+//
+// CANDIDATE URL: defaults to `/`, which (because each fixture's import step runs
+// with activate=true → `page_on_front` set, and the recipe interleaves import →
+// visual-compare per fixture) resolves to THIS fixture's imported front page at
+// capture time — the real imported WordPress output. Both URLs accept per-fixture
+// overrides (`source_url`/`candidate_url` on the fixture, or `sourceUrl`/
+// `candidateUrl` on the step input) to target a specific staged page or imported
+// permalink.
+export function visualParityCompareStep(input = {}) {
+  const fixture = input.fixture || {};
+  const options = normalizeVisualParityRecipeOptions(input);
+  const sourceEntry = `${VISUAL_PARITY_SOURCE_SUBDIR}/${String(options.sourceEntry).replace(/^\/+/, '')}`;
+  const sourceUrl = input.sourceUrl
+    || input.source_url
+    || fixture.source_url
+    || fixture.sourceUrl
+    || `${options.sourceBaseUrl.replace(/\/+$/, '')}/${fixture.id || 'fixture'}/${sourceEntry}`;
+  const candidateUrl = input.candidateUrl
+    || input.candidate_url
+    || fixture.candidate_url
+    || fixture.candidateUrl
+    || options.candidateUrl;
+  return {
+    command: 'wordpress.visual-compare',
+    args: [
+      `source-url=${sourceUrl}`,
+      `candidate-url=${candidateUrl}`,
+      `source-label=${fixture.id ? `${fixture.id}-source` : 'source'}`,
+      `candidate-label=${fixture.id ? `${fixture.id}-candidate` : 'candidate'}`,
+      `viewport=${options.viewport.width}x${options.viewport.height}`,
+      `full-page=${options.fullPage ? 'true' : 'false'}`,
+      `wait-for=${options.waitFor}`,
+      `threshold=${options.pixelThreshold}`,
+    ],
+  };
+}
+
+export function normalizeVisualParityRecipeOptions(input = {}) {
+  const viewport = objectValue(input.visualParityViewport || input.visual_parity_viewport || input.viewport);
+  return {
+    pixelThreshold: finiteNumber(input.pixelThreshold ?? input.pixel_threshold ?? input.visualParityPixelThreshold ?? input.visual_parity_pixel_threshold, DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD),
+    candidateUrl: input.visualParityCandidateUrl || input.visual_parity_candidate_url || input.candidateUrl || DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
+    sourceBaseUrl: input.visualParitySourceBaseUrl || input.visual_parity_source_base_url || input.sourceBaseUrl || DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL,
+    sourceEntry: input.visualParitySourceEntry || input.visual_parity_source_entry || input.sourceEntry || 'index.html',
+    viewport: {
+      width: finiteNumber(viewport.width, DEFAULT_VISUAL_PARITY_VIEWPORT.width),
+      height: finiteNumber(viewport.height, DEFAULT_VISUAL_PARITY_VIEWPORT.height),
+    },
+    // Demoted to optional evidence: full-page capture is opt-in (default false)
+    // so the OOM-prone unbounded screenshot is never the default. Any truthy
+    // `full_page`/`fullPage`/`visual_parity_full_page` re-enables it per fixture.
+    fullPage: isTruthySignal(input.visualParityFullPage ?? input.visual_parity_full_page ?? input.fullPage),
+    waitFor: input.visualParityWaitFor || input.visual_parity_wait_for || input.waitFor || DEFAULT_VISUAL_PARITY_WAIT_FOR,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "static-site-importer",
   "private": true,
   "scripts": {
+    "test:fixture-matrix": "node --test tools/fixture-matrix.test.mjs",
     "test:js-block-validation": "node tests/smoke-generated-theme-block-validation.cjs",
     "test:validation": "node tests/run-validation-harness.cjs"
   },

--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -1,0 +1,65 @@
+{
+  "id": "static-site-importer-fixture-matrix",
+  "description": "Static Site Importer fixture matrix workload that composes upstream WP Codebox recipe contracts while keeping SSI-specific fixture and diagnostic policy in the product repo.",
+  "components": {
+    "static-site-importer": {
+      "component_id": "static-site-importer",
+      "default_ref": "origin/main",
+      "path_setting": "HOMEBOY_RIG_COMPONENT_PATH__STATIC_SITE_IMPORTER_FIXTURE_MATRIX__STATIC_SITE_IMPORTER",
+      "branch": "main"
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "static-site-importer-fixture-matrix:${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.static-site-importer.path}",
+      "/tmp/static-site-importer-fixture-matrix-${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}"
+    ]
+  },
+  "bench": {
+    "default_component": "static-site-importer",
+    "iterations": 1,
+    "warmup_iterations": 0,
+    "result_gates": {
+      "failed_fixture_count": { "lte": 0 }
+    }
+  },
+  "bench_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/static-site-fixture-matrix.bench.mjs",
+        "env_provider_extensions": ["wordpress"]
+      }
+    ]
+  },
+  "bench_profiles": {
+    "smoke": ["static-site-fixture-matrix"],
+    "fixture-matrix": ["static-site-fixture-matrix"]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "Static Site Importer checkout exists",
+        "file": "${components.static-site-importer.path}/static-site-importer.php",
+        "component": "static-site-importer",
+        "component_path_contains": "static-site-importer",
+        "remediation": "Pass homeboy bench --path /path/to/static-site-importer or update components.static-site-importer.path before running static-site-importer-fixture-matrix."
+      },
+      {
+        "kind": "command",
+        "label": "Fixture matrix workload validates",
+        "command": "node \"${package.root}/tools/fixture-matrix.test.mjs\""
+      }
+    ],
+    "down": [
+      {
+        "kind": "command",
+        "label": "Remove run-scoped SSI fixture matrix temp resources",
+        "command": "test -n \"${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}\" && rm -rf \"/tmp/static-site-importer-fixture-matrix-${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}\" || true"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/fixture-matrix/simple-site/fixture.json
+++ b/tests/fixtures/fixture-matrix/simple-site/fixture.json
@@ -1,0 +1,5 @@
+{
+  "class": "marketing/static",
+  "tags": ["landing", "static"],
+  "complexity": 1
+}

--- a/tests/fixtures/fixture-matrix/simple-site/index.html
+++ b/tests/fixtures/fixture-matrix/simple-site/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Simple SSI Fixture</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="site-shell">
+    <h1>Simple SSI Fixture</h1>
+    <p>This fixture proves matrix discovery and artifact packing without running a browser.</p>
+    <a class="button" href="/contact/">Contact</a>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/fixture-matrix/simple-site/style.css
+++ b/tests/fixtures/fixture-matrix/simple-site/style.css
@@ -1,0 +1,14 @@
+.site-shell {
+  font-family: system-ui, sans-serif;
+  margin: 4rem auto;
+  max-width: 42rem;
+}
+
+.button {
+  background: #14532d;
+  border-radius: 999px;
+  color: #fff;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+}

--- a/tools/artifact-intake.mjs
+++ b/tools/artifact-intake.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
+
+const options = parseArgs(process.argv.slice(2));
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const result = materializeGeneratedArtifactFixtures(options);
+if (options.manifest) {
+  fs.writeFileSync(options.manifest, `${JSON.stringify(result, null, 2)}\n`);
+}
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      const [rawKey, rawValue] = arg.slice(2).split('=');
+      const value = rawValue === undefined ? args[index + 1] : rawValue;
+      if (rawValue === undefined) {
+        index += 1;
+      }
+      options[camelCase(rawKey)] = value;
+      continue;
+    }
+    if (!options.artifactRoot) {
+      options.artifactRoot = arg;
+    } else if (!options.fixtureRoot) {
+      options.fixtureRoot = arg;
+    }
+  }
+  return options;
+}
+
+function camelCase(value) {
+  return value.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node tools/artifact-intake.mjs --artifact-root <dir> --fixture-root <dir> [--manifest <file>]\n\nMaterializes generated static-site artifacts into SSI fixture-matrix directories.\n`);
+}

--- a/tools/compare-finding-packets.mjs
+++ b/tools/compare-finding-packets.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_TOP = 15;
+const DIMENSIONS = [
+  ['bucket', 'bucket'],
+  ['group_key', 'group_key'],
+  ['kind', 'kind'],
+  ['fixture_id', 'fixture_id'],
+  ['candidate_repo', 'candidate_repo'],
+  ['selector_family', 'selector_family'],
+];
+
+const isCli = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isCli) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+    } else {
+      const summary = compareFindingPacketFiles(options);
+      process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    }
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+export function compareFindingPacketFiles(options = {}) {
+  const baseFile = requiredString(options.base, '--base');
+  const candidateFile = requiredString(options.candidate, '--candidate');
+  return compareFindingPackets({
+    base: readJsonFile(baseFile),
+    candidate: readJsonFile(candidateFile),
+    base_label: options.baseLabel || options.base_label || path.basename(baseFile),
+    candidate_label: options.candidateLabel || options.candidate_label || path.basename(candidateFile),
+    top: options.top,
+  });
+}
+
+export function compareFindingPackets(input = {}) {
+  const top = positiveInteger(input.top, DEFAULT_TOP);
+  const baseFindings = normalizeFindingPackets(input.base);
+  const candidateFindings = normalizeFindingPackets(input.candidate);
+  const dimensions = Object.fromEntries(DIMENSIONS.map(([key, field]) => [
+    key,
+    topDeltas(countBy(baseFindings, field), countBy(candidateFindings, field), top),
+  ]));
+
+  return {
+    schema: 'static-site-importer/finding-packet-comparison/v1',
+    base_label: input.base_label || input.baseLabel || 'base',
+    candidate_label: input.candidate_label || input.candidateLabel || 'candidate',
+    top,
+    totals: {
+      base: baseFindings.length,
+      candidate: candidateFindings.length,
+      delta: candidateFindings.length - baseFindings.length,
+    },
+    dimensions,
+  };
+}
+
+export function normalizeFindingPackets(input) {
+  const findings = unwrapFindings(input);
+  return findings.map((finding) => normalizeFinding(finding));
+}
+
+export function selectorFamily(selector) {
+  const value = String(selector || '').trim();
+  if (!value) {
+    return '(none)';
+  }
+
+  const firstToken = value.split(/\s+|\s*[>+~]\s*/).find(Boolean) || value;
+  if (firstToken.startsWith('#')) {
+    return `id:${firstToken.slice(1).split(/[:.#[\]]/)[0] || '(unknown)'}`;
+  }
+  if (firstToken.startsWith('.')) {
+    return `class:${firstToken.slice(1).split(/[:.#[\]]/)[0] || '(unknown)'}`;
+  }
+  if (firstToken.startsWith('[')) {
+    return `attr:${firstToken.slice(1).split(/[=\]]/)[0] || '(unknown)'}`;
+  }
+
+  return firstToken.split(/[:.#[\]]/)[0] || firstToken;
+}
+
+function normalizeFinding(finding) {
+  const raw = finding && typeof finding === 'object' ? finding : { reason: String(finding || '') };
+  const rawPayload = raw.raw && typeof raw.raw === 'object' ? raw.raw : {};
+  const groupKey = stringValue(raw.group_key || rawPayload.group_key || raw.category || rawPayload.category, '(missing)');
+  const bucket = stringValue(raw.repair_bucket || rawPayload.repair_bucket || groupKey, '(missing)');
+  const selector = stringValue(raw.selector || rawPayload.selector, '');
+  return {
+    bucket,
+    group_key: groupKey,
+    kind: stringValue(raw.kind || raw.code || raw.type || rawPayload.kind || rawPayload.code || rawPayload.type, '(missing)'),
+    fixture_id: stringValue(raw.fixture_id || rawPayload.fixture_id || raw.fixture || rawPayload.fixture, '(missing)'),
+    candidate_repo: stringValue(raw.candidate_repo || rawPayload.candidate_repo || raw.owner || rawPayload.owner, '(missing)'),
+    selector,
+    selector_family: selectorFamily(selector),
+  };
+}
+
+function unwrapFindings(input) {
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (!input || typeof input !== 'object') {
+    return [];
+  }
+  if (Array.isArray(input.findings)) {
+    return input.findings;
+  }
+  if (Array.isArray(input.packets)) {
+    return input.packets;
+  }
+  if (Array.isArray(input.fanout_groups)) {
+    return input.fanout_groups.flatMap((group) => Array.isArray(group.findings) ? group.findings : []);
+  }
+  return [];
+}
+
+function countBy(findings, field) {
+  const counts = new Map();
+  for (const finding of findings) {
+    const key = finding[field] || '(missing)';
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  return counts;
+}
+
+function topDeltas(baseCounts, candidateCounts, top) {
+  const keys = new Set([...baseCounts.keys(), ...candidateCounts.keys()]);
+  return [...keys].map((key) => {
+    const base = baseCounts.get(key) || 0;
+    const candidate = candidateCounts.get(key) || 0;
+    return { key, base, candidate, delta: candidate - base };
+  })
+    .filter((row) => row.delta !== 0)
+    .sort((left, right) => Math.abs(right.delta) - Math.abs(left.delta) || right.delta - left.delta || left.key.localeCompare(right.key))
+    .slice(0, top);
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      const [rawKey, rawValue] = arg.slice(2).split('=');
+      const value = rawValue === undefined ? args[index + 1] : rawValue;
+      if (rawValue === undefined) {
+        index += 1;
+      }
+      options[camelCase(rawKey)] = value;
+      continue;
+    }
+    if (!options.base) {
+      options.base = arg;
+    } else if (!options.candidate) {
+      options.candidate = arg;
+    }
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Compare finding-packet JSON artifacts and summarize count deltas.\n\nUsage:\n  node tools/compare-finding-packets.mjs --base base.json --candidate candidate.json [--top 20]\n\nOptions:\n  --base <file>             Baseline finding-packets JSON file.\n  --candidate <file>        Candidate finding-packets JSON file.\n  --base-label <label>      Label for the baseline run.\n  --candidate-label <label> Label for the candidate run.\n  --top <count>             Number of rows per dimension. Default: ${DEFAULT_TOP}.\n`);
+}
+
+function readJsonFile(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function requiredString(value, label) {
+  if (!value || typeof value !== 'string') {
+    throw new Error(`Missing required ${label}. Run with --help for usage.`);
+  }
+  return value;
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function stringValue(value, fallback) {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  return String(value);
+}
+
+function camelCase(value) {
+  return value.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1,0 +1,2997 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import runFixtureMatrixBench, {
+  boundedConcurrency,
+  composerPathRepositoryConfig,
+  fixtureMatrixBatchRunSummary,
+  mapWithConcurrency,
+  resolveBlocksEnginePhpTransformerPath,
+  runFixtureMatrix,
+} from '../bench/static-site-fixture-matrix.bench.mjs';
+import {
+  buildCodeFreshness,
+  buildFixtureMatrixRunPlan,
+  CANONICAL_FIXTURE_COUNT,
+  resolvePathFreshness,
+  summarizeBenchRun,
+  summarizeRun,
+} from './run-fixture-matrix.mjs';
+import {
+  compareFindingPackets,
+  selectorFamily,
+} from './compare-finding-packets.mjs';
+import {
+  buildFixtureMatrixRecipe,
+  classifyFixture,
+  classifyStaticSiteFinding,
+  collectBlockComposition,
+  collectEditorValidationDiagnostics,
+  collectEditorValidation,
+  collectFixtureMatrixRunResults,
+  computeFixtureEditorQuality,
+  parseSerializedBlockNames,
+  collectVisualParityDiagnostics,
+  liveWpParityCaptureStep,
+  liveWpParityEnabled,
+  runLiveWpParity,
+  normalizeLiveWpParityReport,
+  buildFixtureArtifact,
+  createFixtureMatrix,
+  editorBlockValidationStep,
+  EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
+  EDITOR_VALIDATE_BLOCKS_COMMAND,
+  EDITOR_VALIDATION_METHOD,
+  normalizeFixtureMatrixResult,
+  normalizeLossClass,
+  stageFixtureSource,
+  VISUAL_PARITY_MISMATCH_KIND,
+  visualParityCompareStep,
+  wordpressServedPath,
+  writeFixtureMatrixArtifacts,
+} from '../lib/fixture-matrix.mjs';
+import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
+
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const fixtureRoot = path.join(packageRoot, 'tests', 'fixtures', 'fixture-matrix');
+
+test('discovers SSI fixtures and writes Blocks Engine site artifacts', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-matrix-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'test-matrix' });
+  const written = writeFixtureMatrixArtifacts({ outputDirectory, matrix });
+  const artifact = JSON.parse(readFileSync(path.join(outputDirectory, 'simple-site', 'artifact.json'), 'utf8'));
+
+  assert.equal(matrix.schema, 'static-site-importer/fixture-matrix/v1');
+  assert.equal(matrix.count, 1);
+  assert.equal(matrix.fixtures[0].id, 'simple-site');
+  assert.equal(artifact.schema, 'blocks-engine/php-transformer/site-artifact/v1');
+  // Files are base64-encoded exactly like the product's `import-theme` CLI, so
+  // hydrate via `content_base64` to read the payload.
+  const indexFile = artifact.files.find((file) => file.path === 'website/index.html');
+  assert.ok(indexFile);
+  assert.ok(Buffer.from(indexFile.content_base64, 'base64').toString('utf8').includes('Simple SSI Fixture'));
+  assert.ok(artifact.files.some((file) => file.path === 'website/style.css'));
+  assert.equal(written.result.summary.generation_status, 'succeeded');
+  assert.equal(written.result.summary.execution_status, 'not_requested');
+  assert.equal(written.result.summary.succeeded, 0);
+  assert.equal(written.result.summary.failed, 0);
+  assert.equal(written.result.summary.not_run, 1);
+  assert.equal(written.result.summary.finding_count, 0);
+  assert.equal(written.result.summary.unacceptable_finding_count, 0);
+  assert.equal(written.result.summary.unacceptable_loss_classes.fixture_not_run, undefined);
+  assert.equal(written.result.findings.some((finding) => finding.loss_class === 'fixture_not_run'), false);
+});
+
+test('execution-requested fixture matrices still fail missing validation results', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'missing-run-result-test' });
+  const result = normalizeFixtureMatrixResult({ matrix, execution_status: 'requested' });
+
+  assert.equal(result.summary.generation_status, 'succeeded');
+  assert.equal(result.summary.execution_status, 'requested');
+  assert.equal(result.summary.succeeded, 0);
+  assert.equal(result.summary.failed, 1);
+  assert.equal(result.summary.not_run, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 1);
+  assert.equal(result.summary.unacceptable_loss_classes.fixture_not_run, 1);
+  assert.equal(result.findings.some((finding) => finding.loss_class === 'fixture_not_run'), true);
+});
+
+test('matrix artifacts use the product base64 encoding for EVERY payload, including text', () => {
+  // Guards the smoke-test-theater regression: the matrix must build artifacts
+  // with the SAME `content_base64` encoding the real SSI `import-theme` CLI
+  // emits (static-site-importer.php base64-encodes every file unconditionally).
+  // A plain-`content` text payload here means the gate is exercising a path the
+  // product never produces — exactly how an empty-style.css bug stayed green.
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'base64-contract' });
+  const artifact = buildFixtureArtifact(matrix.fixtures[0]);
+
+  assert.ok(artifact.files.length >= 2);
+  for (const file of artifact.files) {
+    // Every file carries base64 content and NO plain `content` field, matching
+    // the product contract byte-for-byte.
+    assert.equal(typeof file.content_base64, 'string', `${file.path} must be base64-encoded`);
+    assert.equal(file.content, undefined, `${file.path} must not use a plain content field`);
+  }
+
+  // The text CSS payload (the exact class that hid the dropped-inline-CSS bug)
+  // round-trips through base64 to its real bytes.
+  const cssFile = artifact.files.find((file) => file.path === 'website/style.css');
+  assert.ok(cssFile);
+  assert.equal(cssFile.type, 'text/css');
+  assert.ok(Buffer.from(cssFile.content_base64, 'base64').toString('utf8').includes('.site-shell'));
+});
+
+test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'recipe-test' });
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    playgroundArtifactsDirectory: '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+  });
+
+  assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
+  assert.deepEqual(recipe.inputs.extra_plugins[0], {
+    source: '/tmp/static-site-importer',
+    slug: 'static-site-importer',
+    activate: true,
+  });
+  assert.equal(recipe.workflow.steps[0].command, 'wordpress.wp-cli');
+  assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
+  assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
+  assert.match(recipe.workflow.steps[1].args[0], /--allow-failure/);
+});
+
+test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-recipe-dependency-override-'));
+  const transformerPath = path.join(root, 'blocks-engine', 'php-transformer');
+  mkdirSync(transformerPath, { recursive: true });
+  writeFileSync(path.join(transformerPath, 'composer.json'), JSON.stringify({
+    name: 'automattic/blocks-engine-php-transformer',
+  }));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'recipe-dependency-override-test' });
+
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    dependencyOverrides: {
+      blocks_engine_php_transformer: {
+        package: 'automattic/blocks-engine-php-transformer',
+        path: transformerPath,
+      },
+    },
+  });
+
+  assert.deepEqual(recipe.inputs.dependency_overlays[0], {
+    kind: 'composer-package',
+    package: 'automattic/blocks-engine-php-transformer',
+    consumer: 'static-site-importer',
+    source: transformerPath,
+  });
+  assert.equal(recipe.inputs.mounts.length, 0);
+  assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
+  assert.deepEqual(recipe.metadata.dependency_overrides.blocks_engine_php_transformer, {
+    package: 'automattic/blocks-engine-php-transformer',
+    source_path: transformerPath,
+    applied_by: 'wp_codebox_dependency_overlay',
+    consumer: 'static-site-importer',
+  });
+});
+
+test('fails recipe generation for invalid SSI dependency override paths', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-invalid-dependency-override-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'recipe-invalid-dependency-override-test' });
+
+  assert.throws(() => buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    dependencyOverrides: {
+      blocks_engine_php_transformer: {
+        package: 'automattic/blocks-engine-php-transformer',
+        path: root,
+      },
+    },
+  }), /composer\.json not found/);
+});
+
+test('normalizes SSI diagnostics into product repair groups', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'diagnostic-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          { message: 'Dropped image asset during import' },
+          { message: 'Unexpected or invalid content in imported block' },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.summary.failed, 1);
+  assert.equal(result.summary.groups.dropped_images, 1);
+  assert.equal(result.summary.groups.invalid_block_content, 1);
+  assert.equal(classifyStaticSiteFinding({ message: 'canvas target missing' }).repair_mode, 'runtime-dom-target-parity');
+});
+
+test('gates fixture matrix failures by unacceptable loss classes', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'loss-class-gate-test' });
+  const acceptableResult = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'runtime_dependency_missing_dom_target',
+            loss_class: 'preserved_runtime_island',
+            runtime_carried: true,
+            source_path: 'website/index.html',
+            selector: '#hero canvas',
+            message: 'Runtime island preserved for editor-safe import.',
+          },
+          {
+            kind: 'html_canvas_runtime_fallback',
+            loss_class: 'preserved_runtime_island',
+            runtime_carried: true,
+            source_path: 'website/index.html',
+            selector: '#hero canvas',
+            message: 'Blocks Engine reported the same preserved runtime island.',
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(acceptableResult.summary.succeeded, 1);
+  assert.equal(acceptableResult.summary.failed, 0);
+  assert.equal(acceptableResult.summary.acceptable_finding_count, 1);
+  assert.equal(acceptableResult.summary.unacceptable_finding_count, 0);
+  assert.equal(acceptableResult.summary.preserved_runtime_island_count, 1);
+  assert.equal(acceptableResult.findings.length, 1);
+  assert.equal(acceptableResult.fixtures[0].raw_status, 'failed');
+  assert.equal(acceptableResult.fixtures[0].status, 'passed');
+  assert.equal(acceptableResult.fixtures[0].quality_gate.loss_classes.preserved_runtime_island, 1);
+
+  const unacceptableResult = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+      },
+    ],
+  });
+
+  assert.equal(unacceptableResult.summary.failed, 1);
+  assert.equal(unacceptableResult.summary.unacceptable_finding_count, 1);
+  assert.equal(unacceptableResult.summary.unacceptable_loss_classes.fixture_failed, 1);
+});
+
+test('fails the gate when a preserved_runtime_island carries no runtime-carried signal', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'runtime-island-no-signal-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'html_form_fallback',
+            loss_class: 'preserved_runtime_island',
+            source_path: 'posts/page-contact.post_content',
+            selector: 'form#contact',
+            message: 'Contact form markup preserved but no handler was carried.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const finding = result.findings[0];
+  assert.equal(finding.loss_class, 'preserved_runtime_island');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(finding.acceptable_loss, false);
+  assert.equal(result.summary.preserved_runtime_island_count, 1);
+  assert.equal(result.summary.acceptable_finding_count, 0);
+  assert.equal(result.summary.unacceptable_finding_count, 1);
+  assert.equal(result.summary.failed, 1);
+  assert.equal(result.summary.succeeded, 0);
+  assert.equal(result.fixtures[0].status, 'failed');
+});
+
+test('passes the gate when a preserved_runtime_island carries a runtime-carried signal', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'runtime-island-signal-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'html_form_fallback',
+            loss_class: 'preserved_runtime_island',
+            runtime_mapped: 'wp-block-contact-form',
+            source_path: 'posts/page-contact.post_content',
+            selector: 'form#contact',
+            message: 'Contact form markup preserved and behavior mapped to a native block.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const finding = result.findings[0];
+  assert.equal(finding.loss_class, 'preserved_runtime_island');
+  assert.equal(finding.loss_acceptance, 'acceptable');
+  assert.equal(finding.acceptable_loss, true);
+  assert.equal(result.summary.acceptable_finding_count, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 0);
+  assert.equal(result.summary.succeeded, 1);
+  assert.equal(result.summary.failed, 0);
+  assert.equal(result.fixtures[0].status, 'passed');
+});
+
+test('normalizes the transformer-emitted runtime_island_preserved loss class to the canonical preserved_runtime_island', () => {
+  // The php-transformer emits `runtime_island_preserved` (FallbackDiagnostic /
+  // HtmlTransformer). The alias must deterministically canonicalize it without
+  // relying on the wording regex fallback.
+  assert.equal(normalizeLossClass('runtime_island_preserved'), 'preserved_runtime_island');
+  assert.equal(normalizeLossClass('preserved_runtime_island'), 'preserved_runtime_island');
+  assert.equal(normalizeLossClass('runtime_island'), 'preserved_runtime_island');
+});
+
+test('classifies a transformer runtime_island_preserved finding as acceptable without relying on message wording', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'runtime-island-preserved-alias-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'html_script_fallback',
+            // Exact string emitted by the php-transformer; carries no
+            // "runtime island" wording in kind/message so acceptance must come
+            // from the explicit alias, not the wording regex fallback.
+            loss_class: 'runtime_island_preserved',
+            runtime_carried: true,
+            source_path: 'website/index.html',
+            selector: 'script#app',
+            message: 'Script kept verbatim.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const finding = result.findings[0];
+  assert.equal(finding.loss_class, 'preserved_runtime_island');
+  assert.equal(finding.loss_acceptance, 'acceptable');
+  assert.equal(finding.acceptable_loss, true);
+  assert.equal(result.summary.acceptable_finding_count, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 0);
+  assert.equal(result.summary.preserved_runtime_island_count, 1);
+  assert.equal(result.summary.succeeded, 1);
+  assert.equal(result.summary.failed, 0);
+  assert.equal(result.fixtures[0].status, 'passed');
+});
+
+test('keeps native_conversion findings acceptable without a runtime-carried signal', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'native-conversion-acceptance-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'native_block_conversion',
+            loss_class: 'native_conversion',
+            source_path: 'website/index.html',
+            message: 'Converted natively to editor blocks.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const finding = result.findings[0];
+  assert.equal(finding.loss_class, 'native_conversion');
+  assert.equal(finding.loss_acceptance, 'acceptable');
+  assert.equal(result.summary.acceptable_finding_count, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 0);
+  assert.equal(result.summary.succeeded, 1);
+  assert.equal(result.fixtures[0].status, 'passed');
+});
+
+test('classifies fixtures from the per-fixture manifest as the sole source of truth', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-manifest-'));
+  const shop = path.join(root, 'spring-shop');
+  const shader = path.join(root, 'interactive-demo');
+  mkdirSync(path.join(shop, 'products'), { recursive: true });
+  mkdirSync(path.join(shader, 'assets'), { recursive: true });
+  // The HTML/file content deliberately does NOT match the declared class — the
+  // manifest wins regardless of what a heuristic would have guessed.
+  writeFileSync(path.join(shop, 'index.html'), '<h1>Just a hero</h1>');
+  writeFileSync(path.join(shop, 'products', 'shoe.html'), '<h2>Shoe</h2>');
+  writeFileSync(path.join(shop, 'fixture.json'), JSON.stringify({ class: 'ecommerce/catalog', tags: ['Shop', 'has-cart'], complexity: 3 }));
+  writeFileSync(path.join(shader, 'index.html'), '<h1>Plain marketing copy</h1>');
+  writeFileSync(path.join(shader, 'assets', 'shader.js'), 'document.querySelector("canvas");');
+  writeFileSync(path.join(shader, 'fixture.json'), JSON.stringify({ class: 'canvas/webgl/audio/runtime-heavy', complexity: 9 }));
+
+  const matrix = createFixtureMatrix({ fixture_root: root });
+  const shopFixture = matrix.fixtures.find((fixture) => fixture.id === 'spring-shop');
+  const shaderFixture = matrix.fixtures.find((fixture) => fixture.id === 'interactive-demo');
+
+  // Manifest class wins over anything the heuristic would have inferred.
+  assert.equal(shopFixture.fixture_class, 'ecommerce/catalog');
+  assert.equal(shaderFixture.fixture_class, 'canvas/webgl/audio/runtime-heavy');
+  assert.deepEqual(shopFixture.taxonomy.signals, ['manifest']);
+
+  // Tags and complexity are carried through onto the normalized fixture.
+  assert.deepEqual(shopFixture.tags, ['Shop', 'has-cart']);
+  assert.equal(shopFixture.complexity, 3);
+  // Complexity is clamped into the documented 1-5 range.
+  assert.equal(shaderFixture.complexity, 5);
+  assert.deepEqual(shaderFixture.tags, []);
+
+  // An explicit class injected by tests/runner/result-merge still takes precedence.
+  assert.equal(classifyFixture({ fixture_class: 'docs/blog', directory: shop }).fixture_class, 'docs/blog');
+});
+
+test('falls back to unknown with a loud warning when the manifest is missing or invalid', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-manifest-fallback-'));
+  const missing = path.join(root, 'no-manifest');
+  const invalid = path.join(root, 'bad-class');
+  const broken = path.join(root, 'broken-json');
+  mkdirSync(missing, { recursive: true });
+  mkdirSync(invalid, { recursive: true });
+  mkdirSync(broken, { recursive: true });
+  writeFileSync(path.join(missing, 'index.html'), '<h1>Product Catalog Checkout Cart Shop</h1>');
+  writeFileSync(path.join(invalid, 'index.html'), '<h1>Docs</h1>');
+  writeFileSync(path.join(invalid, 'fixture.json'), JSON.stringify({ class: 'totally-made-up' }));
+  writeFileSync(path.join(broken, 'index.html'), '<h1>Docs</h1>');
+  writeFileSync(path.join(broken, 'fixture.json'), '{ not valid json');
+
+  const warnings = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = (chunk) => { warnings.push(String(chunk)); return true; };
+  let matrix;
+  try {
+    matrix = createFixtureMatrix({ fixture_root: root });
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+  const byId = new Map(matrix.fixtures.map((fixture) => [fixture.id, fixture]));
+
+  // No heuristic guessing — every manifest-less/invalid fixture is unknown.
+  assert.equal(byId.get('no-manifest').fixture_class, 'unknown');
+  assert.deepEqual(byId.get('no-manifest').taxonomy.signals, ['manifest_missing']);
+  assert.equal(byId.get('bad-class').fixture_class, 'unknown');
+  assert.deepEqual(byId.get('bad-class').taxonomy.signals, ['manifest_invalid_class']);
+  assert.equal(byId.get('broken-json').fixture_class, 'unknown');
+
+  // A clear, loud warning naming each offending fixture was emitted.
+  const warningText = warnings.join('');
+  assert.match(warningText, /WARNING:.*no-manifest.*no fixture\.json/s);
+  assert.match(warningText, /WARNING:.*bad-class.*invalid class "totally-made-up"/s);
+  assert.match(warningText, /Failed to parse.*broken-json/s);
+});
+
+test('filters the matrix by manifest class and tag lane', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-filter-'));
+  const cases = [
+    ['landing', { class: 'marketing/static', tags: ['restaurant', 'has-form'] }],
+    ['brochure', { class: 'marketing/static', tags: ['agency'] }],
+    ['storefront', { class: 'ecommerce/catalog', tags: ['restaurant'] }],
+  ];
+  for (const [name, manifest] of cases) {
+    const dir = path.join(root, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'index.html'), `<h1>${name}</h1>`);
+    writeFileSync(path.join(dir, 'fixture.json'), JSON.stringify(manifest));
+  }
+
+  const classLane = createFixtureMatrix({ fixture_root: root, class: 'marketing/static' });
+  assert.deepEqual(classLane.fixtures.map((fixture) => fixture.id).sort(), ['brochure', 'landing']);
+  assert.deepEqual(classLane.filter, { fixture_class: 'marketing/static' });
+
+  const tagLane = createFixtureMatrix({ fixture_root: root, tag: 'restaurant' });
+  assert.deepEqual(tagLane.fixtures.map((fixture) => fixture.id).sort(), ['landing', 'storefront']);
+
+  const combined = createFixtureMatrix({ fixture_root: root, class: 'marketing/static', tag: 'restaurant' });
+  assert.deepEqual(combined.fixtures.map((fixture) => fixture.id), ['landing']);
+});
+
+test('rolls fixture matrix summaries up by fixture class and repair bucket', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-class-rollups-'));
+  const shop = path.join(root, 'shop-catalog');
+  const docs = path.join(root, 'docs-blog');
+  mkdirSync(shop, { recursive: true });
+  mkdirSync(docs, { recursive: true });
+  writeFileSync(path.join(shop, 'index.html'), '<h1>Shop</h1>');
+  writeFileSync(path.join(shop, 'fixture.json'), JSON.stringify({ class: 'ecommerce/catalog' }));
+  writeFileSync(path.join(docs, 'index.html'), '<article>Docs</article>');
+  writeFileSync(path.join(docs, 'fixture.json'), JSON.stringify({ class: 'docs/blog' }));
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'taxonomy-rollup-test' });
+
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'shop-catalog',
+        status: 'failed',
+        diagnostics: [
+          { kind: 'missing_asset', message: 'Missing image asset for product gallery' },
+          { kind: 'invalid_block_content', message: 'Unexpected or invalid content in product card' },
+        ],
+      },
+      {
+        fixture_id: 'docs-blog',
+        status: 'passed',
+      },
+    ],
+  });
+
+  assert.equal(result.fixtures.find((fixture) => fixture.fixture_id === 'shop-catalog').fixture_class, 'ecommerce/catalog');
+  assert.equal(result.findings[0].fixture_class, 'ecommerce/catalog');
+  assert.equal(result.summary.fixture_classes['ecommerce/catalog'], 1);
+  assert.equal(result.summary.classes['ecommerce/catalog'].failed, 1);
+  assert.equal(result.summary.classes['ecommerce/catalog'].repair_buckets.dropped_images, 1);
+  assert.equal(result.summary.classes['ecommerce/catalog'].repair_buckets.invalid_block_content, 1);
+  assert.equal(result.summary.quality_budgets['ecommerce/catalog'].findings_per_fixture, 2);
+  assert.deepEqual(result.summary.quality_budgets['docs/blog'].dominant_repair_buckets, []);
+});
+
+test('aggregates pattern families, fixture exemplars, and diagnostic blind spots', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'diagnostic-rollup-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'runtime_dependency_missing_dom_target',
+            repair_bucket: 'runtime_target_gap',
+            candidate_repo: 'blocks-engine',
+            source_path: 'website/index.html',
+            selector: '#hero canvas',
+            source_html_preview: '<canvas id="hero"></canvas>',
+            emitted_block_preview: '<!-- wp:group -->',
+            message: 'Runtime target #hero canvas is missing after import.',
+          },
+          { message: 'Unclassified import quality issue.' },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.summary.top_pattern_families[0].key, 'runtime_target_gap:runtime_dependency_missing_dom_target:id:hero');
+  assert.equal(result.summary.fixture_exemplars[0].fixture_id, 'simple-site');
+  assert.equal(result.summary.fixture_exemplars[0].source_snippet, '<canvas id="hero"></canvas>');
+  assert.equal(result.fanout_groups[0].count, 1);
+  assert.ok(result.summary.diagnostic_blind_spots.some((spot) => spot.kind === 'generic_finding_family'));
+});
+
+test('suppresses count-only fixture diagnostics from actionable fanout rollups', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'count-only-diagnostic-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          2,
+          {
+            kind: 'core_html_block',
+            repair_bucket: 'fallback_block',
+            selector: 'input#email',
+            source_path: 'posts/page-contact.post_content',
+            message: 'generated_document_contains_core_html',
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.summary.finding_count, 2);
+  assert.equal(result.summary.actionable_finding_count, 1);
+  assert.equal(result.summary.non_actionable_finding_count, 1);
+  assert.equal(result.findings.find((finding) => finding.kind === 'static_site_fixture_diagnostic').actionability, 'count_only');
+  assert.equal(result.summary.top_pattern_families[0].key, 'fallback_block:core_html_block:input');
+  assert.equal(result.summary.top_pattern_families.some((family) => family.key === 'static_site_import_quality:static_site_fixture_diagnostic:(none)'), false);
+  assert.equal(result.fanout_groups.length, 1);
+  assert.equal(result.fanout_groups[0].findings.length, 1);
+  assert.equal(result.fanout_groups[0].findings[0].kind, 'core_html_block');
+});
+
+test('splits acceptable and unacceptable pattern rollups for minion fanout', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-fanout-rollups-'));
+  for (const fixture of ['fixture-alpha', 'fixture-beta', 'fixture-gamma']) {
+    mkdirSync(path.join(root, fixture), { recursive: true });
+    writeFileSync(path.join(root, fixture, 'index.html'), '<main>Fixture</main>');
+  }
+
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'fanout-rollup-test' });
+
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'fixture-alpha',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'layout_shift',
+            candidate_repo: 'blocks-engine',
+            source_path: 'website/index.html',
+            message: 'Unexpected layout shift in imported hero.',
+          },
+          {
+            kind: 'native_block_conversion',
+            loss_class: 'native_conversion',
+            candidate_repo: 'blocks-engine',
+            source_path: 'website/index.html',
+            message: 'Converted natively to editor blocks.',
+          },
+        ],
+      },
+      {
+        fixture_id: 'fixture-beta',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'layout_shift',
+            candidate_repo: 'blocks-engine',
+            source_path: 'website/index.html',
+            message: 'Unexpected layout shift in imported hero.',
+          },
+        ],
+      },
+      {
+        fixture_id: 'fixture-gamma',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'font_color_loss',
+            candidate_repo: 'static-site-importer',
+            source_path: 'website/index.html',
+            message: 'Font color changed after import.',
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.summary.finding_count, 4);
+  assert.equal(result.summary.actionable_finding_count, 4);
+  assert.equal(result.summary.acceptable_finding_count, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 3);
+  assert.equal(result.summary.groups.static_site_import_quality, 4);
+  assert.equal(result.summary.top_acceptable_pattern_families[0].key, 'static_site_import_quality:native_block_conversion:(none)');
+  assert.equal(result.summary.top_unacceptable_pattern_families[0].key, 'static_site_import_quality:layout_shift:(none)');
+  assert.equal(result.summary.top_unacceptable_pattern_families[0].count, 2);
+  assert.equal(result.summary.unacceptable_candidate_repos[0].candidate_repo, 'blocks-engine');
+  assert.equal(result.summary.unacceptable_candidate_repos[0].count, 2);
+  assert.equal(result.summary.unacceptable_candidate_repos[0].top_pattern_families[0].key, 'static_site_import_quality:layout_shift:(none)');
+  assert.equal(result.fanout_groups[0].acceptance, 'unacceptable');
+  assert.equal(result.fanout_groups[0].candidate_repo, 'blocks-engine');
+  assert.equal(result.fanout_groups[0].pattern_family, 'static_site_import_quality:layout_shift:(none)');
+  assert.equal(result.fanout_groups[0].count, 2);
+  assert.notEqual(result.fanout_groups[0].group_key, 'static_site_import_quality');
+});
+
+test('suppresses pre-normalized count-only fixture diagnostics with fixture source paths', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'pre-normalized-count-only-diagnostic-test' });
+  const fixturePath = matrix.fixtures[0].fixture_path;
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        fixture_path: fixturePath,
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'static_site_fixture_diagnostic',
+            group_key: 'static_site_import_quality',
+            repair_bucket: 'static_site_import_quality',
+            source_path: fixturePath,
+            reason: '2',
+          },
+          {
+            kind: 'core_html_block',
+            repair_bucket: 'fallback_block',
+            selector: 'input#email',
+            source_path: 'posts/page-contact.post_content',
+            message: 'generated_document_contains_core_html',
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.summary.finding_count, 2);
+  assert.equal(result.summary.actionable_finding_count, 1);
+  assert.equal(result.summary.non_actionable_finding_count, 1);
+  assert.equal(result.findings.find((finding) => finding.kind === 'static_site_fixture_diagnostic').actionability, 'count_only');
+  assert.equal(result.summary.top_pattern_families.some((family) => family.key === 'static_site_import_quality:static_site_fixture_diagnostic:(none)'), false);
+  assert.equal(result.summary.fixture_exemplars.some((exemplar) => exemplar.kind === 'static_site_fixture_diagnostic'), false);
+  assert.equal(result.summary.diagnostic_blind_spots.some((spot) => spot.exemplars.some((exemplar) => exemplar.kind === 'static_site_fixture_diagnostic')), false);
+  assert.equal(result.fanout_groups.length, 1);
+  assert.equal(result.fanout_groups[0].findings.some((finding) => finding.kind === 'static_site_fixture_diagnostic'), false);
+});
+
+test('collects SSI finding packet source and observed context from fixture artifacts', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-finding-packet-context-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'packet-context-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'import-report.json'), JSON.stringify({
+    success: false,
+    fixture_id: 'simple-site',
+    finding_packets: {
+      packets: [
+        {
+          type: 'runtime_dependency_missing_dom_target',
+          severity: 'error',
+          source: {
+            path: 'website/index.html',
+            selector: '.shader canvas',
+            snippet: '<canvas class="shader"></canvas>',
+          },
+          observed: {
+            reason_code: 'runtime_dependency_missing_dom_target',
+            output: '<!-- wp:html /-->',
+          },
+          expected: {
+            outcome: 'Runtime target should exist after import.',
+          },
+        },
+      ],
+    },
+  }));
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  const finding = result.findings[0];
+
+  assert.equal(result.summary.finding_count, 1);
+  assert.equal(finding.source_path, 'website/index.html');
+  assert.equal(finding.selector, '.shader canvas');
+  assert.equal(finding.selector_family, 'class:shader');
+  assert.equal(finding.source_snippet, '<canvas class="shader"></canvas>');
+  assert.equal(finding.observed_output, '<!-- wp:html /-->');
+});
+
+test('materializes generated artifact roots into matrix-compatible fixtures', () => {
+  const sourceRoot = mkdtempSync(path.join(tmpdir(), 'ssi-generated-artifacts-'));
+  const fixtureOutput = mkdtempSync(path.join(tmpdir(), 'ssi-generated-fixtures-'));
+  mkdirSync(path.join(sourceRoot, 'static-sites', 'alpha', 'assets'), { recursive: true });
+  writeFileSync(path.join(sourceRoot, 'static-sites', 'alpha', 'index.html'), '<h1>Alpha</h1>');
+  writeFileSync(path.join(sourceRoot, 'static-sites', 'alpha', 'assets', 'style.css'), 'body { color: black; }');
+  mkdirSync(path.join(sourceRoot, 'artifact-candidate'), { recursive: true });
+  writeFileSync(path.join(sourceRoot, 'artifact-candidate', 'artifact.json'), JSON.stringify({
+    schema: 'blocks-engine/php-transformer/site-artifact/v1',
+    metadata: { site: 'Beta Site' },
+    files: [
+      { path: 'website/index.html', content: '<h1>Beta</h1>' },
+      { path: 'website/assets/style.css', content: 'body { color: blue; }' },
+    ],
+  }));
+
+  const intake = materializeGeneratedArtifactFixtures({ artifactRoot: sourceRoot, fixtureRoot: fixtureOutput });
+  const matrix = createFixtureMatrix({ fixture_root: intake.fixture_root });
+
+  assert.equal(intake.count, 2);
+  assert.deepEqual(matrix.fixtures.map((fixture) => fixture.id), ['alpha', 'beta-site']);
+  assert.equal(readFileSync(path.join(fixtureOutput, 'alpha', 'index.html'), 'utf8'), '<h1>Alpha</h1>');
+  assert.equal(readFileSync(path.join(fixtureOutput, 'beta-site', 'index.html'), 'utf8'), '<h1>Beta</h1>');
+});
+
+test('resolves Blocks Engine PHP transformer override paths', () => {
+  const repoRoot = mkdtempSync(path.join(tmpdir(), 'blocks-engine-'));
+  const packageRoot = path.join(repoRoot, 'php-transformer');
+  mkdirSync(packageRoot, { recursive: true });
+  writeFileSync(path.join(packageRoot, 'composer.json'), JSON.stringify({
+    name: 'automattic/blocks-engine-php-transformer',
+  }));
+
+  assert.equal(resolveBlocksEnginePhpTransformerPath(repoRoot), packageRoot);
+  assert.equal(resolveBlocksEnginePhpTransformerPath(packageRoot), packageRoot);
+});
+
+test('builds Composer path repository override matching SSI constraints', () => {
+  const config = composerPathRepositoryConfig({
+    require: {
+      'automattic/blocks-engine-php-transformer': '^0.1.15',
+    },
+  }, '/tmp/blocks-engine/php-transformer');
+
+  assert.deepEqual(config, {
+    type: 'path',
+    url: '/tmp/blocks-engine/php-transformer',
+    canonical: true,
+    options: {
+      symlink: false,
+      versions: {
+        'automattic/blocks-engine-php-transformer': '0.1.15',
+      },
+    },
+  });
+});
+
+test('summarizes failed WP Codebox batches with fixture ids and child output tails', () => {
+  const stderr = `${'x'.repeat(4100)}stderr failure for fixture-beta`;
+  const stdout = 'stdout includes child JSON/error context';
+  const summary = fixtureMatrixBatchRunSummary({
+    batchNumber: 2,
+    batchMatrix: { id: 'matrix-batch-002' },
+    fixtures: [{ id: 'fixture-alpha' }, { id: 'fixture-beta' }],
+    batchRecipeFile: '/tmp/wp-codebox-static-site-fixture-matrix-batch-002.json',
+    outputFile: '/tmp/wp-codebox-output-batch-002.json',
+    batchRuntime: { exitCode: 1, json: { ok: false } },
+    batchError: { message: 'recipe-run failed', stderr, stdout },
+  });
+
+  assert.equal(summary.batch, 2);
+  assert.equal(summary.batch_id, 'matrix-batch-002');
+  assert.deepEqual(summary.fixture_ids, ['fixture-alpha', 'fixture-beta']);
+  assert.equal(summary.fixture_count, 2);
+  assert.equal(summary.exit_code, 1);
+  assert.equal(summary.error, 'recipe-run failed');
+  assert.equal(summary.parsed_output, true);
+  assert.equal(summary.stderr_tail.length, 4000);
+  assert.match(summary.stderr_tail, /stderr failure for fixture-beta$/);
+  assert.equal(summary.stdout_tail, stdout);
+});
+
+test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-canonical-matrix-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const blocksEngine = path.join(root, 'blocks-engine');
+  const fixtureRoot = path.join(blocksEngine, 'fixtures', 'websites');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  for (let index = 1; index <= CANONICAL_FIXTURE_COUNT; index += 1) {
+    mkdirSync(path.join(fixtureRoot, `fixture-${String(index).padStart(2, '0')}`), { recursive: true });
+  }
+
+  const plan = buildFixtureMatrixRunPlan({
+    runner: 'homeboy-lab',
+    staticSiteImporter,
+    blocksEngine,
+    homeboyBin: '/tmp/homeboy-latest',
+    runId: 'ssi-matrix-dev-proof',
+    passthrough: ['--batch-size', '5'],
+    skipInstall: true,
+  });
+
+  assert.equal(plan.mode, 'development-override');
+  assert.equal(plan.homeboy_bin, '/tmp/homeboy-latest');
+  assert.equal(plan.fixture_root, fixtureRoot);
+  assert.equal(plan.fixture_count, CANONICAL_FIXTURE_COUNT);
+  assert.equal(plan.fixture_count_matches_canonical, true);
+  assert.equal(plan.namespace, 'ssi-matrix-dev-proof');
+  assert.equal(plan.temp_root, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof');
+  assert.equal(plan.shared_state, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/shared-state');
+  assert.equal(plan.artifact_root, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/artifacts');
+  assert.deepEqual(plan.warnings, []);
+  assert.equal(plan.dependency_overrides.blocks_engine_php_transformer.path, blocksEngine);
+  assert.equal(plan.steps.some((step) => step.args.includes('install')), false);
+  assert.ok(plan.steps.some((step) => step.args.includes('sync')));
+
+  const benchStep = plan.steps.at(-1);
+  assert.deepEqual(benchStep.args.slice(0, 7), ['bench', '--rig', 'static-site-importer-fixture-matrix', '--profile', 'fixture-matrix', '--iterations', '1']);
+  assert.equal(benchStep.command, '/tmp/homeboy-latest');
+  assert.ok(benchStep.args.includes('--runner'));
+  assert.ok(benchStep.args.includes('homeboy-lab'));
+  assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT=${fixtureRoot}`));
+  assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH=${staticSiteImporter}`));
+  assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH=${blocksEngine}`));
+  assert.ok(benchStep.args.includes('bench_env.SSI_FIXTURE_MATRIX_RUN=1'));
+  assert.ok(benchStep.args.includes('static_site_importer_fixture_matrix_namespace=ssi-matrix-dev-proof'));
+  assert.ok(benchStep.args.includes('/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/artifacts'));
+  assert.deepEqual(benchStep.args.slice(-3), ['--', '--batch-size', '5']);
+
+  const releasePlan = buildFixtureMatrixRunPlan({
+    mode: 'release-proof',
+    staticSiteImporter,
+    blocksEngine,
+    passthrough: [],
+  });
+  assert.deepEqual(releasePlan.dependency_overrides, {});
+  assert.equal(releasePlan.steps.at(-1).args.some((arg) => arg.includes('SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH')), false);
+});
+
+test('fixture matrix records generic child command failures for failed WP Codebox batches', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-codebox-failure-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  const outputDirectory = path.join(root, 'artifacts');
+  const helperPath = path.join(root, 'wp-codebox-recipe-helper.cjs');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'failing-fixture'), { recursive: true });
+  writeFileSync(path.join(fixtureRoot, 'failing-fixture', 'index.html'), '<h1>Failing fixture</h1>');
+  writeFileSync(helperPath, `
+function wpCodeboxBin() { return '/tmp/wp-codebox'; }
+function wpCodeboxCommand(bin) { return { command: bin, args: [] }; }
+async function runWpCodeboxRecipe() {
+  const error = new Error('recipe-run failed');
+  error.code = 17;
+  error.stdout = 'stdout line 1\\nstdout line 2';
+  error.stderr = 'stderr line 1\\nstderr line 2';
+  throw error;
+}
+module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
+`, 'utf8');
+  const previousHelper = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+  const previousFixtureRoot = process.env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT;
+  const previousOutputDirectory = process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY;
+  const previousImporterPath = process.env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH;
+  const previousRun = process.env.SSI_FIXTURE_MATRIX_RUN;
+  const previousBatchSize = process.env.SSI_FIXTURE_MATRIX_BATCH_SIZE;
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = helperPath;
+
+  try {
+    const { summary, runtimeError } = await runFixtureMatrix({
+      fixtureRoot,
+      outputDirectory,
+      staticSiteImporterPath: staticSiteImporter,
+      run: true,
+      batchSize: 1,
+    });
+    const failure = summary.runtime.child_command_failures[0];
+
+    // The child's raw failure cause propagates as the runtime error message. The
+    // child's real stderr + stdout tails are surfaced for attribution on the
+    // structured child-command failure below (`stderr_tail`/`stdout_tail`).
+    // Folding those tails into the Error *message* (#560) now lives in the
+    // production WP Codebox recipe helper (quarantined behind tools/wp-codebox
+    // in PR #573), which this test mocks, so the rig path keeps the bare cause.
+    assert.match(runtimeError.message, /^recipe-run failed/);
+    assert.equal(summary.runtime.exit_code, 17);
+    assert.equal(failure.schema, 'homeboy/child-command-failure/v1');
+    assert.equal(failure.exit_status, 17);
+    assert.equal(failure.batch_id, 'batch-001');
+    assert.deepEqual(failure.command.argv, [
+      '/tmp/wp-codebox',
+      'recipe-run',
+      failure.artifact_refs.batch_recipe,
+      '--artifacts-dir', outputDirectory,
+      '--output', failure.artifact_refs.batch_output,
+    ]);
+    assert.equal(failure.stdout_tail, 'stdout line 1\nstdout line 2');
+    assert.equal(failure.stderr_tail, 'stderr line 1\nstderr line 2');
+    assert.equal(failure.artifact_refs.artifacts_directory, outputDirectory);
+    assert.equal(failure.artifact_refs.output_file, failure.artifact_refs.batch_output);
+    assert.ok(readFileSync(path.join(outputDirectory, 'cli-run.json'), 'utf8').includes('child_command_failures'));
+
+    process.env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT = fixtureRoot;
+    process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY = path.join(root, 'bench-export-artifacts');
+    process.env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH = staticSiteImporter;
+    process.env.SSI_FIXTURE_MATRIX_RUN = '1';
+    process.env.SSI_FIXTURE_MATRIX_BATCH_SIZE = '1';
+    // A failing batch must NOT make the bench reject: rejecting makes the harness
+    // discard the whole lane as an assertion_failure. Instead the bench returns
+    // the aggregate with the failed fixture counted (so the
+    // `failed_fixture_count <= 0` result-gate fails the run without discarding it)
+    // and keeps the child-command failure in metadata for attribution.
+    const benchResult = await runFixtureMatrixBench();
+    assert.equal(benchResult.metrics.fixture_count, 1);
+    assert.equal(benchResult.metrics.passed_fixture_count, 0);
+    assert.equal(benchResult.metrics.failed_fixture_count, 1);
+    assert.equal(benchResult.metadata.child_command_failures[0].exit_status, 17);
+    assert.equal(benchResult.metadata.child_command_failures[0].artifact_refs.artifacts_directory, process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY);
+  } finally {
+    if (previousHelper === undefined) {
+      delete process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+    } else {
+      process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = previousHelper;
+    }
+    restoreEnv('SSI_FIXTURE_MATRIX_FIXTURE_ROOT', previousFixtureRoot);
+    restoreEnv('SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY', previousOutputDirectory);
+    restoreEnv('SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH', previousImporterPath);
+    restoreEnv('SSI_FIXTURE_MATRIX_RUN', previousRun);
+    restoreEnv('SSI_FIXTURE_MATRIX_BATCH_SIZE', previousBatchSize);
+  }
+});
+
+test('CLI --no-visual-parity disables visual steps and records a safe WP Codebox replay command', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-focused-codebox-replay-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const cliFixtureRoot = path.join(root, 'fixtures');
+  const outputDirectory = path.join(root, 'artifacts');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(cliFixtureRoot, 'fixture-a'), { recursive: true });
+  writeFileSync(path.join(cliFixtureRoot, 'fixture-a', 'index.html'), '<h1>Focused replay fixture</h1>');
+
+  const result = spawnSync(process.execPath, [
+    path.join(packageRoot, 'bench', 'static-site-fixture-matrix.bench.mjs'),
+    '--fixture-root', cliFixtureRoot,
+    '--output-directory', outputDirectory,
+    '--static-site-importer-path', staticSiteImporter,
+    '--max-depth', '1',
+    '--no-visual-parity',
+  ], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOMEBOY_WP_CODEBOX_RECIPE_HELPER: '',
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /"replay"/);
+
+  const recipeFile = path.join(outputDirectory, 'wp-codebox-static-site-fixture-matrix-recipe.json');
+  const recipe = JSON.parse(readFileSync(recipeFile, 'utf8'));
+  const summary = JSON.parse(readFileSync(path.join(outputDirectory, 'cli-run.json'), 'utf8'));
+  assert.equal(recipe.workflow.steps.some((step) => step.command === 'wordpress.visual-compare'), false);
+  assert.equal(summary.replay.artifacts_directory, path.join(root, 'artifacts-wp-codebox-replay-artifacts'));
+  assert.equal(summary.replay.artifacts_directory.startsWith(`${outputDirectory}${path.sep}`), false);
+  assert.deepEqual(summary.replay.argv, [
+    'wp-codebox',
+    'recipe-run',
+    '--recipe', recipeFile,
+    '--artifacts', summary.replay.artifacts_directory,
+    '--json',
+  ]);
+  assert.match(summary.replay.command, /wp-codebox recipe-run --recipe .* --artifacts .* --json/);
+});
+
+function fakeGitRunner(stateByPath) {
+  return (cwd, args) => {
+    const state = stateByPath[path.resolve(cwd)];
+    if (!state) {
+      return { status: 1, stdout: '', stderr: 'not a git repo' };
+    }
+    const joined = args.join(' ');
+    if (joined === 'rev-parse --is-inside-work-tree') {
+      return { status: 0, stdout: 'true', stderr: '' };
+    }
+    if (joined === 'rev-parse --abbrev-ref HEAD') {
+      return { status: 0, stdout: state.branch || 'trunk', stderr: '' };
+    }
+    if (joined === 'rev-parse HEAD') {
+      return { status: 0, stdout: state.commit || 'deadbeef', stderr: '' };
+    }
+    if (joined === 'status --porcelain') {
+      return { status: 0, stdout: state.dirty ? ' M file.php' : '', stderr: '' };
+    }
+    if (joined === 'rev-parse --abbrev-ref --symbolic-full-name @{upstream}') {
+      return state.upstream
+        ? { status: 0, stdout: state.upstream, stderr: '' }
+        : { status: 128, stdout: '', stderr: 'no upstream' };
+    }
+    if (args[0] === 'rev-list') {
+      return { status: 0, stdout: `${state.behind || 0}\t${state.ahead || 0}`, stderr: '' };
+    }
+    return { status: 1, stdout: '', stderr: 'unhandled git command' };
+  };
+}
+
+test('code freshness guard blocks stale overrides unless explicitly allowed', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-freshness-stale-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const blocksEngine = path.join(root, 'blocks-engine');
+  const fixtureRoot = path.join(blocksEngine, 'fixtures', 'websites');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+
+  const gitRunner = fakeGitRunner({
+    [path.resolve(blocksEngine)]: { branch: 'trunk', upstream: 'origin/trunk', behind: 33, ahead: 0, commit: 'staleabc' },
+    [path.resolve(staticSiteImporter)]: { branch: 'main', upstream: 'origin/main', behind: 0, ahead: 0, commit: 'freshxyz' },
+  });
+
+  const stalePlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    blocksEngine,
+    runId: 'ssi-freshness-stale',
+    skipInstall: true,
+    skipSync: true,
+    gitRunner,
+  });
+
+  assert.equal(stalePlan.code_freshness.would_block, true);
+  assert.deepEqual(stalePlan.code_freshness.stale_overrides, ['blocks_engine_php_transformer_path']);
+  assert.equal(stalePlan.code_freshness.paths.blocks_engine_php_transformer_path.status, 'behind');
+  assert.equal(stalePlan.code_freshness.paths.blocks_engine_php_transformer_path.behind, 33);
+  assert.equal(stalePlan.code_freshness.paths.static_site_importer.status, 'fresh');
+  assert.equal(stalePlan.transformer_commit, 'staleabc');
+  assert.ok(stalePlan.warnings.some((warning) => warning.code === 'stale_override'));
+  assert.equal(stalePlan.warnings.some((warning) => warning.code === 'stale_override_allowed'), false);
+
+  const allowedPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    blocksEngine,
+    runId: 'ssi-freshness-stale-allowed',
+    skipInstall: true,
+    skipSync: true,
+    allowStaleOverride: true,
+    gitRunner,
+  });
+
+  assert.equal(allowedPlan.code_freshness.would_block, true);
+  assert.equal(allowedPlan.allow_stale_override, true);
+  assert.ok(allowedPlan.warnings.some((warning) => warning.code === 'stale_override_allowed'));
+});
+
+test('code freshness guard lets fresh and diverged overrides through with accurate status', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-freshness-fresh-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const blocksEngine = path.join(root, 'blocks-engine');
+  const fixtureRoot = path.join(blocksEngine, 'fixtures', 'websites');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+
+  const freshPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    blocksEngine,
+    runId: 'ssi-freshness-fresh',
+    skipInstall: true,
+    skipSync: true,
+    gitRunner: fakeGitRunner({
+      [path.resolve(blocksEngine)]: { branch: 'trunk', upstream: 'origin/trunk', behind: 0, ahead: 2, commit: 'aheadcommit' },
+      [path.resolve(staticSiteImporter)]: { branch: 'main', upstream: 'origin/main', behind: 0, ahead: 0, commit: 'freshcommit' },
+    }),
+  });
+
+  assert.equal(freshPlan.code_freshness.would_block, false);
+  assert.deepEqual(freshPlan.code_freshness.stale_overrides, []);
+  assert.equal(freshPlan.code_freshness.paths.blocks_engine_php_transformer_path.status, 'ahead');
+  assert.equal(freshPlan.warnings.some((warning) => warning.code === 'stale_override'), false);
+
+  const diverged = resolvePathFreshness(
+    'blocks_engine_php_transformer_path',
+    blocksEngine,
+    fakeGitRunner({
+      [path.resolve(blocksEngine)]: { branch: 'trunk', upstream: 'origin/trunk', behind: 5, ahead: 3, dirty: true, commit: 'divergedc' },
+    }),
+  );
+  assert.equal(diverged.status, 'diverged');
+  assert.equal(diverged.stale, true);
+  assert.equal(diverged.dirty, true);
+});
+
+test('code freshness marks non-git override paths without blocking', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-freshness-nongit-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const blocksEngine = path.join(root, 'blocks-engine');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(blocksEngine, 'fixtures', 'websites', 'fixture-a'), { recursive: true });
+
+  const freshness = buildCodeFreshness(
+    {
+      staticSiteImporter,
+      blocksEngine,
+      blocksEnginePhpTransformerPath: blocksEngine,
+    },
+    fakeGitRunner({}),
+  );
+
+  assert.equal(freshness.would_block, false);
+  assert.equal(freshness.paths.blocks_engine_php_transformer_path.in_git_repo, false);
+  assert.equal(freshness.paths.blocks_engine_php_transformer_path.status, 'not_git');
+});
+
+function restoreEnv(key, value) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+test('fixture matrix dry-run plan surfaces local fallback and dirty workspace warnings', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-warning-plan-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+
+  const plan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot,
+    runId: 'proof/run 1',
+    allowLocalFallback: true,
+    allowDirtyLabWorkspace: true,
+    skipInstall: true,
+    skipSync: true,
+  });
+
+  assert.equal(plan.namespace, 'proof-run-1');
+  assert.equal(plan.temp_root, '/tmp/static-site-importer-fixture-matrix-proof-run-1');
+  // The single-fixture temp corpus drifts from the canonical pin, so the plan
+  // surfaces a non-silent drift warning alongside the routing warnings.
+  assert.deepEqual(plan.warnings.map((warning) => warning.code), [
+    'lab_auto_offload_risk',
+    'local_fallback_allowed',
+    'dirty_lab_workspace_allowed',
+    'canonical_fixture_count_drift',
+  ]);
+  assert.equal(plan.fixture_count_matches_canonical, false);
+  assert.match(
+    plan.warnings.find((warning) => warning.code === 'canonical_fixture_count_drift').message,
+    /CANONICAL_FIXTURE_COUNT is \d+/,
+  );
+});
+
+test('--local forces hot local execution and suppresses the auto-offload-risk warning', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-local-plan-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+
+  const plan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot,
+    local: true,
+    skipInstall: true,
+    skipSync: true,
+  });
+
+  // The auto-offload risk warning is gone; the forced-local note replaces it.
+  const codes = plan.warnings.map((warning) => warning.code);
+  assert.ok(!codes.includes('lab_auto_offload_risk'));
+  assert.ok(codes.includes('forced_local_execution'));
+  assert.equal(plan.local, true);
+
+  // The bench step carries --force-hot --allow-local-hot so homeboy bench stays
+  // local instead of offloading local-only paths to a connected Lab runner.
+  const benchStep = plan.steps.at(-1);
+  assert.ok(benchStep.args.includes('--force-hot'));
+  assert.ok(benchStep.args.includes('--allow-local-hot'));
+});
+
+test('operator summary preserves matrix rollups for fanout agents', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-operator-summary-'));
+  const outputFile = path.join(root, 'homeboy-bench.json');
+  writeFileSync(outputFile, JSON.stringify({
+    run_id: 'ssi-matrix-rollup-proof',
+    result_summary: {
+      failed: 71,
+      finding_count: 1126,
+      groups: { runtime_target_gap: 806 },
+      top_pattern_families: [
+        { key: 'runtime_target_gap:runtime_dependency_missing_dom_target:canvas', count: 312, fixture_ids: ['shader-site'] },
+      ],
+      fixture_exemplars: [
+        { fixture_id: 'shader-site', selector: 'canvas', reason: 'Runtime target missing.' },
+      ],
+      diagnostic_blind_spots: [
+        { kind: 'missing_source_context', count: 12 },
+      ],
+    },
+  }));
+
+  const summary = summarizeRun({
+    mode: 'development-override',
+    run_id: 'planned-run',
+    fixture_count: 71,
+    output_file: outputFile,
+  });
+
+  assert.equal(summary.run_id, 'ssi-matrix-rollup-proof');
+  assert.equal(summary.top_pattern_families[0].count, 312);
+  assert.equal(summary.fixture_exemplars[0].fixture_id, 'shader-site');
+  assert.equal(summary.diagnostic_blind_spots[0].kind, 'missing_source_context');
+});
+
+test('summarizeBenchRun emits the operator summary on a gate-FAIL instead of throwing', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-bench-gate-fail-'));
+  const outputFile = path.join(root, 'homeboy-bench.json');
+  writeFileSync(outputFile, JSON.stringify({
+    run_id: 'ssi-live-2',
+    result_summary: {
+      succeeded: 0,
+      failed: 2,
+      finding_count: 22,
+      groups: { runtime_target_gap: 18, dropped_images: 4 },
+    },
+    artifacts: { run: 'homeboy-runs:ssi-live-2', report: 'https://example.test/report.json' },
+  }));
+
+  const plan = {
+    mode: 'development-override',
+    run_id: 'planned-run',
+    fixture_count: 2,
+    output_file: outputFile,
+  };
+
+  // The bench exited non-zero (gate-FAIL) but wrote a valid result payload.
+  let result;
+  assert.doesNotThrow(() => {
+    result = summarizeBenchRun({ plan, benchStatus: 1, benchLabel: 'Run SSI fixture matrix bench' });
+  });
+
+  assert.equal(result.gateFailed, true);
+  assert.equal(result.summary.status, 'failed');
+  assert.equal(result.summary.run_id, 'ssi-live-2');
+  assert.equal(result.summary.passed_fixture_count, 0);
+  assert.equal(result.summary.failed_fixture_count, 2);
+  assert.equal(result.summary.finding_count, 22);
+  assert.deepEqual(result.summary.top_buckets[0], { key: 'runtime_target_gap', count: 18 });
+  assert.deepEqual(result.summary.artifact_urls, ['homeboy-runs:ssi-live-2', 'https://example.test/report.json']);
+});
+
+test('summarizeBenchRun reports a clean pass when the bench exits zero', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-bench-pass-'));
+  const outputFile = path.join(root, 'homeboy-bench.json');
+  writeFileSync(outputFile, JSON.stringify({
+    run_id: 'ssi-pass',
+    result_summary: { succeeded: 2, failed: 0, finding_count: 0 },
+  }));
+
+  const result = summarizeBenchRun({
+    plan: { mode: 'release-proof', run_id: 'planned-run', fixture_count: 2, output_file: outputFile },
+    benchStatus: 0,
+    benchLabel: 'Run SSI fixture matrix bench',
+  });
+
+  assert.equal(result.gateFailed, false);
+  assert.equal(result.summary.status, 'passed');
+  assert.equal(result.summary.passed_fixture_count, 2);
+  assert.equal(result.summary.failed_fixture_count, 0);
+});
+
+test('summarizeBenchRun still throws when a non-zero bench produced no parseable result', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-bench-crash-'));
+  const missingOutput = path.join(root, 'never-written.json');
+
+  // No output file at all -> genuine crash, keep throwing.
+  assert.throws(
+    () => summarizeBenchRun({
+      plan: { mode: 'development-override', run_id: 'planned-run', output_file: missingOutput },
+      benchStatus: 1,
+      benchLabel: 'Run SSI fixture matrix bench',
+    }),
+    /Run SSI fixture matrix bench failed with exit 1/,
+  );
+
+  // Output exists but is unparseable / carries no result payload -> still a crash.
+  const garbageOutput = path.join(root, 'garbage.json');
+  writeFileSync(garbageOutput, 'not json at all');
+  assert.throws(
+    () => summarizeBenchRun({
+      plan: { mode: 'development-override', run_id: 'planned-run', output_file: garbageOutput },
+      benchStatus: 1,
+      benchLabel: 'Run SSI fixture matrix bench',
+    }),
+    /failed with exit 1/,
+  );
+});
+
+test('mapWithConcurrency runs bounded N in parallel and preserves input ordering', async () => {
+  const items = Array.from({ length: 10 }, (_value, index) => index);
+  let inFlight = 0;
+  let peakInFlight = 0;
+
+  const results = await mapWithConcurrency(items, 3, async (value) => {
+    inFlight += 1;
+    peakInFlight = Math.max(peakInFlight, inFlight);
+    // Yield so the pool genuinely overlaps work rather than resolving instantly.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    inFlight -= 1;
+    return value * 2;
+  });
+
+  // Up to 3 workers actually overlapped (proves real parallelism), never more.
+  assert.equal(peakInFlight, 3);
+  // Results stay aligned to input order regardless of completion order.
+  assert.deepEqual(results, items.map((value) => value * 2));
+});
+
+test('mapWithConcurrency handles empty input and caps the pool at item count', async () => {
+  assert.deepEqual(await mapWithConcurrency([], 4, async () => 1), []);
+
+  let peakInFlight = 0;
+  let inFlight = 0;
+  const results = await mapWithConcurrency([1, 2], 8, async (value) => {
+    inFlight += 1;
+    peakInFlight = Math.max(peakInFlight, inFlight);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    inFlight -= 1;
+    return value;
+  });
+  assert.deepEqual(results, [1, 2]);
+  assert.equal(peakInFlight, 2);
+});
+
+test('boundedConcurrency clamps to the hard cap and falls back on invalid input', () => {
+  assert.equal(boundedConcurrency('8', 4, 16), 8);
+  assert.equal(boundedConcurrency('500', 4, 16), 16);
+  assert.equal(boundedConcurrency(undefined, 4, 16), 4);
+  assert.equal(boundedConcurrency('0', 4, 16), 4);
+  assert.equal(boundedConcurrency('not-a-number', 4, 16), 4);
+  assert.equal(boundedConcurrency('-3', 4, 16), 4);
+});
+
+// A configurable fake WP Codebox recipe runner, injected through the production
+// `HOMEBOY_WP_CODEBOX_RECIPE_HELPER` seam, so these tests exercise the real
+// `runFixtureMatrix` batch-execution path (provision -> collect -> aggregate)
+// without ever spinning a sandbox. Behavior is driven live from env vars so a
+// single helper module can serve every scenario:
+//   - SSI_TEST_RECIPE_STATS_FILE  : where to persist peak concurrent in-flight.
+//   - SSI_TEST_RECIPE_ORDER       : 'forward' | 'reverse' batch completion order.
+//   - SSI_TEST_RECIPE_BATCH_COUNT : total batches (for reverse-order delays).
+//   - SSI_TEST_RECIPE_UNIT_MS     : per-batch delay unit so batches overlap.
+//   - SSI_TEST_RECIPE_THROW_BATCH : batch number that throws (isolation test).
+// Module-level peak tracking is fresh per test because each test writes its own
+// uniquely-pathed helper file (Node caches require() by resolved path).
+function writeConcurrencyRecipeHelper(filePath) {
+  writeFileSync(filePath, `
+const fs = require('node:fs');
+
+let inFlight = 0;
+let peakInFlight = 0;
+
+function recordPeak() {
+  const file = process.env.SSI_TEST_RECIPE_STATS_FILE;
+  if (!file) return;
+  try {
+    fs.writeFileSync(file, JSON.stringify({ peak_in_flight: peakInFlight }));
+  } catch {}
+}
+
+function batchNumberFromOutput(outputFile) {
+  const tail = String(outputFile || '').split('batch-')[1];
+  const parsed = parseInt(tail, 10);
+  return Number.isInteger(parsed) ? parsed : 0;
+}
+
+// The recipe references each fixture via "--slug=<id>" tokens in the wp-cli
+// command args (no top-level fixture_id key), so derive the batch's fixtures by
+// scanning for those slug tokens. Slugs are simple, space-delimited, unquoted
+// values, so a plain split is enough and dodges template-literal escaping.
+function fixtureIdsFromRecipe(recipeFile) {
+  const ids = new Set();
+  try {
+    const text = fs.readFileSync(recipeFile, 'utf8');
+    const segments = text.split('--slug=');
+    for (let index = 1; index < segments.length; index += 1) {
+      const slug = segments[index].split(' ')[0].trim();
+      if (slug) {
+        ids.add(slug);
+      }
+    }
+  } catch {}
+  return [...ids];
+}
+
+function wpCodeboxBin() { return '/tmp/wp-codebox'; }
+function wpCodeboxCommand(bin) { return { command: bin, args: [] }; }
+
+async function runWpCodeboxRecipe(options = {}) {
+  const batchNumber = batchNumberFromOutput(options.outputFile);
+  inFlight += 1;
+  peakInFlight = Math.max(peakInFlight, inFlight);
+  recordPeak();
+
+  const unit = Number(process.env.SSI_TEST_RECIPE_UNIT_MS || '15');
+  const total = Number(process.env.SSI_TEST_RECIPE_BATCH_COUNT || '0');
+  const order = process.env.SSI_TEST_RECIPE_ORDER || 'forward';
+  // Reverse completion: the earliest batch waits longest so it finishes last.
+  const delay = order === 'reverse'
+    ? (total - batchNumber + 1) * unit
+    : batchNumber * unit;
+  await new Promise((resolve) => setTimeout(resolve, Math.max(1, delay)));
+
+  inFlight -= 1;
+
+  const throwBatch = Number(process.env.SSI_TEST_RECIPE_THROW_BATCH || '0');
+  if (throwBatch && throwBatch === batchNumber) {
+    const error = new Error('recipe-run failed for batch ' + batchNumber);
+    error.code = 19;
+    error.stdout = '';
+    error.stderr = 'boom';
+    throw error;
+  }
+
+  const fixtureIds = fixtureIdsFromRecipe(options.recipeFile);
+  return {
+    exitCode: 0,
+    outputFile: options.outputFile,
+    json: { results: fixtureIds.map((id) => ({ fixture_id: id, status: 'succeeded' })) },
+  };
+}
+
+module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
+`, 'utf8');
+}
+
+// Stand up a workspace with N single-fixture batches and a configured fake
+// recipe runner; returns the env keys touched so the caller can restore them.
+function setupConcurrencyWorkspace(prefix, fixtureCount) {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  const outputDirectory = path.join(root, 'artifacts');
+  const helperPath = path.join(root, 'wp-codebox-recipe-helper.cjs');
+  const statsFile = path.join(root, 'recipe-stats.json');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  for (let index = 1; index <= fixtureCount; index += 1) {
+    const fixtureDir = path.join(fixtureRoot, `fixture-${String(index).padStart(2, '0')}`);
+    mkdirSync(fixtureDir, { recursive: true });
+    writeFileSync(path.join(fixtureDir, 'index.html'), `<h1>Fixture ${index}</h1>`);
+  }
+  writeConcurrencyRecipeHelper(helperPath);
+  return { root, staticSiteImporter, fixtureRoot, outputDirectory, helperPath, statsFile };
+}
+
+const CONCURRENCY_ENV_KEYS = [
+  'HOMEBOY_WP_CODEBOX_RECIPE_HELPER',
+  'SSI_TEST_RECIPE_STATS_FILE',
+  'SSI_TEST_RECIPE_ORDER',
+  'SSI_TEST_RECIPE_BATCH_COUNT',
+  'SSI_TEST_RECIPE_UNIT_MS',
+  'SSI_TEST_RECIPE_THROW_BATCH',
+];
+
+function snapshotConcurrencyEnv() {
+  return Object.fromEntries(CONCURRENCY_ENV_KEYS.map((key) => [key, process.env[key]]));
+}
+
+function restoreConcurrencyEnv(snapshot) {
+  for (const key of CONCURRENCY_ENV_KEYS) {
+    restoreEnv(key, snapshot[key]);
+  }
+}
+
+test('runFixtureMatrix caps WP Codebox batches in flight at the configured concurrency', async () => {
+  const snapshot = snapshotConcurrencyEnv();
+  const workspace = setupConcurrencyWorkspace('ssi-concurrency-inflight-', 6);
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = workspace.helperPath;
+  process.env.SSI_TEST_RECIPE_STATS_FILE = workspace.statsFile;
+  process.env.SSI_TEST_RECIPE_UNIT_MS = '20';
+
+  try {
+    const { summary, runtimeError } = await runFixtureMatrix({
+      id: 'inflight-matrix',
+      fixtureRoot: workspace.fixtureRoot,
+      outputDirectory: workspace.outputDirectory,
+      staticSiteImporterPath: workspace.staticSiteImporter,
+      run: true,
+      batchSize: 1,
+      concurrency: 2,
+      visualParity: false,
+    });
+
+    assert.equal(runtimeError, null);
+    // 6 single-fixture batches all executed.
+    assert.equal(summary.runtime.batches.length, 6);
+    assert.equal(summary.runtime.concurrency, 2);
+
+    const stats = JSON.parse(readFileSync(workspace.statsFile, 'utf8'));
+    // At most N (=2) sandboxes were ever live at once, and the pool genuinely
+    // reached the cap (proves real parallelism, not accidental serialization).
+    assert.ok(stats.peak_in_flight <= 2, `peak ${stats.peak_in_flight} exceeded concurrency 2`);
+    assert.equal(stats.peak_in_flight, 2);
+  } finally {
+    restoreConcurrencyEnv(snapshot);
+  }
+});
+
+test('runFixtureMatrix aggregates batch results order-independently of completion order', async () => {
+  const snapshot = snapshotConcurrencyEnv();
+  const workspace = setupConcurrencyWorkspace('ssi-concurrency-order-', 4);
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = workspace.helperPath;
+  process.env.SSI_TEST_RECIPE_BATCH_COUNT = '4';
+  process.env.SSI_TEST_RECIPE_UNIT_MS = '10';
+
+  const runMatrix = async (order) => {
+    process.env.SSI_TEST_RECIPE_ORDER = order;
+    const { summary, runtimeError } = await runFixtureMatrix({
+      id: 'order-matrix',
+      fixtureRoot: workspace.fixtureRoot,
+      outputDirectory: path.join(workspace.root, `artifacts-${order}`),
+      staticSiteImporterPath: workspace.staticSiteImporter,
+      run: true,
+      batchSize: 1,
+      concurrency: 4,
+      visualParity: false,
+    });
+    assert.equal(runtimeError, null);
+    return summary;
+  };
+
+  try {
+    const forward = await runMatrix('forward');
+    const reverse = await runMatrix('reverse');
+
+    // Same fixtures, same metrics regardless of which sandbox finished first.
+    const metrics = (summary) => ({
+      fixture_count: summary.fixture_count,
+      succeeded: summary.result_summary.succeeded,
+      failed: summary.result_summary.failed,
+      not_run: summary.result_summary.not_run,
+      finding_count: summary.result_summary.finding_count,
+    });
+    assert.deepEqual(metrics(reverse), metrics(forward));
+    assert.equal(metrics(forward).succeeded, 4);
+
+    // Batch summaries and fixture identities stay in deterministic matrix order
+    // even though reverse completion finishes batch 4 before batch 1.
+    const batchOrder = (summary) => summary.runtime.batches.map((batch) => batch.batch);
+    const fixtureOrder = (summary) => summary.runtime.batches.flatMap((batch) => batch.fixture_ids);
+    assert.deepEqual(batchOrder(forward), [1, 2, 3, 4]);
+    assert.deepEqual(batchOrder(reverse), [1, 2, 3, 4]);
+    assert.deepEqual(fixtureOrder(reverse), fixtureOrder(forward));
+  } finally {
+    restoreConcurrencyEnv(snapshot);
+  }
+});
+
+test('runFixtureMatrix isolates a throwing batch so sibling batches still complete', async () => {
+  const snapshot = snapshotConcurrencyEnv();
+  const workspace = setupConcurrencyWorkspace('ssi-concurrency-isolation-', 4);
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = workspace.helperPath;
+  process.env.SSI_TEST_RECIPE_BATCH_COUNT = '4';
+  process.env.SSI_TEST_RECIPE_UNIT_MS = '5';
+  process.env.SSI_TEST_RECIPE_THROW_BATCH = '2';
+
+  try {
+    const { summary, runtimeError } = await runFixtureMatrix({
+      id: 'isolation-matrix',
+      fixtureRoot: workspace.fixtureRoot,
+      outputDirectory: workspace.outputDirectory,
+      staticSiteImporterPath: workspace.staticSiteImporter,
+      run: true,
+      batchSize: 1,
+      concurrency: 4,
+      visualParity: false,
+    });
+
+    // The throwing batch surfaces as the runtime error + exit code, but the run
+    // still produced a full summary rather than rejecting.
+    assert.ok(runtimeError);
+    assert.match(runtimeError.message, /batch 2/);
+    assert.equal(summary.runtime.exit_code, 19);
+
+    // Exactly the one failing batch is recorded as a child-command failure.
+    const failures = summary.runtime.child_command_failures;
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].batch_id, 'batch-002');
+    assert.equal(failures[0].exit_status, 19);
+
+    // All four batches still ran; the three non-throwing siblings succeeded,
+    // proving one batch's failure did not sink the others.
+    assert.equal(summary.runtime.batches.length, 4);
+    assert.equal(summary.result_summary.succeeded, 3);
+    assert.equal(summary.result_summary.failed, 1);
+  } finally {
+    restoreConcurrencyEnv(snapshot);
+  }
+});
+
+test('runFixtureMatrixBench returns a partial result with survivors aggregated when a batch fails', async () => {
+  // The bench-harness entry point is where the whole-run discard used to live:
+  // any failing batch made `runFixtureMatrixBench` throw, so the harness recorded
+  // an assertion_failure and dropped the aggregate (every survivor lost). This
+  // proves the harness boundary now isolates the failure -- the bench returns
+  // normally with the survivors aggregated and the failure counted, so the rig's
+  // `failed_fixture_count <= 0` result-gate fails the run WITHOUT discarding it.
+  const concurrencySnapshot = snapshotConcurrencyEnv();
+  const benchEnvKeys = [
+    'SSI_FIXTURE_MATRIX_FIXTURE_ROOT',
+    'SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY',
+    'SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH',
+    'SSI_FIXTURE_MATRIX_RUN',
+    'SSI_FIXTURE_MATRIX_BATCH_SIZE',
+    'SSI_FIXTURE_MATRIX_CONCURRENCY',
+    'SSI_FIXTURE_MATRIX_VISUAL_PARITY',
+  ];
+  const benchEnvSnapshot = Object.fromEntries(benchEnvKeys.map((key) => [key, process.env[key]]));
+  const workspace = setupConcurrencyWorkspace('ssi-bench-isolation-', 4);
+
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = workspace.helperPath;
+  process.env.SSI_TEST_RECIPE_BATCH_COUNT = '4';
+  process.env.SSI_TEST_RECIPE_UNIT_MS = '5';
+  process.env.SSI_TEST_RECIPE_THROW_BATCH = '2';
+  process.env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT = workspace.fixtureRoot;
+  process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY = workspace.outputDirectory;
+  process.env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH = workspace.staticSiteImporter;
+  process.env.SSI_FIXTURE_MATRIX_RUN = '1';
+  process.env.SSI_FIXTURE_MATRIX_BATCH_SIZE = '1';
+  process.env.SSI_FIXTURE_MATRIX_CONCURRENCY = '4';
+  process.env.SSI_FIXTURE_MATRIX_VISUAL_PARITY = '0';
+
+  try {
+    // Does not reject: the failing batch is recorded, not fatal.
+    const benchResult = await runFixtureMatrixBench();
+
+    // The aggregate spans all four fixtures: the three surviving batches passed
+    // and only the failing batch is counted as failed.
+    assert.equal(benchResult.metrics.fixture_count, 4);
+    assert.equal(benchResult.metrics.passed_fixture_count, 3);
+    assert.equal(benchResult.metrics.failed_fixture_count, 1);
+    assert.equal(benchResult.metrics.not_run_fixture_count, 0);
+
+    // The result-gate (failed_fixture_count <= 0) will fail on this, while the
+    // partial result is still emitted and the failing batch stays attributable.
+    const failures = benchResult.metadata.child_command_failures;
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].batch_id, 'batch-002');
+    assert.equal(failures[0].exit_status, 19);
+
+    // The aggregate result artifact was written for the lane to record.
+    const resultPayload = JSON.parse(readFileSync(benchResult.artifacts.result.path, 'utf8'));
+    assert.equal(resultPayload.summary.succeeded, 3);
+    assert.equal(resultPayload.summary.failed, 1);
+  } finally {
+    restoreConcurrencyEnv(concurrencySnapshot);
+    for (const key of benchEnvKeys) {
+      restoreEnv(key, benchEnvSnapshot[key]);
+    }
+  }
+});
+
+test('compares finding packet deltas by repair dimensions', () => {
+  const summary = compareFindingPackets({
+    base_label: 'main',
+    candidate_label: 'candidate',
+    top: 5,
+    base: [
+      { kind: 'unsupported_html_fallback', group_key: 'static_site_import_quality', repair_bucket: 'runtime_target_gap', fixture_id: 'hero-site', candidate_repo: 'blocks-engine', selector: 'script:nth-of-type(1)' },
+      { kind: 'document_metadata_routed', group_key: 'dropped_images', repair_bucket: 'dropped_images', fixture_id: 'shop-site', candidate_repo: 'static-site-importer', selector: '.gallery img' },
+    ],
+    candidate: [
+      { kind: 'document_metadata_routed', group_key: 'dropped_images', repair_bucket: 'dropped_images', fixture_id: 'shop-site', candidate_repo: 'static-site-importer', selector: '.gallery img' },
+      { kind: 'document_metadata_routed', group_key: 'dropped_images', repair_bucket: 'dropped_images', fixture_id: 'portfolio-site', candidate_repo: 'static-site-importer', selector: '.gallery img' },
+      { kind: 'invalid_block_content', group_key: 'invalid_block_content', repair_bucket: 'invalid_block_content', fixture_id: 'portfolio-site', candidate_repo: 'blocks-engine', selector: '#hero .cta' },
+    ],
+  });
+
+  assert.deepEqual(summary.totals, { base: 2, candidate: 3, delta: 1 });
+  assert.deepEqual(summary.dimensions.bucket.slice(0, 2), [
+    { key: 'dropped_images', base: 1, candidate: 2, delta: 1 },
+    { key: 'invalid_block_content', base: 0, candidate: 1, delta: 1 },
+  ]);
+  assert.ok(summary.dimensions.bucket.some((row) => row.key === 'runtime_target_gap' && row.delta === -1));
+  assert.deepEqual(summary.dimensions.fixture_id[0], { key: 'portfolio-site', base: 0, candidate: 2, delta: 2 });
+  assert.equal(selectorFamily('script:nth-of-type(1)'), 'script');
+  assert.equal(selectorFamily('#hero .cta'), 'id:hero');
+});
+
+test('recipe runs a wp.blocks.validateBlock editor-validation step on imported content after each import', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-validation-recipe-test' });
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+  });
+
+  // [activate, validate(simple-site), editor-validation(simple-site)]
+  assert.equal(recipe.workflow.steps[1].command, 'wordpress.wp-cli');
+  assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
+  const editorStep = recipe.workflow.steps[2];
+  // The real validateBlock command, NOT the empty-post canvas probe.
+  assert.equal(editorStep.command, EDITOR_VALIDATE_BLOCKS_COMMAND);
+  assert.equal(editorStep.command, 'wordpress.editor-validate-blocks');
+  // No empty-post `post-new.php` URL and no bare `post-type` (which wp-codebox
+  // resolves to an empty post-new editor): it targets the imported static front
+  // page so it validates real imported content rather than a blank editor.
+  assert.equal(editorStep.args.some((arg) => arg.includes('post-new.php')), false);
+  assert.equal(editorStep.args.some((arg) => arg.startsWith('post-type=')), false);
+  assert.ok(editorStep.args.includes('target=front-page'));
+
+  const disabled = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    editorValidation: false,
+  });
+  assert.equal(disabled.workflow.steps.some((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND), false);
+});
+
+test('--no-editor-validation skips the editor-validate-blocks step while keeping native-rate + findings', () => {
+  // The editor-validate-blocks step launches a browser per site and is the
+  // slowest per-fixture step. --no-editor-validation skips it (companion to
+  // --no-visual-parity) so findings/native-rate still get collected. This proves
+  // the full thread: CLI flag -> bench env -> recipe step omission, plus that the
+  // result still carries native-rate/findings with no editor-validity data.
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-no-editor-validation-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const planFixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(planFixtureRoot, 'fixture-a'), { recursive: true });
+
+  // Default: editor-validation enabled, no skip env setting (unchanged behavior).
+  const enabledPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot: planFixtureRoot,
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(enabledPlan.editor_validation.enabled, true);
+  assert.equal(
+    enabledPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION=0'),
+    false,
+  );
+
+  // --no-editor-validation -> options.editorValidation === false -> env=0 setting
+  // threaded into the bench (mirrors --no-visual-parity exactly).
+  const skippedPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot: planFixtureRoot,
+    editorValidation: false,
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(skippedPlan.editor_validation.enabled, false);
+  assert.ok(skippedPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION=0'));
+
+  // Recipe: the editor-validate-blocks step is present by default and omitted when
+  // disabled, while the import/validate-artifact step (which feeds native-rate and
+  // findings) always survives.
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'no-editor-validation-recipe' });
+  const enabledRecipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+  });
+  assert.ok(enabledRecipe.workflow.steps.some((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND));
+
+  const skippedRecipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    editorValidation: false,
+  });
+  assert.equal(
+    skippedRecipe.workflow.steps.some((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND),
+    false,
+  );
+  assert.ok(skippedRecipe.workflow.steps.some((step) => /static-site-importer validate-artifact/.test(step.args?.[0] ?? '')));
+
+  // With the editor-validation step skipped there is no validateBlock editor-validity
+  // data, but native-rate (from block composition) and findings still flow.
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'passed',
+        // 8 native, 2 core/html => native_conversion_rate 0.8.
+        block_type_counts: {
+          'core/paragraph': 6,
+          'core/heading': 2,
+          'core/html': 2,
+        },
+        diagnostics: [
+          { kind: 'core_html_block', loss_class: 'native_conversion', message: 'Fell back to core/html.' },
+        ],
+      },
+    ],
+  });
+  assert.equal(result.summary.editor_quality.native_conversion_rate, 0.8);
+  assert.equal(result.summary.editor_quality.editor_validated_fixture_count, 0);
+  assert.ok(result.findings.length >= 1);
+});
+
+test('editorBlockValidationStep invokes editor-validate-blocks against the most concrete imported target', () => {
+  // Defaults to the imported static front page (resolved at runtime from
+  // page_on_front by wp-codebox) — real imported content, not an empty editor.
+  const fallback = editorBlockValidationStep({ fixture: { id: 'simple' } });
+  assert.equal(fallback.command, 'wordpress.editor-validate-blocks');
+  assert.deepEqual(fallback.args, ['target=front-page']);
+
+  // An explicit editor URL (e.g. post.php?post=<id>&action=edit) is honored.
+  const byUrl = editorBlockValidationStep({ fixture: { id: 'shop', editor_url: '/wp-admin/post.php?post=42&action=edit' } });
+  assert.equal(byUrl.command, 'wordpress.editor-validate-blocks');
+  assert.ok(byUrl.args.includes('url=/wp-admin/post.php?post=42&action=edit'));
+
+  // An imported post id is preferred over a URL.
+  const byPostId = editorBlockValidationStep({ fixture: { id: 'shop', post_id: 99 } });
+  assert.ok(byPostId.args.includes('post-id=99'));
+
+  // Inline imported content wins over everything else, plus wait passthrough.
+  const byContent = editorBlockValidationStep({
+    content: '<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->',
+    fixture: { id: 'shop', post_id: 99, editor_wait_selector: '.is-root-container' },
+  });
+  assert.ok(byContent.args.includes('content=<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->'));
+  assert.ok(byContent.args.includes('wait-selector=.is-root-container'));
+  assert.equal(byContent.args.some((arg) => arg.startsWith('post-id=')), false);
+});
+
+test('editor-canvas-probe invalid-block warnings become gating editor_block_invalid findings', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-canvas-invalid-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: collectEditorValidationDiagnostics({
+          summary: {
+            selectorSummary: {
+              groups: [
+                {
+                  name: 'editor_block_invalid',
+                  selector: '.block-editor-warning',
+                  count: 2,
+                  visible_count: 2,
+                  first_match: { text: 'This block contains unexpected or invalid content' },
+                },
+              ],
+            },
+          },
+        }),
+      },
+    ],
+  });
+
+  const finding = result.findings[0];
+  assert.equal(finding.kind, 'editor_block_invalid');
+  assert.equal(finding.group_key, 'editor_block_invalid');
+  assert.equal(finding.repair_bucket, 'editor_block_invalid');
+  assert.equal(finding.candidate_repo, 'blocks-engine');
+  assert.equal(finding.loss_class, 'editor_block_invalid');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(finding.selector, '.block-editor-warning');
+  assert.equal(result.summary.unacceptable_finding_count, 1);
+  assert.equal(result.summary.failed, 1);
+  assert.equal(result.summary.succeeded, 0);
+  assert.equal(result.fixtures[0].status, 'failed');
+});
+
+test('per-block editor validity (isValid=false) becomes an editor_block_invalid finding with block name and selector', () => {
+  const diagnostics = collectEditorValidationDiagnostics({
+    editor_validation: {
+      blocks: [
+        { name: 'core/paragraph', clientId: 'abc-1', isValid: true },
+        {
+          name: 'core/columns',
+          clientId: 'abc-2',
+          isValid: false,
+          issues: ['Block validation failed for "core/columns"'],
+        },
+      ],
+    },
+  });
+
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].kind, 'editor_block_invalid');
+  assert.equal(diagnostics[0].block_name, 'core/columns');
+  assert.equal(diagnostics[0].selector, '[data-block="abc-2"]');
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-block-validity-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'failed', diagnostics }],
+  });
+  assert.equal(result.findings[0].observed_block_name, 'core/columns');
+  assert.equal(result.findings[0].loss_acceptance, 'unacceptable');
+  assert.equal(result.fixtures[0].status, 'failed');
+});
+
+test('valid editor blocks produce no editor_block_invalid findings', () => {
+  const noWarnings = collectEditorValidationDiagnostics({
+    summary: {
+      selectorSummary: {
+        groups: [{ name: 'editor_block_invalid', selector: '.block-editor-warning', count: 0, visible_count: 0 }],
+      },
+    },
+    editor_validation: {
+      blocks: [
+        { name: 'core/paragraph', clientId: 'ok-1', isValid: true },
+        { name: 'core/heading', clientId: 'ok-2', isValid: true },
+      ],
+    },
+  });
+  assert.deepEqual(noWarnings, []);
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-valid-negative-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'passed', diagnostics: noWarnings }],
+  });
+  assert.equal(result.summary.unacceptable_finding_count, 0);
+  assert.equal(result.summary.succeeded, 1);
+  assert.equal(result.fixtures[0].status, 'passed');
+});
+
+test('editor_block_invalid findings collected from fixture artifacts gate the matrix', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-validation-artifact-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-validation-artifact-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'editor-canvas-summary.json'), JSON.stringify({
+    schema: 'wp-codebox/editor-canvas-probe/v1',
+    summary: {
+      selectorSummary: {
+        groups: [
+          {
+            name: 'editor_block_invalid',
+            selector: '.block-editor-warning',
+            count: 1,
+            visible_count: 1,
+            first_match: { text: 'This block contains unexpected or invalid content' },
+          },
+        ],
+      },
+    },
+  }));
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  const finding = result.findings.find((item) => item.kind === 'editor_block_invalid');
+  assert.ok(finding, 'expected an editor_block_invalid finding from the canvas-probe artifact');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(result.fixtures[0].status, 'failed');
+});
+
+const ALL_VALID_EDITOR_VALIDATE_BLOCKS = {
+  schema: 'wp-codebox/editor-validate-blocks/v1',
+  validation_method: 'wp.blocks.validateBlock',
+  validation_provider: 'wordpress-block-editor',
+  total_blocks: 3,
+  valid_blocks: 3,
+  invalid_blocks: 0,
+  results: [
+    { name: 'core/heading', isValid: true, issues: [] },
+    { name: 'core/paragraph', isValid: true, issues: [] },
+    { name: 'core/image', isValid: true, issues: [] },
+  ],
+};
+
+test('collectEditorValidation reads the editor-validate-blocks shape into headline metrics', () => {
+  const metrics = collectEditorValidation(ALL_VALID_EDITOR_VALIDATE_BLOCKS);
+  assert.equal(metrics.validation_method, 'wp.blocks.validateBlock');
+  assert.equal(metrics.validation_provider, 'wordpress-block-editor');
+  assert.equal(metrics.total_blocks, 3);
+  assert.equal(metrics.valid_blocks, 3);
+  assert.equal(metrics.invalid_blocks, 0);
+  assert.equal(collectEditorValidation({ unrelated: true }), null);
+});
+
+test('editor-validate-blocks all-valid output reports a 1.0 valid-block rate with zero invalid and no findings', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-validate-valid-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-validate-valid-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(
+    path.join(fixtureDirectory, 'editor-validate-blocks.json'),
+    JSON.stringify({ fixture_id: 'simple-site', success: true, ...ALL_VALID_EDITOR_VALIDATE_BLOCKS }),
+  );
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  const fixture = result.fixtures[0];
+
+  assert.equal(fixture.editor_quality.editor_validated, true);
+  assert.equal(fixture.editor_quality.validation_method, EDITOR_VALIDATION_METHOD);
+  assert.equal(fixture.editor_quality.validation_method, 'wp.blocks.validateBlock');
+  assert.equal(fixture.editor_quality.editor_valid_block_rate, 1);
+  assert.equal(fixture.editor_quality.invalid_block_count, 0);
+  assert.equal(result.findings.some((finding) => finding.kind === 'editor_block_invalid'), false);
+
+  // Summary-level editor-quality surfaces the real validity, distinct from PHP.
+  assert.equal(result.summary.editor_quality.validation_method, 'wp.blocks.validateBlock');
+  assert.equal(result.summary.editor_quality.editor_valid_block_rate, 1);
+  assert.equal(result.summary.editor_quality.invalid_block_count, 0);
+  assert.equal(result.summary.editor_quality.editor_validated_fixture_count, 1);
+  assert.equal(fixture.status, 'passed');
+});
+
+test('editor-validate-blocks result from a codebox execution is associated to the fixture via the import step slug', () => {
+  // Real shape: the per-fixture wp-codebox executions run in order
+  // ([..., validate-artifact, editor-validate-blocks]). The editor step carries
+  // NO fixture id of its own and emits its result as JSON on `result.stdout`,
+  // so the collector must derive the fixture from the import step's --slug and
+  // thread it forward to the editor execution. This is the wiring that makes a
+  // `target=front-page` run report real imported-block counts.
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-validate-codebox-'));
+  const matrix = createFixtureMatrix({
+    fixture_root: fixtureRoot,
+    id: 'editor-validate-codebox-test',
+    fixtures: [{ id: 'simple-site', fixture_path: path.join(fixtureRoot, 'simple-site'), directory: path.join(fixtureRoot, 'simple-site') }],
+  });
+  const codeboxOutput = {
+    success: true,
+    schema: 'wp-codebox/recipe-run-result/v1',
+    executions: [
+      {
+        command: 'wordpress.wp-cli',
+        args: ['command=static-site-importer validate-artifact --artifact=/wordpress/wp-content/uploads/x/simple-site/artifact.json --slug=simple-site --name=Simple --allow-missing-woocommerce --allow-failure'],
+        result: { schema: 'wp-codebox/runtime-command-result/v1', status: 'ok', stdout: JSON.stringify({ success: true, fixture_id: 'simple-site', import_report: { theme_slug: 'simple-site' } }) },
+      },
+      {
+        command: 'wordpress.editor-validate-blocks',
+        args: ['target=front-page'],
+        result: {
+          schema: 'wp-codebox/runtime-command-result/v1',
+          status: 'ok',
+          stdout: JSON.stringify({
+            schema: 'wp-codebox/editor-validate-blocks/v1',
+            validation_method: 'wp.blocks.validateBlock',
+            validation_provider: 'wordpress-block-editor',
+            total_blocks: 5,
+            valid_blocks: 4,
+            invalid_blocks: 1,
+            results: [
+              { name: 'core/navigation', isValid: false, issues: ['Block validation failed for "core/navigation"'] },
+              { name: 'core/heading', isValid: true, issues: [] },
+              { name: 'core/paragraph', isValid: true, issues: [] },
+              { name: 'core/image', isValid: true, issues: [] },
+              { name: 'core/spacer', isValid: true, issues: [] },
+            ],
+          }),
+        },
+      },
+    ],
+  };
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory, codeboxOutput });
+  const fixture = result.fixtures[0];
+
+  // The real validateBlock counts are surfaced on the fixture, not lost.
+  assert.equal(fixture.editor_validation.total_blocks, 5);
+  assert.equal(fixture.editor_validation.valid_blocks, 4);
+  assert.equal(fixture.editor_validation.invalid_blocks, 1);
+  assert.equal(fixture.editor_quality.validation_method, 'wp.blocks.validateBlock');
+  // The one invalid block becomes a gating editor_block_invalid finding.
+  const finding = result.findings.find((item) => item.kind === 'editor_block_invalid');
+  assert.ok(finding, 'expected an editor_block_invalid finding from the codebox editor-validate result');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+});
+
+test('editor-validate-blocks invalid block is counted and surfaced as a gating finding with name and reason', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-validate-invalid-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-validate-invalid-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(
+    path.join(fixtureDirectory, 'editor-validate-blocks.json'),
+    JSON.stringify({
+      fixture_id: 'simple-site',
+      success: false,
+      schema: 'wp-codebox/editor-validate-blocks/v1',
+      validation_method: 'wp.blocks.validateBlock',
+      validation_provider: 'wordpress-block-editor',
+      total_blocks: 3,
+      valid_blocks: 2,
+      invalid_blocks: 1,
+      results: [
+        { name: 'core/heading', isValid: true, issues: [] },
+        { name: 'core/columns', isValid: false, issues: ['Block validation failed for "core/columns": content mismatch'] },
+        { name: 'core/paragraph', isValid: true, issues: [] },
+      ],
+    }),
+  );
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  const fixture = result.fixtures[0];
+
+  // Real editor-validity: 2/3 valid, one invalid.
+  assert.equal(fixture.editor_quality.validation_method, 'wp.blocks.validateBlock');
+  assert.equal(fixture.editor_quality.invalid_block_count, 1);
+  assert.equal(fixture.editor_quality.editor_valid_block_rate, 0.6667);
+  assert.equal(result.summary.editor_quality.invalid_block_count, 1);
+  assert.equal(result.summary.editor_quality.editor_valid_block_rate, 0.6667);
+
+  // The invalid block flows into a gating editor_block_invalid finding carrying
+  // the block name and the validateBlock issue reason.
+  const finding = result.findings.find((item) => item.kind === 'editor_block_invalid');
+  assert.ok(finding, 'expected an editor_block_invalid finding for the invalid block');
+  assert.equal(finding.observed_block_name, 'core/columns');
+  assert.match(finding.reason, /core\/columns/);
+  assert.match(finding.reason, /content mismatch/);
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(fixture.status, 'failed');
+});
+
+test('scores editor-quality metrics from generic block composition and rolls them up', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-editor-quality-'));
+  const marketing = path.join(root, 'marketing-static');
+  const docs = path.join(root, 'docs-blog');
+  mkdirSync(marketing, { recursive: true });
+  mkdirSync(docs, { recursive: true });
+  writeFileSync(path.join(marketing, 'index.html'), '<h1>Landing</h1>');
+  writeFileSync(path.join(marketing, 'fixture.json'), JSON.stringify({ class: 'marketing/static' }));
+  writeFileSync(path.join(docs, 'index.html'), '<article>Docs</article>');
+  writeFileSync(path.join(docs, 'fixture.json'), JSON.stringify({ class: 'docs/blog' }));
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'editor-quality-test' });
+
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'marketing-static',
+        status: 'passed',
+        // 8 native (core/* + jetpack/* + woocommerce/*), 2 core/html => 0.8 / 0.2.
+        block_type_counts: {
+          'core/paragraph': 4,
+          'core/heading': 2,
+          'jetpack/contact-form': 1,
+          'woocommerce/product': 1,
+          'core/html': 2,
+        },
+      },
+      {
+        fixture_id: 'docs-blog',
+        status: 'passed',
+        // 6 native, 4 core/html => 0.6 / 0.4.
+        block_type_counts: {
+          'core/paragraph': 6,
+          'core/html': 4,
+        },
+      },
+    ],
+  });
+
+  const marketingFixture = result.fixtures.find((fixture) => fixture.fixture_id === 'marketing-static');
+  assert.equal(marketingFixture.editor_quality.block_total, 10);
+  assert.equal(marketingFixture.editor_quality.native_block_count, 8);
+  assert.equal(marketingFixture.editor_quality.core_html_block_count, 2);
+  assert.equal(marketingFixture.editor_quality.native_conversion_rate, 0.8);
+  assert.equal(marketingFixture.editor_quality.core_html_fallback_ratio, 0.2);
+  assert.equal(marketingFixture.editor_quality.source, 'block_type_breakdown');
+  assert.equal(marketingFixture.editor_quality.editor_invalid_count, 0);
+
+  // Aggregate uses summed totals (14 native / 20 total = 0.7; 6 core/html / 20 = 0.3).
+  assert.equal(result.summary.editor_quality.block_total, 20);
+  assert.equal(result.summary.editor_quality.native_block_count, 14);
+  assert.equal(result.summary.editor_quality.core_html_block_count, 6);
+  assert.equal(result.summary.editor_quality.native_conversion_rate, 0.7);
+  assert.equal(result.summary.editor_quality.core_html_fallback_ratio, 0.3);
+  assert.equal(result.summary.editor_quality.scored_fixture_count, 2);
+  assert.equal(result.summary.editor_quality.native_rate_gate.enabled, false);
+
+  // Per-class rollup carries the same generic metric.
+  assert.equal(result.summary.quality_budgets['docs/blog'].editor_quality.native_conversion_rate, 0.6);
+  assert.equal(result.summary.classes['marketing/static'].editor_quality.native_conversion_rate, 0.8);
+});
+
+test('parseSerializedBlockNames extracts wp: block names and normalizes core blocks', () => {
+  const markup = [
+    '<!-- wp:heading -->\n<h2>Title</h2>\n<!-- /wp:heading -->',
+    '<!-- wp:paragraph -->\n<p>Body</p>\n<!-- /wp:paragraph -->',
+    '<!-- wp:jetpack/contact-form {"subject":"x"} -->...<!-- /wp:jetpack/contact-form -->',
+    '<!-- wp:spacer {"height":"20px"} /-->',
+    '<!-- wp:html -->\n<svg></svg>\n<!-- /wp:html -->',
+  ].join('\n');
+
+  assert.deepEqual(parseSerializedBlockNames(markup), [
+    'core/heading',
+    'core/paragraph',
+    'jetpack/contact-form',
+    'core/spacer',
+    'core/html',
+  ]);
+  // Closing comments and non-block content never count, and non-strings are safe.
+  assert.deepEqual(parseSerializedBlockNames('<p>no blocks here</p>'), []);
+  assert.deepEqual(parseSerializedBlockNames(null), []);
+});
+
+test('collectBlockComposition computes native rate from serialized post_content (7 native + 3 core/html => 0.7 / 0.3)', () => {
+  const native = [
+    '<!-- wp:heading -->\n<h2>H</h2>\n<!-- /wp:heading -->',
+    '<!-- wp:paragraph -->\n<p>A</p>\n<!-- /wp:paragraph -->',
+    '<!-- wp:paragraph -->\n<p>B</p>\n<!-- /wp:paragraph -->',
+    '<!-- wp:list -->\n<ul><li>x</li></ul>\n<!-- /wp:list -->',
+    '<!-- wp:image {"id":1} -->\n<figure></figure>\n<!-- /wp:image -->',
+    '<!-- wp:jetpack/contact-form -->...<!-- /wp:jetpack/contact-form -->',
+    '<!-- wp:woocommerce/product-collection -->...<!-- /wp:woocommerce/product-collection -->',
+  ];
+  const coreHtml = [
+    '<!-- wp:html -->\n<svg></svg>\n<!-- /wp:html -->',
+    '<!-- wp:html -->\n<canvas></canvas>\n<!-- /wp:html -->',
+    '<!-- wp:html -->\n<audio></audio>\n<!-- /wp:html -->',
+  ];
+  const composition = collectBlockComposition({ post_content: [...native, ...coreHtml].join('\n') });
+
+  assert.equal(composition.source, 'serialized_blocks');
+  assert.equal(composition.block_total, 10);
+  assert.equal(composition.native_block_count, 7);
+  assert.equal(composition.core_html_block_count, 3);
+
+  // The same composition drives the per-fixture editor-quality score.
+  const editorQuality = computeFixtureEditorQuality({ fixture_id: 'serialized', block_composition: composition }, []);
+  assert.equal(editorQuality.scored, true);
+  assert.equal(editorQuality.native_conversion_rate, 0.7);
+  assert.equal(editorQuality.core_html_fallback_ratio, 0.3);
+});
+
+test('collectBlockComposition derives the rate from SSI import-report block_documents on live runs', () => {
+  // Shape that real Lab/WP Codebox runs emit: SSI records each materialized page's
+  // total block_count plus its core/html + freeform fallback counts. No explicit
+  // block_type_counts map is present, which is why the metric used to stay unscored.
+  const payload = {
+    import_report: {
+      materialized_content: {
+        block_documents: [
+          { source_path: 'posts/page-home.post_content', block_count: 5, core_html_block_count: 1, freeform_block_count: 0 },
+          { source_path: 'posts/page-faq.post_content', block_count: 5, core_html_block_count: 2, freeform_block_count: 0 },
+        ],
+      },
+      // Generated-theme duplicates the materialized pages; must not be double counted.
+      generated_theme: {
+        block_documents: [
+          { source_path: 'posts/page-home.post_content', block_count: 5, core_html_block_count: 1, freeform_block_count: 0 },
+          { source_path: 'posts/page-faq.post_content', block_count: 5, core_html_block_count: 2, freeform_block_count: 0 },
+        ],
+      },
+    },
+  };
+  const composition = collectBlockComposition(payload);
+
+  assert.equal(composition.source, 'block_documents');
+  assert.equal(composition.block_total, 10);
+  assert.equal(composition.core_html_block_count, 3);
+  // native = total - core/html - freeform = 10 - 3 - 0 = 7.
+  assert.equal(composition.native_block_count, 7);
+});
+
+test('native_conversion_rate populates end-to-end from an import-report block_documents payload', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'native-rate-live-run-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'passed',
+        import_report: {
+          materialized_content: {
+            block_documents: [
+              // 10 total blocks, 3 of them core/html => 7 native => 0.7 native rate.
+              { source_path: 'posts/page-home.post_content', block_count: 10, core_html_block_count: 3, freeform_block_count: 0 },
+            ],
+          },
+        },
+      },
+    ],
+  });
+
+  const fixture = result.fixtures.find((row) => row.fixture_id === 'simple-site');
+  assert.equal(fixture.editor_quality.scored, true);
+  assert.equal(fixture.editor_quality.source, 'block_documents');
+  assert.equal(fixture.editor_quality.native_conversion_rate, 0.7);
+  assert.equal(fixture.editor_quality.core_html_fallback_ratio, 0.3);
+  // The aggregate now carries a real native rate instead of a 0/0 null.
+  assert.equal(result.summary.editor_quality.native_conversion_rate, 0.7);
+  assert.equal(result.summary.editor_quality.core_html_fallback_ratio, 0.3);
+  assert.equal(result.summary.editor_quality.scored_fixture_count, 1);
+});
+
+test('opt-in native-rate gate fails low-native fixtures while editor_invalid_count reuses #537 findings', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'native-rate-gate-test' });
+  const makeResult = () => ({
+    fixture_id: 'simple-site',
+    status: 'passed',
+    // 3 native / 7 total ≈ 0.43 native conversion rate.
+    block_type_counts: { 'core/paragraph': 3, 'core/html': 4 },
+    diagnostics: [
+      { kind: 'editor_block_invalid', selector: '.block-editor-warning', message: 'Editor rendered 1 invalid-block warning for the imported post.' },
+    ],
+  });
+
+  // Gate off (default): metrics are scored, but no native-rate finding is emitted.
+  const ungated = normalizeFixtureMatrixResult({ matrix, results: [makeResult()] });
+  assert.equal(ungated.fixtures[0].editor_quality.editor_invalid_count, 1);
+  assert.ok(ungated.fixtures[0].editor_quality.native_conversion_rate < 0.5);
+  assert.equal(ungated.findings.some((finding) => finding.kind === 'native_conversion_rate_below_min'), false);
+
+  // Gate on: the low-native fixture earns an unacceptable finding and fails.
+  const gated = normalizeFixtureMatrixResult({ matrix, results: [makeResult()], editorQuality: { minNativeRate: 0.8 } });
+  const finding = gated.findings.find((row) => row.kind === 'native_conversion_rate_below_min');
+  assert.ok(finding, 'expected a native_conversion_rate_below_min finding when the gate is enabled');
+  assert.equal(finding.loss_class, 'low_native_conversion');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(gated.fixtures[0].status, 'failed');
+  assert.equal(gated.summary.editor_quality.native_rate_gate.enabled, true);
+  assert.equal(gated.summary.editor_quality.native_rate_gate.min_native_rate, 0.8);
+});
+
+test('recipe runs a wordpress.visual-compare visual-parity step after each import', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-recipe-test' });
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    pixelThreshold: 0.05,
+  });
+
+  // [activate, validate(simple-site), editor-validation(simple-site), visual-compare(simple-site)]
+  const visualStep = recipe.workflow.steps[3];
+  assert.equal(visualStep.command, 'wordpress.visual-compare');
+  assert.ok(visualStep.args.some((arg) => arg.startsWith('source-url=')));
+  assert.ok(visualStep.args.some((arg) => arg.startsWith('candidate-url=')));
+  assert.ok(visualStep.args.includes('threshold=0.05'));
+
+  const disabled = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    visualParity: false,
+  });
+  assert.equal(disabled.workflow.steps.some((step) => step.command === 'wordpress.visual-compare'), false);
+});
+
+test('visualParityCompareStep composes the existing wordpress.visual-compare command with per-fixture overrides', () => {
+  const step = visualParityCompareStep({
+    fixture: { id: 'shop', source_url: 'http://127.0.0.1:4173/shop/index.html', candidate_url: '/?p=42' },
+    pixelThreshold: 0.2,
+  });
+  assert.equal(step.command, 'wordpress.visual-compare');
+  assert.ok(step.args.includes('source-url=http://127.0.0.1:4173/shop/index.html'));
+  assert.ok(step.args.includes('candidate-url=/?p=42'));
+  assert.ok(step.args.includes('threshold=0.2'));
+  assert.ok(step.args.includes('source-label=shop-source'));
+  assert.ok(step.args.includes('candidate-label=shop-candidate'));
+});
+
+test('visualParityCompareStep demotes full-page capture to an opt-in (default bounded viewport)', () => {
+  // Default: full-page is OFF (the OOM-prone unbounded screenshot is no longer
+  // the default; the deterministic static parity gate is the primary signal).
+  const defaultStep = visualParityCompareStep({ fixture: { id: 'tall' } });
+  assert.ok(defaultStep.args.includes('full-page=false'));
+
+  // Opt-in per fixture re-enables full-page evidence.
+  for (const optIn of [
+    { fixture: { id: 'tall' }, fullPage: true },
+    { fixture: { id: 'tall' }, visual_parity_full_page: true },
+    { fixture: { id: 'tall' }, visualParityFullPage: true },
+  ]) {
+    assert.ok(visualParityCompareStep(optIn).args.includes('full-page=true'));
+  }
+});
+
+test('default visual-parity source-url targets the staged source/ subdir on the served uploads path', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-source-url-test' });
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    playgroundArtifactsDirectory: '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+  });
+
+  // [activate, validate(simple-site), editor-validation(simple-site), visual-compare(simple-site)]
+  const visualStep = recipe.workflow.steps[3];
+  const sourceArg = visualStep.args.find((arg) => arg.startsWith('source-url='));
+  assert.equal(
+    sourceArg,
+    'source-url=/wp-content/uploads/static-site-importer-fixture-matrix/simple-site/source/index.html',
+  );
+  // Candidate defaults to the imported front page served at `/`.
+  assert.ok(visualStep.args.includes('candidate-url=/'));
+});
+
+test('stageFixtureSource copies the raw fixture source into the served source/ subdir', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-parity-stage-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-stage-test' });
+  writeFixtureMatrixArtifacts({ outputDirectory, matrix });
+
+  const sourceDir = path.join(outputDirectory, 'simple-site', 'source');
+  // The fixture's own files (index.html + style.css) are served from source/,
+  // preserving their relative layout so assets resolve.
+  assert.ok(existsSync(path.join(sourceDir, 'index.html')), 'staged source index.html should exist');
+  assert.ok(existsSync(path.join(sourceDir, 'style.css')), 'staged source style.css should exist');
+  assert.equal(
+    readFileSync(path.join(sourceDir, 'index.html'), 'utf8'),
+    readFileSync(path.join(fixtureRoot, 'simple-site', 'index.html'), 'utf8'),
+  );
+  // The import payload (artifact.json) is still written alongside, unchanged.
+  assert.ok(existsSync(path.join(outputDirectory, 'simple-site', 'artifact.json')), 'artifact.json should still be written');
+});
+
+test('stageFixtureSource direct call returns staged relative paths', () => {
+  const fixtureDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-parity-stage-direct-'));
+  const staged = stageFixtureSource(
+    { id: 'simple-site', directory: path.join(fixtureRoot, 'simple-site') },
+    fixtureDirectory,
+  );
+  assert.ok(staged.includes('index.html'));
+  assert.ok(existsSync(path.join(fixtureDirectory, 'source', 'index.html')));
+});
+
+test('wordpressServedPath strips the /wordpress docroot prefix', () => {
+  assert.equal(
+    wordpressServedPath('/wordpress/wp-content/uploads/foo'),
+    '/wp-content/uploads/foo',
+  );
+  // Already-served paths are returned normalized but unchanged in meaning.
+  assert.equal(wordpressServedPath('/wp-content/uploads/foo'), '/wp-content/uploads/foo');
+});
+
+test('(a) visual-compare mismatch at/under threshold produces no finding', () => {
+  const payload = {
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: { mismatchPixels: 1000, totalPixels: 2048000, dimensionMismatch: false },
+  };
+  // ratio ~0.0005, threshold 0.1 -> captured, no diagnostic.
+  assert.deepEqual(collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true }), []);
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-under-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'passed', diagnostics: collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true }) }],
+  });
+  assert.equal(result.findings.some((finding) => finding.kind === VISUAL_PARITY_MISMATCH_KIND), false);
+  assert.equal(result.fixtures[0].status, 'passed');
+});
+
+test('(b) visual-compare mismatch over threshold with gate on becomes a gating unacceptable finding', () => {
+  const payload = {
+    schema: 'homeboy/VisualParityArtifact/v1',
+    summary: { mismatch_pixels: 600000, total_pixels: 2048000, dimension_mismatch: false },
+    artifacts: { source_screenshot: 'files/browser/visual-compare/source.png', candidate_screenshot: 'files/browser/visual-compare/candidate.png', diff_screenshot: 'files/browser/visual-compare/diff.png' },
+  };
+  const diagnostics = collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true });
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].kind, VISUAL_PARITY_MISMATCH_KIND);
+  assert.equal(diagnostics[0].gate, true);
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-gate-on-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'passed', diagnostics }],
+  });
+  const finding = result.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(finding, 'expected a visual_parity_mismatch finding');
+  assert.equal(finding.group_key, 'visual_parity_mismatch');
+  assert.equal(finding.repair_bucket, 'visual_parity_mismatch');
+  assert.equal(finding.candidate_repo, 'blocks-engine');
+  assert.equal(finding.loss_class, 'visual_parity_mismatch');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(result.summary.unacceptable_finding_count, 1);
+  assert.equal(result.fixtures[0].status, 'failed');
+});
+
+test('(c) visual-compare mismatch over threshold with gate off is captured but non-gating', () => {
+  const payload = {
+    schema: 'homeboy/VisualParityArtifact/v1',
+    summary: { mismatch_pixels: 600000, total_pixels: 2048000, dimension_mismatch: false },
+  };
+  const diagnostics = collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: false });
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].gate, undefined);
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-gate-off-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'passed', diagnostics }],
+  });
+  const finding = result.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(finding, 'expected a captured visual_parity_mismatch finding');
+  assert.equal(finding.loss_acceptance, 'acceptable');
+  assert.equal(result.summary.unacceptable_finding_count, 0);
+  assert.equal(result.fixtures[0].status, 'passed');
+});
+
+test('visual-compare artifacts collected from fixture files gate the matrix when gating is opted in', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-parity-artifact-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-artifact-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'visual-diff.json'), JSON.stringify({
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: { mismatchPixels: 700000, totalPixels: 2048000, dimensionMismatch: false },
+    files: {
+      sourceScreenshot: 'files/browser/visual-compare/source.png',
+      candidateScreenshot: 'files/browser/visual-compare/candidate.png',
+      diffScreenshot: 'files/browser/visual-compare/diff.png',
+      visualDiff: 'files/browser/visual-compare/visual-diff.json',
+    },
+  }));
+
+  const gated = collectFixtureMatrixRunResults({ matrix, outputDirectory, visualParity: { threshold: 0.1, gate: true } });
+  const finding = gated.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(finding, 'expected a visual_parity_mismatch finding from the visual-compare artifact');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(gated.fixtures[0].status, 'failed');
+  // The visual_parity_artifacts slot captures screenshots + diff + metrics.
+  assert.equal(gated.fixtures[0].visual_parity_artifacts.schema, 'static-site-importer/visual-parity-artifacts/v1');
+  assert.equal(gated.fixtures[0].visual_parity_artifacts.artifacts.diff_screenshot.status, 'captured');
+  assert.equal(gated.fixtures[0].visual_parity_artifacts.metrics.mismatch_pixels, 700000);
+
+  // Same artifact, gate off (default) -> captured, non-gating.
+  const captured = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  const capturedFinding = captured.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(capturedFinding, 'expected the mismatch to still be captured');
+  assert.equal(capturedFinding.loss_acceptance, 'acceptable');
+  assert.equal(captured.fixtures[0].status, 'passed');
+});
+
+test('visual-compare dimension mismatch gates even with zero pixel metrics when gating is on', () => {
+  const payload = { comparison: { mismatchPixels: 0, totalPixels: 0, dimensionMismatch: true } };
+  const diagnostics = collectVisualParityDiagnostics(payload, { gate: true });
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].dimension_mismatch, true);
+});
+
+test('(fair) dimension-dominated raw ratio does NOT gate when the overlap is faithful', () => {
+  // 1380x7248 source vs 1280x5017 candidate, overlap pixel-perfect. The raw union
+  // ratio is huge (the canvas-size band) but the fair overlap ratio is 0, so a
+  // faithful styled import must NOT produce a gating finding.
+  const totalPixels = 1380 * 7248;
+  const overlapPixels = 1280 * 5017;
+  const payload = {
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: {
+      mismatchPixels: totalPixels - overlapPixels,
+      totalPixels,
+      dimensionMismatch: true,
+      overlapMismatchPixels: 0,
+      overlapPixels,
+      dimensionDeltaPixels: totalPixels - overlapPixels,
+    },
+  };
+  assert.deepEqual(collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true }), []);
+});
+
+test('(fair) a real in-overlap difference still gates on the fair ratio', () => {
+  // 20% of the overlap genuinely differs even though dimensions also differ. The
+  // fair ratio (0.2) exceeds the threshold, so it gates and reports overlap counts.
+  const overlapPixels = 1280 * 5017;
+  const overlapMismatchPixels = Math.round(overlapPixels * 0.2);
+  const totalPixels = 1380 * 7248;
+  const payload = {
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: {
+      mismatchPixels: overlapMismatchPixels + (totalPixels - overlapPixels),
+      totalPixels,
+      dimensionMismatch: true,
+      overlapMismatchPixels,
+      overlapPixels,
+      dimensionDeltaPixels: totalPixels - overlapPixels,
+    },
+  };
+  const diagnostics = collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true });
+  assert.equal(diagnostics.length, 1);
+  assert.ok(Math.abs(diagnostics[0].mismatch_ratio - 0.2) < 0.001, `gating ratio should be the fair ~0.2, got ${diagnostics[0].mismatch_ratio}`);
+  assert.equal(diagnostics[0].mismatch_pixels, overlapMismatchPixels);
+  assert.equal(diagnostics[0].total_pixels, overlapPixels);
+  assert.ok(diagnostics[0].raw_mismatch_ratio > diagnostics[0].mismatch_ratio, 'raw ratio should exceed fair ratio');
+});
+
+test('(fair) pre-overlap evidence falls back to the raw ratio for gating', () => {
+  // Older wp-codebox evidence with no overlap fields still gates on the raw ratio.
+  const payload = {
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: { mismatchPixels: 600000, totalPixels: 2048000, dimensionMismatch: false },
+  };
+  const diagnostics = collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true });
+  assert.equal(diagnostics.length, 1);
+  assert.ok(Math.abs(diagnostics[0].mismatch_ratio - 600000 / 2048000) < 1e-9);
+});
+
+// #554: at lane scale (~30+ fixtures) the aggregate result used to retain each
+// fixture's raw serialized `post_content`/block markup (via `raw: input` and the
+// #552 block-composition path) plus uncapped finding snippets, so JSON.stringify
+// of the assembled result exceeded V8's ~512MB per-string ceiling and threw
+// `Invalid string length`. The output must now be bounded by #fixtures/#findings,
+// not by raw content volume.
+test('bounds the assembled output regardless of per-fixture raw content volume (#554)', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-bounded-output-'));
+  const fixtureCount = 40;
+  // ~5MB serialized post_content + many large finding snippets per fixture, so
+  // the raw input dwarfs any safe serialized-output bound.
+  const hugePostContent = '<!-- wp:paragraph --><p>'.concat('x'.repeat(5 * 1024 * 1024), '</p><!-- /wp:paragraph -->');
+  const hugeSnippet = '<section>'.concat('y'.repeat(200 * 1024), '</section>');
+  let rawContentBytes = 0;
+
+  const results = [];
+  for (let index = 0; index < fixtureCount; index += 1) {
+    const id = `marketing-${String(index).padStart(3, '0')}`;
+    const directory = path.join(root, id);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, 'index.html'), '<h1>Landing</h1>');
+    writeFileSync(path.join(directory, 'fixture.json'), JSON.stringify({ class: 'marketing/static' }));
+
+    // Many findings, each carrying a large source snippet / observed output.
+    const diagnostics = [];
+    for (let findingIndex = 0; findingIndex < 12; findingIndex += 1) {
+      diagnostics.push({
+        kind: 'runtime_dependency_missing_dom_target',
+        repair_bucket: 'runtime_target_gap',
+        candidate_repo: 'blocks-engine',
+        source_path: `website/page-${findingIndex}.html`,
+        selector: `#widget-${findingIndex}`,
+        source_html_preview: hugeSnippet,
+        emitted_block_preview: hugeSnippet,
+        message: `Runtime target missing for widget ${findingIndex}: ${hugeSnippet}`,
+      });
+      rawContentBytes += hugeSnippet.length * 2 + hugeSnippet.length;
+    }
+
+    results.push({
+      fixture_id: id,
+      status: 'failed',
+      // The #552 block-composition path: counts come from block_type_counts; the
+      // raw markup below must NOT survive into the assembled output.
+      block_type_counts: { 'core/paragraph': 7, 'core/html': 3 },
+      post_content: hugePostContent,
+      import_report: {
+        materialized_content: {
+          block_documents: [
+            { source_path: 'posts/page-home.post_content', block_count: 10, core_html_block_count: 3, freeform_block_count: 0, post_content: hugePostContent },
+          ],
+        },
+      },
+      diagnostics,
+    });
+    rawContentBytes += hugePostContent.length * 2;
+  }
+
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'bounded-output-scale-test' });
+  assert.equal(matrix.fixtures.length, fixtureCount);
+
+  const result = normalizeFixtureMatrixResult({ matrix, results });
+
+  // The assembled aggregate must serialize without throwing `Invalid string
+  // length`, and stay well under a safe bound regardless of raw content volume.
+  let serialized;
+  assert.doesNotThrow(() => { serialized = JSON.stringify(result); }, 'assembled result must JSON.stringify successfully');
+  const serializedBytes = Buffer.byteLength(serialized, 'utf8');
+  const FIFTY_MB = 50 * 1024 * 1024;
+  assert.ok(serializedBytes < FIFTY_MB, `serialized output ${serializedBytes} bytes must stay under ${FIFTY_MB} bytes`);
+  // The raw inputs are an order of magnitude larger than the bound: output size
+  // is decoupled from raw content volume, not merely "small for this fixture set".
+  assert.ok(rawContentBytes > 200 * 1024 * 1024, 'sanity: the raw inputs must dwarf the output bound');
+  assert.ok(serializedBytes * 10 < rawContentBytes, 'output must be bounded independently of raw content volume');
+
+  // Raw bulk is dropped: no `raw` blob is retained on fixtures or findings, and
+  // no full-length serialized body survives.
+  assert.ok(result.fixtures.every((fixture) => fixture.raw === undefined), 'fixture results must not retain raw input');
+  assert.ok(result.findings.every((finding) => finding.raw === undefined), 'findings must not retain the raw diagnostic');
+  assert.ok(result.findings.every((finding) => finding.source_snippet.length < hugeSnippet.length), 'finding snippets must be truncated');
+  const retainedPostContent = result.fixtures[0].import_report.materialized_content.block_documents[0].post_content;
+  assert.ok(retainedPostContent.length < hugePostContent.length, 'retained report markup must be truncated');
+
+  // Metrics survive the bounding intact: native rate, block counts, and finding
+  // counts are computed from the full input before raw bulk is dropped.
+  assert.equal(result.summary.editor_quality.block_total, fixtureCount * 10);
+  assert.equal(result.summary.editor_quality.native_block_count, fixtureCount * 7);
+  assert.equal(result.summary.editor_quality.core_html_block_count, fixtureCount * 3);
+  assert.equal(result.summary.editor_quality.native_conversion_rate, 0.7);
+  assert.equal(result.summary.fixture_count, fixtureCount);
+  assert.ok(result.summary.finding_count >= fixtureCount, 'every fixture must contribute findings');
+});
+
+test('live-WP parity capture step is opt-in and off by default', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'live-wp-default' });
+
+  const off = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi' });
+  assert.equal(
+    off.workflow.steps.some((step) => step.command === 'wordpress.capture-html'),
+    false,
+    'capture-html is not emitted unless live-WP parity is explicitly enabled',
+  );
+  assert.equal(liveWpParityEnabled({}), false);
+  assert.equal(liveWpParityEnabled({ live_wp_parity: true }), true);
+});
+
+test('live-WP parity capture step renders DOM HTML deterministically with external requests blocked', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'live-wp-on' });
+  const recipe = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', liveWpParity: true });
+
+  const captureSteps = recipe.workflow.steps.filter((step) => step.command === 'wordpress.capture-html');
+  assert.ok(captureSteps.length >= 1, 'one capture-html step per fixture when enabled');
+  const args = captureSteps[0].args;
+  assert.ok(args.includes('capture=html'), 'captures DOM HTML, not a screenshot');
+  assert.ok(args.includes('network-policy=block'), 'blocks external requests for determinism');
+  assert.ok(args.some((arg) => arg.startsWith('url=')), 'targets the imported candidate URL');
+  assert.ok(args.every((arg) => !arg.includes('screenshot')), 'never requests a screenshot');
+
+  // Same inputs -> identical step (the recipe builder is pure).
+  const repeat = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', liveWpParity: true });
+  assert.deepEqual(
+    repeat.workflow.steps.filter((step) => step.command === 'wordpress.capture-html'),
+    captureSteps,
+  );
+
+  // The standalone step builder honors a per-fixture candidate override.
+  const overridden = liveWpParityCaptureStep({ fixture: { id: 'x', candidate_url: '/about/' } });
+  assert.ok(overridden.args.includes('url=/about/'));
+});
+
+test('runLiveWpParity feeds the captured snapshot to the blocks-engine CLI and surfaces live-WP vs proxy', () => {
+  const cliReport = {
+    schema: 'blocks-engine/php-transformer/live-wp-parity-report/v1',
+    source: 'index.html',
+    candidate: 'snapshot.html',
+    live_wp: {
+      status: 'fail',
+      parity: { score: 0.91, property_parity: 0.97, coverage: 0.94 },
+      summary: { source_total: 100, matched_total: 94, finding_total: 6 },
+      matches: [
+        {
+          source_selector: 'a.cta',
+          target_selector: 'a.cta.wp-element-button',
+          style_deltas: [{ property: 'background-color', source: '#ff0000', target: '' }],
+        },
+      ],
+    },
+    comparison: { live_wp_score: 0.91, proxy_score: 0.7328, delta: 0.1772 },
+  };
+
+  const calls = [];
+  const exec = (command, args) => {
+    calls.push({ command, args });
+    return { status: 0, stdout: JSON.stringify(cliReport), stderr: '' };
+  };
+
+  const result = runLiveWpParity({
+    sourceHtmlPath: '/fixtures/15-saas/index.html',
+    candidateHtmlPath: '/artifacts/15-saas/files/browser/snapshot.html',
+    blocksEnginePhpTransformerPath: '/repo/php-transformer',
+    exec,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'php');
+  assert.ok(calls[0].args[0].endsWith(path.join('tools', 'live-wp-parity', 'run.php')));
+  assert.ok(calls[0].args.includes('--with-proxy'));
+  assert.ok(calls[0].args.includes('--json'));
+  assert.ok(calls[0].args.includes('/artifacts/15-saas/files/browser/snapshot.html'));
+
+  assert.equal(result.schema, 'static-site-importer/live-wp-parity-result/v1');
+  assert.equal(result.score, 0.91);
+  assert.equal(result.finding_total, 6);
+  assert.equal(result.comparison.proxy_score, 0.7328);
+  assert.equal(result.comparison.delta, 0.1772);
+  assert.equal(result.property_diffs.length, 1);
+  assert.equal(result.property_diffs[0].property, 'background-color');
+  assert.equal(result.property_diffs[0].source_selector, 'a.cta');
+});
+
+test('runLiveWpParity surfaces a CLI failure rather than a bogus parity result', () => {
+  const exec = () => ({ status: 2, stdout: '', stderr: 'Candidate file not found: snapshot.html' });
+  assert.throws(
+    () => runLiveWpParity({
+      sourceHtmlPath: '/s.html',
+      candidateHtmlPath: '/c.html',
+      blocksEnginePhpTransformerPath: '/repo/php-transformer',
+      exec,
+    }),
+    /live-wp-parity CLI failed/,
+  );
+});
+
+test('normalizeLiveWpParityReport bounds the per-property diff list', () => {
+  const matches = [{
+    source_selector: 's',
+    target_selector: 't',
+    style_deltas: Array.from({ length: 40 }, (_, i) => ({ property: `p${i}`, source: 'a', target: 'b' })),
+  }];
+  const normalized = normalizeLiveWpParityReport({ live_wp: { matches, parity: { score: 0.5 } } }, { diffLimit: 10 });
+  assert.equal(normalized.property_diffs.length, 10);
+  assert.equal(normalized.score, 0.5);
+  assert.equal(normalized.comparison, undefined, 'no comparison block when the CLI omits --with-proxy');
+});
+
+// End-to-end toggle wiring (PR #578 follow-up): proves the live-WP parity toggle
+// is threaded flag -> env -> recipe -> collector, and that the OFF path is
+// byte-identical to today (capture step absent, result carries no live_wp_parity).
+test('--live-wp-parity threads flag -> env into the bench, OFF leaves it absent', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-live-wp-parity-plan-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const planFixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(planFixtureRoot, 'fixture-a'), { recursive: true });
+
+  // Default: no live-WP parity env setting (unchanged behavior).
+  const offPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot: planFixtureRoot,
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(
+    offPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_LIVE_WP_PARITY=1'),
+    false,
+    'no live-WP parity bench env is emitted unless the flag is passed',
+  );
+
+  // --live-wp-parity -> options.liveWpParity === true -> env=1 setting threaded
+  // into the bench (mirrors --visual-parity-gate).
+  const onPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot: planFixtureRoot,
+    liveWpParity: true,
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.ok(onPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_LIVE_WP_PARITY=1'));
+});
+
+test('live-WP parity toggle adds the capture step + invokes the collector when ON, byte-identical OFF', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'live-wp-toggle' });
+  const fixtureId = matrix.fixtures[0].id;
+
+  // RECIPE: OFF is byte-identical to the same recipe with no live-WP input, and
+  // emits no capture-html step. ON appends exactly one capture-html step.
+  const recipeBaseline = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi' });
+  const recipeOff = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', liveWpParity: false });
+  assert.deepEqual(recipeOff, recipeBaseline, 'liveWpParity:false leaves the recipe byte-identical to today');
+  assert.equal(recipeOff.workflow.steps.some((step) => step.command === 'wordpress.capture-html'), false);
+  const recipeOn = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', liveWpParity: true });
+  assert.equal(recipeOn.workflow.steps.filter((step) => step.command === 'wordpress.capture-html').length, 1);
+
+  // COLLECTOR: stage the captured rendered DOM snapshot + the source so the
+  // host-side collector has both sides to compare.
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-live-wp-collector-'));
+  mkdirSync(path.join(outputDirectory, fixtureId, 'files', 'browser'), { recursive: true });
+  mkdirSync(path.join(outputDirectory, fixtureId, 'source'), { recursive: true });
+  writeFileSync(path.join(outputDirectory, fixtureId, 'files', 'browser', 'snapshot.html'), '<html><body>candidate</body></html>', 'utf8');
+  writeFileSync(path.join(outputDirectory, fixtureId, 'source', 'index.html'), '<html><body>source</body></html>', 'utf8');
+
+  const cliReport = {
+    schema: 'blocks-engine/php-transformer/live-wp-parity-report/v1',
+    source: 'index.html',
+    candidate: 'snapshot.html',
+    live_wp: {
+      status: 'fail',
+      parity: { score: 0.88, property_parity: 0.95, coverage: 0.9 },
+      summary: { source_total: 50, matched_total: 45, finding_total: 5 },
+      matches: [],
+    },
+    comparison: { live_wp_score: 0.88, proxy_score: 0.7, delta: 0.18 },
+  };
+  const calls = [];
+  const exec = (command, args) => {
+    calls.push({ command, args });
+    return { status: 0, stdout: JSON.stringify(cliReport), stderr: '' };
+  };
+
+  // OFF (and absent) are byte-identical and carry no live_wp_parity.
+  const resultAbsent = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  const resultOff = collectFixtureMatrixRunResults({ matrix, outputDirectory, liveWpParity: { enabled: false, exec } });
+  assert.deepEqual(resultOff, resultAbsent, 'disabled live-WP parity is byte-identical to the default collector result');
+  assert.equal(resultAbsent.fixtures[0].live_wp_parity, undefined, 'no live_wp_parity key on the default result');
+  assert.equal(calls.length, 0, 'the comparator is never invoked when the toggle is off');
+
+  // ON: the comparator runs with --with-proxy and the result carries the live-WP
+  // score, the render-free proxy score, and the live-vs-proxy delta.
+  const resultOn = collectFixtureMatrixRunResults({
+    matrix,
+    outputDirectory,
+    liveWpParity: { enabled: true, blocksEnginePhpTransformerPath: '/repo/php-transformer', exec },
+  });
+  assert.equal(calls.length, 1, 'the comparator is invoked once per fixture when on');
+  assert.ok(calls[0].args.includes('--with-proxy'), 'the collector requests the render-free proxy delta');
+  assert.ok(calls[0].args.includes(path.join(outputDirectory, fixtureId, 'files', 'browser', 'snapshot.html')));
+  const liveWp = resultOn.fixtures[0].live_wp_parity;
+  assert.ok(liveWp, 'the fixture result carries a live-WP parity result when on');
+  assert.equal(liveWp.schema, 'static-site-importer/live-wp-parity-result/v1');
+  assert.equal(liveWp.score, 0.88);
+  assert.equal(liveWp.comparison.proxy_score, 0.7);
+  assert.equal(liveWp.comparison.delta, 0.18);
+});
+
+test('live-WP parity collector failure is isolated and never sinks the lane', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'live-wp-isolation' });
+  const fixtureId = matrix.fixtures[0].id;
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-live-wp-isolation-'));
+  mkdirSync(path.join(outputDirectory, fixtureId, 'files', 'browser'), { recursive: true });
+  mkdirSync(path.join(outputDirectory, fixtureId, 'source'), { recursive: true });
+  writeFileSync(path.join(outputDirectory, fixtureId, 'files', 'browser', 'snapshot.html'), '<html></html>', 'utf8');
+  writeFileSync(path.join(outputDirectory, fixtureId, 'source', 'index.html'), '<html></html>', 'utf8');
+
+  // Comparator hard-fails: the collector swallows it (no live_wp_parity) rather
+  // than throwing out of the lane.
+  const exec = () => ({ status: 2, stdout: '', stderr: 'boom' });
+  const result = collectFixtureMatrixRunResults({
+    matrix,
+    outputDirectory,
+    liveWpParity: { enabled: true, blocksEnginePhpTransformerPath: '/repo/php-transformer', exec },
+  });
+  assert.equal(result.fixtures[0].live_wp_parity, undefined, 'a comparator failure yields no live-WP result, not an aborted lane');
+  assert.equal(result.schema, 'static-site-importer/fixture-matrix-result/v1');
+});

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -1,0 +1,672 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const RIG_ID = 'static-site-importer-fixture-matrix';
+// Expected top-level fixture directory count in the canonical corpus
+// (`blocks-engine/fixtures/websites`). This is an intentional drift guard, not a
+// derived value: the corpus lives in a different repo, so deriving the canonical
+// number from whatever happens to be on disk would make the check tautological
+// (always "matches") and defeat its purpose. Bump this deliberately when the
+// corpus grows/shrinks. Source of truth:
+//   git -C blocks-engine ls-tree -d --name-only origin/trunk:fixtures/websites | wc -l
+// Last verified against origin/trunk @ 8ad42fd = 72 directories.
+export const CANONICAL_FIXTURE_COUNT = 72;
+
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const plan = buildFixtureMatrixRunPlan(options);
+
+  if (plan.code_freshness.would_block) {
+    process.stderr.write(freshnessGuardBanner(plan.code_freshness, options));
+  }
+
+  if (options.dryRun) {
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return;
+  }
+
+  if (plan.code_freshness.would_block && !options.allowStaleOverride) {
+    process.exitCode = 1;
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(plan.output_file), { recursive: true });
+
+  // Install/sync run first; a non-zero exit there is a genuine setup failure and
+  // should still abort via runCommand's throw.
+  const benchStep = plan.steps.at(-1);
+  for (const step of plan.steps.slice(0, -1)) {
+    runCommand(step);
+  }
+
+  // The bench step exits non-zero on a gate-FAIL (one or more fixtures failed).
+  // That is an expected, summarizable outcome — not a fatal error — so capture
+  // its exit status instead of throwing. summarizeBenchRun only throws when the
+  // bench genuinely crashed (no parseable result payload written to --output).
+  const benchStatus = runStep(benchStep);
+  const { summary, gateFailed } = summarizeBenchRun({
+    plan,
+    benchStatus,
+    benchLabel: benchStep.label,
+  });
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  if (gateFailed) {
+    process.exitCode = 1;
+  }
+}
+
+export function buildFixtureMatrixRunPlan(input) {
+  const options = normalizeOptions(input);
+  const settings = {
+    SSI_FIXTURE_MATRIX_FIXTURE_ROOT: options.fixtureRoot,
+    SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH: options.staticSiteImporter,
+    SSI_FIXTURE_MATRIX_RUN: '1',
+    ...(options.blocksEnginePhpTransformerPath
+      ? { SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH: options.blocksEnginePhpTransformerPath }
+      : {}),
+    ...(options.batchSize ? { SSI_FIXTURE_MATRIX_BATCH_SIZE: String(options.batchSize) } : {}),
+    ...(options.concurrency ? { SSI_FIXTURE_MATRIX_CONCURRENCY: String(options.concurrency) } : {}),
+    ...(options.wordpressVersion ? { SSI_FIXTURE_MATRIX_WORDPRESS_VERSION: options.wordpressVersion } : {}),
+    ...(options.wpCodeboxBin ? { SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN: options.wpCodeboxBin } : {}),
+    ...(options.editorValidation === false ? { SSI_FIXTURE_MATRIX_EDITOR_VALIDATION: '0' } : {}),
+    ...(options.visualParity === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY: '0' } : {}),
+    ...(options.visualParityGate ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '1' } : {}),
+    ...(options.pixelThreshold ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD: String(options.pixelThreshold) } : {}),
+    // Opt-in live-WP parity capture (off by default). When set, the bench appends
+    // the deterministic `wordpress.capture-html` step per fixture and runs the
+    // blocks-engine live-wp-parity comparator host-side. Absent => byte-identical
+    // to today (no setting emitted, render-free static gate stays primary).
+    ...(options.liveWpParity ? { SSI_FIXTURE_MATRIX_LIVE_WP_PARITY: '1' } : {}),
+    ...(options.minNativeRate ? { SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE: String(options.minNativeRate) } : {}),
+    // Lane/tag selection driven by the per-fixture manifest classification: run a
+    // single class lane (e.g. marketing/static) and/or only fixtures carrying a
+    // given manifest tag.
+    ...(options.class ? { SSI_FIXTURE_MATRIX_CLASS: String(options.class) } : {}),
+    ...(options.tag ? { SSI_FIXTURE_MATRIX_TAG: String(options.tag) } : {}),
+  };
+  const fixtureCount = countTopLevelFixtureDirectories(options.fixtureRoot);
+  const codeFreshness = buildCodeFreshness(options, options.gitRunner || defaultGitRunner);
+  const warnings = [
+    ...buildWarnings(options),
+    ...buildCanonicalDriftWarnings(fixtureCount, options.fixtureRoot),
+    ...buildFreshnessWarnings(codeFreshness, options),
+  ];
+
+  return {
+    schema: 'static-site-importer/fixture-matrix-operator-run/v1',
+    mode: options.mode,
+    rig: RIG_ID,
+    runner: options.runner,
+    local: Boolean(options.local),
+    run_id: options.runId,
+    static_site_importer: options.staticSiteImporter,
+    blocks_engine: options.blocksEngine,
+    homeboy_bin: options.homeboyBin,
+    fixture_root: options.fixtureRoot,
+    fixture_count: fixtureCount,
+    canonical_fixture_count: CANONICAL_FIXTURE_COUNT,
+    fixture_count_matches_canonical: fixtureCount === CANONICAL_FIXTURE_COUNT,
+    output_file: options.output,
+    temp_root: options.tempRoot,
+    artifact_root: options.artifactRoot,
+    shared_state: options.sharedState,
+    namespace: options.namespace,
+    allow_stale_override: Boolean(options.allowStaleOverride),
+    visual_parity: {
+      enabled: options.visualParity !== false,
+      // Opt-in hard gate; default capture-only because pixel diffs can be flaky.
+      gate: Boolean(options.visualParityGate),
+      pixel_threshold: options.pixelThreshold ? Number(options.pixelThreshold) : null,
+    },
+    editor_quality: {
+      // Editor-quality metrics (native_conversion_rate, core_html_fallback_ratio,
+      // editor_invalid_count) are always scored and emitted. The native-rate gate
+      // is opt-in and off by default, mirroring --visual-parity-gate.
+      native_rate_gate: Boolean(options.minNativeRate),
+      min_native_rate: options.minNativeRate ? Number(options.minNativeRate) : null,
+    },
+    editor_validation: {
+      // The wordpress.editor-validate-blocks step launches a browser per site and
+      // is the slowest per-fixture step. --no-editor-validation skips it (mirroring
+      // --no-visual-parity) so a run still produces native-rate/loss-classes/
+      // findings, just without the validateBlock editor-validity data.
+      enabled: options.editorValidation !== false,
+    },
+    code_freshness: codeFreshness,
+    transformer_commit: resolveTransformerCommit(codeFreshness),
+    warnings,
+    dependency_overrides: options.blocksEnginePhpTransformerPath
+      ? { blocks_engine_php_transformer: { path: options.blocksEnginePhpTransformerPath } }
+      : {},
+    steps: buildSteps(options, settings),
+  };
+}
+
+function normalizeOptions(input) {
+  if (!input.staticSiteImporter) {
+    throw new Error('--static-site-importer is required');
+  }
+
+  const blocksEngine = input.blocksEngine ? path.resolve(input.blocksEngine) : '';
+  if (!input.fixtureRoot && !blocksEngine) {
+    throw new Error('--blocks-engine or --fixture-root is required');
+  }
+  const fixtureRoot = path.resolve(input.fixtureRoot || path.join(blocksEngine, 'fixtures', 'websites'));
+
+  const defaultBlocksEnginePhpTransformerPath = input.mode === 'release-proof' ? '' : blocksEngine;
+  const blocksEnginePhpTransformerPath = input.blocksEnginePhpTransformerPath === undefined
+    ? defaultBlocksEnginePhpTransformerPath
+    : (input.blocksEnginePhpTransformerPath ? path.resolve(input.blocksEnginePhpTransformerPath) : '');
+  const mode = input.mode || (blocksEnginePhpTransformerPath ? 'development-override' : 'release-proof');
+  const runId = input.runId || `ssi-matrix-${mode}-${timestamp()}`;
+  const namespace = sanitizePathSegment(input.namespace || runId);
+  const tempRoot = input.tempRoot ? path.resolve(input.tempRoot) : defaultTempRoot(namespace, input);
+  const output = path.resolve(input.output || path.join(process.cwd(), 'artifacts', `${runId}.homeboy-bench.json`));
+
+  return {
+    ...input,
+    mode,
+    runId,
+    namespace,
+    tempRoot,
+    output,
+    fixtureRoot,
+    blocksEngine,
+    blocksEnginePhpTransformerPath,
+    passthrough: Array.isArray(input.passthrough) ? input.passthrough : [],
+    staticSiteImporter: path.resolve(input.staticSiteImporter),
+    sharedState: input.sharedState ? path.resolve(input.sharedState) : path.join(tempRoot, 'shared-state'),
+    artifactRoot: input.artifactRoot ? path.resolve(input.artifactRoot) : path.join(tempRoot, 'artifacts'),
+    runner: input.runner || '',
+    homeboyBin: input.homeboyBin || process.env.HOMEBOY_BIN || 'homeboy',
+  };
+}
+
+function defaultTempRoot(namespace) {
+  return path.resolve(path.join('/tmp', `static-site-importer-fixture-matrix-${namespace}`));
+}
+
+function buildWarnings(options) {
+  return [
+    ...(!options.runner && !options.labOnly && !options.local ? [{
+      code: 'lab_auto_offload_risk',
+      message: 'No --runner/--lab-only/--local routing was provided. `homeboy bench` auto-offloads to a connected default Lab runner, where local --shared-state/--artifact-root paths will fail. Pass --local to force local (hot) execution against local checkouts and a local WP Codebox, or --runner/--lab-only to route to a runner with the paths present.',
+    }] : []),
+    ...(options.local ? [{
+      code: 'forced_local_execution',
+      message: '--local forces hot local execution (--force-hot --allow-local-hot); the bench will not offload to a Lab runner even if one is connected.',
+    }] : []),
+    ...(options.allowLocalFallback ? [{
+      code: 'local_fallback_allowed',
+      message: '--allow-local-fallback permits Lab routing to fall back to local execution if the runner allows it.',
+    }] : []),
+    ...(options.allowDirtyLabWorkspace ? [{
+      code: 'dirty_lab_workspace_allowed',
+      message: '--allow-dirty-lab-workspace permits reusing or overwriting a dirty Lab workspace.',
+    }] : []),
+  ];
+}
+
+// Surface corpus pin drift instead of letting `fixture_count_matches_canonical`
+// be a silently-ignored boolean. A discovered count below the pin means fixtures
+// went missing (or the wrong root was passed); above the pin means the corpus
+// grew and CANONICAL_FIXTURE_COUNT needs an intentional bump.
+function buildCanonicalDriftWarnings(fixtureCount, fixtureRoot) {
+  if (fixtureCount === CANONICAL_FIXTURE_COUNT) {
+    return [];
+  }
+  return [{
+    code: 'canonical_fixture_count_drift',
+    message: `Discovered ${fixtureCount} top-level fixture director${fixtureCount === 1 ? 'y' : 'ies'} in ${fixtureRoot}, but CANONICAL_FIXTURE_COUNT is ${CANONICAL_FIXTURE_COUNT}. ${fixtureCount > CANONICAL_FIXTURE_COUNT ? 'The corpus grew; bump CANONICAL_FIXTURE_COUNT after confirming the new fixtures are intended.' : 'Fixtures are missing or the wrong fixture root was passed; restore the corpus or correct --fixture-root.'}`,
+  }];
+}
+
+export const CODE_FRESHNESS_SCHEMA = 'static-site-importer/fixture-matrix-code-freshness/v1';
+
+// Roles checked for git freshness. Stale (behind/diverged) overrides risk
+// producing phantom findings from code that no longer reflects upstream.
+function freshnessTargets(options) {
+  const targets = [];
+  if (options.blocksEnginePhpTransformerPath) {
+    targets.push({ role: 'blocks_engine_php_transformer_path', path: options.blocksEnginePhpTransformerPath });
+  }
+  if (options.blocksEngine && options.blocksEngine !== options.blocksEnginePhpTransformerPath) {
+    targets.push({ role: 'blocks_engine', path: options.blocksEngine });
+  }
+  if (options.staticSiteImporter) {
+    targets.push({ role: 'static_site_importer', path: options.staticSiteImporter });
+  }
+  return targets;
+}
+
+export function buildCodeFreshness(options, gitRunner = defaultGitRunner) {
+  const paths = {};
+  for (const target of freshnessTargets(options)) {
+    paths[target.role] = resolvePathFreshness(target.role, target.path, gitRunner);
+  }
+  const stale = Object.values(paths).filter((entry) => entry.stale);
+  return {
+    schema: CODE_FRESHNESS_SCHEMA,
+    would_block: stale.length > 0,
+    stale_overrides: stale.map((entry) => entry.role),
+    paths,
+  };
+}
+
+export function resolvePathFreshness(role, targetPath, gitRunner = defaultGitRunner) {
+  const resolved = path.resolve(targetPath);
+  const base = {
+    role,
+    path: resolved,
+    in_git_repo: false,
+    branch: '',
+    upstream: null,
+    behind: 0,
+    ahead: 0,
+    dirty: false,
+    commit: '',
+    status: 'not_git',
+    stale: false,
+  };
+
+  if (!fs.existsSync(resolved)) {
+    return { ...base, status: 'missing' };
+  }
+
+  const inside = gitText(resolved, ['rev-parse', '--is-inside-work-tree'], gitRunner);
+  if (inside.status !== 0 || inside.stdout !== 'true') {
+    return base;
+  }
+
+  base.in_git_repo = true;
+  base.branch = gitText(resolved, ['rev-parse', '--abbrev-ref', 'HEAD'], gitRunner).stdout;
+  base.commit = gitText(resolved, ['rev-parse', 'HEAD'], gitRunner).stdout;
+  base.dirty = gitText(resolved, ['status', '--porcelain'], gitRunner).stdout !== '';
+
+  const upstream = gitText(resolved, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], gitRunner);
+  if (upstream.status !== 0 || !upstream.stdout) {
+    base.status = base.branch === 'HEAD' ? 'detached' : 'no_upstream';
+    return base;
+  }
+
+  base.upstream = upstream.stdout;
+  const counts = gitText(resolved, ['rev-list', '--left-right', '--count', `${upstream.stdout}...HEAD`], gitRunner);
+  if (counts.status === 0 && /^\d+\s+\d+$/.test(counts.stdout)) {
+    const [behind, ahead] = counts.stdout.split(/\s+/).map(Number);
+    base.behind = behind;
+    base.ahead = ahead;
+  }
+
+  base.status = freshnessStatus(base);
+  // Behind or diverged means the override no longer matches upstream — block.
+  base.stale = base.behind > 0;
+  return base;
+}
+
+function freshnessStatus(entry) {
+  if (entry.behind > 0 && entry.ahead > 0) {
+    return 'diverged';
+  }
+  if (entry.behind > 0) {
+    return 'behind';
+  }
+  if (entry.ahead > 0) {
+    return 'ahead';
+  }
+  return 'fresh';
+}
+
+function buildFreshnessWarnings(codeFreshness, options) {
+  const warnings = [];
+  for (const role of codeFreshness.stale_overrides) {
+    const entry = codeFreshness.paths[role];
+    warnings.push({
+      code: 'stale_override',
+      message: `${role} (${entry.path}) is ${entry.status} vs ${entry.upstream} (behind ${entry.behind}, ahead ${entry.ahead}); findings may be phantom from stale code. Refresh it or pass --allow-stale-override to proceed.`,
+    });
+  }
+  if (codeFreshness.would_block && options.allowStaleOverride) {
+    warnings.push({
+      code: 'stale_override_allowed',
+      message: '--allow-stale-override permits running against a stale/diverged override; findings may not reproduce on upstream.',
+    });
+  }
+  return warnings;
+}
+
+function resolveTransformerCommit(codeFreshness) {
+  const entry = codeFreshness?.paths?.blocks_engine_php_transformer_path || codeFreshness?.paths?.blocks_engine;
+  return entry?.commit || '';
+}
+
+function freshnessGuardBanner(codeFreshness, options) {
+  const lines = [
+    '',
+    '================================================================',
+    options.allowStaleOverride
+      ? 'WARNING: running against a STALE/diverged override (--allow-stale-override)'
+      : 'REFUSING TO RUN: a code override is STALE/diverged vs upstream',
+    '================================================================',
+  ];
+  for (const role of codeFreshness.stale_overrides) {
+    const entry = codeFreshness.paths[role];
+    lines.push(`  - ${role}: ${entry.path}`);
+    lines.push(`      branch ${entry.branch} is ${entry.status} vs ${entry.upstream} (behind ${entry.behind}, ahead ${entry.ahead}, ${entry.dirty ? 'dirty' : 'clean'})`);
+    lines.push(`      commit ${entry.commit}`);
+  }
+  lines.push('Findings produced against stale code may not reproduce on upstream (phantom findings).');
+  if (options.allowStaleOverride) {
+    lines.push('Proceeding because --allow-stale-override was passed.');
+  } else {
+    lines.push('Refresh the checkout(s) to upstream, or pass --allow-stale-override to proceed anyway.');
+  }
+  lines.push('================================================================', '');
+  return `${lines.join('\n')}\n`;
+}
+
+function defaultGitRunner(cwd, args) {
+  const result = spawnSync('git', ['-C', cwd, ...args], { encoding: 'utf8' });
+  return {
+    status: result.error ? 1 : (result.status ?? 1),
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+  };
+}
+
+function gitText(cwd, args, gitRunner) {
+  try {
+    return gitRunner(cwd, args);
+  } catch {
+    return { status: 1, stdout: '', stderr: '' };
+  }
+}
+
+function buildSteps(options, settings) {
+  const steps = [];
+  if (!options.skipInstall) {
+    steps.push({
+      label: 'Refresh installed SSI fixture matrix rig',
+      command: options.homeboyBin,
+      args: withCommonRouting(['rig', 'install', packageRoot, '--id', RIG_ID, '--reinstall'], options),
+    });
+  }
+  if (!options.skipSync) {
+    steps.push({
+      label: 'Sync/materialize rig components',
+      command: options.homeboyBin,
+      args: withCommonRouting(['rig', 'sync', RIG_ID], options),
+    });
+  }
+
+  const benchArgs = [
+    'bench',
+    '--rig', RIG_ID,
+    '--profile', 'fixture-matrix',
+    '--iterations', '1',
+    '--path', options.staticSiteImporter,
+    '--shared-state', options.sharedState,
+    '--run-id', options.runId,
+    '--output', options.output,
+    '--json',
+    '--setting', `static_site_importer_fixture_matrix_namespace=${options.namespace}`,
+    ...Object.entries(settings).flatMap(([key, value]) => ['--setting', `bench_env.${key}=${value}`]),
+  ];
+  if (options.artifactRoot) {
+    benchArgs.push('--artifact-root', options.artifactRoot);
+  }
+  const routedBenchArgs = withCommonRouting(benchArgs, options);
+  if (options.passthrough.length > 0) {
+    routedBenchArgs.push('--', ...options.passthrough);
+  }
+  steps.push({
+    label: 'Run SSI fixture matrix bench through Homeboy/Lab/WP Codebox',
+    command: options.homeboyBin,
+    args: routedBenchArgs,
+  });
+
+  return steps;
+}
+
+function withCommonRouting(args, options) {
+  const routed = [...args];
+  // Force local (hot) execution. `homeboy bench` auto-offloads to a default Lab
+  // runner whenever one is connected, even with no --runner flag. The offload
+  // translates component/checkout paths into the remote workspace but passes
+  // --shared-state / --artifact-root through verbatim, so a local absolute path
+  // (e.g. /private/tmp/... or /Users/...) fails on the Linux runner with
+  // "Permission denied" / "No such file". --force-hot --allow-local-hot together
+  // keep the run on this machine so the local checkouts, fixture root, and
+  // shared-state/artifact-root paths all resolve. This is the only way to run
+  // the matrix against local-only paths and a local WP Codebox.
+  if (options.local) {
+    routed.push('--force-hot', '--allow-local-hot');
+  }
+  if (options.runner) {
+    routed.push('--runner', options.runner);
+  }
+  if (options.labOnly) {
+    routed.push('--lab-only');
+  }
+  if (options.allowLocalFallback) {
+    routed.push('--allow-local-fallback');
+  }
+  if (options.detachAfterHandoff) {
+    routed.push('--detach-after-handoff');
+  }
+  if (options.allowDirtyLabWorkspace) {
+    routed.push('--allow-dirty-lab-workspace');
+  }
+  return routed;
+}
+
+function runCommand(step) {
+  const status = runStep(step);
+  if (status !== 0) {
+    throw new Error(`${step.label} failed with exit ${status}`);
+  }
+}
+
+// Run a step and return its exit status without throwing, so callers can decide
+// whether a non-zero exit is fatal (setup) or an expected outcome (bench gate).
+function runStep(step) {
+  process.stderr.write(`\n# ${step.label}\n${shellCommand(step)}\n`);
+  const result = spawnSync(step.command, step.args, { stdio: 'inherit' });
+  return result.status;
+}
+
+// A bench gate-FAIL exits non-zero but still writes a parseable result payload
+// to --output. Distinguish that (summarizable) from a genuine crash (no output
+// or unparseable) so the operator always gets the summary on a failing run.
+// On crash, preserve the historical throw/error behavior.
+export function summarizeBenchRun({ plan, benchStatus, benchLabel = 'bench step' }) {
+  if (benchStatus !== 0 && !benchProducedResult(plan.output_file)) {
+    throw new Error(`${benchLabel} failed with exit ${benchStatus}`);
+  }
+  const gateFailed = benchStatus !== 0;
+  return {
+    gateFailed,
+    summary: summarizeRun(plan, { status: gateFailed ? 'failed' : 'passed' }),
+  };
+}
+
+// The bench RAN if --output exists, parses, and carries a result payload
+// (a `result_summary` somewhere in the tree). That presence is the signal the
+// gate evaluated a real run rather than the process crashing before writing
+// results.
+function benchProducedResult(outputFile) {
+  const output = readJson(outputFile);
+  if (!output || typeof output !== 'object') {
+    return false;
+  }
+  return findFirstKey(output, 'result_summary') !== undefined;
+}
+
+export function summarizeRun(plan, { status } = {}) {
+  const output = readJson(plan.output_file);
+  const resultSummary = findFirstKey(output, 'result_summary') || {};
+  const artifacts = findFirstKey(output, 'artifacts') || findFirstKey(output, 'artifact_refs') || {};
+  const failedFixtureCount = Number(resultSummary.failed || 0);
+  return {
+    schema: 'static-site-importer/fixture-matrix-operator-summary/v1',
+    // Explicit gate outcome; falls back to the failed count when not provided
+    // so the field is always present on success and failure alike.
+    status: status || (failedFixtureCount > 0 ? 'failed' : 'passed'),
+    mode: plan.mode,
+    run_id: findFirstKey(output, 'run_id') || plan.run_id,
+    code_freshness: plan.code_freshness || null,
+    transformer_commit: plan.transformer_commit || resolveTransformerCommit(plan.code_freshness),
+    fixture_count: Number(findFirstKey(output, 'fixture_count') || plan.fixture_count || 0),
+    passed_fixture_count: Number(resultSummary.succeeded || resultSummary.passed || 0),
+    failed_fixture_count: failedFixtureCount,
+    finding_count: Number(resultSummary.finding_count || 0),
+    top_buckets: topObjectCounts(resultSummary.buckets || resultSummary.groups || {}),
+    top_kinds: topObjectCounts(resultSummary.kinds || {}),
+    top_pattern_families: normalizeSummaryRows(resultSummary.top_pattern_families),
+    fixture_exemplars: normalizeSummaryRows(resultSummary.fixture_exemplars),
+    diagnostic_blind_spots: normalizeSummaryRows(resultSummary.diagnostic_blind_spots),
+    artifact_urls: collectArtifactUrls(artifacts),
+    output_file: plan.output_file,
+  };
+}
+
+function parseArgs(args) {
+  const options = { passthrough: [] };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--') {
+      options.passthrough = args.slice(index + 1);
+      break;
+    }
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg.startsWith('--no-')) {
+      options[camelCase(arg.slice(5))] = false;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      const [rawKey, rawValue] = arg.slice(2).split('=');
+      const key = camelCase(rawKey);
+      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'liveWpParity']);
+      if (booleanKeys.has(key)) {
+        options[key] = true;
+        continue;
+      }
+      const value = rawValue === undefined ? args[index + 1] : rawValue;
+      if (rawValue === undefined) {
+        index += 1;
+      }
+      options[key] = value;
+      continue;
+    }
+  }
+  return options;
+}
+
+function countTopLevelFixtureDirectories(fixtureRoot) {
+  try {
+    return fs.readdirSync(fixtureRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
+      .length;
+  } catch {
+    return 0;
+  }
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function findFirstKey(value, key) {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, key)) {
+    return value[key];
+  }
+  for (const child of Object.values(value)) {
+    const found = findFirstKey(child, key);
+    if (found !== undefined) {
+      return found;
+    }
+  }
+  return undefined;
+}
+
+function topObjectCounts(value, limit = 10) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return [];
+  }
+  return Object.entries(value)
+    .map(([key, count]) => ({ key, count: Number(count) }))
+    .filter((row) => Number.isFinite(row.count))
+    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key))
+    .slice(0, limit);
+}
+
+function normalizeSummaryRows(value, limit = 10) {
+  return Array.isArray(value) ? value.slice(0, limit) : [];
+}
+
+function collectArtifactUrls(value) {
+  const urls = [];
+  collectUrls(value, urls);
+  return urls;
+}
+
+function collectUrls(value, urls) {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+  for (const child of Object.values(value)) {
+    if (typeof child === 'string' && /^(https:\/\/|gh:|homeboy-runs:|artifact:|run:)/.test(child)) {
+      urls.push(child);
+    } else {
+      collectUrls(child, urls);
+    }
+  }
+}
+
+function shellCommand(step) {
+  return [step.command, ...step.args].map(shellQuote).join(' ');
+}
+
+function shellQuote(value) {
+  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function camelCase(value) {
+  return value.replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase());
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[-:]/g, '').replace(/\..+/, 'Z');
+}
+
+function sanitizePathSegment(value) {
+  return String(value).replace(/[^A-Za-z0-9_.-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '') || 'run';
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --runner <id> --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n  --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures/websites.\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --runner <id>                       Homeboy Lab runner, for example homeboy-lab.\n  --local                             Force hot local execution (--force-hot --allow-local-hot). Use this to run against local checkouts, a local fixture root, and a local WP Codebox; without it, homeboy bench auto-offloads to a connected default Lab runner where local --shared-state/--artifact-root paths fail.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 4, hard-capped at 16.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind/diverged vs upstream.\n  --no-editor-validation              Skip the wordpress.editor-validate-blocks step (slow, launches a browser per site). Findings/native-rate still produced.\n  --no-visual-parity                  Skip the wordpress.visual-compare render/diff step.\n  --visual-parity-gate                Make pixel mismatch over the threshold a HARD gate. Default: capture-only.\n  --pixel-threshold <ratio>           Max mismatch ratio (mismatch_pixels/total_pixels) before gating. Default 0.1.\n  --live-wp-parity                    Opt-in: capture each imported candidate's rendered DOM (deterministic wordpress.capture-html) and score it against the source with the blocks-engine live-wp-parity comparator (live-WP score + render-free proxy score + delta). Default: off (render-free static gate stays primary).\n  --min-native-rate <ratio>           Opt-in: fail fixtures whose native_conversion_rate is below this ratio (0-1, or a percentage like 80). Default: off (metrics only).\n  --class <fixture-class>             Run only the given manifest class lane (e.g. marketing/static). Default: all classes.\n  --tag <tag>                         Run only fixtures whose manifest tags include this tag. Default: all fixtures.\n  --lab-only                          Require Lab routing.\n  --allow-local-fallback              Allow selected Lab runner local fallback.\n  --allow-dirty-lab-workspace         Allow runner workspace overwrite.\n  --detach-after-handoff              Return after remote runner accepts the job.\n  --skip-install                      Skip homeboy rig install --reinstall.\n  --skip-sync                         Skip homeboy rig sync.\n  --dry-run                           Print the composed plan without running it.\n\nAny args after -- are passed through to the lower-level bench runner.\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/tools/wp-codebox/recipe.mjs
+++ b/tools/wp-codebox/recipe.mjs
@@ -1,0 +1,73 @@
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+
+const require = createRequire(import.meta.url);
+
+function externalHelper() {
+  const helperPath = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+  return helperPath ? require(helperPath) : null;
+}
+
+export function wpCodeboxBin(env = process.env) {
+  const helper = externalHelper();
+  if (helper?.wpCodeboxBin) {
+    return helper.wpCodeboxBin(env);
+  }
+  return env.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN || env.WP_CODEBOX_BIN || 'wp-codebox';
+}
+
+export function wpCodeboxCommand(bin = wpCodeboxBin()) {
+  const helper = externalHelper();
+  if (helper?.wpCodeboxCommand) {
+    return helper.wpCodeboxCommand(bin);
+  }
+  return { command: bin, args: [] };
+}
+
+export async function runWpCodeboxRecipe(options = {}) {
+  const helper = externalHelper();
+  if (helper?.runWpCodeboxRecipe) {
+    return helper.runWpCodeboxRecipe(options);
+  }
+
+  const base = wpCodeboxCommand(options.wpCodeboxBin || wpCodeboxBin());
+  const args = [
+    ...(base.args || []),
+    'recipe-run',
+    '--recipe', options.recipeFile,
+    '--artifacts', options.artifactsDir,
+    '--json',
+  ].filter(Boolean);
+  const result = spawnSync(base.command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  if (options.outputFile) {
+    fs.writeFileSync(options.outputFile, result.stdout || '', 'utf8');
+  }
+  const parsed = parseJsonText(result.stdout);
+  if (result.status !== 0) {
+    const error = new Error(`wp-codebox recipe-run failed with exit ${result.status}`);
+    error.code = result.status || 1;
+    error.stdout = result.stdout || '';
+    error.stderr = result.stderr || '';
+    throw error;
+  }
+
+  return {
+    exitCode: 0,
+    outputFile: options.outputFile,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    json: parsed,
+  };
+}
+
+function parseJsonText(text) {
+  if (!text || !text.trim()) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Move the Static Site Importer fixture matrix rig from homeboy-rigs into this product repo.
- Add repo-local bench, tools, matrix libraries, rig metadata, and minimal test-only smoke fixtures under tests/fixtures/fixture-matrix.
- Keep the canonical static-site fixture corpus in Blocks Engine; docs/examples point real matrix runs at blocks-engine/fixtures/websites.
- Add a local WP Codebox recipe helper so the matrix no longer imports homeboy-rigs shared helpers.
- Document the repo-local fixture matrix workflow and add npm run test:fixture-matrix.

## Verification
- npm run test:fixture-matrix
- node bench/static-site-fixture-matrix.bench.mjs --output-directory /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-repo-local-fixture-matrix-v2 --static-site-importer-path /Users/chubes/Developer/static-site-importer@move-ssi-fixture-matrix-rig --no-visual-parity

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Moving the rig package, adapting repo-local paths/helpers, verification, and PR description drafting.