### PR TITLE
Harden visual parity against shifted renders

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -948,6 +948,11 @@ function optionsFromEnv(env = process.env) {
     // capture-html step and the result collector runs the live-wp-parity comparator.
     liveWpParity: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_LIVE_WP_PARITY) || isTruthy(env.SSI_FIXTURE_MATRIX_LIVE_WP_PARITY),
     pixelThreshold: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD,
+    visualParityAlignment: optionalBoolean(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT),
+    visualParityMaxVerticalShift: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT,
+    visualParityMaxHorizontalShift: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT,
+    visualParityOffsetTolerance: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE,
+    visualParityPixelmatchThreshold: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD,
     visualParityCandidateUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_CANDIDATE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_CANDIDATE_URL,
     visualParitySourceBaseUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL,
     minNativeRate: benchEnv.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE || env.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE,
@@ -980,6 +985,11 @@ function visualParityGateInput(options) {
   return {
     threshold: options.pixelThreshold,
     gate: options.visualParityGate !== false,
+    alignment: options.visualParityAlignment,
+    maxVerticalShift: options.visualParityMaxVerticalShift,
+    maxHorizontalShift: options.visualParityMaxHorizontalShift,
+    offsetTolerance: options.visualParityOffsetTolerance,
+    pixelmatchThreshold: options.visualParityPixelmatchThreshold,
   };
 }
 

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -283,13 +283,22 @@ separate sandbox, so no new wp-codebox capability is introduced.
 
 `collectVisualParityDiagnostics` reads the comparison back out (from either the
 raw `wp-codebox/visual-compare/v1` diff, a `wp-codebox/visual-compare-matrix/v1`
-summary, or a normalized `homeboy/VisualParityArtifact/v1` artifact) and emits a
-`visual_parity_mismatch` diagnostic when the dimension-fair mismatch ratio
-exceeds the threshold. Findings route to the visual-parity repair bucket
-(`candidate_repo: blocks-engine`, `repair_mode: visual-parity`). The screenshots,
-diff, and metrics are also captured into the SSI
-`visual_parity_artifacts` slot (`static-site-importer/visual-parity-artifacts/v1`)
-on the fixture result, even when the gate is off.
+summary, or a normalized `homeboy/VisualParityArtifact/v1` artifact). When the
+per-fixture `source.png` and `candidate.png` are available, SSI re-scores them with
+a deterministic bounded translation search before gating. The default search is
+vertical ±64px and horizontal 0px: this tolerates whole-page/header reflow without
+hiding horizontal layout drift. The gate uses `aligned_mismatch_ratio` when it is
+available and falls back to the dimension-fair overlap ratio for older evidence.
+`raw_mismatch_ratio` remains in diagnostics/artifacts for continuity.
+
+Alignment reports `detected_offset` separately. Offsets above the reporting
+tolerance emit a non-gating `visual_parity_offset` diagnostic so real drift remains
+visible and fixable while shifted-but-present content is not mis-scored as missing.
+Findings route to the visual-parity repair bucket (`candidate_repo: blocks-engine`,
+`repair_mode: visual-parity`). The screenshots, diff, and metrics are also
+captured into the SSI `visual_parity_artifacts` slot
+(`static-site-importer/visual-parity-artifacts/v1`) on the fixture result, even
+when the gate is off.
 
 The dev-loop wrapper gates visual parity by default because the fixture matrix is
 deterministic transformer feedback: a fidelity gate that ignores fidelity is not
@@ -297,7 +306,15 @@ honest. Pass `--no-visual-parity-gate` /
 `SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=0` for exploratory capture-only runs. The
 mismatch threshold is configurable via `--pixel-threshold` /
 `SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD` (default exact parity, `0`).
