### PR TITLE
Add solved fixture regression lane

### DIFF
--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -357,6 +357,26 @@ The promotion lane selects the active target plus every fixture under
 requires every selected fixture to retain `solved_candidate`. A target that is
 not solved or any `solved_regression` fails the aggregate.
 
+CI can run the solved regression corpus without an active target:
+
+```bash
+node tools/run-fixture-matrix.mjs \
+  --static-site-importer . \
+  --blocks-engine /path/to/blocks-engine \
+  --solved-only
+```
+
+`--solved-only` selects all and only valid fixture directories (those containing
+`index.html`) under `fixtures/solved/`. It rejects an empty solved corpus, forces
+the existing `solved_candidate` acceptance gate, and defaults to one isolated WP
+Codebox batch per fixture. Editor validation and gated exact visual parity remain
+required; `--no-editor-validation`, `--no-visual-parity`, and
+`--no-visual-parity-gate` fail before execution. It cannot be combined with the
+target, promotion, or manifest selection flags because the lane must cover the
+complete solved corpus. The replayable plan and operator summary identify this
+lane as `fixtures-solved-only/v1` and include active, solved, and selected corpus
+counts so CI artifacts prove the exact selection.
+
 ```bash
 node tools/promote-solved-fixture.mjs \
   --fixture-id <id> \

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -32,6 +32,7 @@ import {
   buildCodeFreshness,
   buildFixtureMatrixRunPlan,
   CANONICAL_FIXTURE_COUNT,
+  SOLVED_ONLY_LANE_ID,
   resolvePathFreshness,
   summarizeBenchRun,
   summarizeRun,
@@ -2372,6 +2373,46 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
     /requires editor validation and gated visual parity/
   );
 
+  const solvedOnlyPlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    blocksEngine,
+    solvedOnly: true,
+    skipInstall: true,
+    skipSync: true,
+  });
+  assert.equal(solvedOnlyPlan.lane_identity, SOLVED_ONLY_LANE_ID);
+  assert.equal(solvedOnlyPlan.fixture_count, 1);
+  assert.equal(solvedOnlyPlan.selected_active_fixture_count, 0);
+  assert.equal(solvedOnlyPlan.selected_solved_fixture_count, 1);
+  assert.deepEqual(solvedOnlyPlan.lane_filter, {
+    fixture_ids: ['solved-site'],
+    solved_only: true,
+    identity: SOLVED_ONLY_LANE_ID,
+  });
+  assert.ok(solvedOnlyPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_FIXTURE_IDS=solved-site'));
+  assert.ok(solvedOnlyPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE=1'));
+  assert.ok(solvedOnlyPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_BATCH_SIZE=1'));
+
+  const emptySolvedRoot = path.join(root, 'empty-solved-fixtures');
+  mkdirSync(path.join(emptySolvedRoot, 'websites', 'fixture-01'), { recursive: true });
+  writeFileSync(path.join(emptySolvedRoot, 'websites', 'fixture-01', 'index.html'), '<h1>Target</h1>');
+  assert.throws(
+    () => buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot: emptySolvedRoot, solvedOnly: true }),
+    /--solved-only requires at least one valid fixture under .*\/solved/
+  );
+  assert.throws(
+    () => buildFixtureMatrixRunPlan({ staticSiteImporter, blocksEngine, solvedOnly: true, targetFixture: 'fixture-01' }),
+    /--solved-only selects the complete fixtures\/solved corpus and cannot be combined with --target-fixture/
+  );
+  assert.throws(
+    () => buildFixtureMatrixRunPlan({ staticSiteImporter, blocksEngine, solvedOnly: true, class: 'marketing/static' }),
+    /--solved-only selects the complete fixtures\/solved corpus and cannot be combined with --class/
+  );
+  assert.throws(
+    () => buildFixtureMatrixRunPlan({ staticSiteImporter, blocksEngine, solvedOnly: true, editorValidation: false }),
+    /--solved-only requires editor validation and gated visual parity/
+  );
+
   const surfacePlan = buildFixtureMatrixRunPlan({
     runner: 'homeboy-lab',
     staticSiteImporter,
@@ -2443,6 +2484,32 @@ test('fixture matrix operator rejects contradictory local and Lab routing', () =
     staticSiteImporter,
     fixtureRoot,
   }), /--allow-local-fallback selects unpinned lab-or-local placement and cannot be combined with --runner homeboy-lab/);
+});
+
+test('--solved-only selects exactly the valid solved fixture corpus', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-solved-only-selection-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'websites', 'active-site'), { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'solved', 'solved-b'), { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'solved', 'solved-a'), { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'solved', 'incomplete'), { recursive: true });
+  writeFileSync(path.join(fixtureRoot, 'websites', 'active-site', 'index.html'), '<h1>Active</h1>');
+  writeFileSync(path.join(fixtureRoot, 'solved', 'solved-a', 'index.html'), '<h1>Solved A</h1>');
+  writeFileSync(path.join(fixtureRoot, 'solved', 'solved-b', 'index.html'), '<h1>Solved B</h1>');
+
+  const plan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot,
+    solvedOnly: true,
+    skipInstall: true,
+    skipSync: true,
+  });
+
+  assert.deepEqual(plan.lane_filter.fixture_ids, ['solved-a', 'solved-b']);
+  assert.equal(plan.selected_active_fixture_count, 0);
+  assert.equal(plan.selected_solved_fixture_count, 2);
 });
 
 test('fixture matrix operator composes typed placement only for the bench step', () => {
@@ -3195,6 +3262,7 @@ test('operator summary preserves matrix rollups for fanout agents', () => {
   assert.equal(summary.top_pattern_families[0].count, 312);
   assert.equal(summary.fixture_exemplars[0].fixture_id, 'shader-site');
   assert.equal(summary.diagnostic_blind_spots[0].kind, 'missing_source_context');
+  assert.equal(summary.lane_identity, null);
 });
 
 test('summarizeBenchRun emits the operator summary on a gate-FAIL instead of throwing', () => {
@@ -3233,6 +3301,28 @@ test('summarizeBenchRun emits the operator summary on a gate-FAIL instead of thr
   assert.deepEqual(result.summary.top_buckets[0], { key: 'runtime_target_gap', count: 18 });
   assert.equal(result.summary.run_refs.show, 'homeboy runs show ssi-live-2');
   assert.deepEqual(result.summary.artifact_urls, ['homeboy-runs:ssi-live-2', 'https://example.test/report.json']);
+});
+
+test('operator summary preserves solved-only lane identity and corpus counts', () => {
+  const summary = summarizeRun({
+    mode: 'release-proof',
+    run_id: 'solved-only-proof',
+    lane_identity: SOLVED_ONLY_LANE_ID,
+    active_fixture_count: 72,
+    solved_fixture_count: 3,
+    selected_fixture_count: 3,
+    selected_active_fixture_count: 0,
+    selected_solved_fixture_count: 3,
+    fixture_count: 3,
+    output_file: path.join(tmpdir(), 'missing-homeboy-bench.json'),
+  });
+
+  assert.equal(summary.lane_identity, SOLVED_ONLY_LANE_ID);
+  assert.equal(summary.active_fixture_count, 72);
+  assert.equal(summary.solved_fixture_count, 3);
+  assert.equal(summary.selected_fixture_count, 3);
+  assert.equal(summary.selected_active_fixture_count, 0);
+  assert.equal(summary.selected_solved_fixture_count, 3);
 });
 
 test('summarizeBenchRun reports a clean pass when the bench exits zero', () => {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'node:url';
 import { MAX_EXTRA_SURFACE_COUNT, normalizeSurfaceCoverageOptions, normalizeVisualAttributionOptions } from '../lib/fixture-matrix.mjs';
 
 export const RIG_ID = 'static-site-importer-fixture-matrix';
+export const SOLVED_ONLY_LANE_ID = 'fixtures-solved-only/v1';
 // Expected top-level fixture directory count in the canonical corpus
 // (`blocks-engine/fixtures/websites`). This is an intentional drift guard, not a
 // derived value: the corpus lives in a different repo, so deriving the canonical
@@ -167,6 +168,8 @@ export function buildFixtureMatrixRunPlan(input) {
     solved_fixture_count: solvedFixtureCount,
     selected_active_fixture_count: options.selectedActiveFixtureCount,
     selected_solved_fixture_count: options.selectedSolvedFixtureCount,
+    selected_fixture_count: fixtureCount,
+    ...(options.laneIdentity ? { lane_identity: options.laneIdentity } : {}),
     canonical_fixture_count: CANONICAL_FIXTURE_COUNT,
     fixture_count_matches_canonical: activeFixtureCount === CANONICAL_FIXTURE_COUNT,
     lane_filter: laneFilterSummary(options),
@@ -223,6 +226,7 @@ function laneFilterSummary(options) {
     ...(options.fixtureIds.length ? { fixture_ids: options.fixtureIds } : {}),
     ...(options.targetFixture ? { target_fixture: options.targetFixture } : {}),
     ...(options.promotionGate ? { promotion_gate: true } : {}),
+    ...(options.solvedOnly ? { solved_only: true, identity: SOLVED_ONLY_LANE_ID } : {}),
     ...(options.class ? { class: String(options.class) } : {}),
     ...(options.tag ? { tag: String(options.tag) } : {}),
     ...(options.capability ? { capability: String(options.capability) } : {}),
@@ -247,10 +251,12 @@ function normalizeOptions(input) {
     fixtureRoot,
     targetFixture: input.targetFixture,
     promotionGate: input.promotionGate,
+    solvedOnly: input.solvedOnly,
+    input,
   });
 
-  if (input.promotionGate && (input.editorValidation === false || input.visualParity === false || input.visualParityGate === false)) {
-    throw new Error('--promotion-gate requires editor validation and gated visual parity; remove the validation or visual-parity opt-out.');
+  if ((input.promotionGate || input.solvedOnly) && (input.editorValidation === false || input.visualParity === false || input.visualParityGate === false)) {
+    throw new Error(`${input.solvedOnly ? '--solved-only' : '--promotion-gate'} requires editor validation and gated visual parity; remove the validation or visual-parity opt-out.`);
   }
 
   const defaultBlocksEnginePhpTransformerPath = input.mode === 'release-proof' ? '' : blocksEngine;
@@ -292,10 +298,12 @@ function normalizeOptions(input) {
     fixtureIds: selection.fixtureIds,
     targetFixture: selection.targetFixture,
     promotionGate: selection.promotionGate,
-    requireSolvedCandidate: selection.promotionGate,
+    solvedOnly: selection.solvedOnly,
+    laneIdentity: selection.solvedOnly ? SOLVED_ONLY_LANE_ID : '',
+    requireSolvedCandidate: selection.requireSolvedCandidate,
     selectedActiveFixtureCount: selection.selectedActiveFixtureCount,
     selectedSolvedFixtureCount: selection.selectedSolvedFixtureCount,
-    batchSize: input.batchSize || (selection.promotionGate ? 1 : input.batchSize),
+    batchSize: input.batchSize || (selection.isolatedBatches ? 1 : input.batchSize),
     blocksEngine,
     blocksEnginePhpTransformerPath,
     passthrough: Array.isArray(input.passthrough) ? input.passthrough : [],
@@ -309,8 +317,25 @@ function normalizeOptions(input) {
   };
 }
 
-function resolveFixtureSelection({ fixtureRoot, targetFixture, promotionGate }) {
+function resolveFixtureSelection({ fixtureRoot, targetFixture, promotionGate, solvedOnly, input }) {
   const target = String(targetFixture || '').trim();
+  if (solvedOnly) {
+    assertSolvedOnlySelectionIsCompatible(input);
+    const solvedFixtureIds = fixtureDirectoryNames(path.join(fixtureRoot, 'solved'));
+    if (!solvedFixtureIds.length) {
+      throw new Error(`--solved-only requires at least one valid fixture under ${path.join(fixtureRoot, 'solved')}.`);
+    }
+    return {
+      fixtureIds: solvedFixtureIds,
+      targetFixture: '',
+      promotionGate: false,
+      solvedOnly: true,
+      requireSolvedCandidate: true,
+      isolatedBatches: true,
+      selectedActiveFixtureCount: 0,
+      selectedSolvedFixtureCount: solvedFixtureIds.length,
+    };
+  }
   if (promotionGate && !target) {
     throw new Error('--promotion-gate requires --target-fixture <id>.');
   }
@@ -319,6 +344,9 @@ function resolveFixtureSelection({ fixtureRoot, targetFixture, promotionGate }) 
       fixtureIds: [],
       targetFixture: '',
       promotionGate: false,
+      solvedOnly: false,
+      requireSolvedCandidate: false,
+      isolatedBatches: false,
       selectedActiveFixtureCount: 0,
       selectedSolvedFixtureCount: 0,
     };
@@ -333,9 +361,29 @@ function resolveFixtureSelection({ fixtureRoot, targetFixture, promotionGate }) 
     fixtureIds: [...new Set([target, ...solvedFixtureIds])].sort(),
     targetFixture: target,
     promotionGate: Boolean(promotionGate),
+    solvedOnly: false,
+    requireSolvedCandidate: Boolean(promotionGate),
+    isolatedBatches: Boolean(promotionGate),
     selectedActiveFixtureCount: 1,
     selectedSolvedFixtureCount: solvedFixtureIds.length,
   };
+}
+
+function assertSolvedOnlySelectionIsCompatible(input) {
+  const incompatible = [
+    ['targetFixture', '--target-fixture'],
+    ['promotionGate', '--promotion-gate'],
+    ['class', '--class'],
+    ['tag', '--tag'],
+    ['capability', '--capability'],
+    ['capabilities', '--capabilities'],
+    ['riskProfile', '--risk-profile'],
+    ['complexity', '--complexity'],
+    ['maxComplexity', '--max-complexity'],
+  ].filter(([key]) => input[key] !== undefined && input[key] !== false).map(([, flag]) => flag);
+  if (incompatible.length) {
+    throw new Error(`--solved-only selects the complete fixtures/solved corpus and cannot be combined with ${incompatible.join(', ')}.`);
+  }
 }
 
 function fixtureDirectoryNames(fixtureRoot) {
@@ -764,6 +812,12 @@ export function summarizeRun(plan, { status } = {}) {
     code_freshness: plan.code_freshness || null,
     transformer_commit: plan.transformer_commit || resolveTransformerCommit(plan.code_freshness),
     surface_coverage: plan.surface_coverage || null,
+    lane_identity: plan.lane_identity || null,
+    active_fixture_count: Number(plan.active_fixture_count || 0),
+    solved_fixture_count: Number(plan.solved_fixture_count || 0),
+    selected_fixture_count: Number(plan.selected_fixture_count || plan.fixture_count || 0),
+    selected_active_fixture_count: Number(plan.selected_active_fixture_count || 0),
+    selected_solved_fixture_count: Number(plan.selected_solved_fixture_count || 0),
     fixture_count: Number(findFirstKey(output, 'fixture_count') || plan.fixture_count || 0),
     passed_fixture_count: Number(resultSummary.succeeded || resultSummary.passed || 0),
     failed_fixture_count: failedFixtureCount,
@@ -813,7 +867,7 @@ function parseArgs(args) {
     if (arg.startsWith('--')) {
       const [rawKey, rawValue] = arg.slice(2).split('=');
       const key = camelCase(rawKey);
-      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'visualParityAlignment', 'liveWpParity', 'promotionGate']);
+      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'visualParityAlignment', 'liveWpParity', 'promotionGate', 'solvedOnly']);
       if (booleanKeys.has(key)) {
         options[key] = true;
         continue;
@@ -937,7 +991,12 @@ function sanitizePathSegment(value) {
 function printHelp() {
   process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Passes --placement local to homeboy bench.\n  --runner <id>                       Passes --runner <id> to homeboy bench (implies Lab placement).\n  --lab-only                          Passes --placement lab without selecting a runner.\n  --allow-local-fallback              Passes --placement lab-or-local to homeboy bench.\n  no routing flags                    Passes --placement auto to homeboy bench.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote>, --lab-only, or --allow-local-fallback.\n  --lab-only cannot be combined with --allow-local-fallback.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n    --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures, which discovers both fixtures/websites and fixtures/solved.
 \n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 2, hard-capped at 16.\n  --target-fixture <id>               Run one active fixture for the fast inner loop.\n  --promotion-gate                    Run the target plus every solved fixture, one per batch, and require solved_candidate for all.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind upstream.\n  --allow-local-fallback              Permit selected Lab runner fallback to local execution.\n  --allow-dirty-lab-workspace         Permit reusing/overwriting a dirty Lab workspace.\n  --detach-after-handoff              Return after runner daemon accepts the job.\n  --dry-run                           Print the plan without running Homeboy.\n  --skip-install                      Skip rig install.\n  --skip-sync                         Skip rig sync.\n  --no-editor-validation              Omit editor block validation.\n  --no-visual-parity                  Omit visual parity capture.\n  --no-visual-parity-gate             Capture visual parity without gating.\n  --help                              Show this help.\n`);
