### PR TITLE
Link Homeboy node deps extension

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -21,6 +21,9 @@
         ],
         "validation_dependencies": []
       }
+    },
+    "nodejs": {
+      "settings": {}
     }
   },
   "id": "static-site-importer",

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -79,6 +79,13 @@ import { editorOpenStep } from '../lib/fixture-matrix/steps/editor-open-step.mjs
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const fixtureRoot = path.join(packageRoot, 'tests', 'fixtures', 'fixture-matrix');
 
+test('Homeboy component links runtime and dependency extensions', () => {
+  const config = JSON.parse(readFileSync(path.join(packageRoot, 'homeboy.json'), 'utf8'));
+
+  assert.ok(config.extensions?.wordpress, 'WordPress extension is required for fixture runtime workloads');
+  assert.ok(config.extensions?.nodejs, 'Node.js extension is required for Lab dependency hydration');
+});
+
 test('discovers SSI fixtures and writes Blocks Engine site artifacts', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-matrix-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'test-matrix' });


### PR DESCRIPTION
## Summary\n- Link the Homeboy `nodejs` extension in SSI's component config so Lab dependency hydration has a deps-capable extension contract.\n- Add fixture-matrix contract coverage for the required `wordpress` runtime and `nodejs` dependency extension pairing.\n\nFixes #618.\n\n## Testing\n- `npm run test:fixture-matrix`\n- `homeboy deps status static-site-importer --force-hot --allow-local-hot`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** GPT-5.5 via OpenCode\n- **Used for:** Investigated the Homeboy/Homeboy Extensions Lab dependency blocker, made the SSI component contract/test change, and prepared the PR.\n