### PR TITLE
Improve Figma import block-theme parity

### DIFF
--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -110,12 +110,14 @@ class Static_Site_Importer_Page_Materializer {
 		$patterns    = array();
 		$files       = array();
 		$contents    = array();
+		$asset_writes = array();
 		$diagnostics = array();
 
 		foreach ( $pages as $filename => $page ) {
 			$slug         = self::page_slug( $filename, $page );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
 			$content      = self::rewrite_materialized_asset_references( self::source_page_content_blocks( $page, $diagnostics ), $assets, $page->source_key(), $permalinks );
+			$content      = self::promote_inline_svg_html_blocks( $content, $theme_slug, $slug, $asset_writes, $diagnostics );
 
 			$patterns[ $filename ] = $pattern_slug;
 			$files[ $filename ]    = Static_Site_Importer_Theme_Materializer::pattern_file( self::page_title( $filename, $page ), $pattern_slug, $content );
@@ -125,9 +127,103 @@ class Static_Site_Importer_Page_Materializer {
 		return array(
 			'patterns'    => $patterns,
 			'files'       => $files,
+			'asset_writes' => $asset_writes,
 			'contents'    => $contents,
 			'diagnostics' => $diagnostics,
 		);
+	}
+
+	/**
+	 * Promote safe SVG-only core/html blocks to materialized theme SVG assets.
+	 *
+	 * @param string                           $markup       Serialized block markup.
+	 * @param string                           $theme_slug   Generated theme slug.
+	 * @param string                           $page_slug    Page slug for stable asset names.
+	 * @param array<string,string>             $asset_writes Theme-relative SVG writes, passed by reference.
+	 * @param array<int,array<string,mixed>>    $diagnostics  Diagnostics, passed by reference.
+	 * @return string Updated serialized block markup.
+	 */
+	private static function promote_inline_svg_html_blocks( string $markup, string $theme_slug, string $page_slug, array &$asset_writes, array &$diagnostics ): string {
+		if ( '' === trim( $markup ) || ! str_contains( $markup, '<!-- wp:html' ) || ! str_contains( $markup, '<svg' ) ) {
+			return $markup;
+		}
+
+		return preg_replace_callback(
+			'/<!-- wp:html(?:\s+(\{.*?\}))? -->(.*?)<!-- \/wp:html -->/s',
+			static function ( array $matches ) use ( $theme_slug, $page_slug, &$asset_writes, &$diagnostics ): string {
+				$attrs = isset( $matches[1] ) && '' !== trim( (string) $matches[1] ) ? json_decode( (string) $matches[1], true ) : array();
+				$html  = isset( $attrs['content'] ) && is_scalar( $attrs['content'] ) ? (string) $attrs['content'] : (string) $matches[2];
+				$svg   = self::safe_inline_svg( html_entity_decode( trim( $html ), ENT_QUOTES | ENT_HTML5 ) );
+				if ( '' === $svg ) {
+					return $matches[0];
+				}
+
+				$hash          = substr( sha1( $svg ), 0, 12 );
+				$asset_path    = 'assets/materialized/inline-svg/' . sanitize_title( $page_slug ) . '-' . $hash . '.svg';
+				$asset_writes[ $asset_path ] = $svg . "\n";
+				$url           = trailingslashit( get_theme_root_uri( sanitize_key( $theme_slug ) ) ) . sanitize_key( $theme_slug ) . '/' . $asset_path;
+				$alt           = self::svg_accessible_label( $svg );
+				$block_attrs   = array_filter(
+					array(
+						'url'       => esc_url_raw( $url ),
+						'alt'       => $alt,
+						'className' => 'blocks-engine-inline-svg',
+					),
+					static fn( $value ): bool => '' !== $value
+				);
+				$attrs_json    = wp_json_encode( $block_attrs, JSON_UNESCAPED_SLASHES );
+				$alt_attribute = '' !== $alt ? ' alt="' . esc_attr( $alt ) . '"' : ' alt=""';
+
+				$diagnostics[] = array(
+					'type'        => 'inline_svg_materialized',
+					'source'      => 'static-site-importer/page-materializer',
+					'asset_path'  => $asset_path,
+					'block_name'  => 'core/image',
+					'message'     => 'Safe inline SVG core/html block was materialized as a theme SVG asset and core/image block.',
+				);
+
+				return '<!-- wp:image ' . ( false !== $attrs_json ? $attrs_json : '{}' ) . ' --><figure class="wp-block-image blocks-engine-inline-svg"><img src="' . esc_url( $url ) . '"' . $alt_attribute . '/></figure><!-- /wp:image -->';
+			},
+			$markup
+		) ?? $markup;
+	}
+
+	/**
+	 * Return sanitized SVG markup when the payload is a self-contained SVG image.
+	 *
+	 * @param string $svg Candidate SVG markup.
+	 * @return string Safe SVG markup, or empty string when unsupported.
+	 */
+	private static function safe_inline_svg( string $svg ): string {
+		$svg = trim( $svg );
+		if ( '' === $svg || ! preg_match( '/^<svg\b[\s\S]*<\/svg>$/i', $svg ) ) {
+			return '';
+		}
+		if ( preg_match( '/<(script|foreignObject|iframe|object|embed)\b/i', $svg ) || preg_match( '/\son[a-z]+\s*=/i', $svg ) ) {
+			return '';
+		}
+		if ( preg_match( '/\b(?:href|xlink:href|src)\s*=\s*(["\'])(?!#)[^"\']+\1/i', $svg ) ) {
+			return '';
+		}
+
+		return $svg;
+	}
+
+	/**
+	 * Extract a compact accessible label from SVG metadata.
+	 *
+	 * @param string $svg SVG markup.
+	 * @return string Label, or empty string.
+	 */
+	private static function svg_accessible_label( string $svg ): string {
+		if ( preg_match( '/\baria-label\s*=\s*(["\'])(.*?)\1/i', $svg, $matches ) ) {
+			return sanitize_text_field( html_entity_decode( (string) $matches[2], ENT_QUOTES | ENT_HTML5 ) );
+		}
+		if ( preg_match( '/<title\b[^>]*>(.*?)<\/title>/is', $svg, $matches ) ) {
+			return sanitize_text_field( html_entity_decode( wp_strip_all_tags( (string) $matches[1] ), ENT_QUOTES | ENT_HTML5 ) );
+		}
+
+		return '';
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -199,6 +199,12 @@ class Static_Site_Importer_Theme_Generator {
 			Static_Site_Importer_Theme_Materializer::base_theme_writes( $theme_dir, $theme_slug, $theme_name, $materialized['css'], $has_header_part, $has_footer_part, $materialized['scripts'], $materialized['stylesheets'], $artifacts )
 		);
 		$writes = array_merge( $writes, $template_part_writes );
+		foreach ( isset( $page_artifacts['asset_writes'] ) && is_array( $page_artifacts['asset_writes'] ) ? $page_artifacts['asset_writes'] : array() as $relative_path => $content ) {
+			$relative_path = ltrim( str_replace( '\\', '/', (string) $relative_path ), '/' );
+			if ( '' !== $relative_path && ! str_contains( $relative_path, '..' ) ) {
+				$writes[ $theme_dir . '/' . $relative_path ] = (string) $content;
+			}
+		}
 		self::analyze_imported_page_content_documents( $document_pages, $page_artifacts['contents'] );
 
 		self::record_source_documents_summary( $artifacts['documents'] ?? array(), $document_pages, $page_ids, $permalinks );

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -1381,6 +1381,11 @@ class Static_Site_Importer_Theme_Materializer {
 	 * @return true|WP_Error
 	 */
 	public static function write_file( string $path, string $content ) {
+		$dir = dirname( $path );
+		if ( '' !== $dir && '.' !== $dir && ! is_dir( $dir ) && ! wp_mkdir_p( $dir ) ) {
+			return new WP_Error( 'static_site_importer_write_mkdir_failed', sprintf( 'Failed to create generated file directory: %s', $dir ) );
+		}
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writes generated block-theme files to the selected theme directory.
 		$result = file_put_contents( $path, $content );
 		if ( false === $result ) {

--- a/tests/smoke-generated-theme-block-validation.cjs
+++ b/tests/smoke-generated-theme-block-validation.cjs
@@ -69,8 +69,7 @@ if ( ! fs.existsSync( themeDir ) ) {
 }
 
 const targetFiles = [
-  'parts/header.html',
-  'parts/footer.html',
+  ...listFiles( path.join( themeDir, 'parts' ), '.html' ).map( ( file ) => path.join( 'parts', file ) ),
   ...listFiles( path.join( themeDir, 'patterns' ), '.php' ).map( ( file ) => path.join( 'patterns', file ) ),
   ...listFiles( path.join( themeDir, 'templates' ), '.html' ).map( ( file ) => path.join( 'templates', file ) ),
 ];
@@ -91,9 +90,34 @@ for ( const relativePath of targetFiles ) {
   }
 
   const content = extractBlockContent( fs.readFileSync( filePath, 'utf8' ) );
+  checkReferencedTemplateParts( content, relativePath );
   const blocks = withConsoleSilenced( () => parse( content ) );
   blockCount += countBlocks( blocks );
   validateBlocks( blocks, relativePath );
+}
+
+function checkReferencedTemplateParts( content, relativePath ) {
+  for ( const match of content.matchAll( /<!--\s+wp:template-part\s+(\{.*?\})\s+\/-->/g ) ) {
+    let attrs = {};
+    try {
+      attrs = JSON.parse( match[1] );
+    } catch ( error ) {
+      continue;
+    }
+    const slug = String( attrs.slug || '' ).replace( /[^a-z0-9_-]/gi, '' );
+    if ( ! slug ) {
+      continue;
+    }
+    const partPath = path.join( themeDir, 'parts', `${ slug }.html` );
+    if ( ! fs.existsSync( partPath ) ) {
+      failures.push( {
+        file: relativePath,
+        path: `parts/${ slug }.html`,
+        blockName: 'core/template-part',
+        reasons: [ `Referenced template part does not exist: parts/${ slug }.html` ],
+      } );
+    }
+  }
 }
 
 if ( failures.length ) {

--- a/tests/smoke-inline-svg-materialization.php
+++ b/tests/smoke-inline-svg-materialization.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Smoke coverage for safe inline SVG core/html promotion.
+ *
+ * Run from the repository root:
+ * php tests/smoke-inline-svg-materialization.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+foreach (
+	array(
+		'trailingslashit'     => static fn( string $value ): string => rtrim( $value, '/\\' ) . '/',
+		'get_theme_root_uri'  => static fn( string $stylesheet = '' ): string => 'https://example.test/wp-content/themes',
+		'wp_json_encode'      => static fn( mixed $value, int $flags = 0, int $depth = 512 ): string|false => json_encode( $value, $flags, $depth ),
+		'esc_url_raw'         => static fn( string $value ): string => $value,
+		'esc_url'             => static fn( string $value ): string => $value,
+		'esc_attr'            => static fn( string $value ): string => htmlspecialchars( $value, ENT_QUOTES ),
+		'esc_html'            => static fn( string $value ): string => htmlspecialchars( $value, ENT_QUOTES ),
+		'sanitize_text_field' => static fn( string $value ): string => trim( preg_replace( '/\s+/', ' ', wp_strip_all_tags( $value ) ) ?? '' ),
+		'wp_strip_all_tags'   => static fn( string $value ): string => strip_tags( $value ),
+		'sanitize_key'        => static fn( string $value ): string => strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $value ) ?? '' ),
+		'sanitize_title'      => static fn( string $value ): string => trim( strtolower( preg_replace( '/[^a-z0-9]+/i', '-', $value ) ?? '' ), '-' ),
+	) as $function => $implementation
+) {
+	if ( ! function_exists( $function ) ) {
+		eval( 'function ' . $function . '(...$args) { global $ssi_inline_svg_stubs; return $ssi_inline_svg_stubs[__FUNCTION__](...$args); }' );
+	}
+}
+$ssi_inline_svg_stubs = array(
+	'trailingslashit'     => static fn( string $value ): string => rtrim( $value, '/\\' ) . '/',
+	'get_theme_root_uri'  => static fn( string $stylesheet = '' ): string => 'https://example.test/wp-content/themes',
+	'wp_json_encode'      => static fn( mixed $value, int $flags = 0, int $depth = 512 ): string|false => json_encode( $value, $flags, $depth ),
+	'esc_url_raw'         => static fn( string $value ): string => $value,
+	'esc_url'             => static fn( string $value ): string => $value,
+	'esc_attr'            => static fn( string $value ): string => htmlspecialchars( $value, ENT_QUOTES ),
+	'esc_html'            => static fn( string $value ): string => htmlspecialchars( $value, ENT_QUOTES ),
+	'sanitize_text_field' => static fn( string $value ): string => trim( preg_replace( '/\s+/', ' ', strip_tags( $value ) ) ?? '' ),
+	'wp_strip_all_tags'   => static fn( string $value ): string => strip_tags( $value ),
+	'sanitize_key'        => static fn( string $value ): string => strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $value ) ?? '' ),
+	'sanitize_title'      => static fn( string $value ): string => trim( strtolower( preg_replace( '/[^a-z0-9]+/i', '-', $value ) ?? '' ), '-' ),
+);
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-site-identity.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-source-page.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-page-materializer.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$safe_svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" role="img" aria-label="Check"><path d="M0 0h10v10H0z" fill="#6cdab0"></path></svg>';
+$unsafe   = '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><path d="M0 0h10v10H0z"></path></svg>';
+$content  = '<!-- wp:group --><div class="wp-block-group"><!-- wp:html {"content":' . wp_json_encode( $safe_svg ) . '} -->' . $safe_svg . '<!-- /wp:html --><!-- wp:html {"content":' . wp_json_encode( $unsafe ) . '} -->' . $unsafe . '<!-- /wp:html --></div><!-- /wp:group -->';
+$page     = Static_Site_Importer_Source_Page::from_wordpress_document_artifact(
+	array(
+		'source_path'  => 'index.html',
+		'slug'         => 'home',
+		'title'        => 'Home',
+		'entrypoint'   => '1',
+		'block_markup' => $content,
+	)
+);
+
+$artifacts = Static_Site_Importer_Page_Materializer::page_artifacts( array( 'index.html' => $page ), 'inline-svg-theme' );
+$output    = $artifacts['contents']['index.html'] ?? '';
+
+$assert( str_contains( $output, '<!-- wp:image ' ), 'safe-svg-promoted-to-image' );
+$assert( str_contains( $output, 'blocks-engine-inline-svg' ), 'promoted-image-class' );
+$assert( 1 === count( $artifacts['asset_writes'] ?? array() ), 'one-svg-asset-write' );
+$assert( str_contains( array_key_first( $artifacts['asset_writes'] ?? array() ) ?? '', 'assets/materialized/inline-svg/home-' ), 'stable-svg-asset-path' );
+$assert( str_contains( $output, 'onload=' ), 'unsafe-svg-remains-html' );
+$assert( 1 === substr_count( $output, '<!-- wp:html' ), 'only-unsafe-html-remains' );
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'PASS smoke-inline-svg-materialization.php (' . $assertions . " assertions)\n";

--- a/tools/fig-intent-parity-report.mjs
+++ b/tools/fig-intent-parity-report.mjs
@@ -43,7 +43,7 @@ export function buildFigIntentParityReport(options = {}) {
   const generatedText = normalizeText(generated.text).toLowerCase();
   const missingGeneratedText = intentText.values.filter((text) => !generatedText.includes(normalizeText(text).toLowerCase()));
   const wordpress = options.wpRoot ? inspectWordPressSite(path.resolve(options.wpRoot), options) : null;
-  const expectedPageSlugs = expectedWordPressPageSlugs(generated.html_files);
+  const expectedPageSlugs = wordpress?.manifest?.expected_page_slugs?.length ? wordpress.manifest.expected_page_slugs : expectedWordPressPageSlugs(generated.html_files);
   const missingWordPressPageSlugs = wordpress ? missingPageSlugs(expectedPageSlugs, wordpress.pages) : [];
   const regressions = collectRegressions({ fixture, result, generated, intentText, missingGeneratedText, wordpress, missingWordPressPageSlugs });
 
@@ -150,17 +150,38 @@ function inspectWordPressSite(wpRoot, options) {
   const stylesheet = runTextCommand(wpCli, [...baseArgs, 'option', 'get', 'stylesheet'], { optional: true }).trim();
   const themeDir = stylesheet ? path.join(wpRoot, 'wp-content', 'themes', stylesheet) : null;
   const themeFiles = themeDir && fs.existsSync(themeDir) ? listFiles(themeDir) : [];
-  const normalizedText = normalizeText(pages.map((page) => extractVisibleText(page.content)).join(' ')).toLowerCase();
+  const manifest = inspectStaticSiteImporterManifest(themeDir);
+  const scopedPages = manifest.expected_page_slugs.length ? pages.filter((page) => manifest.expected_page_slugs.includes(slugify(page.slug)) || manifest.expected_page_slugs.includes(slugify(page.title))) : pages;
+  const normalizedText = normalizeText(scopedPages.map((page) => extractVisibleText(page.content)).join(' ')).toLowerCase();
 
   return {
     wp_root: wpRoot,
     stylesheet: stylesheet || null,
     theme_asset_count: themeFiles.filter((file) => /\.(avif|gif|jpe?g|png|svg|webp|woff2?|ttf|otf|css)$/i.test(file)).length,
     theme_css_files: themeFiles.filter((file) => /\.css$/i.test(file)),
-    pages: pages.map(({ content, ...page }) => page),
-    fallback_block_count: pages.reduce((total, page) => total + page.fallback_block_count, 0),
-    block_count: pages.reduce((total, page) => total + page.block_count, 0),
+    manifest,
+    pages: scopedPages.map(({ content, ...page }) => page),
+    site_page_count: pages.length,
+    fallback_block_count: scopedPages.reduce((total, page) => total + page.fallback_block_count, 0),
+    block_count: scopedPages.reduce((total, page) => total + page.block_count, 0),
     normalized_text: normalizedText,
+  };
+}
+
+function inspectStaticSiteImporterManifest(themeDir) {
+  const empty = { found: false, expected_page_slugs: [] };
+  if (!themeDir) {
+    return empty;
+  }
+  const manifestPath = path.join(themeDir, 'static-site-importer-manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    return empty;
+  }
+  const manifest = readJson(manifestPath);
+  const desiredPages = Array.isArray(manifest?.desired?.pages) ? manifest.desired.pages : [];
+  return {
+    found: true,
+    expected_page_slugs: [...new Set(desiredPages.map((page) => slugify(page?.slug || page?.title || '')).filter(Boolean))].sort(),
   };
 }
 

--- a/tools/fig-intent-parity-report.test.mjs
+++ b/tools/fig-intent-parity-report.test.mjs
@@ -49,3 +49,48 @@ test('fig intent parity report catches missing generated pages, assets, links, t
   assert.ok(codes.includes('very_large_fixed_width'));
   assert.ok(codes.includes('missing_media_queries'));
 });
+
+test('fig intent parity report scopes WordPress pages to the active SSI manifest', () => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), 'fig-intent-parity-wp-'));
+  const artifactDir = path.join(root, 'site');
+  const wpRoot = path.join(root, 'wp');
+  const themeDir = path.join(wpRoot, 'wp-content', 'themes', 'scoped-theme');
+  fs.mkdirSync(artifactDir, { recursive: true });
+  fs.mkdirSync(themeDir, { recursive: true });
+  fs.writeFileSync(path.join(artifactDir, 'index.html'), '<h1>Home Copy</h1>');
+  fs.writeFileSync(path.join(artifactDir, 'style.css'), '@media (max-width: 600px) { body { width:auto } }');
+  fs.writeFileSync(path.join(themeDir, 'style.css'), 'body{}');
+  fs.writeFileSync(path.join(themeDir, 'static-site-importer-manifest.json'), JSON.stringify({ desired: { pages: [{ slug: 'home', title: 'Home' }] } }));
+
+  const fakeWpCli = path.join(root, 'fake-wp-cli.mjs');
+  fs.writeFileSync(fakeWpCli, `
+const args = process.argv.slice(2);
+if (args.includes('post') && args.includes('list')) {
+  process.stdout.write(JSON.stringify([
+    { ID: 1, post_title: 'Home', post_name: 'home' },
+    { ID: 2, post_title: 'Old Landing', post_name: 'old-landing' }
+  ]));
+} else if (args.includes('post') && args.includes('get') && args.includes('1')) {
+  process.stdout.write('<!-- wp:paragraph --><p>Home Copy</p><!-- /wp:paragraph -->');
+} else if (args.includes('post') && args.includes('get') && args.includes('2')) {
+  process.stdout.write('<!-- wp:html --><div>Unrelated fallback</div><!-- /wp:html -->');
+} else if (args.includes('option') && args.includes('get') && args.includes('stylesheet')) {
+  process.stdout.write('scoped-theme\\n');
+} else {
+  process.exit(1);
+}
+`);
+
+  const summary = { fixtures: [{ id: 'demo', artifact_dir: artifactDir, result_path: path.join(root, 'result.json'), metrics: { page_count: 1 } }] };
+  const result = { metrics: { page_count: 1 }, html: { pages: [{ nodes: [{ type: 'TEXT', name: 'Home Copy' }] }] } };
+  fs.writeFileSync(path.join(root, 'summary.json'), JSON.stringify(summary));
+  fs.writeFileSync(path.join(root, 'result.json'), JSON.stringify(result));
+
+  const report = buildFigIntentParityReport({ summary: path.join(root, 'summary.json'), fixtureId: 'demo', wpRoot, wpCli: `${process.execPath} ${fakeWpCli}` });
+
+  assert.equal(report.wordpress.site_page_count, 2);
+  assert.equal(report.wordpress.pages.length, 1);
+  assert.equal(report.wordpress.fallback_block_count, 0);
+  assert.deepEqual(report.comparisons.expected_wordpress_page_slugs, ['home']);
+  assert.ok(!report.regressions.some((row) => row.code === 'missing_wordpress_pages' || row.code === 'fallback_blocks_present'));
+});


### PR DESCRIPTION
## Summary
- Materialize safe inline SVG-only core/html blocks as generated theme SVG assets and core/image blocks.
- Scope fig-intent parity WordPress page checks to the active SSI source-of-truth manifest so prior test-site pages do not skew one-page imports.
- Update generated-theme block validation to treat template parts as optional unless referenced.

## Validation
- Imported the Fisiostetic generated artifact into a local Studio test site with this branch.
- Before: parity failed with 16 WordPress fallback blocks across the imported output.
- After: parity reports one imported WordPress page, zero fallback blocks, and SSI import quality passes.
- npm run test:js-block-validation -- <local imported Fisiostetic theme>
- node --test tools/fig-intent-parity-report.test.mjs
- npm run test:fixture-matrix
- php tests/smoke-inline-svg-materialization.php
- php tests/smoke-theme-materializer-dry-run.php
- php tests/smoke-website-artifact-document-metadata.php

## Remaining notes
- The remaining Fisiostetic parity warnings are transformer/source-artifact concerns: missing generated text for design-token labels, no media queries, and very large fixed CSS widths.
- No Studio changes were needed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated Fisiostetic import quality, implemented generic SSI fixes, ran local validation, and drafted this PR.