### PR TITLE
Extract static merch card products

### DIFF
--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -501,7 +501,7 @@ class Static_Site_Importer_Transformer_Adapter {
 		$dom      = $this->load_html_document( $html );
 		$xpath    = new DOMXPath( $dom );
 		$products = array();
-		$cards    = $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' product-card ')]" );
+		$cards    = $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' product-card ') or ((self::article or self::div or self::li) and contains(concat(' ', normalize-space(@class), ' '), '-card '))]" );
 		if ( false === $cards ) {
 			return array();
 		}
@@ -511,10 +511,14 @@ class Static_Site_Importer_Transformer_Adapter {
 				continue;
 			}
 			$name  = $this->first_xpath_text( $xpath, './/*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]', $card );
-			$price = $this->price_from_text( $this->first_xpath_text( $xpath, ".//*[contains(concat(' ', normalize-space(@class), ' '), ' price ')]", $card ) );
+			if ( '' === $name ) {
+				$name = $this->first_xpath_text( $xpath, ".//*[contains(@class, 'name') or contains(@class, 'title')]", $card );
+			}
+			$price = $this->price_from_text( $this->first_xpath_text( $xpath, ".//*[contains(@class, 'price')]", $card ) );
 			if ( '' === $price ) {
 				$price = $this->price_from_text( (string) $card->textContent );
 			}
