### PR TITLE
Surface visual compare viewport evidence

### DIFF
--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -295,6 +295,13 @@ function normalizeVisualParityComparison(value, options = {}) {
     return null;
   }
   const compareOptions = objectValue(obj.options || summary.options || visualCompare.options || comparison.options);
+  const viewport = normalizeViewport(firstObject([
+    obj.viewport,
+    summary.viewport,
+    visualCompare.viewport,
+    comparison.viewport,
+    compareOptions.viewport,
+  ]));
   const overlapPixels = firstNumber([summary.overlap_pixels, summary.overlapPixels, visualCompare.overlapPixels, visualCompare.overlap_pixels, comparison.overlapPixels, comparison.overlap_pixels, obj.overlap_pixels, obj.overlapPixels]);
   const dimensionDeltaPixels = firstNumber([summary.dimension_delta_pixels, summary.dimensionDeltaPixels, visualCompare.dimensionDeltaPixels, visualCompare.dimension_delta_pixels, comparison.dimensionDeltaPixels, comparison.dimension_delta_pixels, obj.dimension_delta_pixels, obj.dimensionDeltaPixels]);
   const safeMismatch = Number.isFinite(mismatchPixels) ? mismatchPixels : 0;
@@ -343,6 +350,8 @@ function normalizeVisualParityComparison(value, options = {}) {
     has_overlap_signal: hasOverlapSignal,
     dimension_delta_pixels: safeDimensionDelta,
     dimension_mismatch: dimensionMismatch,
+    viewport,
+    full_page: firstDefined([obj.full_page, obj.fullPage, summary.full_page, summary.fullPage, visualCompare.full_page, visualCompare.fullPage, comparison.full_page, comparison.fullPage, compareOptions.full_page, compareOptions.fullPage]),
     pixelmatch_threshold: firstNumber([compareOptions.threshold, compareOptions.pixelmatchThreshold, compareOptions.pixelmatch_threshold]),
     source_path: firstString([sourceObject.path, sourceObject.url, obj.source_path, obj.sourcePath]),
     source_screenshot: firstRef([artifacts.source_screenshot, artifactSlots.source_screenshot, files.sourceScreenshot, obj.source_screenshot, obj.sourceScreenshot]),
@@ -357,6 +366,32 @@ function normalizeVisualParityComparison(value, options = {}) {
   const withAlignment = aligned ? { ...normalized, ...aligned } : normalized;
   const classification = classifyVisualParityComparisonRegions(withAlignment, options);
   return classification ? { ...withAlignment, ...classification } : withAlignment;
+}
+
+function firstObject(values) {
+  for (const value of values) {
+    const obj = objectValue(value);
+    if (Object.keys(obj).length > 0) {
+      return obj;
+    }
+  }
+  return {};
+}
+
+function firstDefined(values) {
+  for (const value of values) {
+    if (value !== undefined && value !== null && value !== '') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function normalizeViewport(value) {
+  const obj = objectValue(value);
+  const width = finiteNumber(obj.width, 0);
+  const height = finiteNumber(obj.height, 0);
+  return width || height ? compactObject({ width, height }) : undefined;
 }
 
 function normalizeMismatchRegions(values) {
@@ -604,6 +639,8 @@ export function collectVisualParityArtifacts(payload, options = {}) {
       overlap_pixels: comparison.overlap_pixels,
       dimension_delta_pixels: comparison.dimension_delta_pixels,
       dimension_mismatch: comparison.dimension_mismatch,
+      viewport: comparison.viewport,
+      full_page: comparison.full_page,
     }),
     ...(comparison.visual_diff_regions?.length ? { visual_diff_regions: comparison.visual_diff_regions } : {}),
     ...(comparison.visual_diff_cause_summary ? { visual_diff_cause_summary: comparison.visual_diff_cause_summary } : {}),

--- a/lib/fixture-matrix/visual-evidence-report.mjs
+++ b/lib/fixture-matrix/visual-evidence-report.mjs
@@ -289,6 +289,12 @@ function viewportEvidenceRows({ artifacts, artifactRefs }) {
       rows.push(compactObject({ phase: entry.phase, width, height, message: entry.message }));
     }
   };
+  const metrics = objectValue(artifacts.metrics || artifacts.comparison);
+  pushViewport({
+    phase: 'visual-compare',
+    viewport: metrics.viewport,
+    message: metrics.viewport ? `visual compare viewport${metrics.full_page === true ? ' (full-page capture)' : ''}` : '',
+  });
   for (const diagnostic of normalizeArray(artifacts.capture_diagnostics || artifacts.captureDiagnostics || artifacts.visual_explanation?.capture_diagnostics || artifacts.visual_explanation?.captureDiagnostics)) {
     pushViewport(diagnostic);
   }

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -4883,7 +4883,12 @@ test('visual-compare artifacts collected from fixture files gate the matrix when
   mkdirSync(fixtureDirectory, { recursive: true });
   writeFileSync(path.join(fixtureDirectory, 'visual-diff.json'), JSON.stringify({
     schema: 'wp-codebox/visual-compare/v1',
-    comparison: { mismatchPixels: 700000, totalPixels: 2048000, dimensionMismatch: false },
+    comparison: {
+      mismatchPixels: 700000,
+      totalPixels: 2048000,
+      dimensionMismatch: false,
+      options: { viewport: { width: 1280, height: 720 }, fullPage: true },
+    },
     files: {
       sourceScreenshot: 'files/browser/visual-compare/source.png',
       candidateScreenshot: 'files/browser/visual-compare/candidate.png',
@@ -4901,6 +4906,8 @@ test('visual-compare artifacts collected from fixture files gate the matrix when
   assert.equal(gated.fixtures[0].visual_parity_artifacts.schema, 'static-site-importer/visual-parity-artifacts/v1');
   assert.equal(gated.fixtures[0].visual_parity_artifacts.artifacts.diff_screenshot.status, 'captured');
   assert.equal(gated.fixtures[0].visual_parity_artifacts.metrics.mismatch_pixels, 700000);
+  assert.deepEqual(gated.fixtures[0].visual_parity_artifacts.metrics.viewport, { width: 1280, height: 720 });
+  assert.equal(gated.fixtures[0].visual_parity_artifacts.metrics.full_page, true);
   assert.equal(finding.artifact_refs.find((ref) => ref.artifact_id === 'diff_screenshot')?.path, 'files/browser/visual-compare/diff.png');
   const exemplar = gated.summary.top_pattern_families.find((family) => family.kind === VISUAL_PARITY_MISMATCH_KIND)?.exemplars[0];
   assert.equal(exemplar.artifact_refs.find((ref) => ref.artifact_id === 'diff_screenshot')?.path, 'files/browser/visual-compare/diff.png');
@@ -4911,6 +4918,47 @@ test('visual-compare artifacts collected from fixture files gate the matrix when
   assert.ok(capturedFinding, 'expected the mismatch to still be captured');
   assert.equal(capturedFinding.loss_acceptance, 'acceptable');
   assert.equal(captured.fixtures[0].status, 'passed');
+});
+
+test('visual evidence report infers viewport evidence from visual-compare metrics', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-metric-viewport-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-metric-viewport-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(path.join(fixtureDirectory, 'source'), { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'artifact.json'), '{}');
+  writeFileSync(path.join(fixtureDirectory, 'source', 'index.html'), '<h1>Simple SSI Fixture</h1>');
+
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'passed',
+        visual_parity_artifacts: {
+          metrics: {
+            mismatch_pixels: 0,
+            total_pixels: 1000,
+            mismatch_ratio: 0,
+            viewport: { width: 390, height: 844 },
+            full_page: true,
+          },
+          artifacts: {
+            imported_screenshot: { status: 'captured', ref: { path: 'files/browser/visual-compare/candidate-mobile.png', kind: 'browser-visual-candidate-screenshot' } },
+          },
+        },
+      },
+    ],
+  });
+
+  const report = buildVisualParityEvidenceReport({ outputDirectory, matrix, result });
+  const viewport = report.fixtures[0].evidence.viewports.rows[0];
+
+  assert.equal(report.summary.viewport_evidence_fixture_count, 1);
+  assert.equal(report.summary.mobile_viewport_fixture_count, 1);
+  assert.equal(viewport.phase, 'visual-compare');
+  assert.equal(viewport.width, 390);
+  assert.equal(viewport.height, 844);
+  assert.equal(report.fixtures[0].risk.reasons.includes('missing mobile viewport evidence'), false);
 });
 
 test('visual-compare PNGs are copied to the bench artifact root and registered', () => {


### PR DESCRIPTION
## Summary
- Preserve viewport/full-page metadata from visual-compare payloads in SSI visual parity artifacts.
- Let the visual parity evidence report infer viewport/mobile coverage from visual-compare metrics, not only separate capture diagnostics.
- Add fixture-matrix tests for retained visual-compare viewport metadata and mobile viewport evidence inference.

## Diagnostic findings
- Live-WP parity is intentionally opt-in/off by default, so missing live-WP parity evidence is expected unless runs pass the live-WP parity toggle.
- Surface coverage is opt-in for secondary pages; default browser evidence is the front page only.
- The actionable blind spot was viewport evidence: screenshots and visual-compare artifacts could be present, but viewport coverage stayed missing when the runtime reported viewport under visual-compare options rather than capture diagnostics.

## Example output impact
A visual compare payload with options.viewport width 390 height 844 now produces visual_parity_artifacts.metrics.viewport and the evidence report counts viewport_evidence_fixture_count: 1 and mobile_viewport_fixture_count: 1.

## Tests
- npm test -- tools/fixture-matrix.test.mjs
- npm run test:fixture-matrix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the SSI matrix evidence gap, implemented the bounded collector/reporting improvement, and added tests.