### PR TITLE
Split fixture matrix diagnostic decision axes

### DIFF
--- a/docs/gutenberg-incompatibility-registry.md
+++ b/docs/gutenberg-incompatibility-registry.md
@@ -13,6 +13,7 @@ Each pattern row contains:
 - `fallback_kind`: one of `core_html`, `data_uri`, `runtime_island`, or `fidelity_loss`.
 - `impossible_in_core_reason`: concrete reason core blocks cannot represent the structure, behavior, or visual exactly.
 - `classification`: `convertible`, `custom-block-candidate`, or `runtime-island`.
+- `limitation_type`: decision-axis bucket: `real_gutenberg_gap`, `transformer_gap`, `intentional_runtime_preservation`, `visual_only_style_drift`, or `editor_validity_risk`.
 - `no_core_block_path`: whether existing core block semantics have no direct path to parity.
 - `fixture_count`, `fixtures`, `fixture_counts`: recurrence evidence across fixtures.
 - `finding_count`, `signals`, `fallback_kinds`, `impact_score`: aggregate impact from normalized matrix findings, visual diff regions, block composition, and future editor render divergence signals.
@@ -23,6 +24,19 @@ Each pattern row contains:
 Default threshold: `2` distinct fixtures.
 
 A pattern is promoted to `custom-block-candidate` when `no_core_block_path` is true and the pattern appears in at least the threshold number of distinct fixtures. Runtime-island patterns stay `runtime-island` even when recurring. Patterns with a plausible core-block or transformer path stay `convertible` until evidence proves core cannot express them.
+
+## Fixture Decisions
+
+The registry also emits `fixture_decisions[]` so acceptance decisions do not require re-reading pattern evidence by hand:
+
+- `editor_validity_status`: `valid`, `invalid_blocks`, or `not_validated`; this is the corrupt/invalid block risk axis.
+- `native_editability_status`: `native_editable`, `editor_invalid`, `custom_block_candidate`, `runtime_island_preserved`, `html_islands_or_transformer_gap`, or `unknown`.
+- `visible_html_island_count`: visible `core/html` island pressure from block composition and findings.
+- `gutenberg_gap_patterns`: real Gutenberg/custom-block candidate gaps affecting that fixture.
+- `transformer_gap_patterns`: fallback or attribution gaps that should be fixed in SSI/Blocks Engine before calling something a Gutenberg limitation.
+- `intentional_runtime_patterns`: runtime islands preserved by design.
+- `visual_only_patterns`: frontend visual drift patterns that do not imply invalid blocks or lost editability by themselves.
+- `solved_candidate_reason`: present only when the fixture passed, editor validation passed, no HTML/runtime islands remain, and no registry limitation pattern is attached.
 
 ## Seeded Generic Pattern Keys
 

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -26,8 +26,9 @@ export function buildGutenbergIncompatibilityRegistry(result = {}, options = {})
   const threshold = positiveInteger(options.customBlockCandidateFixtureThreshold ?? options.custom_block_candidate_fixture_threshold, DEFAULT_CUSTOM_BLOCK_CANDIDATE_FIXTURE_THRESHOLD);
   const rows = new Map();
   const fixtures = normalizeArray(result.fixtures);
+  const findings = normalizeArray(result.findings);
 
