### PR TITLE
Classify visual diff regions

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -15,6 +15,7 @@ import { runWpCodeboxRecipe, wpCodeboxCommand, wpCodeboxBin } from '../tools/wp-
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
 import {
   buildFixtureMatrixRecipe,
+  classifyVisualDiffRegions,
   collectFixtureMatrixRunResults,
   createFixtureMatrix,
   normalizeFixtureMatrixResult,
@@ -85,6 +86,7 @@ export default async function runFixtureMatrixBench(context = {}) {
       result: { path: summary.result_file },
       summary: { path: path.join(summary.output_directory, 'summary.json') },
       finding_packets: { path: path.join(summary.output_directory, 'finding-packets.json') },
+      visual_diff_classification: { path: path.join(summary.output_directory, 'visual-diff-classification.json') },
       ...(summary.visual_parity_artifacts || {}),
     },
     metadata: {
@@ -255,6 +257,7 @@ export async function runFixtureMatrix(options) {
     result: fileBytes(path.join(outputDirectory, 'static-site-fixture-matrix-result.json')),
     summary: fileBytes(path.join(outputDirectory, 'summary.json')),
     finding_packets: fileBytes(path.join(outputDirectory, 'finding-packets.json')),
+    visual_diff_classification: fileBytes(path.join(outputDirectory, 'visual-diff-classification.json')),
   };
   artifactBytes.total = Object.entries(artifactBytes)
     .filter(([key, value]) => key !== 'total' && Number.isFinite(Number(value)))
@@ -450,16 +453,44 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
     return fixture;
   }
 
+  const updatedVisualParityArtifacts = {
+    ...visualParityArtifacts,
+    owner: 'bench_artifact_root',
+    missing: undefined,
+    artifacts: updatedSlots,
+  };
+  const classification = classifyVisualDiffRegions({
+    visual_parity_artifacts: updatedVisualParityArtifacts,
+    comparison: {
+      ...(visualParityArtifacts.metrics || {}),
+      mismatchPixels: visualParityArtifacts.metrics?.mismatch_pixels,
+      totalPixels: visualParityArtifacts.metrics?.total_pixels,
+      overlapMismatchPixels: visualParityArtifacts.metrics?.overlap_mismatch_pixels,
+      overlapPixels: visualParityArtifacts.metrics?.overlap_pixels,
+      dimensionMismatch: visualParityArtifacts.metrics?.dimension_mismatch,
+    },
+    files: {
+      sourceScreenshot: updatedSlots.source_screenshot?.ref?.path,
+      candidateScreenshot: updatedSlots.imported_screenshot?.ref?.path,
+      diffScreenshot: updatedSlots.diff_screenshot?.ref?.path,
+    },
+  }, { fixtureArtifactsDirectory: outputDirectory });
+
   return {
     ...fixture,
     diagnostics: rewriteDiagnosticArtifactRefs(fixture.diagnostics, rewrites),
     artifact_refs: rewriteArtifactRefs(fixture.artifact_refs, rewrites),
-    visual_parity_artifacts: {
-      ...visualParityArtifacts,
-      owner: 'bench_artifact_root',
-      missing: undefined,
-      artifacts: updatedSlots,
-    },
+    visual_parity_artifacts: classification ? {
+      ...updatedVisualParityArtifacts,
+      visual_diff_regions: classification.visual_diff_regions,
+      visual_diff_cause_summary: classification.visual_diff_cause_summary,
+      visual_diff_classification: classification,
+    } : updatedVisualParityArtifacts,
+    ...(classification ? {
+      visual_diff_regions: classification.visual_diff_regions,
+      visual_diff_cause_summary: classification.visual_diff_cause_summary,
+      visual_diff_classification: classification,
+    } : {}),
   };
 }
 
@@ -865,6 +896,7 @@ function batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outp
     result: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
     summary: path.join(outputDirectory, 'summary.json'),
     finding_packets: path.join(outputDirectory, 'finding-packets.json'),
