### PR TITLE
Add solved corpus promotion gate

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -167,6 +167,7 @@ export async function runFixtureMatrix(options) {
     risk_profile: options.riskProfile || options.risk_profile,
     complexity: options.complexity,
     max_complexity: options.maxComplexity || options.max_complexity,
+    fixture_ids: options.fixtureIds,
   });
   const progress = createFixtureMatrixProgress(matrix, options);
   progress.emit('matrix', 'started');
@@ -250,6 +251,7 @@ export async function runFixtureMatrix(options) {
       results: attributeChildCommandFailures(batchResults.flatMap((result) => result.fixtures), childCommandFailures),
       // Editor-quality scoring is always on; the native-rate gate is opt-in.
       editorQuality: editorQualityGateInput(options),
+      requireSolvedCandidate: options.requireSolvedCandidate,
     });
     performance.result_assembly_ms = elapsedMs(resultAssemblyStartedAt);
     runtime = {
@@ -1307,6 +1309,8 @@ export function optionsFromEnv(env = process.env) {
     maxExplanationCandidates: benchEnv.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES || env.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES,
     explainSelectors: benchEnv.SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS || env.SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS,
     minNativeRate: benchEnv.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE || env.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE,
+    fixtureIds: benchEnv.SSI_FIXTURE_MATRIX_FIXTURE_IDS || env.SSI_FIXTURE_MATRIX_FIXTURE_IDS,
+    requireSolvedCandidate: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE) || isTruthy(env.SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE),
   };
 }
 

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -336,6 +336,27 @@ to `<blocks-engine>/fixtures` and discovers fixtures from both `websites/` and
 Promote a fixture to `fixtures/solved/` only after a matrix run grades it
 `solved_candidate`:
 
