### PR TITLE
Move fixture hydration into Homeboy lifecycle

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import fs from 'node:fs';
-import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -150,7 +149,7 @@ export async function runFixtureMatrix(options) {
   const fixtureRoot = path.resolve(intake?.fixture_root || options.fixtureRoot || path.join(packageRoot, 'tests', 'fixtures', 'fixture-matrix'));
   const staticSiteImporterPath = options.staticSiteImporterPath || process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH || process.cwd();
   const dependencyOverrides = prepareDependencyOverrides(options);
-  ensureComposerDependencies(staticSiteImporterPath, { dependencyOverrides });
+  validateHydratedComposerDependencies(packageRoot);
   const matrix = createFixtureMatrix({
     id: options.id || `static-site-importer-fixture-matrix-${Date.now()}`,
     fixture_root: fixtureRoot,
@@ -757,26 +756,15 @@ export function boundedConcurrency(value, fallback, max) {
   return Math.max(1, Math.min(parsed, max));
 }
 
-function ensureComposerDependencies(pluginPath, options = {}) {
-  const dependencyOverrides = options.dependencyOverrides || {};
-  const blocksEnginePhpTransformerPath = dependencyOverrides.blocks_engine_php_transformer?.path || '';
-  if (blocksEnginePhpTransformerPath) {
-    updateComposerPathRepository(pluginPath, blocksEnginePhpTransformerPath);
-    return;
+export function validateHydratedComposerDependencies(pluginPath) {
+  const autoloadPath = path.join(pluginPath, 'vendor', 'autoload.php');
+  if (fs.existsSync(autoloadPath)) {
+    return autoloadPath;
   }
 
-  if (fs.existsSync(path.join(pluginPath, 'vendor', 'autoload.php')) || !fs.existsSync(path.join(pluginPath, 'composer.json'))) {
-    return;
-  }
-
-  const result = spawnSync('composer', ['install', '--no-interaction', '--prefer-dist', '--no-progress'], {
-    cwd: pluginPath,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (result.status !== 0) {
-    throw new Error(`Composer dependency install failed for ${pluginPath}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
-  }
+  throw new Error(
+    `Homeboy hydration is incomplete: missing ${autoloadPath}. Run \`homeboy rig up static-site-importer-fixture-matrix\`, then rerun the fixture matrix.`,
+  );
 }
 
 function prepareDependencyOverrides(options) {
@@ -819,40 +807,6 @@ function composerPackageName(composerFile) {
   } catch {
     return '';
   }
-}
-
-function updateComposerPathRepository(pluginPath, packagePath) {
-  const composerFile = path.join(pluginPath, 'composer.json');
-  const lockFile = path.join(pluginPath, 'composer.lock');
-  const composerJson = fs.readFileSync(composerFile, 'utf8');
-  const composerLock = fs.existsSync(lockFile) ? fs.readFileSync(lockFile, 'utf8') : null;
-  let result = null;
-  try {
-    configureComposerPathRepository(pluginPath, packagePath);
-    result = spawnSync('composer', ['update', 'automattic/blocks-engine-php-transformer', '--with-dependencies', '--no-interaction', '--prefer-source', '--no-progress'], {
-      cwd: pluginPath,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-  } finally {
-    fs.writeFileSync(composerFile, composerJson);
-    if (composerLock !== null) {
-      fs.writeFileSync(lockFile, composerLock);
-    }
-  }
-  if (result.status !== 0) {
-    throw new Error(`Composer dependency override failed for ${pluginPath}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
-  }
-}
-
-function configureComposerPathRepository(pluginPath, packagePath) {
-  const composerFile = path.join(pluginPath, 'composer.json');
-  const composer = JSON.parse(fs.readFileSync(composerFile, 'utf8'));
-  composer.repositories = composer.repositories && typeof composer.repositories === 'object' && !Array.isArray(composer.repositories)
-    ? composer.repositories
-    : {};
-  composer.repositories['blocks-engine-php-transformer-dev'] = composerPathRepositoryConfig(composer, packagePath);
-  fs.writeFileSync(composerFile, `${JSON.stringify(composer, null, 2)}\n`);
 }
 
 export function composerPathRepositoryConfig(rootComposer, packagePath) {

--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -63,6 +63,13 @@
     "fixture-matrix": ["static-site-fixture-matrix"]
   },
   "pipeline": {
+    "up": [
+      {
+        "kind": "command",
+        "label": "Hydrate Static Site Importer Composer dependencies",
+        "command": "cd \"${components.static-site-importer.path}\" && composer install --no-interaction --prefer-dist --no-progress"
+      }
+    ],
     "check": [
       {
         "kind": "requirement",
@@ -95,6 +102,12 @@
         "label": "Hydrated pngjs entrypoint exists",
         "file": "${components.static-site-importer.path}/node_modules/pngjs/lib/png.js",
         "remediation": "Dependencies are missing. Run `homeboy deps install --path /path/to/static-site-importer` so Homeboy hydrates the checkout, then rerun static-site-importer-fixture-matrix."
+      },
+      {
+        "kind": "requirement",
+        "label": "Hydrated Composer autoloader exists",
+        "file": "${components.static-site-importer.path}/vendor/autoload.php",
+        "remediation": "Composer dependencies are missing. Run `homeboy rig up static-site-importer-fixture-matrix` so Homeboy hydrates the checkout, then rerun the fixture matrix."
       },
       {
         "kind": "requirement",

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -24,6 +24,7 @@ import runFixtureMatrixBench, {
   materializeEditorCanvasArtifacts,
   resolveBlocksEnginePhpTransformerPath,
   runFixtureMatrix,
+  validateHydratedComposerDependencies,
 } from '../bench/static-site-fixture-matrix.bench.mjs';
 import {
   buildCodeFreshness,
@@ -715,6 +716,7 @@ test('fixture-matrix rig preflight is declarative and checks hydrated prerequisi
     'tools/wp-codebox/recipe.mjs',
     'node_modules/pixelmatch/index.js',
     'node_modules/pngjs/lib/png.js',
+    'vendor/autoload.php',
     'includes/class-static-site-importer-transformer-adapter.php',
   ];
   const declaredFiles = checks.map((check) => check.file).filter(Boolean).map((file) => file.replace('${components.static-site-importer.path}/', ''));
@@ -2214,6 +2216,21 @@ test('resolves Blocks Engine PHP transformer override paths', () => {
 
   assert.equal(resolveBlocksEnginePhpTransformerPath(repoRoot), transformerPackageRoot);
   assert.equal(resolveBlocksEnginePhpTransformerPath(transformerPackageRoot), transformerPackageRoot);
+});
+
+test('requires Homeboy-hydrated Composer dependencies without installing them', () => {
+  const pluginRoot = mkdtempSync(path.join(tmpdir(), 'ssi-hydration-'));
+  const expectedAutoload = path.join(pluginRoot, 'vendor', 'autoload.php');
+
+  assert.throws(
+    () => validateHydratedComposerDependencies(pluginRoot),
+    (error) => error.message.includes('Homeboy hydration is incomplete')
+      && error.message.includes('homeboy rig up static-site-importer-fixture-matrix'),
+  );
+
+  mkdirSync(path.dirname(expectedAutoload), { recursive: true });
+  writeFileSync(expectedAutoload, '<?php');
+  assert.equal(validateHydratedComposerDependencies(pluginRoot), expectedAutoload);
 });
 
 test('builds Composer path repository override matching SSI constraints', () => {


### PR DESCRIPTION
## Summary
- remove Composer install/update subprocesses and temporary composer.json mutation from the fixture workload
- hydrate Composer dependencies through the Homeboy rig `up` lifecycle
- fail fast when Homeboy did not materialize `vendor/autoload.php`

Fixes #633.

## How to test
1. Run `homeboy rig lint rigs/static-site-importer-fixture-matrix`.
2. Run `npm test`.
3. Run `php tests/smoke-transformer-adapter.php`.
4. Confirm `bench/static-site-fixture-matrix.bench.mjs` contains no Composer install or update subprocess.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Implemented the Homeboy-owned hydration lifecycle, fail-fast validation, and regression coverage with Chris.