+    visual_diff_classification: path.join(outputDirectory, 'visual-diff-classification.json'),
     batch_recipe: path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`),
     batch_output: path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`),
   };

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -78,6 +78,7 @@ export {
 
 export {
   collectVisualParityDiagnostics,
+  classifyVisualDiffRegions,
   findBestVisualParityOffset,
   normalizeVisualParityGateOptions,
 } from './fixture-matrix/collectors/visual-parity.mjs';

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -72,6 +72,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
   const merged = mergeObjects(payloads);
   const visualParityOptions = { ...visualParity, fixtureArtifactsDirectory };
   const diagnostics = collectFixtureDiagnostics(merged, { visualParity: visualParityOptions });
+  const visualParityArtifacts = collectVisualParityArtifacts(merged, visualParityOptions);
   // Best-effort live-WP parity (opt-in). Returns null when disabled or when the
   // capture/source/comparator is unavailable, keeping the lane isolated.
   const liveWpParityResult = collectLiveWpParity({
@@ -106,7 +107,10 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     diagnostics,
     artifact_refs: collectFixtureArtifactRefs(merged, fixtureArtifactsDirectory),
     artifacts: merged.artifacts || {},
-    visual_parity_artifacts: collectVisualParityArtifacts(merged, visualParityOptions),
+    visual_parity_artifacts: visualParityArtifacts,
+    visual_diff_regions: visualParityArtifacts?.visual_diff_regions || [],
+    visual_diff_cause_summary: visualParityArtifacts?.visual_diff_cause_summary || null,
+    visual_diff_classification: visualParityArtifacts?.visual_diff_classification || null,
     live_wp_parity: liveWpParityResult,
     raw: { payloads },
   });

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -37,6 +37,8 @@ const DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_VERTICAL_SHIFT = 64;
 const DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_HORIZONTAL_SHIFT = 0;
 const DEFAULT_VISUAL_PARITY_ALIGNMENT_OFFSET_TOLERANCE = 2;
 const DEFAULT_VISUAL_PARITY_ALIGNMENT_PIXELMATCH_THRESHOLD = 0.1;
+const DEFAULT_VISUAL_DIFF_CLASSIFICATION_MAX_REGIONS = 8;
+const DEFAULT_VISUAL_DIFF_CLASSIFICATION_MIN_PIXELS = 4;
 
 // Turn `wordpress.visual-compare` evidence into `visual_parity_mismatch`
 // diagnostics, gated on the TRUSTWORTHY (dimension-fair) ratio.
@@ -83,6 +85,8 @@ export function collectVisualParityDiagnostics(payload, options = {}) {
         aligned_mismatch_ratio: comparison.aligned_mismatch_ratio,
         detected_offset: comparison.detected_offset,
         alignment_pixelmatch_threshold: comparison.alignment_pixelmatch_threshold,
+        visual_diff_regions: comparison.visual_diff_regions,
+        visual_diff_cause_summary: comparison.visual_diff_cause_summary,
         raw_mismatch_pixels: comparison.mismatch_pixels,
         raw_total_pixels: comparison.total_pixels,
         raw_mismatch_ratio: comparison.raw_mismatch_ratio,
@@ -149,6 +153,12 @@ function computeAlignedVisualParity(comparison, options = {}) {
   } catch {
     return null;
   }
+}
+
+export function classifyVisualDiffRegions(payload, options = {}) {
+  const gateOptions = normalizeVisualParityGateOptions(options);
+  const comparisons = collectVisualParityComparisons(payload, { ...gateOptions, ...options });
+  return comparisons[0]?.visual_diff_classification || null;
 }
 
 export function findBestVisualParityOffset(source, candidate, options = {}) {
@@ -302,6 +312,10 @@ function mergeVisualParityComparison(left, right) {
     visual_diff: left.visual_diff || right.visual_diff,
     visual_explanation_ref: left.visual_explanation_ref || right.visual_explanation_ref,
     visual_explanation: left.visual_explanation || right.visual_explanation,
+    mismatch_regions: left.mismatch_regions?.length ? left.mismatch_regions : right.mismatch_regions,
+    visual_diff_regions: left.visual_diff_regions?.length ? left.visual_diff_regions : right.visual_diff_regions,
+    visual_diff_cause_summary: Object.keys(left.visual_diff_cause_summary || {}).length ? left.visual_diff_cause_summary : right.visual_diff_cause_summary,
+    visual_diff_classification: left.visual_diff_classification || right.visual_diff_classification,
     aligned_mismatch_pixels: left.aligned_mismatch_pixels ?? right.aligned_mismatch_pixels,
     aligned_total_pixels: left.aligned_total_pixels ?? right.aligned_total_pixels,
     aligned_mismatch_ratio: left.aligned_mismatch_ratio ?? right.aligned_mismatch_ratio,
@@ -373,6 +387,11 @@ function normalizeVisualParityComparison(value, options = {}) {
   const artifactSlots = objectValue(objectValue(obj.visual_parity_artifacts || obj.visualParityArtifacts).artifacts);
   const sourceObject = objectValue(obj.source);
   const visualExplanation = normalizeVisualExplanation(obj);
+  const mismatchRegions = normalizeMismatchRegions([
+    ...normalizeArray(comparison.regions || comparison.mismatchRegions || comparison.mismatch_regions),
+    ...normalizeArray(obj.regions || obj.mismatchRegions || obj.mismatch_regions),
+    ...normalizeArray(visualExplanation?.mismatch_regions || visualExplanation?.mismatchRegions),
+  ]);
   const normalized = {
     mismatch_pixels: safeMismatch,
     total_pixels: safeTotal,
@@ -392,9 +411,424 @@ function normalizeVisualParityComparison(value, options = {}) {
     visual_diff: firstRef([artifacts.visual_diff, artifactSlots.visual_diff, files.visualDiff, obj.visual_diff, obj.visualDiff]),
     visual_explanation_ref: firstRef([artifacts.visual_explanation, artifactSlots.visual_explanation, files.visualExplanation, visualCompare.explanation, obj.visual_explanation_ref, obj.visualExplanationRef]),
     visual_explanation: visualExplanation,
+    mismatch_regions: mismatchRegions,
   };
   const aligned = options.alignment ? computeAlignedVisualParity(normalized, options) : null;
-  return aligned ? { ...normalized, ...aligned } : normalized;
+  const withAlignment = aligned ? { ...normalized, ...aligned } : normalized;
+  const classification = classifyVisualParityComparisonRegions(withAlignment, options);
+  return classification ? { ...withAlignment, ...classification } : withAlignment;
+}
+
+function normalizeMismatchRegions(values) {
+  return values.map((value) => {
+    const row = objectValue(value);
+    const x = Math.floor(finiteNumber(row.x, NaN));
+    const y = Math.floor(finiteNumber(row.y, NaN));
+    const width = Math.floor(finiteNumber(row.width, NaN));
+    const height = Math.floor(finiteNumber(row.height, NaN));
+    const pixels = Math.floor(finiteNumber(row.pixels ?? row.pixel_count ?? row.pixelCount, width * height));
+    if (![x, y, width, height, pixels].every(Number.isFinite) || width <= 0 || height <= 0 || pixels <= 0) {
+      return null;
+    }
+    return { x, y, width, height, pixels };
+  }).filter(Boolean);
+}
+
+function classifyVisualParityComparisonRegions(comparison, options = {}) {
+  const sourcePath = resolveVisualParityArtifactPath(comparison.source_screenshot, options.fixtureArtifactsDirectory);
+  const candidatePath = resolveVisualParityArtifactPath(comparison.candidate_screenshot, options.fixtureArtifactsDirectory);
+  const diffPath = resolveVisualParityArtifactPath(comparison.diff_screenshot, options.fixtureArtifactsDirectory);
+  if (!sourcePath || !candidatePath || !diffPath) {
+    return null;
+  }
+  try {
+    const source = PNG.sync.read(fs.readFileSync(sourcePath));
+    const candidate = PNG.sync.read(fs.readFileSync(candidatePath));
+    const diff = PNG.sync.read(fs.readFileSync(diffPath));
+    const pixelmatchThreshold = clampRatio(finiteNumber(comparison.pixelmatch_threshold ?? options.pixelmatchThreshold ?? options.pixelmatch_threshold, DEFAULT_VISUAL_PARITY_ALIGNMENT_PIXELMATCH_THRESHOLD));
+    const mask = visualDiffMismatchMask(source, candidate, pixelmatchThreshold);
+    const computedRegions = visualCompareMismatchRegions(mask, positiveInteger(options.maxRegions ?? options.visualDiffMaxRegions, DEFAULT_VISUAL_DIFF_CLASSIFICATION_MAX_REGIONS));
+    const fallbackRegions = comparison.mismatch_regions?.length ? comparison.mismatch_regions : visualCompareMismatchRegions(diff, positiveInteger(options.maxRegions ?? options.visualDiffMaxRegions, DEFAULT_VISUAL_DIFF_CLASSIFICATION_MAX_REGIONS));
+    const statsDiff = computedRegions.length > 0 ? mask : diff;
+    const regions = (computedRegions.length > 0 ? computedRegions : fallbackRegions)
+      .filter((region) => region.pixels >= DEFAULT_VISUAL_DIFF_CLASSIFICATION_MIN_PIXELS)
+      .slice(0, positiveInteger(options.maxRegions ?? options.visualDiffMaxRegions, DEFAULT_VISUAL_DIFF_CLASSIFICATION_MAX_REGIONS));
+    const classifiedRegions = regions.map((region) => classifyVisualDiffRegion({ region, source, candidate, diff: statsDiff, comparison }))
+      .filter(Boolean);
+    if (classifiedRegions.length === 0) {
+      return null;
+    }
+    const summary = visualDiffCauseSummary(classifiedRegions);
+    const artifact = {
+      schema: 'static-site-importer/visual-diff-classification/v1',
+      source_screenshot: comparison.source_screenshot,
+      candidate_screenshot: comparison.candidate_screenshot,
+      diff_screenshot: comparison.diff_screenshot,
+      pixelmatch: {
+        threshold: pixelmatchThreshold,
+        metric: 'perceptual_yiq_color_distance',
+      },
+      detected_offset: comparison.detected_offset,
+      visual_diff_regions: classifiedRegions,
+      visual_diff_cause_summary: summary,
+    };
+    return {
+      visual_diff_regions: classifiedRegions,
+      visual_diff_cause_summary: summary,
+      visual_diff_classification: artifact,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function visualDiffMismatchMask(source, candidate, threshold) {
+  const width = Math.min(source.width, candidate.width);
+  const height = Math.min(source.height, candidate.height);
+  if (width <= 0 || height <= 0) {
+    return new PNG({ width: Math.max(source.width, candidate.width), height: Math.max(source.height, candidate.height) });
+  }
+  const sourceCanvas = visualDiffCanvas(source, width, height);
+  const candidateCanvas = visualDiffCanvas(candidate, width, height);
+  const mask = new PNG({ width, height });
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const index = ((y * width) + x) << 2;
+      const isMismatch = yiqColorDistance(
+        { r: sourceCanvas.data[index], g: sourceCanvas.data[index + 1], b: sourceCanvas.data[index + 2], a: sourceCanvas.data[index + 3] },
+        { r: candidateCanvas.data[index], g: candidateCanvas.data[index + 1], b: candidateCanvas.data[index + 2], a: candidateCanvas.data[index + 3] },
+      ) > threshold || Math.abs(sourceCanvas.data[index + 3] - candidateCanvas.data[index + 3]) > 16;
+      if (isMismatch) {
+        mask.data[index] = 255;
+        mask.data[index + 3] = 255;
+      }
+    }
+  }
+  return mask;
+}
+
+function visualDiffCanvas(image, width, height) {
+  if (image.width === width && image.height === height) {
+    return image;
+  }
+  const canvas = new PNG({ width, height });
+  const copyHeight = Math.min(image.height, height);
+  const copyWidth = Math.min(image.width, width);
+  for (let y = 0; y < copyHeight; y += 1) {
+    const sourceStart = (image.width * y) << 2;
+    const targetStart = (width * y) << 2;
+    image.data.copy(canvas.data, targetStart, sourceStart, sourceStart + (copyWidth << 2));
+  }
+  return canvas;
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Math.floor(finiteNumber(value, fallback));
+  return parsed > 0 ? parsed : fallback;
+}
+
+function classifyVisualDiffRegion({ region, source, candidate, diff, comparison }) {
+  const bbox = { x: region.x, y: region.y, width: region.width, height: region.height };
+  const stats = visualDiffRegionStats({ region, source, candidate, diff, offset: comparison.detected_offset });
+  const mapped = mapRegionToVisualExplanation(region, comparison.visual_explanation);
+  const cause = dominantVisualDiffCause(stats, mapped, comparison.detected_offset);
+  return compactObject({
+    bbox,
+    pixel_count: region.pixels,
+    dominant_cause: cause.cause,
+    confidence: cause.confidence,
+    ...(mapped.selector ? { mapped_selector: mapped.selector } : {}),
+    stats: compactObject({
+      mean_yiq_distance: roundMetric(stats.meanYiqDistance),
+      edge_divergence_ratio: roundMetric(stats.edgeDivergenceRatio),
+      source_content_ratio: roundMetric(stats.sourceContentRatio),
+      candidate_content_ratio: roundMetric(stats.candidateContentRatio),
+      source_bbox_content_ratio: roundMetric(stats.sourceBboxContentRatio),
+      candidate_bbox_content_ratio: roundMetric(stats.candidateBboxContentRatio),
+      shifted_match_ratio: Number.isFinite(stats.shiftedMatchRatio) ? roundMetric(stats.shiftedMatchRatio) : undefined,
+    }),
+  });
+}
+
+function dominantVisualDiffCause(stats, mapped, offset) {
+  const offsetMagnitude = detectedOffsetMagnitude(offset);
+  const textHint = /^(?:a|button|span|p|h[1-6]|li|label|strong|em|small)$/i.test(mapped.tag || '') || Boolean(mapped.textChanged);
+  const colorHint = mapped.styleProperties.some((property) => /color|background|fill|stroke/i.test(property));
+  const geometryHint = Boolean(mapped.boundingBoxChanged) || mapped.styleProperties.some((property) => /radius|width|height|margin|padding|border|gap|top|left|right|bottom/i.test(property));
+  const oneSideBlank = Math.min(stats.sourceContentRatio, stats.candidateContentRatio) < 0.08 && Math.max(stats.sourceContentRatio, stats.candidateContentRatio) > 0.18;
+  const regionAspect = Math.max(stats.regionWidth, stats.regionHeight) / Math.max(1, Math.min(stats.regionWidth, stats.regionHeight));
+  if (offsetMagnitude > DEFAULT_VISUAL_PARITY_ALIGNMENT_OFFSET_TOLERANCE && Number.isFinite(stats.shiftedMatchRatio) && stats.shiftedMatchRatio > 0.75) {
+    return { cause: 'position_offset', confidence: 0.86 };
+  }
+  if (oneSideBlank && (stats.regionWidth < 12 || stats.regionHeight < 12 || regionAspect > 3)) {
+    return { cause: 'restyle_geometry', confidence: 0.72 };
+  }
+  if (oneSideBlank && Math.min(stats.sourceBboxContentRatio, stats.candidateBboxContentRatio) < 0.08) {
+    return { cause: 'missing_or_extra_element', confidence: 0.9 };
+  }
+  if (textHint && stats.edgeDivergenceRatio >= 0.12 && stats.meanYiqDistance < 0.35) {
+    return { cause: 'text_typography', confidence: 0.78 };
+  }
+  if ((colorHint || stats.meanYiqDistance >= 0.18) && stats.edgeDivergenceRatio < 0.14 && Math.abs(stats.sourceContentRatio - stats.candidateContentRatio) < 0.25) {
+    return { cause: 'color_shift', confidence: colorHint ? 0.86 : 0.78 };
+  }
+  if (geometryHint || stats.edgeDivergenceRatio >= 0.14) {
+    return { cause: 'restyle_geometry', confidence: geometryHint ? 0.82 : 0.72 };
+  }
+  return { cause: stats.meanYiqDistance >= 0.12 ? 'color_shift' : 'restyle_geometry', confidence: 0.55 };
+}
+
+function visualDiffRegionStats({ region, source, candidate, diff, offset }) {
+  const background = {
+    source: sampleImageBackground(source),
+    candidate: sampleImageBackground(candidate),
+  };
+  let mismatchPixels = 0;
+  let yiqDistance = 0;
+  let sourceContent = 0;
+  let candidateContent = 0;
+  let sourceBboxContent = 0;
+  let candidateBboxContent = 0;
+  let bboxPixels = 0;
+  let edgeDivergence = 0;
+  let edgeSamples = 0;
+  let shiftedSamples = 0;
+  let shiftedMatches = 0;
+  const dx = Math.floor(finiteNumber(offset?.x, 0));
+  const dy = Math.floor(finiteNumber(offset?.y, 0));
+  for (let y = region.y; y < region.y + region.height; y += 1) {
+    for (let x = region.x; x < region.x + region.width; x += 1) {
+      if (!diffPixel(diff, x, y)) {
+        const sourceColor = pixelAt(source, x, y);
+        const candidateColor = pixelAt(candidate, x, y);
+        bboxPixels += 1;
+        if (isContentPixel(sourceColor, background.source)) {
+          sourceBboxContent += 1;
+        }
+        if (isContentPixel(candidateColor, background.candidate)) {
+          candidateBboxContent += 1;
+        }
+        continue;
+      }
+      const sourceColor = pixelAt(source, x, y);
+      const candidateColor = pixelAt(candidate, x, y);
+      bboxPixels += 1;
+      mismatchPixels += 1;
+      yiqDistance += yiqColorDistance(sourceColor, candidateColor);
+      if (isContentPixel(sourceColor, background.source)) {
+        sourceContent += 1;
+        sourceBboxContent += 1;
+      }
+      if (isContentPixel(candidateColor, background.candidate)) {
+        candidateContent += 1;
+        candidateBboxContent += 1;
+      }
+      const sourceEdge = edgeAt(source, x, y);
+      const candidateEdge = edgeAt(candidate, x, y);
+      if (sourceEdge || candidateEdge) {
+        edgeSamples += 1;
+        if (sourceEdge !== candidateEdge) {
+          edgeDivergence += 1;
+        }
+      }
+      if (dx || dy) {
+        const shiftedCandidate = pixelAt(candidate, x + dx, y + dy);
+        if (shiftedCandidate) {
+          shiftedSamples += 1;
+          if (yiqColorDistance(sourceColor, shiftedCandidate) < 0.08) {
+            shiftedMatches += 1;
+          }
+        }
+      }
+    }
+  }
+  return {
+    meanYiqDistance: mismatchPixels > 0 ? yiqDistance / mismatchPixels : 0,
+    regionWidth: region.width,
+    regionHeight: region.height,
+    edgeDivergenceRatio: edgeSamples > 0 ? edgeDivergence / edgeSamples : 0,
+    sourceContentRatio: mismatchPixels > 0 ? sourceContent / mismatchPixels : 0,
+    candidateContentRatio: mismatchPixels > 0 ? candidateContent / mismatchPixels : 0,
+    sourceBboxContentRatio: bboxPixels > 0 ? sourceBboxContent / bboxPixels : 0,
+    candidateBboxContentRatio: bboxPixels > 0 ? candidateBboxContent / bboxPixels : 0,
+    shiftedMatchRatio: shiftedSamples > 0 ? shiftedMatches / shiftedSamples : undefined,
+  };
+}
+
+function visualDiffCauseSummary(regions) {
+  const summary = {};
+  for (const region of regions) {
+    summary[region.dominant_cause] = (summary[region.dominant_cause] || 0) + region.pixel_count;
+  }
+  return Object.fromEntries(Object.entries(summary).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])));
+}
+
+function visualCompareMismatchRegions(diff, maxRegions) {
+  const visited = new Uint8Array(diff.width * diff.height);
+  const regions = [];
+  for (let y = 0; y < diff.height; y += 1) {
+    for (let x = 0; x < diff.width; x += 1) {
+      const index = y * diff.width + x;
+      if (visited[index] || !diffPixel(diff, x, y)) {
+        continue;
+      }
+      regions.push(floodDiffRegion(diff, x, y, visited));
+    }
+  }
+  return regions.sort((a, b) => b.pixels - a.pixels).slice(0, maxRegions);
+}
+
+function floodDiffRegion(diff, startX, startY, visited) {
+  const stack = [[startX, startY]];
+  let minX = startX;
+  let maxX = startX;
+  let minY = startY;
+  let maxY = startY;
+  let pixels = 0;
+  while (stack.length > 0) {
+    const [x, y] = stack.pop();
+    if (x < 0 || y < 0 || x >= diff.width || y >= diff.height) {
+      continue;
+    }
+    const index = y * diff.width + x;
+    if (visited[index] || !diffPixel(diff, x, y)) {
+      continue;
+    }
+    visited[index] = 1;
+    pixels += 1;
+    minX = Math.min(minX, x);
+    maxX = Math.max(maxX, x);
+    minY = Math.min(minY, y);
+    maxY = Math.max(maxY, y);
+    stack.push([x + 1, y], [x - 1, y], [x, y + 1], [x, y - 1]);
+  }
+  return { x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1, pixels };
+}
+
+function diffPixel(image, x, y) {
+  const color = pixelAt(image, x, y);
+  return Boolean(color && (color.r > 0 || color.g > 0 || color.b > 0));
+}
+
+function sampleImageBackground(image) {
+  return pixelAt(image, 0, 0) || { r: 255, g: 255, b: 255, a: 255 };
+}
+
+function pixelAt(image, x, y) {
+  if (!image || x < 0 || y < 0 || x >= image.width || y >= image.height) {
+    return null;
+  }
+  const offset = ((y * image.width) + x) << 2;
+  return { r: image.data[offset], g: image.data[offset + 1], b: image.data[offset + 2], a: image.data[offset + 3] };
+}
+
+function isContentPixel(color, background) {
+  if (!color || color.a < 16) {
+    return false;
+  }
+  return yiqColorDistance(color, background) > 0.06;
+}
+
+function edgeAt(image, x, y) {
+  const center = pixelAt(image, x, y);
+  const right = pixelAt(image, x + 1, y);
+  const down = pixelAt(image, x, y + 1);
+  if (!center || (!right && !down)) {
+    return false;
+  }
+  return (right && luminanceDelta(center, right) > 32) || (down && luminanceDelta(center, down) > 32);
+}
+
+function luminanceDelta(left, right) {
+  return Math.abs(luminance(left) - luminance(right));
+}
+
+function luminance(color) {
+  return (0.299 * color.r) + (0.587 * color.g) + (0.114 * color.b);
+}
+
+function yiqColorDistance(left, right) {
+  if (!left || !right) {
+    return 1;
+  }
+  const y = ((left.r - right.r) * 0.29889531) + ((left.g - right.g) * 0.58662247) + ((left.b - right.b) * 0.11448223);
+  const i = ((left.r - right.r) * 0.59597799) - ((left.g - right.g) * 0.2741761) - ((left.b - right.b) * 0.32180189);
+  const q = ((left.r - right.r) * 0.21147017) - ((left.g - right.g) * 0.52261711) + ((left.b - right.b) * 0.31114694);
+  return Math.sqrt((y * y * 0.5053) + (i * i * 0.299) + (q * q * 0.1957)) / 255;
+}
+
+function mapRegionToVisualExplanation(region, visualExplanation) {
+  const explanation = objectValue(visualExplanation);
+  const candidates = [
+    ...normalizeArray(explanation.changes),
+    ...normalizeArray(explanation.selectors),
+    ...normalizeArray(explanation.selector_diagnostics),
+    ...normalizeArray(explanation.property_diagnostics),
+    ...normalizeArray(explanation.layout_diagnostics),
+  ].map((item) => visualExplanationCandidate(item)).filter(Boolean);
+  let best = null;
+  for (const candidate of candidates) {
+    const score = candidate.bbox ? bboxOverlapRatio(region, candidate.bbox) : 0;
+    if (!best || score > best.score) {
+      best = { ...candidate, score };
+    }
+  }
+  return best && (best.score > 0 || best.selector || best.tag) ? best : { styleProperties: [] };
+}
+
+function visualExplanationCandidate(item) {
+  const row = objectValue(item);
+  const changes = objectValue(row.changes);
+  const boundingBox = objectValue(changes.boundingBox || changes.bounding_box || row.boundingBox || row.bounding_box || row.source_rect || row.sourceRect);
+  const sourceBox = objectValue(boundingBox.source || boundingBox);
+  const candidateBox = objectValue(boundingBox.candidate);
+  const bbox = unionBbox(normalizeBbox(sourceBox), normalizeBbox(candidateBox));
+  const styles = objectValue(changes.styles || row.styles || row.style_deltas || row.styleDeltas);
+  return {
+    selector: firstString([row.selector, row.source_selector, row.sourceSelector, row.target_selector, row.targetSelector, row.path]),
+    tag: firstString([row.tag, row.tagName, row.tag_name]),
+    bbox,
+    styleProperties: Object.keys(styles),
+    boundingBoxChanged: Boolean(changes.boundingBox || changes.bounding_box || row.source_rect || row.sourceRect),
+    textChanged: Boolean(changes.text || row.text || row.source_text || row.sourceText || row.target_text || row.targetText),
+  };
+}
+
+function normalizeBbox(value) {
+  const row = objectValue(value);
+  const x = finiteNumber(row.x, NaN);
+  const y = finiteNumber(row.y, NaN);
+  const width = finiteNumber(row.width, NaN);
+  const height = finiteNumber(row.height, NaN);
+  return [x, y, width, height].every(Number.isFinite) && width > 0 && height > 0 ? { x, y, width, height } : null;
+}
+
+function unionBbox(left, right) {
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+  const x1 = Math.min(left.x, right.x);
+  const y1 = Math.min(left.y, right.y);
+  const x2 = Math.max(left.x + left.width, right.x + right.width);
+  const y2 = Math.max(left.y + left.height, right.y + right.height);
+  return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
+}
+
+function bboxOverlapRatio(left, right) {
+  const x1 = Math.max(left.x, right.x);
+  const y1 = Math.max(left.y, right.y);
+  const x2 = Math.min(left.x + left.width, right.x + right.width);
+  const y2 = Math.min(left.y + left.height, right.y + right.height);
+  const overlap = Math.max(0, x2 - x1) * Math.max(0, y2 - y1);
+  const area = Math.max(1, left.width * left.height);
+  return overlap / area;
+}
+
+function roundMetric(value) {
+  return Math.round(value * 1000) / 1000;
 }
 
 function firstRef(values) {
@@ -448,13 +882,15 @@ function normalizeVisualExplanation(value) {
     ...normalizeArray(obj.capture_diagnostics || obj.captureDiagnostics),
     ...normalizeArray(visualCompare.capture_diagnostics || visualCompare.captureDiagnostics),
   ], ['phase', 'selector', 'source_url', 'target_url', 'viewport', 'full_page', 'reason', 'message']);
+  const mismatchRegions = normalizeMismatchRegions(normalizeArray(explanation.mismatchRegions || explanation.mismatch_regions));
+  const changes = summarizeVisualExplanationChanges(normalizeArray(explanation.changes));
   const counts = compactObject({
     selector_diagnostic_count: evidenceCount(summary.selector_diagnostic_count ?? summary.selectorDiagnosticCount ?? explanation.selector_diagnostic_count ?? explanation.selectorDiagnosticCount, selectors.length),
     property_diagnostic_count: evidenceCount(summary.property_diagnostic_count ?? summary.propertyDiagnosticCount ?? explanation.property_diagnostic_count ?? explanation.propertyDiagnosticCount, properties.length),
     layout_diagnostic_count: evidenceCount(summary.layout_diagnostic_count ?? summary.layoutDiagnosticCount ?? explanation.layout_diagnostic_count ?? explanation.layoutDiagnosticCount, layout.length),
     capture_diagnostic_count: evidenceCount(summary.capture_diagnostic_count ?? summary.captureDiagnosticCount ?? explanation.capture_diagnostic_count ?? explanation.captureDiagnosticCount, capture.length),
   });
-  if (selectors.length === 0 && properties.length === 0 && layout.length === 0 && capture.length === 0 && Object.keys(counts).length === 0) {
+  if (selectors.length === 0 && properties.length === 0 && layout.length === 0 && capture.length === 0 && mismatchRegions.length === 0 && changes.length === 0 && Object.keys(counts).length === 0) {
     return null;
   }
   return boundBlob(compactObject({
@@ -464,7 +900,26 @@ function normalizeVisualExplanation(value) {
     property_diagnostics: properties,
     layout_diagnostics: layout,
     capture_diagnostics: capture,
+    mismatch_regions: mismatchRegions,
+    changes,
   }));
+}
+
+function summarizeVisualExplanationChanges(values) {
+  return values.map((value) => {
+    const row = objectValue(value);
+    const changes = objectValue(row.changes);
+    const boundingBox = objectValue(changes.boundingBox || changes.bounding_box);
+    return boundBlob(compactObject({
+      path: firstString([row.path, row.selector]),
+      tag: firstString([row.tag, row.tagName, row.tag_name]),
+      changes: compactObject({
+        text: changes.text ? true : undefined,
+        boundingBox: changes.boundingBox || changes.bounding_box ? boundingBox : undefined,
+        styles: changes.styles ? Object.fromEntries(Object.keys(objectValue(changes.styles)).map((key) => [key, true])) : undefined,
+      }),
+    }));
+  }).filter((value) => Object.keys(value).length > 0).slice(0, VISUAL_EXPLANATION_SUMMARY_LIMIT);
 }
 
 function isVisualExplanationPayload(value) {
@@ -531,7 +986,7 @@ export function collectVisualParityArtifacts(payload, options = {}) {
   if (comparisons.length === 0) {
     return null;
   }
-  const comparison = comparisons[0];
+  const comparison = selectBestVisualParityArtifactComparison(comparisons);
   const slot = (ref, kind, reason) => (ref
     ? { status: 'captured', kind, ref: artifactRef(kind, ref, 'visual-parity') }
     : { status: 'pending', kind, capture_state: 'not_captured', reason });
@@ -555,6 +1010,9 @@ export function collectVisualParityArtifacts(payload, options = {}) {
       dimension_delta_pixels: comparison.dimension_delta_pixels,
       dimension_mismatch: comparison.dimension_mismatch,
     }),
+    ...(comparison.visual_diff_regions?.length ? { visual_diff_regions: comparison.visual_diff_regions } : {}),
+    ...(comparison.visual_diff_cause_summary ? { visual_diff_cause_summary: comparison.visual_diff_cause_summary } : {}),
+    ...(comparison.visual_diff_classification ? { visual_diff_classification: comparison.visual_diff_classification } : {}),
     ...(comparison.visual_explanation ? { visual_explanation: comparison.visual_explanation } : {}),
     artifacts: {
       source_screenshot: slot(comparison.source_screenshot, 'source_screenshot', 'Source screenshot was not captured by the runtime.'),
@@ -564,4 +1022,21 @@ export function collectVisualParityArtifacts(payload, options = {}) {
       visual_explanation: slot(comparison.visual_explanation_ref, 'visual_explanation', 'Visual explanation output was not captured by the runtime.'),
     },
   };
+}
+
+function selectBestVisualParityArtifactComparison(comparisons) {
+  return [...comparisons].sort((a, b) => visualParityArtifactScore(b) - visualParityArtifactScore(a))[0];
+}
+
+function visualParityArtifactScore(comparison) {
+  return [
+    comparison.source_screenshot,
+    comparison.candidate_screenshot,
+    comparison.diff_screenshot,
+    comparison.visual_diff,
+    comparison.visual_explanation_ref,
+  ].filter(Boolean).length
+    + (comparison.visual_diff_classification ? 10 : 0)
+    + (comparison.visual_diff_regions?.length ? 5 : 0)
+    + (comparison.total_pixels > 0 ? 1 : 0);
 }

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -226,6 +226,8 @@ function visualAttributionFindingFields(raw, rawObserved, rawSelectorEvidence) {
       property_evidence: raw.property_evidence !== undefined || raw.propertyEvidence !== undefined ? boundBlob(normalizeArray(raw.property_evidence || raw.propertyEvidence)) : undefined,
       style_deltas: raw.style_deltas !== undefined || raw.styleDeltas !== undefined ? boundBlob(normalizeArray(raw.style_deltas || raw.styleDeltas)) : undefined,
       visual_diff: raw.visual_diff !== undefined || raw.visualDiff !== undefined ? boundBlob(raw.visual_diff || raw.visualDiff) : undefined,
+      visual_diff_regions: raw.visual_diff_regions !== undefined || raw.visualDiffRegions !== undefined ? boundBlob(normalizeArray(raw.visual_diff_regions || raw.visualDiffRegions)) : undefined,
+      visual_diff_cause_summary: raw.visual_diff_cause_summary !== undefined || raw.visualDiffCauseSummary !== undefined ? boundBlob(raw.visual_diff_cause_summary || raw.visualDiffCauseSummary) : undefined,
     }),
   };
 }

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -113,6 +113,8 @@ export function normalizeFixtureMatrixResult(input = {}) {
       fixture_categories: categoryRollups.fixture_categories,
       fixture_failure_categories: categoryRollups.fixture_failure_categories,
       gate_failure_reasons: categoryRollups.gate_failure_reasons,
+      visual_diff_cause_summary: aggregateVisualDiffCauseSummary(gatedFixtureResults),
+      visual_diff_top_causes: visualDiffTopCauses(gatedFixtureResults),
       groups: Object.fromEntries(Object.entries(grouped).map(([key, items]) => [key, items.length])),
       top_pattern_families: topPatternFamilies(actionableFindings),
       top_acceptable_pattern_families: topPatternFamilies(acceptableActionableFindings),
@@ -415,6 +417,9 @@ export function normalizeFixtureResult(input) {
     artifact_refs: normalizeArray(input.artifact_refs || input.artifactRefs),
     artifacts: input.artifacts || {},
     visual_parity_artifacts: input.visual_parity_artifacts || input.visualParityArtifacts || null,
+    visual_diff_regions: normalizeArray(input.visual_diff_regions || input.visualDiffRegions),
+    visual_diff_cause_summary: input.visual_diff_cause_summary || input.visualDiffCauseSummary || null,
+    visual_diff_classification: input.visual_diff_classification || input.visualDiffClassification || null,
     // Opt-in live-WP parity result (live-WP score + render-free proxy score +
     // delta). Only attached when the collector produced one; absent => the key is
     // omitted entirely so a default (toggle-off) result is byte-identical to today.
@@ -480,6 +485,7 @@ export function writeFixtureMatrixArtifacts(input = {}) {
       artifactRef('result', path.join(outputDirectory, 'static-site-fixture-matrix-result.json'), 'diagnostic'),
       artifactRef('summary', path.join(outputDirectory, 'summary.json'), 'summary'),
       artifactRef('finding-packets', path.join(outputDirectory, 'finding-packets.json'), 'diagnostic'),
+      artifactRef('visual-diff-classification', path.join(outputDirectory, 'visual-diff-classification.json'), 'diagnostic'),
     ],
   };
 }
