### PR TITLE
Add editor fidelity fixture evidence

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -190,6 +190,7 @@ export async function runFixtureMatrix(options) {
   let runtimeError = null;
   let collectedResult = written.result;
   let visualParityArtifacts = {};
+  let editorFidelityArtifacts = {};
   if (options.run) {
     const batchSize = positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE);
     const concurrency = boundedConcurrency(options.concurrency, DEFAULT_BATCH_CONCURRENCY, MAX_BATCH_CONCURRENCY);
@@ -217,6 +218,7 @@ export async function runFixtureMatrix(options) {
       batchRuns.push(outcome.batchRun);
       batchResults.push(outcome.batchResult);
       visualParityArtifacts = { ...visualParityArtifacts, ...(outcome.visualParityArtifacts || {}) };
+      editorFidelityArtifacts = { ...editorFidelityArtifacts, ...(outcome.editorFidelityArtifacts || {}) };
       if (outcome.childCommandFailure) {
         childCommandFailures.push(outcome.childCommandFailure);
       }
@@ -280,6 +282,7 @@ export async function runFixtureMatrix(options) {
     ...(runtime?.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
     result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
     visual_parity_artifacts: visualParityArtifacts,
+    editor_fidelity_artifacts: editorFidelityArtifacts,
     result_summary: collectedResult.summary,
     runtime: runtime ? runtimeSummary(runtime, runtimeError) : null,
   };
@@ -383,6 +386,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     codeboxOutput: batchRuntime?.json,
     codeboxError: batchError,
     visualParity: visualParityGateInput(options),
+    editorFrontendParity: editorFrontendParityGateInput(options),
     liveWpParity: liveWpParityCollectorInput(options),
   });
   const visualCompare = materializeVisualCompareArtifacts({
@@ -390,8 +394,79 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     codeboxArtifactsDirectory,
     outputDirectory,
   });
+  const editorFidelity = materializeEditorFidelityArtifacts({
+    result: visualCompare.result,
+    codeboxArtifactsDirectory,
+    outputDirectory,
+  });
 
-  return { batchRun, batchResult: visualCompare.result, visualParityArtifacts: visualCompare.artifacts, error: batchError, childCommandFailure };
+  return { batchRun, batchResult: editorFidelity.result, visualParityArtifacts: visualCompare.artifacts, editorFidelityArtifacts: editorFidelity.artifacts, error: batchError, childCommandFailure };
+}
+
+export function materializeEditorFidelityArtifacts(input = {}) {
+  const result = input.result || {};
+  const outputDirectory = path.resolve(input.outputDirectory || input.output_directory || '');
+  const codeboxArtifactsDirectory = path.resolve(input.codeboxArtifactsDirectory || input.codebox_artifacts_directory || '');
+  const artifacts = {};
+  const fixtures = Array.isArray(result.fixtures) ? result.fixtures : [];
+  const updatedFixtures = fixtures.map((fixture) => materializeFixtureEditorFidelityArtifacts({
+    fixture,
+    outputDirectory,
+    codeboxArtifactsDirectory,
+    artifacts,
+  }));
+  return {
+    result: { ...result, fixtures: updatedFixtures },
+    artifacts,
+  };
+}
+
+function materializeFixtureEditorFidelityArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory, artifacts }) {
+  const editorParity = fixture.editor_frontend_parity || fixture.editorFrontendParity;
+  const slots = editorParity?.artifacts || {};
+  const fixtureId = fixture.fixture_id || fixture.fixtureId || '';
+  if (!fixtureId || !slots || typeof slots !== 'object') {
+    return fixture;
+  }
+
+  const rewrites = new Map();
+  const updatedSlots = { ...slots };
+  for (const slot of [
+    ['editor_screenshot', 'editor-canvas', ['editor_screenshot']],
+  ]) {
+    const [slotName, fileStem, artifactIds] = slot;
+    const refPath = slots[slotName]?.ref?.path || visualDiagnosticRefPath(fixture.diagnostics, artifactIds);
+    const sourcePath = resolveCodeboxArtifactPath(refPath, codeboxArtifactsDirectory);
+    if (!sourcePath || !fs.existsSync(sourcePath)) {
+      continue;
+    }
+    const persistedPath = path.join(outputDirectory, 'editor-fidelity', fixtureId, `${fileStem}.png`);
+    fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
+    fs.copyFileSync(sourcePath, persistedPath);
+    rewrites.set(refPath, persistedPath);
+    updatedSlots[slotName] = {
+      ...slots[slotName],
+      status: 'captured',
+      kind: slotName,
+      ref: artifactRef(slotName, persistedPath, 'editor-fidelity'),
+    };
+    artifacts[`editor_fidelity_${artifactKey(fixtureId)}_${fileStem.replace(/-/g, '_')}`] = { path: persistedPath };
+  }
+
+  if (rewrites.size === 0) {
+    return fixture;
+  }
+
+  return {
+    ...fixture,
+    diagnostics: rewriteDiagnosticArtifactRefs(fixture.diagnostics, rewrites),
+    artifact_refs: rewriteArtifactRefs(fixture.artifact_refs, rewrites),
+    editor_frontend_parity: {
+      ...editorParity,
+      owner: 'bench_artifact_root',
+      artifacts: updatedSlots,
+    },
+  };
 }
 
 export function materializeVisualCompareArtifacts(input = {}) {
@@ -955,6 +1030,8 @@ function optionsFromEnv(env = process.env) {
     visualParityPixelmatchThreshold: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD,
     visualParityCandidateUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_CANDIDATE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_CANDIDATE_URL,
     visualParitySourceBaseUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL,
+    editorFrontendParityGate: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_EDITOR_FRONTEND_PARITY_GATE) || isTruthy(env.SSI_FIXTURE_MATRIX_EDITOR_FRONTEND_PARITY_GATE),
+    editorFrontendParityThreshold: benchEnv.SSI_FIXTURE_MATRIX_EDITOR_FRONTEND_PARITY_THRESHOLD || env.SSI_FIXTURE_MATRIX_EDITOR_FRONTEND_PARITY_THRESHOLD,
     minNativeRate: benchEnv.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE || env.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE,
   };
 }
@@ -990,6 +1067,13 @@ function visualParityGateInput(options) {
     maxHorizontalShift: options.visualParityMaxHorizontalShift,
     offsetTolerance: options.visualParityOffsetTolerance,
     pixelmatchThreshold: options.visualParityPixelmatchThreshold,
+  };
+}
+
+function editorFrontendParityGateInput(options) {
+  return {
+    threshold: options.editorFrontendParityThreshold,
+    gate: options.editorFrontendParityGate === true,
   };
 }
 

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -215,6 +215,8 @@ The workload composes these generic surfaces:
   includes #1597; older builds reject the recipe at schema validation.
 - WP Codebox `wordpress.visual-compare` command for the pixel visual-parity step
   (see below).
