### PR TITLE
Fix fixture matrix batch failure isolation

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -226,8 +226,8 @@ export async function runFixtureMatrix(options) {
       batchRuns.push(outcome.batchRun);
       batchResults.push(outcome.batchResult);
       visualParityArtifacts = { ...visualParityArtifacts, ...(outcome.visualParityArtifacts || {}) };
-      if (outcome.childCommandFailure) {
-        childCommandFailures.push(outcome.childCommandFailure);
+      for (const failure of outcome.childCommandFailures || []) {
+        childCommandFailures.push(failure);
       }
       // Preserve the original first-failure-by-batch-order semantics: the earliest
       // batch that failed wins, independent of completion order.
@@ -313,9 +313,11 @@ export async function runFixtureMatrix(options) {
 // per-fixture artifact subdirectories, all keyed by the unique batch suffix), so
 // many of these can run concurrently without colliding. Returns a stable outcome
 // the caller folds back together in batch order.
-export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outputDirectory, staticSiteImporterPath, options }) {
+export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outputDirectory, staticSiteImporterPath, options, recovery = false }) {
   const batchNumber = batchIndex + 1;
-  const batchSuffix = String(batchNumber).padStart(3, '0');
+  const batchSuffix = recovery
+    ? `${String(batchNumber).padStart(3, '0')}-recovery-${fixtures[0].id}`
+    : String(batchNumber).padStart(3, '0');
   const batchMatrix = createFixtureMatrix({
     id: `${matrix.id}-batch-${batchSuffix}`,
     fixture_root: matrix.fixture_root,
@@ -368,6 +370,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       fixtures,
       batchNumber,
       batchSuffix,
+      batchId: `batch-${String(batchNumber).padStart(3, '0')}`,
       batchRecipeFile,
       outputFile,
       artifactsDir: codeboxArtifactsDirectory,
@@ -415,7 +418,44 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     outputDirectory,
   });
 
-  return { batchRun, batchResult: editorCanvas.result, visualParityArtifacts: visualCompare.artifacts, error: batchError, childCommandFailure };
+  if (!batchError || recovery) {
+    return {
+      batchRun,
+      batchResult: editorCanvas.result,
+      visualParityArtifacts: visualCompare.artifacts,
+      error: batchError,
+      childCommandFailures: childCommandFailure ? [childCommandFailure] : [],
+    };
+  }
+
+  // A recipe-level failure leaves the sandbox's state untrustworthy. Re-run each
+  // fixture in a fresh sandbox so one stalled step cannot classify its batch peers.
+  const recoveryOutcomes = [];
+  for (const fixture of fixtures) {
+    recoveryOutcomes.push(await runFixtureMatrixBatch({
+      fixtures: [fixture],
+      batchIndex,
+      matrix,
+      outputDirectory,
+      staticSiteImporterPath,
+      options,
+      recovery: true,
+    }));
+  }
+
+  const recoveryErrors = recoveryOutcomes.map((outcome) => outcome.error).filter(Boolean);
+  return {
+    batchRun: {
+      ...batchRun,
+      recovery_attempts: recoveryOutcomes.map((outcome) => outcome.batchRun),
+    },
+    batchResult: {
+      fixtures: recoveryOutcomes.flatMap((outcome) => outcome.batchResult.fixtures || []),
+    },
+    visualParityArtifacts: Object.assign({}, ...recoveryOutcomes.map((outcome) => outcome.visualParityArtifacts || {})),
+    error: recoveryErrors[0] || null,
+    childCommandFailures: recoveryOutcomes.flatMap((outcome) => outcome.childCommandFailures || []),
+  };
 }
 
 export function materializeEditorCanvasArtifacts(input = {}) {
@@ -828,14 +868,14 @@ function runtimeSummary(runtime, runtimeError) {
   };
 }
 
