### PR TITLE
Make theme report artifacts opt-in

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -94,6 +94,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'allow_missing_woocommerce'    => array( 'type' => 'boolean' ),
 						'allow_missing_jetpack'        => array( 'type' => 'boolean' ),
 						'report'                       => array( 'type' => 'string' ),
+						'write_theme_report_artifacts' => array( 'type' => 'boolean' ),
 						'asset_materialization_policy' => array(
 							'type' => 'string',
 							'enum' => array( 'copy_to_theme', 'use_map' ),
@@ -133,6 +134,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 						'allow_missing_woocommerce'    => array( 'type' => 'boolean' ),
 						'allow_missing_jetpack'        => array( 'type' => 'boolean' ),
 						'report'                       => array( 'type' => 'string' ),
+						'write_theme_report_artifacts' => array( 'type' => 'boolean' ),
 						'asset_materialization_policy' => array(
 							'type' => 'string',
 							'enum' => array( 'copy_to_theme', 'use_map' ),
@@ -345,6 +347,7 @@ if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' )
 			'allow_missing_jetpack'        => ! empty( $input['allow_missing_jetpack'] ),
 			'materialize_dependencies'     => array_key_exists( 'materialize_dependencies', $input ) ? (bool) $input['materialize_dependencies'] : true,
 			'report'                       => isset( $input['report'] ) ? (string) $input['report'] : '',
+			'write_theme_report_artifacts' => ! empty( $input['write_theme_report_artifacts'] ),
 			'asset_materialization_policy' => isset( $input['asset_materialization_policy'] ) ? (string) $input['asset_materialization_policy'] : '',
 			'asset_map'                    => isset( $input['asset_map'] ) && is_array( $input['asset_map'] ) ? $input['asset_map'] : array(),
 			'compiler_options'             => isset( $input['compiler_options'] ) && is_array( $input['compiler_options'] ) ? $input['compiler_options'] : array(),

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -131,12 +131,13 @@ class Static_Site_Importer_Theme_Generator {
 			return new WP_Error( 'static_site_importer_theme_exists', sprintf( 'Theme already exists: %s', $theme_slug ) );
 		}
 
-		$import_run_id             = self::import_run_id( $args );
-		$source_artifact_reference = self::source_artifact_reference_from_compiled( $compiled, $args );
-		$source_metadata           = isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array();
-		$source_metadata['source'] = 'website_artifact';
-		$html_path                 = (string) ( $compiled['provenance']['source'] ?? ( $compiled['input']['entry_path'] ?? 'website_artifact' ) );
-		self::$conversion_report   = Static_Site_Importer_Report_Diagnostics::new_conversion_report( $html_path, $source_metadata );
+		$import_run_id                = self::import_run_id( $args );
+		$write_theme_report_artifacts = self::write_theme_report_artifacts_enabled( $args );
+		$source_artifact_reference    = self::source_artifact_reference_from_compiled( $compiled, $args );
+		$source_metadata              = isset( $args['source_metadata'] ) && is_array( $args['source_metadata'] ) ? $args['source_metadata'] : array();
+		$source_metadata['source']    = 'website_artifact';
+		$html_path                    = (string) ( $compiled['provenance']['source'] ?? ( $compiled['input']['entry_path'] ?? 'website_artifact' ) );
+		self::$conversion_report      = Static_Site_Importer_Report_Diagnostics::new_conversion_report( $html_path, $source_metadata );
 		self::$conversion_report['import_run_id']            = $import_run_id;
 		self::$conversion_report['source_artifact']           = $source_artifact_reference;
 		self::$conversion_report['source_of_truth']['import_run_id'] = $import_run_id;
@@ -224,7 +225,7 @@ class Static_Site_Importer_Theme_Generator {
 		self::record_commerce_dependency_check( $args );
 		self::record_form_materialization( $args );
 		self::record_product_materialization( $args );
-		$source_of_truth_manifest                    = self::source_of_truth_manifest( $import_run_id, $source_artifact_reference, $theme_dir, $theme_slug, $page_targets, $page_ids, $permalinks, $writes, $materialized );
+		$source_of_truth_manifest                    = self::source_of_truth_manifest( $import_run_id, $source_artifact_reference, $theme_dir, $theme_slug, $page_targets, $page_ids, $permalinks, $writes, $materialized, $write_theme_report_artifacts );
 		self::$conversion_report['source_of_truth'] = $source_of_truth_manifest;
 		$quality                                    = Static_Site_Importer_Report_Diagnostics::finalize_report( self::$conversion_report, $args );
 		$validation_result      = self::$conversion_report['import_validation_result'] ?? array();
@@ -290,9 +291,11 @@ class Static_Site_Importer_Theme_Generator {
 			return new WP_Error( 'static_site_importer_manifest_encode_failed', 'Failed to encode source-of-truth manifest JSON.' );
 		}
 		$writes[ $theme_dir . '/static-site-importer-manifest.json' ] = $manifest_json . "\n";
-		$writes[ $theme_dir . '/import-report.json' ]            = $report_json . "\n";
-		$writes[ $theme_dir . '/import-validation-result.json' ] = $validation_result_json . "\n";
-		$writes[ $theme_dir . '/finding-packets.json' ]          = $finding_packets_json . "\n";
+		if ( $write_theme_report_artifacts ) {
+			$writes[ $theme_dir . '/import-report.json' ]            = $report_json . "\n";
+			$writes[ $theme_dir . '/import-validation-result.json' ] = $validation_result_json . "\n";
+			$writes[ $theme_dir . '/finding-packets.json' ]          = $finding_packets_json . "\n";
+		}
 		foreach ( $writes as $path => $content ) {
 			$result = Static_Site_Importer_Theme_Materializer::write_file( $path, $content );
 			if ( is_wp_error( $result ) ) {
@@ -343,13 +346,14 @@ class Static_Site_Importer_Theme_Generator {
 			'theme_slug'                      => $theme_slug,
 			'theme_name'                      => $theme_name,
 			'theme_dir'                       => $theme_dir,
-			'report_path'                     => $theme_dir . '/import-report.json',
-			'validation_result_path'          => $theme_dir . '/import-validation-result.json',
-			'finding_packets_path'            => $theme_dir . '/finding-packets.json',
+			'report_path'                     => $write_theme_report_artifacts ? $theme_dir . '/import-report.json' : '',
+			'validation_result_path'          => $write_theme_report_artifacts ? $theme_dir . '/import-validation-result.json' : '',
+			'finding_packets_path'            => $write_theme_report_artifacts ? $theme_dir . '/finding-packets.json' : '',
 			'manifest_path'                   => $theme_dir . '/static-site-importer-manifest.json',
 			'external_report_path'            => $external_report_path,
 			'external_validation_result_path' => $external_validation_result_path,
 			'external_finding_packets_path'   => $external_finding_packets_path,
+			'import_report'                   => self::$conversion_report,
 			'import_report_summary'           => self::$conversion_report['compact_summary'],
 			'import_validation_result'        => $validation_result,
 			'finding_packets'                 => $finding_packets,
@@ -1547,6 +1551,20 @@ class Static_Site_Importer_Theme_Generator {
 	}
 
 	/**
+	 * Whether to persist report/validation/finding JSON into the generated theme.
+	 *
+	 * @param array<string,mixed> $args Import args.
+	 * @return bool
+	 */
+	private static function write_theme_report_artifacts_enabled( array $args ): bool {
+		if ( ! array_key_exists( 'write_theme_report_artifacts', $args ) ) {
+			return false;
+		}
+
+		return false !== filter_var( $args['write_theme_report_artifacts'], FILTER_VALIDATE_BOOLEAN );
+	}
+
+	/**
 	 * Extract artifact identity fields supplied with a source artifact.
 	 *
 	 * @param array<string,mixed> $artifact Website artifact bundle.
@@ -1652,7 +1670,7 @@ class Static_Site_Importer_Theme_Generator {
 	 * @param array<string,mixed>          $materialized  Materialized asset summary.
 	 * @return array<string,mixed>
 	 */
-	private static function source_of_truth_manifest( string $import_run_id, array $artifact, string $theme_dir, string $theme_slug, array $page_targets, array $page_ids, array $permalinks, array $writes, array $materialized ): array {
+	private static function source_of_truth_manifest( string $import_run_id, array $artifact, string $theme_dir, string $theme_slug, array $page_targets, array $page_ids, array $permalinks, array $writes, array $materialized, bool $write_theme_report_artifacts = false ): array {
 		$pages           = array();
 		$existing_pages  = array();
 		foreach ( $page_targets as $filename => $target ) {
@@ -1685,7 +1703,11 @@ class Static_Site_Importer_Theme_Generator {
 				);
 			}
 		}
-		foreach ( array( 'static-site-importer-manifest.json', 'import-report.json', 'import-validation-result.json', 'finding-packets.json' ) as $path ) {
+		$managed_metadata_files = array( 'static-site-importer-manifest.json' );
+		if ( $write_theme_report_artifacts ) {
+			$managed_metadata_files = array_merge( $managed_metadata_files, array( 'import-report.json', 'import-validation-result.json', 'finding-packets.json' ) );
+		}
+		foreach ( $managed_metadata_files as $path ) {
 			$files[] = array(
 				'target_type' => 'theme_file',
 				'path'        => $path,

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -124,6 +124,9 @@ class Static_Site_Importer_Validation_Runtime {
 		$quality                = isset( $import_result['quality'] ) && is_array( $import_result['quality'] ) ? $import_result['quality'] : array();
 		$quality_pass           = ! empty( $quality['pass'] );
 		$import_report          = self::read_json_object_file( $report_path );
+		if ( empty( $import_report ) && isset( $import_result['import_report'] ) && is_array( $import_result['import_report'] ) ) {
+			$import_report = $import_result['import_report'];
+		}
 
 		$result                        = array(
 			'success'       => $quality_pass,

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1405,13 +1405,14 @@ function static_site_importer_rest_persist_preview_attempt( array $attempt ): vo
  */
 function static_site_importer_rest_import_args( array $params ): array {
 	return array(
-		'slug'                      => isset( $params['slug'] ) ? sanitize_title( (string) $params['slug'] ) : '',
-		'name'                      => isset( $params['name'] ) ? sanitize_text_field( (string) $params['name'] ) : '',
-		'activate'                  => ! empty( $params['activate'] ),
-		'overwrite'                 => ! empty( $params['overwrite'] ),
-		'fail_on_quality'           => ! empty( $params['fail_on_quality'] ),
-		'allow_missing_woocommerce' => ! empty( $params['allow_missing_woocommerce'] ),
-		'source_metadata'           => array(
+		'slug'                         => isset( $params['slug'] ) ? sanitize_title( (string) $params['slug'] ) : '',
+		'name'                         => isset( $params['name'] ) ? sanitize_text_field( (string) $params['name'] ) : '',
+		'activate'                     => ! empty( $params['activate'] ),
+		'overwrite'                    => ! empty( $params['overwrite'] ),
+		'fail_on_quality'              => ! empty( $params['fail_on_quality'] ),
+		'allow_missing_woocommerce'    => ! empty( $params['allow_missing_woocommerce'] ),
+		'write_theme_report_artifacts' => ! empty( $params['write_theme_report_artifacts'] ),
+		'source_metadata'              => array(
 			'source' => 'static_site_importer_block',
 		),
 	);

--- a/tests/smoke-import-source-of-truth-manifest.php
+++ b/tests/smoke-import-source-of-truth-manifest.php
@@ -156,11 +156,12 @@ $result = Static_Site_Importer_Theme_Generator::import_website_artifact(
 		),
 	),
 	array(
-		'name'          => 'Source Of Truth Smoke',
-		'slug'          => 'source-of-truth-smoke-theme',
-		'overwrite'     => true,
-		'activate'      => false,
-		'import_run_id' => 'ssi-source-of-truth-smoke-run',
+		'name'                         => 'Source Of Truth Smoke',
+		'slug'                         => 'source-of-truth-smoke-theme',
+		'overwrite'                    => true,
+		'activate'                     => false,
+		'import_run_id'                => 'ssi-source-of-truth-smoke-run',
+		'write_theme_report_artifacts' => true,
 	)
 );
 
@@ -213,11 +214,12 @@ if ( ! is_wp_error( $result ) ) {
 			),
 		),
 		array(
-			'name'          => 'Source Of Truth Smoke',
-			'slug'          => 'source-of-truth-smoke-theme',
-			'overwrite'     => true,
-			'activate'      => false,
-			'import_run_id' => 'ssi-source-of-truth-smoke-reimport-run',
+			'name'                         => 'Source Of Truth Smoke',
+			'slug'                         => 'source-of-truth-smoke-theme',
+			'overwrite'                    => true,
+			'activate'                     => false,
+			'import_run_id'                => 'ssi-source-of-truth-smoke-reimport-run',
+			'write_theme_report_artifacts' => true,
 		)
 	);
 

--- a/tests/smoke-static-interactive-artifact.php
+++ b/tests/smoke-static-interactive-artifact.php
@@ -76,10 +76,11 @@ $artifact = array(
 $result = Static_Site_Importer_Theme_Generator::import_website_artifact(
 	$artifact,
 	array(
-		'name'      => 'Static Interactive Fixture',
-		'slug'      => 'static-interactive-fixture-smoke',
-		'overwrite' => true,
-		'activate'  => false,
+		'name'                         => 'Static Interactive Fixture',
+		'slug'                         => 'static-interactive-fixture-smoke',
+		'overwrite'                    => true,
+		'activate'                     => false,
+		'write_theme_report_artifacts' => true,
 	)
 );
 

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -205,10 +205,10 @@ $assert( ! is_wp_error( $result ), 'import-succeeds', is_wp_error( $result ) ? $
 
 if ( ! is_wp_error( $result ) ) {
 	$theme_dir = $result['theme_dir'];
-	$report    = json_decode( $read( $result['report_path'] ), true );
+	$report    = isset( $result['import_report'] ) && is_array( $result['import_report'] ) ? $result['import_report'] : array();
 	$manifest  = json_decode( $read( $result['manifest_path'] ?? '' ), true );
-	$validation_result = json_decode( $read( $result['validation_result_path'] ?? '' ), true );
-	$finding_packets   = json_decode( $read( $result['finding_packets_path'] ?? '' ), true );
+	$validation_result = isset( $result['import_validation_result'] ) && is_array( $result['import_validation_result'] ) ? $result['import_validation_result'] : array();
+	$finding_packets   = isset( $result['finding_packets'] ) && is_array( $result['finding_packets'] ) ? $result['finding_packets'] : array();
 	$page_ids  = array_values( $result['pages'] ?? array() );
 	$page_id   = (int) ( $page_ids[0] ?? 0 );
 	$progress_events = isset( $result['progress_events'] ) && is_array( $result['progress_events'] ) ? $result['progress_events'] : array();
@@ -239,8 +239,12 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( ! str_contains( $content, '<script' ), 'page-content-has-no-script-fragments' );
 	$assert( 0 === ( $documents['posts/page-home.post_content']['core_html_block_count'] ?? null ), 'report-page-content-has-zero-core-html' );
 	$assert( 0 === ( $report['quality']['core_html_block_count'] ?? null ), 'quality-core-html-count-is-zero' );
-	$assert( is_file( $result['validation_result_path'] ?? '' ), 'validation-result-artifact-is-written' );
-	$assert( is_file( $result['finding_packets_path'] ?? '' ), 'finding-packets-artifact-is-written' );
+	$assert( '' === ( $result['report_path'] ?? '' ), 'theme-report-artifact-is-not-written-by-default' );
+	$assert( '' === ( $result['validation_result_path'] ?? '' ), 'theme-validation-artifact-is-not-written-by-default' );
+	$assert( '' === ( $result['finding_packets_path'] ?? '' ), 'theme-finding-packets-artifact-is-not-written-by-default' );
+	$assert( ! is_file( $theme_dir . '/import-report.json' ), 'theme-report-file-is-absent-by-default' );
+	$assert( ! is_file( $theme_dir . '/import-validation-result.json' ), 'theme-validation-file-is-absent-by-default' );
+	$assert( ! is_file( $theme_dir . '/finding-packets.json' ), 'theme-finding-packets-file-is-absent-by-default' );
 	$assert( is_file( $result['manifest_path'] ?? '' ), 'source-of-truth-manifest-is-written' );
 	$assert( 'ssi-smoke-run-001' === ( $report['import_run_id'] ?? '' ), 'report-includes-import-run-id' );
 	$assert( 'sha256:ember-rye-smoke' === ( $report['source_artifact']['hash'] ?? '' ), 'report-includes-source-artifact-hash' );
@@ -254,7 +258,7 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( 'index.html' === ( $manifest['desired']['pages'][0]['source_path'] ?? '' ), 'manifest-includes-desired-page-source' );
 	$assert( $page_id === (int) ( $manifest['desired']['pages'][0]['materialized_post_id'] ?? 0 ), 'manifest-includes-materialized-page-id' );
 	$assert( 'static-site-importer-manifest.json' === ( $manifest['manifest_path'] ?? '' ), 'manifest-reports-relative-manifest-path' );
-	$assert( in_array( 'import-report.json', array_column( $manifest['desired']['files'] ?? array(), 'path' ), true ), 'manifest-includes-report-file-target' );
+	$assert( ! in_array( 'import-report.json', array_column( $manifest['desired']['files'] ?? array(), 'path' ), true ), 'manifest-omits-report-file-target-by-default' );
 	$assert( '_static_site_importer_provenance' === ( $manifest['desired']['pages'][0]['provenance_meta_key'] ?? '' ), 'manifest-identifies-page-provenance-meta-key' );
 	$provenance = json_decode( (string) get_post_meta( $page_id, '_static_site_importer_provenance', true ), true );
 	$assert( 'ssi-smoke-run-001' === ( $provenance['import_run_id'] ?? '' ), 'page-provenance-meta-includes-import-run-id' );
@@ -300,10 +304,11 @@ $missing_template_parts_result = Static_Site_Importer_Theme_Generator::import_we
 		),
 	),
 	array(
-		'name'      => 'No Header Artifact',
-		'slug'      => 'no-header-artifact-smoke',
-		'overwrite' => true,
-		'activate'  => false,
+		'name'                         => 'No Header Artifact',
+		'slug'                         => 'no-header-artifact-smoke',
+		'overwrite'                    => true,
+		'activate'                     => false,
+		'write_theme_report_artifacts' => true,
 	)
 );
 
@@ -338,10 +343,11 @@ $multi_page_result = Static_Site_Importer_Theme_Generator::import_website_artifa
 		)
 	),
 	array(
-		'name'        => 'Ember Rye Multi Page Artifact',
-		'slug'        => 'ember-rye-multi-page-artifact-smoke',
-		'overwrite'   => true,
-		'activate'    => false,
+		'name'                         => 'Ember Rye Multi Page Artifact',
+		'slug'                         => 'ember-rye-multi-page-artifact-smoke',
+		'overwrite'                    => true,
+		'activate'                     => false,
+		'write_theme_report_artifacts' => true,
 	)
 );
 


### PR DESCRIPTION
## Summary
- stop writing import-report.json, import-validation-result.json, and finding-packets.json into generated themes by default
- keep import report data available in the import result for callers that need stats without filesystem artifacts
- add an explicit write_theme_report_artifacts opt-in for ability/REST/direct import paths
- keep explicit external report output unchanged for validation and Codebox evidence flows

## Testing
- php -l includes/class-static-site-importer-theme-generator.php && php -l includes/class-static-site-importer-validation-runtime.php && php -l includes/abilities.php && php -l includes/rest.php
- php tests/smoke-website-artifact-document-metadata.php
- php tests/smoke-static-interactive-artifact.php
- php tests/smoke-import-source-of-truth-manifest.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Identifying the production-facing filesystem hygiene issue, implementing the opt-in report artifact behavior, updating focused smoke tests, and running verification.