@@ -491,7 +497,50 @@ export function writeFixtureMatrixResultArtifacts(input = {}) {
   writeJsonFile(path.join(outputDirectory, 'static-site-fixture-matrix-result.json'), result);
   writeJsonFile(path.join(outputDirectory, 'summary.json'), result.summary);
   writeJsonFile(path.join(outputDirectory, 'finding-packets.json'), result.findings);
+  writeJsonFile(path.join(outputDirectory, 'visual-diff-classification.json'), visualDiffClassificationArtifact(result));
   return result;
+}
+
+function visualDiffClassificationArtifact(result) {
+  const fixtures = normalizeArray(result.fixtures).map((fixture) => {
+    const artifacts = objectValue(fixture.visual_parity_artifacts || fixture.visualParityArtifacts);
+    return compactObject({
+      fixture_id: fixture.fixture_id,
+      visual_diff_regions: normalizeArray(fixture.visual_diff_regions || artifacts.visual_diff_regions),
+      visual_diff_cause_summary: fixture.visual_diff_cause_summary || artifacts.visual_diff_cause_summary || null,
+      artifact_refs: normalizeArray(fixture.artifact_refs),
+    });
+  }).filter((fixture) => fixture.visual_diff_regions?.length || Object.keys(objectValue(fixture.visual_diff_cause_summary)).length > 0);
+  return {
+    schema: 'static-site-importer/visual-diff-classification-run/v1',
+    matrix_id: result.matrix_id,
+    summary: {
+      visual_diff_cause_summary: aggregateVisualDiffCauseSummary(result.fixtures),
+      visual_diff_top_causes: visualDiffTopCauses(result.fixtures),
+    },
+    fixtures,
+  };
+}
+
+function aggregateVisualDiffCauseSummary(fixtures) {
+  const summary = {};
+  for (const fixture of normalizeArray(fixtures)) {
+    const artifacts = objectValue(fixture.visual_parity_artifacts || fixture.visualParityArtifacts);
+    const causeSummary = objectValue(fixture.visual_diff_cause_summary || fixture.visualDiffCauseSummary || artifacts.visual_diff_cause_summary || artifacts.visualDiffCauseSummary);
+    for (const [cause, pixels] of Object.entries(causeSummary)) {
+      const value = Number(pixels);
+      if (Number.isFinite(value)) {
+        summary[cause] = (summary[cause] || 0) + value;
+      }
+    }
+  }
+  return Object.fromEntries(Object.entries(summary).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])));
+}
+
+function visualDiffTopCauses(fixtures, limit = 5) {
+  return Object.entries(aggregateVisualDiffCauseSummary(fixtures))
+    .slice(0, limit)
+    .map(([cause, pixel_count]) => ({ cause, pixel_count }));
 }
 
 function shouldStageFixtureSources(input = {}) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -45,6 +45,7 @@ import {
   computeFixtureEditorQuality,
   parseSerializedBlockNames,
   collectVisualParityDiagnostics,
+  classifyVisualDiffRegions,
   findBestVisualParityOffset,
   liveWpParityCaptureStep,
   liveWpParityEnabled,
@@ -1345,6 +1346,88 @@ test('findBestVisualParityOffset returns deterministic offset metrics for identi
   assert.equal(score.detected_offset.x, 0);
   assert.equal(score.aligned_mismatch_pixels, 0);
   assert.equal(score.aligned_mismatch_ratio, 0);
+});
+
+test('visual diff region classification identifies pure color-fill changes as color_shift', () => {
+  const { fixtureArtifactsDirectory, payload } = visualDiffClassificationFixture('color-shift', (source, candidate) => {
+    fillRect(source, 8, 8, 24, 18, [20, 90, 160, 255]);
+    fillRect(candidate, 8, 8, 24, 18, [220, 180, 40, 255]);
+  });
+
+  const classification = classifyVisualDiffRegions(payload, { fixtureArtifactsDirectory });
+  assert.equal(classification.visual_diff_regions[0].dominant_cause, 'color_shift');
+  assert.equal(classification.visual_diff_cause_summary.color_shift, classification.visual_diff_regions[0].pixel_count);
+});
+
+test('visual diff region classification identifies blanked content as missing_or_extra_element', () => {
+  const { fixtureArtifactsDirectory, payload } = visualDiffClassificationFixture('missing-element', (source) => {
+    fillRect(source, 8, 8, 24, 18, [20, 90, 160, 255]);
+  });
+
+  const classification = classifyVisualDiffRegions(payload, { fixtureArtifactsDirectory });
+  assert.equal(classification.visual_diff_regions[0].dominant_cause, 'missing_or_extra_element');
+});
+
+test('visual diff region classification identifies shifted blocks as position_offset', () => {
+  const fixtureArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-classify-shift-'));
+  const visualDirectory = path.join(fixtureArtifactsDirectory, 'files', 'browser', 'visual-compare', 'shifted-block');
+  mkdirSync(visualDirectory, { recursive: true });
+  const source = blankPng(48, 40);
+  fillRect(source, 8, 8, 18, 16, [20, 90, 160, 255]);
+  const candidate = shiftedPng(source, 6, 0);
+  const diff = exactDiffPng(source, candidate);
+  writePng(path.join(visualDirectory, 'source.png'), source);
+  writePng(path.join(visualDirectory, 'candidate.png'), candidate);
+  writePng(path.join(visualDirectory, 'diff.png'), diff);
+
+  const classification = classifyVisualDiffRegions(visualComparePayload({
+    sourceScreenshot: 'files/browser/visual-compare/shifted-block/source.png',
+    candidateScreenshot: 'files/browser/visual-compare/shifted-block/candidate.png',
+    diffScreenshot: 'files/browser/visual-compare/shifted-block/diff.png',
+    mismatchPixels: 192,
+    totalPixels: 1920,
+    overlapMismatchPixels: 192,
+    overlapPixels: 1920,
+  }), { fixtureArtifactsDirectory, maxHorizontalShift: 8 });
+
+  assert.equal(classification.visual_diff_regions[0].dominant_cause, 'position_offset');
+});
+
+test('visual diff region classification identifies resized boxes as restyle_geometry', () => {
+  const { fixtureArtifactsDirectory, payload } = visualDiffClassificationFixture('resized-box', (source, candidate) => {
+    fillRect(source, 8, 8, 18, 18, [20, 90, 160, 255]);
+    fillRect(candidate, 8, 8, 28, 18, [20, 90, 160, 255]);
+  });
+
+  const classification = classifyVisualDiffRegions(payload, { fixtureArtifactsDirectory });
+  assert.equal(classification.visual_diff_regions[0].dominant_cause, 'restyle_geometry');
+});
+
+test('visual diff region classification prefers computed screenshot regions over stale upstream regions', () => {
+  const fixtureArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-classify-overlap-'));
+  const visualDirectory = path.join(fixtureArtifactsDirectory, 'files', 'browser', 'visual-compare', 'overlap');
+  mkdirSync(visualDirectory, { recursive: true });
+  const source = blankPng(48, 40);
+  const candidate = blankPng(48, 40);
+  fillRect(source, 8, 8, 24, 18, [20, 90, 160, 255]);
+  fillRect(candidate, 8, 8, 24, 18, [220, 180, 40, 255]);
+  const diff = exactDiffPng(source, candidate);
+  writePng(path.join(visualDirectory, 'source.png'), source);
+  writePng(path.join(visualDirectory, 'candidate.png'), candidate);
+  writePng(path.join(visualDirectory, 'diff.png'), diff);
+
+  const classification = classifyVisualDiffRegions(visualComparePayload({
+    sourceScreenshot: 'files/browser/visual-compare/overlap/source.png',
+    candidateScreenshot: 'files/browser/visual-compare/overlap/candidate.png',
+    diffScreenshot: 'files/browser/visual-compare/overlap/diff.png',
+    mismatchPixels: countDiffPixels(diff),
+    totalPixels: 48 * 40,
+    overlapMismatchPixels: 24 * 18,
+    overlapPixels: 48 * 40,
+    mismatchRegions: [{ x: 0, y: 36, width: 48, height: 4, pixels: 192 }],
+  }), { fixtureArtifactsDirectory });
+
+  assert.deepEqual(classification.visual_diff_regions[0].bbox, { x: 8, y: 8, width: 24, height: 18 });
 });
 
 test('fixture diagnostics drop empty rows and normalize kindless carriers with explicit kind', () => {
@@ -4653,24 +4736,85 @@ test('live-WP parity collector failure is isolated and never sinks the lane', ()
   assert.equal(result.schema, 'static-site-importer/fixture-matrix-result/v1');
 });
 
-function visualComparePayload({ sourceScreenshot, candidateScreenshot, mismatchPixels, totalPixels, overlapMismatchPixels, overlapPixels }) {
+function visualComparePayload({ sourceScreenshot, candidateScreenshot, diffScreenshot, mismatchPixels, totalPixels, overlapMismatchPixels, overlapPixels, dimensionMismatch = false, mismatchRegions = [] }) {
   return {
     schema: 'wp-codebox/visual-compare-matrix/v1',
     comparisons: [
       {
         name: 'synthetic',
         source: { url: 'file:///synthetic/index.html' },
-        files: { sourceScreenshot, candidateScreenshot },
+        files: { sourceScreenshot, candidateScreenshot, ...(diffScreenshot ? { diffScreenshot } : {}) },
         comparison: {
           mismatchPixels,
           totalPixels,
           overlapMismatchPixels,
           overlapPixels,
-          dimensionMismatch: false,
+          dimensionMismatch,
+          ...(mismatchRegions.length ? { mismatchRegions } : {}),
         },
       },
     ],
   };
+}
+
+function visualDiffClassificationFixture(name, mutate) {
+  const fixtureArtifactsDirectory = mkdtempSync(path.join(tmpdir(), `ssi-visual-classify-${name}-`));
+  const visualDirectory = path.join(fixtureArtifactsDirectory, 'files', 'browser', 'visual-compare', name);
+  mkdirSync(visualDirectory, { recursive: true });
+  const source = blankPng(48, 40);
+  const candidate = blankPng(48, 40);
+  mutate(source, candidate);
+  const diff = exactDiffPng(source, candidate);
+  writePng(path.join(visualDirectory, 'source.png'), source);
+  writePng(path.join(visualDirectory, 'candidate.png'), candidate);
+  writePng(path.join(visualDirectory, 'diff.png'), diff);
+  const mismatchPixels = countDiffPixels(diff);
+  return {
+    fixtureArtifactsDirectory,
+    payload: visualComparePayload({
+      sourceScreenshot: `files/browser/visual-compare/${name}/source.png`,
+      candidateScreenshot: `files/browser/visual-compare/${name}/candidate.png`,
+      diffScreenshot: `files/browser/visual-compare/${name}/diff.png`,
+      mismatchPixels,
+      totalPixels: 48 * 40,
+      overlapMismatchPixels: mismatchPixels,
+      overlapPixels: 48 * 40,
+    }),
+  };
+}
+
+function exactDiffPng(source, candidate) {
+  const image = blankPng(source.width, source.height);
+  fillRect(image, 0, 0, image.width, image.height, [0, 0, 0, 0]);
+  for (let y = 0; y < source.height; y += 1) {
+    for (let x = 0; x < source.width; x += 1) {
+      const index = ((y * source.width) + x) << 2;
+      const differs = source.data[index] !== candidate.data[index]
+        || source.data[index + 1] !== candidate.data[index + 1]
+        || source.data[index + 2] !== candidate.data[index + 2]
+        || source.data[index + 3] !== candidate.data[index + 3];
+      if (differs) {
+        image.data[index] = 255;
+        image.data[index + 1] = 0;
+        image.data[index + 2] = 0;
+        image.data[index + 3] = 255;
+      }
+    }
+  }
+  return image;
+}
+
+function countDiffPixels(diff) {
+  let pixels = 0;
+  for (let y = 0; y < diff.height; y += 1) {
+    for (let x = 0; x < diff.width; x += 1) {
+      const index = ((y * diff.width) + x) << 2;
+      if (diff.data[index] || diff.data[index + 1] || diff.data[index + 2]) {
+        pixels += 1;
+      }
+    }
+  }
+  return pixels;
 }
 
 function syntheticVisualParityPng(width, height) {


### PR DESCRIPTION
## Summary
- Add first-class per-region visual diff cause classification.
- Persist `visual-diff-classification.json` as a run artifact.
- Surface classified findings for color shifts, missing/extra elements, position offsets, restyle geometry, and text/typography differences.

## Root cause
Fixture-matrix visual evidence was identifying mismatched pixels but not preserving enough cause-level structure for repair routing. That made the parity loop depend on manual screenshot interpretation.

## Evidence
- Added classification coverage for color shifts, missing/extra elements, position offsets, restyle geometry, and computed screenshot regions.
- Visual-parity journey context: this supports the coffee 34% -> 7% mismatch reduction and artist hero inline-color/nav/button fidelity follow-up by turning visual deltas into actionable repair classes.
- Local verification: `node tools/fixture-matrix.test.mjs` passed 136 tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-cause via fixture-matrix visual evidence, fix design, parity fixtures + diagnostics