### PR TITLE
Classify provider-materializable matrix gaps

### DIFF
--- a/docs/gutenberg-incompatibility-registry.md
+++ b/docs/gutenberg-incompatibility-registry.md
@@ -13,17 +13,18 @@ Each pattern row contains:
 - `fallback_kind`: one of `core_html`, `data_uri`, `runtime_island`, or `fidelity_loss`.
 - `impossible_in_core_reason`: concrete reason core blocks cannot represent the structure, behavior, or visual exactly.
 - `classification`: `convertible`, `custom-block-candidate`, or `runtime-island`.
-- `limitation_type`: decision-axis bucket: `real_gutenberg_gap`, `transformer_gap`, `intentional_runtime_preservation`, `visual_only_style_drift`, or `editor_validity_risk`.
+- `limitation_type`: decision-axis bucket: `real_gutenberg_gap`, `provider_materializable`, `transformer_gap`, `intentional_runtime_preservation`, `visual_only_style_drift`, or `editor_validity_risk`.
 - `no_core_block_path`: whether existing core block semantics have no direct path to parity.
 - `fixture_count`, `fixtures`, `fixture_counts`: recurrence evidence across fixtures.
 - `finding_count`, `signals`, `fallback_kinds`, `impact_score`: aggregate impact from normalized matrix findings, visual diff regions, block composition, and future editor render divergence signals.
+- `provider_materialized_by`: provider evidence, currently Jetpack form blocks and WooCommerce materialization/availability signals, that separates plugin-materializable behavior from a core/Gutenberg impossibility.
 - `example` / `examples`: bounded source selector/snippet/reason evidence.
 
 ## Promotion Rule
 
 Default threshold: `2` distinct fixtures.
 
-A pattern is promoted to `custom-block-candidate` when `no_core_block_path` is true and the pattern appears in at least the threshold number of distinct fixtures. Runtime-island patterns stay `runtime-island` even when recurring. Patterns with a plausible core-block or transformer path stay `convertible` until evidence proves core cannot express them.
+A pattern is promoted to `custom-block-candidate` when `no_core_block_path` is true and the pattern appears in at least the threshold number of distinct fixtures. Runtime-island patterns stay `runtime-island` even when recurring. Patterns with Jetpack/Woo provider evidence are reported as `provider_materializable` rather than `real_gutenberg_gap`. Patterns with a plausible core-block or transformer path stay `convertible` until evidence proves core cannot express them.
 
 ## Fixture Decisions
 
@@ -35,6 +36,7 @@ The registry also emits `fixture_decisions[]` so acceptance decisions do not req
 - `native_editability_status`: `native_editable`, `editor_invalid`, `custom_block_candidate`, `runtime_island_preserved`, `html_islands_or_transformer_gap`, or `unknown`.
 - `visible_html_island_count`: visible `core/html` island pressure from block composition and findings.
 - `gutenberg_gap_patterns`: real Gutenberg/custom-block candidate gaps affecting that fixture.
+- `provider_materializable_patterns`: gaps in core blocks that have plugin-provider evidence, such as Jetpack forms or WooCommerce commerce controls.
 - `transformer_gap_patterns`: fallback or attribution gaps that should be fixed in SSI/Blocks Engine before calling something a Gutenberg limitation.
 - `intentional_runtime_patterns`: runtime islands preserved by design.
 - `visual_only_patterns`: frontend visual drift patterns that do not imply invalid blocks or lost editability by themselves.

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -43,6 +43,7 @@ export function buildGutenbergIncompatibilityRegistry(result = {}, options = {})
       reason: finding.reason || patternDefinition.impossible_in_core_reason,
       signal: finding.kind || finding.reason_code || finding.loss_class,
       observed_block_name: finding.observed_block_name,
+      provider: providerForFinding(finding),
     });
   }
 
