### PR TITLE
Provision capability-declared plugins in the matrix sandbox and drop the blanket WooCommerce waiver

### DIFF
--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -116,6 +116,7 @@ function collectFixtureDiagnostics(payload, options = {}) {
     ...normalizeArray(payload.messages),
     ...normalizeArray(payload.errors),
     ...normalizeArray(payload.warnings),
+    ...collectImportReportDiagnostics(payload),
     ...normalizeArray(payload.upstream_gaps || payload.upstreamGaps).map((gap) => ({ kind: 'upstream_gap', ...objectValue(gap), message: diagnosticMessage(gap) || gap.missing || 'Upstream capability gap detected.' })),
     ...collectBlocksEngineDiagnostics(payload),
     ...collectRuntimeTargetGaps(payload).map((gap) => ({ kind: 'runtime_target_gap', ...objectValue(gap), message: diagnosticMessage(gap) || 'Runtime target gap detected.' })),
@@ -128,6 +129,53 @@ function collectFixtureDiagnostics(payload, options = {}) {
     diagnostics.push({ kind: 'invalid_block_content', synthetic_summary: true, message: `${invalidBlockCount} invalid block${invalidBlockCount === 1 ? '' : 's'} reported by SSI validation.` });
   }
   return dedupeDiagnostics(propagateAcceptedRuntimePreservation(diagnostics));
+}
+
+function collectImportReportDiagnostics(payload) {
+  const reports = [
+    objectValue(payload),
+    objectValue(payload.import_report || payload.importReport || payload.report),
+  ];
+  const blocksEngine = objectValue(payload.blocks_engine || payload.blocksEngine);
+  if (Object.keys(blocksEngine).length > 0) {
+    reports.push(objectValue(blocksEngine.conversion_report || blocksEngine.conversionReport));
+  }
+
+  return reports.flatMap((report) => [
+    ...normalizeArray(report.diagnostics),
+    ...seedingReportDiagnostics(report, 'product_seeding', 'product_seeding_failed'),
+    ...seedingReportDiagnostics(report, 'form_seeding', 'form_seeding_failed'),
+  ]);
+}
+
+function seedingReportDiagnostics(report, key, kind) {
+  const seeding = objectValue(report[key] || report[toCamelCase(key)]);
+  if (Object.keys(seeding).length === 0) {
+    return [];
+  }
+  const counts = objectValue(seeding.counts);
+  const status = String(seeding.status || '').toLowerCase();
+  const reason = String(seeding.reason || '').toLowerCase();
+  const errorCount = numberValue(counts.error);
+  if (status === 'skipped' && ['no_validated_manifest', 'empty_validated_manifest', 'no_form_findings', 'no_product_findings'].includes(reason)) {
+    return [];
+  }
+  if (status === 'completed' && errorCount === 0) {
+    return [];
+  }
+  return [{
+    kind,
+    loss_class: 'importer_materialization_bug',
+    severity: status === 'skipped' ? 'warning' : 'error',
+    source_path: key,
+    message: seeding.reason || `${key} did not complete cleanly.`,
+    status: seeding.status,
+    reason: seeding.reason,
+  }];
+}
+
+function toCamelCase(value) {
+  return String(value || '').replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
 }
 
 function normalizeActionableDiagnosticPayload(diagnostic) {

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -25,6 +25,15 @@ import { editorBlockValidationStep } from './editor-validation-step.mjs';
 import { visualParityCompareStep, normalizeVisualParityRecipeOptions } from './visual-parity-step.mjs';
 import { liveWpParityCaptureStep, liveWpParityEnabled } from './live-wp-parity-step.mjs';
 
+const CAPABILITY_PLUGIN_PROVISIONING = {
+  'commerce-products': [
+    { slug: 'woocommerce', label: 'WooCommerce' },
+  ],
+  forms: [
+    { slug: 'jetpack', label: 'Jetpack' },
+  ],
+};
+
 export function buildFixtureArtifact(fixture, options = {}) {
   const normalized = normalizeFixture(fixture);
   const files = collectFixtureFiles(normalized.directory, options);
@@ -165,15 +174,8 @@ export function buildFixtureMatrixRecipe(input = {}) {
       steps: [
         importer.activationStep,
         ...matrix.fixtures.flatMap((fixture) => [
-          {
-            command: 'wordpress.wp-cli',
-            args: [
-              `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-missing-woocommerce --allow-failure`,
-            ],
-            metadata: fixtureStepMetadata(fixture, 'import', {
-              artifact: path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'),
-            }),
-          },
+          ...fixturePluginProvisioningSteps(fixture),
+          importFixtureStep(fixture, commandArtifactsDirectory),
           ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, ...editorValidationOptions })] : []),
           ...(visualParityEnabled ? [visualParityCompareStep({ fixture, ...visualParityRecipeOptions })] : []),
           ...(liveWpParityCaptureEnabled ? [liveWpParityCaptureStep({ fixture, ...input })] : []),
@@ -184,6 +186,50 @@ export function buildFixtureMatrixRecipe(input = {}) {
       directory: artifactsDirectory,
     },
   };
+}
+
+function importFixtureStep(fixture, commandArtifactsDirectory) {
+  return {
+    command: 'wordpress.wp-cli',
+    args: [
+      `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-failure`,
+    ],
+    metadata: fixtureStepMetadata(fixture, 'import', {
+      artifact: path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'),
+    }),
+  };
+}
+
+function fixturePluginProvisioningSteps(fixture) {
+  const plugins = fixtureCapabilityPlugins(fixture);
+  return plugins.map((plugin) => ({
+    command: 'wordpress.plugin-setup',
+    args: [
+      'action=install',
+      `plugin=${shellToken(plugin.slug)}`,
+      'activate=true',
+    ],
+    metadata: fixtureStepMetadata(fixture, 'provision-plugin', {
+      capability: plugin.capability,
+      plugin_slug: plugin.slug,
+      plugin_label: plugin.label,
+    }),
+  }));
+}
+
+function fixtureCapabilityPlugins(fixture) {
+  const seen = new Set();
+  const plugins = [];
+  for (const capability of normalizeArray(fixture.capabilities).map((item) => String(item || '').trim().toLowerCase()).filter(Boolean)) {
+    for (const plugin of CAPABILITY_PLUGIN_PROVISIONING[capability] || []) {
+      if (seen.has(plugin.slug)) {
+        continue;
+      }
+      seen.add(plugin.slug);
+      plugins.push({ ...plugin, capability });
+    }
+  }
+  return plugins;
 }
 
 function fixtureStepMetadata(fixture, phase, extra = {}) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -145,11 +145,44 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
   assert.match(recipe.workflow.steps[1].args[0], /--allow-failure/);
