### PR TITLE
Wire fixture matrix surface coverage into batch runs

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -178,6 +178,8 @@ export async function runFixtureMatrix(options) {
     staticSiteImporterPlugin: options.staticSiteImporterPlugin,
     staticSiteImporterSlug: options.staticSiteImporterSlug,
     dependencyOverrides,
+    surfaceCoverage: options.surfaceCoverage,
+    maxExtraSurfaces: options.maxExtraSurfaces,
     ...editorValidationRecipeInput(options),
     ...surfaceCoverageRecipeInput(options),
     ...visualParityRecipeInput(options),
@@ -325,6 +327,8 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     staticSiteImporterPlugin: options.staticSiteImporterPlugin,
     staticSiteImporterSlug: options.staticSiteImporterSlug,
     dependencyOverrides: prepareDependencyOverrides(options),
+    surfaceCoverage: options.surfaceCoverage,
+    maxExtraSurfaces: options.maxExtraSurfaces,
     ...editorValidationRecipeInput(options),
     ...surfaceCoverageRecipeInput(options),
     ...visualParityRecipeInput(options),
@@ -965,6 +969,8 @@ function optionsFromEnv(env = process.env) {
     staticSiteImporterPlugin: benchEnv.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PLUGIN || env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PLUGIN,
     entrypoint: benchEnv.SSI_FIXTURE_MATRIX_ENTRYPOINT || env.SSI_FIXTURE_MATRIX_ENTRYPOINT,
     maxDepth: benchEnv.SSI_FIXTURE_MATRIX_MAX_DEPTH || env.SSI_FIXTURE_MATRIX_MAX_DEPTH,
+    surfaceCoverage: benchEnv.SSI_FIXTURE_MATRIX_SURFACE_COVERAGE || env.SSI_FIXTURE_MATRIX_SURFACE_COVERAGE,
+    maxExtraSurfaces: benchEnv.SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES || env.SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES,
     // Lane selection from authored manifest taxonomy.
     fixtureClass: benchEnv.SSI_FIXTURE_MATRIX_CLASS || env.SSI_FIXTURE_MATRIX_CLASS,
     tag: benchEnv.SSI_FIXTURE_MATRIX_TAG || env.SSI_FIXTURE_MATRIX_TAG,
@@ -1157,6 +1163,8 @@ Options:
                                      Blocks Engine repo root or php-transformer package path for Composer.
   --entrypoint <file>                Fixture entrypoint. Defaults to index.html.
   --max-depth <n>                    Fixture discovery depth. Defaults to 2.
+  --surface-coverage <n>             Capture front page plus up to n secondary HTML surfaces.
+  --max-extra-surfaces <n>           Secondary surface cap when surface coverage is boolean/object-driven.
   --class <fixture_class>            Filter to one authored fixture_class lane.
   --tag <tag>                        Filter to fixtures carrying an authored tag.
   --capability <capability>          Filter to fixtures carrying an authored capability.

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2418,6 +2418,84 @@ test('CLI --no-visual-parity disables visual steps and records a safe WP Codebox
   assert.match(summary.replay.command, /wp-codebox recipe-run --recipe .* --artifacts .* --json/);
 });
 
+test('CLI surface coverage reaches bench recipe browser evidence steps', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-surface-coverage-cli-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const cliFixtureRoot = path.join(root, 'fixtures');
+  const fixtureDirectory = path.join(cliFixtureRoot, 'artist');
+  const outputDirectory = path.join(root, 'artifacts');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'index.html'), '<h1>Home</h1>');
+  writeFileSync(path.join(fixtureDirectory, 'contact.html'), '<h1>Contact</h1>');
+  writeFileSync(path.join(fixtureDirectory, 'merch.html'), '<h1>Merch</h1>');
+
+  const result = spawnSync(process.execPath, [
+    path.join(packageRoot, 'bench', 'static-site-fixture-matrix.bench.mjs'),
+    '--fixture-root', cliFixtureRoot,
+    '--output-directory', outputDirectory,
+    '--static-site-importer-path', staticSiteImporter,
+    '--max-depth', '1',
+    '--surface-coverage', '2',
+  ], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOMEBOY_WP_CODEBOX_RECIPE_HELPER: '',
+      HOMEBOY_WP_CODEBOX_BIN: '',
+      SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN: '',
+      WP_CODEBOX_BIN: '',
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const recipe = JSON.parse(readFileSync(path.join(outputDirectory, 'wp-codebox-static-site-fixture-matrix-recipe.json'), 'utf8'));
+  const editorOpenSteps = recipe.workflow.steps.filter((step) => step.command === 'wordpress.editor-open');
+  const visualSteps = recipe.workflow.steps.filter((step) => step.command === 'wordpress.visual-compare');
+  assert.equal(editorOpenSteps.length, 3);
+  assert.equal(visualSteps.length, 3);
+  assert.ok(editorOpenSteps[1].args.includes('url=/contact/'));
+  assert.ok(editorOpenSteps[2].args.includes('url=/merch/'));
+  assert.equal(visualCompareMatrixComparison(visualSteps[2]).candidateUrl, '/merch/');
+});
+
+test('runFixtureMatrix surface coverage reaches executed batch recipes', async () => {
+  const snapshot = snapshotConcurrencyEnv();
+  const workspace = setupConcurrencyWorkspace('ssi-surface-coverage-batch-', 0);
+  const fixtureDirectory = path.join(workspace.fixtureRoot, 'artist');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'index.html'), '<h1>Home</h1>');
+  writeFileSync(path.join(fixtureDirectory, 'contact.html'), '<h1>Contact</h1>');
+  writeFileSync(path.join(fixtureDirectory, 'merch.html'), '<h1>Merch</h1>');
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = workspace.helperPath;
+
+  try {
+    const { summary, runtimeError } = await runFixtureMatrix({
+      id: 'surface-batch-matrix',
+      fixtureRoot: workspace.fixtureRoot,
+      outputDirectory: workspace.outputDirectory,
+      staticSiteImporterPath: workspace.staticSiteImporter,
+      run: true,
+      batchSize: 1,
+      concurrency: 1,
+      surfaceCoverage: 2,
+    });
+
+    assert.equal(runtimeError, null);
+    const batchRecipe = JSON.parse(readFileSync(summary.runtime.batches[0].recipe_file, 'utf8'));
+    const editorOpenSteps = batchRecipe.workflow.steps.filter((step) => step.command === 'wordpress.editor-open');
+    const visualSteps = batchRecipe.workflow.steps.filter((step) => step.command === 'wordpress.visual-compare');
+    assert.equal(editorOpenSteps.length, 3);
+    assert.equal(visualSteps.length, 3);
+    assert.ok(editorOpenSteps[1].args.includes('url=/contact/'));
+    assert.ok(editorOpenSteps[2].args.includes('url=/merch/'));
+    assert.equal(visualCompareMatrixComparison(visualSteps[1]).candidateUrl, '/contact/');
+    assert.equal(visualCompareMatrixComparison(visualSteps[2]).candidateUrl, '/merch/');
+  } finally {
+    restoreConcurrencyEnv(snapshot);
+  }
+});
+
 function visualCompareMatrixComparison(step) {
   const matrixArg = step.args.find((arg) => typeof arg === 'string' && arg.startsWith('matrix-json='));
   assert.ok(matrixArg, 'expected wordpress.visual-compare to use matrix-json');

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -98,6 +98,8 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.concurrency ? { SSI_FIXTURE_MATRIX_CONCURRENCY: String(options.concurrency) } : {}),
     ...(options.wordpressVersion ? { SSI_FIXTURE_MATRIX_WORDPRESS_VERSION: options.wordpressVersion } : {}),
     ...(options.wpCodeboxBin ? { SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN: options.wpCodeboxBin } : {}),
+    ...(options.surfaceCoverage !== undefined ? { SSI_FIXTURE_MATRIX_SURFACE_COVERAGE: String(options.surfaceCoverage) } : {}),
+    ...(options.maxExtraSurfaces ? { SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES: String(options.maxExtraSurfaces) } : {}),
     ...(options.editorValidation === false ? { SSI_FIXTURE_MATRIX_EDITOR_VALIDATION: '0' } : {}),
     ...(options.visualParity === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY: '0' } : {}),
     ...(options.visualParityGate === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '0' } : { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '1' }),


### PR DESCRIPTION
## Summary
- Thread fixture matrix surface coverage from CLI/env options into recipe generation.
- Preserve surface coverage in per-batch WP Codebox recipes so executed runs capture secondary page editor/visual evidence.
- Add regression coverage for CLI recipe generation and executed batch recipes.

## Evidence
- `npm run test:fixture-matrix -- --test-name-pattern "surface coverage|browser surfaces"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed the surface-coverage runner gap, implemented the wiring/tests, and captured Artist fixture evidence.
