### PR TITLE
Migrate fixture matrix to placement routing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: Extra-Chill/homeboy-action@5608026212ba9ff854243fdc167c02d280dfe6b5  # v2.8.13
+      - uses: Extra-Chill/homeboy-action@31e95050206332c4ebd36894387c980c99443ecf  # v2.8.15
         with:
           commands: review test
           args: --extension wordpress

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -511,16 +511,16 @@ offers native capture-freeze controls.
 The wrapper has three execution modes. Use `--dry-run` with any mode to inspect
 the composed Homeboy commands before running the matrix.
 
-### Local Hot Execution
+### Local Placement
 
-`homeboy bench` auto-offloads to a connected default Lab runner whenever one is
-configured — even with no `--runner` flag. The offload translates
-component/checkout paths into the remote workspace but forwards
+`homeboy bench` receives typed placement explicitly. To run the matrix on this
+machine against local checkouts, a local fixture root, and a local WP Codebox,
+pass `--local` to `tools/run-fixture-matrix.mjs`. The wrapper passes
+`--placement local` to the bench command. Local setup commands remain local
+because `homeboy rig install` and `homeboy rig sync` do not support placement.
+Lab execution translates component/checkout paths into the remote workspace but forwards
 `--shared-state`/`--artifact-root` verbatim, so local-only paths fail on the
-runner (`Permission denied`). To run the matrix on this machine against local
-checkouts, a local fixture root, and a local WP Codebox, pass `--local` to
-`tools/run-fixture-matrix.mjs` (it injects `--force-hot --allow-local-hot` into
-every routed Homeboy step):
+runner (`Permission denied`).
 
 ```
 node tools/run-fixture-matrix.mjs \
@@ -531,9 +531,9 @@ node tools/run-fixture-matrix.mjs \
   --wp-codebox-bin <wp-codebox>/packages/cli/dist/index.js
 ```
 
-`--runner local` is accepted as an alias for `--local` because Homeboy's `local`
-runner is not a Lab offload target. The wrapper maps it to the same hot-local
-command plan and does not pass `--runner local` through to Homeboy.
+`--runner local` is accepted as an alias for `--local`. The wrapper maps it to
+the same `--placement local` bench plan and does not pass `--runner local`
+through to Homeboy.
 
 ### Lab Offload
 
