### PR TITLE
Deduplicate hoisted template part shell blocks

### DIFF
--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -102,11 +102,12 @@ class Static_Site_Importer_Page_Materializer {
 	 *
 	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Pages.
 	 * @param string                                          $theme_slug Theme slug.
-	 * @param array<string,array<string,mixed>>                 $assets     Materialized assets keyed by source path.
-	 * @param array<string,string>                              $permalinks Imported page permalinks keyed by source path.
+	 * @param array<string,array<string,mixed>>                 $assets              Materialized assets keyed by source path.
+	 * @param array<string,string>                              $permalinks          Imported page permalinks keyed by source path.
+	 * @param array<string,string>                              $template_part_writes Generated header/footer template part writes keyed by path.
 	 * @return array{patterns:array<string,string>,files:array<string,string>,asset_writes:array<string,string>,contents:array<string,string>,diagnostics:array<int,array<string,mixed>>}
 	 */
-	public static function page_artifacts( array $pages, string $theme_slug, array $assets = array(), array $permalinks = array() ): array {
+	public static function page_artifacts( array $pages, string $theme_slug, array $assets = array(), array $permalinks = array(), array $template_part_writes = array() ): array {
 		$patterns     = array();
 		$files        = array();
 		$contents     = array();
@@ -117,6 +118,7 @@ class Static_Site_Importer_Page_Materializer {
 			$slug         = self::page_slug( $filename, $page );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
 			$content      = self::rewrite_materialized_asset_references( self::source_page_content_blocks( $page, $diagnostics ), $assets, $page->source_key(), $permalinks );
+			$content      = self::dedupe_template_part_shell_blocks( $content, $template_part_writes, $page->source_key(), $diagnostics );
 			$content      = self::promote_inline_svg_html_blocks( $content, $theme_slug, $slug, $asset_writes, $diagnostics );
 			$content      = self::promote_navigation_list_blocks( $content, $diagnostics );
 
@@ -132,6 +134,182 @@ class Static_Site_Importer_Page_Materializer {
 			'contents'     => $contents,
 			'diagnostics'  => $diagnostics,
 		);
+	}
+
+	/**
+	 * Remove global shell blocks from page content after they are hoisted into theme parts.
+	 *
+	 * @param string                        $content              Serialized page block markup.
+	 * @param array<string,string>          $template_part_writes Generated header/footer template part writes keyed by path.
+	 * @param string                        $source_path          Source page path for diagnostics.
+	 * @param array<int,array<string,mixed>> $diagnostics          Diagnostics, passed by reference.
+	 * @return string
+	 */
+	private static function dedupe_template_part_shell_blocks( string $content, array $template_part_writes, string $source_path, array &$diagnostics ): string {
+		if ( '' === trim( $content ) || empty( $template_part_writes ) ) {
+			return $content;
+		}
+
+		$top_level = self::top_level_serialized_blocks( $content );
+		if ( empty( $top_level ) ) {
+			return $content;
+		}
+
+		$header_parts = self::template_part_write_sequences( $template_part_writes, 'header' );
+		$footer_parts = self::template_part_write_sequences( $template_part_writes, 'footer' );
+		$remove_start = 0;
+		$remove_end   = count( $top_level );
+
+		foreach ( $header_parts as $part_blocks ) {
+			$count = count( $part_blocks );
+			if ( $count > 0 && self::block_sequence_matches( array_slice( $top_level, 0, $count ), $part_blocks ) ) {
+				$remove_start = max( $remove_start, $count );
+				break;
+			}
+		}
+
+		foreach ( $footer_parts as $part_blocks ) {
+			$count = count( $part_blocks );
+			if ( $count > 0 && $remove_start <= count( $top_level ) - $count && self::block_sequence_matches( array_slice( $top_level, -$count ), $part_blocks ) ) {
+				$remove_end = min( $remove_end, count( $top_level ) - $count );
+				break;
+			}
+		}
+
+		if ( 0 === $remove_start && count( $top_level ) === $remove_end ) {
+			return $content;
+		}
+
+		$start_offset = $remove_start > 0 ? $top_level[ $remove_start - 1 ]['end'] : 0;
+		$end_offset   = $remove_end < count( $top_level ) ? $top_level[ $remove_end ]['start'] : strlen( $content );
+		$deduped      = trim( substr( $content, $start_offset, $end_offset - $start_offset ) );
+
+		$diagnostics[] = array(
+			'type'        => 'template_part_shell_deduped',
+			'source'      => 'static-site-importer/page-materializer',
+			'source_path' => $source_path,
+			'reason'      => 'matching_header_footer_template_parts',
+			'removed'     => array(
+				'leading_blocks'  => $remove_start,
+				'trailing_blocks' => count( $top_level ) - $remove_end,
+			),
+			'message'     => 'Page body blocks matching generated header/footer template parts were removed to avoid duplicate global shell rendering.',
+		);
+
+		return $deduped;
+	}
+
+	/**
+	 * Return top-level serialized block spans and normalized markup.
+	 *
+	 * @param string $markup Serialized block markup.
+	 * @return array<int,array{start:int,end:int,normalized:string}>
+	 */
+	private static function top_level_serialized_blocks( string $markup ): array {
+		if ( ! preg_match_all( '/<!--\s+(\/)?wp:([a-zA-Z0-9_\-\/]+)([^>]*)-->/', $markup, $matches, PREG_OFFSET_CAPTURE ) ) {
+			return array();
+		}
+
+		$blocks = array();
+		$stack  = array();
+		$count  = count( $matches[0] );
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$comment = $matches[0][ $i ][0];
+			$offset  = $matches[0][ $i ][1];
+			$closing = '/' === ( $matches[1][ $i ][0] ?? '' );
+			$self    = str_ends_with( trim( $matches[3][ $i ][0] ?? '' ), '/' );
+
+			if ( $closing ) {
+				$opened = array_pop( $stack );
+				if ( empty( $stack ) && is_array( $opened ) ) {
+					$end      = $offset + strlen( $comment );
+					$original = substr( $markup, (int) $opened['start'], $end - (int) $opened['start'] );
+					$blocks[] = array(
+						'start'      => (int) $opened['start'],
+						'end'        => $end,
+						'normalized' => self::normalize_shell_block_markup( $original ),
+					);
+				}
+				continue;
+			}
+
+			if ( empty( $stack ) && $self ) {
+				$end      = $offset + strlen( $comment );
+				$original = substr( $markup, $offset, $end - $offset );
+				$blocks[] = array(
+					'start'      => $offset,
+					'end'        => $end,
+					'normalized' => self::normalize_shell_block_markup( $original ),
+				);
+				continue;
+			}
+
+			if ( ! $self ) {
+				$stack[] = array( 'start' => $offset );
+			}
+		}
+
+		return $blocks;
+	}
+
+	/**
+	 * Extract normalized top-level block sequences from generated template part writes.
+	 *
+	 * @param array<string,string> $template_part_writes Generated template part writes.
+	 * @param string               $area                 Template part area.
+	 * @return array<int,array<int,array{normalized:string}>>
+	 */
+	private static function template_part_write_sequences( array $template_part_writes, string $area ): array {
+		$sequences = array();
+		foreach ( $template_part_writes as $path => $markup ) {
+			$normalized_path = strtolower( str_replace( '\\', '/', (string) $path ) );
+			if ( ! str_ends_with( $normalized_path, '/parts/' . $area . '.html' ) ) {
+				continue;
+			}
+
+			$blocks = self::top_level_serialized_blocks( (string) $markup );
+			if ( ! empty( $blocks ) ) {
+				$sequences[] = $blocks;
+			}
+		}
+
+		return $sequences;
+	}
+
+	/**
+	 * Check whether two top-level block sequences are the same rendered shell.
+	 *
+	 * @param array<int,array{normalized:string}> $page_blocks Page block sequence.
+	 * @param array<int,array{normalized:string}> $part_blocks Template part block sequence.
+	 * @return bool
+	 */
+	private static function block_sequence_matches( array $page_blocks, array $part_blocks ): bool {
+		if ( count( $page_blocks ) !== count( $part_blocks ) ) {
+			return false;
+		}
+
+		foreach ( $part_blocks as $index => $part_block ) {
+			if ( ( $page_blocks[ $index ]['normalized'] ?? '' ) !== ( $part_block['normalized'] ?? '' ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Normalize serialized block markup for shell dedupe comparisons.
+	 *
+	 * @param string $markup Serialized block markup.
+	 * @return string
+	 */
+	private static function normalize_shell_block_markup( string $markup ): string {
+		$markup = preg_replace( '/<!--\s+\/?wp:[^>]*?-->/', '', $markup ) ?? $markup;
+		$markup = html_entity_decode( $markup, ENT_QUOTES | ENT_HTML5 );
+		$markup = preg_replace( '/\s+/', ' ', $markup ) ?? $markup;
+
+		return trim( $markup );
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -176,19 +176,19 @@ class Static_Site_Importer_Theme_Generator {
 			return $materialized;
 		}
 
-		$page_artifacts = Static_Site_Importer_Page_Materializer::page_artifacts( $document_pages, $theme_slug, $materialized['assets'], $permalinks );
-		foreach ( $page_artifacts['diagnostics'] as $diagnostic ) {
-			self::$conversion_report['diagnostics'][] = $diagnostic;
-		}
-
-		Static_Site_Importer_Document_Metadata_Reporter::record( self::$conversion_report, $artifacts );
-
 		$template_part_writes = self::template_part_artifact_writes( $theme_dir, $artifacts );
 		if ( is_wp_error( $template_part_writes ) ) {
 			return $template_part_writes;
 		}
 		$has_header_part      = isset( $template_part_writes[ $theme_dir . '/parts/header.html' ] );
 		$has_footer_part      = isset( $template_part_writes[ $theme_dir . '/parts/footer.html' ] );
+
+		$page_artifacts = Static_Site_Importer_Page_Materializer::page_artifacts( $document_pages, $theme_slug, $materialized['assets'], $permalinks, $template_part_writes );
+		foreach ( $page_artifacts['diagnostics'] as $diagnostic ) {
+			self::$conversion_report['diagnostics'][] = $diagnostic;
+		}
+
+		Static_Site_Importer_Document_Metadata_Reporter::record( self::$conversion_report, $artifacts );
 
 		$visual_repair_styles = self::visual_repair_styles_from_artifacts( $artifacts );
 

--- a/tests/smoke-template-part-shell-dedupe.php
+++ b/tests/smoke-template-part-shell-dedupe.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Smoke coverage for header/footer template-part shell dedupe.
+ *
+ * Run from the repository root:
+ * php tests/smoke-template-part-shell-dedupe.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( string $value ): string {
+		return htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key ) ?? '' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		$title = strtolower( trim( $title ) );
+		return trim( preg_replace( '/[^a-z0-9_\-]+/', '-', $title ) ?? '', '-' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $value ): string {
+		return trim( preg_replace( '/\s+/', ' ', wp_strip_all_tags( $value ) ) ?? '' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( string $value ): string {
+		return strip_tags( $value );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-source-page.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-page-materializer.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$header = '<!-- wp:group {"tagName":"header","className":"site-header"} --><header class="wp-block-group site-header"><p>Global Header</p></header><!-- /wp:group -->';
+$footer = '<!-- wp:group {"tagName":"footer","className":"site-footer"} --><footer class="wp-block-group site-footer"><p>Global Footer</p></footer><!-- /wp:group -->';
+$body   = '<!-- wp:paragraph --><p>Article body remains.</p><!-- /wp:paragraph -->';
+
+$page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'index.html',
+		'title'        => 'Home',
+		'block_markup' => $header . "\n" . $body . "\n" . $footer,
+	)
+);
+
+$template_part_writes = array(
+	'/tmp/ssi-theme/parts/header.html' => $header,
+	'/tmp/ssi-theme/parts/footer.html' => $footer,
+);
+
+$artifacts = $page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'index.html' => $page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$template_part_writes
+) : array();
+$content   = (string) ( $artifacts['contents']['index.html'] ?? '' );
+
+$assert( ! str_contains( $content, 'Global Header' ), 'leading-header-shell-removed' );
+$assert( ! str_contains( $content, 'Global Footer' ), 'trailing-footer-shell-removed' );
+$assert( str_contains( $content, 'Article body remains.' ), 'page-body-preserved' );
+$assert( 'template_part_shell_deduped' === ( $artifacts['diagnostics'][0]['type'] ?? '' ), 'dedupe-diagnostic-emitted' );
+$assert( 1 === ( $artifacts['diagnostics'][0]['removed']['leading_blocks'] ?? 0 ), 'diagnostic-leading-count' );
+$assert( 1 === ( $artifacts['diagnostics'][0]['removed']['trailing_blocks'] ?? 0 ), 'diagnostic-trailing-count' );
+
+$article_header = '<!-- wp:group {"tagName":"header","className":"article-header"} --><header class="wp-block-group article-header"><h2>Article Header</h2></header><!-- /wp:group -->';
+$article_footer = '<!-- wp:group {"tagName":"footer","className":"article-footer"} --><footer class="wp-block-group article-footer"><p>Article Footer</p></footer><!-- /wp:group -->';
+$local_page     = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'article.html',
+		'title'        => 'Article',
+		'block_markup' => $body . "\n" . $article_header . "\n" . $article_footer . "\n" . $body,
+	)
+);
+
+$local_artifacts = $local_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'article.html' => $local_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$template_part_writes
+) : array();
+$local_content   = (string) ( $local_artifacts['contents']['article.html'] ?? '' );
+
+$assert( str_contains( $local_content, 'Article Header' ), 'article-local-header-preserved' );
+$assert( str_contains( $local_content, 'Article Footer' ), 'article-local-footer-preserved' );
+$assert( array() === ( $local_artifacts['diagnostics'] ?? array() ), 'article-local-no-dedupe-diagnostic' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'PASS smoke-template-part-shell-dedupe.php (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- Remove page-body shell blocks when they exactly match generated header/footer template parts.
- Resolve template-part writes before page artifacts so page materialization can avoid rendering duplicated global chrome.
- Add smoke coverage for header/footer dedupe while preserving article-local headers/footers.

## Source evidence
- Clean scorecard run abc8b1fa-3239-4191-b430-a0d5e84556a1 shows duplicated global footers in the candidate screenshots for SaaS, Coffee, and Artist, and duplicated masthead/page shell plus footer in CV.
- Source fixtures contain a single global footer/nav shell per page; the candidate output renders the same shell again via generated template parts.
- The scorecard attributes visual/editor failures mostly to Blocks Engine, but SSI owns the materialization seam that combines page content with generated theme template parts.

## Verification
- php tests/smoke-template-part-shell-dedupe.php
- php tests/smoke-theme-materializer-dry-run.php
- php -l includes/class-static-site-importer-page-materializer.php
- php -l includes/class-static-site-importer-theme-generator.php
- php -l tests/smoke-template-part-shell-dedupe.php
- npm run test:fixture-matrix
- npm run test:fig-fixture-e2e

Full four-fixture browser scorecard rerun was attempted against the same fixture set and Blocks Engine transformer commit, but the shared local Homeboy fixture-matrix rig was occupied by other active runs, so after visual/editor metrics are not attached yet.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigated the scorecard evidence, implemented the materialization dedupe, added tests, and ran verification commands.