### PR TITLE
Fix fixture matrix rig preflight cost

### DIFF
--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -73,9 +73,40 @@
         "remediation": "Pass homeboy bench --path /path/to/static-site-importer or update components.static-site-importer.path before running static-site-importer-fixture-matrix."
       },
       {
-        "kind": "command",
-        "label": "Fixture matrix workload validates",
-        "command": "cd \"${package.root}\" && npm ci --ignore-scripts && node \"${package.root}/tools/fixture-matrix.test.mjs\""
+        "kind": "requirement",
+        "label": "Fixture matrix workload entrypoint exists",
+        "file": "${components.static-site-importer.path}/bench/static-site-fixture-matrix.bench.mjs",
+        "remediation": "Refresh the Static Site Importer checkout before running static-site-importer-fixture-matrix."
+      },
+      {
+        "kind": "requirement",
+        "label": "Fixture matrix WP Codebox recipe entrypoint exists",
+        "file": "${components.static-site-importer.path}/tools/wp-codebox/recipe.mjs",
+        "remediation": "Refresh the Static Site Importer checkout before running static-site-importer-fixture-matrix."
+      },
+      {
+        "kind": "requirement",
+        "label": "Hydrated pixelmatch entrypoint exists",
+        "file": "${components.static-site-importer.path}/node_modules/pixelmatch/index.js",
+        "remediation": "Dependencies are missing. Run `homeboy deps install --path /path/to/static-site-importer` so Homeboy hydrates the checkout, then rerun static-site-importer-fixture-matrix."
+      },
+      {
+        "kind": "requirement",
+        "label": "Hydrated pngjs entrypoint exists",
+        "file": "${components.static-site-importer.path}/node_modules/pngjs/lib/png.js",
+        "remediation": "Dependencies are missing. Run `homeboy deps install --path /path/to/static-site-importer` so Homeboy hydrates the checkout, then rerun static-site-importer-fixture-matrix."
+      },
+      {
+        "kind": "requirement",
+        "label": "Static Site Importer transformer adapter exists",
+        "file": "${components.static-site-importer.path}/includes/class-static-site-importer-transformer-adapter.php",
+        "remediation": "Refresh the Static Site Importer checkout before running static-site-importer-fixture-matrix."
+      },
+      {
+        "kind": "requirement",
+        "label": "Node.js runtime exists",
+        "executable": "node",
+        "remediation": "Use a Homeboy runner with Node.js available on PATH before running static-site-importer-fixture-matrix."
       }
     ],
     "down": [

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -705,6 +705,42 @@ test('fixture-matrix rig requires env-backed WP Codebox editor and visual capabi
   assert.ok(tool.capabilities.includes('wordpress.visual-compare'));
 });
 
+test('fixture-matrix rig preflight is declarative and checks hydrated prerequisites deterministically', () => {
+  const rig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs', 'static-site-importer-fixture-matrix', 'rig.json'), 'utf8'));
+  const checks = rig.pipeline.check;
+  const hydrationRemediation = 'Dependencies are missing. Run `homeboy deps install --path /path/to/static-site-importer` so Homeboy hydrates the checkout, then rerun static-site-importer-fixture-matrix.';
+  const requiredFiles = [
+    'static-site-importer.php',
+    'bench/static-site-fixture-matrix.bench.mjs',
+    'tools/wp-codebox/recipe.mjs',
+    'node_modules/pixelmatch/index.js',
+    'node_modules/pngjs/lib/png.js',
+    'includes/class-static-site-importer-transformer-adapter.php',
+  ];
+  const declaredFiles = checks.map((check) => check.file).filter(Boolean).map((file) => file.replace('${components.static-site-importer.path}/', ''));
+  const declaredDirectories = checks.map((check) => check.dir).filter(Boolean).map((dir) => dir.replace('${components.static-site-importer.path}/', ''));
+
+  assert.ok(checks.every((check) => check.kind === 'requirement'));
+  assert.deepEqual(declaredFiles, requiredFiles);
+  assert.deepEqual(declaredDirectories, []);
+  assert.ok(checks.some((check) => check.executable === 'node'));
+  assert.equal(JSON.stringify(checks).includes('npm ci'), false);
+  assert.equal(JSON.stringify(checks).includes('fixture-matrix.test.mjs'), false);
+  assert.equal(checks.filter((check) => check.remediation === hydrationRemediation).length, 2);
+
+  const preflightFailures = (root) => checks.flatMap((check) => {
+    const declared = check.file || check.dir;
+    if (!declared) {
+      return [];
+    }
+    const relativePath = declared.replace('${components.static-site-importer.path}/', '');
+    return existsSync(path.join(root, relativePath)) ? [] : [relativePath];
+  });
+
+  assert.deepEqual(preflightFailures(packageRoot), []);
+  assert.deepEqual(preflightFailures(path.join(packageRoot, 'missing-hydration')), requiredFiles);
+});
+
 test('fixture-matrix WP Codebox batch runner uses Homeboy declared binary', () => {
   assert.equal(wpCodeboxBin({
     HOMEBOY_WP_CODEBOX_BIN: '/runner/wp-codebox-current',


### PR DESCRIPTION
## Summary
- replace the fixture-matrix rig check command with declarative file, Node runtime, and hydrated dependency entrypoint requirements
- retain WP Codebox capability requirements and verify the SSI transformer adapter path
- report a direct Homeboy dependency-install remediation when Node dependencies are absent
- add deterministic rig-contract coverage that prohibits package installation and fixture-matrix test execution

Closes #631

## Preflight cost
A hydrated local rig check completed in 1.90 seconds. The check performs filesystem and executable assertions only; it does not install packages or execute the fixture matrix.

## How to test
1. Run `homeboy deps install --path /path/to/static-site-importer` to hydrate the checkout through Homeboy.
2. Run `homeboy rig check rigs/static-site-importer-fixture-matrix/rig.json --path /path/to/static-site-importer --force-hot --allow-local-hot`.
3. Run `npm test`.
4. Run `php -l static-site-importer.php && php tests/smoke-transformer-adapter.php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode, openai/gpt-5.6-sol
- **Used for:** Collaboratively implemented the declarative rig preflight, added contract tests, and ran verification.