### PR TITLE
Declare fixture matrix bench namespace setting

### DIFF
--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -36,6 +36,9 @@
     "default_component": "static-site-importer",
     "iterations": 1,
     "warmup_iterations": 0,
+    "accepted_settings": [
+      "static_site_importer_fixture_matrix_namespace"
+    ],
     "result_gates": {
       "failed_fixture_count": { "lte": 0 }
     }


### PR DESCRIPTION
## Summary

Closes #539.

Declares the fixture-matrix namespace setting as a rig-owned accepted bench setting:

- `bench.accepted_settings`: `static_site_importer_fixture_matrix_namespace`

This makes the namespace an honest rig input and resolves Homeboy's unknown-setting warning for `tools/run-fixture-matrix.mjs` bench runs.

## Investigation

Homeboy origin/main confirms the schema is `bench.accepted_settings`:

- `src/core/rig/spec.rs:448-453` defines `BenchSpec.accepted_settings` with serde defaulting to the snake_case JSON key.
- `src/commands/bench.rs:527-569` filters unknown setting warnings against rig accepted settings.
- `src/commands/bench/matrix.rs:612-620` passes `spec.bench.accepted_settings` into the warning path for rig-pinned bench runs.

The setting is not simply dropped for the main bench workflow:

- `src/core/engine/execution_context.rs` merges CLI `--setting` values into resolved settings before execution.
- `src/commands/bench/matrix.rs:602-620` resolves the bench context with `args.setting_args` and only warns after resolution.
- `src/commands/bench/matrix.rs:667-675` passes the resolved settings into `run_main_bench_workflow`.

Upstream Homeboy follow-up found during investigation:

- Rig resource interpolation still reads only process environment: `src/core/rig/expand.rs:23-33` expands `resources`, and `src/core/rig/expand.rs:132-134` resolves `${env.NAME}` using `std::env::var(NAME).unwrap_or_default()`.
- `bench_prepare` gets bench settings: `src/commands/bench/matrix.rs:34-39` builds `bench_prepare_settings`, `src/core/rig/runner.rs:304-315` passes them to prepare requirement/pipeline execution, and `src/core/rig/pipeline/command_step.rs:38-40` + `66-79` materialize `HOMEBOY_SETTINGS_*` for command steps.
- `down` does not get bench settings: `src/core/rig/runner.rs:568-572` calls `run_pipeline(rig, "down", false)`, and `src/core/rig/pipeline/mod.rs:31-33` implements that as `run_pipeline_with_settings(..., &[])`.

So this PR fixes the declared-input warning in SSI, but Homeboy still needs an upstream fix if run-scoped rig `resources.*` and `down` cleanup are expected to resolve `${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}` from `homeboy bench --setting ...` rather than from an already-exported process environment variable.

## Verification

- `homeboy rig lint /Users/chubes/Developer/static-site-importer@fix-539-rig-accepted-settings` passed: `success: true`, 6/6 rig package lint steps passed.
- `node tools/fixture-matrix.test.mjs` passed: 117 tests passed, 0 failed.
- `homeboy bench list --rig static-site-importer-fixture-matrix --setting static_site_importer_fixture_matrix_namespace=verify-539 --path /Users/chubes/Developer/static-site-importer@fix-539-rig-accepted-settings` passed and emitted no unknown-setting warning.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via opencode subagent, orchestrated by Claude (claude-fable-5)
- **Used for:** Investigation, implementation, and PR drafting; reviewed by Chris Huber
