### PR TITLE
Update PHP transformer to 0.2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.2.6",
+        "version": "0.2.7",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "908c76a8d9b7679c87f59aa183f09b12ea9f89e6"
+          "reference": "afaf508595155530873dfeed06a53a8173afa833"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.6.zip",
-          "reference": "908c76a8d9b7679c87f59aa183f09b12ea9f89e6"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.7.zip",
+          "reference": "afaf508595155530873dfeed06a53a8173afa833"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.2.6",
+    "automattic/blocks-engine-php-transformer": "^0.2.7",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5194dd13a20183f05d39c3140ba7b3e3",
+    "content-hash": "552000d722c39be028e7da1489f81b52",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.2.6",
+            "version": "0.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "908c76a8d9b7679c87f59aa183f09b12ea9f89e6"
+                "reference": "afaf508595155530873dfeed06a53a8173afa833"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.6.zip",
-                "reference": "908c76a8d9b7679c87f59aa183f09b12ea9f89e6"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.7.zip",
+                "reference": "afaf508595155530873dfeed06a53a8173afa833"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- consume the published `php-transformer-v0.2.7` milestone release
- pin the synthetic Composer package metadata to release commit `afaf508595155530873dfeed06a53a8173afa833`
- update only the Transformer lock entry; transitive dependency versions remain unchanged

PHP Transformer release: https://github.com/Automattic/blocks-engine/releases/tag/php-transformer-v0.2.7

## How to test
1. Run `composer install --no-interaction --prefer-dist`.
2. Run `composer validate --strict`.
3. Run `composer show automattic/blocks-engine-php-transformer` and confirm version `0.2.7`.
4. Run `npm test`.

## Verification note
- `composer validate --strict` passes.
- PHP Transformer canonical tests pass, including 244 parity fixtures and package-install proof.
- Local `npm test` encountered the existing fixture-matrix inactivity timing flake; the same repository CI matrix passed on PR #660.

## Compatibility
- This updates generated transform behavior consumed by SSI but does not change SSI extension APIs or paths.
- The dependency remains within the existing compatible `^0.2` line.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Coordinated the release, updated the exact Composer package pin and lockfile, and ran verification.