### PR TITLE
Add editor-proof fixture acceptance gate

### DIFF
--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -107,6 +107,8 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     diagnostics,
     artifact_refs: collectFixtureArtifactRefs(merged, fixtureArtifactsDirectory),
     artifacts: merged.artifacts || {},
+    editor_canvas: merged.editor_canvas || merged.editorCanvas || merged.editor_canvas_summary || merged.editorCanvasSummary || null,
+    editor_open: merged.editor_open || merged.editorOpen || null,
     visual_parity_artifacts: visualParityArtifacts,
     visual_diff_regions: visualParityArtifacts?.visual_diff_regions || [],
     visual_diff_cause_summary: visualParityArtifacts?.visual_diff_cause_summary || null,
@@ -599,7 +601,7 @@ function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen) {
 }
 
 function hasPayloadData(value) {
-  return ['status', 'success', 'ok', 'passed', 'error', 'diagnostics', 'findings', 'summary', 'artifacts', 'upstream_gaps', 'runtime_target_gaps', 'blocks_engine', 'import_report']
+  return ['status', 'success', 'ok', 'passed', 'error', 'diagnostics', 'findings', 'summary', 'artifacts', 'upstream_gaps', 'runtime_target_gaps', 'blocks_engine', 'import_report', 'editor_canvas', 'editorCanvas', 'editor_open', 'editorOpen']
     .some((key) => Object.hasOwn(value, key));
 }
 

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -604,7 +604,7 @@ function hasPayloadData(value) {
 }
 
 function readFixturePayloadFiles(directory) {
-  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-validate-blocks.json', 'editor-canvas-summary.json', 'visual-compare.json', 'visual-diff.json', 'visual-parity.json', 'visual-explanation.json']
+  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-validate-blocks.json', 'editor-open.json', 'editor-summary.json', 'editor-state.json', 'editor-validity.json', 'editor-canvas-summary.json', 'visual-compare.json', 'visual-diff.json', 'visual-parity.json', 'visual-explanation.json']
     .map((fileName) => readJsonFileIfExists(path.join(directory, fileName)))
     .filter(Boolean);
 }

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -71,7 +71,7 @@ export function buildGutenbergIncompatibilityRegistry(result = {}, options = {})
       custom_block_candidate_count: patterns.filter((row) => row.classification === 'custom-block-candidate').length,
       convertible_count: patterns.filter((row) => row.classification === 'convertible').length,
       runtime_island_count: patterns.filter((row) => row.classification === 'runtime-island').length,
-      fixture_decision_counts: countBy(fixtureDecisions, (row) => row.native_editability_status),
+      fixture_decision_counts: countBy(fixtureDecisions, (row) => row.acceptance_status),
       editor_validity_counts: countBy(fixtureDecisions, (row) => row.editor_validity_status),
       limitation_type_counts: countBy(patterns, (row) => row.limitation_type),
       top_patterns: patterns.slice(0, 10).map((row) => ({ pattern_key: row.pattern_key, classification: row.classification, fixture_count: row.fixture_count, finding_count: row.finding_count, impact_score: row.impact_score })),
