### PR TITLE
Capture editor-open evidence in fixture matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: Extra-Chill/homeboy-action@9474cf7db35bf1a34e5bc59b43a85cda5ec57188  # v2.8.9
         with:
           commands: review test
+          args: --extension wordpress
           php-version: ${{ matrix.php-version }}
           node-version: '24'
           autofix: 'false'

--- a/docs/gutenberg-incompatibility-registry.md
+++ b/docs/gutenberg-incompatibility-registry.md
@@ -13,6 +13,7 @@ Each pattern row contains:
 - `fallback_kind`: one of `core_html`, `data_uri`, `runtime_island`, or `fidelity_loss`.
 - `impossible_in_core_reason`: concrete reason core blocks cannot represent the structure, behavior, or visual exactly.
 - `classification`: `convertible`, `custom-block-candidate`, or `runtime-island`.
+- `limitation_type`: decision-axis bucket: `real_gutenberg_gap`, `transformer_gap`, `intentional_runtime_preservation`, `visual_only_style_drift`, or `editor_validity_risk`.
 - `no_core_block_path`: whether existing core block semantics have no direct path to parity.
 - `fixture_count`, `fixtures`, `fixture_counts`: recurrence evidence across fixtures.
 - `finding_count`, `signals`, `fallback_kinds`, `impact_score`: aggregate impact from normalized matrix findings, visual diff regions, block composition, and future editor render divergence signals.
@@ -23,6 +24,19 @@ Each pattern row contains:
 Default threshold: `2` distinct fixtures.
 
 A pattern is promoted to `custom-block-candidate` when `no_core_block_path` is true and the pattern appears in at least the threshold number of distinct fixtures. Runtime-island patterns stay `runtime-island` even when recurring. Patterns with a plausible core-block or transformer path stay `convertible` until evidence proves core cannot express them.