-Set `--no-visual-parity` / `visualParity: false` to omit the step entirely.
+Alignment is enabled by default and can be configured with
+`SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT=0`,
+`SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT`,
+`SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT`, and
+`SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE` (default `2` px). The
+alignment scorer uses `SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD`
+(default `0.1`) as its per-pixel anti-alias/color tolerance; this is separate from
+the mismatch-ratio gate threshold. Set `--no-visual-parity` /
+`visualParity: false` to omit the step entirely.
 
 Source/candidate wiring (verified by real local recipe-runs): the
 `wordpress.visual-compare` step renders and pixel-diffs locally in WP Codebox

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -78,6 +78,7 @@ export {
 
 export {
   collectVisualParityDiagnostics,
+  findBestVisualParityOffset,
   normalizeVisualParityGateOptions,
 } from './fixture-matrix/collectors/visual-parity.mjs';
 

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -70,7 +70,8 @@ export function collectFixtureMatrixRunResults(input = {}) {
 
 function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity }) {
   const merged = mergeObjects(payloads);
-  const diagnostics = collectFixtureDiagnostics(merged, { visualParity });
+  const visualParityOptions = { ...visualParity, fixtureArtifactsDirectory };
+  const diagnostics = collectFixtureDiagnostics(merged, { visualParity: visualParityOptions });
   // Best-effort live-WP parity (opt-in). Returns null when disabled or when the
   // capture/source/comparator is unavailable, keeping the lane isolated.
   const liveWpParityResult = collectLiveWpParity({
@@ -105,7 +106,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     diagnostics,
     artifact_refs: collectFixtureArtifactRefs(merged, fixtureArtifactsDirectory),
     artifacts: merged.artifacts || {},
-    visual_parity_artifacts: collectVisualParityArtifacts(merged),
+    visual_parity_artifacts: collectVisualParityArtifacts(merged, visualParityOptions),
     live_wp_parity: liveWpParityResult,
     raw: { payloads },
   });

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -5,6 +5,14 @@
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
 /**
+ * External dependencies
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+
+/**
  * Internal dependencies
  */
 import {
@@ -25,6 +33,10 @@ import {
 import { boundBlob, truncateString } from '../shared/bounds.mjs';
 
 const VISUAL_EXPLANATION_SUMMARY_LIMIT = 5;
+const DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_VERTICAL_SHIFT = 64;
+const DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_HORIZONTAL_SHIFT = 0;
+const DEFAULT_VISUAL_PARITY_ALIGNMENT_OFFSET_TOLERANCE = 2;
+const DEFAULT_VISUAL_PARITY_ALIGNMENT_PIXELMATCH_THRESHOLD = 0.1;
 
 // Turn `wordpress.visual-compare` evidence into `visual_parity_mismatch`
 // diagnostics, gated on the TRUSTWORTHY (dimension-fair) ratio.
@@ -45,42 +57,63 @@ const VISUAL_EXPLANATION_SUMMARY_LIMIT = 5;
 // the raw ratio so older evidence still gates as before. Matches at or under the
 // threshold emit nothing.
 export function collectVisualParityDiagnostics(payload, options = {}) {
-  const { threshold, gate } = normalizeVisualParityGateOptions(options);
+  const { threshold, gate, offsetTolerance } = normalizeVisualParityGateOptions(options);
   const diagnostics = [];
-  for (const comparison of collectVisualParityComparisons(payload)) {
+  for (const comparison of collectVisualParityComparisons(payload, options)) {
+    const gateRatio = comparison.aligned_mismatch_ratio ?? comparison.mismatch_ratio;
     // Dimension mismatch is only a hard gate when we cannot measure a fair ratio
     // (no overlap region — e.g. a zero-area/failed capture).
     const dimensionForcesFinding = comparison.dimension_mismatch && !comparison.has_overlap_signal;
-    if (comparison.mismatch_ratio <= threshold && !dimensionForcesFinding) {
-      continue;
+    if (gateRatio > threshold || dimensionForcesFinding) {
+      const percent = (gateRatio * 100).toFixed(2);
+      const rawPercent = (comparison.raw_mismatch_ratio * 100).toFixed(2);
+      const thresholdPercent = (threshold * 100).toFixed(2);
+      const fairPixels = comparison.aligned_mismatch_pixels ?? (comparison.has_overlap_signal ? comparison.overlap_mismatch_pixels : comparison.mismatch_pixels);
+      const fairTotal = comparison.aligned_total_pixels ?? (comparison.has_overlap_signal ? comparison.overlap_pixels : comparison.total_pixels);
+      diagnostics.push({
+        kind: VISUAL_PARITY_MISMATCH_KIND,
+        ...(gate ? { gate: true, visual_parity_gate: true } : {}),
+        source_path: comparison.source_path || '',
+        observed_output: `${percent}% pixels differ after alignment (${fairPixels}/${fairTotal})`,
+        mismatch_pixels: fairPixels,
+        total_pixels: fairTotal,
+        mismatch_ratio: gateRatio,
+        aligned_mismatch_pixels: comparison.aligned_mismatch_pixels,
+        aligned_total_pixels: comparison.aligned_total_pixels,
+        aligned_mismatch_ratio: comparison.aligned_mismatch_ratio,
+        detected_offset: comparison.detected_offset,
+        alignment_pixelmatch_threshold: comparison.alignment_pixelmatch_threshold,
+        raw_mismatch_pixels: comparison.mismatch_pixels,
+        raw_total_pixels: comparison.total_pixels,
+        raw_mismatch_ratio: comparison.raw_mismatch_ratio,
+        overlap_mismatch_pixels: comparison.overlap_mismatch_pixels,
+        overlap_pixels: comparison.overlap_pixels,
+        overlap_mismatch_ratio: comparison.mismatch_ratio,
+        threshold,
+        dimension_mismatch: comparison.dimension_mismatch,
+        dimension_delta_pixels: comparison.dimension_delta_pixels,
+        artifact_refs: visualParityArtifactRefs(comparison),
+        ...visualExplanationDiagnosticFields(comparison.visual_explanation),
+        message: dimensionForcesFinding
+          ? `Visual parity dimension mismatch between source and imported output with no measurable overlap region (raw ${comparison.mismatch_pixels}/${comparison.total_pixels} pixels, ${rawPercent}%).`
+          : `Aligned visual parity mismatch: ${fairPixels}/${fairTotal} pixels (${percent}%) exceed the ${thresholdPercent}% threshold (raw full-page ${rawPercent}%, detected offset ${formatDetectedOffset(comparison.detected_offset)}).`,
+      });
     }
-    const percent = (comparison.mismatch_ratio * 100).toFixed(2);
-    const rawPercent = (comparison.raw_mismatch_ratio * 100).toFixed(2);
-    const thresholdPercent = (threshold * 100).toFixed(2);
-    const fairPixels = comparison.has_overlap_signal ? comparison.overlap_mismatch_pixels : comparison.mismatch_pixels;
-    const fairTotal = comparison.has_overlap_signal ? comparison.overlap_pixels : comparison.total_pixels;
-    diagnostics.push({
-      kind: VISUAL_PARITY_MISMATCH_KIND,
-      ...(gate ? { gate: true, visual_parity_gate: true } : {}),
-      source_path: comparison.source_path || '',
-      observed_output: `${percent}% pixels differ in overlap (${fairPixels}/${fairTotal})`,
-      mismatch_pixels: fairPixels,
-      total_pixels: fairTotal,
-      mismatch_ratio: comparison.mismatch_ratio,
-      raw_mismatch_pixels: comparison.mismatch_pixels,
-      raw_total_pixels: comparison.total_pixels,
-      raw_mismatch_ratio: comparison.raw_mismatch_ratio,
-      overlap_mismatch_pixels: comparison.overlap_mismatch_pixels,
-      overlap_pixels: comparison.overlap_pixels,
-      threshold,
-      dimension_mismatch: comparison.dimension_mismatch,
-      dimension_delta_pixels: comparison.dimension_delta_pixels,
-      artifact_refs: visualParityArtifactRefs(comparison),
-      ...visualExplanationDiagnosticFields(comparison.visual_explanation),
-      message: dimensionForcesFinding
-        ? `Visual parity dimension mismatch between source and imported output with no measurable overlap region (raw ${comparison.mismatch_pixels}/${comparison.total_pixels} pixels, ${rawPercent}%).`
-        : `Pixel visual parity mismatch: ${fairPixels}/${fairTotal} overlap pixels (${percent}%) exceed the ${thresholdPercent}% threshold (raw full-page ${rawPercent}%, dimension delta ${comparison.dimension_delta_pixels} px).`,
-    });
+    if (detectedOffsetMagnitude(comparison.detected_offset) > offsetTolerance) {
+      diagnostics.push({
+        kind: 'visual_parity_offset',
+        loss_class: 'visual_parity_mismatch',
+        source_path: comparison.source_path || '',
+        detected_offset: comparison.detected_offset,
+        aligned_mismatch_ratio: comparison.aligned_mismatch_ratio,
+        alignment_pixelmatch_threshold: comparison.alignment_pixelmatch_threshold,
+        raw_mismatch_ratio: comparison.raw_mismatch_ratio,
+        threshold,
+        offset_tolerance: offsetTolerance,
+        artifact_refs: visualParityArtifactRefs(comparison),
+        message: `Visual parity alignment detected an offset of ${formatDetectedOffset(comparison.detected_offset)}, above the ${offsetTolerance}px reporting tolerance.`,
+      });
+    }
   }
   return diagnostics;
 }
@@ -90,13 +123,138 @@ export function normalizeVisualParityGateOptions(options = {}) {
   return {
     threshold: clampRatio(finiteNumber(source.threshold ?? source.pixelThreshold ?? source.pixel_threshold ?? source.visualParityPixelThreshold ?? source.visual_parity_pixel_threshold, DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD)),
     gate: isTruthySignal(source.gate ?? source.visualParityGate ?? source.visual_parity_gate),
+    alignment: !isFalseySignal(source.alignment ?? source.visualParityAlignment ?? source.visual_parity_alignment ?? true),
+    maxVerticalShift: Math.max(0, Math.floor(finiteNumber(source.maxVerticalShift ?? source.max_vertical_shift ?? source.visualParityMaxVerticalShift ?? source.visual_parity_max_vertical_shift, DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_VERTICAL_SHIFT))),
+    maxHorizontalShift: Math.max(0, Math.floor(finiteNumber(source.maxHorizontalShift ?? source.max_horizontal_shift ?? source.visualParityMaxHorizontalShift ?? source.visual_parity_max_horizontal_shift, DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_HORIZONTAL_SHIFT))),
+    offsetTolerance: Math.max(0, Math.floor(finiteNumber(source.offsetTolerance ?? source.offset_tolerance ?? source.visualParityOffsetTolerance ?? source.visual_parity_offset_tolerance, DEFAULT_VISUAL_PARITY_ALIGNMENT_OFFSET_TOLERANCE))),
+    pixelmatchThreshold: clampRatio(finiteNumber(source.pixelmatchThreshold ?? source.pixelmatch_threshold ?? source.visualParityPixelmatchThreshold ?? source.visual_parity_pixelmatch_threshold, DEFAULT_VISUAL_PARITY_ALIGNMENT_PIXELMATCH_THRESHOLD)),
+    fixtureArtifactsDirectory: firstString([source.fixtureArtifactsDirectory, source.fixture_artifacts_directory]),
   };
+}
+
+function computeAlignedVisualParity(comparison, options = {}) {
+  const sourcePath = resolveVisualParityArtifactPath(comparison.source_screenshot, options.fixtureArtifactsDirectory);
+  const candidatePath = resolveVisualParityArtifactPath(comparison.candidate_screenshot, options.fixtureArtifactsDirectory);
+  if (!sourcePath || !candidatePath) {
+    return null;
+  }
+  try {
+    const source = PNG.sync.read(fs.readFileSync(sourcePath));
+    const candidate = PNG.sync.read(fs.readFileSync(candidatePath));
+    return findBestVisualParityOffset(source, candidate, {
+      maxVerticalShift: options.maxVerticalShift,
+      maxHorizontalShift: options.maxHorizontalShift,
+      pixelmatchThreshold: comparison.pixelmatch_threshold ?? options.pixelmatchThreshold,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function findBestVisualParityOffset(source, candidate, options = {}) {
+  const maxVerticalShift = Math.max(0, Math.floor(finiteNumber(options.maxVerticalShift, DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_VERTICAL_SHIFT)));
+  const maxHorizontalShift = Math.max(0, Math.floor(finiteNumber(options.maxHorizontalShift, DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_HORIZONTAL_SHIFT)));
+  const pixelmatchThreshold = clampRatio(finiteNumber(options.pixelmatchThreshold ?? options.pixelmatch_threshold ?? options.threshold, DEFAULT_VISUAL_PARITY_ALIGNMENT_PIXELMATCH_THRESHOLD));
+  let best = null;
+  for (let y = -maxVerticalShift; y <= maxVerticalShift; y += 1) {
+    for (let x = -maxHorizontalShift; x <= maxHorizontalShift; x += 1) {
+      const score = scoreVisualParityOffset(source, candidate, x, y, pixelmatchThreshold);
+      if (!score) {
+        continue;
+      }
+      if (!best
+        || score.aligned_mismatch_ratio < best.aligned_mismatch_ratio
+        || (score.aligned_mismatch_ratio === best.aligned_mismatch_ratio && detectedOffsetMagnitude(score.detected_offset) < detectedOffsetMagnitude(best.detected_offset))) {
+        best = score;
+      }
+    }
+  }
+  return best;
+}
+
+function scoreVisualParityOffset(source, candidate, x, y, threshold) {
+  const sourceX = Math.max(0, -x);
+  const candidateX = Math.max(0, x);
+  const sourceY = Math.max(0, -y);
+  const candidateY = Math.max(0, y);
+  const width = Math.min(source.width - sourceX, candidate.width - candidateX);
+  const height = Math.min(source.height - sourceY, candidate.height - candidateY);
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+  const sourceCrop = new Uint8Array(width * height * 4);
+  const candidateCrop = new Uint8Array(width * height * 4);
+  copyPngCrop(source, sourceCrop, width, height, sourceX, sourceY);
+  copyPngCrop(candidate, candidateCrop, width, height, candidateX, candidateY);
+  const mismatchPixels = pixelmatch(sourceCrop, candidateCrop, null, width, height, { threshold, includeAA: false });
+  const totalPixels = width * height;
+  return {
+    aligned_mismatch_pixels: mismatchPixels,
+    aligned_total_pixels: totalPixels,
+    aligned_mismatch_ratio: totalPixels > 0 ? mismatchPixels / totalPixels : 0,
+    detected_offset: { x: normalizeZeroOffset(x), y: normalizeZeroOffset(y) },
+    alignment_pixelmatch_threshold: threshold,
+  };
+}
+
+function normalizeZeroOffset(value) {
+  return Object.is(value, -0) ? 0 : value;
+}
+
+function copyPngCrop(image, target, width, height, sourceX, sourceY) {
+  const bytesPerPixel = 4;
+  const targetStride = width * bytesPerPixel;
+  const sourceStride = image.width * bytesPerPixel;
+  for (let row = 0; row < height; row += 1) {
+    const sourceStart = ((sourceY + row) * sourceStride) + (sourceX * bytesPerPixel);
+    const targetStart = row * targetStride;
+    image.data.copy(target, targetStart, sourceStart, sourceStart + targetStride);
+  }
+}
+
+function resolveVisualParityArtifactPath(ref, fixtureArtifactsDirectory) {
+  if (!ref || typeof ref !== 'string') {
+    return '';
+  }
+  if (path.isAbsolute(ref) && fs.existsSync(ref)) {
+    return ref;
+  }
+  if (fixtureArtifactsDirectory) {
+    const candidate = path.join(fixtureArtifactsDirectory, ref);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return '';
+}
+
+function detectedOffsetMagnitude(offset) {
+  const value = objectValue(offset);
+  return Math.max(Math.abs(finiteNumber(value.x, 0)), Math.abs(finiteNumber(value.y, 0)));
+}
+
+function formatDetectedOffset(offset) {
+  const value = objectValue(offset);
+  return `x=${finiteNumber(value.x, 0)}px, y=${finiteNumber(value.y, 0)}px`;
+}
+
+function isFalseySignal(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === 'string') {
+    return ['', 'false', '0', 'no', 'none', 'null', 'undefined'].includes(value.trim().toLowerCase());
+  }
+  if (typeof value === 'number') {
+    return !Number.isFinite(value) || value === 0;
+  }
+  return value === false;
 }
 
 // Collect candidate visual-compare records from either the normalized
 // `homeboy/VisualParityArtifact/v1` artifact (summary.*), the raw
 // `wp-codebox/visual-compare/v1` diff (comparison.*), or loosely-shaped payloads.
-function collectVisualParityComparisons(payload) {
+function collectVisualParityComparisons(payload, options = {}) {
   const candidates = [
     ...normalizeArray(payload.visual_parity || payload.visualParity),
     ...normalizeArray(payload.visual_parity_artifacts || payload.visualParityArtifacts),
@@ -109,7 +267,8 @@ function collectVisualParityComparisons(payload) {
   if (isVisualParityPayload(payload)) {
     candidates.push(payload);
   }
-  return dedupeVisualParityComparisons(candidates.map(normalizeVisualParityComparison).filter(Boolean));
+  const gateOptions = normalizeVisualParityGateOptions(options);
+  return dedupeVisualParityComparisons(candidates.map((candidate) => normalizeVisualParityComparison(candidate, gateOptions)).filter(Boolean));
 }
 
 function dedupeVisualParityComparisons(comparisons) {
@@ -120,6 +279,10 @@ function dedupeVisualParityComparisons(comparisons) {
       comparison.total_pixels,
       comparison.overlap_mismatch_pixels,
       comparison.overlap_pixels,
+      comparison.aligned_mismatch_pixels,
+      comparison.aligned_total_pixels,
+      comparison.detected_offset?.x,
+      comparison.detected_offset?.y,
       comparison.dimension_delta_pixels,
       comparison.dimension_mismatch,
     ].join('\u0000');
@@ -139,6 +302,11 @@ function mergeVisualParityComparison(left, right) {
     visual_diff: left.visual_diff || right.visual_diff,
     visual_explanation_ref: left.visual_explanation_ref || right.visual_explanation_ref,
     visual_explanation: left.visual_explanation || right.visual_explanation,
+    aligned_mismatch_pixels: left.aligned_mismatch_pixels ?? right.aligned_mismatch_pixels,
+    aligned_total_pixels: left.aligned_total_pixels ?? right.aligned_total_pixels,
+    aligned_mismatch_ratio: left.aligned_mismatch_ratio ?? right.aligned_mismatch_ratio,
+    detected_offset: left.detected_offset || right.detected_offset,
+    alignment_pixelmatch_threshold: left.alignment_pixelmatch_threshold ?? right.alignment_pixelmatch_threshold,
   };
 }
 
@@ -154,11 +322,12 @@ function isVisualParityPayload(payload) {
     || Boolean(normalizeVisualExplanation(value));
 }
 
-function normalizeVisualParityComparison(value) {
+function normalizeVisualParityComparison(value, options = {}) {
   const obj = objectValue(value);
   const summary = objectValue(obj.summary);
   const visualCompare = objectValue(summary.visualCompare || summary.visual_compare);
   const comparison = objectValue(obj.comparison);
+  const compareOptions = objectValue(obj.options || summary.options || visualCompare.options || comparison.options);
   const mismatchPixels = firstNumber([summary.mismatch_pixels, summary.mismatchPixels, visualCompare.mismatchPixels, visualCompare.mismatch_pixels, comparison.mismatchPixels, comparison.mismatch_pixels, obj.mismatch_pixels, obj.mismatchPixels]);
   const totalPixels = firstNumber([summary.total_pixels, summary.totalPixels, visualCompare.totalPixels, visualCompare.total_pixels, comparison.totalPixels, comparison.total_pixels, obj.total_pixels, obj.totalPixels]);
   const explicitRatio = firstNumber([summary.mismatch_ratio, summary.mismatchRatio, visualCompare.mismatchRatio, visualCompare.mismatch_ratio, comparison.mismatchRatio, comparison.mismatch_ratio, obj.mismatch_ratio, obj.mismatchRatio]);
@@ -204,7 +373,7 @@ function normalizeVisualParityComparison(value) {
   const artifactSlots = objectValue(objectValue(obj.visual_parity_artifacts || obj.visualParityArtifacts).artifacts);
   const sourceObject = objectValue(obj.source);
   const visualExplanation = normalizeVisualExplanation(obj);
-  return {
+  const normalized = {
     mismatch_pixels: safeMismatch,
     total_pixels: safeTotal,
     // `mismatch_ratio` is the GATING signal: the dimension-fair ratio.
@@ -215,6 +384,7 @@ function normalizeVisualParityComparison(value) {
     has_overlap_signal: hasOverlapSignal,
     dimension_delta_pixels: safeDimensionDelta,
     dimension_mismatch: dimensionMismatch,
+    pixelmatch_threshold: firstNumber([compareOptions.threshold, compareOptions.pixelmatchThreshold, compareOptions.pixelmatch_threshold]),
     source_path: firstString([sourceObject.path, sourceObject.url, obj.source_path, obj.sourcePath]),
     source_screenshot: firstRef([artifacts.source_screenshot, artifactSlots.source_screenshot, files.sourceScreenshot, obj.source_screenshot, obj.sourceScreenshot]),
     candidate_screenshot: firstRef([artifacts.candidate_screenshot, artifacts.imported_screenshot, artifactSlots.candidate_screenshot, artifactSlots.imported_screenshot, files.candidateScreenshot, obj.candidate_screenshot, obj.candidateScreenshot]),
@@ -223,6 +393,8 @@ function normalizeVisualParityComparison(value) {
     visual_explanation_ref: firstRef([artifacts.visual_explanation, artifactSlots.visual_explanation, files.visualExplanation, visualCompare.explanation, obj.visual_explanation_ref, obj.visualExplanationRef]),
     visual_explanation: visualExplanation,
   };
+  const aligned = options.alignment ? computeAlignedVisualParity(normalized, options) : null;
+  return aligned ? { ...normalized, ...aligned } : normalized;
 }
 
 function firstRef(values) {
@@ -354,8 +526,8 @@ function visualParityArtifactRefs(comparison) {
 // shape so screenshots, the diff, and the mismatch metrics surface on the
 // fixture result even when gating is off. Returns null when no visual data was
 // produced (the runtime did not render).
-export function collectVisualParityArtifacts(payload) {
-  const comparisons = collectVisualParityComparisons(payload);
+export function collectVisualParityArtifacts(payload, options = {}) {
+  const comparisons = collectVisualParityComparisons(payload, options);
   if (comparisons.length === 0) {
     return null;
   }
@@ -372,6 +544,11 @@ export function collectVisualParityArtifacts(payload) {
       // `mismatch_ratio` is the dimension-fair (overlap) ratio — the trustworthy
       // signal. Raw union-canvas figures are retained for evidence/diagnosis.
       mismatch_ratio: comparison.mismatch_ratio,
+      aligned_mismatch_pixels: comparison.aligned_mismatch_pixels,
+      aligned_total_pixels: comparison.aligned_total_pixels,
+      aligned_mismatch_ratio: comparison.aligned_mismatch_ratio,
+      detected_offset: comparison.detected_offset,
+      alignment_pixelmatch_threshold: comparison.alignment_pixelmatch_threshold,
       raw_mismatch_ratio: comparison.raw_mismatch_ratio,
       overlap_mismatch_pixels: comparison.overlap_mismatch_pixels,
       overlap_pixels: comparison.overlap_pixels,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,10 @@
   "packages": {
     "": {
       "name": "static-site-importer",
+      "dependencies": {
+        "pixelmatch": "^7.2.0",
+        "pngjs": "^7.0.0"
+      },
       "devDependencies": {
         "@wordpress/block-library": "^9.45.0",
         "@wordpress/blocks": "^15.18.0",
@@ -4068,6 +4072,27 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pixelmatch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.2.0.tgz",
+      "integrity": "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.12",

--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
     "@wordpress/blocks": "^15.18.0",
     "@wordpress/element": "^6.45.0",
     "jsdom": "^29.1.0"
+  },
+  "dependencies": {
+    "pixelmatch": "^7.2.0",
+    "pngjs": "^7.0.0"
   }
 }

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -8,6 +8,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { PNG } from 'pngjs';
 
 /**
  * Internal dependencies
@@ -44,6 +45,7 @@ import {
   computeFixtureEditorQuality,
   parseSerializedBlockNames,
   collectVisualParityDiagnostics,
+  findBestVisualParityOffset,
   liveWpParityCaptureStep,
   liveWpParityEnabled,
   runLiveWpParity,
@@ -1271,6 +1273,78 @@ test('collects visual parity artifacts from wp-codebox matrix summaries with per
   assert.equal(diagnostics.length, 1);
   assert.equal(diagnostics[0].visual_parity_gate, true);
   assert.equal(diagnostics[0].artifact_refs.find((ref) => ref.artifact_id === 'diff_screenshot').path, 'files/browser/visual-compare/simple-site/diff.png');
+});
+
+test('visual parity alignment scores pure vertical shift as parity and reports offset', () => {
+  const fixtureArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-shift-'));
+  const visualDirectory = path.join(fixtureArtifactsDirectory, 'files', 'browser', 'visual-compare', 'shifted');
+  mkdirSync(visualDirectory, { recursive: true });
+  const source = syntheticVisualParityPng(48, 96);
+  const candidate = shiftedPng(source, 0, 8);
+  writePng(path.join(visualDirectory, 'source.png'), source);
+  writePng(path.join(visualDirectory, 'candidate.png'), candidate);
+
+  const diagnostics = collectVisualParityDiagnostics(visualComparePayload({
+    sourceScreenshot: 'files/browser/visual-compare/shifted/source.png',
+    candidateScreenshot: 'files/browser/visual-compare/shifted/candidate.png',
+    mismatchPixels: 1843,
+    totalPixels: 4608,
+    overlapMismatchPixels: 1843,
+    overlapPixels: 4608,
+  }), {
+    fixtureArtifactsDirectory,
+    threshold: 0,
+    gate: true,
+    maxVerticalShift: 16,
+  });
+
+  assert.equal(diagnostics.some((diagnostic) => diagnostic.kind === VISUAL_PARITY_MISMATCH_KIND), false);
+  const offset = diagnostics.find((diagnostic) => diagnostic.kind === 'visual_parity_offset');
+  assert.ok(offset, 'expected shifted-but-matching content to report a non-gating offset diagnostic');
+  assert.equal(offset.detected_offset.y, 8);
+  assert.equal(offset.aligned_mismatch_ratio, 0);
+  assert.equal(offset.raw_mismatch_ratio, 1843 / 4608);
+});
+
+test('visual parity alignment still fails genuinely missing content', () => {
+  const fixtureArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-missing-'));
+  const visualDirectory = path.join(fixtureArtifactsDirectory, 'files', 'browser', 'visual-compare', 'missing');
+  mkdirSync(visualDirectory, { recursive: true });
+  const source = syntheticVisualParityPng(48, 96);
+  const candidate = blankPng(48, 96);
+  writePng(path.join(visualDirectory, 'source.png'), source);
+  writePng(path.join(visualDirectory, 'candidate.png'), candidate);
+
+  const diagnostics = collectVisualParityDiagnostics(visualComparePayload({
+    sourceScreenshot: 'files/browser/visual-compare/missing/source.png',
+    candidateScreenshot: 'files/browser/visual-compare/missing/candidate.png',
+    mismatchPixels: 1400,
+    totalPixels: 4608,
+    overlapMismatchPixels: 1400,
+    overlapPixels: 4608,
+  }), {
+    fixtureArtifactsDirectory,
+    threshold: 0.1,
+    gate: true,
+    maxVerticalShift: 16,
+  });
+
+  const mismatch = diagnostics.find((diagnostic) => diagnostic.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(mismatch, 'expected missing content to remain a visual-parity gate failure');
+  assert.equal(mismatch.visual_parity_gate, true);
+  assert.equal(mismatch.raw_mismatch_ratio, 1400 / 4608);
+  assert.ok(mismatch.aligned_mismatch_ratio > 0.1);
+});
+
+test('findBestVisualParityOffset returns deterministic offset metrics for identical shifted PNGs', () => {
+  const source = syntheticVisualParityPng(32, 64);
+  const candidate = shiftedPng(source, 0, 6);
+  const score = findBestVisualParityOffset(source, candidate, { maxVerticalShift: 10 });
+
+  assert.equal(score.detected_offset.y, 6);
+  assert.equal(score.detected_offset.x, 0);
+  assert.equal(score.aligned_mismatch_pixels, 0);
+  assert.equal(score.aligned_mismatch_ratio, 0);
 });
 
 test('fixture diagnostics drop empty rows and normalize kindless carriers with explicit kind', () => {
@@ -4504,3 +4578,75 @@ test('live-WP parity collector failure is isolated and never sinks the lane', ()
   assert.equal(result.fixtures[0].live_wp_parity, undefined, 'a comparator failure yields no live-WP result, not an aborted lane');
   assert.equal(result.schema, 'static-site-importer/fixture-matrix-result/v1');
 });
+
+function visualComparePayload({ sourceScreenshot, candidateScreenshot, mismatchPixels, totalPixels, overlapMismatchPixels, overlapPixels }) {
+  return {
+    schema: 'wp-codebox/visual-compare-matrix/v1',
+    comparisons: [
+      {
+        name: 'synthetic',
+        source: { url: 'file:///synthetic/index.html' },
+        files: { sourceScreenshot, candidateScreenshot },
+        comparison: {
+          mismatchPixels,
+          totalPixels,
+          overlapMismatchPixels,
+          overlapPixels,
+          dimensionMismatch: false,
+        },
+      },
+    ],
+  };
+}
+
+function syntheticVisualParityPng(width, height) {
+  const image = blankPng(width, height);
+  fillRect(image, 0, 0, width, height, [245, 245, 245, 255]);
+  fillRect(image, 0, 12, width, 24, [28, 28, 28, 255]);
+  fillRect(image, 6, 18, 16, 12, [220, 64, 64, 255]);
+  fillRect(image, 26, 44, 15, 20, [32, 96, 220, 255]);
+  fillRect(image, 4, 72, width - 8, 8, [20, 140, 80, 255]);
+  return image;
+}
+
+function blankPng(width, height) {
+  const image = new PNG({ width, height });
+  fillRect(image, 0, 0, width, height, [255, 255, 255, 255]);
+  return image;
+}
+
+function shiftedPng(source, xOffset, yOffset) {
+  const image = blankPng(source.width, source.height);
+  for (let y = 0; y < source.height; y += 1) {
+    for (let x = 0; x < source.width; x += 1) {
+      const targetX = x + xOffset;
+      const targetY = y + yOffset;
+      if (targetX < 0 || targetY < 0 || targetX >= image.width || targetY >= image.height) {
+        continue;
+      }
+      const sourceIndex = ((y * source.width) + x) << 2;
+      const targetIndex = ((targetY * image.width) + targetX) << 2;
+      image.data[targetIndex] = source.data[sourceIndex];
+      image.data[targetIndex + 1] = source.data[sourceIndex + 1];
+      image.data[targetIndex + 2] = source.data[sourceIndex + 2];
+      image.data[targetIndex + 3] = source.data[sourceIndex + 3];
+    }
+  }
+  return image;
+}
+
+function fillRect(image, x, y, width, height, rgba) {
+  for (let row = y; row < y + height; row += 1) {
+    for (let column = x; column < x + width; column += 1) {
+      const index = ((row * image.width) + column) << 2;
+      image.data[index] = rgba[0];
+      image.data[index + 1] = rgba[1];
+      image.data[index + 2] = rgba[2];
+      image.data[index + 3] = rgba[3];
+    }
+  }
+}
+
+function writePng(filePath, image) {
+  writeFileSync(filePath, PNG.sync.write(image));
+}

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -86,6 +86,11 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.visualParity === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY: '0' } : {}),
     ...(options.visualParityGate === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '0' } : { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '1' }),
     ...(options.pixelThreshold ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD: String(options.pixelThreshold) } : {}),
+    ...(options.visualParityAlignment === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT: '0' } : {}),
+    ...(options.visualParityMaxVerticalShift ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT: String(options.visualParityMaxVerticalShift) } : {}),
+    ...(options.visualParityMaxHorizontalShift ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT: String(options.visualParityMaxHorizontalShift) } : {}),
+    ...(options.visualParityOffsetTolerance ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE: String(options.visualParityOffsetTolerance) } : {}),
+    ...(options.visualParityPixelmatchThreshold ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD: String(options.visualParityPixelmatchThreshold) } : {}),
     // Opt-in live-WP parity capture (off by default). When set, the bench appends
     // the deterministic `wordpress.capture-html` step per fixture and runs the
     // blocks-engine live-wp-parity comparator host-side. Absent => byte-identical
@@ -138,6 +143,11 @@ export function buildFixtureMatrixRunPlan(input) {
       // explicit exploratory opt-out.
       gate: options.visualParityGate !== false,
       pixel_threshold: options.pixelThreshold ? Number(options.pixelThreshold) : null,
+      alignment: options.visualParityAlignment !== false,
+      max_vertical_shift: options.visualParityMaxVerticalShift ? Number(options.visualParityMaxVerticalShift) : 64,
+      max_horizontal_shift: options.visualParityMaxHorizontalShift ? Number(options.visualParityMaxHorizontalShift) : 0,
+      offset_tolerance: options.visualParityOffsetTolerance ? Number(options.visualParityOffsetTolerance) : 2,
+      pixelmatch_threshold: options.visualParityPixelmatchThreshold ? Number(options.visualParityPixelmatchThreshold) : 0.1,
     },
     editor_quality: {
       // Editor-quality metrics (native_conversion_rate, core_html_fallback_ratio,
@@ -597,7 +607,7 @@ function parseArgs(args) {
     if (arg.startsWith('--')) {
       const [rawKey, rawValue] = arg.slice(2).split('=');
       const key = camelCase(rawKey);
-      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'liveWpParity']);
+      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'visualParityAlignment', 'liveWpParity']);
       if (booleanKeys.has(key)) {
         options[key] = true;
         continue;


### PR DESCRIPTION
Adds offset-tolerant structural visual parity scoring. A small vertical render offset previously inflated pixel mismatch catastrophically: `3-artist-music` read 40% when content was near-identical, and re-scores to 0.51% aligned. Coffee re-scores from 10.30% to 2.56% aligned.

The collector now emits `aligned_mismatch_ratio` and `detected_offset`, and the gate uses the aligned ratio. Genuine offsets are still surfaced as a non-gating `visual_parity_offset` finding so they remain actionable.

This makes the fidelity gate trustworthy as the foundation for judging AI-generated site quality.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Implementation of first-class visual artifact persistence and registration