### PR TITLE
Enable block gap support in generated themes

### DIFF
--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -1571,6 +1571,9 @@ class Static_Site_Importer_Theme_Materializer {
 					'contentSize' => '760px',
 					'wideSize'    => '1200px',
 				),
+				'spacing' => array(
+					'blockGap' => true,
+				),
 			),
 		);
 

--- a/tests/smoke-theme-materializer-dry-run.php
+++ b/tests/smoke-theme-materializer-dry-run.php
@@ -168,6 +168,7 @@ $theme_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes(
 $theme_json   = json_decode( $theme_writes[ $theme_dir . '/theme.json' ] ?? '', true );
 $front_page_template = (string) ( $theme_writes[ $theme_dir . '/templates/front-page.html' ] ?? '' );
 $assert( is_array( $theme_json ), 'generated-theme-json-decodes' );
+$assert( true === ( $theme_json['settings']['spacing']['blockGap'] ?? null ), 'generated-theme-enables-block-gap-support' );
 $assert( str_contains( $front_page_template, '<!-- wp:post-content /-->' ), 'post-content-template-uses-neutral-wrapper' );
 $assert( ! str_contains( $front_page_template, '"tagName":"main"' ), 'post-content-template-does-not-duplicate-source-main-selector' );
 $assert(
@@ -259,7 +260,8 @@ $token_theme_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes
 			'theme_json'    => array(
 				'settings' => array(
 					'spacing' => array(
-						'units' => array( 'px', 'rem', '%' ),
+						'blockGap' => false,
+						'units'    => array( 'px', 'rem', '%' ),
 					),
 				),
 				'styles'   => array(
@@ -282,6 +284,7 @@ $assert( '#0f766e' === ( $token_palette[0]['color'] ?? '' ), 'materialization-pl
 $assert( 1 === count( $token_palette ), 'unsafe-materialization-plan-color-token-is-skipped' );
 $assert( 'Inter, Arial, sans-serif' === ( $token_fonts[0]['fontFamily'] ?? '' ), 'materialization-plan-font-token-promotes-to-theme-json' );
 $assert( '960px' === ( $token_theme_json['settings']['layout']['contentSize'] ?? '' ), 'materialization-plan-layout-token-overrides-content-size' );
+$assert( false === ( $token_theme_json['settings']['spacing']['blockGap'] ?? null ), 'materialization-plan-theme-json-fragment-overrides-block-gap-support' );
 $assert( array( 'px', 'rem', '%' ) === ( $token_theme_json['settings']['spacing']['units'] ?? array() ), 'materialization-plan-theme-json-fragment-merges-settings' );
 $assert( 'var(--wp--preset--color--brand-primary)' === ( $token_theme_json['styles']['elements']['link']['color']['text'] ?? '' ), 'materialization-plan-theme-json-fragment-merges-styles' );
 


### PR DESCRIPTION
## Summary

- enable `settings.spacing.blockGap` in generated `theme.json` files
- preserve artifact-provided overrides through the existing deep merge
- cover both the default and override contracts in the theme materializer smoke test

Closes #667.

## Why

Generated themes set `styles.spacing.blockGap` but did not enable the matching setting. WordPress consequently treated block-gap support as disabled and omitted valid per-block gap declarations from generated layout CSS. This caused `core/navigation` blocks carrying `style.spacing.blockGap` to render with the core `0.5em` fallback.

## How to test

1. Run `composer install --no-interaction --prefer-dist`.
2. Run `npm ci`.
3. Run `php tests/smoke-theme-materializer-dry-run.php`.
4. Run `npm test`.
5. Materialize a theme containing a `core/navigation` block with `style.spacing.blockGap` set to `18px`; render it in WordPress and confirm its `wp-container-core-navigation-is-layout-*` rule includes `gap:18px`.

## Compatibility

Generated themes now expose WordPress block-gap controls and honor block-level gap values that were previously ignored. Existing global default spacing remains `0`. Artifact-provided `theme_json.settings.spacing.blockGap` values continue to override the importer default. This changes generated-theme rendering only where content already declares a block gap.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Root-cause investigation, implementation, tests, and PR preparation
