### PR TITLE
Bump Homeboy Action to v2.8.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: Extra-Chill/homeboy-action@9474cf7db35bf1a34e5bc59b43a85cda5ec57188  # v2.8.9
+      - uses: Extra-Chill/homeboy-action@5608026212ba9ff854243fdc167c02d280dfe6b5  # v2.8.13
         with:
           commands: review test
           args: --extension wordpress


### PR DESCRIPTION
## Summary

Pins the Static Site Importer test workflow to Homeboy Action v2.8.13 (`5608026212ba9ff854243fdc167c02d280dfe6b5`). This release detects the installed Homeboy placement contract and uses `--placement local` with Homeboy 0.284.0 while retaining legacy flag compatibility for older binaries.

Fixes #639.

Upstream fix: https://github.com/Extra-Chill/homeboy-action/pull/278

## How to test

1. Check out this branch from a fresh repository clone.
2. Run `npm ci`.
3. Run `composer install --no-interaction --prefer-dist`.
4. Run `npm test`.
5. Confirm 163 fixture-matrix tests, 3 fig-fixture-e2e tests, and 3 solved-fixture promotion tests pass.
6. Inspect `.github/workflows/test.yml` and confirm the action is pinned to `5608026212ba9ff854243fdc167c02d280dfe6b5` with the `v2.8.13` comment.
7. Confirm the GitHub Actions PHP 8.1-8.4 matrix reaches repository tests instead of exiting on the removed `--force-hot` flag.

## Backwards compatibility

No Static Site Importer runtime, API, persisted data, or extension behavior changes. This only updates the immutable CI action pin. Homeboy Action v2.8.13 retains compatibility with both current placement-aware Homeboy binaries and older binaries using the legacy hot-runner flags.

## Verification

- `npm test`: passed on Homeboy Lab
- `git diff --check origin/main...HEAD`: passed
- CI expected: Homeboy Test on PHP 8.1, 8.2, 8.3, and 8.4

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-terra
- **Used for:** Updated the immutable action pin, verified repository tests, and prepared the pull request; Chris reviews and owns the change.
