### PR TITLE
Select nodejs for Homeboy deps hydration

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,5 +1,8 @@
 {
   "auto_cleanup": false,
+  "capability_extensions": {
+    "deps": "nodejs"
+  },
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
     "wordpress": {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -84,6 +84,7 @@ test('Homeboy component links runtime and dependency extensions', () => {
 
   assert.ok(config.extensions?.wordpress, 'WordPress extension is required for fixture runtime workloads');
   assert.ok(config.extensions?.nodejs, 'Node.js extension is required for Lab dependency hydration');
+  assert.equal(config.capability_extensions?.deps, 'nodejs', 'Node.js owns Lab dependency hydration');
 });
 
 test('discovers SSI fixtures and writes Blocks Engine site artifacts', () => {


### PR DESCRIPTION
## Summary\n\n- select `nodejs` as the explicit Homeboy `deps` extension owner\n- keep `wordpress` linked for runtime/browser fixture support\n- extend fixture-matrix contract coverage so Lab hydration ownership stays explicit\n\nDepends on Extra-Chill/homeboy#7722.\nFixes the SSI side of Extra-Chill/homeboy#7721.\n\n## Verification\n\n- `npm run test:fixture-matrix`\n- `git diff --check`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** openai/gpt-5.5 via OpenCode\n- **Used for:** Investigated the Homeboy/SSI extension ownership ambiguity, updated SSI configuration and contract coverage, and drafted this PR description.