### PR TITLE
feat(fixture-matrix): discover solved fixtures and promote solved candidates

### DIFF
--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -305,6 +305,38 @@ human knows the fixture intent. Fixtures without reviewed metadata should remain
 unknown and appear in `manifest_coverage.unknown_fixture_ids`; do not backfill
 truth from directory names or HTML heuristics.
 
+## Solved Fixture Corpus and Promotion
+
+The Blocks Engine fixture corpus has a lifecycle:
+
+- `fixtures/candidates/` — untracked raw generation output (`.gitignore`d).
+- `fixtures/websites/` — active corpus under evaluation.
+- `fixtures/solved/` — permanent regression fixtures.
+
+When `--blocks-engine` is passed, the operator wrapper defaults `--fixture-root`
+to `<blocks-engine>/fixtures` and discovers fixtures from both `websites/` and
+`solved/`. A matrix created from a corpus parent includes `fixture_directories:
+["websites", "solved"]` so the split is visible in artifacts.
+
+Promote a fixture to `fixtures/solved/` only after a matrix run grades it
+`solved_candidate`:
+
+```bash
+node tools/promote-solved-fixture.mjs \
+  --fixture-id <id> \
+  --registry /path/to/run/gutenberg-incompatibility-registry.json \
+  --blocks-engine /path/to/blocks-engine
+```
+
+The tool refuses to move fixtures whose registry decision is not
+`solved_candidate` (no `--force`). It performs the move with `git mv` and prints
+the commit/push next steps.
+
+A solved fixture that regresses in a later matrix run is surfaced as
+`solved_regression` in the registry decision groups and counts. This is a hard
+failure: solved fixtures must stay solved, and a regression requires either a fix
+or a reviewed demotion back to `fixtures/websites/`.
+
 ## Generic Invocation
 
 The workload composes these generic surfaces:

--- a/docs/gutenberg-incompatibility-registry.md
+++ b/docs/gutenberg-incompatibility-registry.md
@@ -41,7 +41,8 @@ The registry also emits `fixture_decisions[]` so acceptance decisions do not req
 - `intentional_runtime_patterns`: runtime islands preserved by design.
 - `visual_only_patterns`: frontend visual drift patterns that do not imply invalid blocks or lost editability by themselves.
 - `solved_candidate_reason`: present only when the fixture passed, editor validation passed, no HTML/runtime islands remain, and no registry limitation pattern is attached.
-- `acceptance_status`: `solved_candidate`, `visual_only_blocker`, `editor_blocker`, `native_editability_blocker`, `provider_runtime_blocker`, or `evidence_gap`. Missing frontend/editor/block-validity evidence is `evidence_gap`; `provider_runtime_blocker` is reserved for failures where the provider/runtime blocked evidence capture.
+- `acceptance_status`: `solved_candidate`, `visual_only_blocker`, `editor_blocker`, `native_editability_blocker`, `provider_runtime_blocker`, `evidence_gap`, or `solved_regression`. Missing frontend/editor/block-validity evidence is `evidence_gap`; `provider_runtime_blocker` is reserved for failures where the provider/runtime blocked evidence capture. `solved_regression` is reserved for fixtures in `fixtures/solved/` whose result is no longer `solved_candidate`.
+- `fixture_corpus`: `active` for fixtures discovered from `fixtures/websites/`, `solved` for fixtures discovered from `fixtures/solved/`.
 
 ## Seeded Generic Pattern Keys
 

