### PR TITLE
Improve Figma import parity materialization

### DIFF
--- a/includes/class-static-site-importer-figma-import.php
+++ b/includes/class-static-site-importer-figma-import.php
@@ -182,7 +182,7 @@ class Static_Site_Importer_Figma_Import {
 			$open_url = (string) $playground['blueprint_url'];
 		}
 
-		return array(
+		$response = array(
 			'schema'          => 'figma-to-wordpress/runner-response/v1',
 			'success'         => true,
 			'status'          => 'created',
@@ -190,6 +190,13 @@ class Static_Site_Importer_Figma_Import {
 			'preview_session' => $preview,
 			'materialization' => self::materialization_summary( $ability_result ),
 		);
+
+		$figma_transform_report = isset( $ability_result['figma_transform_report'] ) && is_array( $ability_result['figma_transform_report'] ) ? $ability_result['figma_transform_report'] : array();
+		if ( ! empty( $figma_transform_report ) ) {
+			$response['figma_transform_report'] = $figma_transform_report;
+		}
+
+		return $response;
 	}
 
 	/**
@@ -263,6 +270,9 @@ class Static_Site_Importer_Figma_Import {
 	 */
 	private static function website_artifact_from_bundle( array $bundle, array $input ) {
 		$files = self::normalize_files( isset( $bundle['files'] ) && is_array( $bundle['files'] ) ? $bundle['files'] : array(), (string) ( $bundle['root'] ?? 'website/' ) );
+		if ( is_wp_error( $files ) ) {
+			return $files;
+		}
 		if ( empty( $files ) ) {
 			return new WP_Error( 'static_site_importer_figma_bundle_empty', 'The Figma artifact bundle did not contain importable files.', array( 'status' => 400 ) );
 		}
@@ -372,6 +382,9 @@ class Static_Site_Importer_Figma_Import {
 		}
 
 		$files = self::normalize_files( isset( $transform['files'] ) && is_array( $transform['files'] ) ? $transform['files'] : array(), 'website/' );
+		if ( is_wp_error( $files ) ) {
+			return $files;
+		}
 		if ( empty( $files ) ) {
 			$diagnostic = self::first_transform_diagnostic( $transform );
 			$data       = array(
@@ -416,10 +429,188 @@ class Static_Site_Importer_Figma_Import {
 		return array(
 			'schema'         => 'static-site-importer/figma-transform-report/v1',
 			'source'         => 'blocks-engine/figma-transformer',
+			'status'         => isset( $transform['status'] ) && is_scalar( $transform['status'] ) ? (string) $transform['status'] : '',
+			'summary'        => self::figma_transform_summary( $figma_report, $transform ),
 			'source_reports' => array(
 				'figma' => $figma_report,
 			),
 		);
+	}
+
+	/**
+	 * Build a compact, stable summary of transformer quality diagnostics.
+	 *
+	 * @param array<string,mixed> $figma_report Raw Blocks Engine Figma report.
+	 * @param array<string,mixed> $transform    Full transform result.
+	 * @return array<string,mixed>
+	 */
+	private static function figma_transform_summary( array $figma_report, array $transform ): array {
+		$page_plan = isset( $figma_report['pages'] ) && is_array( $figma_report['pages'] ) ? $figma_report['pages'] : array();
+		$pages     = isset( $page_plan['pages'] ) && is_array( $page_plan['pages'] ) ? $page_plan['pages'] : array();
+		$diagnostics = isset( $transform['diagnostics'] ) && is_array( $transform['diagnostics'] ) ? $transform['diagnostics'] : array();
+		$artifact_quality = self::first_nested_array( $figma_report, array( 'artifact_quality' ) );
+
+		$selected_pages = array();
+		$page_warnings  = array();
+		foreach ( $pages as $page ) {
+			if ( ! is_array( $page ) ) {
+				continue;
+			}
+
+			$page_summary = array_filter(
+				array(
+					'path'     => isset( $page['path'] ) && is_scalar( $page['path'] ) ? (string) $page['path'] : '',
+					'name'     => isset( $page['name'] ) && is_scalar( $page['name'] ) ? (string) $page['name'] : '',
+					'frame_id' => isset( $page['frame_id'] ) && is_scalar( $page['frame_id'] ) ? (string) $page['frame_id'] : '',
+					'role'     => isset( $page['role'] ) && is_scalar( $page['role'] ) ? (string) $page['role'] : '',
+				)
+			);
+			if ( ! empty( $page_summary ) ) {
+				$selected_pages[] = $page_summary;
+			}
+
+			foreach ( isset( $page['diagnostics'] ) && is_array( $page['diagnostics'] ) ? $page['diagnostics'] : array() as $diagnostic ) {
+				if ( is_array( $diagnostic ) ) {
+					$page_warnings[] = array_merge( $page_summary, self::compact_diagnostic( $diagnostic ) );
+				}
+			}
+		}
+
+		return array(
+			'artifact_quality'   => self::compact_artifact_quality( $artifact_quality ),
+			'page_coverage'      => array(
+				'candidate_count' => isset( $page_plan['candidate_count'] ) && is_numeric( $page_plan['candidate_count'] ) ? (int) $page_plan['candidate_count'] : count( $pages ),
+				'selected_count'  => count( $selected_pages ),
+				'page_count'      => isset( $page_plan['page_count'] ) && is_numeric( $page_plan['page_count'] ) ? (int) $page_plan['page_count'] : count( $selected_pages ),
+			),
+			'selected_pages'     => $selected_pages,
+			'omitted_pages'      => self::compact_named_rows( self::first_nested_array( $figma_report, array( 'omitted_pages', 'omittedFrames', 'omitted_frames' ) ) ),
+			'selected_templates' => self::compact_named_rows( self::first_nested_array( $figma_report, array( 'selected_templates', 'selectedTemplates' ) ) ),
+			'omitted_templates'  => self::compact_named_rows( self::first_nested_array( $figma_report, array( 'omitted_templates', 'omittedTemplates' ) ) ),
+			'missing_assets'     => self::compact_named_rows( self::first_nested_array( $figma_report, array( 'missing_assets', 'missingAssets' ) ) ),
+			'page_warnings'      => $page_warnings,
+			'diagnostic_counts'  => self::diagnostic_counts( $diagnostics ),
+		);
+	}
+
+	/**
+	 * Return the first nested array value matching any key.
+	 *
+	 * @param mixed             $value Source value.
+	 * @param array<int,string> $keys  Candidate keys.
+	 * @return array<string|int,mixed>
+	 */
+	private static function first_nested_array( $value, array $keys ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		foreach ( $keys as $key ) {
+			if ( isset( $value[ $key ] ) && is_array( $value[ $key ] ) ) {
+				return $value[ $key ];
+			}
+		}
+
+		foreach ( $value as $child ) {
+			$found = self::first_nested_array( $child, $keys );
+			if ( ! empty( $found ) ) {
+				return $found;
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Keep only stable, compact fields from a diagnostic row.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic row.
+	 * @return array<string,mixed>
+	 */
+	private static function compact_diagnostic( array $diagnostic ): array {
+		$compact = array();
+		foreach ( array( 'severity', 'code', 'message', 'source', 'reason', 'reason_code' ) as $key ) {
+			if ( isset( $diagnostic[ $key ] ) && is_scalar( $diagnostic[ $key ] ) ) {
+				$compact[ $key ] = (string) $diagnostic[ $key ];
+			}
+		}
+
+		return $compact;
+	}
+
+	/**
+	 * Compact an artifact quality report.
+	 *
+	 * @param array<string|int,mixed> $quality Artifact quality report.
+	 * @return array<string,mixed>
+	 */
+	private static function compact_artifact_quality( array $quality ): array {
+		if ( empty( $quality ) ) {
+			return array();
+		}
+
+		return array_filter(
+			array(
+				'status'         => isset( $quality['status'] ) && is_scalar( $quality['status'] ) ? (string) $quality['status'] : '',
+				'quality_status' => isset( $quality['quality_status'] ) && is_scalar( $quality['quality_status'] ) ? (string) $quality['quality_status'] : '',
+				'summary'        => isset( $quality['summary'] ) && is_array( $quality['summary'] ) ? $quality['summary'] : array(),
+				'signals'        => isset( $quality['signals'] ) && is_array( $quality['signals'] ) ? array_values( array_filter( array_map( static fn ( $signal ) => is_array( $signal ) ? self::compact_diagnostic( $signal ) : array(), $quality['signals'] ) ) ) : array(),
+			)
+		);
+	}
+
+	/**
+	 * Compact a list of page/template/asset rows.
+	 *
+	 * @param array<string|int,mixed> $rows Raw rows.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function compact_named_rows( array $rows ): array {
+		$compact = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$item = array();
+			foreach ( array( 'path', 'name', 'frame_id', 'node_id', 'template', 'reason', 'reason_code', 'message' ) as $key ) {
+				if ( isset( $row[ $key ] ) && is_scalar( $row[ $key ] ) ) {
+					$item[ $key ] = (string) $row[ $key ];
+				}
+			}
+			if ( ! empty( $item ) ) {
+				$compact[] = $item;
+			}
+		}
+
+		return $compact;
+	}
+
+	/**
+	 * Count transform diagnostics by severity and code.
+	 *
+	 * @param array<int,mixed> $diagnostics Diagnostics.
+	 * @return array<string,mixed>
+	 */
+	private static function diagnostic_counts( array $diagnostics ): array {
+		$counts = array(
+			'total'       => 0,
+			'by_severity' => array(),
+			'by_code'     => array(),
+		);
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+
+			++$counts['total'];
+			$severity = isset( $diagnostic['severity'] ) && is_scalar( $diagnostic['severity'] ) ? (string) $diagnostic['severity'] : 'unknown';
+			$code     = isset( $diagnostic['code'] ) && is_scalar( $diagnostic['code'] ) ? (string) $diagnostic['code'] : 'unknown';
+			$counts['by_severity'][ $severity ] = ( $counts['by_severity'][ $severity ] ?? 0 ) + 1;
+			$counts['by_code'][ $code ]         = ( $counts['by_code'][ $code ] ?? 0 ) + 1;
+		}
+
+		return $counts;
 	}
 
 	/**
@@ -525,13 +716,13 @@ class Static_Site_Importer_Figma_Import {
 	 *
 	 * @param array<int,array<string,mixed>> $files Files.
 	 * @param string                         $root  Source root.
-	 * @return array<int,array<string,mixed>>
+	 * @return array<int,array<string,mixed>>|WP_Error
 	 */
-	private static function normalize_files( array $files, string $root ): array {
+	private static function normalize_files( array $files, string $root ) {
 		$normalized = array();
 		$root       = trim( str_replace( '\\', '/', $root ), '/' );
 		foreach ( $files as $file ) {
-			if ( ! isset( $file['path'] ) ) {
+			if ( ! is_array( $file ) || ! isset( $file['path'] ) ) {
 				continue;
 			}
 
@@ -543,8 +734,28 @@ class Static_Site_Importer_Figma_Import {
 			$record = array( 'path' => $path );
 			if ( isset( $file['content_base64'] ) ) {
 				$record['content_base64'] = (string) $file['content_base64'];
+			} elseif ( array_key_exists( 'content', $file ) ) {
+				if ( ! is_scalar( $file['content'] ) ) {
+					return new WP_Error(
+						'static_site_importer_figma_file_payload_invalid',
+						'Figma transformer artifact file content must be scalar.',
+						array(
+							'status' => 400,
+							'path'   => $path,
+						)
+					);
+				}
+
+				$record['content'] = (string) $file['content'];
 			} else {
-				$record['content'] = isset( $file['content'] ) ? (string) $file['content'] : '';
+				return new WP_Error(
+					'static_site_importer_figma_file_payload_missing',
+					'Figma transformer artifact file entries must include content or content_base64 when no local artifact root is available.',
+					array(
+						'status' => 400,
+						'path'   => $path,
+					)
+				);
 			}
 
 			if ( isset( $file['mime_type'] ) ) {

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -488,6 +488,29 @@ class Static_Site_Importer_Page_Materializer {
 			$markup
 		) ?? $markup;
 
+		$markup = preg_replace_callback(
+			'/\burl\(\s*(["\']?)([^"\')]+)\1\s*\)/i',
+			static function ( array $matches ) use ( $replacements, $source_dir ): string {
+				$url        = html_entity_decode( (string) $matches[2], ENT_QUOTES | ENT_HTML5 );
+				$normalized = self::normalize_route_path( $url );
+				if ( '' !== $normalized && isset( $replacements[ $normalized ] ) ) {
+					return 'url("' . esc_url( $replacements[ $normalized ] ) . '")';
+				}
+
+				if ( '' === $normalized || '' === $source_dir || '.' === $source_dir || str_starts_with( $url, '/' ) || preg_match( '#^[a-z][a-z0-9+.-]*:#i', $url ) ) {
+					return $matches[0];
+				}
+
+				$resolved = self::normalize_route_path( $source_dir . '/' . $url );
+				if ( '' === $resolved || ! isset( $replacements[ $resolved ] ) ) {
+					return $matches[0];
+				}
+
+				return 'url("' . esc_url( $replacements[ $resolved ] ) . '")';
+			},
+			$markup
+		) ?? $markup;
+
 		return preg_replace_callback(
 			'/\b(src|href)=([' . "'\"" . '])([^' . "'\"" . ']*)\2/i',
 			static function ( array $matches ) use ( $replacements, $source_dir ): string {

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -196,7 +196,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		$writes = array_merge(
 			$stylesheet_writes,
-			Static_Site_Importer_Theme_Materializer::base_theme_writes( $theme_dir, $theme_slug, $theme_name, $materialized['css'], $has_header_part, $has_footer_part, $materialized['scripts'], $materialized['stylesheets'] )
+			Static_Site_Importer_Theme_Materializer::base_theme_writes( $theme_dir, $theme_slug, $theme_name, $materialized['css'], $has_header_part, $has_footer_part, $materialized['scripts'], $materialized['stylesheets'], $artifacts )
 		);
 		$writes = array_merge( $writes, $template_part_writes );
 		self::analyze_imported_page_content_documents( $document_pages, $page_artifacts['contents'] );

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -25,12 +25,13 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @param bool   $has_footer_part Whether a footer template part exists.
 	 * @param array<int,array<string,mixed>> $scripts     Materialized script asset rows.
 	 * @param array<int,array<string,mixed>> $stylesheets Materialized stylesheet asset rows.
+	 * @param array<string,mixed>            $artifacts   Compiled website artifacts.
 	 * @return array<string,string> Absolute write paths mapped to file contents.
 	 */
-	public static function base_theme_writes( string $theme_dir, string $theme_slug, string $theme_name, string $css, bool $has_header_part, bool $has_footer_part, array $scripts = array(), array $stylesheets = array() ): array {
+	public static function base_theme_writes( string $theme_dir, string $theme_slug, string $theme_name, string $css, bool $has_header_part, bool $has_footer_part, array $scripts = array(), array $stylesheets = array(), array $artifacts = array() ): array {
 		return array(
 			$theme_dir . '/functions.php'             => self::functions_php( $theme_slug, $scripts, $stylesheets ),
-			$theme_dir . '/theme.json'                => self::theme_json( $theme_name, $css ),
+			$theme_dir . '/theme.json'                => self::theme_json( $theme_name, $css, $artifacts ),
 			$theme_dir . '/templates/front-page.html' => self::content_template( '', $has_header_part, $has_footer_part ),
 			$theme_dir . '/templates/page.html'       => self::content_template( '', $has_header_part, $has_footer_part ),
 			$theme_dir . '/templates/index.html'      => self::content_template( '', $has_header_part, $has_footer_part ),
@@ -897,11 +898,12 @@ class Static_Site_Importer_Theme_Materializer {
 	/**
 	 * Build theme.json.
 	 *
-	 * @param string $theme_name Theme name.
-	 * @param string $css        Source CSS.
+	 * @param string              $theme_name Theme name.
+	 * @param string              $css        Source CSS.
+	 * @param array<string,mixed> $artifacts  Compiled website artifacts.
 	 * @return string
 	 */
-	private static function theme_json( string $theme_name, string $css ): string {
+	private static function theme_json( string $theme_name, string $css, array $artifacts = array() ): string {
 		$data = array(
 			'$schema'  => 'https://schemas.wp.org/trunk/theme.json',
 			'version'  => 3,
@@ -930,7 +932,233 @@ class Static_Site_Importer_Theme_Materializer {
 			$data['styles']['typography']['fontFamily'] = $body_font_family;
 		}
 
+		$data = self::merge_theme_json_fragment( $data, self::theme_json_fragment_from_artifacts( $artifacts ) );
+
 		return wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";
+	}
+
+	/**
+	 * Read explicit theme.json metadata from compiled artifacts.
+	 *
+	 * The importer only promotes data under stable generic keys. Figma-specific or
+	 * source-specific inference belongs upstream in the transformer contract.
+	 *
+	 * @param array<string,mixed> $artifacts Compiled website artifacts.
+	 * @return array<string,mixed>
+	 */
+	private static function theme_json_fragment_from_artifacts( array $artifacts ): array {
+		$site      = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
+		$theme     = isset( $site['theme'] ) && is_array( $site['theme'] ) ? $site['theme'] : array();
+		$fragments = array();
+
+		foreach ( array( $artifacts['theme_json'] ?? null, $site['theme_json'] ?? null, $theme['theme_json'] ?? null ) as $candidate ) {
+			if ( is_array( $candidate ) ) {
+				$fragments[] = self::safe_theme_json_fragment( $candidate );
+			}
+		}
+
+		foreach ( array( $artifacts['design_tokens'] ?? null, $site['design_tokens'] ?? null, $theme['design_tokens'] ?? null, $site['tokens'] ?? null ) as $candidate ) {
+			if ( is_array( $candidate ) ) {
+				$fragments[] = self::theme_json_fragment_from_design_tokens( $candidate );
+			}
+		}
+
+		$fragment = array();
+		foreach ( $fragments as $candidate ) {
+			$fragment = self::merge_theme_json_fragment( $fragment, $candidate );
+		}
+
+		return $fragment;
+	}
+
+	/**
+	 * Convert conservative design-token rows into theme.json settings/styles.
+	 *
+	 * @param array<string,mixed> $tokens Design token metadata.
+	 * @return array<string,mixed>
+	 */
+	private static function theme_json_fragment_from_design_tokens( array $tokens ): array {
+		$fragment = array();
+		$palette  = self::theme_json_palette_from_token_rows( $tokens['colors'] ?? $tokens['palette'] ?? array() );
+		$fonts    = self::theme_json_font_families_from_token_rows( $tokens['font_families'] ?? $tokens['fontFamilies'] ?? $tokens['fonts'] ?? array() );
+
+		if ( ! empty( $palette ) ) {
+			$fragment['settings']['color']['palette'] = $palette;
+		}
+
+		if ( ! empty( $fonts ) ) {
+			$fragment['settings']['typography']['fontFamilies'] = $fonts;
+		}
+
+		$layout = isset( $tokens['layout'] ) && is_array( $tokens['layout'] ) ? $tokens['layout'] : array();
+		foreach ( array( 'contentSize', 'wideSize' ) as $key ) {
+			if ( isset( $layout[ $key ] ) && is_scalar( $layout[ $key ] ) && self::is_safe_css_size_value( (string) $layout[ $key ] ) ) {
+				$fragment['settings']['layout'][ $key ] = (string) $layout[ $key ];
+			}
+		}
+
+		return $fragment;
+	}
+
+	/**
+	 * Normalize color token rows for theme.json palette.
+	 *
+	 * @param mixed $rows Token rows.
+	 * @return array<int,array{slug:string,name:string,color:string}>
+	 */
+	private static function theme_json_palette_from_token_rows( mixed $rows ): array {
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$palette = array();
+		$seen    = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$slug  = isset( $row['slug'] ) && is_scalar( $row['slug'] ) ? sanitize_title( (string) $row['slug'] ) : '';
+			$name  = isset( $row['name'] ) && is_scalar( $row['name'] ) ? trim( (string) $row['name'] ) : '';
+			$color = isset( $row['color'] ) && is_scalar( $row['color'] ) ? trim( (string) $row['color'] ) : '';
+
+			if ( '' === $slug || '' === $name || isset( $seen[ $slug ] ) || ! self::is_safe_color_value( $color ) ) {
+				continue;
+			}
+
+			$seen[ $slug ] = true;
+			$palette[]     = array(
+				'slug'  => $slug,
+				'name'  => $name,
+				'color' => $color,
+			);
+		}
+
+		return $palette;
+	}
+
+	/**
+	 * Normalize font-family token rows for theme.json typography settings.
+	 *
+	 * @param mixed $rows Token rows.
+	 * @return array<int,array{slug:string,name:string,fontFamily:string}>
+	 */
+	private static function theme_json_font_families_from_token_rows( mixed $rows ): array {
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$fonts = array();
+		$seen  = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$slug        = isset( $row['slug'] ) && is_scalar( $row['slug'] ) ? sanitize_title( (string) $row['slug'] ) : '';
+			$name        = isset( $row['name'] ) && is_scalar( $row['name'] ) ? trim( (string) $row['name'] ) : '';
+			$font_family = isset( $row['fontFamily'] ) && is_scalar( $row['fontFamily'] ) ? (string) $row['fontFamily'] : ( isset( $row['font_family'] ) && is_scalar( $row['font_family'] ) ? (string) $row['font_family'] : '' );
+
+			if ( '' === $slug || '' === $name || isset( $seen[ $slug ] ) || ! self::is_safe_font_family_value( $font_family ) ) {
+				continue;
+			}
+
+			$seen[ $slug ] = true;
+			$fonts[]       = array(
+				'slug'       => $slug,
+				'name'       => $name,
+				'fontFamily' => trim( $font_family ),
+			);
+		}
+
+		return $fonts;
+	}
+
+	/**
+	 * Filter an explicit theme.json fragment to importer-supported top-level keys.
+	 *
+	 * @param array<string,mixed> $fragment Candidate theme.json fragment.
+	 * @return array<string,mixed>
+	 */
+	private static function safe_theme_json_fragment( array $fragment ): array {
+		$safe = array();
+		foreach ( array( 'settings', 'styles', 'customTemplates', 'templateParts', 'patterns' ) as $key ) {
+			if ( isset( $fragment[ $key ] ) && self::theme_json_value_is_safe( $fragment[ $key ] ) ) {
+				$safe[ $key ] = $fragment[ $key ];
+			}
+		}
+
+		return $safe;
+	}
+
+	/**
+	 * Deep-merge a theme.json fragment into base data.
+	 *
+	 * @param array<string,mixed> $base     Base theme.json data.
+	 * @param array<string,mixed> $fragment Fragment to merge.
+	 * @return array<string,mixed>
+	 */
+	private static function merge_theme_json_fragment( array $base, array $fragment ): array {
+		foreach ( $fragment as $key => $value ) {
+			if ( is_array( $value ) && isset( $base[ $key ] ) && is_array( $base[ $key ] ) && self::array_is_assoc( $value ) && self::array_is_assoc( $base[ $key ] ) ) {
+				$base[ $key ] = self::merge_theme_json_fragment( $base[ $key ], $value );
+			} else {
+				$base[ $key ] = $value;
+			}
+		}
+
+		return $base;
+	}
+
+	/**
+	 * Check whether a theme.json fragment value is JSON-safe and bounded.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @param int   $depth Current recursion depth.
+	 * @return bool
+	 */
+	private static function theme_json_value_is_safe( mixed $value, int $depth = 0 ): bool {
+		if ( $depth > 8 ) {
+			return false;
+		}
+
+		if ( is_string( $value ) ) {
+			return strlen( $value ) <= 1000 && ! preg_match( '/[<>]/', $value );
+		}
+
+		if ( is_int( $value ) || is_float( $value ) || is_bool( $value ) || null === $value ) {
+			return true;
+		}
+
+		if ( ! is_array( $value ) || count( $value ) > 200 ) {
+			return false;
+		}
+
+		foreach ( $value as $key => $child ) {
+			if ( ! is_int( $key ) && ( ! is_string( $key ) || ! preg_match( '/^[A-Za-z0-9_\-]+$/', $key ) ) ) {
+				return false;
+			}
+
+			if ( ! self::theme_json_value_is_safe( $child, $depth + 1 ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether an array has string keys.
+	 *
+	 * @param array<mixed> $array Array to inspect.
+	 * @return bool
+	 */
+	private static function array_is_assoc( array $array ): bool {
+		if ( array() === $array ) {
+			return false;
+		}
+
+		return array_keys( $array ) !== range( 0, count( $array ) - 1 );
 	}
 
 	/**
@@ -1128,6 +1356,21 @@ class Static_Site_Importer_Theme_Materializer {
 		}
 
 		return (bool) preg_match( '/^(?:rgb|rgba|hsl|hsla)\(\s*[-+0-9.%\s,\/]+\s*\)$/i', $value );
+	}
+
+	/**
+	 * Check whether a CSS size is safe to expose in theme.json layout settings.
+	 *
+	 * @param string $value CSS size value.
+	 * @return bool
+	 */
+	private static function is_safe_css_size_value( string $value ): bool {
+		$value = trim( $value );
+		if ( '' === $value || strlen( $value ) > 80 || preg_match( '/[<>;{}]/', $value ) ) {
+			return false;
+		}
+
+		return (bool) preg_match( '/^(?:\d+(?:\.\d+)?(?:px|rem|em|vw|vh|%)|clamp\(\s*[-+0-9.%\s,\/a-z]+\s*\)|min\(\s*[-+0-9.%\s,\/a-z]+\s*\)|max\(\s*[-+0-9.%\s,\/a-z]+\s*\))$/i', $value );
 	}
 
 	/**

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -208,7 +208,7 @@ function static_site_importer_rest_create_playground_open( array $artifact, arra
 	$ref           = hash( 'sha256', $blueprint_json );
 	$blueprint_url = 'https://playground.wordpress.net/#' . rawurlencode( $blueprint_json );
 
-	return array(
+	$result = array(
 		'success'  => true,
 		'preview'  => array(
 			'status'     => 'ready',
@@ -232,6 +232,14 @@ function static_site_importer_rest_create_playground_open( array $artifact, arra
 			),
 		),
 	);
+
+	$source_metadata        = isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array();
+	$figma_transform_report = isset( $source_metadata['figma_transform_report'] ) && is_array( $source_metadata['figma_transform_report'] ) ? $source_metadata['figma_transform_report'] : array();
+	if ( ! empty( $figma_transform_report ) ) {
+		$result['figma_transform_report'] = $figma_transform_report;
+	}
+
+	return $result;
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -1011,6 +1011,20 @@ $generic_fig_artifact = static_site_importer_rest_source_artifact(
 );
 $assert( is_wp_error( $generic_fig_artifact ), 'rest-generic-static-upload-ignores-fig-file' );
 
+$figma_missing_payload = Static_Site_Importer_Figma_Import::website_artifact_from_input(
+	array(
+		'artifact_bundle' => array(
+			'schema' => 'figma-to-wordpress/website-artifact-bundle/v1',
+			'root'   => 'website/',
+			'files'  => array(
+				array( 'path' => 'website/index.html' ),
+			),
+		),
+	)
+);
+$assert( is_wp_error( $figma_missing_payload ), 'figma-bundle-missing-file-payload-errors' );
+$assert( 'static_site_importer_figma_file_payload_missing' === ( is_wp_error( $figma_missing_payload ) ? $figma_missing_payload->get_error_code() : '' ), 'figma-bundle-missing-file-payload-error-code' );
+
 if ( class_exists( 'ZipArchive' ) ) {
 	$fig_payload = array(
 		'name'         => 'Public Import Fixture',
@@ -1128,7 +1142,7 @@ $html_source_page = Static_Site_Importer_Source_Page::from_materialization_plan_
 		'title'        => 'Figma HTML',
 		'slug'         => 'figma-html',
 		'body_format' => 'blocks',
-		'block_markup' => '<!-- wp:heading {"level":1} --><h1>Figma HTML</h1><!-- /wp:heading --><!-- wp:image {"url":"assets/hero.png","alt":"Hero"} --><figure class="wp-block-image"><img src="assets/hero.png" alt="Hero" /></figure><!-- /wp:image -->',
+		'block_markup' => '<!-- wp:heading {"level":1,"style":{"background":{"backgroundImage":"url(assets/bg.png)"}}} --><h1 style="background-image:url(&quot;assets/bg.png&quot;)">Figma HTML</h1><!-- /wp:heading --><!-- wp:image {"url":"assets/hero.png","alt":"Hero"} --><figure class="wp-block-image"><img src="assets/hero.png" alt="Hero" /></figure><!-- /wp:image -->',
 	)
 );
 $assert( ! is_wp_error( $html_source_page ), 'html-materialization-source-page-builds' );
@@ -1137,15 +1151,20 @@ if ( ! is_wp_error( $html_source_page ) ) {
 		array( 'website/index.html' => $html_source_page ),
 		'figma-import',
 		array(
+			'website/assets/bg.png' => array(
+				'final_url' => 'https://example.test/wp-content/themes/figma-import/assets/materialized/website/assets/bg.png',
+			),
 			'website/assets/hero.png' => array(
 				'final_url' => 'https://example.test/wp-content/themes/figma-import/assets/materialized/website/assets/hero.png',
 			),
 		)
 	);
 	$assert( ! str_contains( $html_page_artifacts['contents']['website/index.html'] ?? '', '<!-- wp:html -->' ), 'html-materialization-avoids-core-html-block' );
-	$assert( str_contains( $html_page_artifacts['contents']['website/index.html'] ?? '', '<!-- wp:heading {"level":1} -->' ), 'html-materialization-converts-html-to-blocks' );
+	$assert( str_contains( $html_page_artifacts['contents']['website/index.html'] ?? '', '<!-- wp:heading' ), 'html-materialization-converts-html-to-blocks' );
 	$assert( str_contains( $html_page_artifacts['contents']['website/index.html'] ?? '', 'https://example.test/wp-content/themes/figma-import/assets/materialized/website/assets/hero.png' ), 'html-materialization-rewrites-root-relative-asset-reference' );
 	$assert( ! str_contains( $html_page_artifacts['contents']['website/index.html'] ?? '', '"url":"assets/hero.png"' ), 'html-materialization-rewrites-block-json-asset-reference' );
+	$assert( str_contains( $html_page_artifacts['contents']['website/index.html'] ?? '', 'https://example.test/wp-content/themes/figma-import/assets/materialized/website/assets/bg.png' ), 'html-materialization-rewrites-css-url-asset-reference' );
+	$assert( ! str_contains( $html_page_artifacts['contents']['website/index.html'] ?? '', 'url(assets/bg.png)' ), 'html-materialization-removes-source-css-url-reference' );
 	$assert( array() === $html_page_artifacts['diagnostics'], 'html-materialization-does-not-emit-unsupported-format-diagnostic' );
 }
 
@@ -1271,6 +1290,9 @@ $assert( 'static-site-importer/figma-diagnostics/v1' === ( $figma_diagnostics['s
 $assert( true === ( $figma_diagnostics['request']['has_scenegraph'] ?? null ), 'figma-diagnostics-summarizes-scenegraph-request' );
 $assert( 'website/index.html' === ( $figma_diagnostics['artifact']['entrypoint'] ?? '' ), 'figma-diagnostics-summarizes-artifact-entrypoint' );
 $assert( 'static-site-importer/figma-transform-report/v1' === ( $figma_diagnostics['figma_transform_report']['schema'] ?? '' ), 'figma-diagnostics-exposes-durable-transform-report' );
+$assert( isset( $figma_diagnostics['figma_transform_report']['summary']['page_coverage']['selected_count'] ), 'figma-diagnostics-exposes-page-coverage-summary' );
+$assert( isset( $figma_diagnostics['figma_transform_report']['summary']['selected_pages'] ), 'figma-diagnostics-exposes-selected-pages-summary' );
+$assert( isset( $figma_diagnostics['figma_transform_report']['summary']['artifact_quality'] ), 'figma-diagnostics-exposes-artifact-quality-summary' );
 $assert( isset( $figma_diagnostics['transform_diagnostics']['diagnostic_codes'] ), 'figma-diagnostics-exposes-transform-diagnostics' );
 $assert( 'figma-diagnostics' === ( $figma_diagnostics['production_import_input']['slug'] ?? '' ), 'figma-diagnostics-summarizes-production-import-input' );
 
@@ -1279,6 +1301,7 @@ Static_Site_Importer_Theme_Generator::$last_args     = array();
 $figma_import_result = Static_Site_Importer_Figma_Import::import( $figma_diagnostics_input );
 $assert( true === ( $figma_import_result['success'] ?? null ), 'figma-import-scenegraph-succeeds' );
 $assert( 'static-site-importer/figma-transform-report/v1' === ( $figma_import_result['figma_transform_report']['schema'] ?? '' ), 'figma-import-result-exposes-durable-transform-report' );
+$assert( isset( $figma_import_result['figma_transform_report']['summary']['page_coverage'] ), 'figma-import-result-exposes-transform-summary' );
 $assert( 'static-site-importer/figma-transform-report/v1' === ( Static_Site_Importer_Theme_Generator::$last_artifact['provenance']['figma_transform_report']['schema'] ?? '' ), 'figma-artifact-provenance-preserves-transform-report' );
 $assert( 'static-site-importer/figma-transform-report/v1' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['figma_transform_report']['schema'] ?? '' ), 'figma-import-source-metadata-preserves-transform-report' );
 

--- a/tests/smoke-theme-materializer-dry-run.php
+++ b/tests/smoke-theme-materializer-dry-run.php
@@ -119,6 +119,22 @@ $assert( false === ( $guarded['assets']['images/canonical.svg']['deletion_allowe
 $assert( 'website_artifact_source_retention_guard' === ( $guarded['diagnostics'][0]['type'] ?? '' ), 'canonical-source-guard-emits-diagnostic' );
 $assert( 'canonical_source_retained' === ( $guarded['diagnostics'][0]['reason'] ?? '' ), 'canonical-source-guard-reports-reason' );
 
+$missing_payload = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files(
+	$theme_dir,
+	'https://example.test/wp-content/themes/imported',
+	array(
+		'files' => array(
+			array(
+				'path' => 'images/missing.svg',
+				'kind' => 'image',
+			),
+		),
+	),
+	false
+);
+$assert( is_wp_error( $missing_payload ), 'artifact-file-missing-payload-errors' );
+$assert( 'static_site_importer_materialization_plan_asset_content_missing' === ( is_wp_error( $missing_payload ) ? $missing_payload->get_error_code() : '' ), 'artifact-file-missing-payload-error-code' );
+
 $ephemeral = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files(
 	$theme_dir,
 	'https://example.test/wp-content/themes/imported',
@@ -202,6 +218,72 @@ $unresolved_var_writes = Static_Site_Importer_Theme_Materializer::base_theme_wri
 );
 $unresolved_var_json   = json_decode( $unresolved_var_writes[ $theme_dir . '/theme.json' ] ?? '', true );
 $assert( ! isset( $unresolved_var_json['styles']['typography']['fontFamily'] ), 'unresolved-var-body-font-family-is-not-materialized' );
+
+$token_theme_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes(
+	$theme_dir,
+	'imported-theme',
+	'Imported Theme',
+	'',
+	false,
+	false,
+	array(),
+	array(),
+	array(
+		'site' => array(
+			'schema'        => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'design_tokens' => array(
+				'colors'        => array(
+					array(
+						'slug'  => 'Brand Primary',
+						'name'  => 'Brand Primary',
+						'color' => '#0f766e',
+					),
+					array(
+						'slug'  => 'unsafe-color',
+						'name'  => 'Unsafe Color',
+						'color' => 'url(https://example.test/bad.svg)',
+					),
+				),
+				'font_families' => array(
+					array(
+						'slug'        => 'display',
+						'name'        => 'Display',
+						'font_family' => 'Inter, Arial, sans-serif',
+					),
+				),
+				'layout'        => array(
+					'contentSize' => '960px',
+					'wideSize'    => '1280px',
+				),
+			),
+			'theme_json'    => array(
+				'settings' => array(
+					'spacing' => array(
+						'units' => array( 'px', 'rem', '%' ),
+					),
+				),
+				'styles'   => array(
+					'elements' => array(
+						'link' => array(
+							'color' => array(
+								'text' => 'var(--wp--preset--color--brand-primary)',
+							),
+						),
+					),
+				),
+			),
+		),
+	)
+);
+$token_theme_json   = json_decode( $token_theme_writes[ $theme_dir . '/theme.json' ] ?? '', true );
+$token_palette      = $token_theme_json['settings']['color']['palette'] ?? array();
+$token_fonts        = $token_theme_json['settings']['typography']['fontFamilies'] ?? array();
+$assert( '#0f766e' === ( $token_palette[0]['color'] ?? '' ), 'materialization-plan-color-token-promotes-to-theme-json' );
+$assert( 1 === count( $token_palette ), 'unsafe-materialization-plan-color-token-is-skipped' );
+$assert( 'Inter, Arial, sans-serif' === ( $token_fonts[0]['fontFamily'] ?? '' ), 'materialization-plan-font-token-promotes-to-theme-json' );
+$assert( '960px' === ( $token_theme_json['settings']['layout']['contentSize'] ?? '' ), 'materialization-plan-layout-token-overrides-content-size' );
+$assert( array( 'px', 'rem', '%' ) === ( $token_theme_json['settings']['spacing']['units'] ?? array() ), 'materialization-plan-theme-json-fragment-merges-settings' );
+$assert( 'var(--wp--preset--color--brand-primary)' === ( $token_theme_json['styles']['elements']['link']['color']['text'] ?? '' ), 'materialization-plan-theme-json-fragment-merges-styles' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- Preserve and surface durable Figma transform reports, including compact page coverage and quality summaries.
- Fail clearly when Figma/artifact file rows omit content payloads instead of silently materializing empty files.
- Rewrite CSS url(...) asset references and promote explicit design tokens/theme.json fragments into generated theme.json.
- Add smoke coverage for payload validation, CSS URL rewriting, Figma diagnostics, and theme token materialization.

## Tests
- php -l includes/class-static-site-importer-figma-import.php includes/class-static-site-importer-page-materializer.php includes/class-static-site-importer-theme-generator.php includes/class-static-site-importer-theme-materializer.php includes/rest.php tests/smoke-importer-block.php tests/smoke-theme-materializer-dry-run.php
- php tests/smoke-theme-materializer-dry-run.php
- php tests/smoke-transformer-adapter.php
- php tests/smoke-importer-block.php
- php tests/smoke-visual-repair-css.php
- npm run test:validation

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Reviewed the existing agent-authored changes, ran verification, prepared the commit, and drafted this PR description.