### PR TITLE
Refresh active generated companion plugins

### DIFF
--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -117,12 +117,7 @@ class Static_Site_Importer_Plugin_Materializer {
 
 		$report['files'] = array_keys( $plan['files'] );
 
-		if ( self::available( $availability_check ) ) {
-			$report['status']    = 'already_available';
-			$report['installed'] = true;
-			$report['active']    = true;
-			return $report;
-		}
+		$already_available = self::available( $availability_check );
 
 		$report['attempted'] = true;
 
@@ -131,7 +126,7 @@ class Static_Site_Importer_Plugin_Materializer {
 			return self::failed_report( $report, $written );
 		}
 		$report['installed'] = true;
-		$report['actions'][] = 'installed';
+		$report['actions'][] = $already_available ? 'refreshed' : 'installed';
 
 		if ( false === $plan['activate'] ) {
 			// mu-plugins are always active; no activation call is required.
@@ -170,7 +165,7 @@ class Static_Site_Importer_Plugin_Materializer {
 			);
 		}
 
-		$report['status'] = 'installed_activated';
+		$report['status'] = $already_available ? 'refreshed' : 'installed_activated';
 		return $report;
 	}
 

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -130,6 +130,14 @@ $payload = array(
 						'type'    => 'text',
 						'default' => '',
 					),
+					'nested'  => array(
+						'type'       => 'object',
+						'properties' => array(
+							'caption' => array(
+								'type' => 'text',
+							),
+						),
+					),
 				),
 				'supports'   => array(
 					'interactivity' => true,
@@ -173,6 +181,10 @@ if ( is_array( $descriptor ) ) {
 	$assert( str_contains( $main, "'attributes' =>" ) && str_contains( $main, "'heading' =>" ), 'main-file-declares-php-attributes' );
 	$assert( str_contains( $main, "'content' =>" ) && str_contains( $main, "'text' =>" ), 'main-file-preserves-semantic-attribute-names' );
 	$assert( ! str_contains( $main, "'type' => 'content'" ) && ! str_contains( $main, "'type' => 'text'" ), 'main-file-normalizes-invalid-rest-schema-types' );
+	$builtin_schema_types = array( 'array', 'object', 'string', 'number', 'integer', 'boolean', 'null' );
+	preg_match_all( "/'type' => '([^']+)'/", $main, $type_matches );
+	$invalid_schema_types = array_values( array_diff( $type_matches[1] ?? array(), $builtin_schema_types ) );
+	$assert( array() === $invalid_schema_types, 'main-file-emits-only-builtin-rest-schema-types', implode( ',', $invalid_schema_types ) );
 	$assert( ! str_contains( $main, 'register_block_type( $path )' ), 'main-file-does-not-register-from-block-json-path' );
 
 	// The render.php is the server-rendered template the render_callback runs.
@@ -284,6 +296,15 @@ $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/rend
 $assert( ! file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/block.json' ), 'install-emits-no-block-json' );
 $written_main = file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) ? (string) file_get_contents( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) : '';
 $assert( str_contains( $written_main, 'register_block_type' ), 'written-main-file-registers-blocks' );
+
+// Existing active generated companions are refreshed from the current payload;
+// stale files from an older SSI build must not bypass scaffold normalization.
+file_put_contents( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php', "<?php\nreturn array( 'type' => 'content' );\n" );
+$refresh_report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $payload, static fn (): bool => true );
+$refreshed_main = file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) ? (string) file_get_contents( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) : '';
+$assert( 'refreshed' === ( $refresh_report['status'] ?? '' ), 'active-generated-plugin-refresh-status', (string) ( $refresh_report['status'] ?? '' ) );
+$assert( in_array( 'refreshed', $refresh_report['actions'] ?? array(), true ), 'active-generated-plugin-records-refresh-action' );
+$assert( ! str_contains( $refreshed_main, "'type' => 'content'" ), 'active-generated-plugin-overwrites-stale-invalid-schema' );
 
 // mu-plugin install writes the root loader and needs no activation call.
 $mu_report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( array_merge( $payload, array( 'mu_plugin' => true ) ) );

--- a/tests/smoke-export-theme-ability.php
+++ b/tests/smoke-export-theme-ability.php
@@ -174,6 +174,10 @@ if ( ! function_exists( 'add_action' ) ) {
 	function add_action( string $hook_name, callable|string $callback ): void {}
 }
 
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook_name, ...$args ): void {}
+}
+
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-exporter.php';
 require_once dirname( __DIR__ ) . '/includes/abilities.php';
 


### PR DESCRIPTION
## Summary
- Refresh generated companion plugin files even when the dependency is already active/available.
- Adds artifact-level coverage that generated companion plugin PHP only exports built-in REST schema types.
- Adds a stale active companion-plugin reproduction so old generated files cannot bypass current schema normalization.
- Adds a missing smoke-test `do_action()` stub uncovered by the PHP smoke loop.

## Testing
- `php tests/smoke-companion-plugin.php && php tests/smoke-export-theme-ability.php`
- `for test in tests/smoke-*.php; do php "$test" || exit 1; done`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — orchestrated by Claude (claude-fable-5), implementation by GPT-5.5 subagent
- **Used for:** Root-caused the surviving generated-schema notice and fixed the generation path with output-artifact tests; reviewed by Chris.
