### PR TITLE
Accept preserved runtime island diagnostics

### DIFF
--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -284,8 +284,11 @@ function inferFixtureSuccess(payload, diagnostics, error, payloadCount) {
   if (payload.success === true || payload.ok === true || payload.passed === true) {
     return diagnostics.length === 0 && !error;
   }
-  if (payload.success === false || payload.ok === false || payload.passed === false || payload.status === 'failed' || payload.status === 'error') {
+  if (payload.ok === false || payload.passed === false || payload.status === 'error') {
     return false;
+  }
+  if (payload.success === false || payload.status === 'failed') {
+    return diagnostics.length > 0 && !error;
   }
   if (payload.status === 'passed' || payload.status === 'success') {
     return diagnostics.length === 0 && !error;

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -203,7 +203,14 @@ function hasVisualParityGateSignal(raw) {
 function hasRuntimeCarriedSignal(raw) {
   const rawObject = objectValue(raw);
   const classification = objectValue(rawObject.classification);
-  return RUNTIME_CARRIED_SIGNAL_KEYS.some((key) => isTruthySignal(rawObject[key]) || isTruthySignal(classification[key]));
+  if (RUNTIME_CARRIED_SIGNAL_KEYS.some((key) => isTruthySignal(rawObject[key]) || isTruthySignal(classification[key]))) {
+    return true;
+  }
+
+  return rawObject.repair_mode === 'accepted-runtime-preservation'
+    || rawObject.repairMode === 'accepted-runtime-preservation'
+    || classification.repair_mode === 'accepted-runtime-preservation'
+    || classification.repairMode === 'accepted-runtime-preservation';
 }
 
 export function patternFamily(finding) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -343,6 +343,36 @@ test('passes the gate when a preserved_runtime_island carries a runtime-carried 
   assert.equal(result.fixtures[0].status, 'passed');
 });
 
+test('passes the gate when a preserved_runtime_island is explicitly accepted runtime preservation', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'runtime-island-repair-mode-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'core_html_block',
+            loss_class: 'preserved_runtime_island',
+            repair_mode: 'accepted-runtime-preservation',
+            source_path: 'posts/page-home.post_content',
+            selector: 'canvas#canvas',
+            message: 'Canvas markup preserved for runtime script access.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const finding = result.findings[0];
+  assert.equal(finding.loss_class, 'preserved_runtime_island');
+  assert.equal(finding.loss_acceptance, 'acceptable');
+  assert.equal(finding.acceptable_loss, true);
+  assert.equal(result.summary.succeeded, 1);
+  assert.equal(result.summary.failed, 0);
+});
+
 test('normalizes the transformer-emitted runtime_island_preserved loss class to the canonical preserved_runtime_island', () => {
   // The php-transformer emits `runtime_island_preserved` (FallbackDiagnostic /
   // HtmlTransformer). The alias must deterministically canonicalize it without


### PR DESCRIPTION
## Summary
- Treat explicit accepted runtime-preservation diagnostics as acceptable preserved runtime islands.
- Let failed/success-false payloads normalize through concrete diagnostics when there is no execution error.
- Add fixture-matrix coverage for the accepted runtime-preservation path.

## Verification
- node --test tools/fixture-matrix.test.mjs
- Focused Liquid Bonsai fixture replay: succeeded 1, failed 0, unacceptable findings 0

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** diagnosing fixture-matrix false positives, implementing classifier/intake fixes, and running verification.