### PR TITLE
Fix fixture matrix lifecycle progress and stalled batch recovery

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 /**
  * Internal dependencies
  */
-import { runWpCodeboxRecipe, wpCodeboxCommand, wpCodeboxBin } from '../tools/wp-codebox/recipe.mjs';
+import { DEFAULT_RECIPE_INACTIVITY_TIMEOUT_MS, runWpCodeboxRecipe, wpCodeboxCommand, wpCodeboxBin } from '../tools/wp-codebox/recipe.mjs';
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
 import {
   buildFixtureMatrixRecipe,
@@ -34,6 +34,8 @@ const DEFAULT_BATCH_SIZE = 10;
 // up to the cap.
 const DEFAULT_BATCH_CONCURRENCY = 2;
 const MAX_BATCH_CONCURRENCY = 16;
+export const FIXTURE_MATRIX_PROGRESS_SCHEMA = 'homeboy/workload-progress/v1';
+export const FIXTURE_MATRIX_PROGRESS_PREFIX = '@@homeboy-progress@@ ';
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
 async function main() {
@@ -163,6 +165,8 @@ export async function runFixtureMatrix(options) {
     complexity: options.complexity,
     max_complexity: options.maxComplexity || options.max_complexity,
   });
+  const progress = createFixtureMatrixProgress(matrix, options);
+  progress.emit('matrix', 'started');
   const artifactWriteStartedAt = nowMs();
   const written = writeFixtureMatrixArtifacts({
     outputDirectory,
@@ -216,6 +220,7 @@ export async function runFixtureMatrix(options) {
       outputDirectory,
       staticSiteImporterPath,
       options,
+      progress,
     }));
     performance.batch_execution_ms = elapsedMs(batchExecutionStartedAt);
 
@@ -305,6 +310,7 @@ export async function runFixtureMatrix(options) {
     summary.metadata.artifact_bytes.total = cliRunBaseTotal + summary.metadata.artifact_bytes.cli_run;
   }
   writeJsonArtifact(path.join(outputDirectory, 'cli-run.json'), summary);
+  progress.emit('matrix', runtimeError ? 'failed' : 'completed');
   return { summary, runtimeError, runtime };
 }
 
@@ -313,7 +319,7 @@ export async function runFixtureMatrix(options) {
 // per-fixture artifact subdirectories, all keyed by the unique batch suffix), so
 // many of these can run concurrently without colliding. Returns a stable outcome
 // the caller folds back together in batch order.
-export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outputDirectory, staticSiteImporterPath, options, recovery = false }) {
+export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outputDirectory, staticSiteImporterPath, options, recovery = false, progress }) {
   const batchNumber = batchIndex + 1;
   const batchSuffix = recovery
     ? `${String(batchNumber).padStart(3, '0')}-recovery-${fixtures[0].id}`
@@ -345,6 +351,8 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
   const codeboxArtifactsDirectory = batchCodeboxArtifactsDirectory(outputDirectory, batchSuffix);
   const artifactRefs = batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile, codeboxArtifactsDirectory });
   writeJsonArtifact(batchRecipeFile, batchRecipe);
+  progress?.emit(recovery ? 'recovery' : 'batch', 'started', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery });
+  progress?.emit('fixture', 'started', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery });
 
   let batchRuntime = null;
   let batchError = null;
@@ -357,6 +365,11 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       artifactsDir: codeboxArtifactsDirectory,
       outputFile,
       wpCodeboxBin: options.wpCodeboxBin,
+      inactivityTimeoutMs: batchInactivityTimeoutMs(options),
+      onInactivity: ({ timeout_ms }) => {
+        progress?.emit('batch', 'timeout', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery, timeout_ms });
+        if (recovery) progress?.emit('fixture', 'timeout', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery, timeout_ms });
+      },
     });
   } catch (error) {
     batchError = error;
@@ -417,6 +430,13 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     codeboxArtifactsDirectory,
     outputDirectory,
   });
