### PR TITLE
Stabilize fixture matrix surface coverage

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -179,6 +179,7 @@ export async function runFixtureMatrix(options) {
     staticSiteImporterSlug: options.staticSiteImporterSlug,
     dependencyOverrides,
     ...editorValidationRecipeInput(options),
+    ...surfaceCoverageRecipeInput(options),
     ...visualParityRecipeInput(options),
     ...liveWpParityRecipeInput(options),
   });
@@ -283,6 +284,8 @@ export async function runFixtureMatrix(options) {
       performance,
       artifact_bytes: artifactBytes,
       source_staging: written.metadata?.source_staging,
+      surface_coverage: recipe.metadata?.surface_coverage,
+      runtime_cost_warnings: recipe.metadata?.runtime_cost_warnings || [],
     },
     ...(runtime?.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
     result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
@@ -323,6 +326,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     staticSiteImporterSlug: options.staticSiteImporterSlug,
     dependencyOverrides: prepareDependencyOverrides(options),
     ...editorValidationRecipeInput(options),
+    ...surfaceCoverageRecipeInput(options),
     ...visualParityRecipeInput(options),
     ...liveWpParityRecipeInput(options),
   });
@@ -993,6 +997,8 @@ function optionsFromEnv(env = process.env) {
     visualParitySourceBaseUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL,
     visualParityWaitFor: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_WAIT_FOR || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_WAIT_FOR,
     visualParityDurationMs: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_DURATION_MS || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_DURATION_MS,
+    surfaceCoverage: benchEnv.SSI_FIXTURE_MATRIX_SURFACE_COVERAGE || env.SSI_FIXTURE_MATRIX_SURFACE_COVERAGE,
+    maxExtraSurfaces: benchEnv.SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES || env.SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES,
     minNativeRate: benchEnv.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE || env.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE,
   };
 }
