### PR TITLE
Install fixture matrix rig dependencies

### DIFF
--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -75,7 +75,7 @@
       {
         "kind": "command",
         "label": "Fixture matrix workload validates",
-        "command": "node \"${package.root}/tools/fixture-matrix.test.mjs\""
+        "command": "cd \"${package.root}\" && npm ci --ignore-scripts && node \"${package.root}/tools/fixture-matrix.test.mjs\""
       }
     ],
     "down": [


### PR DESCRIPTION
## Summary
- Ensure the fixture-matrix rig check installs package-lock dependencies before running the Node validation test.
- Fixes lab/offload runs where remapped workspaces do not already have node_modules and fail on pngjs import before the bench can start.

## Evidence
- Blocked artist fixture attempt failed in lab with ERR_MODULE_NOT_FOUND for pngjs from tools/fixture-matrix.test.mjs.
- Local verification: npm ci --ignore-scripts && node tools/fixture-matrix.test.mjs (145 tests passed).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed the fixture-matrix rig dependency failure, implemented the minimal rig check fix, and ran local verification.