### PR TITLE
Add PHP 8.5 zstd support to the Playground importer

### DIFF
--- a/.github/workflows/release-php-wasm-zstd.yml
+++ b/.github/workflows/release-php-wasm-zstd.yml
@@ -1,0 +1,31 @@
+name: Release PHP.wasm zstd
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload:
+    name: Build PHP 8.5 JSPI zstd side module
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          submodules: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run build:php-wasm-zstd -- dist/php-wasm-zstd
+      - name: Verify the PHP.wasm artifact contract
+        run: npm run test:php-wasm-zstd
+      - name: Upload public Playground extension assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.so dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.manifest.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Import a static site or generated website artifact into WordPress pages and a companion block theme.
 
-[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/static-site-importer/main/docs/playground/blueprint.json)
+[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fgithub.com%2FAutomattic%2Fstatic-site-importer%2Freleases%2Flatest%2Fdownload%2Fstatic-site-importer-zstd-php8.5-jspi.manifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FAutomattic%2Fstatic-site-importer%2Fmain%2Fdocs%2Fplayground%2Fblueprint.json)
 
 Static Site Importer is a WordPress plugin. It requires the [Blocks Engine PHP transformer](https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer) Composer package and calls that package's canonical helper functions for generic artifact compilation and format conversion.
 
