### PR TITLE
Deduplicate template chrome in imported page bodies

### DIFF
--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -102,11 +102,12 @@ class Static_Site_Importer_Page_Materializer {
 	 *
 	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Pages.
 	 * @param string                                          $theme_slug Theme slug.
-	 * @param array<string,array<string,mixed>>                 $assets     Materialized assets keyed by source path.
-	 * @param array<string,string>                              $permalinks Imported page permalinks keyed by source path.
+	 * @param array<string,array<string,mixed>>                 $assets              Materialized assets keyed by source path.
+	 * @param array<string,string>                              $permalinks          Imported page permalinks keyed by source path.
+	 * @param array<string,string>                              $template_part_writes Generated header/footer template part writes keyed by path.
 	 * @return array{patterns:array<string,string>,files:array<string,string>,asset_writes:array<string,string>,contents:array<string,string>,diagnostics:array<int,array<string,mixed>>}
 	 */
-	public static function page_artifacts( array $pages, string $theme_slug, array $assets = array(), array $permalinks = array() ): array {
+	public static function page_artifacts( array $pages, string $theme_slug, array $assets = array(), array $permalinks = array(), array $template_part_writes = array() ): array {
 		$patterns     = array();
 		$files        = array();
 		$contents     = array();
@@ -117,6 +118,7 @@ class Static_Site_Importer_Page_Materializer {
 			$slug         = self::page_slug( $filename, $page );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
 			$content      = self::rewrite_materialized_asset_references( self::source_page_content_blocks( $page, $diagnostics ), $assets, $page->source_key(), $permalinks );
+			$content      = self::dedupe_template_part_shell_blocks( $content, $template_part_writes, $page->source_key(), $diagnostics );
 			$content      = self::promote_inline_svg_html_blocks( $content, $theme_slug, $slug, $asset_writes, $diagnostics );
 			$content      = self::promote_navigation_list_blocks( $content, $diagnostics );
 
@@ -132,6 +134,182 @@ class Static_Site_Importer_Page_Materializer {
 			'contents'     => $contents,
 			'diagnostics'  => $diagnostics,
 		);
+	}
+
+	/**
+	 * Remove global shell blocks from page content after they are hoisted into theme parts.
+	 *
+	 * @param string                        $content              Serialized page block markup.
+	 * @param array<string,string>          $template_part_writes Generated header/footer template part writes keyed by path.
+	 * @param string                        $source_path          Source page path for diagnostics.
+	 * @param array<int,array<string,mixed>> $diagnostics          Diagnostics, passed by reference.
+	 * @return string
+	 */
+	private static function dedupe_template_part_shell_blocks( string $content, array $template_part_writes, string $source_path, array &$diagnostics ): string {
+		if ( '' === trim( $content ) || empty( $template_part_writes ) ) {
+			return $content;
+		}
+
+		$top_level = self::top_level_serialized_blocks( $content );
+		if ( empty( $top_level ) ) {
+			return $content;
+		}
+
+		$header_parts = self::template_part_write_sequences( $template_part_writes, 'header' );
+		$footer_parts = self::template_part_write_sequences( $template_part_writes, 'footer' );
+		$remove_start = 0;
+		$remove_end   = count( $top_level );
+
+		foreach ( $header_parts as $part_blocks ) {
+			$count = count( $part_blocks );
+			if ( $count > 0 && self::block_sequence_matches( array_slice( $top_level, 0, $count ), $part_blocks ) ) {
+				$remove_start = max( $remove_start, $count );
+				break;
+			}
+		}
+
+		foreach ( $footer_parts as $part_blocks ) {
+			$count = count( $part_blocks );
+			if ( $count > 0 && $remove_start <= count( $top_level ) - $count && self::block_sequence_matches( array_slice( $top_level, -$count ), $part_blocks ) ) {
+				$remove_end = min( $remove_end, count( $top_level ) - $count );
+				break;
+			}
+		}
+
+		if ( 0 === $remove_start && count( $top_level ) === $remove_end ) {
+			return $content;
+		}
+
+		$start_offset = $remove_start > 0 ? $top_level[ $remove_start - 1 ]['end'] : 0;
+		$end_offset   = $remove_end < count( $top_level ) ? $top_level[ $remove_end ]['start'] : strlen( $content );
+		$deduped      = trim( substr( $content, $start_offset, $end_offset - $start_offset ) );
+
+		$diagnostics[] = array(
+			'type'        => 'template_part_shell_deduped',
+			'source'      => 'static-site-importer/page-materializer',
+			'source_path' => $source_path,
+			'reason'      => 'matching_header_footer_template_parts',
+			'removed'     => array(
+				'leading_blocks'  => $remove_start,
+				'trailing_blocks' => count( $top_level ) - $remove_end,
+			),
+			'message'     => 'Page body blocks matching generated header/footer template parts were removed to avoid duplicate global shell rendering.',
+		);
+
+		return $deduped;
+	}
+
+	/**
+	 * Return top-level serialized block spans and normalized markup.
+	 *
+	 * @param string $markup Serialized block markup.
+	 * @return array<int,array{start:int,end:int,normalized:string}>
+	 */
+	private static function top_level_serialized_blocks( string $markup ): array {
+		if ( ! preg_match_all( '/<!--\s+(\/)?wp:([a-zA-Z0-9_\-\/]+)([^>]*)-->/', $markup, $matches, PREG_OFFSET_CAPTURE ) ) {
+			return array();
+		}
+
+		$blocks = array();
+		$stack  = array();
+		$count  = count( $matches[0] );
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$comment = $matches[0][ $i ][0];
+			$offset  = $matches[0][ $i ][1];
+			$closing = '/' === ( $matches[1][ $i ][0] ?? '' );
+			$self    = str_ends_with( trim( $matches[3][ $i ][0] ?? '' ), '/' );
+
+			if ( $closing ) {
+				$opened = array_pop( $stack );
+				if ( empty( $stack ) && is_array( $opened ) ) {
+					$end      = $offset + strlen( $comment );
+					$original = substr( $markup, (int) $opened['start'], $end - (int) $opened['start'] );
+					$blocks[] = array(
+						'start'      => (int) $opened['start'],
+						'end'        => $end,
+						'normalized' => self::normalize_shell_block_markup( $original ),
+					);
+				}
+				continue;
+			}
+
+			if ( empty( $stack ) && $self ) {
+				$end      = $offset + strlen( $comment );
+				$original = substr( $markup, $offset, $end - $offset );
+				$blocks[] = array(
+					'start'      => $offset,
+					'end'        => $end,
+					'normalized' => self::normalize_shell_block_markup( $original ),
+				);
+				continue;
+			}
+
+			if ( ! $self ) {
+				$stack[] = array( 'start' => $offset );
+			}
+		}
+
+		return $blocks;
+	}
+
+	/**
+	 * Extract normalized top-level block sequences from generated template part writes.
+	 *
+	 * @param array<string,string> $template_part_writes Generated template part writes.
+	 * @param string               $area                 Template part area.
+	 * @return array<int,array<int,array{normalized:string}>>
+	 */
+	private static function template_part_write_sequences( array $template_part_writes, string $area ): array {
+		$sequences = array();
+		foreach ( $template_part_writes as $path => $markup ) {
+			$normalized_path = strtolower( str_replace( '\\', '/', (string) $path ) );
+			if ( ! str_ends_with( $normalized_path, '/parts/' . $area . '.html' ) ) {
+				continue;
+			}
+
+			$blocks = self::top_level_serialized_blocks( (string) $markup );
+			if ( ! empty( $blocks ) ) {
+				$sequences[] = $blocks;
+			}
+		}
+
+		return $sequences;
+	}
+
+	/**
+	 * Check whether two top-level block sequences are the same rendered shell.
+	 *
+	 * @param array<int,array{normalized:string}> $page_blocks Page block sequence.
+	 * @param array<int,array{normalized:string}> $part_blocks Template part block sequence.
+	 * @return bool
+	 */
+	private static function block_sequence_matches( array $page_blocks, array $part_blocks ): bool {
+		if ( count( $page_blocks ) !== count( $part_blocks ) ) {
+			return false;
+		}
+
+		foreach ( $part_blocks as $index => $part_block ) {
+			if ( ( $page_blocks[ $index ]['normalized'] ?? '' ) !== ( $part_block['normalized'] ?? '' ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Normalize serialized block markup for shell dedupe comparisons.
+	 *
+	 * @param string $markup Serialized block markup.
+	 * @return string
+	 */
+	private static function normalize_shell_block_markup( string $markup ): string {
+		$markup = preg_replace( '/<!--\s+\/?wp:[^>]*?-->/', '', $markup ) ?? $markup;
+		$markup = html_entity_decode( $markup, ENT_QUOTES | ENT_HTML5 );
+		$markup = preg_replace( '/\s+/', ' ', $markup ) ?? $markup;
+
+		return trim( $markup );
 	}
 
 	/**

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -104,19 +104,23 @@ class Static_Site_Importer_Page_Materializer {
 	 * @param string                                          $theme_slug Theme slug.
 	 * @param array<string,array<string,mixed>>                 $assets     Materialized assets keyed by source path.
 	 * @param array<string,string>                              $permalinks Imported page permalinks keyed by source path.
+	 * @param array<string,bool>                                $options    Page materialization options.
 	 * @return array{patterns:array<string,string>,files:array<string,string>,asset_writes:array<string,string>,contents:array<string,string>,diagnostics:array<int,array<string,mixed>>}
 	 */
-	public static function page_artifacts( array $pages, string $theme_slug, array $assets = array(), array $permalinks = array() ): array {
+	public static function page_artifacts( array $pages, string $theme_slug, array $assets = array(), array $permalinks = array(), array $options = array() ): array {
 		$patterns     = array();
 		$files        = array();
 		$contents     = array();
 		$asset_writes = array();
 		$diagnostics  = array();
+		$strip_header = ! empty( $options['strip_template_header'] );
+		$strip_footer = ! empty( $options['strip_template_footer'] );
 
 		foreach ( $pages as $filename => $page ) {
 			$slug         = self::page_slug( $filename, $page );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
 			$content      = self::rewrite_materialized_asset_references( self::source_page_content_blocks( $page, $diagnostics ), $assets, $page->source_key(), $permalinks );
+			$content      = self::strip_template_chrome_blocks( $content, $strip_header, $strip_footer, $page->source_key(), $diagnostics );
 			$content      = self::promote_inline_svg_html_blocks( $content, $theme_slug, $slug, $asset_writes, $diagnostics );
 			$content      = self::promote_navigation_list_blocks( $content, $diagnostics );
 
@@ -132,6 +136,137 @@ class Static_Site_Importer_Page_Materializer {
 			'contents'     => $contents,
 			'diagnostics'  => $diagnostics,
 		);
+	}
+
+	/**
+	 * Remove page-level chrome blocks when the generated theme owns template parts.
+	 *
+	 * @param string                       $markup       Serialized block markup.
+	 * @param bool                         $strip_header Whether to strip a leading header block.
+	 * @param bool                         $strip_footer Whether to strip a trailing footer block.
+	 * @param string                       $source_path  Source path for diagnostics.
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics, passed by reference.
+	 * @return string Updated serialized block markup.
+	 */
+	private static function strip_template_chrome_blocks( string $markup, bool $strip_header, bool $strip_footer, string $source_path, array &$diagnostics ): string {
+		if ( '' === trim( $markup ) || ( ! $strip_header && ! $strip_footer ) || ! function_exists( 'parse_blocks' ) || ! function_exists( 'serialize_blocks' ) ) {
+			return $markup;
+		}
+
+		$blocks  = parse_blocks( $markup );
+		$changed = false;
+
+		if ( $strip_header ) {
+			$index = self::first_meaningful_block_index( $blocks );
+			if ( null !== $index && self::is_template_chrome_block( $blocks[ $index ], 'header' ) ) {
+				array_splice( $blocks, $index, 1 );
+				$changed       = true;
+				$diagnostics[] = array(
+					'type'        => 'template_chrome_deduplicated',
+					'source'      => 'static-site-importer/page-materializer',
+					'source_path' => $source_path,
+					'part'        => 'header',
+					'message'     => 'A top-level page header block was removed because the generated theme includes a header template part.',
+				);
+			}
+		}
+
+		if ( $strip_footer ) {
+			$index = self::last_meaningful_block_index( $blocks );
+			if ( null !== $index && self::is_template_chrome_block( $blocks[ $index ], 'footer' ) ) {
+				array_splice( $blocks, $index, 1 );
+				$changed       = true;
+				$diagnostics[] = array(
+					'type'        => 'template_chrome_deduplicated',
+					'source'      => 'static-site-importer/page-materializer',
+					'source_path' => $source_path,
+					'part'        => 'footer',
+					'message'     => 'A top-level page footer block was removed because the generated theme includes a footer template part.',
+				);
+			}
+		}
+
+		return $changed ? trim( serialize_blocks( $blocks ) ) : $markup;
+	}
+
+	/**
+	 * Return the first top-level block carrying meaningful content.
+	 *
+	 * @param array<int,mixed> $blocks Parsed blocks.
+	 * @return int|null
+	 */
+	private static function first_meaningful_block_index( array $blocks ): ?int {
+		foreach ( $blocks as $index => $block ) {
+			if ( self::is_meaningful_parsed_block( $block ) ) {
+				return (int) $index;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Return the last top-level block carrying meaningful content.
+	 *
+	 * @param array<int,mixed> $blocks Parsed blocks.
+	 * @return int|null
+	 */
+	private static function last_meaningful_block_index( array $blocks ): ?int {
+		for ( $index = count( $blocks ) - 1; $index >= 0; --$index ) {
+			if ( self::is_meaningful_parsed_block( $blocks[ $index ] ) ) {
+				return $index;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Determine whether a parsed block contains actual output.
+	 *
+	 * @param mixed $block Parsed block.
+	 * @return bool
+	 */
+	private static function is_meaningful_parsed_block( $block ): bool {
+		if ( ! is_array( $block ) ) {
+			return false;
+		}
+
+		$name    = isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '';
+		$content = isset( $block['innerHTML'] ) && is_scalar( $block['innerHTML'] ) ? trim( (string) $block['innerHTML'] ) : '';
+		$inner   = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : array();
+
+		return '' !== $name || '' !== $content || ! empty( $inner );
+	}
+
+	/**
+	 * Determine whether a top-level parsed block represents a template chrome landmark.
+	 *
+	 * @param mixed  $block Parsed block.
+	 * @param string $part  Template part slug: header or footer.
+	 * @return bool
+	 */
+	private static function is_template_chrome_block( $block, string $part ): bool {
+		if ( ! is_array( $block ) || ! in_array( $part, array( 'header', 'footer' ), true ) ) {
+			return false;
+		}
+
+		$name  = isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '';
+		$attrs = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+		$tag   = isset( $attrs['tagName'] ) && is_scalar( $attrs['tagName'] ) ? strtolower( (string) $attrs['tagName'] ) : '';
+		$class = isset( $attrs['className'] ) && is_scalar( $attrs['className'] ) ? strtolower( (string) $attrs['className'] ) : '';
+
+		if ( $part === $tag ) {
+			return true;
+		}
+
+		if ( 'header' === $part && 'core/navigation' === $name ) {
+			return true;
+		}
+
+		$pattern = 'header' === $part ? '/(^|[-_\s])(?:site-header|header|navbar|navigation|masthead)([-_\s]|$)/' : '/(^|[-_\s])(?:site-footer|footer)([-_\s]|$)/';
+
+		return '' !== $class && (bool) preg_match( $pattern, $class );
 	}
 
 	/**

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -100,25 +100,27 @@ class Static_Site_Importer_Page_Materializer {
 	/**
 	 * Build page-specific template and pattern artifacts.
 	 *
-	 * @param array<string, Static_Site_Importer_Source_Page> $pages      Pages.
-	 * @param string                                          $theme_slug Theme slug.
 	 * @param array<string,array<string,mixed>>                 $assets              Materialized assets keyed by source path.
 	 * @param array<string,string>                              $permalinks          Imported page permalinks keyed by source path.
 	 * @param array<string,string>                              $template_part_writes Generated header/footer template part writes keyed by path.
+	 * @param array<string,bool>                                $options             Page materialization options.
 	 * @return array{patterns:array<string,string>,files:array<string,string>,asset_writes:array<string,string>,contents:array<string,string>,diagnostics:array<int,array<string,mixed>>}
 	 */
-	public static function page_artifacts( array $pages, string $theme_slug, array $assets = array(), array $permalinks = array(), array $template_part_writes = array() ): array {
+	public static function page_artifacts( array $pages, string $theme_slug, array $assets = array(), array $permalinks = array(), array $template_part_writes = array(), array $options = array() ): array {
 		$patterns     = array();
 		$files        = array();
 		$contents     = array();
 		$asset_writes = array();
 		$diagnostics  = array();
+		$strip_header = ! empty( $options['strip_template_header'] );
+		$strip_footer = ! empty( $options['strip_template_footer'] );
 
 		foreach ( $pages as $filename => $page ) {
 			$slug         = self::page_slug( $filename, $page );
 			$pattern_slug = sanitize_key( $theme_slug ) . '/page-' . $slug;
 			$content      = self::rewrite_materialized_asset_references( self::source_page_content_blocks( $page, $diagnostics ), $assets, $page->source_key(), $permalinks );
 			$content      = self::dedupe_template_part_shell_blocks( $content, $template_part_writes, $page->source_key(), $diagnostics );
+			$content      = self::strip_template_chrome_blocks( $content, $strip_header, $strip_footer, $page->source_key(), $diagnostics );
 			$content      = self::promote_inline_svg_html_blocks( $content, $theme_slug, $slug, $asset_writes, $diagnostics );
 			$content      = self::promote_navigation_list_blocks( $content, $diagnostics );
 
@@ -310,6 +312,137 @@ class Static_Site_Importer_Page_Materializer {
 		$markup = preg_replace( '/\s+/', ' ', $markup ) ?? $markup;
 
 		return trim( $markup );
+	}
+
+	/**
+	 * Remove page-level chrome blocks when the generated theme owns template parts.
+	 *
+	 * @param string                       $markup       Serialized block markup.
+	 * @param bool                         $strip_header Whether to strip a leading header block.
+	 * @param bool                         $strip_footer Whether to strip a trailing footer block.
+	 * @param string                       $source_path  Source path for diagnostics.
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics, passed by reference.
+	 * @return string Updated serialized block markup.
+	 */
+	private static function strip_template_chrome_blocks( string $markup, bool $strip_header, bool $strip_footer, string $source_path, array &$diagnostics ): string {
+		if ( '' === trim( $markup ) || ( ! $strip_header && ! $strip_footer ) || ! function_exists( 'parse_blocks' ) || ! function_exists( 'serialize_blocks' ) ) {
+			return $markup;
+		}
+
+		$blocks  = parse_blocks( $markup );
+		$changed = false;
+
+		if ( $strip_header ) {
+			$index = self::first_meaningful_block_index( $blocks );
+			if ( null !== $index && self::is_template_chrome_block( $blocks[ $index ], 'header' ) ) {
+				array_splice( $blocks, $index, 1 );
+				$changed       = true;
+				$diagnostics[] = array(
+					'type'        => 'template_chrome_deduplicated',
+					'source'      => 'static-site-importer/page-materializer',
+					'source_path' => $source_path,
+					'part'        => 'header',
+					'message'     => 'A top-level page header block was removed because the generated theme includes a header template part.',
+				);
+			}
+		}
+
+		if ( $strip_footer ) {
+			$index = self::last_meaningful_block_index( $blocks );
+			if ( null !== $index && self::is_template_chrome_block( $blocks[ $index ], 'footer' ) ) {
+				array_splice( $blocks, $index, 1 );
+				$changed       = true;
+				$diagnostics[] = array(
+					'type'        => 'template_chrome_deduplicated',
+					'source'      => 'static-site-importer/page-materializer',
+					'source_path' => $source_path,
+					'part'        => 'footer',
+					'message'     => 'A top-level page footer block was removed because the generated theme includes a footer template part.',
+				);
+			}
+		}
+
+		return $changed ? trim( serialize_blocks( $blocks ) ) : $markup;
+	}
+
+	/**
+	 * Return the first top-level block carrying meaningful content.
+	 *
+	 * @param array<int,mixed> $blocks Parsed blocks.
+	 * @return int|null
+	 */
+	private static function first_meaningful_block_index( array $blocks ): ?int {
+		foreach ( $blocks as $index => $block ) {
+			if ( self::is_meaningful_parsed_block( $block ) ) {
+				return (int) $index;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Return the last top-level block carrying meaningful content.
+	 *
+	 * @param array<int,mixed> $blocks Parsed blocks.
+	 * @return int|null
+	 */
+	private static function last_meaningful_block_index( array $blocks ): ?int {
+		for ( $index = count( $blocks ) - 1; $index >= 0; --$index ) {
+			if ( self::is_meaningful_parsed_block( $blocks[ $index ] ) ) {
+				return $index;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Determine whether a parsed block contains actual output.
+	 *
+	 * @param mixed $block Parsed block.
+	 * @return bool
+	 */
+	private static function is_meaningful_parsed_block( $block ): bool {
+		if ( ! is_array( $block ) ) {
+			return false;
+		}
+
+		$name    = isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '';
+		$content = isset( $block['innerHTML'] ) && is_scalar( $block['innerHTML'] ) ? trim( (string) $block['innerHTML'] ) : '';
+		$inner   = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : array();
+
+		return '' !== $name || '' !== $content || ! empty( $inner );
+	}
+
+	/**
+	 * Determine whether a top-level parsed block represents a template chrome landmark.
+	 *
+	 * @param mixed  $block Parsed block.
+	 * @param string $part  Template part slug: header or footer.
+	 * @return bool
+	 */
+	private static function is_template_chrome_block( $block, string $part ): bool {
+		if ( ! is_array( $block ) || ! in_array( $part, array( 'header', 'footer' ), true ) ) {
+			return false;
+		}
+
+		$name  = isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '';
+		$attrs = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+		$tag   = isset( $attrs['tagName'] ) && is_scalar( $attrs['tagName'] ) ? strtolower( (string) $attrs['tagName'] ) : '';
+		$class = isset( $attrs['className'] ) && is_scalar( $attrs['className'] ) ? strtolower( (string) $attrs['className'] ) : '';
+
+		if ( $part === $tag ) {
+			return true;
+		}
+
+		if ( 'header' === $part && 'core/navigation' === $name ) {
+			return true;
+		}
+
+		$pattern = 'header' === $part ? '/(^|[-_\s])(?:site-header|header|navbar|navigation|masthead)([-_\s]|$)/' : '/(^|[-_\s])(?:site-footer|footer)([-_\s]|$)/';
+
+		return '' !== $class && (bool) preg_match( $pattern, $class );
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -182,8 +182,17 @@ class Static_Site_Importer_Theme_Generator {
 		}
 		$has_header_part      = isset( $template_part_writes[ $theme_dir . '/parts/header.html' ] );
 		$has_footer_part      = isset( $template_part_writes[ $theme_dir . '/parts/footer.html' ] );
-
-		$page_artifacts = Static_Site_Importer_Page_Materializer::page_artifacts( $document_pages, $theme_slug, $materialized['assets'], $permalinks, $template_part_writes );
+		$page_artifacts       = Static_Site_Importer_Page_Materializer::page_artifacts(
+			$document_pages,
+			$theme_slug,
+			$materialized['assets'],
+			$permalinks,
+			$template_part_writes,
+			array(
+				'strip_template_header' => $has_header_part,
+				'strip_template_footer' => $has_footer_part,
+			)
+		);
 		foreach ( $page_artifacts['diagnostics'] as $diagnostic ) {
 			self::$conversion_report['diagnostics'][] = $diagnostic;
 		}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -176,19 +176,19 @@ class Static_Site_Importer_Theme_Generator {
 			return $materialized;
 		}
 
-		$page_artifacts = Static_Site_Importer_Page_Materializer::page_artifacts( $document_pages, $theme_slug, $materialized['assets'], $permalinks );
-		foreach ( $page_artifacts['diagnostics'] as $diagnostic ) {
-			self::$conversion_report['diagnostics'][] = $diagnostic;
-		}
-
-		Static_Site_Importer_Document_Metadata_Reporter::record( self::$conversion_report, $artifacts );
-
 		$template_part_writes = self::template_part_artifact_writes( $theme_dir, $artifacts );
 		if ( is_wp_error( $template_part_writes ) ) {
 			return $template_part_writes;
 		}
 		$has_header_part      = isset( $template_part_writes[ $theme_dir . '/parts/header.html' ] );
 		$has_footer_part      = isset( $template_part_writes[ $theme_dir . '/parts/footer.html' ] );
+
+		$page_artifacts = Static_Site_Importer_Page_Materializer::page_artifacts( $document_pages, $theme_slug, $materialized['assets'], $permalinks, $template_part_writes );
+		foreach ( $page_artifacts['diagnostics'] as $diagnostic ) {
+			self::$conversion_report['diagnostics'][] = $diagnostic;
+		}
+
+		Static_Site_Importer_Document_Metadata_Reporter::record( self::$conversion_report, $artifacts );
 
 		$visual_repair_styles = self::visual_repair_styles_from_artifacts( $artifacts );
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -176,19 +176,27 @@ class Static_Site_Importer_Theme_Generator {
 			return $materialized;
 		}
 
-		$page_artifacts = Static_Site_Importer_Page_Materializer::page_artifacts( $document_pages, $theme_slug, $materialized['assets'], $permalinks );
-		foreach ( $page_artifacts['diagnostics'] as $diagnostic ) {
-			self::$conversion_report['diagnostics'][] = $diagnostic;
-		}
-
-		Static_Site_Importer_Document_Metadata_Reporter::record( self::$conversion_report, $artifacts );
-
 		$template_part_writes = self::template_part_artifact_writes( $theme_dir, $artifacts );
 		if ( is_wp_error( $template_part_writes ) ) {
 			return $template_part_writes;
 		}
 		$has_header_part      = isset( $template_part_writes[ $theme_dir . '/parts/header.html' ] );
 		$has_footer_part      = isset( $template_part_writes[ $theme_dir . '/parts/footer.html' ] );
+		$page_artifacts       = Static_Site_Importer_Page_Materializer::page_artifacts(
+			$document_pages,
+			$theme_slug,
+			$materialized['assets'],
+			$permalinks,
+			array(
+				'strip_template_header' => $has_header_part,
+				'strip_template_footer' => $has_footer_part,
+			)
+		);
+		foreach ( $page_artifacts['diagnostics'] as $diagnostic ) {
+			self::$conversion_report['diagnostics'][] = $diagnostic;
+		}
+
+		Static_Site_Importer_Document_Metadata_Reporter::record( self::$conversion_report, $artifacts );
 
 		$visual_repair_styles = self::visual_repair_styles_from_artifacts( $artifacts );
 

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -146,6 +146,11 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
   const lossClass = countOnlyDiagnostic ? 'native_conversion' : classifyLossClass({ raw, kind, group_key: group.group_key, repair_bucket: repairBucket, message, result });
   const lossAcceptance = resolveLossAcceptance(lossClass, raw);
   const attributionFields = visualAttributionFindingFields(raw, rawObserved, rawSelectorEvidence);
+  const derivedContext = deriveDiagnosticContext({ raw, kind, message, lossClass });
+  const reasonCode = attributionFields.classification.reason_code || derivedContext.reason_code;
+  const observedBlockName = raw.block_name || rawObserved.block_name || derivedContext.observed_block_name || '';
+  const sourceSnippet = raw.source_html_preview || raw.html_excerpt || rawSource.snippet || rawSelectorEvidence.source_text || rawSelectorEvidence.sourceText || derivedContext.source_snippet || '';
+  const observedOutput = raw.emitted_block_preview || rawObserved.output || rawSelectorEvidence.target_text || rawSelectorEvidence.targetText || derivedContext.observed_output || '';
   return {
     id: raw.id || `${result.fixture_id || 'fixture'}:${group.group_key}:${index + 1}`,
     kind,
@@ -153,6 +158,7 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     group_key: group.group_key,
     repair_bucket: repairBucket,
     ...attributionFields.classification,
+    reason_code: reasonCode,
     severity: raw.severity || (result.status === 'failed' ? 'error' : 'warning'),
     fixture_id: result.fixture_id || '',
     fixture_class: result.fixture_class || result.taxonomy?.fixture_class || 'unknown',
@@ -162,16 +168,16 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     source_path: sourcePath,
     selector,
     selector_family: selectorFamily(selector),
-    pattern_family: attributionFields.classification.pattern_family || patternFamily({ ...raw, kind, group_key: group.group_key, repair_bucket: repairBucket, selector }),
+    pattern_family: attributionFields.classification.pattern_family || patternFamily({ ...raw, kind, group_key: group.group_key, repair_bucket: repairBucket, selector, reason_code: reasonCode, observed_block_name: observedBlockName, loss_class: lossClass, reason: message }),
     // Bound the free-text payload fields: a source snippet / observed block
     // output can carry an entire serialized `post_content` body, which at lane
     // scale balloons the aggregate past V8's per-string limit (#554). Truncate
     // to a sane cap so per-finding size is bounded; classification/metrics above
     // are derived from the full diagnostic before truncation.
     reason: truncateString(message),
-    source_snippet: truncateString(raw.source_html_preview || raw.html_excerpt || rawSource.snippet || rawSelectorEvidence.source_text || rawSelectorEvidence.sourceText || ''),
-    observed_output: truncateString(raw.emitted_block_preview || rawObserved.output || rawSelectorEvidence.target_text || rawSelectorEvidence.targetText || ''),
-    observed_block_name: raw.block_name || rawObserved.block_name || '',
+    source_snippet: truncateString(sourceSnippet),
+    observed_output: truncateString(observedOutput),
+    observed_block_name: observedBlockName,
     recipe_step_index: raw.recipe_step_index ?? raw.recipeStepIndex,
     recipe_phase: raw.recipe_phase || raw.recipePhase,
     command: raw.command,
@@ -208,6 +214,80 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     // serialized markup. All classification above is computed from `raw` before
     // this point; downstream consumers read the bounded top-level fields.
   };
+}
+
+function deriveDiagnosticContext({ raw, kind, message, lossClass }) {
+  const text = String(message || raw.reason || raw.detail || '').trim();
+  if (!text) {
+    return {};
+  }
+
+  if (kind === EDITOR_BLOCK_INVALID_KIND || lossClass === 'editor_block_invalid') {
+    const blockName = firstMatch(text, /Editor reported block "([^"]+)" as invalid/i)
+      || firstMatch(text, /Block validation failed for `%s` \(%o\)\.[\s\S]*?\b(core\/[a-z0-9-]+)/i)
+      || firstMatch(text, /\b(core\/[a-z0-9-]+)\b/i);
+    const mismatch = editorValidationMismatchToken(text);
+    return compactObject({
+      reason_code: ['editor_block_validation', mismatch].filter(Boolean).join('_'),
+      observed_block_name: blockName,
+      observed_output: truncateString([
+        blockName ? `Block validation mismatch for ${blockName}` : 'Block validation mismatch',
+        editorValidationSummary(text),
+      ].filter(Boolean).join(': ')),
+    });
+  }
+
+  if (kind === VISUAL_PARITY_MISMATCH_KIND || lossClass === 'visual_parity_mismatch') {
+    const percent = firstMatch(text, /\((\d+(?:\.\d+)?)%\) exceed/i);
+    return compactObject({
+      reason_code: percent ? 'visual_parity_pixel_mismatch' : 'visual_parity_mismatch',
+      observed_output: truncateString(percent ? `Visual parity pixel mismatch: ${percent}% exceeded threshold.` : text),
+    });
+  }
+
+  if (kind === 'recipe_step_failure' || lossClass === 'runtime_execution_failed') {
+    return compactObject({
+      reason_code: 'recipe_step_failure',
+      observed_output: truncateString(text.split('\n').slice(0, 3).join('\n')),
+    });
+  }
+
+  return {};
+}
+
+function firstMatch(text, pattern) {
+  const match = String(text || '').match(pattern);
+  return match?.[1] || '';
+}
+
+function editorValidationMismatchToken(text) {
+  const lower = String(text || '').toLowerCase();
+  if (/expected attributes/.test(lower)) {
+    return 'attributes_mismatch';
+  }
+  if (/expected attribute/.test(lower)) {
+    if (/\.\s*style\b/.test(lower)) {
+      return 'style_mismatch';
+    }
+    if (/\.\s*class\b/.test(lower)) {
+      return 'class_mismatch';
+    }
+    return 'attribute_mismatch';
+  }
+  return 'invalid_content';
+}
+
+function editorValidationSummary(text) {
+  const value = String(text || '').replace(/\s+/g, ' ').trim();
+  const attributeMismatch = value.match(/Expected attribute[^.]+\.\s*([^;]+;?)/i);
+  if (attributeMismatch?.[1]) {
+    return attributeMismatch[1].slice(0, 240);
+  }
+  const attributesMismatch = value.match(/Expected attributes[^;]+;/i);
+  if (attributesMismatch?.[0]) {
+    return attributesMismatch[0].slice(0, 240);
+  }
+  return value.slice(0, 240);
 }
 
 function visualAttributionFindingFields(raw, rawObserved, rawSelectorEvidence) {
@@ -382,11 +462,26 @@ function hasRuntimeCarriedSignal(raw) {
 }
 
 export function patternFamily(finding) {
+  const selector = selectorFamily(finding.selector);
   return [
     finding.repair_bucket || finding.group_key || 'static_site_import_quality',
     finding.kind || 'diagnostic',
-    selectorFamily(finding.selector),
+    selector !== '(none)' ? selector : diagnosticFamily(finding),
   ].join(':');
+}
+
+function diagnosticFamily(finding) {
+  if (finding.reason_code || finding.reasonCode) {
+    return slugToken(finding.reason_code || finding.reasonCode);
+  }
+  if (finding.observed_block_name || finding.observedBlockName) {
+    return `block:${slugToken(finding.observed_block_name || finding.observedBlockName)}`;
+  }
+  return '(none)';
+}
+
+function slugToken(value) {
+  return String(value || '').trim().toLowerCase().replace(/[^a-z0-9/_-]+/g, '-').replace(/[/_]+/g, '-').replace(/^-+|-+$/g, '') || '(unknown)';
 }
 
 export function selectorFamily(selector) {

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -722,7 +722,7 @@ function fixtureExemplar(finding) {
 function diagnosticBlindSpots(findings) {
   const spots = [];
   const genericFindings = findings.filter((finding) => isGenericFinding(finding));
-  const missingSourceContext = findings.filter((finding) => !finding.selector && !finding.source_snippet && !finding.observed_output);
+  const missingSourceContext = findings.filter((finding) => isMissingSourceContextFinding(finding));
   const missingRuntimeContext = findings.filter((finding) => finding.loss_class === 'runtime_execution_failed' && !finding.command && !finding.batch_id && !finding.stderr_tail && !finding.stdout_tail && normalizeArray(finding.artifact_refs).length === 0);
   if (genericFindings.length > 0) {
     spots.push(blindSpot('generic_finding_family', genericFindings, 'Findings need a specific type, repair bucket, or reason code before fanout.'));
@@ -736,6 +736,14 @@ function diagnosticBlindSpots(findings) {
   return spots;
 }
 
+function isMissingSourceContextFinding(finding) {
+  return !finding.selector
+    && !finding.source_path
+    && !finding.source_snippet
+    && !finding.observed_output
+    && !hasStructuredEvidence(finding);
+}
+
 function blindSpot(kind, findings, recommendation) {
   return {
     kind,
@@ -746,8 +754,9 @@ function blindSpot(kind, findings, recommendation) {
 }
 
 function isGenericFinding(finding) {
+  const pattern = finding.pattern_family || patternFamily(finding);
   return ['static_site_fixture_diagnostic', 'import_diagnostic', 'diagnostic'].includes(finding.kind)
-    || ['static_site_import_quality'].includes(finding.group_key)
+    || pattern.endsWith(':(none)')
     || !finding.reason;
 }
 

--- a/tests/smoke-template-chrome-dedupe.php
+++ b/tests/smoke-template-chrome-dedupe.php
@@ -125,6 +125,7 @@ if ( ! is_wp_error( $page ) ) {
 		'relay-atlas',
 		array(),
 		array(),
+		array(),
 		array(
 			'strip_template_header' => true,
 			'strip_template_footer' => true,

--- a/tests/smoke-template-chrome-dedupe.php
+++ b/tests/smoke-template-chrome-dedupe.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Smoke coverage for page chrome dedupe when theme template parts exist.
+ *
+ * Run from the repository root:
+ * php tests/smoke-template-chrome-dedupe.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook_name, $value ) {
+		unset( $hook_name );
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( string $text ): string {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		return trim( preg_replace( '/[^a-z0-9_\-]+/', '-', strtolower( $title ) ) ?? '', '-' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $value ): string {
+		return trim( strip_tags( $value ) );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( string $value ): string {
+		return strip_tags( $value );
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code, private string $message ) {}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+$wp_root = getenv( 'STATIC_SITE_IMPORTER_WP_ROOT' ) ?: '/Users/chubes/Studio/intelligence-chubes4';
+$parser  = rtrim( $wp_root, '/\\' ) . '/wp-includes/class-wp-block-parser.php';
+$blocks  = rtrim( $wp_root, '/\\' ) . '/wp-includes/blocks.php';
+if ( ! is_readable( $parser ) || ! is_readable( $blocks ) ) {
+	fwrite( STDERR, "SKIP: WordPress parser/serializer files are unavailable. Set STATIC_SITE_IMPORTER_WP_ROOT.\n" );
+	exit( 0 );
+}
+
+require_once $parser;
+require_once $blocks;
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-source-page.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-page-materializer.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$chrome_markup = implode(
+	'',
+	array(
+		'<!-- wp:group {"tagName":"header","className":"site-header"} --><header class="wp-block-group site-header"><!-- wp:navigation --><!-- wp:navigation-link {"label":"Product","url":"#product"} /--><!-- /wp:navigation --></header><!-- /wp:group -->',
+		'<!-- wp:group {"className":"hero"} --><div class="wp-block-group hero"><!-- wp:heading {"level":1} --><h1 class="wp-block-heading">Every launch.</h1><!-- /wp:heading --></div><!-- /wp:group -->',
+		'<!-- wp:group {"tagName":"footer","className":"site-footer"} --><footer class="wp-block-group site-footer"><!-- wp:paragraph --><p>Relay Atlas</p><!-- /wp:paragraph --></footer><!-- /wp:group -->',
+	)
+);
+
+$page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'index.html',
+		'title'        => 'Relay Atlas',
+		'slug'         => 'home',
+		'block_markup' => $chrome_markup,
+	)
+);
+
+$assert( ! is_wp_error( $page ), 'source-page-created', is_wp_error( $page ) ? $page->get_error_message() : '' );
+
+if ( ! is_wp_error( $page ) ) {
+	$without_template_parts = Static_Site_Importer_Page_Materializer::page_artifacts( array( 'index.html' => $page ), 'relay-atlas' );
+	$assert( str_contains( $without_template_parts['contents']['index.html'], 'tagName":"header' ), 'keeps-header-without-template-part' );
+	$assert( str_contains( $without_template_parts['contents']['index.html'], 'tagName":"footer' ), 'keeps-footer-without-template-part' );
+
+	$with_template_parts = Static_Site_Importer_Page_Materializer::page_artifacts(
+		array( 'index.html' => $page ),
+		'relay-atlas',
+		array(),
+		array(),
+		array(
+			'strip_template_header' => true,
+			'strip_template_footer' => true,
+		)
+	);
+
+	$content = $with_template_parts['contents']['index.html'];
+	$assert( ! str_contains( $content, 'tagName":"header' ), 'strips-leading-header-when-template-part-exists' );
+	$assert( ! str_contains( $content, 'tagName":"footer' ), 'strips-trailing-footer-when-template-part-exists' );
+	$assert( str_contains( $content, 'Every launch.' ), 'keeps-page-body-content' );
+
+	$parts = array_values( array_filter( array_map( static fn( array $diagnostic ): string => (string) ( $diagnostic['part'] ?? '' ), $with_template_parts['diagnostics'] ) ) );
+	$assert( array( 'header', 'footer' ) === $parts, 'reports-deduped-template-parts', wp_json_encode( $parts ) ?: '' );
+}
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+fwrite( STDOUT, "OK: {$assertions} assertions\n" );

--- a/tests/smoke-template-part-shell-dedupe.php
+++ b/tests/smoke-template-part-shell-dedupe.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Smoke coverage for header/footer template-part shell dedupe.
+ *
+ * Run from the repository root:
+ * php tests/smoke-template-part-shell-dedupe.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( string $value ): string {
+		return htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key ) ?? '' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		$title = strtolower( trim( $title ) );
+		return trim( preg_replace( '/[^a-z0-9_\-]+/', '-', $title ) ?? '', '-' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $value ): string {
+		return trim( preg_replace( '/\s+/', ' ', wp_strip_all_tags( $value ) ) ?? '' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( string $value ): string {
+		return strip_tags( $value );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-source-page.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-page-materializer.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$header = '<!-- wp:group {"tagName":"header","className":"site-header"} --><header class="wp-block-group site-header"><p>Global Header</p></header><!-- /wp:group -->';
+$footer = '<!-- wp:group {"tagName":"footer","className":"site-footer"} --><footer class="wp-block-group site-footer"><p>Global Footer</p></footer><!-- /wp:group -->';
+$body   = '<!-- wp:paragraph --><p>Article body remains.</p><!-- /wp:paragraph -->';
+
+$page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'index.html',
+		'title'        => 'Home',
+		'block_markup' => $header . "\n" . $body . "\n" . $footer,
+	)
+);
+
+$template_part_writes = array(
+	'/tmp/ssi-theme/parts/header.html' => $header,
+	'/tmp/ssi-theme/parts/footer.html' => $footer,
+);
+
+$artifacts = $page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'index.html' => $page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$template_part_writes
+) : array();
+$content   = (string) ( $artifacts['contents']['index.html'] ?? '' );
+
+$assert( ! str_contains( $content, 'Global Header' ), 'leading-header-shell-removed' );
+$assert( ! str_contains( $content, 'Global Footer' ), 'trailing-footer-shell-removed' );
+$assert( str_contains( $content, 'Article body remains.' ), 'page-body-preserved' );
+$assert( 'template_part_shell_deduped' === ( $artifacts['diagnostics'][0]['type'] ?? '' ), 'dedupe-diagnostic-emitted' );
+$assert( 1 === ( $artifacts['diagnostics'][0]['removed']['leading_blocks'] ?? 0 ), 'diagnostic-leading-count' );
+$assert( 1 === ( $artifacts['diagnostics'][0]['removed']['trailing_blocks'] ?? 0 ), 'diagnostic-trailing-count' );
+
+$article_header = '<!-- wp:group {"tagName":"header","className":"article-header"} --><header class="wp-block-group article-header"><h2>Article Header</h2></header><!-- /wp:group -->';
+$article_footer = '<!-- wp:group {"tagName":"footer","className":"article-footer"} --><footer class="wp-block-group article-footer"><p>Article Footer</p></footer><!-- /wp:group -->';
+$local_page     = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'article.html',
+		'title'        => 'Article',
+		'block_markup' => $body . "\n" . $article_header . "\n" . $article_footer . "\n" . $body,
+	)
+);
+
+$local_artifacts = $local_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'article.html' => $local_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$template_part_writes
+) : array();
+$local_content   = (string) ( $local_artifacts['contents']['article.html'] ?? '' );
+
+$assert( str_contains( $local_content, 'Article Header' ), 'article-local-header-preserved' );
+$assert( str_contains( $local_content, 'Article Footer' ), 'article-local-footer-preserved' );
+$assert( array() === ( $local_artifacts['diagnostics'] ?? array() ), 'article-local-no-dedupe-diagnostic' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'PASS smoke-template-part-shell-dedupe.php (' . $assertions . " assertions)\n";

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -120,6 +120,46 @@ test('execution-requested fixture matrices still fail missing validation results
   assert.equal(result.findings.some((finding) => finding.loss_class === 'fixture_not_run'), true);
 });
 
+test('fixture matrix derives actionable families from selectorless diagnostic reasons', () => {
+  const result = normalizeFixtureMatrixResult({
+    matrix: {
+      id: 'diagnostic-actionability-test',
+      fixture_root: '/tmp/fixtures',
+      fixtures: [{ id: 'saas', fixture_path: '/tmp/fixtures/saas' }],
+    },
+    results: [
+      {
+        fixture_id: 'saas',
+        fixture_path: '/tmp/fixtures/saas',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'editor_block_invalid',
+            source_path: '/tmp/fixtures/saas',
+            reason: 'Editor reported block "core/group" as invalid: Expected attribute `%s` of value `%s`, saw `%s`. style margin-top:0 margin-top:0;max-width:1160px; Block validation failed for `%s` (%o).',
+          },
+          {
+            kind: 'visual_parity_mismatch',
+            source_path: 'file:///tmp/fixtures/saas/source/index.html',
+            reason: 'Aligned visual parity mismatch: 4017764/10002240 pixels (40.17%) exceed the 0.00% threshold.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const editorFinding = result.findings.find((finding) => finding.kind === 'editor_block_invalid');
+  const visualFinding = result.findings.find((finding) => finding.kind === 'visual_parity_mismatch');
+
+  assert.equal(editorFinding.observed_block_name, 'core/group');
+  assert.equal(editorFinding.reason_code, 'editor_block_validation_style_mismatch');
+  assert.equal(editorFinding.pattern_family, 'editor_block_invalid:editor_block_invalid:editor-block-validation-style-mismatch');
+  assert.match(editorFinding.observed_output, /Block validation mismatch for core\/group/);
+  assert.equal(visualFinding.reason_code, 'visual_parity_pixel_mismatch');
+  assert.equal(visualFinding.pattern_family, 'visual_parity_mismatch:visual_parity_mismatch:visual-parity-pixel-mismatch');
+  assert.deepEqual(result.summary.diagnostic_blind_spots || [], []);
+});
+
 test('gutenberg incompatibility registry aggregates recurring custom block candidates across fixtures', () => {
   const result = normalizeFixtureMatrixResult({
     matrix: {


### PR DESCRIPTION
## Summary
- Strip top-level serialized header/footer chrome from imported page bodies when SSI generated matching theme template parts.
- Reorder theme generation so template-part presence is known before page content is materialized.
- Add smoke coverage for keeping body content while removing duplicated template chrome only when template parts exist.

## Root cause
SaaS imported page content included top-level header/footer blocks from the materialization plan while SSI also generated `parts/header.html` and `parts/footer.html` from the source HTML. The block theme template rendered both, duplicating the top nav/header and footer. Button shells and nav serialization were not the primary cause; they looked duplicated because the full header region rendered twice.

## Verification
- `php tests/smoke-template-chrome-dedupe.php` -> OK, 7 assertions.
- `php tests/smoke-safe-html-fallback-reducer.php` -> OK, 38 assertions.
- `php tests/smoke-inline-svg-materialization.php` -> PASS, 6 assertions.
- `php -l includes/class-static-site-importer-page-materializer.php && php -l includes/class-static-site-importer-theme-generator.php && php -l tests/smoke-template-chrome-dedupe.php` -> no syntax errors.
- `homeboy --force-hot --allow-local-hot review static-site-importer --changed-only --summary` -> pass, run `83b4d65e-2b80-4223-a05f-b2eff10438d3`.
- 4-fixture clean-scorecard matrix on SaaS/Coffee/Artist/CV: run `311423cb-692a-4633-87b9-cd27172863ef`. Overall gate still fails on visual mismatch/runtime, but SaaS improved and duplicate chrome is gone.

## Scorecard evidence
- Baseline clean run `25f62159-65b0-4880-927b-b219f80fdf86`: SaaS visual mismatch `40.17%` aligned / `43.70%` raw, candidate PNG shows duplicate top header and duplicate footer.
- Patch run `311423cb-692a-4633-87b9-cd27172863ef`: SaaS visual mismatch `34.20%` aligned / `35.82%` raw, candidate PNG shows one top header and one footer.
- Patch SaaS PNG artifacts: source `8bc9612a-a49f-4598-a075-127b3c1fa4a1-source.png`, candidate `c1a27865-92e9-428c-89ca-31afc914c1e8-candidate.png`, diff `a7eca19e-2fd6-4738-91ca-9b2f65b12006-diff.png` under Homeboy run `311423cb-692a-4633-87b9-cd27172863ef`.
- Guard metrics from patch run: Artist visual mismatch `2.40%` aligned / `2.51%` raw; CV visual mismatch `2.80%` aligned / `11.14%` raw. CV candidate PNG checksum/path is unchanged from baseline, and Artist remains in the same visual-mismatch guard band.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigated scorecard artifacts, implemented the PHP transformer/SSI fix and smoke test, and ran verification/PR preparation.