### PR TITLE
Fix fixture matrix recipe failure flag

### DIFF
--- a/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -44,7 +44,7 @@ export function editorBlockValidationStep(input = {}) {
 
   return {
     command: EDITOR_VALIDATE_BLOCKS_COMMAND,
-    continue_on_error: true,
+    allowFailure: true,
     args,
     metadata: {
       fixture_id: fixture.id,

--- a/lib/fixture-matrix/steps/live-wp-parity-step.mjs
+++ b/lib/fixture-matrix/steps/live-wp-parity-step.mjs
@@ -41,7 +41,7 @@ export function liveWpParityCaptureStep(input = {}) {
     || options.candidateUrl;
   return {
     command: 'wordpress.capture-html',
-    continue_on_error: true,
+    allowFailure: true,
     args: [
       `url=${candidateUrl}`,
       // DOM HTML only — deterministic, no screenshot, no rasterization.

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -209,7 +209,7 @@ function fixturePluginProvisioningSteps(fixture) {
   const plugins = fixtureCapabilityPlugins(fixture);
   return plugins.map((plugin) => ({
     command: 'wordpress.plugin-setup',
-    continue_on_error: true,
+    allowFailure: true,
     args: [
       'action=install',
       `plugin=${shellToken(plugin.slug)}`,

--- a/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -66,7 +66,7 @@ export function visualParityCompareStep(input = {}) {
     || options.candidateUrl;
   return {
     command: 'wordpress.visual-compare',
-    continue_on_error: true,
+    allowFailure: true,
     args: [
       `source-url=${sourceUrl}`,
       `candidate-url=${candidateUrl}`,

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -188,7 +188,7 @@ test('fixture capability manifests drive per-fixture plugin provisioning without
   assert.deepEqual(fixtureSteps('shop-site')[0].args, ['action=install', 'plugin=woocommerce', 'activate=true']);
   assert.deepEqual(fixtureSteps('shop-forms-site')[0].args, ['action=install', 'plugin=woocommerce', 'activate=true']);
   assert.deepEqual(fixtureSteps('shop-forms-site')[1].args, ['action=install', 'plugin=jetpack', 'activate=true']);
-  assert.equal(fixtureSteps('shop-site')[0].continue_on_error, true);
+  assert.equal(fixtureSteps('shop-site')[0].allowFailure, true);
   assert.equal(recipe.workflow.steps.some((step) => /--allow-missing-woocommerce/.test(step.args?.[0] || '')), false);
 });
 
@@ -2597,7 +2597,7 @@ test('recipe runs editor-validate-blocks against imported content after each imp
   assert.equal(editorStep.args.some((arg) => arg.startsWith('post-type=')), false);
   assert.ok(editorStep.args.includes('target=front-page'));
   assert.equal(editorStep.args.some((arg) => arg.startsWith('capture=')), false);
-  assert.equal(editorStep.continue_on_error, true);
+  assert.equal(editorStep.allowFailure, true);
 
   const disabled = buildFixtureMatrixRecipe({
     matrix,
@@ -2698,7 +2698,7 @@ test('editorBlockValidationStep emits editor-validate-blocks against real import
   // page_on_front, while the imported post ID is not known at recipe-build time.
   const fallback = editorBlockValidationStep({ fixture: { id: 'simple' } });
   assert.equal(fallback.command, 'wordpress.editor-validate-blocks');
-  assert.equal(fallback.continue_on_error, true);
+  assert.equal(fallback.allowFailure, true);
   assert.deepEqual(fallback.args, ['target=front-page']);
 
   // An explicit editor URL (e.g. post.php?post=<id>&action=edit) is honored.
@@ -2970,9 +2970,9 @@ test('fixture matrix recipe steps emit fixture attribution metadata for import e
 
   assert.equal(steps.find((step) => step.metadata.phase === 'import').metadata.artifact, '/artifacts/static-site-importer-fixture-matrix/simple-site/artifact.json');
   assert.equal(steps.find((step) => step.metadata.phase === 'editor').metadata.target, 'front-page');
-  assert.equal(steps.find((step) => step.metadata.phase === 'editor').continue_on_error, true);
+  assert.equal(steps.find((step) => step.metadata.phase === 'editor').allowFailure, true);
   assert.equal(steps.find((step) => step.metadata.phase === 'visual').metadata.candidate_url, '/');
-  assert.equal(steps.find((step) => step.metadata.phase === 'visual').continue_on_error, true);
+  assert.equal(steps.find((step) => step.metadata.phase === 'visual').allowFailure, true);
   assert.match(steps.find((step) => step.metadata.phase === 'visual').metadata.source_url, /simple-site\/source\/index\.html$/);
 });
 
@@ -3500,7 +3500,7 @@ test('visualParityCompareStep composes the existing wordpress.visual-compare com
     pixelThreshold: 0.2,
   });
   assert.equal(step.command, 'wordpress.visual-compare');
-  assert.equal(step.continue_on_error, true);
+  assert.equal(step.allowFailure, true);
   assert.ok(step.args.includes('source-url=http://127.0.0.1:4173/shop/index.html'));
   assert.ok(step.args.includes('candidate-url=/?p=42'));
   assert.ok(step.args.includes('threshold=0.2'));
@@ -4197,7 +4197,7 @@ test('live-WP parity capture step renders DOM HTML deterministically with extern
 
   // The standalone step builder honors a per-fixture candidate override.
   const overridden = liveWpParityCaptureStep({ fixture: { id: 'x', candidate_url: '/about/' } });
-  assert.equal(overridden.continue_on_error, true);
+  assert.equal(overridden.allowFailure, true);
   assert.equal(overridden.metadata.fixture_id, 'x');
   assert.ok(overridden.args.includes('url=/about/'));
 });


### PR DESCRIPTION
## Summary
- Replace generated WP Codebox recipe step `continue_on_error` properties with the supported `allowFailure` boolean.
- Update fixture-matrix assertions to lock the recipe wire format to `allowFailure`.

## Root cause
SSI PR #550 emitted `continue_on_error: true` in generated `workspace-recipe/v1` steps. WP Codebox recipe steps use an `additionalProperties: false` schema, so that unsupported property fails schema validation with `$.workflow.steps[N] must NOT have additional properties`.

## Verified upstream contract
The WP Codebox step fault-isolation property is `allowFailure` (boolean), not `continue_on_error`. This change keeps the existing fault-isolation semantics while emitting the contract-supported property name.

## Proof
- `node tools/fixture-matrix.test.mjs` passes: 126 tests, 0 failures.
- Generated a real dry fixture-matrix recipe; generated steps contain `allowFailure` and no `continue_on_error` matches.
- Validated that generated recipe with local WP Codebox: `wp-codebox recipe validate --recipe <generated-recipe> --json` returned `valid: true` with 19 steps and zero issues.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagent
- **Used for:** Root-cause analysis of the recipe schema rejection and drafting the property rename + test updates