### PR TITLE
Persist visual compare screenshots as bench artifacts

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -85,6 +85,7 @@ export default async function runFixtureMatrixBench(context = {}) {
       result: { path: summary.result_file },
       summary: { path: path.join(summary.output_directory, 'summary.json') },
       finding_packets: { path: path.join(summary.output_directory, 'finding-packets.json') },
+      ...(summary.visual_parity_artifacts || {}),
     },
     metadata: {
       matrix_id: summary.matrix_id,
@@ -188,6 +189,7 @@ export async function runFixtureMatrix(options) {
   let runtime = null;
   let runtimeError = null;
   let collectedResult = written.result;
+  let visualParityArtifacts = {};
   if (options.run) {
     const batchSize = positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE);
     const concurrency = boundedConcurrency(options.concurrency, DEFAULT_BATCH_CONCURRENCY, MAX_BATCH_CONCURRENCY);
@@ -214,6 +216,7 @@ export async function runFixtureMatrix(options) {
     for (const outcome of batchOutcomes) {
       batchRuns.push(outcome.batchRun);
       batchResults.push(outcome.batchResult);
+      visualParityArtifacts = { ...visualParityArtifacts, ...(outcome.visualParityArtifacts || {}) };
       if (outcome.childCommandFailure) {
         childCommandFailures.push(outcome.childCommandFailure);
       }
@@ -276,6 +279,7 @@ export async function runFixtureMatrix(options) {
     },
     ...(runtime?.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
     result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
+    visual_parity_artifacts: visualParityArtifacts,
     result_summary: collectedResult.summary,
     runtime: runtime ? runtimeSummary(runtime, runtimeError) : null,
   };
@@ -381,8 +385,147 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     visualParity: visualParityGateInput(options),
     liveWpParity: liveWpParityCollectorInput(options),
   });
+  const visualCompare = materializeVisualCompareArtifacts({
+    result: batchResult,
+    codeboxArtifactsDirectory,
+    outputDirectory,
+  });
 
-  return { batchRun, batchResult, error: batchError, childCommandFailure };
+  return { batchRun, batchResult: visualCompare.result, visualParityArtifacts: visualCompare.artifacts, error: batchError, childCommandFailure };
+}
+
+export function materializeVisualCompareArtifacts(input = {}) {
+  const result = input.result || {};
+  const outputDirectory = path.resolve(input.outputDirectory || input.output_directory || '');
+  const codeboxArtifactsDirectory = path.resolve(input.codeboxArtifactsDirectory || input.codebox_artifacts_directory || '');
+  const artifacts = {};
+  const fixtures = Array.isArray(result.fixtures) ? result.fixtures : [];
+  const updatedFixtures = fixtures.map((fixture) => materializeFixtureVisualCompareArtifacts({
+    fixture,
+    outputDirectory,
+    codeboxArtifactsDirectory,
+    artifacts,
+  }));
+  return {
+    result: { ...result, fixtures: updatedFixtures },
+    artifacts,
+  };
+}
+
+function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory, artifacts }) {
+  const visualParityArtifacts = fixture.visual_parity_artifacts || fixture.visualParityArtifacts;
+  const slots = visualParityArtifacts?.artifacts || {};
+  const fixtureId = fixture.fixture_id || fixture.fixtureId || '';
+  if (!fixtureId || !slots || typeof slots !== 'object') {
+    return fixture;
+  }
+
+  const rewrites = new Map();
+  const updatedSlots = { ...slots };
+  for (const slot of [
+    ['source_screenshot', 'source', ['source_screenshot']],
+    ['imported_screenshot', 'candidate', ['imported_screenshot', 'candidate_screenshot']],
+    ['diff_screenshot', 'diff', ['diff_screenshot']],
+  ]) {
+    const [slotName, fileStem, artifactIds] = slot;
+    const refPath = slots[slotName]?.ref?.path || visualDiagnosticRefPath(fixture.diagnostics, artifactIds);
+    const sourcePath = resolveCodeboxArtifactPath(refPath, codeboxArtifactsDirectory);
+    if (!sourcePath || !fs.existsSync(sourcePath)) {
+      continue;
+    }
+    const persistedPath = path.join(outputDirectory, 'visual-compare', fixtureId, `${fileStem}.png`);
+    fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
+    fs.copyFileSync(sourcePath, persistedPath);
+    rewrites.set(refPath, persistedPath);
+    updatedSlots[slotName] = {
+      ...slots[slotName],
+      status: 'captured',
+      kind: slotName,
+      ref: artifactRef(slotName, persistedPath, 'visual-parity'),
+    };
+    artifacts[`visual_compare_${artifactKey(fixtureId)}_${fileStem}`] = { path: persistedPath };
+  }
+
+  if (rewrites.size === 0) {
+    return fixture;
+  }
+
+  return {
+    ...fixture,
+    diagnostics: rewriteDiagnosticArtifactRefs(fixture.diagnostics, rewrites),
+    artifact_refs: rewriteArtifactRefs(fixture.artifact_refs, rewrites),
+    visual_parity_artifacts: {
+      ...visualParityArtifacts,
+      owner: 'bench_artifact_root',
+      missing: undefined,
+      artifacts: updatedSlots,
+    },
+  };
+}
+
+function visualDiagnosticRefPath(diagnostics, artifactIds) {
+  for (const diagnostic of Array.isArray(diagnostics) ? diagnostics : []) {
+    for (const ref of Array.isArray(diagnostic?.artifact_refs) ? diagnostic.artifact_refs : []) {
+      if (artifactIds.includes(ref?.artifact_id) && ref.path) {
+        return ref.path;
+      }
+    }
+  }
+  return '';
+}
+
+function resolveCodeboxArtifactPath(refPath, codeboxArtifactsDirectory) {
+  if (!refPath || !codeboxArtifactsDirectory) {
+    return '';
+  }
+  if (path.isAbsolute(refPath)) {
+    return refPath;
+  }
+  const directPath = path.join(codeboxArtifactsDirectory, refPath);
+  if (fs.existsSync(directPath)) {
+    return directPath;
+  }
+  for (const entry of safeReadDirectory(codeboxArtifactsDirectory)) {
+    if (!entry.name.startsWith('runtime-') || !entry.isDirectory()) {
+      continue;
+    }
+    const runtimePath = path.join(codeboxArtifactsDirectory, entry.name, refPath);
+    if (fs.existsSync(runtimePath)) {
+      return runtimePath;
+    }
+  }
+  return directPath;
+}
+
+function safeReadDirectory(directory) {
+  try {
+    return fs.readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function rewriteDiagnosticArtifactRefs(diagnostics, rewrites) {
+  return Array.isArray(diagnostics)
+    ? diagnostics.map((diagnostic) => ({ ...diagnostic, artifact_refs: rewriteArtifactRefs(diagnostic.artifact_refs, rewrites) }))
+    : diagnostics;
+}
+
+function rewriteArtifactRefs(refs, rewrites) {
+  return Array.isArray(refs)
+    ? refs.map((ref) => rewrites.has(ref?.path) ? { ...ref, path: rewrites.get(ref.path) } : ref)
+    : refs;
+}
+
+function artifactRef(artifactId, filePath, kind) {
+  return { schema: 'homeboy/artifact-ref/v1', artifact_id: artifactId, kind, path: filePath };
+}
+
+function artifactKey(value) {
+  return String(value || 'fixture')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '_')
+    .replace(/^_+|_+$/g, '') || 'fixture';
 }
 
 // Bounded-concurrency map that preserves input ordering. Spawns at most `limit`

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -17,6 +17,7 @@ import runFixtureMatrixBench, {
   composerPathRepositoryConfig,
   fixtureMatrixBatchRunSummary,
   mapWithConcurrency,
+  materializeVisualCompareArtifacts,
   resolveBlocksEnginePhpTransformerPath,
   runFixtureMatrix,
 } from '../bench/static-site-fixture-matrix.bench.mjs';
@@ -3845,6 +3846,63 @@ test('visual-compare artifacts collected from fixture files gate the matrix when
   assert.ok(capturedFinding, 'expected the mismatch to still be captured');
   assert.equal(capturedFinding.loss_acceptance, 'acceptable');
   assert.equal(captured.fixtures[0].status, 'passed');
+});
+
+test('visual-compare PNGs are copied to the bench artifact root and registered', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-persisted-output-'));
+  const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-codebox-artifacts-'));
+  const runtimeDirectory = path.join(codeboxArtifactsDirectory, 'runtime-123', 'files', 'browser', 'visual-compare', 'simple-site');
+  mkdirSync(runtimeDirectory, { recursive: true });
+  for (const fileName of ['source.png', 'candidate.png', 'diff.png']) {
+    writeFileSync(path.join(runtimeDirectory, fileName), `fake ${fileName}`);
+  }
+
+  const result = {
+    fixtures: [
+      {
+        fixture_id: 'simple-site',
+        diagnostics: [
+          {
+            kind: VISUAL_PARITY_MISMATCH_KIND,
+            artifact_refs: [
+              { schema: 'homeboy/artifact-ref/v1', artifact_id: 'source_screenshot', kind: 'visual-parity', path: 'files/browser/visual-compare/simple-site/source.png' },
+              { schema: 'homeboy/artifact-ref/v1', artifact_id: 'candidate_screenshot', kind: 'visual-parity', path: 'files/browser/visual-compare/simple-site/candidate.png' },
+              { schema: 'homeboy/artifact-ref/v1', artifact_id: 'diff_screenshot', kind: 'visual-parity', path: 'files/browser/visual-compare/simple-site/diff.png' },
+            ],
+          },
+        ],
+        visual_parity_artifacts: {
+          schema: 'static-site-importer/visual-parity-artifacts/v1',
+          owner: 'codebox_runtime',
+          artifacts: {
+            source_screenshot: { status: 'captured', ref: { path: 'files/browser/visual-compare/simple-site/source.png' } },
+            imported_screenshot: { status: 'pending', capture_state: 'not_captured' },
+            diff_screenshot: { status: 'captured', ref: { path: 'files/browser/visual-compare/simple-site/diff.png' } },
+          },
+        },
+      },
+    ],
+  };
+
+  const persisted = materializeVisualCompareArtifacts({ result, outputDirectory, codeboxArtifactsDirectory });
+  const fixture = persisted.result.fixtures[0];
+
+  assert.deepEqual(Object.keys(persisted.artifacts).sort(), [
+    'visual_compare_simple-site_candidate',
+    'visual_compare_simple-site_diff',
+    'visual_compare_simple-site_source',
+  ]);
+  for (const [key, artifact] of Object.entries(persisted.artifacts)) {
+    assert.ok(existsSync(artifact.path), `${key} should point at a copied PNG`);
+    assert.equal(artifact.path.includes('homeboy-run-'), false, 'persisted artifact must not live in a transient Homeboy runtime dir');
+    assert.ok(artifact.path.startsWith(path.join(outputDirectory, 'visual-compare', 'simple-site')));
+  }
+  assert.equal(readFileSync(path.join(outputDirectory, 'visual-compare', 'simple-site', 'source.png'), 'utf8'), 'fake source.png');
+  assert.equal(fixture.visual_parity_artifacts.owner, 'bench_artifact_root');
+  assert.equal(fixture.visual_parity_artifacts.artifacts.source_screenshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'source.png'));
+  assert.equal(fixture.visual_parity_artifacts.artifacts.imported_screenshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'candidate.png'));
+  assert.equal(fixture.visual_parity_artifacts.artifacts.diff_screenshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'diff.png'));
+  assert.equal(fixture.diagnostics[0].artifact_refs.find((ref) => ref.artifact_id === 'diff_screenshot').path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'diff.png'));
 });
 
 test('visual-compare dimension mismatch gates even with zero pixel metrics when gating is on', () => {


### PR DESCRIPTION
Closes #557.

Implements first-class persistence and registration for per-fixture visual-compare PNGs. Source, candidate, and diff screenshots are copied out of the transient WP Codebox runtime directory into the bench artifact root, then registered so `homeboy runs artifacts <run-id>` lists them directly.

This eliminates raw-path spelunking and permission prompts for visual diagnostics. The live-proof shape is six PNG `bench_artifact` entries at persisted paths outside `homeboy-run-*` tmp directories.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Implementation of first-class visual artifact persistence and registration