--- a/lib/fixture-matrix/fixtures.mjs
+++ b/lib/fixture-matrix/fixtures.mjs
@@ -29,31 +29,64 @@ import {
 
 export function discoverFixtures(root, options = {}) {
   const fixtureRoot = requiredDirectory(root || options.fixtureRoot || options.fixture_root, 'fixtureRoot');
+  const searchRoots = resolveFixtureSearchRoots(fixtureRoot);
   const entrypoint = options.entrypoint || 'index.html';
   const maxDepth = finiteNumber(options.maxDepth ?? options.max_depth, 2);
   const fixtures = [];
 
-  visitFixtureDirectory(fixtureRoot, 0, maxDepth, (directory) => {
-    const entryPath = path.join(directory, entrypoint);
-    if (!fs.existsSync(entryPath) || !fs.statSync(entryPath).isFile()) {
-      return;
-    }
+  for (const searchRoot of searchRoots) {
+    visitFixtureDirectory(searchRoot, 0, maxDepth, (directory) => {
+      const entryPath = path.join(directory, entrypoint);
+      if (!fs.existsSync(entryPath) || !fs.statSync(entryPath).isFile()) {
+        return;
+      }
 
-    fixtures.push(normalizeFixture({ root: fixtureRoot, directory, entrypoint }));
-  });
+      fixtures.push(normalizeFixture({ root: searchRoot, directory, entrypoint, fixture_corpus: corpusLabelForSearchRoot(searchRoot, fixtureRoot) }));
+    });
+  }
 
   return fixtures.sort((left, right) => left.id.localeCompare(right.id));
 }
 
+// Resolve the actual directories to search for fixtures. If the requested root
+// contains a `websites/` subdirectory, treat it as a Blocks Engine corpus parent
+// and search both `websites/` (active corpus) and `solved/` (regression corpus).
+// This keeps `--fixture-root <blocks-engine>/fixtures` working while discovering
+// solved regression fixtures automatically. Any other root is searched as-is.
+export function resolveFixtureSearchRoots(fixtureRoot) {
+  const websitesRoot = path.join(fixtureRoot, 'websites');
+  if (!fs.existsSync(websitesRoot) || !fs.statSync(websitesRoot).isDirectory()) {
+    return [fixtureRoot];
+  }
+  const roots = [websitesRoot];
+  const solvedRoot = path.join(fixtureRoot, 'solved');
+  if (fs.existsSync(solvedRoot) && fs.statSync(solvedRoot).isDirectory()) {
+    roots.push(solvedRoot);
+  }
+  return roots;
+}
+
+function corpusLabelForSearchRoot(searchRoot, fixtureRoot) {
+  const normalizedSearchRoot = path.resolve(searchRoot);
+  const normalizedFixtureRoot = path.resolve(fixtureRoot);
+  if (normalizedSearchRoot === path.join(normalizedFixtureRoot, 'solved')) {
+    return 'solved';
+  }
+  return 'active';
+}
+
 export function createFixtureMatrix(input = {}) {
-  const normalized = normalizeArray(input.fixtures || discoverFixtures(input.fixture_root || input.fixtureRoot, input))
+  const requestedRoot = input.fixture_root || input.fixtureRoot || '';
+  const normalized = normalizeArray(input.fixtures || discoverFixtures(requestedRoot, input))
     .map((fixture) => normalizeFixture(fixture));
   const filter = normalizeFixtureFilter(input);
   const fixtures = filter ? normalized.filter((fixture) => fixtureMatchesFilter(fixture, filter)) : normalized;
+  const corpusLayout = requestedRoot ? detectCorpusLayout(requestedRoot) : null;
   return {
     schema: FIXTURE_MATRIX_SCHEMA,
     id: input.id || input.run_id || input.runId || 'static-site-importer-fixture-matrix',
-    fixture_root: input.fixture_root || input.fixtureRoot || fixtures[0]?.fixture_root || normalized[0]?.fixture_root || '',
+    fixture_root: corpusLayout ? corpusLayout.fixture_root : (requestedRoot || fixtures[0]?.fixture_root || normalized[0]?.fixture_root || ''),
+    ...(corpusLayout ? { fixture_directories: corpusLayout.fixture_directories } : {}),
     entrypoint: input.entrypoint || 'index.html',
     ...(filter ? { filter } : {}),
     count: fixtures.length,
@@ -64,6 +97,23 @@ export function createFixtureMatrix(input = {}) {
       summary: input.summary_artifact || input.summaryArtifact || 'summary.json',
       findings: input.findings_artifact || input.findingsArtifact || 'finding-packets.json',
     },
+  };
+}
+
+function detectCorpusLayout(fixtureRoot) {
+  const resolvedRoot = path.resolve(fixtureRoot);
+  const websitesRoot = path.join(resolvedRoot, 'websites');
+  if (!fs.existsSync(websitesRoot) || !fs.statSync(websitesRoot).isDirectory()) {
+    return null;
+  }
+  const directories = ['websites'];
+  const solvedRoot = path.join(resolvedRoot, 'solved');
+  if (fs.existsSync(solvedRoot) && fs.statSync(solvedRoot).isDirectory()) {
+    directories.push('solved');
+  }
+  return {
+    fixture_root: resolvedRoot,
+    fixture_directories: directories,
   };
 }
 
@@ -262,12 +312,14 @@ export function normalizeFixture(input) {
   const capabilities = normalizeManifestCapabilities(manifest?.capabilities ?? input.capabilities);
   const riskProfile = normalizeManifestRiskProfile(manifest?.risk_profile ?? manifest?.riskProfile ?? input.risk_profile ?? input.riskProfile);
   const qualityBudgets = normalizeManifestQualityBudgets(manifest?.quality_budgets ?? manifest?.qualityBudgets ?? input.quality_budgets ?? input.qualityBudgets);
+  const fixtureCorpus = input.fixture_corpus || corpusLabelForSearchRoot(root, root);
   return {
     id,
     label: input.label || input.name || id,
     directory,
     fixture_path: directory,
     fixture_root: root,
+    fixture_corpus: fixtureCorpus,
     entrypoint: input.entrypoint || 'index.html',
     fixture_class: taxonomy.fixture_class,
     tags,

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -369,8 +369,12 @@ function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
     runtimeIslandPatterns,
     editorRiskPatterns,
   });
+  const finalAcceptance = fixtureIsSolved(fixture) && acceptance.status !== 'solved_candidate'
+    ? { solved_candidate: false, status: 'solved_regression', reason: 'solved fixture no longer meets solved_candidate criteria' }
+    : acceptance;
   return compactObject({
     fixture_id: fixture.fixture_id || fixture.id || '',
+    fixture_corpus: fixture.fixture_corpus || 'active',
     frontend_visual_status: frontendVisualStatus,
     editor_canvas_status: editorCanvasStatus,
     block_validity_status: editorValidityStatus,
@@ -385,11 +389,15 @@ function fixtureDecision(fixture, fixtureFindings, fixturePatterns) {
     intentional_runtime_patterns: runtimeIslandPatterns,
     visual_only_patterns: visualOnlyPatterns,
     editor_risk_patterns: editorRiskPatterns,
-    solved_candidate: acceptance.solved_candidate,
-    solved_candidate_reason: acceptance.reason,
-    acceptance_status: acceptance.status,
-    acceptance_reason: acceptance.reason,
+    solved_candidate: finalAcceptance.solved_candidate,
+    solved_candidate_reason: finalAcceptance.reason,
+    acceptance_status: finalAcceptance.status,
+    acceptance_reason: finalAcceptance.reason,
   });
+}
+
+function fixtureIsSolved(fixture) {
+  return fixture.fixture_corpus === 'solved' || /[/\\]fixtures[/\\]solved([/\\]|$)/.test(String(fixture.fixture_path || fixture.path || ''));
 }
 
 function nativeEditabilityStatusForFixture({ editorValidityStatus, visibleHtmlIslandCount, runtimeIslandCount, gutenbergGapPatterns, providerMaterializablePatterns, transformerGapPatterns }) {

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -376,6 +376,7 @@ function attachFixtureTaxonomy(result, fixture) {
   return {
     ...result,
     fixture_path: result.fixture_path || fixture.fixture_path,
+    fixture_corpus: fixture.fixture_corpus || result.fixture_corpus || 'active',
     fixture_class: fixtureClass,
     tags,
     complexity,

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "scripts": {
     "fig-intent-parity": "node tools/fig-intent-parity-report.mjs",
     "fig-fixture-e2e": "node tools/run-fig-fixture-e2e.mjs",
-    "test": "npm run test:fixture-matrix && npm run test:fig-fixture-e2e",
+    "test": "npm run test:fixture-matrix && npm run test:fig-fixture-e2e && npm run test:promote-solved-fixture",
     "test:fig-fixture-e2e": "node --test tools/run-fig-fixture-e2e.test.mjs",
     "test:fixture-matrix": "node --test tools/fixture-matrix.test.mjs",
+    "test:promote-solved-fixture": "node --test tools/promote-solved-fixture.test.mjs",
     "test:js-block-validation": "node tests/smoke-generated-theme-block-validation.cjs",
     "test:validation": "node tests/run-validation-harness.cjs"
   },

--- a/registry/gutenberg-incompatibility-registry.schema.json
+++ b/registry/gutenberg-incompatibility-registry.schema.json
@@ -53,7 +53,7 @@
     "editor_canvas_status": { "enum": ["visible", "diverged", "not_captured", "provider_runtime_blocked"] },
     "editor_validity_status": { "enum": ["valid", "invalid_blocks", "not_validated"] },
     "native_editability_status": { "enum": ["native_editable", "editor_invalid", "custom_block_candidate", "runtime_island_preserved", "html_islands_or_transformer_gap", "unknown"] },
-    "acceptance_status": { "enum": ["solved_candidate", "visual_only_blocker", "editor_blocker", "native_editability_blocker", "provider_runtime_blocker", "evidence_gap"] },
+    "acceptance_status": { "enum": ["solved_candidate", "visual_only_blocker", "editor_blocker", "native_editability_blocker", "provider_runtime_blocker", "evidence_gap", "solved_regression"] },
     "top_pattern": {
       "type": "object",
       "required": ["pattern_key", "classification", "fixture_count", "finding_count", "impact_score"],
@@ -97,6 +97,7 @@
       "required": ["fixture_id", "frontend_visual_status", "editor_canvas_status", "block_validity_status", "editor_validity_status", "native_editability_status", "visible_html_island_count", "runtime_island_count", "visible_runtime_or_html_islands", "gutenberg_gap_patterns", "provider_materializable_patterns", "transformer_gap_patterns", "intentional_runtime_patterns", "visual_only_patterns", "solved_candidate", "acceptance_status", "acceptance_reason"],
       "properties": {
         "fixture_id": { "type": "string" },
+        "fixture_corpus": { "enum": ["active", "solved"] },
         "frontend_visual_status": { "$ref": "#/$defs/frontend_visual_status" },
         "editor_canvas_status": { "$ref": "#/$defs/editor_canvas_status" },
         "block_validity_status": { "$ref": "#/$defs/editor_validity_status" },

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2170,7 +2170,8 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-canonical-matrix-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
   const blocksEngine = path.join(root, 'blocks-engine');
-  const canonicalFixtureRoot = path.join(blocksEngine, 'fixtures', 'websites');
+  const corpusRoot = path.join(blocksEngine, 'fixtures');
+  const canonicalFixtureRoot = path.join(corpusRoot, 'websites');
   mkdirSync(staticSiteImporter, { recursive: true });
   for (let index = 1; index <= CANONICAL_FIXTURE_COUNT; index += 1) {
     mkdirSync(path.join(canonicalFixtureRoot, `fixture-${String(index).padStart(2, '0')}`), { recursive: true });
@@ -2188,7 +2189,9 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
 
   assert.equal(plan.mode, 'development-override');
   assert.equal(plan.homeboy_bin, '/tmp/homeboy-latest');
-  assert.equal(plan.fixture_root, canonicalFixtureRoot);
+  assert.equal(plan.fixture_root, corpusRoot);
+  assert.equal(plan.active_fixture_count, CANONICAL_FIXTURE_COUNT);
+  assert.equal(plan.solved_fixture_count, 0);
   assert.equal(plan.fixture_count, CANONICAL_FIXTURE_COUNT);
   assert.equal(plan.fixture_count_matches_canonical, true);
   assert.equal(plan.namespace, 'ssi-matrix-dev-proof');
@@ -2206,7 +2209,7 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.equal(benchStep.command, '/tmp/homeboy-latest');
   assert.ok(benchStep.args.includes('--runner'));
   assert.ok(benchStep.args.includes('homeboy-lab'));
-  assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT=${canonicalFixtureRoot}`));
+  assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT=${corpusRoot}`));
   assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH=${staticSiteImporter}`));
   assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH=${blocksEngine}`));
   assert.ok(benchStep.args.includes('bench_env.SSI_FIXTURE_MATRIX_RUN=1'));
@@ -5908,3 +5911,100 @@ function fillRect(image, x, y, width, height, rgba) {
 function writePng(filePath, image) {
   writeFileSync(filePath, PNG.sync.write(image));
 }
+
+test('fixture discovery includes both websites and solved corpus directories', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-corpus-discovery-'));
+  const websitesDir = path.join(root, 'websites', 'active-site');
+  const solvedDir = path.join(root, 'solved', 'solved-site');
+  mkdirSync(websitesDir, { recursive: true });
+  mkdirSync(solvedDir, { recursive: true });
+  writeFileSync(path.join(websitesDir, 'index.html'), '<h1>Active</h1>');
+  writeFileSync(path.join(websitesDir, 'fixture.json'), JSON.stringify({ fixture_class: 'marketing/static' }));
+  writeFileSync(path.join(solvedDir, 'index.html'), '<h1>Solved</h1>');
+  writeFileSync(path.join(solvedDir, 'fixture.json'), JSON.stringify({ fixture_class: 'docs/blog' }));
+
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'corpus-discovery-test' });
+
+  assert.equal(matrix.fixture_root, root);
+  assert.deepEqual(matrix.fixture_directories, ['websites', 'solved']);
+  assert.equal(matrix.count, 2);
+  const ids = matrix.fixtures.map((fixture) => fixture.id).sort();
+  assert.deepEqual(ids, ['active-site', 'solved-site']);
+  const solvedFixture = matrix.fixtures.find((fixture) => fixture.id === 'solved-site');
+  assert.equal(solvedFixture.fixture_corpus, 'solved');
+  assert.equal(solvedFixture.fixture_class, 'docs/blog');
+});
+
+test('fixture discovery falls back to single root when no websites subdirectory exists', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-single-root-discovery-'));
+  const fixtureDir = path.join(root, 'simple-site');
+  mkdirSync(fixtureDir, { recursive: true });
+  writeFileSync(path.join(fixtureDir, 'index.html'), '<h1>Simple</h1>');
+  writeFileSync(path.join(fixtureDir, 'fixture.json'), JSON.stringify({ fixture_class: 'marketing/static' }));
+
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'single-root-discovery-test' });
+
+  assert.equal(matrix.fixture_root, root);
+  assert.equal(matrix.fixture_directories, undefined);
+  assert.equal(matrix.count, 1);
+  assert.equal(matrix.fixtures[0].id, 'simple-site');
+  assert.equal(matrix.fixtures[0].fixture_corpus, 'active');
+});
+
+test('solved fixture that regresses is reported as solved_regression', () => {
+  const registry = buildGutenbergIncompatibilityRegistry({
+    matrix_id: 'solved-regression-test',
+    fixtures: [
+      {
+        fixture_id: 'cv',
+        fixture_corpus: 'solved',
+        fixture_path: '/fixtures/solved/cv',
+        status: 'passed',
+        artifact_refs: [{ artifact_id: 'editor-open-screenshot', kind: 'screenshot', path: 'files/browser/editor-open/cv/screenshot.png' }],
+        visual_parity_artifacts: { comparison: { mismatch_ratio: 0.05 } },
+        block_composition: { block_total: 8, native_block_count: 8, core_html_block_count: 0 },
+        editor_quality: { editor_validated_block_total: 8, editor_invalid_count: 0, core_html_block_count: 0 },
+      },
+    ],
+    findings: [
+      {
+        fixture_id: 'cv',
+        kind: 'visual_parity_mismatch',
+        loss_class: 'visual_parity_mismatch',
+        loss_acceptance: 'unacceptable',
+        reason: 'Aligned visual parity mismatch: 5% exceed threshold.',
+      },
+    ],
+  });
+  const decision = registry.fixture_decisions.find((row) => row.fixture_id === 'cv');
+
+  assert.equal(decision.fixture_corpus, 'solved');
+  assert.equal(decision.acceptance_status, 'solved_regression');
+  assert.equal(decision.solved_candidate, false);
+  assert.equal(registry.summary.fixture_decision_counts.solved_regression, 1);
+  assert.deepEqual(registry.summary.fixture_decision_groups.solved_regression, ['cv']);
+});
+
+test('solved fixture that stays solved_candidate keeps solved_candidate status', () => {
+  const registry = buildGutenbergIncompatibilityRegistry({
+    matrix_id: 'solved-stays-solved-test',
+    fixtures: [
+      {
+        fixture_id: 'cv',
+        fixture_corpus: 'solved',
+        fixture_path: '/fixtures/solved/cv',
+        status: 'passed',
+        artifact_refs: [{ artifact_id: 'editor-open-screenshot', kind: 'screenshot', path: 'files/browser/editor-open/cv/screenshot.png' }],
+        visual_parity_artifacts: { comparison: { mismatch_ratio: 0 } },
+        block_composition: { block_total: 8, native_block_count: 8, core_html_block_count: 0 },
+        editor_quality: { editor_validated_block_total: 8, editor_invalid_count: 0, core_html_block_count: 0 },
+      },
+    ],
+    findings: [],
+  });
+  const decision = registry.fixture_decisions.find((row) => row.fixture_id === 'cv');
+
+  assert.equal(decision.fixture_corpus, 'solved');
+  assert.equal(decision.acceptance_status, 'solved_candidate');
+  assert.equal(decision.solved_candidate, true);
+});

