### PR TITLE
Materialize template parts from source HTML artifacts

### DIFF
--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -500,7 +500,7 @@ class Static_Site_Importer_Page_Materializer {
 	 * @param string                       $source_path Source path for diagnostics.
 	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics, passed by reference.
 	 */
-	private static function html_to_blocks( string $body, string $source_path, array &$diagnostics ): string {
+	public static function html_to_blocks( string $body, string $source_path, array &$diagnostics ): string {
 		if ( ! function_exists( 'blocks_engine_php_transformer_convert_format' ) ) {
 			$diagnostics[] = array(
 				'type'        => 'missing_transformer_bridge',

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -93,7 +93,7 @@ class Static_Site_Importer_Theme_Generator {
 		if ( is_wp_error( $compiled ) ) {
 			return $compiled;
 		}
-		if ( isset( $artifact['files'] ) && is_array( $artifact['files'] ) ) {
+		if ( isset( $artifact['files'] ) && is_array( $artifact['files'] ) && empty( $compiled['artifacts']['source_files'] ) ) {
 			if ( ! isset( $compiled['artifacts'] ) || ! is_array( $compiled['artifacts'] ) ) {
 				$compiled['artifacts'] = array();
 			}

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -32,10 +32,37 @@ class Static_Site_Importer_Theme_Materializer {
 		return array(
 			$theme_dir . '/functions.php'             => self::functions_php( $theme_slug, $scripts, $stylesheets ),
 			$theme_dir . '/theme.json'                => self::theme_json( $theme_name, $css, $artifacts ),
+			$theme_dir . '/templates/404.html'        => self::not_found_template( $has_header_part, $has_footer_part ),
+			$theme_dir . '/templates/archive.html'    => self::archive_template( $has_header_part, $has_footer_part ),
 			$theme_dir . '/templates/front-page.html' => self::content_template( '', $has_header_part, $has_footer_part ),
 			$theme_dir . '/templates/page.html'       => self::content_template( '', $has_header_part, $has_footer_part ),
 			$theme_dir . '/templates/index.html'      => self::content_template( '', $has_header_part, $has_footer_part ),
 		);
+	}
+
+	/**
+	 * Build the generated archive template.
+	 *
+	 * @param bool $has_header_part Whether a shared header template part was generated.
+	 * @param bool $has_footer_part Whether a shared footer template part was generated.
+	 * @return string
+	 */
+	private static function archive_template( bool $has_header_part, bool $has_footer_part ): string {
+		return self::content_template( '', $has_header_part, $has_footer_part );
+	}
+
+	/**
+	 * Build the generated 404 template.
+	 *
+	 * @param bool $has_header_part Whether a shared header template part was generated.
+	 * @param bool $has_footer_part Whether a shared footer template part was generated.
+	 * @return string
+	 */
+	private static function not_found_template( bool $has_header_part, bool $has_footer_part ): string {
+		$body = '<!-- wp:heading {"level":1} --><h1 class="wp-block-heading">Page not found</h1><!-- /wp:heading -->' . "\n\n" .
+			'<!-- wp:paragraph --><p>The requested page could not be found.</p><!-- /wp:paragraph -->';
+
+		return self::content_template( $body, $has_header_part, $has_footer_part );
 	}
 
 	/**
@@ -689,6 +716,10 @@ class Static_Site_Importer_Theme_Materializer {
 			$template_parts = isset( $artifacts['template_parts'] ) && is_array( $artifacts['template_parts'] ) ? $artifacts['template_parts'] : array();
 		}
 
+		if ( empty( $template_parts ) ) {
+			$template_parts = self::source_file_template_parts( $artifacts );
+		}
+
 		$writes  = array();
 		$reports = array();
 		foreach ( $template_parts as $template_part ) {
@@ -718,6 +749,127 @@ class Static_Site_Importer_Theme_Materializer {
 			'writes'  => $writes,
 			'reports' => $reports,
 		);
+	}
+
+	/**
+	 * Extract header/footer parts from source HTML files when the compiler has not
+	 * emitted explicit template-part artifacts.
+	 *
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function source_file_template_parts( array $artifacts ): array {
+		$files = isset( $artifacts['source_files'] ) && is_array( $artifacts['source_files'] ) ? $artifacts['source_files'] : array();
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) || ! isset( $file['path'] ) || ! is_scalar( $file['path'] ) ) {
+				continue;
+			}
+
+			$path = (string) $file['path'];
+			if ( ! preg_match( '/\.html?$/i', $path ) ) {
+				continue;
+			}
+
+			$content = '';
+			if ( isset( $file['content'] ) && is_scalar( $file['content'] ) ) {
+				$content = (string) $file['content'];
+			} elseif ( isset( $file['content_base64'] ) && is_scalar( $file['content_base64'] ) ) {
+				$decoded = base64_decode( (string) $file['content_base64'], true );
+				if ( false !== $decoded ) {
+					$content = $decoded;
+				}
+			}
+			if ( '' === $content ) {
+				continue;
+			}
+
+			$parts = self::template_parts_from_html( $content, $path );
+			if ( ! empty( $parts ) ) {
+				return $parts;
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Convert source HTML landmarks into reusable block theme parts.
+	 *
+	 * @param string $html        Source HTML document.
+	 * @param string $source_path Source file path for reports.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function template_parts_from_html( string $html, string $source_path ): array {
+		$document  = new Static_Site_Importer_Document( $html );
+		$fragments = $document->fragments();
+		$parts     = array();
+
+		foreach ( array( 'header', 'footer' ) as $slug ) {
+			$fragment = trim( (string) ( $fragments[ $slug ] ?? '' ) );
+			if ( '' === $fragment ) {
+				$fragment = self::first_landmark_html( $html, $slug );
+			}
+			if ( '' === trim( $fragment ) ) {
+				continue;
+			}
+
+			$diagnostics = array();
+			$markup      = Static_Site_Importer_Page_Materializer::html_to_blocks( self::strip_inline_svg_markup( $fragment ), $source_path . '#' . $slug, $diagnostics );
+			if ( '' === trim( $markup ) ) {
+				continue;
+			}
+
+			$parts[] = array(
+				'source_path'  => $source_path . '#' . $slug,
+				'slug'         => $slug,
+				'title'        => ucfirst( $slug ),
+				'area'         => $slug,
+				'generated'    => true,
+				'block_markup' => trim( $markup ) . "\n",
+			);
+		}
+
+		return $parts;
+	}
+
+	/**
+	 * Remove inline SVG from synthesized source-derived template parts.
+	 *
+	 * @param string $html HTML fragment.
+	 * @return string
+	 */
+	private static function strip_inline_svg_markup( string $html ): string {
+		if ( '' === trim( $html ) || ! str_contains( strtolower( $html ), '<svg' ) ) {
+			return $html;
+		}
+
+		return (string) preg_replace( '#<svg\b[^>]*>.*?</svg>#is', '', $html );
+	}
+
+	/**
+	 * Return the first matching landmark's outer HTML.
+	 *
+	 * @param string $html Source HTML document.
+	 * @param string $tag  Landmark tag name.
+	 * @return string
+	 */
+	private static function first_landmark_html( string $html, string $tag ): string {
+		if ( '' === trim( $html ) ) {
+			return '';
+		}
+
+		$dom      = new DOMDocument();
+		$previous = libxml_use_internal_errors( true );
+		$loaded   = $dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+		if ( ! $loaded ) {
+			return '';
+		}
+
+		$nodes = $dom->getElementsByTagName( $tag );
+		$node  = $nodes->length > 0 ? $nodes->item( 0 ) : null;
+		return $node instanceof DOMElement ? trim( (string) $dom->saveHTML( $node ) ) : '';
 	}
 
 	/**

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -94,6 +94,7 @@ class Static_Site_Importer_Transformer_Adapter {
 		$artifacts['document_metadata'] = $this->document_metadata_from_compiled_site( $compiled_site_metadata_source );
 		$artifacts['documents']         = ! empty( $view['documents'] ) && is_array( $view['documents'] ) ? $view['documents'] : ( isset( $result['documents'] ) && is_array( $result['documents'] ) ? $result['documents'] : array() );
 		$artifacts['files']             = $this->artifact_files_from_site_report( $materialization_plan, ! empty( $view ) ? $view : $result );
+		$artifacts['source_files']      = $this->source_files_from_artifact( $artifact );
 		$artifacts['site']              = $materialization_plan;
 		$artifacts['compiled_site']     = ! empty( $view['compiled_site'] ) && is_array( $view['compiled_site'] ) ? $view['compiled_site'] : array();
 		$artifacts['template_parts']    = isset( $materialization_plan['template_parts'] ) && is_array( $materialization_plan['template_parts'] ) ? $materialization_plan['template_parts'] : array();
@@ -111,6 +112,50 @@ class Static_Site_Importer_Transformer_Adapter {
 		}
 
 		return $compiled;
+	}
+
+	/**
+	 * Preserve safe source artifact files for downstream WordPress materializers.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @return array<int,array<string,string>>
+	 */
+	private function source_files_from_artifact( array $artifact ): array {
+		$files  = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
+		$result = array();
+
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) || ! isset( $file['path'] ) || ! is_scalar( $file['path'] ) ) {
+				continue;
+			}
+
+			$path = ltrim( str_replace( '\\', '/', (string) $file['path'] ), '/' );
+			if ( '' === $path || str_contains( $path, '..' ) ) {
+				continue;
+			}
+
+			$content = '';
+			if ( isset( $file['content'] ) && is_scalar( $file['content'] ) ) {
+				$content = (string) $file['content'];
+			} elseif ( isset( $file['content_base64'] ) && is_scalar( $file['content_base64'] ) ) {
+				$decoded = base64_decode( (string) $file['content_base64'], true );
+				if ( false === $decoded ) {
+					continue;
+				}
+				$content = $decoded;
+			}
+
+			if ( '' === $content ) {
+				continue;
+			}
+
+			$result[] = array(
+				'path'    => $path,
+				'content' => $content,
+			);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -68,6 +68,12 @@ if ( ! function_exists( 'esc_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( string $text ): string {
+		return strip_tags( $text );
+	}
+}
+
 if ( ! function_exists( 'trailingslashit' ) ) {
 	function trailingslashit( string $value ): string {
 		return rtrim( $value, '/\\' ) . '/';
@@ -226,6 +232,41 @@ $navigation_part_writes = is_array( $navigation_part_result ) ? $navigation_part
 $navigation_part_reports = is_array( $navigation_part_result ) ? $navigation_part_result['reports'] : array();
 $assert( str_contains( (string) ( $navigation_part_writes['/tmp/visual-repair-smoke/parts/header.html'] ?? '' ), 'wp:navigation-link' ), 'materialization-plan-navigation-row-is-used-for-header' );
 $assert( array( 'website/index.html#main-nav' ) === ( $navigation_part_reports[0]['source_paths'] ?? array() ), 'materialization-plan-navigation-source-path-is-reported' );
+
+if ( ! function_exists( 'blocks_engine_php_transformer_convert_format' ) ) {
+	function blocks_engine_php_transformer_convert_format( string $content, string $from, string $to, array $options = array() ): array {
+		unset( $from, $to, $options );
+		$text = trim( preg_replace( '/\s+/', ' ', wp_strip_all_tags( $content ) ) ?? '' );
+		return array(
+			'serialized_blocks' => '<!-- wp:paragraph --><p>' . esc_html( $text ) . '</p><!-- /wp:paragraph -->',
+			'diagnostics'       => array(),
+		);
+	}
+}
+
+$source_file_part_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
+	'/tmp/visual-repair-smoke',
+	array(
+		'source_files' => array(
+			array(
+				'path'    => 'index.html',
+				'content' => '<!doctype html><html><body><main><header><nav><a href="/news/">News</a><svg><path d="M0 0h1v1z" /></svg></nav></header><article><h1>Home</h1></article><footer><p>Footer</p></footer></main></body></html>',
+			),
+		),
+	)
+);
+$assert( is_array( $source_file_part_result ), 'source-file-template-part-fallback-succeeds' );
+$source_file_part_writes = is_array( $source_file_part_result ) ? $source_file_part_result['writes'] : array();
+$source_file_part_reports = is_array( $source_file_part_result ) ? $source_file_part_result['reports'] : array();
+$assert( isset( $source_file_part_writes['/tmp/visual-repair-smoke/parts/header.html'] ), 'source-file-template-part-fallback-writes-header' );
+$assert( isset( $source_file_part_writes['/tmp/visual-repair-smoke/parts/footer.html'] ), 'source-file-template-part-fallback-writes-footer' );
+$assert( ! str_contains( (string) $source_file_part_writes['/tmp/visual-repair-smoke/parts/header.html'], '<!-- wp:html' ), 'source-file-template-part-fallback-strips-inline-svg-html-fallback' );
+$assert( array( 'index.html#header' ) === ( $source_file_part_reports[0]['source_paths'] ?? array() ), 'source-file-template-part-fallback-reports-header-source' );
+
+$base_theme_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes( '/tmp/visual-repair-smoke', 'visual-repair-smoke', 'Visual Repair Smoke', '', true, true );
+$assert( isset( $base_theme_writes['/tmp/visual-repair-smoke/templates/404.html'] ), 'base-theme-writes-404-template' );
+$assert( isset( $base_theme_writes['/tmp/visual-repair-smoke/templates/archive.html'] ), 'base-theme-writes-archive-template' );
+$assert( str_contains( $base_theme_writes['/tmp/visual-repair-smoke/templates/404.html'], 'wp:template-part {"slug":"header"' ), 'base-theme-404-template-uses-header-part' );
 
 $empty_template_part_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
 	'/tmp/visual-repair-smoke',


### PR DESCRIPTION
## Summary
- Preserve decoded source HTML artifact files in the compiled SSI artifact envelope.
- Generate generic header/footer template parts from source HTML landmarks when the compiler does not emit explicit template-part artifacts.
- Add base archive and 404 templates so generated block themes include the expected FSE template set.
- Keep synthesized template parts free of inline SVG `core/html` fallbacks.

## FSE Pilot Evidence
The FSE Pilot HTML artifact was imported headlessly through SSI. The import used only generated HTML/static artifact files as input; no `.fig -> blocks` shortcut was used in SSI.

Before:
- Pages: 3
- Templates: 6 (`front-page`, `index`, `page`, plus 3 page-specific templates)
- Template parts: 0
- `fallback_count`: 2
- `core_html_block_count`: 0

After:
- Pages: 3
- Templates: 8 (`404`, `archive`, `front-page`, `index`, `page`, plus 3 page-specific templates)
- Template parts: 2 (`parts/header.html`, `parts/footer.html`)
- All generated templates reference header/footer template parts.
- `fallback_count`: 2
- `core_html_block_count`: 0

## Tests
- `php tests/smoke-visual-repair-css.php`
- `php tests/smoke-transformer-adapter.php`
- PHP syntax checks for changed PHP files
- Headless SSI import of the FSE Pilot HTML artifact in a local WordPress runtime
- `node tests/smoke-generated-theme-block-validation.cjs <generated-theme-path>`

## Blockers / Follow-ups
- The remaining `fallback_count=2` entries are existing `html_form_fallback` diagnostics from the source FSE HTML forms. They render as `jetpack/contact-form` block markup in the report but are still counted as unsupported fallback diagnostics by the current quality contract.
- Source-derived template parts strip inline SVG before conversion to avoid introducing `core/html` fallback blocks. A fuller follow-up would materialize SVG assets for template parts the same way page content already does.

## AI Assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the generic SSI source-HTML template part materialization path, ran the FSE Pilot artifact import, added smoke coverage, and prepared this PR.