+			$selector = $this->source_selector_for_card( $card );
 
 			$product = $this->normalize_product_report_row(
 				array(
@@ -522,7 +526,9 @@ class Static_Site_Importer_Transformer_Adapter {
 					'name'             => $name,
 					'slug'             => $this->sanitize_slug( $name ),
 					'regular_price'    => $price,
-					'source_selectors' => array( '.product-card' ),
+					'description'      => $this->first_xpath_text( $xpath, ".//*[contains(@class, 'desc') or contains(@class, 'description')]", $card ),
+					'categories'       => array( $this->first_xpath_text( $xpath, ".//*[contains(@class, 'tag') or contains(@class, 'category') or contains(@class, 'type')]", $card ) ),
+					'source_selectors' => array( $selector ),
 					'source_path'      => $source_path,
 				)
 			);
@@ -532,6 +538,23 @@ class Static_Site_Importer_Transformer_Adapter {
 		}
 
 		return $products;
+	}
+
+	/**
+	 * Return the most specific class selector for a detected product card.
+	 *
+	 * @param DOMElement $card Detected product card element.
+	 * @return string
+	 */
+	private function source_selector_for_card( DOMElement $card ): string {
+		$classes = preg_split( '/\s+/', trim( $card->getAttribute( 'class' ) ) );
+		foreach ( is_array( $classes ) ? $classes : array() as $class ) {
+			if ( '' !== $class && ( 'product-card' === $class || str_ends_with( $class, '-card' ) ) ) {
+				return '.' . $class;
+			}
+		}
+
+		return '.product-card';
 	}
 
 	/**

--- a/tests/smoke-website-artifact-bundle-data-products.php
+++ b/tests/smoke-website-artifact-bundle-data-products.php
@@ -157,8 +157,12 @@ JSON;
 
 	// Rendered HTML carries a product card for a product that also exists in the
 	// bundle data, with a different price, to prove bundle-data wins on dedupe.
+	// It also carries Artist merch-style cards whose product metadata is static
+	// while quantity/add controls remain source HTML runtime controls.
 	$index_html = '<!doctype html><html><body>'
 		. '<article class="product-card"><h2>Oatmeal Dinner Plate</h2><p class="price">$99.00</p></article>'
+		. '<article class="merch-card reveal"><div class="merch-tag">Apparel</div><div class="merch-name">EP Heavyweight Tee</div><p class="merch-desc">Washed black tee.</p><div class="merch-price">$30</div><button class="qty-btn">+</button><span class="qty-display">1</span><button class="add-to-cart">Add</button></article>'
+		. '<article class="merch-card reveal"><div class="merch-tag">Vinyl</div><div class="merch-name">EP on Vinyl</div><p class="merch-desc">Limited pressing.</p><div class="merch-price">$28</div><button class="add-to-cart">Add</button></article>'
 		. '<div id="featuredGrid" class="grid"></div>'
 		. '</body></html>';
 
@@ -195,7 +199,7 @@ JSON;
 	}
 
 	$assert( ! is_wp_error( $compiled ), 'compile-succeeds', is_wp_error( $compiled ) ? $compiled->get_error_message() : '' );
-	$assert( 4 === count( $products ), 'extracts-three-js-and-one-json-product', 'count=' . count( $products ) );
+	$assert( 6 === count( $products ), 'extracts-bundle-json-and-static-commerce-card-products', 'count=' . count( $products ) );
 
 	// js/products.js products materialize with name/price/category/description.
 	$plate = $by_slug['oatmeal-dinner-plate'] ?? array();
@@ -217,6 +221,16 @@ JSON;
 	$assert( array( 'Gear' ) === ( $dripper['categories'] ?? array() ), 'json-type-synonym-to-category' );
 	$assert( str_contains( (string) ( $dripper['description'] ?? '' ), 'pour-over cone' ), 'json-desc-synonym-to-description' );
 
+	$tee = $by_slug['ep-heavyweight-tee'] ?? array();
+	$assert( 'EP Heavyweight Tee' === ( $tee['name'] ?? '' ), 'merch-card-name-class-to-name' );
+	$assert( '30.00' === ( $tee['regular_price'] ?? '' ), 'merch-card-price-class-to-price' );
+	$assert( array( 'Apparel' ) === ( $tee['categories'] ?? array() ), 'merch-card-tag-to-category' );
+	$assert( array( '.merch-card' ) === ( $tee['source_selectors'] ?? array() ), 'merch-card-source-selector' );
+	$assert( str_contains( (string) ( $tee['description'] ?? '' ), 'Washed black' ), 'merch-card-description' );
+
+	$vinyl = $by_slug['ep-on-vinyl'] ?? array();
+	$assert( '28.00' === ( $vinyl['regular_price'] ?? '' ), 'second-merch-card-extracted' );
+
 	// Non-product arrays are not misdetected.
 	$assert( ! isset( $by_slug['home'] ) && ! isset( $by_slug['shop'] ) && ! isset( $by_slug['contact'] ), 'navigation-array-not-detected' );
 
@@ -232,7 +246,7 @@ JSON;
 		)
 	);
 	$assert( array() === ( $validation['errors'] ?? array() ), 'woo-adapter-validator-accepts-bundle-products', implode( '; ', array_map( static fn ( $e ) => ( $e['path'] ?? '' ) . ' ' . ( $e['message'] ?? '' ), $validation['errors'] ?? array() ) ) );
-	$assert( 4 === count( $validation['products'] ?? array() ), 'woo-adapter-validator-preserves-product-count' );
+	$assert( 6 === count( $validation['products'] ?? array() ), 'woo-adapter-validator-preserves-product-count' );
 	$assert( 'Oatmeal Dinner Plate' === ( $validation['products'][0]['name'] ?? ( $by_slug['oatmeal-dinner-plate']['name'] ?? '' ) ), 'woo-adapter-validator-preserves-name' );
 
 	if ( $failures ) {


### PR DESCRIPTION
## Summary
- Extract product metadata from generic static commerce cards such as Artist merch `.merch-card` markup.
- Preserve quantity/add-to-cart controls as source/runtime HTML; this does not emulate cart state or add-to-cart behavior.
- Extend bundle product smoke coverage for merch card names, prices, categories, descriptions, selectors, and Woo manifest validation.

## Verification
- `php tests/smoke-website-artifact-bundle-data-products.php`
- `php tests/smoke-website-artifact-products-manifest.php`
- `php tests/smoke-product-materializer.php`
- `npm run test:fixture-matrix`
- Artist merch targeted matrix: `node bench/static-site-fixture-matrix.bench.mjs --fixture-root /Users/chubes/Developer/blocks-engine@cook-artist-merch-commerce-controls/fixtures/websites --tag artist --entrypoint merch.html --static-site-importer-path /Users/chubes/Developer/static-site-importer@cook-artist-merch-commerce-controls --blocks-engine-php-transformer-path /Users/chubes/Developer/blocks-engine@cook-artist-merch-commerce-controls --output-directory /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-artist-merch-after --run --batch-size 1 --concurrency 1 --no-editor-validation`

Artist merch result: WooCommerce active, products manifest valid with 5 merch products, product seeding completed with 5 created products. Visual gate still fails on style/layout mismatch: aligned 2.40% (132435/5524480), raw full-page 7.07%.

## Commerce runtime boundary
The extracted products are native Woo products. The source controls `button.qty-btn`, `span.qty-display`, and `button.add-to-cart` remain preserved HTML/runtime controls because cart state and add-to-cart behavior are outside SSI product seeding.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigated Artist merch artifacts, implemented the product extraction/test change, and ran verification.