-  for (const finding of normalizeArray(result.findings)) {
+  for (const finding of findings) {
     const patternDefinition = classifyFindingPattern(finding);
     if (!patternDefinition) {
       continue;
@@ -52,6 +53,7 @@ export function buildGutenbergIncompatibilityRegistry(result = {}, options = {})
   }
 
   const patterns = [...rows.values()].map((row) => finalizeRow(row, threshold)).sort(sortRows);
+  const fixtureDecisions = buildFixtureDecisions(fixtures, findings, patterns);
   return {
     schema: GUTENBERG_INCOMPATIBILITY_REGISTRY_SCHEMA,
     matrix_id: result.matrix_id || '',
@@ -69,8 +71,12 @@ export function buildGutenbergIncompatibilityRegistry(result = {}, options = {})
       custom_block_candidate_count: patterns.filter((row) => row.classification === 'custom-block-candidate').length,
       convertible_count: patterns.filter((row) => row.classification === 'convertible').length,
       runtime_island_count: patterns.filter((row) => row.classification === 'runtime-island').length,
+      fixture_decision_counts: countBy(fixtureDecisions, (row) => row.native_editability_status),
+      editor_validity_counts: countBy(fixtureDecisions, (row) => row.editor_validity_status),
+      limitation_type_counts: countBy(patterns, (row) => row.limitation_type),
       top_patterns: patterns.slice(0, 10).map((row) => ({ pattern_key: row.pattern_key, classification: row.classification, fixture_count: row.fixture_count, finding_count: row.finding_count, impact_score: row.impact_score })),
     },
+    fixture_decisions: fixtureDecisions,
     patterns,
   };
 }
@@ -86,15 +92,19 @@ export function renderGutenbergIncompatibilityRegistryMarkdown(registry = {}) {
     `Matrix: \`${registry.matrix_id || '(unknown)'}\``,
     `Promotion rule: ${registry.promotion_rule?.rule || ''}`,
     '',
-    '| Rank | Pattern | Classification | Fixtures | Findings | Impact | Reason |',
-    '| ---: | --- | --- | ---: | ---: | ---: | --- |',
+    '| Rank | Pattern | Limitation Type | Classification | Fixtures | Findings | Impact | Reason |',
+    '| ---: | --- | --- | --- | ---: | ---: | ---: | --- |',
   ];
   normalizeArray(registry.patterns).forEach((row, index) => {
-    lines.push(`| ${index + 1} | \`${row.pattern_key}\` | ${row.classification} | ${row.fixture_count} | ${row.finding_count} | ${row.impact_score} | ${table(row.impossible_in_core_reason)} |`);
+    lines.push(`| ${index + 1} | \`${row.pattern_key}\` | ${row.limitation_type || '(unknown)'} | ${row.classification} | ${row.fixture_count} | ${row.finding_count} | ${row.impact_score} | ${table(row.impossible_in_core_reason)} |`);
   });
+  lines.push('', '## Fixture Decisions', '', '| Fixture | Editor Validity | Native Editability | HTML Islands | Runtime Islands | Gutenberg Gaps | Visual-only Patterns | Solved Candidate |', '| --- | --- | --- | ---: | ---: | --- | --- | --- |');
+  for (const row of normalizeArray(registry.fixture_decisions)) {
+    lines.push(`| \`${row.fixture_id}\` | ${row.editor_validity_status} | ${row.native_editability_status} | ${row.visible_html_island_count || 0} | ${row.runtime_island_count || 0} | ${(row.gutenberg_gap_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${(row.visual_only_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${row.solved_candidate_reason || '(no)'} |`);
+  }
   lines.push('', '## Pattern Evidence', '');
   for (const row of normalizeArray(registry.patterns)) {
-    lines.push(`### ${row.pattern_key}`, '', `- Description: ${row.description}`, `- Fallback kind: \`${row.fallback_kind}\``, `- Classification: \`${row.classification}\``, `- Fixtures: ${row.fixtures.join(', ') || '(none)'}`, `- Reason: ${row.impossible_in_core_reason}`);
+    lines.push(`### ${row.pattern_key}`, '', `- Description: ${row.description}`, `- Limitation type: \`${row.limitation_type || '(unknown)'}\``, `- Fallback kind: \`${row.fallback_kind}\``, `- Classification: \`${row.classification}\``, `- Fixtures: ${row.fixtures.join(', ') || '(none)'}`, `- Reason: ${row.impossible_in_core_reason}`);
     if (row.example?.selector || row.example?.source_snippet) {
       lines.push(`- Example selector/snippet: \`${String(row.example.selector || row.example.source_snippet).replace(/`/g, '\\`').slice(0, 180)}\``);
     }