+Use the target lane while iterating, then the target-plus-solved promotion lane
+before promotion:
+
+```bash
+node tools/run-fixture-matrix.mjs \
+  --static-site-importer . \
+  --blocks-engine /path/to/blocks-engine \
+  --target-fixture <id>
+
+node tools/run-fixture-matrix.mjs \
+  --static-site-importer . \
+  --blocks-engine /path/to/blocks-engine \
+  --target-fixture <id> \
+  --promotion-gate
+```
+
+The promotion lane selects the active target plus every fixture under
+`fixtures/solved/`, defaults to one fixture per isolated WP Codebox batch, and
+requires every selected fixture to retain `solved_candidate`. A target that is
+not solved or any `solved_regression` fails the aggregate.
+
 ```bash
 node tools/promote-solved-fixture.mjs \
   --fixture-id <id> \

--- a/lib/fixture-matrix/fixtures.mjs
+++ b/lib/fixture-matrix/fixtures.mjs
@@ -244,6 +244,10 @@ export function normalizeManifestComplexity(value) {
 // Build the active class/tag filter from runner/bench/test options, or null when
 // no filter is requested. Supports a single class and one-or-more tags.
 function normalizeFixtureFilter(input = {}) {
+  const fixtureIds = normalizeArray(input.fixture_ids || input.fixtureIds)
+    .flatMap((value) => String(value || '').split(','))
+    .map((value) => slug(value))
+    .filter(Boolean);
   const classValue = normalizeFixtureClass(input.class || input.fixture_class || input.fixtureClass);
   let fixtureClass = '';
   if (classValue && classValue !== 'unknown') {
@@ -258,10 +262,11 @@ function normalizeFixtureFilter(input = {}) {
   const hasMaxComplexity = input.max_complexity !== undefined || input.maxComplexity !== undefined;
   const complexity = hasComplexity ? normalizeManifestComplexity(input.complexity) : null;
   const maxComplexity = hasMaxComplexity ? normalizeManifestComplexity(input.max_complexity ?? input.maxComplexity) : null;
-  if (!fixtureClass && tags.length === 0 && capabilities.length === 0 && !riskProfile && complexity === null && maxComplexity === null) {
+  if (fixtureIds.length === 0 && !fixtureClass && tags.length === 0 && capabilities.length === 0 && !riskProfile && complexity === null && maxComplexity === null) {
     return null;
   }
   return {
+    ...(fixtureIds.length ? { fixture_ids: [...new Set(fixtureIds)].sort() } : {}),
     ...(fixtureClass ? { fixture_class: fixtureClass } : {}),
     ...(tags.length ? { tags } : {}),
     ...(capabilities.length ? { capabilities } : {}),
@@ -272,6 +277,9 @@ function normalizeFixtureFilter(input = {}) {
 }
 
 function fixtureMatchesFilter(fixture, filter) {
+  if (filter.fixture_ids && !filter.fixture_ids.includes(fixture.id)) {
+    return false;
+  }
   if (filter.fixture_class && fixture.fixture_class !== filter.fixture_class) {
     return false;
   }

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -90,7 +90,17 @@ export function normalizeFixtureMatrixResult(input = {}) {
   const grouped = groupFindings(actionableFindings);
   const acceptableActionableFindings = actionableFindings.filter((finding) => finding.loss_acceptance === 'acceptable');
   const unacceptableActionableFindings = actionableFindings.filter((finding) => finding.loss_acceptance !== 'acceptable');
-  const gatedFixtureResults = fixtureResults.map((result) => attachFixtureEditorQuality(applyFixtureQualityGate(result, findings, { executionRequested }), editorQualityByFixture.get(result.fixture_id)));
+  const initialGatedFixtureResults = fixtureResults.map((result) => attachFixtureEditorQuality(applyFixtureQualityGate(result, findings, { executionRequested }), editorQualityByFixture.get(result.fixture_id)));
+  const initialGutenbergRegistry = buildGutenbergIncompatibilityRegistry({
+    schema: FIXTURE_MATRIX_RESULT_SCHEMA,
+    matrix_id: matrix.id,
+    fixtures: initialGatedFixtureResults,
+    findings,
+  });
+  const requireSolvedCandidate = input.requireSolvedCandidate === true || input.require_solved_candidate === true;
+  const gatedFixtureResults = requireSolvedCandidate
+    ? applySolvedCandidateGate(initialGatedFixtureResults, initialGutenbergRegistry)
+    : initialGatedFixtureResults;
   const lossClassCounts = countBy(findings, (finding) => finding.loss_class || 'unsupported_loss');
   const acceptanceCounts = countBy(findings, (finding) => finding.loss_acceptance || 'unacceptable');
   const classRollups = fixtureClassRollups(gatedFixtureResults, findings);
@@ -147,6 +157,7 @@ export function normalizeFixtureMatrixResult(input = {}) {
       editor_quality: aggregateEditorQuality([...editorQualityByFixture.values()], nativeRateGate),
       slow_fixtures: slowFixtures,
       matrix_evidence_readiness: evidenceReadiness,
+      solved_candidate_gate: solvedCandidateGateSummary(gatedFixtureResults, requireSolvedCandidate),
       metadata: {
         slow_fixtures: slowFixtures,
       },
@@ -159,6 +170,53 @@ export function normalizeFixtureMatrixResult(input = {}) {
       slow_fixtures: slowFixtures,
     },
     fanout_groups: fanoutGroups.map((group, index) => ({ ...group, index })),
+  };
+}
+
+function applySolvedCandidateGate(fixtures, registry) {
+  const decisions = new Map(normalizeArray(registry.fixture_decisions).map((decision) => [decision.fixture_id, decision]));
+  return fixtures.map((fixture) => {
+    const decision = decisions.get(fixture.fixture_id);
+    if (!decision || decision.acceptance_status === 'solved_candidate') {
+      return fixture;
+    }
+    const solvedRegression = decision.acceptance_status === 'solved_regression';
+    const category = solvedRegression ? 'solved_regression' : 'promotion_candidate_failed';
+    const reason = solvedRegression
+      ? 'Solved fixture no longer meets the solved_candidate acceptance contract.'
+      : `Promotion target has acceptance_status "${decision.acceptance_status || 'unknown'}"; expected "solved_candidate".`;
+    const gateReason = {
+      category,
+      categories: [category],
+      kind: category,
+      loss_class: category,
+      repair_bucket: 'fixture_acceptance',
+      candidate_repo: 'static-site-importer',
+      reason,
+    };
+    return {
+      ...fixture,
+      status: 'failed',
+      success: false,
+      quality_gate: {
+        ...(fixture.quality_gate || {}),
+        status: 'failed',
+        fixture_categories: uniqueSorted([...(fixture.quality_gate?.fixture_categories || []), category]),
+        failure_categories: uniqueSorted([...(fixture.quality_gate?.failure_categories || []), category]),
+        gate_failure_reasons: [...(fixture.quality_gate?.gate_failure_reasons || []), gateReason],
+      },
+    };
+  });
+}
+
+function solvedCandidateGateSummary(fixtures, enabled) {
+  const failures = fixtures.filter((fixture) => normalizeArray(fixture.quality_gate?.failure_categories)
+    .some((category) => category === 'solved_regression' || category === 'promotion_candidate_failed'));
+  return {
+    enabled,
+    required_status: enabled ? 'solved_candidate' : null,
+    failed_fixture_count: failures.length,
+    failed_fixture_ids: failures.map((fixture) => fixture.fixture_id).sort(),
   };
 }
 
@@ -249,16 +307,28 @@ function fixtureCategoryRollups(fixtureResults, findings) {
   for (const result of fixtureResults) {
     const fixtureFindings = findingsByFixture.get(result.fixture_id) || [];
     const unacceptableFindings = fixtureFindings.filter((finding) => finding.loss_acceptance === 'unacceptable');
-    for (const category of uniqueSorted(fixtureFindings.flatMap(findingCategories))) {
+    const qualityGate = objectValue(result.quality_gate);
+    const allCategories = uniqueSorted([
+      ...fixtureFindings.flatMap(findingCategories),
+      ...normalizeArray(qualityGate.fixture_categories),
+    ]);
+    for (const category of allCategories) {
       fixtureCategories[category] = (fixtureCategories[category] || 0) + 1;
     }
     if (result.status !== 'failed') {
       continue;
     }
-    for (const category of uniqueSorted(unacceptableFindings.flatMap(findingCategories))) {
+    const failureCategories = uniqueSorted([
+      ...unacceptableFindings.flatMap(findingCategories),
+      ...normalizeArray(qualityGate.failure_categories),
+    ]);
+    for (const category of failureCategories) {
       fixtureFailureCategories[category] = (fixtureFailureCategories[category] || 0) + 1;
     }
     reasonRows.push(...gateFailureReasons(unacceptableFindings).map((reason) => ({ fixture_id: result.fixture_id, ...reason })));
+    reasonRows.push(...normalizeArray(qualityGate.gate_failure_reasons)
+      .filter((reason) => ['solved_regression', 'promotion_candidate_failed'].includes(reason.category))
+      .map((reason) => ({ fixture_id: result.fixture_id, ...reason })));
   }
 
   return {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2278,6 +2278,10 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   for (let index = 1; index <= CANONICAL_FIXTURE_COUNT; index += 1) {
     mkdirSync(path.join(canonicalFixtureRoot, `fixture-${String(index).padStart(2, '0')}`), { recursive: true });
   }
+  writeFileSync(path.join(canonicalFixtureRoot, 'fixture-01', 'index.html'), '<h1>Target</h1>');
+  const solvedFixtureRoot = path.join(corpusRoot, 'solved', 'solved-site');
+  mkdirSync(solvedFixtureRoot, { recursive: true });
+  writeFileSync(path.join(solvedFixtureRoot, 'index.html'), '<h1>Solved</h1>');
 
   const plan = buildFixtureMatrixRunPlan({
     runner: 'homeboy-lab',
@@ -2293,8 +2297,8 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.equal(plan.homeboy_bin, '/tmp/homeboy-latest');
   assert.equal(plan.fixture_root, corpusRoot);
   assert.equal(plan.active_fixture_count, CANONICAL_FIXTURE_COUNT);
-  assert.equal(plan.solved_fixture_count, 0);
-  assert.equal(plan.fixture_count, CANONICAL_FIXTURE_COUNT);
+  assert.equal(plan.solved_fixture_count, 1);
+  assert.equal(plan.fixture_count, CANONICAL_FIXTURE_COUNT + 1);
   assert.equal(plan.fixture_count_matches_canonical, true);
   assert.equal(plan.namespace, 'ssi-matrix-dev-proof');
   assert.equal(plan.temp_root, '/tmp/static-site-importer-fixture-matrix-ssi-matrix-dev-proof');
@@ -2330,6 +2334,44 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.deepEqual(releasePlan.dependency_overrides, {});
   assert.equal(releasePlan.steps.at(-1).args.some((arg) => arg.includes('SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH')), false);
 
+  const targetPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    blocksEngine,
+    targetFixture: 'fixture-01',
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(targetPlan.fixture_count, 1);
+  assert.deepEqual(targetPlan.lane_filter.fixture_ids, ['fixture-01']);
+  assert.equal(targetPlan.lane_filter.promotion_gate, undefined);
+  assert.ok(targetPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_FIXTURE_IDS=fixture-01'));
+
+  const promotionPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    blocksEngine,
+    targetFixture: 'fixture-01',
+    promotionGate: true,
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(promotionPlan.fixture_count, 2);
+  assert.equal(promotionPlan.selected_active_fixture_count, 1);
+  assert.equal(promotionPlan.selected_solved_fixture_count, 1);
+  assert.deepEqual(promotionPlan.lane_filter.fixture_ids, ['fixture-01', 'solved-site']);
+  assert.equal(promotionPlan.lane_filter.promotion_gate, true);
+  assert.ok(promotionPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_FIXTURE_IDS=fixture-01,solved-site'));
+  assert.ok(promotionPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE=1'));
+  assert.ok(promotionPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_BATCH_SIZE=1'));
+
+  assert.throws(
+    () => buildFixtureMatrixRunPlan({ staticSiteImporter, blocksEngine, promotionGate: true }),
+    /--promotion-gate requires --target-fixture/
+  );
+  assert.throws(
+    () => buildFixtureMatrixRunPlan({ staticSiteImporter, blocksEngine, targetFixture: 'fixture-01', promotionGate: true, visualParity: false }),
+    /requires editor validation and gated visual parity/
+  );
+
   const surfacePlan = buildFixtureMatrixRunPlan({
     runner: 'homeboy-lab',
     staticSiteImporter,
@@ -2340,7 +2382,7 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   });
   assert.equal(surfacePlan.surface_coverage.extra_surfaces_per_fixture, MAX_EXTRA_SURFACE_COUNT);
   assert.equal(surfacePlan.surface_coverage.capped, true);
-  assert.equal(surfacePlan.surface_coverage.max_browser_surface_count, CANONICAL_FIXTURE_COUNT * (MAX_EXTRA_SURFACE_COUNT + 1));
+  assert.equal(surfacePlan.surface_coverage.max_browser_surface_count, (CANONICAL_FIXTURE_COUNT + 1) * (MAX_EXTRA_SURFACE_COUNT + 1));
   assert.ok(surfacePlan.warnings.some((warning) => warning.code === 'surface_coverage_runtime_cost'));
 
   const explicitOutput = path.join(root, 'custom-output', 'homeboy-bench.json');
@@ -6381,6 +6423,25 @@ test('fixture discovery falls back to single root when no websites subdirectory 
   assert.equal(matrix.fixtures[0].fixture_corpus, 'active');
 });
 
+test('fixture id filters select an active target plus solved regressions without staging copies', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-id-filter-'));
+  for (const [corpus, id] of [['websites', 'target-site'], ['websites', 'other-site'], ['solved', 'solved-site']]) {
+    const directory = path.join(root, corpus, id);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, 'index.html'), `<h1>${id}</h1>`);
+    writeFileSync(path.join(directory, 'fixture.json'), JSON.stringify({ fixture_class: 'marketing/static' }));
+  }
+
+  const matrix = createFixtureMatrix({
+    fixture_root: root,
+    fixture_ids: 'target-site,solved-site',
+  });
+
+  assert.deepEqual(matrix.filter.fixture_ids, ['solved-site', 'target-site']);
+  assert.deepEqual(matrix.fixtures.map((fixture) => fixture.id), ['solved-site', 'target-site']);
+  assert.equal(matrix.fixtures.find((fixture) => fixture.id === 'solved-site').fixture_corpus, 'solved');
+});
+
 test('solved fixture that regresses is reported as solved_regression', () => {
   const registry = buildGutenbergIncompatibilityRegistry({
     matrix_id: 'solved-regression-test',
@@ -6437,4 +6498,52 @@ test('solved fixture that stays solved_candidate keeps solved_candidate status',
   assert.equal(decision.fixture_corpus, 'solved');
   assert.equal(decision.acceptance_status, 'solved_candidate');
   assert.equal(decision.solved_candidate, true);
+});
+
+test('solved-candidate gate hard-fails regressions while preserving acceptance evidence', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-solved-candidate-gate-'));
+  for (const [corpus, id] of [['websites', 'target-site'], ['solved', 'solved-site']]) {
+    const directory = path.join(root, corpus, id);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, 'index.html'), `<h1>${id}</h1>`);
+    writeFileSync(path.join(directory, 'fixture.json'), JSON.stringify({ fixture_class: 'marketing/static' }));
+  }
+  const matrix = createFixtureMatrix({ fixture_root: root });
+  const acceptedResult = (fixtureId) => ({
+    fixture_id: fixtureId,
+    status: 'passed',
+    artifact_refs: [{ artifact_id: 'editor-open-screenshot', kind: 'screenshot', path: `files/browser/editor-open/${fixtureId}/screenshot.png` }],
+    visual_parity_artifacts: { comparison: { mismatch_ratio: 0 } },
+    block_composition: { block_total: 8, native_block_count: 8, core_html_block_count: 0 },
+    editor_validation: { total_blocks: 8, valid_blocks: 8, invalid_blocks: 0, validation_method: 'wp.blocks.validateBlock' },
+  });
+  const solvedRegression = {
+    ...acceptedResult('solved-site'),
+    visual_parity_artifacts: { comparison: { mismatch_ratio: 0.05 } },
+    diagnostics: [{
+      fixture_id: 'solved-site',
+      kind: 'visual_parity_mismatch',
+      loss_class: 'visual_parity_mismatch',
+      loss_acceptance: 'unacceptable',
+      reason: 'Exact visual parity regressed.',
+    }],
+  };
+
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [acceptedResult('target-site'), solvedRegression],
+    requireSolvedCandidate: true,
+  });
+
+  assert.equal(result.summary.succeeded, 1);
+  assert.equal(result.summary.failed, 1);
+  assert.deepEqual(result.summary.solved_candidate_gate, {
+    enabled: true,
+    required_status: 'solved_candidate',
+    failed_fixture_count: 1,
+    failed_fixture_ids: ['solved-site'],
+  });
+  assert.equal(result.summary.fixture_failure_categories.solved_regression, 1);
+  assert.ok(result.summary.gate_failure_reasons.some((reason) => reason.fixture_id === 'solved-site' && reason.category === 'solved_regression'));
+  assert.equal(result.gutenberg_incompatibility_registry.fixture_decisions.find((decision) => decision.fixture_id === 'solved-site').acceptance_status, 'solved_regression');
 });

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -94,6 +94,8 @@ export function buildFixtureMatrixRunPlan(input) {
     SSI_FIXTURE_MATRIX_FIXTURE_ROOT: options.fixtureRoot,
     SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH: options.staticSiteImporter,
     SSI_FIXTURE_MATRIX_RUN: '1',
+    ...(options.fixtureIds.length ? { SSI_FIXTURE_MATRIX_FIXTURE_IDS: options.fixtureIds.join(',') } : {}),
+    ...(options.requireSolvedCandidate ? { SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE: '1' } : {}),
     ...(options.blocksEnginePhpTransformerPath
       ? { SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH: options.blocksEnginePhpTransformerPath }
       : {}),
@@ -136,7 +138,7 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.maxComplexity ? { SSI_FIXTURE_MATRIX_MAX_COMPLEXITY: String(options.maxComplexity) } : {}),
   };
   const corpusCounts = countCorpusFixtureDirectories(options.fixtureRoot);
-  const fixtureCount = corpusCounts.total;
+  const fixtureCount = options.fixtureIds.length || corpusCounts.total;
   const activeFixtureCount = corpusCounts.active;
   const solvedFixtureCount = corpusCounts.solved;
   const codeFreshness = buildCodeFreshness(options, options.gitRunner || defaultGitRunner);
@@ -163,6 +165,8 @@ export function buildFixtureMatrixRunPlan(input) {
     fixture_count: fixtureCount,
     active_fixture_count: activeFixtureCount,
     solved_fixture_count: solvedFixtureCount,
+    selected_active_fixture_count: options.selectedActiveFixtureCount,
+    selected_solved_fixture_count: options.selectedSolvedFixtureCount,
     canonical_fixture_count: CANONICAL_FIXTURE_COUNT,
     fixture_count_matches_canonical: activeFixtureCount === CANONICAL_FIXTURE_COUNT,
     lane_filter: laneFilterSummary(options),
@@ -216,6 +220,9 @@ export function buildFixtureMatrixRunPlan(input) {
 
 function laneFilterSummary(options) {
   return {
+    ...(options.fixtureIds.length ? { fixture_ids: options.fixtureIds } : {}),
+    ...(options.targetFixture ? { target_fixture: options.targetFixture } : {}),
+    ...(options.promotionGate ? { promotion_gate: true } : {}),
     ...(options.class ? { class: String(options.class) } : {}),
     ...(options.tag ? { tag: String(options.tag) } : {}),
     ...(options.capability ? { capability: String(options.capability) } : {}),
@@ -236,6 +243,15 @@ function normalizeOptions(input) {
     throw new Error('--blocks-engine or --fixture-root is required');
   }
   const fixtureRoot = path.resolve(input.fixtureRoot || path.join(blocksEngine, 'fixtures'));
+  const selection = resolveFixtureSelection({
+    fixtureRoot,
+    targetFixture: input.targetFixture,
+    promotionGate: input.promotionGate,
+  });
+
+  if (input.promotionGate && (input.editorValidation === false || input.visualParity === false || input.visualParityGate === false)) {
+    throw new Error('--promotion-gate requires editor validation and gated visual parity; remove the validation or visual-parity opt-out.');
+  }
 
   const defaultBlocksEnginePhpTransformerPath = input.mode === 'release-proof' ? '' : blocksEngine;
   let blocksEnginePhpTransformerPath = defaultBlocksEnginePhpTransformerPath;
@@ -273,6 +289,13 @@ function normalizeOptions(input) {
     tempRoot,
     output,
     fixtureRoot,
+    fixtureIds: selection.fixtureIds,
+    targetFixture: selection.targetFixture,
+    promotionGate: selection.promotionGate,
+    requireSolvedCandidate: selection.promotionGate,
+    selectedActiveFixtureCount: selection.selectedActiveFixtureCount,
+    selectedSolvedFixtureCount: selection.selectedSolvedFixtureCount,
+    batchSize: input.batchSize || (selection.promotionGate ? 1 : input.batchSize),
     blocksEngine,
     blocksEnginePhpTransformerPath,
     passthrough: Array.isArray(input.passthrough) ? input.passthrough : [],
@@ -284,6 +307,46 @@ function normalizeOptions(input) {
     homeboyBin: input.homeboyBin || process.env.HOMEBOY_BIN || 'homeboy',
     ...normalizeVisualAttributionOptions(input),
   };
+}
+
+function resolveFixtureSelection({ fixtureRoot, targetFixture, promotionGate }) {
+  const target = String(targetFixture || '').trim();
+  if (promotionGate && !target) {
+    throw new Error('--promotion-gate requires --target-fixture <id>.');
+  }
+  if (!target) {
+    return {
+      fixtureIds: [],
+      targetFixture: '',
+      promotionGate: false,
+      selectedActiveFixtureCount: 0,
+      selectedSolvedFixtureCount: 0,
+    };
+  }
+
+  const activeRoot = path.join(fixtureRoot, 'websites');
+  if (!fs.existsSync(path.join(activeRoot, target, 'index.html'))) {
+    throw new Error(`--target-fixture "${target}" was not found under ${activeRoot}.`);
+  }
+  const solvedFixtureIds = promotionGate ? fixtureDirectoryNames(path.join(fixtureRoot, 'solved')) : [];
+  return {
+    fixtureIds: [...new Set([target, ...solvedFixtureIds])].sort(),
+    targetFixture: target,
+    promotionGate: Boolean(promotionGate),
+    selectedActiveFixtureCount: 1,
+    selectedSolvedFixtureCount: solvedFixtureIds.length,
+  };
+}
+
+function fixtureDirectoryNames(fixtureRoot) {
+  try {
+    return fs.readdirSync(fixtureRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.') && fs.existsSync(path.join(fixtureRoot, entry.name, 'index.html')))
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    return [];
+  }
 }
 
 function normalizeExecutionTarget(input) {
@@ -750,7 +813,7 @@ function parseArgs(args) {
     if (arg.startsWith('--')) {
       const [rawKey, rawValue] = arg.slice(2).split('=');
       const key = camelCase(rawKey);
-      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'visualParityAlignment', 'liveWpParity']);
+      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'visualParityAlignment', 'liveWpParity', 'promotionGate']);
       if (booleanKeys.has(key)) {
         options[key] = true;
         continue;
@@ -873,7 +936,7 @@ function sanitizePathSegment(value) {
 
 function printHelp() {
   process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Passes --placement local to homeboy bench.\n  --runner <id>                       Passes --runner <id> to homeboy bench (implies Lab placement).\n  --lab-only                          Passes --placement lab without selecting a runner.\n  --allow-local-fallback              Passes --placement lab-or-local to homeboy bench.\n  no routing flags                    Passes --placement auto to homeboy bench.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote>, --lab-only, or --allow-local-fallback.\n  --lab-only cannot be combined with --allow-local-fallback.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n    --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures, which discovers both fixtures/websites and fixtures/solved.
-\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 4, hard-capped at 16.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind upstream.\n  --allow-local-fallback              Permit selected Lab runner fallback to local execution.\n  --allow-dirty-lab-workspace         Permit reusing/overwriting a dirty Lab workspace.\n  --detach-after-handoff              Return after runner daemon accepts the job.\n  --dry-run                           Print the plan without running Homeboy.\n  --skip-install                      Skip rig install.\n  --skip-sync                         Skip rig sync.\n  --no-editor-validation              Omit editor block validation.\n  --no-visual-parity                  Omit visual parity capture.\n  --no-visual-parity-gate             Capture visual parity without gating.\n  --help                              Show this help.\n`);
+\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 2, hard-capped at 16.\n  --target-fixture <id>               Run one active fixture for the fast inner loop.\n  --promotion-gate                    Run the target plus every solved fixture, one per batch, and require solved_candidate for all.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind upstream.\n  --allow-local-fallback              Permit selected Lab runner fallback to local execution.\n  --allow-dirty-lab-workspace         Permit reusing/overwriting a dirty Lab workspace.\n  --detach-after-handoff              Return after runner daemon accepts the job.\n  --dry-run                           Print the plan without running Homeboy.\n  --skip-install                      Skip rig install.\n  --skip-sync                         Skip rig sync.\n  --no-editor-validation              Omit editor block validation.\n  --no-visual-parity                  Omit visual parity capture.\n  --no-visual-parity-gate             Capture visual parity without gating.\n  --help                              Show this help.\n`);
   printVisualAttributionHelp();
 }
 


### PR DESCRIPTION
## Summary
- add a target-only fixture lane and a target-plus-solved promotion lane
- require every promotion fixture to retain `solved_candidate`, with solved regressions surfaced as a hard aggregate failure
- document the operator workflow and cover fixture selection, one-fixture batching, required evidence gates, and regression reporting

Fixes #659

## How to test
1. Run `node --test --test-name-pattern="builds one-command canonical Blocks Engine fixture matrix plan|fixture id filters select an active target plus solved regressions without staging copies|solved-candidate gate hard-fails regressions while preserving acceptance evidence" tools/fixture-matrix.test.mjs`.
2. With a Blocks Engine checkout containing an active fixture and `fixtures/solved/15-saas`, run `node tools/run-fixture-matrix.mjs --static-site-importer . --blocks-engine /path/to/blocks-engine --target-fixture 27-university-department --promotion-gate --dry-run`.
3. Confirm the plan selects the target plus `15-saas`, emits `SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE=1`, keeps editor validation and gated visual parity enabled, and emits `SSI_FIXTURE_MATRIX_BATCH_SIZE=1`.

## Verification note
- The complete `npm test` run twice encountered the existing inactivity-recovery timing test with one healthy child timing out under the test suite load. That same test passes in isolation; the promotion-gate tests pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Implemented the fixture selection and promotion gate, added regression coverage and documentation, and verified the operator plan.