@@ -546,24 +546,30 @@ node tools/run-fixture-matrix.mjs \
   --blocks-engine <blocks-engine-checkout>
 ```
 
-This passes `--runner homeboy-lab` to Homeboy and does not inject
-`--force-hot --allow-local-hot`, so Homeboy can hand the bench to the connected
-runner. Use `--lab-only` without `--local` when any Lab runner is acceptable and a
-local fallback should be treated as a failure.
+This passes `--placement lab --runner homeboy-lab` to Homeboy. Use `--lab-only`
+without `--local` when any Lab runner is acceptable; it passes `--placement lab`
+without a named runner.
+
+Use `--allow-local-fallback` when a Lab preference may fall back to the local
+machine. The wrapper passes `--placement lab-or-local` (and preserves a named
+`--runner` when supplied).
 
 ### Default / Auto Routing
 
-With no `--local`, `--runner`, or `--lab-only`, the wrapper leaves routing to
-`homeboy bench`. In environments with a connected default Lab runner this may
-offload automatically. If you need deterministic local execution, pass `--local`;
-if you need deterministic Lab execution, pass `--runner <id>` or `--lab-only`.
+With no `--local`, `--runner`, `--lab-only`, or `--allow-local-fallback`, the wrapper passes
+`--placement auto` to `homeboy bench`. Homeboy selects the execution location
+from its command contract, controller pressure, and ready Lab capacity. If you
+need deterministic local execution, pass `--local`; if you need deterministic
+Lab execution, pass `--runner <id>` or `--lab-only`.
 
 Mutual-exclusion rules:
 
 - `--local` cannot be combined with `--runner <remote>`.
 - `--local` cannot be combined with `--lab-only`.
-- Pick exactly one explicit target for deterministic runs: local-hot (`--local`)
-  or Lab offload (`--runner homeboy-lab` / `--lab-only`).
+- `--allow-local-fallback` selects `lab-or-local` placement and cannot be
+  combined with `--local` or `--lab-only`.
+- Pick exactly one explicit target for deterministic runs: local (`--local`) or
+  Lab (`--runner homeboy-lab` / `--lab-only`).
 
 Notes:
 - The `editor-validate-blocks` step (#1597) requires a wp-codebox build that

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2193,22 +2193,46 @@ test('fixture matrix operator rejects contradictory local and Lab routing', () =
     runner: 'homeboy-lab',
     staticSiteImporter,
     fixtureRoot,
-  }), /--local forces hot execution on this machine and cannot be combined with --runner homeboy-lab/);
+  }), /--local selects local placement and cannot be combined with --runner homeboy-lab/);
 
   assert.throws(() => buildFixtureMatrixRunPlan({
     local: true,
     labOnly: true,
     staticSiteImporter,
     fixtureRoot,
-  }), /--local forces hot execution on this machine and cannot be combined with --lab-only/);
+  }), /--local selects local placement and cannot be combined with --lab-only/);
+
+  assert.throws(() => buildFixtureMatrixRunPlan({
+    local: true,
+    allowLocalFallback: true,
+    staticSiteImporter,
+    fixtureRoot,
+  }), /--allow-local-fallback selects lab-or-local placement and cannot be combined with --local/);
+
+  assert.throws(() => buildFixtureMatrixRunPlan({
+    labOnly: true,
+    allowLocalFallback: true,
+    staticSiteImporter,
+    fixtureRoot,
+  }), /--allow-local-fallback selects lab-or-local placement and cannot be combined with --lab-only/);
 });
 
-test('fixture matrix operator composes legible local-hot and Lab offload routing', () => {
+test('fixture matrix operator composes typed placement only for the bench step', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-routing-plan-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
   const fixtureRoot = path.join(root, 'fixtures');
   mkdirSync(staticSiteImporter, { recursive: true });
   mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+
+  const setupPlan = buildFixtureMatrixRunPlan({
+    runner: 'homeboy-lab',
+    staticSiteImporter,
+    fixtureRoot,
+  });
+  assert.deepEqual(setupPlan.steps.slice(0, -1).map((step) => step.args), [
+    ['rig', 'install', path.dirname(path.dirname(fileURLToPath(import.meta.url))), '--id', 'static-site-importer-fixture-matrix', '--reinstall'],
+    ['rig', 'sync', 'static-site-importer-fixture-matrix'],
+  ]);
 
   const labPlan = buildFixtureMatrixRunPlan({
     runner: 'homeboy-lab',
@@ -2218,14 +2242,12 @@ test('fixture matrix operator composes legible local-hot and Lab offload routing
     skipSync: true,
   });
   const labArgs = labPlan.steps.at(-1).args;
-  assert.equal(labPlan.execution_target, 'lab-offload:homeboy-lab');
+  assert.equal(labPlan.execution_target, 'lab:homeboy-lab');
+  assert.equal(labPlan.placement, 'lab');
   assert.equal(labPlan.shared_state, '');
   assert.equal(labPlan.artifact_root, '');
-  assert.match(labPlan.steps.at(-1).label, /lab-offload:homeboy-lab/);
-  assert.ok(labArgs.includes('--runner'));
-  assert.ok(labArgs.includes('homeboy-lab'));
-  assert.equal(labArgs.includes('--force-hot'), false);
-  assert.equal(labArgs.includes('--allow-local-hot'), false);
+  assert.match(labPlan.steps.at(-1).label, /lab:homeboy-lab/);
+  assert.deepEqual(labArgs.slice(-4), ['--placement', 'lab', '--runner', 'homeboy-lab']);
   assert.equal(labArgs.includes('--shared-state'), false);
   assert.equal(labArgs.includes('--artifact-root'), false);
 
@@ -2252,10 +2274,10 @@ test('fixture matrix operator composes legible local-hot and Lab offload routing
     skipSync: true,
   });
   const localArgs = localPlan.steps.at(-1).args;
-  assert.equal(localPlan.execution_target, 'local-hot');
-  assert.match(localPlan.steps.at(-1).label, /local-hot/);
-  assert.ok(localArgs.includes('--force-hot'));
-  assert.ok(localArgs.includes('--allow-local-hot'));
+  assert.equal(localPlan.execution_target, 'local');
+  assert.equal(localPlan.placement, 'local');
+  assert.match(localPlan.steps.at(-1).label, /local/);
+  assert.deepEqual(localArgs.slice(-2), ['--placement', 'local']);
   assert.equal(localArgs.includes('--runner'), false);
 
   const runnerLocalPlan = buildFixtureMatrixRunPlan({
@@ -2266,12 +2288,52 @@ test('fixture matrix operator composes legible local-hot and Lab offload routing
     skipSync: true,
   });
   const runnerLocalArgs = runnerLocalPlan.steps.at(-1).args;
-  assert.equal(runnerLocalPlan.execution_target, 'local-hot');
+  assert.equal(runnerLocalPlan.execution_target, 'local');
   assert.equal(runnerLocalPlan.runner, '');
   assert.equal(runnerLocalPlan.local, true);
-  assert.ok(runnerLocalArgs.includes('--force-hot'));
-  assert.ok(runnerLocalArgs.includes('--allow-local-hot'));
+  assert.deepEqual(runnerLocalArgs.slice(-2), ['--placement', 'local']);
   assert.equal(runnerLocalArgs.includes('--runner'), false);
+
+  const labOnlyPlan = buildFixtureMatrixRunPlan({
+    labOnly: true,
+    staticSiteImporter,
+    fixtureRoot,
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(labOnlyPlan.execution_target, 'lab');
+  assert.deepEqual(labOnlyPlan.steps.at(-1).args.slice(-2), ['--placement', 'lab']);
+
+  const fallbackPlan = buildFixtureMatrixRunPlan({
+    runner: 'homeboy-lab',
+    allowLocalFallback: true,
+    staticSiteImporter,
+    fixtureRoot,
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(fallbackPlan.execution_target, 'lab-or-local:homeboy-lab');
+  assert.deepEqual(fallbackPlan.steps.at(-1).args.slice(-4), ['--placement', 'lab-or-local', '--runner', 'homeboy-lab']);
+
+  const unnamedFallbackPlan = buildFixtureMatrixRunPlan({
+    allowLocalFallback: true,
+    staticSiteImporter,
+    fixtureRoot,
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(unnamedFallbackPlan.execution_target, 'lab-or-local');
+  assert.deepEqual(unnamedFallbackPlan.steps.at(-1).args.slice(-2), ['--placement', 'lab-or-local']);
+  assert.ok(!unnamedFallbackPlan.warnings.some((warning) => warning.code === 'lab_auto_offload_risk'));
+
+  const autoPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot,
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(autoPlan.execution_target, 'auto');
+  assert.deepEqual(autoPlan.steps.at(-1).args.slice(-2), ['--placement', 'auto']);
 });
 
 test('fixture matrix operator plan forwards complexity lane settings', () => {
@@ -2810,10 +2872,9 @@ test('fixture matrix dry-run plan surfaces local fallback and dirty workspace wa
 
   assert.equal(plan.namespace, 'proof-run-1');
   assert.equal(plan.temp_root, '/tmp/static-site-importer-fixture-matrix-proof-run-1');
-  // The single-fixture temp corpus drifts from the canonical pin, so the plan
-  // surfaces a non-silent drift warning alongside the routing warnings.
+  // Explicit fallback resolves to lab-or-local rather than auto; the
+  // single-fixture temp corpus also surfaces a non-silent drift warning.
   assert.deepEqual(plan.warnings.map((warning) => warning.code), [
-    'lab_auto_offload_risk',
     'local_fallback_allowed',
     'dirty_lab_workspace_allowed',
     'canonical_fixture_count_drift',
@@ -2825,7 +2886,7 @@ test('fixture matrix dry-run plan surfaces local fallback and dirty workspace wa
   );
 });
 
-test('--local forces hot local execution and suppresses the auto-offload-risk warning', () => {
+test('--local selects typed local placement and suppresses the auto-placement warning', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-local-plan-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
   const localFixtureRoot = path.join(root, 'fixtures');
@@ -2840,17 +2901,15 @@ test('--local forces hot local execution and suppresses the auto-offload-risk wa
     skipSync: true,
   });
 
-  // The auto-offload risk warning is gone; the forced-local note replaces it.
+  // The auto-placement warning is gone; the local-placement note replaces it.
   const codes = plan.warnings.map((warning) => warning.code);
   assert.ok(!codes.includes('lab_auto_offload_risk'));
   assert.ok(codes.includes('forced_local_execution'));
   assert.equal(plan.local, true);
 
-  // The bench step carries --force-hot --allow-local-hot so homeboy bench stays
-  // local instead of offloading local-only paths to a connected Lab runner.
+  // The bench step carries typed local placement so local-only paths stay local.
   const benchStep = plan.steps.at(-1);
-  assert.ok(benchStep.args.includes('--force-hot'));
-  assert.ok(benchStep.args.includes('--allow-local-hot'));
+  assert.deepEqual(benchStep.args.slice(-2), ['--placement', 'local']);
 });
 
 test('operator summary preserves matrix rollups for fanout agents', () => {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -148,6 +148,7 @@ export function buildFixtureMatrixRunPlan(input) {
     schema: 'static-site-importer/fixture-matrix-operator-run/v1',
     mode: options.mode,
     execution_target: options.executionTarget,
+    placement: options.placement,
     rig: RIG_ID,
     runner: options.runner,
     local: Boolean(options.local),
@@ -283,25 +284,36 @@ function normalizeExecutionTarget(input) {
   const labOnly = Boolean(input.labOnly);
 
   if (local && runner) {
-    throw new Error(`--local forces hot execution on this machine and cannot be combined with --runner ${runner}. Use --local for local-hot execution, or use --runner ${runner} without --local for Lab offload.`);
+    throw new Error(`--local selects local placement and cannot be combined with --runner ${runner}. Use --local for this machine, or use --runner ${runner} without --local for Lab placement.`);
   }
   if (local && labOnly) {
-    throw new Error('--local forces hot execution on this machine and cannot be combined with --lab-only. Use --local for local-hot execution, or use --lab-only/--runner without --local for Lab offload.');
+    throw new Error('--local selects local placement and cannot be combined with --lab-only. Use --local for this machine, or use --lab-only/--runner for Lab placement.');
+  }
+  if (local && input.allowLocalFallback) {
+    throw new Error('--allow-local-fallback selects lab-or-local placement and cannot be combined with --local. Use one placement selector.');
+  }
+  if (labOnly && input.allowLocalFallback) {
+    throw new Error('--allow-local-fallback selects lab-or-local placement and cannot be combined with --lab-only. Use one placement selector.');
   }
 
+  let placement = 'auto';
   let executionTarget = 'auto';
   if (local) {
-    executionTarget = 'local-hot';
-  } else if (runner) {
-    executionTarget = `lab-offload:${runner}`;
+    placement = 'local';
+    executionTarget = 'local';
   } else if (labOnly) {
-    executionTarget = 'lab-offload:auto';
+    placement = 'lab';
+    executionTarget = 'lab';
+  } else if (runner || input.allowLocalFallback) {
+    placement = input.allowLocalFallback ? 'lab-or-local' : 'lab';
+    executionTarget = runner ? `${placement}:${runner}` : placement;
   }
 
   return {
     runner,
     local,
     labOnly,
+    placement,
     executionTarget,
   };
 }
@@ -312,18 +324,18 @@ function defaultTempRoot(namespace) {
 
 function buildWarnings(options) {
   return [
-    ...(!options.runner && !options.labOnly && !options.local ? [{
+    ...(options.placement === 'auto' ? [{
       code: 'lab_auto_offload_risk',
-      message: 'No --runner/--lab-only/--local routing was provided. `homeboy bench` may auto-offload to a connected default Lab runner. Default --shared-state/--artifact-root paths are omitted unless --local or explicit path overrides are provided.',
+      message: 'No --runner/--lab-only/--local routing was provided. The bench uses Homeboy typed auto placement, which may select a connected Lab runner. Default --shared-state/--artifact-root paths are omitted unless --local or explicit path overrides are provided.',
     }] : []),
     ...labLocalTempPathWarnings(options),
     ...(options.local ? [{
       code: 'forced_local_execution',
-      message: '--local forces hot local execution (--force-hot --allow-local-hot); the bench will not offload to a Lab runner even if one is connected.',
+      message: '--local passes --placement local to the bench, so Homeboy runs it on this machine.',
     }] : []),
-    ...(options.allowLocalFallback ? [{
+    ...(options.placement === 'lab-or-local' ? [{
       code: 'local_fallback_allowed',
-      message: '--allow-local-fallback permits Lab routing to fall back to local execution if the runner allows it.',
+      message: '--allow-local-fallback maps the bench to --placement lab-or-local.',
     }] : []),
     ...(options.allowDirtyLabWorkspace ? [{
       code: 'dirty_lab_workspace_allowed',
@@ -561,14 +573,14 @@ function buildSteps(options, settings) {
     steps.push({
       label: `Refresh installed SSI fixture matrix rig (${options.executionTarget})`,
       command: options.homeboyBin,
-      args: withCommonRouting(['rig', 'install', packageRoot, '--id', RIG_ID, '--reinstall'], options),
+      args: ['rig', 'install', packageRoot, '--id', RIG_ID, '--reinstall'],
     });
   }
   if (!options.skipSync) {
     steps.push({
       label: `Sync/materialize rig components (${options.executionTarget})`,
       command: options.homeboyBin,
-      args: withCommonRouting(['rig', 'sync', RIG_ID], options),
+      args: ['rig', 'sync', RIG_ID],
     });
   }
 
@@ -590,7 +602,7 @@ function buildSteps(options, settings) {
   if (options.artifactRoot) {
     benchArgs.push('--artifact-root', options.artifactRoot);
   }
-  const routedBenchArgs = withCommonRouting(benchArgs, options);
+  const routedBenchArgs = withBenchRouting(benchArgs, options);
   if (options.passthrough.length > 0) {
     routedBenchArgs.push('--', ...options.passthrough);
   }
@@ -603,28 +615,11 @@ function buildSteps(options, settings) {
   return steps;
 }
 
-function withCommonRouting(args, options) {
+function withBenchRouting(args, options) {
   const routed = [...args];
-  // Force local (hot) execution. `homeboy bench` auto-offloads to a default Lab
-  // runner whenever one is connected, even with no --runner flag. The offload
-  // translates component/checkout paths into the remote workspace but passes
-  // --shared-state / --artifact-root through verbatim, so a local absolute path
-  // (e.g. /private/tmp/... or /Users/...) fails on the Linux runner with
-  // "Permission denied" / "No such file". --force-hot --allow-local-hot together
-  // keep the run on this machine so the local checkouts, fixture root, and
-  // shared-state/artifact-root paths all resolve. This is the only way to run
-  // the matrix against local-only paths and a local WP Codebox.
-  if (options.local) {
-    routed.push('--force-hot', '--allow-local-hot');
-  }
+  routed.push('--placement', options.placement);
   if (options.runner) {
     routed.push('--runner', options.runner);
-  }
-  if (options.labOnly) {
-    routed.push('--lab-only');
-  }
-  if (options.allowLocalFallback) {
-    routed.push('--allow-local-fallback');
   }
   if (options.detachAfterHandoff) {
     routed.push('--detach-after-handoff');
@@ -862,7 +857,7 @@ function sanitizePathSegment(value) {
 }
 
 function printHelp() {
-  process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Local hot execution on this machine. Injects --force-hot --allow-local-hot into routed Homeboy steps.\n  --runner <id>                       Lab offload to a Homeboy runner, for example homeboy-lab. Does not inject hot-local flags.\n  --lab-only                          Require Lab routing, using Homeboy's selected/default Lab runner.\n  no routing flags                    Auto mode; lets homeboy bench decide routing.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote> or --lab-only. Pick local-hot or Lab offload.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n    --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures, which discovers both fixtures/websites and fixtures/solved.
+  process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Passes --placement local to homeboy bench.\n  --runner <id>                       Passes --placement lab --runner <id> to homeboy bench.\n  --lab-only                          Passes --placement lab without selecting a runner.\n  --allow-local-fallback              Passes --placement lab-or-local to homeboy bench.\n  no routing flags                    Passes --placement auto to homeboy bench.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote>, --lab-only, or --allow-local-fallback.\n  --lab-only cannot be combined with --allow-local-fallback.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n    --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures, which discovers both fixtures/websites and fixtures/solved.
 \n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 4, hard-capped at 16.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind upstream.\n  --allow-local-fallback              Permit selected Lab runner fallback to local execution.\n  --allow-dirty-lab-workspace         Permit reusing/overwriting a dirty Lab workspace.\n  --detach-after-handoff              Return after runner daemon accepts the job.\n  --dry-run                           Print the plan without running Homeboy.\n  --skip-install                      Skip rig install.\n  --skip-sync                         Skip rig sync.\n  --no-editor-validation              Omit editor block validation.\n  --no-visual-parity                  Omit visual parity capture.\n  --no-visual-parity-gate             Capture visual parity without gating.\n  --help                              Show this help.\n`);
 }
 