@@ -98,9 +98,9 @@ export function renderGutenbergIncompatibilityRegistryMarkdown(registry = {}) {
   normalizeArray(registry.patterns).forEach((row, index) => {
     lines.push(`| ${index + 1} | \`${row.pattern_key}\` | ${row.limitation_type || '(unknown)'} | ${row.classification} | ${row.fixture_count} | ${row.finding_count} | ${row.impact_score} | ${table(row.impossible_in_core_reason)} |`);
   });
-  lines.push('', '## Fixture Decisions', '', '| Fixture | Editor Validity | Native Editability | HTML Islands | Runtime Islands | Gutenberg Gaps | Visual-only Patterns | Solved Candidate |', '| --- | --- | --- | ---: | ---: | --- | --- | --- |');
+  lines.push('', '## Fixture Decisions', '', '| Fixture | Acceptance | Frontend Visual | Editor Canvas | Block Validity | Native Editability | Runtime/HTML Islands | Gutenberg Gaps | Visual-only Patterns | Reason |', '| --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- |');
   for (const row of normalizeArray(registry.fixture_decisions)) {
-    lines.push(`| \`${row.fixture_id}\` | ${row.editor_validity_status} | ${row.native_editability_status} | ${row.visible_html_island_count || 0} | ${row.runtime_island_count || 0} | ${(row.gutenberg_gap_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${(row.visual_only_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${row.solved_candidate_reason || '(no)'} |`);
+    lines.push(`| \`${row.fixture_id}\` | ${row.acceptance_status || '(unknown)'} | ${row.frontend_visual_status || '(unknown)'} | ${row.editor_canvas_status || '(unknown)'} | ${row.block_validity_status || row.editor_validity_status || '(unknown)'} | ${row.native_editability_status} | ${row.visible_runtime_or_html_islands || 0} | ${(row.gutenberg_gap_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${(row.visual_only_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${table(row.solved_candidate_reason || row.acceptance_reason || '') || '(none)'} |`);
   }
   lines.push('', '## Pattern Evidence', '');
   for (const row of normalizeArray(registry.patterns)) {
@@ -313,7 +313,10 @@ function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
   const transformerGapPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'transformer_gap').map((row) => row.pattern_key));
   const visualOnlyPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'visual_only_style_drift').map((row) => row.pattern_key));
   const runtimeIslandPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'intentional_runtime_preservation').map((row) => row.pattern_key));
+  const editorRiskPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'editor_validity_risk').map((row) => row.pattern_key));
   const editorValidityStatus = editorInvalidCount > 0 ? 'invalid_blocks' : editorValidated ? 'valid' : 'not_validated';
+  const frontendVisualStatus = frontendVisualStatusForFixture(fixture, fixtureFindings, visualOnlyPatterns);
+  const editorCanvasStatus = editorCanvasStatusForFixture(fixture, fixtureFindings, editorRiskPatterns);
   const nativeEditabilityStatus = nativeEditabilityStatusForFixture({
     editorValidityStatus,
     visibleHtmlIslandCount,
@@ -321,17 +324,38 @@ function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
     gutenbergGapPatterns,
     transformerGapPatterns,
   });
+  const visibleRuntimeOrHtmlIslands = visibleHtmlIslandCount + runtimeIslandCount;
+  const acceptance = acceptanceDecision({
+    frontendVisualStatus,
+    editorCanvasStatus,
+    editorValidityStatus,
+    nativeEditabilityStatus,
+    visibleRuntimeOrHtmlIslands,
+    gutenbergGapPatterns,
+    transformerGapPatterns,
+    visualOnlyPatterns,
+    runtimeIslandPatterns,
+    editorRiskPatterns,
+  });
   return compactObject({
     fixture_id: fixture.fixture_id || fixture.id || '',
+    frontend_visual_status: frontendVisualStatus,
+    editor_canvas_status: editorCanvasStatus,
+    block_validity_status: editorValidityStatus,
     editor_validity_status: editorValidityStatus,
     native_editability_status: nativeEditabilityStatus,
     visible_html_island_count: visibleHtmlIslandCount,
     runtime_island_count: runtimeIslandCount,
+    visible_runtime_or_html_islands: visibleRuntimeOrHtmlIslands,
     gutenberg_gap_patterns: gutenbergGapPatterns,
     transformer_gap_patterns: transformerGapPatterns,
     intentional_runtime_patterns: runtimeIslandPatterns,
     visual_only_patterns: visualOnlyPatterns,
-    solved_candidate_reason: solvedCandidateReason({ fixture, editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, transformerGapPatterns, visualOnlyPatterns }),
+    editor_risk_patterns: editorRiskPatterns,
+    solved_candidate: acceptance.solved_candidate,
+    solved_candidate_reason: acceptance.reason,
+    acceptance_status: acceptance.status,
+    acceptance_reason: acceptance.reason,
   });
 }
 