@@ -253,13 +263,15 @@ function addEvidence(rows, definition, evidence) {
 function finalizeRow(row, threshold) {
   const fixtureCount = row.fixtures.length;
   const classification = row.base_classification === 'runtime-island' ? 'runtime-island' : row.no_core_block_path && fixtureCount >= threshold ? 'custom-block-candidate' : row.base_classification === 'custom-block-candidate' ? 'convertible' : row.base_classification;
+  const fallbackKind = dominantKey(row.fallback_kinds) || row.fallback_kind;
   return compactObject({
     pattern_key: row.pattern_key,
     description: row.description,
-    fallback_kind: dominantKey(row.fallback_kinds) || row.fallback_kind,
+    fallback_kind: fallbackKind,
     fallback_kinds: sortCountObject(row.fallback_kinds),
     impossible_in_core_reason: row.impossible_in_core_reason,
     classification,
+    limitation_type: limitationType({ ...row, classification, fallback_kind: fallbackKind }),
     no_core_block_path: row.no_core_block_path,
     fixture_count: fixtureCount,
     finding_count: row.finding_count,
@@ -272,6 +284,126 @@ function finalizeRow(row, threshold) {
     example: row.examples[0] ? boundBlob(row.examples[0]) : undefined,
     examples: boundBlob(row.examples),
   });
+}
+
+function buildFixtureDecisions(fixtures, findings, patterns) {
+  const patternsByFixture = new Map();
+  for (const row of patterns) {
+    for (const fixtureId of normalizeArray(row.fixtures)) {
+      patternsByFixture.set(fixtureId, [...(patternsByFixture.get(fixtureId) || []), row]);
+    }
+  }
+  const findingsByFixture = new Map();
+  for (const finding of findings) {
+    const fixtureId = finding.fixture_id || '';
+    findingsByFixture.set(fixtureId, [...(findingsByFixture.get(fixtureId) || []), finding]);
+  }
+  return fixtures.map((fixture) => {
+    const fixtureId = fixture.fixture_id || fixture.id || '';
+    return fixtureDecision(fixture, findingsByFixture.get(fixtureId) || [], patternsByFixture.get(fixtureId) || []);
+  });
+}
+
+function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
+  const editorInvalidCount = editorInvalidCountForFixture(fixture, fixtureFindings);
+  const editorValidated = editorValidatedForFixture(fixture);
+  const visibleHtmlIslandCount = visibleHtmlIslandCountForFixture(fixture, fixtureFindings);
+  const runtimeIslandCount = fixtureFindings.filter((finding) => finding.loss_class === 'preserved_runtime_island').length;
+  const gutenbergGapPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'real_gutenberg_gap').map((row) => row.pattern_key));
+  const transformerGapPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'transformer_gap').map((row) => row.pattern_key));
+  const visualOnlyPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'visual_only_style_drift').map((row) => row.pattern_key));
+  const runtimeIslandPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'intentional_runtime_preservation').map((row) => row.pattern_key));
+  const editorValidityStatus = editorInvalidCount > 0 ? 'invalid_blocks' : editorValidated ? 'valid' : 'not_validated';
+  const nativeEditabilityStatus = nativeEditabilityStatusForFixture({
+    editorValidityStatus,
+    visibleHtmlIslandCount,
+    runtimeIslandCount,
+    gutenbergGapPatterns,
+    transformerGapPatterns,
+  });
+  return compactObject({
+    fixture_id: fixture.fixture_id || fixture.id || '',
+    editor_validity_status: editorValidityStatus,
+    native_editability_status: nativeEditabilityStatus,
+    visible_html_island_count: visibleHtmlIslandCount,
+    runtime_island_count: runtimeIslandCount,
+    gutenberg_gap_patterns: gutenbergGapPatterns,
+    transformer_gap_patterns: transformerGapPatterns,
+    intentional_runtime_patterns: runtimeIslandPatterns,
+    visual_only_patterns: visualOnlyPatterns,
+    solved_candidate_reason: solvedCandidateReason({ fixture, editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, transformerGapPatterns, visualOnlyPatterns }),
+  });
+}
+
+function nativeEditabilityStatusForFixture({ editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, transformerGapPatterns }) {
+  if (editorValidityStatus === 'invalid_blocks') {
+    return 'editor_invalid';
+  }
+  if (gutenbergGapPatterns.length > 0) {
+    return 'custom_block_candidate';
+  }
+  if (runtimeIslandCount > 0) {
+    return 'runtime_island_preserved';
+  }
+  if (visibleHtmlIslandCount > 0 || transformerGapPatterns.length > 0) {
+    return 'html_islands_or_transformer_gap';
+  }
+  if (editorValidityStatus === 'not_validated') {
+    return 'unknown';
+  }
+  return 'native_editable';
+}
+
+function solvedCandidateReason({ fixture, editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, transformerGapPatterns, visualOnlyPatterns }) {
+  if (fixture.status !== 'passed' || editorValidityStatus !== 'valid' || visibleHtmlIslandCount > 0 || runtimeIslandCount > 0 || gutenbergGapPatterns.length > 0 || transformerGapPatterns.length > 0 || visualOnlyPatterns.length > 0) {
+    return '';
+  }
+  return 'passed editor validity, native editability, and visual parity without limitation patterns';
+}
+
+function limitationType(row) {
+  if (row.classification === 'runtime-island') {
+    return 'intentional_runtime_preservation';
+  }
+  if (row.pattern_key === 'editor-render-divergence' || (row.fallback_kind === 'fidelity_loss' && !row.pattern_key.startsWith('visual-'))) {
+    return 'editor_validity_risk';
+  }
+  if (row.pattern_key.startsWith('visual-')) {
+    return 'visual_only_style_drift';
+  }
+  if (row.no_core_block_path) {
+    return 'real_gutenberg_gap';
+  }
+  return 'transformer_gap';
+}
+
+function visibleHtmlIslandCountForFixture(fixture, fixtureFindings) {
+  const blockTypes = objectValue(fixture.block_composition?.block_types || fixture.block_composition?.block_type_counts || fixture.blockComposition?.blockTypes || fixture.blockComposition?.blockTypeCounts);
+  const blockCompositionCount = numberValue(blockTypes['core/html'] || fixture.block_composition?.core_html_block_count || fixture.blockComposition?.coreHtmlBlockCount || fixture.editor_quality?.core_html_block_count);
+  const findingCount = fixtureFindings.filter((finding) => fallbackKindForFinding(finding, { fallback_kind: '' }) === 'core_html').length;
+  return Math.max(blockCompositionCount, findingCount);
+}
+
+function editorInvalidCountForFixture(fixture, fixtureFindings) {
+  return numberValue(fixture.editor_quality?.editor_invalid_count || fixture.editor_quality?.invalid_block_count || fixture.editor_validation?.invalid_block_count || fixture.editor_validation?.invalid_count)
+    + fixtureFindings.filter((finding) => finding.loss_class === 'editor_block_invalid' || finding.loss_class === 'invalid_block_content').length;
+}
+
+function editorValidatedForFixture(fixture) {
+  return numberValue(fixture.editor_quality?.editor_validated_block_total || fixture.editor_validation?.block_total || fixture.editor_validation?.total_block_count || fixture.editor_validation?.total) > 0;
+}
+
+function countBy(items, iteratee) {
+  const counts = {};
+  for (const item of normalizeArray(items)) {
+    const key = iteratee(item) || 'unknown';
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return sortCountObject(counts);
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values.filter(Boolean))].sort();
 }
 
 function sortRows(left, right) {

--- a/registry/gutenberg-incompatibility-registry.schema.json
+++ b/registry/gutenberg-incompatibility-registry.schema.json
@@ -33,16 +33,23 @@
         "custom_block_candidate_count": { "type": "integer", "minimum": 0 },
         "convertible_count": { "type": "integer", "minimum": 0 },
         "runtime_island_count": { "type": "integer", "minimum": 0 },
+        "fixture_decision_counts": { "$ref": "#/$defs/counts" },
+        "editor_validity_counts": { "$ref": "#/$defs/counts" },
+        "limitation_type_counts": { "$ref": "#/$defs/counts" },
         "top_patterns": { "type": "array", "items": { "$ref": "#/$defs/top_pattern" } }
       },
       "additionalProperties": false
     },
