### PR TITLE
Avoid host temp paths in Lab fixture matrix runs

### DIFF
--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -58,8 +58,11 @@ lower-level bench:
 - `homeboy bench --rig static-site-importer-fixture-matrix --profile fixture-matrix --iterations 1`
 
 It sets the SSI matrix bench environment for the canonical fixture root, Static
-Site Importer checkout, WP Codebox execution, shared state, and optional Blocks
-Engine PHP transformer override. By default, `--blocks-engine` also supplies the
+Site Importer checkout, WP Codebox execution, and optional Blocks Engine PHP
+transformer override. Lab-routed runs omit default `--shared-state` and
+`--artifact-root` paths so Homeboy can choose runner-local locations; use
+`--local` for host-local state paths, or pass explicit paths only when they exist
+on the runner. By default, `--blocks-engine` also supplies the
 release-free transformer override path. Use `--blocks-engine-php-transformer-path`
 to point at a different repo/package, or run a final release/bump proof with
 `--mode release-proof` and the released SSI dependency installed.

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1997,8 +1997,8 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.equal(plan.namespace, 'ssi-matrix-dev-proof');
   assert.equal(plan.temp_root, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof');
   assert.equal(plan.output_file, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/ssi-matrix-dev-proof.homeboy-bench.json');
-  assert.equal(plan.shared_state, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/shared-state');
-  assert.equal(plan.artifact_root, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/artifacts');
+  assert.equal(plan.shared_state, '');
+  assert.equal(plan.artifact_root, '');
   assert.deepEqual(plan.warnings, []);
   assert.equal(plan.dependency_overrides.blocks_engine_php_transformer.path, blocksEngine);
   assert.equal(plan.steps.some((step) => step.args.includes('install')), false);
@@ -2015,7 +2015,8 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.ok(benchStep.args.includes('bench_env.SSI_FIXTURE_MATRIX_RUN=1'));
   assert.ok(benchStep.args.includes('bench_env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=1'));
   assert.ok(benchStep.args.includes('static_site_importer_fixture_matrix_namespace=ssi-matrix-dev-proof'));
-  assert.ok(benchStep.args.includes('/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof/artifacts'));
+  assert.equal(benchStep.args.includes('--shared-state'), false);
+  assert.equal(benchStep.args.includes('--artifact-root'), false);
   assert.deepEqual(benchStep.args.slice(-3), ['--', '--batch-size', '5']);
 
   const releasePlan = buildFixtureMatrixRunPlan({
@@ -2096,11 +2097,30 @@ test('fixture matrix operator composes legible local-hot and Lab offload routing
   });
   const labArgs = labPlan.steps.at(-1).args;
   assert.equal(labPlan.execution_target, 'lab-offload:homeboy-lab');
+  assert.equal(labPlan.shared_state, '');
+  assert.equal(labPlan.artifact_root, '');
   assert.match(labPlan.steps.at(-1).label, /lab-offload:homeboy-lab/);
   assert.ok(labArgs.includes('--runner'));
   assert.ok(labArgs.includes('homeboy-lab'));
   assert.equal(labArgs.includes('--force-hot'), false);
   assert.equal(labArgs.includes('--allow-local-hot'), false);
+  assert.equal(labArgs.includes('--shared-state'), false);
+  assert.equal(labArgs.includes('--artifact-root'), false);
+
+  const explicitMacTempLabPlan = buildFixtureMatrixRunPlan({
+    runner: 'homeboy-lab',
+    staticSiteImporter,
+    fixtureRoot,
+    sharedState: '/var/folders/ab/example/shared-state',
+    artifactRoot: '/private/var/folders/ab/example/artifacts',
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.ok(explicitMacTempLabPlan.steps.at(-1).args.includes('/var/folders/ab/example/shared-state'));
+  assert.ok(explicitMacTempLabPlan.steps.at(-1).args.includes('/private/var/folders/ab/example/artifacts'));
+  const explicitMacTempWarningCodes = explicitMacTempLabPlan.warnings.map((warning) => warning.code);
+  assert.ok(explicitMacTempWarningCodes.includes('lab_local_shared_state_path'));
+  assert.ok(explicitMacTempWarningCodes.includes('lab_local_artifact_root_path'));
 
   const localPlan = buildFixtureMatrixRunPlan({
     local: true,

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -230,6 +230,9 @@ function normalizeOptions(input) {
   const tempRoot = input.tempRoot ? path.resolve(input.tempRoot) : defaultTempRoot(namespace, input);
   const output = path.resolve(input.output || path.join(tempRoot, `${runId}.homeboy-bench.json`));
   const executionTarget = normalizeExecutionTarget(input);
+  const executionIsLocal = executionTarget.local;
+  const sharedStateExplicit = Boolean(input.sharedState);
+  const artifactRootExplicit = Boolean(input.artifactRoot);
 
   return {
     ...input,
@@ -244,8 +247,10 @@ function normalizeOptions(input) {
     blocksEnginePhpTransformerPath,
     passthrough: Array.isArray(input.passthrough) ? input.passthrough : [],
     staticSiteImporter: path.resolve(input.staticSiteImporter),
-    sharedState: input.sharedState ? path.resolve(input.sharedState) : path.join(tempRoot, 'shared-state'),
-    artifactRoot: input.artifactRoot ? path.resolve(input.artifactRoot) : path.join(tempRoot, 'artifacts'),
+    sharedState: sharedStateExplicit ? path.resolve(input.sharedState) : (executionIsLocal ? path.join(tempRoot, 'shared-state') : ''),
+    artifactRoot: artifactRootExplicit ? path.resolve(input.artifactRoot) : (executionIsLocal ? path.join(tempRoot, 'artifacts') : ''),
+    sharedStateExplicit,
+    artifactRootExplicit,
     homeboyBin: input.homeboyBin || process.env.HOMEBOY_BIN || 'homeboy',
   };
 }
@@ -287,8 +292,9 @@ function buildWarnings(options) {
   return [
     ...(!options.runner && !options.labOnly && !options.local ? [{
       code: 'lab_auto_offload_risk',
-      message: 'No --runner/--lab-only/--local routing was provided. `homeboy bench` auto-offloads to a connected default Lab runner, where local --shared-state/--artifact-root paths will fail. Pass --local to force local (hot) execution against local checkouts and a local WP Codebox, or --runner/--lab-only to route to a runner with the paths present.',
+      message: 'No --runner/--lab-only/--local routing was provided. `homeboy bench` may auto-offload to a connected default Lab runner. Default --shared-state/--artifact-root paths are omitted unless --local or explicit path overrides are provided.',
     }] : []),
+    ...labLocalTempPathWarnings(options),
     ...(options.local ? [{
       code: 'forced_local_execution',
       message: '--local forces hot local execution (--force-hot --allow-local-hot); the bench will not offload to a Lab runner even if one is connected.',
@@ -302,6 +308,30 @@ function buildWarnings(options) {
       message: '--allow-dirty-lab-workspace permits reusing or overwriting a dirty Lab workspace.',
     }] : []),
   ];
+}
+
+function labLocalTempPathWarnings(options) {
+  if (!isLabRouted(options)) {
+    return [];
+  }
+  return [
+    ...(options.sharedStateExplicit && isMacLocalTempPath(options.sharedState) ? [{
+      code: 'lab_local_shared_state_path',
+      message: `--shared-state points at macOS local temp (${options.sharedState}). Lab runners are Linux hosts and cannot use operator-local temp paths; omit --shared-state to let Homeboy choose runner-local state, or pass a path that exists on the runner.`,
+    }] : []),
+    ...(options.artifactRootExplicit && isMacLocalTempPath(options.artifactRoot) ? [{
+      code: 'lab_local_artifact_root_path',
+      message: `--artifact-root points at macOS local temp (${options.artifactRoot}). Lab runners are Linux hosts and cannot use operator-local temp paths; omit --artifact-root to let Homeboy choose runner-local artifacts, or pass a path that exists on the runner.`,
+    }] : []),
+  ];
+}
+
+function isLabRouted(options) {
+  return Boolean(options.runner || options.labOnly || (!options.local && !options.runner));
+}
+
+function isMacLocalTempPath(value) {
+  return /^\/(?:private\/)?var\/folders\//.test(String(value || ''));
 }
 
 // Surface corpus pin drift instead of letting `fixture_count_matches_canonical`
@@ -525,13 +555,15 @@ function buildSteps(options, settings) {
     '--profile', 'fixture-matrix',
     '--iterations', '1',
     '--path', options.staticSiteImporter,
-    '--shared-state', options.sharedState,
     '--run-id', options.runId,
     '--output', options.output,
     '--json',
     '--setting', `static_site_importer_fixture_matrix_namespace=${options.namespace}`,
     ...Object.entries(settings).flatMap(([key, value]) => ['--setting', `bench_env.${key}=${value}`]),
   ];
+  if (options.sharedState) {
+    benchArgs.push('--shared-state', options.sharedState);
+  }
   if (options.artifactRoot) {
     benchArgs.push('--artifact-root', options.artifactRoot);
   }


### PR DESCRIPTION
## Summary
- omit default `--shared-state` and `--artifact-root` paths for Lab/auto fixture matrix wrapper runs so Homeboy can choose runner-local paths
- keep host-local defaults for `--local` and warn when explicit Lab paths point at macOS `/var/folders` temp locations
- document the Lab path behavior in the fixture matrix workflow

## Testing
- `npm run test:fixture-matrix`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Audited the Homeboy/SSI Lab path papercuts, implemented the SSI wrapper guard, updated tests/docs, and ran verification.