### PR TITLE
ci: bump homeboy-action to v2.8.9 (review umbrella)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: Extra-Chill/homeboy-action@51ae1b48299c60f3850f68780adb1a42951ce9c8  # v2.8.6
+      - uses: Extra-Chill/homeboy-action@9474cf7db35bf1a34e5bc59b43a85cda5ec57188  # v2.8.9
         with:
           commands: review test
           php-version: ${{ matrix.php-version }}


### PR DESCRIPTION
## Summary
- Bumps `Extra-Chill/homeboy-action` from v2.8.6 to v2.8.9.
- homeboy folded test/audit/lint/build under the `homeboy review` umbrella.
- The old action pin emitted bare `homeboy test`, which now fails with `unrecognized subcommand 'test'` and was failing SSI CI across open PRs.\n- The v2.8.9 action contains the migration to the review-umbrella CLI shape.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents\n- **Used for:** Diagnosing the homeboy review-umbrella CLI migration and bumping the action pin