### PR TITLE
Add truthful Gutenberg incompatibility registry

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -87,6 +87,8 @@ export default async function runFixtureMatrixBench(context = {}) {
       summary: { path: path.join(summary.output_directory, 'summary.json') },
       finding_packets: { path: path.join(summary.output_directory, 'finding-packets.json') },
       visual_diff_classification: { path: path.join(summary.output_directory, 'visual-diff-classification.json') },
+      gutenberg_incompatibility_registry: { path: path.join(summary.output_directory, 'gutenberg-incompatibility-registry.json') },
+      gutenberg_incompatibility_registry_report: { path: path.join(summary.output_directory, 'gutenberg-incompatibility-registry.md') },
       ...(summary.visual_parity_artifacts || {}),
     },
     metadata: {
@@ -258,6 +260,8 @@ export async function runFixtureMatrix(options) {
     summary: fileBytes(path.join(outputDirectory, 'summary.json')),
     finding_packets: fileBytes(path.join(outputDirectory, 'finding-packets.json')),
     visual_diff_classification: fileBytes(path.join(outputDirectory, 'visual-diff-classification.json')),
+    gutenberg_incompatibility_registry: fileBytes(path.join(outputDirectory, 'gutenberg-incompatibility-registry.json')),
+    gutenberg_incompatibility_registry_report: fileBytes(path.join(outputDirectory, 'gutenberg-incompatibility-registry.md')),
   };
   artifactBytes.total = Object.entries(artifactBytes)
     .filter(([key, value]) => key !== 'total' && Number.isFinite(Number(value)))

--- a/docs/gutenberg-incompatibility-registry.md
+++ b/docs/gutenberg-incompatibility-registry.md
@@ -1,0 +1,48 @@
+# Gutenberg Incompatibility Registry
+
+The fixture matrix emits `gutenberg-incompatibility-registry.json` and `gutenberg-incompatibility-registry.md` for every run. The JSON artifact is the deterministic decision engine for identifying recurring HTML/CSS/runtime patterns where WordPress core blocks cannot preserve source parity without `core/html`, a data URI fallback, a runtime island, or measurable fidelity loss.
+
+Schema: `registry/gutenberg-incompatibility-registry.schema.json`
+
+## Pattern Record
+
+Each pattern row contains:
+
+- `pattern_key`: stable generic taxonomy key, never a fixture-specific key.
+- `description`: human description of the source architecture.
+- `fallback_kind`: one of `core_html`, `data_uri`, `runtime_island`, or `fidelity_loss`.
+- `impossible_in_core_reason`: concrete reason core blocks cannot represent the structure, behavior, or visual exactly.
+- `classification`: `convertible`, `custom-block-candidate`, or `runtime-island`.
+- `no_core_block_path`: whether existing core block semantics have no direct path to parity.
+- `fixture_count`, `fixtures`, `fixture_counts`: recurrence evidence across fixtures.
+- `finding_count`, `signals`, `fallback_kinds`, `impact_score`: aggregate impact from normalized matrix findings, visual diff regions, block composition, and future editor render divergence signals.
+- `example` / `examples`: bounded source selector/snippet/reason evidence.
+
+## Promotion Rule
+
+Default threshold: `2` distinct fixtures.
+
+A pattern is promoted to `custom-block-candidate` when `no_core_block_path` is true and the pattern appears in at least the threshold number of distinct fixtures. Runtime-island patterns stay `runtime-island` even when recurring. Patterns with a plausible core-block or transformer path stay `convertible` until evidence proves core cannot express them.
+
+## Seeded Generic Pattern Keys
+
+- `static-form`: newsletter/contact/static form markup with fields, submission semantics, validation, and response behavior. Core has no generic form block.
+- `js-commerce-controls`: quantity steppers, add-to-cart controls, cart counters, product option state, and commerce mutation behavior. Core blocks do not provide purchase-control semantics.
+- `inline-svg-filter-gradient`: inline SVG DOM with `defs`, filters, masks, clip paths, gradients, symbols, or data-URI SVG preservation. Core image/media blocks cannot preserve arbitrary editable SVG DOM graphs.
+- `css-grid-masonry`: masonry/dense grid layouts that require source-order-independent packing or arbitrary grid placement semantics.
+- `position-sticky-nav`: sticky/fixed navigation or header behavior coupled to scroll state or offsets. This is initially `convertible` because simple sticky layout can be approximated by core layout/navigation blocks.
+- `editor-render-divergence`: future editor-fidelity signal for frontend/editor render divergence.
+- `legitimate-runtime-island`: expected runtime behavior that is intentionally preserved rather than converted into static editable attributes.
+
+## Existing Signal Inputs
+
+- Normalized finding packets from `lib/fixture-matrix/findings.mjs`, including `loss_class`, `reason_code`, `pattern_family`, `selector`, `source_snippet`, and `observed_block_name`.
+- Core HTML block composition counts from `lib/fixture-matrix/collectors/quality-metrics.mjs` via `block_composition` / `editor_quality.core_html_block_count`.
+- Visual diff region causes from `visual_diff_regions` / `visual-diff-classification.json`.
+- Future editor-fidelity lane rows named `editor_render_divergence` or `editor_render_divergences` on a fixture result.
+
+## Current Strong Custom-Block Candidate Shapes
+
+- Static form: `<form>` architecture with input/select/textarea controls, submit buttons, labels, hidden fields, validation/response state, and newsletter/contact semantics. This should become a generic form block candidate when recurrence crosses threshold.
+- JS commerce controls: product purchase controls containing quantity inputs/steppers, add-to-cart buttons, option selectors, price/cart state, and runtime mutation. This should become a commerce control block candidate when recurrence crosses threshold.
+- SVG filter/gradient artwork: inline SVGs with defs/filter/gradient/mask/clip-path graphs or SVG data URIs whose DOM/ID graph must survive exactly. This should become an SVG artwork block candidate when recurrence crosses threshold.

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -59,6 +59,13 @@ export {
   writeFixtureMatrixResultArtifacts,
 } from './fixture-matrix/result.mjs';
 
+export {
+  GUTENBERG_INCOMPATIBILITY_REGISTRY_SCHEMA,
+  DEFAULT_CUSTOM_BLOCK_CANDIDATE_FIXTURE_THRESHOLD,
+  buildGutenbergIncompatibilityRegistry,
+  renderGutenbergIncompatibilityRegistryMarkdown,
+} from './fixture-matrix/gutenberg-incompatibility-registry.mjs';
+
 export { collectFixtureMatrixRunResults } from './fixture-matrix/collectors/run-intake.mjs';
 
 export { classifyStaticSiteFinding, normalizeLossClass } from './fixture-matrix/findings.mjs';

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -10,6 +10,7 @@ export const DEFAULT_CUSTOM_BLOCK_CANDIDATE_FIXTURE_THRESHOLD = 2;
 const PATTERNS = [
   pattern('static-form', 'Static newsletter/contact/search-style form markup that requires fields, submission semantics, validation, and response behavior.', 'core_html', 'WordPress core has no generic form block with field schema, submit handling, validation state, and submission response behavior.', 'custom-block-candidate', true, /<form\b|\bnewsletter\b|\bcontact\s+form\b|\bsubscribe\b/i),
   pattern('js-commerce-controls', 'Commerce controls such as quantity steppers, add-to-cart controls, cart counters, and product option interactions.', 'runtime_island', 'Core blocks do not provide commerce purchase controls, quantity-stepper behavior, product option state, cart mutation, or add-to-cart runtime semantics.', 'custom-block-candidate', true, /quantity|\bqty\b|add[-_\s]?to[-_\s]?cart|\bcart\b|checkout|product[-_\s]?grid|product[-_\s]?option|woocommerce|\bprice\b/i),
+  pattern('contact-layout', 'Contact/social layout islands that combine contact affordances, decorative media, and layout wrappers not represented by a single core block.', 'core_html', 'Core blocks can represent individual contact links and media, but not an arbitrary contact widget/layout island with source-specific wrapper semantics as one editable primitive.', 'custom-block-candidate', true, /\bcontact(?:[-_\s]?(?:content|layout|card|section|widget|info|details?))?\b|mailto:|tel:|\bsocial[-_\s]?(?:links?|icons?)\b/i),
   pattern('inline-svg-filter-gradient', 'Inline SVG artwork that depends on defs such as filters, masks, clip paths, gradients, symbols, or data-URI SVG preservation.', 'core_html', 'Core image/media blocks cannot preserve arbitrary inline SVG DOM, defs/filter graphs, gradient IDs, masks, clip paths, or scriptable SVG structure as editable block attributes.', 'custom-block-candidate', true, /<svg\b|<filter\b|<lineargradient\b|<radialgradient\b|<clippath\b|<mask\b|<defs\b|data:image\/svg\+xml|svg[-_\s]?(?:filter|gradient|mask|clip|defs)/i),
   pattern('css-grid-masonry', 'CSS grid/masonry layouts that rely on dense auto-placement, masonry-like columns, or source-order-independent packing.', 'fidelity_loss', 'Core layout blocks expose grid/flex controls but do not model masonry packing, dense auto-placement, or arbitrary CSS grid placement semantics as editable attributes.', 'custom-block-candidate', true, /masonry|grid-auto-flow\s*:\s*dense|column-count|columns\s*:|css[-_\s]?grid|grid-template|grid-area/i),
   pattern('position-sticky-nav', 'Sticky/fixed navigation or header behavior coupled to source scroll state, offsets, or JavaScript classes.', 'fidelity_loss', 'Core navigation/group blocks can approximate simple sticky positioning, but source-specific scroll state, offset choreography, and JS class toggles require transformer/runtime work before a custom block decision.', 'convertible', false, /position\s*:\s*(?:sticky|fixed)|sticky[-_\s]?nav|fixed[-_\s]?(?:nav|header)|scroll[-_\s]?(?:state|class)/i),
@@ -107,6 +108,10 @@ function classifyFindingPattern(finding) {
   if (explicit) {
     return explicit;
   }
+  const diagnostic = diagnosticPattern(finding);
+  if (diagnostic) {
+    return diagnostic;
+  }
   const haystack = findingHaystack(finding);
   for (const item of PATTERNS) {
     if (item.match.test(haystack)) {
@@ -125,8 +130,46 @@ function classifyFindingPattern(finding) {
   return null;
 }
 
+function diagnosticPattern(finding) {
+  const keys = [
+    finding.reason_code,
+    finding.reasonCode,
+    finding.pattern_family,
+    finding.patternFamily,
+    finding.repair_bucket,
+    finding.repairBucket,
+    finding.diagnostic_code,
+    finding.diagnosticCode,
+    finding.kind,
+  ].map(slug).filter(Boolean);
+  for (const key of keys) {
+    const mapped = DIAGNOSTIC_PATTERN_KEYS[key];
+    if (mapped) {
+      return PATTERNS.find((item) => item.pattern_key === mapped);
+    }
+  }
+  return null;
+}
+
+const DIAGNOSTIC_PATTERN_KEYS = {
+  html_form_fallback: 'static-form',
+  form_requires_runtime: 'static-form',
+  interactive_form: 'static-form',
+  preserve_form_markup_or_replace_with_form_block_integration: 'static-form',
+  html_product_grid_fallback: 'js-commerce-controls',
+  commerce_product_grid: 'js-commerce-controls',
+  commerce_product_grid_detected: 'js-commerce-controls',
+  interactive_control_behavior_lost: 'js-commerce-controls',
+  interactive_control: 'js-commerce-controls',
+  restore_interactive_behavior: 'js-commerce-controls',
+  html_inline_svg_fallback: 'inline-svg-filter-gradient',
+  html_unsafe_inline_svg: 'inline-svg-filter-gradient',
+  inline_svg: 'inline-svg-filter-gradient',
+  materialize_static_asset: 'inline-svg-filter-gradient',
+};
+
 function findingHaystack(finding) {
-  return [finding.pattern_key, finding.patternKey, finding.kind, finding.category, finding.group_key, finding.repair_bucket, finding.reason_code, finding.reasonCode, finding.reason, finding.selector, finding.selector_family, finding.source_path, finding.source_snippet, finding.observed_output, finding.observed_block_name, finding.loss_class].filter(Boolean).join(' ');
+  return [finding.pattern_key, finding.patternKey, finding.kind, finding.category, finding.group_key, finding.repair_bucket, finding.reason_code, finding.reasonCode, finding.pattern_family, finding.patternFamily, finding.reason, finding.selector, finding.selector_family, finding.source_path, finding.source_snippet, finding.observed_output, finding.observed_block_name, finding.loss_class].filter(Boolean).join(' ');
 }
 
 function fallbackPatternKey(finding) {

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -274,11 +274,22 @@ function finalizeRow(row, threshold) {
 }
 
 function sortRows(left, right) {
-  return classificationRank(left.classification) - classificationRank(right.classification) || right.fixture_count - left.fixture_count || right.impact_score - left.impact_score || right.finding_count - left.finding_count || left.pattern_key.localeCompare(right.pattern_key);
+  return classificationRank(left.classification) - classificationRank(right.classification)
+    || Number(Boolean(right.no_core_block_path)) - Number(Boolean(left.no_core_block_path))
+    || right.fixture_count - left.fixture_count
+    || patternRank(left.pattern_key) - patternRank(right.pattern_key)
+    || right.impact_score - left.impact_score
+    || right.finding_count - left.finding_count
+    || left.pattern_key.localeCompare(right.pattern_key);
 }
 
 function classificationRank(value) {
   return value === 'custom-block-candidate' ? 0 : value === 'convertible' ? 1 : 2;
+}
+
+function patternRank(patternKey) {
+  const index = PATTERNS.findIndex((item) => item.pattern_key === patternKey);
+  return index === -1 ? PATTERNS.length : index;
 }
 
 function sortCountObject(value) {

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -80,6 +80,7 @@ export function renderGutenbergIncompatibilityRegistryMarkdown(registry = {}) {
     '# Gutenberg Incompatibility Registry',
     '',
     'Generated from Static Site Importer fixture-matrix findings. This records generic HTML/CSS/runtime patterns where core blocks cannot preserve source parity without a fallback, transformer fix, runtime island, or future custom block.',
+    'Tracked no-core-block-path candidates remain `convertible` until they appear in enough distinct fixtures to satisfy the promotion rule; broader corpus runs are expected to promote recurring form/contact/commerce patterns once recurrence is observed.',
     '',
     `Schema: \`${registry.schema || GUTENBERG_INCOMPATIBILITY_REGISTRY_SCHEMA}\``,
     `Matrix: \`${registry.matrix_id || '(unknown)'}\``,

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -1,0 +1,256 @@
+// Gutenberg incompatibility registry aggregation for fixture-matrix runs.
+// Consumes generic findings, visual diff regions, and future editor render divergence signals.
+
+import { boundBlob } from './shared/bounds.mjs';
+import { compactObject, normalizeArray, numberValue, objectValue, pushUnique, slug } from './shared/utils.mjs';
+
+export const GUTENBERG_INCOMPATIBILITY_REGISTRY_SCHEMA = 'static-site-importer/gutenberg-incompatibility-registry/v1';
+export const DEFAULT_CUSTOM_BLOCK_CANDIDATE_FIXTURE_THRESHOLD = 2;
+
+const PATTERNS = [
+  pattern('static-form', 'Static newsletter/contact/search-style form markup that requires fields, submission semantics, validation, and response behavior.', 'core_html', 'WordPress core has no generic form block with field schema, submit handling, validation state, and submission response behavior.', 'custom-block-candidate', true, /<form\b|\bnewsletter\b|\bcontact\s+form\b|\bsubscribe\b/i),
+  pattern('js-commerce-controls', 'Commerce controls such as quantity steppers, add-to-cart controls, cart counters, and product option interactions.', 'runtime_island', 'Core blocks do not provide commerce purchase controls, quantity-stepper behavior, product option state, cart mutation, or add-to-cart runtime semantics.', 'custom-block-candidate', true, /quantity|\bqty\b|add[-_\s]?to[-_\s]?cart|\bcart\b|checkout|product[-_\s]?grid|product[-_\s]?option|woocommerce|\bprice\b/i),
+  pattern('inline-svg-filter-gradient', 'Inline SVG artwork that depends on defs such as filters, masks, clip paths, gradients, symbols, or data-URI SVG preservation.', 'core_html', 'Core image/media blocks cannot preserve arbitrary inline SVG DOM, defs/filter graphs, gradient IDs, masks, clip paths, or scriptable SVG structure as editable block attributes.', 'custom-block-candidate', true, /<svg\b|<filter\b|<lineargradient\b|<radialgradient\b|<clippath\b|<mask\b|<defs\b|data:image\/svg\+xml|svg[-_\s]?(?:filter|gradient|mask|clip|defs)/i),
+  pattern('css-grid-masonry', 'CSS grid/masonry layouts that rely on dense auto-placement, masonry-like columns, or source-order-independent packing.', 'fidelity_loss', 'Core layout blocks expose grid/flex controls but do not model masonry packing, dense auto-placement, or arbitrary CSS grid placement semantics as editable attributes.', 'custom-block-candidate', true, /masonry|grid-auto-flow\s*:\s*dense|column-count|columns\s*:|css[-_\s]?grid|grid-template|grid-area/i),
+  pattern('position-sticky-nav', 'Sticky/fixed navigation or header behavior coupled to source scroll state, offsets, or JavaScript classes.', 'fidelity_loss', 'Core navigation/group blocks can approximate simple sticky positioning, but source-specific scroll state, offset choreography, and JS class toggles require transformer/runtime work before a custom block decision.', 'convertible', false, /position\s*:\s*(?:sticky|fixed)|sticky[-_\s]?nav|fixed[-_\s]?(?:nav|header)|scroll[-_\s]?(?:state|class)/i),
+  pattern('editor-render-divergence', 'Markup renders on the frontend but diverges or disappears in the block editor canvas.', 'fidelity_loss', 'Editor render divergence means a block representation exists but editor serialization/rendering cannot reproduce the frontend output without transformer or block support.', 'convertible', false, /editor[_\s-]?render[_\s-]?divergence|editor canvas divergence|frontend.*editor/i),
+  pattern('legitimate-runtime-island', 'Preserved interactive/runtime island whose behavior is carried intentionally rather than converted into static core block attributes.', 'runtime_island', 'The source behavior depends on runtime JavaScript or browser APIs that core static blocks do not execute as editable content.', 'runtime-island', true, /runtime island|runtime_island|script requires runtime|canvas|webgl|audio|video player|animation runtime/i),
+];
+
+function pattern(pattern_key, description, fallback_kind, impossible_in_core_reason, base_classification, no_core_block_path, match) {
+  return { pattern_key, description, fallback_kind, impossible_in_core_reason, base_classification, no_core_block_path, match };
+}
+
+export function buildGutenbergIncompatibilityRegistry(result = {}, options = {}) {
+  const threshold = positiveInteger(options.customBlockCandidateFixtureThreshold ?? options.custom_block_candidate_fixture_threshold, DEFAULT_CUSTOM_BLOCK_CANDIDATE_FIXTURE_THRESHOLD);
+  const rows = new Map();
+  const fixtures = normalizeArray(result.fixtures);
+
+  for (const finding of normalizeArray(result.findings)) {
+    const patternDefinition = classifyFindingPattern(finding);
+    if (!patternDefinition) {
+      continue;
+    }
+    addEvidence(rows, patternDefinition, {
+      fixture_id: finding.fixture_id,
+      fallback_kind: fallbackKindForFinding(finding, patternDefinition),
+      impact: numberValue(finding.impact || finding.pixel_count || finding.count || 1) || 1,
+      selector: finding.selector,
+      source_path: finding.source_path || finding.path,
+      source_snippet: finding.source_snippet,
+      reason: finding.reason || patternDefinition.impossible_in_core_reason,
+      signal: finding.kind || finding.reason_code || finding.loss_class,
+      observed_block_name: finding.observed_block_name,
+    });
+  }
+
+  for (const fixture of fixtures) {
+    addVisualDiffEvidence(rows, fixture);
+    addEditorRenderDivergenceEvidence(rows, fixture);
+    addCoreHtmlCompositionEvidence(rows, fixture);
+  }
+
+  const patterns = [...rows.values()].map((row) => finalizeRow(row, threshold)).sort(sortRows);
+  return {
+    schema: GUTENBERG_INCOMPATIBILITY_REGISTRY_SCHEMA,
+    matrix_id: result.matrix_id || '',
+    generated_from: {
+      result_schema: result.schema || '',
+      fixture_count: fixtures.length,
+      finding_count: normalizeArray(result.findings).length,
+    },
+    promotion_rule: {
+      custom_block_candidate_fixture_threshold: threshold,
+      rule: `classification becomes custom-block-candidate when no_core_block_path is true and the pattern appears in at least ${threshold} distinct fixtures; runtime-island patterns remain runtime-island.`,
+    },
+    summary: {
+      pattern_count: patterns.length,
+      custom_block_candidate_count: patterns.filter((row) => row.classification === 'custom-block-candidate').length,
+      convertible_count: patterns.filter((row) => row.classification === 'convertible').length,
+      runtime_island_count: patterns.filter((row) => row.classification === 'runtime-island').length,
+      top_patterns: patterns.slice(0, 10).map((row) => ({ pattern_key: row.pattern_key, classification: row.classification, fixture_count: row.fixture_count, finding_count: row.finding_count, impact_score: row.impact_score })),
+    },
+    patterns,
+  };
+}
+
+export function renderGutenbergIncompatibilityRegistryMarkdown(registry = {}) {
+  const lines = [
+    '# Gutenberg Incompatibility Registry',
+    '',
+    'Generated from Static Site Importer fixture-matrix findings. This records generic HTML/CSS/runtime patterns where core blocks cannot preserve source parity without a fallback, transformer fix, runtime island, or future custom block.',
+    '',
+    `Schema: \`${registry.schema || GUTENBERG_INCOMPATIBILITY_REGISTRY_SCHEMA}\``,
+    `Matrix: \`${registry.matrix_id || '(unknown)'}\``,
+    `Promotion rule: ${registry.promotion_rule?.rule || ''}`,
+    '',
+    '| Rank | Pattern | Classification | Fixtures | Findings | Impact | Reason |',
+    '| ---: | --- | --- | ---: | ---: | ---: | --- |',
+  ];
+  normalizeArray(registry.patterns).forEach((row, index) => {
+    lines.push(`| ${index + 1} | \`${row.pattern_key}\` | ${row.classification} | ${row.fixture_count} | ${row.finding_count} | ${row.impact_score} | ${table(row.impossible_in_core_reason)} |`);
+  });
+  lines.push('', '## Pattern Evidence', '');
+  for (const row of normalizeArray(registry.patterns)) {
+    lines.push(`### ${row.pattern_key}`, '', `- Description: ${row.description}`, `- Fallback kind: \`${row.fallback_kind}\``, `- Classification: \`${row.classification}\``, `- Fixtures: ${row.fixtures.join(', ') || '(none)'}`, `- Reason: ${row.impossible_in_core_reason}`);
+    if (row.example?.selector || row.example?.source_snippet) {
+      lines.push(`- Example selector/snippet: \`${String(row.example.selector || row.example.source_snippet).replace(/`/g, '\\`').slice(0, 180)}\``);
+    }
+    lines.push('');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function classifyFindingPattern(finding) {
+  const explicitKey = slug(finding.pattern_key || finding.patternKey || finding.reason_code || finding.reasonCode);
+  const explicit = explicitKey ? PATTERNS.find((item) => item.pattern_key === explicitKey) : null;
+  if (explicit) {
+    return explicit;
+  }
+  const haystack = findingHaystack(finding);
+  for (const item of PATTERNS) {
+    if (item.match.test(haystack)) {
+      return item;
+    }
+  }
+  if (finding.observed_block_name === 'core/html' || finding.loss_class === 'unsupported_loss' || /core\/html/i.test(haystack)) {
+    return pattern(fallbackPatternKey(finding), 'Generic core/html fallback that needs a more specific transformer reason code.', 'core_html', finding.reason || 'The transformer emitted core/html or unsupported fallback without a stable incompatibility pattern.', 'convertible', false, /$a/);
+  }
+  if (finding.loss_class === 'preserved_runtime_island') {
+    return PATTERNS.find((item) => item.pattern_key === 'legitimate-runtime-island');
+  }
+  if (finding.loss_class === 'visual_parity_mismatch' && finding.loss_acceptance === 'unacceptable') {
+    return pattern(`visual-${slug(finding.reason_code || finding.pattern_family || 'fidelity-loss')}`, 'Visual parity loss from structured visual-diff classification.', 'fidelity_loss', finding.reason || 'Visual diff classification found a parity loss after block conversion.', 'convertible', false, /$a/);
+  }
+  return null;
+}
+
+function findingHaystack(finding) {
+  return [finding.pattern_key, finding.patternKey, finding.kind, finding.category, finding.group_key, finding.repair_bucket, finding.reason_code, finding.reasonCode, finding.reason, finding.selector, finding.selector_family, finding.source_path, finding.source_snippet, finding.observed_output, finding.observed_block_name, finding.loss_class].filter(Boolean).join(' ');
+}
+
+function fallbackPatternKey(finding) {
+  if (finding.reason_code || finding.reasonCode) {
+    return slug(finding.reason_code || finding.reasonCode);
+  }
+  if (finding.pattern_family) {
+    return slug(finding.pattern_family);
+  }
+  if (finding.selector_family && finding.selector_family !== '(none)') {
+    return `core-html-${slug(finding.selector_family)}`;
+  }
+  return 'core-html-unspecified';
+}
+
+function fallbackKindForFinding(finding, patternDefinition) {
+  if (finding.observed_block_name === 'core/html' || /core\/html/i.test(finding.reason || finding.observed_output || '')) {
+    return 'core_html';
+  }
+  if (finding.loss_class === 'preserved_runtime_island') {
+    return 'runtime_island';
+  }
+  if (finding.loss_class === 'missing_asset' && /data:image/i.test(finding.source_snippet || finding.reason || '')) {
+    return 'data_uri';
+  }
+  if (finding.loss_class === 'visual_parity_mismatch' || finding.loss_class === 'editor_block_invalid') {
+    return 'fidelity_loss';
+  }
+  return patternDefinition.fallback_kind;
+}
+
+function addVisualDiffEvidence(rows, fixture) {
+  for (const region of normalizeArray(fixture.visual_diff_regions || fixture.visualDiffRegions)) {
+    const cause = region.dominant_cause || region.cause;
+    if (!cause) {
+      continue;
+    }
+    const definition = pattern(`visual-${slug(cause)}`, `Visual diff region classified as ${cause}.`, 'fidelity_loss', `Visual diff classifier attributed mismatch pixels to ${cause}; inspect selector evidence to decide whether this is transformer-convertible or a missing block capability.`, 'convertible', false, /$a/);
+    addEvidence(rows, definition, { fixture_id: fixture.fixture_id, fallback_kind: 'fidelity_loss', impact: numberValue(region.pixel_count), selector: region.mapped_selector || region.selector, reason: definition.impossible_in_core_reason, signal: 'visual_diff_classification' });
+  }
+}
+
+function addEditorRenderDivergenceEvidence(rows, fixture) {
+  const definition = PATTERNS.find((item) => item.pattern_key === 'editor-render-divergence');
+  for (const divergence of normalizeArray(fixture.editor_render_divergence || fixture.editorRenderDivergence || fixture.editor_render_divergences || fixture.editorRenderDivergences)) {
+    const row = objectValue(divergence);
+    addEvidence(rows, definition, { fixture_id: fixture.fixture_id, fallback_kind: 'fidelity_loss', impact: numberValue(row.impact || row.pixel_count || row.count || 1), selector: row.selector, source_snippet: row.source_snippet || row.sourceSnippet, reason: row.reason || row.message || definition.impossible_in_core_reason, signal: 'editor_render_divergence' });
+  }
+}
+
+function addCoreHtmlCompositionEvidence(rows, fixture) {
+  const blockTypes = objectValue(fixture.block_composition?.block_types || fixture.blockComposition?.blockTypes);
+  const count = numberValue(blockTypes['core/html'] || fixture.editor_quality?.core_html_block_count);
+  if (count <= 0) {
+    return;
+  }
+  const definition = pattern('core-html-unspecified', 'Fixture contains core/html fallback blocks without structured transformer reason diagnostics.', 'core_html', 'Block composition counted core/html fallback blocks but no stable source pattern was emitted; add transformer reason codes for attribution.', 'convertible', false, /$a/);
+  addEvidence(rows, definition, { fixture_id: fixture.fixture_id, fallback_kind: 'core_html', impact: count, reason: definition.impossible_in_core_reason, signal: 'block_composition_core_html' });
+}
+
+function addEvidence(rows, definition, evidence) {
+  if (!definition || !evidence.fixture_id) {
+    return;
+  }
+  const row = rows.get(definition.pattern_key) || { ...definition, fallback_kinds: {}, fixtures: [], fixture_counts: {}, selectors: [], source_paths: [], signals: {}, examples: [], finding_count: 0, impact_score: 0 };
+  row.finding_count += 1;
+  row.impact_score += Math.max(1, numberValue(evidence.impact || 1));
+  row.fallback_kinds[evidence.fallback_kind || definition.fallback_kind] = (row.fallback_kinds[evidence.fallback_kind || definition.fallback_kind] || 0) + 1;
+  row.signals[evidence.signal || 'finding'] = (row.signals[evidence.signal || 'finding'] || 0) + 1;
+  row.fixture_counts[evidence.fixture_id] = (row.fixture_counts[evidence.fixture_id] || 0) + 1;
+  pushUnique(row.fixtures, evidence.fixture_id, 100);
+  pushUnique(row.selectors, evidence.selector, 10);
+  pushUnique(row.source_paths, evidence.source_path, 10);
+  if (row.examples.length < 3) {
+    row.examples.push(compactObject({ fixture_id: evidence.fixture_id, selector: evidence.selector, source_path: evidence.source_path, source_snippet: evidence.source_snippet, reason: evidence.reason, observed_block_name: evidence.observed_block_name, signal: evidence.signal }));
+  }
+  rows.set(definition.pattern_key, row);
+}
+
+function finalizeRow(row, threshold) {
+  const fixtureCount = row.fixtures.length;
+  const classification = row.base_classification === 'runtime-island' ? 'runtime-island' : row.no_core_block_path && fixtureCount >= threshold ? 'custom-block-candidate' : row.base_classification === 'custom-block-candidate' ? 'convertible' : row.base_classification;
+  return compactObject({
+    pattern_key: row.pattern_key,
+    description: row.description,
+    fallback_kind: dominantKey(row.fallback_kinds) || row.fallback_kind,
+    fallback_kinds: sortCountObject(row.fallback_kinds),
+    impossible_in_core_reason: row.impossible_in_core_reason,
+    classification,
+    no_core_block_path: row.no_core_block_path,
+    fixture_count: fixtureCount,
+    finding_count: row.finding_count,
+    impact_score: Number(row.impact_score.toFixed(2)),
+    fixtures: [...row.fixtures].sort(),
+    fixture_counts: sortCountObject(row.fixture_counts),
+    selectors: row.selectors,
+    source_paths: row.source_paths,
+    signals: sortCountObject(row.signals),
+    example: row.examples[0] ? boundBlob(row.examples[0]) : undefined,
+    examples: boundBlob(row.examples),
+  });
+}
+
+function sortRows(left, right) {
+  return classificationRank(left.classification) - classificationRank(right.classification) || right.fixture_count - left.fixture_count || right.impact_score - left.impact_score || right.finding_count - left.finding_count || left.pattern_key.localeCompare(right.pattern_key);
+}
+
+function classificationRank(value) {
+  return value === 'custom-block-candidate' ? 0 : value === 'convertible' ? 1 : 2;
+}
+
+function sortCountObject(value) {
+  return Object.fromEntries(Object.entries(value || {}).sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0])));
+}
+
+function dominantKey(value) {
+  return Object.entries(sortCountObject(value))[0]?.[0] || '';
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Math.floor(Number(value));
+  return parsed > 0 ? parsed : fallback;
+}
+
+function table(value) {
+  return String(value || '').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+}

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -47,6 +47,10 @@ import {
   patternFamily,
 } from './findings.mjs';
 import {
+  buildGutenbergIncompatibilityRegistry,
+  renderGutenbergIncompatibilityRegistryMarkdown,
+} from './gutenberg-incompatibility-registry.mjs';
+import {
   collectBlockComposition,
   computeFixtureEditorQuality,
   attachFixtureEditorQuality,
@@ -88,6 +92,12 @@ export function normalizeFixtureMatrixResult(input = {}) {
   const classRollups = fixtureClassRollups(gatedFixtureResults, findings);
   const fanoutGroups = buildFanoutGroups(actionableFindings);
   const categoryRollups = fixtureCategoryRollups(gatedFixtureResults, findings);
+  const gutenbergIncompatibilityRegistry = buildGutenbergIncompatibilityRegistry({
+    schema: FIXTURE_MATRIX_RESULT_SCHEMA,
+    matrix_id: matrix.id,
+    fixtures: gatedFixtureResults,
+    findings,
+  });
   const slowFixtures = normalizeSlowFixtures(input.slow_fixtures || input.slowFixtures);
 
   return {
@@ -115,6 +125,7 @@ export function normalizeFixtureMatrixResult(input = {}) {
       gate_failure_reasons: categoryRollups.gate_failure_reasons,
       visual_diff_cause_summary: aggregateVisualDiffCauseSummary(gatedFixtureResults),
       visual_diff_top_causes: visualDiffTopCauses(gatedFixtureResults),
+      gutenberg_incompatibility_registry: gutenbergIncompatibilityRegistry.summary,
       groups: Object.fromEntries(Object.entries(grouped).map(([key, items]) => [key, items.length])),
       top_pattern_families: topPatternFamilies(actionableFindings),
       top_acceptable_pattern_families: topPatternFamilies(acceptableActionableFindings),
@@ -136,6 +147,7 @@ export function normalizeFixtureMatrixResult(input = {}) {
     },
     fixtures: gatedFixtureResults,
     findings,
+    gutenberg_incompatibility_registry: gutenbergIncompatibilityRegistry,
     slow_fixtures: slowFixtures,
     metadata: {
       slow_fixtures: slowFixtures,
@@ -464,6 +476,8 @@ export function writeFixtureMatrixArtifacts(input = {}) {
     'static-site-fixture-matrix-result.json',
     'summary.json',
     'finding-packets.json',
+    'gutenberg-incompatibility-registry.json',
+    'gutenberg-incompatibility-registry.md',
   ].reduce((total, fileName) => total + fileBytes(path.join(outputDirectory, fileName)), 0);
   artifactBytes.total = artifactBytes.fixture_artifacts + artifactBytes.staged_source + artifactBytes.matrix + artifactBytes.result_artifacts;
 
@@ -486,6 +500,8 @@ export function writeFixtureMatrixArtifacts(input = {}) {
       artifactRef('summary', path.join(outputDirectory, 'summary.json'), 'summary'),
       artifactRef('finding-packets', path.join(outputDirectory, 'finding-packets.json'), 'diagnostic'),
       artifactRef('visual-diff-classification', path.join(outputDirectory, 'visual-diff-classification.json'), 'diagnostic'),
+      artifactRef('gutenberg-incompatibility-registry', path.join(outputDirectory, 'gutenberg-incompatibility-registry.json'), 'diagnostic'),
+      artifactRef('gutenberg-incompatibility-registry-report', path.join(outputDirectory, 'gutenberg-incompatibility-registry.md'), 'summary'),
     ],
   };
 }
@@ -498,6 +514,8 @@ export function writeFixtureMatrixResultArtifacts(input = {}) {
   writeJsonFile(path.join(outputDirectory, 'summary.json'), result.summary);
   writeJsonFile(path.join(outputDirectory, 'finding-packets.json'), result.findings);
   writeJsonFile(path.join(outputDirectory, 'visual-diff-classification.json'), visualDiffClassificationArtifact(result));
+  writeJsonFile(path.join(outputDirectory, 'gutenberg-incompatibility-registry.json'), result.gutenberg_incompatibility_registry || buildGutenbergIncompatibilityRegistry(result));
+  fs.writeFileSync(path.join(outputDirectory, 'gutenberg-incompatibility-registry.md'), renderGutenbergIncompatibilityRegistryMarkdown(result.gutenberg_incompatibility_registry || buildGutenbergIncompatibilityRegistry(result)));
   return result;
 }
 

--- a/registry/gutenberg-incompatibility-registry.schema.json
+++ b/registry/gutenberg-incompatibility-registry.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "static-site-importer/gutenberg-incompatibility-registry/v1",
+  "title": "Static Site Importer Gutenberg Incompatibility Registry",
+  "type": "object",
+  "required": ["schema", "matrix_id", "promotion_rule", "summary", "patterns"],
+  "properties": {
+    "schema": { "const": "static-site-importer/gutenberg-incompatibility-registry/v1" },
+    "matrix_id": { "type": "string" },
+    "generated_from": {
+      "type": "object",
+      "properties": {
+        "result_schema": { "type": "string" },
+        "fixture_count": { "type": "integer", "minimum": 0 },
+        "finding_count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "promotion_rule": {
+      "type": "object",
+      "required": ["custom_block_candidate_fixture_threshold", "rule"],
+      "properties": {
+        "custom_block_candidate_fixture_threshold": { "type": "integer", "minimum": 1 },
+        "rule": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": ["pattern_count", "custom_block_candidate_count", "convertible_count", "runtime_island_count", "top_patterns"],
+      "properties": {
+        "pattern_count": { "type": "integer", "minimum": 0 },
+        "custom_block_candidate_count": { "type": "integer", "minimum": 0 },
+        "convertible_count": { "type": "integer", "minimum": 0 },
+        "runtime_island_count": { "type": "integer", "minimum": 0 },
+        "top_patterns": { "type": "array", "items": { "$ref": "#/$defs/top_pattern" } }
+      },
+      "additionalProperties": false
+    },
+    "patterns": { "type": "array", "items": { "$ref": "#/$defs/pattern" } }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "classification": { "enum": ["convertible", "custom-block-candidate", "runtime-island"] },
+    "fallback_kind": { "enum": ["core_html", "data_uri", "runtime_island", "fidelity_loss"] },
+    "top_pattern": {
+      "type": "object",
+      "required": ["pattern_key", "classification", "fixture_count", "finding_count", "impact_score"],
+      "properties": {
+        "pattern_key": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "classification": { "$ref": "#/$defs/classification" },
+        "fixture_count": { "type": "integer", "minimum": 0 },
+        "finding_count": { "type": "integer", "minimum": 0 },
+        "impact_score": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "pattern": {
+      "type": "object",
+      "required": ["pattern_key", "description", "fallback_kind", "impossible_in_core_reason", "classification", "no_core_block_path", "fixture_count", "finding_count", "impact_score", "fixtures", "signals"],
+      "properties": {
+        "pattern_key": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "description": { "type": "string" },
+        "fallback_kind": { "$ref": "#/$defs/fallback_kind" },
+        "fallback_kinds": { "$ref": "#/$defs/counts" },
+        "impossible_in_core_reason": { "type": "string" },
+        "classification": { "$ref": "#/$defs/classification" },
+        "no_core_block_path": { "type": "boolean" },
+        "fixture_count": { "type": "integer", "minimum": 0 },
+        "finding_count": { "type": "integer", "minimum": 0 },
+        "impact_score": { "type": "number", "minimum": 0 },
+        "fixtures": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "fixture_counts": { "$ref": "#/$defs/counts" },
+        "selectors": { "type": "array", "items": { "type": "string" } },
+        "source_paths": { "type": "array", "items": { "type": "string" } },
+        "signals": { "$ref": "#/$defs/counts" },
+        "example": { "type": "object" },
+        "examples": { "type": "array", "items": { "type": "object" } }
+      },
+      "additionalProperties": false
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 0 }
+    }
+  }
+}

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -187,6 +187,42 @@ test('gutenberg incompatibility registry keeps runtime islands separate and cons
   assert.equal(byKey['editor-render-divergence'].signals.editor_render_divergence, 1);
 });
 
+test('gutenberg incompatibility registry attributes nested svg to the outer fallback island', () => {
+  const registry = buildGutenbergIncompatibilityRegistry({
+    matrix_id: 'nested-svg-attribution',
+    fixtures: [
+      { fixture_id: 'artist' },
+      { fixture_id: 'coffee' },
+    ],
+    findings: [
+      {
+        fixture_id: 'artist',
+        kind: 'unsupported_html_fallback',
+        observed_block_name: 'core/html',
+        reason_code: 'html_unsupported_element',
+        pattern_family: 'html_div',
+        selector: 'div.contact-content',
+        source_snippet: '<div class="contact-content"><a href="mailto:test@example.com"><svg><defs><linearGradient id="g"></linearGradient></defs></svg>Email</a></div>',
+      },
+      {
+        fixture_id: 'coffee',
+        kind: 'unsupported_html_fallback',
+        observed_block_name: 'core/html',
+        reason_code: 'html_inline_svg_fallback',
+        pattern_family: 'inline_svg',
+        selector: 'a.nav-logo > svg',
+        source_snippet: '<svg><defs><linearGradient id="g"></linearGradient></defs></svg>',
+      },
+    ],
+  });
+  const byKey = Object.fromEntries(registry.patterns.map((row) => [row.pattern_key, row]));
+
+  assert.equal(byKey['contact-layout'].finding_count, 1);
+  assert.equal(byKey['contact-layout'].fixtures[0], 'artist');
+  assert.equal(byKey['inline-svg-filter-gradient'].finding_count, 1);
+  assert.equal(byKey['inline-svg-filter-gradient'].fixtures[0], 'coffee');
+});
+
 test('gutenberg incompatibility registry artifacts are written with fixture matrix outputs', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-gutenberg-registry-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'gutenberg-registry-artifact-test' });

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -56,6 +56,7 @@ import {
   editorBlockValidationStep,
   EDITOR_VALIDATE_BLOCKS_COMMAND,
   EDITOR_VALIDATION_METHOD,
+  buildGutenbergIncompatibilityRegistry,
   normalizeFixtureMatrixResult,
   normalizeLossClass,
   stageFixtureSource,
@@ -110,6 +111,103 @@ test('execution-requested fixture matrices still fail missing validation results
   assert.equal(result.summary.unacceptable_finding_count, 1);
   assert.equal(result.summary.unacceptable_loss_classes.fixture_not_run, 1);
   assert.equal(result.findings.some((finding) => finding.loss_class === 'fixture_not_run'), true);
+});
+
+test('gutenberg incompatibility registry aggregates recurring custom block candidates across fixtures', () => {
+  const result = normalizeFixtureMatrixResult({
+    matrix: {
+      id: 'gutenberg-registry-synthetic',
+      fixture_root: '/tmp/fixtures',
+      fixtures: [
+        { id: 'artist', fixture_path: '/tmp/fixtures/artist' },
+        { id: 'coffee', fixture_path: '/tmp/fixtures/coffee' },
+        { id: 'saas', fixture_path: '/tmp/fixtures/saas' },
+      ],
+    },
+    results: [
+      {
+        fixture_id: 'artist',
+        status: 'failed',
+        diagnostics: [
+          { kind: 'unsupported_html_fallback', observed: { block_name: 'core/html' }, selector: '.newsletter form', source: { snippet: '<form class="newsletter"><input type="email"><button>Subscribe</button></form>' }, reason: 'No core form block can represent newsletter form submission.' },
+          { kind: 'unsupported_html_fallback', observed: { block_name: 'core/html' }, selector: '.logo svg', source: { snippet: '<svg><defs><linearGradient id="g"></linearGradient></defs></svg>' }, reason: 'Inline SVG gradient fallback.' },
+        ],
+      },
+      {
+        fixture_id: 'coffee',
+        status: 'failed',
+        diagnostics: [
+          { kind: 'unsupported_html_fallback', observed: { block_name: 'core/html' }, selector: '.map svg', source: { snippet: '<svg><filter id="blur"></filter></svg>' }, reason: 'Inline SVG filter fallback.' },
+        ],
+      },
+      {
+        fixture_id: 'saas',
+        status: 'failed',
+        diagnostics: [
+          { kind: 'preserved_runtime_island', loss_class: 'preserved_runtime_island', runtime_carried: true, selector: '.cart-control', source: { snippet: '<button class="add-to-cart">Add to cart</button><input class="qty" type="number">' }, reason: 'Quantity stepper and add-to-cart require runtime.' },
+          { kind: 'unsupported_html_fallback', observed: { block_name: 'core/html' }, selector: '.signup form', source: { snippet: '<form><input name="email"><button>Start</button></form>' }, reason: 'Static form fallback.' },
+        ],
+      },
+    ],
+  });
+
+  const registry = result.gutenberg_incompatibility_registry;
+  const byKey = Object.fromEntries(registry.patterns.map((row) => [row.pattern_key, row]));
+
+  assert.equal(registry.schema, 'static-site-importer/gutenberg-incompatibility-registry/v1');
+  assert.equal(byKey['static-form'].classification, 'custom-block-candidate');
+  assert.equal(byKey['static-form'].fixture_count, 2);
+  assert.equal(byKey['inline-svg-filter-gradient'].classification, 'custom-block-candidate');
+  assert.equal(byKey['inline-svg-filter-gradient'].fixture_count, 2);
+  assert.equal(byKey['js-commerce-controls'].classification, 'convertible');
+  assert.equal(byKey['js-commerce-controls'].fixture_count, 1);
+  assert.deepEqual(registry.summary.top_patterns[0].classification, 'custom-block-candidate');
+});
+
+test('gutenberg incompatibility registry keeps runtime islands separate and consumes editor divergence signals', () => {
+  const registry = buildGutenbergIncompatibilityRegistry({
+    matrix_id: 'runtime-and-editor-signals',
+    fixtures: [
+      {
+        fixture_id: 'canvas-fixture',
+        editor_render_divergence: [{ selector: '.hero-card', reason: 'Frontend renders but editor canvas drops the transformed child.' }],
+      },
+      {
+        fixture_id: 'runtime-fixture',
+      },
+    ],
+    findings: [
+      { fixture_id: 'runtime-fixture', kind: 'preserved_runtime_island', loss_class: 'preserved_runtime_island', runtime_carried: true, selector: 'canvas', reason: 'Canvas runtime island preserved.' },
+    ],
+  });
+  const byKey = Object.fromEntries(registry.patterns.map((row) => [row.pattern_key, row]));
+
+  assert.equal(byKey['legitimate-runtime-island'].classification, 'runtime-island');
+  assert.equal(byKey['editor-render-divergence'].classification, 'convertible');
+  assert.equal(byKey['editor-render-divergence'].signals.editor_render_divergence, 1);
+});
+
+test('gutenberg incompatibility registry artifacts are written with fixture matrix outputs', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-gutenberg-registry-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'gutenberg-registry-artifact-test' });
+  const written = writeFixtureMatrixArtifacts({
+    outputDirectory,
+    matrix,
+    result: normalizeFixtureMatrixResult({
+      matrix,
+      results: [
+        {
+          fixture_id: 'simple-site',
+          status: 'failed',
+          diagnostics: [{ kind: 'unsupported_html_fallback', observed: { block_name: 'core/html' }, source: { snippet: '<form><input><button>Send</button></form>' }, reason: 'No core form block.' }],
+        },
+      ],
+    }),
+  });
+
+  assert.ok(existsSync(path.join(outputDirectory, 'gutenberg-incompatibility-registry.json')));
+  assert.ok(existsSync(path.join(outputDirectory, 'gutenberg-incompatibility-registry.md')));
+  assert.ok(written.artifact_refs.some((ref) => ref.artifact_id === 'gutenberg-incompatibility-registry'));
 });
 
 test('matrix artifacts use the product base64 encoding for EVERY payload, including text', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -223,6 +223,33 @@ test('gutenberg incompatibility registry attributes nested svg to the outer fall
   assert.equal(byKey['inline-svg-filter-gradient'].fixtures[0], 'coffee');
 });
 
+test('gutenberg incompatibility registry ranks tracked custom-block candidates before visual-only evidence', () => {
+  const registry = buildGutenbergIncompatibilityRegistry({
+    matrix_id: 'tracked-candidate-ranking',
+    fixtures: [
+      {
+        fixture_id: 'artist',
+        visual_diff_regions: [{ dominant_cause: 'restyle_geometry', pixel_count: 100000 }],
+      },
+    ],
+    findings: [
+      {
+        fixture_id: 'artist',
+        kind: 'unsupported_html_fallback',
+        observed_block_name: 'core/html',
+        reason_code: 'html_form_fallback',
+        pattern_family: 'interactive_form',
+        selector: 'form.newsletter-form',
+        source_snippet: '<form class="newsletter-form"><input type="email"><button>Subscribe</button></form>',
+      },
+    ],
+  });
+
+  assert.equal(registry.patterns[0].pattern_key, 'static-form');
+  assert.equal(registry.patterns[0].classification, 'convertible');
+  assert.equal(registry.patterns[1].pattern_key, 'visual-restyle_geometry');
+});
+
 test('gutenberg incompatibility registry artifacts are written with fixture matrix outputs', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-gutenberg-registry-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'gutenberg-registry-artifact-test' });


### PR DESCRIPTION
## Summary
- Add the Gutenberg incompatibility registry artifact to fixture-matrix outputs.
- Fix registry attribution so structured fallback diagnostics are classified by their outer/dominant reason before scanning source HTML snippets.
- Keep incidental nested SVGs inside larger core/html islands from being counted as independent top-level SVG incompatibilities.
- Rank tracked no-core-block-path candidates before generic visual-only evidence, while keeping promotion honest until the fixture threshold is met.

## Attribution accuracy
Root cause was in the SSI aggregator, not Blocks Engine transformer emission. Blocks Engine only emits `html_inline_svg_fallback` when the SVG element itself falls through conversion; SSI was inferring SVG from `source_snippet` inside `classifyFindingPattern()` before honoring `reason_code` / `pattern_family`.

Fix:
- map structured diagnostics first: `html_form_fallback` / `interactive_form` => `static-form`, commerce/control diagnostics => `js-commerce-controls`, explicit SVG diagnostics => `inline-svg-filter-gradient`.
- add generic `contact-layout` tracking for contact/social layout islands.
- leave snippet regex matching as fallback for unstructured findings.
- add regression coverage for nested SVG inside a contact island and for candidate ranking ahead of visual-only evidence.

## Live 4-fixture evidence
Final Homeboy run: `c276df01-599b-4e76-83b4-156e17b5c77f` at SSI `88503fd` with copied fixtures and Blocks Engine trunk override.

Registry artifact:
- `gutenberg_incompatibility_registry`: `8bc37e76-36d3-46fd-a2ae-78d825e410c4`
- `gutenberg_incompatibility_registry_report`: `fe598798-c6a5-4594-81e1-bbb89762f2e5`

Corrected ranked registry:
1. `static-form` — convertible, 1 fixture (`3-artist-music`), 4 findings.
2. `js-commerce-controls` — convertible, 1 fixture (`3-artist-music`), 3 findings.
3. `contact-layout` — convertible, 1 fixture (`3-artist-music`), 1 finding.
4. `inline-svg-filter-gradient` — convertible, 1 fixture (`2-onepager-coffee`), 2 findings; these are the legitimate standalone coffee SVG cases.

Artist fallback findings now attribute to the real outer causes: `div.contact-content`, `form.newsletter-form`, `button.qty-btn`, `span.qty-display`, `button.add-to-cart`. SVG is no longer the top-ranked candidate from artist's contact layout.

Note: the bench status is `fail` due existing visual mismatch gates across the four fixtures; the WP Codebox batch itself exited `0` and the registry artifacts regenerated successfully.

## Promotion status
Promotion rule remains `>=2` distinct fixtures and `no_core_block_path: true`.
- `static-form`: tracked, not promoted; fixture_count 1 (`3-artist-music`).
- `js-commerce-controls`: tracked, not promoted; fixture_count 1 (`3-artist-music`).
- `contact-layout`: tracked, not promoted; fixture_count 1 (`3-artist-music`).
- broader corpus runs should promote recurring form/contact/commerce candidates when recurrence is observed.

## Tests
- `node tools/fixture-matrix.test.mjs` (143/143 passing)
- Live Homeboy matrix run `c276df01-599b-4e76-83b4-156e17b5c77f` regenerated registry artifacts.

## Blocks Engine
No Blocks Engine PR needed. Transformer diagnostics already emit structured `reason_code` / `pattern_family`; the mis-attribution was in SSI's registry classifier.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode with Claude Fable 5 orchestrator + GPT-5.5 subagents
- **Used for:** Registry design follow-through, attribution root-cause analysis, implementation, tests, and live evidence review.
