### PR TITLE
Preserve skip links while deduplicating template headers

### DIFF
--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -166,17 +166,19 @@ class Static_Site_Importer_Page_Materializer {
 		$footer_count = 0;
 		$matched_header_part = '';
 		$matched_footer_part = '';
+		$header_candidate_start = 0;
+		while ( $header_candidate_start < count( $top_level ) && self::is_accessibility_prelude_block( $top_level[ $header_candidate_start ] ) ) {
+			$header_candidate_start++;
+		}
 
 		foreach ( $header_parts as $part ) {
 			$part_blocks = $part['blocks'];
 			$count       = count( $part_blocks );
-			for ( $start = 0; $count > 0 && $start <= count( $top_level ) - $count; $start++ ) {
-				if ( self::block_sequence_matches( array_slice( $top_level, $start, $count ), $part_blocks ) ) {
-					$header_start         = $start;
-					$header_count         = $count;
-					$matched_header_part = $part['path'];
-					break 2;
-				}
+			if ( $count > 0 && $header_candidate_start <= count( $top_level ) - $count && self::block_sequence_matches( array_slice( $top_level, $header_candidate_start, $count ), $part_blocks ) ) {
+				$header_start         = $header_candidate_start;
+				$header_count         = $count;
+				$matched_header_part = $part['path'];
+				break;
 			}
 		}
 
@@ -283,6 +285,25 @@ class Static_Site_Importer_Page_Materializer {
 		}
 
 		return $blocks;
+	}
+
+	/**
+	 * Check whether a top-level block is a same-page skip link.
+	 *
+	 * @param array{normalized:string} $block Top-level serialized block.
+	 * @return bool
+	 */
+	private static function is_accessibility_prelude_block( array $block ): bool {
+		if ( ! preg_match( '/<a\b[^>]*>/i', $block['normalized'], $matches ) ) {
+			return false;
+		}
+
+		$anchor = $matches[0];
+		if ( ! preg_match( '/\bclass\s*=\s*(["\'])(.*?)\1/is', $anchor, $class_matches ) || ! preg_match( '/(?:^|\s)skip-link(?:\s|$)/i', $class_matches[2] ) ) {
+			return false;
+		}
+
+		return 1 === preg_match( '/\bhref\s*=\s*(["\'])#.*?\1/is', $anchor );
 	}
 
 	/**

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -160,53 +160,70 @@ class Static_Site_Importer_Page_Materializer {
 
 		$header_parts = self::template_part_write_sequences( $template_part_writes, 'header' );
 		$footer_parts = self::template_part_write_sequences( $template_part_writes, 'footer' );
-		$remove_start = 0;
-		$remove_end   = count( $top_level );
+		$header_start = null;
+		$footer_start = null;
+		$header_count = 0;
+		$footer_count = 0;
 		$matched_header_part = '';
 		$matched_footer_part = '';
 
 		foreach ( $header_parts as $part ) {
 			$part_blocks = $part['blocks'];
-			$count = count( $part_blocks );
-			if ( $count > 0 && self::block_sequence_matches( array_slice( $top_level, 0, $count ), $part_blocks ) ) {
-				$remove_start = max( $remove_start, $count );
-				$matched_header_part = $part['path'];
-				break;
+			$count       = count( $part_blocks );
+			for ( $start = 0; $count > 0 && $start <= count( $top_level ) - $count; $start++ ) {
+				if ( self::block_sequence_matches( array_slice( $top_level, $start, $count ), $part_blocks ) ) {
+					$header_start         = $start;
+					$header_count         = $count;
+					$matched_header_part = $part['path'];
+					break 2;
+				}
 			}
 		}
 
 		foreach ( $footer_parts as $part ) {
 			$part_blocks = $part['blocks'];
 			$count = count( $part_blocks );
-			if ( $count > 0 && $remove_start <= count( $top_level ) - $count && self::block_sequence_matches( array_slice( $top_level, -$count ), $part_blocks ) ) {
-				$remove_end = min( $remove_end, count( $top_level ) - $count );
+			$start = count( $top_level ) - $count;
+			if ( $count > 0 && ( null === $header_start || $header_start + $header_count <= $start ) && self::block_sequence_matches( array_slice( $top_level, -$count ), $part_blocks ) ) {
+				$footer_start = $start;
+				$footer_count = $count;
 				$matched_footer_part = $part['path'];
 				break;
 			}
 		}
 
-		if ( 0 === $remove_start && count( $top_level ) === $remove_end ) {
+		if ( null === $header_start && null === $footer_start ) {
 			return $content;
 		}
 
-		$start_offset = $remove_start > 0 ? $top_level[ $remove_start - 1 ]['end'] : 0;
-		$end_offset   = $remove_end < count( $top_level ) ? $top_level[ $remove_end ]['start'] : strlen( $content );
-		$deduped      = trim( substr( $content, $start_offset, $end_offset - $start_offset ) );
+		$removals     = array();
+		if ( null !== $header_start ) {
+			$removals[] = array( 'start' => $top_level[ $header_start ]['start'], 'end' => $top_level[ $header_start + $header_count - 1 ]['end'] );
+		}
+		if ( null !== $footer_start ) {
+			$removals[] = array( 'start' => $top_level[ $footer_start ]['start'], 'end' => $top_level[ $footer_start + $footer_count - 1 ]['end'] );
+		}
+
+		$deduped = $content;
+		foreach ( array_reverse( $removals ) as $removal ) {
+			$deduped = substr( $deduped, 0, $removal['start'] ) . substr( $deduped, $removal['end'] );
+		}
+		$deduped = trim( $deduped );
 
 		$diagnostics[] = array(
 			'type'                         => 'template_part_shell_deduped',
 			'source'                       => 'static-site-importer/page-materializer',
 			'source_path'                  => $source_path,
 			'reason'                       => 'matching_header_footer_template_parts',
-			'removed_header_blocks'        => $remove_start,
-			'removed_footer_blocks'        => count( $top_level ) - $remove_end,
+			'removed_header_blocks'        => $header_count,
+			'removed_footer_blocks'        => $footer_count,
 			'matched_header_template_part' => $matched_header_part,
 			'matched_footer_template_part' => $matched_footer_part,
 			'preserved_local_header_count' => self::html_tag_count( $deduped, 'header' ),
 			'preserved_local_footer_count' => self::html_tag_count( $deduped, 'footer' ),
 			'removed'                      => array(
-				'leading_blocks'  => $remove_start,
-				'trailing_blocks' => count( $top_level ) - $remove_end,
+				'leading_blocks'  => $header_count,
+				'trailing_blocks' => $footer_count,
 			),
 			'message'                      => 'Page body blocks matching generated header/footer template parts were removed to avoid duplicate global shell rendering.',
 		);

--- a/tests/smoke-template-part-shell-dedupe.php
+++ b/tests/smoke-template-part-shell-dedupe.php
@@ -121,6 +121,27 @@ $assert( ! str_contains( $skip_link_content, 'Global Header' ), 'skip-link-follo
 $assert( ! str_contains( $skip_link_content, 'Global Footer' ), 'skip-link-page-footer-removed' );
 $assert( str_contains( $skip_link_content, 'Article body remains.' ), 'skip-link-page-body-preserved' );
 
+$body_header_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'body-header.html',
+		'title'        => 'Body Header',
+		'block_markup' => $body . "\n" . $header . "\n" . $footer,
+	)
+);
+
+$body_header_artifacts = $body_header_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'body-header.html' => $body_header_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$template_part_writes
+) : array();
+$body_header_content   = (string) ( $body_header_artifacts['contents']['body-header.html'] ?? '' );
+
+$assert( str_contains( $body_header_content, 'Article body remains.' ), 'body-before-identical-header-preserved' );
+$assert( str_contains( $body_header_content, 'Global Header' ), 'identical-header-after-body-preserved' );
+$assert( ! str_contains( $body_header_content, 'Global Footer' ), 'body-header-page-footer-removed' );
+
 $local_shell_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
 	array(
 		'source_path'  => 'local-shell.html',

--- a/tests/smoke-template-part-shell-dedupe.php
+++ b/tests/smoke-template-part-shell-dedupe.php
@@ -62,6 +62,7 @@ $footer = '<!-- wp:group {"tagName":"footer","className":"site-footer"} --><foot
 $body   = '<!-- wp:paragraph --><p>Article body remains.</p><!-- /wp:paragraph -->';
 $article_header = '<!-- wp:group {"tagName":"header","className":"article-header"} --><header class="wp-block-group article-header"><h2>Article Header</h2></header><!-- /wp:group -->';
 $article_footer = '<!-- wp:group {"tagName":"footer","className":"article-footer"} --><footer class="wp-block-group article-footer"><p>Article Footer</p></footer><!-- /wp:group -->';
+$skip_link = '<!-- wp:html --><a class="skip-link" href="#main">Skip to content</a><!-- /wp:html -->';
 
 $page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
 	array(
@@ -97,6 +98,28 @@ $assert( 'parts/header.html' === ( $artifacts['diagnostics'][0]['matched_header_
 $assert( 'parts/footer.html' === ( $artifacts['diagnostics'][0]['matched_footer_template_part'] ?? '' ), 'diagnostic-footer-template-part-match' );
 $assert( 0 === ( $artifacts['diagnostics'][0]['preserved_local_header_count'] ?? -1 ), 'diagnostic-no-local-header-after-global-dedupe' );
 $assert( 0 === ( $artifacts['diagnostics'][0]['preserved_local_footer_count'] ?? -1 ), 'diagnostic-no-local-footer-after-global-dedupe' );
+
+$skip_link_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'skip-link.html',
+		'title'        => 'Skip Link',
+		'block_markup' => $skip_link . "\n" . $header . "\n" . $body . "\n" . $footer,
+	)
+);
+
+$skip_link_artifacts = $skip_link_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'skip-link.html' => $skip_link_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$template_part_writes
+) : array();
+$skip_link_content   = (string) ( $skip_link_artifacts['contents']['skip-link.html'] ?? '' );
+
+$assert( str_contains( $skip_link_content, 'Skip to content' ), 'skip-link-preserved-before-global-header' );
+$assert( ! str_contains( $skip_link_content, 'Global Header' ), 'skip-link-followed-global-header-removed' );
+$assert( ! str_contains( $skip_link_content, 'Global Footer' ), 'skip-link-page-footer-removed' );
+$assert( str_contains( $skip_link_content, 'Article body remains.' ), 'skip-link-page-body-preserved' );
 
 $local_shell_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
 	array(
@@ -142,6 +165,27 @@ $local_content   = (string) ( $local_artifacts['contents']['article.html'] ?? ''
 $assert( str_contains( $local_content, 'Article Header' ), 'article-local-header-preserved' );
 $assert( str_contains( $local_content, 'Article Footer' ), 'article-local-footer-preserved' );
 $assert( array() === ( $local_artifacts['diagnostics'] ?? array() ), 'article-local-no-dedupe-diagnostic' );
+
+$nonmatching_prelude_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'nonmatching-prelude.html',
+		'title'        => 'Nonmatching Prelude',
+		'block_markup' => $skip_link . "\n" . $article_header . "\n" . $body . "\n" . $footer,
+	)
+);
+
+$nonmatching_prelude_artifacts = $nonmatching_prelude_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'nonmatching-prelude.html' => $nonmatching_prelude_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$template_part_writes
+) : array();
+$nonmatching_prelude_content   = (string) ( $nonmatching_prelude_artifacts['contents']['nonmatching-prelude.html'] ?? '' );
+
+$assert( str_contains( $nonmatching_prelude_content, 'Skip to content' ), 'nonmatching-prelude-preserved' );
+$assert( str_contains( $nonmatching_prelude_content, 'Article Header' ), 'nonmatching-header-preserved' );
+$assert( ! str_contains( $nonmatching_prelude_content, 'Global Footer' ), 'nonmatching-prelude-footer-removed' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- preserve contiguous leading same-page `.skip-link` blocks while removing a following page header that exactly matches the generated global header template part
- keep shell deduplication bounded to offset zero or that accessibility prelude, so matching headers after body content remain local page content
- add regression coverage for skip-link preservation, global shell removal, nonmatching headers, local headers/footers, and diagnostic counts

Fixes the duplicate global header found in the `72-why-wordpress` representative fixture under #489.

## How to test
1. Run `php tests/smoke-template-part-shell-dedupe.php`.
2. Confirm it reports `PASS smoke-template-part-shell-dedupe.php (31 assertions)`.
3. Run `php tests/smoke-template-chrome-dedupe.php`.
4. Confirm it reports `OK: 7 assertions`.

## Compatibility
This changes only the private page-materialization shell dedupe behavior. There is no public API or extension-path compatibility impact. Pages with an exact generated-header match after ordinary body content continue to preserve that local header.

## Evidence
- Tracking issue and representative-fixture context: https://github.com/Automattic/static-site-importer/issues/489
- Candidate commit: `7f76933ef002d195ee1cc5bf21069e0f40b1c972`
- Homeboy deterministic gate: `php tests/smoke-template-chrome-dedupe.php` passed with 7 assertions
- CI-equivalent coverage is provided by this PR's GitHub Actions matrix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the representative fixture, drafted the implementation and regression coverage, and ran deterministic verification; Chris reviews and owns the change.