### PR TITLE
Fix fixture matrix bench output location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 vendor/
 build/
+artifacts/
 .homeboy/
 .homeboy-build/
 .phpunit.result.cache

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1296,6 +1296,7 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.equal(plan.fixture_count_matches_canonical, true);
   assert.equal(plan.namespace, 'ssi-matrix-dev-proof');
   assert.equal(plan.temp_root, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof');
+  assert.equal(plan.output_file, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/ssi-matrix-dev-proof.homeboy-bench.json');
   assert.equal(plan.shared_state, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/shared-state');
   assert.equal(plan.artifact_root, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/artifacts');
   assert.deepEqual(plan.warnings, []);
@@ -1324,6 +1325,14 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   });
   assert.deepEqual(releasePlan.dependency_overrides, {});
   assert.equal(releasePlan.steps.at(-1).args.some((arg) => arg.includes('SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH')), false);
+
+  const explicitOutput = path.join(root, 'custom-output', 'homeboy-bench.json');
+  const explicitOutputPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    blocksEngine,
+    output: explicitOutput,
+  });
+  assert.equal(explicitOutputPlan.output_file, explicitOutput);
 });
 
 test('fixture matrix records generic child command failures for failed WP Codebox batches', async () => {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -175,7 +175,7 @@ function normalizeOptions(input) {
   const runId = input.runId || `ssi-matrix-${mode}-${timestamp()}`;
   const namespace = sanitizePathSegment(input.namespace || runId);
   const tempRoot = input.tempRoot ? path.resolve(input.tempRoot) : defaultTempRoot(namespace, input);
-  const output = path.resolve(input.output || path.join(process.cwd(), 'artifacts', `${runId}.homeboy-bench.json`));
+  const output = path.resolve(input.output || path.join(tempRoot, `${runId}.homeboy-bench.json`));
 
   return {
     ...input,


### PR DESCRIPTION
## Problem
`tools/run-fixture-matrix.mjs` defaulted the structured Homeboy bench output to `artifacts/<run-id>.homeboy-bench.json` inside the SSI repo. That repo is also the linked Homeboy rig package root, so the next rig-package-lint pass could scan the previous run artifact and fail portable-path checks on absolute runtime evidence.

## Fix
- Default the wrapper `--output` file to the existing per-run temp root: `/tmp/static-site-importer-fixture-matrix-<run-id>/<run-id>.homeboy-bench.json`.
- Preserve explicit `--output` values verbatim.
- Add `artifacts/` to `.gitignore` so accidental repo-local artifacts are not tracked.
- Checked `docs/fixture-matrix.md`; it did not mention the old default output path.

## Test Evidence
- `node tools/fixture-matrix.test.mjs`
  - `117` tests passed, `0` failed.
- Dry-run sanity check:
  - `node tools/run-fixture-matrix.mjs --local --static-site-importer /Users/chubes/Developer/static-site-importer@fix-537-matrix-output-location --blocks-engine /Users/chubes/Developer/blocks-engine --fixture-root /Users/chubes/Developer/blocks-engine/fixtures/websites --run-id test-537 --dry-run`
  - Confirmed `output_file`: `/tmp/static-site-importer-fixture-matrix-test-537/test-537.homeboy-bench.json`
  - Confirmed bench `--output` uses the same temp-root path, while `artifact_root` remains `/tmp/static-site-importer-fixture-matrix-test-537/artifacts`. No structured bench output is planned under the repo.

Closes #537

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via opencode subagent, orchestrated by Claude (claude-fable-5)
- **Used for:** Implementation, tests, and PR drafting; reviewed by Chris Huber