### PR TITLE
Preserve fixture matrix surface evidence

### DIFF
--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -73,6 +73,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
   const visualParityOptions = { ...visualParity, fixtureArtifactsDirectory };
   const diagnostics = collectFixtureDiagnostics(merged, { visualParity: visualParityOptions });
   const visualParityArtifacts = collectVisualParityArtifacts(merged, visualParityOptions);
+  const surfaces = collectSurfaceResults(payloads, { visualParityOptions });
   // Best-effort live-WP parity (opt-in). Returns null when disabled or when the
   // capture/source/comparator is unavailable, keeping the lane isolated.
   const liveWpParityResult = collectLiveWpParity({
@@ -107,6 +108,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     diagnostics,
     artifact_refs: collectFixtureArtifactRefs(merged, fixtureArtifactsDirectory),
     artifacts: merged.artifacts || {},
+    surfaces,
     editor_canvas: merged.editor_canvas || merged.editorCanvas || merged.editor_canvas_summary || merged.editorCanvasSummary || null,
     editor_open: merged.editor_open || merged.editorOpen || null,
     visual_parity_artifacts: visualParityArtifacts,
@@ -116,6 +118,57 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     live_wp_parity: liveWpParityResult,
     raw: { payloads },
   });
+}
+
+function collectSurfaceResults(payloads, { visualParityOptions }) {
+  const bySurface = new Map();
+  for (const payload of payloads) {
+    if (!hasSurfaceEvidence(payload)) {
+      continue;
+    }
+    const surface = surfaceFields(payload);
+    const surfaceId = surface.surface_id || 'front-page';
+    const visualParityArtifacts = collectVisualParityArtifacts(payload, visualParityOptions);
+    const existing = bySurface.get(surfaceId) || { surface_id: surfaceId };
+    bySurface.set(surfaceId, compactObject({
+      ...existing,
+      ...surface,
+      artifact_refs: dedupeArtifactRefs([
+        ...normalizeArray(existing.artifact_refs),
+        ...collectPayloadArtifactRefs(payload),
+      ]),
+      editor_validation: existing.editor_validation || collectEditorValidation(payload),
+      editor_canvas: existing.editor_canvas || payload.editor_canvas || payload.editorCanvas || payload.editor_canvas_summary || payload.editorCanvasSummary || null,
+      editor_open: existing.editor_open || payload.editor_open || payload.editorOpen || null,
+      visual_parity_artifacts: mergeVisualParityArtifacts(existing.visual_parity_artifacts, visualParityArtifacts),
+      visual_diff_regions: normalizeArray(existing.visual_diff_regions).length ? existing.visual_diff_regions : (visualParityArtifacts?.visual_diff_regions || []),
+      visual_diff_cause_summary: existing.visual_diff_cause_summary || visualParityArtifacts?.visual_diff_cause_summary || null,
+      visual_diff_classification: existing.visual_diff_classification || visualParityArtifacts?.visual_diff_classification || null,
+    }));
+  }
+  return [...bySurface.values()].sort((left, right) => surfaceSortKey(left).localeCompare(surfaceSortKey(right)));
+}
+
+function hasSurfaceEvidence(payload) {
+  const visualArtifacts = collectVisualParityArtifacts(payload, {});
+  return Boolean(
+    surfaceFields(payload).surface_id
+    || collectEditorValidation(payload)
+    || payload.editor_canvas || payload.editorCanvas || payload.editor_canvas_summary || payload.editorCanvasSummary
+    || payload.editor_open || payload.editorOpen
+    || visualArtifacts
+    || collectPayloadArtifactRefs(payload).length
+  );
+}
+
+function mergeVisualParityArtifacts(left, right) {
+  if (!left) {
+    return right || null;
+  }
+  if (!right) {
+    return left;
+  }
+  return mergeObjects([left, right]);
 }
 
 function collectFixtureDiagnostics(payload, options = {}) {
@@ -307,6 +360,17 @@ function findingPacketDiagnostic(packet) {
 }
 
 function collectFixtureArtifactRefs(payload, fixtureArtifactsDirectory) {
+  const refs = collectPayloadArtifactRefs(payload);
+  for (const fileName of ['artifact.json', 'validation-result.json', 'import-report.json']) {
+    const filePath = path.join(fixtureArtifactsDirectory, fileName);
+    if (fs.existsSync(filePath)) {
+      refs.push(artifactRef(fileName.replace(/\.json$/, ''), filePath, fileName === 'artifact.json' ? 'input' : 'diagnostic'));
+    }
+  }
+  return dedupeArtifactRefs(refs);
+}
+
+function collectPayloadArtifactRefs(payload) {
   const refs = [...normalizeArray(payload.artifact_refs || payload.artifactRefs), ...normalizeArray(payload.artifacts?.refs)];
   for (const [key, value] of Object.entries(payload.artifacts || {})) {
     if (value && typeof value === 'object' && !Array.isArray(value) && (value.path || value.file || value.href)) {
@@ -315,13 +379,20 @@ function collectFixtureArtifactRefs(payload, fixtureArtifactsDirectory) {
       refs.push({ artifact_id: key, kind: key, path: value });
     }
   }
-  for (const fileName of ['artifact.json', 'validation-result.json', 'import-report.json']) {
-    const filePath = path.join(fixtureArtifactsDirectory, fileName);
-    if (fs.existsSync(filePath)) {
-      refs.push(artifactRef(fileName.replace(/\.json$/, ''), filePath, fileName === 'artifact.json' ? 'input' : 'diagnostic'));
+  return dedupeArtifactRefs(refs);
+}
+
+function dedupeArtifactRefs(refs) {
+  const seen = new Set();
+  return normalizeArray(refs).filter((ref) => {
+    const row = objectValue(ref);
+    const key = [row.artifact_id || row.id || '', row.kind || '', row.path || row.file || row.href || ''].join('\u0000');
+    if (seen.has(key)) {
+      return false;
     }
-  }
-  return refs;
+    seen.add(key);
+    return true;
+  });
 }
 
 function collectRuntimePayloads(value) {
@@ -565,18 +636,19 @@ function collectRecipeBrowserEvidencePayloads(value) {
     .filter((evidence) => evidence.fixture_id);
 }
 
-function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen) {
+function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen, inheritedSurface = {}) {
   if (!value || typeof value !== 'object' || seen.has(value)) {
     return;
   }
   seen.add(value);
   const fixtureId = fixtureIdentity(value) || inheritedFixtureId;
+  const surface = { ...inheritedSurface, ...surfaceFields(value) };
   if (fixtureId && hasPayloadData(value)) {
-    payloads.push({ fixture_id: fixtureId, ...value });
+    payloads.push({ fixture_id: fixtureId, ...surface, ...value });
   }
   for (const key of ['stdout', 'stderr', 'output', 'result']) {
     for (const parsed of parseJsonPayloadsFromText(value[key])) {
-      payloads.push({ fixture_id: fixtureId, ...parsed });
+      payloads.push({ fixture_id: fixtureId, ...surface, ...parsed });
     }
   }
   if (Array.isArray(value)) {
@@ -588,7 +660,7 @@ function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen) {
     let carried = inheritedFixtureId;
     for (const child of value) {
       const childFixtureId = (child && typeof child === 'object') ? (fixtureIdentity(child) || carried) : carried;
-      visitRuntimePayloads(child, childFixtureId, payloads, seen);
+      visitRuntimePayloads(child, childFixtureId, payloads, seen, surface);
       if (childFixtureId) {
         carried = childFixtureId;
       }
@@ -596,8 +668,24 @@ function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen) {
     return;
   }
   for (const child of Object.values(value)) {
-    visitRuntimePayloads(child, fixtureId, payloads, seen);
+    visitRuntimePayloads(child, fixtureId, payloads, seen, surface);
   }
+}
+
+function surfaceFields(payload) {
+  const metadata = objectValue(payload.metadata || payload.recipeStepMetadata || payload.recipe_step_metadata);
+  return compactObject({
+    surface_id: payload.surface_id || payload.surfaceId || metadata.surface_id || metadata.surfaceId,
+    surface_label: payload.surface_label || payload.surfaceLabel || metadata.surface_label || metadata.surfaceLabel,
+    source_entry: payload.source_entry || payload.sourceEntry || metadata.source_entry || metadata.sourceEntry,
+    target: payload.target || metadata.target,
+    url: payload.url || payload.candidate_url || payload.candidateUrl || metadata.url || metadata.candidate_url || metadata.candidateUrl,
+  });
+}
+
+function surfaceSortKey(surface) {
+  const id = surface.surface_id || '';
+  return id === 'front-page' ? '' : id;
 }
 
 function hasPayloadData(value) {

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -129,6 +129,7 @@ export function normalizeFixtureMatrixResult(input = {}) {
       gate_failure_reasons: categoryRollups.gate_failure_reasons,
       visual_diff_cause_summary: aggregateVisualDiffCauseSummary(gatedFixtureResults),
       visual_diff_top_causes: visualDiffTopCauses(gatedFixtureResults),
+      surface_evidence: aggregateSurfaceEvidence(gatedFixtureResults),
       gutenberg_incompatibility_registry: gutenbergIncompatibilityRegistry.summary,
       groups: Object.fromEntries(Object.entries(grouped).map(([key, items]) => [key, items.length])),
       top_pattern_families: topPatternFamilies(actionableFindings),
@@ -432,6 +433,7 @@ export function normalizeFixtureResult(input) {
     diagnostics: boundBlob(normalizeArray(input.diagnostics || input.findings || input.messages)),
     artifact_refs: normalizeArray(input.artifact_refs || input.artifactRefs),
     artifacts: input.artifacts || {},
+    surfaces: normalizeArray(input.surfaces || input.surface_results || input.surfaceResults).map(normalizeSurfaceResult),
     editor_canvas: boundBlob(input.editor_canvas || input.editorCanvas || null),
     editor_open: boundBlob(input.editor_open || input.editorOpen || null),
     visual_parity_artifacts: input.visual_parity_artifacts || input.visualParityArtifacts || null,
@@ -443,6 +445,25 @@ export function normalizeFixtureResult(input) {
     // omitted entirely so a default (toggle-off) result is byte-identical to today.
     ...(liveWpParityResult ? { live_wp_parity: liveWpParityResult } : {}),
   };
+}
+
+function normalizeSurfaceResult(input) {
+  const row = objectValue(input);
+  return compactObject({
+    surface_id: row.surface_id || row.surfaceId || row.id || '',
+    surface_label: row.surface_label || row.surfaceLabel || row.label || '',
+    source_entry: row.source_entry || row.sourceEntry || '',
+    target: row.target || '',
+    url: row.url || row.candidate_url || row.candidateUrl || '',
+    artifact_refs: normalizeArray(row.artifact_refs || row.artifactRefs),
+    editor_validation: row.editor_validation || row.editorValidation || null,
+    editor_canvas: boundBlob(row.editor_canvas || row.editorCanvas || null),
+    editor_open: boundBlob(row.editor_open || row.editorOpen || null),
+    visual_parity_artifacts: row.visual_parity_artifacts || row.visualParityArtifacts || null,
+    visual_diff_regions: normalizeArray(row.visual_diff_regions || row.visualDiffRegions),
+    visual_diff_cause_summary: row.visual_diff_cause_summary || row.visualDiffCauseSummary || null,
+    visual_diff_classification: row.visual_diff_classification || row.visualDiffClassification || null,
+  });
 }
 
 export function writeFixtureMatrixArtifacts(input = {}) {
@@ -572,6 +593,42 @@ function visualDiffTopCauses(fixtures, limit = 5) {
   return Object.entries(aggregateVisualDiffCauseSummary(fixtures))
     .slice(0, limit)
     .map(([cause, pixel_count]) => ({ cause, pixel_count }));
+}
+
+function aggregateSurfaceEvidence(fixtures) {
+  const surfaces = normalizeArray(fixtures).flatMap((fixture) => normalizeArray(fixture.surfaces).map((surface) => ({ fixture_id: fixture.fixture_id, ...surface })));
+  return {
+    surface_count: surfaces.length,
+    visual_surface_count: surfaces.filter((surface) => hasVisualSurfaceEvidence(surface)).length,
+    editor_surface_count: surfaces.filter((surface) => hasEditorSurfaceEvidence(surface)).length,
+    rows: surfaces.map((surface) => compactObject({
+      fixture_id: surface.fixture_id,
+      surface_id: surface.surface_id,
+      source_entry: surface.source_entry,
+      target: surface.target,
+      url: surface.url,
+      visual_artifact_paths: surfaceArtifactPaths(surface).filter((artifactPath) => /visual|screenshot|diff|\.png$/i.test(artifactPath)),
+      editor_artifact_paths: surfaceArtifactPaths(surface).filter((artifactPath) => /editor/i.test(artifactPath)),
+    })),
+  };
+}
+
+function hasVisualSurfaceEvidence(surface) {
+  const artifacts = objectValue(surface.visual_parity_artifacts || surface.visualParityArtifacts);
+  return Object.keys(objectValue(artifacts.artifacts)).length > 0
+    || Object.keys(objectValue(artifacts.metrics || artifacts.comparison)).length > 0
+    || surfaceArtifactPaths(surface).some((artifactPath) => /visual|screenshot|diff|\.png$/i.test(artifactPath));
+}
+
+function hasEditorSurfaceEvidence(surface) {
+  return Boolean(surface.editor_validation || surface.editorValidation || surface.editor_canvas || surface.editorCanvas || surface.editor_open || surface.editorOpen)
+    || surfaceArtifactPaths(surface).some((artifactPath) => /editor/i.test(artifactPath));
+}
+
+function surfaceArtifactPaths(surface) {
+  return normalizeArray(surface.artifact_refs || surface.artifactRefs)
+    .map((ref) => objectValue(ref).path || objectValue(ref).file || objectValue(ref).href || '')
+    .filter(Boolean);
 }
 
 function shouldStageFixtureSources(input = {}) {

--- a/lib/fixture-matrix/visual-evidence-report.mjs
+++ b/lib/fixture-matrix/visual-evidence-report.mjs
@@ -26,6 +26,7 @@ export function buildVisualParityEvidenceReport(input = {}) {
     const manifest = fixtureById.get(fixture.fixture_id) || {};
     return fixtureEvidenceRow({ fixture, manifest, findings: findingsByFixture.get(fixture.fixture_id) || [], outputDirectory });
   });
+  const surfaces = fixtures.flatMap((fixture) => fixture.surfaces);
   const riskCounts = countBy(fixtures, (fixture) => fixture.risk.level);
 
   return {
@@ -37,8 +38,12 @@ export function buildVisualParityEvidenceReport(input = {}) {
       staged_source_fixture_count: fixtures.filter((fixture) => fixture.stages.staged_source_html.status === 'present').length,
       imported_snapshot_fixture_count: fixtures.filter((fixture) => fixture.stages.imported_wordpress_theme.status === 'present').length,
       visual_compare_fixture_count: fixtures.filter((fixture) => fixture.evidence.visual_compare.status === 'present').length,
+      visual_compare_surface_count: surfaces.filter((surface) => surface.evidence.visual_compare.status === 'present').length,
+      editor_surface_count: surfaces.filter((surface) => surface.evidence.editor.status === 'present').length,
       screenshot_fixture_count: fixtures.filter((fixture) => fixture.evidence.screenshots.status === 'present').length,
+      screenshot_surface_count: surfaces.filter((surface) => surface.evidence.screenshots.status === 'present').length,
       viewport_evidence_fixture_count: fixtures.filter((fixture) => fixture.evidence.viewports.status === 'present').length,
+      viewport_evidence_surface_count: surfaces.filter((surface) => surface.evidence.viewports.status === 'present').length,
       mobile_viewport_fixture_count: fixtures.filter((fixture) => fixture.evidence.viewports.has_mobile).length,
       live_wp_parity_fixture_count: fixtures.filter((fixture) => fixture.evidence.live_wp_parity.status === 'present').length,
       missing_asset_fixture_count: fixtures.filter((fixture) => fixture.asset_resolution.missing_asset_count > 0).length,
@@ -51,6 +56,7 @@ export function buildVisualParityEvidenceReport(input = {}) {
         .map((fixture) => ({ fixture_id: fixture.fixture_id, score: fixture.risk.score, level: fixture.risk.level, reasons: fixture.risk.reasons })),
     },
     fixtures,
+    surfaces,
     limitations: [
       'This report scores deterministic evidence availability and known artifact risks; it is not a pixel-diff substitute.',
       'Viewport evidence is inferred from captured browser evidence metadata and screenshot refs; missing mobile evidence means no mobile capture was observed in the matrix artifacts.',
@@ -61,8 +67,8 @@ export function buildVisualParityEvidenceReport(input = {}) {
 
 export function renderVisualParityEvidenceReportMarkdown(report) {
   const summary = objectValue(report.summary);
-  const rows = normalizeArray(report.fixtures)
-    .map((fixture) => `| ${fixture.fixture_id} | ${fixture.risk.level} (${fixture.risk.score}) | ${fixture.stages.generated_html_artifact.status} | ${fixture.stages.imported_wordpress_theme.status} | ${fixture.evidence.visual_compare.status} | ${fixture.evidence.screenshots.status} | ${fixture.evidence.viewports.status}${fixture.evidence.viewports.has_mobile ? ' + mobile' : ''} | ${fixture.block_theme.native_conversion_rate} | ${fixture.block_theme.core_html_block_count} | ${fixture.asset_resolution.missing_asset_count} |`)
+  const rows = normalizeArray(report.surfaces)
+    .map((surface) => `| ${surface.fixture_id} | ${surface.surface_id} | ${surface.source_entry || ''} | ${surface.risk.level} (${surface.risk.score}) | ${surface.evidence.editor.status} | ${surface.evidence.visual_compare.status} | ${surface.evidence.screenshots.status} | ${surface.evidence.viewports.status}${surface.evidence.viewports.has_mobile ? ' + mobile' : ''} | ${surface.artifact_paths.join('<br>')} |`)
     .join('\n');
   return [
     '# Visual Parity Evidence Report',
@@ -71,16 +77,17 @@ export function renderVisualParityEvidenceReportMarkdown(report) {
     '',
     `Fixtures: ${summary.fixture_count || 0}`,
     `Imported snapshots: ${summary.imported_snapshot_fixture_count || 0}`,
-    `Visual compare evidence: ${summary.visual_compare_fixture_count || 0}`,
-    `Screenshot evidence: ${summary.screenshot_fixture_count || 0}`,
-    `Viewport evidence: ${summary.viewport_evidence_fixture_count || 0}`,
+    `Visual compare evidence: ${summary.visual_compare_surface_count || 0} surface(s) across ${summary.visual_compare_fixture_count || 0} fixture(s)`,
+    `Editor evidence: ${summary.editor_surface_count || 0} surface(s)`,
+    `Screenshot evidence: ${summary.screenshot_surface_count || 0} surface(s) across ${summary.screenshot_fixture_count || 0} fixture(s)`,
+    `Viewport evidence: ${summary.viewport_evidence_surface_count || 0} surface(s) across ${summary.viewport_evidence_fixture_count || 0} fixture(s)`,
     `Mobile viewport evidence: ${summary.mobile_viewport_fixture_count || 0}`,
     `Fixtures with missing assets: ${summary.missing_asset_fixture_count || 0}`,
     `Fixtures with core/html blocks: ${summary.core_html_fixture_count || 0}`,
     '',
-    '| Fixture | Risk | Generated HTML | Imported WP Snapshot | Visual Compare | Screenshots | Viewports | Native Rate | Core HTML | Missing Assets |',
-    '|---|---:|---|---|---|---|---|---:|---:|---:|',
-    rows || '| _none_ |  |  |  |  |  |  |  |  |  |',
+    '| Fixture | Surface | Source Entry | Risk | Editor | Visual Compare | Screenshots | Viewports | Artifact Paths |',
+    '|---|---|---|---:|---|---|---|---|---|',
+    rows || '| _none_ |  |  |  |  |  |  |  |  |',
     '',
     '## Limitations',
     '',
@@ -108,6 +115,7 @@ function fixtureEvidenceRow({ fixture, manifest, findings, outputDirectory }) {
   const visualComparePresent = Object.keys(visualMetrics).length > 0 || Object.keys(visualArtifacts).length > 0 || artifactRefs.some((ref) => /visual-(compare|diff)|screenshot/i.test(`${ref.artifact_id || ''} ${ref.kind || ''} ${ref.path || ''}`));
   const importedSnapshotPresent = fileExists(fixturePath(outputDirectory, fixtureId, 'files', 'browser', 'snapshot.html')) || artifactRefs.some((ref) => /snapshot\.html|capture-html|browser.*html/i.test(`${ref.artifact_id || ''} ${ref.kind || ''} ${ref.path || ''}`));
   const risk = computeRisk({ artifactPath, sourcePath, importedSnapshotPresent, visualComparePresent, screenshotRefs, viewportRows, missingAssets, coreHtmlBlockCount, fixture });
+  const surfaces = surfaceEvidenceRows({ fixture, outputDirectory, fallback: { visualComparePresent, screenshotRefs, viewportRows, risk } });
 
   return {
     fixture_id: fixtureId,
@@ -131,6 +139,7 @@ function fixtureEvidenceRow({ fixture, manifest, findings, outputDirectory }) {
       },
       live_wp_parity: stageStatus(Boolean(fixture.live_wp_parity), fixture.live_wp_parity ? `score ${numberValue(fixture.live_wp_parity.score, 0)}` : ''),
     },
+    surfaces,
     asset_resolution: {
       missing_asset_count: missingAssets.length,
       examples: missingAssets.slice(0, 5).map((item) => compactObject({ kind: item.kind, path: item.path || item.url || item.source_path, message: item.message || item.reason })),
@@ -143,6 +152,70 @@ function fixtureEvidenceRow({ fixture, manifest, findings, outputDirectory }) {
       editor_invalid_count: numberValue(editorQuality.editor_invalid_count, 0),
     },
     risk,
+  };
+}
+
+function surfaceEvidenceRows({ fixture, outputDirectory, fallback }) {
+  const rows = normalizeArray(fixture.surfaces).length ? normalizeArray(fixture.surfaces) : [{ surface_id: 'front-page', source_entry: fixture.entrypoint || 'index.html', artifact_refs: fixture.artifact_refs, visual_parity_artifacts: fixture.visual_parity_artifacts, editor_validation: fixture.editor_validation, editor_canvas: fixture.editor_canvas, editor_open: fixture.editor_open }];
+  return rows.map((surface) => surfaceEvidenceRow({ fixture, surface, outputDirectory, fallback }));
+}
+
+function surfaceEvidenceRow({ fixture, surface, outputDirectory, fallback }) {
+  const fixtureId = fixture.fixture_id || '';
+  const surfaceId = surface.surface_id || 'front-page';
+  const artifactRefs = normalizeArray(surface.artifact_refs);
+  const artifacts = objectValue(surface.visual_parity_artifacts);
+  const visualArtifacts = objectValue(artifacts.artifacts);
+  const visualMetrics = objectValue(artifacts.metrics || artifacts.comparison);
+  const screenshotRefs = screenshotArtifacts(visualArtifacts, artifactRefs);
+  const viewportRows = viewportEvidenceRows({ artifacts, artifactRefs });
+  const visualComparePresent = Object.keys(visualMetrics).length > 0 || Object.keys(visualArtifacts).length > 0 || artifactRefs.some((ref) => /visual-(compare|diff)|screenshot/i.test(`${ref.artifact_id || ''} ${ref.kind || ''} ${ref.path || ''}`));
+  const editorPresent = Boolean(surface.editor_validation || surface.editor_canvas || surface.editor_open || artifactRefs.some((ref) => /editor/i.test(`${ref.artifact_id || ''} ${ref.kind || ''} ${ref.path || ''}`)));
+  const artifactPaths = dedupeStrings(artifactRefs.map((ref) => ref.path || ref.file || ref.href).filter(Boolean));
+  const risk = computeSurfaceRisk({ visualComparePresent, editorPresent, screenshotRefs, viewportRows, artifactPaths });
+  return {
+    fixture_id: fixtureId,
+    surface_id: surfaceId,
+    surface_label: surface.surface_label || surfaceId,
+    source_entry: surface.source_entry || '',
+    target: surface.target || '',
+    url: surface.url || '',
+    evidence: {
+      editor: stageStatus(editorPresent, editorPresent ? 'editor validation/canvas/open evidence' : ''),
+      visual_compare: stageStatus(visualComparePresent, visualComparePresent ? 'visual parity metrics/artifacts' : ''),
+      screenshots: {
+        status: screenshotRefs.length ? 'present' : 'missing',
+        count: screenshotRefs.length,
+        refs: screenshotRefs.slice(0, 8),
+      },
+      viewports: {
+        status: viewportRows.length ? 'present' : 'missing',
+        count: viewportRows.length,
+        has_mobile: viewportRows.some((row) => numberValue(row.width, 0) > 0 && numberValue(row.width, 0) <= 480),
+        rows: viewportRows.slice(0, 8),
+      },
+    },
+    artifact_paths: artifactPaths,
+    risk: fallback?.risk && surfaceId === 'front-page' ? fallback.risk : risk,
+  };
+}
+
+function computeSurfaceRisk({ visualComparePresent, editorPresent, screenshotRefs, viewportRows, artifactPaths }) {
+  const reasons = [];
+  let score = 0;
+  const add = (points, reason) => {
+    score += points;
+    reasons.push(reason);
+  };
+  if (!editorPresent) add(10, 'missing editor evidence');
+  if (!visualComparePresent) add(15, 'missing visual compare artifact');
+  if (!screenshotRefs.length) add(10, 'missing screenshot refs');
+  if (!viewportRows.length) add(8, 'missing viewport evidence');
+  if (!artifactPaths.length) add(6, 'missing artifact refs');
+  return {
+    score,
+    level: score >= 40 ? 'high' : score >= 15 ? 'medium' : 'low',
+    reasons,
   };
 }
 
@@ -233,6 +306,15 @@ function dedupeByPath(refs) {
     const key = ref.path || ref.id || JSON.stringify(ref);
     if (seen.has(key)) return false;
     seen.add(key);
+    return true;
+  });
+}
+
+function dedupeStrings(values) {
+  const seen = new Set();
+  return values.filter((value) => {
+    if (seen.has(value)) return false;
+    seen.add(value);
     return true;
   });
 }

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -3446,6 +3446,82 @@ test('fixture matrix secondary editor targets fall back to runtime slug resoluti
   assert.equal(resolved.editor_target_source, 'surface-slug-fallback');
 });
 
+test('fixture matrix result preserves per-surface visual and editor artifacts', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-surface-result-'));
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-surface-result-artifacts-'));
+  const fixtureDirectory = path.join(root, 'artist');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'fixture.json'), JSON.stringify({ id: 'artist', label: 'Artist' }));
+  writeFileSync(path.join(fixtureDirectory, 'index.html'), '<main>Home</main>');
+  writeFileSync(path.join(fixtureDirectory, 'about.html'), '<main>About</main>');
+
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'surface-result-test' });
+  const execution = ({ phase, surfaceId, sourceEntry, output }) => ({
+    recipePhase: phase,
+    recipeStepIndex: surfaceId === 'front-page' ? 1 : 2,
+    metadata: {
+      fixture_id: 'artist',
+      surface_id: surfaceId,
+      source_entry: sourceEntry,
+      target: surfaceId === 'front-page' ? 'front-page' : '/about/',
+      candidate_url: surfaceId === 'front-page' ? '/' : '/about/',
+    },
+    output: JSON.stringify(output),
+  });
+  const visualOutput = (surfaceId, sourceEntry) => ({
+    schema: 'wp-codebox/visual-compare/v1',
+    summary: { mismatch_pixels: surfaceId === 'front-page' ? 0 : 10, total_pixels: 1000, overlap_mismatch_pixels: surfaceId === 'front-page' ? 0 : 10, overlap_pixels: 1000 },
+    artifacts: {
+      source_screenshot: `files/browser/visual/${surfaceId}/source.png`,
+      imported_screenshot: `files/browser/visual/${surfaceId}/imported.png`,
+      diff_screenshot: `files/browser/visual/${surfaceId}/diff.png`,
+    },
+    source: { path: sourceEntry },
+  });
+  const editorOutput = (surfaceId) => ({
+    schema: 'wordpress/editor-validate-blocks/v1',
+    validation_method: EDITOR_VALIDATION_METHOD,
+    total_blocks: 2,
+    valid_blocks: 2,
+    invalid_blocks: 0,
+    results: [{ name: 'core/paragraph', isValid: true }, { name: 'core/heading', isValid: true }],
+    artifacts: {
+      editor_screenshot: `files/browser/editor-open/artist/${surfaceId}/screenshot.png`,
+    },
+  });
+
+  const result = collectFixtureMatrixRunResults({
+    matrix,
+    outputDirectory,
+    codeboxOutput: {
+      executions: [
+        execution({ phase: 'editor', surfaceId: 'front-page', sourceEntry: 'index.html', output: editorOutput('front-page') }),
+        execution({ phase: 'visual', surfaceId: 'front-page', sourceEntry: 'index.html', output: visualOutput('front-page', 'index.html') }),
+        execution({ phase: 'editor', surfaceId: 'about', sourceEntry: 'about.html', output: editorOutput('about') }),
+        execution({ phase: 'visual', surfaceId: 'about', sourceEntry: 'about.html', output: visualOutput('about', 'about.html') }),
+      ],
+    },
+  });
+
+  const fixture = result.fixtures[0];
+  const surfaces = Object.fromEntries(fixture.surfaces.map((surface) => [surface.surface_id, surface]));
+  assert.deepEqual(Object.keys(surfaces), ['front-page', 'about']);
+  assert.equal(surfaces['front-page'].source_entry, 'index.html');
+  assert.equal(surfaces.about.source_entry, 'about.html');
+  assert.ok(surfaces['front-page'].artifact_refs.some((ref) => ref.path === 'files/browser/visual/front-page/source.png'));
+  assert.ok(surfaces.about.artifact_refs.some((ref) => ref.path === 'files/browser/editor-open/artist/about/screenshot.png'));
+  assert.equal(result.summary.surface_evidence.surface_count, 2);
+  assert.equal(result.summary.surface_evidence.visual_surface_count, 2);
+  assert.equal(result.summary.surface_evidence.editor_surface_count, 2);
+  assert.deepEqual(result.summary.surface_evidence.rows.map((row) => `${row.fixture_id}/${row.surface_id}`), ['artist/front-page', 'artist/about']);
+
+  const report = buildVisualParityEvidenceReport({ outputDirectory, matrix, result });
+  assert.deepEqual(report.surfaces.map((surface) => `${surface.fixture_id}/${surface.surface_id}`), ['artist/front-page', 'artist/about']);
+  assert.equal(report.summary.visual_compare_surface_count, 2);
+  assert.equal(report.summary.editor_surface_count, 2);
+  assert.ok(report.surfaces.find((surface) => surface.surface_id === 'about').artifact_paths.includes('files/browser/visual/about/source.png'));
+});
+
 test('--no-editor-validation skips the editor browser step while keeping native-rate + findings', () => {
   // The editor browser step launches a browser per site and is the
   // slowest per-fixture step. --no-editor-validation skips it (companion to


### PR DESCRIPTION
## Summary
- Preserve per-surface editor and visual evidence rows during fixture-matrix result intake.
- Add summary/report surface rollups and per-surface artifact paths to the visual parity evidence report.
- Cover synthetic multi-surface WP Codebox command outputs so secondary surfaces do not collapse into the fixture front page.

## Testing
- npm run test:fixture-matrix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the reporting/intake changes, added synthetic fixture-matrix coverage, and ran verification.