### PR TITLE
Guard WordPress body class stylesheet collisions

### DIFF
--- a/includes/class-static-site-importer-stylesheet-materializer.php
+++ b/includes/class-static-site-importer-stylesheet-materializer.php
@@ -138,9 +138,10 @@ class Static_Site_Importer_Stylesheet_Materializer {
 	 */
 	private static function style_css( string $theme_name, string $css, array $visual_repair_styles = array() ): string {
 		$admin_bar_bridge = self::admin_bar_top_chrome_css( $css );
+		$body_class_guard = self::wordpress_body_class_collision_guard_css( $css );
 		$repair_css       = self::visual_repair_css_for_target( $visual_repair_styles, 'frontend' );
 
-		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Materialized from a compiled website artifact.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $admin_bar_bridge . $repair_css;
+		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Materialized from a compiled website artifact.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $body_class_guard . $admin_bar_bridge . $repair_css;
 	}
 
 	/**
@@ -154,6 +155,96 @@ class Static_Site_Importer_Stylesheet_Materializer {
 		$repair_css = self::visual_repair_css_for_target( $visual_repair_styles, 'editor' );
 
 		return "/*\nStatic Site Importer editor styles.\nGenerated separately from frontend style.css so editor wrapper repairs do not leak to public rendering.\n*/\n\n" . $css . "\n" . $repair_css;
+	}
+
+	/**
+	 * Prevent source utility/page classes from styling WordPress' generated body classes.
+	 *
+	 * WordPress adds generic classes such as `page` and `home` to <body>. Static
+	 * sites commonly use the same tokens for inner page wrappers, and layout rules
+	 * on those source classes must not shrink or pad the WordPress shell itself.
+	 *
+	 * @param string $css Source CSS.
+	 * @return string CSS guard rules.
+	 */
+	private static function wordpress_body_class_collision_guard_css( string $css ): string {
+		$body_classes = array(
+			'admin-bar',
+			'archive',
+			'attachment',
+			'author',
+			'blog',
+			'category',
+			'customize-support',
+			'date',
+			'error404',
+			'home',
+			'logged-in',
+			'no-customize-support',
+			'page',
+			'page-child',
+			'page-parent',
+			'page-template',
+			'page-template-default',
+			'paged',
+			'post-type-archive',
+			'privacy-policy',
+			'rtl',
+			'search',
+			'search-no-results',
+			'search-results',
+			'single',
+			'tag',
+			'wp-custom-logo',
+			'wp-embed-responsive',
+		);
+		$collisions   = array();
+
+		foreach ( self::layout_class_selectors_from_css( $css ) as $class_name ) {
+			if ( in_array( $class_name, $body_classes, true ) ) {
+				$collisions[] = $class_name;
+			}
+		}
+
+		$collisions = array_values( array_unique( $collisions ) );
+		if ( empty( $collisions ) ) {
+			return '';
+		}
+
+		$rules = array();
+		foreach ( $collisions as $class_name ) {
+			$rules[] = 'body.' . $class_name;
+		}
+
+		return "\n/* Static Site Importer: keep imported wrapper classes from styling WordPress body classes. */\n"
+			. implode( ', ', $rules ) . ' { width: auto; max-width: none; margin: 0; padding: 0; }' . "\n";
+	}
+
+	/**
+	 * @param string $css Source CSS.
+	 * @return array<int,string> Class selectors whose rule carries layout geometry.
+	 */
+	private static function layout_class_selectors_from_css( string $css ): array {
+		$css     = preg_replace( '/\/\*.*?\*\//s', '', $css ) ?? $css;
+		$classes = array();
+		if ( '' === trim( $css ) || ! preg_match_all( '/([^{}@][^{}]*)\{([^{}]*)\}/', $css, $matches, PREG_SET_ORDER ) ) {
+			return array();
+		}
+
+		foreach ( $matches as $match ) {
+			$body = (string) $match[2];
+			if ( ! preg_match( '/(?:^|;)\s*(?:width|max-width|min-width|margin|margin-[a-z-]+|padding|padding-[a-z-]+)\s*:/i', $body ) ) {
+				continue;
+			}
+
+			foreach ( explode( ',', (string) $match[1] ) as $selector ) {
+				if ( preg_match_all( '/\.([A-Za-z_-][A-Za-z0-9_-]*)/', $selector, $class_matches ) ) {
+					$classes = array_merge( $classes, $class_matches[1] );
+				}
+			}
+		}
+
+		return array_values( array_unique( $classes ) );
 	}
 
 	/**

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -150,6 +150,18 @@ $assert( str_contains( $editor_css, '.editor-styles-wrapper .glow-orb { opacity:
 $assert( str_contains( $editor_css, '.compiled-site-repair { display: block; }' ), 'editor-includes-compiled-site-repair-css', $editor_css );
 $assert( ! str_contains( $editor_css, '.should-not-appear' ), 'unknown-target-repair-css-is-ignored', $editor_css );
 
+$body_guard_writes = Static_Site_Importer_Stylesheet_Materializer::stylesheet_writes(
+	'/tmp/body-class-guard-smoke',
+	'Body Class Guard Smoke',
+	'.page { max-width: 720px; margin: 0 auto; padding: 5rem 2rem; } .admin-bar { padding-top: 2rem; } .home { color: red; } .card { max-width: 20rem; }',
+	array(),
+	array()
+);
+$body_guard_css    = (string) ( $body_guard_writes['/tmp/body-class-guard-smoke/style.css'] ?? '' );
+$assert( str_contains( $body_guard_css, 'body.page, body.admin-bar { width: auto; max-width: none; margin: 0; padding: 0; }' ), 'style-guards-wordpress-body-class-collisions', $body_guard_css );
+$assert( ! str_contains( $body_guard_css, 'body.card' ), 'style-does-not-guard-non-wordpress-body-class', $body_guard_css );
+$assert( ! str_contains( $body_guard_css, 'body.home' ), 'style-does-not-guard-non-layout-body-class', $body_guard_css );
+
 $documents      = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'documents_from_compiled_site_pages' );
 $missing_source = $documents->invoke(
 	null,


### PR DESCRIPTION
## Summary

Fixes a generic WordPress body-class collision in generated theme stylesheets.

WordPress adds generic classes such as `page`, `home`, `blog`, `single`, `archive`, `search`, `logged-in`, and `admin-bar` to `<body>`. Some static sites use those same class names for inner layout wrappers. When source CSS includes layout geometry on a colliding class, for example `.page { max-width: 720px; padding: ... }`, the generated WordPress theme can accidentally apply source wrapper geometry to `body.page`, shrinking or padding the whole WordPress shell.

## Fix

The stylesheet materializer now emits a frontend-only body-class neutralizer when both conditions are true:

- The source stylesheet has a class selector that collides with a known WordPress core `body_class()` token.
- The matching rule contains layout geometry (`width`, `max-width`, `min-width`, `margin*`, or `padding*`).

Example emitted guard:

```css
body.page { width: auto; max-width: none; margin: 0; padding: 0; }
```

The guard is generic and fixture-independent. It does not emit for unrelated classes, and it does not emit for known body-class tokens that only carry non-layout declarations.

## CV Proof

Fixture: `31-personal-cv-academic`

Before baseline from lane report:

- Aligned mismatch: `2.64%`
- Height delta: `+771px`
- Failure mode: WordPress `body.page` inherited source `.page` wrapper geometry and shrank the page shell to the CV wrapper width.

After this fix, run twice against fresh Blocks Engine `origin/trunk` (`de34d57`) and this SSI branch:

- Run 1: aligned mismatch `2.70%`, source `1280x9061`, candidate `1280x9093`, height delta `+32px`, offset `x=0,y=0`.
- Run 2: aligned mismatch `2.70%`, source `1280x9061`, candidate `1280x9093`, height delta `+32px`, offset `x=0,y=0`.
- Editor quality held: `0` core/html fallbacks, `219/219` valid blocks, `100%` native conversion.
- PNG verdict: candidate is no longer shrunk by the WordPress body class collision; remaining diff is thin text/horizontal geometry, not the catastrophic body-shell width/height drift.

Homeboy run evidence:

- Run 1: `homeboy runs show 41236c92-a455-45d1-9bb6-15a6df9e14bf`
- Run 2: `homeboy runs show 28ed8b74-d6cd-4eb3-bb85-22db9e2bb0e1`

## Corpus Impact

Quick corpus scan found 21 fixtures with source CSS layout selectors colliding with known WordPress body classes:

`11-nonprofit-campaign`, `16-astro-docs-content-collection`, `17-markdown-blog-launch-site`, `18-static-content-library`, `19-product-catalog`, `20-switchback-woocommerce-extra-hard`, `23-recipe-blog`, `26-government-municipal`, `27-university-department`, `31-personal-cv-academic`, `38-medical-clinic`, `45-markdown-ssg-blog`, `47-digital-garden`, `49-terminal-text-adventure`, `50-web-audio-synth`, `51-cursed-arg-site`, `59-spreadsheet`, `60-node-editor`, `67-dataviz-studio`, `69-markdown-editor`, `83-startup-docs-hub`.

Most common collisions were `.tag`, `.page`, `.search`, `.search-results`, and `.search-no-results`.

## Tests

- `node tools/fixture-matrix.test.mjs`
- `php tests/smoke-visual-repair-css.php`
- `php tests/smoke-theme-materializer-dry-run.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Root-causing the WordPress body-class CSS collision and the generic neutralizer guard
