### PR TITLE
Use fixture entrypoint for visual source URL

### DIFF
--- a/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -50,7 +50,8 @@ import { objectValue, finiteNumber, isTruthySignal } from '../shared/utils.mjs';
 export function visualParityCompareStep(input = {}) {
   const fixture = input.fixture || {};
   const options = normalizeVisualParityRecipeOptions(input);
-  const sourceEntry = `${VISUAL_PARITY_SOURCE_SUBDIR}/${String(options.sourceEntry).replace(/^\/+/, '')}`;
+  const entrypoint = options.sourceEntry || fixture.entrypoint || 'index.html';
+  const sourceEntry = `${VISUAL_PARITY_SOURCE_SUBDIR}/${String(entrypoint).replace(/^\/+/, '')}`;
   const sourceUrl = input.sourceUrl
     || input.source_url
     || fixture.source_url
@@ -82,7 +83,7 @@ export function normalizeVisualParityRecipeOptions(input = {}) {
     pixelThreshold: finiteNumber(input.pixelThreshold ?? input.pixel_threshold ?? input.visualParityPixelThreshold ?? input.visual_parity_pixel_threshold, DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD),
     candidateUrl: input.visualParityCandidateUrl || input.visual_parity_candidate_url || input.candidateUrl || DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
     sourceBaseUrl: input.visualParitySourceBaseUrl || input.visual_parity_source_base_url || input.sourceBaseUrl || DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL,
-    sourceEntry: input.visualParitySourceEntry || input.visual_parity_source_entry || input.sourceEntry || 'index.html',
+    sourceEntry: input.visualParitySourceEntry || input.visual_parity_source_entry || input.sourceEntry || '',
     viewport: {
       width: finiteNumber(viewport.width, DEFAULT_VISUAL_PARITY_VIEWPORT.width),
       height: finiteNumber(viewport.height, DEFAULT_VISUAL_PARITY_VIEWPORT.height),

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2472,6 +2472,17 @@ test('default visual-parity source-url targets the staged source/ subdir on the 
   assert.ok(visualStep.args.includes('candidate-url=/'));
 });
 
+test('default visual-parity source-url follows nested fixture entrypoint', () => {
+  const step = visualParityCompareStep({
+    fixture: { id: 'liquid-bonsai', entrypoint: 'saveweb2zip-com-liquidbonsai-com/index.html' },
+    sourceBaseUrl: '/wp-content/uploads/static-site-importer-fixture-matrix',
+  });
+
+  assert.ok(
+    step.args.includes('source-url=/wp-content/uploads/static-site-importer-fixture-matrix/liquid-bonsai/source/saveweb2zip-com-liquidbonsai-com/index.html'),
+  );
+});
+
 test('stageFixtureSource copies the raw fixture source into the served source/ subdir', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-parity-stage-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-stage-test' });


### PR DESCRIPTION
## Summary
- make visual parity source URLs default to the fixture entrypoint instead of hard-coded index.html
- preserve explicit visual source entry overrides
- add coverage for nested fixture entrypoints like Liquid Bonsai

## Testing
- node --test tools/fixture-matrix.test.mjs

## Verification note
A focused Liquid Bonsai visual-only run with this branch captured the correct nested source URL:
/wp-content/uploads/static-site-importer-fixture-matrix/liquid-bonsai/source/saveweb2zip-com-liquidbonsai-com/index.html

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the nested-entrypoint visual evidence bug, implementing the source URL fix, adding coverage, and running targeted verification.