### PR TITLE
Fix static form provider materialization

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -71,7 +71,7 @@ class Static_Site_Importer_Form_Seeder {
 		$report['status']               = 'completed';
 
 		foreach ( $forms as $form ) {
-			$row               = self::seed_form( $form, $available );
+			$row               = $available ? self::seed_form( $form, true ) : self::unavailable_form_row( $form );
 			$report['forms'][] = $row;
 
 			$status = $row['status'] ?? 'error';
@@ -83,6 +83,24 @@ class Static_Site_Importer_Form_Seeder {
 		}
 
 		return $report;
+	}
+
+	/**
+	 * Report a form that cannot be materialized until its configured provider is active.
+	 *
+	 * @param array<string, mixed> $form Validated form row.
+	 * @return array<string, mixed>
+	 */
+	private static function unavailable_form_row( array $form ): array {
+		return array(
+			'selector'       => isset( $form['selector'] ) && is_scalar( $form['selector'] ) ? (string) $form['selector'] : '',
+			'source_path'    => isset( $form['source_path'] ) && is_scalar( $form['source_path'] ) ? (string) $form['source_path'] : '',
+			'provider'       => self::PROVIDER_ID,
+			'block_name'     => 'jetpack/contact-form',
+			'status'         => 'skipped',
+			'reason'         => 'provider_unavailable',
+			'runtime_mapped' => false,
+		);
 	}
 
 	/**

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1443,6 +1443,26 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
+	 * Determine whether import diagnostics require a form provider.
+	 *
+	 * This is intentionally shared with dependency provisioning so the provider is
+	 * active before the same finding is converted and grafted into page content.
+	 *
+	 * @param array<string,mixed> $report Import report.
+	 * @return bool
+	 */
+	public static function has_materializable_form_findings( array $report ): bool {
+		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( is_array( $diagnostic ) && self::is_materializable_form_diagnostic( $diagnostic ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Determine whether a diagnostic can be passed to the form provider.
 	 *
 	 * @param array<string,mixed> $diagnostic Diagnostic row.

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -2972,14 +2972,16 @@ class Static_Site_Importer_Theme_Generator {
 			'plugins' => array(),
 		);
 
-		$intent  = self::commerce_dependency_intent();
-		$adapter = Static_Site_Importer_Entity_Materializer_Registry::product_adapter();
-		if ( ! $intent['present'] ) {
-			self::$conversion_report['plugin_materialization']['reason'] = 'no_plugin_backed_intent';
-			return;
+		$adapters = array();
+		if ( self::commerce_dependency_intent()['present'] ) {
+			$adapters[] = Static_Site_Importer_Entity_Materializer_Registry::product_adapter();
 		}
-		if ( ! empty( $args[ (string) ( $adapter['waiver_arg'] ?? 'allow_missing_woocommerce' ) ] ) ) {
-			self::$conversion_report['plugin_materialization']['reason'] = 'woocommerce_requirement_waived';
+		if ( Static_Site_Importer_Report_Diagnostics::has_materializable_form_findings( self::$conversion_report ) ) {
+			$adapters[] = Static_Site_Importer_Entity_Materializer_Registry::form_adapter();
+		}
+
+		if ( empty( $adapters ) ) {
+			self::$conversion_report['plugin_materialization']['reason'] = 'no_plugin_backed_intent';
 			return;
 		}
 		if ( array_key_exists( 'materialize_dependencies', $args ) && false === (bool) $args['materialize_dependencies'] ) {
@@ -2987,7 +2989,20 @@ class Static_Site_Importer_Theme_Generator {
 			return;
 		}
 
-		$reports = Static_Site_Importer_Entity_Materializer_Registry::materialize_plugin_dependencies( $adapter );
+		$reports = array();
+		foreach ( $adapters as $adapter ) {
+			$waiver_arg = (string) ( $adapter['waiver_arg'] ?? '' );
+			if ( '' !== $waiver_arg && ! empty( $args[ $waiver_arg ] ) ) {
+				continue;
+			}
+			$reports = array_merge( $reports, Static_Site_Importer_Entity_Materializer_Registry::materialize_plugin_dependencies( $adapter ) );
+		}
+
+		if ( empty( $reports ) ) {
+			self::$conversion_report['plugin_materialization']['reason'] = 'plugin_requirements_waived';
+			return;
+		}
+
 		self::$conversion_report['plugin_materialization'] = array(
 			'status'  => self::plugin_materialization_status( $reports ),
 			'plugins' => $reports,

--- a/tests/smoke-form-materializer.php
+++ b/tests/smoke-form-materializer.php
@@ -44,6 +44,20 @@ namespace {
 		}
 	}
 
+	$GLOBALS['ssi_jetpack_form_blocks_available'] = true;
+
+	if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
+		class WP_Block_Type_Registry {
+			public static function get_instance(): self {
+				return new self();
+			}
+
+			public function is_registered( string $name ): bool {
+				return ! empty( $GLOBALS['ssi_jetpack_form_blocks_available'] ) && in_array( $name, array( 'jetpack/contact-form', 'jetpack/field-text' ), true );
+			}
+		}
+	}
+
 	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-woo-product-seeder.php';
 	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-form-seeder.php';
 	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
@@ -122,6 +136,16 @@ namespace {
 	$assert( str_contains( $markup, 'hello@example.com' ), 'markup-mailto-recipient' );
 	$assert( str_contains( $markup, '"options":["Sales","Support"]' ), 'markup-select-options' );
 
+	// --- Provider blocks are never claimed without the provider runtime --------
+	$GLOBALS['ssi_jetpack_form_blocks_available'] = false;
+	$unavailable_seed                              = Static_Site_Importer_Form_Seeder::seed( $forms_manifest );
+	$unavailable_row                               = $unavailable_seed['forms'][0] ?? array();
+	$assert( 1 === ( $unavailable_seed['counts']['skipped'] ?? 0 ), 'seed-unavailable-provider-skips-form' );
+	$assert( 'provider_unavailable' === ( $unavailable_row['reason'] ?? '' ), 'seed-unavailable-provider-reason' );
+	$assert( false === ( $unavailable_row['runtime_mapped'] ?? true ), 'seed-unavailable-provider-not-runtime-mapped' );
+	$assert( empty( $unavailable_row['block_markup'] ), 'seed-unavailable-provider-emits-no-block-markup' );
+	$GLOBALS['ssi_jetpack_form_blocks_available'] = true;
+
 	// --- Native html_form_fallback row is enriched into a form finding -------
 	$enrich   = new ReflectionMethod( 'Static_Site_Importer_Report_Diagnostics', 'diagnostic_from_conversion_report_fallback' );
 	$enriched = $enrich->invoke(
@@ -144,6 +168,8 @@ namespace {
 	$assert( isset( $enriched['form']['action'] ) && 'mailto:hello@example.com' === $enriched['form']['action'], 'enrich-carries-form-metadata' );
 	$assert( isset( $enriched['controls'][0]['type'] ) && 'email' === $enriched['controls'][0]['type'], 'enrich-carries-controls' );
 	$assert( 'form' === ( $enriched['tag'] ?? '' ), 'enrich-tag-form' );
+	$assert( Static_Site_Importer_Report_Diagnostics::has_materializable_form_findings( array( 'diagnostics' => array( $enriched ) ) ), 'form-finding-requires-provider-dependency' );
+	$assert( ! Static_Site_Importer_Report_Diagnostics::has_materializable_form_findings( array( 'diagnostics' => array( array( 'diagnostic_code' => 'html_product_grid_fallback' ) ) ) ), 'non-form-finding-does-not-require-provider-dependency' );
 
 	// --- Gate loop: a mapped form finding receives the runtime-mapped signal --
 	$report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );

--- a/tests/smoke-transformer-adapter.php
+++ b/tests/smoke-transformer-adapter.php
@@ -9,6 +9,18 @@
  */
 
 namespace {
+	if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
+		class WP_Block_Type_Registry {
+			public static function get_instance(): self {
+				return new self();
+			}
+
+			public function is_registered( string $name ): bool {
+				return in_array( $name, array( 'jetpack/contact-form', 'jetpack/field-text' ), true );
+			}
+		}
+	}
+
 	function blocks_engine_php_transformer_compile_artifact( array $artifact, array $options = array() ): array {
 		$GLOBALS['ssi_transformer_adapter_compile_calls'][] = array( $artifact, $options );
 		if ( isset( $GLOBALS['ssi_transformer_adapter_result_override'] ) && is_array( $GLOBALS['ssi_transformer_adapter_result_override'] ) ) {


### PR DESCRIPTION
## Summary
- provision the selected form provider whenever import diagnostics contain materializable static forms
- emit and graft Jetpack form blocks only after its runtime is available
- cover provider availability and dependency-intent behavior in form and transformer adapter smokes

Closes #625

## Testing
1. `npm test`
2. `php tests/smoke-form-materializer.php`
3. `php tests/smoke-contact-layout-transformer.php`
4. `php tests/smoke-transformer-adapter.php`
5. `php -l includes/class-static-site-importer-form-seeder.php`
6. `php -l includes/class-static-site-importer-report-diagnostics.php`
7. `php -l includes/class-static-site-importer-theme-generator.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Investigated the import dependency and form materialization path, implemented the provider-availability contract, and added behavioral coverage.