### PR TITLE
Harden fixture matrix visual diagnostics

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -798,8 +798,8 @@ function optionsFromEnv(env = process.env) {
     wpCodeboxBin: benchEnv.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN || env.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN,
     editorValidation: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION ?? env.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION),
     visualParity: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY),
-    visualParityGate: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE) || isTruthy(env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE),
-    visualParityFullPage: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE) || isTruthy(env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE),
+    visualParityGate: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE ?? true),
+    visualParityFullPage: optionalBoolean(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE),
     // Opt-in live-WP parity capture + comparison. Off by default; mirrors the
     // visual-parity-gate truthy env mapping. When on, the recipe appends the
     // capture-html step and the result collector runs the live-wp-parity comparator.
@@ -822,7 +822,7 @@ function editorValidationRecipeInput(options) {
 }
 
 // Visual-parity options shared by the recipe (capture step) and the result
-// collector (gating). Enable defaults on; gating defaults off (opt-in).
+// collector (gating). Capture and gating default on for honest dev-loop fidelity.
 function visualParityRecipeInput(options) {
   return {
     visualParity: options.visualParity !== false,
@@ -836,7 +836,7 @@ function visualParityRecipeInput(options) {
 function visualParityGateInput(options) {
   return {
     threshold: options.pixelThreshold,
-    gate: options.visualParityGate === true,
+    gate: options.visualParityGate !== false,
   };
 }
 
@@ -891,6 +891,13 @@ function isTruthy(value) {
 
 function isFalsy(value) {
   return value === false || value === '0' || value === 'false' || value === 'no' || value === 'off';
+}
+
+function optionalBoolean(value) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  return !isFalsy(value);
 }
 
 function chunk(items, size) {

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -70,10 +70,12 @@ performance benchmark. The rig and wrapper run a single Homeboy bench iteration
 by default; use repeated runs only for explicitly separate performance work.
 
 Output is a JSON operator summary with the run ID, fixture count, pass/fail
-counts, finding count, top buckets/kinds when present in Homeboy output, artifact
-URLs, and the structured Homeboy bench output file. Pass `--dry-run` to inspect
-the composed commands without running Lab/WP Codebox. Arguments after `--` are
-forwarded to the lower-level bench, preserving the existing script options:
+counts, finding count, top buckets/kinds when present in Homeboy output, a
+`run_refs` block with ready-to-run `homeboy runs show <id>` / `homeboy runs
+artifacts <id>` commands, artifact URLs, and the structured Homeboy bench output
+file. Pass `--dry-run` to inspect the composed commands without running
+Lab/WP Codebox. Arguments after `--` are forwarded to the lower-level bench,
+preserving the existing script options:
 
 ### Code freshness guard
 
@@ -270,31 +272,31 @@ Structural, feature, and editor-block validity all run *without ever rendering a
 browser*. After each fixture's import step, `buildFixtureMatrixRecipe` appends a
 `wordpress.visual-compare` step that renders the fixture's original static source
 vs the imported WordPress candidate in the same WP Codebox sandbox and emits
-`source.png`/`candidate.png`/`diff.png` plus `mismatch_pixels`/`total_pixels`
-(`wp-codebox/visual-compare/v1`). This is the exact recipe command the reusable
-`runVisualParityWorkload` helper composes in homeboy-extensions — the matrix
-emits it inline rather than spinning up a separate sandbox, so no new wp-codebox
-capability is introduced.
+`source.png`/`candidate.png`/`diff.png` plus `mismatch_pixels`/`total_pixels`.
+SSI sends the command as a one-entry `matrix-json` comparison so wp-codebox writes
+screenshots under `files/browser/visual-compare/<fixture-id>/...`; batch runs keep
+per-fixture visual evidence instead of overwriting every fixture into the default
+`files/browser/visual-compare/{source,candidate,diff}.png` paths. This is the
+exact recipe command the reusable `runVisualParityWorkload` helper composes in
+homeboy-extensions — the matrix emits it inline rather than spinning up a
+separate sandbox, so no new wp-codebox capability is introduced.
 
 `collectVisualParityDiagnostics` reads the comparison back out (from either the
-raw `wp-codebox/visual-compare/v1` diff or a normalized
-`homeboy/VisualParityArtifact/v1` artifact) and emits a `visual_parity_mismatch`
-diagnostic when `mismatch_pixels / total_pixels` exceeds the threshold (or a
-dimension mismatch is reported). Findings route to the visual-parity repair
-bucket (`candidate_repo: blocks-engine`, `repair_mode: visual-parity`). The
-screenshots, diff, and metrics are also captured into the SSI
+raw `wp-codebox/visual-compare/v1` diff, a `wp-codebox/visual-compare-matrix/v1`
+summary, or a normalized `homeboy/VisualParityArtifact/v1` artifact) and emits a
+`visual_parity_mismatch` diagnostic when the dimension-fair mismatch ratio
+exceeds the threshold. Findings route to the visual-parity repair bucket
+(`candidate_repo: blocks-engine`, `repair_mode: visual-parity`). The screenshots,
+diff, and metrics are also captured into the SSI
 `visual_parity_artifacts` slot (`static-site-importer/visual-parity-artifacts/v1`)
 on the fixture result, even when the gate is off.
 
-Gating is **opt-in**, because pixel diffs can be flaky. By default a mismatch is
-captured but non-gating (the `visual_parity_mismatch` loss class resolves to
-`acceptable`). Pass `--visual-parity-gate` (run wrapper) /
-`SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=1` to make a mismatch-over-threshold a
-HARD gate (the loss class flips to the unacceptable, fixture-failing form, the
-same conditional-acceptance pattern as `preserved_runtime_island`). The mismatch
-threshold is configurable via `--pixel-threshold` /
-`SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD` (default `0.1`, also passed as
-the per-pixel `threshold=` arg so a higher value loosens the gate monotonically).
+The dev-loop wrapper gates visual parity by default because the fixture matrix is
+deterministic transformer feedback: a fidelity gate that ignores fidelity is not
+honest. Pass `--no-visual-parity-gate` /
+`SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=0` for exploratory capture-only runs. The
+mismatch threshold is configurable via `--pixel-threshold` /
+`SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD` (default exact parity, `0`).
 Set `--no-visual-parity` / `visualParity: false` to omit the step entirely.
 
 Source/candidate wiring (verified by real local recipe-runs): the
@@ -314,18 +316,10 @@ to target a specific staged page or imported permalink. The wiring,
 source-staging, finding-parsing, threshold, and gating logic are unit-tested in
 `tools/fixture-matrix.test.mjs`.
 
-Sandbox egress note: a captured page that references external resources (Google
-Fonts, CDNs) would otherwise hang an egress-free sandbox until the 120s browser
-timeout. `wordpress.visual-compare` aborts cross-origin requests during capture by
-default (`block-external-requests`, wp-codebox) so both source and candidate
-render deterministically (offline, system-font fallback) and the comparison
-completes fast. Real measured ratios (15-saas, 38-medical-clinic, default
-viewport): the imported candidate currently diverges sharply from the source
-(0.94 and 0.44 mismatch ratios with dimension drift) — dominated by oversized
-inline SVG icons that lose CSS sizing and a frontend theme stylesheet that is not
-applied to the rendered page. The gate is capture-only by default
-(`--visual-parity-gate` to enforce); at any reasonable `--pixel-threshold` these
-imports are nowhere near the 1:1 project gate.
+Capture is full-page by default. wp-codebox's URL-target default is also
+full-page, but SSI previously overrode it with `full-page=false`, which limited
+the evidence to the requested viewport and missed below-the-fold regressions. Use
+`visualParityFullPage: false` only for an explicitly bounded exploratory run.
 
 ## Running the matrix locally
 

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -102,6 +102,7 @@ function collectVisualParityComparisons(payload) {
     ...normalizeArray(payload.visual_parity_artifacts || payload.visualParityArtifacts),
     ...normalizeArray(payload.visual_compare || payload.visualCompare),
     ...normalizeArray(payload.visual_diff || payload.visualDiff),
+    ...normalizeArray(payload.comparisons),
     ...normalizeArray(payload.visual_parity?.comparisons || payload.visualParity?.comparisons),
     ...normalizeArray(payload.visual_explanation?.comparisons || payload.visualExplanation?.comparisons),
   ];

--- a/lib/fixture-matrix/shared/constants.mjs
+++ b/lib/fixture-matrix/shared/constants.mjs
@@ -51,8 +51,8 @@ export const EDITOR_BLOCK_INVALID_DEFAULT_DETAIL = 'This block contains unexpect
 // command emits `source.png`/`candidate.png`/`diff.png` plus
 // `mismatch_pixels`/`total_pixels`, which `collectVisualParityDiagnostics` reads
 // back out. No new wp-codebox capability is introduced. Capture is on by
-// default; gating on mismatch-over-threshold is opt-in (pixel diffs can be
-// flaky) and is expressed as the conditional `visual_parity_mismatch` loss class.
+// default; the dev-loop wrapper gates on mismatch-over-threshold by default, with
+// an explicit exploratory opt-out.
 export const VISUAL_PARITY_MISMATCH_KIND = 'visual_parity_mismatch';
 export const VISUAL_TIMEOUT_KIND = 'visual_timeout';
 
@@ -95,8 +95,8 @@ export const DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL = '/wp-content/uploads/static
 export const VISUAL_PARITY_SOURCE_SUBDIR = 'source';
 export const DEFAULT_VISUAL_PARITY_VIEWPORT = { width: 1280, height: 1600 };
 export const DEFAULT_VISUAL_PARITY_WAIT_FOR = 'domcontentloaded';
-// A finding only gates when it carries an explicit opt-in gate signal; absent
-// that, a mismatch is captured but non-gating (capture-only default).
+// A finding gates when it carries an explicit gate signal. The dev-loop wrapper
+// sends this by default; direct collector callers can still run capture-only.
 export const VISUAL_PARITY_GATE_SIGNAL_KEYS = ['gate', 'visual_parity_gate', 'visualParityGate'];
 
 export const DEFAULT_FINDING_GROUPS = {

--- a/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -3,16 +3,8 @@
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
 //
-// PRIMARY PARITY SIGNAL: the deterministic, render-free static style parity gate
-// (blocks-engine php-transformer `composer static-parity`) is the primary parity
-// signal — same inputs yield a byte-identical 0..1 score plus a per-element /
-// per-property diff, with no rasterization, no dimension-sensitivity, and no OOM.
-// This full-page pixelmatch step is DEMOTED to optional visual EVIDENCE: it is
-// non-gating by default (see findings.mjs `resolveLossAcceptance`) and now also
-// captures a bounded viewport by default rather than a full-page screenshot,
-// because unbounded full-page capture OOM'd on tall (~6000px) pages. Full-page
-// capture remains available per-fixture via an explicit `full_page`/`fullPage`
-// opt-in.
+// PRIMARY PARITY SIGNAL: fixture-matrix visual parity is full-page by default so
+// below-the-fold regressions are visible and, in the dev loop, gating.
 /**
  * Internal dependencies
  */
@@ -24,7 +16,7 @@ import {
   DEFAULT_VISUAL_PARITY_WAIT_FOR,
   VISUAL_PARITY_SOURCE_SUBDIR,
 } from '../shared/constants.mjs';
-import { objectValue, finiteNumber, isTruthySignal } from '../shared/utils.mjs';
+import { objectValue, finiteNumber } from '../shared/utils.mjs';
 
 // Compose the existing `wordpress.visual-compare` recipe command into a
 // per-fixture visual-parity step. This is the same command the reusable
@@ -64,19 +56,27 @@ export function visualParityCompareStep(input = {}) {
     || fixture.candidate_url
     || fixture.candidateUrl
     || options.candidateUrl;
+  const matrix = {
+    comparisons: [
+      {
+        name: fixture.id || 'fixture',
+        sourceUrl,
+        candidateUrl,
+        sourceLabel: fixture.id ? `${fixture.id}-source` : 'source',
+        candidateLabel: fixture.id ? `${fixture.id}-candidate` : 'candidate',
+        viewport: `${options.viewport.width}x${options.viewport.height}`,
+        fullPage: options.fullPage,
+        waitFor: options.waitFor,
+        blockExternalRequests: options.blockExternalRequests,
+        threshold: options.pixelThreshold,
+      },
+    ],
+  };
   return {
     command: 'wordpress.visual-compare',
     allowFailure: true,
     args: [
-      `source-url=${sourceUrl}`,
-      `candidate-url=${candidateUrl}`,
-      `source-label=${fixture.id ? `${fixture.id}-source` : 'source'}`,
-      `candidate-label=${fixture.id ? `${fixture.id}-candidate` : 'candidate'}`,
-      `viewport=${options.viewport.width}x${options.viewport.height}`,
-      `full-page=${options.fullPage ? 'true' : 'false'}`,
-      `wait-for=${options.waitFor}`,
-      `block-external-requests=${options.blockExternalRequests ? 'true' : 'false'}`,
-      `threshold=${options.pixelThreshold}`,
+      `matrix-json=${JSON.stringify(matrix)}`,
     ],
     metadata: {
       fixture_id: fixture.id,
@@ -99,10 +99,7 @@ export function normalizeVisualParityRecipeOptions(input = {}) {
       width: finiteNumber(viewport.width, DEFAULT_VISUAL_PARITY_VIEWPORT.width),
       height: finiteNumber(viewport.height, DEFAULT_VISUAL_PARITY_VIEWPORT.height),
     },
-    // Demoted to optional evidence: full-page capture is opt-in (default false)
-    // so the OOM-prone unbounded screenshot is never the default. Any truthy
-    // `full_page`/`fullPage`/`visual_parity_full_page` re-enables it per fixture.
-    fullPage: isTruthySignal(input.visualParityFullPage ?? input.visual_parity_full_page ?? input.fullPage),
+    fullPage: !isFalseySignal(input.visualParityFullPage ?? input.visual_parity_full_page ?? input.fullPage ?? input.full_page ?? true),
     waitFor: input.visualParityWaitFor || input.visual_parity_wait_for || input.waitFor || DEFAULT_VISUAL_PARITY_WAIT_FOR,
     blockExternalRequests: !isFalseySignal(input.visualParityBlockExternalRequests ?? input.visual_parity_block_external_requests ?? input.blockExternalRequests ?? input.block_external_requests),
   };

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1243,6 +1243,35 @@ test('emits one visual parity mismatch when raw and artifact evidence describe t
   assert.equal(diagnostics[0].source_path, 'file:///tmp/source/index.html');
 });
 
+test('collects visual parity artifacts from wp-codebox matrix summaries with per-fixture refs', () => {
+  const diagnostics = collectVisualParityDiagnostics({
+    schema: 'wp-codebox/visual-compare-matrix/v1',
+    comparisons: [
+      {
+        name: 'simple-site',
+        source: { url: 'file:///tmp/artifacts/simple-site/source/index.html' },
+        files: {
+          sourceScreenshot: 'files/browser/visual-compare/simple-site/source.png',
+          candidateScreenshot: 'files/browser/visual-compare/simple-site/candidate.png',
+          diffScreenshot: 'files/browser/visual-compare/simple-site/diff.png',
+          visualDiff: 'files/browser/visual-compare/simple-site/visual-diff.json',
+        },
+        comparison: {
+          mismatchPixels: 994,
+          totalPixels: 1000,
+          overlapMismatchPixels: 994,
+          overlapPixels: 1000,
+          dimensionMismatch: false,
+        },
+      },
+    ],
+  }, { threshold: 0, gate: true });
+
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].visual_parity_gate, true);
+  assert.equal(diagnostics[0].artifact_refs.find((ref) => ref.artifact_id === 'diff_screenshot').path, 'files/browser/visual-compare/simple-site/diff.png');
+});
+
 test('fixture diagnostics drop empty rows and normalize kindless carriers with explicit kind', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-diagnostic-hygiene-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'diagnostic-hygiene-test' });
@@ -1491,6 +1520,7 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH=${staticSiteImporter}`));
   assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH=${blocksEngine}`));
   assert.ok(benchStep.args.includes('bench_env.SSI_FIXTURE_MATRIX_RUN=1'));
