### PR TITLE
ci: use review test command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: Extra-Chill/homeboy-action@42636bb42a936a11339ba8424c6589ea542a76e1  # v2.8.2
+      - uses: Extra-Chill/homeboy-action@51ae1b48299c60f3850f68780adb1a42951ce9c8  # v2.8.6
         with:
-          commands: test
+          commands: review test
           php-version: ${{ matrix.php-version }}
           node-version: '24'
           autofix: 'false'


### PR DESCRIPTION
Part of the review-pillar vocabulary cut (Extra-Chill/homeboy#7456, homeboy#7590).

Updates the Homeboy test workflow to the review-nested test command and refreshes the action SHA pin to the current v2 head.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Applied the workflow vocabulary update and prepared this PR.