-function buildWpCodeboxChildCommandFailure({ error, fixtures, batchNumber, batchSuffix, batchRecipeFile, outputFile, artifactsDir, wpCodeboxBin: bin, artifactRefs }) {
+function buildWpCodeboxChildCommandFailure({ error, fixtures, batchNumber, batchSuffix, batchId, batchRecipeFile, outputFile, artifactsDir, wpCodeboxBin: bin, artifactRefs }) {
   const command = wpCodeboxRecipeRunCommand({ recipeFile: batchRecipeFile, artifactsDir, outputFile, wpCodeboxBin: bin });
   return {
     schema: 'homeboy/child-command-failure/v1',
     kind: 'child_command_failed',
     label: `WP Codebox recipe-run batch ${batchSuffix}`,
     batch: batchNumber,
-    batch_id: `batch-${batchSuffix}`,
+    batch_id: batchId || `batch-${batchSuffix}`,
     fixture_ids: normalizeFixtureIds(fixtures),
     command: command.command,
     command_argv: command.argv,

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2485,7 +2485,7 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     assert.equal(failure.error_code, 17);
     assert.equal(failure.error_signal, 'SIGKILL');
     assert.equal(failure.batch_id, 'batch-001');
-    const expectedCodeboxArtifactsDirectory = path.join(root, 'artifacts-wp-codebox-batch-001-artifacts');
+    const expectedCodeboxArtifactsDirectory = path.join(root, 'artifacts-wp-codebox-batch-001-recovery-failing-fixture-artifacts');
     assert.deepEqual(failure.command_argv, [
       '/tmp/wp-codebox',
       'recipe-run',
@@ -2525,7 +2525,7 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     assert.equal(benchResult.metadata.child_command_failures[0].error_signal, 'SIGKILL');
     assert.equal(
       benchResult.metadata.child_command_failures[0].artifact_refs.artifacts_directory,
-      `${process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY}-wp-codebox-batch-001-artifacts`,
+      `${process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY}-wp-codebox-batch-001-recovery-failing-fixture-artifacts`,
     );
     const benchBatchRecipe = JSON.parse(readFileSync(benchResult.metadata.child_command_failures[0].artifact_refs.batch_recipe, 'utf8'));
     const benchVisualStep = benchBatchRecipe.workflow.steps.find((step) => step.command === 'wordpress.visual-compare');
@@ -3422,6 +3422,66 @@ test('runFixtureMatrix isolates a throwing batch so sibling batches still comple
     assert.equal(summary.result_summary.failed, 1);
   } finally {
     restoreConcurrencyEnv(snapshot);
+  }
+});
+
+test('runFixtureMatrix recovers healthy fixtures from a poisoned batch sandbox', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-recovery-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const failureFixtureRoot = path.join(root, 'fixtures');
+  const outputDirectory = path.join(root, 'artifacts');
+  const helperPath = path.join(root, 'wp-codebox-recipe-helper.cjs');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  for (const fixtureId of ['healthy-before', 'hanging', 'healthy-after']) {
+    const fixtureDirectory = path.join(failureFixtureRoot, fixtureId);
+    mkdirSync(fixtureDirectory, { recursive: true });
+    writeFileSync(path.join(fixtureDirectory, 'index.html'), `<h1>${fixtureId}</h1>`);
+  }
+  writeFileSync(helperPath, `
+const fs = require('node:fs');
+function fixtureIds(recipeFile) {
+  return [...new Set(fs.readFileSync(recipeFile, 'utf8').split('--slug=').slice(1).map((part) => part.split(' ')[0]))];
+}
+function wpCodeboxBin() { return '/tmp/wp-codebox'; }
+function wpCodeboxCommand(bin) { return { command: bin, args: [] }; }
+async function runWpCodeboxRecipe(options) {
+  const ids = fixtureIds(options.recipeFile);
+  if (ids.includes('hanging')) {
+    const error = new Error('fixture hanging exceeded its deadline');
+    error.code = 124;
+    error.stderr = 'hanging fixture stderr';
+    error.stdout = 'hanging fixture stdout';
+    throw error;
+  }
+  return { exitCode: 0, outputFile: options.outputFile, json: { results: ids.map((fixture_id) => ({ fixture_id, status: 'succeeded' })) } };
+}
+module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
+`, 'utf8');
+  const previousHelper = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = helperPath;
+
+  try {
+    const { summary, runtimeError } = await runFixtureMatrix({
+      id: 'poisoned-batch-recovery',
+      fixtureRoot: failureFixtureRoot,
+      outputDirectory,
+      staticSiteImporterPath: staticSiteImporter,
+      run: true,
+      batchSize: 3,
+      visualParity: false,
+    });
+
+    assert.match(runtimeError.message, /hanging/);
+    assert.equal(summary.result_summary.succeeded, 2);
+    assert.equal(summary.result_summary.failed, 1);
+    assert.deepEqual(summary.runtime.child_command_failures.map((failure) => failure.fixture_ids), [['hanging']]);
+    const recovery = summary.runtime.batches[0].recovery_attempts;
+    assert.equal(recovery.length, 3);
+    assert.deepEqual(recovery.map((attempt) => attempt.fixture_ids[0]).sort(), ['hanging', 'healthy-after', 'healthy-before']);
+    assert.equal(recovery.find((attempt) => attempt.fixture_ids[0] === 'hanging').stderr_tail, 'hanging fixture stderr');
+    assert.equal(summary.runtime.batches[0].stderr_tail, 'hanging fixture stderr');
+  } finally {
+    restoreEnv('HOMEBOY_WP_CODEBOX_RECIPE_HELPER', previousHelper);
   }
 });
 


### PR DESCRIPTION
## Summary
- recover each fixture in a fresh WP Codebox sandbox after its shared batch recipe fails
- retain the failed batch plus each recovery attempt as separate artifact evidence
- attribute a remaining failure only to its failing fixture

Fixes #624

## Testing
1. Run `npm test`.
2. Run `php tests/smoke-transformer-adapter.php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Investigated the batch timeout propagation, implemented fixture-level sandbox recovery, and added behavioral coverage.