+  printSolvedOnlyHelp();
   printVisualAttributionHelp();
+}
+
+function printSolvedOnlyHelp() {
+  process.stdout.write('  --solved-only                       Run every valid fixtures/solved fixture, one per batch, and require solved_candidate for all.\n');
 }
 
 // Visual attribution controls are separate so the main usage text remains


### PR DESCRIPTION
## Summary
Add solved fixture regression lane

## What changed
- Task objective: Implement issue #668 in the existing fixture-matrix operator wrapper. Add a --solved-only lane that selects all and only valid fixtures under fixtures/solved, rejects an empty solved corpus before execution, requires every selected fixture to remain solved\_candidate, and defaults to one fixture per isolated WP Codebox batch. Keep --promotion-gate behavior intact and make incompatible selection flags fail clearly. Preserve editor validation, native-editability evaluation, and gated exact visual parity. Record a deterministic solved-only lane identity plus active/solved/selected counts in replayable plan and operator-summary output so CI artifacts prove what ran. Add focused high-signal tests for exact solved selection, empty-corpus rejection, incompatible flags, required settings/batch size, and summary fields. Document the CI-facing command and contract in docs/fixture-matrix.md. Make the smallest correct change; do not edit CHANGELOG.md.
- Verified candidate changed 3 file(s): docs/fixture-matrix.md, tools/fixture-matrix.test.mjs, tools/run-fixture-matrix.mjs.
- Cook completed 1 deterministic verification gate(s) before finalization.
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.

## How to test
1. Run `npm run test:fixture-matrix`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Compatibility impact is unknown from durable task and promotion evidence. The candidate is bounded to 3 changed file(s): docs/fixture-matrix.md, tools/fixture-matrix.test.mjs, tools/run-fixture-matrix.mjs; review externally consumed interfaces in this scope.

## Evidence
- Base unchanged since verification: main remains at eb0ef18bb94e7ce449f6cbf33428005630689b1a.
- CI expected: Homeboy CI after push
- Cook deterministic verification: 1 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable source evidence: https://github.com/Automattic/static-site-importer/issues/668
- Verified candidate scope: 3 changed file(s): docs/fixture-matrix.md, tools/fixture-matrix.test.mjs, tools/run-fixture-matrix.mjs.
- Verified finalization base: main at eb0ef18bb94e7ce449f6cbf33428005630689b1a
- gate-1: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** AI-assisted
- **Model:** openai/gpt-5.6-terra
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.
