### PR TITLE
Reduce generated HTML fallback blocks

### DIFF
--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -646,7 +646,7 @@ class Static_Site_Importer_Page_Materializer {
 	 * @return string|null Serialized block markup, or null when unsupported.
 	 */
 	private static function safe_html_fragment_to_blocks( string $html ): ?string {
-		if ( preg_match( '/<\s*(?:script|style|iframe|canvas|svg|form|input|select|textarea)\b/i', $html ) ) {
+		if ( preg_match( '/<\s*(?:script|style|iframe|canvas|svg)\b/i', $html ) ) {
 			return null;
 		}
 
@@ -730,11 +730,43 @@ class Static_Site_Importer_Page_Materializer {
 			return self::image_block( $node, $attrs );
 		}
 
+		if ( 'picture' === $tag ) {
+			$image = self::first_descendant_element( $node, 'img' );
+			return $image instanceof DOMElement ? self::image_block( $image, $attrs ) : null;
+		}
+
 		if ( 'figure' === $tag ) {
-			$children = self::element_children( $node );
-			if ( 1 === count( $children ) && 'img' === strtolower( $children[0]->tagName ) ) {
-				return self::image_block( $children[0], $attrs );
+			return self::figure_block( $node, $attrs );
+		}
+
+		if ( 'blockquote' === $tag ) {
+			return self::quote_block( $node, $attrs );
+		}
+
+		if ( 'hr' === $tag ) {
+			return self::separator_block( $attrs );
+		}
+
+		if ( 'form' === $tag ) {
+			return self::search_block( $node, $attrs );
+		}
+
+		if ( 'label' === $tag ) {
+			$content = self::safe_inline_html( $node );
+			return null === $content ? null : self::paragraph_block( $content, $attrs );
+		}
+
+		if ( 'input' === $tag ) {
+			$type  = strtolower( trim( $node->getAttribute( 'type' ) ) );
+			$name  = strtolower( trim( $node->getAttribute( 'name' ) ) );
+			$value = trim( $node->getAttribute( 'value' ) );
+			if ( in_array( $type, array( 'search', 'text' ), true ) && in_array( $name, array( 's', 'search', 'q' ), true ) ) {
+				return self::search_input_block( $node, $attrs );
 			}
+			if ( in_array( $type, array( 'button', 'submit', 'reset' ), true ) && '' !== $value ) {
+				return self::buttons_block( self::button_block( array_merge( $attrs, array( 'text' => self::escape_html( $value ) ) ) ) );
+			}
+			return null;
 		}
 
 		if ( in_array( $tag, array( 'div', 'section', 'header', 'footer', 'main', 'article', 'aside', 'nav' ), true ) ) {
@@ -790,6 +822,19 @@ class Static_Site_Importer_Page_Materializer {
 		}
 
 		return $children;
+	}
+
+	/**
+	 * Return the first descendant element with the requested tag name.
+	 *
+	 * @param DOMElement $element Element.
+	 * @param string     $tag     Tag name.
+	 * @return DOMElement|null
+	 */
+	private static function first_descendant_element( DOMElement $element, string $tag ): ?DOMElement {
+		$matches = $element->getElementsByTagName( $tag );
+		$match   = $matches->item( 0 );
+		return $match instanceof DOMElement ? $match : null;
 	}
 
 	/**
@@ -930,6 +975,215 @@ class Static_Site_Importer_Page_Materializer {
 		}
 
 		return self::serialized_block_markup( 'core/image', $attrs, '<figure class="wp-block-image' . self::extra_classes( $attrs ) . '"><img src="' . self::escape_attr( $src ) . '" alt="' . self::escape_attr( $alt ) . '" /></figure>' );
+	}
+
+	/**
+	 * Build an image block from a static figure/picture wrapper.
+	 *
+	 * @param DOMElement          $element Figure element.
+	 * @param array<string,mixed> $attrs   Block attrs.
+	 * @return string|null
+	 */
+	private static function figure_block( DOMElement $element, array $attrs ): ?string {
+		$children = self::element_children( $element );
+		if ( array() === $children || count( $children ) > 2 ) {
+			return null;
+		}
+
+		$image   = null;
+		$caption = '';
+		foreach ( $children as $child ) {
+			$tag = strtolower( $child->tagName );
+			if ( 'img' === $tag ) {
+				$image = $child;
+				continue;
+			}
+			if ( 'picture' === $tag ) {
+				$image = self::first_descendant_element( $child, 'img' );
+				continue;
+			}
+			if ( 'figcaption' === $tag ) {
+				$caption = self::safe_inline_html( $child );
+				if ( null === $caption ) {
+					return null;
+				}
+				continue;
+			}
+			return null;
+		}
+
+		if ( ! $image instanceof DOMElement ) {
+			return null;
+		}
+
+		$src = trim( $image->getAttribute( 'src' ) );
+		if ( '' === $src ) {
+			return null;
+		}
+
+		$attrs['url'] = $src;
+		$alt          = $image->getAttribute( 'alt' );
+		if ( '' !== $alt ) {
+			$attrs['alt'] = $alt;
+		}
+		if ( '' !== $caption ) {
+			$attrs['caption'] = $caption;
+		}
+
+		return self::serialized_block_markup( 'core/image', $attrs, '<figure class="wp-block-image' . self::extra_classes( $attrs ) . '"><img src="' . self::escape_attr( $src ) . '" alt="' . self::escape_attr( $alt ) . '" />' . ( '' === $caption ? '' : '<figcaption class="wp-element-caption">' . $caption . '</figcaption>' ) . '</figure>' );
+	}
+
+	/**
+	 * Build a static quote block.
+	 *
+	 * @param DOMElement          $element Blockquote element.
+	 * @param array<string,mixed> $attrs   Block attrs.
+	 * @return string|null
+	 */
+	private static function quote_block( DOMElement $element, array $attrs ): ?string {
+		$value    = '';
+		$citation = '';
+		foreach ( iterator_to_array( $element->childNodes ) as $child ) {
+			if ( XML_TEXT_NODE === $child->nodeType ) {
+				$text = trim( (string) $child->textContent );
+				if ( '' !== $text ) {
+					$value .= '<p>' . self::escape_html( $text ) . '</p>';
+				}
+				continue;
+			}
+
+			if ( ! $child instanceof DOMElement ) {
+				continue;
+			}
+
+			$tag     = strtolower( $child->tagName );
+			$content = self::safe_inline_html( $child );
+			if ( null === $content ) {
+				return null;
+			}
+			if ( 'cite' === $tag ) {
+				$citation = $content;
+				continue;
+			}
+			if ( 'p' !== $tag ) {
+				return null;
+			}
+			$value .= '<p>' . $content . '</p>';
+		}
+
+		if ( '' === trim( $value ) ) {
+			return null;
+		}
+
+		$attrs['value'] = $value;
+		if ( '' !== $citation ) {
+			$attrs['citation'] = $citation;
+		}
+
+		return self::serialized_block_markup( 'core/quote', $attrs, '<blockquote class="wp-block-quote' . self::extra_classes( $attrs ) . '">' . $value . ( '' === $citation ? '' : '<cite>' . $citation . '</cite>' ) . '</blockquote>' );
+	}
+
+	/**
+	 * Build a separator block.
+	 *
+	 * @param array<string,mixed> $attrs Block attrs.
+	 * @return string
+	 */
+	private static function separator_block( array $attrs ): string {
+		return self::serialized_block_markup( 'core/separator', $attrs, '<hr class="wp-block-separator has-alpha-channel-opacity' . self::extra_classes( $attrs ) . '" />' );
+	}
+
+	/**
+	 * Build a static search block from a non-runtime search form.
+	 *
+	 * @param DOMElement          $element Form element.
+	 * @param array<string,mixed> $attrs   Block attrs.
+	 * @return string|null
+	 */
+	private static function search_block( DOMElement $element, array $attrs ): ?string {
+		$inputs = iterator_to_array( $element->getElementsByTagName( 'input' ) );
+		if ( array() === $inputs || 0 !== $element->getElementsByTagName( 'textarea' )->length || 0 !== $element->getElementsByTagName( 'select' )->length ) {
+			return null;
+		}
+
+		$search_input = null;
+		$button_text  = '';
+		foreach ( $inputs as $input ) {
+			if ( ! $input instanceof DOMElement ) {
+				continue;
+			}
+			$type = strtolower( trim( $input->getAttribute( 'type' ) ) );
+			$name = strtolower( trim( $input->getAttribute( 'name' ) ) );
+			if ( in_array( $type, array( '', 'search', 'text' ), true ) && in_array( $name, array( '', 's', 'search', 'q' ), true ) ) {
+				$search_input = $input;
+				continue;
+			}
+			if ( in_array( $type, array( 'submit', 'button' ), true ) ) {
+				$button_text = trim( $input->getAttribute( 'value' ) );
+				continue;
+			}
+			if ( 'hidden' !== $type ) {
+				return null;
+			}
+		}
+
+		foreach ( iterator_to_array( $element->getElementsByTagName( 'button' ) ) as $button ) {
+			if ( ! $button instanceof DOMElement ) {
+				continue;
+			}
+			$content = self::safe_inline_html( $button );
+			if ( null === $content ) {
+				return null;
+			}
+			$button_text = trim( wp_strip_all_tags( $content ) );
+		}
+
+		$class = ' ' . strtolower( $element->getAttribute( 'class' ) ) . ' ';
+		$role  = strtolower( trim( $element->getAttribute( 'role' ) ) );
+		if ( ! $search_input instanceof DOMElement || ( 'search' !== $role && ! str_contains( $class, ' search' ) && ! str_contains( $class, 'search-' ) && ! str_contains( $class, '-search' ) ) ) {
+			return null;
+		}
+
+		$label       = trim( $search_input->getAttribute( 'aria-label' ) ) ?: 'Search';
+		$placeholder = trim( $search_input->getAttribute( 'placeholder' ) );
+		$action      = trim( $element->getAttribute( 'action' ) ) ?: '/';
+		if ( '' === $button_text ) {
+			$button_text = 'Search';
+		}
+
+		return self::search_block_markup( $attrs, $label, $placeholder, $button_text, $action );
+	}
+
+	/**
+	 * Build a static search block from a standalone generated search input.
+	 *
+	 * @param DOMElement          $element Input element.
+	 * @param array<string,mixed> $attrs   Block attrs.
+	 * @return string
+	 */
+	private static function search_input_block( DOMElement $element, array $attrs ): string {
+		$label       = trim( $element->getAttribute( 'aria-label' ) ) ?: 'Search';
+		$placeholder = trim( $element->getAttribute( 'placeholder' ) );
+		return self::search_block_markup( $attrs, $label, $placeholder, 'Search', '/' );
+	}
+
+	/**
+	 * Serialize a static search block.
+	 *
+	 * @param array<string,mixed> $attrs       Block attrs.
+	 * @param string              $label       Search label.
+	 * @param string              $placeholder Input placeholder.
+	 * @param string              $button_text Button text.
+	 * @param string              $action      Form action URL.
+	 * @return string
+	 */
+	private static function search_block_markup( array $attrs, string $label, string $placeholder, string $button_text, string $action ): string {
+		$attrs['label']       = $label;
+		$attrs['buttonText']  = $button_text;
+		$attrs['placeholder'] = $placeholder;
+		$attrs['query']       = array( 'post_type' => 'post' );
+
+		return self::serialized_block_markup( 'core/search', $attrs, '<form role="search" method="get" class="wp-block-search' . self::extra_classes( $attrs ) . '" action="' . self::escape_attr( $action ) . '"><label class="wp-block-search__label">' . self::escape_html( $label ) . '</label><div class="wp-block-search__inside-wrapper"><input class="wp-block-search__input" placeholder="' . self::escape_attr( $placeholder ) . '" value="" type="search" name="s" required /><button aria-label="' . self::escape_attr( $button_text ) . '" class="wp-block-search__button wp-element-button" type="submit">' . self::escape_html( $button_text ) . '</button></div></form>' );
 	}
 
 	/**

--- a/tests/smoke-safe-html-fallback-reducer.php
+++ b/tests/smoke-safe-html-fallback-reducer.php
@@ -74,6 +74,10 @@ $input = implode(
 		'<!-- wp:group {"className":"outer"} --><div class="wp-block-group outer">',
 		'<!-- wp:html {"content":""} --><!-- /wp:html -->',
 		'<!-- wp:html {"content":"<section class=\"hero\"><h2 class=\"title\">Care <em>that works</em></h2><p class=\"lede\">Book today</p><img class=\"photo\" src=\"assets/hero.jpg\" alt=\"Clinic room\"><ul class=\"ticks\"><li>Assessment</li><li>Treatment</li></ul><a class=\"cta\" href=\"/book/\">Reserve</a></section>"} --><section class="hero"><h2 class="title">Care <em>that works</em></h2><p class="lede">Book today</p><img class="photo" src="assets/hero.jpg" alt="Clinic room"><ul class="ticks"><li>Assessment</li><li>Treatment</li></ul><a class="cta" href="/book/">Reserve</a></section><!-- /wp:html -->',
+		'<!-- wp:html {"content":"<figure class=\"case-study\"><picture><source srcset=\"assets/team.webp\" type=\"image/webp\"><img src=\"assets/team.jpg\" alt=\"Care team\"></picture><figcaption>Care team caption</figcaption></figure>"} --><figure class="case-study"><picture><source srcset="assets/team.webp" type="image/webp"><img src="assets/team.jpg" alt="Care team"></picture><figcaption>Care team caption</figcaption></figure><!-- /wp:html -->',
+		'<!-- wp:html {"content":"<form class=\"site-search\" role=\"search\" action=\"/search/\"><label>Find care</label><input type=\"search\" name=\"s\" placeholder=\"Search services\" aria-label=\"Search services\"><button type=\"submit\">Go</button></form>"} --><form class="site-search" role="search" action="/search/"><label>Find care</label><input type="search" name="s" placeholder="Search services" aria-label="Search services"><button type="submit">Go</button></form><!-- /wp:html -->',
+		'<!-- wp:html {"content":"<input class=\"generated-search\" type=\"search\" name=\"s\" placeholder=\"Email Search for...\" aria-label=\"Email Search for...\">"} --><input class="generated-search" type="search" name="s" placeholder="Email Search for..." aria-label="Email Search for..."><!-- /wp:html -->',
+		'<!-- wp:html {"content":"<blockquote class=\"pull\"><p>Movement changed everything.</p><cite>Patient story</cite></blockquote><hr class=\"rule\">"} --><blockquote class="pull"><p>Movement changed everything.</p><cite>Patient story</cite></blockquote><hr class="rule"><!-- /wp:html -->',
 		'<!-- wp:html {"content":"<form class=\"lead-form\"><input name=\"email\"></form>"} --><form class="lead-form"><input name="email"></form><!-- /wp:html -->',
 		'</div><!-- /wp:group -->',
 	)
@@ -86,20 +90,30 @@ $output     = $method->invoke( null, $input );
 $before = $count_blocks( $input );
 $after  = $count_blocks( $output );
 
-$assert( 3 === ( $before['core/html'] ?? 0 ), 'before-has-three-html-fallbacks' );
+$assert( 7 === ( $before['core/html'] ?? 0 ), 'before-has-seven-html-fallbacks' );
 $assert( 1 === ( $after['core/html'] ?? 0 ), 'after-keeps-only-unsupported-form-fallback', print_r( $after, true ) );
 $assert( 2 === ( $after['core/group'] ?? 0 ), 'existing-and-section-groups-preserved' );
 $assert( 1 === ( $after['core/heading'] ?? 0 ), 'heading-converted' );
 $assert( 1 === ( $after['core/paragraph'] ?? 0 ), 'paragraph-converted' );
-$assert( 1 === ( $after['core/image'] ?? 0 ), 'image-converted' );
+$assert( 2 === ( $after['core/image'] ?? 0 ), 'images-converted' );
 $assert( 1 === ( $after['core/list'] ?? 0 ), 'list-converted' );
 $assert( 2 === ( $after['core/list-item'] ?? 0 ), 'list-items-converted' );
 $assert( 1 === ( $after['core/buttons'] ?? 0 ), 'button-wrapper-converted' );
 $assert( 1 === ( $after['core/button'] ?? 0 ), 'button-converted' );
+$assert( 2 === ( $after['core/search'] ?? 0 ), 'search-patterns-converted' );
+$assert( 1 === ( $after['core/quote'] ?? 0 ), 'blockquote-converted' );
+$assert( 1 === ( $after['core/separator'] ?? 0 ), 'separator-converted' );
 $assert( str_contains( $output, 'className":"hero' ), 'section-class-preserved' );
 $assert( str_contains( $output, 'className":"title' ), 'heading-class-preserved' );
 $assert( str_contains( $output, 'assets/hero.jpg' ), 'image-src-preserved' );
 $assert( str_contains( $output, 'Clinic room' ), 'image-alt-preserved' );
+$assert( str_contains( $output, 'assets/team.jpg' ), 'picture-img-src-preserved' );
+$assert( str_contains( $output, 'Care team caption' ), 'figure-caption-preserved' );
+$assert( str_contains( $output, '/search/' ), 'search-action-preserved' );
+$assert( str_contains( $output, 'Search services' ), 'search-placeholder-preserved' );
+$assert( str_contains( $output, 'Email Search for...' ), 'standalone-search-placeholder-preserved' );
+$assert( str_contains( $output, 'className":"generated-search' ), 'standalone-search-class-preserved' );
+$assert( str_contains( $output, 'Patient story' ), 'quote-citation-preserved' );
 $assert( str_contains( $output, '/book/' ), 'button-url-preserved' );
 $assert( str_contains( $output, '<form class="lead-form"><input name="email"></form>' ), 'unsupported-form-fallback-preserved' );
 


### PR DESCRIPTION
## Summary
- Reduces safe static HTML fallbacks in SSI's HTML-artifact-to-block materializer by converting more bounded HTML fragments to native core blocks.
- Adds generic conversions for static figure/picture captions, blockquotes, separators, search forms, standalone generated search inputs, and input-submit buttons.
- Keeps arbitrary non-search forms as core/html fallbacks so runtime/contact/newsletter behavior is not silently flattened.

## Scope
- HTML-to-block conversion only in Static Site Importer.
- No .fig parser changes.
- No direct .fig -> blocks path added.

## Fallback Counts
- Direct reducer smoke fixture: core/html fallbacks reduced from 7 to 1. The remaining fallback is the unsupported non-search lead form.
- FSE generated .fig fixture available locally: import matrix ran before/after with editor validation and visual parity disabled. The matrix reports carried Blocks Engine fallback diagnostics unchanged, but SSI editor-quality output reports core_html_block_count: 0 before and after, so it is not a useful SSI reducer delta for this PR.
- Fisiostetic and TT5 .fig/latest generated HTML artifacts were not present in the local blocks-engine checkout or this SSI worktree, so I could not produce reliable fixture-specific before/after counts for them in this pass.

## Tests
- php tests/smoke-safe-html-fallback-reducer.php
- php -l includes/class-static-site-importer-page-materializer.php
- php -l tests/smoke-safe-html-fallback-reducer.php
- FSE-only generated fixture import command completed before/after with tools/run-fig-fixture-e2e.mjs using the local FSE Pilot .fig fixture, expected fixture count 1, editor validation disabled, visual parity disabled, and min native rate 0.

## Unsupported Patterns / Caveats
- Runtime forms/newsletter/contact forms remain fallbacks or materialized runtime islands.
- Inline SVG remains handled by the existing SVG materialization path.
- Elements with inline style remain unsupported by this reducer to avoid silently losing authored presentation.
- Complex nested lists/menus and richer form controls remain outside this bounded conversion.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the bounded SSI HTML fallback reducer changes, added smoke coverage, ran local verification, and drafted this PR description.