@@ -354,11 +378,60 @@ function nativeEditabilityStatusForFixture({ editorValidityStatus, visibleHtmlIs
   return 'native_editable';
 }
 
-function solvedCandidateReason({ fixture, editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, transformerGapPatterns, visualOnlyPatterns }) {
-  if (fixture.status !== 'passed' || editorValidityStatus !== 'valid' || visibleHtmlIslandCount > 0 || runtimeIslandCount > 0 || gutenbergGapPatterns.length > 0 || transformerGapPatterns.length > 0 || visualOnlyPatterns.length > 0) {
-    return '';
+function frontendVisualStatusForFixture(fixture, fixtureFindings, visualOnlyPatterns) {
+  if (hasProviderRuntimeBlocker(fixtureFindings)) {
+    return 'provider_runtime_blocked';
   }
-  return 'passed editor validity, native editability, and visual parity without limitation patterns';
+  if (visualOnlyPatterns.length > 0 || fixtureFindings.some((finding) => finding.loss_class === 'visual_parity_mismatch' || finding.kind === 'visual_parity_mismatch')) {
+    return 'visual_mismatch';
+  }
+  if (fixture.status === 'passed' || hasVisualEvidence(fixture)) {
+    return 'passed';
+  }
+  return 'not_evaluated';
+}
+
+function editorCanvasStatusForFixture(fixture, fixtureFindings, editorRiskPatterns) {
+  if (hasProviderRuntimeBlocker(fixtureFindings)) {
+    return 'provider_runtime_blocked';
+  }
+  if (editorRiskPatterns.length > 0 || fixtureFindings.some((finding) => finding.kind === 'editor_render_divergence' || finding.loss_class === 'editor_render_divergence')) {
+    return 'diverged';
+  }
+  if (hasEditorCanvasEvidence(fixture)) {
+    return 'visible';
+  }
+  return 'not_captured';
+}
+
+function acceptanceDecision({ frontendVisualStatus, editorCanvasStatus, editorValidityStatus, nativeEditabilityStatus, visibleRuntimeOrHtmlIslands, gutenbergGapPatterns, transformerGapPatterns, visualOnlyPatterns, runtimeIslandPatterns, editorRiskPatterns }) {
+  if (frontendVisualStatus === 'provider_runtime_blocked' || editorCanvasStatus === 'provider_runtime_blocked' || frontendVisualStatus === 'not_evaluated' || editorCanvasStatus === 'not_captured' || editorValidityStatus === 'not_validated') {
+    return { solved_candidate: false, status: 'provider_runtime_blocker', reason: 'required frontend visual, editor canvas, or block-validity evidence is missing or blocked by the provider/runtime' };
+  }
+  if (editorValidityStatus === 'invalid_blocks' || editorCanvasStatus === 'diverged' || editorRiskPatterns.length > 0) {
+    return { solved_candidate: false, status: 'editor_blocker', reason: 'editor canvas or block validation evidence shows imported content is not reliably visible and valid in the editor' };
+  }
+  if (nativeEditabilityStatus !== 'native_editable' || visibleRuntimeOrHtmlIslands > 0 || gutenbergGapPatterns.length > 0 || transformerGapPatterns.length > 0 || runtimeIslandPatterns.length > 0) {
+    return { solved_candidate: false, status: 'native_editability_blocker', reason: 'frontend-visible content still depends on runtime/html islands, transformer gaps, or a real Gutenberg capability gap' };
+  }
+  if (frontendVisualStatus === 'visual_mismatch' || visualOnlyPatterns.length > 0) {
+    return { solved_candidate: false, status: 'visual_only_blocker', reason: 'native editor evidence is acceptable but frontend visual parity still differs from the source' };
+  }
+  return { solved_candidate: true, status: 'solved_candidate', reason: 'passed frontend visual parity, editor canvas evidence, block validity, and native editability without limitation patterns' };
+}
+
+function hasProviderRuntimeBlocker(fixtureFindings) {
+  return fixtureFindings.some((finding) => ['runtime_execution_failed', 'visual_timeout', 'fixture_not_run', 'fixture_failed', 'visual_evidence_missing'].includes(finding.loss_class) || ['visual_timeout', 'fixture_not_run', 'fixture_failed'].includes(finding.kind));
+}
+
+function hasVisualEvidence(fixture) {
+  return Object.keys(objectValue(fixture.visual_parity_artifacts || fixture.visualParityArtifacts || fixture.visual_diff_classification || fixture.visualDiffClassification)).length > 0
+    || normalizeArray(fixture.visual_diff_regions || fixture.visualDiffRegions).length > 0;
+}
+
+function hasEditorCanvasEvidence(fixture) {
+  return Object.keys(objectValue(fixture.editor_canvas || fixture.editorCanvas || fixture.editor_canvas_summary || fixture.editorCanvasSummary || fixture.editor_open || fixture.editorOpen)).length > 0
+    || normalizeArray(fixture.artifact_refs || fixture.artifactRefs).some((ref) => /editor-(?:open|state|canvas|summary)|editor_open|editor_canvas/i.test(String(ref.path || ref.href || ref.artifact_id || ref.kind || '')));
 }
 
 function limitationType(row) {

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -428,6 +428,8 @@ export function normalizeFixtureResult(input) {
     diagnostics: boundBlob(normalizeArray(input.diagnostics || input.findings || input.messages)),
     artifact_refs: normalizeArray(input.artifact_refs || input.artifactRefs),
     artifacts: input.artifacts || {},
+    editor_canvas: boundBlob(input.editor_canvas || input.editorCanvas || null),
+    editor_open: boundBlob(input.editor_open || input.editorOpen || null),
     visual_parity_artifacts: input.visual_parity_artifacts || input.visualParityArtifacts || null,
     visual_diff_regions: normalizeArray(input.visual_diff_regions || input.visualDiffRegions),
     visual_diff_cause_summary: input.visual_diff_cause_summary || input.visualDiffCauseSummary || null,

--- a/lib/fixture-matrix/steps/editor-open-step.mjs
+++ b/lib/fixture-matrix/steps/editor-open-step.mjs
@@ -1,0 +1,53 @@
+// Editor-open recipe step for the Static Site Importer fixture matrix.
+// Captures real block-editor canvas evidence for the imported front page.
+/**
+ * Internal dependencies
+ */
+import {
+  EDITOR_OPEN_COMMAND,
+  DEFAULT_EDITOR_VALIDATION_TARGET,
+} from '../shared/constants.mjs';
+import { firstPresent, fixtureStepMetadata } from './shared.mjs';
+
+export function editorOpenStep(input = {}) {
+  const fixture = input.fixture || {};
+
+  const postId = firstPresent([input.postId, input.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
+  const url = firstPresent([input.url, input.editorOpenUrl, input.editor_open_url, fixture.editor_url, fixture.editorUrl]);
+  const target = firstPresent([input.target, input.editorOpenTarget, input.editor_open_target, fixture.editor_target, fixture.editorTarget, fixture.target]);
+
+  const args = [];
+  if (postId !== undefined) {
+    args.push(`post-id=${postId}`);
+  } else if (url !== undefined) {
+    args.push(`url=${url}`);
+  } else if (target !== undefined) {
+    args.push(`target=${target}`);
+  } else {
+    args.push(`target=${DEFAULT_EDITOR_VALIDATION_TARGET}`);
+  }
+
+  const waitSelector = firstPresent([input.waitSelector, input.wait_selector, fixture.editor_wait_selector, fixture.editorWaitSelector]);
+  if (waitSelector !== undefined) {
+    args.push(`wait-selector=${waitSelector}`);
+  }
+  const waitTimeout = firstPresent([input.waitTimeout, input.wait_timeout, fixture.editor_wait_timeout, fixture.editorWaitTimeout]);
+  if (waitTimeout !== undefined) {
+    args.push(`wait-timeout=${waitTimeout}`);
+  }
+
+  args.push('capture=screenshot,editor-state,editor-validity');
+  args.push(`artifact-prefix=files/browser/editor-open/${fixture.id}`);
+
+  return {
+    command: EDITOR_OPEN_COMMAND,
+    allowFailure: true,
+    args,
+    metadata: fixtureStepMetadata(fixture, 'editor-open', {
+      artifact_prefix: `files/browser/editor-open/${fixture.id}`,
+      ...(postId !== undefined ? { post_id: postId } : {}),
+      ...(url !== undefined ? { url } : {}),
+      ...(target !== undefined ? { target } : { target: DEFAULT_EDITOR_VALIDATION_TARGET }),
+    }),
+  };
+}

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -27,6 +27,7 @@ import {
   shellToken,
 } from '../shared/utils.mjs';
 import { createFixtureMatrix, normalizeFixture, collectFixtureFiles } from '../fixtures.mjs';
+import { editorOpenStep } from './editor-open-step.mjs';
 import { editorBlockValidationStep } from './editor-validation-step.mjs';
 import { visualParityCompareStep, normalizeVisualParityRecipeOptions } from './visual-parity-step.mjs';
 import { liveWpParityCaptureStep, liveWpParityEnabled } from './live-wp-parity-step.mjs';
@@ -130,6 +131,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const stagedFiles = normalizeArray(input.stagedFiles || input.staged_files);
   const extraPlugins = [importer.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)];
   const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
+  const editorOpenEnabled = editorValidationEnabled && input.editorOpen !== false && input.editor_open !== false;
   // Real-content validation options forwarded to the editor-validate-blocks step.
   // No empty-post default: when nothing concrete is provided, the step targets
   // `front-page`, which wp-codebox resolves to the imported static front page
@@ -186,6 +188,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
         ...matrix.fixtures.flatMap((fixture) => [
           ...fixturePluginProvisioningSteps(fixture),
           importFixtureStep(fixture, commandArtifactsDirectory),
+          ...(editorOpenEnabled ? [editorOpenStep({ fixture, ...editorValidationOptions })] : []),
           ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, ...editorValidationOptions })] : []),
           ...(visualParityEnabled ? [visualParityDeterministicCssStep(fixture)] : []),
           ...(visualParityEnabled ? [visualParityCompareStep({ fixture, ...visualParityRecipeOptions })] : []),

--- a/registry/gutenberg-incompatibility-registry.schema.json
+++ b/registry/gutenberg-incompatibility-registry.schema.json
@@ -48,8 +48,11 @@
     "classification": { "enum": ["convertible", "custom-block-candidate", "runtime-island"] },
     "fallback_kind": { "enum": ["core_html", "data_uri", "runtime_island", "fidelity_loss"] },
     "limitation_type": { "enum": ["real_gutenberg_gap", "transformer_gap", "intentional_runtime_preservation", "visual_only_style_drift", "editor_validity_risk"] },
+    "frontend_visual_status": { "enum": ["passed", "visual_mismatch", "not_evaluated", "provider_runtime_blocked"] },
+    "editor_canvas_status": { "enum": ["visible", "diverged", "not_captured", "provider_runtime_blocked"] },
     "editor_validity_status": { "enum": ["valid", "invalid_blocks", "not_validated"] },
     "native_editability_status": { "enum": ["native_editable", "editor_invalid", "custom_block_candidate", "runtime_island_preserved", "html_islands_or_transformer_gap", "unknown"] },
+    "acceptance_status": { "enum": ["solved_candidate", "visual_only_blocker", "editor_blocker", "native_editability_blocker", "provider_runtime_blocker"] },
     "top_pattern": {
       "type": "object",
       "required": ["pattern_key", "classification", "fixture_count", "finding_count", "impact_score"],
@@ -89,18 +92,26 @@
     },
     "fixture_decision": {
       "type": "object",
-      "required": ["fixture_id", "editor_validity_status", "native_editability_status", "visible_html_island_count", "runtime_island_count", "gutenberg_gap_patterns", "transformer_gap_patterns", "intentional_runtime_patterns", "visual_only_patterns"],
+      "required": ["fixture_id", "frontend_visual_status", "editor_canvas_status", "block_validity_status", "editor_validity_status", "native_editability_status", "visible_html_island_count", "runtime_island_count", "visible_runtime_or_html_islands", "gutenberg_gap_patterns", "transformer_gap_patterns", "intentional_runtime_patterns", "visual_only_patterns", "solved_candidate", "acceptance_status", "acceptance_reason"],
       "properties": {
         "fixture_id": { "type": "string" },
+        "frontend_visual_status": { "$ref": "#/$defs/frontend_visual_status" },
+        "editor_canvas_status": { "$ref": "#/$defs/editor_canvas_status" },
+        "block_validity_status": { "$ref": "#/$defs/editor_validity_status" },
         "editor_validity_status": { "$ref": "#/$defs/editor_validity_status" },
         "native_editability_status": { "$ref": "#/$defs/native_editability_status" },
         "visible_html_island_count": { "type": "number", "minimum": 0 },
         "runtime_island_count": { "type": "integer", "minimum": 0 },
+        "visible_runtime_or_html_islands": { "type": "number", "minimum": 0 },
         "gutenberg_gap_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "transformer_gap_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "intentional_runtime_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "visual_only_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
-        "solved_candidate_reason": { "type": "string" }
+        "editor_risk_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "solved_candidate": { "type": "boolean" },
+        "solved_candidate_reason": { "type": "string" },
+        "acceptance_status": { "$ref": "#/$defs/acceptance_status" },
+        "acceptance_reason": { "type": "string" }
       },
       "additionalProperties": false
     },

--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -25,6 +25,7 @@
         "command": "wp-codebox",
         "env": ["HOMEBOY_WP_CODEBOX_BIN"],
         "capabilities": [
+          "wordpress.editor-open",
           "wordpress.editor-validate-blocks",
           "wordpress.visual-compare"
         ],

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -428,6 +428,7 @@ test('fixture-matrix rig requires env-backed WP Codebox editor and visual capabi
   assert.ok(tool, 'expected a wp-codebox runner tool requirement');
   assert.equal(tool.command, 'wp-codebox');
   assert.deepEqual(tool.env, ['HOMEBOY_WP_CODEBOX_BIN']);
+  assert.ok(tool.capabilities.includes('wordpress.editor-open'));
   assert.ok(tool.capabilities.includes('wordpress.editor-validate-blocks'));
   assert.ok(tool.capabilities.includes('wordpress.visual-compare'));
 });
@@ -3096,10 +3097,15 @@ test('recipe runs editor-validate-blocks against imported content after each imp
     staticSiteImporterPath: '/tmp/static-site-importer',
   });
 
-  // [activate, validate(simple-site), editor-validate-blocks(simple-site)]
+  // [activate, validate(simple-site), editor-open(simple-site), editor-validate-blocks(simple-site)]
   assert.equal(recipe.workflow.steps[1].command, 'wordpress.wp-cli');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
-  const editorStep = recipe.workflow.steps[2];
+  const editorOpenStep = recipe.workflow.steps[2];
+  assert.equal(editorOpenStep.command, 'wordpress.editor-open');
+  assert.ok(editorOpenStep.args.includes('target=front-page'));
+  assert.ok(editorOpenStep.args.includes('capture=screenshot,editor-state,editor-validity'));
+  assert.ok(editorOpenStep.args.includes('artifact-prefix=files/browser/editor-open/simple-site'));
+  const editorStep = recipe.workflow.steps[3];
   assert.equal(editorStep.command, EDITOR_VALIDATE_BLOCKS_COMMAND);
   assert.equal(editorStep.command, 'wordpress.editor-validate-blocks');
   assert.equal(editorStep.args.some((arg) => arg.includes('post-new.php')), false);
@@ -3977,12 +3983,12 @@ test('recipe runs a wordpress.visual-compare visual-parity step after each impor
     pixelThreshold: 0.05,
   });
 
-  // [activate, validate(simple-site), editor-validation(simple-site), visual-setup(simple-site), visual-compare(simple-site)]
-  const visualSetupStep = recipe.workflow.steps[3];
+  // [activate, validate(simple-site), editor-open(simple-site), editor-validation(simple-site), visual-setup(simple-site), visual-compare(simple-site)]
+  const visualSetupStep = recipe.workflow.steps[4];
   assert.equal(visualSetupStep.command, 'wordpress.wp-cli');
   assert.equal(visualSetupStep.metadata.phase, 'visual-setup');
   assert.match(visualSetupStep.args[0], /wp_update_custom_css_post/);
-  const visualStep = recipe.workflow.steps[4];
+  const visualStep = recipe.workflow.steps[5];
   assert.equal(visualStep.command, 'wordpress.visual-compare');
   const comparison = visualCompareMatrixComparison(visualStep);
   assert.equal(comparison.sourceUrl, 'file:///tmp/artifacts/simple-site/source/index.html');

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -195,20 +195,36 @@ test('gutenberg incompatibility registry separates fixture decision axes', () =>
       {
         fixture_id: 'cv',
         status: 'passed',
+        artifact_refs: [{ artifact_id: 'editor-open-screenshot', kind: 'screenshot', path: 'files/browser/editor-open/cv/screenshot.png' }],
+        visual_parity_artifacts: { comparison: { mismatch_ratio: 0 } },
         block_composition: { block_total: 8, native_block_count: 8, core_html_block_count: 0 },
         editor_quality: { editor_validated_block_total: 8, editor_invalid_count: 0, core_html_block_count: 0 },
       },
       {
         fixture_id: 'artist',
         status: 'failed',
+        artifact_refs: [{ artifact_id: 'editor-open-screenshot', kind: 'screenshot', path: 'files/browser/editor-open/artist/screenshot.png' }],
         block_composition: { block_total: 10, native_block_count: 9, core_html_block_count: 1 },
         editor_quality: { editor_validated_block_total: 10, editor_invalid_count: 0, core_html_block_count: 1 },
         visual_diff_regions: [{ dominant_cause: 'position_offset', pixel_count: 2500 }],
       },
       {
+        fixture_id: 'coffee',
+        status: 'failed',
+        artifact_refs: [{ artifact_id: 'editor-open-screenshot', kind: 'screenshot', path: 'files/browser/editor-open/coffee/screenshot.png' }],
+        editor_quality: { editor_validated_block_total: 12, editor_invalid_count: 0, core_html_block_count: 0 },
+        visual_diff_regions: [{ dominant_cause: 'font_metric_drift', pixel_count: 900 }],
+      },
+      {
         fixture_id: 'saas',
         status: 'failed',
+        artifact_refs: [{ artifact_id: 'editor-open-screenshot', kind: 'screenshot', path: 'files/browser/editor-open/saas/screenshot.png' }],
+        visual_parity_artifacts: { comparison: { mismatch_ratio: 0 } },
         editor_quality: { editor_validated_block_total: 6, editor_invalid_count: 1, core_html_block_count: 0 },
+      },
+      {
+        fixture_id: 'runtime-provider',
+        status: 'failed',
       },
     ],
     findings: [
@@ -227,26 +243,54 @@ test('gutenberg incompatibility registry separates fixture decision axes', () =>
         selector: '.hero',
         reason: 'Editor block validation failed.',
       },
+      {
+        fixture_id: 'runtime-provider',
+        kind: 'recipe_step_failure',
+        loss_class: 'runtime_execution_failed',
+        reason: 'wp-codebox command failed before evidence capture.',
+      },
     ],
   });
   const decisions = Object.fromEntries(registry.fixture_decisions.map((row) => [row.fixture_id, row]));
   const patterns = Object.fromEntries(registry.patterns.map((row) => [row.pattern_key, row]));
   const markdown = renderGutenbergIncompatibilityRegistryMarkdown(registry);
 