--- a/tools/promote-solved-fixture.mjs
+++ b/tools/promote-solved-fixture.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+/**
+ * External dependencies
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return { ok: true };
+  }
+
+  const result = promoteSolvedFixture(options);
+  process.stdout.write(`${result.message}\n`);
+  return result;
+}
+
+export function promoteSolvedFixture(options) {
+  validateOptions(options);
+
+  const registry = readJson(options.registry);
+  if (!registry || typeof registry !== 'object') {
+    throw new Error(`Registry file is missing or invalid: ${options.registry}`);
+  }
+
+  const decisions = Array.isArray(registry.fixture_decisions) ? registry.fixture_decisions : [];
+  const decision = decisions.find((row) => row.fixture_id === options.fixtureId);
+  if (!decision) {
+    throw new Error(`Fixture "${options.fixtureId}" not found in registry decisions.`);
+  }
+
+  if (decision.acceptance_status !== 'solved_candidate') {
+    throw new Error(`Fixture "${options.fixtureId}" has acceptance_status "${decision.acceptance_status}"; promotion requires "solved_candidate".`);
+  }
+
+  const blocksEngine = path.resolve(options.blocksEngine);
+  const source = path.join(blocksEngine, 'fixtures', 'websites', options.fixtureId);
+  const target = path.join(blocksEngine, 'fixtures', 'solved', options.fixtureId);
+
+  if (!fs.existsSync(source)) {
+    throw new Error(`Source fixture does not exist: ${source}`);
+  }
+  if (fs.existsSync(target)) {
+    throw new Error(`Target already exists (duplicate fixture ID?): ${target}`);
+  }
+
+  const gitResult = spawnSync('git', ['-C', blocksEngine, 'mv', `fixtures/websites/${options.fixtureId}`, `fixtures/solved/${options.fixtureId}`], {
+    encoding: 'utf8',
+  });
+  if (gitResult.status !== 0) {
+    throw new Error(`git mv failed: ${gitResult.stderr || gitResult.stdout || `exit ${gitResult.status}`}`);
+  }
+
+  return {
+    ok: true,
+    fixture_id: options.fixtureId,
+    blocks_engine: blocksEngine,
+    message: [
+      `Promoted ${options.fixtureId} to fixtures/solved/.`,
+      '',
+      'Next steps:',
+      `  cd ${blocksEngine}`,
+      `  git status`,
+      `  git commit -m "promote(fixture): move ${options.fixtureId} to solved corpus"`,
+      '  git push origin <branch>',
+      '',
+      `Registry: ${path.resolve(options.registry)}`,
+    ].join('\n'),
+  };
+}
+
+function validateOptions(options) {
+  if (!options.fixtureId) {
+    throw new Error('--fixture-id is required');
+  }
+  if (!options.registry) {
+    throw new Error('--registry is required');
+  }
+  if (!options.blocksEngine) {
+    throw new Error('--blocks-engine is required');
+  }
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      const [rawKey, rawValue] = arg.slice(2).split('=');
+      const key = camelCase(rawKey);
+      const value = rawValue === undefined ? args[index + 1] : rawValue;
+      if (rawValue === undefined) {
+        index += 1;
+      }
+      options[key] = value;
+      continue;
+    }
+  }
+  return options;
+}
+
+function camelCase(value) {
+  return value.replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase());
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node tools/promote-solved-fixture.mjs --fixture-id <id> --registry <path> --blocks-engine <path>
+
+Promote a fixture from blocks-engine/fixtures/websites/ to fixtures/solved/.
+
+The registry row for the fixture must have acceptance_status "solved_candidate".
+Any other status is refused (no --force). The move is performed with "git mv" in
+the blocks-engine checkout.
+
+Options:
+  --fixture-id <id>       Fixture ID matching a registry fixture_decisions row.
+  --registry <path>       Path to a gutenberg-incompatibility-registry.json from a matrix run.
+  --blocks-engine <path>  Blocks Engine checkout path.
+  --help, -h              Show this help.
+`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tools/promote-solved-fixture.test.mjs
+++ b/tools/promote-solved-fixture.test.mjs
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import assert from 'node:assert/strict';
+import { execSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Internal dependencies
+ */
+import { promoteSolvedFixture } from './promote-solved-fixture.mjs';
+
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function createTempGitRepo(prefix) {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  execSync('git init', { cwd: root, stdio: 'ignore' });
+  execSync('git config user.email "test@example.com"', { cwd: root, stdio: 'ignore' });
+  execSync('git config user.name "Test"', { cwd: root, stdio: 'ignore' });
+  return root;
+}
+
+function writeRegistry(root, decisions) {
+  const registry = {
+    schema: 'static-site-importer/gutenberg-incompatibility-registry/v1',
+    matrix_id: 'test-matrix',
+    fixture_decisions: decisions,
+  };
+  const filePath = path.join(root, 'gutenberg-incompatibility-registry.json');
+  writeFileSync(filePath, JSON.stringify(registry, null, 2));
+  return filePath;
+}
+
+function setupFixture(blocksEngine, fixtureId) {
+  const fixtureDir = path.join(blocksEngine, 'fixtures', 'websites', fixtureId);
+  const solvedDir = path.join(blocksEngine, 'fixtures', 'solved');
+  mkdirSync(fixtureDir, { recursive: true });
+  mkdirSync(solvedDir, { recursive: true });
+  writeFileSync(path.join(fixtureDir, 'index.html'), `<h1>${fixtureId}</h1>`);
+  writeFileSync(path.join(fixtureDir, 'fixture.json'), JSON.stringify({ fixture_class: 'marketing/static' }));
+  execSync('git add fixtures', { cwd: blocksEngine, stdio: 'ignore' });
+  execSync(`git commit -m "add ${fixtureId}"`, { cwd: blocksEngine, stdio: 'ignore' });
+}
+
+test('refuses to promote a fixture that is not solved_candidate', () => {
+  const blocksEngine = createTempGitRepo('ssi-promote-not-solved-');
+  setupFixture(blocksEngine, 'visual-only');
+  const registryPath = writeRegistry(mkdtempSync(path.join(tmpdir(), 'ssi-promote-registry-')), [
+    { fixture_id: 'visual-only', acceptance_status: 'visual_only_blocker' },
+  ]);
+
+  assert.throws(
+    () => promoteSolvedFixture({ fixtureId: 'visual-only', registry: registryPath, blocksEngine }),
+    /acceptance_status "visual_only_blocker".*requires "solved_candidate"/
+  );
+  assert.strictEqual(spawnSync('git', ['-C', blocksEngine, 'status', '--porcelain']).stdout.toString(), '');
+});
+
+test('refuses to promote a missing registry row', () => {
+  const blocksEngine = createTempGitRepo('ssi-promote-missing-row-');
+  setupFixture(blocksEngine, 'missing');
+  const registryPath = writeRegistry(mkdtempSync(path.join(tmpdir(), 'ssi-promote-registry-')), [
+    { fixture_id: 'other', acceptance_status: 'solved_candidate' },
+  ]);
+
+  assert.throws(
+    () => promoteSolvedFixture({ fixtureId: 'missing', registry: registryPath, blocksEngine }),
+    /Fixture "missing" not found in registry decisions/
+  );
+});
+
+test('promotes a solved_candidate fixture via git mv', () => {
+  const blocksEngine = createTempGitRepo('ssi-promote-solved-');
+  setupFixture(blocksEngine, 'simple-site');
+  const registryPath = writeRegistry(mkdtempSync(path.join(tmpdir(), 'ssi-promote-registry-')), [
+    { fixture_id: 'simple-site', acceptance_status: 'solved_candidate' },
+  ]);
+
+  const result = promoteSolvedFixture({ fixtureId: 'simple-site', registry: registryPath, blocksEngine });
+
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.fixture_id, 'simple-site');
+  assert.strictEqual(result.blocks_engine, path.resolve(blocksEngine));
+  assert.strictEqual(spawnSync('git', ['-C', blocksEngine, 'status', '--porcelain']).stdout.toString().includes('fixtures/solved/simple-site'), true);
+  assert.strictEqual(spawnSync('git', ['-C', blocksEngine, 'ls-files', 'fixtures/websites/simple-site']).stdout.toString(), '');
+  assert.strictEqual(spawnSync('git', ['-C', blocksEngine, 'ls-files', 'fixtures/solved/simple-site/index.html']).stdout.toString().trim(), 'fixtures/solved/simple-site/index.html');
+});

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -131,12 +131,15 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.complexity ? { SSI_FIXTURE_MATRIX_COMPLEXITY: String(options.complexity) } : {}),
     ...(options.maxComplexity ? { SSI_FIXTURE_MATRIX_MAX_COMPLEXITY: String(options.maxComplexity) } : {}),
   };
