### PR TITLE
Fix fixture matrix runner routing

### DIFF
--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2293,6 +2293,13 @@ test('fixture matrix operator rejects contradictory local and Lab routing', () =
     staticSiteImporter,
     fixtureRoot,
   }), /--allow-local-fallback selects lab-or-local placement and cannot be combined with --lab-only/);
+
+  assert.throws(() => buildFixtureMatrixRunPlan({
+    runner: 'homeboy-lab',
+    allowLocalFallback: true,
+    staticSiteImporter,
+    fixtureRoot,
+  }), /--allow-local-fallback selects unpinned lab-or-local placement and cannot be combined with --runner homeboy-lab/);
 });
 
 test('fixture matrix operator composes typed placement only for the bench step', () => {
@@ -2325,7 +2332,7 @@ test('fixture matrix operator composes typed placement only for the bench step',
   assert.equal(labPlan.shared_state, '');
   assert.equal(labPlan.artifact_root, '');
   assert.match(labPlan.steps.at(-1).label, /lab:homeboy-lab/);
-  assert.deepEqual(labArgs.slice(-4), ['--placement', 'lab', '--runner', 'homeboy-lab']);
+  assert.deepEqual(labArgs.slice(-2), ['--runner', 'homeboy-lab']);
   assert.equal(labArgs.includes('--shared-state'), false);
   assert.equal(labArgs.includes('--artifact-root'), false);
 
@@ -2382,17 +2389,6 @@ test('fixture matrix operator composes typed placement only for the bench step',
   assert.equal(labOnlyPlan.execution_target, 'lab');
   assert.deepEqual(labOnlyPlan.steps.at(-1).args.slice(-2), ['--placement', 'lab']);
 
-  const fallbackPlan = buildFixtureMatrixRunPlan({
-    runner: 'homeboy-lab',
-    allowLocalFallback: true,
-    staticSiteImporter,
-    fixtureRoot,
-    skipInstall: true,
-    skipSync: true,
-  });
-  assert.equal(fallbackPlan.execution_target, 'lab-or-local:homeboy-lab');
-  assert.deepEqual(fallbackPlan.steps.at(-1).args.slice(-4), ['--placement', 'lab-or-local', '--runner', 'homeboy-lab']);
-
   const unnamedFallbackPlan = buildFixtureMatrixRunPlan({
     allowLocalFallback: true,
     staticSiteImporter,
@@ -2412,6 +2408,35 @@ test('fixture matrix operator composes typed placement only for the bench step',
   });
   assert.equal(autoPlan.execution_target, 'auto');
   assert.deepEqual(autoPlan.steps.at(-1).args.slice(-2), ['--placement', 'auto']);
+});
+
+test('fixture matrix operator projects exact Homeboy arguments for every routing mode', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-routing-projection-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+
+  const cases = [
+    ['auto', {}, ['--placement', 'auto']],
+    ['explicit runner', { runner: 'homeboy-lab' }, ['--runner', 'homeboy-lab']],
+    ['local', { local: true }, ['--placement', 'local']],
+    ['runner local alias', { runner: 'local' }, ['--placement', 'local']],
+    ['lab only', { labOnly: true }, ['--placement', 'lab']],
+    ['local fallback', { allowLocalFallback: true }, ['--placement', 'lab-or-local']],
+  ];
+
+  for (const [name, routing, expected] of cases) {
+    const args = buildFixtureMatrixRunPlan({
+      ...routing,
+      staticSiteImporter,
+      fixtureRoot,
+      skipInstall: true,
+      skipSync: true,
+    }).steps.at(-1).args;
+    const start = args.findIndex((arg) => arg === '--placement' || arg === '--runner');
+    assert.deepEqual(args.slice(start), expected, name);
+  }
 });
 
 test('fixture matrix operator plan forwards complexity lane settings', () => {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -304,6 +304,9 @@ function normalizeExecutionTarget(input) {
   if (labOnly && input.allowLocalFallback) {
     throw new Error('--allow-local-fallback selects lab-or-local placement and cannot be combined with --lab-only. Use one placement selector.');
   }
+  if (runner && input.allowLocalFallback) {
+    throw new Error(`--allow-local-fallback selects unpinned lab-or-local placement and cannot be combined with --runner ${runner}. Use one routing selector.`);
+  }
 
   let placement = 'auto';
   let executionTarget = 'auto';
@@ -626,7 +629,9 @@ function buildSteps(options, settings) {
 
 function withBenchRouting(args, options) {
   const routed = [...args];
-  routed.push('--placement', options.placement);
+  if (!(options.runner && options.placement === 'lab')) {
+    routed.push('--placement', options.placement);
+  }
   if (options.runner) {
     routed.push('--runner', options.runner);
   }
@@ -867,7 +872,7 @@ function sanitizePathSegment(value) {
 }
 
 function printHelp() {
-  process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Passes --placement local to homeboy bench.\n  --runner <id>                       Passes --placement lab --runner <id> to homeboy bench.\n  --lab-only                          Passes --placement lab without selecting a runner.\n  --allow-local-fallback              Passes --placement lab-or-local to homeboy bench.\n  no routing flags                    Passes --placement auto to homeboy bench.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote>, --lab-only, or --allow-local-fallback.\n  --lab-only cannot be combined with --allow-local-fallback.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n    --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures, which discovers both fixtures/websites and fixtures/solved.
+  process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Passes --placement local to homeboy bench.\n  --runner <id>                       Passes --runner <id> to homeboy bench (implies Lab placement).\n  --lab-only                          Passes --placement lab without selecting a runner.\n  --allow-local-fallback              Passes --placement lab-or-local to homeboy bench.\n  no routing flags                    Passes --placement auto to homeboy bench.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote>, --lab-only, or --allow-local-fallback.\n  --lab-only cannot be combined with --allow-local-fallback.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n    --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures, which discovers both fixtures/websites and fixtures/solved.
 \n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 4, hard-capped at 16.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind upstream.\n  --allow-local-fallback              Permit selected Lab runner fallback to local execution.\n  --allow-dirty-lab-workspace         Permit reusing/overwriting a dirty Lab workspace.\n  --detach-after-handoff              Return after runner daemon accepts the job.\n  --dry-run                           Print the plan without running Homeboy.\n  --skip-install                      Skip rig install.\n  --skip-sync                         Skip rig sync.\n  --no-editor-validation              Omit editor block validation.\n  --no-visual-parity                  Omit visual parity capture.\n  --no-visual-parity-gate             Capture visual parity without gating.\n  --help                              Show this help.\n`);
   printVisualAttributionHelp();
 }


### PR DESCRIPTION
## Summary

- emit only `--runner <id>` for explicit runner routing because Homeboy now infers Lab placement
- preserve standalone local, Lab-only, automatic fallback, and auto placement projections
- reject `--runner` combined with `--allow-local-fallback` because pinned runners and placement policy are mutually exclusive in Homeboy
- add exact argument-projection coverage for every valid routing mode

Closes #652.

## How to test

1. Run `npm run test:fixture-matrix`.
2. Confirm all 173 tests pass.
3. Run `node tools/run-fixture-matrix.mjs --runner homeboy-lab --skip-install --skip-sync --static-site-importer "$PWD" --fixture-root <fixture-root> --dry-run`.
4. Inspect the final bench step and confirm it contains `--runner homeboy-lab` without `--placement`.

## Compatibility

Explicit runner routing now follows Homeboy’s current mutually exclusive CLI contract. Callers combining `--runner` with `--allow-local-fallback` receive an actionable validation error instead of a downstream Homeboy argument conflict; unpinned `--allow-local-fallback` continues to emit `--placement lab-or-local`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Implemented the routing repair and deterministic argument-projection coverage; Chris reviewed and owns the change.