### PR TITLE
Hydrate mixed SSI dependencies with WordPress provider

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,7 +1,7 @@
 {
   "auto_cleanup": false,
   "capability_extensions": {
-    "deps": "nodejs"
+    "deps": "wordpress"
   },
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -88,7 +88,7 @@ test('Homeboy component links runtime and dependency extensions', () => {
 
   assert.ok(config.extensions?.wordpress, 'WordPress extension is required for fixture runtime workloads');
   assert.ok(config.extensions?.nodejs, 'Node.js extension is required for Lab dependency hydration');
-  assert.equal(config.capability_extensions?.deps, 'nodejs', 'Node.js owns Lab dependency hydration');
+  assert.equal(config.capability_extensions?.deps, 'wordpress', 'WordPress owns npm and Composer Lab hydration');
 });
 
 test('discovers SSI fixtures and writes Blocks Engine site artifacts', () => {


### PR DESCRIPTION
## Summary
- select the WordPress dependency provider for Static Site Importer
- hydrate Composer and npm dependencies through one Homeboy provider invocation
- preserve the fixture workload as validation-only with no package-manager subprocesses

Fixes #635.

## How to test
1. Run `homeboy deps install --path /path/to/static-site-importer`.
2. Confirm the result reports one `wordpress` provider install.
3. Confirm its output includes both Composer installation and `npm ci`.
4. Run `npm test`.
5. Run `php tests/smoke-transformer-adapter.php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed Lab hydration against a real fixture run and implemented the dependency-owner correction and coverage with Chris.