+- WP Codebox `wordpress.editor-open post-id=<id> capture=...,screenshot,...` for
+  editor-canvas screenshot evidence when the imported page id is available.
 
 SSI-specific behavior remains here: plugin slug/defaults, fixture artifact
 packing, `static-site-importer validate-artifact` command construction,
@@ -264,6 +266,57 @@ step and returned `validation_method: wp.blocks.validateBlock`,
 unit-tested in `tools/fixture-matrix.test.mjs`. The remaining enablement for a
 true imported-content assertion is targeting the imported post rather than a
 blank editor (gap documented above).
+
+## Editor-Fidelity Capture
+
+The editor-fidelity lane checks the gap between block validity and actual editor
+rendering. A fixture can have valid serialized blocks and a faithful frontend while
+the real block editor canvas shows blank/broken content or opaque fallback islands.
+
+SSI surfaces the imported front-page record generically from the import result:
+`source_documents.pages[]`, `source_of_truth.desired.pages[]`, or the returned
+`pages` map. The chosen record lands on the fixture result as `imported_front_page`
+with `post_id`, `post_type`, `source_path`, and `permalink` when available.
+
+The wp-codebox command used for the screenshot is:
+
+```text
+wordpress.editor-open post-id=<imported-front-page-post-id> post-type=page capture=steps,console,errors,html,screenshot,editor-state
+```
+
+`wordpress.editor-open` opens `/wp-admin/post.php?post=<id>&action=edit`, waits for
+the block editor shell, and writes `files/browser/editor-screenshot.png` as a
+full-page screenshot. SSI persists that screenshot under
+`editor-fidelity/<fixture-id>/editor-canvas.png` when wp-codebox exposes it in the
+run artifacts.
+
+When both the editor screenshot and imported frontend screenshot are available,
+`collectEditorFrontendParity` scores editor-canvas vs frontend-candidate PNGs using
+the same bounded offset-tolerant pixelmatch path as visual parity. Metrics land on
+`fixture.editor_frontend_parity.metrics`:
+
+- `raw_mismatch_pixels`, `raw_total_pixels`, `raw_mismatch_ratio`
+- `aligned_mismatch_pixels`, `aligned_total_pixels`, `aligned_mismatch_ratio`
+- `detected_offset`
+- `alignment_pixelmatch_threshold`
+
+Over-threshold divergence emits `editor_render_divergence`. Like visual parity,
+capture/scoring is non-gating by default. Pass
+`--editor-frontend-parity-gate` / `SSI_FIXTURE_MATRIX_EDITOR_FRONTEND_PARITY_GATE=1`
+to make over-threshold divergence unacceptable. The threshold is configurable via
+`--editor-frontend-parity-threshold` /
+`SSI_FIXTURE_MATRIX_EDITOR_FRONTEND_PARITY_THRESHOLD`; the default is exact parity
+(`0`).
+
+Current wp-codebox gap: recipes are static and cannot interpolate the JSON output
+of the SSI import step into a later `post-id=<id>` argument. SSI now writes and
+collects the imported page id, and the step helper composes the correct
+`wordpress.editor-open` command when a post id is known, but a single in-sandbox
+recipe needs an upstream wp-codebox primitive such as output interpolation,
+`target=front-page` support for `wordpress.editor-open`, or a composed
+`wordpress.editor-open-imported-front-page` style command. Without that, live runs
+can persist/score editor screenshots only when the screenshot artifact is produced
+by a post-id-targeted editor step.
 
 ## Pixel Visual Parity Gate
 

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -22,6 +22,7 @@ export {
   EDITOR_VALIDATE_BLOCKS_SCHEMA,
   EDITOR_VALIDATION_METHOD,
   EDITOR_VALIDATION_PROVIDER,
+  EDITOR_RENDER_DIVERGENCE_KIND,
   DEFAULT_EDITOR_VALIDATION_POST_TYPE,
   VISUAL_PARITY_MISMATCH_KIND,
   LOW_NATIVE_CONVERSION_KIND,
@@ -43,6 +44,8 @@ export {
 } from './fixture-matrix/steps/recipe-builder.mjs';
 
 export { editorBlockValidationStep } from './fixture-matrix/steps/editor-validation-step.mjs';
+
+export { editorCanvasCaptureStep } from './fixture-matrix/steps/editor-fidelity-step.mjs';
 
 export { visualParityCompareStep } from './fixture-matrix/steps/visual-parity-step.mjs';
 
@@ -81,6 +84,13 @@ export {
   findBestVisualParityOffset,
   normalizeVisualParityGateOptions,
 } from './fixture-matrix/collectors/visual-parity.mjs';
+
+export {
+  collectEditorFrontendParity,
+  collectEditorFrontendParityDiagnostics,
+  collectImportedFrontPage,
+  normalizeEditorFrontendParityOptions,
+} from './fixture-matrix/collectors/editor-fidelity.mjs';
 
 export {
   runLiveWpParity,

--- a/lib/fixture-matrix/collectors/editor-fidelity.mjs
+++ b/lib/fixture-matrix/collectors/editor-fidelity.mjs
@@ -1,0 +1,294 @@
+// Editor-fidelity collector: imported frontend screenshot vs block-editor canvas
+// screenshot scoring and artifact slot normalization.
+
+/**
+ * External dependencies
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+
+/**
+ * Internal dependencies
+ */
+import {
+  DEFAULT_EDITOR_FRONTEND_PARITY_PIXEL_THRESHOLD,
+  EDITOR_RENDER_DIVERGENCE_KIND,
+} from '../shared/constants.mjs';
+import {
+  artifactRef,
+  clampRatio,
+  compactObject,
+  finiteNumber,
+  firstNumber,
+  firstString,
+  isTruthySignal,
+  normalizeArray,
+  objectValue,
+} from '../shared/utils.mjs';
+import { findBestVisualParityOffset } from './visual-parity.mjs';
+
+const DEFAULT_PIXELMATCH_THRESHOLD = 0.1;
+const DEFAULT_MAX_VERTICAL_SHIFT = 64;
+const DEFAULT_MAX_HORIZONTAL_SHIFT = 0;
+
+export function collectImportedFrontPage(payload) {
+  const row = importedPageRows(payload).find((page) => page.is_front_page || page.source_path === 'website/index.html' || /(?:^|\/)index\.html$/i.test(page.source_path || ''))
+    || importedPageRows(payload)[0]
+    || null;
+  return row ? compactObject(row) : null;
+}
+
+export function collectEditorFrontendParity(payload, options = {}) {
+  const normalized = normalizeEditorFrontendParity(payload, options);
+  const fallbackArtifacts = fallbackEditorFrontendArtifacts(payload);
+  if (!normalized && !fallbackArtifacts) {
+    return null;
+  }
+  return {
+    schema: 'static-site-importer/editor-frontend-parity/v1',
+    metrics: normalized ? compactObject({
+      raw_mismatch_pixels: normalized.raw_mismatch_pixels,
+      raw_total_pixels: normalized.raw_total_pixels,
+      raw_mismatch_ratio: normalized.raw_mismatch_ratio,
+      aligned_mismatch_pixels: normalized.aligned_mismatch_pixels,
+      aligned_total_pixels: normalized.aligned_total_pixels,
+      aligned_mismatch_ratio: normalized.aligned_mismatch_ratio,
+      detected_offset: normalized.detected_offset,
+      alignment_pixelmatch_threshold: normalized.alignment_pixelmatch_threshold,
+    }) : {},
+    artifacts: normalized ? editorFrontendParityArtifacts(normalized) : fallbackArtifacts,
+  };
+}
+
+function fallbackEditorFrontendArtifacts(payload) {
+  const editorScreenshot = firstRef(editorScreenshotRefs(payload));
+  const frontendScreenshot = firstRef(frontendScreenshotRefs(payload));
+  if (!editorScreenshot && !frontendScreenshot) {
+    return null;
+  }
+  return editorFrontendParityArtifacts({ editor_screenshot: editorScreenshot, frontend_screenshot: frontendScreenshot });
+}
+
+export function collectEditorFrontendParityDiagnostics(payload, options = {}) {
+  const parity = normalizeEditorFrontendParity(payload, options);
+  if (!parity) {
+    return [];
+  }
+  const gate = normalizeEditorFrontendParityOptions(options).gate;
+  const threshold = normalizeEditorFrontendParityOptions(options).threshold;
+  const ratio = parity.aligned_mismatch_ratio ?? parity.raw_mismatch_ratio;
+  if (ratio <= threshold) {
+    return [];
+  }
+  const percent = (ratio * 100).toFixed(2);
+  const thresholdPercent = (threshold * 100).toFixed(2);
+  return [{
+    kind: EDITOR_RENDER_DIVERGENCE_KIND,
+    loss_class: 'editor_render_divergence',
+    ...(gate ? { gate: true, editor_frontend_parity_gate: true } : {}),
+    post_id: parity.post_id,
+    mismatch_ratio: ratio,
+    raw_mismatch_ratio: parity.raw_mismatch_ratio,
+    aligned_mismatch_ratio: parity.aligned_mismatch_ratio,
+    raw_mismatch_pixels: parity.raw_mismatch_pixels,
+    raw_total_pixels: parity.raw_total_pixels,
+    aligned_mismatch_pixels: parity.aligned_mismatch_pixels,
+    aligned_total_pixels: parity.aligned_total_pixels,
+    detected_offset: parity.detected_offset,
+    threshold,
+    artifact_refs: editorFrontendParityArtifactRefs(parity),
+    message: `Editor canvas diverges from imported frontend: ${percent}% pixels differ after alignment, exceeding the ${thresholdPercent}% threshold.`,
+  }];
+}
+
+export function normalizeEditorFrontendParityOptions(options = {}) {
+  const source = objectValue(options);
+  return {
+    threshold: clampRatio(finiteNumber(source.threshold ?? source.pixelThreshold ?? source.pixel_threshold ?? source.editorFrontendParityThreshold ?? source.editor_frontend_parity_threshold, DEFAULT_EDITOR_FRONTEND_PARITY_PIXEL_THRESHOLD)),
+    gate: isTruthySignal(source.gate ?? source.editorFrontendParityGate ?? source.editor_frontend_parity_gate),
+    maxVerticalShift: Math.max(0, Math.floor(finiteNumber(source.maxVerticalShift ?? source.max_vertical_shift, DEFAULT_MAX_VERTICAL_SHIFT))),
+    maxHorizontalShift: Math.max(0, Math.floor(finiteNumber(source.maxHorizontalShift ?? source.max_horizontal_shift, DEFAULT_MAX_HORIZONTAL_SHIFT))),
+    pixelmatchThreshold: clampRatio(finiteNumber(source.pixelmatchThreshold ?? source.pixelmatch_threshold, DEFAULT_PIXELMATCH_THRESHOLD)),
+    fixtureArtifactsDirectory: firstString([source.fixtureArtifactsDirectory, source.fixture_artifacts_directory]),
+  };
+}
+
+function normalizeEditorFrontendParity(payload, rawOptions = {}) {
+  const options = normalizeEditorFrontendParityOptions(rawOptions);
+  const editorScreenshot = firstRef(editorScreenshotRefs(payload));
+  const frontendScreenshot = firstRef(frontendScreenshotRefs(payload));
+  const editorPath = resolveArtifactPath(editorScreenshot, options.fixtureArtifactsDirectory);
+  const frontendPath = resolveArtifactPath(frontendScreenshot, options.fixtureArtifactsDirectory);
+  if (!editorPath || !frontendPath) {
+    return null;
+  }
+  try {
+    const editor = PNG.sync.read(fs.readFileSync(editorPath));
+    const frontend = PNG.sync.read(fs.readFileSync(frontendPath));
+    const raw = scoreOverlap(frontend, editor, options.pixelmatchThreshold);
+    const aligned = findBestVisualParityOffset(frontend, editor, {
+      maxVerticalShift: options.maxVerticalShift,
+      maxHorizontalShift: options.maxHorizontalShift,
+      pixelmatchThreshold: options.pixelmatchThreshold,
+    });
+    return compactObject({
+      post_id: importedPostId(payload),
+      editor_screenshot: editorScreenshot,
+      frontend_screenshot: frontendScreenshot,
+      raw_mismatch_pixels: raw.mismatchPixels,
+      raw_total_pixels: raw.totalPixels,
+      raw_mismatch_ratio: raw.totalPixels > 0 ? raw.mismatchPixels / raw.totalPixels : 0,
+      aligned_mismatch_pixels: aligned?.aligned_mismatch_pixels,
+      aligned_total_pixels: aligned?.aligned_total_pixels,
+      aligned_mismatch_ratio: aligned?.aligned_mismatch_ratio,
+      detected_offset: aligned?.detected_offset,
+      alignment_pixelmatch_threshold: options.pixelmatchThreshold,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function scoreOverlap(left, right, threshold) {
+  const width = Math.min(left.width, right.width);
+  const height = Math.min(left.height, right.height);
+  if (width <= 0 || height <= 0) {
+    return { mismatchPixels: 0, totalPixels: 0 };
+  }
+  const leftCrop = new Uint8Array(width * height * 4);
+  const rightCrop = new Uint8Array(width * height * 4);
+  copyPngCrop(left, leftCrop, width, height);
+  copyPngCrop(right, rightCrop, width, height);
+  return { mismatchPixels: pixelmatch(leftCrop, rightCrop, null, width, height, { threshold, includeAA: false }), totalPixels: width * height };
+}
+
+function copyPngCrop(image, target, width, height) {
+  const bytesPerPixel = 4;
+  const targetStride = width * bytesPerPixel;
+  const sourceStride = image.width * bytesPerPixel;
+  for (let row = 0; row < height; row += 1) {
+    image.data.copy(target, row * targetStride, row * sourceStride, row * sourceStride + targetStride);
+  }
+}
+
+function importedPageRows(payload) {
+  const root = objectValue(payload);
+  const report = objectValue(root.import_report || root.importReport || root.report || root.result?.import_report || root.result?.importReport);
+  const sourceDocs = objectValue(root.source_documents || root.sourceDocuments || report.source_documents || report.sourceDocuments || root.result?.source_documents || root.result?.sourceDocuments);
+  const sourcePages = normalizeArray(sourceDocs.pages || sourceDocs.Pages);
+  const pagesMap = objectValue(root.pages || root.result?.pages || report.pages);
+  const sourceOfTruthPages = normalizeArray(objectValue(objectValue(root.source_of_truth || root.sourceOfTruth || report.source_of_truth || report.sourceOfTruth).desired).pages);
+  const rows = [];
+  for (const page of sourcePages) {
+    const row = pageRow(page);
+    if (row.post_id) rows.push(row);
+  }
+  for (const page of sourceOfTruthPages) {
+    const row = pageRow(page);
+    if (row.post_id) rows.push(row);
+  }
+  for (const [sourcePath, postId] of Object.entries(pagesMap)) {
+    const numeric = Number(postId);
+    if (Number.isInteger(numeric) && numeric > 0) {
+      rows.push({ source_path: sourcePath, post_id: numeric, post_type: 'page' });
+    }
+  }
+  return dedupePages(rows);
+}
+
+function pageRow(page) {
+  const obj = objectValue(page);
+  const target = objectValue(obj.target);
+  const postId = firstNumber([obj.post_id, obj.postId, obj.materialized_post_id, obj.materializedPostId, target.post_id, target.postId]);
+  return compactObject({
+    source_path: firstString([obj.source_path, obj.sourcePath, obj.path, obj.filename, obj.file]),
+    post_id: Number.isInteger(postId) && postId > 0 ? postId : undefined,
+    post_type: firstString([obj.post_type, obj.postType, target.post_type, target.postType, 'page']),
+    permalink: firstString([obj.permalink, obj.url]),
+    is_front_page: Boolean(obj.is_front_page || obj.isFrontPage || /(?:^|\/)index\.html$/i.test(String(obj.source_path || obj.path || ''))),
+  });
+}
+
+function dedupePages(rows) {
+  const seen = new Set();
+  return rows.filter((row) => {
+    const key = `${row.post_id}:${row.source_path || ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function importedPostId(payload) {
+  return collectImportedFrontPage(payload)?.post_id || firstNumber([payload.post_id, payload.postId]);
+}
+
+function editorScreenshotRefs(payload) {
+  const files = objectValue(payload.files);
+  const artifacts = objectValue(payload.artifacts);
+  const editor = objectValue(payload.editor_frontend_parity || payload.editorFrontendParity || payload.editor_fidelity || payload.editorFidelity);
+  return [
+    files.screenshot,
+    artifacts.editor_screenshot,
+    artifacts.editorScreenshot,
+    editor.editor_screenshot,
+    editor.editorScreenshot,
+    payload.editor_screenshot,
+    payload.editorScreenshot,
+  ];
+}
+
+function frontendScreenshotRefs(payload) {
+  const artifacts = objectValue(payload.artifacts);
+  const visualArtifacts = objectValue(objectValue(payload.visual_parity_artifacts || payload.visualParityArtifacts).artifacts);
+  const editor = objectValue(payload.editor_frontend_parity || payload.editorFrontendParity || payload.editor_fidelity || payload.editorFidelity);
+  return [
+    artifacts.imported_screenshot,
+    artifacts.candidate_screenshot,
+    visualArtifacts.imported_screenshot?.ref,
+    visualArtifacts.candidate_screenshot?.ref,
+    editor.frontend_screenshot,
+    editor.frontendScreenshot,
+    payload.frontend_screenshot,
+    payload.frontendScreenshot,
+  ];
+}
+
+function firstRef(values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+    const obj = objectValue(value);
+    const ref = firstString([obj.path, obj.file, obj.href, obj.url, obj.artifact_name, obj.artifactName]);
+    if (ref) return ref;
+  }
+  return '';
+}
+
+function resolveArtifactPath(ref, fixtureArtifactsDirectory) {
+  if (!ref || typeof ref !== 'string') return '';
+  if (path.isAbsolute(ref) && fs.existsSync(ref)) return ref;
+  if (fixtureArtifactsDirectory) {
+    const candidate = path.join(fixtureArtifactsDirectory, ref);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return '';
+}
+
+function editorFrontendParityArtifacts(parity) {
+  const slot = (ref, kind, reason) => (ref
+    ? { status: 'captured', kind, ref: artifactRef(kind, ref, 'editor-fidelity') }
+    : { status: 'pending', kind, capture_state: 'not_captured', reason });
+  return {
+    editor_screenshot: slot(parity.editor_screenshot, 'editor_screenshot', 'Editor canvas screenshot was not captured.'),
+    frontend_screenshot: slot(parity.frontend_screenshot, 'frontend_screenshot', 'Imported frontend screenshot was not captured.'),
+  };
+}
+
+function editorFrontendParityArtifactRefs(parity) {
+  return [
+    ['editor_screenshot', parity.editor_screenshot],
+    ['frontend_screenshot', parity.frontend_screenshot],
+  ].filter(([, ref]) => Boolean(ref)).map(([id, ref]) => artifactRef(id, ref, 'editor-fidelity'));
+}

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -31,6 +31,12 @@ import { dedupeDiagnostics } from '../findings.mjs';
 import { collectQualityMetrics, collectBlockComposition } from './quality-metrics.mjs';
 import { collectEditorValidationDiagnostics, collectEditorValidation } from './editor-validation.mjs';
 import {
+  collectEditorFrontendParity,
+  collectEditorFrontendParityDiagnostics,
+  collectImportedFrontPage,
+  normalizeEditorFrontendParityOptions,
+} from './editor-fidelity.mjs';
+import {
   collectVisualParityDiagnostics,
   collectVisualParityArtifacts,
   normalizeVisualParityGateOptions,
@@ -51,6 +57,7 @@ export function collectFixtureMatrixRunResults(input = {}) {
   runtimePayloads.push(...collectChildCommandFailurePayloads(input.childCommandFailures || input.child_command_failures || codeboxOutput?.child_command_failures || codeboxOutput?.runtime?.child_command_failures));
   const slowFixtures = collectSlowFixtureDiagnostics(runtimePayloads);
   const visualParity = normalizeVisualParityGateOptions(input.visualParity || input.visual_parity || input);
+  const editorFrontendParity = normalizeEditorFrontendParityOptions(input.editorFrontendParity || input.editor_frontend_parity || input.editorFidelity || input.editor_fidelity || input);
   // Opt-in live-WP parity collection. Off by default: when absent (or disabled),
   // `enabled` is false and no live-WP comparison runs, so the per-fixture result
   // is byte-identical to today. When on, each fixture's captured rendered DOM is
@@ -62,16 +69,17 @@ export function collectFixtureMatrixRunResults(input = {}) {
       ...runtimePayloads.filter((payload) => fixtureIdentity(payload) === fixture.id),
       ...readFixturePayloadFiles(fixtureArtifactsDirectory),
     ];
-    return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity });
+    return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, editorFrontendParity, liveWpParity });
   });
 
   return normalizeFixtureMatrixResult({ matrix, results, slow_fixtures: slowFixtures });
 }
 
-function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity }) {
+function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, editorFrontendParity, liveWpParity }) {
   const merged = mergeObjects(payloads);
   const visualParityOptions = { ...visualParity, fixtureArtifactsDirectory };
-  const diagnostics = collectFixtureDiagnostics(merged, { visualParity: visualParityOptions });
+  const editorFrontendParityOptions = { ...editorFrontendParity, fixtureArtifactsDirectory };
+  const diagnostics = collectFixtureDiagnostics(merged, { visualParity: visualParityOptions, editorFrontendParity: editorFrontendParityOptions });
   // Best-effort live-WP parity (opt-in). Returns null when disabled or when the
   // capture/source/comparator is unavailable, keeping the lane isolated.
   const liveWpParityResult = collectLiveWpParity({
@@ -99,6 +107,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     // `wordpress.editor-validate-blocks` command, distinct from the PHP
     // round-trip's structural `invalid_block_counts`.
     editor_validation: collectEditorValidation(merged),
+    imported_front_page: collectImportedFrontPage(merged),
     blocks_engine_diagnostics: collectBlocksEngineDiagnostics(merged),
     invalid_block_counts: collectInvalidBlockCounts(merged),
     missing_assets: collectMissingAssets(merged),
@@ -107,6 +116,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     artifact_refs: collectFixtureArtifactRefs(merged, fixtureArtifactsDirectory),
     artifacts: merged.artifacts || {},
     visual_parity_artifacts: collectVisualParityArtifacts(merged, visualParityOptions),
+    editor_frontend_parity: collectEditorFrontendParity(merged, editorFrontendParityOptions),
     live_wp_parity: liveWpParityResult,
     raw: { payloads },
   });
@@ -129,6 +139,7 @@ function collectFixtureDiagnostics(payload, options = {}) {
     ...collectMissingAssets(payload).map((asset) => ({ kind: missingAssetKind(asset), ...objectValue(asset), message: diagnosticMessage(asset) || 'Missing imported asset.' })),
     ...editorValidationDiagnostics,
     ...collectVisualParityDiagnostics(payload, options.visualParity),
+    ...collectEditorFrontendParityDiagnostics(payload, options.editorFrontendParity),
   ].map(normalizeActionableDiagnosticPayload).filter(Boolean);
   const invalidBlockCount = Object.values(collectInvalidBlockCounts(payload)).reduce((sum, value) => sum + numberValue(value), 0);
   if (invalidBlockCount > 0 && editorValidationDiagnostics.length === 0) {

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -18,10 +18,12 @@ import {
   UNACCEPTABLE_LOSS_CLASSES,
   RUNTIME_CARRIED_SIGNAL_KEYS,
   VISUAL_PARITY_GATE_SIGNAL_KEYS,
+  EDITOR_FRONTEND_PARITY_GATE_SIGNAL_KEYS,
   LOW_NATIVE_CONVERSION_KIND,
   VISUAL_PARITY_MISMATCH_KIND,
   VISUAL_TIMEOUT_KIND,
   EDITOR_BLOCK_INVALID_KIND,
+  EDITOR_RENDER_DIVERGENCE_KIND,
 } from './shared/constants.mjs';
 import {
   normalizeArray,
@@ -320,6 +322,9 @@ function classifyLossClass({ raw, kind, group_key, repair_bucket, message, resul
   if (group_key === 'visual_parity_mismatch' || kind === VISUAL_PARITY_MISMATCH_KIND || /visual parity mismatch|pixel (?:diff|mismatch)/i.test(haystack)) {
     return 'visual_parity_mismatch';
   }
+  if (group_key === 'editor_render_divergence' || kind === EDITOR_RENDER_DIVERGENCE_KIND || /editor[-_\s]+frontend[-_\s]+parity|editor canvas.*frontend/i.test(haystack)) {
+    return 'editor_render_divergence';
+  }
   if (group_key === 'editor_block_invalid' || kind === EDITOR_BLOCK_INVALID_KIND || /editor block validation|block-editor-warning|this block contains unexpected or invalid content/i.test(haystack)) {
     return 'editor_block_invalid';
   }
@@ -357,6 +362,9 @@ function resolveLossAcceptance(lossClass, raw) {
     // run explicitly opted into gating (the parser stamps a gate signal).
     return hasVisualParityGateSignal(raw) ? 'unacceptable' : 'acceptable';
   }
+  if (lossClass === 'editor_render_divergence') {
+    return hasEditorFrontendParityGateSignal(raw) ? 'unacceptable' : 'acceptable';
+  }
   return ACCEPTABLE_LOSS_CLASSES.has(lossClass) ? 'acceptable' : 'unacceptable';
 }
 
@@ -364,6 +372,12 @@ function hasVisualParityGateSignal(raw) {
   const rawObject = objectValue(raw);
   const classification = objectValue(rawObject.classification);
   return VISUAL_PARITY_GATE_SIGNAL_KEYS.some((key) => isTruthySignal(rawObject[key]) || isTruthySignal(classification[key]));
+}
+
+function hasEditorFrontendParityGateSignal(raw) {
+  const rawObject = objectValue(raw);
+  const classification = objectValue(rawObject.classification);
+  return EDITOR_FRONTEND_PARITY_GATE_SIGNAL_KEYS.some((key) => isTruthySignal(rawObject[key]) || isTruthySignal(classification[key]));
 }
 
 function hasRuntimeCarriedSignal(raw) {
@@ -465,6 +479,8 @@ export function normalizeLossClass(value) {
     visual_parity_mismatch: 'visual_parity_mismatch',
     visual_parity: 'visual_parity_mismatch',
     pixel_mismatch: 'visual_parity_mismatch',
+    editor_render_divergence: 'editor_render_divergence',
+    editor_frontend_parity: 'editor_render_divergence',
     missing_asset: 'missing_asset',
     missing_assets: 'missing_asset',
     missing_output: 'missing_output',

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -253,6 +253,9 @@ function findingCategories(finding) {
   if (lossClass === 'visual_parity_mismatch') {
     categories.push('visual_mismatch');
   }
+  if (lossClass === 'editor_render_divergence') {
+    categories.push('editor_render_divergence');
+  }
   if (lossClass === 'visual_timeout' || finding.kind === 'visual_timeout') {
     categories.push('visual_timeout');
   }
@@ -306,7 +309,7 @@ function hasPrimitiveEvidence(finding) {
 }
 
 function hasStructuredEvidence(finding) {
-  if (finding.loss_class === 'visual_parity_mismatch' || finding.kind === 'visual_parity_mismatch') {
+  if (finding.loss_class === 'visual_parity_mismatch' || finding.kind === 'visual_parity_mismatch' || finding.loss_class === 'editor_render_divergence' || finding.kind === 'editor_render_divergence') {
     return true;
   }
 
@@ -400,6 +403,7 @@ export function normalizeFixtureResult(input) {
     // + validation_method), distinct from the PHP round-trip. Round-trips through
     // re-normalization so editor-quality scoring can read it.
     editor_validation: input.editor_validation || input.editorValidation || null,
+    imported_front_page: input.imported_front_page || input.importedFrontPage || null,
     // Retained report blobs can carry raw serialized markup (e.g.
     // `import_report.materialized_content.block_documents[].post_content`). Bound
     // every retained string so the per-fixture result scales with #findings, not
@@ -415,6 +419,7 @@ export function normalizeFixtureResult(input) {
     artifact_refs: normalizeArray(input.artifact_refs || input.artifactRefs),
     artifacts: input.artifacts || {},
     visual_parity_artifacts: input.visual_parity_artifacts || input.visualParityArtifacts || null,
+    editor_frontend_parity: input.editor_frontend_parity || input.editorFrontendParity || null,
     // Opt-in live-WP parity result (live-WP score + render-free proxy score +
     // delta). Only attached when the collector produced one; absent => the key is
     // omitted entirely so a default (toggle-off) result is byte-identical to today.

--- a/lib/fixture-matrix/shared/constants.mjs
+++ b/lib/fixture-matrix/shared/constants.mjs
@@ -31,6 +31,8 @@ export const EDITOR_VALIDATE_BLOCKS_COMMAND = 'wordpress.editor-validate-blocks'
 export const EDITOR_VALIDATE_BLOCKS_SCHEMA = 'wp-codebox/editor-validate-blocks/v1';
 export const EDITOR_VALIDATION_METHOD = 'wp.blocks.validateBlock';
 export const EDITOR_VALIDATION_PROVIDER = 'wordpress-block-editor';
+export const EDITOR_RENDER_DIVERGENCE_KIND = 'editor_render_divergence';
+export const DEFAULT_EDITOR_FRONTEND_PARITY_PIXEL_THRESHOLD = 0;
 // The per-fixture recipe interleaves import then editor validation. `front-page`
 // resolves at runtime to the just-imported `page_on_front`, so validation targets
 // real imported content even when the imported post ID is not known at recipe
@@ -98,6 +100,7 @@ export const DEFAULT_VISUAL_PARITY_WAIT_FOR = 'domcontentloaded';
 // A finding gates when it carries an explicit gate signal. The dev-loop wrapper
 // sends this by default; direct collector callers can still run capture-only.
 export const VISUAL_PARITY_GATE_SIGNAL_KEYS = ['gate', 'visual_parity_gate', 'visualParityGate'];
+export const EDITOR_FRONTEND_PARITY_GATE_SIGNAL_KEYS = ['gate', 'editor_frontend_parity_gate', 'editorFrontendParityGate'];
 
 export const DEFAULT_FINDING_GROUPS = {
   // Low native-conversion-rate gate findings route to the transformer's
@@ -125,6 +128,11 @@ export const DEFAULT_FINDING_GROUPS = {
     patterns: [/visual_parity_mismatch/i, /visual parity/i, /pixel (?:diff|mismatch|parity)/i],
     candidate_repo: 'blocks-engine',
     repair_mode: 'visual-parity',
+  },
+  editor_render_divergence: {
+    patterns: [/editor_render_divergence/i, /editor[-_\s]+frontend[-_\s]+parity/i, /editor canvas.*frontend/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'editor-render-parity',
   },
   visual_timeout: {
     patterns: [/visual_timeout/i, /visual[-_\s]+compare.*timeout/i, /candidate[-_\s]+capture.*timeout/i, /navigation timeout/i, /browser_navigation_timeout/i],
@@ -176,6 +184,7 @@ export const ACCEPTABLE_LOSS_CLASSES = new Set([
   // become unacceptable when an explicit gate signal is present. See
   // `resolveLossAcceptance`. This mirrors the conditional `preserved_runtime_island`.
   'visual_parity_mismatch',
+  'editor_render_divergence',
 ]);
 
 export const UNACCEPTABLE_LOSS_CLASSES = new Set([
@@ -193,6 +202,7 @@ export const UNACCEPTABLE_LOSS_CLASSES = new Set([
   'runtime_execution_failed',
   'visual_timeout',
   'visual_evidence_missing',
+  'editor_evidence_missing',
   'fixture_status_mismatch',
 ]);
 

--- a/lib/fixture-matrix/steps/editor-fidelity-step.mjs
+++ b/lib/fixture-matrix/steps/editor-fidelity-step.mjs
@@ -1,0 +1,55 @@
+// Editor-fidelity recipe step for the Static Site Importer fixture matrix.
+// Opens the real imported page in the block editor by post id and captures a
+// replayable full-page editor screenshot via WP Codebox.
+
+/**
+ * Internal dependencies
+ */
+import { EDITOR_OPEN_COMMAND } from '../shared/constants.mjs';
+
+function present(value) {
+  return value !== undefined && value !== null && String(value).trim() !== '';
+}
+
+export function editorCanvasCaptureStep(input = {}) {
+  const fixture = input.fixture || {};
+  const postId = firstPresent([input.postId, input.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
+  if (!present(postId)) {
+    return null;
+  }
+
+  const args = [
+    `post-id=${postId}`,
+    `post-type=${firstPresent([input.postType, input.post_type, fixture.editor_post_type, fixture.editorPostType, fixture.post_type, fixture.postType]) || 'page'}`,
+    'capture=steps,console,errors,html,screenshot,editor-state',
+  ];
+  const waitSelector = firstPresent([input.waitSelector, input.wait_selector, fixture.editor_wait_selector, fixture.editorWaitSelector]);
+  if (waitSelector !== undefined) {
+    args.push(`wait-selector=${waitSelector}`);
+  }
+  const waitTimeout = firstPresent([input.waitTimeout, input.wait_timeout, fixture.editor_wait_timeout, fixture.editorWaitTimeout]);
+  if (waitTimeout !== undefined) {
+    args.push(`wait-timeout=${waitTimeout}`);
+  }
+
+  return {
+    command: EDITOR_OPEN_COMMAND,
+    allowFailure: true,
+    args,
+    metadata: {
+      fixture_id: fixture.id,
+      fixture_path: fixture.fixture_path || fixture.directory,
+      phase: 'editor-fidelity',
+      post_id: postId,
+    },
+  };
+}
+
+function firstPresent(values) {
+  for (const value of values) {
+    if (present(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -27,6 +27,7 @@ import {
 } from '../shared/utils.mjs';
 import { createFixtureMatrix, normalizeFixture, collectFixtureFiles } from '../fixtures.mjs';
 import { editorBlockValidationStep } from './editor-validation-step.mjs';
+import { editorCanvasCaptureStep } from './editor-fidelity-step.mjs';
 import { visualParityCompareStep, normalizeVisualParityRecipeOptions } from './visual-parity-step.mjs';
 import { liveWpParityCaptureStep, liveWpParityEnabled } from './live-wp-parity-step.mjs';
 
@@ -125,6 +126,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const stagedFiles = normalizeArray(input.stagedFiles || input.staged_files);
   const extraPlugins = [importer.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)];
   const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
+  const editorFidelityEnabled = input.editorFidelity !== false && input.editor_fidelity !== false;
   // Real-content validation options forwarded to the editor-validate-blocks step.
   // No empty-post default: when nothing concrete is provided, the step targets
   // `front-page`, which wp-codebox resolves to the imported static front page
@@ -182,6 +184,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
           ...fixturePluginProvisioningSteps(fixture),
           importFixtureStep(fixture, commandArtifactsDirectory),
           ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, ...editorValidationOptions })] : []),
+          ...(editorFidelityEnabled ? [editorCanvasCaptureStep({ fixture, ...input })].filter(Boolean) : []),
           ...(visualParityEnabled ? [visualParityCompareStep({ fixture, ...visualParityRecipeOptions })] : []),
           ...(liveWpParityCaptureEnabled ? [liveWpParityCaptureStep({ fixture, ...input })] : []),
         ]),

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -19,6 +19,7 @@ import runFixtureMatrixBench, {
   fixtureMatrixBatchRunSummary,
   mapWithConcurrency,
   materializeVisualCompareArtifacts,
+  materializeEditorFidelityArtifacts,
   resolveBlocksEnginePhpTransformerPath,
   runFixtureMatrix,
 } from '../bench/static-site-fixture-matrix.bench.mjs';
@@ -41,6 +42,9 @@ import {
   collectBlockComposition,
   collectEditorValidationDiagnostics,
   collectEditorValidation,
+  collectEditorFrontendParity,
+  collectEditorFrontendParityDiagnostics,
+  collectImportedFrontPage,
   collectFixtureMatrixRunResults,
   computeFixtureEditorQuality,
   parseSerializedBlockNames,
@@ -53,6 +57,8 @@ import {
   buildFixtureArtifact,
   createFixtureMatrix,
   editorBlockValidationStep,
+  editorCanvasCaptureStep,
+  EDITOR_RENDER_DIVERGENCE_KIND,
   EDITOR_VALIDATE_BLOCKS_COMMAND,
   EDITOR_VALIDATION_METHOD,
   normalizeFixtureMatrixResult,
@@ -4053,6 +4059,116 @@ test('visual-compare PNGs are copied to the bench artifact root and registered',
   assert.equal(fixture.diagnostics[0].artifact_refs.find((ref) => ref.artifact_id === 'diff_screenshot').path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'diff.png'));
 });
 
+test('editor-canvas capture step opens the imported post id and captures a screenshot', () => {
+  const step = editorCanvasCaptureStep({ fixture: { id: 'simple-site', post_id: 123, post_type: 'page' }, waitTimeout: '30s' });
+
+  assert.equal(step.command, 'wordpress.editor-open');
+  assert.equal(step.allowFailure, true);
+  assert.ok(step.args.includes('post-id=123'));
+  assert.ok(step.args.includes('post-type=page'));
+  assert.ok(step.args.includes('capture=steps,console,errors,html,screenshot,editor-state'));
+  assert.ok(step.args.includes('wait-timeout=30s'));
+  assert.equal(step.metadata.phase, 'editor-fidelity');
+  assert.equal(step.metadata.post_id, 123);
+  assert.equal(editorCanvasCaptureStep({ fixture: { id: 'simple-site' } }), null);
+});
+
+test('imported front-page post id is surfaced from SSI import provenance', () => {
+  const payload = {
+    result: { pages: { 'website/index.html': 77 } },
+    source_documents: {
+      pages: [
+        { source_path: 'website/about.html', post_id: 78, post_type: 'page', permalink: 'https://example.test/about/' },
+        { source_path: 'website/index.html', post_id: 77, post_type: 'page', permalink: 'https://example.test/' },
+      ],
+    },
+  };
+
+  assert.deepEqual(collectImportedFrontPage(payload), {
+    source_path: 'website/index.html',
+    post_id: 77,
+    post_type: 'page',
+    permalink: 'https://example.test/',
+    is_front_page: true,
+  });
+});
+
+test('editor frontend parity metrics emit editor_render_divergence only when over threshold', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-parity-'));
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  const frontend = solidPng(4, 4, [255, 255, 255, 255]);
+  const editor = solidPng(4, 4, [0, 0, 0, 255]);
+  writePng(path.join(fixtureDirectory, 'frontend.png'), frontend);
+  writePng(path.join(fixtureDirectory, 'editor.png'), editor);
+  const payload = {
+    post_id: 77,
+    editor_screenshot: 'editor.png',
+    frontend_screenshot: 'frontend.png',
+  };
+
+  const parity = collectEditorFrontendParity(payload, { fixtureArtifactsDirectory: fixtureDirectory });
+  assert.equal(parity.schema, 'static-site-importer/editor-frontend-parity/v1');
+  assert.equal(parity.metrics.raw_mismatch_pixels, 16);
+  assert.equal(parity.metrics.raw_total_pixels, 16);
+  assert.equal(parity.metrics.raw_mismatch_ratio, 1);
+
+  assert.deepEqual(collectEditorFrontendParityDiagnostics(payload, { fixtureArtifactsDirectory: fixtureDirectory, threshold: 1, gate: true }), []);
+  const diagnostics = collectEditorFrontendParityDiagnostics(payload, { fixtureArtifactsDirectory: fixtureDirectory, threshold: 0.1, gate: true });
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].kind, EDITOR_RENDER_DIVERGENCE_KIND);
+  assert.equal(diagnostics[0].gate, true);
+  assert.equal(diagnostics[0].editor_frontend_parity_gate, true);
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-parity-gate-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'passed', diagnostics }],
+  });
+  const finding = result.findings.find((item) => item.kind === EDITOR_RENDER_DIVERGENCE_KIND);
+  assert.equal(finding.loss_class, 'editor_render_divergence');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(result.fixtures[0].status, 'failed');
+});
+
+test('editor canvas screenshots are copied to the bench artifact root and registered', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-persisted-output-'));
+  const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-codebox-artifacts-'));
+  const runtimeDirectory = path.join(codeboxArtifactsDirectory, 'runtime-123', 'files', 'browser');
+  mkdirSync(runtimeDirectory, { recursive: true });
+  writeFileSync(path.join(runtimeDirectory, 'editor-screenshot.png'), 'fake editor screenshot');
+  const result = {
+    fixtures: [
+      {
+        fixture_id: 'simple-site',
+        diagnostics: [
+          {
+            kind: EDITOR_RENDER_DIVERGENCE_KIND,
+            artifact_refs: [
+              { schema: 'homeboy/artifact-ref/v1', artifact_id: 'editor_screenshot', kind: 'editor-fidelity', path: 'files/browser/editor-screenshot.png' },
+            ],
+          },
+        ],
+        editor_frontend_parity: {
+          schema: 'static-site-importer/editor-frontend-parity/v1',
+          artifacts: {
+            editor_screenshot: { status: 'captured', ref: { path: 'files/browser/editor-screenshot.png' } },
+          },
+        },
+      },
+    ],
+  };
+
+  const persisted = materializeEditorFidelityArtifacts({ result, outputDirectory, codeboxArtifactsDirectory });
+  const artifact = persisted.artifacts['editor_fidelity_simple-site_editor_canvas'];
+  assert.ok(artifact, 'expected editor fidelity artifact registration');
+  assert.equal(readFileSync(artifact.path, 'utf8'), 'fake editor screenshot');
+  assert.equal(artifact.path, path.join(outputDirectory, 'editor-fidelity', 'simple-site', 'editor-canvas.png'));
+  assert.equal(persisted.result.fixtures[0].editor_frontend_parity.owner, 'bench_artifact_root');
+  assert.equal(persisted.result.fixtures[0].editor_frontend_parity.artifacts.editor_screenshot.ref.path, artifact.path);
+  assert.equal(persisted.result.fixtures[0].diagnostics[0].artifact_refs[0].path, artifact.path);
+});
+
 test('visual-compare dimension mismatch gates even with zero pixel metrics when gating is on', () => {
   const payload = { comparison: { mismatchPixels: 0, totalPixels: 0, dimensionMismatch: true } };
   const diagnostics = collectVisualParityDiagnostics(payload, { gate: true });
@@ -4686,6 +4802,12 @@ function syntheticVisualParityPng(width, height) {
 function blankPng(width, height) {
   const image = new PNG({ width, height });
   fillRect(image, 0, 0, width, height, [255, 255, 255, 255]);
+  return image;
+}
+
+function solidPng(width, height, rgba) {
+  const image = new PNG({ width, height });
+  fillRect(image, 0, 0, width, height, rgba);
   return image;
 }
 

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -105,6 +105,8 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.visualParityMaxHorizontalShift ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT: String(options.visualParityMaxHorizontalShift) } : {}),
     ...(options.visualParityOffsetTolerance ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE: String(options.visualParityOffsetTolerance) } : {}),
     ...(options.visualParityPixelmatchThreshold ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD: String(options.visualParityPixelmatchThreshold) } : {}),
+    ...(options.editorFrontendParityGate ? { SSI_FIXTURE_MATRIX_EDITOR_FRONTEND_PARITY_GATE: '1' } : {}),
+    ...(options.editorFrontendParityThreshold ? { SSI_FIXTURE_MATRIX_EDITOR_FRONTEND_PARITY_THRESHOLD: String(options.editorFrontendParityThreshold) } : {}),
     // Opt-in live-WP parity capture (off by default). When set, the bench appends
     // the deterministic `wordpress.capture-html` step per fixture and runs the
     // blocks-engine live-wp-parity comparator host-side. Absent => byte-identical
@@ -177,6 +179,11 @@ export function buildFixtureMatrixRunPlan(input) {
       // --no-visual-parity) so a run still produces native-rate/loss-classes/
       // findings, just without the validateBlock editor-validity data.
       enabled: options.editorValidation !== false,
+    },
+    editor_fidelity: {
+      enabled: true,
+      gate: options.editorFrontendParityGate === true,
+      threshold: options.editorFrontendParityThreshold ? Number(options.editorFrontendParityThreshold) : null,
     },
     code_freshness: codeFreshness,
     transformer_commit: resolveTransformerCommit(codeFreshness),
@@ -652,7 +659,7 @@ function parseArgs(args) {
     if (arg.startsWith('--')) {
       const [rawKey, rawValue] = arg.slice(2).split('=');
       const key = camelCase(rawKey);
-      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'visualParityAlignment', 'liveWpParity']);
+      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'visualParityAlignment', 'liveWpParity', 'editorFrontendParityGate']);
       if (booleanKeys.has(key)) {
         options[key] = true;
         continue;


### PR DESCRIPTION
## Summary
- Add editor-canvas screenshot capture plumbing for imported posts.
- Add editor/frontend parity scoring and `editor_render_divergence` diagnostics.
- Keep the editor fidelity gate opt-in so unavailable editor capture does not fabricate a pass or create false failures.

## Current limitation
This is intentionally a draft scaffolding PR. The live run did not produce the editor screenshot because wp-codebox recipes cannot currently interpolate the imported post id into a later editor-open step. The scoring, persistence, and diagnostic scaffolding is covered, but live editor capture is blocked on that upstream wp-codebox recipe interpolation gap.

## Root cause
Fixture-matrix can validate frontend visual parity and block validity, but it does not yet preserve editor-canvas evidence that proves the same imported content renders faithfully in the editor.

## Evidence
- Added tests for editor-canvas capture step construction, imported post-id provenance, editor/frontend parity scoring, copied screenshot artifact registration, and opt-in behavior.
- Visual-parity journey context: this is the next evidence layer after the coffee 34% -> 7% mismatch reduction and artist hero inline-color/nav/button fidelity work.
- Local verification: `node tools/fixture-matrix.test.mjs` passed 135 tests.

## Merge status
Draft only. Do not merge until the wp-codebox recipe interpolation gap is fixed and a live run proves editor screenshot capture works.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-cause via fixture-matrix visual evidence, fix design, parity fixtures + diagnostics