### PR TITLE
Extract fixture matrix editor target builder

### DIFF
--- a/lib/fixture-matrix/steps/editor-open-step.mjs
+++ b/lib/fixture-matrix/steps/editor-open-step.mjs
@@ -5,46 +5,19 @@
  */
 import {
   EDITOR_OPEN_COMMAND,
-  DEFAULT_EDITOR_VALIDATION_TARGET,
 } from '../shared/constants.mjs';
-import { firstPresent, fixtureStepMetadata } from './shared.mjs';
+import { editorStepTarget, firstPresent, fixtureStepMetadata } from './shared.mjs';
 
 export function editorOpenStep(input = {}) {
   const fixture = input.fixture || {};
   const surface = input.surface || null;
-
-  const postId = firstPresent([input.postId, input.post_id, surface?.postId, surface?.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
-  const url = firstPresent([input.url, input.editorOpenUrl, input.editor_open_url, surface?.url, fixture.editor_url, fixture.editorUrl]);
-  const target = firstPresent([input.target, input.editorOpenTarget, input.editor_open_target, surface?.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
-  const postType = firstPresent([input.postType, input.post_type, surface?.postType, surface?.post_type]);
-  const postSlug = firstPresent([input.postSlug, input.post_slug, surface?.postSlug, surface?.post_slug]);
   const artifactPrefix = firstPresent([input.artifactPrefix, input.artifact_prefix, surface?.artifact_prefix]) || `files/browser/editor-open/${fixture.id}`;
+  const resolvedTarget = editorStepTarget(input, fixture, surface, {
+    urlAliases: ['editorOpenUrl', 'editor_open_url'],
+    targetAliases: ['editorOpenTarget', 'editor_open_target'],
+  });
 
-  const args = [];
-  if (postId !== undefined) {
-    args.push(`post-id=${postId}`);
-  } else if (postSlug !== undefined) {
-    if (postType !== undefined) {
-      args.push(`post-type=${postType}`);
-    }
-    args.push(`post-slug=${postSlug}`);
-  } else if (url !== undefined) {
-    args.push(`url=${url}`);
-  } else if (target !== undefined) {
-    args.push(`target=${target}`);
-  } else {
-    args.push(`target=${DEFAULT_EDITOR_VALIDATION_TARGET}`);
-  }
-
-  const waitSelector = firstPresent([input.waitSelector, input.wait_selector, fixture.editor_wait_selector, fixture.editorWaitSelector]);
-  if (waitSelector !== undefined) {
-    args.push(`wait-selector=${waitSelector}`);
-  }
-  const waitTimeout = firstPresent([input.waitTimeout, input.wait_timeout, fixture.editor_wait_timeout, fixture.editorWaitTimeout]);
-  if (waitTimeout !== undefined) {
-    args.push(`wait-timeout=${waitTimeout}`);
-  }
-
+  const args = [...resolvedTarget.args];
   args.push('capture=screenshot,editor-state,editor-validity');
   args.push(`artifact-prefix=${artifactPrefix}`);
 
@@ -55,12 +28,7 @@ export function editorOpenStep(input = {}) {
     metadata: fixtureStepMetadata(fixture, 'editor-open', {
       artifact_prefix: artifactPrefix,
       ...(surface?.id ? { surface_id: surface.id } : {}),
-      ...(postId !== undefined ? { post_id: postId } : {}),
-      ...(postSlug !== undefined ? { post_slug: postSlug } : {}),
-      ...(postType !== undefined ? { post_type: postType } : {}),
-      ...(url !== undefined ? { url } : {}),
-      ...(target !== undefined ? { target } : { target: DEFAULT_EDITOR_VALIDATION_TARGET }),
-      ...(surface?.editor_target_source ? { editor_target_source: surface.editor_target_source } : {}),
+      ...resolvedTarget.metadata,
     }),
   };
 }

--- a/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -8,57 +8,23 @@
  */
 import {
   EDITOR_VALIDATE_BLOCKS_COMMAND,
-  DEFAULT_EDITOR_VALIDATION_TARGET,
 } from '../shared/constants.mjs';
-import { firstPresent, fixtureStepMetadata } from './shared.mjs';
+import { editorStepTarget, fixtureStepMetadata } from './shared.mjs';
 
 export function editorBlockValidationStep(input = {}) {
   const fixture = input.fixture || {};
   const surface = input.surface || null;
-
-  const postId = firstPresent([input.postId, input.post_id, surface?.postId, surface?.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
-  const url = firstPresent([input.url, input.editorValidationUrl, input.editor_validation_url, surface?.url, fixture.editor_url, fixture.editorUrl]);
-  const target = firstPresent([input.target, surface?.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
-  const postType = firstPresent([input.postType, input.post_type, surface?.postType, surface?.post_type]);
-  const postSlug = firstPresent([input.postSlug, input.post_slug, surface?.postSlug, surface?.post_slug]);
-
-  const args = [];
-  if (postId !== undefined) {
-    args.push(`post-id=${postId}`);
-  } else if (postSlug !== undefined) {
-    if (postType !== undefined) {
-      args.push(`post-type=${postType}`);
-    }
-    args.push(`post-slug=${postSlug}`);
-  } else if (url !== undefined) {
-    args.push(`url=${url}`);
-  } else if (target !== undefined) {
-    args.push(`target=${target}`);
-  } else {
-    args.push(`target=${DEFAULT_EDITOR_VALIDATION_TARGET}`);
-  }
-
-  const waitSelector = firstPresent([input.waitSelector, input.wait_selector, fixture.editor_wait_selector, fixture.editorWaitSelector]);
-  if (waitSelector !== undefined) {
-    args.push(`wait-selector=${waitSelector}`);
-  }
-  const waitTimeout = firstPresent([input.waitTimeout, input.wait_timeout, fixture.editor_wait_timeout, fixture.editorWaitTimeout]);
-  if (waitTimeout !== undefined) {
-    args.push(`wait-timeout=${waitTimeout}`);
-  }
+  const resolvedTarget = editorStepTarget(input, fixture, surface, {
+    urlAliases: ['editorValidationUrl', 'editor_validation_url'],
+  });
 
   return {
     command: EDITOR_VALIDATE_BLOCKS_COMMAND,
     allowFailure: true,
-    args,
+    args: resolvedTarget.args,
     metadata: fixtureStepMetadata(fixture, 'editor', {
       ...(surface?.id ? { surface_id: surface.id } : {}),
-      ...(postId !== undefined ? { post_id: postId } : {}),
-      ...(postSlug !== undefined ? { post_slug: postSlug } : {}),
-      ...(postType !== undefined ? { post_type: postType } : {}),
-      ...(url !== undefined ? { url } : {}),
-      ...(target !== undefined ? { target } : { target: DEFAULT_EDITOR_VALIDATION_TARGET }),
-      ...(surface?.editor_target_source ? { editor_target_source: surface.editor_target_source } : {}),
+      ...resolvedTarget.metadata,
     }),
   };
 }

--- a/lib/fixture-matrix/steps/shared.mjs
+++ b/lib/fixture-matrix/steps/shared.mjs
@@ -1,3 +1,5 @@
+import { DEFAULT_EDITOR_VALIDATION_TARGET } from '../shared/constants.mjs';
+
 export function fixtureStepMetadata(fixture = {}, phase, fields = {}) {
   return {
     fixture_id: fixture.id,
@@ -16,6 +18,53 @@ export function firstPresent(values) {
   return undefined;
 }
 
+export function editorStepTarget(input = {}, fixture = {}, surface = null, options = {}) {
+  const urlAliases = Array.isArray(options.urlAliases) ? options.urlAliases : [];
+  const targetAliases = Array.isArray(options.targetAliases) ? options.targetAliases : [];
+  const postId = firstPresent([input.postId, input.post_id, surface?.postId, surface?.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
+  const url = firstPresent([input.url, ...valuesForKeys(input, urlAliases), surface?.url, fixture.editor_url, fixture.editorUrl]);
+  const target = firstPresent([input.target, ...valuesForKeys(input, targetAliases), surface?.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
+  const postType = firstPresent([input.postType, input.post_type, surface?.postType, surface?.post_type]);
+  const postSlug = firstPresent([input.postSlug, input.post_slug, surface?.postSlug, surface?.post_slug]);
+
+  const args = [];
+  if (postId !== undefined) {
+    args.push(`post-id=${postId}`);
+  } else if (postSlug !== undefined) {
+    if (postType !== undefined) {
+      args.push(`post-type=${postType}`);
+    }
+    args.push(`post-slug=${postSlug}`);
+  } else if (url !== undefined) {
+    args.push(`url=${url}`);
+  } else if (target !== undefined) {
+    args.push(`target=${target}`);
+  } else {
+    args.push(`target=${DEFAULT_EDITOR_VALIDATION_TARGET}`);
+  }
+
+  const waitSelector = firstPresent([input.waitSelector, input.wait_selector, fixture.editor_wait_selector, fixture.editorWaitSelector]);
+  if (waitSelector !== undefined) {
+    args.push(`wait-selector=${waitSelector}`);
+  }
+  const waitTimeout = firstPresent([input.waitTimeout, input.wait_timeout, fixture.editor_wait_timeout, fixture.editorWaitTimeout]);
+  if (waitTimeout !== undefined) {
+    args.push(`wait-timeout=${waitTimeout}`);
+  }
+
+  return {
+    args,
+    metadata: {
+      ...(postId !== undefined ? { post_id: postId } : {}),
+      ...(postSlug !== undefined ? { post_slug: postSlug } : {}),
+      ...(postType !== undefined ? { post_type: postType } : {}),
+      ...(url !== undefined ? { url } : {}),
+      ...(target !== undefined ? { target } : { target: DEFAULT_EDITOR_VALIDATION_TARGET }),
+      ...(surface?.editor_target_source ? { editor_target_source: surface.editor_target_source } : {}),
+    },
+  };
+}
+
 export function resolveFixtureCandidateUrl(input = {}, fixture = {}, fallback) {
   return input.candidateUrl
     || input.candidate_url
@@ -26,4 +75,8 @@ export function resolveFixtureCandidateUrl(input = {}, fixture = {}, fallback) {
 
 function present(value) {
   return value !== undefined && value !== null && String(value).trim() !== '';
+}
+
+function valuesForKeys(source = {}, keys = []) {
+  return keys.map((key) => source[key]);
 }

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -74,6 +74,7 @@ import {
 } from '../lib/fixture-matrix.mjs';
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
 import { runWpCodeboxRecipe, wpCodeboxBin } from './wp-codebox/recipe.mjs';
+import { editorOpenStep } from '../lib/fixture-matrix/steps/editor-open-step.mjs';
 
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const fixtureRoot = path.join(packageRoot, 'tests', 'fixtures', 'fixture-matrix');
@@ -3631,6 +3632,52 @@ test('editorBlockValidationStep emits editor-validate-blocks against real import
   });
   assert.ok(withWait.args.includes('post-id=99'));
   assert.ok(withWait.args.includes('wait-selector=.is-root-container'));
+});
+
+test('editor step target builder preserves validation and open command precedence', () => {
+  const surface = {
+    id: 'contact',
+    postSlug: 'contact',
+    postType: 'page',
+    target: '/contact/',
+    editor_target_source: 'surface-slug-fallback',
+  };
+  const validation = editorBlockValidationStep({ fixture: { id: 'artist' }, surface });
+  assert.deepEqual(validation.args, ['post-type=page', 'post-slug=contact']);
+  assert.deepEqual(validation.metadata, {
+    fixture_id: 'artist',
+    fixture_path: undefined,
+    phase: 'editor',
+    surface_id: 'contact',
+    post_slug: 'contact',
+    post_type: 'page',
+    target: '/contact/',
+    editor_target_source: 'surface-slug-fallback',
+  });
+
+  const open = editorOpenStep({
+    fixture: { id: 'artist', editor_url: '/wp-admin/post.php?post=8&action=edit' },
+    surface: { id: 'contact', postId: 42, target: '/contact/', artifact_prefix: 'files/editor/contact' },
+    editorOpenTarget: 'front-page',
+    waitTimeout: 12000,
+  });
+  assert.equal(open.command, 'wordpress.editor-open');
+  assert.deepEqual(open.args, [
+    'post-id=42',
+    'wait-timeout=12000',
+    'capture=screenshot,editor-state,editor-validity',
+    'artifact-prefix=files/editor/contact',
+  ]);
+  assert.deepEqual(open.metadata, {
+    fixture_id: 'artist',
+    fixture_path: undefined,
+    phase: 'editor-open',
+    artifact_prefix: 'files/editor/contact',
+    surface_id: 'contact',
+    post_id: 42,
+    url: '/wp-admin/post.php?post=8&action=edit',
+    target: 'front-page',
+  });
 });
 
 test('editor-canvas-probe invalid-block warnings become gating editor_block_invalid findings', () => {


### PR DESCRIPTION
## Summary
- Extract shared editor target/argument resolution for fixture matrix editor-open and editor-validation steps.
- Keep command argument precedence and metadata behavior unchanged across post ID, post slug, URL, target, and wait options.
- Add coverage for the shared behavior across both editor step builders.

## Tests
- npm run test:fixture-matrix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Inspected fixture matrix internals, implemented the behavior-preserving refactor, added tests, and ran verification.