+    "fixture_decisions": { "type": "array", "items": { "$ref": "#/$defs/fixture_decision" } },
     "patterns": { "type": "array", "items": { "$ref": "#/$defs/pattern" } }
   },
   "additionalProperties": false,
   "$defs": {
     "classification": { "enum": ["convertible", "custom-block-candidate", "runtime-island"] },
     "fallback_kind": { "enum": ["core_html", "data_uri", "runtime_island", "fidelity_loss"] },
+    "limitation_type": { "enum": ["real_gutenberg_gap", "transformer_gap", "intentional_runtime_preservation", "visual_only_style_drift", "editor_validity_risk"] },
+    "editor_validity_status": { "enum": ["valid", "invalid_blocks", "not_validated"] },
+    "native_editability_status": { "enum": ["native_editable", "editor_invalid", "custom_block_candidate", "runtime_island_preserved", "html_islands_or_transformer_gap", "unknown"] },
     "top_pattern": {
       "type": "object",
       "required": ["pattern_key", "classification", "fixture_count", "finding_count", "impact_score"],
@@ -57,7 +64,7 @@
     },
     "pattern": {
       "type": "object",
-      "required": ["pattern_key", "description", "fallback_kind", "impossible_in_core_reason", "classification", "no_core_block_path", "fixture_count", "finding_count", "impact_score", "fixtures", "signals"],
+      "required": ["pattern_key", "description", "fallback_kind", "impossible_in_core_reason", "classification", "limitation_type", "no_core_block_path", "fixture_count", "finding_count", "impact_score", "fixtures", "signals"],
       "properties": {
         "pattern_key": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
         "description": { "type": "string" },
@@ -65,6 +72,7 @@
         "fallback_kinds": { "$ref": "#/$defs/counts" },
         "impossible_in_core_reason": { "type": "string" },
         "classification": { "$ref": "#/$defs/classification" },
+        "limitation_type": { "$ref": "#/$defs/limitation_type" },
         "no_core_block_path": { "type": "boolean" },
         "fixture_count": { "type": "integer", "minimum": 0 },
         "finding_count": { "type": "integer", "minimum": 0 },
@@ -76,6 +84,23 @@
         "signals": { "$ref": "#/$defs/counts" },
         "example": { "type": "object" },
         "examples": { "type": "array", "items": { "type": "object" } }
+      },
+      "additionalProperties": false
+    },
+    "fixture_decision": {
+      "type": "object",
+      "required": ["fixture_id", "editor_validity_status", "native_editability_status", "visible_html_island_count", "runtime_island_count", "gutenberg_gap_patterns", "transformer_gap_patterns", "intentional_runtime_patterns", "visual_only_patterns"],
+      "properties": {
+        "fixture_id": { "type": "string" },
+        "editor_validity_status": { "$ref": "#/$defs/editor_validity_status" },
+        "native_editability_status": { "$ref": "#/$defs/native_editability_status" },
+        "visible_html_island_count": { "type": "number", "minimum": 0 },
+        "runtime_island_count": { "type": "integer", "minimum": 0 },
+        "gutenberg_gap_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "transformer_gap_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "intentional_runtime_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "visual_only_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "solved_candidate_reason": { "type": "string" }
       },
       "additionalProperties": false
     },

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -57,6 +57,7 @@ import {
   EDITOR_VALIDATE_BLOCKS_COMMAND,
   EDITOR_VALIDATION_METHOD,
   buildGutenbergIncompatibilityRegistry,
+  renderGutenbergIncompatibilityRegistryMarkdown,
   normalizeFixtureMatrixResult,
   normalizeLossClass,
   stageFixtureSource,
@@ -185,6 +186,68 @@ test('gutenberg incompatibility registry keeps runtime islands separate and cons
   assert.equal(byKey['legitimate-runtime-island'].classification, 'runtime-island');
   assert.equal(byKey['editor-render-divergence'].classification, 'convertible');
   assert.equal(byKey['editor-render-divergence'].signals.editor_render_divergence, 1);
+});
+
+test('gutenberg incompatibility registry separates fixture decision axes', () => {
+  const registry = buildGutenbergIncompatibilityRegistry({
+    matrix_id: 'decision-axis-map',
+    fixtures: [
+      {
+        fixture_id: 'cv',
+        status: 'passed',
+        block_composition: { block_total: 8, native_block_count: 8, core_html_block_count: 0 },
+        editor_quality: { editor_validated_block_total: 8, editor_invalid_count: 0, core_html_block_count: 0 },
+      },
+      {
+        fixture_id: 'artist',
+        status: 'failed',
+        block_composition: { block_total: 10, native_block_count: 9, core_html_block_count: 1 },
+        editor_quality: { editor_validated_block_total: 10, editor_invalid_count: 0, core_html_block_count: 1 },
+        visual_diff_regions: [{ dominant_cause: 'position_offset', pixel_count: 2500 }],
+      },
+      {
+        fixture_id: 'saas',
+        status: 'failed',
+        editor_quality: { editor_validated_block_total: 6, editor_invalid_count: 1, core_html_block_count: 0 },
+      },
+    ],
+    findings: [
+      {
+        fixture_id: 'artist',
+        kind: 'unsupported_html_fallback',
+        observed_block_name: 'core/html',
+        reason_code: 'html_form_fallback',
+        selector: 'form.newsletter',
+        source_snippet: '<form><input type="email"><button>Subscribe</button></form>',
+      },
+      {
+        fixture_id: 'saas',
+        kind: 'editor_block_invalid',
+        loss_class: 'editor_block_invalid',
+        selector: '.hero',
+        reason: 'Editor block validation failed.',
+      },
+    ],
+  });
+  const decisions = Object.fromEntries(registry.fixture_decisions.map((row) => [row.fixture_id, row]));
+  const patterns = Object.fromEntries(registry.patterns.map((row) => [row.pattern_key, row]));
+  const markdown = renderGutenbergIncompatibilityRegistryMarkdown(registry);
+
+  assert.equal(decisions.cv.editor_validity_status, 'valid');
+  assert.equal(decisions.cv.native_editability_status, 'native_editable');
+  assert.equal(decisions.cv.solved_candidate_reason, 'passed editor validity, native editability, and visual parity without limitation patterns');
+  assert.equal(decisions.artist.native_editability_status, 'custom_block_candidate');
+  assert.equal(decisions.artist.visible_html_island_count, 1);
+  assert.deepEqual(decisions.artist.gutenberg_gap_patterns, ['static-form']);
+  assert.deepEqual(decisions.artist.visual_only_patterns, ['visual-position_offset']);
+  assert.equal(decisions.saas.editor_validity_status, 'invalid_blocks');
+  assert.equal(decisions.saas.native_editability_status, 'editor_invalid');
+  assert.equal(patterns['static-form'].limitation_type, 'real_gutenberg_gap');
+  assert.equal(patterns['visual-position_offset'].limitation_type, 'visual_only_style_drift');
+  assert.equal(registry.summary.fixture_decision_counts.native_editable, 1);
+  assert.equal(registry.summary.editor_validity_counts.invalid_blocks, 1);
+  assert.match(markdown, /## Fixture Decisions/);
+  assert.match(markdown, /`static-form`/);
 });
 
 test('gutenberg incompatibility registry attributes nested svg to the outer fallback island', () => {


### PR DESCRIPTION
## Summary
- add fixture-level decision rows to the Gutenberg incompatibility registry
- classify registry patterns by limitation type: real Gutenberg gaps, transformer gaps, runtime preservation, visual-only drift, and editor-validity risk
- render the new decision table in the markdown report and document the schema fields

## Testing
- npm run test:fixture-matrix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the registry/report/schema/test changes and ran fixture-matrix verification.