### PR TITLE
Group fixture acceptance decisions in registry

### DIFF
--- a/docs/gutenberg-incompatibility-registry.md
+++ b/docs/gutenberg-incompatibility-registry.md
@@ -29,6 +29,8 @@ A pattern is promoted to `custom-block-candidate` when `no_core_block_path` is t
 
 The registry also emits `fixture_decisions[]` so acceptance decisions do not require re-reading pattern evidence by hand:
 
+- `summary.fixture_decision_counts`: deterministic counts by `acceptance_status`.
+- `summary.fixture_decision_groups`: deterministic, sorted fixture IDs by `acceptance_status`; use this for quick review of solved candidates and blocker cohorts before drilling into the full decision table.
 - `editor_validity_status`: `valid`, `invalid_blocks`, or `not_validated`; this is the corrupt/invalid block risk axis.
 - `native_editability_status`: `native_editable`, `editor_invalid`, `custom_block_candidate`, `runtime_island_preserved`, `html_islands_or_transformer_gap`, or `unknown`.
 - `visible_html_island_count`: visible `core/html` island pressure from block composition and findings.

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -72,6 +72,7 @@ export function buildGutenbergIncompatibilityRegistry(result = {}, options = {})
       convertible_count: patterns.filter((row) => row.classification === 'convertible').length,
       runtime_island_count: patterns.filter((row) => row.classification === 'runtime-island').length,
       fixture_decision_counts: countBy(fixtureDecisions, (row) => row.acceptance_status),
+      fixture_decision_groups: groupFixtureDecisionsByAcceptance(fixtureDecisions),
       editor_validity_counts: countBy(fixtureDecisions, (row) => row.editor_validity_status),
       limitation_type_counts: countBy(patterns, (row) => row.limitation_type),
       top_patterns: patterns.slice(0, 10).map((row) => ({ pattern_key: row.pattern_key, classification: row.classification, fixture_count: row.fixture_count, finding_count: row.finding_count, impact_score: row.impact_score })),
