### PR TITLE
Refactor fixture matrix surface evidence parsing

### DIFF
--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -41,6 +41,7 @@ import {
   normalizeLiveWpParityCollectorOptions,
 } from './live-wp-parity.mjs';
 import { normalizeFixtureMatrixResult, normalizeFixtureResult } from '../result.mjs';
+import { surfaceFields } from '../shared/surface-evidence.mjs';
 
 export function collectFixtureMatrixRunResults(input = {}) {
   const matrix = input.matrix || createFixtureMatrix(input);
@@ -670,17 +671,6 @@ function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen, inherit
   for (const child of Object.values(value)) {
     visitRuntimePayloads(child, fixtureId, payloads, seen, surface);
   }
-}
-
-function surfaceFields(payload) {
-  const metadata = objectValue(payload.metadata || payload.recipeStepMetadata || payload.recipe_step_metadata);
-  return compactObject({
-    surface_id: payload.surface_id || payload.surfaceId || metadata.surface_id || metadata.surfaceId,
-    surface_label: payload.surface_label || payload.surfaceLabel || metadata.surface_label || metadata.surfaceLabel,
-    source_entry: payload.source_entry || payload.sourceEntry || metadata.source_entry || metadata.sourceEntry,
-    target: payload.target || metadata.target,
-    url: payload.url || payload.candidate_url || payload.candidateUrl || metadata.url || metadata.candidate_url || metadata.candidateUrl,
-  });
 }
 
 function surfaceSortKey(surface) {

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -55,6 +55,12 @@ import {
   renderVisualParityEvidenceReportMarkdown,
 } from './visual-evidence-report.mjs';
 import {
+  hasEditorSurfaceEvidence,
+  hasVisualSurfaceEvidence,
+  surfaceArtifactPaths,
+  surfaceFields,
+} from './shared/surface-evidence.mjs';
+import {
   collectBlockComposition,
   computeFixtureEditorQuality,
   attachFixtureEditorQuality,
@@ -449,12 +455,13 @@ export function normalizeFixtureResult(input) {
 
 function normalizeSurfaceResult(input) {
   const row = objectValue(input);
+  const fields = surfaceFields(row, { includeGenericAliases: true });
   return compactObject({
-    surface_id: row.surface_id || row.surfaceId || row.id || '',
-    surface_label: row.surface_label || row.surfaceLabel || row.label || '',
-    source_entry: row.source_entry || row.sourceEntry || '',
-    target: row.target || '',
-    url: row.url || row.candidate_url || row.candidateUrl || '',
+    surface_id: fields.surface_id || '',
+    surface_label: fields.surface_label || '',
+    source_entry: fields.source_entry || '',
+    target: fields.target || '',
+    url: fields.url || '',
     artifact_refs: normalizeArray(row.artifact_refs || row.artifactRefs),
     editor_validation: row.editor_validation || row.editorValidation || null,
     editor_canvas: boundBlob(row.editor_canvas || row.editorCanvas || null),
@@ -611,24 +618,6 @@ function aggregateSurfaceEvidence(fixtures) {
       editor_artifact_paths: surfaceArtifactPaths(surface).filter((artifactPath) => /editor/i.test(artifactPath)),
     })),
   };
-}
-
-function hasVisualSurfaceEvidence(surface) {
-  const artifacts = objectValue(surface.visual_parity_artifacts || surface.visualParityArtifacts);
-  return Object.keys(objectValue(artifacts.artifacts)).length > 0
-    || Object.keys(objectValue(artifacts.metrics || artifacts.comparison)).length > 0
-    || surfaceArtifactPaths(surface).some((artifactPath) => /visual|screenshot|diff|\.png$/i.test(artifactPath));
-}
-
-function hasEditorSurfaceEvidence(surface) {
-  return Boolean(surface.editor_validation || surface.editorValidation || surface.editor_canvas || surface.editorCanvas || surface.editor_open || surface.editorOpen)
-    || surfaceArtifactPaths(surface).some((artifactPath) => /editor/i.test(artifactPath));
-}
-
-function surfaceArtifactPaths(surface) {
-  return normalizeArray(surface.artifact_refs || surface.artifactRefs)
-    .map((ref) => objectValue(ref).path || objectValue(ref).file || objectValue(ref).href || '')
-    .filter(Boolean);
 }
 
 function shouldStageFixtureSources(input = {}) {

--- a/lib/fixture-matrix/shared/surface-evidence.mjs
+++ b/lib/fixture-matrix/shared/surface-evidence.mjs
@@ -1,0 +1,33 @@
+// Shared parsing helpers for fixture-matrix surface evidence payloads.
+
+import { compactObject, normalizeArray, objectValue } from './utils.mjs';
+
+export function surfaceFields(payload, options = {}) {
+  const metadata = objectValue(payload.metadata || payload.recipeStepMetadata || payload.recipe_step_metadata);
+  const includeGenericAliases = options.includeGenericAliases === true;
+  return compactObject({
+    surface_id: payload.surface_id || payload.surfaceId || (includeGenericAliases ? payload.id : undefined) || metadata.surface_id || metadata.surfaceId,
+    surface_label: payload.surface_label || payload.surfaceLabel || (includeGenericAliases ? payload.label : undefined) || metadata.surface_label || metadata.surfaceLabel,
+    source_entry: payload.source_entry || payload.sourceEntry || metadata.source_entry || metadata.sourceEntry,
+    target: payload.target || metadata.target,
+    url: payload.url || payload.candidate_url || payload.candidateUrl || metadata.url || metadata.candidate_url || metadata.candidateUrl,
+  });
+}
+
+export function surfaceArtifactPaths(surface) {
+  return normalizeArray(surface.artifact_refs || surface.artifactRefs)
+    .map((ref) => objectValue(ref).path || objectValue(ref).file || objectValue(ref).href || '')
+    .filter(Boolean);
+}
+
+export function hasVisualSurfaceEvidence(surface) {
+  const artifacts = objectValue(surface.visual_parity_artifacts || surface.visualParityArtifacts);
+  return Object.keys(objectValue(artifacts.artifacts)).length > 0
+    || Object.keys(objectValue(artifacts.metrics || artifacts.comparison)).length > 0
+    || surfaceArtifactPaths(surface).some((artifactPath) => /visual|screenshot|diff|\.png$/i.test(artifactPath));
+}
+
+export function hasEditorSurfaceEvidence(surface) {
+  return Boolean(surface.editor_validation || surface.editorValidation || surface.editor_canvas || surface.editorCanvas || surface.editor_open || surface.editorOpen)
+    || surfaceArtifactPaths(surface).some((artifactPath) => /editor/i.test(artifactPath));
+}


### PR DESCRIPTION
## Summary
- Extract shared fixture-matrix surface evidence parsing helpers.
- Reuse the helpers from run-intake and result shaping.
- Preserve existing alias behavior while reducing duplicate snake/camel field handling.

## Testing
- npm run test:fixture-matrix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted and verified the behavior-preserving refactor under Chris's direction.