### PR TITLE
Add canonical v2 site plan materializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Import a static site or generated website artifact into WordPress pages and a co
 
 Static Site Importer is a WordPress plugin. It requires the [Blocks Engine PHP transformer](https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer) Composer package and calls that package's canonical helper functions for generic artifact compilation and format conversion.
 
+## Canonical Site Plans
+
+`static-site-importer/materialize-wordpress-site-plan` is the generic plan-only boundary for a `blocks-engine/wordpress-site-plan/v2` produced by Blocks Engine 0.4.0. SSI calls the package's canonical validator and resolver, then owns WordPress/filesystem preflight, materialization, reconciliation, and the `static-site-importer/materialization-receipt/v1` response. It accepts no source HTML or transformer result envelope.
+
+For an isolated runtime matrix, invoke the ability with `plan`, `slug`, and optional `overwrite`, or use:
+
+```bash
+wp static-site-importer materialize-wordpress-site-plan --plan=/path/to/plan.json --slug=generated-site
+```
+
 ## Architecture Stack
 
 Static Site Importer is the WordPress materialization layer for static website inputs. It accepts two related shapes:
@@ -42,7 +52,7 @@ When a generated artifact contains full-document HTML, Static Site Importer rout
 - Composer dependencies installed with `composer install`.
 - Node dependencies installed only when running the JavaScript block-validation smoke tests.
 
-SSI requires `automattic/blocks-engine-php-transformer:^0.2.6` in Composer to align installed dependencies with the tagged Blocks Engine PHP transformer release. Until the package is published on Packagist, `composer.json` includes an explicit package repository for the `php-transformer-v0.2.6` tag at `908c76a` with autoloading rooted at the Blocks Engine monorepo archive's `php-transformer/src/` directory. Remove that repository override once Packagist serves the package metadata.
+SSI requires `automattic/blocks-engine-php-transformer:^0.4.0`. Until the package is published on Packagist, `composer.json` includes an explicit package repository for the `php-transformer-v0.4.0` tag with autoloading rooted at the Blocks Engine monorepo archive's `php-transformer/src/` directory. Remove that repository override once Packagist serves the package metadata.
 
 At runtime, SSI loads the transformer package from `vendor/` and calls `blocks_engine_php_transformer_compile_artifact()` and `blocks_engine_php_transformer_convert_format()` directly.
 

--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.2.7",
+        "version": "0.4.0",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "afaf508595155530873dfeed06a53a8173afa833"
+          "reference": "c44910cdd8533d646d236fc7ad86c40e8d7d91df"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.7.zip",
-          "reference": "afaf508595155530873dfeed06a53a8173afa833"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.0.zip",
+          "reference": "c44910cdd8533d646d236fc7ad86c40e8d7d91df"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.1",
-    "automattic/blocks-engine-php-transformer": "^0.2.7",
+    "automattic/blocks-engine-php-transformer": "^0.4.0",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "552000d722c39be028e7da1489f81b52",
+    "content-hash": "660ef8278df6a9ef19fa25ce3181d719",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.2.7",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "afaf508595155530873dfeed06a53a8173afa833"
+                "reference": "c44910cdd8533d646d236fc7ad86c40e8d7d91df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.2.7.zip",
-                "reference": "afaf508595155530873dfeed06a53a8173afa833"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.0.zip",
+                "reference": "c44910cdd8533d646d236fc7ad86c40e8d7d91df"
             },
             "require": {
                 "league/commonmark": "^2.5",
@@ -147,16 +147,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
                 "shasum": ""
             },
             "require": {
@@ -178,8 +178,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -250,7 +250,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-07-12T15:29:16+00:00"
         },
         {
             "name": "league/config",
@@ -492,16 +492,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "url": "https://api.github.com/repos/nette/utils/zipball/b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0",
                 "shasum": ""
             },
             "require": {
@@ -521,7 +521,7 @@
             },
             "suggest": {
                 "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-iconv": "to use Strings::chr(), ord() and reverse()",
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
@@ -577,9 +577,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.4"
+                "source": "https://github.com/nette/utils/tree/v4.1.5"
             },
