### PR TITLE
Configure fixture visual attribution depth

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -21,6 +21,7 @@ import {
   normalizeFixtureMatrixResult,
   writeFixtureMatrixArtifacts,
   writeFixtureMatrixResultArtifacts,
+  normalizeVisualAttributionOptions,
 } from '../lib/fixture-matrix.mjs';
 
 const DEFAULT_BATCH_SIZE = 10;
@@ -299,6 +300,7 @@ export async function runFixtureMatrix(options) {
       source_staging: written.metadata?.source_staging,
       surface_coverage: recipe.metadata?.surface_coverage,
       runtime_cost_warnings: recipe.metadata?.runtime_cost_warnings || [],
+      visual_attribution: normalizeVisualAttributionOptions(options),
     },
     ...(runtime?.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
     result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
@@ -1253,7 +1255,7 @@ function parseArgs(args) {
   return options;
 }
 
-function optionsFromEnv(env = process.env) {
+export function optionsFromEnv(env = process.env) {
   const benchEnv = settingsBenchEnv(env);
   return {
     fixtureRoot: benchEnv.SSI_FIXTURE_MATRIX_FIXTURE_ROOT || env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT,
@@ -1298,6 +1300,9 @@ function optionsFromEnv(env = process.env) {
     visualParitySourceBaseUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL,
     visualParityWaitFor: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_WAIT_FOR || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_WAIT_FOR,
     visualParityDurationMs: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_DURATION_MS || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_DURATION_MS,
+    maxExplanationElements: benchEnv.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS || env.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS,
+    maxExplanationCandidates: benchEnv.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES || env.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES,
+    explainSelectors: benchEnv.SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS || env.SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS,
     minNativeRate: benchEnv.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE || env.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE,
   };
 }
@@ -1330,6 +1335,7 @@ function visualParityRecipeInput(options) {
     visualParityFullPage: options.visualParityFullPage,
     visualParityWaitFor: options.visualParityWaitFor,
     visualParityDurationMs: options.visualParityDurationMs,
+    ...normalizeVisualAttributionOptions(options),
   };
 }
 

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -492,6 +492,17 @@ alignment scorer uses `SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD`
 the mismatch-ratio gate threshold. Set `--no-visual-parity` /
 `visualParity: false` to omit the step entirely.
 
+Visual-attribution depth is opt-in and uses WP Codebox's public matrix fields.
+Pass `--max-explanation-elements <n>`, `--max-explanation-candidates <n>`, and
+`--explain-selectors <selector[,selector...]>` through the operator wrapper, or
+set `SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS`,
+`SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES`, and
+`SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS` for direct bench runs. Positive integer
+limits and trimmed, de-duplicated selector lists are forwarded to every visual
+comparison as `maxExplanationElements`, `maxExplanationCandidates`, and
+`explainSelectors`. Leaving them unset preserves WP Codebox's defaults and the
+existing recipe JSON.
+
 Source/candidate wiring (verified by real local recipe-runs): the
 `wordpress.visual-compare` step renders and pixel-diffs locally in WP Codebox
 against the real two pages. `writeFixtureMatrixArtifacts` stages each fixture's

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -53,7 +53,10 @@ export {
 
 export { editorBlockValidationStep } from './fixture-matrix/steps/editor-validation-step.mjs';
 
-export { visualParityCompareStep } from './fixture-matrix/steps/visual-parity-step.mjs';
+export {
+  visualParityCompareStep,
+  normalizeVisualAttributionOptions,
+} from './fixture-matrix/steps/visual-parity-step.mjs';
 
 export {
   liveWpParityCaptureStep,

--- a/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -70,6 +70,9 @@ export function visualParityCompareStep(input = {}) {
         durationMs: options.duration,
         blockExternalRequests: options.blockExternalRequests,
         threshold: options.pixelThreshold,
+        ...(options.maxExplanationElements ? { maxExplanationElements: options.maxExplanationElements } : {}),
+        ...(options.maxExplanationCandidates ? { maxExplanationCandidates: options.maxExplanationCandidates } : {}),
+        ...(options.explainSelectors.length ? { explainSelectors: options.explainSelectors } : {}),
       },
     ],
   };
@@ -102,7 +105,28 @@ export function normalizeVisualParityRecipeOptions(input = {}) {
     waitFor: input.visualParityWaitFor || input.visual_parity_wait_for || input.waitFor || DEFAULT_VISUAL_PARITY_WAIT_FOR,
     duration: normalizeDuration(input.visualParityDurationMs ?? input.visual_parity_duration_ms ?? input.durationMs ?? input.duration_ms ?? input.duration, DEFAULT_VISUAL_PARITY_SETTLE_DURATION_MS),
     blockExternalRequests: !isFalseySignal(input.visualParityBlockExternalRequests ?? input.visual_parity_block_external_requests ?? input.blockExternalRequests ?? input.block_external_requests),
+    ...normalizeVisualAttributionOptions(input),
   };
+}
+
+// These optional WP Codebox fields retain its bounded defaults when omitted,
+// preserving the existing matrix-json output byte-for-byte.
+export function normalizeVisualAttributionOptions(input = {}) {
+  return {
+    maxExplanationElements: positiveInteger(input.maxExplanationElements ?? input.max_explanation_elements),
+    maxExplanationCandidates: positiveInteger(input.maxExplanationCandidates ?? input.max_explanation_candidates),
+    explainSelectors: normalizeSelectorList(input.explainSelectors ?? input.explain_selectors),
+  };
+}
+
+function positiveInteger(value) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function normalizeSelectorList(value) {
+  const values = Array.isArray(value) ? value : typeof value === 'string' ? value.split(',') : [];
+  return [...new Set(values.map((selector) => String(selector || '').trim()).filter(Boolean))];
 }
 
 function normalizeDuration(value, fallbackMs) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -22,6 +22,7 @@ import runFixtureMatrixBench, {
   mapWithConcurrency,
   materializeVisualCompareArtifacts,
   materializeEditorCanvasArtifacts,
+  optionsFromEnv,
   resolveWordPressVisualAttributionNormalizer,
   resolveBlocksEnginePhpTransformerPath,
   runFixtureMatrix,
@@ -73,6 +74,7 @@ import {
   VISUAL_PARITY_DETERMINISTIC_CSS,
   VISUAL_PARITY_MISMATCH_KIND,
   visualParityCompareStep,
+  normalizeVisualAttributionOptions,
   wordpressServedPath,
   writeFixtureMatrixArtifacts,
 } from '../lib/fixture-matrix.mjs';
@@ -4712,6 +4714,110 @@ test('visualParityCompareStep composes the existing wordpress.visual-compare com
   assert.equal(comparison.sourceLabel, 'shop-source');
   assert.equal(comparison.candidateLabel, 'shop-candidate');
   assert.equal(comparison.fullPage, true);
+});
+
+test('visual attribution options normalize positive limits and targeted selector lists', () => {
+  assert.deepEqual(normalizeVisualAttributionOptions({
+    maxExplanationElements: '500',
+    max_explanation_candidates: 600,
+    explainSelectors: [' .hero ', '.hero', '', '#footer'],
+  }), {
+    maxExplanationElements: 500,
+    maxExplanationCandidates: 600,
+    explainSelectors: ['.hero', '#footer'],
+  });
+  assert.deepEqual(normalizeVisualAttributionOptions({
+    maxExplanationElements: '0',
+    maxExplanationCandidates: '1.5',
+    explainSelectors: ' .hero, #footer, .hero ',
+  }), {
+    maxExplanationElements: undefined,
+    maxExplanationCandidates: undefined,
+    explainSelectors: ['.hero', '#footer'],
+  });
+});
+
+test('visual attribution defaults leave visual-compare matrix JSON byte-compatible', () => {
+  const step = visualParityCompareStep({ fixture: { id: 'shop' } });
+  assert.equal(step.args[0], 'matrix-json={"comparisons":[{"name":"shop","sourceUrl":"/wp-content/uploads/static-site-importer-fixture-matrix/shop/source/index.html","candidateUrl":"/","sourceLabel":"shop-source","candidateLabel":"shop-candidate","viewport":"1280x1600","fullPage":true,"waitFor":"duration","durationMs":"4000ms","blockExternalRequests":true,"threshold":0}]}');
+});
+
+test('visual attribution options reach every fixture matrix comparison', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-recipe-'));
+  const fixtureDirectory = path.join(root, 'fixture');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'index.html'), '<h1>Home</h1>');
+  writeFileSync(path.join(fixtureDirectory, 'contact.html'), '<h1>Contact</h1>');
+  const recipe = buildFixtureMatrixRecipe({
+    matrix: createFixtureMatrix({ fixture_root: root }),
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    surfaceCoverage: 1,
+    maxExplanationElements: 500,
+    maxExplanationCandidates: 600,
+    explainSelectors: '.hero, #footer',
+  });
+  const comparisons = recipe.workflow.steps
+    .filter((step) => step.command === 'wordpress.visual-compare')
+    .map(visualCompareMatrixComparison);
+  assert.equal(comparisons.length, 2);
+  for (const comparison of comparisons) {
+    assert.equal(comparison.maxExplanationElements, 500);
+    assert.equal(comparison.maxExplanationCandidates, 600);
+    assert.deepEqual(comparison.explainSelectors, ['.hero', '#footer']);
+  }
+});
+
+test('fixture matrix maps visual attribution environment settings', () => {
+  const options = optionsFromEnv({
+    SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS: '500',
+    SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES: '600',
+    SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS: '.hero, #footer',
+  });
+  assert.equal(options.maxExplanationElements, '500');
+  assert.equal(options.maxExplanationCandidates, '600');
+  assert.equal(options.explainSelectors, '.hero, #footer');
+});
+
+test('fixture matrix operator plan exposes and forwards visual attribution settings', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-plan-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'fixture'), { recursive: true });
+  const plan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot,
+    maxExplanationElements: '500',
+    maxExplanationCandidates: '600',
+    explainSelectors: '.hero, #footer',
+  });
+  assert.deepEqual(plan.visual_attribution, {
+    max_explanation_elements: 500,
+    max_explanation_candidates: 600,
+    explain_selectors: ['.hero', '#footer'],
+  });
+  const args = plan.steps.at(-1).args;
+  assert.ok(args.includes('bench_env.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS=500'));
+  assert.ok(args.includes('bench_env.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES=600'));
+  assert.ok(args.includes('bench_env.SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS=.hero,#footer'));
+});
+
+test('fixture matrix evidence records effective visual attribution settings', async () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-evidence-'));
+  const { summary } = await runFixtureMatrix({
+    fixtureRoot,
+    outputDirectory,
+    staticSiteImporterPath: packageRoot,
+    maxExplanationElements: 500,
+    maxExplanationCandidates: 600,
+    explainSelectors: '.hero, #footer',
+  });
+  assert.deepEqual(summary.metadata.visual_attribution, {
+    maxExplanationElements: 500,
+    maxExplanationCandidates: 600,
+    explainSelectors: ['.hero', '#footer'],
+  });
 });
 
 test('visualParityCompareStep requests full-page capture by default with explicit opt-out', () => {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 /**
  * Internal dependencies
  */
-import { MAX_EXTRA_SURFACE_COUNT, normalizeSurfaceCoverageOptions } from '../lib/fixture-matrix.mjs';
+import { MAX_EXTRA_SURFACE_COUNT, normalizeSurfaceCoverageOptions, normalizeVisualAttributionOptions } from '../lib/fixture-matrix.mjs';
 
 export const RIG_ID = 'static-site-importer-fixture-matrix';
 // Expected top-level fixture directory count in the canonical corpus
@@ -113,6 +113,9 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.visualParityMaxHorizontalShift ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT: String(options.visualParityMaxHorizontalShift) } : {}),
     ...(options.visualParityOffsetTolerance ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE: String(options.visualParityOffsetTolerance) } : {}),
     ...(options.visualParityPixelmatchThreshold ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD: String(options.visualParityPixelmatchThreshold) } : {}),