+  assert.ok(benchStep.args.includes('bench_env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=1'));
   assert.ok(benchStep.args.includes('static_site_importer_fixture_matrix_namespace=ssi-matrix-dev-proof'));
   assert.ok(benchStep.args.includes('/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/artifacts'));
   assert.deepEqual(benchStep.args.slice(-3), ['--', '--batch-size', '5']);
@@ -1511,6 +1541,14 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
     output: explicitOutput,
   });
   assert.equal(explicitOutputPlan.output_file, explicitOutput);
+
+  const visualGateOptOutPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    blocksEngine,
+    visualParityGate: false,
+  });
+  assert.equal(visualGateOptOutPlan.visual_parity.gate, false);
+  assert.ok(visualGateOptOutPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=0'));
 });
 
 test('fixture matrix operator plan forwards complexity lane settings', () => {
@@ -1633,7 +1671,7 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     );
     const benchBatchRecipe = JSON.parse(readFileSync(benchResult.metadata.child_command_failures[0].artifact_refs.batch_recipe, 'utf8'));
     const benchVisualStep = benchBatchRecipe.workflow.steps.find((step) => step.command === 'wordpress.visual-compare');
-    assert.ok(benchVisualStep.args.includes('full-page=true'), 'bench env can opt visual parity back into full-page screenshots');
+    assert.equal(visualCompareMatrixComparison(benchVisualStep).fullPage, true, 'bench defaults visual parity to full-page screenshots');
   } finally {
     if (previousHelper === undefined) {
       delete process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
@@ -1800,6 +1838,14 @@ test('CLI --no-visual-parity disables visual steps and records a safe WP Codebox
   ]);
   assert.match(summary.replay.command, /wp-codebox recipe-run --recipe .* --artifacts .* --json/);
 });