@@ -98,6 +99,13 @@ export function renderGutenbergIncompatibilityRegistryMarkdown(registry = {}) {
   normalizeArray(registry.patterns).forEach((row, index) => {
     lines.push(`| ${index + 1} | \`${row.pattern_key}\` | ${row.limitation_type || '(unknown)'} | ${row.classification} | ${row.fixture_count} | ${row.finding_count} | ${row.impact_score} | ${table(row.impossible_in_core_reason)} |`);
   });
+  const decisionGroups = objectValue(registry.summary?.fixture_decision_groups);
+  if (Object.keys(decisionGroups).length > 0) {
+    lines.push('', '## Fixture Decision Groups', '', '| Acceptance | Fixtures |', '| --- | --- |');
+    for (const status of Object.keys(decisionGroups).sort()) {
+      lines.push(`| ${status} | ${normalizeArray(decisionGroups[status]).map((fixtureId) => `\`${fixtureId}\``).join(', ') || '(none)'} |`);
+    }
+  }
   lines.push('', '## Fixture Decisions', '', '| Fixture | Acceptance | Frontend Visual | Editor Canvas | Block Validity | Native Editability | Runtime/HTML Islands | Gutenberg Gaps | Visual-only Patterns | Reason |', '| --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- |');
   for (const row of normalizeArray(registry.fixture_decisions)) {
     lines.push(`| \`${row.fixture_id}\` | ${row.acceptance_status || '(unknown)'} | ${row.frontend_visual_status || '(unknown)'} | ${row.editor_canvas_status || '(unknown)'} | ${row.block_validity_status || row.editor_validity_status || '(unknown)'} | ${row.native_editability_status} | ${row.visible_runtime_or_html_islands || 0} | ${(row.gutenberg_gap_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${(row.visual_only_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${table(row.solved_candidate_reason || row.acceptance_reason || '') || '(none)'} |`);
@@ -473,6 +481,16 @@ function countBy(items, iteratee) {
     counts[key] = (counts[key] || 0) + 1;
   }
   return sortCountObject(counts);
+}
+
+function groupFixtureDecisionsByAcceptance(fixtureDecisions) {
+  const groups = {};
+  for (const decision of normalizeArray(fixtureDecisions)) {
+    const status = decision.acceptance_status || 'unknown';
+    groups[status] = groups[status] || [];
+    pushUnique(groups[status], decision.fixture_id || 'unknown');
+  }
+  return Object.fromEntries(Object.entries(groups).sort(([left], [right]) => left.localeCompare(right)).map(([status, fixtureIds]) => [status, [...fixtureIds].sort()]));
 }
 
 function uniqueSorted(values) {

--- a/registry/gutenberg-incompatibility-registry.schema.json
+++ b/registry/gutenberg-incompatibility-registry.schema.json
@@ -27,13 +27,14 @@
     },
     "summary": {
       "type": "object",
-      "required": ["pattern_count", "custom_block_candidate_count", "convertible_count", "runtime_island_count", "top_patterns"],
+      "required": ["pattern_count", "custom_block_candidate_count", "convertible_count", "runtime_island_count", "fixture_decision_counts", "fixture_decision_groups", "editor_validity_counts", "limitation_type_counts", "top_patterns"],
       "properties": {
         "pattern_count": { "type": "integer", "minimum": 0 },
         "custom_block_candidate_count": { "type": "integer", "minimum": 0 },
         "convertible_count": { "type": "integer", "minimum": 0 },
         "runtime_island_count": { "type": "integer", "minimum": 0 },
         "fixture_decision_counts": { "$ref": "#/$defs/counts" },
+        "fixture_decision_groups": { "$ref": "#/$defs/fixture_decision_groups" },
         "editor_validity_counts": { "$ref": "#/$defs/counts" },
         "limitation_type_counts": { "$ref": "#/$defs/counts" },
         "top_patterns": { "type": "array", "items": { "$ref": "#/$defs/top_pattern" } }
@@ -118,6 +119,15 @@
     "counts": {
       "type": "object",
       "additionalProperties": { "type": "integer", "minimum": 0 }
+    },
+    "fixture_decision_groups": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/acceptance_status" },
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" },
+        "uniqueItems": true
+      }
     }
   }
 }

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -287,7 +287,16 @@ test('gutenberg incompatibility registry separates fixture decision axes', () =>
   assert.equal(registry.summary.fixture_decision_counts.editor_blocker, 1);
   assert.equal(registry.summary.fixture_decision_counts.native_editability_blocker, 1);
   assert.equal(registry.summary.fixture_decision_counts.provider_runtime_blocker, 1);
+  assert.deepEqual(registry.summary.fixture_decision_groups, {
+    editor_blocker: ['saas'],
+    native_editability_blocker: ['artist'],
+    provider_runtime_blocker: ['runtime-provider'],
+    solved_candidate: ['cv'],
+    visual_only_blocker: ['coffee'],
+  });
   assert.equal(registry.summary.editor_validity_counts.invalid_blocks, 1);
+  assert.match(markdown, /## Fixture Decision Groups/);
+  assert.match(markdown, /\| solved_candidate \| `cv` \|/);
   assert.match(markdown, /## Fixture Decisions/);
   assert.match(markdown, /solved_candidate/);
   assert.match(markdown, /native_editability_blocker/);


### PR DESCRIPTION
## Summary
- add deterministic `summary.fixture_decision_groups` to the Gutenberg incompatibility registry
- render fixture acceptance cohorts in the Markdown report before the full decision table
- tighten the registry schema and fixture-matrix test coverage around solved/blocker grouping

## Tests
- `npm run test:fixture-matrix`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Audited the fixture-matrix acceptance decision surfaces, implemented the grouping/report/schema/test update, and ran targeted verification.