+    ...(options.maxExplanationElements ? { SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS: String(options.maxExplanationElements) } : {}),
+    ...(options.maxExplanationCandidates ? { SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES: String(options.maxExplanationCandidates) } : {}),
+    ...(options.explainSelectors.length ? { SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS: options.explainSelectors.join(',') } : {}),
     ...(options.surfaceCoverage ? { SSI_FIXTURE_MATRIX_SURFACE_COVERAGE: String(options.surfaceCoverage) } : {}),
     ...(options.maxExtraSurfaces ? { SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES: String(options.maxExtraSurfaces) } : {}),
     // Opt-in live-WP parity capture (off by default). When set, the bench appends
@@ -180,6 +183,11 @@ export function buildFixtureMatrixRunPlan(input) {
       max_horizontal_shift: options.visualParityMaxHorizontalShift ? Number(options.visualParityMaxHorizontalShift) : 0,
       offset_tolerance: options.visualParityOffsetTolerance ? Number(options.visualParityOffsetTolerance) : 2,
       pixelmatch_threshold: options.visualParityPixelmatchThreshold ? Number(options.visualParityPixelmatchThreshold) : 0.1,
+    },
+    visual_attribution: {
+      max_explanation_elements: options.maxExplanationElements ?? null,
+      max_explanation_candidates: options.maxExplanationCandidates ?? null,
+      explain_selectors: options.explainSelectors,
     },
     editor_quality: {
       // Editor-quality metrics (native_conversion_rate, core_html_fallback_ratio,
@@ -274,6 +282,7 @@ function normalizeOptions(input) {
     sharedStateExplicit,
     artifactRootExplicit,
     homeboyBin: input.homeboyBin || process.env.HOMEBOY_BIN || 'homeboy',
+    ...normalizeVisualAttributionOptions(input),
   };
 }
 