+  if (!batchError || recovery) {
+    for (const fixture of editorCanvas.result.fixtures || []) {
+      const fixtureId = fixture.fixture_id || fixture.fixtureId || '';
+      progress?.emit('fixture', fixture.status === 'failed' ? 'failed' : 'completed', { fixture_id: fixtureId, batch: batchNumber, recovery });
+    }
+  }
+  progress?.emit(recovery ? 'recovery' : 'batch', batchError ? (batchError.inactivityTimedOut ? 'timeout' : 'failed') : 'completed', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery });
 
   if (!batchError || recovery) {
     return {
@@ -430,9 +450,8 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
 
   // A recipe-level failure leaves the sandbox's state untrustworthy. Re-run each
   // fixture in a fresh sandbox so one stalled step cannot classify its batch peers.
-  const recoveryOutcomes = [];
-  for (const fixture of fixtures) {
-    recoveryOutcomes.push(await runFixtureMatrixBatch({
+  progress?.emit('recovery', 'started', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery: true });
+  const recoveryOutcomes = await mapWithConcurrency(fixtures, boundedConcurrency(options.recoveryConcurrency, DEFAULT_BATCH_CONCURRENCY, MAX_BATCH_CONCURRENCY), (fixture) => runFixtureMatrixBatch({
       fixtures: [fixture],
       batchIndex,
       matrix,
@@ -440,8 +459,8 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       staticSiteImporterPath,
       options,
       recovery: true,
+      progress,
     }));
-  }
 
   const recoveryErrors = recoveryOutcomes.map((outcome) => outcome.error).filter(Boolean);
   return {
@@ -456,6 +475,34 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     error: recoveryErrors[0] || null,
     childCommandFailures: recoveryOutcomes.flatMap((outcome) => outcome.childCommandFailures || []),
   };
+}
+
+function createFixtureMatrixProgress(matrix, options) {
+  const complete = new Set();
+  const write = typeof options.progress === 'function'
+    ? options.progress
+    : (event) => process.stdout.write(`${FIXTURE_MATRIX_PROGRESS_PREFIX}${JSON.stringify(event)}\n`);
+  return {
+    emit(phase, status, details = {}) {
+      const fixtureId = details.fixture_id || '';
+      if (phase === 'fixture' && fixtureId && ['completed', 'failed', 'timeout'].includes(status)) complete.add(fixtureId);
+      write({
+        schema: FIXTURE_MATRIX_PROGRESS_SCHEMA,
+        phase,
+        status,
+        current: fixtureId ? { kind: 'fixture', id: fixtureId } : { kind: phase, id: matrix.id },
+        completed: complete.size,
+        total: matrix.count,
+        ...(details.batch ? { batch: details.batch } : {}),
+        ...(details.recovery ? { recovery: true } : {}),
+        ...(details.timeout_ms ? { timeout_ms: details.timeout_ms } : {}),
+      });
+    },
+  };
+}
+
+function batchInactivityTimeoutMs(options) {
+  return positiveInteger(options.batchInactivityTimeoutMs || options.batch_inactivity_timeout_ms, DEFAULT_RECIPE_INACTIVITY_TIMEOUT_MS);
 }
 
 export function materializeEditorCanvasArtifacts(input = {}) {
@@ -1090,6 +1137,7 @@ function optionsFromEnv(env = process.env) {
     wordpressVersion: benchEnv.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION || env.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION,
     batchSize: benchEnv.SSI_FIXTURE_MATRIX_BATCH_SIZE || env.SSI_FIXTURE_MATRIX_BATCH_SIZE,
     concurrency: benchEnv.SSI_FIXTURE_MATRIX_CONCURRENCY || env.SSI_FIXTURE_MATRIX_CONCURRENCY,
+    batchInactivityTimeoutMs: benchEnv.SSI_FIXTURE_MATRIX_BATCH_INACTIVITY_TIMEOUT_MS || env.SSI_FIXTURE_MATRIX_BATCH_INACTIVITY_TIMEOUT_MS,
     run: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_RUN) || isTruthy(env.SSI_FIXTURE_MATRIX_RUN),
     wpCodeboxBin: benchEnv.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN || env.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN,
     editorValidation: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION ?? env.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION),

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -34,8 +34,8 @@ const DEFAULT_BATCH_SIZE = 10;
 // up to the cap.
 const DEFAULT_BATCH_CONCURRENCY = 2;
 const MAX_BATCH_CONCURRENCY = 16;
-export const FIXTURE_MATRIX_PROGRESS_SCHEMA = 'homeboy/workload-progress/v1';
-export const FIXTURE_MATRIX_PROGRESS_PREFIX = '@@homeboy-progress@@ ';
+export const FIXTURE_MATRIX_PROGRESS_SCHEMA = 'homeboy/runner-progress/v1';
+export const FIXTURE_MATRIX_PROGRESS_PREFIX = 'HOMEBOY_RUNNER_PROGRESS ';
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
 async function main() {
@@ -489,13 +489,15 @@ function createFixtureMatrixProgress(matrix, options) {
       write({
         schema: FIXTURE_MATRIX_PROGRESS_SCHEMA,
         phase,
-        status,
-        current: fixtureId ? { kind: 'fixture', id: fixtureId } : { kind: phase, id: matrix.id },
+        current_item: fixtureId || matrix.id,
         completed: complete.size,
         total: matrix.count,
-        ...(details.batch ? { batch: details.batch } : {}),
-        ...(details.recovery ? { recovery: true } : {}),
-        ...(details.timeout_ms ? { timeout_ms: details.timeout_ms } : {}),
+        metadata: {
+          lifecycle_status: status,
+          ...(details.batch ? { batch: details.batch } : {}),
+          ...(details.recovery ? { recovery: true } : {}),
+          ...(details.timeout_ms ? { timeout_ms: details.timeout_ms } : {}),
+        },
       });
     },
   };

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -16,6 +16,7 @@ import { PNG } from 'pngjs';
 import runFixtureMatrixBench, {
   boundedConcurrency,
   composerPathRepositoryConfig,
+  FIXTURE_MATRIX_PROGRESS_PREFIX,
   FIXTURE_MATRIX_PROGRESS_SCHEMA,
   fixtureMatrixBatchRunSummary,
   mapWithConcurrency,
@@ -3486,7 +3487,7 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
   }
 });
 
-test('fixture matrix emits ordered lifecycle progress and isolates a silent shared batch promptly', async () => {
+test('fixture matrix emits Homeboy runner-progress lifecycle events and isolates a silent shared batch promptly', async () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-progress-'));
   const fixtureRoot = path.join(root, 'fixtures');
   const outputDirectory = path.join(root, 'artifacts');
@@ -3520,25 +3521,53 @@ if (ids.includes('hanging')) {
     run: true,
     batchSize: 3,
     recoveryConcurrency: 2,
-    batchInactivityTimeoutMs: 100,
+    batchInactivityTimeoutMs: 250,
     visualParity: false,
     wpCodeboxBin,
     progress: (event) => events.push(event),
   });
-  assert.ok(Date.now() - startedAt < 1500, 'inactivity recovery must not wait for a long command timeout');
+  assert.ok(Date.now() - startedAt < 2000, 'inactivity recovery must not wait for a long command timeout');
   assert.equal(summary.result_summary.succeeded, 2);
   assert.equal(summary.result_summary.failed, 1);
   assert.deepEqual(events.map((event) => event.schema), Array(events.length).fill(FIXTURE_MATRIX_PROGRESS_SCHEMA));
-  assert.ok(events.every((event) => Number.isInteger(event.completed) && event.completed >= 0 && event.total === 3 && event.current?.id));
-  assert.ok(events.find((event) => event.phase === 'batch' && event.status === 'timeout'));
-  assert.ok(events.find((event) => event.phase === 'fixture' && event.status === 'timeout' && event.current.id === 'hanging'));
-  const recoveryStart = events.findIndex((event) => event.phase === 'recovery' && event.status === 'started');
-  const healthyAfterComplete = events.findIndex((event) => event.phase === 'fixture' && event.status === 'completed' && event.current.id === 'healthy-after');
-  const matrixComplete = events.findIndex((event) => event.phase === 'matrix' && event.status === 'failed');
-  assert.ok(recoveryStart > events.findIndex((event) => event.phase === 'batch' && event.status === 'timeout'));
+  assert.ok(events.every((event) => Number.isInteger(event.completed) && event.completed >= 0 && event.total === 3 && event.current_item));
+  assert.ok(events.find((event) => event.phase === 'batch' && event.metadata.lifecycle_status === 'timeout'));
+  assert.ok(events.find((event) => event.phase === 'fixture' && event.metadata.lifecycle_status === 'timeout' && event.current_item === 'hanging'));
+  const recoveryStart = events.findIndex((event) => event.phase === 'recovery' && event.metadata.lifecycle_status === 'started');
+  const healthyAfterComplete = events.findIndex((event) => event.phase === 'fixture' && event.metadata.lifecycle_status === 'completed' && event.current_item === 'healthy-after');
+  const matrixComplete = events.findIndex((event) => event.phase === 'matrix' && event.metadata.lifecycle_status === 'failed');
+  assert.ok(recoveryStart > events.findIndex((event) => event.phase === 'batch' && event.metadata.lifecycle_status === 'timeout'));
   assert.ok(healthyAfterComplete > recoveryStart && healthyAfterComplete < matrixComplete);
   assert.equal(events.at(-1).completed, 3);
+
+  // This mirrors Homeboy #7874's accepted child envelope. SSI lifecycle detail
+  // stays in metadata, while an injected terminal-state field is rejected.
+  const accepted = events.map((event) => parseHomeboyRunnerProgress(`${FIXTURE_MATRIX_PROGRESS_PREFIX}${JSON.stringify(event)}`));
+  assert.ok(accepted.every(Boolean), 'start, completion, failure, timeout, and recovery events are accepted by Homeboy');
+  assert.ok(accepted.some((event) => event.metadata.lifecycle_status === 'started'));
+  assert.ok(accepted.some((event) => event.metadata.lifecycle_status === 'completed'));
+  assert.ok(accepted.some((event) => event.metadata.lifecycle_status === 'failed'));
+  assert.ok(accepted.some((event) => event.metadata.lifecycle_status === 'timeout'));
+  assert.ok(accepted.some((event) => event.phase === 'recovery'));
+  assert.equal(parseHomeboyRunnerProgress(`${FIXTURE_MATRIX_PROGRESS_PREFIX}${JSON.stringify({ ...events[0], status: 'succeeded' })}`), null);
 });
+
+function parseHomeboyRunnerProgress(line) {
+  const payload = line.startsWith(FIXTURE_MATRIX_PROGRESS_PREFIX) ? line.slice(FIXTURE_MATRIX_PROGRESS_PREFIX.length) : '';
+  try {
+    const event = JSON.parse(payload);
+    const allowed = new Set(['schema', 'phase', 'current_item', 'completed', 'total', 'metadata']);
+    if (event.schema !== FIXTURE_MATRIX_PROGRESS_SCHEMA
+      || Object.keys(event).some((key) => !allowed.has(key))
+      || (!event.phase && !event.current_item && event.completed === undefined && event.total === undefined && event.metadata === undefined)
+      || (event.completed !== undefined && event.total !== undefined && event.completed > event.total)) {
+      return null;
+    }
+    return event;
+  } catch {
+    return null;
+  }
+}
 
 test('runFixtureMatrixBench returns a partial result with survivors aggregated when a batch fails', async () => {
   // The bench-harness entry point is where the whole-run discard used to live:

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -16,6 +16,7 @@ import { PNG } from 'pngjs';
 import runFixtureMatrixBench, {
   boundedConcurrency,
   composerPathRepositoryConfig,
+  FIXTURE_MATRIX_PROGRESS_SCHEMA,
   fixtureMatrixBatchRunSummary,
   mapWithConcurrency,
   materializeVisualCompareArtifacts,
@@ -3483,6 +3484,60 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
   } finally {
     restoreEnv('HOMEBOY_WP_CODEBOX_RECIPE_HELPER', previousHelper);
   }
+});
+
+test('fixture matrix emits ordered lifecycle progress and isolates a silent shared batch promptly', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-progress-'));
+  const fixtureRoot = path.join(root, 'fixtures');
+  const outputDirectory = path.join(root, 'artifacts');
+  const wpCodeboxBin = path.join(root, 'wp-codebox');
+  for (const fixtureId of ['healthy-before', 'hanging', 'healthy-after']) {
+    mkdirSync(path.join(fixtureRoot, fixtureId), { recursive: true });
+    writeFileSync(path.join(fixtureRoot, fixtureId, 'index.html'), `<h1>${fixtureId}</h1>`);
+  }
+  writeFileSync(wpCodeboxBin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const recipePath = process.argv[process.argv.indexOf('--recipe') + 1];
+const recipe = fs.readFileSync(recipePath, 'utf8');
+const recovery = path.basename(recipePath).match(/-recovery-(.+)\\.json$/);
+const ids = recovery ? [recovery[1]] : [...new Set(recipe.split('--slug=').slice(1).map((part) => part.split(' ')[0]))];
+if (ids.includes('hanging')) {
+  setInterval(() => {}, 1000);
+} else {
+  const output = process.argv[process.argv.indexOf('--output') + 1];
+  fs.writeFileSync(output, JSON.stringify({ results: ids.map((fixture_id) => ({ fixture_id, status: 'succeeded' })) }));
+}
+`, 'utf8');
+  chmodSync(wpCodeboxBin, 0o755);
+  const events = [];
+  const startedAt = Date.now();
+  const { summary } = await runFixtureMatrix({
+    id: 'progress-matrix',
+    fixtureRoot,
+    outputDirectory,
+    staticSiteImporterPath: path.join(root, 'static-site-importer'),
+    run: true,
+    batchSize: 3,
+    recoveryConcurrency: 2,
+    batchInactivityTimeoutMs: 100,
+    visualParity: false,
+    wpCodeboxBin,
+    progress: (event) => events.push(event),
+  });
+  assert.ok(Date.now() - startedAt < 1500, 'inactivity recovery must not wait for a long command timeout');
+  assert.equal(summary.result_summary.succeeded, 2);
+  assert.equal(summary.result_summary.failed, 1);
+  assert.deepEqual(events.map((event) => event.schema), Array(events.length).fill(FIXTURE_MATRIX_PROGRESS_SCHEMA));
+  assert.ok(events.every((event) => Number.isInteger(event.completed) && event.completed >= 0 && event.total === 3 && event.current?.id));
+  assert.ok(events.find((event) => event.phase === 'batch' && event.status === 'timeout'));
+  assert.ok(events.find((event) => event.phase === 'fixture' && event.status === 'timeout' && event.current.id === 'hanging'));
+  const recoveryStart = events.findIndex((event) => event.phase === 'recovery' && event.status === 'started');
+  const healthyAfterComplete = events.findIndex((event) => event.phase === 'fixture' && event.status === 'completed' && event.current.id === 'healthy-after');
+  const matrixComplete = events.findIndex((event) => event.phase === 'matrix' && event.status === 'failed');
+  assert.ok(recoveryStart > events.findIndex((event) => event.phase === 'batch' && event.status === 'timeout'));
+  assert.ok(healthyAfterComplete > recoveryStart && healthyAfterComplete < matrixComplete);
+  assert.equal(events.at(-1).completed, 3);
 });
 
 test('runFixtureMatrixBench returns a partial result with survivors aggregated when a batch fails', async () => {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -99,6 +99,7 @@ export function buildFixtureMatrixRunPlan(input) {
       : {}),
     ...(options.batchSize ? { SSI_FIXTURE_MATRIX_BATCH_SIZE: String(options.batchSize) } : {}),
     ...(options.concurrency ? { SSI_FIXTURE_MATRIX_CONCURRENCY: String(options.concurrency) } : {}),
+    ...(options.batchInactivityTimeoutMs ? { SSI_FIXTURE_MATRIX_BATCH_INACTIVITY_TIMEOUT_MS: String(options.batchInactivityTimeoutMs) } : {}),
     ...(options.wordpressVersion ? { SSI_FIXTURE_MATRIX_WORDPRESS_VERSION: options.wordpressVersion } : {}),
     ...(options.wpCodeboxBin ? { SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN: options.wpCodeboxBin } : {}),
     ...(options.surfaceCoverage !== undefined ? { SSI_FIXTURE_MATRIX_SURFACE_COVERAGE: String(options.surfaceCoverage) } : {}),

--- a/tools/wp-codebox/recipe.mjs
+++ b/tools/wp-codebox/recipe.mjs
@@ -8,6 +8,7 @@ import fs from 'node:fs';
 const require = createRequire(import.meta.url);
 const WP_CODEBOX_RECIPE_MAX_BUFFER = 64 * 1024 * 1024;
 const WP_CODEBOX_RECIPE_TAIL_BYTES = 64 * 1024;
+export const DEFAULT_RECIPE_INACTIVITY_TIMEOUT_MS = 120000;
 
 function externalHelper() {
   const helperPath = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
@@ -40,7 +41,7 @@ export async function runWpCodeboxRecipe(options = {}) {
   const args = recipeRunArgs(base, options, { output: Boolean(options.outputFile) });
 
   if (options.outputFile) {
-    const result = await spawnRecipeWithTails(base.command, args);
+    const result = await spawnRecipeWithTails(base.command, args, options);
     if (result.status !== 0 && recipeRunOutputUnsupported(result)) {
       return runWpCodeboxRecipeStdoutFallback(base, options);
     }
@@ -111,6 +112,8 @@ function childFailureError(result) {
   const error = new Error(childFailureMessage(result));
   error.code = result.error?.code || result.status || 1;
   error.signal = result.signal || result.error?.signal || '';
+  error.inactivityTimedOut = Boolean(result.inactivityTimedOut);
+  error.inactivityTimeoutMs = result.inactivityTimeoutMs || 0;
   error.stdout = result.stdout || '';
   error.stderr = result.stderr || '';
   return error;
@@ -121,27 +124,53 @@ function recipeRunOutputUnsupported(result) {
   return /Unknown option:\s*--output/.test(text);
 }
 
-function spawnRecipeWithTails(command, args) {
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function spawnRecipeWithTails(command, args, options = {}) {
   return new Promise((resolve) => {
     const stdout = new RingTextBuffer(WP_CODEBOX_RECIPE_TAIL_BYTES);
     const stderr = new RingTextBuffer(WP_CODEBOX_RECIPE_TAIL_BYTES);
     const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
     let spawnError = null;
+    const inactivityTimeoutMs = positiveInteger(options.inactivityTimeoutMs, DEFAULT_RECIPE_INACTIVITY_TIMEOUT_MS);
+    let inactivityTimedOut = false;
+    let timer = null;
+    const resetInactivityTimer = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        inactivityTimedOut = true;
+        options.onInactivity?.({ timeout_ms: inactivityTimeoutMs });
+        child.kill('SIGTERM');
+      }, inactivityTimeoutMs);
+    };
 
-    child.stdout?.on('data', (chunk) => stdout.push(chunk));
-    child.stderr?.on('data', (chunk) => stderr.push(chunk));
+    child.stdout?.on('data', (chunk) => {
+      stdout.push(chunk);
+      resetInactivityTimer();
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr.push(chunk);
+      resetInactivityTimer();
+    });
     child.on('error', (error) => {
       spawnError = error;
     });
     child.on('close', (status, signal) => {
+      clearTimeout(timer);
       resolve({
         status,
         signal,
         error: spawnError,
+        inactivityTimedOut,
+        inactivityTimeoutMs,
         stdout: stdout.toString(),
         stderr: stderr.toString(),
       });
     });
+    resetInactivityTimer();
   });
 }
 


### PR DESCRIPTION
## Summary
- Emit Homeboy #7874-compatible `HOMEBOY_RUNNER_PROGRESS ` JSONL envelopes using `homeboy/runner-progress/v1` for matrix, batch, fixture, and recovery lifecycle states.
- Preserve SSI lifecycle detail in `metadata.lifecycle_status`, batch, recovery, and timeout fields while leaving Homeboy as the sole terminal-state authority.
- Bound silent shared WP Codebox batches with a configurable 120-second inactivity budget, preserve original batch failure evidence, and recover fixtures in fresh sandboxes with bounded concurrency.

Closes #629

## Timeout Design
- `SSI_FIXTURE_MATRIX_BATCH_INACTIVITY_TIMEOUT_MS` defaults to 120000ms. Any child stdout or stderr resets the watchdog.
- A silent shared batch receives SIGTERM when its inactivity budget is consumed; its recipe/output/tails remain in the original batch summary.
- Recovery runs one fixture per fresh sandbox with bounded concurrency, allowing healthy siblings to finish while the stalled fixture reaches its isolated timeout.

## Progress Protocol
```text
HOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"fixture","current_item":"healthy-after","completed":1,"total":3,"metadata":{"lifecycle_status":"completed","batch":1,"recovery":true}}
```
Only Homeboy protocol fields are emitted at the envelope root: `schema`, `phase`, `current_item`, `completed`, `total`, and `metadata`. The fixture-matrix contract test feeds start, completion, failure, timeout, and recovery records through Homeboy's accepted shape and proves an injected root `status` field is rejected.

## Testing
1. Run `npm test`.
2. Run `php -l static-site-importer.php`.
3. Run `php -l includes/class-static-site-importer-theme-generator.php`.
4. The fixture-matrix suite exercises healthy/stalled/healthy ordering with a real silent child process, prompt recovery, survivor completion, preserved failure paths, and Homeboy progress-protocol compatibility.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode, openai/gpt-5.6-sol, and openai/gpt-5.6-terra
- **Used for:** Implemented the fixture lifecycle recovery and Homeboy protocol alignment with Chris's requested acceptance criteria.