### PR TITLE
Fix SSI Codebox fixture artifact staging

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -42,8 +42,9 @@ async function main() {
   }
 }
 
-export default async function runFixtureMatrixBench() {
-  const options = { ...optionsFromEnv(), ...parseArgs(process.argv.slice(2)) };
+export default async function runFixtureMatrixBench(context = {}) {
+  const args = Array.isArray(context.args) ? context.args : process.argv.slice(2);
+  const options = { ...optionsFromEnv(), ...parseArgs(args) };
   // Per-fixture / per-batch failures (PHP OOM in collect_artifacts, capture
   // failures, child timeouts) are already isolated inside `runFixtureMatrix`:
   // each failing batch is recorded as failed fixtures and folded into the

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -105,6 +105,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const importer = normalizeStaticSiteImporterPlugin(input);
   const dependencyOverrideSetup = buildDependencyOverrideSetup(input, importer);
   const mounts = normalizeArray(input.mounts);
+  const stagedFiles = normalizeArray(input.stagedFiles || input.staged_files);
   const extraPlugins = [importer.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)];
   const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
   // Real-content validation options forwarded to the editor-validate-blocks step.
@@ -135,11 +136,12 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const liveWpParityCaptureEnabled = liveWpParityEnabled(input);
 
   if (playgroundArtifactsDirectory) {
-    mounts.push({
-      source: artifactsDirectory,
-      target: playgroundArtifactsDirectory,
-      mode: 'readwrite',
-    });
+    for (const fixture of matrix.fixtures) {
+      stagedFiles.push({
+        source: path.join(artifactsDirectory, fixture.id, 'artifact.json'),
+        target: path.join(playgroundArtifactsDirectory, fixture.id, 'artifact.json'),
+      });
+    }
   }
 
   return {
@@ -150,6 +152,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
     },
     inputs: {
       mounts,
+      stagedFiles,
       extra_plugins: extraPlugins,
       ...(dependencyOverrideSetup.dependencyOverlays.length
         ? { dependency_overlays: dependencyOverrideSetup.dependencyOverlays }

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -145,6 +145,11 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
   assert.match(recipe.workflow.steps[1].args[0], /--allow-failure/);
+  assert.deepEqual(recipe.inputs.stagedFiles[0], {
+    source: '/tmp/artifacts/simple-site/artifact.json',
+    target: '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix/simple-site/artifact.json',
+  });
+  assert.deepEqual(recipe.inputs.mounts, []);
 });
 
 test('fixture-matrix rig requires env-backed WP Codebox editor and visual capabilities', () => {
@@ -1867,6 +1872,63 @@ test('runFixtureMatrixBench returns a partial result with survivors aggregated w
     assert.equal(resultPayload.summary.failed, 1);
   } finally {
     restoreConcurrencyEnv(concurrencySnapshot);
+    for (const key of benchEnvKeys) {
+      restoreEnv(key, benchEnvSnapshot[key]);
+    }
+  }
+});
+
+test('runFixtureMatrixBench reads workload args from context.args when imported', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-bench-context-args-'));
+  const contextFixtureRoot = path.join(root, 'context-fixtures');
+  const argvFixtureRoot = path.join(root, 'argv-fixtures');
+  const outputDirectory = path.join(root, 'context-artifacts');
+  const argvOutputDirectory = path.join(root, 'argv-artifacts');
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  mkdirSync(path.join(contextFixtureRoot, 'context-fixture'), { recursive: true });
+  mkdirSync(path.join(argvFixtureRoot, 'argv-fixture'), { recursive: true });
+  mkdirSync(staticSiteImporter, { recursive: true });
+  writeFileSync(path.join(contextFixtureRoot, 'context-fixture', 'index.html'), '<h1>Context fixture</h1>');
+  writeFileSync(path.join(argvFixtureRoot, 'argv-fixture', 'index.html'), '<h1>Argv fixture</h1>');
+
+  const previousArgv = process.argv;
+  const benchEnvKeys = [
+    'SSI_FIXTURE_MATRIX_FIXTURE_ROOT',
+    'SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY',
+    'SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH',
+    'SSI_FIXTURE_MATRIX_RUN',
+    'HOMEBOY_BENCH_ARTIFACTS_DIR',
+  ];
+  const benchEnvSnapshot = Object.fromEntries(benchEnvKeys.map((key) => [key, process.env[key]]));
+
+  for (const key of benchEnvKeys) {
+    delete process.env[key];
+  }
+  process.argv = [
+    'node',
+    'homeboy-nodejs-bench-runner',
+    '--fixture-root', argvFixtureRoot,
+    '--output-directory', argvOutputDirectory,
+    '--static-site-importer-path', staticSiteImporter,
+  ];
+
+  try {
+    const benchResult = await runFixtureMatrixBench({
+      args: [
+        '--fixture-root', contextFixtureRoot,
+        '--output-directory', outputDirectory,
+        '--static-site-importer-path', staticSiteImporter,
+      ],
+    });
+
+    assert.equal(benchResult.metrics.fixture_count, 1);
+    assert.equal(benchResult.metadata.fixture_root, path.resolve(contextFixtureRoot));
+    assert.equal(benchResult.metadata.output_directory, path.resolve(outputDirectory));
+    const matrix = JSON.parse(readFileSync(benchResult.artifacts.matrix.path, 'utf8'));
+    assert.deepEqual(matrix.fixtures.map((fixture) => fixture.id), ['context-fixture']);
+    assert.equal(existsSync(path.join(argvOutputDirectory, 'matrix.json')), false);
+  } finally {
+    process.argv = previousArgv;
     for (const key of benchEnvKeys) {
       restoreEnv(key, benchEnvSnapshot[key]);
     }


### PR DESCRIPTION
## Summary
- Use WP Codebox staged files for per-fixture artifact JSON instead of a readwrite artifact-directory mount.
- Preserve empty mounts while still passing dependency overlays.
- Read Homeboy NodeJS workload args from the provided context so Lab passthrough args execute the requested fixture run.

## Verification
- `node --test tools/fixture-matrix.test.mjs` passed: 100/100.
- `php -l static-site-importer.php` passed.
- Homeboy Lab one-fixture run executed WP Codebox successfully and exposed real downstream conversion findings instead of infrastructure blockers. Persisted run ID: `83763671-22f6-41e2-b707-9b4edb665201`.

## Notes
- `php tests/smoke-importer-block.php` was not runnable in the clean worktree because Composer dependencies were not installed (`vendor/autoload.php` missing).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed the Lab workflow blockers, ported the current-layout SSI fixture matrix fix, added regression coverage, and ran targeted verification.