@@ -1004,6 +1010,13 @@ function optionsFromEnv(env = process.env) {
 function editorValidationRecipeInput(options) {
   return {
     editorValidation: options.editorValidation !== false,
+  };
+}
+
+function surfaceCoverageRecipeInput(options) {
+  return {
+    surfaceCoverage: options.surfaceCoverage,
+    maxExtraSurfaces: options.maxExtraSurfaces,
   };
 }
 
@@ -1153,6 +1166,7 @@ Options:
   --wordpress-version <version>      WP Codebox WordPress version. Defaults to latest.
   --batch-size <n>                   Fixtures per WP Codebox run when --run is used. Defaults to 10.
   --concurrency <n>                  Batches (WP Codebox sandboxes) to run in parallel. Defaults to ${DEFAULT_BATCH_CONCURRENCY}, hard-capped at ${MAX_BATCH_CONCURRENCY}.
+  --surface-coverage <n>             Opt into bounded secondary page browser evidence per fixture. Hard-capped at 5 extra surfaces.
   --no-editor-validation            Skip browser editor block validation.
   --no-visual-parity                Skip wordpress.visual-compare recipe steps. Same as SSI_FIXTURE_MATRIX_VISUAL_PARITY=0.
   --run                             Execute WP Codebox recipes. Omit locally to only materialize artifacts.

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -310,6 +310,21 @@ step (the slowest per-site step, it launches a browser per fixture); the run
 still produces native-rate, loss-classes, pattern-families, and the rest of the
 findings — just no `validateBlock` editor-validity data.
 
+## Bounded Surface Coverage
+
+Browser evidence defaults to the imported front page only. Multi-page evidence is
+opt-in with `--surface-coverage <n>` on the operator wrapper, or
+`SSI_FIXTURE_MATRIX_SURFACE_COVERAGE=<n>` / `SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES=<n>`
+for the bench. The matrix caps requested secondary pages at `5` extra surfaces
+per fixture, keeps HTML paths sorted lexicographically, and emits a
+`surface_coverage` summary plus `surface_coverage_runtime_cost` warning so run
+cost is visible before execution.
+
+Surface artifact names are deterministic and collision-safe. If two HTML entries
+map to the same route-derived ID, such as `about.html` and `about/index.html`,
+the later surface receives a stable suffix (`about--2`) for editor-open artifact
+prefixes and visual comparison names.
+
 Live caveat: the `editor-validate-blocks` step runs locally in WP Codebox today
 (see "Running the matrix locally" below) — a real local recipe-run executed the
 step and returned `validation_method: wp.blocks.validateBlock`,

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -43,7 +43,13 @@ export {
   normalizeStaticSiteImporterPlugin,
 } from './fixture-matrix/steps/recipe-builder.mjs';
 
-export { selectFixtureSurfaces, normalizeSurfaceCoverageOptions } from './fixture-matrix/steps/surfaces.mjs';
+export {
+  DEFAULT_EXTRA_SURFACE_COUNT,
+  MAX_EXTRA_SURFACE_COUNT,
+  normalizeSurfaceCoverageOptions,
+  selectFixtureSurfaces,
+  summarizeSurfaceCoverage,
+} from './fixture-matrix/steps/surfaces.mjs';
 
 export { editorBlockValidationStep } from './fixture-matrix/steps/editor-validation-step.mjs';
 

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -32,7 +32,7 @@ import { editorBlockValidationStep } from './editor-validation-step.mjs';
 import { visualParityCompareStep, normalizeVisualParityRecipeOptions } from './visual-parity-step.mjs';
 import { liveWpParityCaptureStep, liveWpParityEnabled } from './live-wp-parity-step.mjs';
 import { fixtureStepMetadata } from './shared.mjs';
-import { selectFixtureSurfaces } from './surfaces.mjs';
+import { selectFixtureSurfaces, summarizeSurfaceCoverage } from './surfaces.mjs';
 
 const CAPABILITY_PLUGIN_PROVISIONING = {
   'commerce-products': [
@@ -159,6 +159,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
   // screenshot) per fixture; the captured snapshot.html is fed host-side to the
   // blocks-engine live-wp-parity runner (see collectors/live-wp-parity.mjs).
   const liveWpParityCaptureEnabled = liveWpParityEnabled(input);
+  const surfaceCoverage = summarizeSurfaceCoverage(matrix.fixtures, input);
 
   if (playgroundArtifactsDirectory) {
     for (const fixture of matrix.fixtures) {
@@ -202,6 +203,17 @@ export function buildFixtureMatrixRecipe(input = {}) {
     artifacts: {
       directory: artifactsDirectory,
     },
+    metadata: {
+      surface_coverage: surfaceCoverage,
+      runtime_cost_warnings: surfaceCoverage.enabled ? [surfaceCoverageRuntimeWarning(surfaceCoverage)] : [],
+    },
+  };
+}
+
+function surfaceCoverageRuntimeWarning(surfaceCoverage) {
+  return {
+    code: 'surface_coverage_runtime_cost',
+    message: `Surface coverage is enabled: ${surfaceCoverage.total_surface_count} browser surfaces will run across ${surfaceCoverage.fixture_count} fixtures (${surfaceCoverage.extra_surfaces_per_fixture} extra per fixture, max ${surfaceCoverage.max_extra_surfaces}).`,
   };
 }
 

--- a/lib/fixture-matrix/steps/surfaces.mjs
+++ b/lib/fixture-matrix/steps/surfaces.mjs
@@ -16,6 +16,9 @@ const FRONT_PAGE_SURFACE = Object.freeze({
   candidate_url: '/',
 });
 
+export const DEFAULT_EXTRA_SURFACE_COUNT = 2;
+export const MAX_EXTRA_SURFACE_COUNT = 5;
+
 export function selectFixtureSurfaces(fixture, options = {}) {
   const config = normalizeSurfaceCoverageOptions(options);
   const surfaces = [FRONT_PAGE_SURFACE];
@@ -30,30 +33,64 @@ export function selectFixtureSurfaces(fixture, options = {}) {
     .map((file) => surfaceFromHtmlPath(file.relative_path))
     .filter((surface) => surface.id !== FRONT_PAGE_SURFACE.id);
 
-  return surfaces.concat(files.slice(0, config.extraSurfaceCount));
+  return surfaces.concat(uniqueSurfaceIds(files).slice(0, config.extraSurfaceCount));
+}
+
+export function summarizeSurfaceCoverage(fixtures = [], options = {}) {
+  const config = normalizeSurfaceCoverageOptions(options);
+  const perFixture = fixtures.map((fixture) => {
+    const surfaces = selectFixtureSurfaces(fixture, options);
+    return {
+      fixture_id: fixture.id,
+      surface_count: surfaces.length,
+      extra_surface_count: Math.max(0, surfaces.length - 1),
+      surface_ids: surfaces.map((surface) => surface.id),
+    };
+  });
+  const totalSurfaceCount = perFixture.reduce((total, row) => total + row.surface_count, 0);
+  const extraSurfaceCount = perFixture.reduce((total, row) => total + row.extra_surface_count, 0);
+  return {
+    enabled: config.extraSurfaceCount > 0,
+    requested_extra_surfaces: config.requestedExtraSurfaceCount,
+    max_extra_surfaces: config.maxExtraSurfaceCount,
+    extra_surfaces_per_fixture: config.extraSurfaceCount,
+    capped: config.extraSurfaceCount < config.requestedExtraSurfaceCount,
+    fixture_count: perFixture.length,
+    total_surface_count: totalSurfaceCount,
+    total_extra_surface_count: extraSurfaceCount,
+    browser_step_multiplier: totalSurfaceCount,
+    per_fixture: perFixture,
+  };
 }
 
 export function normalizeSurfaceCoverageOptions(input = {}) {
   const raw = input.surfaceCoverage ?? input.surface_coverage ?? input.browserSurfaceCoverage ?? input.browser_surface_coverage;
   if (raw === undefined || raw === null || raw === false || raw === 'false' || raw === '0' || raw === 0) {
-    return { extraSurfaceCount: 0 };
+    return normalizedConfig(0);
   }
 
   if (raw === true) {
-    return { extraSurfaceCount: positiveInteger(input.maxExtraSurfaces ?? input.max_extra_surfaces, 2) };
+    return normalizedConfig(input.maxExtraSurfaces ?? input.max_extra_surfaces, DEFAULT_EXTRA_SURFACE_COUNT);
   }
 
   if (typeof raw === 'number' || (typeof raw === 'string' && /^\d+$/.test(raw.trim()))) {
-    return { extraSurfaceCount: positiveInteger(raw, 0) };
+    return normalizedConfig(raw, 0);
   }
 
   if (typeof raw === 'object') {
-    return {
-      extraSurfaceCount: positiveInteger(raw.maxExtraSurfaces ?? raw.max_extra_surfaces ?? raw.extraSurfaceCount ?? raw.extra_surface_count, 2),
-    };
+    return normalizedConfig(raw.maxExtraSurfaces ?? raw.max_extra_surfaces ?? raw.extraSurfaceCount ?? raw.extra_surface_count, DEFAULT_EXTRA_SURFACE_COUNT);
   }
 
-  return { extraSurfaceCount: 0 };
+  return normalizedConfig(0);
+}
+
+function normalizedConfig(value, fallback = DEFAULT_EXTRA_SURFACE_COUNT) {
+  const requested = positiveInteger(value, fallback);
+  return {
+    requestedExtraSurfaceCount: requested,
+    maxExtraSurfaceCount: MAX_EXTRA_SURFACE_COUNT,
+    extraSurfaceCount: Math.min(requested, MAX_EXTRA_SURFACE_COUNT),
+  };
 }
 
 function surfaceFromHtmlPath(relativePath) {
@@ -72,6 +109,21 @@ function surfaceFromHtmlPath(relativePath) {
     source_entry: normalized,
     candidate_url: `/${slug}/`,
   };
+}
+
+function uniqueSurfaceIds(surfaces) {
+  const seen = new Map();
+  return surfaces.map((surface) => {
+    const count = seen.get(surface.id) || 0;
+    seen.set(surface.id, count + 1);
+    if (count === 0) {
+      return surface;
+    }
+    return {
+      ...surface,
+      id: `${surface.id}--${count + 1}`,
+    };
+  });
 }
 
 function normalizeRoutePath(filePath) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -49,6 +49,8 @@ import {
   findBestVisualParityOffset,
   liveWpParityCaptureStep,
   liveWpParityEnabled,
+  MAX_EXTRA_SURFACE_COUNT,
+  normalizeSurfaceCoverageOptions,
   runLiveWpParity,
   normalizeLiveWpParityReport,
   selectFixtureSurfaces,
@@ -540,7 +542,8 @@ test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () 
   });
   assert.equal(recipe.inputs.mounts.length, 0);
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
-  assert.equal(recipe.metadata, undefined);
+  assert.equal(recipe.metadata.surface_coverage.enabled, false);
+  assert.deepEqual(recipe.metadata.runtime_cost_warnings, []);
 });
 
 test('fails recipe generation for invalid SSI dependency override paths', () => {
@@ -2021,6 +2024,20 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.deepEqual(releasePlan.dependency_overrides, {});
   assert.equal(releasePlan.steps.at(-1).args.some((arg) => arg.includes('SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH')), false);
 
+  const surfacePlan = buildFixtureMatrixRunPlan({
+    runner: 'homeboy-lab',
+    staticSiteImporter,
+    blocksEngine,
+    surfaceCoverage: '99',
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(surfacePlan.surface_coverage.extra_surfaces_per_fixture, MAX_EXTRA_SURFACE_COUNT);
+  assert.equal(surfacePlan.surface_coverage.capped, true);
+  assert.equal(surfacePlan.surface_coverage.max_browser_surface_count, CANONICAL_FIXTURE_COUNT * (MAX_EXTRA_SURFACE_COUNT + 1));
+  assert.ok(surfacePlan.warnings.some((warning) => warning.code === 'surface_coverage_runtime_cost'));
+  assert.ok(surfacePlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_SURFACE_COVERAGE=99'));
+
   const explicitOutput = path.join(root, 'custom-output', 'homeboy-bench.json');
   const explicitOutputPlan = buildFixtureMatrixRunPlan({
     staticSiteImporter,
@@ -3229,16 +3246,21 @@ test('recipe runs editor-validate-blocks against imported content after each imp
 test('fixture matrix browser surfaces default to front page and opt into bounded secondary pages', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-surface-fixture-'));
   const fixtureDirectory = path.join(root, 'artist');
+  mkdirSync(path.join(fixtureDirectory, 'about'), { recursive: true });
   mkdirSync(path.join(fixtureDirectory, 'merch'), { recursive: true });
   writeFileSync(path.join(fixtureDirectory, 'fixture.json'), JSON.stringify({ id: 'artist', label: 'Artist' }));
   writeFileSync(path.join(fixtureDirectory, 'index.html'), '<main>Home</main>');
+  writeFileSync(path.join(fixtureDirectory, 'about.html'), '<main>About flat</main>');
+  writeFileSync(path.join(fixtureDirectory, 'about', 'index.html'), '<main>About nested</main>');
   writeFileSync(path.join(fixtureDirectory, 'contact.html'), '<main><form><input name="email"></form></main>');
   writeFileSync(path.join(fixtureDirectory, 'merch', 'index.html'), '<main><button>Add to cart</button></main>');
 
   const discoveredMatrix = createFixtureMatrix({ fixture_root: root, id: 'surface-recipe-test' });
   const matrix = { ...discoveredMatrix, fixtures: discoveredMatrix.fixtures.filter((fixture) => fixture.id === 'artist'), count: 1 };
   assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0]).map((surface) => surface.id), ['front-page']);
-  assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: { maxExtraSurfaces: 1 } }).map((surface) => surface.id), ['front-page', 'contact']);
+  assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: { maxExtraSurfaces: 1 } }).map((surface) => surface.id), ['front-page', 'about']);
+  assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: 99 }).map((surface) => surface.id), ['front-page', 'about', 'about--2', 'contact', 'merch']);
+  assert.equal(normalizeSurfaceCoverageOptions({ surfaceCoverage: 99 }).extraSurfaceCount, MAX_EXTRA_SURFACE_COUNT);
 
   const defaultRecipe = buildFixtureMatrixRecipe({
     matrix,
@@ -3262,20 +3284,23 @@ test('fixture matrix browser surfaces default to front page and opt into bounded
   assert.equal(editorValidationSteps.length, 3);
   assert.equal(visualSteps.length, 3);
   assert.ok(editorOpenSteps[0].args.includes('artifact-prefix=files/browser/editor-open/artist'));
-  assert.ok(editorOpenSteps[1].args.includes('url=/contact/'));
-  assert.ok(editorOpenSteps[1].args.includes('artifact-prefix=files/browser/editor-open/artist/contact'));
-  assert.ok(editorOpenSteps[2].args.includes('url=/merch/'));
-  assert.ok(editorOpenSteps[2].args.includes('artifact-prefix=files/browser/editor-open/artist/merch'));
-  assert.ok(editorValidationSteps[1].args.includes('url=/contact/'));
+  assert.ok(editorOpenSteps[1].args.includes('url=/about/'));
+  assert.ok(editorOpenSteps[1].args.includes('artifact-prefix=files/browser/editor-open/artist/about'));
+  assert.ok(editorOpenSteps[2].args.includes('url=/about/'));
+  assert.ok(editorOpenSteps[2].args.includes('artifact-prefix=files/browser/editor-open/artist/about--2'));
+  assert.ok(editorValidationSteps[1].args.includes('url=/about/'));
 
-  const contactComparison = visualCompareMatrixComparison(visualSteps[1]);
-  assert.equal(contactComparison.name, 'artist--contact');
-  assert.equal(contactComparison.sourceUrl, 'file:///tmp/artifacts/artist/source/contact.html');
-  assert.equal(contactComparison.candidateUrl, '/contact/');
-  const merchComparison = visualCompareMatrixComparison(visualSteps[2]);
-  assert.equal(merchComparison.name, 'artist--merch');
-  assert.equal(merchComparison.sourceUrl, 'file:///tmp/artifacts/artist/source/merch/index.html');
-  assert.equal(merchComparison.candidateUrl, '/merch/');
+  const aboutComparison = visualCompareMatrixComparison(visualSteps[1]);
+  assert.equal(aboutComparison.name, 'artist--about');
+  assert.equal(aboutComparison.sourceUrl, 'file:///tmp/artifacts/artist/source/about.html');
+  assert.equal(aboutComparison.candidateUrl, '/about/');
+  const nestedAboutComparison = visualCompareMatrixComparison(visualSteps[2]);
+  assert.equal(nestedAboutComparison.name, 'artist--about--2');
+  assert.equal(nestedAboutComparison.sourceUrl, 'file:///tmp/artifacts/artist/source/about/index.html');
+  assert.equal(nestedAboutComparison.candidateUrl, '/about/');
+  assert.equal(multiSurfaceRecipe.metadata.surface_coverage.extra_surfaces_per_fixture, 2);
+  assert.equal(multiSurfaceRecipe.metadata.surface_coverage.total_surface_count, 3);
+  assert.equal(multiSurfaceRecipe.metadata.runtime_cost_warnings[0].code, 'surface_coverage_runtime_cost');
 });
 
 test('--no-editor-validation skips the editor browser step while keeping native-rate + findings', () => {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -8,6 +8,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { MAX_EXTRA_SURFACE_COUNT, normalizeSurfaceCoverageOptions } from '../lib/fixture-matrix.mjs';
+
 export const RIG_ID = 'static-site-importer-fixture-matrix';
 // Expected top-level fixture directory count in the canonical corpus
 // (`blocks-engine/fixtures/websites`). This is an intentional drift guard, not a
@@ -105,6 +107,8 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.visualParityMaxHorizontalShift ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT: String(options.visualParityMaxHorizontalShift) } : {}),
     ...(options.visualParityOffsetTolerance ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE: String(options.visualParityOffsetTolerance) } : {}),
     ...(options.visualParityPixelmatchThreshold ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD: String(options.visualParityPixelmatchThreshold) } : {}),