+  assert.equal(decisions.cv.frontend_visual_status, 'passed');
+  assert.equal(decisions.cv.editor_canvas_status, 'visible');
+  assert.equal(decisions.cv.block_validity_status, 'valid');
   assert.equal(decisions.cv.editor_validity_status, 'valid');
   assert.equal(decisions.cv.native_editability_status, 'native_editable');
-  assert.equal(decisions.cv.solved_candidate_reason, 'passed editor validity, native editability, and visual parity without limitation patterns');
+  assert.equal(decisions.cv.solved_candidate, true);
+  assert.equal(decisions.cv.acceptance_status, 'solved_candidate');
+  assert.equal(decisions.cv.solved_candidate_reason, 'passed frontend visual parity, editor canvas evidence, block validity, and native editability without limitation patterns');
   assert.equal(decisions.artist.native_editability_status, 'custom_block_candidate');
+  assert.equal(decisions.artist.frontend_visual_status, 'visual_mismatch');
+  assert.equal(decisions.artist.editor_canvas_status, 'visible');
+  assert.equal(decisions.artist.acceptance_status, 'native_editability_blocker');
   assert.equal(decisions.artist.visible_html_island_count, 1);
+  assert.equal(decisions.artist.visible_runtime_or_html_islands, 1);
   assert.deepEqual(decisions.artist.gutenberg_gap_patterns, ['static-form']);
   assert.deepEqual(decisions.artist.visual_only_patterns, ['visual-position_offset']);
