### PR TITLE
Add opt-in fixture matrix surface coverage

### DIFF
--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -43,6 +43,8 @@ export {
   normalizeStaticSiteImporterPlugin,
 } from './fixture-matrix/steps/recipe-builder.mjs';
 
+export { selectFixtureSurfaces, normalizeSurfaceCoverageOptions } from './fixture-matrix/steps/surfaces.mjs';
+
 export { editorBlockValidationStep } from './fixture-matrix/steps/editor-validation-step.mjs';
 
 export { visualParityCompareStep } from './fixture-matrix/steps/visual-parity-step.mjs';

--- a/lib/fixture-matrix/steps/editor-open-step.mjs
+++ b/lib/fixture-matrix/steps/editor-open-step.mjs
@@ -1,5 +1,5 @@
 // Editor-open recipe step for the Static Site Importer fixture matrix.
-// Captures real block-editor canvas evidence for the imported front page.
+// Captures real block-editor canvas evidence for an imported page surface.
 /**
  * Internal dependencies
  */
@@ -11,10 +11,12 @@ import { firstPresent, fixtureStepMetadata } from './shared.mjs';
 
 export function editorOpenStep(input = {}) {
   const fixture = input.fixture || {};
+  const surface = input.surface || null;
 
   const postId = firstPresent([input.postId, input.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
-  const url = firstPresent([input.url, input.editorOpenUrl, input.editor_open_url, fixture.editor_url, fixture.editorUrl]);
-  const target = firstPresent([input.target, input.editorOpenTarget, input.editor_open_target, fixture.editor_target, fixture.editorTarget, fixture.target]);
+  const url = firstPresent([input.url, input.editorOpenUrl, input.editor_open_url, surface?.url, fixture.editor_url, fixture.editorUrl]);
+  const target = firstPresent([input.target, input.editorOpenTarget, input.editor_open_target, surface?.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
+  const artifactPrefix = firstPresent([input.artifactPrefix, input.artifact_prefix, surface?.artifact_prefix]) || `files/browser/editor-open/${fixture.id}`;
 
   const args = [];
   if (postId !== undefined) {
@@ -37,14 +39,15 @@ export function editorOpenStep(input = {}) {
   }
 
   args.push('capture=screenshot,editor-state,editor-validity');
-  args.push(`artifact-prefix=files/browser/editor-open/${fixture.id}`);
+  args.push(`artifact-prefix=${artifactPrefix}`);
 
   return {
     command: EDITOR_OPEN_COMMAND,
     allowFailure: true,
     args,
     metadata: fixtureStepMetadata(fixture, 'editor-open', {
-      artifact_prefix: `files/browser/editor-open/${fixture.id}`,
+      artifact_prefix: artifactPrefix,
+      ...(surface?.id ? { surface_id: surface.id } : {}),
       ...(postId !== undefined ? { post_id: postId } : {}),
       ...(url !== undefined ? { url } : {}),
       ...(target !== undefined ? { target } : { target: DEFAULT_EDITOR_VALIDATION_TARGET }),

--- a/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -14,10 +14,11 @@ import { firstPresent, fixtureStepMetadata } from './shared.mjs';
 
 export function editorBlockValidationStep(input = {}) {
   const fixture = input.fixture || {};
+  const surface = input.surface || null;
 
   const postId = firstPresent([input.postId, input.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
-  const url = firstPresent([input.url, input.editorValidationUrl, input.editor_validation_url, fixture.editor_url, fixture.editorUrl]);
-  const target = firstPresent([input.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
+  const url = firstPresent([input.url, input.editorValidationUrl, input.editor_validation_url, surface?.url, fixture.editor_url, fixture.editorUrl]);
+  const target = firstPresent([input.target, surface?.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
 
   const args = [];
   if (postId !== undefined) {
@@ -44,6 +45,7 @@ export function editorBlockValidationStep(input = {}) {
     allowFailure: true,
     args,
     metadata: fixtureStepMetadata(fixture, 'editor', {
+      ...(surface?.id ? { surface_id: surface.id } : {}),
       ...(postId !== undefined ? { post_id: postId } : {}),
       ...(url !== undefined ? { url } : {}),
       ...(target !== undefined ? { target } : { target: DEFAULT_EDITOR_VALIDATION_TARGET }),

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -32,6 +32,7 @@ import { editorBlockValidationStep } from './editor-validation-step.mjs';
 import { visualParityCompareStep, normalizeVisualParityRecipeOptions } from './visual-parity-step.mjs';
 import { liveWpParityCaptureStep, liveWpParityEnabled } from './live-wp-parity-step.mjs';
 import { fixtureStepMetadata } from './shared.mjs';
+import { selectFixtureSurfaces } from './surfaces.mjs';
 
 const CAPABILITY_PLUGIN_PROVISIONING = {
   'commerce-products': [
@@ -185,21 +186,69 @@ export function buildFixtureMatrixRecipe(input = {}) {
     workflow: {
       steps: [
         importer.activationStep,
-        ...matrix.fixtures.flatMap((fixture) => [
-          ...fixturePluginProvisioningSteps(fixture),
-          importFixtureStep(fixture, commandArtifactsDirectory),
-          ...(editorOpenEnabled ? [editorOpenStep({ fixture, ...editorValidationOptions })] : []),
-          ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, ...editorValidationOptions })] : []),
-          ...(visualParityEnabled ? [visualParityDeterministicCssStep(fixture)] : []),
-          ...(visualParityEnabled ? [visualParityCompareStep({ fixture, ...visualParityRecipeOptions })] : []),
-          ...(liveWpParityCaptureEnabled ? [liveWpParityCaptureStep({ fixture, ...input })] : []),
-        ]),
+        ...matrix.fixtures.flatMap((fixture) => fixtureWorkflowSteps({
+          fixture,
+          input,
+          commandArtifactsDirectory,
+          editorOpenEnabled,
+          editorValidationEnabled,
+          editorValidationOptions,
+          visualParityEnabled,
+          visualParityRecipeOptions,
+          liveWpParityCaptureEnabled,
+        })),
       ],
     },
     artifacts: {
       directory: artifactsDirectory,
     },
   };
+}
+
+function fixtureWorkflowSteps(options) {
+  const {
+    fixture,
+    input,
+    commandArtifactsDirectory,
+    editorOpenEnabled,
+    editorValidationEnabled,
+    editorValidationOptions,
+    visualParityEnabled,
+    visualParityRecipeOptions,
+    liveWpParityCaptureEnabled,
+  } = options;
+  const surfaces = selectFixtureSurfaces(fixture, input);
+
+  return [
+    ...fixturePluginProvisioningSteps(fixture),
+    importFixtureStep(fixture, commandArtifactsDirectory),
+    ...surfaces.flatMap((surface, index) => [
+      ...(editorOpenEnabled ? [editorOpenStep({
+        fixture,
+        surface: editorSurface(surface),
+        ...editorValidationOptions,
+        artifactPrefix: editorArtifactPrefix(fixture, surface),
+      })] : []),
+      ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, surface: editorSurface(surface), ...editorValidationOptions })] : []),
+      ...(visualParityEnabled && index === 0 ? [visualParityDeterministicCssStep(fixture)] : []),
+      ...(visualParityEnabled ? [visualParityCompareStep({ fixture, surface, ...visualParityRecipeOptions })] : []),
+    ]),
+    ...(liveWpParityCaptureEnabled ? [liveWpParityCaptureStep({ fixture, ...input })] : []),
+  ];
+}
+
+function editorSurface(surface) {
+  if (surface.id === 'front-page') {
+    return surface;
+  }
+  return { ...surface, url: surface.target };
+}
+
+function editorArtifactPrefix(fixture, surface) {
+  if (surface.id === 'front-page') {
+    return `files/browser/editor-open/${fixture.id}`;
+  }
+  return `files/browser/editor-open/${fixture.id}/${surface.id}`;
 }
 
 function importFixtureStep(fixture, commandArtifactsDirectory) {

--- a/lib/fixture-matrix/steps/surfaces.mjs
+++ b/lib/fixture-matrix/steps/surfaces.mjs
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import path from 'node:path';
+
+/**
+ * Internal dependencies
+ */
+import { collectFixtureFiles, normalizeFixture } from '../fixtures.mjs';
+
+const FRONT_PAGE_SURFACE = Object.freeze({
+  id: 'front-page',
+  label: 'Front page',
+  target: 'front-page',
+  source_entry: 'index.html',
+  candidate_url: '/',
+});
+
+export function selectFixtureSurfaces(fixture, options = {}) {
+  const config = normalizeSurfaceCoverageOptions(options);
+  const surfaces = [FRONT_PAGE_SURFACE];
+  if (config.extraSurfaceCount <= 0) {
+    return surfaces;
+  }
+
+  const normalized = normalizeFixture(fixture);
+  const files = collectFixtureFiles(normalized.directory, options)
+    .filter((file) => isHtmlPath(file.relative_path))
+    .sort((left, right) => left.relative_path.localeCompare(right.relative_path))
+    .map((file) => surfaceFromHtmlPath(file.relative_path))
+    .filter((surface) => surface.id !== FRONT_PAGE_SURFACE.id);
+
+  return surfaces.concat(files.slice(0, config.extraSurfaceCount));
+}
+
+export function normalizeSurfaceCoverageOptions(input = {}) {
+  const raw = input.surfaceCoverage ?? input.surface_coverage ?? input.browserSurfaceCoverage ?? input.browser_surface_coverage;
+  if (raw === undefined || raw === null || raw === false || raw === 'false' || raw === '0' || raw === 0) {
+    return { extraSurfaceCount: 0 };
+  }
+
+  if (raw === true) {
+    return { extraSurfaceCount: positiveInteger(input.maxExtraSurfaces ?? input.max_extra_surfaces, 2) };
+  }
+
+  if (typeof raw === 'number' || (typeof raw === 'string' && /^\d+$/.test(raw.trim()))) {
+    return { extraSurfaceCount: positiveInteger(raw, 0) };
+  }
+
+  if (typeof raw === 'object') {
+    return {
+      extraSurfaceCount: positiveInteger(raw.maxExtraSurfaces ?? raw.max_extra_surfaces ?? raw.extraSurfaceCount ?? raw.extra_surface_count, 2),
+    };
+  }
+
+  return { extraSurfaceCount: 0 };
+}
+
+function surfaceFromHtmlPath(relativePath) {
+  const normalized = normalizeRoutePath(relativePath);
+  if (/^index\.html?$/i.test(normalized)) {
+    return FRONT_PAGE_SURFACE;
+  }
+  const extensionless = normalized.replace(/\.(?:html?)$/i, '');
+  const slugPath = extensionless.endsWith('/index') ? extensionless.slice(0, -6) : extensionless;
+  const slug = slugPath.split('/').filter(Boolean).join('-') || 'home';
+  const id = slug || 'front-page';
+  return {
+    id,
+    label: normalized,
+    target: `/${slug}/`,
+    source_entry: normalized,
+    candidate_url: `/${slug}/`,
+  };
+}
+
+function normalizeRoutePath(filePath) {
+  return path.posix.normalize(String(filePath || '').replace(/\\+/g, '/')).replace(/^\.\//, '').replace(/^\/+/, '');
+}
+
+function isHtmlPath(filePath) {
+  return /\.html?$/i.test(filePath);
+}
+
+function positiveInteger(value, fallback) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) {
+    return fallback;
+  }
+  return Math.floor(number);
+}

--- a/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -45,19 +45,21 @@ import { fixtureStepMetadata, resolveFixtureCandidateUrl } from './shared.mjs';
 // permalink.
 export function visualParityCompareStep(input = {}) {
   const fixture = input.fixture || {};
+  const surface = input.surface || null;
   const options = normalizeVisualParityRecipeOptions(input);
-  const entrypoint = options.sourceEntry || fixture.entrypoint || 'index.html';
+  const entrypoint = surface?.source_entry || options.sourceEntry || fixture.entrypoint || 'index.html';
   const sourceEntry = `${VISUAL_PARITY_SOURCE_SUBDIR}/${String(entrypoint).replace(/^\/+/, '')}`;
   const sourceUrl = input.sourceUrl
     || input.source_url
     || fixture.source_url
     || fixture.sourceUrl
     || `${options.sourceBaseUrl.replace(/\/+$/, '')}/${fixture.id || 'fixture'}/${sourceEntry}`;
-  const candidateUrl = resolveFixtureCandidateUrl(input, fixture, options.candidateUrl);
+  const candidateUrl = surface?.candidate_url || resolveFixtureCandidateUrl(input, fixture, options.candidateUrl);
+  const comparisonName = surface?.id && surface.id !== 'front-page' ? `${fixture.id || 'fixture'}--${surface.id}` : fixture.id || 'fixture';
   const matrix = {
     comparisons: [
       {
-        name: fixture.id || 'fixture',
+        name: comparisonName,
         sourceUrl,
         candidateUrl,
         sourceLabel: fixture.id ? `${fixture.id}-source` : 'source',
@@ -78,6 +80,7 @@ export function visualParityCompareStep(input = {}) {
       `matrix-json=${JSON.stringify(matrix)}`,
     ],
     metadata: fixtureStepMetadata(fixture, 'visual', {
+      ...(surface?.id ? { surface_id: surface.id } : {}),
       source_url: sourceUrl,
       candidate_url: candidateUrl,
     }),

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -51,6 +51,7 @@ import {
   liveWpParityEnabled,
   runLiveWpParity,
   normalizeLiveWpParityReport,
+  selectFixtureSurfaces,
   buildFixtureArtifact,
   createFixtureMatrix,
   editorBlockValidationStep,
@@ -3210,6 +3211,58 @@ test('recipe runs editor-validate-blocks against imported content after each imp
     editorValidation: false,
   });
   assert.equal(disabled.workflow.steps.some((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND), false);
+});
+
+test('fixture matrix browser surfaces default to front page and opt into bounded secondary pages', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-surface-fixture-'));
+  const fixtureDirectory = path.join(root, 'artist');
+  mkdirSync(path.join(fixtureDirectory, 'merch'), { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'fixture.json'), JSON.stringify({ id: 'artist', label: 'Artist' }));
+  writeFileSync(path.join(fixtureDirectory, 'index.html'), '<main>Home</main>');
+  writeFileSync(path.join(fixtureDirectory, 'contact.html'), '<main><form><input name="email"></form></main>');
+  writeFileSync(path.join(fixtureDirectory, 'merch', 'index.html'), '<main><button>Add to cart</button></main>');
+
+  const discoveredMatrix = createFixtureMatrix({ fixture_root: root, id: 'surface-recipe-test' });
+  const matrix = { ...discoveredMatrix, fixtures: discoveredMatrix.fixtures.filter((fixture) => fixture.id === 'artist'), count: 1 };
+  assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0]).map((surface) => surface.id), ['front-page']);
+  assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: { maxExtraSurfaces: 1 } }).map((surface) => surface.id), ['front-page', 'contact']);
+
+  const defaultRecipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+  });
+  assert.equal(defaultRecipe.workflow.steps.filter((step) => step.command === 'wordpress.editor-open').length, 1);
+  assert.equal(defaultRecipe.workflow.steps.filter((step) => step.command === 'wordpress.visual-compare').length, 1);
+
+  const multiSurfaceRecipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    surfaceCoverage: { maxExtraSurfaces: 2 },
+  });
+  const editorOpenSteps = multiSurfaceRecipe.workflow.steps.filter((step) => step.command === 'wordpress.editor-open');
+  const editorValidationSteps = multiSurfaceRecipe.workflow.steps.filter((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND);
+  const visualSteps = multiSurfaceRecipe.workflow.steps.filter((step) => step.command === 'wordpress.visual-compare');
+
+  assert.equal(editorOpenSteps.length, 3);
+  assert.equal(editorValidationSteps.length, 3);
+  assert.equal(visualSteps.length, 3);
+  assert.ok(editorOpenSteps[0].args.includes('artifact-prefix=files/browser/editor-open/artist'));
+  assert.ok(editorOpenSteps[1].args.includes('url=/contact/'));
+  assert.ok(editorOpenSteps[1].args.includes('artifact-prefix=files/browser/editor-open/artist/contact'));
+  assert.ok(editorOpenSteps[2].args.includes('url=/merch/'));
+  assert.ok(editorOpenSteps[2].args.includes('artifact-prefix=files/browser/editor-open/artist/merch'));
+  assert.ok(editorValidationSteps[1].args.includes('url=/contact/'));
+
+  const contactComparison = visualCompareMatrixComparison(visualSteps[1]);
+  assert.equal(contactComparison.name, 'artist--contact');
+  assert.equal(contactComparison.sourceUrl, 'file:///tmp/artifacts/artist/source/contact.html');
+  assert.equal(contactComparison.candidateUrl, '/contact/');
+  const merchComparison = visualCompareMatrixComparison(visualSteps[2]);
+  assert.equal(merchComparison.name, 'artist--merch');
+  assert.equal(merchComparison.sourceUrl, 'file:///tmp/artifacts/artist/source/merch/index.html');
+  assert.equal(merchComparison.candidateUrl, '/merch/');
 });
 
 test('--no-editor-validation skips the editor browser step while keeping native-rate + findings', () => {


### PR DESCRIPTION
## Summary
- add an opt-in bounded surface selector for fixture-matrix browser evidence
- preserve default front-page editor-open/editor-validation/visual-compare behavior
- name secondary editor and visual artifacts by fixture plus surface, e.g. artist/contact and artist--contact

## Testing
- npm run test:fixture-matrix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the opt-in surface selector, updated recipe step composition, and added fixture-matrix tests under Chris's direction.