+    ...(options.surfaceCoverage ? { SSI_FIXTURE_MATRIX_SURFACE_COVERAGE: String(options.surfaceCoverage) } : {}),
+    ...(options.maxExtraSurfaces ? { SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES: String(options.maxExtraSurfaces) } : {}),
     // Opt-in live-WP parity capture (off by default). When set, the bench appends
     // the deterministic `wordpress.capture-html` step per fixture and runs the
     // blocks-engine live-wp-parity comparator host-side. Absent => byte-identical
@@ -126,6 +130,7 @@ export function buildFixtureMatrixRunPlan(input) {
   const codeFreshness = buildCodeFreshness(options, options.gitRunner || defaultGitRunner);
   const warnings = [
     ...buildWarnings(options),
+    ...buildSurfaceCoverageWarnings(options, fixtureCount),
     ...buildCanonicalDriftWarnings(fixtureCount, options.fixtureRoot),
     ...buildFreshnessWarnings(codeFreshness, options),
   ];
@@ -178,6 +183,7 @@ export function buildFixtureMatrixRunPlan(input) {
       // findings, just without the validateBlock editor-validity data.
       enabled: options.editorValidation !== false,
     },
+    surface_coverage: surfaceCoveragePlanSummary(options, fixtureCount),
     code_freshness: codeFreshness,
     transformer_commit: resolveTransformerCommit(codeFreshness),
     warnings,
@@ -307,6 +313,30 @@ function buildCanonicalDriftWarnings(fixtureCount, fixtureRoot) {
   return [{
     code: 'canonical_fixture_count_drift',
     message: `Discovered ${fixtureCount} top-level fixture director${fixtureCount === 1 ? 'y' : 'ies'} in ${fixtureRoot}, but CANONICAL_FIXTURE_COUNT is ${CANONICAL_FIXTURE_COUNT}. ${fixtureCount > CANONICAL_FIXTURE_COUNT ? 'The corpus grew; bump CANONICAL_FIXTURE_COUNT after confirming the new fixtures are intended.' : 'Fixtures are missing or the wrong fixture root was passed; restore the corpus or correct --fixture-root.'}`,
+  }];
+}
+
+function surfaceCoveragePlanSummary(options, fixtureCount) {
+  const config = normalizeSurfaceCoverageOptions(options);
+  return {
+    enabled: config.extraSurfaceCount > 0,
+    requested_extra_surfaces: config.requestedExtraSurfaceCount,
+    max_extra_surfaces: config.maxExtraSurfaceCount,
+    extra_surfaces_per_fixture: config.extraSurfaceCount,
+    capped: config.extraSurfaceCount < config.requestedExtraSurfaceCount,
+    fixture_count: fixtureCount,
+    max_browser_surface_count: fixtureCount * (1 + config.extraSurfaceCount),
+  };
+}
+
+function buildSurfaceCoverageWarnings(options, fixtureCount) {
+  const summary = surfaceCoveragePlanSummary(options, fixtureCount);
+  if (!summary.enabled) {
+    return [];
+  }
+  return [{
+    code: 'surface_coverage_runtime_cost',
+    message: `Surface coverage is enabled: up to ${summary.max_browser_surface_count} browser surfaces will run (${summary.extra_surfaces_per_fixture} extra per fixture, capped at ${MAX_EXTRA_SURFACE_COUNT}). Use --no-editor-validation or --no-visual-parity when collecting narrower evidence.`,
   }];
 }
 
@@ -604,6 +634,7 @@ export function summarizeRun(plan, { status } = {}) {
     run_id: findFirstKey(output, 'run_id') || plan.run_id,
     code_freshness: plan.code_freshness || null,
     transformer_commit: plan.transformer_commit || resolveTransformerCommit(plan.code_freshness),
+    surface_coverage: plan.surface_coverage || null,
     fixture_count: Number(findFirstKey(output, 'fixture_count') || plan.fixture_count || 0),
     passed_fixture_count: Number(resultSummary.succeeded || resultSummary.passed || 0),
     failed_fixture_count: failedFixtureCount,


### PR DESCRIPTION
## Summary
- cap opt-in extra fixture surfaces and expose deterministic surface coverage summaries
- forward surface coverage settings through the operator and bench env
- make secondary surface artifact/comparison names collision-safe
- document bounded multi-surface behavior and runtime-cost warnings

## Testing
- npm run test:fixture-matrix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Inspected the #582 implementation, added guardrails/tests/docs, and prepared this PR description.