### PR TITLE
Materialize preserved runtime scripts

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -64,23 +64,23 @@ class Static_Site_Importer_Companion_Plugin {
 			);
 		}
 
-		$blocks = self::payload_blocks( $payload );
-		if ( empty( $blocks ) ) {
+		$blocks          = self::payload_blocks( $payload );
+		$plugin_slug     = 'ssi-' . $site_slug;
+		$block_namespace = $plugin_slug;
+		$preserved       = self::preserved_js( $payload, $block_namespace );
+		if ( empty( $blocks ) && empty( $preserved ) ) {
 			return new WP_Error(
-				'static_site_importer_companion_plugin_blocks_missing',
-				'Companion-plugin payload must declare at least one block with a name.'
+				'static_site_importer_companion_plugin_content_missing',
+				'Companion-plugin payload must declare at least one block or preserved script.'
 			);
 		}
 
-		$plugin_slug     = 'ssi-' . $site_slug;
-		$block_namespace = $plugin_slug;
 		$mu_plugin       = ! empty( $payload['mu_plugin'] );
 		$site_name       = self::site_name( $payload, $site_slug );
 
 		$files       = array();
 		$block_names = array();
 		$block_specs = array();
-		$preserved   = self::preserved_js( $payload, $block_namespace );
 
 		foreach ( $blocks as $block ) {
 			$built = self::build_block( $block, $block_namespace );
@@ -121,6 +121,15 @@ class Static_Site_Importer_Companion_Plugin {
 			// than theme-coupled.
 			'island_handles' => array_map(
 				static fn ( array $island ): string => (string) $island['handle'],
+				$preserved
+			),
+			'runtime_scripts' => array_map(
+				static fn ( array $island ): array => array(
+					'handle'      => (string) $island['handle'],
+					'block'       => (string) $island['block'],
+					'selector'    => (string) $island['selector'],
+					'source_path' => (string) $island['source_path'],
+				),
 				$preserved
 			),
 			'loader_file'    => '',
@@ -445,6 +454,8 @@ class Static_Site_Importer_Companion_Plugin {
 			$relative_raw = isset( $entry['src'] ) && is_scalar( $entry['src'] ) ? self::sanitize_relative_path( (string) $entry['src'] ) : '';
 			$relative     = '' !== $relative_raw ? $relative_raw : 'islands/' . $handle . '.js';
 			$block        = isset( $entry['block'] ) && is_scalar( $entry['block'] ) ? (string) $entry['block'] : '';
+			$selector     = isset( $entry['selector'] ) && is_scalar( $entry['selector'] ) ? (string) $entry['selector'] : '';
+			$source_path  = isset( $entry['source_path'] ) && is_scalar( $entry['source_path'] ) ? (string) $entry['source_path'] : '';
 
 			$islands[] = array(
 				'handle'       => $handle,
@@ -453,6 +464,8 @@ class Static_Site_Importer_Companion_Plugin {
 				// Scope: enqueue only when this block renders. Empty block means
 				// the island is unscoped, but slice 1 only emits scoped islands.
 				'block'        => $block,
+				'selector'     => $selector,
+				'source_path'  => $source_path,
 			);
 		}
 
@@ -590,6 +603,20 @@ class Static_Site_Importer_Companion_Plugin {
 		$lines[] = '}';
 		$lines[] = sprintf( "add_filter( 'render_block', '%s_enqueue_islands', 10, 2 );", $fn_prefix );
 		$lines[] = '';
+		$lines[] = '/** Enqueue preserved scripts that apply to the rendered frontend document. */';
+		$lines[] = sprintf( 'function %s_enqueue_global_islands() {', $fn_prefix );
+		$lines[] = "\tif ( ! function_exists( 'wp_enqueue_script' ) ) {";
+		$lines[] = "\t\treturn;";
+		$lines[] = "\t}";
+		$lines[] = sprintf( "\tforeach ( %s_islands() as \$island ) {", $fn_prefix );
+		$lines[] = "\t\tif ( '' !== ( \$island['block'] ?? '' ) || '' === ( \$island['src'] ?? '' ) ) {";
+		$lines[] = "\t\t\tcontinue;";
+		$lines[] = "\t\t}";
+		$lines[] = sprintf( "\t\twp_enqueue_script( \$island['handle'], %s_URL . \$island['src'], array(), '1.0.0', true );", strtoupper( $fn_prefix ) );
+		$lines[] = "\t}";
+		$lines[] = '}';
+		$lines[] = sprintf( "add_action( 'wp_enqueue_scripts', '%s_enqueue_global_islands' );", $fn_prefix );
+		$lines[] = '';
 
 		return implode( "\n", $lines );
 	}
@@ -639,10 +666,12 @@ class Static_Site_Importer_Companion_Plugin {
 		$rows = array();
 		foreach ( $preserved as $island ) {
 			$rows[] = sprintf(
-				"\t\tarray( 'handle' => '%s', 'src' => '%s', 'block' => '%s' ),",
+				"\t\tarray( 'handle' => '%s', 'src' => '%s', 'block' => '%s', 'selector' => '%s', 'source_path' => '%s' ),",
 				self::php_single_quote( $island['handle'] ),
 				self::php_single_quote( $island['relative_src'] ),
-				self::php_single_quote( $island['block'] )
+				self::php_single_quote( $island['block'] ),
+				self::php_single_quote( $island['selector'] ),
+				self::php_single_quote( $island['source_path'] )
 			);
 		}
 

--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -369,6 +369,7 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 
 		$block_names    = array();
 		$island_handles = array();
+		$runtime_scripts = array();
 		$payload        = isset( $dependency['payload'] ) && is_array( $dependency['payload'] ) ? $dependency['payload'] : array();
 		$scaffold       = empty( $payload ) ? null : Static_Site_Importer_Companion_Plugin::scaffold( $payload );
 		if ( is_array( $scaffold ) && isset( $scaffold['block_names'] ) && is_array( $scaffold['block_names'] ) ) {
@@ -376,6 +377,9 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 		}
 		if ( is_array( $scaffold ) && isset( $scaffold['island_handles'] ) && is_array( $scaffold['island_handles'] ) ) {
 			$island_handles = array_values( array_map( 'strval', $scaffold['island_handles'] ) );
+		}
+		if ( is_array( $scaffold ) && isset( $scaffold['runtime_scripts'] ) && is_array( $scaffold['runtime_scripts'] ) ) {
+			$runtime_scripts = array_values( $scaffold['runtime_scripts'] );
 		}
 
 		return array(
@@ -392,6 +396,7 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 			// scoped; lets the gate/diagnostics treat preserved island JS as
 			// companion-plugin-carried instead of theme-coupled.
 			'island_handles' => $island_handles,
+			'runtime_scripts' => $runtime_scripts,
 		);
 	}
 

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -466,6 +466,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	public static function finalize_quality_report( array &$report, array $args ): array {
 		$materialization_plan = isset( $report['blocks_engine']['materialization_plan'] ) && is_array( $report['blocks_engine']['materialization_plan'] ) ? $report['blocks_engine']['materialization_plan'] : array();
+		self::mark_active_companion_script_fallbacks_materialized( $report );
 		self::mark_materialized_script_fallbacks_carried( $report, $materialization_plan );
 		self::normalize_import_diagnostics( $report );
 
@@ -2878,6 +2879,27 @@ class Static_Site_Importer_Report_Diagnostics {
 
 		if ( ! empty( $resolved ) ) {
 			$report['quality']['fallback_count'] = max( 0, (int) ( $report['quality']['fallback_count'] ?? 0 ) - count( $resolved ) );
+		}
+	}
+
+	/**
+	 * Reconcile late-added fallback rows against active companion dependencies.
+	 *
+	 * @param array<string,mixed> $report Import report.
+	 * @return void
+	 */
+	private static function mark_active_companion_script_fallbacks_materialized( array &$report ): void {
+		$dependencies = $report['companion_plugins']['dependencies'] ?? array();
+		if ( ! is_array( $dependencies ) ) {
+			return;
+		}
+
+		foreach ( $dependencies as $slug => $dependency ) {
+			if ( ! is_array( $dependency ) || empty( $dependency['active'] ) ) {
+				continue;
+			}
+			$runtime_scripts = isset( $dependency['runtime_scripts'] ) && is_array( $dependency['runtime_scripts'] ) ? $dependency['runtime_scripts'] : array();
+			self::mark_companion_script_fallbacks_materialized( $report, $runtime_scripts, (string) $slug );
 		}
 	}
 

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -574,6 +574,8 @@ class Static_Site_Importer_Report_Diagnostics {
 
 		if ( ! empty( $row['active'] ) ) {
 			$island_handles = isset( $row['island_handles'] ) && is_array( $row['island_handles'] ) ? $row['island_handles'] : array();
+			$runtime_scripts = isset( $row['runtime_scripts'] ) && is_array( $row['runtime_scripts'] ) ? $row['runtime_scripts'] : array();
+			self::mark_companion_script_fallbacks_materialized( $report, $runtime_scripts, $slug );
 			$present        = array(
 				'code'           => 'companion_plugin_present',
 				'severity'       => 'info',
@@ -2822,6 +2824,61 @@ class Static_Site_Importer_Report_Diagnostics {
 			}
 		}
 		unset( $diagnostic );
+	}
+
+	/**
+	 * Resolve script fallback diagnostics after the generated companion plugin is active.
+	 *
+	 * @param array<string,mixed>            $report          Import report.
+	 * @param array<int,array<string,mixed>> $runtime_scripts Materialized companion scripts.
+	 * @param string                         $slug             Companion plugin slug.
+	 * @return void
+	 */
+	private static function mark_companion_script_fallbacks_materialized( array &$report, array $runtime_scripts, string $slug ): void {
+		$selectors = array();
+		foreach ( $runtime_scripts as $script ) {
+			if ( ! is_array( $script ) ) {
+				continue;
+			}
+			$selector = self::first_scalar( $script, array( 'selector' ) );
+			if ( '' !== $selector ) {
+				$selectors[ $selector ] = true;
+			}
+		}
+		if ( empty( $selectors ) || empty( $report['diagnostics'] ) || ! is_array( $report['diagnostics'] ) ) {
+			return;
+		}
+
+		$resolved = array();
+		foreach ( $report['diagnostics'] as &$diagnostic ) {
+			if ( ! is_array( $diagnostic ) || ! self::is_script_runtime_fallback_diagnostic( $diagnostic ) ) {
+				continue;
+			}
+			$selector = self::first_scalar( $diagnostic, array( 'selector' ) );
+			if ( '' === $selector || ! isset( $selectors[ $selector ] ) ) {
+				continue;
+			}
+
+			$diagnostic['original_code']                 = self::first_scalar( $diagnostic, array( 'code', 'diagnostic_code', 'kind', 'type' ) );
+			$diagnostic['code']                          = 'runtime_script_materialized';
+			$diagnostic['diagnostic_code']               = 'runtime_script_materialized';
+			$diagnostic['kind']                          = 'runtime_script_materialized';
+			$diagnostic['type']                          = 'runtime_script_materialized';
+			$diagnostic['severity']                      = 'info';
+			$diagnostic['loss_class']                    = Static_Site_Importer_Diagnostic_Loss_Classes::NATIVE_CONVERSION;
+			$diagnostic['diagnostic_class']              = Static_Site_Importer_Diagnostic_Loss_Classes::NATIVE_CONVERSION;
+			$diagnostic['repair_bucket']                 = Static_Site_Importer_Diagnostic_Loss_Classes::NATIVE_CONVERSION;
+			$diagnostic['runtime_carried']               = true;
+			$diagnostic['materialized_runtime_provider'] = 'companion_plugin';
+			$diagnostic['companion_plugin']              = $slug;
+			$diagnostic['message']                       = sprintf( 'Runtime script is materialized by active companion plugin %s.', $slug );
+			$resolved[ $selector ]                       = true;
+		}
+		unset( $diagnostic );
+
+		if ( ! empty( $resolved ) ) {
+			$report['quality']['fallback_count'] = max( 0, (int) ( $report['quality']['fallback_count'] ?? 0 ) - count( $resolved ) );
+		}
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -254,7 +254,7 @@ class Static_Site_Importer_Theme_Generator {
 
 		self::analyze_generated_theme_block_documents( $writes, $theme_dir );
 		self::$conversion_report['theme_slug'] = $theme_slug;
-		self::materialize_required_plugins( $args );
+		self::materialize_required_plugins( $args, $artifacts, $theme_slug, $theme_name );
 		self::record_product_seeding_report( $args );
 		self::record_commerce_dependency_check( $args );
 		self::record_form_materialization( $args, $page_artifacts['contents'] );
@@ -2969,10 +2969,13 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Materialize plugins required by detected source intent.
 	 *
-	 * @param array<string, mixed> $args Import args.
+	 * @param array<string, mixed> $args      Import args.
+	 * @param array<string, mixed> $artifacts Compiled artifact envelope.
+	 * @param string               $theme_slug Generated theme slug.
+	 * @param string               $theme_name Generated theme name.
 	 * @return void
 	 */
-	private static function materialize_required_plugins( array $args ): void {
+	private static function materialize_required_plugins( array $args, array $artifacts, string $theme_slug, string $theme_name ): void {
 		self::$conversion_report['plugin_materialization'] = array(
 			'status'  => 'skipped',
 			'plugins' => array(),
@@ -2986,16 +2989,34 @@ class Static_Site_Importer_Theme_Generator {
 			$adapters[] = Static_Site_Importer_Entity_Materializer_Registry::form_adapter();
 		}
 
-		if ( empty( $adapters ) ) {
+		$companion_payload = isset( $artifacts['companion_plugin_payload'] ) && is_array( $artifacts['companion_plugin_payload'] ) ? $artifacts['companion_plugin_payload'] : array();
+		if ( ! empty( $companion_payload ) ) {
+			$companion_payload['site_slug'] = '' !== (string) ( $companion_payload['site_slug'] ?? '' ) ? (string) $companion_payload['site_slug'] : $theme_slug;
+			$companion_payload['site_name'] = '' !== (string) ( $companion_payload['site_name'] ?? '' ) ? (string) $companion_payload['site_name'] : $theme_name;
+		}
+
+		if ( empty( $adapters ) && empty( $companion_payload ) ) {
 			self::$conversion_report['plugin_materialization']['reason'] = 'no_plugin_backed_intent';
 			return;
 		}
+		$reports = array();
 		if ( array_key_exists( 'materialize_dependencies', $args ) && false === (bool) $args['materialize_dependencies'] ) {
+			if ( ! empty( $companion_payload ) ) {
+				$dependency = Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_dependency( $companion_payload );
+				Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( self::$conversion_report, $dependency, false );
+			}
 			self::$conversion_report['plugin_materialization']['reason'] = 'dependency_materialization_disabled';
 			return;
 		}
 
-		$reports = array();
+		if ( ! empty( $companion_payload ) ) {
+			$dependency = Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_dependency( $companion_payload );
+			$slug       = (string) ( $dependency['slug'] ?? '' );
+			if ( '' !== $slug ) {
+				$reports[ $slug ] = Static_Site_Importer_Entity_Materializer_Registry::materialize_companion_dependency( $dependency );
+			}
+			Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( self::$conversion_report, $dependency, false );
+		}
 		foreach ( $adapters as $adapter ) {
 			$waiver_arg = (string) ( $adapter['waiver_arg'] ?? '' );
 			if ( '' !== $waiver_arg && ! empty( $args[ $waiver_arg ] ) ) {

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -99,6 +99,8 @@ class Static_Site_Importer_Transformer_Adapter {
 		$artifacts['compiled_site']     = ! empty( $view['compiled_site'] ) && is_array( $view['compiled_site'] ) ? $view['compiled_site'] : array();
 		$artifacts['template_parts']    = isset( $materialization_plan['template_parts'] ) && is_array( $materialization_plan['template_parts'] ) ? $materialization_plan['template_parts'] : array();
 		$artifacts['visual_repair']     = isset( $materialization_plan['visual_repair'] ) && is_array( $materialization_plan['visual_repair'] ) ? $materialization_plan['visual_repair'] : array();
+		$source_reports                 = isset( $result['source_reports'] ) && is_array( $result['source_reports'] ) ? $result['source_reports'] : array();
+		$artifacts['companion_plugin_payload'] = isset( $source_reports['companion_plugin_payload'] ) && is_array( $source_reports['companion_plugin_payload'] ) ? $source_reports['companion_plugin_payload'] : array();
 
 		$compiled['artifacts'] = $artifacts;
 

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -198,7 +198,7 @@ function collectFixtureDiagnostics(payload, options = {}) {
   if (invalidBlockCount > 0 && editorValidationDiagnostics.length === 0) {
     diagnostics.push({ kind: 'invalid_block_content', synthetic_summary: true, message: `${invalidBlockCount} invalid block${invalidBlockCount === 1 ? '' : 's'} reported by SSI validation.` });
   }
-  return dedupeDiagnostics(propagateAcceptedRuntimePreservation(diagnostics));
+  return dedupeDiagnostics(propagateAcceptedRuntimePreservation(suppressMaterializedScriptFallbackEchoes(diagnostics)));
 }
 
 function collectImportReportDiagnostics(payload) {
@@ -211,11 +211,40 @@ function collectImportReportDiagnostics(payload) {
     reports.push(objectValue(blocksEngine.conversion_report || blocksEngine.conversionReport));
   }
 
-  return reports.flatMap((report) => [
+  const diagnostics = reports.flatMap((report) => [
     ...normalizeArray(report.diagnostics),
     ...seedingReportDiagnostics(report, 'product_seeding', 'product_seeding_failed'),
     ...seedingReportDiagnostics(report, 'form_seeding', 'form_seeding_failed'),
   ]);
+  return suppressMaterializedScriptFallbackEchoes(diagnostics);
+}
+
+function suppressMaterializedScriptFallbackEchoes(diagnostics) {
+  const materializedScripts = new Set(diagnostics
+    .filter((diagnostic) => ['runtime_script_materialized'].includes(String(diagnostic?.code || diagnostic?.kind || diagnostic?.type || '')))
+    .map(scriptDiagnosticKey)
+    .filter(Boolean));
+
+  return diagnostics.filter((diagnostic) => !isRawScriptFallback(diagnostic) || !materializedScripts.has(scriptDiagnosticKey(diagnostic)));
+}
+
+function scriptDiagnosticKey(diagnostic) {
+  const row = objectValue(diagnostic);
+  const sourcePath = firstString([row.source_path, row.sourcePath, row.path, row.source]);
+  const selector = firstString([row.selector, row.runtime_target_selector, row.runtimeTargetSelector]);
+  return sourcePath && selector ? `${sourcePath}\u0000${selector}` : '';
+}
+
+function isRawScriptFallback(diagnostic) {
+  const row = objectValue(diagnostic);
+  return /html[_-]script[_-]fallback|script[_-]requires[_-]runtime/i.test([
+    row.code,
+    row.diagnostic_code,
+    row.kind,
+    row.type,
+    row.reason,
+    row.reason_code,
+  ].filter(Boolean).join(' '));
 }
 
 function seedingReportDiagnostics(report, key, kind) {

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -414,7 +414,10 @@ function normalizeMismatchRegions(values) {
 }
 
 function classifyVisualParityComparisonRegions(comparison, options = {}) {
-  const sourcePath = resolveVisualParityArtifactPath(comparison.source_screenshot, options.fixtureArtifactsDirectory);
+	if (comparison.mismatch_pixels === 0 && comparison.dimension_delta_pixels === 0) {
+		return null;
+	}
+	const sourcePath = resolveVisualParityArtifactPath(comparison.source_screenshot, options.fixtureArtifactsDirectory);
   const candidatePath = resolveVisualParityArtifactPath(comparison.candidate_screenshot, options.fixtureArtifactsDirectory);
   const diffPath = resolveVisualParityArtifactPath(comparison.diff_screenshot, options.fixtureArtifactsDirectory);
   if (!sourcePath || !candidatePath || !diffPath) {

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -202,6 +202,17 @@ $materialized = array_values( array_filter( $report['diagnostics'] ?? array(), s
 $assert( 1 === count( $materialized ), 'companion-materialization-resolves-script-fallback' );
 $assert( 'native_conversion' === ( $materialized[0]['loss_class'] ?? '' ), 'materialized-script-is-native-conversion-outcome' );
 $assert( 0 === ( $report['quality']['fallback_count'] ?? -1 ), 'materialized-script-no-longer-counts-as-fallback' );
+$report['diagnostics'][] = array(
+	'code'        => 'html_script_fallback',
+	'kind'        => 'html',
+	'tag'         => 'script',
+	'selector'    => 'script:nth-of-type(1)',
+	'source_path' => 'index.html',
+	'reason'      => 'script_requires_runtime',
+);
+Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $report, array() );
+$unresolved = array_filter( $report['diagnostics'], static fn ( array $d ): bool => 'html_script_fallback' === ( $d['code'] ?? '' ) );
+$assert( empty( $unresolved ), 'finalization-reconciles-late-script-fallback-rows' );
 $stored = $report['companion_plugins']['dependencies']['ssi-example-site']['island_handles'] ?? null;
 $assert( array( 'hero-island' ) === $stored, 'report-stores-companion-island-handles' );
 

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -97,6 +97,8 @@ $payload     = array(
 			'handle'  => 'hero-island',
 			'content' => $island_body,
 			'block'   => 'ssi-example-site/custom-hero',
+			'selector' => 'script:nth-of-type(1)',
+			'source_path' => 'index.html',
 		),
 	),
 );
@@ -108,6 +110,7 @@ $assert( is_array( $descriptor ), 'scaffold-returns-descriptor', is_array( $desc
 
 if ( is_array( $descriptor ) ) {
 	$assert( array( 'hero-island' ) === ( $descriptor['island_handles'] ?? null ), 'descriptor-exposes-island-handles' );
+	$assert( 'script:nth-of-type(1)' === ( $descriptor['runtime_scripts'][0]['selector'] ?? '' ), 'descriptor-exposes-runtime-selector' );
 
 	$files = $descriptor['files'];
 	$main  = $files['ssi-example-site/ssi-example-site.php'] ?? '';
@@ -122,6 +125,17 @@ if ( is_array( $descriptor ) ) {
 	);
 	$assert( 1 === count( $island_files ), 'companion-emits-one-island-js-file' );
 	$assert( in_array( $island_body, array_values( $island_files ), true ), 'companion-island-file-carries-js-body' );
+}
+
+$script_only = $payload;
+$script_only['blocks'] = array();
+$script_only['preserved_js'][0]['block'] = '';
+$script_only_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $script_only );
+$assert( is_array( $script_only_descriptor ), 'script-only-companion-is-supported' );
+if ( is_array( $script_only_descriptor ) ) {
+	$script_only_main = $script_only_descriptor['files']['ssi-example-site/ssi-example-site.php'] ?? '';
+	$assert( str_contains( $script_only_main, "add_action( 'wp_enqueue_scripts'" ), 'script-only-companion-enqueues-on-frontend' );
+	$assert( str_contains( $script_only_main, "'' !== ( \$island['block'] ?? '' )" ), 'global-enqueue-is-limited-to-unscoped-scripts' );
 }
 
 // 2. Theme decoupling: the generated theme functions.php no longer enqueues a
@@ -170,11 +184,24 @@ $assert( array( 'hero-island' ) === ( $row['island_handles'] ?? null ), 'depende
 // Active companion: present diagnostic flags JS as runtime-carried theme-independently.
 $GLOBALS['ssi_companion_js_active'] = true;
 $report                            = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+$report['quality']['fallback_count'] = 1;
+$report['diagnostics'][] = array(
+	'code'       => 'html_script_fallback',
+	'kind'       => 'unsupported_html_fallback',
+	'type'       => 'unsupported_html_fallback',
+	'tag'        => 'script',
+	'selector'   => 'script:nth-of-type(1)',
+	'source_path' => 'index.html',
+);
 Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( $report, $dependency, false );
 $present = array_values( array_filter( $report['diagnostics'] ?? array(), static fn ( array $d ): bool => 'companion_plugin_present' === ( $d['code'] ?? '' ) ) );
 $assert( 1 === count( $present ), 'present-diagnostic-emitted-when-active' );
 $assert( array( 'hero-island' ) === ( $present[0]['island_handles'] ?? null ), 'present-diagnostic-carries-island-handles' );
 $assert( true === ( $present[0]['runtime_carried'] ?? false ), 'present-diagnostic-flags-runtime-carried' );
+$materialized = array_values( array_filter( $report['diagnostics'] ?? array(), static fn ( array $d ): bool => 'runtime_script_materialized' === ( $d['code'] ?? '' ) ) );
+$assert( 1 === count( $materialized ), 'companion-materialization-resolves-script-fallback' );
+$assert( 'native_conversion' === ( $materialized[0]['loss_class'] ?? '' ), 'materialized-script-is-native-conversion-outcome' );
+$assert( 0 === ( $report['quality']['fallback_count'] ?? -1 ), 'materialized-script-no-longer-counts-as-fallback' );
 $stored = $report['companion_plugins']['dependencies']['ssi-example-site']['island_handles'] ?? null;
 $assert( array( 'hero-island' ) === $stored, 'report-stores-companion-island-handles' );
 

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2137,6 +2137,40 @@ test('propagates accepted runtime preservation across duplicate script diagnosti
   assert.equal(result.findings.every((finding) => finding.loss_acceptance === 'acceptable'), true);
 });
 
+test('resolved companion scripts suppress raw conversion-report fallback echoes', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-runtime-materialized-intake-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'runtime-materialized-intake-test' });
+  const codeboxOutput = {
+    fixture_id: 'simple-site',
+    status: 'passed',
+    import_report: {
+      diagnostics: [{
+        code: 'runtime_script_materialized',
+        kind: 'runtime_script_materialized',
+        loss_class: 'native_conversion',
+        source_path: 'website/index.html',
+        selector: 'script:nth-of-type(1)',
+      }],
+    },
+    blocks_engine: {
+      conversion_report: {
+        diagnostics: [{
+          code: 'html_script_fallback',
+          kind: 'html',
+          reason: 'script_requires_runtime',
+          source_path: 'website/index.html',
+          selector: 'script:nth-of-type(1)',
+        }],
+      },
+    },
+  };
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory, codeboxOutput });
+  assert.equal(result.findings.some((finding) => finding.kind === 'html'), false);
+  assert.equal(result.findings.filter((finding) => finding.kind === 'runtime_script_materialized').length, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 0);
+});
+
 test('materializes generated artifact roots into matrix-compatible fixtures', () => {
   const sourceRoot = mkdtempSync(path.join(tmpdir(), 'ssi-generated-artifacts-'));
   const fixtureOutput = mkdtempSync(path.join(tmpdir(), 'ssi-generated-fixtures-'));

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1898,6 +1898,31 @@ test('visual diff region classification prefers computed screenshot regions over
   assert.deepEqual(classification.visual_diff_regions[0].bbox, { x: 8, y: 8, width: 24, height: 18 });
 });
 
+test('visual diff classification discards stale regions for an exact pixel match', () => {
+  const fixtureArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-classify-identical-'));
+  const visualDirectory = path.join(fixtureArtifactsDirectory, 'files', 'browser', 'visual-compare', 'identical');
+  mkdirSync(visualDirectory, { recursive: true });
+  const source = syntheticVisualParityPng(48, 40);
+  const candidate = PNG.sync.read(PNG.sync.write(source));
+  const diff = exactDiffPng(source, candidate);
+  writePng(path.join(visualDirectory, 'source.png'), source);
+  writePng(path.join(visualDirectory, 'candidate.png'), candidate);
+  writePng(path.join(visualDirectory, 'diff.png'), diff);
+
+  const classification = classifyVisualDiffRegions(visualComparePayload({
+    sourceScreenshot: 'files/browser/visual-compare/identical/source.png',
+    candidateScreenshot: 'files/browser/visual-compare/identical/candidate.png',
+    diffScreenshot: 'files/browser/visual-compare/identical/diff.png',
+    mismatchPixels: 0,
+    totalPixels: 48 * 40,
+    overlapMismatchPixels: 0,
+    overlapPixels: 48 * 40,
+    mismatchRegions: [{ x: 0, y: 0, width: 48, height: 40, pixels: 48 * 40 }],
+  }), { fixtureArtifactsDirectory });
+
+  assert.equal(classification, null);
+});
+
 test('fixture diagnostics drop empty rows and normalize kindless carriers with explicit kind', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-diagnostic-hygiene-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'diagnostic-hygiene-test' });


### PR DESCRIPTION
## Summary
- materialize preserved runtime JavaScript through generated companion plugins
- reconcile materialized script diagnostics and suppress duplicate raw fallback echoes
- discard stale visual regions when exact screenshot comparison reports zero changed pixels

Follow-up to #655. Completes the runtime-script path exercised by Automattic/blocks-engine#624.

## How to test
1. Run `composer install --no-interaction --prefer-dist --no-progress`.
2. Run `npm ci`.
3. Run `npm test`.
4. Confirm all 180 fixture-matrix tests, 3 Figma E2E tests, and 3 solved-fixture promotion tests pass.

## Runtime evidence
The exact `15-saas` fixture matrix completed successfully with 294/294 editor-valid native blocks, zero `core/html` blocks, zero unacceptable findings, an active `ssi-15-saas` companion plugin, and identical source/candidate screenshots across 9,955,320 pixels. The registry classified the fixture as `solved_candidate` with zero visible HTML or runtime islands.

## Compatibility
This is additive companion-plugin behavior for preserved runtime scripts. Existing generated plugin dependencies and public interfaces remain supported; no extension path is removed or renamed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Implemented the runtime materialization and diagnostic reconciliation changes, added regression coverage, and verified the exact fixture workflow with Chris.