### PR TITLE
Resolve secondary surface editor targets

### DIFF
--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -47,6 +47,7 @@ export {
   DEFAULT_EXTRA_SURFACE_COUNT,
   MAX_EXTRA_SURFACE_COUNT,
   normalizeSurfaceCoverageOptions,
+  resolveSurfaceEditorTarget,
   selectFixtureSurfaces,
   summarizeSurfaceCoverage,
 } from './fixture-matrix/steps/surfaces.mjs';

--- a/lib/fixture-matrix/steps/editor-open-step.mjs
+++ b/lib/fixture-matrix/steps/editor-open-step.mjs
@@ -13,14 +13,21 @@ export function editorOpenStep(input = {}) {
   const fixture = input.fixture || {};
   const surface = input.surface || null;
 
-  const postId = firstPresent([input.postId, input.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
+  const postId = firstPresent([input.postId, input.post_id, surface?.postId, surface?.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
   const url = firstPresent([input.url, input.editorOpenUrl, input.editor_open_url, surface?.url, fixture.editor_url, fixture.editorUrl]);
   const target = firstPresent([input.target, input.editorOpenTarget, input.editor_open_target, surface?.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
+  const postType = firstPresent([input.postType, input.post_type, surface?.postType, surface?.post_type]);
+  const postSlug = firstPresent([input.postSlug, input.post_slug, surface?.postSlug, surface?.post_slug]);
   const artifactPrefix = firstPresent([input.artifactPrefix, input.artifact_prefix, surface?.artifact_prefix]) || `files/browser/editor-open/${fixture.id}`;
 
   const args = [];
   if (postId !== undefined) {
     args.push(`post-id=${postId}`);
+  } else if (postSlug !== undefined) {
+    if (postType !== undefined) {
+      args.push(`post-type=${postType}`);
+    }
+    args.push(`post-slug=${postSlug}`);
   } else if (url !== undefined) {
     args.push(`url=${url}`);
   } else if (target !== undefined) {
@@ -49,8 +56,11 @@ export function editorOpenStep(input = {}) {
       artifact_prefix: artifactPrefix,
       ...(surface?.id ? { surface_id: surface.id } : {}),
       ...(postId !== undefined ? { post_id: postId } : {}),
+      ...(postSlug !== undefined ? { post_slug: postSlug } : {}),
+      ...(postType !== undefined ? { post_type: postType } : {}),
       ...(url !== undefined ? { url } : {}),
       ...(target !== undefined ? { target } : { target: DEFAULT_EDITOR_VALIDATION_TARGET }),
+      ...(surface?.editor_target_source ? { editor_target_source: surface.editor_target_source } : {}),
     }),
   };
 }

--- a/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -16,13 +16,20 @@ export function editorBlockValidationStep(input = {}) {
   const fixture = input.fixture || {};
   const surface = input.surface || null;
 
-  const postId = firstPresent([input.postId, input.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
+  const postId = firstPresent([input.postId, input.post_id, surface?.postId, surface?.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
   const url = firstPresent([input.url, input.editorValidationUrl, input.editor_validation_url, surface?.url, fixture.editor_url, fixture.editorUrl]);
   const target = firstPresent([input.target, surface?.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
+  const postType = firstPresent([input.postType, input.post_type, surface?.postType, surface?.post_type]);
+  const postSlug = firstPresent([input.postSlug, input.post_slug, surface?.postSlug, surface?.post_slug]);
 
   const args = [];
   if (postId !== undefined) {
     args.push(`post-id=${postId}`);
+  } else if (postSlug !== undefined) {
+    if (postType !== undefined) {
+      args.push(`post-type=${postType}`);
+    }
+    args.push(`post-slug=${postSlug}`);
   } else if (url !== undefined) {
     args.push(`url=${url}`);
   } else if (target !== undefined) {
@@ -47,8 +54,11 @@ export function editorBlockValidationStep(input = {}) {
     metadata: fixtureStepMetadata(fixture, 'editor', {
       ...(surface?.id ? { surface_id: surface.id } : {}),
       ...(postId !== undefined ? { post_id: postId } : {}),
+      ...(postSlug !== undefined ? { post_slug: postSlug } : {}),
+      ...(postType !== undefined ? { post_type: postType } : {}),
       ...(url !== undefined ? { url } : {}),
       ...(target !== undefined ? { target } : { target: DEFAULT_EDITOR_VALIDATION_TARGET }),
+      ...(surface?.editor_target_source ? { editor_target_source: surface.editor_target_source } : {}),
     }),
   };
 }

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -32,7 +32,7 @@ import { editorBlockValidationStep } from './editor-validation-step.mjs';
 import { visualParityCompareStep, normalizeVisualParityRecipeOptions } from './visual-parity-step.mjs';
 import { liveWpParityCaptureStep, liveWpParityEnabled } from './live-wp-parity-step.mjs';
 import { fixtureStepMetadata } from './shared.mjs';
-import { selectFixtureSurfaces, summarizeSurfaceCoverage } from './surfaces.mjs';
+import { resolveSurfaceEditorTarget, selectFixtureSurfaces, summarizeSurfaceCoverage } from './surfaces.mjs';
 
 const CAPABILITY_PLUGIN_PROVISIONING = {
   'commerce-products': [
@@ -237,11 +237,11 @@ function fixtureWorkflowSteps(options) {
     ...surfaces.flatMap((surface, index) => [
       ...(editorOpenEnabled ? [editorOpenStep({
         fixture,
-        surface: editorSurface(surface),
+        surface: editorSurface(surface, { fixture, ...input }),
         ...editorValidationOptions,
         artifactPrefix: editorArtifactPrefix(fixture, surface),
       })] : []),
-      ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, surface: editorSurface(surface), ...editorValidationOptions })] : []),
+      ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, surface: editorSurface(surface, { fixture, ...input }), ...editorValidationOptions })] : []),
       ...(visualParityEnabled && index === 0 ? [visualParityDeterministicCssStep(fixture)] : []),
       ...(visualParityEnabled ? [visualParityCompareStep({ fixture, surface, ...visualParityRecipeOptions })] : []),
     ]),
@@ -249,11 +249,11 @@ function fixtureWorkflowSteps(options) {
   ];
 }
 
-function editorSurface(surface) {
+function editorSurface(surface, input = {}) {
   if (surface.id === 'front-page') {
     return surface;
   }
-  return { ...surface, url: surface.target };
+  return resolveSurfaceEditorTarget(surface, input);
 }
 
 function editorArtifactPrefix(fixture, surface) {

--- a/lib/fixture-matrix/steps/surfaces.mjs
+++ b/lib/fixture-matrix/steps/surfaces.mjs
@@ -63,6 +63,32 @@ export function summarizeSurfaceCoverage(fixtures = [], options = {}) {
   };
 }
 
+export function resolveSurfaceEditorTarget(surface, input = {}) {
+  if (!surface || surface.id === FRONT_PAGE_SURFACE.id) {
+    return surface;
+  }
+
+  const page = findImportedSurfacePage(surface, input);
+  const postId = positiveIntegerValue(page?.materialized_post_id ?? page?.materializedPostId ?? page?.post_id ?? page?.postId);
+  if (postId !== undefined) {
+    return {
+      ...surface,
+      postId,
+      post_id: postId,
+      editor_target_source: 'import-report',
+    };
+  }
+
+  return {
+    ...surface,
+    postType: 'page',
+    post_type: 'page',
+    postSlug: surfacePostSlug(surface),
+    post_slug: surfacePostSlug(surface),
+    editor_target_source: 'surface-slug-fallback',
+  };
+}
+
 export function normalizeSurfaceCoverageOptions(input = {}) {
   const raw = input.surfaceCoverage ?? input.surface_coverage ?? input.browserSurfaceCoverage ?? input.browser_surface_coverage;
   if (raw === undefined || raw === null || raw === false || raw === 'false' || raw === '0' || raw === 0) {
@@ -111,6 +137,84 @@ function surfaceFromHtmlPath(relativePath) {
   };
 }
 
+function findImportedSurfacePage(surface, input = {}) {
+  const pages = importedPages(input);
+  if (!pages.length) {
+    return null;
+  }
+
+  const sourceKeys = surfaceSourceKeys(surface);
+  const routeKeys = surfaceRouteKeys(surface);
+  return pages.find((page) => {
+    const pageSourceKeys = surfaceSourceKeys({ source_entry: page.source_path ?? page.sourcePath ?? page.path ?? page.source ?? '' });
+    if ([...pageSourceKeys].some((key) => sourceKeys.has(key))) {
+      return true;
+    }
+
+    const permalink = page.permalink || page.url || page.candidate_url || page.candidateUrl || '';
+    const slug = page.slug || page.post_name || page.postName || '';
+    const pageRouteKeys = new Set([
+      ...surfaceRouteKeys({ target: permalink, candidate_url: permalink }),
+      ...surfaceRouteKeys({ target: slug, candidate_url: slug }),
+    ]);
+    return [...pageRouteKeys].some((key) => routeKeys.has(key));
+  }) || null;
+}
+
+function importedPages(input = {}) {
+  const reports = [
+    input.import_report,
+    input.importReport,
+    input.report,
+    input.fixture?.import_report,
+    input.fixture?.importReport,
+  ].filter((report) => report && typeof report === 'object');
+  const pages = [];
+  for (const report of reports) {
+    pages.push(...arrayValue(report.desired?.pages));
+    pages.push(...arrayValue(report.source_of_truth_manifest?.desired?.pages));
+    pages.push(...arrayValue(report.sourceOfTruthManifest?.desired?.pages));
+    pages.push(...arrayValue(report.materialized_pages));
+    pages.push(...arrayValue(report.materializedPages));
+    pages.push(...arrayValue(report.pages));
+  }
+  pages.push(...arrayValue(input.materialized_pages));
+  pages.push(...arrayValue(input.materializedPages));
+  return pages.filter((page) => page && typeof page === 'object');
+}
+
+function surfaceSourceKeys(surface) {
+  const raw = String(surface?.source_entry || surface?.source_path || surface?.sourcePath || '').trim();
+  const normalized = normalizeRoutePath(raw.replace(/^website\//, ''));
+  const withoutExtension = normalized.replace(/\.(?:html?)$/i, '').replace(/\/index$/i, '');
+  return new Set([normalized, withoutExtension, `website/${normalized}`].filter(Boolean));
+}
+
+function surfaceRouteKeys(surface) {
+  const values = [surface?.target, surface?.candidate_url, surface?.candidateUrl].map((value) => String(value || '').trim()).filter(Boolean);
+  return new Set(values.map((value) => {
+    try {
+      value = new URL(value).pathname;
+    } catch {
+      // Relative routes and slugs are expected here.
+    }
+    return normalizeRoutePath(value).replace(/\/index$/i, '');
+  }).filter(Boolean));
+}
+
+function surfacePostSlug(surface) {
+  const source = String(surface?.source_entry || '').replace(/^website\//, '');
+  const sourceSlug = normalizeRoutePath(source).replace(/\.(?:html?)$/i, '').replace(/\/index$/i, '').split('/').filter(Boolean).pop();
+  if (sourceSlug) {
+    return sourceSlug;
+  }
+  return [...surfaceRouteKeys(surface)][0]?.split('/').filter(Boolean).pop() || String(surface?.id || '').replace(/--\d+$/, '') || 'page';
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) ? value : [];
+}
+
 function uniqueSurfaceIds(surfaces) {
   const seen = new Map();
   return surfaces.map((surface) => {
@@ -140,4 +244,12 @@ function positiveInteger(value, fallback) {
     return fallback;
   }
   return Math.floor(number);
+}
+
+function positiveIntegerValue(value) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) {
+    return undefined;
+  }
+  return number;
 }

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -51,6 +51,7 @@ import {
   liveWpParityEnabled,
   MAX_EXTRA_SURFACE_COUNT,
   normalizeSurfaceCoverageOptions,
+  resolveSurfaceEditorTarget,
   runLiveWpParity,
   normalizeLiveWpParityReport,
   selectFixtureSurfaces,
@@ -2455,8 +2456,10 @@ test('CLI surface coverage reaches bench recipe browser evidence steps', () => {
   const visualSteps = recipe.workflow.steps.filter((step) => step.command === 'wordpress.visual-compare');
   assert.equal(editorOpenSteps.length, 3);
   assert.equal(visualSteps.length, 3);
-  assert.ok(editorOpenSteps[1].args.includes('url=/contact/'));
-  assert.ok(editorOpenSteps[2].args.includes('url=/merch/'));
+  assert.ok(editorOpenSteps[1].args.includes('post-type=page'));
+  assert.ok(editorOpenSteps[1].args.includes('post-slug=contact'));
+  assert.ok(editorOpenSteps[2].args.includes('post-type=page'));
+  assert.ok(editorOpenSteps[2].args.includes('post-slug=merch'));
   assert.equal(visualCompareMatrixComparison(visualSteps[2]).candidateUrl, '/merch/');
 });
 
@@ -2488,8 +2491,10 @@ test('runFixtureMatrix surface coverage reaches executed batch recipes', async (
     const visualSteps = batchRecipe.workflow.steps.filter((step) => step.command === 'wordpress.visual-compare');
     assert.equal(editorOpenSteps.length, 3);
     assert.equal(visualSteps.length, 3);
-    assert.ok(editorOpenSteps[1].args.includes('url=/contact/'));
-    assert.ok(editorOpenSteps[2].args.includes('url=/merch/'));
+    assert.ok(editorOpenSteps[1].args.includes('post-type=page'));
+    assert.ok(editorOpenSteps[1].args.includes('post-slug=contact'));
+    assert.ok(editorOpenSteps[2].args.includes('post-type=page'));
+    assert.ok(editorOpenSteps[2].args.includes('post-slug=merch'));
     assert.equal(visualCompareMatrixComparison(visualSteps[1]).candidateUrl, '/contact/');
     assert.equal(visualCompareMatrixComparison(visualSteps[2]).candidateUrl, '/merch/');
   } finally {
@@ -3364,11 +3369,14 @@ test('fixture matrix browser surfaces default to front page and opt into bounded
   assert.equal(editorValidationSteps.length, 3);
   assert.equal(visualSteps.length, 3);
   assert.ok(editorOpenSteps[0].args.includes('artifact-prefix=files/browser/editor-open/artist'));
-  assert.ok(editorOpenSteps[1].args.includes('url=/about/'));
+  assert.ok(editorOpenSteps[1].args.includes('post-type=page'));
+  assert.ok(editorOpenSteps[1].args.includes('post-slug=about'));
   assert.ok(editorOpenSteps[1].args.includes('artifact-prefix=files/browser/editor-open/artist/about'));
-  assert.ok(editorOpenSteps[2].args.includes('url=/about/'));
+  assert.ok(editorOpenSteps[2].args.includes('post-type=page'));
+  assert.ok(editorOpenSteps[2].args.includes('post-slug=about'));
   assert.ok(editorOpenSteps[2].args.includes('artifact-prefix=files/browser/editor-open/artist/about--2'));
-  assert.ok(editorValidationSteps[1].args.includes('url=/about/'));
+  assert.ok(editorValidationSteps[1].args.includes('post-type=page'));
+  assert.ok(editorValidationSteps[1].args.includes('post-slug=about'));
 
   const aboutComparison = visualCompareMatrixComparison(visualSteps[1]);
   assert.equal(aboutComparison.name, 'artist--about');
@@ -3381,6 +3389,61 @@ test('fixture matrix browser surfaces default to front page and opt into bounded
   assert.equal(multiSurfaceRecipe.metadata.surface_coverage.extra_surfaces_per_fixture, 2);
   assert.equal(multiSurfaceRecipe.metadata.surface_coverage.total_surface_count, 3);
   assert.equal(multiSurfaceRecipe.metadata.runtime_cost_warnings[0].code, 'surface_coverage_runtime_cost');
+});
+
+test('fixture matrix resolves secondary editor targets from imported page metadata', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-surface-targets-'));
+  const fixtureDirectory = path.join(root, 'artist');
+  mkdirSync(path.join(fixtureDirectory, 'merch'), { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'fixture.json'), JSON.stringify({ id: 'artist', label: 'Artist' }));
+  writeFileSync(path.join(fixtureDirectory, 'index.html'), '<main>Home</main>');
+  writeFileSync(path.join(fixtureDirectory, 'contact.html'), '<main>Contact</main>');
+  writeFileSync(path.join(fixtureDirectory, 'merch', 'index.html'), '<main>Merch</main>');
+
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'surface-target-test' });
+  const importReport = {
+    desired: {
+      pages: [
+        { source_path: 'website/index.html', materialized_post_id: 101, slug: 'home', permalink: '/' },
+        { source_path: 'website/contact.html', materialized_post_id: 202, slug: 'contact', permalink: '/contact/' },
+        { source_path: 'website/merch/index.html', materialized_post_id: 303, slug: 'merch', permalink: '/merch/' },
+      ],
+    },
+  };
+
+  const surfaces = selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: 2 });
+  assert.deepEqual(surfaces.map((surface) => surface.id), ['front-page', 'contact', 'merch']);
+  assert.equal(resolveSurfaceEditorTarget(surfaces[1], { importReport }).postId, 202);
+  assert.equal(resolveSurfaceEditorTarget(surfaces[2], { importReport }).postId, 303);
+
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    surfaceCoverage: 2,
+    importReport,
+  });
+  const editorOpenSteps = recipe.workflow.steps.filter((step) => step.command === 'wordpress.editor-open');
+  const editorValidationSteps = recipe.workflow.steps.filter((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND);
+  const visualSteps = recipe.workflow.steps.filter((step) => step.command === 'wordpress.visual-compare');
+
+  assert.ok(editorOpenSteps[0].args.includes('target=front-page'));
+  assert.ok(editorOpenSteps[1].args.includes('post-id=202'));
+  assert.ok(editorOpenSteps[2].args.includes('post-id=303'));
+  assert.ok(editorValidationSteps[1].args.includes('post-id=202'));
+  assert.ok(editorValidationSteps[2].args.includes('post-id=303'));
+  assert.equal(visualCompareMatrixComparison(visualSteps[1]).candidateUrl, '/contact/');
+  assert.equal(visualCompareMatrixComparison(visualSteps[2]).candidateUrl, '/merch/');
+});
+
+test('fixture matrix secondary editor targets fall back to runtime slug resolution when imported page id is unavailable', () => {
+  const surface = { id: 'contact', target: '/contact/', source_entry: 'contact.html', candidate_url: '/contact/' };
+  const resolved = resolveSurfaceEditorTarget(surface, { importReport: { desired: { pages: [{ source_path: 'website/contact.html', slug: 'contact' }] } } });
+
+  assert.equal(resolved.postId, undefined);
+  assert.equal(resolved.postSlug, 'contact');
+  assert.equal(resolved.postType, 'page');
+  assert.equal(resolved.editor_target_source, 'surface-slug-fallback');
 });
 
 test('--no-editor-validation skips the editor browser step while keeping native-rate + findings', () => {


### PR DESCRIPTION
## Summary
- Resolve fixture-matrix secondary editor surfaces to concrete `post-id` values when import/materialization metadata is available.
- Fall back to generic runtime slug targets (`post-type=page post-slug=<slug>`) instead of frontend URLs for secondary editor-open/editor-validation commands.
- Keep front-page editor behavior unchanged and keep visual compare on frontend candidate URLs.

Depends on Automattic/wp-codebox#1738 for runtime `post-slug` editor target support.

## Tests
- `npm run test:fixture-matrix`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented and verified the surface target resolver and fixture-matrix tests under Chris's direction.
