### PR TITLE
Preserve visual parity evidence in fixture matrix

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -238,7 +238,8 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
   });
   const batchRecipeFile = path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`);
   const outputFile = path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`);
-  const artifactRefs = batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile });
+  const codeboxArtifactsDirectory = batchCodeboxArtifactsDirectory(outputDirectory, batchSuffix);
+  const artifactRefs = batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile, codeboxArtifactsDirectory });
   fs.writeFileSync(batchRecipeFile, `${JSON.stringify(batchRecipe, null, 2)}\n`);
 
   let batchRuntime = null;
@@ -247,7 +248,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
   try {
     batchRuntime = await runWpCodeboxRecipe({
       recipeFile: batchRecipeFile,
-      artifactsDir: outputDirectory,
+      artifactsDir: codeboxArtifactsDirectory,
       outputFile,
       wpCodeboxBin: options.wpCodeboxBin,
     });
@@ -264,7 +265,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       batchSuffix,
       batchRecipeFile,
       outputFile,
-      artifactsDir: outputDirectory,
+      artifactsDir: codeboxArtifactsDirectory,
       wpCodeboxBin: options.wpCodeboxBin,
       artifactRefs,
     });
@@ -276,6 +277,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     fixtures,
     batchRecipeFile,
     outputFile,
+    codeboxArtifactsDirectory,
     batchRuntime,
     batchError,
   });
@@ -445,6 +447,7 @@ export function fixtureMatrixBatchRunSummary(input = {}) {
     fixture_count: fixtureIds.length,
     recipe_file: input.batchRecipeFile || '',
     output_file: input.outputFile || '',
+    codebox_artifacts_directory: input.codeboxArtifactsDirectory || '',
     exit_code: batchRuntime?.exitCode ?? 0,
     error: batchError ? batchError.message : '',
     stderr_tail: batchError ? textTail(batchError.stderr) : '',
@@ -535,11 +538,18 @@ function replayArtifactsDirectory(outputDirectory) {
   return path.join(path.dirname(resolved), `${path.basename(resolved)}-wp-codebox-replay-artifacts`);
 }
 
-function batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile }) {
+function batchCodeboxArtifactsDirectory(outputDirectory, batchSuffix) {
+  const resolved = path.resolve(outputDirectory);
+  return path.join(path.dirname(resolved), `${path.basename(resolved)}-wp-codebox-batch-${batchSuffix}-artifacts`);
+}
+
+function batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile, codeboxArtifactsDirectory }) {
   return {
-    artifacts_directory: outputDirectory,
+    artifacts_directory: codeboxArtifactsDirectory,
     recipe_file: batchRecipeFile,
     output_file: outputFile,
+    fixture_artifacts_directory: outputDirectory,
+    codebox_artifacts_directory: codeboxArtifactsDirectory,
     cli_run: path.join(outputDirectory, 'cli-run.json'),
     matrix: path.join(outputDirectory, 'matrix.json'),
     result: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
@@ -619,6 +629,7 @@ function optionsFromEnv(env = process.env) {
     editorValidation: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION ?? env.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION),
     visualParity: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY),
     visualParityGate: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE) || isTruthy(env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE),
+    visualParityFullPage: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE) || isTruthy(env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE),
     // Opt-in live-WP parity capture + comparison. Off by default; mirrors the
     // visual-parity-gate truthy env mapping. When on, the recipe appends the
     // capture-html step and the result collector runs the live-wp-parity comparator.
