### PR TITLE
Detect client-rendered URL import shells

### DIFF
--- a/includes/class-static-site-importer-url-fetcher.php
+++ b/includes/class-static-site-importer-url-fetcher.php
@@ -34,7 +34,8 @@ class Static_Site_Importer_URL_Fetcher {
 	public static function fetch_to_work_dir( string $url, string $work_dir, array $args = array() ) {
 		$timeout   = max( self::CONNECT_TIMEOUT_FLOOR, (int) ( $args['timeout'] ?? self::DEFAULT_TIMEOUT ) );
 		$max_bytes = max( 1, (int) ( $args['max_bytes'] ?? self::DEFAULT_MAX_BYTES ) );
-		$current   = trim( $url );
+		$initial   = self::normalize_url( $url );
+		$current   = $initial;
 		$started   = gmdate( 'c' );
 		$redirects = array();
 
@@ -87,6 +88,18 @@ class Static_Site_Importer_URL_Fetcher {
 				return new WP_Error( 'static_site_importer_url_empty_body', 'The URL returned an empty HTML response.' );
 			}
 
+			$source_diagnostic = self::html_source_diagnostic( $response['body'] );
+			if ( ! empty( $source_diagnostic ) && 'error' === ( $source_diagnostic['severity'] ?? '' ) ) {
+				return new WP_Error(
+					'static_site_importer_url_client_rendered_app',
+					'This URL appears to be a JavaScript-rendered application shell. Static Site Importer can import server-rendered HTML, but this page needs a browser-rendered capture before it can produce WordPress blocks.',
+					array(
+						'status'     => 422,
+						'diagnostic' => $source_diagnostic,
+					)
+				);
+			}
+
 			wp_mkdir_p( $work_dir );
 			$html_path = trailingslashit( $work_dir ) . 'index.html';
 			$written   = file_put_contents( $html_path, $response['body'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writes fetched static HTML to the importer source fixture.
@@ -98,7 +111,7 @@ class Static_Site_Importer_URL_Fetcher {
 				'html_path' => $html_path,
 				'metadata'  => array(
 					'source_type'     => 'url',
-					'source_url'      => $url,
+					'source_url'      => $initial,
 					'final_url'       => $current,
 					'status_code'     => $status,
 					'content_type'    => $content_type,
@@ -114,12 +127,66 @@ class Static_Site_Importer_URL_Fetcher {
 	}
 
 	/**
+	 * Normalize operator-entered public URLs before validation.
+	 *
+	 * @param string $url URL or bare host/path such as example.com/about.
+	 * @return string
+	 */
+	public static function normalize_url( string $url ): string {
+		$url = trim( $url );
+		if ( '' === $url || preg_match( '/^[a-z][a-z0-9+.-]*:/i', $url ) ) {
+			return $url;
+		}
+
+		if ( preg_match( '/^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::\d+)?(?:[\/?#]|$)/', $url ) ) {
+			return 'https://' . $url;
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Detect source HTML that is present but not statically importable.
+	 *
+	 * @param string $html Source HTML.
+	 * @return array<string,mixed>
+	 */
+	public static function html_source_diagnostic( string $html ): array {
+		$markup_bytes = strlen( $html );
+		$script_count = preg_match_all( '#<script\b#i', $html );
+		$app_shell    = preg_match( '#\bid=(?:"|\')(?:root|app|__next|gatsby-focus-wrapper|mount)(?:"|\')#i', $html );
+		$text_html    = preg_replace( '#<script\b[^>]*>.*?</script>#is', ' ', $html );
+		$text_html    = preg_replace( '#<style\b[^>]*>.*?</style>#is', ' ', (string) $text_html );
+		$text_html    = preg_replace( '#<template\b[^>]*>.*?</template>#is', ' ', (string) $text_html );
+		$stripped     = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( (string) $text_html ) : strip_tags( (string) $text_html );
+		$text         = html_entity_decode( trim( preg_replace( '/\s+/', ' ', $stripped ) ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$text_chars   = strlen( $text );
+		$text_ratio   = $markup_bytes > 0 ? $text_chars / $markup_bytes : 0;
+
+		if ( ( $script_count >= 20 && $text_chars < 1000 && $text_ratio < 0.02 ) || ( $script_count >= 3 && $text_chars < 200 && $app_shell ) ) {
+			return array(
+				'type'          => 'client_rendered_app_shell',
+				'severity'      => 'error',
+				'message'       => 'Fetched HTML is dominated by JavaScript with little server-visible page content.',
+				'script_count'  => $script_count,
+				'text_chars'    => $text_chars,
+				'markup_bytes'  => $markup_bytes,
+				'text_ratio'    => $text_ratio,
+				'repair_bucket' => 'browser_rendered_capture_required',
+			);
+		}
+
+		return array();
+	}
+
+	/**
 	 * Validate a URL before connecting.
 	 *
 	 * @param string $url URL.
 	 * @return array{url:string,scheme:string,host:string,port:int,path:string,ips:array<int,string>}|WP_Error
 	 */
 	public static function validate_url( string $url ) {
+		$url   = self::normalize_url( $url );
 		$parts = wp_parse_url( $url );
 		if ( ! is_array( $parts ) ) {
 			return new WP_Error( 'static_site_importer_url_invalid', 'Enter a valid URL.' );

--- a/includes/class-static-site-importer-url-import-runtime.php
+++ b/includes/class-static-site-importer-url-import-runtime.php
@@ -13,6 +13,10 @@ if ( ! class_exists( 'Static_Site_Importer_Transformer_Adapter' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-transformer-adapter.php';
 }
 
+if ( ! class_exists( 'Static_Site_Importer_URL_Fetcher' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-url-fetcher.php';
+}
+
 /**
  * Imports a source URL through a provider that returns a website artifact.
  */
@@ -25,13 +29,30 @@ class Static_Site_Importer_URL_Import_Runtime {
 	 * @return array<string,mixed>|WP_Error
 	 */
 	public static function import_url( array $input ) {
-		$url = isset( $input['url'] ) ? trim( (string) $input['url'] ) : '';
+		$runtime = self::website_artifact_from_url( $input );
+		if ( is_wp_error( $runtime ) ) {
+			return $runtime;
+		}
+
+		$args = self::import_args( $input, $runtime );
+		return Static_Site_Importer_Theme_Generator::import_website_artifact( $runtime['artifact'], $args );
+	}
+
+	/**
+	 * Resolve a URL into a website artifact without importing it.
+	 *
+	 * @param array<string,mixed> $input Ability-style input.
+	 * @return array<string,mixed>|WP_Error Runtime output containing artifact/source_metadata/provider.
+	 */
+	public static function website_artifact_from_url( array $input ) {
+		$url = isset( $input['url'] ) ? Static_Site_Importer_URL_Fetcher::normalize_url( (string) $input['url'] ) : '';
 		if ( '' === $url ) {
 			return new WP_Error( 'static_site_importer_missing_url', 'The url input is required.' );
 		}
 
-		$request = self::provider_request( $url, $input );
-		$runtime = self::resolve_provider( $request );
+		$input['url'] = $url;
+		$request      = self::provider_request( $url, $input );
+		$runtime      = self::resolve_provider( $request );
 		if ( is_wp_error( $runtime ) ) {
 			return $runtime;
 		}
@@ -41,8 +62,9 @@ class Static_Site_Importer_URL_Import_Runtime {
 			return new WP_Error( 'static_site_importer_url_provider_missing_artifact', 'The URL import provider did not return a website artifact.' );
 		}
 
-		$args = self::import_args( $input, $runtime );
-		return Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $args );
+		$runtime['artifact'] = $artifact;
+
+		return $runtime;
 	}
 
 	/**

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -13,6 +13,10 @@ if ( ! class_exists( 'Static_Site_Importer_Site_Identity' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-site-identity.php';
 }
 
+if ( ! class_exists( 'Static_Site_Importer_URL_Import_Runtime' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-url-import-runtime.php';
+}
+
 /**
  * Register Static Site Importer REST routes.
  *
@@ -529,9 +533,28 @@ function static_site_importer_rest_open_in_playground( array $source, array $inp
 	$input['activate']  = true;
 	$input['overwrite'] = true;
 
-	$artifact = static_site_importer_rest_source_artifact( $source );
-	if ( is_wp_error( $artifact ) ) {
-		return $artifact;
+	if ( static_site_importer_rest_is_url_only_source( $source ) ) {
+		$runtime = Static_Site_Importer_URL_Import_Runtime::website_artifact_from_url(
+			array(
+				'url' => (string) $source['url'],
+			)
+		);
+		if ( is_wp_error( $runtime ) ) {
+			return $runtime;
+		}
+
+		$artifact        = $runtime['artifact'];
+		$source_metadata = isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array();
+		if ( isset( $runtime['source_metadata'] ) && is_array( $runtime['source_metadata'] ) ) {
+			$source_metadata = array_merge( $source_metadata, $runtime['source_metadata'] );
+		}
+		$source_metadata['url_import_provider'] = isset( $runtime['provider'] ) ? (string) $runtime['provider'] : 'public-url-fetcher';
+		$input['source_metadata']              = $source_metadata;
+	} else {
+		$artifact = static_site_importer_rest_source_artifact( $source );
+		if ( is_wp_error( $artifact ) ) {
+			return $artifact;
+		}
 	}
 	$input['artifact'] = $artifact;
 
@@ -661,7 +684,7 @@ function static_site_importer_rest_apply_to_current_site( array $source, array $
 	};
 
 	if ( ! isset( $source['figma_file'] ) && isset( $source['url'] ) && '' !== trim( (string) $source['url'] ) ) {
-		$input['url'] = esc_url_raw( (string) $source['url'] );
+		$input['url'] = esc_url_raw( Static_Site_Importer_URL_Fetcher::normalize_url( (string) $source['url'] ) );
 		if ( isset( $params['provider'] ) ) {
 			$input['provider'] = sanitize_key( (string) $params['provider'] );
 		}
@@ -1433,6 +1456,19 @@ function static_site_importer_rest_source_artifact( array $source ) {
 		return Static_Site_Importer_Figma_Import::website_artifact_from_input( array( 'source' => $source ) );
 	}
 
+	if ( static_site_importer_rest_is_url_only_source( $source ) ) {
+		$runtime = Static_Site_Importer_URL_Import_Runtime::website_artifact_from_url(
+			array(
+				'url' => (string) $source['url'],
+			)
+		);
+		if ( is_wp_error( $runtime ) ) {
+			return $runtime;
+		}
+
+		return $runtime['artifact'];
+	}
+
 	$files = array();
 
 	if ( isset( $source['html'] ) && '' !== trim( (string) $source['html'] ) ) {
@@ -1499,6 +1535,30 @@ function static_site_importer_rest_source_artifact( array $source ) {
 		'entrypoint' => static_site_importer_rest_entrypoint( $files ),
 		'files'      => $files,
 	);
+}
+
+/**
+ * Determine whether a source contains only a URL and no inline/uploaded artifact.
+ *
+ * @param array<string,mixed> $source Source payload.
+ * @return bool
+ */
+function static_site_importer_rest_is_url_only_source( array $source ): bool {
+	if ( ! isset( $source['url'] ) || '' === trim( (string) $source['url'] ) ) {
+		return false;
+	}
+
+	if ( isset( $source['html'] ) && '' !== trim( (string) $source['html'] ) ) {
+		return false;
+	}
+
+	foreach ( array( 'files', 'archive', 'figma_file' ) as $key ) {
+		if ( isset( $source[ $key ] ) && is_array( $source[ $key ] ) && ! empty( $source[ $key ] ) ) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -177,6 +177,12 @@ if ( ! function_exists( 'add_action' ) ) {
 	}
 }
 
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, mixed ...$args ): void {
+		unset( $hook, $args );
+	}
+}
+
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( string $name, $default = false ) {
 		if ( array_key_exists( $name, $GLOBALS['ssi_options'] ) ) {
@@ -753,6 +759,75 @@ $assert( str_contains( (string) $playground_blueprint_code, "'slug' => 'generate
 $assert( str_contains( (string) $playground_blueprint_code, "'name' => 'Generated WordPress Website'" ), 'rest-playground-open-blueprint-uses-generated-theme-name' );
 $assert( ! str_contains( (string) $playground_blueprint_code, 'imported-website-artifact' ), 'rest-playground-open-blueprint-omits-legacy-theme-slug' );
 $assert( ! str_contains( (string) $playground_blueprint_code, 'Codebox' ), 'rest-playground-open-blueprint-does-not-introduce-codebox' );
+
+$GLOBALS['ssi_last_url_provider_request'] = array();
+add_filter(
+	'static_site_importer_url_import_provider',
+	static function ( mixed $output, array $request ): mixed {
+		if ( 'https://facebook.com' !== ( $request['url'] ?? '' ) ) {
+			return $output;
+		}
+
+		$GLOBALS['ssi_last_url_provider_request'] = $request;
+
+		return array(
+			'provider'        => 'test-url-playground-provider',
+			'artifact'        => array(
+				'schema' => Static_Site_Importer_Transformer_Adapter::WEBSITE_ARTIFACT_SCHEMA,
+				'files'  => array(
+					array(
+						'path'    => 'website/index.html',
+						'content' => '<!doctype html><html><head><title>Facebook Fixture</title></head><body><main>Facebook Fixture</main></body></html>',
+					),
+				),
+			),
+			'source_metadata' => array(
+				'source_url' => $request['url'],
+			),
+		);
+	},
+	10,
+	2
+);
+
+$url_playground_response = static_site_importer_rest_create_import(
+	new WP_REST_Request(
+		array(
+			'apply_to_current_site' => false,
+			'open_in_playground'    => true,
+			'source'                => array(
+				'url' => 'facebook.com',
+			),
+		)
+	)
+);
+$assert( ! is_wp_error( $url_playground_response ), 'rest-playground-url-only-does-not-error', is_wp_error( $url_playground_response ) ? $url_playground_response->get_error_code() . ': ' . $url_playground_response->get_error_message() : '' );
+if ( is_wp_error( $url_playground_response ) ) {
+	$url_playground_response = array();
+}
+$assert( true === ( $url_playground_response['success'] ?? null ), 'rest-playground-url-only-succeeds' );
+$assert( 'https://facebook.com' === ( $GLOBALS['ssi_last_url_provider_request']['url'] ?? '' ), 'rest-playground-url-only-normalizes-bare-host' );
+$url_playground_blueprint_json = rawurldecode( substr( (string) ( $url_playground_response['preview']['playground']['blueprint_url'] ?? '' ), strlen( 'https://playground.wordpress.net/#' ) ) );
+$url_playground_blueprint      = json_decode( $url_playground_blueprint_json, true );
+$url_playground_import_code    = is_array( $url_playground_blueprint ) ? (string) ( $url_playground_blueprint['steps'][2]['code'] ?? '' ) : '';
+$assert( str_contains( $url_playground_blueprint_json, 'Facebook Fixture' ), 'rest-playground-url-only-blueprint-contains-fetched-artifact' );
+$assert( str_contains( $url_playground_import_code, "'source_url' => 'https://facebook.com'" ), 'rest-playground-url-only-blueprint-preserves-source-url' );
+$assert( str_contains( $url_playground_import_code, "'url_import_provider' => 'test-url-playground-provider'" ), 'rest-playground-url-only-blueprint-preserves-provider' );
+$assert( array() === Static_Site_Importer_Theme_Generator::$last_args, 'rest-playground-url-only-does-not-import-current-site' );
+
+Static_Site_Importer_Theme_Generator::$last_args = array();
+$current_site_url_response = static_site_importer_rest_create_import(
+	new WP_REST_Request(
+		array(
+			'apply_to_current_site' => true,
+			'source'                => array(
+				'url' => 'facebook.com',
+			),
+		)
+	)
+);
+$assert( ! is_wp_error( $current_site_url_response ), 'rest-current-site-url-only-does-not-error', is_wp_error( $current_site_url_response ) ? $current_site_url_response->get_error_code() . ': ' . $current_site_url_response->get_error_message() : '' );
+$assert( 'https://facebook.com' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['source_url'] ?? '' ), 'rest-current-site-url-only-normalizes-bare-host' );
 
 // A real source document title now names the generated theme/site via the
 // site-identity primitive instead of collapsing to the generic constant.

--- a/tests/smoke-url-import-runtime.php
+++ b/tests/smoke-url-import-runtime.php
@@ -160,7 +160,7 @@ add_filter(
 
 $result = Static_Site_Importer_URL_Import_Runtime::import_url(
 	array(
-		'url'             => 'https://private.example.test/',
+		'url'             => 'private.example.test/',
 		'slug'            => 'private-import',
 		'overwrite'       => true,
 		'source_metadata' => array( 'requested_by' => 'external-caller' ),
@@ -174,6 +174,24 @@ $assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['overwrite'
 $assert( 'external-caller' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['requested_by'] ?? '' ), 'caller-metadata-preserved' );
 $assert( 'private' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['visibility'] ?? '' ), 'provider-metadata-merged' );
 $assert( 'test-private-runtime' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['url_import_provider'] ?? '' ), 'provider-recorded' );
+
+$runtime_artifact = Static_Site_Importer_URL_Import_Runtime::website_artifact_from_url(
+	array(
+		'url' => 'facebook.com',
+	)
+);
+
+$assert( ! is_wp_error( $runtime_artifact ), 'runtime-artifact-succeeds-for-bare-host' );
+$assert( 'website/index.html' === ( $runtime_artifact['artifact']['files'][0]['path'] ?? '' ), 'runtime-artifact-returns-website-file' );
+$assert( 'https://facebook.com' === ( $runtime_artifact['source_metadata']['source_url'] ?? '' ), 'runtime-artifact-normalizes-bare-host-url' );
+
+$client_shell_html = '<!doctype html><html><head><title>App</title>' . str_repeat( '<script src="/app.js"></script>', 25 ) . '</head><body><div id="root"></div></body></html>' . str_repeat( ' ', 120000 );
+$client_shell_diagnostic = Static_Site_Importer_URL_Fetcher::html_source_diagnostic( $client_shell_html );
+$assert( 'client_rendered_app_shell' === ( $client_shell_diagnostic['type'] ?? '' ), 'client-rendered-shell-diagnostic-detected' );
+$assert( 'browser_rendered_capture_required' === ( $client_shell_diagnostic['repair_bucket'] ?? '' ), 'client-rendered-shell-repair-bucket' );
+
+$server_rendered_diagnostic = Static_Site_Importer_URL_Fetcher::html_source_diagnostic( '<!doctype html><html><head><title>Server</title></head><body><main><h1>Server rendered</h1><p>' . str_repeat( 'Useful page content. ', 80 ) . '</p></main><script src="/tracking.js"></script></body></html>' );
+$assert( array() === $server_rendered_diagnostic, 'server-rendered-html-not-flagged-as-client-shell' );
 
 $ability = static_site_importer_ability_import_url(
 	array(


### PR DESCRIPTION
## Summary
- Route URL-only Playground imports through the shared URL provider/fetcher boundary instead of building an empty artifact from metadata-only source input.
- Normalize bare host input like `facebook.com` to `https://facebook.com` for both Playground and current-site URL imports.
- Detect JavaScript-heavy client-rendered app shells and return a clear `static_site_importer_url_client_rendered_app` error with diagnostic data instead of proceeding to a blank import.
- Preserve URL provider/source metadata in Playground import blueprints.

## Verification
- `php tests/smoke-url-import-runtime.php`
- `php tests/smoke-importer-block.php`
- `php -l includes/class-static-site-importer-url-fetcher.php && php -l includes/class-static-site-importer-url-import-runtime.php && php -l includes/rest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the URL-only block import path, implementing the client-rendered shell diagnostic, adding regression coverage, and drafting this PR description.