+  assert.equal(decisions.coffee.native_editability_status, 'native_editable');
+  assert.equal(decisions.coffee.acceptance_status, 'visual_only_blocker');
+  assert.deepEqual(decisions.coffee.visual_only_patterns, ['visual-font_metric_drift']);
+  assert.equal(decisions.saas.editor_canvas_status, 'visible');
   assert.equal(decisions.saas.editor_validity_status, 'invalid_blocks');
   assert.equal(decisions.saas.native_editability_status, 'editor_invalid');
+  assert.equal(decisions.saas.acceptance_status, 'editor_blocker');
+  assert.equal(decisions['runtime-provider'].frontend_visual_status, 'provider_runtime_blocked');
+  assert.equal(decisions['runtime-provider'].acceptance_status, 'provider_runtime_blocker');
   assert.equal(patterns['static-form'].limitation_type, 'real_gutenberg_gap');
   assert.equal(patterns['visual-position_offset'].limitation_type, 'visual_only_style_drift');
-  assert.equal(registry.summary.fixture_decision_counts.native_editable, 1);
+  assert.equal(registry.summary.fixture_decision_counts.solved_candidate, 1);
+  assert.equal(registry.summary.fixture_decision_counts.visual_only_blocker, 1);
+  assert.equal(registry.summary.fixture_decision_counts.editor_blocker, 1);
+  assert.equal(registry.summary.fixture_decision_counts.native_editability_blocker, 1);
+  assert.equal(registry.summary.fixture_decision_counts.provider_runtime_blocker, 1);
   assert.equal(registry.summary.editor_validity_counts.invalid_blocks, 1);
   assert.match(markdown, /## Fixture Decisions/);
+  assert.match(markdown, /solved_candidate/);
+  assert.match(markdown, /native_editability_blocker/);
   assert.match(markdown, /`static-form`/);
 });
 
