### PR TITLE
Decompose mixed HTML fallback containers

### DIFF
--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -815,7 +815,7 @@ class Static_Site_Importer_Page_Materializer {
 	 * @return string|null Serialized block markup, or null when unsupported.
 	 */
 	private static function safe_html_fragment_to_blocks( string $html ): ?string {
-		if ( preg_match( '/<\s*(?:script|style|iframe|canvas|svg|select|textarea)\b/i', $html ) ) {
+		if ( preg_match( '/<\s*(?:script|style|iframe|canvas)\b/i', $html ) ) {
 			return null;
 		}
 
@@ -885,6 +885,9 @@ class Static_Site_Importer_Page_Materializer {
 		}
 
 		if ( in_array( $tag, array( 'a', 'button' ), true ) ) {
+			if ( 'button' === $tag && self::is_runtime_control_element( $node ) ) {
+				return null;
+			}
 			$content = self::safe_inline_html( $node );
 			if ( null === $content || '' === trim( wp_strip_all_tags( $content ) ) ) {
 				return null;
@@ -974,7 +977,7 @@ class Static_Site_Importer_Page_Materializer {
 			foreach ( iterator_to_array( $node->childNodes ) as $child ) {
 				$child_markup = self::safe_dom_node_to_block_markup( $child );
 				if ( null === $child_markup ) {
-					return null;
+					$child_markup = self::fallback_markup_for_dom_node( $child );
 				}
 				$children .= $child_markup;
 			}
@@ -990,6 +993,56 @@ class Static_Site_Importer_Page_Materializer {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Preserve an unsupported child as a bounded fallback inside an otherwise native container.
+	 *
+	 * @param DOMNode $node DOM node.
+	 * @return string
+	 */
+	private static function fallback_markup_for_dom_node( DOMNode $node ): string {
+		$html = self::dom_node_outer_html( $node );
+		return '' === trim( $html ) ? '' : self::serialized_block_markup( 'core/html', array( 'content' => $html ), $html );
+	}
+
+	/**
+	 * Serialize a DOM node back to its fragment HTML.
+	 *
+	 * @param DOMNode $node DOM node.
+	 * @return string
+	 */
+	private static function dom_node_outer_html( DOMNode $node ): string {
+		if ( $node instanceof DOMText ) {
+			return (string) $node->textContent;
+		}
+
+		if ( $node->ownerDocument instanceof DOMDocument ) {
+			return (string) $node->ownerDocument->saveHTML( $node );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Detect source controls whose behavior depends on commerce/runtime JavaScript.
+	 *
+	 * @param DOMElement $element Element.
+	 * @return bool
+	 */
+	private static function is_runtime_control_element( DOMElement $element ): bool {
+		$class = strtolower( trim( preg_replace( '/\s+/', ' ', $element->getAttribute( 'class' ) ) ?? '' ) );
+		if ( '' !== $class && preg_match( '/(^|[-_\s])(?:add-to-cart|qty|quantity|cart)([-_\s]|$)/', $class ) ) {
+			return true;
+		}
+
+		foreach ( iterator_to_array( $element->attributes ) as $attribute ) {
+			if ( $attribute instanceof DOMAttr && preg_match( '/^data-(?:dir|cart|quantity|qty|product|product-id)$/', strtolower( $attribute->name ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -1056,6 +1109,9 @@ class Static_Site_Importer_Page_Materializer {
 			}
 
 			$tag = strtolower( $child->tagName );
+			if ( 'svg' === $tag && 'true' === strtolower( trim( $child->getAttribute( 'aria-hidden' ) ) ) ) {
+				continue;
+			}
 			if ( ! in_array( $tag, array( 'a', 'br', 'strong', 'b', 'em', 'i', 'span', 'small', 'mark', 'sub', 'sup' ), true ) || $child->hasAttribute( 'style' ) ) {
 				return null;
 			}

--- a/tests/smoke-safe-html-fallback-reducer.php
+++ b/tests/smoke-safe-html-fallback-reducer.php
@@ -134,6 +134,27 @@ $assert( str_contains( $output, 'primary-nav' ), 'nav-class-preserved' );
 $assert( str_contains( $output, 'Search posts' ), 'search-placeholder-preserved' );
 $assert( str_contains( $output, '<form class="lead-form"><input name="email"></form>' ), 'unsupported-form-fallback-preserved' );
 
+$mixed_contact_html = '<div class="contact-content"><aside class="contact-sidebar"><div class="contact-block"><div class="label">Booking</div><h3>Book a Show</h3><p>Email <a href="mailto:booking@example.com" class="contact-email"><svg aria-hidden="true" viewBox="0 0 16 16"><path d="M1 1h14v14H1z"/></svg> booking@example.com</a></p></div></aside><div class="contact-form-wrap"><h2>Send a Message</h2><form class="contact-form"><label>Name<input name="name"></label><select name="topic"><option>Booking</option></select><textarea name="message"></textarea><button type="submit">Send</button></form></div></div>';
+$mixed_contact_input = '<!-- wp:html ' . wp_json_encode( array( 'content' => $mixed_contact_html ) ) . ' -->' . $mixed_contact_html . '<!-- /wp:html -->';
+$mixed_contact_output = $method->invoke( null, $mixed_contact_input );
+$mixed_contact_after  = $count_blocks( $mixed_contact_output );
+
+$assert( 1 === ( $count_blocks( $mixed_contact_input )['core/html'] ?? 0 ), 'mixed-contact-before-single-large-html' );
+$assert( 1 === ( $mixed_contact_after['core/html'] ?? 0 ), 'mixed-contact-after-single-bounded-form-html', print_r( $mixed_contact_after, true ) );
+$assert( 3 <= ( $mixed_contact_after['core/group'] ?? 0 ), 'mixed-contact-static-layout-groups-converted', print_r( $mixed_contact_after, true ) );
+$assert( in_array( 'core/heading', array_keys( $mixed_contact_after ), true ), 'mixed-contact-heading-converted' );
+$assert( str_contains( $mixed_contact_output, 'booking@example.com' ), 'mixed-contact-link-text-preserved' );
+$assert( str_contains( $mixed_contact_output, '<form class="contact-form">' ), 'mixed-contact-runtime-form-preserved' );
+
+$cart_control_html = '<article class="merch-card"><h3>EP Tee</h3><p>Washed black tee.</p><button class="qty-btn" data-dir="down" aria-label="Decrease quantity">-</button><span class="qty-display" aria-live="polite">1</span><button class="add-to-cart">Add</button></article>';
+$cart_control_input = '<!-- wp:html ' . wp_json_encode( array( 'content' => $cart_control_html ) ) . ' -->' . $cart_control_html . '<!-- /wp:html -->';
+$cart_control_output = $method->invoke( null, $cart_control_input );
+$cart_control_after  = $count_blocks( $cart_control_output );
+
+$assert( 3 === ( $cart_control_after['core/html'] ?? 0 ), 'cart-controls-remain-bounded-html-islands', print_r( $cart_control_after, true ) );
+$assert( 0 === ( $cart_control_after['core/button'] ?? 0 ), 'cart-controls-not-faked-as-core-buttons', print_r( $cart_control_after, true ) );
+$assert( str_contains( $cart_control_output, 'class="add-to-cart"' ), 'cart-add-control-preserved' );
+
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
 	exit( 1 );


### PR DESCRIPTION
## Summary
- Decompose safe static children inside mixed `core/html` fallback containers instead of preserving the entire container as raw HTML.
- Preserve unsupported child nodes as bounded `core/html` islands inside native groups.
- Keep cart/quantity runtime controls as HTML rather than converting them into fake static buttons.

## Artist evidence
- Baseline fresh Lab run: `55267331-ad9c-4a71-9a41-be7cb9254c95`.
- Baseline Artist structured island map from `finding-packets.json` / result artifact: contact `div.contact-content`, Jetpack-mapped newsletter forms on home/contact, merch `button.qty-btn`, `span.qty-display`, and `button.add-to-cart`.
- Local transform proof against exported Artist `contact.html`: post-materializer output for the contact body has `core/html: 0`, with static contact layout decomposed into native groups/headings/paragraphs.
- Full rig rerun was blocked by an active shared `static-site-importer-fixture-matrix` bench in another worktree; direct workload invocation against the exported fixture root returned zero fixtures, so I am not claiming a full Artist matrix delta from that path.

## Verification
- `node --test tools/fixture-matrix.test.mjs`
- `php tests/smoke-safe-html-fallback-reducer.php`
- `php tests/smoke-contact-layout-transformer.php`
- `php tests/smoke-form-materializer.php`
- `php tests/smoke-product-materializer.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Inspected Artist fixture-matrix artifacts, mapped remaining fallback/runtime islands, implemented the generic reducer change, and ran verification.