### PR DESCRIPTION
Closes #646.

## Summary

- replace retired `--force-hot --allow-local-hot` routing with Homeboy's typed placement contract
- keep `rig install` and `rig sync` free of unsupported execution-routing flags
- define exact local, Lab, auto, and Lab-with-local-fallback plans
- reject contradictory fallback selections instead of silently applying precedence
- update Homeboy Action to `v2.8.15`, which supports scoped placement after Extra-Chill/homeboy-action#281

Homeboy PR Extra-Chill/homeboy#7998 retired the legacy flags in favor of `--placement local|lab|auto|lab-or-local`. SSI PR #562 predated that migration, leaving the fixture-matrix wrapper unable to start on current Homeboy.

## How to test

1. Check out this branch on a fresh clone.
2. Run `npm run test:fixture-matrix`.
3. Confirm all 164 fixture-matrix tests pass.
4. Run `node tools/run-fixture-matrix.mjs --static-site-importer "$PWD" --blocks-engine /path/to/blocks-engine --local --dry-run --skip-install --skip-sync`.
5. Confirm the generated bench step ends in `--placement local` and contains neither retired flag.
6. Repeat the dry run with `--runner homeboy-lab` and confirm the bench step ends in `--placement lab --runner homeboy-lab` while setup steps contain no placement or runner flags.

## Validation

- `npm run test:fixture-matrix` passed: 164/164.
- Local dry-run plan emitted `--placement local`.
- Node syntax checks passed.
- `git diff --check` passed.
- Initial CI exposed the stale `v2.8.13` Action pin invoking removed global hot flags; the branch now uses the released upstream repair in `v2.8.15`.

## Compatibility

This removes support for Homeboy's retired hot-local flags from the wrapper's generated commands. Wrapper CLI aliases remain available: `--local`, `--runner local`, `--runner <id>`, `--lab-only`, and `--allow-local-fallback` now map to the current placement contract. No extension paths change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode
- **Used for:** Tracing the Homeboy routing migration, implementing the wrapper/test/documentation update, and reviewing placement edge cases. Chris Huber reviewed and remains responsible for the change.
