### PR TITLE
Clear SSI release gate blockers

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 
+/**
+ * External dependencies
+ */
 import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+/**
+ * Internal dependencies
+ */
 import { runWpCodeboxRecipe, wpCodeboxCommand, wpCodeboxBin } from '../tools/wp-codebox/recipe.mjs';
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
 import {

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -361,7 +361,7 @@ if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' )
 			return static_site_importer_ability_error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
 		}
 
-		return static_site_importer_ability_import_success( is_array( $result ) ? $result : array(), $input );
+		return static_site_importer_ability_import_success( $result, $input );
 	}
 }
 

--- a/includes/block.php
+++ b/includes/block.php
@@ -68,6 +68,7 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 	 * @param array<string,string> $attrs      Extra wrapper attributes (name => value).
 	 * @param array<string,mixed>  $attributes Block attributes.
 	 */
+	/** @var mixed $wrapper_attrs */
 	$wrapper_attrs = apply_filters( 'static_site_importer_block_wrapper_attributes', array(), $attributes );
 	$extra_attr    = '';
 	if ( is_array( $wrapper_attrs ) ) {

--- a/includes/class-static-site-importer-block-document-reporter.php
+++ b/includes/class-static-site-importer-block-document-reporter.php
@@ -35,8 +35,8 @@ class Static_Site_Importer_Block_Document_Reporter {
 				continue;
 			}
 
-			$block_markup = self::generated_block_document_markup( $relative_path, $content );
-			$analysis     = self::analyze_generated_block_document( $relative_path, $block_markup, $report );
+			$block_markup                                   = self::generated_block_document_markup( $relative_path, $content );
+			$analysis                                       = self::analyze_generated_block_document( $relative_path, $block_markup, $report );
 			$report['generated_theme']['block_documents'][] = $analysis;
 		}
 	}