@@ -648,6 +659,7 @@ function visualParityRecipeInput(options) {
     pixelThreshold: options.pixelThreshold,
     visualParityCandidateUrl: options.visualParityCandidateUrl,
     visualParitySourceBaseUrl: options.visualParitySourceBaseUrl,
+    visualParityFullPage: options.visualParityFullPage,
   };
 }
 

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -231,7 +231,31 @@ function collectFixtureArtifactRefs(payload, fixtureArtifactsDirectory) {
 function collectRuntimePayloads(value) {
   const payloads = [];
   visitRuntimePayloads(value, '', payloads, new Set());
+  payloads.push(...collectRecipeBrowserEvidencePayloads(value));
   return payloads;
+}
+
+function collectRecipeBrowserEvidencePayloads(value) {
+  const root = objectValue(value);
+  const executions = normalizeArray(root.executions).filter((execution) => execution && typeof execution === 'object');
+  const fixtureByStep = new Map();
+  let carriedFixtureId = '';
+  for (const execution of executions) {
+    const fixtureId = fixtureIdentity(execution) || carriedFixtureId;
+    const phase = execution.recipePhase;
+    const index = execution.recipeStepIndex;
+    if (fixtureId && phase !== undefined && index !== undefined) {
+      fixtureByStep.set(`${phase}:${index}`, fixtureId);
+    }
+    if (fixtureId) {
+      carriedFixtureId = fixtureId;
+    }
+  }
+
+  return normalizeArray(root.browserEvidence || root.browser_evidence)
+    .filter((evidence) => evidence && typeof evidence === 'object')
+    .map((evidence) => ({ fixture_id: fixtureByStep.get(`${evidence.phase}:${evidence.index}`) || fixtureIdentity(evidence), ...evidence }))
+    .filter((evidence) => evidence.fixture_id);
 }
 
 function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen) {

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -275,7 +275,7 @@ function hasPayloadData(value) {
 }
 
 function readFixturePayloadFiles(directory) {
-  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-validate-blocks.json', 'editor-canvas-summary.json', 'visual-compare.json', 'visual-diff.json', 'visual-parity.json']
+  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-validate-blocks.json', 'editor-canvas-summary.json', 'visual-compare.json', 'visual-diff.json', 'visual-parity.json', 'visual-explanation.json']
     .map((fileName) => readJsonFileIfExists(path.join(directory, fileName)))
     .filter(Boolean);
 }

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -117,24 +117,26 @@ function isVisualParityPayload(payload) {
   return Boolean(value.comparison && typeof value.comparison === 'object')
     || (objectValue(value.summary).mismatch_pixels !== undefined)
     || (objectValue(value.summary).total_pixels !== undefined)
+    || Boolean(objectValue(objectValue(value.summary).visualCompare || objectValue(value.summary).visual_compare).mismatchPixels !== undefined)
     || Boolean(normalizeVisualExplanation(value));
 }
 
 function normalizeVisualParityComparison(value) {
   const obj = objectValue(value);
   const summary = objectValue(obj.summary);
+  const visualCompare = objectValue(summary.visualCompare || summary.visual_compare);
   const comparison = objectValue(obj.comparison);
-  const mismatchPixels = firstNumber([summary.mismatch_pixels, summary.mismatchPixels, comparison.mismatchPixels, comparison.mismatch_pixels, obj.mismatch_pixels, obj.mismatchPixels]);
-  const totalPixels = firstNumber([summary.total_pixels, summary.totalPixels, comparison.totalPixels, comparison.total_pixels, obj.total_pixels, obj.totalPixels]);
-  const explicitRatio = firstNumber([summary.mismatch_ratio, summary.mismatchRatio, comparison.mismatchRatio, comparison.mismatch_ratio, obj.mismatch_ratio, obj.mismatchRatio]);
+  const mismatchPixels = firstNumber([summary.mismatch_pixels, summary.mismatchPixels, visualCompare.mismatchPixels, visualCompare.mismatch_pixels, comparison.mismatchPixels, comparison.mismatch_pixels, obj.mismatch_pixels, obj.mismatchPixels]);
+  const totalPixels = firstNumber([summary.total_pixels, summary.totalPixels, visualCompare.totalPixels, visualCompare.total_pixels, comparison.totalPixels, comparison.total_pixels, obj.total_pixels, obj.totalPixels]);
+  const explicitRatio = firstNumber([summary.mismatch_ratio, summary.mismatchRatio, visualCompare.mismatchRatio, visualCompare.mismatch_ratio, comparison.mismatchRatio, comparison.mismatch_ratio, obj.mismatch_ratio, obj.mismatchRatio]);
   // Dimension-fair (overlap-region) metrics emitted by wp-codebox's trustworthy
   // visual-compare. When present these drive the gate; otherwise the fair ratio
   // falls back to the raw union-canvas ratio for backward compatibility.
-  const overlapMismatchPixels = firstNumber([summary.overlap_mismatch_pixels, summary.overlapMismatchPixels, comparison.overlapMismatchPixels, comparison.overlap_mismatch_pixels, obj.overlap_mismatch_pixels, obj.overlapMismatchPixels]);
-  const overlapPixels = firstNumber([summary.overlap_pixels, summary.overlapPixels, comparison.overlapPixels, comparison.overlap_pixels, obj.overlap_pixels, obj.overlapPixels]);
-  const overlapRatio = firstNumber([summary.overlap_mismatch_ratio, summary.overlapMismatchRatio, comparison.overlapMismatchRatio, comparison.overlap_mismatch_ratio, obj.overlap_mismatch_ratio, obj.overlapMismatchRatio]);
-  const dimensionDeltaPixels = firstNumber([summary.dimension_delta_pixels, summary.dimensionDeltaPixels, comparison.dimensionDeltaPixels, comparison.dimension_delta_pixels, obj.dimension_delta_pixels, obj.dimensionDeltaPixels]);
-  const dimensionMismatch = Boolean(summary.dimension_mismatch ?? comparison.dimensionMismatch ?? comparison.dimension_mismatch ?? obj.dimension_mismatch);
+  const overlapMismatchPixels = firstNumber([summary.overlap_mismatch_pixels, summary.overlapMismatchPixels, visualCompare.overlapMismatchPixels, visualCompare.overlap_mismatch_pixels, comparison.overlapMismatchPixels, comparison.overlap_mismatch_pixels, obj.overlap_mismatch_pixels, obj.overlapMismatchPixels]);
+  const overlapPixels = firstNumber([summary.overlap_pixels, summary.overlapPixels, visualCompare.overlapPixels, visualCompare.overlap_pixels, comparison.overlapPixels, comparison.overlap_pixels, obj.overlap_pixels, obj.overlapPixels]);
+  const overlapRatio = firstNumber([summary.overlap_mismatch_ratio, summary.overlapMismatchRatio, visualCompare.overlapMismatchRatio, visualCompare.overlap_mismatch_ratio, comparison.overlapMismatchRatio, comparison.overlap_mismatch_ratio, obj.overlap_mismatch_ratio, obj.overlapMismatchRatio]);
+  const dimensionDeltaPixels = firstNumber([summary.dimension_delta_pixels, summary.dimensionDeltaPixels, visualCompare.dimensionDeltaPixels, visualCompare.dimension_delta_pixels, comparison.dimensionDeltaPixels, comparison.dimension_delta_pixels, obj.dimension_delta_pixels, obj.dimensionDeltaPixels]);
+  const dimensionMismatch = Boolean(summary.dimension_mismatch ?? summary.dimensionMismatch ?? visualCompare.dimensionMismatch ?? visualCompare.dimension_mismatch ?? comparison.dimensionMismatch ?? comparison.dimension_mismatch ?? obj.dimension_mismatch);
   const hasMetrics = [mismatchPixels, totalPixels, explicitRatio, overlapRatio, overlapMismatchPixels].some((metric) => Number.isFinite(metric));
   if (!hasMetrics && !dimensionMismatch) {
     return null;
@@ -169,12 +171,27 @@ function normalizeVisualParityComparison(value) {
     dimension_delta_pixels: safeDimensionDelta,
     dimension_mismatch: dimensionMismatch,
     source_path: firstString([sourceObject.path, sourceObject.url, obj.source_path, obj.sourcePath]),
-    source_screenshot: firstString([artifacts.source_screenshot, files.sourceScreenshot, obj.source_screenshot, obj.sourceScreenshot]),
-    candidate_screenshot: firstString([artifacts.candidate_screenshot, artifacts.imported_screenshot, files.candidateScreenshot, obj.candidate_screenshot, obj.candidateScreenshot]),
-    diff_screenshot: firstString([artifacts.diff_screenshot, files.diffScreenshot, obj.diff_screenshot, obj.diffScreenshot]),
-    visual_diff: firstString([artifacts.visual_diff, files.visualDiff, obj.visual_diff, obj.visualDiff]),
+    source_screenshot: firstRef([artifacts.source_screenshot, files.sourceScreenshot, obj.source_screenshot, obj.sourceScreenshot]),
+    candidate_screenshot: firstRef([artifacts.candidate_screenshot, artifacts.imported_screenshot, files.candidateScreenshot, obj.candidate_screenshot, obj.candidateScreenshot]),
+    diff_screenshot: firstRef([artifacts.diff_screenshot, files.diffScreenshot, obj.diff_screenshot, obj.diffScreenshot]),
+    visual_diff: firstRef([artifacts.visual_diff, files.visualDiff, obj.visual_diff, obj.visualDiff]),
+    visual_explanation_ref: firstRef([artifacts.visual_explanation, files.visualExplanation, visualCompare.explanation, obj.visual_explanation_ref, obj.visualExplanationRef]),
     visual_explanation: visualExplanation,
   };
+}
+
+function firstRef(values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+    const obj = objectValue(value);
+    const ref = firstString([obj.path, obj.file, obj.href, obj.url, obj.artifact_name, obj.artifactName]);
+    if (ref) {
+      return ref;
+    }
+  }
+  return '';
 }
 
 // Generic visual-explanation intake. The upstream schema may evolve; this accepts
@@ -182,13 +199,16 @@ function normalizeVisualParityComparison(value) {
 // selector/property/layout/capture diagnostics are summarized and bounded.
 function normalizeVisualExplanation(value) {
   const obj = objectValue(value);
-  const explanation = objectValue(obj.visual_explanation || obj.visualExplanation || obj.explanation || (isVisualExplanationPayload(obj) ? obj : null));
+  const visualCompare = objectValue(objectValue(obj.summary).visualCompare || objectValue(obj.summary).visual_compare);
+  const explanation = objectValue(obj.visual_explanation || obj.visualExplanation || obj.explanation || objectValue(obj.summary).visualExplanation || objectValue(obj.summary).visual_explanation || visualCompare.visualExplanation || visualCompare.visual_explanation || (isVisualExplanationPayload(obj) ? obj : null));
   const summary = { ...objectValue(obj.summary), ...objectValue(explanation.summary) };
   const selectors = summarizeVisualEvidenceItems([
     ...normalizeArray(explanation.selector_diagnostics || explanation.selectorDiagnostics),
     ...normalizeArray(explanation.selectors),
     ...normalizeArray(explanation.selector_mismatches || explanation.selectorMismatches),
+    ...normalizeArray(explanation.selector_deltas || explanation.selectorDeltas),
     ...normalizeArray(obj.selector_diagnostics || obj.selectorDiagnostics),
+    ...normalizeArray(obj.selector_deltas || obj.selectorDeltas),
   ], ['selector', 'source_selector', 'target_selector', 'reason', 'message', 'mismatch_ratio', 'mismatch_pixels']);
   const properties = summarizeVisualEvidenceItems([
     ...normalizeArray(explanation.property_diagnostics || explanation.propertyDiagnostics),
@@ -200,12 +220,16 @@ function normalizeVisualExplanation(value) {
     ...normalizeArray(explanation.layout_diagnostics || explanation.layoutDiagnostics),
     ...normalizeArray(explanation.layout),
     ...normalizeArray(explanation.layout_diffs || explanation.layoutDiffs),
+    ...normalizeArray(explanation.layout_drift || explanation.layoutDrift),
     ...normalizeArray(obj.layout_diagnostics || obj.layoutDiagnostics),
+    ...normalizeArray(obj.layout_drift || obj.layoutDrift),
+    ...normalizeArray(visualCompare.layout_drift || visualCompare.layoutDrift),
   ], ['selector', 'source_selector', 'target_selector', 'property', 'source_rect', 'target_rect', 'expected', 'observed', 'delta', 'reason', 'message']);
   const capture = summarizeVisualEvidenceItems([
     ...normalizeArray(explanation.capture_diagnostics || explanation.captureDiagnostics),
     ...normalizeArray(explanation.capture),
     ...normalizeArray(obj.capture_diagnostics || obj.captureDiagnostics),
+    ...normalizeArray(visualCompare.capture_diagnostics || visualCompare.captureDiagnostics),
   ], ['phase', 'selector', 'source_url', 'target_url', 'viewport', 'full_page', 'reason', 'message']);
   const counts = compactObject({
     selector_diagnostic_count: evidenceCount(summary.selector_diagnostic_count ?? summary.selectorDiagnosticCount ?? explanation.selector_diagnostic_count ?? explanation.selectorDiagnosticCount, selectors.length),
@@ -315,6 +339,7 @@ export function collectVisualParityArtifacts(payload) {
       imported_screenshot: slot(comparison.candidate_screenshot, 'imported_screenshot', 'Imported WordPress screenshot was not captured by the runtime.'),
       diff_screenshot: slot(comparison.diff_screenshot, 'diff_screenshot', 'Diff screenshot was not captured by the runtime.'),
       visual_diff: slot(comparison.visual_diff, 'visual_diff', 'Visual diff output was not captured by the runtime.'),
+      visual_explanation: slot(comparison.visual_explanation_ref, 'visual_explanation', 'Visual explanation output was not captured by the runtime.'),
     },
   };
 }

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -20,6 +20,9 @@ import {
   isTruthySignal,
   artifactRef,
 } from '../shared/utils.mjs';
+import { boundBlob, truncateString } from '../shared/bounds.mjs';
+
+const VISUAL_EXPLANATION_SUMMARY_LIMIT = 5;
 
 // Turn `wordpress.visual-compare` evidence into `visual_parity_mismatch`
 // diagnostics, gated on the TRUSTWORTHY (dimension-fair) ratio.
@@ -71,6 +74,7 @@ export function collectVisualParityDiagnostics(payload, options = {}) {
       dimension_mismatch: comparison.dimension_mismatch,
       dimension_delta_pixels: comparison.dimension_delta_pixels,
       artifact_refs: visualParityArtifactRefs(comparison),
+      ...visualExplanationDiagnosticFields(comparison.visual_explanation),
       message: dimensionForcesFinding
         ? `Visual parity dimension mismatch between source and imported output with no measurable overlap region (raw ${comparison.mismatch_pixels}/${comparison.total_pixels} pixels, ${rawPercent}%).`
         : `Pixel visual parity mismatch: ${fairPixels}/${fairTotal} overlap pixels (${percent}%) exceed the ${thresholdPercent}% threshold (raw full-page ${rawPercent}%, dimension delta ${comparison.dimension_delta_pixels} px).`,
@@ -97,6 +101,7 @@ function collectVisualParityComparisons(payload) {
     ...normalizeArray(payload.visual_compare || payload.visualCompare),
     ...normalizeArray(payload.visual_diff || payload.visualDiff),
     ...normalizeArray(payload.visual_parity?.comparisons || payload.visualParity?.comparisons),
+    ...normalizeArray(payload.visual_explanation?.comparisons || payload.visualExplanation?.comparisons),
   ];
   if (isVisualParityPayload(payload)) {
     candidates.push(payload);
@@ -111,7 +116,8 @@ function isVisualParityPayload(payload) {
   }
   return Boolean(value.comparison && typeof value.comparison === 'object')
     || (objectValue(value.summary).mismatch_pixels !== undefined)
-    || (objectValue(value.summary).total_pixels !== undefined);
+    || (objectValue(value.summary).total_pixels !== undefined)
+    || Boolean(normalizeVisualExplanation(value));
 }
 
 function normalizeVisualParityComparison(value) {
@@ -150,6 +156,7 @@ function normalizeVisualParityComparison(value) {
   const files = objectValue(obj.files);
   const artifacts = objectValue(obj.artifacts);
   const sourceObject = objectValue(obj.source);
+  const visualExplanation = normalizeVisualExplanation(obj);
   return {
     mismatch_pixels: safeMismatch,
     total_pixels: safeTotal,
@@ -166,7 +173,101 @@ function normalizeVisualParityComparison(value) {
     candidate_screenshot: firstString([artifacts.candidate_screenshot, artifacts.imported_screenshot, files.candidateScreenshot, obj.candidate_screenshot, obj.candidateScreenshot]),
     diff_screenshot: firstString([artifacts.diff_screenshot, files.diffScreenshot, obj.diff_screenshot, obj.diffScreenshot]),
     visual_diff: firstString([artifacts.visual_diff, files.visualDiff, obj.visual_diff, obj.visualDiff]),
+    visual_explanation: visualExplanation,
   };
+}
+
+// Generic visual-explanation intake. The upstream schema may evolve; this accepts
+// the documented sample shape from the subagent prompt without product buckets:
+// selector/property/layout/capture diagnostics are summarized and bounded.
+function normalizeVisualExplanation(value) {
+  const obj = objectValue(value);
+  const explanation = objectValue(obj.visual_explanation || obj.visualExplanation || obj.explanation || (isVisualExplanationPayload(obj) ? obj : null));
+  const summary = { ...objectValue(obj.summary), ...objectValue(explanation.summary) };
+  const selectors = summarizeVisualEvidenceItems([
+    ...normalizeArray(explanation.selector_diagnostics || explanation.selectorDiagnostics),
+    ...normalizeArray(explanation.selectors),
+    ...normalizeArray(explanation.selector_mismatches || explanation.selectorMismatches),
+    ...normalizeArray(obj.selector_diagnostics || obj.selectorDiagnostics),
+  ], ['selector', 'source_selector', 'target_selector', 'reason', 'message', 'mismatch_ratio', 'mismatch_pixels']);
+  const properties = summarizeVisualEvidenceItems([
+    ...normalizeArray(explanation.property_diagnostics || explanation.propertyDiagnostics),
+    ...normalizeArray(explanation.properties),
+    ...normalizeArray(explanation.property_diffs || explanation.propertyDiffs),
+    ...normalizeArray(obj.property_diagnostics || obj.propertyDiagnostics),
+  ], ['selector', 'source_selector', 'target_selector', 'property', 'source_value', 'target_value', 'expected', 'observed', 'delta', 'reason', 'message']);
+  const layout = summarizeVisualEvidenceItems([
+    ...normalizeArray(explanation.layout_diagnostics || explanation.layoutDiagnostics),
+    ...normalizeArray(explanation.layout),
+    ...normalizeArray(explanation.layout_diffs || explanation.layoutDiffs),
+    ...normalizeArray(obj.layout_diagnostics || obj.layoutDiagnostics),
+  ], ['selector', 'source_selector', 'target_selector', 'property', 'source_rect', 'target_rect', 'expected', 'observed', 'delta', 'reason', 'message']);
+  const capture = summarizeVisualEvidenceItems([
+    ...normalizeArray(explanation.capture_diagnostics || explanation.captureDiagnostics),
+    ...normalizeArray(explanation.capture),
+    ...normalizeArray(obj.capture_diagnostics || obj.captureDiagnostics),
+  ], ['phase', 'selector', 'source_url', 'target_url', 'viewport', 'full_page', 'reason', 'message']);
+  const counts = compactObject({
+    selector_diagnostic_count: evidenceCount(summary.selector_diagnostic_count ?? summary.selectorDiagnosticCount ?? explanation.selector_diagnostic_count ?? explanation.selectorDiagnosticCount, selectors.length),
+    property_diagnostic_count: evidenceCount(summary.property_diagnostic_count ?? summary.propertyDiagnosticCount ?? explanation.property_diagnostic_count ?? explanation.propertyDiagnosticCount, properties.length),
+    layout_diagnostic_count: evidenceCount(summary.layout_diagnostic_count ?? summary.layoutDiagnosticCount ?? explanation.layout_diagnostic_count ?? explanation.layoutDiagnosticCount, layout.length),
+    capture_diagnostic_count: evidenceCount(summary.capture_diagnostic_count ?? summary.captureDiagnosticCount ?? explanation.capture_diagnostic_count ?? explanation.captureDiagnosticCount, capture.length),
+  });
+  if (selectors.length === 0 && properties.length === 0 && layout.length === 0 && capture.length === 0 && Object.keys(counts).length === 0) {
+    return null;
+  }
+  return boundBlob(compactObject({
+    schema: firstString([explanation.schema, obj.schema]),
+    summary: counts,
+    selector_diagnostics: selectors,
+    property_diagnostics: properties,
+    layout_diagnostics: layout,
+    capture_diagnostics: capture,
+  }));
+}
+
+function isVisualExplanationPayload(value) {
+  return typeof value.schema === 'string' && /visual.?explanation/i.test(value.schema);
+}
+
+function summarizeVisualEvidenceItems(values, keys) {
+  return values
+    .map((value) => summarizeVisualEvidenceItem(value, keys))
+    .filter((value) => Object.keys(value).length > 0)
+    .slice(0, VISUAL_EXPLANATION_SUMMARY_LIMIT);
+}
+
+function summarizeVisualEvidenceItem(value, keys) {
+  const obj = objectValue(value);
+  if (Object.keys(obj).length === 0) {
+    return typeof value === 'string' ? { message: truncateString(value) } : {};
+  }
+  return boundBlob(compactObject(Object.fromEntries(keys.map((key) => [key, obj[key] ?? obj[toCamelCase(key)]]))));
+}
+
+function visualExplanationDiagnosticFields(visualExplanation) {
+  if (!visualExplanation) {
+    return {};
+  }
+  return {
+    visual_explanation_summary: visualExplanation.summary || {},
+    visual_selector_diagnostics: visualExplanation.selector_diagnostics || [],
+    visual_property_diagnostics: visualExplanation.property_diagnostics || [],
+    visual_layout_diagnostics: visualExplanation.layout_diagnostics || [],
+    visual_capture_diagnostics: visualExplanation.capture_diagnostics || [],
+  };
+}
+
+function evidenceCount(value, fallback) {
+  const number = Number(value);
+  if (Number.isFinite(number) && number >= 0) {
+    return number;
+  }
+  return fallback > 0 ? fallback : undefined;
+}
+
+function toCamelCase(value) {
+  return value.replace(/_([a-z])/g, (_, char) => char.toUpperCase());
 }
 
 function visualParityArtifactRefs(comparison) {
@@ -208,6 +309,7 @@ export function collectVisualParityArtifacts(payload) {
       dimension_delta_pixels: comparison.dimension_delta_pixels,
       dimension_mismatch: comparison.dimension_mismatch,
     }),
+    ...(comparison.visual_explanation ? { visual_explanation: comparison.visual_explanation } : {}),
     artifacts: {
       source_screenshot: slot(comparison.source_screenshot, 'source_screenshot', 'Source screenshot was not captured by the runtime.'),
       imported_screenshot: slot(comparison.candidate_screenshot, 'imported_screenshot', 'Imported WordPress screenshot was not captured by the runtime.'),

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -21,7 +21,7 @@ import {
   objectValue,
   isTruthySignal,
 } from './shared/utils.mjs';
-import { truncateString } from './shared/bounds.mjs';
+import { boundBlob, truncateString } from './shared/bounds.mjs';
 
 export function classifyStaticSiteFinding(input = {}) {
   const haystack = [input.kind, input.type, input.code, input.category, input.repair_bucket, input.group_key, input.message, input.reason, input.detail]
@@ -89,6 +89,7 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     source_snippet: truncateString(raw.source_html_preview || raw.html_excerpt || rawSource.snippet || ''),
     observed_output: truncateString(raw.emitted_block_preview || rawObserved.output || ''),
     observed_block_name: raw.block_name || rawObserved.block_name || '',
+    ...visualExplanationFindingFields(raw),
     repair_mode: raw.repair_mode || group.repair_mode,
     candidate_repo: raw.candidate_repo || group.candidate_repo,
     loss_class: lossClass,
@@ -102,6 +103,22 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     // serialized markup. All classification above is computed from `raw` before
     // this point; downstream consumers read the bounded top-level fields.
   };
+}
+
+function visualExplanationFindingFields(raw) {
+  const fields = {};
+  for (const [outputKey, inputKey] of [
+    ['visual_explanation_summary', 'visual_explanation_summary'],
+    ['visual_selector_diagnostics', 'visual_selector_diagnostics'],
+    ['visual_property_diagnostics', 'visual_property_diagnostics'],
+    ['visual_layout_diagnostics', 'visual_layout_diagnostics'],
+    ['visual_capture_diagnostics', 'visual_capture_diagnostics'],
+  ]) {
+    if (raw[inputKey] !== undefined) {
+      fields[outputKey] = boundBlob(raw[inputKey]);
+    }
+  }
+  return fields;
 }
 
 export function isActionableFinding(finding) {

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -20,6 +20,7 @@ import {
   normalizeArray,
   objectValue,
   isTruthySignal,
+  compactObject,
 } from './shared/utils.mjs';
 import { boundBlob, truncateString } from './shared/bounds.mjs';
 
@@ -57,21 +58,24 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
   const rawObserved = objectValue(raw.observed);
   const rawExpected = objectValue(raw.expected);
   const rawReproduction = objectValue(raw.reproduction_context || raw.reproductionContext);
+  const rawSelectorEvidence = objectValue(raw.selector_evidence || raw.selectorEvidence);
   const message = raw.message || raw.reason || raw.detail || rawObserved.reason_code || rawExpected.outcome || raw.code || result.error || '';
   const group = classifyStaticSiteFinding({ ...raw, message });
   const kind = raw.kind || raw.code || raw.type || rawObserved.reason_code || 'static_site_fixture_diagnostic';
-  const selector = raw.selector || rawSource.selector || rawReproduction.selector || '';
+  const selector = raw.selector || rawSource.selector || rawReproduction.selector || rawSelectorEvidence.source_selector || rawSelectorEvidence.sourceSelector || rawSelectorEvidence.target_selector || rawSelectorEvidence.targetSelector || '';
   const sourcePath = raw.source_path || raw.path || rawSource.path || rawReproduction.source_path || result.fixture_path || '';
   const repairBucket = raw.repair_bucket || group.group_key;
   const countOnlyDiagnostic = isCountOnlyStaticSiteFixtureDiagnostic({ raw, result, kind, message, selector });
   const lossClass = countOnlyDiagnostic ? 'native_conversion' : classifyLossClass({ raw, kind, group_key: group.group_key, repair_bucket: repairBucket, message, result });
   const lossAcceptance = resolveLossAcceptance(lossClass, raw);
+  const attributionFields = visualAttributionFindingFields(raw, rawObserved, rawSelectorEvidence);
   return {
     id: raw.id || `${result.fixture_id || 'fixture'}:${group.group_key}:${index + 1}`,
     kind,
     category: raw.category || group.group_key,
     group_key: group.group_key,
     repair_bucket: repairBucket,
+    ...attributionFields.classification,
     severity: raw.severity || (result.status === 'failed' ? 'error' : 'warning'),
     fixture_id: result.fixture_id || '',
     fixture_class: result.fixture_class || result.taxonomy?.fixture_class || 'unknown',
@@ -79,16 +83,17 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     source_path: sourcePath,
     selector,
     selector_family: selectorFamily(selector),
-    pattern_family: patternFamily({ ...raw, kind, group_key: group.group_key, repair_bucket: repairBucket, selector }),
+    pattern_family: attributionFields.classification.pattern_family || patternFamily({ ...raw, kind, group_key: group.group_key, repair_bucket: repairBucket, selector }),
     // Bound the free-text payload fields: a source snippet / observed block
     // output can carry an entire serialized `post_content` body, which at lane
     // scale balloons the aggregate past V8's per-string limit (#554). Truncate
     // to a sane cap so per-finding size is bounded; classification/metrics above
     // are derived from the full diagnostic before truncation.
     reason: truncateString(message),
-    source_snippet: truncateString(raw.source_html_preview || raw.html_excerpt || rawSource.snippet || ''),
-    observed_output: truncateString(raw.emitted_block_preview || rawObserved.output || ''),
+    source_snippet: truncateString(raw.source_html_preview || raw.html_excerpt || rawSource.snippet || rawSelectorEvidence.source_text || rawSelectorEvidence.sourceText || ''),
+    observed_output: truncateString(raw.emitted_block_preview || rawObserved.output || rawSelectorEvidence.target_text || rawSelectorEvidence.targetText || ''),
     observed_block_name: raw.block_name || rawObserved.block_name || '',
+    ...attributionFields.evidence,
     ...visualExplanationFindingFields(raw),
     repair_mode: raw.repair_mode || group.repair_mode,
     candidate_repo: raw.candidate_repo || group.candidate_repo,
@@ -102,6 +107,26 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     // duplicates the (already-bounded) classified fields and can carry raw
     // serialized markup. All classification above is computed from `raw` before
     // this point; downstream consumers read the bounded top-level fields.
+  };
+}
+
+function visualAttributionFindingFields(raw, rawObserved, rawSelectorEvidence) {
+  const confidence = Number(raw.confidence ?? raw.classification?.confidence);
+  const classification = compactObject({
+    reason_code: raw.reason_code || raw.reasonCode || rawObserved.reason_code || rawObserved.reasonCode,
+    repair_bucket: raw.repair_bucket || raw.repairBucket,
+    pattern_family: raw.pattern_family || raw.patternFamily || raw.classification?.pattern_family || raw.classification?.patternFamily,
+    confidence: Number.isFinite(confidence) && confidence >= 0 && confidence <= 1 ? confidence : undefined,
+  });
+
+  return {
+    classification,
+    evidence: compactObject({
+      selector_evidence: Object.keys(rawSelectorEvidence).length > 0 ? boundBlob(rawSelectorEvidence) : undefined,
+      property_evidence: raw.property_evidence !== undefined || raw.propertyEvidence !== undefined ? boundBlob(normalizeArray(raw.property_evidence || raw.propertyEvidence)) : undefined,
+      style_deltas: raw.style_deltas !== undefined || raw.styleDeltas !== undefined ? boundBlob(normalizeArray(raw.style_deltas || raw.styleDeltas)) : undefined,
+      visual_diff: raw.visual_diff !== undefined || raw.visualDiff !== undefined ? boundBlob(raw.visual_diff || raw.visualDiff) : undefined,
+    }),
   };
 }
 

--- a/lib/fixture-matrix/shared/constants.mjs
+++ b/lib/fixture-matrix/shared/constants.mjs
@@ -74,7 +74,7 @@ export const NON_NATIVE_FALLBACK_BLOCK_NAMES = new Set([CORE_HTML_BLOCK_NAME, 'c
 // positive `--min-native-rate`/`minNativeRate` threshold.
 export const LOW_NATIVE_CONVERSION_KIND = 'native_conversion_rate_below_min';
 
-export const DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD = 0.1;
+export const DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD = 0;
 // Candidate (imported WordPress output) URL. The per-fixture import step runs
 // with activate=true, which sets `show_on_front=page` + `page_on_front` to the
 // imported front page (see Static_Site_Importer_Theme_Generator::front_page_id).

--- a/lib/fixture-matrix/shared/constants.mjs
+++ b/lib/fixture-matrix/shared/constants.mjs
@@ -10,11 +10,9 @@ export const WEBSITE_ARTIFACT_SCHEMA = 'blocks-engine/php-transformer/site-artif
 export const DEFAULT_ENTRYPOINT = 'website/index.html';
 export const DEFAULT_IMPORTER_SLUG = 'static-site-importer';
 
-// Editor browser evidence wiring. The default recipe step uses the stable
-// `wordpress.editor-open` command shape accepted by the WP Codebox recipe schema
-// deployed in Homeboy Lab. Newer artifacts from `wordpress.editor-validate-blocks`
-// are still parsed by the collectors when available, but the matrix must not emit
-// that command by default until the runner-side schema consistently supports it.
+// Editor browser evidence wiring. The default recipe step emits
+// `wordpress.editor-validate-blocks`, and the fixture-matrix rig declares that
+// runner tool capability before Homeboy dispatches Lab evidence runs.
 //
 // The legacy `wordpress.editor-canvas-probe` selector shape (`.block-editor-warning`
 // / `is-invalid` DOM warnings) is still parsed for backward compatibility with
@@ -33,10 +31,11 @@ export const EDITOR_VALIDATE_BLOCKS_COMMAND = 'wordpress.editor-validate-blocks'
 export const EDITOR_VALIDATE_BLOCKS_SCHEMA = 'wp-codebox/editor-validate-blocks/v1';
 export const EDITOR_VALIDATION_METHOD = 'wp.blocks.validateBlock';
 export const EDITOR_VALIDATION_PROVIDER = 'wordpress-block-editor';
-// Stable editor-open target. The imported-content validation gate remains SSI's
-// PHP/native-rate validation; this browser step captures editor runtime evidence
-// without requiring a newer runner-only command.
-export const DEFAULT_EDITOR_VALIDATION_TARGET = 'site';
+// The per-fixture recipe interleaves import then editor validation. `front-page`
+// resolves at runtime to the just-imported `page_on_front`, so validation targets
+// real imported content even when the imported post ID is not known at recipe
+// generation time.
+export const DEFAULT_EDITOR_VALIDATION_TARGET = 'front-page';
 // Retained for callers that still forward an explicit editor post type; the
 // default target no longer keys off it.
 export const DEFAULT_EDITOR_VALIDATION_POST_TYPE = 'page';

--- a/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -1,13 +1,11 @@
 // Editor-validation recipe step for the Static Site Importer fixture matrix.
 //
-// Emits a WP Codebox schema-supported editor browser step for the fixture matrix.
-// The runner-side schema currently used by Homeboy Lab accepts `wordpress.editor-open`
-// but rejects the newer `wordpress.editor-validate-blocks` command before imports
-// can run. SSI's imported-content gate remains the PHP/native-rate validation; this
-// step captures generic editor runtime evidence without depending on a newer binary.
+// Emits a WP Codebox validateBlock browser step for the fixture matrix.
+// The rig declares this runner capability up front so unavailable validation fails
+// before evidence runs instead of silently degrading to an editor-open smoke test.
 
 import {
-  EDITOR_OPEN_COMMAND,
+  EDITOR_VALIDATE_BLOCKS_COMMAND,
   DEFAULT_EDITOR_VALIDATION_TARGET,
 } from '../shared/constants.mjs';
 
@@ -33,8 +31,6 @@ export function editorBlockValidationStep(input = {}) {
     args.push(`target=${DEFAULT_EDITOR_VALIDATION_TARGET}`);
   }
 
-  args.push('capture=editor-state');
-
   const waitSelector = firstPresent([input.waitSelector, input.wait_selector, fixture.editor_wait_selector, fixture.editorWaitSelector]);
   if (waitSelector !== undefined) {
     args.push(`wait-selector=${waitSelector}`);
@@ -45,7 +41,7 @@ export function editorBlockValidationStep(input = {}) {
   }
 
   return {
-    command: EDITOR_OPEN_COMMAND,
+    command: EDITOR_VALIDATE_BLOCKS_COMMAND,
     args,
   };
 }

--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -18,6 +18,20 @@
       "/tmp/static-site-importer-fixture-matrix-${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}"
     ]
   },
+  "requirements": {
+    "runner_tools": [
+      {
+        "tool": "wp-codebox",
+        "command": "wp-codebox",
+        "env": ["HOMEBOY_WP_CODEBOX_BIN"],
+        "capabilities": [
+          "wordpress.editor-validate-blocks",
+          "wordpress.visual-compare"
+        ],
+        "remediation": "Use a runner with a WP Codebox binary from HOMEBOY_WP_CODEBOX_BIN that supports fixture-matrix browser validation and visual comparison commands."
+      }
+    ]
+  },
   "bench": {
     "default_component": "static-site-importer",
     "iterations": 1,

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -3000,6 +3000,86 @@ test('visual-explanation.json is merged into collected visual parity artifacts g
   assert.equal(result.fixtures[0].visual_parity_artifacts.visual_explanation.property_diagnostics[0].property, 'background-color');
 });
 
+test('WP Codebox recipe browserEvidence visual refs are preserved with fixture identity', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-codebox-browser-evidence-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'codebox-browser-evidence-test' });
+  const codeboxOutput = {
+    schema: 'wp-codebox/recipe-run/v1',
+    executions: [
+      {
+        command: 'wordpress.wp-cli',
+        args: ['command=static-site-importer validate-artifact --artifact=/artifacts/simple-site/artifact.json --slug=simple-site --allow-failure'],
+        recipePhase: 'steps',
+        recipeStepIndex: 1,
+        exitCode: 0,
+      },
+      {
+        command: 'wordpress.visual-compare',
+        args: ['source-label=simple-site-source', 'candidate-label=simple-site-candidate'],
+        recipePhase: 'steps',
+        recipeStepIndex: 2,
+        exitCode: 0,
+      },
+    ],
+    browserEvidence: [
+      {
+        schema: 'wp-codebox/recipe-browser-evidence/v1',
+        phase: 'steps',
+        index: 2,
+        command: 'wordpress.visual-compare',
+        status: 'completed',
+        files: {
+          sourceScreenshot: { path: 'files/browser/visual-compare/source.png', kind: 'browser-visual-source-screenshot' },
+          candidateScreenshot: { path: 'files/browser/visual-compare/candidate.png', kind: 'browser-visual-candidate-screenshot' },
+          diffScreenshot: { path: 'files/browser/visual-compare/diff.png', kind: 'browser-visual-diff-screenshot' },
+          visualDiff: { path: 'files/browser/visual-compare/visual-diff.json', kind: 'browser-visual-diff' },
+          visualExplanation: { path: 'files/browser/visual-compare/visual-explanation.json', kind: 'browser-visual-explanation' },
+          summary: { path: 'files/browser/visual-compare/summary.json', kind: 'browser-summary' },
+        },
+        summary: {
+          visualCompare: {
+            mismatchPixels: 357562,
+            totalPixels: 2048000,
+            mismatchRatio: 357562 / 2048000,
+            overlapMismatchPixels: 357562,
+            overlapPixels: 2048000,
+            dimensionMismatch: false,
+            captureDiagnostics: [{ phase: 'candidate', message: 'captured imported viewport' }],
+          },
+          visualExplanation: {
+            schema: 'wp-codebox/visual-explanation/v1',
+            selector_diagnostic_count: 1,
+            layout_diagnostic_count: 1,
+            capture_diagnostic_count: 1,
+            selector_deltas: [{ selector: '.hero', reason: 'text shifted' }],
+            layout_drift: [{ selector: '.hero', delta: { y: 12 }, message: 'hero moved down' }],
+          },
+        },
+      },
+    ],
+  };
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory, codeboxOutput, visualParity: { threshold: 0.1, gate: true } });
+  const fixture = result.fixtures[0];
+  const artifacts = fixture.visual_parity_artifacts.artifacts;
+  const finding = result.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+
+  assert.equal(fixture.fixture_id, 'simple-site');
+  assert.equal(fixture.visual_parity_artifacts.metrics.mismatch_pixels, 357562);
+  assert.equal(artifacts.source_screenshot.status, 'captured');
+  assert.equal(artifacts.source_screenshot.ref.path, 'files/browser/visual-compare/source.png');
+  assert.equal(artifacts.imported_screenshot.ref.path, 'files/browser/visual-compare/candidate.png');
+  assert.equal(artifacts.diff_screenshot.ref.path, 'files/browser/visual-compare/diff.png');
+  assert.equal(artifacts.visual_diff.ref.path, 'files/browser/visual-compare/visual-diff.json');
+  assert.equal(artifacts.visual_explanation.ref.path, 'files/browser/visual-compare/visual-explanation.json');
+  assert.equal(fixture.visual_parity_artifacts.visual_explanation.selector_diagnostics[0].selector, '.hero');
+  assert.equal(fixture.visual_parity_artifacts.visual_explanation.layout_diagnostics[0].selector, '.hero');
+  assert.ok(finding, 'expected a visual parity finding from WP Codebox browserEvidence');
+  assert.equal(finding.visual_selector_diagnostics[0].selector, '.hero');
+  assert.equal(finding.visual_layout_diagnostics[0].message, 'hero moved down');
+  assert.equal(finding.visual_capture_diagnostics[0].phase, 'candidate');
+});
+
 // #554: at lane scale (~30+ fixtures) the aggregate result used to retain each
 // fixture's raw serialized `post_content`/block markup (via `raw: input` and the
 // #552 block-composition path) plus uncapped finding snippets, so JSON.stringify

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -55,6 +55,7 @@ import {
   writeFixtureMatrixArtifacts,
 } from '../lib/fixture-matrix.mjs';
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
+import { wpCodeboxBin } from './wp-codebox/recipe.mjs';
 
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const fixtureRoot = path.join(packageRoot, 'tests', 'fixtures', 'fixture-matrix');
@@ -155,6 +156,17 @@ test('fixture-matrix rig requires env-backed WP Codebox editor and visual capabi
   assert.deepEqual(tool.env, ['HOMEBOY_WP_CODEBOX_BIN']);
   assert.ok(tool.capabilities.includes('wordpress.editor-validate-blocks'));
   assert.ok(tool.capabilities.includes('wordpress.visual-compare'));
+});
+
+test('fixture-matrix WP Codebox batch runner uses Homeboy declared binary', () => {
+  assert.equal(wpCodeboxBin({
+    HOMEBOY_WP_CODEBOX_BIN: '/runner/wp-codebox-current',
+    WP_CODEBOX_BIN: '/stale/wp-codebox',
+  }), '/runner/wp-codebox-current');
+  assert.equal(wpCodeboxBin({
+    SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN: '/explicit/wp-codebox',
+    HOMEBOY_WP_CODEBOX_BIN: '/runner/wp-codebox-current',
+  }), '/explicit/wp-codebox');
 });
 
 test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () => {
@@ -1048,6 +1060,7 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
   const previousImporterPath = process.env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH;
   const previousRun = process.env.SSI_FIXTURE_MATRIX_RUN;
   const previousBatchSize = process.env.SSI_FIXTURE_MATRIX_BATCH_SIZE;
+  const previousVisualParityFullPage = process.env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE;
   process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = helperPath;
 
   try {
@@ -1071,16 +1084,21 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     assert.equal(failure.schema, 'homeboy/child-command-failure/v1');
     assert.equal(failure.exit_status, 17);
     assert.equal(failure.batch_id, 'batch-001');
+    const expectedCodeboxArtifactsDirectory = path.join(root, 'artifacts-wp-codebox-batch-001-artifacts');
     assert.deepEqual(failure.command.argv, [
       '/tmp/wp-codebox',
       'recipe-run',
       failure.artifact_refs.batch_recipe,
-      '--artifacts-dir', outputDirectory,
+      '--artifacts-dir', expectedCodeboxArtifactsDirectory,
       '--output', failure.artifact_refs.batch_output,
     ]);
     assert.equal(failure.stdout_tail, 'stdout line 1\nstdout line 2');
     assert.equal(failure.stderr_tail, 'stderr line 1\nstderr line 2');
-    assert.equal(failure.artifact_refs.artifacts_directory, outputDirectory);
+    assert.equal(failure.artifact_refs.artifacts_directory, expectedCodeboxArtifactsDirectory);
+    assert.equal(failure.artifact_refs.fixture_artifacts_directory, outputDirectory);
+    assert.equal(failure.artifact_refs.codebox_artifacts_directory, expectedCodeboxArtifactsDirectory);
+    assert.equal(path.dirname(expectedCodeboxArtifactsDirectory), path.dirname(outputDirectory));
+    assert.equal(expectedCodeboxArtifactsDirectory.startsWith(`${outputDirectory}${path.sep}`), false);
     assert.equal(failure.artifact_refs.output_file, failure.artifact_refs.batch_output);
     assert.ok(readFileSync(path.join(outputDirectory, 'cli-run.json'), 'utf8').includes('child_command_failures'));
 
@@ -1089,6 +1107,7 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     process.env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH = staticSiteImporter;
     process.env.SSI_FIXTURE_MATRIX_RUN = '1';
     process.env.SSI_FIXTURE_MATRIX_BATCH_SIZE = '1';
+    process.env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE = '1';
     // A failing batch must NOT make the bench reject: rejecting makes the harness
     // discard the whole lane as an assertion_failure. Instead the bench returns
     // the aggregate with the failed fixture counted (so the
@@ -1099,7 +1118,13 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     assert.equal(benchResult.metrics.passed_fixture_count, 0);
     assert.equal(benchResult.metrics.failed_fixture_count, 1);
     assert.equal(benchResult.metadata.child_command_failures[0].exit_status, 17);
-    assert.equal(benchResult.metadata.child_command_failures[0].artifact_refs.artifacts_directory, process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY);
+    assert.equal(
+      benchResult.metadata.child_command_failures[0].artifact_refs.artifacts_directory,
+      `${process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY}-wp-codebox-batch-001-artifacts`,
+    );
+    const benchBatchRecipe = JSON.parse(readFileSync(benchResult.metadata.child_command_failures[0].artifact_refs.batch_recipe, 'utf8'));
+    const benchVisualStep = benchBatchRecipe.workflow.steps.find((step) => step.command === 'wordpress.visual-compare');
+    assert.ok(benchVisualStep.args.includes('full-page=true'), 'bench env can opt visual parity back into full-page screenshots');
   } finally {
     if (previousHelper === undefined) {
       delete process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
@@ -1111,6 +1136,7 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     restoreEnv('SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH', previousImporterPath);
     restoreEnv('SSI_FIXTURE_MATRIX_RUN', previousRun);
     restoreEnv('SSI_FIXTURE_MATRIX_BATCH_SIZE', previousBatchSize);
+    restoreEnv('SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE', previousVisualParityFullPage);
   }
 });
 
@@ -2551,6 +2577,15 @@ test('recipe runs a wordpress.visual-compare visual-parity step after each impor
   assert.ok(visualStep.args.includes('block-external-requests=true'));
   assert.ok(visualStep.args.includes('threshold=0.05'));
 
+  const defaultThresholdRecipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+  });
+  const defaultThresholdVisualStep = defaultThresholdRecipe.workflow.steps[3];
+  assert.equal(defaultThresholdVisualStep.command, 'wordpress.visual-compare');
+  assert.ok(defaultThresholdVisualStep.args.includes('threshold=0'), 'visual parity defaults to exact pixel parity');
+
   const disabled = buildFixtureMatrixRecipe({
     matrix,
     artifactsDirectory: '/tmp/artifacts',
@@ -2833,6 +2868,72 @@ test('(fair) pre-overlap evidence falls back to the raw ratio for gating', () =>
   const diagnostics = collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true });
   assert.equal(diagnostics.length, 1);
   assert.ok(Math.abs(diagnostics[0].mismatch_ratio - 600000 / 2048000) < 1e-9);
+});
+
+test('visual-compare diagnostics retain bounded generic visual-explanation evidence', () => {
+  const payload = {
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: { mismatchPixels: 600000, totalPixels: 2048000, dimensionMismatch: false },
+    visual_explanation: {
+      schema: 'wp-codebox/visual-explanation/v1',
+      summary: { selector_diagnostic_count: 7, property_diagnostic_count: 1, layout_diagnostic_count: 1, capture_diagnostic_count: 1 },
+      selectors: Array.from({ length: 7 }, (_, index) => ({ selector: `.card-${index}`, reason: `selector mismatch ${index}` })),
+      properties: [{ selector: '.hero', property: 'font-size', source_value: '48px', target_value: '32px', reason: 'computed style differs' }],
+      layout: [{ selector: '.hero', source_rect: { width: 1280 }, target_rect: { width: 960 }, delta: { width: -320 } }],
+      capture: [{ phase: 'source', viewport: { width: 1280, height: 720 }, message: 'captured bounded viewport' }],
+    },
+  };
+
+  const diagnostics = collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true });
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].kind, VISUAL_PARITY_MISMATCH_KIND);
+  assert.equal(diagnostics[0].visual_explanation_summary.selector_diagnostic_count, 7);
+  assert.equal(diagnostics[0].visual_selector_diagnostics.length, 5, 'selector evidence is bounded');
+  assert.equal(diagnostics[0].visual_selector_diagnostics[0].selector, '.card-0');
+  assert.equal(diagnostics[0].visual_property_diagnostics[0].property, 'font-size');
+  assert.equal(diagnostics[0].visual_layout_diagnostics[0].selector, '.hero');
+  assert.equal(diagnostics[0].visual_capture_diagnostics[0].phase, 'source');
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-explanation-finding-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'passed', diagnostics }],
+  });
+  const finding = result.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(finding, 'expected visual parity finding');
+  assert.equal(finding.loss_class, 'visual_parity_mismatch');
+  assert.equal(finding.repair_bucket, 'visual_parity_mismatch');
+  assert.equal(finding.visual_selector_diagnostics.length, 5);
+  assert.equal(finding.visual_property_diagnostics[0].property, 'font-size');
+});
+
+test('visual-explanation.json is merged into collected visual parity artifacts generically', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-explanation-artifact-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-explanation-artifact-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'visual-compare.json'), JSON.stringify({
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: { mismatchPixels: 700000, totalPixels: 2048000, dimensionMismatch: false },
+  }));
+  writeFileSync(path.join(fixtureDirectory, 'visual-explanation.json'), JSON.stringify({
+    visual_explanation: {
+      schema: 'wp-codebox/visual-explanation/v1',
+      selector_diagnostic_count: 1,
+      property_diagnostic_count: 1,
+      selector_diagnostics: [{ selector: 'a.cta', reason: 'button alignment differs' }],
+      property_diagnostics: [{ selector: 'a.cta', property: 'background-color', source_value: '#000', target_value: '#111' }],
+    },
+  }));
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory, visualParity: { threshold: 0.1, gate: true } });
+  const finding = result.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(finding, 'expected visual parity finding from collected files');
+  assert.equal(finding.loss_class, 'visual_parity_mismatch');
+  assert.equal(finding.visual_selector_diagnostics[0].selector, 'a.cta');
+  assert.equal(finding.visual_property_diagnostics[0].property, 'background-color');
+  assert.equal(result.fixtures[0].visual_parity_artifacts.visual_explanation.selector_diagnostics[0].selector, 'a.cta');
+  assert.equal(result.fixtures[0].visual_parity_artifacts.visual_explanation.property_diagnostics[0].property, 'background-color');
 });
 
 // #554: at lane scale (~30+ fixtures) the aggregate result used to retain each

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2907,6 +2907,70 @@ test('visual-compare diagnostics retain bounded generic visual-explanation evide
   assert.equal(finding.visual_property_diagnostics[0].property, 'font-size');
 });
 
