### PR TITLE
Bump php transformer to 0.2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.2.3",
+        "version": "0.2.4",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "d802899a7f8f406b26aeb4cf46805cb297e09e53"
+          "reference": "cff4eac3c0b3adf2bcf73f0b9c12e1e7d39cd673"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.3.zip",
-          "reference": "d802899a7f8f406b26aeb4cf46805cb297e09e53"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.4.zip",
+          "reference": "cff4eac3c0b3adf2bcf73f0b9c12e1e7d39cd673"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.2.3",
+    "automattic/blocks-engine-php-transformer": "^0.2.4",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe7fd8f43cb4eee23238780b505edb29",
+    "content-hash": "5b840db914996af9a691ae6bec690cdb",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "d802899a7f8f406b26aeb4cf46805cb297e09e53"
+                "reference": "cff4eac3c0b3adf2bcf73f0b9c12e1e7d39cd673"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.3.zip",
-                "reference": "d802899a7f8f406b26aeb4cf46805cb297e09e53"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.4.zip",
+                "reference": "cff4eac3c0b3adf2bcf73f0b9c12e1e7d39cd673"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- Bump the bundled Blocks Engine PHP transformer package repository from 0.2.3 to 0.2.4.
- Update the Composer constraint and lock file to the php-transformer-v0.2.4 release tag.

## Verification
- php -l includes/class-static-site-importer-theme-generator.php
- php -l includes/class-static-site-importer-validation-runtime.php
- php -l includes/abilities.php
- php -l includes/rest.php
- php tests/smoke-website-artifact-document-metadata.php
- php tests/smoke-static-interactive-artifact.php
- php tests/smoke-import-source-of-truth-manifest.php
- node --test tools/fixture-matrix.test.mjs
- Focused Liquid Bonsai fixture replay: succeeded 1, failed 0, unacceptable findings 0

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** updating the dependency pin, refreshing the lock file, and running verification.