### PR TITLE
Fix fixture matrix editor canvas evidence

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -409,8 +409,71 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     codeboxArtifactsDirectory,
     outputDirectory,
   });
+  const editorCanvas = materializeEditorCanvasArtifacts({
+    result: visualCompare.result,
+    codeboxArtifactsDirectory,
+    outputDirectory,
+  });
 
-  return { batchRun, batchResult: visualCompare.result, visualParityArtifacts: visualCompare.artifacts, error: batchError, childCommandFailure };
+  return { batchRun, batchResult: editorCanvas.result, visualParityArtifacts: visualCompare.artifacts, error: batchError, childCommandFailure };
+}
+
+export function materializeEditorCanvasArtifacts(input = {}) {
+  const result = input.result || {};
+  const outputDirectory = path.resolve(input.outputDirectory || input.output_directory || '');
+  const codeboxArtifactsDirectory = path.resolve(input.codeboxArtifactsDirectory || input.codebox_artifacts_directory || '');
+  return {
+    result: {
+      ...result,
+      fixtures: arrayValue(result.fixtures).map((fixture) => materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory })),
+    },
+  };
+}
+
+function materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory }) {
+  const fixtureId = fixture.fixture_id || fixture.fixtureId || '';
+  if (!fixtureId) {
+    return fixture;
+  }
+  const rewrites = new Map();
+  for (const ref of arrayValue(fixture.artifact_refs)) {
+    if (ref?.kind !== 'editor-canvas' || !ref.path) {
+      continue;
+    }
+    const sourcePath = resolveCodeboxArtifactPath(ref.path, codeboxArtifactsDirectory);
+    if (!sourcePath || !fs.existsSync(sourcePath)) {
+      continue;
+    }
+    const persistedPath = path.join(outputDirectory, 'editor-canvas', fixtureId, path.basename(ref.path));
+    fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
+    fs.copyFileSync(sourcePath, persistedPath);
+    rewrites.set(ref.path, persistedPath);
+  }
+  if (rewrites.size === 0) {
+    return fixture;
+  }
+  return {
+    ...fixture,
+    artifact_refs: rewriteArtifactRefs(fixture.artifact_refs, rewrites),
+    editor_canvas: rewriteEditorEvidencePaths(fixture.editor_canvas, rewrites),
+    editor_open: rewriteEditorEvidencePaths(fixture.editor_open, rewrites),
+    surfaces: arrayValue(fixture.surfaces).map((surface) => ({
+      ...surface,
+      artifact_refs: rewriteArtifactRefs(surface.artifact_refs, rewrites),
+      editor_canvas: rewriteEditorEvidencePaths(surface.editor_canvas, rewrites),
+      editor_open: rewriteEditorEvidencePaths(surface.editor_open, rewrites),
+    })),
+  };
+}
+
+function rewriteEditorEvidencePaths(value, rewrites) {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  const files = value.files && typeof value.files === 'object'
+    ? Object.fromEntries(Object.entries(value.files).map(([key, filePath]) => [key, rewrites.get(filePath) || filePath]))
+    : undefined;
+  return { ...value, ...(files ? { files } : {}), ...(value.screenshot ? { screenshot: rewrites.get(value.screenshot) || value.screenshot } : {}) };
 }
 
 export function materializeVisualCompareArtifacts(input = {}) {

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -107,7 +107,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     missing_assets: collectMissingAssets(merged),
     runtime_target_gaps: collectRuntimeTargetGaps(merged),
     diagnostics,
-    artifact_refs: collectFixtureArtifactRefs(merged, fixtureArtifactsDirectory),
+    artifact_refs: collectFixtureArtifactRefs(payloads, fixtureArtifactsDirectory),
     artifacts: merged.artifacts || {},
     surfaces,
     editor_canvas: merged.editor_canvas || merged.editorCanvas || merged.editor_canvas_summary || merged.editorCanvasSummary || null,
@@ -360,8 +360,8 @@ function findingPacketDiagnostic(packet) {
   return { ...row, kind };
 }
 
-function collectFixtureArtifactRefs(payload, fixtureArtifactsDirectory) {
-  const refs = collectPayloadArtifactRefs(payload);
+function collectFixtureArtifactRefs(payloads, fixtureArtifactsDirectory) {
+  const refs = normalizeArray(payloads).flatMap(collectPayloadArtifactRefs);
   for (const fileName of ['artifact.json', 'validation-result.json', 'import-report.json']) {
     const filePath = path.join(fixtureArtifactsDirectory, fileName);
     if (fs.existsSync(filePath)) {
@@ -378,6 +378,11 @@ function collectPayloadArtifactRefs(payload) {
       refs.push({ artifact_id: key, kind: value.kind || key, ...value });
     } else if (typeof value === 'string') {
       refs.push({ artifact_id: key, kind: key, path: value });
+    }
+  }
+  for (const [key, value] of Object.entries(objectValue(objectValue(payload.editor_open || payload.editorOpen).files))) {
+    if (typeof value === 'string' && value) {
+      refs.push({ artifact_id: `editor-open-${key}`, kind: 'editor-canvas', path: value });
     }
   }
   return dedupeArtifactRefs(refs);
@@ -401,7 +406,35 @@ function collectRuntimePayloads(value) {
   visitRuntimePayloads(value, '', payloads, new Set());
   payloads.push(...collectRecipeStepFailurePayloads(value));
   payloads.push(...collectRecipeBrowserEvidencePayloads(value));
-  return payloads;
+  return payloads.map(normalizeEditorOpenPayload);
+}
+
+// `wordpress.editor-open` writes its browser evidence as a command result with a
+// top-level `files` map. Normalize that native shape at the intake boundary so the
+// matrix consumes the same screenshot/state/validity evidence the runner emitted.
+function normalizeEditorOpenPayload(payload) {
+  if (payload?.command !== 'wordpress.editor-open') {
+    return payload;
+  }
+  const files = objectValue(payload.files);
+  if (typeof files.screenshot !== 'string' || !files.screenshot) {
+    return payload;
+  }
+  return {
+    ...payload,
+    editor_open: {
+      schema: 'wp-codebox/editor-open/v1',
+      target: payload.target,
+      requested_url: payload.requestedUrl || payload.requested_url,
+      final_url: payload.finalUrl || payload.final_url,
+      files,
+      summary: objectValue(payload.summary),
+    },
+    editor_canvas: {
+      status: 'captured',
+      screenshot: files.screenshot,
+    },
+  };
 }
 
 function collectRecipeStepFailurePayloads(value) {

--- a/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
+++ b/lib/fixture-matrix/gutenberg-incompatibility-registry.mjs
@@ -433,6 +433,9 @@ function frontendVisualStatusForFixture(fixture, fixtureFindings, visualOnlyPatt
 }
 
 function editorCanvasStatusForFixture(fixture, fixtureFindings, editorRiskPatterns) {
+  if (hasEditorCanvasCaptureFailure(fixtureFindings)) {
+    return 'capture_failed';
+  }
   if (hasProviderRuntimeBlocker(fixtureFindings)) {
     return 'provider_runtime_blocked';
   }
@@ -446,6 +449,9 @@ function editorCanvasStatusForFixture(fixture, fixtureFindings, editorRiskPatter
 }
 
 function acceptanceDecision({ frontendVisualStatus, editorCanvasStatus, editorValidityStatus, nativeEditabilityStatus, visibleRuntimeOrHtmlIslands, gutenbergGapPatterns, providerMaterializablePatterns, transformerGapPatterns, visualOnlyPatterns, runtimeIslandPatterns, editorRiskPatterns }) {
+  if (editorCanvasStatus === 'capture_failed') {
+    return { solved_candidate: false, status: 'editor_capture_failed', reason: 'editor canvas capture was requested but did not complete' };
+  }
   if (frontendVisualStatus === 'provider_runtime_blocked' || editorCanvasStatus === 'provider_runtime_blocked') {
     return { solved_candidate: false, status: 'provider_runtime_blocker', reason: 'required frontend visual or editor canvas evidence is blocked by the provider/runtime' };
   }
@@ -466,6 +472,11 @@ function acceptanceDecision({ frontendVisualStatus, editorCanvasStatus, editorVa
 
 function hasProviderRuntimeBlocker(fixtureFindings) {
   return fixtureFindings.some((finding) => ['runtime_execution_failed', 'visual_timeout', 'fixture_not_run', 'fixture_failed', 'visual_evidence_missing'].includes(finding.loss_class) || ['visual_timeout', 'fixture_not_run', 'fixture_failed'].includes(finding.kind));
+}
+
+function hasEditorCanvasCaptureFailure(fixtureFindings) {
+  return fixtureFindings.some((finding) => finding.kind === 'recipe_step_failure'
+    && (finding.command === 'wordpress.editor-open' || String(finding.recipe_phase || '').toLowerCase() === 'editor-open'));
 }
 
 function hasVisualEvidence(fixture) {

--- a/registry/gutenberg-incompatibility-registry.schema.json
+++ b/registry/gutenberg-incompatibility-registry.schema.json
@@ -50,10 +50,10 @@
     "fallback_kind": { "enum": ["core_html", "data_uri", "runtime_island", "fidelity_loss"] },
     "limitation_type": { "enum": ["real_gutenberg_gap", "provider_materializable", "transformer_gap", "intentional_runtime_preservation", "visual_only_style_drift", "editor_validity_risk"] },
     "frontend_visual_status": { "enum": ["passed", "visual_mismatch", "not_evaluated", "provider_runtime_blocked"] },
-    "editor_canvas_status": { "enum": ["visible", "diverged", "not_captured", "provider_runtime_blocked"] },
+    "editor_canvas_status": { "enum": ["visible", "diverged", "not_captured", "capture_failed", "provider_runtime_blocked"] },
     "editor_validity_status": { "enum": ["valid", "invalid_blocks", "not_validated"] },
     "native_editability_status": { "enum": ["native_editable", "editor_invalid", "custom_block_candidate", "runtime_island_preserved", "html_islands_or_transformer_gap", "unknown"] },
-    "acceptance_status": { "enum": ["solved_candidate", "visual_only_blocker", "editor_blocker", "native_editability_blocker", "provider_runtime_blocker", "evidence_gap", "solved_regression"] },
+    "acceptance_status": { "enum": ["solved_candidate", "visual_only_blocker", "editor_blocker", "editor_capture_failed", "native_editability_blocker", "provider_runtime_blocker", "evidence_gap", "solved_regression"] },
     "top_pattern": {
       "type": "object",
       "required": ["pattern_key", "classification", "fixture_count", "finding_count", "impact_score"],

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -19,6 +19,7 @@ import runFixtureMatrixBench, {
   fixtureMatrixBatchRunSummary,
   mapWithConcurrency,
   materializeVisualCompareArtifacts,
+  materializeEditorCanvasArtifacts,
   resolveBlocksEnginePhpTransformerPath,
   runFixtureMatrix,
 } from '../bench/static-site-fixture-matrix.bench.mjs';
@@ -1974,7 +1975,7 @@ test('fixture diagnostics drop empty rows and normalize kindless carriers with e
   assert.equal(result.summary.loss_classes.unsupported_loss, undefined);
 });
 
-test('fixture matrix intake preserves editor-open canvas evidence for acceptance decisions', () => {
+test('fixture matrix intake consumes native editor-open output as canvas evidence and attaches all emitted artifact refs', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-canvas-intake-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-canvas-intake-test' });
   const codeboxOutput = {
@@ -1987,16 +1988,12 @@ test('fixture matrix intake preserves editor-open canvas evidence for acceptance
       {
         command: 'wordpress.editor-open',
         status: 'success',
-        editor_canvas: {
-          selector_summary: {
-            groups: [{ name: 'block-list', selector: '.block-editor-block-list__layout', count: 4 }],
-          },
+        files: {
+          screenshot: 'files/browser/editor-screenshot.png',
+          editorState: 'files/browser/editor-state.json',
+          editorValidity: 'files/browser/editor-validity.json',
         },
-        editor_open: {
-          artifacts: {
-            screenshot: 'files/browser/editor-open/simple-site/screenshot.png',
-          },
-        },
+        summary: { editor: { blockCount: 4 } },
       },
     ],
   };
@@ -2005,9 +2002,69 @@ test('fixture matrix intake preserves editor-open canvas evidence for acceptance
   const registry = buildGutenbergIncompatibilityRegistry(result);
   const decision = registry.fixture_decisions.find((row) => row.fixture_id === 'simple-site');
 
-  assert.equal(result.fixtures[0].editor_canvas.selector_summary.groups[0].count, 4);
-  assert.equal(result.fixtures[0].editor_open.artifacts.screenshot, 'files/browser/editor-open/simple-site/screenshot.png');
+  assert.equal(result.fixtures[0].editor_canvas.screenshot, 'files/browser/editor-screenshot.png');
+  assert.equal(result.fixtures[0].editor_open.files.screenshot, 'files/browser/editor-screenshot.png');
+  assert.deepEqual(result.fixtures[0].artifact_refs.filter((ref) => ref.kind === 'editor-canvas').map((ref) => ref.path), [
+    'files/browser/editor-screenshot.png',
+    'files/browser/editor-state.json',
+    'files/browser/editor-validity.json',
+  ]);
   assert.equal(decision.editor_canvas_status, 'visible');
+});
+
+test('editor-open capture failure is distinct from editor evidence not requested', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-capture-failure-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      diagnostics: [{ kind: 'recipe_step_failure', command: 'wordpress.editor-open', recipe_phase: 'editor-open', message: 'Editor navigation timed out.' }],
+    }],
+  });
+  const decision = buildGutenbergIncompatibilityRegistry(result).fixture_decisions[0];
+
+  assert.equal(decision.editor_canvas_status, 'capture_failed');
+  assert.equal(decision.acceptance_status, 'editor_capture_failed');
+});
+
+test('editor canvas artifacts are persisted in the matrix artifact root and refs are rewritten', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-canvas-output-'));
+  const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-canvas-codebox-'));
+  const sourceDirectory = path.join(codeboxArtifactsDirectory, 'runtime-001', 'files', 'browser');
+  mkdirSync(sourceDirectory, { recursive: true });
+  writeFileSync(path.join(sourceDirectory, 'editor-screenshot.png'), 'screenshot');
+  writeFileSync(path.join(sourceDirectory, 'editor-state.json'), '{"blocks":3}');
+  const result = materializeEditorCanvasArtifacts({
+    outputDirectory,
+    codeboxArtifactsDirectory,
+    result: {
+      fixtures: [{
+        fixture_id: 'simple-site',
+        artifact_refs: [
+          { artifact_id: 'editor-open-screenshot', kind: 'editor-canvas', path: 'files/browser/editor-screenshot.png' },
+          { artifact_id: 'editor-open-editorState', kind: 'editor-canvas', path: 'files/browser/editor-state.json' },
+        ],
+        editor_canvas: { screenshot: 'files/browser/editor-screenshot.png' },
+        editor_open: { files: { screenshot: 'files/browser/editor-screenshot.png', editorState: 'files/browser/editor-state.json' } },
+        surfaces: [{
+          surface_id: 'front-page',
+          artifact_refs: [{ artifact_id: 'editor-open-screenshot', kind: 'editor-canvas', path: 'files/browser/editor-screenshot.png' }],
+          editor_open: { files: { screenshot: 'files/browser/editor-screenshot.png' } },
+        }],
+      }],
+    },
+  });
+  const fixture = result.result.fixtures[0];
+  const screenshotPath = path.join(outputDirectory, 'editor-canvas', 'simple-site', 'editor-screenshot.png');
+  const statePath = path.join(outputDirectory, 'editor-canvas', 'simple-site', 'editor-state.json');
+
+  assert.equal(existsSync(screenshotPath), true);
+  assert.equal(existsSync(statePath), true);
+  assert.equal(fixture.editor_canvas.screenshot, screenshotPath);
+  assert.equal(fixture.editor_open.files.editorState, statePath);
+  assert.equal(fixture.surfaces[0].editor_open.files.screenshot, screenshotPath);
+  assert.deepEqual(fixture.artifact_refs.map((ref) => ref.path), [screenshotPath, statePath]);
 });
 
 test('collects SSI finding packet source and observed context from fixture artifacts', () => {


### PR DESCRIPTION
## Summary
- Normalize native `wordpress.editor-open` results into editor-canvas evidence, including screenshot/state/validity artifact refs.
- Persist editor evidence from the Codebox batch artifact root into the matrix artifact root and rewrite result/surface refs.
- Distinguish requested editor capture failures from editor evidence that was not requested or captured, and keep solved-candidate gating based on the captured evidence.

Fixes #623

## Testing
1. Run `npm test`
2. Run `npm run test:fixture-matrix`

Additional verification: `npm run test:js-block-validation` requires an imported generated theme and cannot run in a clean checkout. `npm run test:validation` currently fails the existing Website artifact document metadata smoke checks; this PR does not modify that PHP path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Investigated the WP Codebox editor-open result contract, implemented fixture-matrix evidence intake and persistence, and added behavioral coverage.