### PR TITLE
Add plan-only WordPress materialization boundary

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -97,6 +97,28 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 		);
 
 		static_site_importer_register_ability_once(
+			'static-site-importer/materialize-wordpress-site-plan',
+			array(
+				'label'               => __( 'Materialize WordPress Site Plan', 'static-site-importer' ),
+				'description'         => __( 'Materialize a validated Blocks Engine WordPress site plan without compiling source artifacts.', 'static-site-importer' ),
+				'category'            => STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'plan'      => array( 'type' => 'object' ),
+						'slug'      => array( 'type' => 'string' ),
+						'overwrite' => array( 'type' => 'boolean' ),
+					),
+					'required'   => array( 'plan', 'slug' ),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'static_site_importer_ability_materialize_wordpress_site_plan',
+				'permission_callback' => 'static_site_importer_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		static_site_importer_register_ability_once(
 			'static-site-importer/import-website-artifact',
 			array(
 				'label'               => __( 'Import Website Artifact', 'static-site-importer' ),
@@ -239,6 +261,25 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 				'execute_callback'    => 'static_site_importer_ability_validate_artifact',
 				'permission_callback' => 'static_site_importer_ability_permission_callback',
 				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_materialize_wordpress_site_plan' ) ) {
+	/**
+	 * Ability callback for the self-contained Blocks Engine plan boundary.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	function static_site_importer_ability_materialize_wordpress_site_plan( array $input ): array {
+		$plan = isset( $input['plan'] ) && is_array( $input['plan'] ) ? $input['plan'] : array();
+		return Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+			$plan,
+			array(
+				'slug'      => isset( $input['slug'] ) ? (string) $input['slug'] : '',
+				'overwrite' => ! empty( $input['overwrite'] ),
 			)
 		);
 	}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -35,8 +35,15 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			'files' => array(),
 		);
 		$skipped = $preflight['skipped'];
+		$post_ids = array();
 		foreach ( $preflight['posts'] as $document ) {
 			if ( ! empty( $document['protected'] ) ) {
+				$post_ids[ $document['source_path'] ] = $document['existing_post_id'];
+				continue;
+			}
+			$parent_id = '' === $document['parent_source_path'] ? 0 : (int) ( $post_ids[ $document['parent_source_path'] ] ?? 0 );
+			if ( '' !== $document['parent_source_path'] && ! $parent_id ) {
+				$skipped[] = array( 'target' => $document['reconciliation_identity'], 'reason' => 'parent_not_materialized' );
 				continue;
 			}
 			$postarr = array(
@@ -45,6 +52,7 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'post_status'  => $document['status'],
 				'post_type'    => $document['post_type'],
 				'post_content' => $document['final_block_markup'],
+				'post_parent'  => $parent_id,
 			);
 			if ( $document['existing_post_id'] ) {
 				$postarr['ID'] = $document['existing_post_id'];
@@ -63,6 +71,7 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'source_path'               => $document['source_path'],
 				'reconciliation_identity'   => $document['reconciliation_identity'],
 			);
+			$post_ids[ $document['source_path'] ] = (int) $post_id;
 		}
 
 		foreach ( $preflight['files'] as $file ) {
@@ -110,12 +119,12 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		if ( '' === $state['theme_slug'] || $state['theme_slug'] !== (string) ( $args['slug'] ?? '' ) ) {
 			return self::reject( $state, 'invalid_theme_slug' );
 		}
-		if ( ! self::valid_source( $plan['source'] ) || ! self::valid_quality( $plan['quality'] ) ) {
+		if ( ! self::valid_source( $plan['source'] ) || ! self::valid_quality( $plan['quality'] ) || ! self::valid_rows( $plan ) ) {
 			return self::reject( $state, 'invalid_source_or_quality' );
 		}
 		$assets = array();
 		foreach ( $plan['assets'] as $asset ) {
-			if ( ! is_array( $asset ) || ! self::safe_path( $asset['source_path'] ?? null ) || ! self::safe_path( $asset['target_path'] ?? null ) || ! is_string( $asset['mime_type'] ?? null ) || ! is_string( $asset['hash'] ?? null ) || ! self::hash( $asset['hash'] ) || ! self::valid_load( $asset['load'] ?? null ) ) {
+			if ( ! is_array( $asset ) || ! self::safe_path( $asset['source_path'] ?? null ) || ! self::safe_path( $asset['target_path'] ?? null ) || ! is_string( $asset['source'] ?? null ) || ! is_string( $asset['kind'] ?? null ) || ! is_string( $asset['role'] ?? null ) || ! is_string( $asset['intent'] ?? null ) || ! is_string( $asset['mime_type'] ?? null ) || ! is_string( $asset['media'] ?? null ) || ! self::optional_hash( $asset['hash'] ?? null ) || ! self::valid_load( $asset['load'] ?? null ) ) {
 				return self::reject( $state, 'invalid_asset_identity' );
 			}
 			$assets[ $asset['source_path'] . "\n" . $asset['target_path'] ] = $asset;
@@ -146,6 +155,9 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			$target_path = ( 'template' === $document['kind'] ? 'templates/' : 'parts/' ) . $document['slug'] . '.html';
 			$state['files'][] = self::file_row( $target_path, $document['final_block_markup'], $document['reconciliation_identity'] );
 		}
+		if ( ! self::order_posts_by_parent( $state['posts'] ) ) {
+			return self::reject( $state, 'invalid_page_parent_identity' );
+		}
 		foreach ( $plan['writes'] as $write ) {
 			$file = self::write_file_row( $write, $assets );
 			if ( is_wp_error( $file ) ) {
@@ -161,12 +173,16 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		}
 		$seen = array();
 		foreach ( $state['files'] as &$file ) {
-			if ( isset( $seen[ $file['target_path'] ] ) ) {
+			$target_key = strtolower( $file['target_path'] );
+			if ( isset( $seen[ $target_key ] ) || self::reserved_target( $file['target_path'] ) ) {
 				return self::reject( $state, 'duplicate_target_path' );
 			}
-			$seen[ $file['target_path'] ] = true;
+			$seen[ $target_key ] = true;
 			$file['path'] = $theme_dir . '/' . $file['target_path'];
-			if ( file_exists( $file['path'] ) && empty( $args['overwrite'] ) ) {
+			if ( ! self::destination_is_ready( $theme_dir, $file['target_path'] ) ) {
+				return self::reject( $state, 'unsafe_destination_path' );
+			}
+			if ( ( file_exists( $file['path'] ) || is_link( $file['path'] ) ) && empty( $args['overwrite'] ) ) {
 				return self::reject( $state, 'file_conflict' );
 			}
 		}
@@ -179,11 +195,8 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	private static function documents( array $documents, string $kind ): array {
 		$validated = array();
 		foreach ( $documents as $document ) {
-			if ( ! is_array( $document ) || ! self::safe_path( $document['source_path'] ?? null ) || ! is_string( $document['slug'] ?? null ) || '' === sanitize_key( $document['slug'] ) || ! is_string( $document['title'] ?? null ) || ! is_string( $document['post_type'] ?? null ) || ! is_string( $document['parent_source_path'] ?? null ) || ! is_bool( $document['entrypoint'] ?? null ) || ! is_string( $document['final_block_markup'] ?? null ) || '' === trim( $document['final_block_markup'] ) || ! str_contains( $document['final_block_markup'], '<!-- wp:' ) || ! is_array( $document['metadata'] ?? null ) || ! is_array( $document['provenance'] ?? null ) || ! self::hash( $document['reconciliation_identity'] ?? null ) ) {
+			if ( ! is_array( $document ) || ! self::safe_path( $document['source_path'] ?? null ) || ! is_string( $document['slug'] ?? null ) || '' === sanitize_key( $document['slug'] ) || ! is_string( $document['title'] ?? null ) || ! is_string( $document['post_type'] ?? null ) || ! is_string( $document['parent_source_path'] ?? null ) || ! is_bool( $document['entrypoint'] ?? null ) || ! is_string( $document['final_block_markup'] ?? null ) || ! self::valid_block_markup( $document['final_block_markup'] ) || ! is_array( $document['metadata'] ?? null ) || ! is_array( $document['provenance'] ?? null ) || ! self::hash( $document['reconciliation_identity'] ?? null ) || ! hash_equals( $document['reconciliation_identity'], hash( 'sha256', $document['source_path'] . "\n" . $document['final_block_markup'] ) ) || ( 'template_part' === $kind ? ! is_string( $document['area'] ?? null ) || '' === $document['area'] : null !== ( $document['area'] ?? null ) ) ) {
 			return array( new WP_Error( 'invalid_' . $kind . '_document' ) );
-			}
-			if ( 'template_part' === $kind && ( ! is_string( $document['area'] ?? null ) || '' === $document['area'] ) ) {
-				return array( new WP_Error( 'invalid_template_part_area' ) );
 			}
 			$validated[] = array_merge( $document, array( 'kind' => $kind, 'slug' => sanitize_key( $document['slug'] ), 'status' => 'publish' ) );
 		}
@@ -192,7 +205,7 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	/** @return array<string,mixed>|WP_Error */
 	private static function write_file_row( $write, array $assets ) {
-		if ( ! is_array( $write ) || 'theme_asset' !== ( $write['kind'] ?? null ) || ! self::safe_path( $write['source_path'] ?? null ) || ! self::safe_path( $write['target_path'] ?? null ) || ! is_array( $write['payload'] ?? null ) || ! is_string( $write['mime_type'] ?? null ) || '' === $write['mime_type'] || ! self::hash( $write['hash'] ?? null ) ) {
+		if ( ! is_array( $write ) || 'theme_asset' !== ( $write['kind'] ?? null ) || ! self::safe_path( $write['source_path'] ?? null ) || ! self::safe_path( $write['target_path'] ?? null ) || ! is_array( $write['payload'] ?? null ) || ! is_string( $write['mime_type'] ?? null ) || ! is_string( $write['media'] ?? null ) || ! self::optional_hash( $write['hash'] ?? null ) || ! self::valid_load( $write['load'] ?? null ) ) {
 			return new WP_Error( 'invalid_theme_asset_write' );
 		}
 		$encoding = $write['payload']['encoding'] ?? null;
@@ -205,7 +218,7 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return new WP_Error( 'inconsistent_asset_identity' );
 		}
 		$content = 'base64' === $encoding ? base64_decode( $data, true ) : $data;
-		if ( false === $content || ( 'utf8' === $encoding && 1 !== preg_match( '//u', $content ) ) || ! hash_equals( $write['hash'], hash( 'sha256', $content ) ) ) {
+		if ( false === $content || ( 'utf8' === $encoding && 1 !== preg_match( '//u', $content ) ) || ( '' !== $write['hash'] && ! hash_equals( $write['hash'], hash( 'sha256', $content ) ) ) ) {
 			return new WP_Error( 'inconsistent_asset_payload' );
 		}
 		return self::file_row( $write['target_path'], $content, hash( 'sha256', $write['source_path'] . "\n" . $write['target_path'] . "\n" . $write['hash'] ) );
@@ -218,7 +231,7 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	/** @param array<string,mixed> $source */
 	private static function valid_source( array $source ): bool {
-		return 'blocks-engine/php-transformer/compiled-site/v1' === ( $source['schema'] ?? null ) && self::hash( $source['source_hash'] ?? null ) && self::safe_path( $source['entry_path'] ?? null ) && is_array( $source['provenance'] ?? null );
+		return 'blocks-engine/php-transformer/compiled-site/v1' === ( $source['schema'] ?? null ) && self::hash( $source['source_hash'] ?? null ) && is_string( $source['entry_path'] ?? null ) && ( '' === $source['entry_path'] || self::safe_path( $source['entry_path'] ) ) && is_array( $source['provenance'] ?? null );
 	}
 
 	/** @param array<string,mixed> $quality */
@@ -228,6 +241,120 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	private static function valid_load( $load ): bool {
 		return is_array( $load ) && is_string( $load['placement'] ?? null ) && is_string( $load['type'] ?? null ) && is_bool( $load['defer'] ?? null ) && is_bool( $load['async'] ?? null );
+	}
+
+	/** @param array<string,mixed> $plan */
+	private static function valid_rows( array $plan ): bool {
+		foreach ( array( 'routes' => array( 'kind', 'source_path', 'target_path', 'target_slug', 'source_relation', 'order' ), 'navigation_links' => array( 'kind', 'source_path', 'source_relation', 'order' ), 'menus' => array( 'kind', 'source_path', 'target_slug', 'source_relation', 'order', 'items' ), 'asset_rewrite_candidates' => array( 'scope', 'source_path', 'asset_path' ) ) as $key => $fields ) {
+			foreach ( $plan[ $key ] as $row ) {
+				if ( ! is_array( $row ) ) {
+					return false;
+				}
+				foreach ( $fields as $field ) {
+					if ( ! array_key_exists( $field, $row ) || ( ! is_string( $row[ $field ] ) && ! is_int( $row[ $field ] ) ) ) {
+						return false;
+					}
+				}
+				if ( 'navigation_links' === $key ) {
+					foreach ( array( 'target_path', 'target_slug' ) as $field ) {
+						if ( array_key_exists( $field, $row ) && ! is_string( $row[ $field ] ) ) {
+							return false;
+						}
+					}
+				}
+			}
+		}
+		foreach ( array( 'stylesheets', 'scripts', 'fonts', 'images', 'template_parts' ) as $key ) {
+			if ( isset( $plan['theme'][ $key ] ) && ! is_array( $plan['theme'][ $key ] ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Reject markup that is not a balanced sequence of serialized block comments.
+	 */
+	private static function valid_block_markup( string $markup ): bool {
+		if ( '' === trim( $markup ) || ! preg_match_all( '/<!--\s*(\/)?wp:([A-Za-z0-9_\/-]+)(?:\s+(\{.*?\}))?\s*(\/)?-->/s', $markup, $matches, PREG_SET_ORDER ) ) {
+			return false;
+		}
+		$stack = array();
+		foreach ( $matches as $match ) {
+			$is_closing = '/' === ( $match[1] ?? '' );
+			$is_single  = '/' === ( $match[4] ?? '' );
+			$name       = $match[2];
+			$attributes = $match[3] ?? '';
+			if ( '' !== $attributes && ! is_array( json_decode( $attributes, true ) ) ) {
+				return false;
+			}
+			if ( $is_closing ) {
+				if ( $is_single || $name !== array_pop( $stack ) ) {
+					return false;
+				}
+				continue;
+			}
+			if ( ! $is_single ) {
+				$stack[] = $name;
+			}
+		}
+		return empty( $stack );
+	}
+
+	/** @param array<int,array<string,mixed>> $posts */
+	private static function order_posts_by_parent( array &$posts ): bool {
+		$by_source = array();
+		foreach ( $posts as $post ) {
+			if ( isset( $by_source[ $post['source_path'] ] ) ) {
+				return false;
+			}
+			$by_source[ $post['source_path'] ] = $post;
+		}
+		$ordered = array();
+		while ( ! empty( $by_source ) ) {
+			$progress = false;
+			foreach ( $by_source as $source_path => $post ) {
+				if ( '' !== $post['parent_source_path'] && ! isset( $ordered[ $post['parent_source_path'] ] ) ) {
+					if ( ! isset( $by_source[ $post['parent_source_path'] ] ) ) {
+						return false;
+					}
+					continue;
+				}
+				$ordered[ $source_path ] = $post;
+				unset( $by_source[ $source_path ] );
+				$progress = true;
+			}
+			if ( ! $progress ) {
+				return false;
+			}
+		}
+		$posts = array_values( $ordered );
+		return true;
+	}
+
+	private static function destination_is_ready( string $theme_dir, string $target_path ): bool {
+		if ( is_link( rtrim( $theme_dir, '/' ) ) ) {
+			return false;
+		}
+		$current = rtrim( $theme_dir, '/' );
+		foreach ( explode( '/', dirname( $target_path ) ) as $segment ) {
+			if ( '.' === $segment ) {
+				continue;
+			}
+			$current .= '/' . $segment;
+			if ( is_link( $current ) || ( file_exists( $current ) && ! is_dir( $current ) ) ) {
+				return false;
+			}
+			if ( is_dir( $current ) && ! is_writable( $current ) ) {
+				return false;
+			}
+		}
+		return ! is_link( $theme_dir . '/' . $target_path );
+	}
+
+	private static function reserved_target( string $target_path ): bool {
+		$lower = strtolower( $target_path );
+		return str_starts_with( $lower, '.git/' ) || str_starts_with( $lower, 'node_modules/' ) || preg_match( '/(?:^|\/)\.(?:htaccess|user\.ini)$/', $lower ) || preg_match( '/\.(?:php|phtml|phar)$/', $lower );
 	}
 
 	private static function safe_path( $path ): bool {
@@ -246,6 +373,10 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		return is_string( $value ) && 1 === preg_match( '/^[a-f0-9]{64}$/', $value );
 	}
 
+	private static function optional_hash( $value ): bool {
+		return is_string( $value ) && ( '' === $value || self::hash( $value ) );
+	}
+
 	/** @param array<string,mixed> $state @return array<string,mixed> */
 	private static function reject( array $state, string $code ): array {
 		$state['diagnostics'][] = array( 'code' => $code );
@@ -254,16 +385,18 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	/** @param array<string,mixed> $state @param array<string,mixed> $applied @param array<int,array<string,mixed>> $skipped @return array<string,mixed> */
 	private static function receipt( string $status, array $state, array $applied, array $skipped ): array {
+		$planned_identities = array_merge( array_column( $state['posts'] ?? array(), 'reconciliation_identity' ), array_column( $state['files'] ?? array(), 'reconciliation_identity' ) );
+		$plan_diagnostics   = isset( $state['plan']['diagnostics'] ) && is_array( $state['plan']['diagnostics'] ) ? $state['plan']['diagnostics'] : array();
 		return array(
 			'schema'                      => self::RECEIPT_SCHEMA,
 			'status'                      => $status,
 			'plan_hash'                   => $state['plan_hash'],
 			'source'                      => $state['source'],
-			'reconciliation_identities'   => array_merge( array_column( $applied['posts'] ?? array(), 'reconciliation_identity' ), array_column( $applied['files'] ?? array(), 'reconciliation_identity' ) ),
+			'reconciliation_identities'   => $planned_identities,
 			'wordpress'                   => array( 'posts' => $applied['posts'] ?? array() ),
 			'generated_files'             => $applied['files'] ?? array(),
 			'skipped_targets'             => $skipped,
-			'diagnostics'                 => $state['diagnostics'],
+			'diagnostics'                 => array_merge( $plan_diagnostics, $state['diagnostics'] ),
 		);
 	}
 

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Materializes the Blocks Engine WordPress site-plan contract.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Applies final Blocks Engine WordPress site plans without source transformation.
+ */
+class Static_Site_Importer_WordPress_Site_Plan_Materializer {
+
+	public const PLAN_SCHEMA    = 'blocks-engine/wordpress-site-plan/v1';
+	public const RECEIPT_SCHEMA = 'static-site-importer/materialization-receipt/v1';
+
+	/**
+	 * Preflight and apply a self-contained WordPress site plan.
+	 *
+	 * @param array<string,mixed> $plan Plan emitted by Blocks Engine.
+	 * @param array<string,mixed> $args Materialization arguments.
+	 * @return array<string,mixed>
+	 */
+	public static function materialize( array $plan, array $args = array() ): array {
+		$preflight = self::preflight( $plan, $args );
+		if ( ! empty( $preflight['diagnostics'] ) ) {
+			return self::receipt( 'rejected', $preflight, array(), array() );
+		}
+
+		$applied = array(
+			'posts' => array(),
+			'files' => array(),
+		);
+		$skipped = $preflight['skipped'];
+		foreach ( $preflight['posts'] as $document ) {
+			if ( ! empty( $document['protected'] ) ) {
+				continue;
+			}
+			$postarr = array(
+				'post_title'   => $document['title'],
+				'post_name'    => $document['slug'],
+				'post_status'  => $document['status'],
+				'post_type'    => $document['post_type'],
+				'post_content' => $document['final_block_markup'],
+			);
+			if ( $document['existing_post_id'] ) {
+				$postarr['ID'] = $document['existing_post_id'];
+			}
+			$post_id = wp_insert_post( $postarr, true );
+			if ( is_wp_error( $post_id ) ) {
+				$skipped[] = array( 'target' => $document['reconciliation_identity'], 'reason' => $post_id->get_error_code() );
+				continue;
+			}
+			$provenance = wp_json_encode( $document['provenance'], JSON_UNESCAPED_SLASHES );
+			update_post_meta( (int) $post_id, '_static_site_importer_provenance', wp_slash( false === $provenance ? '{}' : $provenance ) );
+			update_post_meta( (int) $post_id, '_static_site_importer_source_path', $document['source_path'] );
+			update_post_meta( (int) $post_id, '_static_site_importer_reconciliation_identity', $document['reconciliation_identity'] );
+			$applied['posts'][] = array(
+				'id'                        => (int) $post_id,
+				'source_path'               => $document['source_path'],
+				'reconciliation_identity'   => $document['reconciliation_identity'],
+			);
+		}
+
+		foreach ( $preflight['files'] as $file ) {
+			if ( ! wp_mkdir_p( dirname( $file['path'] ) ) || false === file_put_contents( $file['path'], $file['content'] ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Applies a preflighted plan payload to its declared generated-theme target.
+				$skipped[] = array( 'target' => $file['target_path'], 'reason' => 'write_failed' );
+				continue;
+			}
+			$applied['files'][] = array(
+				'path'                      => $file['target_path'],
+				'hash'                      => hash( 'sha256', $file['content'] ),
+				'reconciliation_identity'   => $file['reconciliation_identity'],
+			);
+		}
+
+		$status = empty( $skipped ) ? 'applied' : 'partial';
+		return self::receipt( $status, $preflight, $applied, $skipped );
+	}
+
+	/**
+	 * Validate every target and payload before creating any post or directory.
+	 *
+	 * @param array<string,mixed> $plan Plan emitted by Blocks Engine.
+	 * @param array<string,mixed> $args Materialization arguments.
+	 * @return array<string,mixed>
+	 */
+	private static function preflight( array $plan, array $args ): array {
+		$state = array(
+			'diagnostics' => array(),
+			'posts'       => array(),
+			'files'       => array(),
+			'skipped'     => array(),
+			'plan'        => $plan,
+			'plan_hash'   => self::plan_hash( $plan ),
+			'source'      => isset( $plan['source'] ) && is_array( $plan['source'] ) ? $plan['source'] : array(),
+			'theme_slug'  => sanitize_key( (string) ( $args['slug'] ?? '' ) ),
+		);
+		if ( self::PLAN_SCHEMA !== ( $plan['schema'] ?? null ) ) {
+			return self::reject( $state, 'unsupported_schema' );
+		}
+		foreach ( array( 'source', 'pages', 'templates', 'template_parts', 'assets', 'writes', 'routes', 'navigation_links', 'menus', 'asset_rewrite_candidates', 'theme', 'visual_repair', 'diagnostics', 'quality' ) as $key ) {
+			if ( ! isset( $plan[ $key ] ) || ! is_array( $plan[ $key ] ) ) {
+				return self::reject( $state, 'missing_or_invalid_' . $key );
+			}
+		}
+		if ( '' === $state['theme_slug'] || $state['theme_slug'] !== (string) ( $args['slug'] ?? '' ) ) {
+			return self::reject( $state, 'invalid_theme_slug' );
+		}
+		if ( ! self::valid_source( $plan['source'] ) || ! self::valid_quality( $plan['quality'] ) ) {
+			return self::reject( $state, 'invalid_source_or_quality' );
+		}
+		$assets = array();
+		foreach ( $plan['assets'] as $asset ) {
+			if ( ! is_array( $asset ) || ! self::safe_path( $asset['source_path'] ?? null ) || ! self::safe_path( $asset['target_path'] ?? null ) || ! is_string( $asset['mime_type'] ?? null ) || ! is_string( $asset['hash'] ?? null ) || ! self::hash( $asset['hash'] ) || ! self::valid_load( $asset['load'] ?? null ) ) {
+				return self::reject( $state, 'invalid_asset_identity' );
+			}
+			$assets[ $asset['source_path'] . "\n" . $asset['target_path'] ] = $asset;
+		}
+
+		$documents = array_merge(
+			self::documents( $plan['pages'], 'page' ),
+			self::documents( $plan['templates'], 'template' ),
+			self::documents( $plan['template_parts'], 'template_part' )
+		);
+		foreach ( $documents as $document ) {
+			if ( is_wp_error( $document ) ) {
+				return self::reject( $state, $document->get_error_code() );
+			}
+			if ( 'page' === $document['kind'] ) {
+				$existing = get_page_by_path( $document['slug'], OBJECT, $document['post_type'] );
+				$document['existing_post_id'] = $existing instanceof WP_Post ? (int) $existing->ID : 0;
+				$document['protected'] = $existing instanceof WP_Post && '' === (string) get_post_meta( $existing->ID, '_static_site_importer_reconciliation_identity', true );
+				if ( $document['existing_post_id'] && ! $document['protected'] && empty( $args['overwrite'] ) ) {
+					return self::reject( $state, 'post_conflict' );
+				}
+				if ( $document['protected'] ) {
+					$state['skipped'][] = array( 'target' => $document['reconciliation_identity'], 'reason' => 'protected_post' );
+				}
+				$state['posts'][] = $document;
+				continue;
+			}
+			$target_path = ( 'template' === $document['kind'] ? 'templates/' : 'parts/' ) . $document['slug'] . '.html';
+			$state['files'][] = self::file_row( $target_path, $document['final_block_markup'], $document['reconciliation_identity'] );
+		}
+		foreach ( $plan['writes'] as $write ) {
+			$file = self::write_file_row( $write, $assets );
+			if ( is_wp_error( $file ) ) {
+				return self::reject( $state, $file->get_error_code() );
+			}
+			$state['files'][] = $file;
+		}
+
+		$theme_dir = trailingslashit( get_theme_root() ) . $state['theme_slug'];
+		$parent    = dirname( $theme_dir );
+		if ( ! is_dir( $parent ) || ! is_writable( $parent ) ) {
+			return self::reject( $state, 'theme_destination_not_ready' );
+		}
+		$seen = array();
+		foreach ( $state['files'] as &$file ) {
+			if ( isset( $seen[ $file['target_path'] ] ) ) {
+				return self::reject( $state, 'duplicate_target_path' );
+			}
+			$seen[ $file['target_path'] ] = true;
+			$file['path'] = $theme_dir . '/' . $file['target_path'];
+			if ( file_exists( $file['path'] ) && empty( $args['overwrite'] ) ) {
+				return self::reject( $state, 'file_conflict' );
+			}
+		}
+		unset( $file );
+
+		return $state;
+	}
+
+	/** @return array<int,array<string,mixed>|WP_Error> */
+	private static function documents( array $documents, string $kind ): array {
+		$validated = array();
+		foreach ( $documents as $document ) {
+			if ( ! is_array( $document ) || ! self::safe_path( $document['source_path'] ?? null ) || ! is_string( $document['slug'] ?? null ) || '' === sanitize_key( $document['slug'] ) || ! is_string( $document['title'] ?? null ) || ! is_string( $document['post_type'] ?? null ) || ! is_string( $document['parent_source_path'] ?? null ) || ! is_bool( $document['entrypoint'] ?? null ) || ! is_string( $document['final_block_markup'] ?? null ) || '' === trim( $document['final_block_markup'] ) || ! str_contains( $document['final_block_markup'], '<!-- wp:' ) || ! is_array( $document['metadata'] ?? null ) || ! is_array( $document['provenance'] ?? null ) || ! self::hash( $document['reconciliation_identity'] ?? null ) ) {
+			return array( new WP_Error( 'invalid_' . $kind . '_document' ) );
+			}
+			if ( 'template_part' === $kind && ( ! is_string( $document['area'] ?? null ) || '' === $document['area'] ) ) {
+				return array( new WP_Error( 'invalid_template_part_area' ) );
+			}
+			$validated[] = array_merge( $document, array( 'kind' => $kind, 'slug' => sanitize_key( $document['slug'] ), 'status' => 'publish' ) );
+		}
+		return $validated;
+	}
+
+	/** @return array<string,mixed>|WP_Error */
+	private static function write_file_row( $write, array $assets ) {
+		if ( ! is_array( $write ) || 'theme_asset' !== ( $write['kind'] ?? null ) || ! self::safe_path( $write['source_path'] ?? null ) || ! self::safe_path( $write['target_path'] ?? null ) || ! is_array( $write['payload'] ?? null ) || ! is_string( $write['mime_type'] ?? null ) || '' === $write['mime_type'] || ! self::hash( $write['hash'] ?? null ) ) {
+			return new WP_Error( 'invalid_theme_asset_write' );
+		}
+		$encoding = $write['payload']['encoding'] ?? null;
+		$data     = $write['payload']['data'] ?? null;
+		if ( ! in_array( $encoding, array( 'utf8', 'base64' ), true ) || ! is_string( $data ) ) {
+			return new WP_Error( 'invalid_asset_payload' );
+		}
+		$asset = $assets[ $write['source_path'] . "\n" . $write['target_path'] ] ?? null;
+		if ( ! is_array( $asset ) || $asset['mime_type'] !== $write['mime_type'] || $asset['hash'] !== $write['hash'] ) {
+			return new WP_Error( 'inconsistent_asset_identity' );
+		}
+		$content = 'base64' === $encoding ? base64_decode( $data, true ) : $data;
+		if ( false === $content || ( 'utf8' === $encoding && 1 !== preg_match( '//u', $content ) ) || ! hash_equals( $write['hash'], hash( 'sha256', $content ) ) ) {
+			return new WP_Error( 'inconsistent_asset_payload' );
+		}
+		return self::file_row( $write['target_path'], $content, hash( 'sha256', $write['source_path'] . "\n" . $write['target_path'] . "\n" . $write['hash'] ) );
+	}
+
+	/** @return array<string,mixed> */
+	private static function file_row( string $target_path, string $content, string $identity ): array {
+		return array( 'target_path' => $target_path, 'content' => $content, 'reconciliation_identity' => $identity );
+	}
+
+	/** @param array<string,mixed> $source */
+	private static function valid_source( array $source ): bool {
+		return 'blocks-engine/php-transformer/compiled-site/v1' === ( $source['schema'] ?? null ) && self::hash( $source['source_hash'] ?? null ) && self::safe_path( $source['entry_path'] ?? null ) && is_array( $source['provenance'] ?? null );
+	}
+
+	/** @param array<string,mixed> $quality */
+	private static function valid_quality( array $quality ): bool {
+		return is_string( $quality['status'] ?? null ) && is_array( $quality['metrics'] ?? null ) && is_array( $quality['fallbacks'] ?? null );
+	}
+
+	private static function valid_load( $load ): bool {
+		return is_array( $load ) && is_string( $load['placement'] ?? null ) && is_string( $load['type'] ?? null ) && is_bool( $load['defer'] ?? null ) && is_bool( $load['async'] ?? null );
+	}
+
+	private static function safe_path( $path ): bool {
+		if ( ! is_string( $path ) || '' === $path || str_contains( $path, "\0" ) || str_contains( $path, '\\' ) || str_starts_with( $path, '/' ) || preg_match( '/^[A-Za-z]:/', $path ) ) {
+			return false;
+		}
+		foreach ( explode( '/', $path ) as $segment ) {
+			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static function hash( $value ): bool {
+		return is_string( $value ) && 1 === preg_match( '/^[a-f0-9]{64}$/', $value );
+	}
+
+	/** @param array<string,mixed> $state @return array<string,mixed> */
+	private static function reject( array $state, string $code ): array {
+		$state['diagnostics'][] = array( 'code' => $code );
+		return $state;
+	}
+
+	/** @param array<string,mixed> $state @param array<string,mixed> $applied @param array<int,array<string,mixed>> $skipped @return array<string,mixed> */
+	private static function receipt( string $status, array $state, array $applied, array $skipped ): array {
+		return array(
+			'schema'                      => self::RECEIPT_SCHEMA,
+			'status'                      => $status,
+			'plan_hash'                   => $state['plan_hash'],
+			'source'                      => $state['source'],
+			'reconciliation_identities'   => array_merge( array_column( $applied['posts'] ?? array(), 'reconciliation_identity' ), array_column( $applied['files'] ?? array(), 'reconciliation_identity' ) ),
+			'wordpress'                   => array( 'posts' => $applied['posts'] ?? array() ),
+			'generated_files'             => $applied['files'] ?? array(),
+			'skipped_targets'             => $skipped,
+			'diagnostics'                 => $state['diagnostics'],
+		);
+	}
+
+	private static function plan_hash( array $plan ): string {
+		$json = wp_json_encode( $plan, JSON_UNESCAPED_SLASHES );
+		return hash( 'sha256', false === $json ? '' : $json );
+	}
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -58,6 +58,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-as
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document-metadata-reporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-page-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-materializer.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-wordpress-site-plan-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-stylesheet-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-form-seeder.php';

--- a/tests/smoke-ability-registration-idempotent.php
+++ b/tests/smoke-ability-registration-idempotent.php
@@ -50,6 +50,7 @@ require dirname( __DIR__ ) . '/includes/abilities.php';
 
 $expected_abilities = array(
 	'static-site-importer/export-theme',
+	'static-site-importer/materialize-wordpress-site-plan',
 	'static-site-importer/import-website-artifact',
 	'static-site-importer/import-url',
 	'static-site-importer/import-figma',

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Contract coverage for the isolated WordPress site-plan materializer.
+ *
+ * Run from the repository root:
+ * php tests/smoke-wordpress-site-plan-materializer.php
+ *
+ * @package StaticSiteImporter
+ */
+
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+define( 'OBJECT', 'OBJECT' );
+$GLOBALS['ssi_plan_posts'] = array();
+$GLOBALS['ssi_plan_meta']  = array();
+$GLOBALS['ssi_plan_writes'] = 0;
+$GLOBALS['ssi_plan_meta_writes'] = 0;
+$GLOBALS['ssi_plan_directory_writes'] = 0;
+$GLOBALS['ssi_plan_root'] = sys_get_temp_dir() . '/ssi-plan-materializer-' . uniqid();
+mkdir( $GLOBALS['ssi_plan_root'], 0777, true );
+
+class WP_Error {
+	private string $code;
+	public function __construct( string $code ) { $this->code = $code; }
+	public function get_error_code(): string { return $this->code; }
+}
+class WP_Post { public int $ID; public function __construct( int $id ) { $this->ID = $id; } }
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+function sanitize_key( string $value ): string { return strtolower( (string) preg_replace( '/[^a-z0-9_-]/', '', $value ) ); }
+function get_theme_root(): string { return $GLOBALS['ssi_plan_root']; }
+function trailingslashit( string $path ): string { return rtrim( $path, '/' ) . '/'; }
+function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
+function wp_slash( string $value ): string { return addslashes( $value ); }
+function get_page_by_path( string $slug, $output, string $type ) { return $GLOBALS['ssi_plan_posts'][ $type . ':' . $slug ] ?? null; }
+function get_post_meta( int $id, string $key, bool $single ) { return $GLOBALS['ssi_plan_meta'][ $id ][ $key ] ?? ''; }
+function update_post_meta( int $id, string $key, string $value ): void { $GLOBALS['ssi_plan_meta'][ $id ][ $key ] = $value; $GLOBALS['ssi_plan_meta_writes']++; }
+function wp_insert_post( array $postarr, bool $wp_error ) {
+	$id = isset( $postarr['ID'] ) ? (int) $postarr['ID'] : count( $GLOBALS['ssi_plan_posts'] ) + 1;
+	$GLOBALS['ssi_plan_posts'][ $postarr['post_type'] . ':' . $postarr['post_name'] ] = new WP_Post( $id );
+	$GLOBALS['ssi_plan_writes']++;
+	return $id;
+}
+function wp_mkdir_p( string $path ): bool { $GLOBALS['ssi_plan_directory_writes']++; return is_dir( $path ) || mkdir( $path, 0777, true ); }
+
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-wordpress-site-plan-materializer.php';
+
+$hash = static fn ( string $value ): string => hash( 'sha256', $value );
+$plan = array(
+	'schema' => 'blocks-engine/wordpress-site-plan/v1',
+	'source' => array( 'schema' => 'blocks-engine/php-transformer/compiled-site/v1', 'source_hash' => $hash( 'source' ), 'entry_path' => 'index.html', 'provenance' => array( 'origin' => 'fixture' ) ),
+	'pages' => array( array( 'source_path' => 'index.html', 'slug' => 'home', 'title' => 'Home', 'post_type' => 'page', 'parent_source_path' => '', 'entrypoint' => true, 'final_block_markup' => '<!-- wp:paragraph --><p>Exact plan markup</p><!-- /wp:paragraph -->', 'metadata' => array(), 'provenance' => array( 'origin' => 'fixture' ), 'reconciliation_identity' => $hash( 'page' ) ) ),
+	'templates' => array( array( 'source_path' => 'templates/landing.html', 'slug' => 'landing', 'title' => 'Landing', 'post_type' => 'wp_template', 'parent_source_path' => '', 'entrypoint' => false, 'final_block_markup' => '<!-- wp:post-content /-->', 'metadata' => array(), 'provenance' => array(), 'reconciliation_identity' => $hash( 'template' ) ) ),
+	'template_parts' => array( array( 'source_path' => 'parts/header.html', 'slug' => 'header', 'title' => 'Header', 'post_type' => 'wp_template_part', 'parent_source_path' => '', 'entrypoint' => false, 'area' => 'header', 'final_block_markup' => '<!-- wp:paragraph --><p>Header</p><!-- /wp:paragraph -->', 'metadata' => array(), 'provenance' => array(), 'reconciliation_identity' => $hash( 'part' ) ) ),
+	'assets' => array( array( 'source_path' => 'assets/site.css', 'target_path' => 'assets/site.css', 'mime_type' => 'text/css', 'hash' => $hash( 'body{color:#123}' ), 'load' => array( 'placement' => '', 'type' => '', 'defer' => false, 'async' => false ) ) ),
+	'writes' => array( array( 'kind' => 'theme_asset', 'source_path' => 'assets/site.css', 'target_path' => 'assets/site.css', 'payload' => array( 'encoding' => 'utf8', 'data' => 'body{color:#123}' ), 'mime_type' => 'text/css', 'media' => '', 'hash' => $hash( 'body{color:#123}' ), 'load' => array( 'placement' => '', 'type' => '', 'defer' => false, 'async' => false ) ) ),
+	'routes' => array(), 'navigation_links' => array(), 'menus' => array(), 'asset_rewrite_candidates' => array(), 'theme' => array(), 'visual_repair' => array(), 'diagnostics' => array(), 'quality' => array( 'status' => 'completed', 'metrics' => array(), 'fallbacks' => array() ),
+);
+
+$receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'plan-theme' ) );
+assert( 'applied' === $receipt['status'] );
+assert( 1 === $receipt['wordpress']['posts'][0]['id'] );
+assert( 'static-site-importer/materialization-receipt/v1' === $receipt['schema'] );
+assert( '<!-- wp:paragraph --><p>Header</p><!-- /wp:paragraph -->' === file_get_contents( $GLOBALS['ssi_plan_root'] . '/plan-theme/parts/header.html' ) );
+assert( 'body{color:#123}' === file_get_contents( $GLOBALS['ssi_plan_root'] . '/plan-theme/assets/site.css' ) );
+
+foreach ( array(
+	'unsupported_schema' => static function ( array $candidate ): array { $candidate['schema'] = 'blocks-engine/wordpress-site-plan/v0'; return $candidate; },
+	'missing_markup' => static function ( array $candidate ): array { $candidate['pages'][0]['final_block_markup'] = ''; return $candidate; },
+	'unsafe_path' => static function ( array $candidate ): array { $candidate['writes'][0]['target_path'] = '../escape.css'; return $candidate; },
+	'bad_payload' => static function ( array $candidate ): array { $candidate['writes'][0]['payload']['encoding'] = 'rot13'; return $candidate; },
+	'bad_hash' => static function ( array $candidate ): array { $candidate['writes'][0]['hash'] = str_repeat( '0', 64 ); return $candidate; },
+	'bad_mime' => static function ( array $candidate ): array { $candidate['writes'][0]['mime_type'] = 'text/plain'; return $candidate; },
+) as $case => $mutate ) {
+	$before_posts = $GLOBALS['ssi_plan_writes'];
+	$before_meta = $GLOBALS['ssi_plan_meta_writes'];
+	$before_directories = $GLOBALS['ssi_plan_directory_writes'];
+	$before_files = count( glob( $GLOBALS['ssi_plan_root'] . '/invalid-' . $case . '/**/*' ) ?: array() );
+	$result = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $mutate( $plan ), array( 'slug' => 'invalid-' . $case ) );
+	assert( 'rejected' === $result['status'] );
+	assert( $before_posts === $GLOBALS['ssi_plan_writes'] );
+	assert( $before_meta === $GLOBALS['ssi_plan_meta_writes'] );
+	assert( $before_directories === $GLOBALS['ssi_plan_directory_writes'] );
+	assert( $before_files === count( glob( $GLOBALS['ssi_plan_root'] . '/invalid-' . $case . '/**/*' ) ?: array() ) );
+}
+
+echo "WordPress site plan materializer smoke passed.\n";

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -15,6 +15,8 @@ $GLOBALS['ssi_plan_meta']  = array();
 $GLOBALS['ssi_plan_writes'] = 0;
 $GLOBALS['ssi_plan_meta_writes'] = 0;
 $GLOBALS['ssi_plan_directory_writes'] = 0;
+$GLOBALS['ssi_plan_option_writes'] = 0;
+$GLOBALS['ssi_plan_post_args'] = array();
 $GLOBALS['ssi_plan_root'] = sys_get_temp_dir() . '/ssi-plan-materializer-' . uniqid();
 mkdir( $GLOBALS['ssi_plan_root'], 0777, true );
 
@@ -33,9 +35,11 @@ function wp_slash( string $value ): string { return addslashes( $value ); }
 function get_page_by_path( string $slug, $output, string $type ) { return $GLOBALS['ssi_plan_posts'][ $type . ':' . $slug ] ?? null; }
 function get_post_meta( int $id, string $key, bool $single ) { return $GLOBALS['ssi_plan_meta'][ $id ][ $key ] ?? ''; }
 function update_post_meta( int $id, string $key, string $value ): void { $GLOBALS['ssi_plan_meta'][ $id ][ $key ] = $value; $GLOBALS['ssi_plan_meta_writes']++; }
+function update_option( string $key, $value ): void { $GLOBALS['ssi_plan_option_writes']++; }
 function wp_insert_post( array $postarr, bool $wp_error ) {
 	$id = isset( $postarr['ID'] ) ? (int) $postarr['ID'] : count( $GLOBALS['ssi_plan_posts'] ) + 1;
 	$GLOBALS['ssi_plan_posts'][ $postarr['post_type'] . ':' . $postarr['post_name'] ] = new WP_Post( $id );
+	$GLOBALS['ssi_plan_post_args'][ $id ] = $postarr;
 	$GLOBALS['ssi_plan_writes']++;
 	return $id;
 }
@@ -47,10 +51,13 @@ $hash = static fn ( string $value ): string => hash( 'sha256', $value );
 $plan = array(
 	'schema' => 'blocks-engine/wordpress-site-plan/v1',
 	'source' => array( 'schema' => 'blocks-engine/php-transformer/compiled-site/v1', 'source_hash' => $hash( 'source' ), 'entry_path' => 'index.html', 'provenance' => array( 'origin' => 'fixture' ) ),
-	'pages' => array( array( 'source_path' => 'index.html', 'slug' => 'home', 'title' => 'Home', 'post_type' => 'page', 'parent_source_path' => '', 'entrypoint' => true, 'final_block_markup' => '<!-- wp:paragraph --><p>Exact plan markup</p><!-- /wp:paragraph -->', 'metadata' => array(), 'provenance' => array( 'origin' => 'fixture' ), 'reconciliation_identity' => $hash( 'page' ) ) ),
-	'templates' => array( array( 'source_path' => 'templates/landing.html', 'slug' => 'landing', 'title' => 'Landing', 'post_type' => 'wp_template', 'parent_source_path' => '', 'entrypoint' => false, 'final_block_markup' => '<!-- wp:post-content /-->', 'metadata' => array(), 'provenance' => array(), 'reconciliation_identity' => $hash( 'template' ) ) ),
-	'template_parts' => array( array( 'source_path' => 'parts/header.html', 'slug' => 'header', 'title' => 'Header', 'post_type' => 'wp_template_part', 'parent_source_path' => '', 'entrypoint' => false, 'area' => 'header', 'final_block_markup' => '<!-- wp:paragraph --><p>Header</p><!-- /wp:paragraph -->', 'metadata' => array(), 'provenance' => array(), 'reconciliation_identity' => $hash( 'part' ) ) ),
-	'assets' => array( array( 'source_path' => 'assets/site.css', 'target_path' => 'assets/site.css', 'mime_type' => 'text/css', 'hash' => $hash( 'body{color:#123}' ), 'load' => array( 'placement' => '', 'type' => '', 'defer' => false, 'async' => false ) ) ),
+	'pages' => array(
+		array( 'source_path' => 'child.html', 'slug' => 'child', 'title' => 'Child', 'post_type' => 'page', 'parent_source_path' => 'index.html', 'entrypoint' => false, 'final_block_markup' => '<!-- wp:paragraph --><p>Child markup</p><!-- /wp:paragraph -->', 'metadata' => array(), 'provenance' => array(), 'reconciliation_identity' => $hash( "child.html\n<!-- wp:paragraph --><p>Child markup</p><!-- /wp:paragraph -->" ) ),
+		array( 'source_path' => 'index.html', 'slug' => 'home', 'title' => 'Home', 'post_type' => 'page', 'parent_source_path' => '', 'entrypoint' => true, 'final_block_markup' => '<!-- wp:paragraph --><p>Exact plan markup</p><!-- /wp:paragraph -->', 'metadata' => array(), 'provenance' => array( 'origin' => 'fixture' ), 'reconciliation_identity' => $hash( "index.html\n<!-- wp:paragraph --><p>Exact plan markup</p><!-- /wp:paragraph -->" ) ),
+	),
+	'templates' => array( array( 'source_path' => 'templates/landing.html', 'slug' => 'landing', 'title' => 'Landing', 'post_type' => 'wp_template', 'parent_source_path' => '', 'entrypoint' => false, 'final_block_markup' => '<!-- wp:post-content /-->', 'metadata' => array(), 'provenance' => array(), 'reconciliation_identity' => $hash( "templates/landing.html\n<!-- wp:post-content /-->" ) ) ),
+	'template_parts' => array( array( 'source_path' => 'parts/header.html', 'slug' => 'header', 'title' => 'Header', 'post_type' => 'wp_template_part', 'parent_source_path' => '', 'entrypoint' => false, 'area' => 'header', 'final_block_markup' => '<!-- wp:paragraph --><p>Header</p><!-- /wp:paragraph -->', 'metadata' => array(), 'provenance' => array(), 'reconciliation_identity' => $hash( "parts/header.html\n<!-- wp:paragraph --><p>Header</p><!-- /wp:paragraph -->" ) ) ),
+	'assets' => array( array( 'source_path' => 'assets/site.css', 'target_path' => 'assets/site.css', 'source' => 'fixture', 'kind' => 'css', 'role' => 'stylesheet', 'intent' => '', 'mime_type' => 'text/css', 'media' => '', 'hash' => $hash( 'body{color:#123}' ), 'load' => array( 'placement' => '', 'type' => '', 'defer' => false, 'async' => false ) ) ),
 	'writes' => array( array( 'kind' => 'theme_asset', 'source_path' => 'assets/site.css', 'target_path' => 'assets/site.css', 'payload' => array( 'encoding' => 'utf8', 'data' => 'body{color:#123}' ), 'mime_type' => 'text/css', 'media' => '', 'hash' => $hash( 'body{color:#123}' ), 'load' => array( 'placement' => '', 'type' => '', 'defer' => false, 'async' => false ) ) ),
 	'routes' => array(), 'navigation_links' => array(), 'menus' => array(), 'asset_rewrite_candidates' => array(), 'theme' => array(), 'visual_repair' => array(), 'diagnostics' => array(), 'quality' => array( 'status' => 'completed', 'metrics' => array(), 'fallbacks' => array() ),
 );
@@ -58,9 +65,19 @@ $plan = array(
 $receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'plan-theme' ) );
 assert( 'applied' === $receipt['status'] );
 assert( 1 === $receipt['wordpress']['posts'][0]['id'] );
+assert( 2 === $receipt['wordpress']['posts'][1]['id'] );
+assert( 1 === $GLOBALS['ssi_plan_post_args'][2]['post_parent'] );
 assert( 'static-site-importer/materialization-receipt/v1' === $receipt['schema'] );
 assert( '<!-- wp:paragraph --><p>Header</p><!-- /wp:paragraph -->' === file_get_contents( $GLOBALS['ssi_plan_root'] . '/plan-theme/parts/header.html' ) );
 assert( 'body{color:#123}' === file_get_contents( $GLOBALS['ssi_plan_root'] . '/plan-theme/assets/site.css' ) );
+
+$without_declared_hashes = $plan;
+$without_declared_hashes['source']['entry_path'] = '';
+$without_declared_hashes['assets'][0]['hash'] = '';
+$without_declared_hashes['writes'][0]['hash'] = '';
+$hash_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $without_declared_hashes, array( 'slug' => 'plan-theme-without-hashes', 'overwrite' => true ) );
+assert( 'applied' === $hash_receipt['status'] );
+assert( $hash( 'body{color:#123}' ) === $hash_receipt['generated_files'][2]['hash'] );
 
 foreach ( array(
 	'unsupported_schema' => static function ( array $candidate ): array { $candidate['schema'] = 'blocks-engine/wordpress-site-plan/v0'; return $candidate; },
@@ -69,17 +86,34 @@ foreach ( array(
 	'bad_payload' => static function ( array $candidate ): array { $candidate['writes'][0]['payload']['encoding'] = 'rot13'; return $candidate; },
 	'bad_hash' => static function ( array $candidate ): array { $candidate['writes'][0]['hash'] = str_repeat( '0', 64 ); return $candidate; },
 	'bad_mime' => static function ( array $candidate ): array { $candidate['writes'][0]['mime_type'] = 'text/plain'; return $candidate; },
+	'malformed_block_markup' => static function ( array $candidate ): array { $candidate['pages'][0]['final_block_markup'] = '<!-- wp:paragraph --><p>Broken'; return $candidate; },
+	'case_collision' => static function ( array $candidate ): array { $candidate['writes'][] = array_merge( $candidate['writes'][0], array( 'target_path' => 'assets/SITE.css' ) ); $candidate['assets'][] = array_merge( $candidate['assets'][0], array( 'target_path' => 'assets/SITE.css' ) ); return $candidate; },
 ) as $case => $mutate ) {
 	$before_posts = $GLOBALS['ssi_plan_writes'];
 	$before_meta = $GLOBALS['ssi_plan_meta_writes'];
 	$before_directories = $GLOBALS['ssi_plan_directory_writes'];
+	$before_options = $GLOBALS['ssi_plan_option_writes'];
 	$before_files = count( glob( $GLOBALS['ssi_plan_root'] . '/invalid-' . $case . '/**/*' ) ?: array() );
 	$result = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $mutate( $plan ), array( 'slug' => 'invalid-' . $case ) );
 	assert( 'rejected' === $result['status'] );
 	assert( $before_posts === $GLOBALS['ssi_plan_writes'] );
 	assert( $before_meta === $GLOBALS['ssi_plan_meta_writes'] );
 	assert( $before_directories === $GLOBALS['ssi_plan_directory_writes'] );
+	assert( $before_options === $GLOBALS['ssi_plan_option_writes'] );
 	assert( $before_files === count( glob( $GLOBALS['ssi_plan_root'] . '/invalid-' . $case . '/**/*' ) ?: array() ) );
 }
+
+$symlink_theme = $GLOBALS['ssi_plan_root'] . '/symlink-theme';
+mkdir( $symlink_theme, 0777, true );
+symlink( sys_get_temp_dir(), $symlink_theme . '/assets' );
+$before_posts = $GLOBALS['ssi_plan_writes'];
+$before_meta = $GLOBALS['ssi_plan_meta_writes'];
+$before_directories = $GLOBALS['ssi_plan_directory_writes'];
+$symlink_result = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'symlink-theme', 'overwrite' => true ) );
+assert( 'rejected' === $symlink_result['status'] );
+assert( 'unsafe_destination_path' === $symlink_result['diagnostics'][0]['code'] );
+assert( $before_posts === $GLOBALS['ssi_plan_writes'] );
+assert( $before_meta === $GLOBALS['ssi_plan_meta_writes'] );
+assert( $before_directories === $GLOBALS['ssi_plan_directory_writes'] );
 
 echo "WordPress site plan materializer smoke passed.\n";


### PR DESCRIPTION
## Summary
- Add `static-site-importer/materialize-wordpress-site-plan`, accepting only `blocks-engine/wordpress-site-plan/v1`.
- Preflight the entire desired state before any WordPress or filesystem mutation.
- Materialize final block markup directly and return `static-site-importer/materialization-receipt/v1`.
- Keep every existing WebsiteArtifact, REST, CLI, Playground, export, and legacy materialization path unchanged.

Closes https://github.com/Automattic/static-site-importer/issues/657
Relates to https://github.com/Automattic/blocks-engine/issues/632

## What changed
- Added an isolated plan materializer and public ability.
- Validates schema rows, deterministic reconciliation identities, balanced serialized block markup, parent graphs, safe target paths, payload encoding, optional hashes, MIME declarations, collisions, symlinks, reserved targets, and destination readiness before applying anything.
- Applies pages parent-first with provenance/reconciliation metadata, templates, template parts, and declared theme writes.
- Returns applied, rejected, or partial receipts with WordPress IDs, generated file hashes, diagnostics, plan hash, and planned reconciliation identities.
- Added deterministic accepted-materialization and zero-mutation rejection coverage.

## How to test
1. Run `php tests/smoke-wordpress-site-plan-materializer.php`; expect `WordPress site plan materializer smoke passed.`
2. Run `php tests/smoke-importer-block.php`; expect 325 passing assertions.
3. Run `php tests/smoke-transformer-adapter.php`; expect 102 passing assertions.
4. Run `npm run test:validation`; expect all 11 validation steps to pass.
5. Run `npm run test:fixture-matrix`; expect all 182 tests to pass.
6. Run `git diff --check origin/main...HEAD`.

## Compatibility
This is additive. `static-site-importer/import-website-artifact` remains unchanged for its confirmed `Automattic/wp-codebox` consumer. Existing REST, CLI, Playground, completion-hook, page-meta, source-of-truth manifest, reverse-export, and legacy transformer-envelope behavior remains operational. The new materializer does not inspect `TransformerResult`, `compiled_site`, `MaterializationView`, source files, private compiled envelopes, or HTML conversion.

## Upstream dependency
Blocks Engine PR https://github.com/Automattic/blocks-engine/pull/635 merged the producer, but `automattic/blocks-engine-php-transformer` v0.2.7 remains the latest release. This PR therefore adds the direct consumer boundary without pinning an unreleased commit. Routing WebsiteArtifact compilation through `source_reports.wordpress_site_plan` remains a follow-up after a release containing the producer.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Model:** openai/gpt-5.6-sol
- **Used for:** Architecture, implementation, security hardening, compatibility analysis, deterministic tests, and review with Chris Huber.