### PR TITLE
Improve fixture diagnostic actionability

### DIFF
--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -146,6 +146,11 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
   const lossClass = countOnlyDiagnostic ? 'native_conversion' : classifyLossClass({ raw, kind, group_key: group.group_key, repair_bucket: repairBucket, message, result });
   const lossAcceptance = resolveLossAcceptance(lossClass, raw);
   const attributionFields = visualAttributionFindingFields(raw, rawObserved, rawSelectorEvidence);
+  const derivedContext = deriveDiagnosticContext({ raw, kind, message, lossClass });
+  const reasonCode = attributionFields.classification.reason_code || derivedContext.reason_code;
+  const observedBlockName = raw.block_name || rawObserved.block_name || derivedContext.observed_block_name || '';
+  const sourceSnippet = raw.source_html_preview || raw.html_excerpt || rawSource.snippet || rawSelectorEvidence.source_text || rawSelectorEvidence.sourceText || derivedContext.source_snippet || '';
+  const observedOutput = raw.emitted_block_preview || rawObserved.output || rawSelectorEvidence.target_text || rawSelectorEvidence.targetText || derivedContext.observed_output || '';
   return {
     id: raw.id || `${result.fixture_id || 'fixture'}:${group.group_key}:${index + 1}`,
     kind,
@@ -153,6 +158,7 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     group_key: group.group_key,
     repair_bucket: repairBucket,
     ...attributionFields.classification,
+    reason_code: reasonCode,
     severity: raw.severity || (result.status === 'failed' ? 'error' : 'warning'),
     fixture_id: result.fixture_id || '',
     fixture_class: result.fixture_class || result.taxonomy?.fixture_class || 'unknown',
@@ -162,16 +168,16 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     source_path: sourcePath,
     selector,
     selector_family: selectorFamily(selector),
-    pattern_family: attributionFields.classification.pattern_family || patternFamily({ ...raw, kind, group_key: group.group_key, repair_bucket: repairBucket, selector }),
+    pattern_family: attributionFields.classification.pattern_family || patternFamily({ ...raw, kind, group_key: group.group_key, repair_bucket: repairBucket, selector, reason_code: reasonCode, observed_block_name: observedBlockName, loss_class: lossClass, reason: message }),
     // Bound the free-text payload fields: a source snippet / observed block
     // output can carry an entire serialized `post_content` body, which at lane
     // scale balloons the aggregate past V8's per-string limit (#554). Truncate
     // to a sane cap so per-finding size is bounded; classification/metrics above
     // are derived from the full diagnostic before truncation.
     reason: truncateString(message),
-    source_snippet: truncateString(raw.source_html_preview || raw.html_excerpt || rawSource.snippet || rawSelectorEvidence.source_text || rawSelectorEvidence.sourceText || ''),
-    observed_output: truncateString(raw.emitted_block_preview || rawObserved.output || rawSelectorEvidence.target_text || rawSelectorEvidence.targetText || ''),
-    observed_block_name: raw.block_name || rawObserved.block_name || '',
+    source_snippet: truncateString(sourceSnippet),
+    observed_output: truncateString(observedOutput),
+    observed_block_name: observedBlockName,
     recipe_step_index: raw.recipe_step_index ?? raw.recipeStepIndex,
     recipe_phase: raw.recipe_phase || raw.recipePhase,
     command: raw.command,
@@ -208,6 +214,80 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     // serialized markup. All classification above is computed from `raw` before
     // this point; downstream consumers read the bounded top-level fields.
   };