@@ -135,9 +135,11 @@ add_filter(
 
 Open Static Site Importer in a disposable WordPress Playground site:
 
-[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/static-site-importer/main/docs/playground/blueprint.json)
+[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fgithub.com%2FAutomattic%2Fstatic-site-importer%2Freleases%2Flatest%2Fdownload%2Fstatic-site-importer-zstd-php8.5-jspi.manifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FAutomattic%2Fstatic-site-importer%2Fmain%2Fdocs%2Fplayground%2Fblueprint.json)
 
-The blueprint installs and activates the packaged Static Site Importer release, logs the visitor in, and opens `/import/` with the `static-site-importer/importer` block configured to generate a WordPress website. Testers can upload site files, choose a folder, upload a ZIP, or paste HTML.
+The blueprint installs and activates the packaged Static Site Importer release, logs the visitor in, and opens `/import/` with the `static-site-importer/importer` block configured to generate a WordPress website. Playground loads the PHP 8.5 JSPI `zstd` side module before PHP starts, so the existing Figma upload flow can decode zstd-compressed `.fig` canvas chunks. Testers can upload site files, choose a folder, upload a ZIP, paste HTML, or upload a Figma file.
+
+The extension manifest and side module are immutable named assets on each SSI GitHub Release. They are produced from pinned `php-ext-zstd` and vendored `libzstd` source by the release workflow. The README URL targets `releases/latest`, so it becomes usable after the first release containing these two assets has finished its upload; no unpublished branch, localhost URL, PECL installation, or host `zstd` executable is used.
 
 URL intake rules:
 

--- a/docs/playground/blueprint.json
+++ b/docs/playground/blueprint.json
@@ -2,7 +2,7 @@
   "$schema": "https://playground.wordpress.net/blueprint-schema.json",
   "landingPage": "/import/",
   "preferredVersions": {
-    "php": "8.2",
+    "php": "8.5",
     "wp": "latest"
   },
   "features": {

--- a/docs/playground/extensions/zstd-php8.5-jspi.manifest.json
+++ b/docs/playground/extensions/zstd-php8.5-jspi.manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "zstd",
+  "version": "0.13.3",
+  "mode": "php-extension",
+  "artifacts": [
+    {
+      "phpVersion": "8.5",
+      "sourcePath": "https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer-zstd-php8.5-jspi.so"
+    }
+  ]
+}

--- a/includes/class-static-site-importer-figma-import.php
+++ b/includes/class-static-site-importer-figma-import.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Static_Site_Importer_Figma_Import {
 	/**
-	 * Register the default local Zstandard decoder for .fig uploads.
+	 * Register the default Zstandard decoder for .fig uploads.
 	 */
 	public static function register_default_zstd_decoder(): void {
 		if ( ! function_exists( 'add_filter' ) ) {
@@ -24,7 +24,18 @@ class Static_Site_Importer_Figma_Import {
 		add_filter(
 			'blocks_engine_figma_transformer_zstd_decoder',
 			static function ( $decoder ) {
-				if ( is_callable( $decoder ) || ! class_exists( '\Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCommandDecoder' ) ) {
+				if ( is_callable( $decoder ) ) {
+					return $decoder;
+				}
+
+				if ( function_exists( 'zstd_uncompress' ) ) {
+					return static function ( string $compressed ): string {
+						$uncompressed = zstd_uncompress( $compressed );
+						return is_string( $uncompressed ) ? $uncompressed : '';
+					};
+				}
+
+				if ( ! class_exists( '\\Automattic\\BlocksEngine\\FigmaTransformer\\Compression\\ZstdCommandDecoder' ) ) {
 					return $decoder;
 				}
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "scripts": {
     "fig-intent-parity": "node tools/fig-intent-parity-report.mjs",
     "fig-fixture-e2e": "node tools/run-fig-fixture-e2e.mjs",
-    "test": "npm run test:fixture-matrix && npm run test:fig-fixture-e2e && npm run test:promote-solved-fixture",
+    "test": "npm run test:fixture-matrix && npm run test:fig-fixture-e2e && npm run test:promote-solved-fixture && npm run test:php-wasm-zstd",
     "test:fig-fixture-e2e": "node --test tools/run-fig-fixture-e2e.test.mjs",
     "test:fixture-matrix": "node --test tools/fixture-matrix.test.mjs",
     "test:promote-solved-fixture": "node --test tools/promote-solved-fixture.test.mjs",
+    "test:php-wasm-zstd": "node --test tools/php-wasm-zstd.test.mjs",
+    "build:php-wasm-zstd": "bash tools/build-php-wasm-zstd.sh",
     "test:js-block-validation": "node tests/smoke-generated-theme-block-validation.cjs",
     "test:validation": "node tests/run-validation-harness.cjs"
   },

--- a/tests/figma-zstd-decoder.php
+++ b/tests/figma-zstd-decoder.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Behavioral checks for the Figma zstd decoder registration.
+ *
+ * Run from the repository root:
+ * php tests/figma-zstd-decoder.php native
+ * php -n tests/figma-zstd-decoder.php command
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( 2 !== $argc || ! in_array( $argv[1], array( 'native', 'command' ), true ) ) {
+	fwrite( STDERR, "Usage: php tests/figma-zstd-decoder.php <native|command>\n" );
+	exit( 2 );
+}
+
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+$filters = array();
+
+function add_filter( string $hook, callable $callback ): bool {
+	global $filters;
+	$filters[ $hook ][] = $callback;
+	return true;
+}
+
+function apply_filters( string $hook, $value ) {
+	global $filters;
+	foreach ( $filters[ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value );
+	}
+	return $value;
+}
+
+if ( 'native' === $argv[1] ) {
+	if ( ! function_exists( 'zstd_uncompress' ) ) {
+		function zstd_uncompress( string $compressed ): string {
+			return 'native:' . $compressed;
+		}
+	}
+
+	putenv( 'STATIC_SITE_IMPORTER_FIGMA_ZSTD_COMMAND=/definitely-not-a-zstd-command' );
+} else {
+	$command = tempnam( sys_get_temp_dir(), 'ssi-zstd-command-' );
+	if ( false === $command ) {
+		fwrite( STDERR, "Could not create zstd command fixture.\n" );
+		exit( 1 );
+	}
+	file_put_contents( $command, "#!/bin/sh\ncat\n" );
+	chmod( $command, 0700 );
+	putenv( 'STATIC_SITE_IMPORTER_FIGMA_ZSTD_COMMAND=' . $command );
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-figma-import.php';
+
+Static_Site_Importer_Figma_Import::register_default_zstd_decoder();
+$decoder = apply_filters( 'blocks_engine_figma_transformer_zstd_decoder', null );
+
+if ( 'native' === $argv[1] ) {
+	if ( ! is_callable( $decoder ) || ( ! extension_loaded( 'zstd' ) && 'native:compressed' !== $decoder( 'compressed' ) ) ) {
+		fwrite( STDERR, "Native zstd decoder was not preferred.\n" );
+		exit( 1 );
+	}
+} else {
+	try {
+		$result = is_callable( $decoder ) ? $decoder( 'compressed', array() ) : null;
+	} finally {
+		unlink( $command );
+	}
+	if ( ! is_array( $result ) || 'compressed' !== ( $result['data'] ?? null ) ) {
+		fwrite( STDERR, "Zstd command fallback did not decode the payload.\n" );
+		exit( 1 );
+	}
+}

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -448,12 +448,15 @@ $assert( str_contains( $plugin_source, "vendor/automattic/blocks-engine-php-tran
 $assert( str_contains( $plugin_source, "vendor/automattic/blocks-engine-php-transformer/php-transformer.php" ), 'loads-composer-path-transformer-bootstrap' );
 $assert( str_contains( $plugin_source, 'Static_Site_Importer_Figma_Import::register_default_zstd_decoder();' ), 'plugin-registers-figma-zstd-decoder' );
 
-$known_zstd_command = false;
-foreach ( array( '/opt/homebrew/bin/zstd', '/usr/local/bin/zstd', '/usr/bin/zstd' ) as $known_zstd_path ) {
-	$known_zstd_command = $known_zstd_command || is_executable( $known_zstd_path );
-}
-$figma_zstd_decoder = apply_filters( 'blocks_engine_figma_transformer_zstd_decoder', null );
-$assert( ! $known_zstd_command || is_callable( $figma_zstd_decoder ), 'figma-zstd-decoder-registers-when-command-exists' );
+$zstd_decoder_test = escapeshellarg( dirname( __DIR__ ) . '/tests/figma-zstd-decoder.php' );
+$zstd_native_output = array();
+$zstd_native_status = 0;
+exec( escapeshellarg( PHP_BINARY ) . ' -n ' . $zstd_decoder_test . ' native 2>&1', $zstd_native_output, $zstd_native_status );
+$assert( 0 === $zstd_native_status, 'figma-zstd-decoder-prefers-native-extension', implode( "\n", $zstd_native_output ) );
+$zstd_command_output = array();
+$zstd_command_status = 0;
+exec( escapeshellarg( PHP_BINARY ) . ' -n ' . $zstd_decoder_test . ' command 2>&1', $zstd_command_output, $zstd_command_status );
+$assert( 0 === $zstd_command_status, 'figma-zstd-decoder-falls-back-to-command', implode( "\n", $zstd_command_output ) );
 
 $rest_source = file_get_contents( dirname( __DIR__ ) . '/includes/rest.php' );
 $assert( is_string( $rest_source ), 'rest-source-readable' );

--- a/tools/build-php-wasm-zstd.sh
+++ b/tools/build-php-wasm-zstd.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the PHP 8.5 JSPI side module with the same Emscripten toolchain that
+# @php-wasm/compile-extension uses for the Playground PHP runtime.
+readonly EXT_ZSTD_REF='0bf5825ad683e637211a0eacec4fe545992f5b67'
+readonly LIBZSTD_REF='63779c798237346c2b245c546c40b72a5a5913fe'
+readonly PHP_WASM_COMPILE_EXTENSION_VERSION='3.1.45'
+readonly ARTIFACT_NAME='static-site-importer-zstd-php8.5-jspi.so'
+readonly MANIFEST_NAME='static-site-importer-zstd-php8.5-jspi.manifest.json'
+readonly RELEASE_BASE_URL='https://github.com/Automattic/static-site-importer/releases/latest/download'
+
+root="$(git rev-parse --show-toplevel)"
+out_dir="${1:-$root/dist/php-wasm-zstd}"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+git clone --quiet --no-checkout https://github.com/kjdev/php-ext-zstd.git "$work_dir/php-ext-zstd"
+git -C "$work_dir/php-ext-zstd" checkout --quiet --detach "$EXT_ZSTD_REF"
+git -C "$work_dir/php-ext-zstd" submodule update --init --recursive
+
+actual_libzstd_ref="$(git -C "$work_dir/php-ext-zstd/zstd" rev-parse HEAD)"
+if [ "$actual_libzstd_ref" != "$LIBZSTD_REF" ]; then
+	echo "Unexpected libzstd source: $actual_libzstd_ref" >&2
+	exit 1
+fi
+
+rm -rf "$out_dir"
+mkdir -p "$out_dir"
+npx --yes "@php-wasm/compile-extension@$PHP_WASM_COMPILE_EXTENSION_VERSION" \
+	--source "$work_dir/php-ext-zstd" \
+	--name zstd \
+	--php-versions 8.5 \
+	--extra-cflags '-U__x86_64__' \
+	--out "$out_dir"
+
+module_path="$out_dir/zstd-php8.5-jspi.so"
+if [ ! -f "$module_path" ]; then
+	echo "PHP.wasm compiler did not produce $module_path" >&2
+	exit 1
+fi
+mv "$module_path" "$out_dir/$ARTIFACT_NAME"
+
+node -e '
+const fs = require("node:fs");
+const [output, manifestName, artifactName, releaseBase] = process.argv.slice(1);
+const manifest = {
+  name: "zstd",
+  version: "0.13.3",
+  mode: "php-extension",
+  artifacts: [{ phpVersion: "8.5", sourcePath: `${releaseBase}/${artifactName}` }],
+};
+fs.writeFileSync(`${output}/${manifestName}`, JSON.stringify(manifest, null, 2) + "\n");
+manifest.artifacts[0].sourcePath = artifactName;
+fs.writeFileSync(`${output}/manifest.json`, JSON.stringify(manifest, null, 2) + "\n");
+' "$out_dir" "$MANIFEST_NAME" "$ARTIFACT_NAME" "$RELEASE_BASE_URL"
+
+printf 'Built %s and %s in %s\n' "$ARTIFACT_NAME" "$MANIFEST_NAME" "$out_dir"

--- a/tools/php-wasm-zstd.test.mjs
+++ b/tools/php-wasm-zstd.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+const root = path.resolve( import.meta.dirname, '..' );
+const releaseBase = 'https://github.com/Automattic/static-site-importer/releases/latest/download';
+const manifestUrl = `${ releaseBase }/static-site-importer-zstd-php8.5-jspi.manifest.json`;
+
+test( 'PHP.wasm zstd build uses pinned JSPI-compatible upstream sources', async () => {
+	const build = await readFile( path.join( root, 'tools/build-php-wasm-zstd.sh' ), 'utf8' );
+	assert.match( build, /EXT_ZSTD_REF='0bf5825ad683e637211a0eacec4fe545992f5b67'/ );
+	assert.match( build, /LIBZSTD_REF='63779c798237346c2b245c546c40b72a5a5913fe'/ );
+	assert.match( build, /PHP_WASM_COMPILE_EXTENSION_VERSION='3\.1\.45'/ );
+	assert.match( build, /@php-wasm\/compile-extension@\$PHP_WASM_COMPILE_EXTENSION_VERSION/ );
+	assert.match( build, /--php-versions 8\.5/ );
+	assert.match( build, /--extra-cflags '-U__x86_64__'/ );
+	assert.doesNotMatch( build, /pecl|zstd -d|\/usr\/bin\/zstd/i );
+} );
+
+test( 'manifest publishes a PHP 8.5 JSPI zstd artifact through the release contract', async () => {
+	const manifest = JSON.parse( await readFile( path.join( root, 'docs/playground/extensions/zstd-php8.5-jspi.manifest.json' ), 'utf8' ) );
+	assert.equal( manifest.name, 'zstd' );
+	assert.equal( manifest.mode, 'php-extension' );
+	assert.deepEqual( manifest.artifacts, [ {
+		phpVersion: '8.5',
+		sourcePath: `${ releaseBase }/static-site-importer-zstd-php8.5-jspi.so`,
+	} ] );
+} );
+
+test( 'Playground starts PHP 8.5 and both README launch links load zstd before boot', async () => {
+	const [ blueprint, readme ] = await Promise.all( [
+		readFile( path.join( root, 'docs/playground/blueprint.json' ), 'utf8' ),
+		readFile( path.join( root, 'README.md' ), 'utf8' ),
+	] );
+	assert.equal( JSON.parse( blueprint ).preferredVersions.php, '8.5' );
+	const links = [ ...readme.matchAll( /\]\((https:\/\/playground\.wordpress\.net\/\?[^)]+)\)/g ) ].map( ( match ) => match[ 1 ] );
+	assert.equal( links.length, 2 );
+	for ( const link of links ) {
+		const url = new URL( link );
+		assert.equal( url.searchParams.get( 'php' ), '8.5' );
+		assert.equal( url.searchParams.get( 'php-extension' ), manifestUrl );
+		assert.equal( url.searchParams.get( 'blueprint-url' ), 'https://raw.githubusercontent.com/Automattic/static-site-importer/main/docs/playground/blueprint.json' );
+	}
+} );


### PR DESCRIPTION
## Summary

- build and publish a pinned PHP 8.5 JSPI `ext-zstd` side module and manifest with releases
- load the extension before Playground boots through the repeatable `php-extension` launch parameter
- prefer `zstd_uncompress()` for `.fig` uploads while preserving the existing host `zstd` command decoder as a native fallback
- update both README launch links and the checked-in blueprint to PHP 8.5

Closes #656.

## How to test

1. Run `npm ci`.
2. Run `composer install --no-interaction`.
3. Run `npm test`.
4. Run `php tests/smoke-importer-block.php`.
5. Confirm all Node suites pass and the importer smoke reports 325 assertions.
6. After release assets are published, open either README Playground link and import a zstd-compressed `.fig` file.

## Compatibility

- Native PHP environments keep the existing `ZstdCommandDecoder` fallback when `ext-zstd` is unavailable.
- Playground prefers the PHP extension because host commands are unavailable in the browser runtime.
- The README launch links reference release-backed assets; the extension manifest and side module become usable after the first release containing this workflow publishes them. No release is performed by this PR.

## Evidence

- Fixture matrix: 182 passed.
- Fig fixture E2E: 3 passed.
- Solved fixture promotion: 3 passed.
- PHP.wasm zstd contract: 3 passed.
- Importer block smoke: 325 assertions passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol with OpenCode and Homeboy
- **Used for:** Designed the PHP.wasm extension contract, implemented build/release and decoder integration, preserved native fallback compatibility, and verified the rebased candidate with Chris.