### PR TITLE
Fix fixture matrix diagnostic hygiene

### DIFF
--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -122,7 +122,7 @@ function collectFixtureDiagnostics(payload, options = {}) {
     ...collectMissingAssets(payload).map((asset) => ({ kind: missingAssetKind(asset), ...objectValue(asset), message: diagnosticMessage(asset) || 'Missing imported asset.' })),
     ...editorValidationDiagnostics,
     ...collectVisualParityDiagnostics(payload, options.visualParity),
-  ].filter(isActionableDiagnosticPayload);
+  ].map(normalizeActionableDiagnosticPayload).filter(Boolean);
   const invalidBlockCount = Object.values(collectInvalidBlockCounts(payload)).reduce((sum, value) => sum + numberValue(value), 0);
   if (invalidBlockCount > 0 && editorValidationDiagnostics.length === 0) {
     diagnostics.push({ kind: 'invalid_block_content', synthetic_summary: true, message: `${invalidBlockCount} invalid block${invalidBlockCount === 1 ? '' : 's'} reported by SSI validation.` });
@@ -130,10 +130,10 @@ function collectFixtureDiagnostics(payload, options = {}) {
   return dedupeDiagnostics(propagateAcceptedRuntimePreservation(diagnostics));
 }
 
-function isActionableDiagnosticPayload(diagnostic) {
+function normalizeActionableDiagnosticPayload(diagnostic) {
   const row = objectValue(diagnostic);
   if (Object.keys(row).length === 0) {
-    return false;
+    return null;
   }
 
   // Runtime command telemetry proves that an evidence step ran, but it is not a
@@ -141,10 +141,12 @@ function isActionableDiagnosticPayload(diagnostic) {
   // same payload family into actionable findings when there is an actual issue.
   const keys = Object.keys(row).sort();
   if (keys.every((key) => ['command', 'durationMs', 'finishedAt', 'startedAt', 'timing'].includes(key))) {
-    return false;
+    return null;
   }
 
-  return true;
+  const source = objectValue(row.source_diagnostic || row.sourceDiagnostic || row.source);
+  const kind = firstString([row.kind, row.code, row.type, row.reason_code, row.reasonCode, source.kind, source.code, source.type, source.reason_code, source.reasonCode, row.loss_class, row.lossClass]);
+  return kind ? { ...row, kind } : null;
 }
 
 function propagateAcceptedRuntimePreservation(diagnostics) {
@@ -228,7 +230,20 @@ function collectFindingPacketDiagnostics(payload) {
     ...normalizeArray(payload.finding_packets?.packets || payload.findingPackets?.packets),
     ...normalizeArray(payload.import_report?.finding_packets?.packets || payload.importReport?.finding_packets?.packets),
     ...normalizeArray(payload.report?.finding_packets?.packets),
-  ];
+  ].map(findingPacketDiagnostic).filter(Boolean);
+}
+
+function findingPacketDiagnostic(packet) {
+  const row = objectValue(packet);
+  if (Object.keys(row).length === 0) {
+    return null;
+  }
+  const source = objectValue(row.source_diagnostic || row.sourceDiagnostic || row.source);
+  const kind = firstString([row.kind, row.code, row.type, row.reason_code, row.reasonCode, source.kind, source.code, source.type, source.reason_code, source.reasonCode]);
+  if (!kind) {
+    return null;
+  }
+  return { ...row, kind };
 }
 
 function collectFixtureArtifactRefs(payload, fixtureArtifactsDirectory) {

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -106,7 +106,37 @@ function collectVisualParityComparisons(payload) {
   if (isVisualParityPayload(payload)) {
     candidates.push(payload);
   }
-  return candidates.map(normalizeVisualParityComparison).filter(Boolean);
+  return dedupeVisualParityComparisons(candidates.map(normalizeVisualParityComparison).filter(Boolean));
+}
+
+function dedupeVisualParityComparisons(comparisons) {
+  const byMetrics = new Map();
+  for (const comparison of comparisons) {
+    const key = [
+      comparison.mismatch_pixels,
+      comparison.total_pixels,
+      comparison.overlap_mismatch_pixels,
+      comparison.overlap_pixels,
+      comparison.dimension_delta_pixels,
+      comparison.dimension_mismatch,
+    ].join('\u0000');
+    const existing = byMetrics.get(key);
+    byMetrics.set(key, existing ? mergeVisualParityComparison(existing, comparison) : comparison);
+  }
+  return [...byMetrics.values()];
+}
+
+function mergeVisualParityComparison(left, right) {
+  return {
+    ...left,
+    source_path: left.source_path || right.source_path,
+    source_screenshot: left.source_screenshot || right.source_screenshot,
+    candidate_screenshot: left.candidate_screenshot || right.candidate_screenshot,
+    diff_screenshot: left.diff_screenshot || right.diff_screenshot,
+    visual_diff: left.visual_diff || right.visual_diff,
+    visual_explanation_ref: left.visual_explanation_ref || right.visual_explanation_ref,
+    visual_explanation: left.visual_explanation || right.visual_explanation,
+  };
 }
 
 function isVisualParityPayload(payload) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1144,6 +1144,80 @@ test('does not classify visual parity mismatch findings as missing evidence', ()
   assert.equal(result.summary.fixture_categories.missing_evidence, undefined);
 });
 
+test('emits one visual parity mismatch when raw and artifact evidence describe the same comparison', () => {
+  const diagnostics = collectVisualParityDiagnostics({
+    visual_compare: {
+      comparison: {
+        mismatch_pixels: 125,
+        total_pixels: 1000,
+        overlap_mismatch_pixels: 125,
+        overlap_pixels: 1000,
+        dimension_mismatch: false,
+      },
+    },
+    visual_parity_artifacts: {
+      mismatch_pixels: 125,
+      total_pixels: 1000,
+      overlap_mismatch_pixels: 125,
+      overlap_pixels: 1000,
+      dimension_mismatch: false,
+      source_path: 'file:///tmp/source/index.html',
+    },
+  }, { threshold: 0 });
+
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].kind, VISUAL_PARITY_MISMATCH_KIND);
+  assert.equal(diagnostics[0].source_path, 'file:///tmp/source/index.html');
+});
+
+test('fixture diagnostics drop empty rows and normalize kindless carriers with explicit kind', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-diagnostic-hygiene-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'diagnostic-hygiene-test' });
+  const codeboxOutput = {
+    fixture_id: 'simple-site',
+    status: 'passed',
+    diagnostics: [
+      {},
+      {
+        loss_class: 'preserved_runtime_island',
+        message: 'Script runtime was preserved intentionally.',
+        runtime_carried: true,
+      },
+      {
+        loss_class: 'editable_approximation',
+        message: 'Converted to an editable approximation.',
+      },
+    ],
+    import_report: {
+      finding_packets: {
+        packets: [
+          {},
+          {
+            type: 'core_html_block',
+            loss_class: 'editable_approximation',
+            source_diagnostic: {
+              source_path: 'posts/page-home.post_content',
+              selector: 'section.hero',
+            },
+            message: 'Core HTML fallback remained editable.',
+          },
+        ],
+      },
+    },
+  };
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory, codeboxOutput });
+  const diagnostics = result.fixtures[0].diagnostics;
+
+  assert.equal(diagnostics.length, 3);
+  assert.equal(diagnostics.every((diagnostic) => diagnostic && Object.keys(diagnostic).length > 0), true);
+  assert.equal(diagnostics.every((diagnostic) => typeof diagnostic.kind === 'string' && diagnostic.kind.length > 0), true);
+  assert.equal(result.summary.finding_count, 3);
+  assert.equal(result.summary.loss_classes.preserved_runtime_island, 1);
+  assert.equal(result.summary.loss_classes.editable_approximation, 2);
+  assert.equal(result.summary.loss_classes.unsupported_loss, undefined);
+});
+
 test('collects SSI finding packet source and observed context from fixture artifacts', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-finding-packet-context-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'packet-context-test' });


### PR DESCRIPTION
## Summary
- Dedupes visual parity comparison candidates before `visual_parity_mismatch` diagnostics are emitted.
- Normalizes fixture diagnostic intake so empty rows are dropped and diagnostic-like rows/finding packets carry an explicit `kind`.
- Adds fixture-matrix regressions for single visual mismatch emission and no empty/kind-less diagnostics.

Fixes #543.

## Testing
- `node tools/fixture-matrix.test.mjs` (121 passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Root-cause investigation, source changes, regression tests, and verification.