+
+function visualCompareMatrixComparison(step) {
+  const matrixArg = step.args.find((arg) => typeof arg === 'string' && arg.startsWith('matrix-json='));
+  assert.ok(matrixArg, 'expected wordpress.visual-compare to use matrix-json');
+  const matrix = JSON.parse(matrixArg.slice('matrix-json='.length));
+  assert.equal(matrix.comparisons.length, 1);
+  return matrix.comparisons[0];
+}
 
 function fakeGitRunner(stateByPath) {
   return (cwd, args) => {
@@ -2035,6 +2081,11 @@ test('operator summary preserves matrix rollups for fanout agents', () => {
   });
 
   assert.equal(summary.run_id, 'ssi-matrix-rollup-proof');
+  assert.deepEqual(summary.run_refs, {
+    homeboy_run_id: 'ssi-matrix-rollup-proof',
+    show: 'homeboy runs show ssi-matrix-rollup-proof',
+    artifacts: 'homeboy runs artifacts ssi-matrix-rollup-proof',
+  });
   assert.equal(summary.top_pattern_families[0].count, 312);
   assert.equal(summary.fixture_exemplars[0].fixture_id, 'shader-site');
   assert.equal(summary.diagnostic_blind_spots[0].kind, 'missing_source_context');
@@ -2074,6 +2125,7 @@ test('summarizeBenchRun emits the operator summary on a gate-FAIL instead of thr
   assert.equal(result.summary.failed_fixture_count, 2);
   assert.equal(result.summary.finding_count, 22);
   assert.deepEqual(result.summary.top_buckets[0], { key: 'runtime_target_gap', count: 18 });
+  assert.equal(result.summary.run_refs.show, 'homeboy runs show ssi-live-2');
   assert.deepEqual(result.summary.artifact_urls, ['homeboy-runs:ssi-live-2', 'https://example.test/report.json']);
 });
 
@@ -3471,10 +3523,11 @@ test('recipe runs a wordpress.visual-compare visual-parity step after each impor
   // [activate, validate(simple-site), editor-validation(simple-site), visual-compare(simple-site)]
   const visualStep = recipe.workflow.steps[3];
   assert.equal(visualStep.command, 'wordpress.visual-compare');
-  assert.ok(visualStep.args.some((arg) => arg.startsWith('source-url=')));
-  assert.ok(visualStep.args.some((arg) => arg.startsWith('candidate-url=')));
-  assert.ok(visualStep.args.includes('block-external-requests=true'));
-  assert.ok(visualStep.args.includes('threshold=0.05'));
+  const comparison = visualCompareMatrixComparison(visualStep);
+  assert.equal(comparison.sourceUrl, 'file:///tmp/artifacts/simple-site/source/index.html');
+  assert.equal(comparison.candidateUrl, '/');
+  assert.equal(comparison.fullPage, true);
+  assert.equal(comparison.threshold, 0.05);
 
   const defaultThresholdRecipe = buildFixtureMatrixRecipe({
     matrix,
@@ -3483,7 +3536,7 @@ test('recipe runs a wordpress.visual-compare visual-parity step after each impor
   });
   const defaultThresholdVisualStep = defaultThresholdRecipe.workflow.steps[3];
   assert.equal(defaultThresholdVisualStep.command, 'wordpress.visual-compare');
-  assert.ok(defaultThresholdVisualStep.args.includes('threshold=0'), 'visual parity defaults to exact pixel parity');
+  assert.equal(visualCompareMatrixComparison(defaultThresholdVisualStep).threshold, 0, 'visual parity defaults to exact pixel parity');
 
   const disabled = buildFixtureMatrixRecipe({
     matrix,
@@ -3501,28 +3554,26 @@ test('visualParityCompareStep composes the existing wordpress.visual-compare com
   });
   assert.equal(step.command, 'wordpress.visual-compare');
   assert.equal(step.allowFailure, true);
-  assert.ok(step.args.includes('source-url=http://127.0.0.1:4173/shop/index.html'));
-  assert.ok(step.args.includes('candidate-url=/?p=42'));
-  assert.ok(step.args.includes('threshold=0.2'));
-  assert.ok(step.args.includes('source-label=shop-source'));
-  assert.ok(step.args.includes('candidate-label=shop-candidate'));
-  assert.ok(step.args.includes('block-external-requests=true'));
-  assert.ok(visualParityCompareStep({ fixture: { id: 'shop' }, block_external_requests: false }).args.includes('block-external-requests=false'));
+  const comparison = visualCompareMatrixComparison(step);
+  assert.equal(comparison.name, 'shop');
+  assert.equal(comparison.sourceUrl, 'http://127.0.0.1:4173/shop/index.html');
+  assert.equal(comparison.candidateUrl, '/?p=42');
+  assert.equal(comparison.threshold, 0.2);
+  assert.equal(comparison.sourceLabel, 'shop-source');
+  assert.equal(comparison.candidateLabel, 'shop-candidate');
+  assert.equal(comparison.fullPage, true);
 });
 
-test('visualParityCompareStep demotes full-page capture to an opt-in (default bounded viewport)', () => {
-  // Default: full-page is OFF (the OOM-prone unbounded screenshot is no longer
-  // the default; the deterministic static parity gate is the primary signal).
+test('visualParityCompareStep requests full-page capture by default with explicit opt-out', () => {
   const defaultStep = visualParityCompareStep({ fixture: { id: 'tall' } });
-  assert.ok(defaultStep.args.includes('full-page=false'));
+  assert.equal(visualCompareMatrixComparison(defaultStep).fullPage, true);
 
-  // Opt-in per fixture re-enables full-page evidence.
-  for (const optIn of [
-    { fixture: { id: 'tall' }, fullPage: true },
-    { fixture: { id: 'tall' }, visual_parity_full_page: true },
-    { fixture: { id: 'tall' }, visualParityFullPage: true },
+  for (const optOut of [
+    { fixture: { id: 'tall' }, fullPage: false },
+    { fixture: { id: 'tall' }, full_page: 'false' },
+    { fixture: { id: 'tall' }, visual_parity_full_page: '0' },
   ]) {
-    assert.ok(visualParityCompareStep(optIn).args.includes('full-page=true'));
+    assert.equal(visualCompareMatrixComparison(visualParityCompareStep(optOut)).fullPage, false);
   }
 });
 
@@ -3537,13 +3588,12 @@ test('default visual-parity source-url targets the staged source/ subdir as a fi
 
   // [activate, validate(simple-site), editor-validation(simple-site), visual-compare(simple-site)]
   const visualStep = recipe.workflow.steps[3];
-  const sourceArg = visualStep.args.find((arg) => arg.startsWith('source-url='));
   assert.equal(
-    sourceArg,
-    'source-url=file:///tmp/artifacts/simple-site/source/index.html',
+    visualCompareMatrixComparison(visualStep).sourceUrl,
+    'file:///tmp/artifacts/simple-site/source/index.html',
   );
   // Candidate defaults to the imported front page served at `/`.
-  assert.ok(visualStep.args.includes('candidate-url=/'));
+  assert.equal(visualCompareMatrixComparison(visualStep).candidateUrl, '/');
 });
 
 test('explicit visual-parity source base can still target a served uploads path', () => {
@@ -3557,7 +3607,7 @@ test('explicit visual-parity source base can still target a served uploads path'
   });
 
   const visualStep = recipe.workflow.steps[3];
-  assert.ok(visualStep.args.includes('source-url=/wp-content/uploads/static-site-importer-fixture-matrix/simple-site/source/index.html'));
+  assert.equal(visualCompareMatrixComparison(visualStep).sourceUrl, '/wp-content/uploads/static-site-importer-fixture-matrix/simple-site/source/index.html');
 });
 
 test('default visual-parity source-url follows nested fixture entrypoint', () => {
@@ -3567,7 +3617,7 @@ test('default visual-parity source-url follows nested fixture entrypoint', () =>
   });
 
   assert.ok(
-    step.args.includes('source-url=/wp-content/uploads/static-site-importer-fixture-matrix/liquid-bonsai/source/saveweb2zip-com-liquidbonsai-com/index.html'),
+    visualCompareMatrixComparison(step).sourceUrl === '/wp-content/uploads/static-site-importer-fixture-matrix/liquid-bonsai/source/saveweb2zip-com-liquidbonsai-com/index.html',
   );
 });
 

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -84,7 +84,7 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.wpCodeboxBin ? { SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN: options.wpCodeboxBin } : {}),
     ...(options.editorValidation === false ? { SSI_FIXTURE_MATRIX_EDITOR_VALIDATION: '0' } : {}),
     ...(options.visualParity === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY: '0' } : {}),
-    ...(options.visualParityGate ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '1' } : {}),
+    ...(options.visualParityGate === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '0' } : { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '1' }),
     ...(options.pixelThreshold ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD: String(options.pixelThreshold) } : {}),
     // Opt-in live-WP parity capture (off by default). When set, the bench appends
     // the deterministic `wordpress.capture-html` step per fixture and runs the
