### PR TITLE
fix: load visual attribution normalizer module directly

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -812,7 +812,13 @@ export function resolveWordPressVisualAttributionNormalizer({ normalizer, loader
       if (!extensionPath) {
         return null;
       }
-      extension = require(path.resolve(extensionPath));
+      const resolvedExtensionPath = path.resolve(extensionPath);
+      const normalizerModulePath = path.join(resolvedExtensionPath, 'lib', 'wordpress-visual-attribution.js');
+      // Dev overlays include this self-contained module without the extension's
+      // unrelated package-root dependencies.
+      extension = fs.existsSync(normalizerModulePath)
+        ? require(normalizerModulePath)
+        : require(resolvedExtensionPath);
     }
     return typeof extension?.normalizeWordPressVisualAttribution === 'function'
       ? extension.normalizeWordPressVisualAttribution

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -22,6 +22,7 @@ import runFixtureMatrixBench, {
   mapWithConcurrency,
   materializeVisualCompareArtifacts,
   materializeEditorCanvasArtifacts,
+  resolveWordPressVisualAttributionNormalizer,
   resolveBlocksEnginePhpTransformerPath,
   runFixtureMatrix,
   validateHydratedComposerDependencies,
@@ -5051,6 +5052,30 @@ test('visual-compare attribution degrades explicitly when sidecars or the extens
   assert.ok(attribution.limitations.some((message) => message.includes('DOM snapshot')));
   assert.equal(persisted.result.fixtures[0].visual_parity_artifacts.visual_attribution_summary.status, 'limited');
   assert.equal(persisted.result.fixtures[0].visual_parity_artifacts.visual_attribution_summary.limitations_count, 3);
+});
+
+test('visual attribution normalizer loads its direct module before package-root fallback', () => {
+  const directModuleRoot = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-direct-'));
+  const directModulePath = path.join(directModuleRoot, 'lib', 'wordpress-visual-attribution.js');
+  mkdirSync(path.dirname(directModulePath), { recursive: true });
+  writeFileSync(path.join(directModuleRoot, 'index.js'), "throw new Error('package root must not load');\n");
+  writeFileSync(directModulePath, 'module.exports.normalizeWordPressVisualAttribution = () => ({ source: \'direct\' });\n');
+
+  const packageFallbackRoot = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-fallback-'));
+  writeFileSync(path.join(packageFallbackRoot, 'index.js'), 'module.exports.normalizeWordPressVisualAttribution = () => ({ source: \'package-root\' });\n');
+
+  const invalidDirectModuleRoot = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-invalid-direct-'));
+  const invalidDirectModulePath = path.join(invalidDirectModuleRoot, 'lib', 'wordpress-visual-attribution.js');
+  mkdirSync(path.dirname(invalidDirectModulePath), { recursive: true });
+  writeFileSync(path.join(invalidDirectModuleRoot, 'index.js'), 'module.exports.normalizeWordPressVisualAttribution = () => ({ source: \'package-root\' });\n');
+  writeFileSync(invalidDirectModulePath, 'module.exports = {};\n');
+
+  const missingModuleRoot = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-missing-'));
+
+  assert.equal(resolveWordPressVisualAttributionNormalizer({ homeboyExtensionPath: directModuleRoot })().source, 'direct');
+  assert.equal(resolveWordPressVisualAttributionNormalizer({ homeboyExtensionPath: packageFallbackRoot })().source, 'package-root');
+  assert.equal(resolveWordPressVisualAttributionNormalizer({ homeboyExtensionPath: invalidDirectModuleRoot }), null);
+  assert.equal(resolveWordPressVisualAttributionNormalizer({ homeboyExtensionPath: missingModuleRoot }), null);
 });
 
 test('visual-compare dimension mismatch gates even with zero pixel metrics when gating is on', () => {


### PR DESCRIPTION
## Summary
- Load `lib/wordpress-visual-attribution.js` directly from `HOMEBOY_EXTENSION_PATH` when present, avoiding unrelated package-root initialization in isolated development overlays.
- Retain package-root resolution only when the direct normalizer module is absent.
- Preserve limited-attribution degradation when the direct module has an invalid contract or no usable module is available.

Fixes #641

## How to test
1. Install dependencies with `npm install`.
2. Run `npm test`.
3. Run `node --check bench/static-site-fixture-matrix.bench.mjs && node --check tools/fixture-matrix.test.mjs && git diff --check`.

## Backward compatibility
- Existing full Homeboy WordPress extension package roots remain supported through the package-root fallback when the direct normalizer module is absent. Invalid or missing normalizers continue to emit explicit limited-attribution output.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Collaboratively implemented and tested the normalizer module resolution change; Chris remains responsible for the change.