### PR TITLE
fixture-matrix: keep WP Codebox recipes schema compatible

### DIFF
--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -155,9 +155,6 @@ export function buildFixtureMatrixRecipe(input = {}) {
         ? { dependency_overlays: dependencyOverrideSetup.dependencyOverlays }
         : {}),
     },
-    ...(Object.keys(dependencyOverrideSetup.metadata).length
-      ? { metadata: { dependency_overrides: dependencyOverrideSetup.metadata } }
-      : {}),
     workflow: {
       steps: [
         importer.activationStep,
@@ -185,7 +182,7 @@ function buildDependencyOverrideSetup(input, importer) {
   const blocksEnginePhpTransformer = overrides.blocks_engine_php_transformer || overrides.blocksEnginePhpTransformer;
   const rawPackagePath = blocksEnginePhpTransformer?.path || '';
   if (!rawPackagePath) {
-    return { dependencyOverlays: [], metadata: {} };
+    return { dependencyOverlays: [] };
   }
 
   const packagePath = path.resolve(rawPackagePath);
@@ -211,14 +208,6 @@ function buildDependencyOverrideSetup(input, importer) {
         source: packagePath,
       },
     ],
-    metadata: {
-      blocks_engine_php_transformer: {
-        package: packageName,
-        source_path: packagePath,
-        applied_by: 'wp_codebox_dependency_overlay',
-        consumer: importer.slug,
-      },
-    },
   };
 }
 

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -176,12 +176,7 @@ test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () 
   });
   assert.equal(recipe.inputs.mounts.length, 0);
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
-  assert.deepEqual(recipe.metadata.dependency_overrides.blocks_engine_php_transformer, {
-    package: 'automattic/blocks-engine-php-transformer',
-    source_path: transformerPath,
-    applied_by: 'wp_codebox_dependency_overlay',
-    consumer: 'static-site-importer',
-  });
+  assert.equal(recipe.metadata, undefined);
 });
 
 test('fails recipe generation for invalid SSI dependency override paths', () => {


### PR DESCRIPTION
## Summary
- Remove unsupported top-level recipe metadata from generated WP Codebox recipes.
- Keep dependency override details in the supported setup/dependency overlay shape.
- Update fixture-matrix coverage for schema-compatible recipe generation.

## Testing
- npm run test:fixture-matrix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the WP Codebox recipe schema failure, drafting the minimal fixture-matrix change, and running verification.