### PR TITLE
Avoid duplicate main wrapper in generated templates

### DIFF
--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -52,7 +52,7 @@ class Static_Site_Importer_Theme_Materializer {
 		return trim(
 			$header_part . "\n\n" .
 			$background_blocks . "\n\n" .
-			'<!-- wp:post-content {"tagName":"main"} /-->' . "\n\n" .
+			'<!-- wp:post-content /-->' . "\n\n" .
 			$footer_part
 		) . "\n";
 	}

--- a/tests/smoke-theme-materializer-dry-run.php
+++ b/tests/smoke-theme-materializer-dry-run.php
@@ -150,7 +150,10 @@ $theme_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes(
 	false
 );
 $theme_json   = json_decode( $theme_writes[ $theme_dir . '/theme.json' ] ?? '', true );
+$front_page_template = (string) ( $theme_writes[ $theme_dir . '/templates/front-page.html' ] ?? '' );
 $assert( is_array( $theme_json ), 'generated-theme-json-decodes' );
+$assert( str_contains( $front_page_template, '<!-- wp:post-content /-->' ), 'post-content-template-uses-neutral-wrapper' );
+$assert( ! str_contains( $front_page_template, '"tagName":"main"' ), 'post-content-template-does-not-duplicate-source-main-selector' );
 $assert(
 	'"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif' === ( $theme_json['styles']['typography']['fontFamily'] ?? '' ),
 	'body-font-family-is-materialized-in-theme-json',


### PR DESCRIPTION
## Summary
- Avoid emitting a second `<main>` wrapper in generated content templates by using the neutral post-content wrapper.
- Add smoke coverage to assert the generated front-page template does not include the duplicate `tagName":"main"` selector target.

## Root cause
SSI content template emitted `<!-- wp:post-content {"tagName":"main"} /-->`, creating a second `<main>` that source CSS targets. That doubled the nav-height padding and produced a blank band pushing the hero down.

## Evidence
- `php tests/smoke-theme-materializer-dry-run.php`
- `node tools/fixture-matrix.test.mjs`
- Fixture-matrix visual parity for `3-artist-music` improved `0.9939 -> 0.1471` in a controlled run with only this + button fix applied.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-cause analysis via fixture-matrix visual parity evidence, fix drafting, and regression tests