### PR TITLE
Classify missing fixture evidence separately

### DIFF
--- a/docs/gutenberg-incompatibility-registry.md
+++ b/docs/gutenberg-incompatibility-registry.md
@@ -39,6 +39,7 @@ The registry also emits `fixture_decisions[]` so acceptance decisions do not req
 - `intentional_runtime_patterns`: runtime islands preserved by design.
 - `visual_only_patterns`: frontend visual drift patterns that do not imply invalid blocks or lost editability by themselves.
 - `solved_candidate_reason`: present only when the fixture passed, editor validation passed, no HTML/runtime islands remain, and no registry limitation pattern is attached.
+- `acceptance_status`: `solved_candidate`, `visual_only_blocker`, `editor_blocker`, `native_editability_blocker`, `provider_runtime_blocker`, or `evidence_gap`. Missing frontend/editor/block-validity evidence is `evidence_gap`; `provider_runtime_blocker` is reserved for failures where the provider/runtime blocked evidence capture.
 
 ## Seeded Generic Pattern Keys
 

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -413,8 +413,11 @@ function editorCanvasStatusForFixture(fixture, fixtureFindings, editorRiskPatter
 }
 
 function acceptanceDecision({ frontendVisualStatus, editorCanvasStatus, editorValidityStatus, nativeEditabilityStatus, visibleRuntimeOrHtmlIslands, gutenbergGapPatterns, transformerGapPatterns, visualOnlyPatterns, runtimeIslandPatterns, editorRiskPatterns }) {
-  if (frontendVisualStatus === 'provider_runtime_blocked' || editorCanvasStatus === 'provider_runtime_blocked' || frontendVisualStatus === 'not_evaluated' || editorCanvasStatus === 'not_captured' || editorValidityStatus === 'not_validated') {
-    return { solved_candidate: false, status: 'provider_runtime_blocker', reason: 'required frontend visual, editor canvas, or block-validity evidence is missing or blocked by the provider/runtime' };
+  if (frontendVisualStatus === 'provider_runtime_blocked' || editorCanvasStatus === 'provider_runtime_blocked') {
+    return { solved_candidate: false, status: 'provider_runtime_blocker', reason: 'required frontend visual or editor canvas evidence is blocked by the provider/runtime' };
+  }
+  if (frontendVisualStatus === 'not_evaluated' || editorCanvasStatus === 'not_captured' || editorValidityStatus === 'not_validated') {
+    return { solved_candidate: false, status: 'evidence_gap', reason: 'required frontend visual, editor canvas, or block-validity evidence is missing' };
   }
   if (editorValidityStatus === 'invalid_blocks' || editorCanvasStatus === 'diverged' || editorRiskPatterns.length > 0) {
     return { solved_candidate: false, status: 'editor_blocker', reason: 'editor canvas or block validation evidence shows imported content is not reliably visible and valid in the editor' };

--- a/registry/gutenberg-incompatibility-registry.schema.json
+++ b/registry/gutenberg-incompatibility-registry.schema.json
@@ -53,7 +53,7 @@
     "editor_canvas_status": { "enum": ["visible", "diverged", "not_captured", "provider_runtime_blocked"] },
     "editor_validity_status": { "enum": ["valid", "invalid_blocks", "not_validated"] },
     "native_editability_status": { "enum": ["native_editable", "editor_invalid", "custom_block_candidate", "runtime_island_preserved", "html_islands_or_transformer_gap", "unknown"] },
-    "acceptance_status": { "enum": ["solved_candidate", "visual_only_blocker", "editor_blocker", "native_editability_blocker", "provider_runtime_blocker"] },
+    "acceptance_status": { "enum": ["solved_candidate", "visual_only_blocker", "editor_blocker", "native_editability_blocker", "provider_runtime_blocker", "evidence_gap"] },
     "top_pattern": {
       "type": "object",
       "required": ["pattern_key", "classification", "fixture_count", "finding_count", "impact_score"],

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -226,6 +226,13 @@ test('gutenberg incompatibility registry separates fixture decision axes', () =>
         fixture_id: 'runtime-provider',
         status: 'failed',
       },
+      {
+        fixture_id: 'cv-missing-editor-evidence',
+        status: 'passed',
+        visual_parity_artifacts: { comparison: { mismatch_ratio: 0 } },
+        block_composition: { block_total: 8, native_block_count: 8, core_html_block_count: 0 },
+        editor_quality: { editor_validated_block_total: 8, editor_invalid_count: 0, core_html_block_count: 0 },
+      },
     ],
     findings: [
       {
@@ -280,6 +287,10 @@ test('gutenberg incompatibility registry separates fixture decision axes', () =>
   assert.equal(decisions.saas.acceptance_status, 'editor_blocker');
   assert.equal(decisions['runtime-provider'].frontend_visual_status, 'provider_runtime_blocked');
   assert.equal(decisions['runtime-provider'].acceptance_status, 'provider_runtime_blocker');
+  assert.equal(decisions['cv-missing-editor-evidence'].frontend_visual_status, 'passed');
+  assert.equal(decisions['cv-missing-editor-evidence'].editor_canvas_status, 'not_captured');
+  assert.equal(decisions['cv-missing-editor-evidence'].native_editability_status, 'native_editable');
+  assert.equal(decisions['cv-missing-editor-evidence'].acceptance_status, 'evidence_gap');
   assert.equal(patterns['static-form'].limitation_type, 'real_gutenberg_gap');
   assert.equal(patterns['visual-position_offset'].limitation_type, 'visual_only_style_drift');
   assert.equal(registry.summary.fixture_decision_counts.solved_candidate, 1);
@@ -287,7 +298,9 @@ test('gutenberg incompatibility registry separates fixture decision axes', () =>
   assert.equal(registry.summary.fixture_decision_counts.editor_blocker, 1);
   assert.equal(registry.summary.fixture_decision_counts.native_editability_blocker, 1);
   assert.equal(registry.summary.fixture_decision_counts.provider_runtime_blocker, 1);
+  assert.equal(registry.summary.fixture_decision_counts.evidence_gap, 1);
   assert.deepEqual(registry.summary.fixture_decision_groups, {
+    evidence_gap: ['cv-missing-editor-evidence'],
     editor_blocker: ['saas'],
     native_editability_blocker: ['artist'],
     provider_runtime_blocker: ['runtime-provider'],


### PR DESCRIPTION
## Summary
- Add an `evidence_gap` acceptance status for missing frontend/editor/block-validity evidence.
- Keep `provider_runtime_blocker` reserved for actual provider/runtime-blocked evidence capture.
- Cover CV-like native-editable fixtures that lack editor canvas capture so they are not mislabeled as provider/runtime blockers.

## Tests
- `npm run test:fixture-matrix`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed the fixture acceptance status bug, drafted the code/test/docs change, and ran verification.