+}
+
+function deriveDiagnosticContext({ raw, kind, message, lossClass }) {
+  const text = String(message || raw.reason || raw.detail || '').trim();
+  if (!text) {
+    return {};
+  }
+
+  if (kind === EDITOR_BLOCK_INVALID_KIND || lossClass === 'editor_block_invalid') {
+    const blockName = firstMatch(text, /Editor reported block "([^"]+)" as invalid/i)
+      || firstMatch(text, /Block validation failed for `%s` \(%o\)\.[\s\S]*?\b(core\/[a-z0-9-]+)/i)
+      || firstMatch(text, /\b(core\/[a-z0-9-]+)\b/i);
+    const mismatch = editorValidationMismatchToken(text);
+    return compactObject({
+      reason_code: ['editor_block_validation', mismatch].filter(Boolean).join('_'),
+      observed_block_name: blockName,
+      observed_output: truncateString([
+        blockName ? `Block validation mismatch for ${blockName}` : 'Block validation mismatch',
+        editorValidationSummary(text),
+      ].filter(Boolean).join(': ')),
+    });
+  }
+
+  if (kind === VISUAL_PARITY_MISMATCH_KIND || lossClass === 'visual_parity_mismatch') {
+    const percent = firstMatch(text, /\((\d+(?:\.\d+)?)%\) exceed/i);
+    return compactObject({
+      reason_code: percent ? 'visual_parity_pixel_mismatch' : 'visual_parity_mismatch',
+      observed_output: truncateString(percent ? `Visual parity pixel mismatch: ${percent}% exceeded threshold.` : text),
+    });
+  }
+
+  if (kind === 'recipe_step_failure' || lossClass === 'runtime_execution_failed') {
+    return compactObject({
+      reason_code: 'recipe_step_failure',
+      observed_output: truncateString(text.split('\n').slice(0, 3).join('\n')),
+    });
+  }
+
+  return {};
+}
+
+function firstMatch(text, pattern) {
+  const match = String(text || '').match(pattern);
+  return match?.[1] || '';
+}
+
+function editorValidationMismatchToken(text) {
+  const lower = String(text || '').toLowerCase();
+  if (/expected attributes/.test(lower)) {
+    return 'attributes_mismatch';
+  }
+  if (/expected attribute/.test(lower)) {
+    if (/\.\s*style\b/.test(lower)) {
+      return 'style_mismatch';
+    }
+    if (/\.\s*class\b/.test(lower)) {
+      return 'class_mismatch';
+    }
+    return 'attribute_mismatch';
+  }
+  return 'invalid_content';
+}
+
+function editorValidationSummary(text) {
+  const value = String(text || '').replace(/\s+/g, ' ').trim();
+  const attributeMismatch = value.match(/Expected attribute[^.]+\.\s*([^;]+;?)/i);
+  if (attributeMismatch?.[1]) {
+    return attributeMismatch[1].slice(0, 240);
+  }
+  const attributesMismatch = value.match(/Expected attributes[^;]+;/i);
+  if (attributesMismatch?.[0]) {
+    return attributesMismatch[0].slice(0, 240);
+  }
+  return value.slice(0, 240);
 }
 
 function visualAttributionFindingFields(raw, rawObserved, rawSelectorEvidence) {
@@ -382,11 +462,26 @@ function hasRuntimeCarriedSignal(raw) {
 }
 
 export function patternFamily(finding) {
+  const selector = selectorFamily(finding.selector);
   return [
     finding.repair_bucket || finding.group_key || 'static_site_import_quality',
     finding.kind || 'diagnostic',
-    selectorFamily(finding.selector),
+    selector !== '(none)' ? selector : diagnosticFamily(finding),
   ].join(':');
+}
+
+function diagnosticFamily(finding) {
+  if (finding.reason_code || finding.reasonCode) {
+    return slugToken(finding.reason_code || finding.reasonCode);
+  }
+  if (finding.observed_block_name || finding.observedBlockName) {
+    return `block:${slugToken(finding.observed_block_name || finding.observedBlockName)}`;
+  }
+  return '(none)';
+}
+
+function slugToken(value) {
+  return String(value || '').trim().toLowerCase().replace(/[^a-z0-9/_-]+/g, '-').replace(/[/_]+/g, '-').replace(/^-+|-+$/g, '') || '(unknown)';
 }
 
 export function selectorFamily(selector) {

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -733,7 +733,7 @@ function fixtureExemplar(finding) {
 function diagnosticBlindSpots(findings) {
   const spots = [];
   const genericFindings = findings.filter((finding) => isGenericFinding(finding));
-  const missingSourceContext = findings.filter((finding) => !finding.selector && !finding.source_snippet && !finding.observed_output);
+  const missingSourceContext = findings.filter((finding) => isMissingSourceContextFinding(finding));
   const missingRuntimeContext = findings.filter((finding) => finding.loss_class === 'runtime_execution_failed' && !finding.command && !finding.batch_id && !finding.stderr_tail && !finding.stdout_tail && normalizeArray(finding.artifact_refs).length === 0);
   if (genericFindings.length > 0) {
     spots.push(blindSpot('generic_finding_family', genericFindings, 'Findings need a specific type, repair bucket, or reason code before fanout.'));
@@ -747,6 +747,14 @@ function diagnosticBlindSpots(findings) {
   return spots;
 }
 
+function isMissingSourceContextFinding(finding) {
+  return !finding.selector
+    && !finding.source_path
+    && !finding.source_snippet
+    && !finding.observed_output
+    && !hasStructuredEvidence(finding);
+}
+
 function blindSpot(kind, findings, recommendation) {
   return {
     kind,
@@ -757,8 +765,9 @@ function blindSpot(kind, findings, recommendation) {
 }
 
 function isGenericFinding(finding) {
+  const pattern = finding.pattern_family || patternFamily(finding);
   return ['static_site_fixture_diagnostic', 'import_diagnostic', 'diagnostic'].includes(finding.kind)
-    || ['static_site_import_quality'].includes(finding.group_key)
+    || pattern.endsWith(':(none)')
     || !finding.reason;
 }
 

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -120,6 +120,46 @@ test('execution-requested fixture matrices still fail missing validation results
   assert.equal(result.findings.some((finding) => finding.loss_class === 'fixture_not_run'), true);
 });
 
+test('fixture matrix derives actionable families from selectorless diagnostic reasons', () => {
+  const result = normalizeFixtureMatrixResult({
+    matrix: {
+      id: 'diagnostic-actionability-test',
+      fixture_root: '/tmp/fixtures',
+      fixtures: [{ id: 'saas', fixture_path: '/tmp/fixtures/saas' }],
+    },
+    results: [
+      {
+        fixture_id: 'saas',
+        fixture_path: '/tmp/fixtures/saas',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'editor_block_invalid',
+            source_path: '/tmp/fixtures/saas',
+            reason: 'Editor reported block "core/group" as invalid: Expected attribute `%s` of value `%s`, saw `%s`. style margin-top:0 margin-top:0;max-width:1160px; Block validation failed for `%s` (%o).',
+          },
+          {
+            kind: 'visual_parity_mismatch',
+            source_path: 'file:///tmp/fixtures/saas/source/index.html',
+            reason: 'Aligned visual parity mismatch: 4017764/10002240 pixels (40.17%) exceed the 0.00% threshold.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const editorFinding = result.findings.find((finding) => finding.kind === 'editor_block_invalid');
+  const visualFinding = result.findings.find((finding) => finding.kind === 'visual_parity_mismatch');
+
+  assert.equal(editorFinding.observed_block_name, 'core/group');
+  assert.equal(editorFinding.reason_code, 'editor_block_validation_style_mismatch');
+  assert.equal(editorFinding.pattern_family, 'editor_block_invalid:editor_block_invalid:editor-block-validation-style-mismatch');
+  assert.match(editorFinding.observed_output, /Block validation mismatch for core\/group/);
+  assert.equal(visualFinding.reason_code, 'visual_parity_pixel_mismatch');
+  assert.equal(visualFinding.pattern_family, 'visual_parity_mismatch:visual_parity_mismatch:visual-parity-pixel-mismatch');
+  assert.deepEqual(result.summary.diagnostic_blind_spots || [], []);
+});
+
 test('gutenberg incompatibility registry aggregates recurring custom block candidates across fixtures', () => {
   const result = normalizeFixtureMatrixResult({
     matrix: {


### PR DESCRIPTION
## Summary
- derive reason codes, block names, observed-output summaries, and pattern families from selectorless editor/visual/runtime diagnostic reasons
- treat source paths and structured diagnostic evidence as source context when computing blind spot scorecard rows
- add regression coverage for clean-scorecard selectorless diagnostics

## Diagnostic quality
Before, clean-scorecard rows like editor block validation and visual parity mismatches collapsed to families such as `editor_block_invalid:editor_block_invalid:(none)` and counted as `missing_source_context` despite source paths.

After, the same rows normalize into families like `editor_block_invalid:editor_block_invalid:editor-block-validation-style-mismatch` and `visual_parity_mismatch:visual_parity_mismatch:visual-parity-pixel-mismatch`, with bounded `observed_output` summaries and no false missing-source blind spot for rows with source paths/structured evidence.

## Testing
- `npm run test:fixture-matrix`
- `npm test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated scorecard artifacts, traced diagnostic normalization, implemented the fix and tests, and prepared this PR description.