-            "time": "2026-05-11T20:49:54+00:00"
+            "time": "2026-07-17T23:02:45+00:00"
         },
         {
             "name": "psr/event-dispatcher",

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -97,6 +97,24 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 		);
 
 		static_site_importer_register_ability_once(
+			'static-site-importer/materialize-wordpress-site-plan',
+			array(
+				'label'               => __( 'Materialize WordPress Site Plan', 'static-site-importer' ),
+				'description'         => __( 'Apply a canonical Blocks Engine WordPress site plan to this WordPress runtime.', 'static-site-importer' ),
+				'category'            => STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array( 'plan' => array( 'type' => 'object' ), 'slug' => array( 'type' => 'string' ), 'overwrite' => array( 'type' => 'boolean' ) ),
+					'required'   => array( 'plan', 'slug' ),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'static_site_importer_ability_materialize_wordpress_site_plan',
+				'permission_callback' => 'static_site_importer_ability_permission_callback',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		static_site_importer_register_ability_once(
 			'static-site-importer/import-website-artifact',
 			array(
 				'label'               => __( 'Import Website Artifact', 'static-site-importer' ),
@@ -240,6 +258,16 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 				'permission_callback' => 'static_site_importer_ability_permission_callback',
 				'meta'                => array( 'show_in_rest' => true ),
 			)
+		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_materialize_wordpress_site_plan' ) ) {
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	function static_site_importer_ability_materialize_wordpress_site_plan( array $input ): array {
+		return Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+			isset( $input['plan'] ) && is_array( $input['plan'] ) ? $input['plan'] : array(),
+			array( 'slug' => (string) ( $input['slug'] ?? '' ), 'overwrite' => ! empty( $input['overwrite'] ) )
 		);
 	}
 }

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * Applies the canonical Blocks Engine WordPress site plan to a WordPress runtime.
+ *
+ * @package StaticSiteImporter
+ */
+
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver;
+
+final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
+	public const RECEIPT_SCHEMA = 'static-site-importer/materialization-receipt/v1';
+	private const RECONCILIATION_META_KEY = '_static_site_importer_reconciliation_identity';
+
+	/**
+	 * Materialize a fully canonical v2 plan. Compilation and plan validation belong to Blocks Engine.
+	 *
+	 * @param array<string,mixed> $plan Canonical v2 plan.
+	 * @param array<string,mixed> $args Materialization options.
+	 * @return array<string,mixed> Receipt.
+	 */
+	public static function materialize( array $plan, array $args = array() ): array {
+		$state = array(
+			'plan'        => $plan,
+			'plan_hash'   => self::hash( $plan ),
+			'diagnostics' => array(),
+			'applied'     => array( 'posts' => array(), 'files' => array(), 'operations' => array() ),
+			'skipped'     => array(),
+		);
+
+		try {
+			WordPressSitePlan::assertValid( $plan );
+		} catch ( InvalidArgumentException $error ) {
+			$state['diagnostics'][] = array( 'reason_code' => 'canonical_plan_rejected' );
+			return self::receipt( 'rejected', $state );
+		}
+
+		try {
+			$slug = sanitize_key( (string) ( $args['slug'] ?? '' ) );
+			if ( '' === $slug ) {
+				throw new InvalidArgumentException( 'invalid_theme_slug' );
+			}
+			$theme_root = get_theme_root();
+			if ( ! is_string( $theme_root ) || ! is_dir( $theme_root ) || ! is_writable( $theme_root ) ) {
+				throw new InvalidArgumentException( 'theme_destination_not_ready' );
+			}
+			$theme_dir = trailingslashit( $theme_root ) . $slug;
+			if ( is_link( $theme_dir ) || ( file_exists( $theme_dir ) && ! is_dir( $theme_dir ) ) ) {
+				throw new InvalidArgumentException( 'unsafe_theme_destination' );
+			}
+			$theme_uri = trailingslashit( get_theme_root_uri() ) . $slug;
+			try {
+				$resolved = ( new WordPressSitePlanResolver() )->resolve( $plan, array( 'theme_uri' => $theme_uri ) );
+			} catch ( InvalidArgumentException $error ) {
+				throw new InvalidArgumentException( 'canonical_destination_rejected' );
+			}
+			$state['resolved'] = $resolved;
+			$state['theme_dir'] = $theme_dir;
+			self::preflight( $state, ! empty( $args['overwrite'] ) );
+		} catch ( InvalidArgumentException $error ) {
+			$state['diagnostics'][] = array( 'reason_code' => $error->getMessage() );
+			return self::receipt( 'rejected', $state );
+		}
+
+		foreach ( $state['ordered_pages'] as $page ) {
+			$post = self::materialize_page( $page, $state['source_ids'] );
+			if ( is_wp_error( $post ) ) {
+				return self::failed_receipt( $state, $post->get_error_code() );
+			}
+			$state['page_ids'][ $page['reconciliation_identity'] ] = $post;
+			$state['source_ids'][ $page['source_path'] ] = $post;
+			$state['applied']['posts'][] = array( 'id' => $post, 'reconciliation_identity' => $page['reconciliation_identity'] );
+		}
+
+		foreach ( $state['resolved']['writes'] as $write ) {
+			$result = self::write_file( $state['theme_dir'], $write );
+			if ( is_wp_error( $result ) ) {
+				return self::failed_receipt( $state, $result->get_error_code() );
+			}
+			$state['applied']['files'][] = $result;
+		}
+
+		foreach ( $state['resolved']['operations'] as $operation ) {
+			$result = self::apply_operation( $operation, $state['page_ids'] );
+			if ( is_wp_error( $result ) ) {
+				return self::failed_receipt( $state, $result->get_error_code() );
+			}
+			$state['applied']['operations'][] = $result;
+		}
+
+		return self::receipt( 'complete', $state );
+	}
+
+	/** @param array<string,mixed> $state */
+	private static function preflight( array &$state, bool $overwrite ): void {
+		$pages_by_slug = array();
+		$state['page_ids'] = array();
+		$state['source_ids'] = array();
+		foreach ( $state['resolved']['pages'] as $page ) {
+			$key = strtolower( $page['slug'] );
+			if ( isset( $pages_by_slug[ $key ] ) ) {
+				throw new InvalidArgumentException( 'duplicate_page_slug' );
+			}
+			$pages_by_slug[ $key ] = true;
+			$existing = self::reconciled_post( $page['reconciliation_identity'] );
+			if ( $existing ) {
+				$state['page_ids'][ $page['reconciliation_identity'] ] = (int) $existing->ID;
+				$state['source_ids'][ $page['source_path'] ] = (int) $existing->ID;
+				continue;
+			}
+			$conflict = get_page_by_path( $page['slug'], OBJECT, 'page' );
+			if ( $conflict && ! $overwrite ) {
+				throw new InvalidArgumentException( 'post_conflict' );
+			}
+		}
+		$state['ordered_pages'] = self::parent_ordered_pages( $state['resolved']['pages'] );
+		if ( null === $state['ordered_pages'] ) {
+			throw new InvalidArgumentException( 'invalid_page_parent_identity' );
+		}
+		foreach ( $state['resolved']['operations'] as $operation ) {
+			if ( 'site_reading' !== $operation['kind'] || ! isset( $state['page_ids'][ $operation['front_page_reconciliation_identity'] ] ) && ! self::page_exists_in_plan( $state['resolved']['pages'], $operation['front_page_reconciliation_identity'] ) ) {
+				throw new InvalidArgumentException( 'unsupported_operation' );
+			}
+		}
+		foreach ( $state['resolved']['writes'] as $write ) {
+			$path = $state['theme_dir'] . '/' . $write['target_path'];
+			if ( ! self::safe_destination( $state['theme_dir'], $write['target_path'] ) ) {
+				throw new InvalidArgumentException( 'unsafe_destination_path' );
+			}
+			if ( is_dir( $path ) || ( file_exists( $path ) && ! $overwrite && self::file_hash( $path ) !== self::payload_hash( $write ) ) ) {
+				throw new InvalidArgumentException( 'file_conflict' );
+			}
+		}
+	}
+
+	/** @param array<string,mixed> $page @param array<string,int> $source_ids */
+	private static function materialize_page( array $page, array $source_ids ) {
+		$parent = '' === $page['parent_source_path'] ? 0 : ( $source_ids[ $page['parent_source_path'] ] ?? false );
+		if ( false === $parent ) {
+			return new WP_Error( 'missing_parent_page' );
+		}
+		$existing = self::reconciled_post( $page['reconciliation_identity'] );
+		$post = array(
+			'ID'           => $existing ? (int) $existing->ID : 0,
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => $page['title'],
+			'post_name'    => $page['slug'],
+			'post_parent'  => $parent,
+			'post_content' => wp_slash( $page['resolved_block_markup'] ),
+		);
+		$id = wp_insert_post( $post, true );
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+		update_post_meta( (int) $id, self::RECONCILIATION_META_KEY, $page['reconciliation_identity'] );
+		return (int) $id;
+	}
+
+	/** @param array<string,mixed> $write */
+	private static function write_file( string $theme_dir, array $write ) {
+		$path = $theme_dir . '/' . $write['target_path'];
+		if ( ! is_dir( dirname( $path ) ) && ! wp_mkdir_p( dirname( $path ) ) ) {
+			return new WP_Error( 'theme_directory_create_failed' );
+		}
+		$data = 'base64' === $write['payload']['encoding'] ? base64_decode( $write['payload']['data'], true ) : $write['payload']['data'];
+		$temp = tempnam( dirname( $path ), '.ssi-plan-' );
+		if ( false === $data || false === $temp || false === file_put_contents( $temp, $data ) || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Atomically materializes the canonical declared theme write.
+			if ( is_string( $temp ) && file_exists( $temp ) ) {
+				unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes a failed temporary materialization file.
+			}
+			return new WP_Error( 'theme_write_failed' );
+		}
+		return array( 'target_path' => $write['target_path'], 'hash' => hash( 'sha256', $data ), 'reconciliation_identity' => hash( 'sha256', $write['source_path'] . "\n" . $write['target_path'] ) );
+	}
+
+	/** @param array<string,mixed> $operation @param array<string,int> $page_ids */
+	private static function apply_operation( array $operation, array $page_ids ) {
+		$id = $page_ids[ $operation['front_page_reconciliation_identity'] ] ?? 0;
+		if ( ! $id ) {
+			return new WP_Error( 'operation_target_missing' );
+		}
+		update_option( 'show_on_front', $operation['show_on_front'] );
+		update_option( 'page_on_front', $id );
+		return array( 'kind' => $operation['kind'], 'order' => $operation['order'], 'reconciliation_identity' => $operation['front_page_reconciliation_identity'] );
+	}
+
+	private static function reconciled_post( string $identity ) {
+		$posts = get_posts( array( 'post_type' => 'page', 'post_status' => 'any', 'meta_key' => self::RECONCILIATION_META_KEY, 'meta_value' => $identity, 'numberposts' => 1 ) );
+		return isset( $posts[0] ) ? $posts[0] : null;
+	}
+
+	/** @param array<int,array<string,mixed>> $pages */
+	private static function page_exists_in_plan( array $pages, string $identity ): bool {
+		foreach ( $pages as $page ) {
+			if ( $page['reconciliation_identity'] === $identity ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** @param array<int,array<string,mixed>> $pages @return array<int,array<string,mixed>>|null */
+	private static function parent_ordered_pages( array $pages ): ?array {
+		$remaining = array();
+		foreach ( $pages as $page ) {
+			$remaining[ $page['source_path'] ] = $page;
+		}
+		$ordered = array();
+		while ( ! empty( $remaining ) ) {
+			$progress = false;
+			foreach ( $remaining as $source => $page ) {
+				$parent = $page['parent_source_path'];
+				if ( '' !== $parent && ! isset( $ordered[ $parent ] ) ) {
+					if ( ! isset( $remaining[ $parent ] ) ) {
+						return null;
+					}
+					continue;
+				}
+				$ordered[ $source ] = $page;
+				unset( $remaining[ $source ] );
+				$progress = true;
+			}
+			if ( ! $progress ) {
+				return null;
+			}
+		}
+		return array_values( $ordered );
+	}
+
+	private static function safe_destination( string $theme_dir, string $target ): bool {
+		$current = rtrim( $theme_dir, '/' );
+		foreach ( explode( '/', dirname( $target ) ) as $segment ) {
+			if ( '.' === $segment ) {
+				continue;
+			}
+			$current .= '/' . $segment;
+			if ( is_link( $current ) || ( file_exists( $current ) && ! is_dir( $current ) ) || ( is_dir( $current ) && ! is_writable( $current ) ) ) {
+				return false;
+			}
+		}
+		return ! is_link( $theme_dir . '/' . $target );
+	}
+
+	/** @param array<string,mixed> $write */
+	private static function payload_hash( array $write ): string {
+		$data = 'base64' === $write['payload']['encoding'] ? base64_decode( $write['payload']['data'], true ) : $write['payload']['data'];
+		return is_string( $data ) ? hash( 'sha256', $data ) : '';
+	}
+
+	private static function file_hash( string $path ): string {
+		$data = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Preflight hashes a declared destination file.
+		return false === $data ? '' : hash( 'sha256', $data );
+	}
+
+	/** @param array<string,mixed> $state */
+	private static function failed_receipt( array $state, string $reason ): array {
+		$state['diagnostics'][] = array( 'reason_code' => $reason );
+		return self::receipt( 'partial', $state );
+	}
+
+	/** @param array<string,mixed> $state @return array<string,mixed> */
+	private static function receipt( string $status, array $state ): array {
+		$plan = $state['plan'];
+		return array(
+			'schema'                    => self::RECEIPT_SCHEMA,
+			'status'                    => $status,
+			'plan_hash'                 => $state['plan_hash'],
+			'reconciliation_identities' => array_merge( array_column( $plan['pages'] ?? array(), 'reconciliation_identity' ), array_map( static fn( array $write ): string => hash( 'sha256', $write['source_path'] . "\n" . $write['target_path'] ), $plan['writes'] ?? array() ) ),
+			'wordpress'                 => $state['applied']['posts'],
+			'generated_files'           => $state['applied']['files'],
+			'operations'                => $state['applied']['operations'],
+			'skipped_targets'           => $state['skipped'],
+			'diagnostics'               => $state['diagnostics'],
+		);
+	}
+
+	/** @param array<string,mixed> $plan */
+	private static function hash( array $plan ): string {
+		return hash( 'sha256', (string) wp_json_encode( $plan, JSON_UNESCAPED_SLASHES ) );
+	}
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "fig-intent-parity": "node tools/fig-intent-parity-report.mjs",
     "fig-fixture-e2e": "node tools/run-fig-fixture-e2e.mjs",
-    "test": "npm run test:fixture-matrix && npm run test:fig-fixture-e2e && npm run test:promote-solved-fixture && npm run test:php-wasm-zstd",
+    "test": "npm run test:site-plan-materializer && npm run test:fixture-matrix && npm run test:fig-fixture-e2e && npm run test:promote-solved-fixture && npm run test:php-wasm-zstd",
+    "test:site-plan-materializer": "php tests/smoke-wordpress-site-plan-materializer.php",
     "test:fig-fixture-e2e": "node --test tools/run-fig-fixture-e2e.test.mjs",
     "test:fixture-matrix": "node --test tools/fixture-matrix.test.mjs",
     "test:promote-solved-fixture": "node --test tools/promote-solved-fixture.test.mjs",

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -73,6 +73,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-fi
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-exporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-block-document-reporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-generator.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-wordpress-site-plan-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/abilities.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/block.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/rest.php';
@@ -121,6 +122,25 @@ if ( ! function_exists( 'static_site_importer_cli_write_validation_output' ) ) {
 }
 
 if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
+	WP_CLI::add_command(
+		'static-site-importer materialize-wordpress-site-plan',
+		static function ( array $args, array $assoc_args ): void {
+			unset( $args );
+			$input = isset( $assoc_args['plan'] ) ? file_get_contents( (string) $assoc_args['plan'] ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- CLI reads an operator-supplied canonical plan.
+			$plan  = is_string( $input ) ? json_decode( $input, true ) : null;
+			if ( ! is_array( $plan ) || empty( $assoc_args['slug'] ) ) {
+				WP_CLI::error( 'Provide --plan=<canonical-plan.json> and --slug=<theme-slug>.' );
+			}
+			$receipt = static_site_importer_ability_materialize_wordpress_site_plan(
+				array( 'plan' => $plan, 'slug' => (string) $assoc_args['slug'], 'overwrite' => isset( $assoc_args['overwrite'] ) )
+			);
+			WP_CLI::line( (string) wp_json_encode( $receipt, JSON_UNESCAPED_SLASHES ) );
+			if ( 'complete' !== $receipt['status'] ) {
+				WP_CLI::halt( 1 );
+			}
+		}
+	);
+
 	WP_CLI::add_command(
 		'static-site-importer import-theme',
 		static function ( array $args, array $assoc_args ): void {

--- a/tests/smoke-ability-registration-idempotent.php
+++ b/tests/smoke-ability-registration-idempotent.php
@@ -50,6 +50,7 @@ require dirname( __DIR__ ) . '/includes/abilities.php';
 
 $expected_abilities = array(
 	'static-site-importer/export-theme',
+	'static-site-importer/materialize-wordpress-site-plan',
 	'static-site-importer/import-website-artifact',
 	'static-site-importer/import-url',
 	'static-site-importer/import-figma',

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Isolated v2 plan materialization contract coverage.
+ *
+ * Run: php tests/smoke-wordpress-site-plan-materializer.php
+ *
+ * @package StaticSiteImporter
+ */
+
+require dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler;
+
+define( 'OBJECT', 'OBJECT' );
+$GLOBALS['ssi_plan_root']       = sys_get_temp_dir() . '/ssi-plan-' . bin2hex( random_bytes( 4 ) );
+$GLOBALS['ssi_plan_posts']      = array();
+$GLOBALS['ssi_plan_meta']       = array();
+$GLOBALS['ssi_plan_fail_after'] = 0;
+mkdir( $GLOBALS['ssi_plan_root'], 0777, true );
+
+class WP_Error {
+	private string $code;
+	public function __construct( string $code ) { $this->code = $code; }
+	public function get_error_code(): string { return $this->code; }
+}
+class WP_Post {
+	public int $ID;
+	public function __construct( int $id ) { $this->ID = $id; }
+}
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+function sanitize_key( string $value ): string { return strtolower( (string) preg_replace( '/[^a-z0-9_-]/', '', $value ) ); }
+function get_theme_root(): string { return $GLOBALS['ssi_plan_root']; }
+function get_theme_root_uri(): string { return 'https://example.test/wp-content/themes'; }
+function trailingslashit( string $path ): string { return rtrim( $path, '/' ) . '/'; }
+function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
+function wp_slash( string $value ): string { return addslashes( $value ); }
+function wp_mkdir_p( string $path ): bool { return is_dir( $path ) || mkdir( $path, 0777, true ); }
+function update_option( string $key, $value ): void { $GLOBALS['ssi_plan_options'][ $key ] = $value; }
+function update_post_meta( int $id, string $key, string $value ): void { $GLOBALS['ssi_plan_meta'][ $id ][ $key ] = $value; }
+function get_posts( array $args ): array {
+	foreach ( $GLOBALS['ssi_plan_meta'] as $id => $meta ) {
+		if ( ( $meta[ $args['meta_key'] ] ?? null ) === $args['meta_value'] ) { return array( new WP_Post( $id ) ); }
+	}
+	return array();
+}
+function get_page_by_path( string $slug, $output, string $type ) {
+	foreach ( $GLOBALS['ssi_plan_posts'] as $id => $post ) { if ( $post['post_name'] === $slug ) { return new WP_Post( $id ); } }
+	return null;
+}
+function wp_insert_post( array $post, bool $wp_error ) {
+	if ( $GLOBALS['ssi_plan_fail_after'] && count( $GLOBALS['ssi_plan_posts'] ) >= $GLOBALS['ssi_plan_fail_after'] ) { return new WP_Error( 'simulated_post_failure' ); }
+	$id = ! empty( $post['ID'] ) ? (int) $post['ID'] : count( $GLOBALS['ssi_plan_posts'] ) + 1;
+	$GLOBALS['ssi_plan_posts'][ $id ] = $post;
+	return $id;
+}
+
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-wordpress-site-plan-materializer.php';
+
+$artifact = array(
+	'entrypoint' => 'index.html',
+	'files'      => array(
+		'index.html'       => '<header><p>Header</p></header><main><img src="assets/logo.svg"><h1>Home</h1></main>',
+		'about.html'       => '<main><h1>About</h1></main>',
+		'assets/logo.svg'  => '<svg xmlns="http://www.w3.org/2000/svg"/>',
+		'assets/site.css'  => 'main { background: url(assets/logo.svg); }',
+	),
+);
+$result = ( new ArtifactCompiler() )->compile( $artifact )->toArray();
+$plan   = $result['source_reports']['wordpress_site_plan'];
+assert( 'blocks-engine/wordpress-site-plan/v2' === $plan['schema'] );
+
+$receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan' ) );
+assert( 'complete' === $receipt['status'] );
+assert( 'static-site-importer/materialization-receipt/v1' === $receipt['schema'] );
+assert( count( $plan['writes'] ) === count( $receipt['generated_files'] ) );
+assert( file_exists( $GLOBALS['ssi_plan_root'] . '/site-plan/templates/front-page.html' ) );
+assert( str_contains( file_get_contents( $GLOBALS['ssi_plan_root'] . '/site-plan/assets/assets/site.css' ), 'https://example.test/wp-content/themes/site-plan/assets/assets/logo.svg' ) );
+assert( 'page' === $GLOBALS['ssi_plan_options']['show_on_front'] );
+
+$repeat = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan' ) );
+assert( 'complete' === $repeat['status'] );
+assert( count( $GLOBALS['ssi_plan_posts'] ) === count( $plan['pages'] ) );
+
+$before_posts = count( $GLOBALS['ssi_plan_posts'] );
+$before_files = count( glob( $GLOBALS['ssi_plan_root'] . '/reject/**/*' ) ?: array() );
+$invalid = $plan;
+$invalid['schema'] = 'blocks-engine/wordpress-site-plan/v1';
+$rejected = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $invalid, array( 'slug' => 'reject' ) );
+assert( 'rejected' === $rejected['status'] );
+assert( $before_posts === count( $GLOBALS['ssi_plan_posts'] ) );
+assert( $before_files === count( glob( $GLOBALS['ssi_plan_root'] . '/reject/**/*' ) ?: array() ) );
+
+$unsafe = $GLOBALS['ssi_plan_root'] . '/unsafe';
+mkdir( $unsafe, 0777, true );
+symlink( sys_get_temp_dir(), $unsafe . '/assets' );
+$unsafe_result = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'unsafe', 'overwrite' => true ) );
+assert( 'rejected' === $unsafe_result['status'] );
+assert( 'unsafe_destination_path' === $unsafe_result['diagnostics'][0]['reason_code'] );
+
+$GLOBALS['ssi_plan_posts']      = array();
+$GLOBALS['ssi_plan_meta']       = array();
+$GLOBALS['ssi_plan_fail_after'] = 1;
+$partial = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'partial-plan' ) );
+assert( 'partial' === $partial['status'] );
+assert( 'simulated_post_failure' === $partial['diagnostics'][0]['reason_code'] );
+
+echo "WordPress site plan materializer smoke passed.\n";

--- a/tools/run-fig-fixture-e2e.mjs
+++ b/tools/run-fig-fixture-e2e.mjs
@@ -140,8 +140,8 @@ export function summarizeRun({ plan, transformStatus, matrixStatus }) {
   const transformFixtures = Array.isArray(transformSummary?.fixtures) ? transformSummary.fixtures : [];
   const completedTransforms = transformFixtures.filter((fixture) => fixture.status === 'completed');
   const failedTransforms = transformFixtures.filter((fixture) => fixture.status && fixture.status !== 'completed');
-  const matrixResultSummary = matrixSummary?.result_summary || {};
-  const failedImportFixtures = Number(matrixResultSummary.failed || 0);
+  const matrixResultSummary = matrixResultSummaryFrom(matrixSummary);
+  const failedImportFixtures = Number(matrixResultSummary?.failed || 0);
   const matrixNativeRate = minFixtureNativeRate(matrixSummary);
   const metrics = summaryMetrics({ plan, transformStatus, matrixStatus, transformSummary, matrixSummary });
   const baselineComparison = compareBaseline(plan, metrics);
@@ -161,6 +161,12 @@ export function summarizeRun({ plan, transformStatus, matrixStatus }) {
   }
   if (matrixStatus && matrixStatus.status !== 0) {
     failures.push(`SSI matrix command exited ${matrixStatus.status}`);
+  }
+  if (plan.run_import_matrix && matrixSummary && !matrixResultSummary) {
+    failures.push('SSI matrix summary is missing fixture result accounting');
+  }
+  if (matrixResultSummary && matrixFixtureAccounting(matrixResultSummary) !== Number(matrixSummary?.fixture_count || 0)) {
+    failures.push('SSI matrix fixture result accounting does not match fixture_count');
   }
   if (matrixSummary && failedImportFixtures > plan.thresholds.max_import_failures) {
     failures.push(`${failedImportFixtures} SSI matrix fixture(s) failed`);
@@ -215,9 +221,9 @@ export function summarizeRun({ plan, transformStatus, matrixStatus }) {
       summary_path: plan.artifacts.matrix_summary,
       result_path: plan.artifacts.matrix_result,
       fixture_count: Number(matrixSummary?.fixture_count || 0),
-      passed_fixture_count: Number(matrixResultSummary.succeeded || 0),
+      passed_fixture_count: Number(matrixResultSummary?.succeeded || 0),
       failed_fixture_count: failedImportFixtures,
-      finding_count: Number(matrixResultSummary.finding_count || 0),
+      finding_count: Number(matrixResultSummary?.finding_count || 0),
       min_native_conversion_rate: matrixNativeRate,
     },
     artifacts: plan.artifacts,
@@ -365,7 +371,7 @@ function normalizeFixtures(value) {
 
 function summaryMetrics({ plan, transformStatus, matrixStatus, transformSummary, matrixSummary }) {
   const transformFixtures = Array.isArray(transformSummary?.fixtures) ? transformSummary.fixtures : [];
-  const matrixResultSummary = matrixSummary?.result_summary || {};
+  const matrixResultSummary = matrixResultSummaryFrom(matrixSummary);
   const transformDuration = numberOr(transformStatus?.duration_ms, sumFixtureMetric(transformFixtures, 'duration_ms'));
   const importDuration = numberOr(matrixStatus?.duration_ms, numberOr(matrixSummary?.runtime?.duration_ms, null));
   return {
@@ -379,9 +385,9 @@ function summaryMetrics({ plan, transformStatus, matrixStatus, transformSummary,
     transform_missing_asset_count: sumQuality(transformFixtures, transformMissingAssetCount),
     import_matrix_enabled: plan.run_import_matrix ? 1 : 0,
     import_matrix_fixture_count: Number(matrixSummary?.fixture_count || 0),
-    import_matrix_passed_fixture_count: Number(matrixResultSummary.succeeded || 0),
-    import_matrix_failed_fixture_count: Number(matrixResultSummary.failed || 0),
-    import_matrix_finding_count: Number(matrixResultSummary.finding_count || 0),
+    import_matrix_passed_fixture_count: Number(matrixResultSummary?.succeeded || 0),
+    import_matrix_failed_fixture_count: Number(matrixResultSummary?.failed || 0),
+    import_matrix_finding_count: Number(matrixResultSummary?.finding_count || 0),
     import_matrix_min_native_conversion_rate: minFixtureNativeRate(matrixSummary),
   };
 }
@@ -479,7 +485,7 @@ function roundRatio(value) {
 }
 
 function minFixtureNativeRate(matrixSummary) {
-  const aggregateRate = Number(matrixSummary?.result_summary?.editor_quality?.native_conversion_rate);
+  const aggregateRate = Number(matrixResultSummaryFrom(matrixSummary)?.editor_quality?.native_conversion_rate);
   if (Number.isFinite(aggregateRate)) {
     return aggregateRate;
   }
@@ -488,6 +494,23 @@ function minFixtureNativeRate(matrixSummary) {
     .map((fixture) => Number(fixture?.editor_quality?.native_conversion_rate))
     .filter((rate) => Number.isFinite(rate));
   return rates.length ? Math.min(...rates) : null;
+}
+
+function matrixResultSummaryFrom(matrixSummary) {
+  if (!matrixSummary || typeof matrixSummary !== 'object') {
+    return null;
+  }
+  const candidate = matrixSummary.result_summary && typeof matrixSummary.result_summary === 'object'
+    ? matrixSummary.result_summary
+    : matrixSummary;
+  return ['succeeded', 'failed'].every((key) => Number.isInteger(Number(candidate[key])))
+    && (candidate.not_run === undefined || Number.isInteger(Number(candidate.not_run)))
+    ? { ...candidate, not_run: Number(candidate.not_run || 0) }
+    : null;
+}
+
+function matrixFixtureAccounting(summary) {
+  return Number(summary.succeeded) + Number(summary.failed) + Number(summary.not_run);
 }
 
 function readJsonIfExists(filePath) {

--- a/tools/run-fig-fixture-e2e.test.mjs
+++ b/tools/run-fig-fixture-e2e.test.mjs
@@ -167,3 +167,63 @@ test('summary compares staged metrics against a baseline when requested', () => 
   assert.equal(summary.baseline_comparison.regressions[0].metric, 'transform_duration_ms');
   assert.ok(summary.failures.some((failure) => failure.includes('transform_duration_ms regressed')));
 });
+
+test('summary consumes root-level fixture accounting and fails the real matrix result', () => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), 'ssi-fig-e2e-root-summary-'));
+  const matrixSummary = path.join(root, 'summary.json');
+  fs.writeFileSync(matrixSummary, JSON.stringify({
+    fixture_count: 3,
+    succeeded: 0,
+    failed: 3,
+    not_run: 0,
+    finding_count: 19,
+  }));
+  const plan = summaryPlan(root, matrixSummary);
+
+  const summary = summarizeRun({ plan, transformStatus: null, matrixStatus: { status: 0, duration_ms: 1 } });
+
+  assert.equal(summary.status, 'failed');
+  assert.equal(summary.import_matrix.failed_fixture_count, 3);
+  assert.equal(summary.import_matrix.finding_count, 19);
+  assert.ok(summary.failures.includes('3 SSI matrix fixture(s) failed'));
+});
+
+test('summary fails closed when fixture accounting is absent or incomplete', () => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), 'ssi-fig-e2e-invalid-summary-'));
+  const matrixSummary = path.join(root, 'summary.json');
+  fs.writeFileSync(matrixSummary, JSON.stringify({ fixture_count: 3 }));
+  const plan = summaryPlan(root, matrixSummary);
+
+  const summary = summarizeRun({ plan, transformStatus: null, matrixStatus: { status: 0, duration_ms: 1 } });
+
+  assert.equal(summary.status, 'failed');
+  assert.ok(summary.failures.includes('SSI matrix summary is missing fixture result accounting'));
+});
+
+function summaryPlan(root, matrixSummary) {
+  return {
+    fixture_count: 3,
+    expected_fixture_count: 3,
+    run_import_matrix: true,
+    thresholds: {
+      max_transform_failures: 0,
+      max_import_failures: 0,
+      min_native_rate: 1,
+      max_transform_vector_placeholders: 0,
+      max_transform_missing_assets: 0,
+      max_import_findings: null,
+      max_baseline_regression_ratio: null,
+    },
+    artifacts: {
+      transform_summary: path.join(root, 'missing-transform-summary.json'),
+      matrix_summary: matrixSummary,
+      matrix_result: path.join(root, 'matrix-result.json'),
+      matrix_output_directory: root,
+    },
+    steps: {
+      transform: { command: 'transform' },
+      import_matrix: { command: 'matrix' },
+    },
+    warnings: [],
+  };
+}


### PR DESCRIPTION
## Summary

Closes #657.

Add the canonical plan-only WordPress materialization boundary using Blocks Engine PHP Transformer 0.4.0 and `blocks-engine/wordpress-site-plan/v2`.

Blocks Engine remains the sole owner of canonical plan validation, destination-independent theme generation, asset-token validation, and destination resolution. SSI accepts the validated/resolved plan and owns only WordPress/filesystem preflight, page reconciliation, atomic theme writes, ordered site operations, provenance, and `static-site-importer/materialization-receipt/v1`.

The new boundary is available through:

- Ability: `static-site-importer/materialize-wordpress-site-plan`
- WP-CLI: `wp static-site-importer materialize-wordpress-site-plan --plan=/path/to/plan.json --slug=generated-site`

Existing website-artifact, REST, admin, CLI, Playground, export, and legacy materialization paths remain unchanged.

The Figma E2E wrapper now also consumes the matrix collector's actual root-level fixture accounting, validates that fixture totals reconcile, and fails closed when accounting is absent. This fixes a reproduced false green where a real run containing 3 failed fixtures and 19 findings was summarized as passed with zero results.

## How to test

1. Run `composer validate`.
2. Run `composer check-platform-reqs`.
3. Run `php tests/smoke-wordpress-site-plan-materializer.php`.
4. Run `npm test` and confirm the canonical materializer smoke plus all 182 fixture-matrix tests pass.
5. Run `npm run test:validation` and confirm all 11 runtime validation steps pass.
6. Run `node --test tools/run-fig-fixture-e2e.test.mjs` and confirm root-level failed fixture accounting makes the wrapper fail.
7. In an isolated WordPress checkout with this plugin loaded, run `wp static-site-importer materialize-wordpress-site-plan --plan=/path/to/v2-plan.json --slug=generated-site`.
8. Confirm the receipt is `complete`, generated theme files match declared hashes, pages contain the plan's resolved block markup, and the declared front-page operation is applied.

## Backwards compatibility

This is additive. No existing extension path or persisted import shape is removed or routed through v2. The new ability and CLI command accept only the new v2 contract; v1 is rejected before mutation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `openai/gpt-5.6-sol`
- **Used for:** Implemented the v2 materializer, receipt boundary, ability/CLI surfaces, reconciliation behavior, tests, documentation, and Figma E2E fixture-accounting repair. Chris reviews and owns the change.