+test('visual parity findings preserve generic attribution fields and bounded context', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-attribution-finding-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'passed',
+        diagnostics: [
+          {
+            id: 'visual-001',
+            kind: VISUAL_PARITY_MISMATCH_KIND,
+            category: 'visual',
+            severity: 'warning',
+            summary: 'Button styling differs between source and import.',
+            reason_code: 'visual_style_delta',
+            repair_bucket: 'visual_parity_mismatch',
+            pattern_family: 'visual_parity_mismatch:button_style:class:hero',
+            confidence: 0.82,
+            selector_evidence: {
+              source_selector: '.hero .cta',
+              target_selector: '.wp-block-button__link',
+              source_text: 'Start now',
+              target_text: 'Start now',
+            },
+            property_evidence: [
+              {
+                property: 'background-color',
+                source_value: '#111111',
+                target_value: '#ffffff',
+                delta: 'changed',
+              },
+            ],
+            style_deltas: [
+              {
+                property: 'border-radius',
+                source_value: '999px',
+                target_value: '4px',
+                severity: 'warning',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+  const finding = result.findings.find((item) => item.id === 'visual-001');
+  assert.ok(finding, 'expected visual parity finding');
+  assert.equal(finding.loss_class, 'visual_parity_mismatch');
+  assert.equal(finding.reason_code, 'visual_style_delta');
+  assert.equal(finding.repair_bucket, 'visual_parity_mismatch');
+  assert.equal(finding.pattern_family, 'visual_parity_mismatch:button_style:class:hero');
+  assert.equal(finding.confidence, 0.82);
+  assert.equal(finding.selector, '.hero .cta');
+  assert.equal(finding.selector_family, 'class:hero');
+  assert.equal(finding.source_snippet, 'Start now');
+  assert.equal(finding.observed_output, 'Start now');
+  assert.equal(finding.selector_evidence.target_selector, '.wp-block-button__link');
+  assert.equal(finding.property_evidence[0].property, 'background-color');
+  assert.equal(finding.style_deltas[0].property, 'border-radius');
+  assert.equal(result.summary.diagnostic_blind_spots.some((spot) => spot.kind === 'missing_source_context'), false);
+});
+
 test('visual-explanation.json is merged into collected visual parity artifacts generically', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-explanation-artifact-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-explanation-artifact-test' });

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -44,7 +44,6 @@ import {
   createFixtureMatrix,
   editorBlockValidationStep,
   EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
-  EDITOR_OPEN_COMMAND,
   EDITOR_VALIDATE_BLOCKS_COMMAND,
   EDITOR_VALIDATION_METHOD,
   normalizeFixtureMatrixResult,
@@ -145,6 +144,17 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
   assert.match(recipe.workflow.steps[1].args[0], /--allow-failure/);
+});
+
+test('fixture-matrix rig requires env-backed WP Codebox editor and visual capabilities', () => {
+  const rig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs', 'static-site-importer-fixture-matrix', 'rig.json'), 'utf8'));
+  const tool = rig.requirements.runner_tools.find((item) => item.tool === 'wp-codebox');
+
+  assert.ok(tool, 'expected a wp-codebox runner tool requirement');
+  assert.equal(tool.command, 'wp-codebox');
+  assert.deepEqual(tool.env, ['HOMEBOY_WP_CODEBOX_BIN']);
+  assert.ok(tool.capabilities.includes('wordpress.editor-validate-blocks'));
+  assert.ok(tool.capabilities.includes('wordpress.visual-compare'));
 });
 
 test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () => {
@@ -1864,7 +1874,7 @@ test('compares finding packet deltas by repair dimensions', () => {
   assert.equal(selectorFamily('#hero .cta'), 'id:hero');
 });
 
-test('recipe runs a schema-supported editor-open step after each import', () => {
+test('recipe runs editor-validate-blocks against imported content after each import', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-validation-recipe-test' });
   const recipe = buildFixtureMatrixRecipe({
     matrix,
@@ -1872,17 +1882,16 @@ test('recipe runs a schema-supported editor-open step after each import', () => 
     staticSiteImporterPath: '/tmp/static-site-importer',
   });
 
-  // [activate, validate(simple-site), editor-open(simple-site)]
+  // [activate, validate(simple-site), editor-validate-blocks(simple-site)]
   assert.equal(recipe.workflow.steps[1].command, 'wordpress.wp-cli');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
   const editorStep = recipe.workflow.steps[2];
-  // Use the command accepted by the runner-side WP Codebox recipe schema.
-  assert.equal(editorStep.command, EDITOR_OPEN_COMMAND);
-  assert.equal(editorStep.command, 'wordpress.editor-open');
+  assert.equal(editorStep.command, EDITOR_VALIDATE_BLOCKS_COMMAND);
+  assert.equal(editorStep.command, 'wordpress.editor-validate-blocks');
   assert.equal(editorStep.args.some((arg) => arg.includes('post-new.php')), false);
   assert.equal(editorStep.args.some((arg) => arg.startsWith('post-type=')), false);
-  assert.ok(editorStep.args.includes('target=site'));
-  assert.ok(editorStep.args.includes('capture=editor-state'));
+  assert.ok(editorStep.args.includes('target=front-page'));
+  assert.equal(editorStep.args.some((arg) => arg.startsWith('capture=')), false);
 
   const disabled = buildFixtureMatrixRecipe({
     matrix,
@@ -1890,7 +1899,7 @@ test('recipe runs a schema-supported editor-open step after each import', () => 
     staticSiteImporterPath: '/tmp/static-site-importer',
     editorValidation: false,
   });
-  assert.equal(disabled.workflow.steps.some((step) => step.command === EDITOR_OPEN_COMMAND), false);
+  assert.equal(disabled.workflow.steps.some((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND), false);
 });
 
 test('--no-editor-validation skips the editor browser step while keeping native-rate + findings', () => {
@@ -1930,7 +1939,7 @@ test('--no-editor-validation skips the editor browser step while keeping native-
   assert.equal(skippedPlan.editor_validation.enabled, false);
   assert.ok(skippedPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION=0'));
 
-  // Recipe: the editor-open step is present by default and omitted when
+  // Recipe: the editor-validate-blocks step is present by default and omitted when
   // disabled, while the import/validate-artifact step (which feeds native-rate and
   // findings) always survives.
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'no-editor-validation-recipe' });
@@ -1939,7 +1948,7 @@ test('--no-editor-validation skips the editor browser step while keeping native-
     artifactsDirectory: '/tmp/artifacts',
     staticSiteImporterPath: '/tmp/static-site-importer',
   });
-  assert.ok(enabledRecipe.workflow.steps.some((step) => step.command === EDITOR_OPEN_COMMAND));
+  assert.ok(enabledRecipe.workflow.steps.some((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND));
 
   const skippedRecipe = buildFixtureMatrixRecipe({
     matrix,
@@ -1948,7 +1957,7 @@ test('--no-editor-validation skips the editor browser step while keeping native-
     editorValidation: false,
   });
   assert.equal(
-    skippedRecipe.workflow.steps.some((step) => step.command === EDITOR_OPEN_COMMAND),
+    skippedRecipe.workflow.steps.some((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND),
     false,
   );
   assert.ok(skippedRecipe.workflow.steps.some((step) => /static-site-importer validate-artifact/.test(step.args?.[0] ?? '')));
@@ -1978,18 +1987,18 @@ test('--no-editor-validation skips the editor browser step while keeping native-
   assert.ok(result.findings.length >= 1);
 });
 
-test('editorBlockValidationStep emits the schema-supported editor-open shape', () => {
-  // Defaults to the site editor because that target is accepted by the runner-side
-  // WP Codebox schema currently used by Homeboy Lab.
+test('editorBlockValidationStep emits editor-validate-blocks against real imported content', () => {
+  // Defaults to the imported front page because the import step has just set
+  // page_on_front, while the imported post ID is not known at recipe-build time.
   const fallback = editorBlockValidationStep({ fixture: { id: 'simple' } });
-  assert.equal(fallback.command, 'wordpress.editor-open');
-  assert.deepEqual(fallback.args, ['target=site', 'capture=editor-state']);
+  assert.equal(fallback.command, 'wordpress.editor-validate-blocks');
+  assert.deepEqual(fallback.args, ['target=front-page']);
 
   // An explicit editor URL (e.g. post.php?post=<id>&action=edit) is honored.
   const byUrl = editorBlockValidationStep({ fixture: { id: 'shop', editor_url: '/wp-admin/post.php?post=42&action=edit' } });
-  assert.equal(byUrl.command, 'wordpress.editor-open');
+  assert.equal(byUrl.command, 'wordpress.editor-validate-blocks');
   assert.ok(byUrl.args.includes('url=/wp-admin/post.php?post=42&action=edit'));
-  assert.ok(byUrl.args.includes('capture=editor-state'));
+  assert.equal(byUrl.args.some((arg) => arg.startsWith('capture=')), false);
 
   // An imported post id is preferred over a URL.
   const byPostId = editorBlockValidationStep({ fixture: { id: 'shop', post_id: 99 } });
@@ -2241,6 +2250,41 @@ test('editor-validate-blocks result from a codebox execution is associated to th
   const finding = result.findings.find((item) => item.kind === 'editor_block_invalid');
   assert.ok(finding, 'expected an editor_block_invalid finding from the codebox editor-validate result');
   assert.equal(finding.loss_acceptance, 'unacceptable');
+});
+
+test('unavailable editor validation fails honestly without fabricated validated-block metrics', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-validate-unavailable-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-validate-unavailable-test' });
+  const codeboxOutput = {
+    success: false,
+    schema: 'wp-codebox/recipe-run-result/v1',
+    executions: [
+      {
+        command: 'wordpress.wp-cli',
+        args: ['command=static-site-importer validate-artifact --artifact=/wordpress/wp-content/uploads/x/simple-site/artifact.json --slug=simple-site --name=Simple --allow-missing-woocommerce --allow-failure'],
+        result: { schema: 'wp-codebox/runtime-command-result/v1', status: 'ok', stdout: JSON.stringify({ success: true, fixture_id: 'simple-site' }) },
+      },
+      {
+        command: 'wordpress.editor-validate-blocks',
+        args: ['target=front-page'],
+        result: {
+          schema: 'wp-codebox/runtime-command-result/v1',
+          status: 'error',
+          error: 'Unknown command wordpress.editor-validate-blocks',
+        },
+      },
+    ],
+  };
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory, codeboxOutput });
+  const fixture = result.fixtures[0];
+
+  assert.equal(fixture.status, 'failed');
+  assert.equal(fixture.editor_validation, null);
+  assert.notEqual(fixture.editor_quality.editor_validated, true);
+  assert.equal(fixture.editor_quality.editor_validated_block_total, undefined);
+  assert.equal(fixture.editor_quality.invalid_block_count, undefined);
+  assert.match(fixture.error, /Unknown command wordpress\.editor-validate-blocks/);
 });
 
 test('editor-validate-blocks invalid block is counted and surfaced as a gating finding with name and reason', () => {

--- a/tools/wp-codebox/recipe.mjs
+++ b/tools/wp-codebox/recipe.mjs
@@ -15,7 +15,7 @@ export function wpCodeboxBin(env = process.env) {
   if (helper?.wpCodeboxBin) {
     return helper.wpCodeboxBin(env);
   }
-  return env.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN || env.WP_CODEBOX_BIN || 'wp-codebox';
+  return env.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN || env.HOMEBOY_WP_CODEBOX_BIN || env.WP_CODEBOX_BIN || 'wp-codebox';
 }
 
 export function wpCodeboxCommand(bin = wpCodeboxBin()) {


### PR DESCRIPTION
## Summary
- require the runner-provided WP Codebox binary and safe sibling artifacts directory for fixture-matrix runs
- wire full-page visual parity controls with a strict default threshold of `0`
- collect and preserve bounded generic `visual-explanation.json` evidence on `visual_parity_mismatch` findings
- preserve generic visual attribution fields from finding packets, including `reason_code`, `pattern_family`, `confidence`, selector evidence, property evidence, style deltas, and bounded selector text context
- preserve WP Codebox aggregate `browserEvidence.files` visual refs, nested `summary.visualCompare` metrics, and visual explanation diagnostics in fixture-matrix results

## Testing
- `node --test tools/fixture-matrix.test.mjs`
- `npm run test:fixture-matrix`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing fixture-matrix visual evidence and attribution plumbing, tests, and PR preparation.