### PR TITLE
Report final post-graft block quality

### DIFF
--- a/includes/class-static-site-importer-block-document-reporter.php
+++ b/includes/class-static-site-importer-block-document-reporter.php
@@ -42,6 +42,30 @@ class Static_Site_Importer_Block_Document_Reporter {
 	}
 
 	/**
+	 * Clear generated-document analysis before analyzing mutated final documents.
+	 *
+	 * @param array<string,mixed> $report Conversion report (mutated by reference).
+	 * @return void
+	 */
+	public static function reset_generated_block_document_analysis( array &$report ): void {
+		foreach ( array( 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count' ) as $metric ) {
+			$report['quality'][ $metric ] = 0;
+		}
+
+		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
+		$report['diagnostics'] = array_values(
+			array_filter(
+				$diagnostics,
+				static function ( $diagnostic ): bool {
+					return ! is_array( $diagnostic ) || 'generated_theme_block_analysis' !== (string) ( $diagnostic['stage'] ?? '' );
+				}
+			)
+		);
+		$report['materialized_content']['block_documents'] = array();
+		$report['generated_theme']['block_documents']      = array();
+	}
+
+	/**
 	 * Determine whether a generated file should contain block markup.
 	 *
 	 * @param string $relative_path Theme-relative path.
@@ -120,6 +144,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 			$validation_message  = $serialization_mismatch ? 'Serialized block document differs from generated block markup.' : 'Generated block document contains parser-exposed invalid block markup.';
 			$diagnostic          = array(
 				'type'                      => 'invalid_block_document',
+				'stage'                     => 'generated_theme_block_analysis',
 				'source'                    => $relative_path,
 				'block_count'               => $block_count,
 				'core_html_block_count'     => $core_html_count,
@@ -250,7 +275,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 			$html = $block['innerHTML'];
 		}
 
-		$report['diagnostics'][] = Static_Site_Importer_Report_Diagnostics::fallback_diagnostic_entry(
+		$diagnostic = Static_Site_Importer_Report_Diagnostics::fallback_diagnostic_entry(
 			'core_html_block',
 			$source,
 			$html,
@@ -261,6 +286,12 @@ class Static_Site_Importer_Block_Document_Reporter {
 			),
 			$block
 		);
+		if ( 'form' === strtolower( (string) ( $diagnostic['tag_name'] ?? '' ) ) ) {
+			$manifest               = Static_Site_Importer_Report_Diagnostics::form_manifest_from_html( $html );
+			$diagnostic['form']     = $manifest['form'];
+			$diagnostic['controls'] = $manifest['controls'];
+		}
+		$report['diagnostics'][] = $diagnostic;
 	}
 
 	/**

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1179,6 +1179,8 @@ class Static_Site_Importer_Report_Diagnostics {
 				$extracted = self::extract_form_manifest_from_diagnostic( $diagnostic );
 				$controls  = isset( $extracted['controls'] ) && is_array( $extracted['controls'] ) ? $extracted['controls'] : array();
 				$form      = isset( $extracted['form'] ) && is_array( $extracted['form'] ) ? $extracted['form'] : $form;
+				$report['diagnostics'][ $index ]['controls'] = $controls;
+				$report['diagnostics'][ $index ]['form']     = $form;
 			}
 			$manifest_forms[] = array(
 				'selector'    => isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '',
@@ -1218,7 +1220,11 @@ class Static_Site_Importer_Report_Diagnostics {
 			$report['diagnostics'][ $index ] = self::mark_form_finding_mapped( $report['diagnostics'][ $index ], $row, $seeding['provider'] );
 			$report['diagnostics'][ $index ] = self::add_form_graft_source_path( $report['diagnostics'][ $index ], $report );
 
-			if ( ! empty( $page_contents ) ) {
+			$generated_document_owns_graft = ! self::is_generated_core_html_form_diagnostic( $report['diagnostics'][ $index ] )
+				&& self::has_matching_generated_form_diagnostic( $report['diagnostics'][ $index ], $report['diagnostics'] );
+			if ( $generated_document_owns_graft ) {
+				$report['diagnostics'][ $index ]['graft_delegated_to_generated_document'] = true;
+			} elseif ( ! empty( $page_contents ) ) {
 				$markup = isset( $row['block_markup'] ) && is_scalar( $row['block_markup'] ) ? (string) $row['block_markup'] : '';
 				$graft  = self::graft_form_block_into_page_contents( $report['diagnostics'][ $index ], $markup, $page_contents );
 				if ( $graft['grafted'] ) {
@@ -1278,7 +1284,9 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return bool
 	 */
 	private static function is_generated_core_html_form_diagnostic( array $diagnostic ): bool {
-		if ( 'core/html' !== (string) ( $diagnostic['block_name'] ?? '' ) ) {
+		$is_generated_core_html = 'core/html' === (string) ( $diagnostic['block_name'] ?? '' )
+			|| 'generated_document_contains_core_html' === (string) ( $diagnostic['reason'] ?? $diagnostic['reason_code'] ?? '' );
+		if ( ! $is_generated_core_html ) {
 			return false;
 		}
 
@@ -1292,6 +1300,60 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
+	 * Check whether a generated-document finding owns the same form as a source finding.
+	 *
+	 * Named controls provide stable identity when generated URLs and Figma instance
+	 * classes differ from the source document.
+	 *
+	 * @param array<string,mixed>              $finding    Source form finding.
+	 * @param array<int,array<string,mixed>>    $diagnostics Import diagnostics.
+	 * @return bool
+	 */
+	private static function has_matching_generated_form_diagnostic( array $finding, array $diagnostics ): bool {
+		$identity = self::named_form_control_identity( $finding );
+		if ( empty( $identity ) ) {
+			return false;
+		}
+
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) || ! self::is_generated_core_html_form_diagnostic( $diagnostic ) ) {
+				continue;
+			}
+			if ( $identity === self::named_form_control_identity( $diagnostic ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Build stable identities for named form controls.
+	 *
+	 * @param array<string,mixed> $finding Form finding.
+	 * @return array<int,string>
+	 */
+	private static function named_form_control_identity( array $finding ): array {
+		$identity = array();
+		$controls = isset( $finding['controls'] ) && is_array( $finding['controls'] ) ? $finding['controls'] : array();
+		foreach ( $controls as $control ) {
+			if ( ! is_array( $control ) ) {
+				continue;
+			}
+			$name = isset( $control['name'] ) && is_scalar( $control['name'] ) ? strtolower( trim( (string) $control['name'] ) ) : '';
+			$id   = isset( $control['id'] ) && is_scalar( $control['id'] ) ? strtolower( trim( (string) $control['id'] ) ) : '';
+			if ( '' === $name && '' === $id ) {
+				continue;
+			}
+			$tag        = isset( $control['tag'] ) && is_scalar( $control['tag'] ) ? strtolower( trim( (string) $control['tag'] ) ) : '';
+			$type       = isset( $control['type'] ) && is_scalar( $control['type'] ) ? strtolower( trim( (string) $control['type'] ) ) : '';
+			$identity[] = implode( ':', array( $tag, $type, $name, $id ) );
+		}
+		sort( $identity );
+		return $identity;
+	}
+
+	/**
 	 * Extract the provider manifest shape from a generated core/html form diagnostic.
 	 *
 	 * @param array<string,mixed> $diagnostic Diagnostic row.
@@ -1299,6 +1361,16 @@ class Static_Site_Importer_Report_Diagnostics {
 	 */
 	private static function extract_form_manifest_from_diagnostic( array $diagnostic ): array {
 		$html = self::first_scalar( $diagnostic, array( 'source_html_preview', 'html_excerpt', 'excerpt' ) );
+		return self::form_manifest_from_html( $html );
+	}
+
+	/**
+	 * Extract a provider-neutral form manifest from complete HTML.
+	 *
+	 * @param string $html Form HTML.
+	 * @return array{form:array<string,string>,controls:array<int,array<string,mixed>>}
+	 */
+	public static function form_manifest_from_html( string $html ): array {
 		if ( '' === $html || ! str_contains( strtolower( $html ), '<form' ) ) {
 			return array(
 				'form'     => array(),

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -229,12 +229,6 @@ class Static_Site_Importer_Theme_Generator {
 		}
 		self::analyze_imported_page_content_documents( $document_pages, $page_artifacts['contents'] );
 
-		$source_template_writes = Static_Site_Importer_Theme_Materializer::source_document_template_writes( $theme_dir, $page_artifacts['contents'] );
-		$writes                 = array_merge( $writes, $source_template_writes['writes'] );
-		foreach ( $source_template_writes['reports'] as $report ) {
-			self::$conversion_report['generated_theme']['templates'][] = $report;
-		}
-
 		self::record_source_documents_summary( $artifacts['documents'] ?? array(), $document_pages, $page_ids, $permalinks );
 		foreach ( array_keys( $page_artifacts['patterns'] ) as $filename ) {
 			$page = $document_pages[ $filename ] ?? null;
@@ -257,8 +251,35 @@ class Static_Site_Importer_Theme_Generator {
 		self::materialize_required_plugins( $args, $artifacts, $theme_slug, $theme_name );
 		self::record_product_seeding_report( $args );
 		self::record_commerce_dependency_check( $args );
-		self::record_form_materialization( $args, $page_artifacts['contents'] );
+
+		$form_documents = $page_artifacts['contents'];
+		foreach ( $writes as $path => $content ) {
+			$relative_path = ltrim( str_replace( trailingslashit( $theme_dir ), '', $path ), '/' );
+			if ( str_starts_with( $relative_path, 'templates/' ) || str_starts_with( $relative_path, 'parts/' ) || str_starts_with( $relative_path, 'patterns/' ) ) {
+				$form_documents[ $relative_path ] = $content;
+			}
+		}
+		self::record_form_materialization( $args, $form_documents );
+		foreach ( array_keys( $page_artifacts['contents'] ) as $filename ) {
+			$page_artifacts['contents'][ $filename ] = $form_documents[ $filename ];
+		}
+		foreach ( $writes as $path => $content ) {
+			$relative_path = ltrim( str_replace( trailingslashit( $theme_dir ), '', $path ), '/' );
+			if ( array_key_exists( $relative_path, $form_documents ) ) {
+				$writes[ $path ] = $form_documents[ $relative_path ];
+			}
+		}
 		self::record_product_materialization( $args, $page_artifacts['contents'] );
+
+		$source_template_writes = Static_Site_Importer_Theme_Materializer::source_document_template_writes( $theme_dir, $page_artifacts['contents'] );
+		$writes                 = array_merge( $writes, $source_template_writes['writes'] );
+		foreach ( $source_template_writes['reports'] as $report ) {
+			self::$conversion_report['generated_theme']['templates'][] = $report;
+		}
+
+		Static_Site_Importer_Block_Document_Reporter::reset_generated_block_document_analysis( self::$conversion_report );
+		self::analyze_imported_page_content_documents( $document_pages, $page_artifacts['contents'] );
+		self::analyze_generated_theme_block_documents( $writes, $theme_dir );
 		$source_of_truth_manifest                    = self::source_of_truth_manifest( $import_run_id, $source_artifact_reference, $theme_dir, $theme_slug, $page_targets, $page_ids, $permalinks, $writes, $materialized, $write_theme_report_artifacts );
 		self::$conversion_report['source_of_truth'] = $source_of_truth_manifest;
 		$quality                                    = Static_Site_Importer_Report_Diagnostics::finalize_report( self::$conversion_report, $args );

--- a/tests/smoke-form-materializer.php
+++ b/tests/smoke-form-materializer.php
@@ -280,6 +280,36 @@ namespace {
 	$assert( ! str_contains( (string) $duplicate_generated_contents['posts/page-home.post_content'], '<!-- wp:html' ), 'graft-generated-home-core-html-removed' );
 	$assert( ! str_contains( (string) $duplicate_generated_contents['posts/page-contact.post_content'], '<!-- wp:html' ), 'graft-generated-contact-core-html-removed' );
 
+	// A source fallback delegates to its generated-document finding instead of
+	// reporting a duplicate unanchorable graft after URL/class normalization.
+	$delegated_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
+	$delegated_report['diagnostics'][] = array(
+		'type'            => 'unsupported_html_fallback',
+		'diagnostic_code' => 'html_form_fallback',
+		'source_path'     => 'website/index.html',
+		'selector'        => 'main > form',
+		'form'            => array( 'class' => 'source-form', 'action' => 'index.html', 'method' => 'post' ),
+		'controls'        => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ) ),
+	);
+	$delegated_report['diagnostics'][] = array(
+		'type'                => 'core_html_block',
+		'reason'              => 'generated_document_contains_core_html',
+		'stage'               => 'generated_theme_block_analysis',
+		'source'              => 'parts/footer.html',
+		'source_path'         => 'parts/footer.html',
+		'selector'            => 'form.generated-form',
+		'tag_name'            => 'FORM',
+		'block_name'          => 'core/html',
+		'source_html_preview' => $core_html_form,
+		'form'                => array( 'class' => 'newsletter-form', 'action' => '#', 'method' => 'post' ),
+		'controls'            => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ) ),
+	);
+	$delegated_contents = array( 'parts/footer.html' => $core_html_block( $core_html_form ) );
+	$delegated_seeding  = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $delegated_report, array(), $delegated_contents );
+	$assert( true === ( $delegated_report['diagnostics'][0]['graft_delegated_to_generated_document'] ?? false ), 'source-form-graft-delegated' );
+	$assert( 1 === ( $delegated_seeding['grafted_count'] ?? 0 ), 'delegated-generated-form-grafted-once' );
+	$assert( 0 === count( array_filter( $delegated_report['diagnostics'], static fn ( array $diagnostic ): bool => 'form_block_graft_unanchorable' === ( $diagnostic['type'] ?? '' ) ) ), 'delegated-source-form-no-unanchorable-warning' );
+
 	// --- Form finding enrich carries readable_blocks for graft anchoring --------
 	$enrich_readable = $enrich->invoke(
 		null,

--- a/tests/smoke-materialized-block-content-validation.php
+++ b/tests/smoke-materialized-block-content-validation.php
@@ -180,6 +180,20 @@ $analyze->invoke(
 $slash_report = $report_property->getValue();
 $assert( 0 === ( $slash_report['quality']['invalid_block_count'] ?? -1 ), 'escaped-url-slashes-are-not-invalid-blocks' );
 
+$form_html    = '<form class="newsletter" action="#" method="post"><input type="email" name="email" required><button type="submit">Subscribe</button></form>';
+$form_content = '<!-- wp:html ' . wp_json_encode( array( 'content' => $form_html ) ) . ' -->' . $form_html . '<!-- /wp:html -->';
+$form_report  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( '/tmp/source/index.html' );
+Static_Site_Importer_Block_Document_Reporter::analyze_generated_block_document( 'parts/footer.html', $form_content, $form_report );
+$form_findings = array_values( array_filter( $form_report['diagnostics'], static fn ( array $diagnostic ): bool => 'generated_document_contains_core_html' === ( $diagnostic['reason'] ?? '' ) ) );
+$form_finding  = $form_findings[0] ?? array();
+$assert( 'email' === ( $form_finding['controls'][0]['name'] ?? '' ), 'generated-form-diagnostic-retains-control-name' );
+$assert( 'post' === ( $form_finding['form']['method'] ?? '' ), 'generated-form-diagnostic-retains-method' );
+
+Static_Site_Importer_Block_Document_Reporter::reset_generated_block_document_analysis( $form_report );
+Static_Site_Importer_Block_Document_Reporter::analyze_generated_block_document( 'parts/footer.html', '<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-email {"label":"Email"} /--><!-- /wp:jetpack/contact-form -->', $form_report );
+$assert( 0 === ( $form_report['quality']['core_html_block_count'] ?? -1 ), 'post-graft-analysis-has-no-core-html' );
+$assert( 0 === count( array_filter( $form_report['diagnostics'], static fn ( array $diagnostic ): bool => 'generated_document_contains_core_html' === ( $diagnostic['reason'] ?? '' ) ) ), 'pre-graft-core-html-diagnostic-removed' );
+
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
 	exit( 1 );


### PR DESCRIPTION
## Summary
- retain complete generated-form metadata so provider materialization does not depend on truncated diagnostic previews
- graft provider blocks into generated posts, templates, parts, and patterns before final writes
- rebuild generated block diagnostics and quality counts from final post-graft documents
- delegate duplicate source-form grafts to their matching generated-document findings

Addresses #289.

## How to test
1. Run `npm ci && npm test`.
2. Run `php tests/smoke-form-materializer.php`.
3. Run `php tests/smoke-materialized-block-content-validation.php`.
4. Confirm both PHP smoke suites pass with 88 and 22 assertions respectively.

## Behavior and compatibility
- Import reports now describe final materialized documents instead of retaining generated-document diagnostics captured before provider grafting.
- Report consumers may observe resolved `generated_document_contains_core_html` findings and their quality counts disappear after successful grafting.
- Generated form diagnostics gain complete provider-neutral `form` and `controls` metadata.
- No public CLI or extension API changes.

## Evidence
- Full SSI `npm test` suite passes.
- A real FSE fixture import reduced findings from 11 to 3 accepted provenance records, with no generated fallback or graft-failure finding remaining.
- The same run produced native conversion rate `1.0`, generated `core/html` count `0`, and `141/141` editor-valid blocks when combined with the companion Blocks Engine change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with `openai/gpt-5.6-sol`
- **Used for:** Root-cause analysis, implementation, regression tests, and verification under Chris Huber direction.