### PR TITLE
Fix WordPress plugin release packaging

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -24,9 +24,6 @@
         ],
         "validation_dependencies": []
       }
-    },
-    "nodejs": {
-      "settings": {}
     }
   },
   "id": "static-site-importer",

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -84,11 +84,11 @@ import { runWpCodeboxRecipe, wpCodeboxBin } from './wp-codebox/recipe.mjs';
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const fixtureRoot = path.join(packageRoot, 'tests', 'fixtures', 'fixture-matrix');
 
-test('Homeboy component links runtime and dependency extensions', () => {
+test('Homeboy component assigns runtime and dependency capabilities to WordPress', () => {
   const config = JSON.parse(readFileSync(path.join(packageRoot, 'homeboy.json'), 'utf8'));
 
   assert.ok(config.extensions?.wordpress, 'WordPress extension is required for fixture runtime workloads');
-  assert.ok(config.extensions?.nodejs, 'Node.js extension is required for Lab dependency hydration');
+  assert.equal(config.extensions?.nodejs, undefined, 'Node.js must not register npm release actions for this WordPress plugin');
   assert.equal(config.capability_extensions?.deps, 'wordpress', 'WordPress owns npm and Composer Lab hydration');
 });
 


### PR DESCRIPTION
## Summary
- remove the redundant component-level Node.js extension from SSI release configuration
- keep WordPress as the explicit owner of Composer and npm dependency hydration
- guard against re-registering npm release actions for this WordPress plugin

## Root cause
Homeboy invokes `release.package` for every linked component extension. SSI linked Node.js for dependency hydration even though `capability_extensions.deps` already delegates hydration to WordPress. During the `v1.3.0` release, Node.js tried to package the private, versionless `package.json` and safely stopped before tag or push.

The fixture-matrix rig retains its own Node.js dependency declaration, so Lab workload execution is unchanged.

## How to test
1. Run `node --test --test-name-pattern="Homeboy component assigns runtime and dependency capabilities to WordPress" tools/fixture-matrix.test.mjs`.
2. Run `homeboy release static-site-importer --path "$PWD" --dry-run`.
3. Confirm the release plan contains WordPress packaging/publishing and no `publish.nodejs` step.

## Compatibility
- No SSI runtime API, extension path, or generated-site behavior changes.
- This only narrows release action ownership to the WordPress extension.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Diagnosed the blocked release contract, corrected component extension ownership, and added regression coverage.