@@ -860,6 +869,13 @@ function sanitizePathSegment(value) {
 function printHelp() {
   process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Passes --placement local to homeboy bench.\n  --runner <id>                       Passes --placement lab --runner <id> to homeboy bench.\n  --lab-only                          Passes --placement lab without selecting a runner.\n  --allow-local-fallback              Passes --placement lab-or-local to homeboy bench.\n  no routing flags                    Passes --placement auto to homeboy bench.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote>, --lab-only, or --allow-local-fallback.\n  --lab-only cannot be combined with --allow-local-fallback.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n    --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures, which discovers both fixtures/websites and fixtures/solved.
 \n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 4, hard-capped at 16.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind upstream.\n  --allow-local-fallback              Permit selected Lab runner fallback to local execution.\n  --allow-dirty-lab-workspace         Permit reusing/overwriting a dirty Lab workspace.\n  --detach-after-handoff              Return after runner daemon accepts the job.\n  --dry-run                           Print the plan without running Homeboy.\n  --skip-install                      Skip rig install.\n  --skip-sync                         Skip rig sync.\n  --no-editor-validation              Omit editor block validation.\n  --no-visual-parity                  Omit visual parity capture.\n  --no-visual-parity-gate             Capture visual parity without gating.\n  --help                              Show this help.\n`);
+  printVisualAttributionHelp();
+}
+
+// Visual attribution controls are separate so the main usage text remains
+// readable alongside the long routing contract above.
+function printVisualAttributionHelp() {
+  process.stdout.write('  --max-explanation-elements <n>      Maximum source elements for visual attribution.\n  --max-explanation-candidates <n>    Maximum candidate elements for visual attribution.\n  --explain-selectors <list>          Comma-separated selectors targeted for visual attribution.\n');
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## Summary
- expose fixture-matrix options and environment settings for visual explanation depth and targeted selectors
- pass `maxExplanationElements`, `maxExplanationCandidates`, and `explainSelectors` through every WP Codebox matrix comparison
- preserve byte-compatible recipes when settings are absent
- report effective attribution settings in operator plans and run evidence

Closes #649

## How to test
1. Check out this branch in a fresh clone.
2. Run `npm ci` and `composer install --no-interaction`.
3. Run `npm test`.
4. Run the fixture-matrix wrapper with `--max-explanation-elements 100 --max-explanation-candidates 500 --explain-selectors "#pricing,#final-cta"`.
5. Inspect the generated `matrix-json` and confirm all three configured fields are present in each visual comparison.
6. Rerun without those options and confirm the generated recipe remains unchanged from the default contract.

## Verification
- 172 fixture-matrix tests pass
- 3 Figma fixture E2E tests pass
- 3 solved-promotion tests pass
- `git diff --check` passes

## Backwards compatibility
Additive operator/recipe contract. Existing default recipes remain byte-compatible when the new settings are absent.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Implemented and reviewed option normalization, matrix propagation, evidence, documentation, tests, and PR.