### PR TITLE
Bump bundled php-transformer pin to v0.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.2.2",
+        "version": "0.2.3",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "4fcc9de3c6dfa2c6334b95d865709fd12fdb7d63"
+          "reference": "d802899a7f8f406b26aeb4cf46805cb297e09e53"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.2.zip",
-          "reference": "4fcc9de3c6dfa2c6334b95d865709fd12fdb7d63"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.3.zip",
+          "reference": "d802899a7f8f406b26aeb4cf46805cb297e09e53"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.2.2",
+    "automattic/blocks-engine-php-transformer": "^0.2.3",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16948bcf72c28856a918a5eda84953b0",
+    "content-hash": "fe7fd8f43cb4eee23238780b505edb29",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "4fcc9de3c6dfa2c6334b95d865709fd12fdb7d63"
+                "reference": "d802899a7f8f406b26aeb4cf46805cb297e09e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.2.zip",
-                "reference": "4fcc9de3c6dfa2c6334b95d865709fd12fdb7d63"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.3.zip",
+                "reference": "d802899a7f8f406b26aeb4cf46805cb297e09e53"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Bump the bundled `automattic/blocks-engine-php-transformer` package repository from `0.2.2` to `0.2.3`.
- Point the dist archive at `php-transformer-v0.2.3` and the release commit `d802899a7f8f406b26aeb4cf46805cb297e09e53`.
- Update the required transformer constraint to `^0.2.3`.

## Release
- https://github.com/Automattic/blocks-engine/releases/tag/php-transformer-v0.2.3

## Testing
- `npm run test:fixture-matrix`
- `composer validate --strict`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Dependency bump, Composer lock refresh, verification, and PR preparation.
