### PR TITLE
Normalize companion block schema types

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -239,6 +239,8 @@ class Static_Site_Importer_Companion_Plugin {
 		'example'         => 'example',
 	);
 
+	private const JSON_SCHEMA_TYPES = array( 'array', 'object', 'string', 'number', 'integer', 'boolean', 'null' );
+
 	/**
 	 * Build one PHP-only dynamic block: its render.php (+ any carried assets) and
 	 * the PHP registration spec the main plugin file feeds to register_block_type.
@@ -344,9 +346,76 @@ class Static_Site_Importer_Companion_Plugin {
 		// Attributes must be a map for WP_Block_Type::prepare_attributes_for_render.
 		if ( isset( $args['attributes'] ) && ! is_array( $args['attributes'] ) ) {
 			unset( $args['attributes'] );
+		} elseif ( isset( $args['attributes'] ) ) {
+			$args['attributes'] = self::normalize_attribute_schemas( $args['attributes'] );
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Normalize generated block attribute schemas before WordPress REST validates them.
+	 *
+	 * @param array<string,mixed> $attributes Block attribute schema map.
+	 * @return array<string,mixed>
+	 */
+	private static function normalize_attribute_schemas( array $attributes ): array {
+		foreach ( $attributes as $name => $schema ) {
+			if ( is_array( $schema ) ) {
+				$attributes[ $name ] = self::normalize_json_schema_types( $schema );
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Convert semantic producer type labels into valid JSON Schema types.
+	 *
+	 * @param array<string,mixed> $schema JSON Schema fragment.
+	 * @return array<string,mixed>
+	 */
+	private static function normalize_json_schema_types( array $schema ): array {
+		if ( isset( $schema['type'] ) ) {
+			if ( is_string( $schema['type'] ) && ! in_array( $schema['type'], self::JSON_SCHEMA_TYPES, true ) ) {
+				$schema['type'] = 'string';
+			} elseif ( is_array( $schema['type'] ) ) {
+				$types          = array_values( array_intersect( $schema['type'], self::JSON_SCHEMA_TYPES ) );
+				$schema['type'] = ! empty( $types ) ? $types : 'string';
+			}
+		}
+
+		foreach ( array( 'properties', 'patternProperties' ) as $key ) {
+			if ( ! isset( $schema[ $key ] ) || ! is_array( $schema[ $key ] ) ) {
+				continue;
+			}
+
+			foreach ( $schema[ $key ] as $property => $property_schema ) {
+				if ( is_array( $property_schema ) ) {
+					$schema[ $key ][ $property ] = self::normalize_json_schema_types( $property_schema );
+				}
+			}
+		}
+
+		foreach ( array( 'items', 'additionalProperties' ) as $key ) {
+			if ( isset( $schema[ $key ] ) && is_array( $schema[ $key ] ) ) {
+				$schema[ $key ] = self::normalize_json_schema_types( $schema[ $key ] );
+			}
+		}
+
+		foreach ( array( 'oneOf', 'anyOf', 'allOf' ) as $key ) {
+			if ( ! isset( $schema[ $key ] ) || ! is_array( $schema[ $key ] ) ) {
+				continue;
+			}
+
+			foreach ( $schema[ $key ] as $index => $nested_schema ) {
+				if ( is_array( $nested_schema ) ) {
+					$schema[ $key ][ $index ] = self::normalize_json_schema_types( $nested_schema );
+				}
+			}
+		}
+
+		return $schema;
 	}
 
 	/**

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -122,6 +122,14 @@ $payload = array(
 						'type'    => 'string',
 						'default' => '',
 					),
+					'content' => array(
+						'type'    => 'content',
+						'default' => '',
+					),
+					'text'    => array(
+						'type'    => 'text',
+						'default' => '',
+					),
 				),
 				'supports'   => array(
 					'interactivity' => true,
@@ -163,6 +171,8 @@ if ( is_array( $descriptor ) ) {
 	$assert( str_contains( $main, "'api_version' => 3" ), 'main-file-declares-api-version' );
 	$assert( str_contains( $main, "'name' => 'ssi-example-site/custom-hero'" ), 'main-file-carries-namespaced-block-name' );
 	$assert( str_contains( $main, "'attributes' =>" ) && str_contains( $main, "'heading' =>" ), 'main-file-declares-php-attributes' );
+	$assert( str_contains( $main, "'content' =>" ) && str_contains( $main, "'text' =>" ), 'main-file-preserves-semantic-attribute-names' );
+	$assert( ! str_contains( $main, "'type' => 'content'" ) && ! str_contains( $main, "'type' => 'text'" ), 'main-file-normalizes-invalid-rest-schema-types' );
 	$assert( ! str_contains( $main, 'register_block_type( $path )' ), 'main-file-does-not-register-from-block-json-path' );
 
 	// The render.php is the server-rendered template the render_callback runs.


### PR DESCRIPTION
## Summary
- Normalize generated companion block attribute schema types before embedding them in PHP block registration specs.
- Convert semantic producer labels like `content` and `text` to the JSON Schema builtin `string` so WordPress REST validation does not emit invalid schema notices.
- Add smoke coverage proving semantic attribute names are preserved while invalid `type` values are not emitted.

## Testing
- `php tests/smoke-companion-plugin.php`
- `php tests/smoke-companion-plugin-js.php`
- `php -l includes/class-static-site-importer-companion-plugin.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — orchestrated by Claude (claude-fable-5), implementation by GPT-5.5 subagent
- **Used for:** Root-cause investigation, code changes, targeted verification, and PR preparation