@@ -64,7 +65,7 @@ export function buildGutenbergIncompatibilityRegistry(result = {}, options = {})
     },
     promotion_rule: {
       custom_block_candidate_fixture_threshold: threshold,
-      rule: `classification becomes custom-block-candidate when no_core_block_path is true and the pattern appears in at least ${threshold} distinct fixtures; runtime-island patterns remain runtime-island.`,
+      rule: `classification becomes custom-block-candidate when no_core_block_path is true and the pattern appears in at least ${threshold} distinct fixtures; runtime-island patterns remain runtime-island; provider-materializable patterns are reported separately from real Gutenberg gaps when Jetpack/Woo evidence is present.`,
     },
     summary: {
       pattern_count: patterns.length,
@@ -106,13 +107,16 @@ export function renderGutenbergIncompatibilityRegistryMarkdown(registry = {}) {
       lines.push(`| ${status} | ${normalizeArray(decisionGroups[status]).map((fixtureId) => `\`${fixtureId}\``).join(', ') || '(none)'} |`);
     }
   }
-  lines.push('', '## Fixture Decisions', '', '| Fixture | Acceptance | Frontend Visual | Editor Canvas | Block Validity | Native Editability | Runtime/HTML Islands | Gutenberg Gaps | Visual-only Patterns | Reason |', '| --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- |');
+  lines.push('', '## Fixture Decisions', '', '| Fixture | Acceptance | Frontend Visual | Editor Canvas | Block Validity | Native Editability | Runtime/HTML Islands | Gutenberg Gaps | Provider-Materializable | Visual-only Patterns | Reason |', '| --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |');
   for (const row of normalizeArray(registry.fixture_decisions)) {
-    lines.push(`| \`${row.fixture_id}\` | ${row.acceptance_status || '(unknown)'} | ${row.frontend_visual_status || '(unknown)'} | ${row.editor_canvas_status || '(unknown)'} | ${row.block_validity_status || row.editor_validity_status || '(unknown)'} | ${row.native_editability_status} | ${row.visible_runtime_or_html_islands || 0} | ${(row.gutenberg_gap_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${(row.visual_only_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${table(row.solved_candidate_reason || row.acceptance_reason || '') || '(none)'} |`);
+    lines.push(`| \`${row.fixture_id}\` | ${row.acceptance_status || '(unknown)'} | ${row.frontend_visual_status || '(unknown)'} | ${row.editor_canvas_status || '(unknown)'} | ${row.block_validity_status || row.editor_validity_status || '(unknown)'} | ${row.native_editability_status} | ${row.visible_runtime_or_html_islands || 0} | ${(row.gutenberg_gap_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${(row.provider_materializable_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${(row.visual_only_patterns || []).map((key) => `\`${key}\``).join(', ') || '(none)'} | ${table(row.solved_candidate_reason || row.acceptance_reason || '') || '(none)'} |`);
   }
   lines.push('', '## Pattern Evidence', '');
   for (const row of normalizeArray(registry.patterns)) {
     lines.push(`### ${row.pattern_key}`, '', `- Description: ${row.description}`, `- Limitation type: \`${row.limitation_type || '(unknown)'}\``, `- Fallback kind: \`${row.fallback_kind}\``, `- Classification: \`${row.classification}\``, `- Fixtures: ${row.fixtures.join(', ') || '(none)'}`, `- Reason: ${row.impossible_in_core_reason}`);
+    if (Object.keys(objectValue(row.provider_materialized_by)).length > 0) {
+      lines.push(`- Provider materialized by: ${Object.keys(row.provider_materialized_by).map((provider) => `\`${provider}\``).join(', ')}`);
+    }
     if (row.example?.selector || row.example?.source_snippet) {
       lines.push(`- Example selector/snippet: \`${String(row.example.selector || row.example.source_snippet).replace(/`/g, '\\`').slice(0, 180)}\``);
     }