-  const fixtureCount = countTopLevelFixtureDirectories(options.fixtureRoot);
+  const corpusCounts = countCorpusFixtureDirectories(options.fixtureRoot);
+  const fixtureCount = corpusCounts.total;
+  const activeFixtureCount = corpusCounts.active;
+  const solvedFixtureCount = corpusCounts.solved;
   const codeFreshness = buildCodeFreshness(options, options.gitRunner || defaultGitRunner);
   const warnings = [
     ...buildWarnings(options),
     ...buildSurfaceCoverageWarnings(options, fixtureCount),
-    ...buildCanonicalDriftWarnings(fixtureCount, options.fixtureRoot),
+    ...buildCanonicalDriftWarnings(activeFixtureCount, corpusCounts.active_root),
     ...buildFreshnessWarnings(codeFreshness, options),
   ];
 
@@ -153,8 +156,10 @@ export function buildFixtureMatrixRunPlan(input) {
     homeboy_bin: options.homeboyBin,
     fixture_root: options.fixtureRoot,
     fixture_count: fixtureCount,
+    active_fixture_count: activeFixtureCount,
+    solved_fixture_count: solvedFixtureCount,
     canonical_fixture_count: CANONICAL_FIXTURE_COUNT,
-    fixture_count_matches_canonical: fixtureCount === CANONICAL_FIXTURE_COUNT,
+    fixture_count_matches_canonical: activeFixtureCount === CANONICAL_FIXTURE_COUNT,
     lane_filter: laneFilterSummary(options),
     output_file: options.output,
     temp_root: options.tempRoot,
@@ -220,7 +225,7 @@ function normalizeOptions(input) {
   if (!input.fixtureRoot && !blocksEngine) {
     throw new Error('--blocks-engine or --fixture-root is required');
   }
-  const fixtureRoot = path.resolve(input.fixtureRoot || path.join(blocksEngine, 'fixtures', 'websites'));
+  const fixtureRoot = path.resolve(input.fixtureRoot || path.join(blocksEngine, 'fixtures'));
 
   const defaultBlocksEnginePhpTransformerPath = input.mode === 'release-proof' ? '' : blocksEngine;
   let blocksEnginePhpTransformerPath = defaultBlocksEnginePhpTransformerPath;
@@ -353,14 +358,15 @@ function isMacLocalTempPath(value) {
 // Surface corpus pin drift instead of letting `fixture_count_matches_canonical`
 // be a silently-ignored boolean. A discovered count below the pin means fixtures
 // went missing (or the wrong root was passed); above the pin means the corpus
-// grew and CANONICAL_FIXTURE_COUNT needs an intentional bump.
-function buildCanonicalDriftWarnings(fixtureCount, fixtureRoot) {
-  if (fixtureCount === CANONICAL_FIXTURE_COUNT) {
+// grew and CANONICAL_FIXTURE_COUNT needs an intentional bump. The pin applies
+// to the active corpus (`fixtures/websites`), not the solved regression corpus.
+function buildCanonicalDriftWarnings(activeFixtureCount, activeRoot) {
+  if (activeFixtureCount === CANONICAL_FIXTURE_COUNT) {
     return [];
   }
   return [{
     code: 'canonical_fixture_count_drift',
-    message: `Discovered ${fixtureCount} top-level fixture director${fixtureCount === 1 ? 'y' : 'ies'} in ${fixtureRoot}, but CANONICAL_FIXTURE_COUNT is ${CANONICAL_FIXTURE_COUNT}. ${fixtureCount > CANONICAL_FIXTURE_COUNT ? 'The corpus grew; bump CANONICAL_FIXTURE_COUNT after confirming the new fixtures are intended.' : 'Fixtures are missing or the wrong fixture root was passed; restore the corpus or correct --fixture-root.'}`,
+    message: `Discovered ${activeFixtureCount} top-level fixture director${activeFixtureCount === 1 ? 'y' : 'ies'} in ${activeRoot}, but CANONICAL_FIXTURE_COUNT is ${CANONICAL_FIXTURE_COUNT}. ${activeFixtureCount > CANONICAL_FIXTURE_COUNT ? 'The corpus grew; bump CANONICAL_FIXTURE_COUNT after confirming the new fixtures are intended.' : 'Fixtures are missing or the wrong root was passed; restore the corpus or correct --fixture-root.'}`,
   }];
 }
 
@@ -749,6 +755,23 @@ function parseArgs(args) {
   return options;
 }
 
+function countCorpusFixtureDirectories(fixtureRoot) {
+  const activeRoot = path.join(fixtureRoot, 'websites');
+  const solvedRoot = path.join(fixtureRoot, 'solved');
+  const active = fs.existsSync(activeRoot) && fs.statSync(activeRoot).isDirectory()
+    ? countTopLevelFixtureDirectories(activeRoot)
+    : countTopLevelFixtureDirectories(fixtureRoot);
+  const solved = fs.existsSync(solvedRoot) && fs.statSync(solvedRoot).isDirectory()
+    ? countTopLevelFixtureDirectories(solvedRoot)
+    : 0;
+  return {
+    active,
+    solved,
+    total: active + solved,
+    active_root: fs.existsSync(activeRoot) && fs.statSync(activeRoot).isDirectory() ? activeRoot : fixtureRoot,
+  };
+}
+
 function countTopLevelFixtureDirectories(fixtureRoot) {
   try {
     return fs.readdirSync(fixtureRoot, { withFileTypes: true })
@@ -838,7 +861,8 @@ function sanitizePathSegment(value) {
 }
 
 function printHelp() {
-  process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Local hot execution on this machine. Injects --force-hot --allow-local-hot into routed Homeboy steps.\n  --runner <id>                       Lab offload to a Homeboy runner, for example homeboy-lab. Does not inject hot-local flags.\n  --lab-only                          Require Lab routing, using Homeboy's selected/default Lab runner.\n  no routing flags                    Auto mode; lets homeboy bench decide routing.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote> or --lab-only. Pick local-hot or Lab offload.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n  --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures/websites.\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 4, hard-capped at 16.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind upstream.\n  --allow-local-fallback              Permit selected Lab runner fallback to local execution.\n  --allow-dirty-lab-workspace         Permit reusing/overwriting a dirty Lab workspace.\n  --detach-after-handoff              Return after runner daemon accepts the job.\n  --dry-run                           Print the plan without running Homeboy.\n  --skip-install                      Skip rig install.\n  --skip-sync                         Skip rig sync.\n  --no-editor-validation              Omit editor block validation.\n  --no-visual-parity                  Omit visual parity capture.\n  --no-visual-parity-gate             Capture visual parity without gating.\n  --help                              Show this help.\n`);
+  process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Local hot execution on this machine. Injects --force-hot --allow-local-hot into routed Homeboy steps.\n  --runner <id>                       Lab offload to a Homeboy runner, for example homeboy-lab. Does not inject hot-local flags.\n  --lab-only                          Require Lab routing, using Homeboy's selected/default Lab runner.\n  no routing flags                    Auto mode; lets homeboy bench decide routing.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote> or --lab-only. Pick local-hot or Lab offload.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n    --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures, which discovers both fixtures/websites and fixtures/solved.
+\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 4, hard-capped at 16.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind upstream.\n  --allow-local-fallback              Permit selected Lab runner fallback to local execution.\n  --allow-dirty-lab-workspace         Permit reusing/overwriting a dirty Lab workspace.\n  --detach-after-handoff              Return after runner daemon accepts the job.\n  --dry-run                           Print the plan without running Homeboy.\n  --skip-install                      Skip rig install.\n  --skip-sync                         Skip rig sync.\n  --no-editor-validation              Omit editor block validation.\n  --no-visual-parity                  Omit visual parity capture.\n  --no-visual-parity-gate             Capture visual parity without gating.\n  --help                              Show this help.\n`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
This PR extends the Static Site Importer fixture matrix to treat the Blocks Engine "solved" corpus as a permanent regression guard, and adds a promotion tool.

## What changed
- Fixture discovery now includes both `fixtures/websites` and `fixtures/solved` when `--fixture-root` points at a Blocks Engine corpus parent.
- Solved fixtures that regress are surfaced as a new `acceptance_status`: `solved_regression`.
- Updated the registry JSON schema and markdown to include `solved_regression` and `fixture_corpus`.
- `tools/run-fixture-matrix.mjs` now defaults `--fixture-root` to `<blocks-engine>/fixtures` and reports active/solved counts separately.
- Added `tools/promote-solved-fixture.mjs` and focused tests. The tool refuses non-`solved_candidate` rows and performs the `git mv`.
- Updated `docs/fixture-matrix.md` and `docs/gutenberg-incompatibility-registry.md` with the promotion workflow.

## Related PR
- blocks-engine companion: https://github.com/Automattic/blocks-engine/pull/590

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.5 via OpenCode (orchestrator), Kimi K2.7 Code via OpenCode (implementation)
- **Used for:** Designed and implemented the solved-fixture promotion mechanic

Refs Automattic/static-site-importer#489