+  assert.doesNotMatch(recipe.workflow.steps[1].args[0], /--allow-missing-woocommerce/);
   assert.deepEqual(recipe.inputs.stagedFiles[0], {
     source: '/tmp/artifacts/simple-site/artifact.json',
     target: '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix/simple-site/artifact.json',
   });
   assert.deepEqual(recipe.inputs.mounts, []);
+});
+
+test('fixture capability manifests drive per-fixture plugin provisioning without waivers', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-recipe-capabilities-'));
+  const plain = path.join(root, 'plain-site');
+  const shop = path.join(root, 'shop-site');
+  const shopForms = path.join(root, 'shop-forms-site');
+  for (const directory of [plain, shop, shopForms]) {
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, 'index.html'), '<h1>Fixture</h1>');
+  }
+  writeFileSync(path.join(plain, 'fixture.json'), JSON.stringify({ class: 'marketing/static' }));
+  writeFileSync(path.join(shop, 'fixture.json'), JSON.stringify({ class: 'ecommerce/catalog', capabilities: ['commerce-products'] }));
+  writeFileSync(path.join(shopForms, 'fixture.json'), JSON.stringify({ class: 'ecommerce/catalog', capabilities: ['forms', 'commerce-products'] }));
+
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'recipe-capability-provisioning-test' });
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    editorValidation: false,
+    visualParity: false,
+  });
+  const fixtureSteps = (id) => recipe.workflow.steps.filter((step) => step.metadata?.fixture_id === id);
+
+  assert.deepEqual(fixtureSteps('plain-site').map((step) => step.command), ['wordpress.wp-cli']);
+  assert.deepEqual(fixtureSteps('shop-site').map((step) => step.command), ['wordpress.plugin-setup', 'wordpress.wp-cli']);
+  assert.deepEqual(fixtureSteps('shop-forms-site').map((step) => step.command), ['wordpress.plugin-setup', 'wordpress.plugin-setup', 'wordpress.wp-cli']);
+  assert.deepEqual(fixtureSteps('shop-site')[0].args, ['action=install', 'plugin=woocommerce', 'activate=true']);
+  assert.deepEqual(fixtureSteps('shop-forms-site')[0].args, ['action=install', 'plugin=woocommerce', 'activate=true']);
+  assert.deepEqual(fixtureSteps('shop-forms-site')[1].args, ['action=install', 'plugin=jetpack', 'activate=true']);
+  assert.equal(recipe.workflow.steps.some((step) => /--allow-missing-woocommerce/.test(step.args?.[0] || '')), false);
 });
 
 test('fixture-matrix rig requires env-backed WP Codebox editor and visual capabilities', () => {
@@ -888,6 +921,39 @@ test('accepted native-conversion diagnostics with reason and source path are not
 
   assert.equal(result.findings[0].loss_class, 'native_conversion');
   assert.equal(result.summary.fixture_categories.missing_evidence, undefined);
+});
+
+test('collects import-report dependency and seeding diagnostics into fixture findings', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-import-report-diagnostics-'));
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'import-report.json'), JSON.stringify({
+    status: 'failed',
+    diagnostics: [
+      {
+        code: 'woocommerce_missing',
+        severity: 'error',
+        source: 'commerce.dependencies.woocommerce',
+        message: 'WooCommerce is required for this import.',
+      },
+    ],
+    product_seeding: {
+      status: 'skipped',
+      reason: 'woocommerce_required_but_missing',
+      counts: { created: 0, updated: 0, skipped: 2, error: 0 },
+    },
+  }));
+
+  const result = collectFixtureMatrixRunResults({
+    matrix: createFixtureMatrix({ fixture_root: fixtureRoot, id: 'import-report-diagnostics-test' }),
+    outputDirectory,
+  });
+  const diagnostics = result.fixtures[0].diagnostics;
+
+  assert.ok(diagnostics.some((diagnostic) => diagnostic.kind === 'woocommerce_missing'));
+  assert.ok(diagnostics.some((diagnostic) => diagnostic.kind === 'product_seeding_failed'));
+  assert.equal(result.fixtures[0].status, 'failed');
+  assert.equal(result.summary.unacceptable_loss_classes.importer_materialization_bug >= 1, true);
 });
 
 test('suppresses count-only fixture diagnostics from actionable fanout rollups', () => {


### PR DESCRIPTION
## Problem

The fixture matrix hardcoded `--allow-missing-woocommerce` into every import step, so commerce-bearing fixtures always imported in degraded theme-only mode: no plugin materialization, no product seeding, no dependency gate. The matrix was structurally incapable of measuring the real commerce pipeline — the same harness-gap class as the theme-materialization gap (#546).

## Fix

- **Capability-driven provisioning**: fixtures whose authored manifest capabilities include `commerce-products` get a `wordpress.plugin-setup` step (WooCommerce installed by wp.org slug + activated) before their import step; `forms` provisions Jetpack. Declarative capability→plugin map colocated with the recipe builder; no fixture-id logic; manifests remain the sole source of truth.
- **Waiver removed** from the matrix import command. The importer's three-state dependency gate now runs honestly: provisioned fixtures seed real products; an unprovisioned commerce import fails loudly (`woocommerce_missing` hard error) instead of silently degrading.
- **Seeding visibility**: failed/skipped `product_seeding` / `form_seeding` reports and import-report diagnostics now lift into fixture diagnostics (`importer_materialization_bug` loss class) so materialization failures can never be swallowed.
- Non-capability fixtures get zero provisioning steps (no slowdown, no behavior change).

## Verification

- `node tools/fixture-matrix.test.mjs`: 123 passing (new coverage: provisioning steps for capability fixtures, waiver absence, non-commerce no-op, seeding diagnostic intake).
- **Live sandbox proof (fixture 19-product-catalog)**: `wordpress.plugin-setup` ok — WooCommerce 10.9.3 downloaded from wp.org (sandbox egress confirmed), active; import diagnostic `woocommerce_present`; `product_seeding.status: completed` with **10 products created, 0 errors**, no waiver path used.
- Complexity-1 regression lane (7 non-commerce fixtures): 7/7 pass, finding set identical to trunk baseline.

Companion corpus PR (authored capabilities on fixtures 19/20): Automattic/blocks-engine#494.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.5 (claude-fable-5) via opencode, orchestrated agent workflow
- **Used for:** wp-codebox provisioning contract investigation, implementation, live sandbox verification. Reviewed and regression-verified by Chris Huber via the fixture matrix.