@@ -253,11 +257,14 @@ function addEvidence(rows, definition, evidence) {
   if (!definition || !evidence.fixture_id) {
     return;
   }
-  const row = rows.get(definition.pattern_key) || { ...definition, fallback_kinds: {}, fixtures: [], fixture_counts: {}, selectors: [], source_paths: [], signals: {}, examples: [], finding_count: 0, impact_score: 0 };
+  const row = rows.get(definition.pattern_key) || { ...definition, fallback_kinds: {}, fixtures: [], fixture_counts: {}, selectors: [], source_paths: [], signals: {}, provider_materialized_by: {}, examples: [], finding_count: 0, impact_score: 0 };
   row.finding_count += 1;
   row.impact_score += Math.max(1, numberValue(evidence.impact || 1));
   row.fallback_kinds[evidence.fallback_kind || definition.fallback_kind] = (row.fallback_kinds[evidence.fallback_kind || definition.fallback_kind] || 0) + 1;
   row.signals[evidence.signal || 'finding'] = (row.signals[evidence.signal || 'finding'] || 0) + 1;
+  if (evidence.provider) {
+    row.provider_materialized_by[evidence.provider] = (row.provider_materialized_by[evidence.provider] || 0) + 1;
+  }
   row.fixture_counts[evidence.fixture_id] = (row.fixture_counts[evidence.fixture_id] || 0) + 1;
   pushUnique(row.fixtures, evidence.fixture_id, 100);
   pushUnique(row.selectors, evidence.selector, 10);
@@ -289,6 +296,7 @@ function finalizeRow(row, threshold) {
     selectors: row.selectors,
     source_paths: row.source_paths,
     signals: sortCountObject(row.signals),
+    provider_materialized_by: sortCountObject(row.provider_materialized_by),
     example: row.examples[0] ? boundBlob(row.examples[0]) : undefined,
     examples: boundBlob(row.examples),
   });
@@ -318,6 +326,7 @@ function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
   const visibleHtmlIslandCount = visibleHtmlIslandCountForFixture(fixture, fixtureFindings);
   const runtimeIslandCount = fixtureFindings.filter((finding) => finding.loss_class === 'preserved_runtime_island').length;
   const gutenbergGapPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'real_gutenberg_gap').map((row) => row.pattern_key));
+  const providerMaterializablePatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'provider_materializable').map((row) => row.pattern_key));
   const transformerGapPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'transformer_gap').map((row) => row.pattern_key));
   const visualOnlyPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'visual_only_style_drift').map((row) => row.pattern_key));
   const runtimeIslandPatterns = uniqueSorted(fixturePatterns.filter((row) => row.limitation_type === 'intentional_runtime_preservation').map((row) => row.pattern_key));
@@ -330,6 +339,7 @@ function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
     visibleHtmlIslandCount,
     runtimeIslandCount,
     gutenbergGapPatterns,
+    providerMaterializablePatterns,
     transformerGapPatterns,
   });
   const visibleRuntimeOrHtmlIslands = visibleHtmlIslandCount + runtimeIslandCount;
@@ -340,6 +350,7 @@ function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
     nativeEditabilityStatus,
     visibleRuntimeOrHtmlIslands,
     gutenbergGapPatterns,
+    providerMaterializablePatterns,
     transformerGapPatterns,
     visualOnlyPatterns,
     runtimeIslandPatterns,
@@ -356,6 +367,7 @@ function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
     runtime_island_count: runtimeIslandCount,
     visible_runtime_or_html_islands: visibleRuntimeOrHtmlIslands,
     gutenberg_gap_patterns: gutenbergGapPatterns,
+    provider_materializable_patterns: providerMaterializablePatterns,
     transformer_gap_patterns: transformerGapPatterns,
     intentional_runtime_patterns: runtimeIslandPatterns,
     visual_only_patterns: visualOnlyPatterns,
@@ -367,7 +379,7 @@ function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
   });
 }
 
