### PR TITLE
Add staged fig fixture regression metrics

### DIFF
--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -81,7 +81,8 @@ fixture corpus. The wrapper composes existing repo-owned surfaces:
   result, editor-quality, visual-parity, and finding-packet artifacts.
 - `artifacts/fig-fixture-e2e/summary.json` aggregates pass/fail status with
   thresholds for exactly three fixtures, zero transform failures, zero import
-  failures, and a default minimum native conversion rate of `1`.
+  failures, zero Blocks Engine vector placeholders/missing assets, and a default
+  minimum native conversion rate of `1`.
 
 Example:
 
@@ -93,6 +94,30 @@ node tools/run-fig-fixture-e2e.mjs \
   --output-directory /path/to/artifacts/fig-fixture-e2e \
   --run
 ```
+
+The summary keeps the two architecture links separate. Blocks Engine transform
+metrics are under `transform` and `metrics.transform_*`; SSI import/materialization
+metrics are under `import_matrix` and `metrics.import_matrix_*`. Use these fields
+for performance and quality regression gates instead of treating `.fig -> blocks`
+as one opaque operation.
+
+To compare a candidate run to a saved baseline summary, pass the previous
+`summary.json` and an allowed regression ratio:
+
+```bash
+node tools/run-fig-fixture-e2e.mjs \
+  --blocks-engine /path/to/blocks-engine \
+  --static-site-importer /path/to/static-site-importer \
+  --baseline-summary /path/to/baseline/summary.json \
+  --max-baseline-regression-ratio 0.10 \
+  --max-import-findings 0 \
+  --run
+```
+
+`baseline_comparison.deltas` reports signed deltas for stage durations and quality
+counters. When `--max-baseline-regression-ratio` is set, positive deltas above the
+budget fail the wrapper; leave it unset to collect comparison evidence without a
+hard performance gate.
 
 Pass fixture paths with repeated `--fixture <path>` arguments instead of
 `SSI_FIG_E2E_FIXTURES` when that is easier for shells/scripts. Use `--dry-run` to
@@ -108,14 +133,28 @@ Sample summary shape:
   "status": "passed",
   "fixture_count": 3,
   "expected_fixture_count": 3,
+  "metrics": {
+    "transform_duration_ms": 12345,
+    "import_matrix_duration_ms": 67890,
+    "total_duration_ms": 80235,
+    "transform_vector_placeholder_count": 0,
+    "transform_missing_asset_count": 0,
+    "import_matrix_finding_count": 0,
+    "import_matrix_min_native_conversion_rate": 1
+  },
   "transform": {
+    "duration_ms": 12345,
     "completed_fixture_count": 3,
-    "failed_fixture_count": 0
+    "failed_fixture_count": 0,
+    "vector_placeholder_count": 0,
+    "missing_asset_count": 0
   },
   "import_matrix": {
     "enabled": true,
+    "duration_ms": 67890,
     "passed_fixture_count": 3,
     "failed_fixture_count": 0,
+    "finding_count": 0,
     "min_native_conversion_rate": 1
   }
 }

--- a/tools/run-fig-fixture-e2e.mjs
+++ b/tools/run-fig-fixture-e2e.mjs
@@ -12,6 +12,15 @@ import { fileURLToPath } from 'node:url';
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const DEFAULT_EXPECTED_FIXTURE_COUNT = 3;
 const SUMMARY_SCHEMA = 'static-site-importer/fig-fixture-e2e-summary/v1';
+const BASELINE_METRICS = [
+  'transform_duration_ms',
+  'import_matrix_duration_ms',
+  'total_duration_ms',
+  'transform_vector_placeholder_count',
+  'transform_missing_asset_count',
+  'import_matrix_finding_count',
+  'import_matrix_failed_fixture_count',
+];
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   try {
@@ -96,6 +105,7 @@ export function buildFigFixtureE2EPlan(input = {}) {
     static_site_importer: options.staticSiteImporter,
     blocks_engine_php_transformer_path: options.blocksEnginePhpTransformerPath,
     output_directory: options.outputDirectory,
+    baseline_summary: options.baselineSummary,
     artifacts: {
       plan: path.join(options.outputDirectory, 'plan.json'),
       summary: summaryPath,
@@ -108,6 +118,10 @@ export function buildFigFixtureE2EPlan(input = {}) {
       max_transform_failures: 0,
       max_import_failures: 0,
       min_native_rate: options.minNativeRate,
+      max_transform_vector_placeholders: options.maxTransformVectorPlaceholders,
+      max_transform_missing_assets: options.maxTransformMissingAssets,
+      max_import_findings: options.maxImportFindings,
+      max_baseline_regression_ratio: options.maxBaselineRegressionRatio,
     },
     steps: {
       transform: commandStep('figma-transform', transformArgv, { cwd: path.join(options.blocksEngine, 'figma-transformer') }),
@@ -126,6 +140,8 @@ export function summarizeRun({ plan, transformStatus, matrixStatus }) {
   const matrixResultSummary = matrixSummary?.result_summary || {};
   const failedImportFixtures = Number(matrixResultSummary.failed || 0);
   const matrixNativeRate = minFixtureNativeRate(matrixSummary);
+  const metrics = summaryMetrics({ plan, transformStatus, matrixStatus, transformSummary, matrixSummary });
+  const baselineComparison = compareBaseline(plan, metrics);
   const failures = [];
 
   if (plan.fixture_count !== plan.expected_fixture_count) {
@@ -149,6 +165,18 @@ export function summarizeRun({ plan, transformStatus, matrixStatus }) {
   if (matrixNativeRate !== null && matrixNativeRate < plan.thresholds.min_native_rate) {
     failures.push(`minimum native conversion rate ${matrixNativeRate} is below ${plan.thresholds.min_native_rate}`);
   }
+  if (metrics.transform_vector_placeholder_count > plan.thresholds.max_transform_vector_placeholders) {
+    failures.push(`${metrics.transform_vector_placeholder_count} Blocks Engine vector placeholder(s) exceeded ${plan.thresholds.max_transform_vector_placeholders}`);
+  }
+  if (metrics.transform_missing_asset_count > plan.thresholds.max_transform_missing_assets) {
+    failures.push(`${metrics.transform_missing_asset_count} Blocks Engine missing asset(s) exceeded ${plan.thresholds.max_transform_missing_assets}`);
+  }
+  if (plan.thresholds.max_import_findings !== null && metrics.import_matrix_finding_count > plan.thresholds.max_import_findings) {
+    failures.push(`${metrics.import_matrix_finding_count} SSI finding(s) exceeded ${plan.thresholds.max_import_findings}`);
+  }
+  for (const regression of baselineComparison.regressions) {
+    failures.push(`${regression.metric} regressed by ${regression.ratio} vs baseline ${baselineComparison.baseline_summary_path}`);
+  }
 
   return {
     schema: SUMMARY_SCHEMA,
@@ -157,14 +185,22 @@ export function summarizeRun({ plan, transformStatus, matrixStatus }) {
     failures,
     fixture_count: plan.fixture_count,
     expected_fixture_count: plan.expected_fixture_count,
+    metrics,
+    baseline_comparison: baselineComparison,
     transform: {
       exit_code: transformStatus?.status ?? null,
+      duration_ms: metrics.transform_duration_ms,
       summary_path: plan.artifacts.transform_summary,
       completed_fixture_count: completedTransforms.length,
       failed_fixture_count: failedTransforms.length,
+      vector_placeholder_count: metrics.transform_vector_placeholder_count,
+      missing_asset_count: metrics.transform_missing_asset_count,
       fixtures: transformFixtures.map((fixture) => ({
         id: fixture.id,
         status: fixture.status,
+        duration_ms: numberOr(fixture.duration_ms, null),
+        vector_placeholder_count: transformVectorPlaceholderCount(fixture),
+        missing_asset_count: transformMissingAssetCount(fixture),
         artifact_dir: fixture.artifact_dir || null,
         result_path: fixture.result_path || null,
       })),
@@ -172,6 +208,7 @@ export function summarizeRun({ plan, transformStatus, matrixStatus }) {
     import_matrix: {
       enabled: plan.run_import_matrix,
       exit_code: matrixStatus?.status ?? null,
+      duration_ms: metrics.import_matrix_duration_ms,
       summary_path: plan.artifacts.matrix_summary,
       result_path: plan.artifacts.matrix_result,
       fixture_count: Number(matrixSummary?.fixture_count || 0),
@@ -200,12 +237,17 @@ function normalizeOptions(input) {
     blocksEnginePhpTransformerPath: path.resolve(input.blocksEnginePhpTransformerPath || input.blocks_engine_php_transformer_path || process.env.SSI_FIG_E2E_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH || blocksEngine),
     fixtures,
     outputDirectory,
+    baselineSummary: input.baselineSummary || input.baseline_summary || process.env.SSI_FIG_E2E_BASELINE_SUMMARY || '',
     expectedFixtureCount: positiveInteger(input.expectedFixtureCount || input.expected_fixture_count || process.env.SSI_FIG_E2E_EXPECTED_FIXTURE_COUNT, DEFAULT_EXPECTED_FIXTURE_COUNT),
     maxPages: positiveInteger(input.maxPages || input.max_pages || process.env.SSI_FIG_E2E_MAX_PAGES, 3),
     maxNodes: positiveInteger(input.maxNodes || input.max_nodes || process.env.SSI_FIG_E2E_MAX_NODES, 5000),
     batchSize: positiveInteger(input.batchSize || input.batch_size || process.env.SSI_FIG_E2E_BATCH_SIZE, 3),
     concurrency: positiveInteger(input.concurrency || process.env.SSI_FIG_E2E_CONCURRENCY, 1),
     minNativeRate: finiteNumber(input.minNativeRate || input.min_native_rate || process.env.SSI_FIG_E2E_MIN_NATIVE_RATE, 1),
+    maxTransformVectorPlaceholders: finiteNumber(input.maxTransformVectorPlaceholders || input.max_transform_vector_placeholders || process.env.SSI_FIG_E2E_MAX_TRANSFORM_VECTOR_PLACEHOLDERS, 0),
+    maxTransformMissingAssets: finiteNumber(input.maxTransformMissingAssets || input.max_transform_missing_assets || process.env.SSI_FIG_E2E_MAX_TRANSFORM_MISSING_ASSETS, 0),
+    maxImportFindings: finiteNumber(input.maxImportFindings || input.max_import_findings || process.env.SSI_FIG_E2E_MAX_IMPORT_FINDINGS, null),
+    maxBaselineRegressionRatio: finiteNumber(input.maxBaselineRegressionRatio || input.max_baseline_regression_ratio || process.env.SSI_FIG_E2E_MAX_BASELINE_REGRESSION_RATIO, null),
     phpBin: input.phpBin || input.php_bin || process.env.SSI_FIG_E2E_PHP_BIN || 'php',
     nodeBin: input.nodeBin || input.node_bin || process.env.SSI_FIG_E2E_NODE_BIN || process.execPath,
     wpCodeboxBin: input.wpCodeboxBin || input.wp_codebox_bin || process.env.SSI_FIG_E2E_WP_CODEBOX_BIN || '',
@@ -318,6 +360,118 @@ function normalizeFixtures(value) {
   return raw.map((fixture) => String(fixture || '').trim()).filter(Boolean).map((fixture) => path.resolve(fixture));
 }
 
+function summaryMetrics({ plan, transformStatus, matrixStatus, transformSummary, matrixSummary }) {
+  const transformFixtures = Array.isArray(transformSummary?.fixtures) ? transformSummary.fixtures : [];
+  const matrixResultSummary = matrixSummary?.result_summary || {};
+  const transformDuration = numberOr(transformStatus?.duration_ms, sumFixtureMetric(transformFixtures, 'duration_ms'));
+  const importDuration = numberOr(matrixStatus?.duration_ms, numberOr(matrixSummary?.runtime?.duration_ms, null));
+  return {
+    transform_duration_ms: transformDuration,
+    import_matrix_duration_ms: importDuration,
+    total_duration_ms: sumFinite([transformDuration, importDuration]),
+    transform_fixture_count: transformFixtures.length,
+    transform_completed_fixture_count: transformFixtures.filter((fixture) => fixture.status === 'completed').length,
+    transform_failed_fixture_count: transformFixtures.filter((fixture) => fixture.status && fixture.status !== 'completed').length,
+    transform_vector_placeholder_count: sumQuality(transformFixtures, transformVectorPlaceholderCount),
+    transform_missing_asset_count: sumQuality(transformFixtures, transformMissingAssetCount),
+    import_matrix_enabled: plan.run_import_matrix ? 1 : 0,
+    import_matrix_fixture_count: Number(matrixSummary?.fixture_count || 0),
+    import_matrix_passed_fixture_count: Number(matrixResultSummary.succeeded || 0),
+    import_matrix_failed_fixture_count: Number(matrixResultSummary.failed || 0),
+    import_matrix_finding_count: Number(matrixResultSummary.finding_count || 0),
+    import_matrix_min_native_conversion_rate: minFixtureNativeRate(matrixSummary),
+  };
+}
+
+function compareBaseline(plan, metrics) {
+  const baselineSummaryPath = plan.baseline_summary || '';
+  const baseline = baselineSummaryPath ? readJsonIfExists(baselineSummaryPath) : null;
+  const maxRegressionRatio = numberOr(plan.thresholds?.max_baseline_regression_ratio, null);
+  const deltas = [];
+  const regressions = [];
+
+  for (const metric of BASELINE_METRICS) {
+    const baselineValue = Number(baseline?.metrics?.[metric]);
+    const currentValue = Number(metrics?.[metric]);
+    if (!Number.isFinite(baselineValue) || !Number.isFinite(currentValue)) {
+      continue;
+    }
+    const delta = currentValue - baselineValue;
+    const ratio = baselineValue === 0 ? (delta > 0 ? Number.POSITIVE_INFINITY : 0) : delta / baselineValue;
+    const entry = { metric, baseline: baselineValue, current: currentValue, delta, ratio: roundRatio(ratio) };
+    deltas.push(entry);
+    if (maxRegressionRatio !== null && delta > 0 && ratio > maxRegressionRatio) {
+      regressions.push(entry);
+    }
+  }
+
+  return {
+    baseline_summary_path: baselineSummaryPath || null,
+    compared_metric_count: deltas.length,
+    max_regression_ratio: maxRegressionRatio,
+    deltas,
+    regressions,
+  };
+}
+
+function transformVectorPlaceholderCount(fixture) {
+  return numberOr(fixture?.vector_placeholders || fixture?.artifact_quality?.vectors?.placeholders || fixture?.quality_summary?.vector_placeholders, 0);
+}
+
+function transformMissingAssetCount(fixture) {
+  const direct = firstNumber([
+    fixture?.missing_asset_count,
+    fixture?.missing_assets_count,
+    fixture?.quality_summary?.missing_asset_count,
+    fixture?.quality_summary?.missing_assets,
+    fixture?.artifact_quality?.missing_asset_count,
+    fixture?.artifact_quality?.missing_assets_count,
+    fixture?.artifact_quality?.summary?.missing_asset_count,
+    fixture?.artifact_quality?.summary?.missing_assets,
+  ]);
+  if (direct !== null) {
+    return direct;
+  }
+  const codes = Array.isArray(fixture?.diagnostic_codes) ? fixture.diagnostic_codes : [];
+  return codes.filter((code) => String(code).includes('missing_asset')).length;
+}
+
+function sumFixtureMetric(fixtures, key) {
+  const total = fixtures.reduce((sum, fixture) => sum + numberOr(fixture?.[key], 0), 0);
+  return total || null;
+}
+
+function sumQuality(fixtures, getter) {
+  return fixtures.reduce((sum, fixture) => sum + getter(fixture), 0);
+}
+
+function sumFinite(values) {
+  const finiteValues = values.filter((value) => value !== null && value !== undefined && value !== '' && Number.isFinite(Number(value)));
+  return finiteValues.length ? finiteValues.reduce((sum, value) => sum + Number(value), 0) : null;
+}
+
+function firstNumber(values) {
+  for (const value of values) {
+    const number = Number(value);
+    if (Number.isFinite(number)) {
+      return number;
+    }
+  }
+  return null;
+}
+
+function numberOr(value, fallback = 0) {
+  if (value === null || value === undefined || value === '') {
+    return fallback;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function roundRatio(value) {
+  return Number.isFinite(value) ? Math.round(value * 10000) / 10000 : value;
+}
+
 function minFixtureNativeRate(matrixSummary) {
   const aggregateRate = Number(matrixSummary?.result_summary?.editor_quality?.native_conversion_rate);
   if (Number.isFinite(aggregateRate)) {
@@ -355,6 +509,9 @@ function positiveInteger(value, fallback) {
 }
 
 function finiteNumber(value, fallback) {
+  if (value === null || value === undefined || value === '') {
+    return fallback;
+  }
   const number = Number(value);
   return Number.isFinite(number) ? number : fallback;
 }
@@ -373,5 +530,5 @@ function shellQuote(value) {
 }
 
 function printHelp() {
-  process.stdout.write(`Usage: node tools/run-fig-fixture-e2e.mjs --blocks-engine <path> --fixture <file.fig> --fixture <file.fig> --fixture <file.fig> [options]\n\nRuns Blocks Engine Figma transforms and feeds the generated artifacts into the SSI WP Codebox fixture matrix.\n\nOptions:\n  --fixture <path>                         .fig fixture path. Repeat exactly three times for the release gate.\n  --blocks-engine <path>                   Blocks Engine checkout containing figma-transformer/. Required.\n  --static-site-importer <path>            SSI checkout. Defaults to this repo.\n  --blocks-engine-php-transformer-path <path>\n                                           Composer path override for SSI import. Defaults to --blocks-engine.\n  --output-directory <path>                Artifact root. Defaults to ./artifacts/fig-fixture-e2e.\n  --run                                    Launch SSI import/parity through WP Codebox. Without this, writes transform artifacts and a replayable matrix recipe only.\n  --dry-run                                Write plan/summary without running transform or import.\n  --expected-fixture-count <n>             Defaults to 3.\n  --min-native-rate <n>                    Defaults to 1.\n  --batch-size <n>                         Defaults to 3.\n  --concurrency <n>                        Defaults to 1.\n  --wp-codebox-bin <path>                  WP Codebox binary override for the SSI matrix.\n  --no-editor-validation                   Skip editor block validation.\n  --no-visual-parity                       Skip visual compare.\n  --live-wp-parity                         Enable live WP HTML parity capture.\n\nEnvironment equivalents:\n  SSI_FIG_E2E_BLOCKS_ENGINE=/path/to/blocks-engine\n  SSI_FIG_E2E_FIXTURES=/path/Fisiostetic.fig:${path.join('<path>', 'FSE Pilot Build Theme.fig')}:/path/Twenty Twenty-Five.fig\n  SSI_FIG_E2E_RUN=1\n`);
+  process.stdout.write(`Usage: node tools/run-fig-fixture-e2e.mjs --blocks-engine <path> --fixture <file.fig> --fixture <file.fig> --fixture <file.fig> [options]\n\nRuns Blocks Engine Figma transforms and feeds the generated artifacts into the SSI WP Codebox fixture matrix.\n\nOptions:\n  --fixture <path>                         .fig fixture path. Repeat exactly three times for the release gate.\n  --blocks-engine <path>                   Blocks Engine checkout containing figma-transformer/. Required.\n  --static-site-importer <path>            SSI checkout. Defaults to this repo.\n  --blocks-engine-php-transformer-path <path>\n                                           Composer path override for SSI import. Defaults to --blocks-engine.\n  --output-directory <path>                Artifact root. Defaults to ./artifacts/fig-fixture-e2e.\n  --baseline-summary <path>                Previous summary.json to compare staged metrics against.\n  --max-baseline-regression-ratio <n>      Fail if compared numeric metrics regress by more than this ratio.\n  --run                                    Launch SSI import/parity through WP Codebox. Without this, writes transform artifacts and a replayable matrix recipe only.\n  --dry-run                                Write plan/summary without running transform or import.\n  --expected-fixture-count <n>             Defaults to 3.\n  --min-native-rate <n>                    Defaults to 1.\n  --max-transform-vector-placeholders <n>  Defaults to 0.\n  --max-transform-missing-assets <n>       Defaults to 0.\n  --max-import-findings <n>                Optional SSI finding count budget.\n  --batch-size <n>                         Defaults to 3.\n  --concurrency <n>                        Defaults to 1.\n  --wp-codebox-bin <path>                  WP Codebox binary override for the SSI matrix.\n  --no-editor-validation                   Skip editor block validation.\n  --no-visual-parity                       Skip visual compare.\n  --live-wp-parity                         Enable live WP HTML parity capture.\n\nEnvironment equivalents:\n  SSI_FIG_E2E_BLOCKS_ENGINE=/path/to/blocks-engine\n  SSI_FIG_E2E_FIXTURES=/path/Fisiostetic.fig:${path.join('<path>', 'FSE Pilot Build Theme.fig')}:/path/Twenty Twenty-Five.fig\n  SSI_FIG_E2E_RUN=1\n`);
 }

--- a/tools/run-fig-fixture-e2e.test.mjs
+++ b/tools/run-fig-fixture-e2e.test.mjs
@@ -27,6 +27,8 @@ test('builds deterministic fig transform and SSI import matrix commands for thre
     outputDirectory: path.join(root, 'artifacts'),
     run: true,
     wpCodeboxBin: '/usr/local/bin/wp-codebox',
+    maxTransformVectorPlaceholders: 2,
+    maxImportFindings: 5,
   });
 
   assert.equal(plan.fixture_count, 3);
@@ -37,6 +39,8 @@ test('builds deterministic fig transform and SSI import matrix commands for thre
   assert.ok(plan.steps.import_matrix.argv.includes('--run'));
   assert.ok(plan.steps.import_matrix.argv.includes('--wp-codebox-bin'));
   assert.ok(plan.steps.import_matrix.command.includes('static-site-fixture-matrix.bench.mjs'));
+  assert.equal(plan.thresholds.max_transform_vector_placeholders, 2);
+  assert.equal(plan.thresholds.max_import_findings, 5);
 });
 
 test('summary fails when transform/import thresholds are not met', () => {
@@ -51,7 +55,15 @@ test('summary fails when transform/import thresholds are not met', () => {
     fixture_count: 3,
     expected_fixture_count: 3,
     run_import_matrix: true,
-    thresholds: { max_transform_failures: 0, max_import_failures: 0, min_native_rate: 1 },
+    thresholds: {
+      max_transform_failures: 0,
+      max_import_failures: 0,
+      min_native_rate: 1,
+      max_transform_vector_placeholders: 0,
+      max_transform_missing_assets: 0,
+      max_import_findings: 3,
+      max_baseline_regression_ratio: null,
+    },
     artifacts: {
       transform_summary: path.join(transformDirectory, 'summary.json'),
       matrix_summary: path.join(matrixDirectory, 'summary.json'),
@@ -64,19 +76,88 @@ test('summary fails when transform/import thresholds are not met', () => {
     },
     warnings: [],
   };
-  fs.writeFileSync(plan.artifacts.transform_summary, JSON.stringify({ fixtures: [{ id: 'a', status: 'completed' }, { id: 'b', status: 'failed' }] }));
+  fs.writeFileSync(plan.artifacts.transform_summary, JSON.stringify({
+    fixtures: [
+      { id: 'a', status: 'completed', duration_ms: 100, vector_placeholders: 1 },
+      { id: 'b', status: 'failed', duration_ms: 200, missing_asset_count: 1 },
+    ],
+  }));
   fs.writeFileSync(plan.artifacts.matrix_summary, JSON.stringify({
     fixture_count: 2,
     result_summary: { succeeded: 1, failed: 1, finding_count: 4, editor_quality: { native_conversion_rate: 0.75 } },
   }));
 
-  const summary = summarizeRun({ plan, transformStatus: { status: 0 }, matrixStatus: { status: 1 } });
+  const summary = summarizeRun({ plan, transformStatus: { status: 0, duration_ms: 350 }, matrixStatus: { status: 1, duration_ms: 450 } });
 
   assert.equal(summary.status, 'failed');
+  assert.equal(summary.metrics.transform_duration_ms, 350);
+  assert.equal(summary.metrics.import_matrix_duration_ms, 450);
+  assert.equal(summary.metrics.transform_vector_placeholder_count, 1);
+  assert.equal(summary.metrics.transform_missing_asset_count, 1);
   assert.equal(summary.transform.completed_fixture_count, 1);
   assert.equal(summary.import_matrix.failed_fixture_count, 1);
   assert.equal(summary.import_matrix.min_native_conversion_rate, 0.75);
   assert.ok(summary.failures.some((failure) => failure.includes('Figma transform')));
   assert.ok(summary.failures.some((failure) => failure.includes('SSI matrix')));
   assert.ok(summary.failures.some((failure) => failure.includes('native conversion rate')));
+  assert.ok(summary.failures.some((failure) => failure.includes('vector placeholder')));
+  assert.ok(summary.failures.some((failure) => failure.includes('missing asset')));
+  assert.ok(summary.failures.some((failure) => failure.includes('SSI finding')));
+});
+
+test('summary compares staged metrics against a baseline when requested', () => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), 'ssi-fig-e2e-baseline-'));
+  const outputDirectory = path.join(root, 'artifacts');
+  const transformDirectory = path.join(outputDirectory, 'figma-transform');
+  const matrixDirectory = path.join(outputDirectory, 'ssi-matrix');
+  fs.mkdirSync(transformDirectory, { recursive: true });
+  fs.mkdirSync(matrixDirectory, { recursive: true });
+  const baselineSummary = path.join(root, 'baseline-summary.json');
+  fs.writeFileSync(baselineSummary, JSON.stringify({
+    metrics: {
+      transform_duration_ms: 100,
+      import_matrix_duration_ms: 200,
+      total_duration_ms: 300,
+      import_matrix_finding_count: 1,
+    },
+  }));
+
+  const plan = {
+    fixture_count: 3,
+    expected_fixture_count: 3,
+    run_import_matrix: true,
+    baseline_summary: baselineSummary,
+    thresholds: {
+      max_transform_failures: 0,
+      max_import_failures: 0,
+      min_native_rate: 1,
+      max_transform_vector_placeholders: 0,
+      max_transform_missing_assets: 0,
+      max_import_findings: null,
+      max_baseline_regression_ratio: 0.25,
+    },
+    artifacts: {
+      transform_summary: path.join(transformDirectory, 'summary.json'),
+      matrix_summary: path.join(matrixDirectory, 'summary.json'),
+      matrix_result: path.join(matrixDirectory, 'static-site-fixture-matrix-result.json'),
+      matrix_output_directory: matrixDirectory,
+    },
+    steps: {
+      transform: { command: 'php figma-fixture-matrix.php' },
+      import_matrix: { command: 'node static-site-fixture-matrix.bench.mjs' },
+    },
+    warnings: [],
+  };
+  fs.writeFileSync(plan.artifacts.transform_summary, JSON.stringify({ fixtures: [{ id: 'a', status: 'completed' }] }));
+  fs.writeFileSync(plan.artifacts.matrix_summary, JSON.stringify({
+    fixture_count: 1,
+    result_summary: { succeeded: 1, failed: 0, finding_count: 1, editor_quality: { native_conversion_rate: 1 } },
+  }));
+
+  const summary = summarizeRun({ plan, transformStatus: { status: 0, duration_ms: 140 }, matrixStatus: { status: 0, duration_ms: 200 } });
+
+  assert.equal(summary.status, 'failed');
+  assert.equal(summary.baseline_comparison.compared_metric_count, 4);
+  assert.equal(summary.baseline_comparison.regressions[0].metric, 'transform_duration_ms');
+  assert.ok(summary.failures.some((failure) => failure.includes('transform_duration_ms regressed')));
 });


### PR DESCRIPTION
## Summary
- Add a structured metrics block to the three-fixture fig E2E wrapper, keeping Blocks Engine transform and SSI import/materialization measurements separate.
- Add quality thresholds for transform vector placeholders/missing assets and optional SSI finding budgets.
- Add baseline summary comparison with optional regression-ratio failure gates.
- Document the staged command and sample summary shape.

## Testing
- npm run test:fig-fixture-e2e
- node tools/run-fig-fixture-e2e.mjs --blocks-engine /Users/chubes/Developer/blocks-engine@inspect-staged-pipeline-gates --fixture <tmp>/Fisiostetic.fig --fixture <tmp>/FSE\ Pilot\ Build\ Theme.fig --fixture <tmp>/Twenty\ Twenty-Five.fig --output-directory <tmp>/artifacts --dry-run

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected the existing Blocks Engine/SSI harnesses, drafted the wrapper metrics/baseline changes, updated tests/docs, and ran local verification.