### PR TITLE
Guard ability registration idempotently

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -23,6 +23,9 @@ if ( ! function_exists( 'static_site_importer_register_ability_category' ) ) {
 		if ( ! function_exists( 'wp_register_ability_category' ) ) {
 			return;
 		}
+		if ( function_exists( 'wp_get_ability_category' ) && wp_get_ability_category( STATIC_SITE_IMPORTER_ABILITY_CATEGORY ) ) {
+			return;
+		}
 
 		wp_register_ability_category(
 			STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
@@ -31,6 +34,23 @@ if ( ! function_exists( 'static_site_importer_register_ability_category' ) ) {
 				'description' => __( 'Website artifact materialization capabilities.', 'static-site-importer' ),
 			)
 		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_register_ability_once' ) ) {
+	/**
+	 * Register an ability unless it already exists in the current runtime.
+	 *
+	 * @param string               $name Ability name.
+	 * @param array<string, mixed> $args Ability arguments.
+	 * @return void
+	 */
+	function static_site_importer_register_ability_once( string $name, array $args ): void {
+		if ( function_exists( 'wp_get_ability' ) && wp_get_ability( $name ) ) {
+			return;
+		}
+
+		wp_register_ability( $name, $args );
 	}
 }
 
@@ -45,7 +65,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			return;
 		}
 
-		wp_register_ability(
+		static_site_importer_register_ability_once(
 			'static-site-importer/export-theme',
 			array(
 				'label'               => __( 'Export Website Artifact', 'static-site-importer' ),
@@ -76,7 +96,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			)
 		);
 
-		wp_register_ability(
+		static_site_importer_register_ability_once(
 			'static-site-importer/import-website-artifact',
 			array(
 				'label'               => __( 'Import Website Artifact', 'static-site-importer' ),
@@ -113,7 +133,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			)
 		);
 
-		wp_register_ability(
+		static_site_importer_register_ability_once(
 			'static-site-importer/import-url',
 			array(
 				'label'               => __( 'Import URL', 'static-site-importer' ),
@@ -153,7 +173,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			)
 		);
 
-		wp_register_ability(
+		static_site_importer_register_ability_once(
 			'static-site-importer/import-figma',
 			array(
 				'label'               => __( 'Import Figma Design', 'static-site-importer' ),
@@ -188,7 +208,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			)
 		);
 
-		wp_register_ability(
+		static_site_importer_register_ability_once(
 			'static-site-importer/validate-artifact',
 			array(
 				'label'               => __( 'Validate Static Site Artifact', 'static-site-importer' ),

--- a/tests/smoke-ability-registration-idempotent.php
+++ b/tests/smoke-ability-registration-idempotent.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Smoke test: ability registration is idempotent across repeated includes.
+ *
+ * Run from the repository root:
+ * php tests/smoke-ability-registration-idempotent.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['ssi_ability_categories'] = array();
+$GLOBALS['ssi_abilities']          = array();
+
+function __( string $text, string $domain = 'default' ): string {
+	return $text;
+}
+
+function doing_action( string $hook ): bool {
+	return false;
+}
+
+function did_action( string $hook ): int {
+	return in_array( $hook, array( 'wp_abilities_api_categories_init', 'wp_abilities_api_init' ), true ) ? 1 : 0;
+}
+
+function wp_get_ability_category( string $slug ): ?array {
+	return $GLOBALS['ssi_ability_categories'][ $slug ] ?? null;
+}
+
+function wp_register_ability_category( string $slug, array $args ): ?array {
+	$GLOBALS['ssi_ability_categories'][ $slug ] = $args;
+	return $args;
+}
+
+function wp_get_ability( string $name ): ?array {
+	return $GLOBALS['ssi_abilities'][ $name ] ?? null;
+}
+
+function wp_register_ability( string $name, array $args ): ?array {
+	$GLOBALS['ssi_abilities'][ $name ] = $args;
+	return $args;
+}
+
+require dirname( __DIR__ ) . '/includes/abilities.php';
+require dirname( __DIR__ ) . '/includes/abilities.php';
+
+$expected_abilities = array(
+	'static-site-importer/export-theme',
+	'static-site-importer/import-website-artifact',
+	'static-site-importer/import-url',
+	'static-site-importer/import-figma',
+	'static-site-importer/validate-artifact',
+);
+
+assert( array( STATIC_SITE_IMPORTER_ABILITY_CATEGORY ) === array_keys( $GLOBALS['ssi_ability_categories'] ) );
+assert( $expected_abilities === array_keys( $GLOBALS['ssi_abilities'] ) );
+
+echo "Ability registration idempotency smoke passed.\n";


### PR DESCRIPTION
## Summary
- Make Static Site Importer ability/category registration idempotent when the plugin file is included after Abilities API init.
- Add a smoke test proving repeated includes do not register duplicate abilities.

## Testing
- php -l includes/abilities.php
- php -l tests/smoke-ability-registration-idempotent.php
- php tests/smoke-ability-registration-idempotent.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via opencode
- **Used for:** Diagnosed duplicate Abilities API registration in the contained WordPress Build preview runtime and drafted the idempotency fix/test.