@@ -1702,6 +1746,42 @@ test('fixture diagnostics drop empty rows and normalize kindless carriers with e
   assert.equal(result.summary.loss_classes.preserved_runtime_island, 1);
   assert.equal(result.summary.loss_classes.editable_approximation, 2);
   assert.equal(result.summary.loss_classes.unsupported_loss, undefined);
+});
+
+test('fixture matrix intake preserves editor-open canvas evidence for acceptance decisions', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-canvas-intake-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-canvas-intake-test' });
+  const codeboxOutput = {
+    executions: [
+      {
+        command: 'wordpress.wp-cli',
+        args: ['command=static-site-importer validate-artifact --slug=simple-site --artifact=/tmp/simple-site/artifact.json'],
+        status: 'success',
+      },
+      {
+        command: 'wordpress.editor-open',
+        status: 'success',
+        editor_canvas: {
+          selector_summary: {
+            groups: [{ name: 'block-list', selector: '.block-editor-block-list__layout', count: 4 }],
+          },
+        },
+        editor_open: {
+          artifacts: {
+            screenshot: 'files/browser/editor-open/simple-site/screenshot.png',
+          },
+        },
+      },
+    ],
+  };
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory, codeboxOutput });
+  const registry = buildGutenbergIncompatibilityRegistry(result);
+  const decision = registry.fixture_decisions.find((row) => row.fixture_id === 'simple-site');
+
+  assert.equal(result.fixtures[0].editor_canvas.selector_summary.groups[0].count, 4);
+  assert.equal(result.fixtures[0].editor_open.artifacts.screenshot, 'files/browser/editor-open/simple-site/screenshot.png');
+  assert.equal(decision.editor_canvas_status, 'visible');
 });
 
 test('collects SSI finding packet source and observed context from fixture artifacts', () => {


### PR DESCRIPTION
## Summary
- add the editor-open fixture-matrix evidence step from #573 on a clean current-main branch
- preserve editor-open/editor-canvas evidence through fixture-matrix intake and normalized result output
- add deterministic fixture acceptance decisions across frontend visual parity, editor canvas evidence, block validity, and native editability
- render fixture decisions as solved, visual-only blocker, editor blocker, native editability blocker, or provider/runtime blocker

## Verification
- npm run test:fixture-matrix

## Notes
- #573 is green but its PR diff includes unrelated already-merged files; this PR carries only the editor-open commit plus the acceptance gate work.
- A fresh CV/Artist/Coffee/SaaS matrix was not run locally because this checkout only includes the simple-site fixture and HOMEBOY_WP_CODEBOX_BIN is not configured in this shell.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected #573, cherry-picked the clean editor-open evidence work, implemented and tested the acceptance decision gate, and prepared this PR.