### PR TITLE
Carry source form labels into Jetpack fields

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1534,6 +1534,9 @@ class Static_Site_Importer_Report_Diagnostics {
 
 				$label = trim( $control_node->getAttribute( 'aria-label' ) );
 				if ( '' === $label ) {
+					$label = self::label_text_for_form_control( $control_node, $doc );
+				}
+				if ( '' === $label ) {
 					$label = trim( $control_node->textContent );
 				}
 				if ( '' !== $label ) {
@@ -1552,6 +1555,69 @@ class Static_Site_Importer_Report_Diagnostics {
 			'form'     => $form,
 			'controls' => $controls,
 		);
+	}
+
+	/**
+	 * Resolve a form control's associated label text from parsed source HTML.
+	 *
+	 * @param DOMElement  $control_node Source form control node.
+	 * @param DOMDocument $doc          Parsed document.
+	 * @return string
+	 */
+	private static function label_text_for_form_control( DOMElement $control_node, DOMDocument $doc ): string {
+		$id = trim( $control_node->getAttribute( 'id' ) );
+		if ( '' !== $id ) {
+			foreach ( $doc->getElementsByTagName( 'label' ) as $label_node ) {
+				if ( ! $label_node instanceof DOMElement || trim( $label_node->getAttribute( 'for' ) ) !== $id ) {
+					continue;
+				}
+
+				$text = self::form_label_visible_text( $label_node );
+				if ( '' !== $text ) {
+					return $text;
+				}
+			}
+		}
+
+		$node = $control_node->parentNode;
+		while ( $node instanceof DOMElement ) {
+			if ( 'label' === strtolower( $node->tagName ) ) {
+				return self::form_label_visible_text( $node );
+			}
+			if ( 'form' === strtolower( $node->tagName ) ) {
+				break;
+			}
+			$node = $node->parentNode;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Return label copy without nested form-control values.
+	 *
+	 * @param DOMElement $label_node Label element.
+	 * @return string
+	 */
+	private static function form_label_visible_text( DOMElement $label_node ): string {
+		$clone = $label_node->cloneNode( true );
+		if ( ! $clone instanceof DOMElement ) {
+			return '';
+		}
+
+		foreach ( array( 'input', 'textarea', 'select', 'button' ) as $tag_name ) {
+			$nodes = array();
+			foreach ( $clone->getElementsByTagName( $tag_name ) as $node ) {
+				$nodes[] = $node;
+			}
+			foreach ( $nodes as $node ) {
+				if ( $node instanceof DOMNode && $node->parentNode instanceof DOMNode ) {
+					$node->parentNode->removeChild( $node );
+				}
+			}
+		}
+
+		return trim( preg_replace( '/\s+/', ' ', $clone->textContent ) ?? $clone->textContent );
 	}
 
 	/**

--- a/tests/smoke-form-materializer.php
+++ b/tests/smoke-form-materializer.php
@@ -254,6 +254,29 @@ namespace {
 	$assert( ! str_contains( (string) $duplicate_generated_contents['posts/page-home.post_content'], '<!-- wp:html' ), 'graft-generated-home-core-html-removed' );
 	$assert( ! str_contains( (string) $duplicate_generated_contents['posts/page-contact.post_content'], '<!-- wp:html' ), 'graft-generated-contact-core-html-removed' );
 
+	// --- Generated core/html labels carry into Jetpack fields ---------------------
+	$labelled_contact_form = '<form class="contact-form" action="mailto:artist@example.com" method="post"><label class="screen-reader-text" for="contact-name">Your name</label><input id="contact-name" type="text" name="name" placeholder="Name"><label>Email address <input type="email" name="email" placeholder="you@example.com" required></label><button type="submit">Send</button></form>';
+	$labelled_report       = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/contact.html' );
+	$labelled_report['diagnostics'][] = array(
+		'type'                => 'core_html_block',
+		'diagnostic_code'     => 'generated_document_contains_core_html',
+		'reason_code'         => 'generated_document_contains_core_html',
+		'loss_class'          => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path'         => 'posts/page-contact.post_content',
+		'selector'            => 'form.contact-form',
+		'tag_name'            => 'FORM',
+		'block_name'          => 'core/html',
+		'source_html_preview' => $labelled_contact_form,
+	);
+	$labelled_contents = array( 'posts/page-contact.post_content' => $core_html_block( $labelled_contact_form ) );
+	$labelled_seeding  = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $labelled_report, array(), $labelled_contents );
+	$labelled_grafted  = (string) ( $labelled_contents['posts/page-contact.post_content'] ?? '' );
+	$assert( 1 === ( $labelled_seeding['mapped_count'] ?? 0 ), 'graft-generated-labelled-form-mapped' );
+	$assert( 1 === ( $labelled_seeding['grafted_count'] ?? 0 ), 'graft-generated-labelled-form-grafted' );
+	$assert( str_contains( $labelled_grafted, '"label":"Your name"' ), 'graft-generated-label-for-carried' );
+	$assert( str_contains( $labelled_grafted, '"label":"Email address"' ), 'graft-generated-wrapped-label-carried' );
+	$assert( str_contains( $labelled_grafted, '"placeholder":"Name"' ), 'graft-generated-placeholder-still-carried' );
+
 	// --- Form finding enrich carries readable_blocks for graft anchoring --------
 	$enrich_readable = $enrich->invoke(
 		null,


### PR DESCRIPTION
## Summary
- Carry associated source labels from generated core/html forms into seeded Jetpack field labels.
- Supports both label[for] and wrapped label controls while preserving existing aria-label, placeholder, and graft behavior.
- Adds smoke coverage for a front/contact-style generated form with screen-reader and wrapped labels.

## Verification
- php tests/smoke-form-materializer.php
- php -l includes/class-static-site-importer-report-diagnostics.php
- php -l tests/smoke-form-materializer.php
- php tests/smoke-transformer-adapter.php
- npm run test:fixture-matrix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Audited SSI Jetpack form materialization paths, implemented label extraction, added tests, and ran verification.