-function nativeEditabilityStatusForFixture({ editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, transformerGapPatterns }) {
+function nativeEditabilityStatusForFixture({ editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, providerMaterializablePatterns, transformerGapPatterns }) {
   if (editorValidityStatus === 'invalid_blocks') {
     return 'editor_invalid';
   }
@@ -377,7 +389,7 @@ function nativeEditabilityStatusForFixture({ editorValidityStatus, visibleHtmlIs
   if (runtimeIslandCount > 0) {
     return 'runtime_island_preserved';
   }
-  if (visibleHtmlIslandCount > 0 || transformerGapPatterns.length > 0) {
+  if (visibleHtmlIslandCount > 0 || providerMaterializablePatterns.length > 0 || transformerGapPatterns.length > 0) {
     return 'html_islands_or_transformer_gap';
   }
   if (editorValidityStatus === 'not_validated') {
@@ -412,7 +424,7 @@ function editorCanvasStatusForFixture(fixture, fixtureFindings, editorRiskPatter
   return 'not_captured';
 }
 
-function acceptanceDecision({ frontendVisualStatus, editorCanvasStatus, editorValidityStatus, nativeEditabilityStatus, visibleRuntimeOrHtmlIslands, gutenbergGapPatterns, transformerGapPatterns, visualOnlyPatterns, runtimeIslandPatterns, editorRiskPatterns }) {
+function acceptanceDecision({ frontendVisualStatus, editorCanvasStatus, editorValidityStatus, nativeEditabilityStatus, visibleRuntimeOrHtmlIslands, gutenbergGapPatterns, providerMaterializablePatterns, transformerGapPatterns, visualOnlyPatterns, runtimeIslandPatterns, editorRiskPatterns }) {
   if (frontendVisualStatus === 'provider_runtime_blocked' || editorCanvasStatus === 'provider_runtime_blocked') {
     return { solved_candidate: false, status: 'provider_runtime_blocker', reason: 'required frontend visual or editor canvas evidence is blocked by the provider/runtime' };
   }
@@ -422,8 +434,8 @@ function acceptanceDecision({ frontendVisualStatus, editorCanvasStatus, editorVa
   if (editorValidityStatus === 'invalid_blocks' || editorCanvasStatus === 'diverged' || editorRiskPatterns.length > 0) {
     return { solved_candidate: false, status: 'editor_blocker', reason: 'editor canvas or block validation evidence shows imported content is not reliably visible and valid in the editor' };
   }
-  if (nativeEditabilityStatus !== 'native_editable' || visibleRuntimeOrHtmlIslands > 0 || gutenbergGapPatterns.length > 0 || transformerGapPatterns.length > 0 || runtimeIslandPatterns.length > 0) {
-    return { solved_candidate: false, status: 'native_editability_blocker', reason: 'frontend-visible content still depends on runtime/html islands, transformer gaps, or a real Gutenberg capability gap' };
+  if (nativeEditabilityStatus !== 'native_editable' || visibleRuntimeOrHtmlIslands > 0 || gutenbergGapPatterns.length > 0 || providerMaterializablePatterns.length > 0 || transformerGapPatterns.length > 0 || runtimeIslandPatterns.length > 0) {
+    return { solved_candidate: false, status: 'native_editability_blocker', reason: 'frontend-visible content still depends on runtime/html islands, provider-materializable blocks, transformer gaps, or a real Gutenberg capability gap' };
   }
   if (frontendVisualStatus === 'visual_mismatch' || visualOnlyPatterns.length > 0) {
     return { solved_candidate: false, status: 'visual_only_blocker', reason: 'native editor evidence is acceptable but frontend visual parity still differs from the source' };
@@ -455,10 +467,32 @@ function limitationType(row) {
   if (row.pattern_key.startsWith('visual-')) {
     return 'visual_only_style_drift';
   }
+  if (isProviderMaterializable(row)) {
+    return 'provider_materializable';
+  }
   if (row.no_core_block_path) {
     return 'real_gutenberg_gap';
   }
   return 'transformer_gap';
+}
+
+function isProviderMaterializable(row) {
+  return ['static-form', 'js-commerce-controls'].includes(row.pattern_key) && Object.keys(objectValue(row.provider_materialized_by)).length > 0;
+}
+
+function providerForFinding(finding) {
+  const blockName = String(finding.observed_block_name || finding.block_name || '');
+  if (blockName.startsWith('jetpack/')) {
+    return 'jetpack';
+  }
+  if (blockName.startsWith('woocommerce/')) {
+    return 'woocommerce';
+  }
+  const haystack = findingHaystack(finding);
+  if (/woocommerce_present|commerce\.dependencies\.woocommerce|woocommerce is active/i.test(haystack)) {
+    return 'woocommerce';
+  }
+  return '';
 }
 
 function visibleHtmlIslandCountForFixture(fixture, fixtureFindings) {

--- a/registry/gutenberg-incompatibility-registry.schema.json
+++ b/registry/gutenberg-incompatibility-registry.schema.json
@@ -48,7 +48,7 @@
   "$defs": {
     "classification": { "enum": ["convertible", "custom-block-candidate", "runtime-island"] },
     "fallback_kind": { "enum": ["core_html", "data_uri", "runtime_island", "fidelity_loss"] },
-    "limitation_type": { "enum": ["real_gutenberg_gap", "transformer_gap", "intentional_runtime_preservation", "visual_only_style_drift", "editor_validity_risk"] },
+    "limitation_type": { "enum": ["real_gutenberg_gap", "provider_materializable", "transformer_gap", "intentional_runtime_preservation", "visual_only_style_drift", "editor_validity_risk"] },
     "frontend_visual_status": { "enum": ["passed", "visual_mismatch", "not_evaluated", "provider_runtime_blocked"] },
     "editor_canvas_status": { "enum": ["visible", "diverged", "not_captured", "provider_runtime_blocked"] },
     "editor_validity_status": { "enum": ["valid", "invalid_blocks", "not_validated"] },
@@ -86,6 +86,7 @@
         "selectors": { "type": "array", "items": { "type": "string" } },
         "source_paths": { "type": "array", "items": { "type": "string" } },
         "signals": { "$ref": "#/$defs/counts" },
+        "provider_materialized_by": { "$ref": "#/$defs/counts" },
         "example": { "type": "object" },
         "examples": { "type": "array", "items": { "type": "object" } }
       },
@@ -93,7 +94,7 @@
     },
     "fixture_decision": {
       "type": "object",
-      "required": ["fixture_id", "frontend_visual_status", "editor_canvas_status", "block_validity_status", "editor_validity_status", "native_editability_status", "visible_html_island_count", "runtime_island_count", "visible_runtime_or_html_islands", "gutenberg_gap_patterns", "transformer_gap_patterns", "intentional_runtime_patterns", "visual_only_patterns", "solved_candidate", "acceptance_status", "acceptance_reason"],
+      "required": ["fixture_id", "frontend_visual_status", "editor_canvas_status", "block_validity_status", "editor_validity_status", "native_editability_status", "visible_html_island_count", "runtime_island_count", "visible_runtime_or_html_islands", "gutenberg_gap_patterns", "provider_materializable_patterns", "transformer_gap_patterns", "intentional_runtime_patterns", "visual_only_patterns", "solved_candidate", "acceptance_status", "acceptance_reason"],
       "properties": {
         "fixture_id": { "type": "string" },
         "frontend_visual_status": { "$ref": "#/$defs/frontend_visual_status" },
@@ -105,6 +106,7 @@
         "runtime_island_count": { "type": "integer", "minimum": 0 },
         "visible_runtime_or_html_islands": { "type": "number", "minimum": 0 },
         "gutenberg_gap_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "provider_materializable_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "transformer_gap_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "intentional_runtime_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "visual_only_patterns": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -193,6 +193,76 @@ test('gutenberg incompatibility registry keeps runtime islands separate and cons
   assert.equal(byKey['editor-render-divergence'].signals.editor_render_divergence, 1);
 });
 
+test('gutenberg incompatibility registry separates provider-materializable forms and commerce from core gaps', () => {
+  const registry = buildGutenbergIncompatibilityRegistry({
+    matrix_id: 'provider-materializable-patterns',
+    fixtures: [
+      { fixture_id: 'provider-fixture' },
+      { fixture_id: 'core-gap-fixture' },
+    ],
+    findings: [
+      {
+        fixture_id: 'provider-fixture',
+        kind: 'core_html_block',
+        observed_block_name: 'jetpack/contact-form',
+        reason_code: 'generated_document_contains_core_html',
+        selector: 'form.newsletter-form',
+        source_snippet: '<form class="newsletter-form"><input type="email"><button>Subscribe</button></form>',
+      },
+      {
+        fixture_id: 'provider-fixture',
+        kind: 'woocommerce_present',
+        source_path: 'commerce.dependencies.woocommerce',
+        reason: 'WooCommerce is active; commerce-bearing import will seed products.',
+      },
+      {
+        fixture_id: 'provider-fixture',
+        kind: 'core_html_block',
+        observed_block_name: 'core/html',
+        selector: 'button.add-to-cart',
+        source_snippet: '<button class="add-to-cart">Add</button>',
+      },
+      {
+        fixture_id: 'core-gap-fixture',
+        kind: 'core_html_block',
+        observed_block_name: 'core/html',
+        reason_code: 'html_form_fallback',
+        selector: 'form.unmapped',
+        source_snippet: '<form><input name="email"><button>Submit</button></form>',
+      },
+    ],
+  });
+  const providerDecision = registry.fixture_decisions.find((row) => row.fixture_id === 'provider-fixture');
+  const coreGapDecision = registry.fixture_decisions.find((row) => row.fixture_id === 'core-gap-fixture');
+  const patterns = Object.fromEntries(registry.patterns.map((row) => [row.pattern_key, row]));
+
+  assert.equal(patterns['static-form'].limitation_type, 'provider_materializable');
+  assert.equal(patterns['static-form'].provider_materialized_by.jetpack, 1);
+  assert.equal(patterns['js-commerce-controls'].limitation_type, 'provider_materializable');
+  assert.equal(patterns['js-commerce-controls'].provider_materialized_by.woocommerce, 1);
+  assert.deepEqual(providerDecision.provider_materializable_patterns, ['js-commerce-controls', 'static-form']);
+  assert.deepEqual(providerDecision.gutenberg_gap_patterns, []);
+  assert.deepEqual(coreGapDecision.gutenberg_gap_patterns, []);
+
+  const noProviderRegistry = buildGutenbergIncompatibilityRegistry({
+    matrix_id: 'plain-core-gap-patterns',
+    fixtures: [{ fixture_id: 'core-gap-fixture' }],
+    findings: [
+      {
+        fixture_id: 'core-gap-fixture',
+        kind: 'core_html_block',
+        observed_block_name: 'core/html',
+        reason_code: 'html_form_fallback',
+        selector: 'form.unmapped',
+        source_snippet: '<form><input name="email"><button>Submit</button></form>',
+      },
+    ],
+  });
+  const noProviderPatterns = Object.fromEntries(noProviderRegistry.patterns.map((row) => [row.pattern_key, row]));
+
+  assert.equal(noProviderPatterns['static-form'].limitation_type, 'real_gutenberg_gap');
+});
+
 test('gutenberg incompatibility registry separates fixture decision axes', () => {
   const registry = buildGutenbergIncompatibilityRegistry({
     matrix_id: 'decision-axis-map',


### PR DESCRIPTION
## Summary
- add provider-materializable registry classification for Jetpack/Woo-backed patterns
- keep provider-backed forms and commerce controls out of real Gutenberg gap buckets
- expose provider-materializable fixture-decision patterns in JSON/Markdown reports

## Testing
- npm test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Audited SSI matrix artifacts, implemented the registry/reporting classification fix, and added regression coverage.