### PR TITLE
feat: retain visual attribution artifacts

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -6,6 +6,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 /**
  * Internal dependencies
@@ -36,6 +37,7 @@ const MAX_BATCH_CONCURRENCY = 16;
 export const FIXTURE_MATRIX_PROGRESS_SCHEMA = 'homeboy/runner-progress/v1';
 export const FIXTURE_MATRIX_PROGRESS_PREFIX = 'HOMEBOY_RUNNER_PROGRESS ';
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const require = createRequire(import.meta.url);
 
 async function main() {
   const options = { ...optionsFromEnv(), ...parseArgs(process.argv.slice(2)) };
@@ -423,6 +425,9 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     result: batchResult,
     codeboxArtifactsDirectory,
     outputDirectory,
+    visualAttributionNormalizer: options.visualAttributionNormalizer,
+    visualAttributionLoader: options.visualAttributionLoader,
+    homeboyExtensionPath: options.homeboyExtensionPath,
   });
   const editorCanvas = materializeEditorCanvasArtifacts({
     result: visualCompare.result,
@@ -575,6 +580,9 @@ export function materializeVisualCompareArtifacts(input = {}) {
     outputDirectory,
     codeboxArtifactsDirectory,
     artifacts,
+    visualAttributionNormalizer: input.visualAttributionNormalizer,
+    visualAttributionLoader: input.visualAttributionLoader,
+    homeboyExtensionPath: input.homeboyExtensionPath,
   }));
   return {
     result: { ...result, fixtures: updatedFixtures },
@@ -582,7 +590,7 @@ export function materializeVisualCompareArtifacts(input = {}) {
   };
 }
 
-function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory, artifacts }) {
+function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory, artifacts, visualAttributionNormalizer, visualAttributionLoader, homeboyExtensionPath }) {
   const visualParityArtifacts = fixture.visual_parity_artifacts || fixture.visualParityArtifacts;
   const slots = visualParityArtifacts?.artifacts || {};
   const fixtureId = fixture.fixture_id || fixture.fixtureId || '';
@@ -596,6 +604,10 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
     ['source_screenshot', 'source', ['source_screenshot']],
     ['imported_screenshot', 'candidate', ['imported_screenshot', 'candidate_screenshot']],
     ['diff_screenshot', 'diff', ['diff_screenshot']],
+    ['visual_diff', 'visual-diff.json', ['visual_diff']],
+    ['visual_explanation', 'visual-explanation.json', ['visual_explanation']],
+    ['source_dom_snapshot', 'source-dom-snapshot.json', ['source_dom_snapshot']],
+    ['candidate_dom_snapshot', 'candidate-dom-snapshot.json', ['candidate_dom_snapshot']],
   ]) {
     const [slotName, fileStem, artifactIds] = slot;
     const refPath = slots[slotName]?.ref?.path || visualDiagnosticRefPath(fixture.diagnostics, artifactIds);
@@ -603,7 +615,7 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
     if (!sourcePath || !fs.existsSync(sourcePath)) {
       continue;
     }
-    const persistedPath = path.join(outputDirectory, 'visual-compare', fixtureId, `${fileStem}.png`);
+    const persistedPath = path.join(outputDirectory, 'visual-compare', fixtureId, fileStem.includes('.') ? fileStem : `${fileStem}.png`);
     fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
     fs.copyFileSync(sourcePath, persistedPath);
     rewrites.set(refPath, persistedPath);
@@ -642,6 +654,23 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
       diffScreenshot: updatedSlots.diff_screenshot?.ref?.path,
     },
   }, { fixtureArtifactsDirectory: outputDirectory });
+  const visualAttribution = materializeVisualAttribution({
+    fixture,
+    fixtureId,
+    outputDirectory,
+    slots: updatedSlots,
+    normalizer: visualAttributionNormalizer,
+    loader: visualAttributionLoader,
+    homeboyExtensionPath,
+  });
+  if (visualAttribution) {
+    updatedSlots.visual_attribution = {
+      status: 'captured',
+      kind: 'visual_attribution',
+      ref: artifactRef('visual_attribution', visualAttribution.path, 'visual-parity'),
+    };
+    artifacts[`visual_compare_${artifactKey(fixtureId)}_visual-attribution`] = { path: visualAttribution.path };
+  }
 
   return {
     ...fixture,
@@ -659,6 +688,87 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
       visual_diff_classification: classification,
     } : {}),
   };
+}
+
+function materializeVisualAttribution({ fixture, fixtureId, outputDirectory, slots, normalizer, loader, homeboyExtensionPath }) {
+  const visualDiffPath = slots.visual_diff?.ref?.path;
+  if (!visualDiffPath) {
+    return null;
+  }
+  const refs = {
+    visualExplanation: slots.visual_explanation?.ref?.path,
+    sourceDomSnapshot: slots.source_dom_snapshot?.ref?.path,
+    candidateDomSnapshot: slots.candidate_dom_snapshot?.ref?.path,
+  };
+  const visualDiff = readJsonArtifact(visualDiffPath);
+  const visualExplanation = readJsonArtifact(refs.visualExplanation);
+  const sourceDomSnapshot = readJsonArtifact(refs.sourceDomSnapshot);
+  const candidateDomSnapshot = readJsonArtifact(refs.candidateDomSnapshot);
+  const activeNormalizer = resolveWordPressVisualAttributionNormalizer({ normalizer, loader, homeboyExtensionPath });
+  let attribution;
+  try {
+    attribution = activeNormalizer
+      ? activeNormalizer({
+        visualDiff,
+        visualExplanation,
+        sourceDomSnapshot,
+        candidateDomSnapshot,
+        refs,
+        candidateProvenance: fixture.candidate_provenance || fixture.candidateProvenance,
+      })
+      : unavailableVisualAttribution(refs, visualExplanation, sourceDomSnapshot, candidateDomSnapshot);
+  } catch {
+    attribution = unavailableVisualAttribution(refs, visualExplanation, sourceDomSnapshot, candidateDomSnapshot, 'The Homeboy WordPress extension normalizer failed; attribution is limited to retained pixel evidence.');
+  }
+  const persistedPath = path.join(outputDirectory, 'visual-compare', fixtureId, 'visual-attribution.json');
+  writeJsonArtifact(persistedPath, attribution);
+  return { path: persistedPath };
+}
+
+function unavailableVisualAttribution(refs, visualExplanation, sourceDomSnapshot, candidateDomSnapshot, normalizerLimitation = 'The Homeboy WordPress extension normalizer was unavailable; attribution is limited to retained pixel evidence.') {
+  return {
+    schema: 'static-site-importer/visual-attribution-unavailable/v1',
+    evidence: refs,
+    limitations: [
+      normalizerLimitation,
+      ...(visualExplanation ? [] : ['WP Codebox visual explanation sidecar was not captured.']),
+      ...(sourceDomSnapshot && candidateDomSnapshot ? [] : ['WP Codebox DOM snapshot sidecars were not both captured.']),
+    ],
+  };
+}
+
+function readJsonArtifact(filePath) {
+  if (!filePath) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export function resolveWordPressVisualAttributionNormalizer({ normalizer, loader, homeboyExtensionPath } = {}) {
+  if (typeof normalizer === 'function') {
+    return normalizer;
+  }
+  try {
+    let extension;
+    if (typeof loader === 'function') {
+      extension = loader();
+    } else {
+      const extensionPath = homeboyExtensionPath || process.env.HOMEBOY_EXTENSION_PATH;
+      if (!extensionPath) {
+        return null;
+      }
+      extension = require(path.resolve(extensionPath));
+    }
+    return typeof extension?.normalizeWordPressVisualAttribution === 'function'
+      ? extension.normalizeWordPressVisualAttribution
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function visualDiagnosticRefPath(diagnostics, artifactIds) {

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -34,6 +34,7 @@ const DEFAULT_BATCH_SIZE = 10;
 // up to the cap.
 const DEFAULT_BATCH_CONCURRENCY = 2;
 const MAX_BATCH_CONCURRENCY = 16;
+const VISUAL_ATTRIBUTION_TOP_FINDINGS_LIMIT = 5;
 export const FIXTURE_MATRIX_PROGRESS_SCHEMA = 'homeboy/runner-progress/v1';
 export const FIXTURE_MATRIX_PROGRESS_PREFIX = 'HOMEBOY_RUNNER_PROGRESS ';
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
@@ -670,6 +671,7 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
       ref: artifactRef('visual_attribution', visualAttribution.path, 'visual-parity'),
     };
     artifacts[`visual_compare_${artifactKey(fixtureId)}_visual-attribution`] = { path: visualAttribution.path };
+    updatedVisualParityArtifacts.visual_attribution_summary = summarizeVisualAttribution(visualAttribution.attribution, visualAttribution.path);
   }
 
   return {
@@ -722,7 +724,56 @@ function materializeVisualAttribution({ fixture, fixtureId, outputDirectory, slo
   }
   const persistedPath = path.join(outputDirectory, 'visual-compare', fixtureId, 'visual-attribution.json');
   writeJsonArtifact(persistedPath, attribution);
-  return { path: persistedPath };
+  return { path: persistedPath, attribution };
+}
+
+function summarizeVisualAttribution(attribution, attributionPath) {
+  const value = attribution && typeof attribution === 'object' ? attribution : {};
+  const selectorDeltas = Array.isArray(value.selector_deltas) ? value.selector_deltas : [];
+  const styleDeltas = value.computed_style_deltas && typeof value.computed_style_deltas === 'object'
+    ? value.computed_style_deltas
+    : {};
+  const elements = value.elements && typeof value.elements === 'object' ? value.elements : {};
+  const summary = value.summary && typeof value.summary === 'object' ? value.summary : {};
+  return {
+    schema: typeof value.schema === 'string' ? value.schema : 'static-site-importer/visual-attribution-unavailable/v1',
+    status: value.schema === 'homeboy/WordPressVisualAttribution/v1' ? 'available' : 'limited',
+    mismatch_region_count: Array.isArray(value.mismatch_regions) ? value.mismatch_regions.length : 0,
+    selector_delta_count: selectorDeltas.length,
+    geometry_delta_count: selectorDeltas.filter((delta) => hasVisualAttributionGeometryDelta(delta?.bounding_box?.delta)).length,
+    computed_style_delta_counts: Object.fromEntries(Object.entries(styleDeltas)
+      .filter(([, deltas]) => Array.isArray(deltas))
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([category, deltas]) => [category, deltas.length])),
+    changed_count: finiteVisualAttributionCount(summary.changed, elements.changed),
+    added_count: finiteVisualAttributionCount(summary.added, elements.added),
+    removed_count: finiteVisualAttributionCount(summary.removed, elements.removed),
+    top_findings: (Array.isArray(value.top_findings) ? value.top_findings : [])
+      .slice(0, VISUAL_ATTRIBUTION_TOP_FINDINGS_LIMIT)
+      .map((finding) => compactVisualAttributionFinding(finding)),
+    limitations_count: Array.isArray(value.limitations) ? value.limitations.length : 0,
+    attribution_ref: attributionPath,
+  };
+}
+
+function hasVisualAttributionGeometryDelta(delta) {
+  return Object.values(delta && typeof delta === 'object' ? delta : {}).some((value) => Number(value) !== 0);
+}
+
+function finiteVisualAttributionCount(summaryValue, elements) {
+  const value = Number(summaryValue);
+  return Number.isFinite(value) && value >= 0 ? value : (Array.isArray(elements) ? elements.length : 0);
+}
+
+function compactVisualAttributionFinding(value) {
+  const finding = value && typeof value === 'object' ? value : {};
+  return Object.fromEntries(Object.entries({
+    kind: finding.kind,
+    summary: finding.summary,
+    selector: finding.selector,
+    category: finding.category,
+    property: finding.property,
+  }).filter(([, entry]) => typeof entry === 'string' && entry));
 }
 
 function unavailableVisualAttribution(refs, visualExplanation, sourceDomSnapshot, candidateDomSnapshot, normalizerLimitation = 'The Homeboy WordPress extension normalizer was unavailable; attribution is limited to retained pixel evidence.') {

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -251,6 +251,8 @@ function mergeVisualParityComparison(left, right) {
     diff_screenshot: left.diff_screenshot || right.diff_screenshot,
     visual_diff: left.visual_diff || right.visual_diff,
     visual_explanation_ref: left.visual_explanation_ref || right.visual_explanation_ref,
+    source_dom_snapshot: left.source_dom_snapshot || right.source_dom_snapshot,
+    candidate_dom_snapshot: left.candidate_dom_snapshot || right.candidate_dom_snapshot,
     visual_explanation: left.visual_explanation || right.visual_explanation,
     mismatch_regions: left.mismatch_regions?.length ? left.mismatch_regions : right.mismatch_regions,
     visual_diff_regions: left.visual_diff_regions?.length ? left.visual_diff_regions : right.visual_diff_regions,
@@ -359,6 +361,8 @@ function normalizeVisualParityComparison(value, options = {}) {
     diff_screenshot: firstRef([artifacts.diff_screenshot, artifactSlots.diff_screenshot, files.diffScreenshot, obj.diff_screenshot, obj.diffScreenshot]),
     visual_diff: firstRef([artifacts.visual_diff, artifactSlots.visual_diff, files.visualDiff, obj.visual_diff, obj.visualDiff]),
     visual_explanation_ref: firstRef([artifacts.visual_explanation, artifactSlots.visual_explanation, files.visualExplanation, visualCompare.explanation, obj.visual_explanation_ref, obj.visualExplanationRef]),
+    source_dom_snapshot: firstRef([artifacts.source_dom_snapshot, artifactSlots.source_dom_snapshot, files.sourceDomSnapshot, obj.source_dom_snapshot, obj.sourceDomSnapshot]),
+    candidate_dom_snapshot: firstRef([artifacts.candidate_dom_snapshot, artifactSlots.candidate_dom_snapshot, files.candidateDomSnapshot, obj.candidate_dom_snapshot, obj.candidateDomSnapshot]),
     visual_explanation: visualExplanation,
     mismatch_regions: mismatchRegions,
   };
@@ -602,6 +606,9 @@ function visualParityArtifactRefs(comparison) {
     ['candidate_screenshot', comparison.candidate_screenshot],
     ['diff_screenshot', comparison.diff_screenshot],
     ['visual_diff', comparison.visual_diff],
+    ['visual_explanation', comparison.visual_explanation_ref],
+    ['source_dom_snapshot', comparison.source_dom_snapshot],
+    ['candidate_dom_snapshot', comparison.candidate_dom_snapshot],
   ]
     .filter(([, ref]) => Boolean(ref))
     .map(([id, ref]) => artifactRef(id, ref, 'visual-parity'));
@@ -652,6 +659,8 @@ export function collectVisualParityArtifacts(payload, options = {}) {
       diff_screenshot: slot(comparison.diff_screenshot, 'diff_screenshot', 'Diff screenshot was not captured by the runtime.'),
       visual_diff: slot(comparison.visual_diff, 'visual_diff', 'Visual diff output was not captured by the runtime.'),
       visual_explanation: slot(comparison.visual_explanation_ref, 'visual_explanation', 'Visual explanation output was not captured by the runtime.'),
+      source_dom_snapshot: slot(comparison.source_dom_snapshot, 'source_dom_snapshot', 'Source DOM snapshot was not captured by the runtime.'),
+      candidate_dom_snapshot: slot(comparison.candidate_dom_snapshot, 'candidate_dom_snapshot', 'Candidate DOM snapshot was not captured by the runtime.'),
     },
   };
 }
@@ -667,6 +676,8 @@ function visualParityArtifactScore(comparison) {
     comparison.diff_screenshot,
     comparison.visual_diff,
     comparison.visual_explanation_ref,
+    comparison.source_dom_snapshot,
+    comparison.candidate_dom_snapshot,
   ].filter(Boolean).length
     + (comparison.visual_diff_classification ? 10 : 0)
     + (comparison.visual_diff_regions?.length ? 5 : 0)

--- a/lib/fixture-matrix/visual-evidence-report.mjs
+++ b/lib/fixture-matrix/visual-evidence-report.mjs
@@ -46,6 +46,8 @@ export function buildVisualParityEvidenceReport(input = {}) {
       viewport_evidence_surface_count: surfaces.filter((surface) => surface.evidence.viewports.status === 'present').length,
       mobile_viewport_fixture_count: fixtures.filter((fixture) => fixture.evidence.viewports.has_mobile).length,
       live_wp_parity_fixture_count: fixtures.filter((fixture) => fixture.evidence.live_wp_parity.status === 'present').length,
+      visual_attribution_fixture_count: fixtures.filter((fixture) => fixture.evidence.visual_attribution.status === 'available').length,
+      limited_visual_attribution_fixture_count: fixtures.filter((fixture) => fixture.evidence.visual_attribution.status === 'limited').length,
       missing_asset_fixture_count: fixtures.filter((fixture) => fixture.asset_resolution.missing_asset_count > 0).length,
       core_html_fixture_count: fixtures.filter((fixture) => fixture.block_theme.core_html_block_count > 0).length,
       risk_counts: riskCounts,
@@ -82,6 +84,7 @@ export function renderVisualParityEvidenceReportMarkdown(report) {
     `Screenshot evidence: ${summary.screenshot_surface_count || 0} surface(s) across ${summary.screenshot_fixture_count || 0} fixture(s)`,
     `Viewport evidence: ${summary.viewport_evidence_surface_count || 0} surface(s) across ${summary.viewport_evidence_fixture_count || 0} fixture(s)`,
     `Mobile viewport evidence: ${summary.mobile_viewport_fixture_count || 0}`,
+    `Visual attribution: ${summary.visual_attribution_fixture_count || 0} available, ${summary.limited_visual_attribution_fixture_count || 0} limited`,
     `Fixtures with missing assets: ${summary.missing_asset_fixture_count || 0}`,
     `Fixtures with core/html blocks: ${summary.core_html_fixture_count || 0}`,
     '',
@@ -138,6 +141,7 @@ function fixtureEvidenceRow({ fixture, manifest, findings, outputDirectory }) {
         rows: viewportRows.slice(0, 8),
       },
       live_wp_parity: stageStatus(Boolean(fixture.live_wp_parity), fixture.live_wp_parity ? `score ${numberValue(fixture.live_wp_parity.score, 0)}` : ''),
+      visual_attribution: visualAttributionEvidence(artifacts),
     },
     surfaces,
     asset_resolution: {
@@ -194,9 +198,21 @@ function surfaceEvidenceRow({ fixture, surface, fallback }) {
         has_mobile: viewportRows.some((row) => numberValue(row.width, 0) > 0 && numberValue(row.width, 0) <= 480),
         rows: viewportRows.slice(0, 8),
       },
+      visual_attribution: visualAttributionEvidence(artifacts),
     },
     artifact_paths: artifactPaths,
     risk: fallback?.risk && surfaceId === 'front-page' ? fallback.risk : risk,
+  };
+}
+
+function visualAttributionEvidence(artifacts) {
+  const summary = objectValue(artifacts.visual_attribution_summary || artifacts.visualAttributionSummary);
+  if (Object.keys(summary).length === 0) {
+    return { status: 'missing' };
+  }
+  return {
+    ...summary,
+    status: summary.status === 'available' ? 'available' : 'limited',
   };
 }
 

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -5304,7 +5304,7 @@ test('visual evidence report infers viewport evidence from visual-compare metric
   assert.equal(report.fixtures[0].risk.reasons.includes('missing mobile viewport evidence'), false);
 });
 
-test('visual-compare PNGs are copied to the bench artifact root and registered', () => {
+test('visual-compare sidecars are normalized and retained under the bench artifact root', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-persisted-output-'));
   const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-codebox-artifacts-'));
   const runtimeDirectory = path.join(codeboxArtifactsDirectory, 'runtime-123', 'files', 'browser', 'visual-compare', 'simple-site');
@@ -5312,11 +5312,27 @@ test('visual-compare PNGs are copied to the bench artifact root and registered',
   for (const fileName of ['source.png', 'candidate.png', 'diff.png']) {
     writeFileSync(path.join(runtimeDirectory, fileName), `fake ${fileName}`);
   }
+  writeFileSync(path.join(runtimeDirectory, 'visual-diff.json'), JSON.stringify({
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: { mismatchPixels: 120, totalPixels: 1000, mismatchRatio: 0.12, dimensionMismatch: false },
+  }));
+  writeFileSync(path.join(runtimeDirectory, 'visual-explanation.json'), JSON.stringify({
+    schema: 'wp-codebox/visual-explanation/v1',
+    mismatchRegions: [{ x: 10, y: 20, width: 30, height: 40, pixels: 120 }],
+    selectorDeltas: [{ selector: '.hero', sourcePath: '0.1', candidatePath: '0.1', boundingBox: { delta: { y: 12 } }, styles: [{ property: 'color', source: '#000', candidate: '#fff' }] }],
+  }));
+  for (const fileName of ['source-dom-snapshot.json', 'candidate-dom-snapshot.json']) {
+    writeFileSync(path.join(runtimeDirectory, fileName), JSON.stringify({
+      schema: 'wp-codebox/browser-dom-snapshot/v1',
+      snapshot: { elementCount: 3, capturedElements: [{ path: '0.1' }], truncated: false },
+    }));
+  }
 
   const result = {
     fixtures: [
       {
         fixture_id: 'simple-site',
+        candidate_provenance: { '0.1': { block: 'core/cover' } },
         diagnostics: [
           {
             kind: VISUAL_PARITY_MISMATCH_KIND,
@@ -5334,22 +5350,45 @@ test('visual-compare PNGs are copied to the bench artifact root and registered',
             source_screenshot: { status: 'captured', ref: { path: 'files/browser/visual-compare/simple-site/source.png' } },
             imported_screenshot: { status: 'pending', capture_state: 'not_captured' },
             diff_screenshot: { status: 'captured', ref: { path: 'files/browser/visual-compare/simple-site/diff.png' } },
+            visual_diff: { status: 'captured', ref: { path: 'files/browser/visual-compare/simple-site/visual-diff.json' } },
+            visual_explanation: { status: 'captured', ref: { path: 'files/browser/visual-compare/simple-site/visual-explanation.json' } },
+            source_dom_snapshot: { status: 'captured', ref: { path: 'files/browser/visual-compare/simple-site/source-dom-snapshot.json' } },
+            candidate_dom_snapshot: { status: 'captured', ref: { path: 'files/browser/visual-compare/simple-site/candidate-dom-snapshot.json' } },
           },
         },
       },
     ],
   };
 
-  const persisted = materializeVisualCompareArtifacts({ result, outputDirectory, codeboxArtifactsDirectory });
+  let normalizerInput;
+  const persisted = materializeVisualCompareArtifacts({
+    result,
+    outputDirectory,
+    codeboxArtifactsDirectory,
+    visualAttributionNormalizer(input) {
+      normalizerInput = input;
+      return {
+        schema: 'homeboy/WordPressVisualAttribution/v1',
+        mismatch_regions: input.visualExplanation.mismatchRegions,
+        top_findings: [{ kind: 'geometry', selector: '.hero' }, { kind: 'style', property: 'color' }],
+        computed_style_deltas: { paint: [{ property: 'color' }] },
+      };
+    },
+  });
   const fixture = persisted.result.fixtures[0];
 
   assert.deepEqual(Object.keys(persisted.artifacts).sort(), [
     'visual_compare_simple-site_candidate',
+    'visual_compare_simple-site_candidate-dom-snapshot.json',
     'visual_compare_simple-site_diff',
     'visual_compare_simple-site_source',
+    'visual_compare_simple-site_source-dom-snapshot.json',
+    'visual_compare_simple-site_visual-attribution',
+    'visual_compare_simple-site_visual-diff.json',
+    'visual_compare_simple-site_visual-explanation.json',
   ]);
   for (const [key, artifact] of Object.entries(persisted.artifacts)) {
-    assert.ok(existsSync(artifact.path), `${key} should point at a copied PNG`);
+    assert.ok(existsSync(artifact.path), `${key} should point at a retained artifact`);
     assert.equal(artifact.path.includes('homeboy-run-'), false, 'persisted artifact must not live in a transient Homeboy runtime dir');
     assert.ok(artifact.path.startsWith(path.join(outputDirectory, 'visual-compare', 'simple-site')));
   }
@@ -5359,6 +5398,42 @@ test('visual-compare PNGs are copied to the bench artifact root and registered',
   assert.equal(fixture.visual_parity_artifacts.artifacts.imported_screenshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'candidate.png'));
   assert.equal(fixture.visual_parity_artifacts.artifacts.diff_screenshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'diff.png'));
   assert.equal(fixture.diagnostics[0].artifact_refs.find((ref) => ref.artifact_id === 'diff_screenshot').path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'diff.png'));
+  assert.equal(fixture.visual_parity_artifacts.artifacts.visual_diff.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'visual-diff.json'));
+  assert.equal(fixture.visual_parity_artifacts.artifacts.source_dom_snapshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'source-dom-snapshot.json'));
+  assert.equal(fixture.visual_parity_artifacts.artifacts.visual_attribution.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'visual-attribution.json'));
+  assert.equal(normalizerInput.visualExplanation.selectorDeltas[0].boundingBox.delta.y, 12);
+  assert.equal(normalizerInput.sourceDomSnapshot.snapshot.elementCount, 3);
+  assert.deepEqual(normalizerInput.candidateProvenance, { '0.1': { block: 'core/cover' } });
+  assert.equal(JSON.parse(readFileSync(fixture.visual_parity_artifacts.artifacts.visual_attribution.ref.path, 'utf8')).top_findings.length, 2);
+});
+
+test('visual-compare attribution degrades explicitly when sidecars or the extension normalizer are unavailable', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-degraded-output-'));
+  const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-degraded-codebox-'));
+  const runtimeDirectory = path.join(codeboxArtifactsDirectory, 'runtime-123', 'files', 'browser', 'visual-compare', 'simple-site');
+  mkdirSync(runtimeDirectory, { recursive: true });
+  writeFileSync(path.join(runtimeDirectory, 'visual-diff.json'), JSON.stringify({ schema: 'wp-codebox/visual-compare/v1', comparison: { mismatchPixels: 1, totalPixels: 10 } }));
+
+  const persisted = materializeVisualCompareArtifacts({
+    outputDirectory,
+    codeboxArtifactsDirectory,
+    result: {
+      fixtures: [{
+        fixture_id: 'simple-site',
+        visual_parity_artifacts: {
+          artifacts: {
+            visual_diff: { status: 'captured', ref: { path: 'files/browser/visual-compare/simple-site/visual-diff.json' } },
+          },
+        },
+      }],
+    },
+  });
+
+  const attributionPath = persisted.result.fixtures[0].visual_parity_artifacts.artifacts.visual_attribution.ref.path;
+  const attribution = JSON.parse(readFileSync(attributionPath, 'utf8'));
+  assert.equal(attribution.schema, 'static-site-importer/visual-attribution-unavailable/v1');
+  assert.ok(attribution.limitations.some((message) => message.includes('normalizer was unavailable')));
+  assert.ok(attribution.limitations.some((message) => message.includes('DOM snapshot')));
 });
 
 test('visual-compare dimension mismatch gates even with zero pixel metrics when gating is on', () => {
@@ -5588,6 +5663,8 @@ test('WP Codebox recipe browserEvidence visual refs are preserved with fixture i
           diffScreenshot: { path: 'files/browser/visual-compare/diff.png', kind: 'browser-visual-diff-screenshot' },
           visualDiff: { path: 'files/browser/visual-compare/visual-diff.json', kind: 'browser-visual-diff' },
           visualExplanation: { path: 'files/browser/visual-compare/visual-explanation.json', kind: 'browser-visual-explanation' },
+          sourceDomSnapshot: { path: 'files/browser/visual-compare/source-dom-snapshot.json', kind: 'browser-source-dom-snapshot' },
+          candidateDomSnapshot: { path: 'files/browser/visual-compare/candidate-dom-snapshot.json', kind: 'browser-candidate-dom-snapshot' },
           summary: { path: 'files/browser/visual-compare/summary.json', kind: 'browser-summary' },
         },
         summary: {
@@ -5626,6 +5703,8 @@ test('WP Codebox recipe browserEvidence visual refs are preserved with fixture i
   assert.equal(artifacts.diff_screenshot.ref.path, 'files/browser/visual-compare/diff.png');
   assert.equal(artifacts.visual_diff.ref.path, 'files/browser/visual-compare/visual-diff.json');
   assert.equal(artifacts.visual_explanation.ref.path, 'files/browser/visual-compare/visual-explanation.json');
+  assert.equal(artifacts.source_dom_snapshot.ref.path, 'files/browser/visual-compare/source-dom-snapshot.json');
+  assert.equal(artifacts.candidate_dom_snapshot.ref.path, 'files/browser/visual-compare/candidate-dom-snapshot.json');
   assert.equal(fixture.visual_parity_artifacts.visual_explanation.selector_diagnostics[0].selector, '.hero');
   assert.equal(fixture.visual_parity_artifacts.visual_explanation.layout_diagnostics[0].selector, '.hero');
   assert.ok(finding, 'expected a visual parity finding from WP Codebox browserEvidence');

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -5370,8 +5370,12 @@ test('visual-compare sidecars are normalized and retained under the bench artifa
       return {
         schema: 'homeboy/WordPressVisualAttribution/v1',
         mismatch_regions: input.visualExplanation.mismatchRegions,
-        top_findings: [{ kind: 'geometry', selector: '.hero' }, { kind: 'style', property: 'color' }],
-        computed_style_deltas: { paint: [{ property: 'color' }] },
+        selector_deltas: [{ bounding_box: { delta: { y: 12 } } }],
+        top_findings: Array.from({ length: 8 }, (_, index) => ({ kind: index === 0 ? 'geometry' : 'style', selector: '.hero', property: `property-${index}` })),
+        computed_style_deltas: { paint: [{ property: 'color' }], typography: [{ property: 'font-size' }, { property: 'line-height' }] },
+        elements: { changed: [{ path: '0.1' }], added: [], removed: [{ path: '0.2' }] },
+        summary: { changed: 1, added: 0, removed: 1 },
+        limitations: ['Attribution uses bounded browser evidence.'],
       };
     },
   });
@@ -5404,7 +5408,21 @@ test('visual-compare sidecars are normalized and retained under the bench artifa
   assert.equal(normalizerInput.visualExplanation.selectorDeltas[0].boundingBox.delta.y, 12);
   assert.equal(normalizerInput.sourceDomSnapshot.snapshot.elementCount, 3);
   assert.deepEqual(normalizerInput.candidateProvenance, { '0.1': { block: 'core/cover' } });
-  assert.equal(JSON.parse(readFileSync(fixture.visual_parity_artifacts.artifacts.visual_attribution.ref.path, 'utf8')).top_findings.length, 2);
+  assert.equal(JSON.parse(readFileSync(fixture.visual_parity_artifacts.artifacts.visual_attribution.ref.path, 'utf8')).top_findings.length, 8);
+  assert.deepEqual(fixture.visual_parity_artifacts.visual_attribution_summary, {
+    schema: 'homeboy/WordPressVisualAttribution/v1',
+    status: 'available',
+    mismatch_region_count: 1,
+    selector_delta_count: 1,
+    geometry_delta_count: 1,
+    computed_style_delta_counts: { paint: 1, typography: 2 },
+    changed_count: 1,
+    added_count: 0,
+    removed_count: 1,
+    top_findings: Array.from({ length: 5 }, (_, index) => ({ kind: index === 0 ? 'geometry' : 'style', selector: '.hero', property: `property-${index}` })),
+    limitations_count: 1,
+    attribution_ref: path.join(outputDirectory, 'visual-compare', 'simple-site', 'visual-attribution.json'),
+  });
 });
 
 test('visual-compare attribution degrades explicitly when sidecars or the extension normalizer are unavailable', () => {
@@ -5434,6 +5452,8 @@ test('visual-compare attribution degrades explicitly when sidecars or the extens
   assert.equal(attribution.schema, 'static-site-importer/visual-attribution-unavailable/v1');
   assert.ok(attribution.limitations.some((message) => message.includes('normalizer was unavailable')));
   assert.ok(attribution.limitations.some((message) => message.includes('DOM snapshot')));
+  assert.equal(persisted.result.fixtures[0].visual_parity_artifacts.visual_attribution_summary.status, 'limited');
+  assert.equal(persisted.result.fixtures[0].visual_parity_artifacts.visual_attribution_summary.limitations_count, 3);
 });
 
 test('visual-compare dimension mismatch gates even with zero pixel metrics when gating is on', () => {
@@ -5740,6 +5760,20 @@ test('visual parity evidence report summarizes staged output evidence and layout
         visual_parity_artifacts: {
           metrics: { mismatch_pixels: 0, total_pixels: 1000, mismatch_ratio: 0 },
           capture_diagnostics: [{ phase: 'candidate', viewport: { width: 1280, height: 720 }, message: 'desktop viewport captured' }],
+          visual_attribution_summary: {
+            schema: 'homeboy/WordPressVisualAttribution/v1',
+            status: 'available',
+            mismatch_region_count: 2,
+            selector_delta_count: 3,
+            geometry_delta_count: 1,
+            computed_style_delta_counts: { paint: 2 },
+            changed_count: 3,
+            added_count: 1,
+            removed_count: 0,
+            top_findings: [{ kind: 'geometry', selector: '.hero' }],
+            limitations_count: 0,
+            attribution_ref: 'visual-compare/simple-site/visual-attribution.json',
+          },
           artifacts: {
             source_screenshot: { status: 'captured', ref: { path: 'files/browser/visual-compare/source.png', kind: 'browser-visual-source-screenshot' } },
             imported_screenshot: { status: 'captured', ref: { path: 'files/browser/visual-compare/candidate.png', kind: 'browser-visual-candidate-screenshot' } },
@@ -5761,11 +5795,17 @@ test('visual parity evidence report summarizes staged output evidence and layout
   assert.equal(report.summary.screenshot_fixture_count, 1);
   assert.equal(report.summary.viewport_evidence_fixture_count, 1);
   assert.equal(report.summary.mobile_viewport_fixture_count, 0);
+  assert.equal(report.summary.visual_attribution_fixture_count, 1);
+  assert.equal(report.summary.limited_visual_attribution_fixture_count, 0);
   assert.equal(report.summary.missing_asset_fixture_count, 1);
   assert.equal(report.summary.core_html_fixture_count, 1);
   assert.equal(fixture.asset_resolution.missing_asset_count, 1);
   assert.equal(fixture.block_theme.native_conversion_rate, 0.8);
   assert.equal(fixture.block_theme.core_html_block_count, 1);
+  assert.equal(fixture.evidence.visual_attribution.status, 'available');
+  assert.equal(fixture.evidence.visual_attribution.geometry_delta_count, 1);
+  assert.equal(fixture.evidence.visual_attribution.attribution_ref, 'visual-compare/simple-site/visual-attribution.json');
+  assert.equal(report.surfaces[0].evidence.visual_attribution.selector_delta_count, 3);
   assert.ok(fixture.risk.reasons.includes('missing mobile viewport evidence'));
   assert.ok(fixture.risk.reasons.includes('1 missing asset signal(s)'));
   assert.ok(fixture.risk.reasons.includes('1 core/html block(s)'));


### PR DESCRIPTION
## Summary
- Retain WP Codebox visual diff, explanation, and source/candidate DOM sidecars under the fixture-matrix artifact root.
- Normalize retained sidecars through the active Homeboy WordPress extension and persist `visual-attribution.json`.
- Register rewritten artifact references and preserve explicit pixel-only limitations when attribution inputs or the normalizer are unavailable.

Fixes #637

## How to test
1. Install dependencies with `npm install`.
2. Run `npm run test:fixture-matrix`.
3. Run `npm test`.
4. Set `HOMEBOY_EXTENSION_PATH` to a Homeboy WordPress extension v3.24+ package root and run the fixture matrix; inspect each `visual-compare/<fixture>/visual-attribution.json` alongside its retained sidecars.

## Backward compatibility
- Older pixel-only WP Codebox output remains supported. It retains existing screenshot behavior and emits an explicit attribution limitation when visual-explanation or DOM-snapshot sidecars are absent.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Collaboratively implemented and tested the visual-attribution artifact integration; Chris remains responsible for the change.