+
+## Fixture Decisions
+
+The registry also emits `fixture_decisions[]` so acceptance decisions do not require re-reading pattern evidence by hand:
+
+- `editor_validity_status`: `valid`, `invalid_blocks`, or `not_validated`; this is the corrupt/invalid block risk axis.
+- `native_editability_status`: `native_editable`, `editor_invalid`, `custom_block_candidate`, `runtime_island_preserved`, `html_islands_or_transformer_gap`, or `unknown`.
+- `visible_html_island_count`: visible `core/html` island pressure from block composition and findings.
+- `gutenberg_gap_patterns`: real Gutenberg/custom-block candidate gaps affecting that fixture.
+- `transformer_gap_patterns`: fallback or attribution gaps that should be fixed in SSI/Blocks Engine before calling something a Gutenberg limitation.
+- `intentional_runtime_patterns`: runtime islands preserved by design.
+- `visual_only_patterns`: frontend visual drift patterns that do not imply invalid blocks or lost editability by themselves.
+- `solved_candidate_reason`: present only when the fixture passed, editor validation passed, no HTML/runtime islands remain, and no registry limitation pattern is attached.
 
 ## Seeded Generic Pattern Keys
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -2,6 +2,7 @@
   "auto_cleanup": false,
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
+    "nodejs": {},
     "wordpress": {
       "settings": {
         "bench_env": {

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -23,6 +23,9 @@ if ( ! function_exists( 'static_site_importer_register_ability_category' ) ) {
 		if ( ! function_exists( 'wp_register_ability_category' ) ) {
 			return;
 		}
+		if ( function_exists( 'wp_get_ability_category' ) && wp_get_ability_category( STATIC_SITE_IMPORTER_ABILITY_CATEGORY ) ) {
+			return;
+		}
 
 		wp_register_ability_category(
 			STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
@@ -31,6 +34,23 @@ if ( ! function_exists( 'static_site_importer_register_ability_category' ) ) {
 				'description' => __( 'Website artifact materialization capabilities.', 'static-site-importer' ),
 			)
 		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_register_ability_once' ) ) {
+	/**
+	 * Register an ability unless it already exists in the current runtime.
+	 *
+	 * @param string               $name Ability name.
+	 * @param array<string, mixed> $args Ability arguments.
+	 * @return void
+	 */
+	function static_site_importer_register_ability_once( string $name, array $args ): void {
+		if ( function_exists( 'wp_get_ability' ) && wp_get_ability( $name ) ) {
+			return;
+		}
+
+		wp_register_ability( $name, $args );
 	}
 }
 
@@ -45,7 +65,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			return;
 		}
 
-		wp_register_ability(
+		static_site_importer_register_ability_once(
 			'static-site-importer/export-theme',
 			array(
 				'label'               => __( 'Export Website Artifact', 'static-site-importer' ),
@@ -76,7 +96,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			)
 		);
 
-		wp_register_ability(
+		static_site_importer_register_ability_once(
 			'static-site-importer/import-website-artifact',
 			array(
 				'label'               => __( 'Import Website Artifact', 'static-site-importer' ),
@@ -113,7 +133,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			)
 		);
 
-		wp_register_ability(
+		static_site_importer_register_ability_once(
 			'static-site-importer/import-url',
 			array(
 				'label'               => __( 'Import URL', 'static-site-importer' ),
@@ -153,7 +173,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			)
 		);
 
-		wp_register_ability(
+		static_site_importer_register_ability_once(
 			'static-site-importer/import-figma',
 			array(
 				'label'               => __( 'Import Figma Design', 'static-site-importer' ),
@@ -188,7 +208,7 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			)
 		);
 
-		wp_register_ability(
+		static_site_importer_register_ability_once(
 			'static-site-importer/validate-artifact',
 			array(
 				'label'               => __( 'Validate Static Site Artifact', 'static-site-importer' ),

--- a/includes/class-static-site-importer-stylesheet-materializer.php
+++ b/includes/class-static-site-importer-stylesheet-materializer.php
@@ -138,9 +138,10 @@ class Static_Site_Importer_Stylesheet_Materializer {
 	 */
 	private static function style_css( string $theme_name, string $css, array $visual_repair_styles = array() ): string {
 		$admin_bar_bridge = self::admin_bar_top_chrome_css( $css );
+		$body_class_guard = self::wordpress_body_class_collision_guard_css( $css );
 		$repair_css       = self::visual_repair_css_for_target( $visual_repair_styles, 'frontend' );
 
-		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Materialized from a compiled website artifact.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $admin_bar_bridge . $repair_css;
+		return "/*\nTheme Name: " . $theme_name . "\nAuthor: Static Site Importer\nDescription: Materialized from a compiled website artifact.\nVersion: 0.1.0\nRequires at least: 6.6\n*/\n\n" . $css . "\n" . $body_class_guard . $admin_bar_bridge . $repair_css;
 	}
 
 	/**
@@ -154,6 +155,96 @@ class Static_Site_Importer_Stylesheet_Materializer {
 		$repair_css = self::visual_repair_css_for_target( $visual_repair_styles, 'editor' );
 
 		return "/*\nStatic Site Importer editor styles.\nGenerated separately from frontend style.css so editor wrapper repairs do not leak to public rendering.\n*/\n\n" . $css . "\n" . $repair_css;
+	}
+
+	/**
+	 * Prevent source utility/page classes from styling WordPress' generated body classes.
+	 *
+	 * WordPress adds generic classes such as `page` and `home` to <body>. Static
+	 * sites commonly use the same tokens for inner page wrappers, and layout rules
+	 * on those source classes must not shrink or pad the WordPress shell itself.
+	 *
+	 * @param string $css Source CSS.
+	 * @return string CSS guard rules.
+	 */
+	private static function wordpress_body_class_collision_guard_css( string $css ): string {
+		$body_classes = array(
+			'admin-bar',
+			'archive',
+			'attachment',
+			'author',
+			'blog',
+			'category',
+			'customize-support',
+			'date',
+			'error404',
+			'home',
+			'logged-in',
+			'no-customize-support',
+			'page',
+			'page-child',
+			'page-parent',
+			'page-template',
+			'page-template-default',
+			'paged',
+			'post-type-archive',
+			'privacy-policy',
+			'rtl',
+			'search',
+			'search-no-results',
+			'search-results',
+			'single',
+			'tag',
+			'wp-custom-logo',
+			'wp-embed-responsive',
+		);
+		$collisions   = array();
+
+		foreach ( self::layout_class_selectors_from_css( $css ) as $class_name ) {
+			if ( in_array( $class_name, $body_classes, true ) ) {
+				$collisions[] = $class_name;
+			}
+		}
+
+		$collisions = array_values( array_unique( $collisions ) );
+		if ( empty( $collisions ) ) {
+			return '';
+		}
+
+		$rules = array();
+		foreach ( $collisions as $class_name ) {
+			$rules[] = 'body.' . $class_name;
+		}
+
+		return "\n/* Static Site Importer: keep imported wrapper classes from styling WordPress body classes. */\n"
+			. implode( ', ', $rules ) . ' { width: auto; max-width: none; margin: 0; padding: 0; }' . "\n";
+	}
+
+	/**
+	 * @param string $css Source CSS.
+	 * @return array<int,string> Class selectors whose rule carries layout geometry.
+	 */
+	private static function layout_class_selectors_from_css( string $css ): array {
+		$css     = preg_replace( '/\/\*.*?\*\//s', '', $css ) ?? $css;
+		$classes = array();
+		if ( '' === trim( $css ) || ! preg_match_all( '/([^{}@][^{}]*)\{([^{}]*)\}/', $css, $matches, PREG_SET_ORDER ) ) {
+			return array();
+		}
+
+		foreach ( $matches as $match ) {
+			$body = (string) $match[2];
+			if ( ! preg_match( '/(?:^|;)\s*(?:width|max-width|min-width|margin|margin-[a-z-]+|padding|padding-[a-z-]+)\s*:/i', $body ) ) {
+				continue;
+			}
+
+			foreach ( explode( ',', (string) $match[1] ) as $selector ) {
+				if ( preg_match_all( '/\.([A-Za-z_-][A-Za-z0-9_-]*)/', $selector, $class_matches ) ) {
+					$classes = array_merge( $classes, $class_matches[1] );
+				}
+			}
+		}
+
+		return array_values( array_unique( $classes ) );
 	}
 
 	/**

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -604,7 +604,7 @@ function hasPayloadData(value) {
 }
 
 function readFixturePayloadFiles(directory) {
-  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-validate-blocks.json', 'editor-canvas-summary.json', 'visual-compare.json', 'visual-diff.json', 'visual-parity.json', 'visual-explanation.json']
+  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-validate-blocks.json', 'editor-open.json', 'editor-summary.json', 'editor-state.json', 'editor-validity.json', 'editor-canvas-summary.json', 'visual-compare.json', 'visual-diff.json', 'visual-parity.json', 'visual-explanation.json']
     .map((fileName) => readJsonFileIfExists(path.join(directory, fileName)))
     .filter(Boolean);
 }

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -26,8 +26,9 @@ export function buildGutenbergIncompatibilityRegistry(result = {}, options = {})
   const threshold = positiveInteger(options.customBlockCandidateFixtureThreshold ?? options.custom_block_candidate_fixture_threshold, DEFAULT_CUSTOM_BLOCK_CANDIDATE_FIXTURE_THRESHOLD);
   const rows = new Map();
   const fixtures = normalizeArray(result.fixtures);
+  const findings = normalizeArray(result.findings);
 
-  for (const finding of normalizeArray(result.findings)) {
+  for (const finding of findings) {
     const patternDefinition = classifyFindingPattern(finding);
     if (!patternDefinition) {
       continue;
@@ -52,6 +53,7 @@ export function buildGutenbergIncompatibilityRegistry(result = {}, options = {})
   }
 
   const patterns = [...rows.values()].map((row) => finalizeRow(row, threshold)).sort(sortRows);
+  const fixtureDecisions = buildFixtureDecisions(fixtures, findings, patterns);
   return {
     schema: GUTENBERG_INCOMPATIBILITY_REGISTRY_SCHEMA,
     matrix_id: result.matrix_id || '',
@@ -69,8 +71,12 @@ export function buildGutenbergIncompatibilityRegistry(result = {}, options = {})
       custom_block_candidate_count: patterns.filter((row) => row.classification === 'custom-block-candidate').length,
       convertible_count: patterns.filter((row) => row.classification === 'convertible').length,
       runtime_island_count: patterns.filter((row) => row.classification === 'runtime-island').length,
+      fixture_decision_counts: countBy(fixtureDecisions, (row) => row.native_editability_status),
+      editor_validity_counts: countBy(fixtureDecisions, (row) => row.editor_validity_status),
+      limitation_type_counts: countBy(patterns, (row) => row.limitation_type),
       top_patterns: patterns.slice(0, 10).map((row) => ({ pattern_key: row.pattern_key, classification: row.classification, fixture_count: row.fixture_count, finding_count: row.finding_count, impact_score: row.impact_score })),
     },
+    fixture_decisions: fixtureDecisions,
     patterns,
   };
 }
@@ -86,15 +92,19 @@ export function renderGutenbergIncompatibilityRegistryMarkdown(registry = {}) {
     `Matrix: \`${registry.matrix_id || '(unknown)'}\``,
     `Promotion rule: ${registry.promotion_rule?.rule || ''}`,
     '',
-    '| Rank | Pattern | Classification | Fixtures | Findings | Impact | Reason |',
-    '| ---: | --- | --- | ---: | ---: | ---: | --- |',
+    '| Rank | Pattern | Limitation Type | Classification | Fixtures | Findings | Impact | Reason |',
+    '| ---: | --- | --- | --- | ---: | ---: | ---: | --- |',
   ];
   normalizeArray(registry.patterns).forEach((row, index) => {
-    lines.push(`| ${index + 1} | \`${row.pattern_key}\` | ${row.classification} | ${row.fixture_count} | ${row.finding_count} | ${row.impact_score} | ${table(row.impossible_in_core_reason)} |`);
+    lines.push(`| ${index + 1} | \`${row.pattern_key}\` | ${row.limitation_type || '(unknown)'} | ${row.classification} | ${row.fixture_count} | ${row.finding_count} | ${row.impact_score} | ${table(row.impossible_in_core_reason)} |`);
   });
+  lines.push('', '## Fixture Decisions', '', '| Fixture | Editor Validity | Native Editability | HTML Islands | Runtime Islands | Gutenberg Gaps | Visual-only Patterns | Solved Candidate |', '| --- | --- | --- | ---: | ---: | --- | --- | --- |');
+  for (const row of normalizeArray(registry.fixture_decisions)) {
+    lines.push(`| \`${row.fixture_id}\` | ${row.editor_validity_status} | ${row.native_editability_status} | ${row.visible_html_island_count || 0} | ${row.runtime_island_count || 0} | ${(row.gutenberg_gap_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${(row.visual_only_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${row.solved_candidate_reason || '(no)'} |`);
+  }
   lines.push('', '## Pattern Evidence', '');
   for (const row of normalizeArray(registry.patterns)) {
-    lines.push(`### ${row.pattern_key}`, '', `- Description: ${row.description}`, `- Fallback kind: \`${row.fallback_kind}\``, `- Classification: \`${row.classification}\``, `- Fixtures: ${row.fixtures.join(', ') || '(none)'}`, `- Reason: ${row.impossible_in_core_reason}`);
+    lines.push(`### ${row.pattern_key}`, '', `- Description: ${row.description}`, `- Limitation type: \`${row.limitation_type || '(unknown)'}\``, `- Fallback kind: \`${row.fallback_kind}\``, `- Classification: \`${row.classification}\``, `- Fixtures: ${row.fixtures.join(', ') || '(none)'}`, `- Reason: ${row.impossible_in_core_reason}`);
     if (row.example?.selector || row.example?.source_snippet) {
       lines.push(`- Example selector/snippet: \`${String(row.example.selector || row.example.source_snippet).replace(/`/g, '\\`').slice(0, 180)}\``);
     }
@@ -253,13 +263,15 @@ function addEvidence(rows, definition, evidence) {
 function finalizeRow(row, threshold) {
   const fixtureCount = row.fixtures.length;
   const classification = row.base_classification === 'runtime-island' ? 'runtime-island' : row.no_core_block_path && fixtureCount >= threshold ? 'custom-block-candidate' : row.base_classification === 'custom-block-candidate' ? 'convertible' : row.base_classification;
+  const fallbackKind = dominantKey(row.fallback_kinds) || row.fallback_kind;
   return compactObject({
     pattern_key: row.pattern_key,
     description: row.description,
-    fallback_kind: dominantKey(row.fallback_kinds) || row.fallback_kind,
+    fallback_kind: fallbackKind,
     fallback_kinds: sortCountObject(row.fallback_kinds),
     impossible_in_core_reason: row.impossible_in_core_reason,
     classification,
+    limitation_type: limitationType({ ...row, classification, fallback_kind: fallbackKind }),
     no_core_block_path: row.no_core_block_path,
     fixture_count: fixtureCount,
     finding_count: row.finding_count,
@@ -272,6 +284,126 @@ function finalizeRow(row, threshold) {
     example: row.examples[0] ? boundBlob(row.examples[0]) : undefined,
     examples: boundBlob(row.examples),
   });
+}
+
+function buildFixtureDecisions(fixtures, findings, patterns) {
+  const patternsByFixture = new Map();
+  for (const row of patterns) {
+    for (const fixtureId of normalizeArray(row.fixtures)) {
+      patternsByFixture.set(fixtureId, [...(patternsByFixture.get(fixtureId) || []), row]);
+    }
+  }
+  const findingsByFixture = new Map();
+  for (const finding of findings) {
+    const fixtureId = finding.fixture_id || '';
+    findingsByFixture.set(fixtureId, [...(findingsByFixture.get(fixtureId) || []), finding]);
+  }
+  return fixtures.map((fixture) => {
+    const fixtureId = fixture.fixture_id || fixture.id || '';
+    return fixtureDecision(fixture, findingsByFixture.get(fixtureId) || [], patternsByFixture.get(fixtureId) || []);
+  });
+}
+
+function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
+  const editorInvalidCount = editorInvalidCountForFixture(fixture, fixtureFindings);
+  const editorValidated = editorValidatedForFixture(fixture);
+  const visibleHtmlIslandCount = visibleHtmlIslandCountForFixture(fixture, fixtureFindings);
+  const runtimeIslandCount = fixtureFindings.filter((finding) => finding.loss_class === 'preserved_runtime_island').length;
+  const gutenbergGapPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'real_gutenberg_gap').map((row) => row.pattern_key));
+  const transformerGapPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'transformer_gap').map((row) => row.pattern_key));
+  const visualOnlyPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'visual_only_style_drift').map((row) => row.pattern_key));
+  const runtimeIslandPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'intentional_runtime_preservation').map((row) => row.pattern_key));
+  const editorValidityStatus = editorInvalidCount > 0 ? 'invalid_blocks' : editorValidated ? 'valid' : 'not_validated';
+  const nativeEditabilityStatus = nativeEditabilityStatusForFixture({
+    editorValidityStatus,
+    visibleHtmlIslandCount,
+    runtimeIslandCount,
+    gutenbergGapPatterns,
+    transformerGapPatterns,
+  });
+  return compactObject({
+    fixture_id: fixture.fixture_id || fixture.id || '',
+    editor_validity_status: editorValidityStatus,
+    native_editability_status: nativeEditabilityStatus,
+    visible_html_island_count: visibleHtmlIslandCount,
+    runtime_island_count: runtimeIslandCount,
+    gutenberg_gap_patterns: gutenbergGapPatterns,
+    transformer_gap_patterns: transformerGapPatterns,
+    intentional_runtime_patterns: runtimeIslandPatterns,
+    visual_only_patterns: visualOnlyPatterns,
+    solved_candidate_reason: solvedCandidateReason({ fixture, editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, transformerGapPatterns, visualOnlyPatterns }),
+  });
+}
+
+function nativeEditabilityStatusForFixture({ editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, transformerGapPatterns }) {
+  if (editorValidityStatus === 'invalid_blocks') {
+    return 'editor_invalid';
+  }
+  if (gutenbergGapPatterns.length > 0) {
+    return 'custom_block_candidate';
+  }
+  if (runtimeIslandCount > 0) {
+    return 'runtime_island_preserved';
+  }
+  if (visibleHtmlIslandCount > 0 || transformerGapPatterns.length > 0) {
+    return 'html_islands_or_transformer_gap';
+  }
+  if (editorValidityStatus === 'not_validated') {
+    return 'unknown';
+  }
+  return 'native_editable';
+}
+
+function solvedCandidateReason({ fixture, editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, transformerGapPatterns, visualOnlyPatterns }) {
+  if (fixture.status !== 'passed' || editorValidityStatus !== 'valid' || visibleHtmlIslandCount > 0 || runtimeIslandCount > 0 || gutenbergGapPatterns.length > 0 || transformerGapPatterns.length > 0 || visualOnlyPatterns.length > 0) {
+    return '';
+  }
+  return 'passed editor validity, native editability, and visual parity without limitation patterns';
+}
+
+function limitationType(row) {
+  if (row.classification === 'runtime-island') {
+    return 'intentional_runtime_preservation';
+  }
+  if (row.pattern_key === 'editor-render-divergence' || (row.fallback_kind === 'fidelity_loss' && !row.pattern_key.startsWith('visual-'))) {
+    return 'editor_validity_risk';
+  }
+  if (row.pattern_key.startsWith('visual-')) {
+    return 'visual_only_style_drift';
+  }
+  if (row.no_core_block_path) {
+    return 'real_gutenberg_gap';
+  }
+  return 'transformer_gap';
+}
+
+function visibleHtmlIslandCountForFixture(fixture, fixtureFindings) {
+  const blockTypes = objectValue(fixture.block_composition?.block_types || fixture.block_composition?.block_type_counts || fixture.blockComposition?.blockTypes || fixture.blockComposition?.blockTypeCounts);
+  const blockCompositionCount = numberValue(blockTypes['core/html'] || fixture.block_composition?.core_html_block_count || fixture.blockComposition?.coreHtmlBlockCount || fixture.editor_quality?.core_html_block_count);
+  const findingCount = fixtureFindings.filter((finding) => fallbackKindForFinding(finding, { fallback_kind: '' }) === 'core_html').length;
+  return Math.max(blockCompositionCount, findingCount);
+}
+
+function editorInvalidCountForFixture(fixture, fixtureFindings) {
+  return numberValue(fixture.editor_quality?.editor_invalid_count || fixture.editor_quality?.invalid_block_count || fixture.editor_validation?.invalid_block_count || fixture.editor_validation?.invalid_count)
+    + fixtureFindings.filter((finding) => finding.loss_class === 'editor_block_invalid' || finding.loss_class === 'invalid_block_content').length;
+}
+
+function editorValidatedForFixture(fixture) {
+  return numberValue(fixture.editor_quality?.editor_validated_block_total || fixture.editor_validation?.block_total || fixture.editor_validation?.total_block_count || fixture.editor_validation?.total) > 0;
+}
+
+function countBy(items, iteratee) {
+  const counts = {};
+  for (const item of normalizeArray(items)) {
+    const key = iteratee(item) || 'unknown';
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return sortCountObject(counts);
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values.filter(Boolean))].sort();
 }
 
 function sortRows(left, right) {

--- a/lib/fixture-matrix/steps/editor-open-step.mjs
+++ b/lib/fixture-matrix/steps/editor-open-step.mjs
@@ -1,0 +1,53 @@
+// Editor-open recipe step for the Static Site Importer fixture matrix.
+// Captures real block-editor canvas evidence for the imported front page.
+/**
+ * Internal dependencies
+ */
+import {
+  EDITOR_OPEN_COMMAND,
+  DEFAULT_EDITOR_VALIDATION_TARGET,
+} from '../shared/constants.mjs';
+import { firstPresent, fixtureStepMetadata } from './shared.mjs';
+
+export function editorOpenStep(input = {}) {
+  const fixture = input.fixture || {};
+
+  const postId = firstPresent([input.postId, input.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
+  const url = firstPresent([input.url, input.editorOpenUrl, input.editor_open_url, fixture.editor_url, fixture.editorUrl]);
+  const target = firstPresent([input.target, input.editorOpenTarget, input.editor_open_target, fixture.editor_target, fixture.editorTarget, fixture.target]);
+
+  const args = [];
+  if (postId !== undefined) {
+    args.push(`post-id=${postId}`);
+  } else if (url !== undefined) {
+    args.push(`url=${url}`);
+  } else if (target !== undefined) {
+    args.push(`target=${target}`);
+  } else {
+    args.push(`target=${DEFAULT_EDITOR_VALIDATION_TARGET}`);
+  }
+
+  const waitSelector = firstPresent([input.waitSelector, input.wait_selector, fixture.editor_wait_selector, fixture.editorWaitSelector]);
+  if (waitSelector !== undefined) {
+    args.push(`wait-selector=${waitSelector}`);
+  }
+  const waitTimeout = firstPresent([input.waitTimeout, input.wait_timeout, fixture.editor_wait_timeout, fixture.editorWaitTimeout]);
+  if (waitTimeout !== undefined) {
+    args.push(`wait-timeout=${waitTimeout}`);
+  }
+
+  args.push('capture=screenshot,editor-state,editor-validity');
+  args.push(`artifact-prefix=files/browser/editor-open/${fixture.id}`);
+
+  return {
+    command: EDITOR_OPEN_COMMAND,
+    allowFailure: true,
+    args,
+    metadata: fixtureStepMetadata(fixture, 'editor-open', {
+      artifact_prefix: `files/browser/editor-open/${fixture.id}`,
+      ...(postId !== undefined ? { post_id: postId } : {}),
+      ...(url !== undefined ? { url } : {}),
+      ...(target !== undefined ? { target } : { target: DEFAULT_EDITOR_VALIDATION_TARGET }),
+    }),
+  };
+}

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -27,6 +27,7 @@ import {
   shellToken,
 } from '../shared/utils.mjs';
 import { createFixtureMatrix, normalizeFixture, collectFixtureFiles } from '../fixtures.mjs';
+import { editorOpenStep } from './editor-open-step.mjs';
 import { editorBlockValidationStep } from './editor-validation-step.mjs';
 import { visualParityCompareStep, normalizeVisualParityRecipeOptions } from './visual-parity-step.mjs';
 import { liveWpParityCaptureStep, liveWpParityEnabled } from './live-wp-parity-step.mjs';
@@ -130,6 +131,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const stagedFiles = normalizeArray(input.stagedFiles || input.staged_files);
   const extraPlugins = [importer.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)];
   const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
+  const editorOpenEnabled = editorValidationEnabled && input.editorOpen !== false && input.editor_open !== false;
   // Real-content validation options forwarded to the editor-validate-blocks step.
   // No empty-post default: when nothing concrete is provided, the step targets
   // `front-page`, which wp-codebox resolves to the imported static front page
@@ -186,6 +188,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
         ...matrix.fixtures.flatMap((fixture) => [
           ...fixturePluginProvisioningSteps(fixture),
           importFixtureStep(fixture, commandArtifactsDirectory),
+          ...(editorOpenEnabled ? [editorOpenStep({ fixture, ...editorValidationOptions })] : []),
           ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, ...editorValidationOptions })] : []),
           ...(visualParityEnabled ? [visualParityDeterministicCssStep(fixture)] : []),
           ...(visualParityEnabled ? [visualParityCompareStep({ fixture, ...visualParityRecipeOptions })] : []),

--- a/registry/gutenberg-incompatibility-registry.schema.json
+++ b/registry/gutenberg-incompatibility-registry.schema.json
@@ -33,16 +33,23 @@
         "custom_block_candidate_count": { "type": "integer", "minimum": 0 },
         "convertible_count": { "type": "integer", "minimum": 0 },
         "runtime_island_count": { "type": "integer", "minimum": 0 },
+        "fixture_decision_counts": { "$ref": "#/$defs/counts" },
+        "editor_validity_counts": { "$ref": "#/$defs/counts" },
+        "limitation_type_counts": { "$ref": "#/$defs/counts" },
         "top_patterns": { "type": "array", "items": { "$ref": "#/$defs/top_pattern" } }
       },
       "additionalProperties": false
     },
+    "fixture_decisions": { "type": "array", "items": { "$ref": "#/$defs/fixture_decision" } },
     "patterns": { "type": "array", "items": { "$ref": "#/$defs/pattern" } }
   },
   "additionalProperties": false,
   "$defs": {
     "classification": { "enum": ["convertible", "custom-block-candidate", "runtime-island"] },
     "fallback_kind": { "enum": ["core_html", "data_uri", "runtime_island", "fidelity_loss"] },
+    "limitation_type": { "enum": ["real_gutenberg_gap", "transformer_gap", "intentional_runtime_preservation", "visual_only_style_drift", "editor_validity_risk"] },
+    "editor_validity_status": { "enum": ["valid", "invalid_blocks", "not_validated"] },
+    "native_editability_status": { "enum": ["native_editable", "editor_invalid", "custom_block_candidate", "runtime_island_preserved", "html_islands_or_transformer_gap", "unknown"] },
     "top_pattern": {
       "type": "object",
       "required": ["pattern_key", "classification", "fixture_count", "finding_count", "impact_score"],
@@ -57,7 +64,7 @@
     },
     "pattern": {
       "type": "object",
-      "required": ["pattern_key", "description", "fallback_kind", "impossible_in_core_reason", "classification", "no_core_block_path", "fixture_count", "finding_count", "impact_score", "fixtures", "signals"],
+      "required": ["pattern_key", "description", "fallback_kind", "impossible_in_core_reason", "classification", "limitation_type", "no_core_block_path", "fixture_count", "finding_count", "impact_score", "fixtures", "signals"],
       "properties": {
         "pattern_key": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
         "description": { "type": "string" },
@@ -65,6 +72,7 @@
         "fallback_kinds": { "$ref": "#/$defs/counts" },
         "impossible_in_core_reason": { "type": "string" },
         "classification": { "$ref": "#/$defs/classification" },
+        "limitation_type": { "$ref": "#/$defs/limitation_type" },
         "no_core_block_path": { "type": "boolean" },
         "fixture_count": { "type": "integer", "minimum": 0 },
         "finding_count": { "type": "integer", "minimum": 0 },
@@ -76,6 +84,23 @@
         "signals": { "$ref": "#/$defs/counts" },
         "example": { "type": "object" },
         "examples": { "type": "array", "items": { "type": "object" } }
+      },
+      "additionalProperties": false
+    },
+    "fixture_decision": {
+      "type": "object",
+      "required": ["fixture_id", "editor_validity_status", "native_editability_status", "visible_html_island_count", "runtime_island_count", "gutenberg_gap_patterns", "transformer_gap_patterns", "intentional_runtime_patterns", "visual_only_patterns"],
+      "properties": {
+        "fixture_id": { "type": "string" },
+        "editor_validity_status": { "$ref": "#/$defs/editor_validity_status" },
+        "native_editability_status": { "$ref": "#/$defs/native_editability_status" },
+        "visible_html_island_count": { "type": "number", "minimum": 0 },
+        "runtime_island_count": { "type": "integer", "minimum": 0 },
+        "gutenberg_gap_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "transformer_gap_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "intentional_runtime_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "visual_only_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "solved_candidate_reason": { "type": "string" }
       },
       "additionalProperties": false
     },

--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -25,6 +25,7 @@
         "command": "wp-codebox",
         "env": ["HOMEBOY_WP_CODEBOX_BIN"],
         "capabilities": [
+          "wordpress.editor-open",
           "wordpress.editor-validate-blocks",
           "wordpress.visual-compare"
         ],

--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -36,6 +36,12 @@
     "default_component": "static-site-importer",
     "iterations": 1,
     "warmup_iterations": 0,
+    "path_inputs": [
+      "--path",
+      "bench_env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT",
+      "bench_env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH",
+      "bench_env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH"
+    ],
     "accepted_settings": [
       "static_site_importer_fixture_matrix_namespace"
     ],

--- a/tests/smoke-ability-registration-idempotent.php
+++ b/tests/smoke-ability-registration-idempotent.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Smoke test: ability registration is idempotent across repeated includes.
+ *
+ * Run from the repository root:
+ * php tests/smoke-ability-registration-idempotent.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['ssi_ability_categories'] = array();
+$GLOBALS['ssi_abilities']          = array();
+
+function __( string $text, string $domain = 'default' ): string {
+	return $text;
+}
+
+function doing_action( string $hook ): bool {
+	return false;
+}
+
+function did_action( string $hook ): int {
+	return in_array( $hook, array( 'wp_abilities_api_categories_init', 'wp_abilities_api_init' ), true ) ? 1 : 0;
+}
+
+function wp_get_ability_category( string $slug ): ?array {
+	return $GLOBALS['ssi_ability_categories'][ $slug ] ?? null;
+}
+
+function wp_register_ability_category( string $slug, array $args ): ?array {
+	$GLOBALS['ssi_ability_categories'][ $slug ] = $args;
+	return $args;
+}
+
+function wp_get_ability( string $name ): ?array {
+	return $GLOBALS['ssi_abilities'][ $name ] ?? null;
+}
+
+function wp_register_ability( string $name, array $args ): ?array {
+	$GLOBALS['ssi_abilities'][ $name ] = $args;
+	return $args;
+}
+
+require dirname( __DIR__ ) . '/includes/abilities.php';
+require dirname( __DIR__ ) . '/includes/abilities.php';
+
+$expected_abilities = array(
+	'static-site-importer/export-theme',
+	'static-site-importer/import-website-artifact',
+	'static-site-importer/import-url',
+	'static-site-importer/import-figma',
+	'static-site-importer/validate-artifact',
+);
+
+assert( array( STATIC_SITE_IMPORTER_ABILITY_CATEGORY ) === array_keys( $GLOBALS['ssi_ability_categories'] ) );
+assert( $expected_abilities === array_keys( $GLOBALS['ssi_abilities'] ) );
+
+echo "Ability registration idempotency smoke passed.\n";

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -150,6 +150,18 @@ $assert( str_contains( $editor_css, '.editor-styles-wrapper .glow-orb { opacity:
 $assert( str_contains( $editor_css, '.compiled-site-repair { display: block; }' ), 'editor-includes-compiled-site-repair-css', $editor_css );
 $assert( ! str_contains( $editor_css, '.should-not-appear' ), 'unknown-target-repair-css-is-ignored', $editor_css );
 
+$body_guard_writes = Static_Site_Importer_Stylesheet_Materializer::stylesheet_writes(
+	'/tmp/body-class-guard-smoke',
+	'Body Class Guard Smoke',
+	'.page { max-width: 720px; margin: 0 auto; padding: 5rem 2rem; } .admin-bar { padding-top: 2rem; } .home { color: red; } .card { max-width: 20rem; }',
+	array(),
+	array()
+);
+$body_guard_css    = (string) ( $body_guard_writes['/tmp/body-class-guard-smoke/style.css'] ?? '' );
+$assert( str_contains( $body_guard_css, 'body.page, body.admin-bar { width: auto; max-width: none; margin: 0; padding: 0; }' ), 'style-guards-wordpress-body-class-collisions', $body_guard_css );
+$assert( ! str_contains( $body_guard_css, 'body.card' ), 'style-does-not-guard-non-wordpress-body-class', $body_guard_css );
+$assert( ! str_contains( $body_guard_css, 'body.home' ), 'style-does-not-guard-non-layout-body-class', $body_guard_css );
+
 $documents      = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'documents_from_compiled_site_pages' );
 $missing_source = $documents->invoke(
 	null,

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -428,6 +428,7 @@ test('fixture-matrix rig requires env-backed WP Codebox editor and visual capabi
   assert.ok(tool, 'expected a wp-codebox runner tool requirement');
   assert.equal(tool.command, 'wp-codebox');
   assert.deepEqual(tool.env, ['HOMEBOY_WP_CODEBOX_BIN']);
+  assert.ok(tool.capabilities.includes('wordpress.editor-open'));
   assert.ok(tool.capabilities.includes('wordpress.editor-validate-blocks'));
   assert.ok(tool.capabilities.includes('wordpress.visual-compare'));
 });
@@ -3096,10 +3097,15 @@ test('recipe runs editor-validate-blocks against imported content after each imp
     staticSiteImporterPath: '/tmp/static-site-importer',
   });
 
-  // [activate, validate(simple-site), editor-validate-blocks(simple-site)]
+  // [activate, validate(simple-site), editor-open(simple-site), editor-validate-blocks(simple-site)]
   assert.equal(recipe.workflow.steps[1].command, 'wordpress.wp-cli');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
-  const editorStep = recipe.workflow.steps[2];
+  const editorOpenStep = recipe.workflow.steps[2];
+  assert.equal(editorOpenStep.command, 'wordpress.editor-open');
+  assert.ok(editorOpenStep.args.includes('target=front-page'));
+  assert.ok(editorOpenStep.args.includes('capture=screenshot,editor-state,editor-validity'));
+  assert.ok(editorOpenStep.args.includes('artifact-prefix=files/browser/editor-open/simple-site'));
+  const editorStep = recipe.workflow.steps[3];
   assert.equal(editorStep.command, EDITOR_VALIDATE_BLOCKS_COMMAND);
   assert.equal(editorStep.command, 'wordpress.editor-validate-blocks');
   assert.equal(editorStep.args.some((arg) => arg.includes('post-new.php')), false);
@@ -3977,12 +3983,12 @@ test('recipe runs a wordpress.visual-compare visual-parity step after each impor
     pixelThreshold: 0.05,
   });
 
-  // [activate, validate(simple-site), editor-validation(simple-site), visual-setup(simple-site), visual-compare(simple-site)]
-  const visualSetupStep = recipe.workflow.steps[3];
+  // [activate, validate(simple-site), editor-open(simple-site), editor-validation(simple-site), visual-setup(simple-site), visual-compare(simple-site)]
+  const visualSetupStep = recipe.workflow.steps[4];
   assert.equal(visualSetupStep.command, 'wordpress.wp-cli');
   assert.equal(visualSetupStep.metadata.phase, 'visual-setup');
   assert.match(visualSetupStep.args[0], /wp_update_custom_css_post/);
-  const visualStep = recipe.workflow.steps[4];
+  const visualStep = recipe.workflow.steps[5];
   assert.equal(visualStep.command, 'wordpress.visual-compare');
   const comparison = visualCompareMatrixComparison(visualStep);
   assert.equal(comparison.sourceUrl, 'file:///tmp/artifacts/simple-site/source/index.html');

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -57,6 +57,7 @@ import {
   EDITOR_VALIDATE_BLOCKS_COMMAND,
   EDITOR_VALIDATION_METHOD,
   buildGutenbergIncompatibilityRegistry,
+  renderGutenbergIncompatibilityRegistryMarkdown,
   normalizeFixtureMatrixResult,
   normalizeLossClass,
   stageFixtureSource,
@@ -185,6 +186,68 @@ test('gutenberg incompatibility registry keeps runtime islands separate and cons
   assert.equal(byKey['legitimate-runtime-island'].classification, 'runtime-island');
   assert.equal(byKey['editor-render-divergence'].classification, 'convertible');
   assert.equal(byKey['editor-render-divergence'].signals.editor_render_divergence, 1);
+});
+
+test('gutenberg incompatibility registry separates fixture decision axes', () => {
+  const registry = buildGutenbergIncompatibilityRegistry({
+    matrix_id: 'decision-axis-map',
+    fixtures: [
+      {
+        fixture_id: 'cv',
+        status: 'passed',
+        block_composition: { block_total: 8, native_block_count: 8, core_html_block_count: 0 },
+        editor_quality: { editor_validated_block_total: 8, editor_invalid_count: 0, core_html_block_count: 0 },
+      },
+      {
+        fixture_id: 'artist',
+        status: 'failed',
+        block_composition: { block_total: 10, native_block_count: 9, core_html_block_count: 1 },
+        editor_quality: { editor_validated_block_total: 10, editor_invalid_count: 0, core_html_block_count: 1 },
+        visual_diff_regions: [{ dominant_cause: 'position_offset', pixel_count: 2500 }],
+      },
+      {
+        fixture_id: 'saas',
+        status: 'failed',
+        editor_quality: { editor_validated_block_total: 6, editor_invalid_count: 1, core_html_block_count: 0 },
+      },
+    ],
+    findings: [
+      {
+        fixture_id: 'artist',
+        kind: 'unsupported_html_fallback',
+        observed_block_name: 'core/html',
+        reason_code: 'html_form_fallback',
+        selector: 'form.newsletter',
+        source_snippet: '<form><input type="email"><button>Subscribe</button></form>',
+      },
+      {
+        fixture_id: 'saas',
+        kind: 'editor_block_invalid',
+        loss_class: 'editor_block_invalid',
+        selector: '.hero',
+        reason: 'Editor block validation failed.',
+      },
+    ],
+  });
+  const decisions = Object.fromEntries(registry.fixture_decisions.map((row) => [row.fixture_id, row]));
+  const patterns = Object.fromEntries(registry.patterns.map((row) => [row.pattern_key, row]));
+  const markdown = renderGutenbergIncompatibilityRegistryMarkdown(registry);
+
+  assert.equal(decisions.cv.editor_validity_status, 'valid');
+  assert.equal(decisions.cv.native_editability_status, 'native_editable');
+  assert.equal(decisions.cv.solved_candidate_reason, 'passed editor validity, native editability, and visual parity without limitation patterns');
+  assert.equal(decisions.artist.native_editability_status, 'custom_block_candidate');
+  assert.equal(decisions.artist.visible_html_island_count, 1);
+  assert.deepEqual(decisions.artist.gutenberg_gap_patterns, ['static-form']);
+  assert.deepEqual(decisions.artist.visual_only_patterns, ['visual-position_offset']);
+  assert.equal(decisions.saas.editor_validity_status, 'invalid_blocks');
+  assert.equal(decisions.saas.native_editability_status, 'editor_invalid');
+  assert.equal(patterns['static-form'].limitation_type, 'real_gutenberg_gap');
+  assert.equal(patterns['visual-position_offset'].limitation_type, 'visual_only_style_drift');
+  assert.equal(registry.summary.fixture_decision_counts.native_editable, 1);
+  assert.equal(registry.summary.editor_validity_counts.invalid_blocks, 1);
+  assert.match(markdown, /## Fixture Decisions/);
+  assert.match(markdown, /`static-form`/);
 });
 
 test('gutenberg incompatibility registry attributes nested svg to the outer fallback island', () => {


### PR DESCRIPTION
## Summary
- add a per-fixture `wordpress.editor-open` step to the SSI fixture matrix so runs capture real editor canvas screenshots and editor state for imported front pages
- require the `wordpress.editor-open` wp-codebox capability alongside existing editor validation and visual comparison
- teach fixture-matrix intake to recognize editor-open artifact payload names

## Verification
- `npm run test:fixture-matrix`
- CV editor parity run with fixed wp-codebox source binary: `/tmp/ssi-editor-parity-cv-fixed-20260706/static-site-fixture-matrix-result.json`
- Artist editor parity run with fixed wp-codebox source binary: `/tmp/ssi-editor-parity-artist-fixed-20260706/static-site-fixture-matrix-result.json`
- Coffee editor parity run with fixed wp-codebox source binary: `/tmp/ssi-editor-parity-coffee-fixed-20260706/static-site-fixture-matrix-result.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the SSI fixture-matrix editor-open capture step, ran fixture evidence, and prepared this PR summary.