@@ -173,7 +173,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	private static function analyze_generated_block_list( array $blocks, int &$block_count, int &$core_html_count, int &$freeform_count, int &$invalid_count, array &$invalid_blocks, array &$report, string $source = '', array $path = array() ): void {
 		foreach ( $blocks as $index => $block ) {
 			$block_path = array_merge( $path, array( $index ) );
-			$name = isset( $block['blockName'] ) ? $block['blockName'] : null;
+			$name       = isset( $block['blockName'] ) ? $block['blockName'] : null;
 			if ( is_string( $name ) && '' !== $name ) {
 				++$block_count;
 				if ( 'core/html' === $name ) {
@@ -353,7 +353,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 		}
 
 		$blocks = parse_blocks( $markup );
-		return self::canonicalize_parsed_block_values_for_report( is_array( $blocks ) ? $blocks : array() );
+		return self::canonicalize_parsed_block_values_for_report( $blocks );
 	}
 
 	/**

--- a/includes/class-static-site-importer-bundle-data-source.php
+++ b/includes/class-static-site-importer-bundle-data-source.php
@@ -235,10 +235,15 @@ class Static_Site_Importer_Bundle_Data_Source {
 		}
 
 		if ( self::is_object_list( $value ) ) {
+			/** @var array<int,array<string,mixed>> $objects */
 			$objects = array();
 			foreach ( $value as $entry ) {
 				if ( is_array( $entry ) && ! array_is_list( $entry ) ) {
-					$objects[] = $entry;
+					$object = array();
+					foreach ( $entry as $key => $item ) {
+						$object[ (string) $key ] = $item;
+					}
+					$objects[] = $object;
 				}
 			}
 			if ( array() !== $objects ) {

--- a/includes/class-static-site-importer-bundle-data-source.php
+++ b/includes/class-static-site-importer-bundle-data-source.php
@@ -204,6 +204,7 @@ class Static_Site_Importer_Bundle_Data_Source {
 	 * @return array<int,array<int,array<string,mixed>>>
 	 */
 	private static function object_arrays_from_source( string $source, string $ext ): array {
+		/** @var array<int,array<int,array<string,mixed>>> $collected */
 		$collected = array();
 
 		if ( 'json' === $ext ) {
@@ -558,7 +559,7 @@ class Static_Site_Importer_Bundle_Data_Source {
 			return self::PARSE_FAILED;
 		}
 
-		return ( (float) $raw === floor( (float) $raw ) && ! str_contains( $raw, '.' ) && ! str_contains( strtolower( $raw ), 'e' ) )
+		return ( floor( (float) $raw ) === (float) $raw && ! str_contains( $raw, '.' ) && ! str_contains( strtolower( $raw ), 'e' ) )
 			? (int) $raw
 			: (float) $raw;
 	}
@@ -723,8 +724,8 @@ class Static_Site_Importer_Bundle_Data_Source {
 			$next = $index + 1 < $length ? $source[ $index + 1 ] : '';
 
 			if ( '"' === $char || "'" === $char || '`' === $char ) {
-				$end  = self::skip_string( $source, $index );
-				$out .= substr( $source, $index, $end - $index );
+				$end   = self::skip_string( $source, $index );
+				$out  .= substr( $source, $index, $end - $index );
 				$index = $end;
 				continue;
 			}
@@ -771,8 +772,8 @@ class Static_Site_Importer_Bundle_Data_Source {
 		}
 
 		$matches = 0;
-		foreach ( $objects as $object ) {
-			if ( is_array( $object ) && self::is_product_shaped_object( $object ) ) {
+		foreach ( $objects as $item ) {
+			if ( self::is_product_shaped_object( $item ) ) {
 				++$matches;
 			}
 		}
@@ -783,13 +784,13 @@ class Static_Site_Importer_Bundle_Data_Source {
 	/**
 	 * Determine whether a single object carries product-shaped fields.
 	 *
-	 * @param array<string,mixed> $object Object.
+	 * @param array<string,mixed> $item Object.
 	 * @return bool
 	 */
-	private static function is_product_shaped_object( array $object ): bool {
-		$normalized = self::normalized_keys( $object );
-		$name       = self::first_key_value( $object, $normalized, self::NAME_KEYS );
-		$price      = self::first_key_value( $object, $normalized, self::PRICE_KEYS );
+	private static function is_product_shaped_object( array $item ): bool {
+		$normalized = self::normalized_keys( $item );
+		$name       = self::first_key_value( $item, $normalized, self::NAME_KEYS );
+		$price      = self::first_key_value( $item, $normalized, self::PRICE_KEYS );
 
 		return '' !== self::scalar_text( $name ) && '' !== self::price_to_decimal( $price );
 	}
@@ -797,15 +798,15 @@ class Static_Site_Importer_Bundle_Data_Source {
 	/**
 	 * Map a product-shaped object to a generic product report row.
 	 *
-	 * @param array<string,mixed> $object      Source object.
+	 * @param array<string,mixed> $item        Source object.
 	 * @param string              $source_path Artifact source path.
 	 * @return array<string,mixed>
 	 */
-	private static function product_row_from_object( array $object, string $source_path ): array {
-		$normalized = self::normalized_keys( $object );
+	private static function product_row_from_object( array $item, string $source_path ): array {
+		$normalized = self::normalized_keys( $item );
 
-		$name  = self::scalar_text( self::first_key_value( $object, $normalized, self::NAME_KEYS ) );
-		$price = self::price_to_decimal( self::first_key_value( $object, $normalized, self::PRICE_KEYS ) );
+		$name  = self::scalar_text( self::first_key_value( $item, $normalized, self::NAME_KEYS ) );
+		$price = self::price_to_decimal( self::first_key_value( $item, $normalized, self::PRICE_KEYS ) );
 		if ( '' === $name || '' === $price ) {
 			return array();
 		}
@@ -813,28 +814,28 @@ class Static_Site_Importer_Bundle_Data_Source {
 		$row = array(
 			'kind'             => 'product',
 			'name'             => $name,
-			'slug'             => self::slug_from_object( $object, $normalized, $name ),
+			'slug'             => self::slug_from_object( $item, $normalized, $name ),
 			'regular_price'    => $price,
 			'source_path'      => $source_path,
 			'source_selectors' => array( 'bundle-data:' . self::basename_path( $source_path ) ),
 		);
 
-		$sale = self::price_to_decimal( self::first_key_value( $object, $normalized, self::SALE_PRICE_KEYS ) );
+		$sale = self::price_to_decimal( self::first_key_value( $item, $normalized, self::SALE_PRICE_KEYS ) );
 		if ( '' !== $sale ) {
 			$row['sale_price'] = $sale;
 		}
 
-		$description = self::scalar_text( self::first_key_value( $object, $normalized, self::DESCRIPTION_KEYS ) );
+		$description = self::scalar_text( self::first_key_value( $item, $normalized, self::DESCRIPTION_KEYS ) );
 		if ( '' !== $description ) {
 			$row['description'] = $description;
 		}
 
-		$image = self::scalar_text( self::first_key_value( $object, $normalized, self::IMAGE_KEYS ) );
+		$image = self::scalar_text( self::first_key_value( $item, $normalized, self::IMAGE_KEYS ) );
 		if ( '' !== $image ) {
 			$row['image'] = $image;
 		}
 
-		$categories = self::string_collection( self::first_key_value( $object, $normalized, self::CATEGORY_KEYS ) );
+		$categories = self::string_collection( self::first_key_value( $item, $normalized, self::CATEGORY_KEYS ) );
 		if ( array() !== $categories ) {
 			$row['categories'] = $categories;
 		}
@@ -845,13 +846,13 @@ class Static_Site_Importer_Bundle_Data_Source {
 	/**
 	 * Derive a slug from an identifier-like field, falling back to the name.
 	 *
-	 * @param array<string,mixed>   $object     Source object.
+	 * @param array<string,mixed>   $item       Source object.
 	 * @param array<string,string>  $normalized Normalized-key map.
 	 * @param string                $name       Resolved product name.
 	 * @return string
 	 */
-	private static function slug_from_object( array $object, array $normalized, string $name ): string {
-		$candidate = self::scalar_text( self::first_key_value( $object, $normalized, self::SLUG_KEYS ) );
+	private static function slug_from_object( array $item, array $normalized, string $name ): string {
+		$candidate = self::scalar_text( self::first_key_value( $item, $normalized, self::SLUG_KEYS ) );
 		$source    = '' !== $candidate ? $candidate : $name;
 
 		return self::slugify( $source );
@@ -874,12 +875,12 @@ class Static_Site_Importer_Bundle_Data_Source {
 	/**
 	 * Map an object's keys to their normalized forms (lowercase alphanumerics).
 	 *
-	 * @param array<string,mixed> $object Source object.
+	 * @param array<string,mixed> $item Source object.
 	 * @return array<string,string> Normalized key => original key.
 	 */
-	private static function normalized_keys( array $object ): array {
+	private static function normalized_keys( array $item ): array {
 		$map = array();
-		foreach ( array_keys( $object ) as $key ) {
+		foreach ( array_keys( $item ) as $key ) {
 			$map[ self::normalize_key( (string) $key ) ] = (string) $key;
 		}
 
@@ -899,17 +900,17 @@ class Static_Site_Importer_Bundle_Data_Source {
 	/**
 	 * Return the first value whose normalized key matches a synonym.
 	 *
-	 * @param array<string,mixed>  $object     Source object.
+	 * @param array<string,mixed>  $item       Source object.
 	 * @param array<string,string> $normalized Normalized-key map.
 	 * @param array<int,string>    $synonyms   Normalized synonym list.
 	 * @return mixed
 	 */
-	private static function first_key_value( array $object, array $normalized, array $synonyms ): mixed {
+	private static function first_key_value( array $item, array $normalized, array $synonyms ): mixed {
 		foreach ( $synonyms as $synonym ) {
 			if ( isset( $normalized[ $synonym ] ) ) {
 				$original = $normalized[ $synonym ];
-				if ( array_key_exists( $original, $object ) ) {
-					return $object[ $original ];
+				if ( array_key_exists( $original, $item ) ) {
+					return $item[ $original ];
 				}
 			}
 		}

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -709,7 +709,7 @@ class Static_Site_Importer_Companion_Plugin {
 
 		if ( is_float( $value ) ) {
 			// var_export keeps a parseable float literal (e.g. trailing .0).
-			return var_export( $value, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_var_export -- Generating a deterministic PHP literal for the scaffolded plugin file.
+			return var_export( $value, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generating a deterministic PHP literal for the scaffolded plugin file.
 		}
 
 		return "'" . self::php_single_quote( (string) $value ) . "'";

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -103,7 +103,7 @@ class Static_Site_Importer_Form_Seeder {
 				'skipped' => 0,
 				'error'   => 0,
 			),
-			'forms'     => array(),
+			'forms'                => array(),
 		);
 	}
 
@@ -132,7 +132,7 @@ class Static_Site_Importer_Form_Seeder {
 		$field_text_block   = false;
 
 		if ( class_exists( 'WP_Block_Type_Registry' ) ) {
-			$registry = WP_Block_Type_Registry::get_instance();
+			$registry           = WP_Block_Type_Registry::get_instance();
 			$contact_form_block = $registry->is_registered( 'jetpack/contact-form' );
 			$field_text_block   = $registry->is_registered( 'jetpack/field-text' );
 		}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1179,11 +1179,11 @@ class Static_Site_Importer_Report_Diagnostics {
 		$validation = Static_Site_Importer_Entity_Materializer_Registry::validate_manifest_generic( $adapter, array( 'forms' => $manifest_forms ) );
 		$seeding    = Static_Site_Importer_Entity_Materializer_Registry::materialize( $adapter, array( 'forms' => isset( $validation['forms'] ) && is_array( $validation['forms'] ) ? $validation['forms'] : array() ) );
 
-		$seeding['provider']     = Static_Site_Importer_Entity_Materializer_Registry::provider_for( 'form' );
-		$seeding['form_count']   = count( $manifest_forms );
-		$seeding['mapped_count'] = 0;
+		$seeding['provider']      = Static_Site_Importer_Entity_Materializer_Registry::provider_for( 'form' );
+		$seeding['form_count']    = count( $manifest_forms );
+		$seeding['mapped_count']  = 0;
 		$seeding['grafted_count'] = 0;
-		$seeding['waived']       = ! empty( $args[ (string) ( $adapter['waiver_arg'] ?? 'allow_missing_jetpack' ) ] );
+		$seeding['waived']        = ! empty( $args[ (string) ( $adapter['waiver_arg'] ?? 'allow_missing_jetpack' ) ] );
 		if ( ! empty( $validation['errors'] ) ) {
 			$seeding['validation_errors'] = $validation['errors'];
 		}
@@ -1291,7 +1291,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		foreach ( $documents as $document ) {
-			if ( ! is_array( $document ) || $source_path !== (string) ( $document['source_path'] ?? '' ) ) {
+			if ( ! is_array( $document ) || (string) ( $document['source_path'] ?? '' ) !== $source_path ) {
 				continue;
 			}
 
@@ -1457,7 +1457,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return array<int,array{serialized:string,html:string}>
 	 */
 	private static function serialized_core_html_blocks( string $content ): array {
-		$blocks = array();
+		$blocks  = array();
 		$matches = array();
 		preg_match_all( '/<!--\s+wp:html\s+(\{.*?\})\s+\/-->/s', $content, $matches, PREG_SET_ORDER );
 		preg_match_all( '/<!--\s+wp:html\s+(\{.*?\})\s+-->(.*?)<!--\s+\/wp:html\s+-->/s', $content, $wrapped_matches, PREG_SET_ORDER );
@@ -1561,7 +1561,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		$source_base = basename( $source_path );
-		return '' !== $source_base && $source_base === basename( $key );
+		return '' !== $source_base && basename( $key ) === $source_base;
 	}
 
 	/**
@@ -1595,9 +1595,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	private static function serialize_readable_form_blocks( array $readable_blocks ): string {
 		$serialized = '';
 		foreach ( array_values( $readable_blocks ) as $block ) {
-			if ( is_array( $block ) ) {
-				$serialized .= self::serialize_readable_form_block( $block );
-			}
+			$serialized .= self::serialize_readable_form_block( $block );
 		}
 		return $serialized;
 	}
@@ -1637,9 +1635,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		if ( ! is_array( $inner_content ) ) {
 			$serialized = '';
 			foreach ( $inner_blocks as $inner_block ) {
-				if ( is_array( $inner_block ) ) {
-					$serialized .= self::serialize_readable_form_block( $inner_block );
-				}
+				$serialized .= self::serialize_readable_form_block( $inner_block );
 			}
 			return $serialized . ( isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ? $block['innerHTML'] : '' );
 		}
@@ -1670,6 +1666,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			return '';
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Fallback only for non-WordPress smoke tests; WordPress runtimes use wp_json_encode().
 		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $attrs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( $attrs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 		if ( ! is_string( $encoded ) ) {
 			return '';
@@ -1744,7 +1741,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'products'       => $manifest_products,
 		);
 		$validation = Static_Site_Importer_Entity_Materializer_Registry::validate_manifest( $adapter, $manifest );
-		$validated  = isset( $validation['products'] ) && is_array( $validation['products'] ) ? $validation['products'] : array();
+		$validated  = $validation['products'];
 
 		$seeding = Static_Site_Importer_Entity_Materializer_Registry::materialize( $adapter, array( 'products' => $validated ) );
 
@@ -1925,9 +1922,11 @@ class Static_Site_Importer_Report_Diagnostics {
 		$dot_count   = substr_count( $clean, '.' );
 
 		$decimal_sep = '';
-		if ( $comma_count > 0 && $dot_count > 0 ) {
+		if ( 0 < $comma_count && 0 < $dot_count ) {
 			// When both separators appear, the rightmost one is the decimal point.
-			$decimal_sep = ( (int) strrpos( $clean, ',' ) > (int) strrpos( $clean, '.' ) ) ? ',' : '.';
+			$comma_position = strrpos( $clean, ',' );
+			$dot_position   = strrpos( $clean, '.' );
+			$decimal_sep    = false !== $comma_position && false !== $dot_position && $comma_position > $dot_position ? ',' : '.';
 		} elseif ( 1 === $comma_count && 0 === $dot_count ) {
 			$decimal_sep = self::is_decimal_tail( $clean, ',' ) ? ',' : '';
 		} elseif ( 1 === $dot_count && 0 === $comma_count ) {
@@ -2412,10 +2411,10 @@ class Static_Site_Importer_Report_Diagnostics {
 				continue;
 			}
 
-			$asset                                  = $script_assets[ $key ];
-			$diagnostic['runtime_carried']           = true;
-			$diagnostic['loss_class']                = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
-			$diagnostic['diagnostic_class']          = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
+			$asset                                    = $script_assets[ $key ];
+			$diagnostic['runtime_carried']            = true;
+			$diagnostic['loss_class']                 = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
+			$diagnostic['diagnostic_class']           = Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND;
 			$diagnostic['materialized_runtime_asset'] = $asset;
 			if ( empty( $diagnostic['message'] ) ) {
 				$diagnostic['message'] = sprintf( 'Script fallback is carried by materialized theme asset %s.', (string) ( $asset['path'] ?? '' ) );

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1927,9 +1927,9 @@ class Static_Site_Importer_Report_Diagnostics {
 			$comma_position = strrpos( $clean, ',' );
 			$dot_position   = strrpos( $clean, '.' );
 			$decimal_sep    = false !== $comma_position && false !== $dot_position && $comma_position > $dot_position ? ',' : '.';
-		} elseif ( 1 === $comma_count && 0 === $dot_count ) {
+		} elseif ( 1 === $comma_count ) {
 			$decimal_sep = self::is_decimal_tail( $clean, ',' ) ? ',' : '';
-		} elseif ( 1 === $dot_count && 0 === $comma_count ) {
+		} elseif ( 1 === $dot_count ) {
 			$decimal_sep = self::is_decimal_tail( $clean, '.' ) ? '.' : '';
 		}
 		// Repeated single separators (e.g. "1,234,567") are digit grouping only.

--- a/includes/class-static-site-importer-site-identity.php
+++ b/includes/class-static-site-importer-site-identity.php
@@ -159,7 +159,7 @@ class Static_Site_Importer_Site_Identity {
 		}
 
 		$parts = preg_split( '/\s+(?:\||\x{2014}|\x{2013}|-)\s+/u', $title );
-		$first = is_array( $parts ) && isset( $parts[0] ) ? trim( (string) $parts[0] ) : $title;
+		$first = is_array( $parts ) ? trim( (string) $parts[0] ) : $title;
 
 		return '' !== $first ? $first : $title;
 	}

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -999,13 +999,13 @@ class Static_Site_Importer_Theme_Materializer {
 		for ( $pass = 0; $pass < 5; $pass++ ) {
 			$expanded = preg_replace_callback(
 				'/var\(\s*(--[A-Za-z0-9_-]+)\s*(?:,\s*([^()]*))?\)/',
-				static function ( array $match ) use ( $properties ): string {
-					$name = (string) $match[1];
+				static function ( array $matches ) use ( $properties ): string {
+					$name = (string) $matches[1];
 					if ( isset( $properties[ $name ] ) && '' !== $properties[ $name ] ) {
 						return $properties[ $name ];
 					}
 
-					return ( isset( $match[2] ) && '' !== trim( (string) $match[2] ) ) ? trim( (string) $match[2] ) : (string) $match[0];
+					return ( isset( $matches[2] ) && '' !== trim( (string) $matches[2] ) ) ? trim( (string) $matches[2] ) : (string) $matches[0];
 				},
 				$value
 			);

--- a/includes/class-static-site-importer-url-fetcher.php
+++ b/includes/class-static-site-importer-url-fetcher.php
@@ -158,10 +158,11 @@ class Static_Site_Importer_URL_Fetcher {
 		$text_html    = preg_replace( '#<script\b[^>]*>.*?</script>#is', ' ', $html );
 		$text_html    = preg_replace( '#<style\b[^>]*>.*?</style>#is', ' ', (string) $text_html );
 		$text_html    = preg_replace( '#<template\b[^>]*>.*?</template>#is', ' ', (string) $text_html );
-		$stripped     = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( (string) $text_html ) : strip_tags( (string) $text_html );
-		$text         = html_entity_decode( trim( preg_replace( '/\s+/', ' ', $stripped ) ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
-		$text_chars   = strlen( $text );
-		$text_ratio   = $markup_bytes > 0 ? $text_chars / $markup_bytes : 0;
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- Fallback only for non-WordPress smoke tests; WordPress runtimes use wp_strip_all_tags().
+		$stripped   = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( (string) $text_html ) : strip_tags( (string) $text_html );
+		$text       = html_entity_decode( trim( preg_replace( '/\s+/', ' ', $stripped ) ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$text_chars = strlen( $text );
+		$text_ratio = $markup_bytes > 0 ? $text_chars / $markup_bytes : 0;
 
 		if ( ( $script_count >= 20 && $text_chars < 1000 && $text_ratio < 0.02 ) || ( $script_count >= 3 && $text_chars < 200 && $app_shell ) ) {
 			return array(

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -481,7 +481,7 @@ function static_site_importer_rest_create_import( WP_REST_Request $request ) {
 	if ( isset( $params['provider_args'] ) && is_array( $params['provider_args'] ) ) {
 		$input['provider_args'] = $params['provider_args'];
 	}
-	$mode   = static_site_importer_rest_import_mode( $params );
+	$mode = static_site_importer_rest_import_mode( $params );
 
 	if ( 'playground' === $mode ) {
 		$result = static_site_importer_rest_open_in_playground( $source, $input );
@@ -492,7 +492,7 @@ function static_site_importer_rest_create_import( WP_REST_Request $request ) {
 		return rest_ensure_response( $result );
 	}
 
-	$result = static_site_importer_rest_apply_to_current_site( $source, $input, $params );
+	$result = static_site_importer_rest_apply_to_current_site( $source, $input );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -546,14 +546,12 @@ function static_site_importer_rest_open_in_playground( array $source, array $inp
 
 	$artifact        = $runtime['artifact'];
 	$source_metadata = isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array();
-	if ( isset( $runtime['source_metadata'] ) && is_array( $runtime['source_metadata'] ) ) {
-		$source_metadata = array_merge( $source_metadata, $runtime['source_metadata'] );
-	}
-	if ( 'url' === (string) ( $source_metadata['source_type'] ?? '' ) && isset( $runtime['provider'] ) && '' !== (string) $runtime['provider'] ) {
+	$source_metadata = array_merge( $source_metadata, $runtime['source_metadata'] );
+	if ( 'url' === (string) ( $source_metadata['source_type'] ?? '' ) && '' !== (string) $runtime['provider'] ) {
 		$source_metadata['url_import_provider'] = (string) $runtime['provider'];
 	}
 	$input['source_metadata'] = $source_metadata;
-	$input['artifact'] = $artifact;
+	$input['artifact']        = $artifact;
 
 	$identity = Static_Site_Importer_Site_Identity::resolve(
 		array(
@@ -659,10 +657,9 @@ function static_site_importer_build_playground_preview( array $artifact, array $
  *
  * @param array<string,mixed> $source Source payload.
  * @param array<string,mixed> $input  Import args.
- * @param array<string,mixed> $params Request params.
  * @return array<string,mixed>|WP_Error
  */
-function static_site_importer_rest_apply_to_current_site( array $source, array $input, array $params ) {
+function static_site_importer_rest_apply_to_current_site( array $source, array $input ) {
 	$decorate_current_site_preview = static function ( $result ) {
 		if ( ! is_array( $result ) ) {
 			return $result;
@@ -686,10 +683,8 @@ function static_site_importer_rest_apply_to_current_site( array $source, array $
 	}
 
 	$source_metadata = isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array();
-	if ( isset( $runtime['source_metadata'] ) && is_array( $runtime['source_metadata'] ) ) {
-		$source_metadata = array_merge( $source_metadata, $runtime['source_metadata'] );
-	}
-	if ( 'url' === (string) ( $source_metadata['source_type'] ?? '' ) && isset( $runtime['provider'] ) && '' !== (string) $runtime['provider'] ) {
+	$source_metadata = array_merge( $source_metadata, $runtime['source_metadata'] );
+	if ( 'url' === (string) ( $source_metadata['source_type'] ?? '' ) && '' !== (string) $runtime['provider'] ) {
 		$source_metadata['url_import_provider'] = (string) $runtime['provider'];
 	}
 	$input['source_metadata'] = $source_metadata;
@@ -958,10 +953,6 @@ function static_site_importer_rest_codebox_artifact_files( array $artifact ): ar
 	$files          = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
 
 	foreach ( $files as $file ) {
-		if ( ! is_array( $file ) ) {
-			continue;
-		}
-
 		$path = isset( $file['path'] ) ? (string) $file['path'] : '';
 		$path = preg_replace( '#^website/#', '', $path );
 		$path = static_site_importer_rest_codebox_artifact_path( (string) $path );
@@ -1486,7 +1477,7 @@ function static_site_importer_rest_source_runtime( array $source, array $input =
 			return $runtime;
 		}
 
-		$source_metadata = isset( $runtime['source_metadata'] ) && is_array( $runtime['source_metadata'] ) ? $runtime['source_metadata'] : array();
+		$source_metadata                = isset( $runtime['source_metadata'] ) && is_array( $runtime['source_metadata'] ) ? $runtime['source_metadata'] : array();
 		$source_metadata['source_type'] = isset( $source_metadata['source_type'] ) ? (string) $source_metadata['source_type'] : 'url';
 
 		return array(

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1569,13 +1569,9 @@ function static_site_importer_rest_source_runtime( array $source, array $input =
  *
  * @param array<int,array<string,mixed>> $files Artifact files.
  * @return true|WP_Error
- */
+	 */
 function static_site_importer_rest_validate_static_html_sources( array $files ) {
 	foreach ( $files as $file ) {
-		if ( ! is_array( $file ) ) {
-			continue;
-		}
-
 		$path = isset( $file['path'] ) ? (string) $file['path'] : '';
 		if ( ! preg_match( '/\.html?$/i', $path ) ) {
 			continue;

--- a/lib/artifact-intake.mjs
+++ b/lib/artifact-intake.mjs
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import fs from 'node:fs';
 import path from 'node:path';
 

--- a/lib/fixture-matrix/collectors/editor-validation.mjs
+++ b/lib/fixture-matrix/collectors/editor-validation.mjs
@@ -4,7 +4,9 @@
 //
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
-
+/**
+ * Internal dependencies
+ */
 import {
   EDITOR_BLOCK_INVALID_KIND,
   EDITOR_INVALID_BLOCK_SELECTOR_GROUP,

--- a/lib/fixture-matrix/collectors/live-wp-parity.mjs
+++ b/lib/fixture-matrix/collectors/live-wp-parity.mjs
@@ -13,11 +13,16 @@
 // given a fixed snapshot the report is byte-identical run to run. With --with-proxy
 // the CLI also reports the render-free proxy score so callers can read the live-WP
 // vs proxy delta directly.
-
+/**
+ * External dependencies
+ */
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
+/**
+ * Internal dependencies
+ */
 import { VISUAL_PARITY_SOURCE_SUBDIR } from '../shared/constants.mjs';
 import { objectValue, finiteNumber, compactObject, isTruthySignal } from '../shared/utils.mjs';
 

--- a/lib/fixture-matrix/collectors/quality-metrics.mjs
+++ b/lib/fixture-matrix/collectors/quality-metrics.mjs
@@ -4,7 +4,9 @@
 //
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
-
+/**
+ * Internal dependencies
+ */
 import {
   NATIVE_BLOCK_NAMESPACES,
   CORE_HTML_BLOCK_NAME,
@@ -271,11 +273,11 @@ function blockDocumentEntries(payload) {
   const object = objectValue(payload);
   const importReport = objectValue(object.import_report || object.importReport || object.report);
   const materialized = objectValue(importReport.materialized_content || importReport.materializedContent || object.materialized_content || object.materializedContent);
-  const generatedTheme = objectValue(importReport.generated_theme || importReport.generatedTheme || object.generated_theme || object.generatedTheme);
   const materializedDocuments = blockDocumentList(materialized.block_documents || materialized.blockDocuments);
   if (materializedDocuments.length > 0) {
     return materializedDocuments;
   }
+  const generatedTheme = objectValue(importReport.generated_theme || importReport.generatedTheme || object.generated_theme || object.generatedTheme);
   const generatedDocuments = blockDocumentList(generatedTheme.block_documents || generatedTheme.blockDocuments);
   if (generatedDocuments.length > 0) {
     return generatedDocuments;

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -4,10 +4,15 @@
 //
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
-
+/**
+ * External dependencies
+ */
 import fs from 'node:fs';
 import path from 'node:path';
 
+/**
+ * Internal dependencies
+ */
 import {
   normalizeArray,
   objectValue,
@@ -153,13 +158,13 @@ function seedingReportDiagnostics(report, key, kind) {
   if (Object.keys(seeding).length === 0) {
     return [];
   }
-  const counts = objectValue(seeding.counts);
   const status = String(seeding.status || '').toLowerCase();
   const reason = String(seeding.reason || '').toLowerCase();
-  const errorCount = numberValue(counts.error);
   if (status === 'skipped' && ['no_validated_manifest', 'empty_validated_manifest', 'no_form_findings', 'no_product_findings'].includes(reason)) {
     return [];
   }
+  const counts = objectValue(seeding.counts);
+  const errorCount = numberValue(counts.error);
   if (status === 'completed' && errorCount === 0) {
     return [];
   }

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -4,7 +4,9 @@
 //
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
-
+/**
+ * Internal dependencies
+ */
 import {
   VISUAL_PARITY_MISMATCH_KIND,
   DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD,
@@ -163,28 +165,39 @@ function normalizeVisualParityComparison(value) {
   // visual-compare. When present these drive the gate; otherwise the fair ratio
   // falls back to the raw union-canvas ratio for backward compatibility.
   const overlapMismatchPixels = firstNumber([summary.overlap_mismatch_pixels, summary.overlapMismatchPixels, visualCompare.overlapMismatchPixels, visualCompare.overlap_mismatch_pixels, comparison.overlapMismatchPixels, comparison.overlap_mismatch_pixels, obj.overlap_mismatch_pixels, obj.overlapMismatchPixels]);
-  const overlapPixels = firstNumber([summary.overlap_pixels, summary.overlapPixels, visualCompare.overlapPixels, visualCompare.overlap_pixels, comparison.overlapPixels, comparison.overlap_pixels, obj.overlap_pixels, obj.overlapPixels]);
   const overlapRatio = firstNumber([summary.overlap_mismatch_ratio, summary.overlapMismatchRatio, visualCompare.overlapMismatchRatio, visualCompare.overlap_mismatch_ratio, comparison.overlapMismatchRatio, comparison.overlap_mismatch_ratio, obj.overlap_mismatch_ratio, obj.overlapMismatchRatio]);
-  const dimensionDeltaPixels = firstNumber([summary.dimension_delta_pixels, summary.dimensionDeltaPixels, visualCompare.dimensionDeltaPixels, visualCompare.dimension_delta_pixels, comparison.dimensionDeltaPixels, comparison.dimension_delta_pixels, obj.dimension_delta_pixels, obj.dimensionDeltaPixels]);
   const dimensionMismatch = Boolean(summary.dimension_mismatch ?? summary.dimensionMismatch ?? visualCompare.dimensionMismatch ?? visualCompare.dimension_mismatch ?? comparison.dimensionMismatch ?? comparison.dimension_mismatch ?? obj.dimension_mismatch);
   const hasMetrics = [mismatchPixels, totalPixels, explicitRatio, overlapRatio, overlapMismatchPixels].some((metric) => Number.isFinite(metric));
   if (!hasMetrics && !dimensionMismatch) {
     return null;
   }
+  const overlapPixels = firstNumber([summary.overlap_pixels, summary.overlapPixels, visualCompare.overlapPixels, visualCompare.overlap_pixels, comparison.overlapPixels, comparison.overlap_pixels, obj.overlap_pixels, obj.overlapPixels]);
+  const dimensionDeltaPixels = firstNumber([summary.dimension_delta_pixels, summary.dimensionDeltaPixels, visualCompare.dimensionDeltaPixels, visualCompare.dimension_delta_pixels, comparison.dimensionDeltaPixels, comparison.dimension_delta_pixels, obj.dimension_delta_pixels, obj.dimensionDeltaPixels]);
   const safeMismatch = Number.isFinite(mismatchPixels) ? mismatchPixels : 0;
   const safeTotal = Number.isFinite(totalPixels) ? totalPixels : 0;
-  const rawRatio = safeTotal > 0 ? safeMismatch / safeTotal : (Number.isFinite(explicitRatio) ? explicitRatio : 0);
+  let rawRatio = 0;
+  if (safeTotal > 0) {
+    rawRatio = safeMismatch / safeTotal;
+  } else if (Number.isFinite(explicitRatio)) {
+    rawRatio = explicitRatio;
+  }
   // The fair ratio is the overlap mismatch over the overlap area. Prefer explicit
   // counts, then an explicit overlap ratio, then degrade to the raw ratio.
   const safeOverlapPixels = Number.isFinite(overlapPixels) ? overlapPixels : 0;
   const safeOverlapMismatch = Number.isFinite(overlapMismatchPixels) ? overlapMismatchPixels : 0;
   const hasOverlapSignal = safeOverlapPixels > 0 || Number.isFinite(overlapRatio);
-  const fairRatio = safeOverlapPixels > 0
-    ? safeOverlapMismatch / safeOverlapPixels
-    : (Number.isFinite(overlapRatio) ? overlapRatio : rawRatio);
-  const safeDimensionDelta = Number.isFinite(dimensionDeltaPixels)
-    ? dimensionDeltaPixels
-    : (safeTotal > 0 && safeOverlapPixels > 0 ? safeTotal - safeOverlapPixels : 0);
+  let fairRatio = rawRatio;
+  if (safeOverlapPixels > 0) {
+    fairRatio = safeOverlapMismatch / safeOverlapPixels;
+  } else if (Number.isFinite(overlapRatio)) {
+    fairRatio = overlapRatio;
+  }
+  let safeDimensionDelta = 0;
+  if (Number.isFinite(dimensionDeltaPixels)) {
+    safeDimensionDelta = dimensionDeltaPixels;
+  } else if (safeTotal > 0 && safeOverlapPixels > 0) {
+    safeDimensionDelta = safeTotal - safeOverlapPixels;
+  }
   const files = objectValue(obj.files);
   const artifacts = objectValue(obj.artifacts);
   const artifactSlots = objectValue(objectValue(obj.visual_parity_artifacts || obj.visualParityArtifacts).artifacts);

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -1,11 +1,17 @@
 // Finding classification, loss-class derivation, and honest loss-acceptance
 // (#535) for the Static Site Importer fixture matrix.
+/* eslint-disable camelcase -- Finding packets intentionally preserve snake_case artifact schema fields. */
 //
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
-
+/**
+ * External dependencies
+ */
 import path from 'node:path';
 
+/**
+ * Internal dependencies
+ */
 import {
   DEFAULT_FINDING_GROUPS,
   ACCEPTABLE_LOSS_CLASSES,

--- a/lib/fixture-matrix/fixtures.mjs
+++ b/lib/fixture-matrix/fixtures.mjs
@@ -3,10 +3,15 @@
 //
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
-
+/**
+ * External dependencies
+ */
 import fs from 'node:fs';
 import path from 'node:path';
 
+/**
+ * Internal dependencies
+ */
 import {
   FIXTURE_MATRIX_SCHEMA,
   FIXTURE_CLASSES,
@@ -190,8 +195,12 @@ export function normalizeManifestComplexity(value) {
 // no filter is requested. Supports a single class and one-or-more tags.
 function normalizeFixtureFilter(input = {}) {
   const classValue = normalizeFixtureClass(input.class || input.fixture_class || input.fixtureClass);
-  const fixtureClass = classValue && classValue !== 'unknown' ? classValue
-    : ((input.class || input.fixture_class || input.fixtureClass) ? 'unknown' : '');
+  let fixtureClass = '';
+  if (classValue && classValue !== 'unknown') {
+    fixtureClass = classValue;
+  } else if (input.class || input.fixture_class || input.fixtureClass) {
+    fixtureClass = 'unknown';
+  }
   const tags = normalizeManifestTags(input.tag || input.tags).map((tag) => tag.toLowerCase());
   const capabilities = normalizeManifestCapabilities(input.capability || input.capabilities);
   const riskProfile = input.risk_profile || input.riskProfile ? normalizeManifestRiskProfile(input.risk_profile || input.riskProfile) : '';

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -3,10 +3,15 @@
 //
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
-
+/**
+ * External dependencies
+ */
 import fs from 'node:fs';
 import path from 'node:path';
 
+/**
+ * Internal dependencies
+ */
 import {
   FIXTURE_MATRIX_RESULT_SCHEMA,
   ACCEPTABLE_LOSS_CLASSES,

--- a/lib/fixture-matrix/shared/utils.mjs
+++ b/lib/fixture-matrix/shared/utils.mjs
@@ -2,10 +2,15 @@
 //
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242). Pure utilities only — no behavior.
-
+/**
+ * External dependencies
+ */
 import fs from 'node:fs';
 import path from 'node:path';
 
+/**
+ * Internal dependencies
+ */
 import { DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD } from './constants.mjs';
 
 export function pushUnique(values, value, limit) {
@@ -56,13 +61,27 @@ export function isTruthySignal(value) {
 
 export function fileType(filePath) {
   const extension = path.extname(filePath).toLowerCase();
-  if (extension === '.html' || extension === '.htm') return 'text/html';
-  if (extension === '.css') return 'text/css';
-  if (extension === '.js' || extension === '.mjs') return 'application/javascript';
-  if (extension === '.svg') return 'image/svg+xml';
-  if (extension === '.png') return 'image/png';
-  if (extension === '.jpg' || extension === '.jpeg') return 'image/jpeg';
-  if (extension === '.webp') return 'image/webp';
+  if (extension === '.html' || extension === '.htm') {
+    return 'text/html';
+  }
+  if (extension === '.css') {
+    return 'text/css';
+  }
+  if (extension === '.js' || extension === '.mjs') {
+    return 'application/javascript';
+  }
+  if (extension === '.svg') {
+    return 'image/svg+xml';
+  }
+  if (extension === '.png') {
+    return 'image/png';
+  }
+  if (extension === '.jpg' || extension === '.jpeg') {
+    return 'image/jpeg';
+  }
+  if (extension === '.webp') {
+    return 'image/webp';
+  }
   return 'application/octet-stream';
 }
 
@@ -75,8 +94,12 @@ export function isTextPayloadType(type) {
 }
 
 export function normalizeArray(value) {
-  if (Array.isArray(value)) return value;
-  if (value === undefined || value === null || value === '') return [];
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value === undefined || value === null || value === '') {
+    return [];
+  }
   return [value];
 }
 
@@ -163,7 +186,9 @@ export function parseJsonPayloadsFromText(text) {
     candidates.add(trimmed.slice(firstObject, lastObject + 1));
   }
   for (const candidate of candidates) {
-    if (!candidate || !candidate.startsWith('{')) continue;
+    if (!candidate || !candidate.startsWith('{')) {
+      continue;
+    }
     try {
       const parsed = JSON.parse(candidate);
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
@@ -200,8 +225,8 @@ export function writeJsonFile(filePath, payload) {
   fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`);
 }
 
-export function artifactRef(artifact_id, filePath, kind) {
-  return { schema: 'homeboy/artifact-ref/v1', artifact_id, kind, path: filePath };
+export function artifactRef(artifactId, filePath, kind) {
+  return { schema: 'homeboy/artifact-ref/v1', artifact_id: artifactId, kind, path: filePath };
 }
 
 export function slug(value) {

--- a/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -3,7 +3,9 @@
 // Emits a WP Codebox validateBlock browser step for the fixture matrix.
 // The rig declares this runner capability up front so unavailable validation fails
 // before evidence runs instead of silently degrading to an editor-open smoke test.
-
+/**
+ * Internal dependencies
+ */
 import {
   EDITOR_VALIDATE_BLOCKS_COMMAND,
   DEFAULT_EDITOR_VALIDATION_TARGET,

--- a/lib/fixture-matrix/steps/live-wp-parity-step.mjs
+++ b/lib/fixture-matrix/steps/live-wp-parity-step.mjs
@@ -17,7 +17,9 @@
 // blocks-engine live-wp-parity runner by `runLiveWpParity`
 // (see ../collectors/live-wp-parity.mjs), which surfaces the live-WP parity score
 // and per-property diff alongside the render-free proxy score.
-
+/**
+ * Internal dependencies
+ */
 import {
   DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
   DEFAULT_VISUAL_PARITY_WAIT_FOR,

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -3,11 +3,16 @@
 //
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
-
+/**
+ * External dependencies
+ */
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+/**
+ * Internal dependencies
+ */
 import {
   WEBSITE_ARTIFACT_SCHEMA,
   DEFAULT_ENTRYPOINT,
@@ -274,82 +279,6 @@ function buildDependencyOverrideSetup(input, importer) {
       },
     ],
   };
-}
-
-function dependencyOverrideComposerSetupPhp({ pluginPath, packagePath, packageName }) {
-  return `
-if (!defined('STDERR')) {
-    define('STDERR', fopen('php://stderr', 'wb'));
-}
-if (!defined('STDOUT')) {
-    define('STDOUT', fopen('php://stdout', 'wb'));
-}
-$pluginPath = ${phpString(pluginPath)};
-$packagePath = ${phpString(packagePath)};
-$packageName = ${phpString(packageName)};
-$composerFile = $pluginPath . '/composer.json';
-$packageComposerFile = $packagePath . '/composer.json';
-if (!file_exists($composerFile)) {
-    fwrite(STDERR, "Static Site Importer composer.json not found at $composerFile\\n");
-    exit(1);
-}
-if (!file_exists($packageComposerFile)) {
-    fwrite(STDERR, "Dependency override composer.json not found at $packageComposerFile\\n");
-    exit(1);
-}
-$packageComposer = json_decode(file_get_contents($packageComposerFile), true);
-if (!is_array($packageComposer) || ($packageComposer['name'] ?? '') !== $packageName) {
-    fwrite(STDERR, "Dependency override package mismatch at $packageComposerFile\\n");
-    exit(1);
-}
-$composer = json_decode(file_get_contents($composerFile), true);
-if (!is_array($composer)) {
-    fwrite(STDERR, "Static Site Importer composer.json is invalid JSON at $composerFile\\n");
-    exit(1);
-}
-$constraint = $composer['require'][$packageName] ?? '0.1.15';
-$version = preg_match('/^\\^?(\\d+\\.\\d+\\.\\d+)$/', trim((string) $constraint), $matches) ? $matches[1] : '0.1.15';
-$composer['repositories'] = isset($composer['repositories']) && is_array($composer['repositories']) ? $composer['repositories'] : [];
-$composer['repositories']['blocks-engine-php-transformer-dev'] = [
-    'type' => 'path',
-    'url' => $packagePath,
-    'canonical' => true,
-    'options' => [
-        'symlink' => false,
-        'versions' => [ $packageName => $version ],
-    ],
-];
-file_put_contents($composerFile, json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\\n");
-$descriptorSpec = [
-    0 => ['pipe', 'r'],
-    1 => ['pipe', 'w'],
-    2 => ['pipe', 'w'],
-];
-$process = proc_open(['composer', 'update', $packageName, '--with-dependencies', '--no-interaction', '--prefer-source', '--no-progress'], $descriptorSpec, $pipes, $pluginPath);
-if (!is_resource($process)) {
-    fwrite(STDERR, "Failed to start composer for SSI dependency override\\n");
-    exit(1);
-}
-fclose($pipes[0]);
-$stdout = stream_get_contents($pipes[1]);
-$stderr = stream_get_contents($pipes[2]);
-fclose($pipes[1]);
-fclose($pipes[2]);
-$exitCode = proc_close($process);
-if ($exitCode !== 0) {
-    fwrite(STDERR, "SSI dependency override composer update failed with exit $exitCode\\n" . $stderr . $stdout);
-    exit($exitCode ?: 1);
-}
-`;
-}
-
-function phpString(value) {
-  return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
-}
-
-function wpCliDoubleQuotedToken(value) {
-  const text = String(value || '');
-  return `"${text.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
 // Convert an in-sandbox WordPress filesystem path into its web-served path by

--- a/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -13,7 +13,9 @@
 // because unbounded full-page capture OOM'd on tall (~6000px) pages. Full-page
 // capture remains available per-fixture via an explicit `full_page`/`fullPage`
 // opt-in.
-
+/**
+ * Internal dependencies
+ */
 import {
   DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD,
   DEFAULT_VISUAL_PARITY_CANDIDATE_URL,

--- a/tools/artifact-intake.mjs
+++ b/tools/artifact-intake.mjs
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 
+/**
+ * External dependencies
+ */
 import fs from 'node:fs';
+
+/**
+ * Internal dependencies
+ */
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
 
 const options = parseArgs(process.argv.slice(2));
@@ -16,11 +23,11 @@ if (options.manifest) {
 process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 
 function parseArgs(args) {
-  const options = {};
+  const parsedOptions = {};
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === '--help' || arg === '-h') {
-      options.help = true;
+      parsedOptions.help = true;
       continue;
     }
     if (arg.startsWith('--')) {
@@ -29,16 +36,16 @@ function parseArgs(args) {
       if (rawValue === undefined) {
         index += 1;
       }
-      options[camelCase(rawKey)] = value;
+      parsedOptions[camelCase(rawKey)] = value;
       continue;
     }
-    if (!options.artifactRoot) {
-      options.artifactRoot = arg;
-    } else if (!options.fixtureRoot) {
-      options.fixtureRoot = arg;
+    if (!parsedOptions.artifactRoot) {
+      parsedOptions.artifactRoot = arg;
+    } else if (!parsedOptions.fixtureRoot) {
+      parsedOptions.fixtureRoot = arg;
     }
   }
-  return options;
+  return parsedOptions;
 }
 
 function camelCase(value) {

--- a/tools/compare-finding-packets.mjs
+++ b/tools/compare-finding-packets.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+/**
+ * External dependencies
+ */
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
@@ -5,6 +8,10 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+
+/**
+ * Internal dependencies
+ */
 import runFixtureMatrixBench, {
   boundedConcurrency,
   composerPathRepositoryConfig,
@@ -43,7 +50,6 @@ import {
   buildFixtureArtifact,
   createFixtureMatrix,
   editorBlockValidationStep,
-  EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
   EDITOR_VALIDATE_BLOCKS_COMMAND,
   EDITOR_VALIDATION_METHOD,
   normalizeFixtureMatrixResult,
@@ -1386,14 +1392,14 @@ test('materializes generated artifact roots into matrix-compatible fixtures', ()
 
 test('resolves Blocks Engine PHP transformer override paths', () => {
   const repoRoot = mkdtempSync(path.join(tmpdir(), 'blocks-engine-'));
-  const packageRoot = path.join(repoRoot, 'php-transformer');
-  mkdirSync(packageRoot, { recursive: true });
-  writeFileSync(path.join(packageRoot, 'composer.json'), JSON.stringify({
+  const transformerPackageRoot = path.join(repoRoot, 'php-transformer');
+  mkdirSync(transformerPackageRoot, { recursive: true });
+  writeFileSync(path.join(transformerPackageRoot, 'composer.json'), JSON.stringify({
     name: 'automattic/blocks-engine-php-transformer',
   }));
 
-  assert.equal(resolveBlocksEnginePhpTransformerPath(repoRoot), packageRoot);
-  assert.equal(resolveBlocksEnginePhpTransformerPath(packageRoot), packageRoot);
+  assert.equal(resolveBlocksEnginePhpTransformerPath(repoRoot), transformerPackageRoot);
+  assert.equal(resolveBlocksEnginePhpTransformerPath(transformerPackageRoot), transformerPackageRoot);
 });
 
 test('builds Composer path repository override matching SSI constraints', () => {
@@ -1445,10 +1451,10 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-canonical-matrix-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
   const blocksEngine = path.join(root, 'blocks-engine');
-  const fixtureRoot = path.join(blocksEngine, 'fixtures', 'websites');
+  const canonicalFixtureRoot = path.join(blocksEngine, 'fixtures', 'websites');
   mkdirSync(staticSiteImporter, { recursive: true });
   for (let index = 1; index <= CANONICAL_FIXTURE_COUNT; index += 1) {
-    mkdirSync(path.join(fixtureRoot, `fixture-${String(index).padStart(2, '0')}`), { recursive: true });
+    mkdirSync(path.join(canonicalFixtureRoot, `fixture-${String(index).padStart(2, '0')}`), { recursive: true });
   }
 
   const plan = buildFixtureMatrixRunPlan({
@@ -1463,7 +1469,7 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
 
   assert.equal(plan.mode, 'development-override');
   assert.equal(plan.homeboy_bin, '/tmp/homeboy-latest');
-  assert.equal(plan.fixture_root, fixtureRoot);
+  assert.equal(plan.fixture_root, canonicalFixtureRoot);
   assert.equal(plan.fixture_count, CANONICAL_FIXTURE_COUNT);
   assert.equal(plan.fixture_count_matches_canonical, true);
   assert.equal(plan.namespace, 'ssi-matrix-dev-proof');
@@ -1481,7 +1487,7 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.equal(benchStep.command, '/tmp/homeboy-latest');
   assert.ok(benchStep.args.includes('--runner'));
   assert.ok(benchStep.args.includes('homeboy-lab'));
-  assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT=${fixtureRoot}`));
+  assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT=${canonicalFixtureRoot}`));
   assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH=${staticSiteImporter}`));
   assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH=${blocksEngine}`));
   assert.ok(benchStep.args.includes('bench_env.SSI_FIXTURE_MATRIX_RUN=1'));
@@ -1510,13 +1516,13 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
 test('fixture matrix operator plan forwards complexity lane settings', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-complexity-plan-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
-  const fixtureRoot = path.join(root, 'fixtures');
+  const laneFixtureRoot = path.join(root, 'fixtures');
   mkdirSync(staticSiteImporter, { recursive: true });
-  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+  mkdirSync(path.join(laneFixtureRoot, 'fixture-a'), { recursive: true });
 
   const plan = buildFixtureMatrixRunPlan({
     staticSiteImporter,
-    fixtureRoot,
+    fixtureRoot: laneFixtureRoot,
     complexity: '2',
     maxComplexity: '3',
     skipInstall: true,
@@ -1532,12 +1538,12 @@ test('fixture matrix operator plan forwards complexity lane settings', () => {
 test('fixture matrix records generic child command failures for failed WP Codebox batches', async () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-codebox-failure-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
-  const fixtureRoot = path.join(root, 'fixtures');
+  const failureFixtureRoot = path.join(root, 'fixtures');
   const outputDirectory = path.join(root, 'artifacts');
   const helperPath = path.join(root, 'wp-codebox-recipe-helper.cjs');
   mkdirSync(staticSiteImporter, { recursive: true });
-  mkdirSync(path.join(fixtureRoot, 'failing-fixture'), { recursive: true });
-  writeFileSync(path.join(fixtureRoot, 'failing-fixture', 'index.html'), '<h1>Failing fixture</h1>');
+  mkdirSync(path.join(failureFixtureRoot, 'failing-fixture'), { recursive: true });
+  writeFileSync(path.join(failureFixtureRoot, 'failing-fixture', 'index.html'), '<h1>Failing fixture</h1>');
   writeFileSync(helperPath, `
 function wpCodeboxBin() { return '/tmp/wp-codebox'; }
 function wpCodeboxCommand(bin) { return { command: bin, args: [] }; }
@@ -1562,7 +1568,7 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
 
   try {
     const { summary, runtimeError } = await runFixtureMatrix({
-      fixtureRoot,
+      fixtureRoot: failureFixtureRoot,
       outputDirectory,
       staticSiteImporterPath: staticSiteImporter,
       run: true,
@@ -1604,7 +1610,7 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     assert.equal(failure.artifact_refs.output_file, failure.artifact_refs.batch_output);
     assert.ok(readFileSync(path.join(outputDirectory, 'cli-run.json'), 'utf8').includes('child_command_failures'));
 
-    process.env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT = fixtureRoot;
+    process.env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT = failureFixtureRoot;
     process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY = path.join(root, 'bench-export-artifacts');
     process.env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH = staticSiteImporter;
     process.env.SSI_FIXTURE_MATRIX_RUN = '1';
@@ -1646,13 +1652,13 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
 test('WP Codebox recipe runner streams oversized child output and reads result JSON from --output', async () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-codebox-large-output-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
-  const fixtureRoot = path.join(root, 'fixtures');
+  const largeOutputFixtureRoot = path.join(root, 'fixtures');
   const outputDirectory = path.join(root, 'artifacts');
   const fakeCodeboxBin = path.join(root, 'fake-wp-codebox.mjs');
   const fixtureId = 'large-output-fixture';
   mkdirSync(staticSiteImporter, { recursive: true });
-  mkdirSync(path.join(fixtureRoot, fixtureId), { recursive: true });
-  writeFileSync(path.join(fixtureRoot, fixtureId, 'index.html'), '<h1>Large output fixture</h1>');
+  mkdirSync(path.join(largeOutputFixtureRoot, fixtureId), { recursive: true });
+  writeFileSync(path.join(largeOutputFixtureRoot, fixtureId, 'index.html'), '<h1>Large output fixture</h1>');
   writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 import { writeFileSync } from 'node:fs';
 const outputIndex = process.argv.indexOf('--output');
@@ -1669,7 +1675,7 @@ for (let index = 0; index < 12; index += 1) {
   chmodSync(fakeCodeboxBin, 0o755);
 
   const { summary, runtimeError } = await runFixtureMatrix({
-    fixtureRoot,
+    fixtureRoot: largeOutputFixtureRoot,
     outputDirectory,
     staticSiteImporterPath: staticSiteImporter,
     run: true,
@@ -1830,9 +1836,9 @@ test('code freshness guard blocks stale overrides unless explicitly allowed', ()
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-freshness-stale-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
   const blocksEngine = path.join(root, 'blocks-engine');
-  const fixtureRoot = path.join(blocksEngine, 'fixtures', 'websites');
+  const staleFixtureRoot = path.join(blocksEngine, 'fixtures', 'websites');
   mkdirSync(staticSiteImporter, { recursive: true });
-  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+  mkdirSync(path.join(staleFixtureRoot, 'fixture-a'), { recursive: true });
 
   const gitRunner = fakeGitRunner({
     [path.resolve(blocksEngine)]: { branch: 'trunk', upstream: 'origin/trunk', behind: 33, ahead: 0, commit: 'staleabc' },
@@ -1876,9 +1882,9 @@ test('code freshness guard lets fresh and diverged overrides through with accura
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-freshness-fresh-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
   const blocksEngine = path.join(root, 'blocks-engine');
-  const fixtureRoot = path.join(blocksEngine, 'fixtures', 'websites');
+  const freshFixtureRoot = path.join(blocksEngine, 'fixtures', 'websites');
   mkdirSync(staticSiteImporter, { recursive: true });
-  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+  mkdirSync(path.join(freshFixtureRoot, 'fixture-a'), { recursive: true });
 
   const freshPlan = buildFixtureMatrixRunPlan({
     staticSiteImporter,
@@ -1941,13 +1947,13 @@ function restoreEnv(key, value) {
 test('fixture matrix dry-run plan surfaces local fallback and dirty workspace warnings', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-warning-plan-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
-  const fixtureRoot = path.join(root, 'fixtures');
+  const warningFixtureRoot = path.join(root, 'fixtures');
   mkdirSync(staticSiteImporter, { recursive: true });
-  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+  mkdirSync(path.join(warningFixtureRoot, 'fixture-a'), { recursive: true });
 
   const plan = buildFixtureMatrixRunPlan({
     staticSiteImporter,
-    fixtureRoot,
+    fixtureRoot: warningFixtureRoot,
     runId: 'proof/run 1',
     allowLocalFallback: true,
     allowDirtyLabWorkspace: true,
@@ -1975,13 +1981,13 @@ test('fixture matrix dry-run plan surfaces local fallback and dirty workspace wa
 test('--local forces hot local execution and suppresses the auto-offload-risk warning', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-local-plan-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
-  const fixtureRoot = path.join(root, 'fixtures');
+  const localFixtureRoot = path.join(root, 'fixtures');
   mkdirSync(staticSiteImporter, { recursive: true });
-  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+  mkdirSync(path.join(localFixtureRoot, 'fixture-a'), { recursive: true });
 
   const plan = buildFixtureMatrixRunPlan({
     staticSiteImporter,
-    fixtureRoot,
+    fixtureRoot: localFixtureRoot,
     local: true,
     skipInstall: true,
     skipSync: true,
@@ -2261,18 +2267,18 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
 function setupConcurrencyWorkspace(prefix, fixtureCount) {
   const root = mkdtempSync(path.join(tmpdir(), prefix));
   const staticSiteImporter = path.join(root, 'static-site-importer');
-  const fixtureRoot = path.join(root, 'fixtures');
+  const concurrencyFixtureRoot = path.join(root, 'fixtures');
   const outputDirectory = path.join(root, 'artifacts');
   const helperPath = path.join(root, 'wp-codebox-recipe-helper.cjs');
   const statsFile = path.join(root, 'recipe-stats.json');
   mkdirSync(staticSiteImporter, { recursive: true });
   for (let index = 1; index <= fixtureCount; index += 1) {
-    const fixtureDir = path.join(fixtureRoot, `fixture-${String(index).padStart(2, '0')}`);
+    const fixtureDir = path.join(concurrencyFixtureRoot, `fixture-${String(index).padStart(2, '0')}`);
     mkdirSync(fixtureDir, { recursive: true });
     writeFileSync(path.join(fixtureDir, 'index.html'), `<h1>Fixture ${index}</h1>`);
   }
   writeConcurrencyRecipeHelper(helperPath);
-  return { root, staticSiteImporter, fixtureRoot, outputDirectory, helperPath, statsFile };
+  return { root, staticSiteImporter, fixtureRoot: concurrencyFixtureRoot, outputDirectory, helperPath, statsFile };
 }
 
 const CONCURRENCY_ENV_KEYS = [

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+/**
+ * External dependencies
+ */
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -183,9 +186,10 @@ function normalizeOptions(input) {
   const fixtureRoot = path.resolve(input.fixtureRoot || path.join(blocksEngine, 'fixtures', 'websites'));
 
   const defaultBlocksEnginePhpTransformerPath = input.mode === 'release-proof' ? '' : blocksEngine;
-  const blocksEnginePhpTransformerPath = input.blocksEnginePhpTransformerPath === undefined
-    ? defaultBlocksEnginePhpTransformerPath
-    : (input.blocksEnginePhpTransformerPath ? path.resolve(input.blocksEnginePhpTransformerPath) : '');
+  let blocksEnginePhpTransformerPath = defaultBlocksEnginePhpTransformerPath;
+  if (input.blocksEnginePhpTransformerPath !== undefined) {
+    blocksEnginePhpTransformerPath = input.blocksEnginePhpTransformerPath ? path.resolve(input.blocksEnginePhpTransformerPath) : '';
+  }
   const mode = input.mode || (blocksEnginePhpTransformerPath ? 'development-override' : 'release-proof');
   const runId = input.runId || `ssi-matrix-${mode}-${timestamp()}`;
   const namespace = sanitizePathSegment(input.namespace || runId);

--- a/tools/wp-codebox/recipe.mjs
+++ b/tools/wp-codebox/recipe.mjs
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { spawn, spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import fs from 'node:fs';


### PR DESCRIPTION
## Summary
- fix PHP release-gate PHPCS/PHPStan blockers
- fix fixture-matrix JavaScript ESLint blockers
- keep the changes focused on release-gate compliance so SSI can release after the php-transformer 0.2.5 dependency update

## Verification
- `composer validate --strict`
- `npm run test:fixture-matrix`
- `HOMEBOY_RELEASE_GATE_LOCAL_HOT=allowed homeboy lint static-site-importer --force-hot --allow-local-hot`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Coordinating PHP and JS release-gate cleanup agents, consolidating their patches, and verifying the release gate.