@@ -134,14 +134,15 @@ export function buildFixtureMatrixRunPlan(input) {
     allow_stale_override: Boolean(options.allowStaleOverride),
     visual_parity: {
       enabled: options.visualParity !== false,
-      // Opt-in hard gate; default capture-only because pixel diffs can be flaky.
-      gate: Boolean(options.visualParityGate),
+      // Honest dev-loop fidelity gate by default; --no-visual-parity-gate is the
+      // explicit exploratory opt-out.
+      gate: options.visualParityGate !== false,
       pixel_threshold: options.pixelThreshold ? Number(options.pixelThreshold) : null,
     },
     editor_quality: {
       // Editor-quality metrics (native_conversion_rate, core_html_fallback_ratio,
       // editor_invalid_count) are always scored and emitted. The native-rate gate
-      // is opt-in and off by default, mirroring --visual-parity-gate.
+      // is opt-in and off by default.
       native_rate_gate: Boolean(options.minNativeRate),
       min_native_rate: options.minNativeRate ? Number(options.minNativeRate) : null,
     },
@@ -559,8 +560,21 @@ export function summarizeRun(plan, { status } = {}) {
     top_pattern_families: normalizeSummaryRows(resultSummary.top_pattern_families),
     fixture_exemplars: normalizeSummaryRows(resultSummary.fixture_exemplars),
     diagnostic_blind_spots: normalizeSummaryRows(resultSummary.diagnostic_blind_spots),
+    run_refs: buildRunRefs(findFirstKey(output, 'run_id') || plan.run_id, plan.homeboy_bin),
     artifact_urls: collectArtifactUrls(artifacts),
     output_file: plan.output_file,
+  };
+}
+
+function buildRunRefs(runId, homeboyBin = 'homeboy') {
+  const id = String(runId || '').trim();
+  if (!id) {
+    return null;
+  }
+  return {
+    homeboy_run_id: id,
+    show: `${homeboyBin} runs show ${id}`,
+    artifacts: `${homeboyBin} runs artifacts ${id}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- Request full-page visual parity capture by default in the fixture matrix, with an explicit `--no-visual-parity-gate` opt-out for the dev loop.
- Preserve per-fixture visual screenshot refs in matrix JSON and surface Homeboy run refs in the operator summary.
- Document the hardened diagnostics flow and cover it with fixture matrix tests.

## Blind spots fixed
- Viewport-only capture: SSI passed `full-page=false` against wp-codebox's default-true visual capture behavior, so full-page regressions could be hidden.
- Screenshot collision: per-fixture screenshots used last-write-wins paths, so later fixtures could overwrite earlier evidence.
- Capture-only gate: a `99.4%` pixel mismatch could pass because visual parity evidence was collected without gating by default.
- Unshareable operator evidence: summaries exposed raw tmp paths instead of Homeboy run refs that operators can trace.

## Verification
- `node tools/fixture-matrix.test.mjs` passes with 127 tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-cause analysis via fixture-matrix visual parity evidence, fix drafting, and regression tests