### PR TITLE
Materialize block theme templates from artifacts

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -144,6 +144,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			),
 			'generated_theme'         => array(
 				'document_metadata' => array(),
+				'templates'         => array(),
 				'template_parts'    => array(),
 				'block_documents'   => array(),
 				'freeform_blocks'   => array(),

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -93,6 +93,12 @@ class Static_Site_Importer_Theme_Generator {
 		if ( is_wp_error( $compiled ) ) {
 			return $compiled;
 		}
+		if ( isset( $artifact['files'] ) && is_array( $artifact['files'] ) ) {
+			if ( ! isset( $compiled['artifacts'] ) || ! is_array( $compiled['artifacts'] ) ) {
+				$compiled['artifacts'] = array();
+			}
+			$compiled['artifacts']['source_files'] = $artifact['files'];
+		}
 		$document_pages   = self::website_artifact_source_pages( $compiled );
 		if ( is_wp_error( $document_pages ) ) {
 			return $document_pages;
@@ -198,8 +204,19 @@ class Static_Site_Importer_Theme_Generator {
 			$stylesheet_writes,
 			Static_Site_Importer_Theme_Materializer::base_theme_writes( $theme_dir, $theme_slug, $theme_name, $materialized['css'], $has_header_part, $has_footer_part, $materialized['scripts'], $materialized['stylesheets'], $artifacts )
 		);
+		$template_writes = self::template_artifact_writes( $theme_dir, $artifacts );
+		if ( is_wp_error( $template_writes ) ) {
+			return $template_writes;
+		}
+		$writes = array_merge( $writes, $template_writes );
 		$writes = array_merge( $writes, $template_part_writes );
 		self::analyze_imported_page_content_documents( $document_pages, $page_artifacts['contents'] );
+
+		$source_template_writes = Static_Site_Importer_Theme_Materializer::source_document_template_writes( $theme_dir, $page_artifacts['contents'] );
+		$writes                 = array_merge( $writes, $source_template_writes['writes'] );
+		foreach ( $source_template_writes['reports'] as $report ) {
+			self::$conversion_report['generated_theme']['templates'][] = $report;
+		}
 
 		self::record_source_documents_summary( $artifacts['documents'] ?? array(), $document_pages, $page_ids, $permalinks );
 		foreach ( array_keys( $page_artifacts['patterns'] ) as $filename ) {
@@ -2048,6 +2065,26 @@ class Static_Site_Importer_Theme_Generator {
 
 		foreach ( $result['reports'] as $report ) {
 			self::$conversion_report['generated_theme']['template_parts'][] = $report;
+		}
+
+		return $result['writes'];
+	}
+
+	/**
+	 * Normalize full template artifacts into generated theme writes.
+	 *
+	 * @param string              $theme_dir Theme directory.
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
+	 * @return array<string,string>|WP_Error Absolute write paths keyed to serialized block markup.
+	 */
+	private static function template_artifact_writes( string $theme_dir, array $artifacts ) {
+		$result = Static_Site_Importer_Theme_Materializer::template_artifact_writes( $theme_dir, $artifacts );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		foreach ( $result['reports'] as $report ) {
+			self::$conversion_report['generated_theme']['templates'][] = $report;
 		}
 
 		return $result['writes'];

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -109,6 +109,9 @@ class Static_Site_Importer_Theme_Materializer {
 		}
 
 		$files       = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
+		if ( isset( $artifacts['source_files'] ) && is_array( $artifacts['source_files'] ) ) {
+			$files = array_merge( $files, $artifacts['source_files'] );
+		}
 		$css         = array();
 		$assets      = array();
 		$diagnostics = array();
@@ -273,6 +276,14 @@ class Static_Site_Importer_Theme_Materializer {
 			}
 		}
 
+		$supplemental = self::materialize_supplemental_artifact_file_assets( $theme_dir, $theme_uri, $artifacts, $assets, $order, $write_files );
+		if ( is_wp_error( $supplemental ) ) {
+			return $supplemental;
+		}
+		foreach ( $supplemental['diagnostics'] as $diagnostic ) {
+			$diagnostics[] = $diagnostic;
+		}
+
 		$font_stylesheets = self::materialize_font_materialization_stylesheets( $theme_dir, $theme_uri, $site, $assets, $order, $write_files );
 		if ( is_wp_error( $font_stylesheets ) ) {
 			return $font_stylesheets;
@@ -287,6 +298,81 @@ class Static_Site_Importer_Theme_Materializer {
 			'stylesheets' => $stylesheets,
 			'diagnostics' => $diagnostics,
 		);
+	}
+
+	/**
+	 * Materialize payload-bearing artifact files omitted from a native asset plan.
+	 *
+	 * Some generators emit CSS that references artifact-local files while their
+	 * native materialization plan only lists assets observed in DOM nodes. SSI owns
+	 * the final theme filesystem, so it keeps those file payloads available and in
+	 * the asset map for CSS URL rewriting.
+	 *
+	 * @param string                            $theme_dir   Theme directory.
+	 * @param string                            $theme_uri   Theme URI.
+	 * @param array<string,mixed>               $artifacts   WordPress artifacts from Blocks Engine.
+	 * @param array<string,array<string,mixed>> $assets      Materialized asset rows keyed by source path.
+	 * @param int                               $order       Current materialization order.
+	 * @param bool                              $write_files Whether to write materialized asset files.
+	 * @return array{diagnostics:array<int,array<string,mixed>>}|WP_Error
+	 */
+	private static function materialize_supplemental_artifact_file_assets( string $theme_dir, string $theme_uri, array $artifacts, array &$assets, int &$order, bool $write_files = true ) {
+		$files       = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
+		$diagnostics = array();
+
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$relative = self::normalize_artifact_materialization_path( isset( $file['path'] ) && is_scalar( $file['path'] ) ? (string) $file['path'] : '' );
+			if ( '' === $relative || isset( $assets[ $relative ] ) ) {
+				continue;
+			}
+
+			$lower = strtolower( $relative );
+			$kind  = isset( $file['kind'] ) && is_scalar( $file['kind'] ) ? (string) $file['kind'] : '';
+			if ( 'html' === $kind || 'css' === $kind || 'js' === $kind || str_ends_with( $lower, '.html' ) || str_ends_with( $lower, '.htm' ) || str_ends_with( $lower, '.css' ) || str_ends_with( $lower, '.js' ) ) {
+				continue;
+			}
+
+			$content = self::materialization_plan_asset_content( $file, $relative );
+			if ( is_wp_error( $content ) ) {
+				return $content;
+			}
+
+			$retention = self::source_retention_policy( $file, $relative, 'website_artifact.files' );
+			if ( isset( $retention['diagnostic'] ) ) {
+				$diagnostics[] = $retention['diagnostic'];
+			}
+
+			$target_relative = 'assets/materialized/' . $relative;
+			$target          = trailingslashit( $theme_dir ) . $target_relative;
+			if ( $write_files ) {
+				$dir = dirname( $target );
+				if ( ! wp_mkdir_p( $dir ) ) {
+					return new WP_Error( 'static_site_importer_supplemental_artifact_asset_mkdir_failed', sprintf( 'Failed to create supplemental artifact asset directory: %s', $dir ) );
+				}
+
+				$result = self::write_file( $target, $content );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+			}
+
+			++$order;
+			$assets[ $relative ] = self::materialization_plan_asset_report(
+				array_merge( $file, array( 'origin' => 'website_artifact.files' ) ),
+				$relative,
+				trailingslashit( $theme_uri ) . $target_relative,
+				$target_relative,
+				self::mime_type( $target ),
+				$order,
+				$retention
+			);
+		}
+
+		return array( 'diagnostics' => $diagnostics );
 	}
 
 	/**
@@ -794,6 +880,195 @@ class Static_Site_Importer_Theme_Materializer {
 			'generated'          => ! empty( $template_part['generated'] ),
 			'source_paths'       => $source_paths,
 			'source_hash'        => isset( $template_part['source_hash'] ) && is_scalar( $template_part['source_hash'] ) ? (string) $template_part['source_hash'] : '',
+			'block_markup_bytes' => strlen( $markup ),
+			'block_markup_hash'  => hash( 'sha256', $markup ),
+		);
+	}
+
+	/**
+	 * Normalize compiler-declared WordPress template artifacts into generated theme writes.
+	 *
+	 * @param string              $theme_dir Theme directory.
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
+	 * @return array{writes:array<string,string>,reports:array<int,array<string,mixed>>}|WP_Error Absolute write paths and report rows.
+	 */
+	public static function template_artifact_writes( string $theme_dir, array $artifacts ) {
+		$templates = self::template_artifacts_from_materialization_plan( $artifacts );
+		if ( is_wp_error( $templates ) ) {
+			return $templates;
+		}
+
+		$writes  = array();
+		$reports = array();
+		foreach ( $templates as $template ) {
+			if ( ! is_array( $template ) ) {
+				return new WP_Error( 'static_site_importer_template_invalid', 'Template artifacts must be arrays.' );
+			}
+
+			$relative = self::template_artifact_relative_path( $template );
+			if ( '' === $relative ) {
+				return new WP_Error( 'static_site_importer_template_unsupported', 'Template artifacts must resolve to a safe templates/*.html path.' );
+			}
+
+			$markup = self::template_artifact_markup( $template );
+			if ( '' === trim( $markup ) ) {
+				return new WP_Error( 'static_site_importer_template_markup_empty', 'Template artifact block markup must not be empty.' );
+			}
+
+			$writes[ trailingslashit( $theme_dir ) . $relative ] = $markup;
+			$reports[] = self::template_artifact_report_payload( $relative, $template, $markup );
+		}
+
+		return array(
+			'writes'  => $writes,
+			'reports' => $reports,
+		);
+	}
+
+	/**
+	 * Build block template writes from conventional source document names.
+	 *
+	 * @param string               $theme_dir Theme directory.
+	 * @param array<string,string> $contents  Converted block markup keyed by source path.
+	 * @return array{writes:array<string,string>,reports:array<int,array<string,mixed>>}
+	 */
+	public static function source_document_template_writes( string $theme_dir, array $contents ): array {
+		$template_map = array(
+			'404'            => '404',
+			'archive'        => 'archive',
+			'search'         => 'search',
+			'search-results' => 'search',
+		);
+		$writes       = array();
+		$reports      = array();
+
+		foreach ( $contents as $source_path => $content ) {
+			$slug          = sanitize_title( preg_replace( '/\.[^.]+$/', '', basename( (string) $source_path ) ) ?? '' );
+			$template_slug = $template_map[ $slug ] ?? '';
+			if ( '' === $template_slug || '' === trim( (string) $content ) ) {
+				continue;
+			}
+
+			$relative            = 'templates/' . $template_slug . '.html';
+			$writes[ trailingslashit( $theme_dir ) . $relative ] = trim( (string) $content ) . "\n";
+			$reports[]           = array(
+				'path'              => $relative,
+				'slug'              => $template_slug,
+				'source'            => 'source_document',
+				'source_path'       => (string) $source_path,
+				'block_count'       => substr_count( (string) $content, '<!-- wp:' ),
+				'core_html_blocks'  => substr_count( (string) $content, '<!-- wp:html' ),
+			);
+		}
+
+		return array(
+			'writes'  => $writes,
+			'reports' => $reports,
+		);
+	}
+
+	/**
+	 * Read generic WordPress template writes from a Blocks Engine materialization plan.
+	 *
+	 * @param array<string,mixed> $artifacts WordPress artifacts from the transformer adapter.
+	 * @return array<int,array<string,mixed>>|WP_Error Template artifacts.
+	 */
+	private static function template_artifacts_from_materialization_plan( array $artifacts ) {
+		$site = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
+		if ( 'blocks-engine/php-transformer/materialization-plan/v1' !== (string) ( $site['schema'] ?? '' ) ) {
+			return array();
+		}
+
+		$template_rows = array();
+		if ( array_key_exists( 'template_writes', $site ) ) {
+			if ( ! is_array( $site['template_writes'] ) ) {
+				return new WP_Error( 'static_site_importer_materialization_plan_template_writes_invalid', 'Blocks Engine materialization_plan.template_writes must be an array.' );
+			}
+
+			foreach ( $site['template_writes'] as $write ) {
+				if ( ! is_array( $write ) ) {
+					return new WP_Error( 'static_site_importer_materialization_plan_template_write_invalid', 'Blocks Engine template write entries must be arrays.' );
+				}
+
+				if ( 'wp_template' !== (string) ( $write['type'] ?? '' ) ) {
+					continue;
+				}
+
+				$template_rows[] = $write;
+			}
+		}
+
+		if ( array_key_exists( 'templates', $site ) ) {
+			if ( ! is_array( $site['templates'] ) ) {
+				return new WP_Error( 'static_site_importer_materialization_plan_templates_invalid', 'Blocks Engine materialization_plan.templates must be an array.' );
+			}
+
+			foreach ( $site['templates'] as $template ) {
+				if ( ! is_array( $template ) ) {
+					return new WP_Error( 'static_site_importer_materialization_plan_template_invalid', 'Blocks Engine template entries must be arrays.' );
+				}
+
+				$template_rows[] = $template;
+			}
+		}
+
+		return $template_rows;
+	}
+
+	/**
+	 * Resolve a template artifact to a generated theme template path.
+	 *
+	 * @param array<string,mixed> $template Template artifact.
+	 * @return string Relative theme path, or empty string when unsupported.
+	 */
+	private static function template_artifact_relative_path( array $template ): string {
+		foreach ( array( 'path', 'theme_path', 'file' ) as $key ) {
+			if ( isset( $template[ $key ] ) && is_scalar( $template[ $key ] ) ) {
+				$relative = self::normalize_artifact_materialization_path( (string) $template[ $key ] );
+				if ( preg_match( '#^templates/[A-Za-z0-9._-]+\.html$#', $relative ) ) {
+					return $relative;
+				}
+			}
+		}
+
+		$slug = isset( $template['slug'] ) && is_scalar( $template['slug'] ) ? sanitize_title( (string) $template['slug'] ) : '';
+		if ( '' === $slug ) {
+			return '';
+		}
+
+		return 'templates/' . $slug . '.html';
+	}
+
+	/**
+	 * Extract serialized block markup from a template artifact.
+	 *
+	 * @param array<string,mixed> $template Template artifact.
+	 * @return string Serialized block markup.
+	 */
+	private static function template_artifact_markup( array $template ): string {
+		foreach ( array( 'block_markup', 'content', 'markup' ) as $key ) {
+			if ( isset( $template[ $key ] ) && is_scalar( $template[ $key ] ) ) {
+				return (string) $template[ $key ];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build a compact report row for a materialized template artifact.
+	 *
+	 * @param string              $path     Relative generated theme path.
+	 * @param array<string,mixed> $template Template artifact.
+	 * @param string              $markup   Serialized block markup.
+	 * @return array<string,mixed>
+	 */
+	private static function template_artifact_report_payload( string $path, array $template, string $markup ): array {
+		return array(
+			'path'               => $path,
+			'slug'               => isset( $template['slug'] ) && is_scalar( $template['slug'] ) ? (string) $template['slug'] : preg_replace( '#^templates/(.+)\.html$#', '$1', $path ),
+			'title'              => isset( $template['title'] ) && is_scalar( $template['title'] ) ? (string) $template['title'] : '',
+			'source_path'        => isset( $template['source_path'] ) && is_scalar( $template['source_path'] ) ? (string) $template['source_path'] : '',
 			'block_markup_bytes' => strlen( $markup ),
 			'block_markup_hash'  => hash( 'sha256', $markup ),
 		);

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -318,6 +318,9 @@ class Static_Site_Importer_Theme_Materializer {
 	 */
 	private static function materialize_supplemental_artifact_file_assets( string $theme_dir, string $theme_uri, array $artifacts, array &$assets, int &$order, bool $write_files = true ) {
 		$files       = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
+		if ( isset( $artifacts['source_files'] ) && is_array( $artifacts['source_files'] ) ) {
+			$files = array_merge( $files, $artifacts['source_files'] );
+		}
 		$diagnostics = array();
 
 		foreach ( $files as $file ) {

--- a/tests/smoke-theme-materializer-dry-run.php
+++ b/tests/smoke-theme-materializer-dry-run.php
@@ -285,6 +285,129 @@ $assert( '960px' === ( $token_theme_json['settings']['layout']['contentSize'] ??
 $assert( array( 'px', 'rem', '%' ) === ( $token_theme_json['settings']['spacing']['units'] ?? array() ), 'materialization-plan-theme-json-fragment-merges-settings' );
 $assert( 'var(--wp--preset--color--brand-primary)' === ( $token_theme_json['styles']['elements']['link']['color']['text'] ?? '' ), 'materialization-plan-theme-json-fragment-merges-styles' );
 
+$supplemental_assets = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files(
+	$theme_dir,
+	'https://example.test/wp-content/themes/imported',
+	array(
+		'site'  => array(
+			'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'assets' => array(
+				array(
+					'path'    => 'style.css',
+					'kind'    => 'css',
+					'content' => '.hero { background-image: url("images/hero.png"); }',
+				),
+			),
+		),
+		'files' => array(
+			array(
+				'path'           => 'images/hero.png',
+				'kind'           => 'image',
+				'content_base64' => base64_encode( 'png-bytes' ),
+			),
+		),
+	),
+	false
+);
+$assert( ! is_wp_error( $supplemental_assets ), 'supplemental-artifact-assets-succeed', is_wp_error( $supplemental_assets ) ? $supplemental_assets->get_error_message() : '' );
+$assert( isset( $supplemental_assets['assets']['images/hero.png'] ), 'supplemental-artifact-asset-added-to-asset-map' );
+$assert( str_contains( $supplemental_assets['css'] ?? '', 'assets/materialized/images/hero.png' ), 'supplemental-artifact-asset-rewrites-css-url' );
+
+$template_writes = Static_Site_Importer_Theme_Materializer::template_artifact_writes(
+	$theme_dir,
+	array(
+		'site' => array(
+			'schema'          => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'template_writes' => array(
+				array(
+					'type'    => 'wp_template',
+					'slug'    => 'archive',
+					'content' => '<!-- wp:query --><!-- wp:post-template --><!-- wp:post-title /--><!-- /wp:post-template --><!-- /wp:query -->',
+				),
+				array(
+					'type'    => 'wp_template',
+					'path'    => 'templates/404.html',
+					'content' => '<!-- wp:heading {"level":1} --><h1>Not found</h1><!-- /wp:heading -->',
+				),
+			),
+		),
+	)
+);
+$assert( ! is_wp_error( $template_writes ), 'template-artifact-writes-succeed', is_wp_error( $template_writes ) ? $template_writes->get_error_message() : '' );
+$assert( isset( $template_writes['writes'][ $theme_dir . '/templates/archive.html' ] ), 'archive-template-write-materializes-from-slug' );
+$assert( isset( $template_writes['writes'][ $theme_dir . '/templates/404.html' ] ), '404-template-write-materializes-from-path' );
+$assert( 'templates/archive.html' === ( $template_writes['reports'][0]['path'] ?? '' ), 'template-write-report-records-path' );
+
+$source_template_writes = Static_Site_Importer_Theme_Materializer::source_document_template_writes(
+	$theme_dir,
+	array(
+		'archive.html'        => '<!-- wp:query --><!-- wp:post-template --><!-- wp:post-title /--><!-- /wp:post-template --><!-- /wp:query -->',
+		'search-results.html' => '<!-- wp:search /-->',
+		'about.html'          => '<!-- wp:paragraph --><p>About</p><!-- /wp:paragraph -->',
+	)
+);
+$assert( isset( $source_template_writes['writes'][ $theme_dir . '/templates/archive.html' ] ), 'archive-source-document-materializes-template' );
+$assert( isset( $source_template_writes['writes'][ $theme_dir . '/templates/search.html' ] ), 'search-results-source-document-materializes-search-template' );
+$assert( ! isset( $source_template_writes['writes'][ $theme_dir . '/templates/about.html' ] ), 'ordinary-source-document-does-not-materialize-template' );
+
+$supplemental_asset = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files(
+	$theme_dir,
+	'https://example.test/wp-content/themes/imported',
+	array(
+		'site'  => array(
+			'schema' => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'assets' => array(
+				array(
+					'path'    => 'style.css',
+					'kind'    => 'css',
+					'content' => '.hero{background-image:url("assets/hero.jpg")}',
+				),
+			),
+		),
+		'files' => array(
+			array(
+				'path'           => 'assets/hero.jpg',
+				'kind'           => 'image',
+				'content_base64' => base64_encode( 'fake-jpeg' ),
+			),
+		),
+	),
+	false
+);
+$assert( ! is_wp_error( $supplemental_asset ), 'supplemental-artifact-asset-succeeds', is_wp_error( $supplemental_asset ) ? $supplemental_asset->get_error_message() : '' );
+$assert( isset( $supplemental_asset['assets']['assets/hero.jpg'] ), 'supplemental-artifact-asset-is-reported' );
+$assert( str_contains( (string) ( $supplemental_asset['css'] ?? '' ), 'assets/materialized/assets/hero.jpg' ), 'supplemental-artifact-asset-rewrites-css-url' );
+
+$unsafe_template_writes = Static_Site_Importer_Theme_Materializer::template_artifact_writes(
+	$theme_dir,
+	array(
+		'site' => array(
+			'schema'          => 'blocks-engine/php-transformer/materialization-plan/v1',
+			'template_writes' => array(
+				array(
+					'type'    => 'wp_template',
+					'path'    => '../404.html',
+					'content' => '<!-- wp:post-content /-->',
+				),
+			),
+		),
+	)
+);
+$assert( is_wp_error( $unsafe_template_writes ), 'unsafe-template-path-errors' );
+$assert( 'static_site_importer_template_unsupported' === ( is_wp_error( $unsafe_template_writes ) ? $unsafe_template_writes->get_error_code() : '' ), 'unsafe-template-path-error-code' );
+
+$source_template_writes = Static_Site_Importer_Theme_Materializer::source_document_template_writes(
+	$theme_dir,
+	array(
+		'archive.html' => '<!-- wp:query --><!-- wp:post-template --><!-- wp:post-title /--><!-- /wp:post-template --><!-- /wp:query -->',
+		'404.html'     => '<!-- wp:heading {"level":1} --><h1>Not found</h1><!-- /wp:heading -->',
+		'index.html'   => '<!-- wp:post-content /-->',
+	)
+);
+$assert( isset( $source_template_writes['writes'][ $theme_dir . '/templates/archive.html' ] ), 'source-archive-document-materializes-archive-template' );
+$assert( isset( $source_template_writes['writes'][ $theme_dir . '/templates/404.html' ] ), 'source-404-document-materializes-404-template' );
+$assert( ! isset( $source_template_writes['writes'][ $theme_dir . '/templates/index.html' ] ), 'source-index-document-does-not-override-base-index-template' );
+
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
 	exit( 1 );


### PR DESCRIPTION
## Summary
- Materialize compiler-declared WordPress template writes into generated block themes, including archive and 404 templates.
- Materialize conventional source documents such as archive.html, search-results.html, and 404.html as real block templates instead of only page-specific templates.
- Keep supplemental payload-bearing artifact files available for CSS URL rewriting when native asset plans omit them, including raw source files preserved outside the compiled asset subset.
- Report generated templates in the import diagnostics payload.

## TT5 Community evidence
- Blocks Engine source: fresh `origin/trunk` at `be3575d9` (`Extract fallback finding normalization (#526)`), which includes PR #520 (`c11e8d8e`).
- Generated artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/tt5-ssi-20260706/artifact`.
- Transformer result: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/tt5-ssi-20260706/transform-result.json`.
- Transformer summary: `success_with_warnings`, 30 pages, 83 assets, 114 files.
- Before SSI validation: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/tt5-ssi-20260706/ssi-validation-before.json`.
- Before result: 32 theme HTML files, 37 JPGs, 2 PNGs, 38 SVGs, 0 generated template reports, 5 unresolved source-relative CSS asset URLs.
- After SSI validation: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/tt5-ssi-20260706/ssi-validation-after-final.json`.
- After import report: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/tt5-ssi-20260706/ssi-validation-after-final-artifacts/import-report.json`.
- After result: 35 theme HTML files, 43 JPGs, 2 PNGs, 38 SVGs, 3 generated template reports (`templates/404.html`, `templates/search.html`, `templates/archive.html`), 0 unresolved source-relative CSS asset URLs.
- Generated-artifact parity report: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/tt5-ssi-20260706/parity-report/tt5-community-fig-intent-parity.json` and `.md` sibling.
- Parity report status: failed with 2 generated-artifact regressions. The WP import path is no longer blocked by missing template files or broken CSS asset URLs.

## Remaining blockers
- TT5 import quality still fails on Blocks Engine-owned `core/html` fallback warnings: 109 before, 120 after because the new 404/search/archive templates are now also validated and counted.
- The fallback warnings are native conversion/editor-fidelity work in Blocks Engine/php-transformer, not an SSI theme materialization failure.
- `tools/fig-intent-parity-report.mjs --wp-root ...` timed out locally after 120s; the artifact-only parity report and SSI current-runtime validation artifacts were captured instead.

## Testing
- `php tests/smoke-theme-materializer-dry-run.php`
- `php tests/smoke-transformer-adapter.php`
- `php -l includes/class-static-site-importer-theme-materializer.php`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `node --test tools/fig-intent-parity-report.test.mjs`
- `npm run test:fixture-matrix`
- Headless current-runtime import verification against the FSE Pilot generated website artifact; generated theme now includes `templates/archive.html`. Remaining failures are Blocks Engine `core/html` fallback warnings for SVG/form/input conversion, not missing SSI theme files.
- Headless current-runtime import verification against the fresh TT5 Community artifact from Blocks Engine trunk after PR #520.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the generic SSI materialization changes, ran targeted smoke tests and headless import verification, generated TT5 evidence, and drafted this PR description.
