### PR TITLE
Restore exact parity for generated site chrome and SVG media

### DIFF
--- a/includes/class-static-site-importer-media-materializer.php
+++ b/includes/class-static-site-importer-media-materializer.php
@@ -15,9 +15,10 @@ final class Static_Site_Importer_Media_Materializer {
 	 *
 	 * @param array<string,mixed>                         $artifacts           Compiled artifacts.
 	 * @param array<string,array<string,mixed>>           $materialized_assets Materialized asset reports keyed by source path.
+	 * @param string                                      $svg_font_faces      Self-contained font CSS for matching SVG text.
 	 * @return array{attachments:array<int,array<string,mixed>>,replacements:array<string,array{url:string,id:int}>}|WP_Error
 	 */
-	public static function materialize_sanitized_svgs( array $artifacts, array $materialized_assets ) {
+	public static function materialize_sanitized_svgs( array $artifacts, array $materialized_assets, string $svg_font_faces = '' ) {
 		$site   = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
 		$assets = isset( $site['assets'] ) && is_array( $site['assets'] ) ? $site['assets'] : array();
 		$result = array(
@@ -55,6 +56,9 @@ final class Static_Site_Importer_Media_Materializer {
 			$processed[ $source_path ] = true;
 
 			$content = self::asset_content( $asset );
+			if ( '' !== $svg_font_faces ) {
+				$content = Static_Site_Importer_Theme_Materializer::embed_svg_font_faces( $content, $svg_font_faces );
+			}
 			if ( '' === $content || ! self::is_safe_svg( $content ) ) {
 				return new WP_Error( 'static_site_importer_generated_svg_unsafe', sprintf( 'Generated SVG failed the attachment safety gate: %s', $source_path ) );
 			}

--- a/includes/class-static-site-importer-media-materializer.php
+++ b/includes/class-static-site-importer-media-materializer.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Materialize importer-owned media into the WordPress Media Library.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class Static_Site_Importer_Media_Materializer {
+	/**
+	 * Create attachments for sanitized SVG assets emitted by the transformer.
+	 *
+	 * @param array<string,mixed>                         $artifacts           Compiled artifacts.
+	 * @param array<string,array<string,mixed>>           $materialized_assets Materialized asset reports keyed by source path.
+	 * @return array{attachments:array<int,array<string,mixed>>,replacements:array<string,array{url:string,id:int}>}|WP_Error
+	 */
+	public static function materialize_sanitized_svgs( array $artifacts, array $materialized_assets ) {
+		$site   = isset( $artifacts['site'] ) && is_array( $artifacts['site'] ) ? $artifacts['site'] : array();
+		$assets = isset( $site['assets'] ) && is_array( $site['assets'] ) ? $site['assets'] : array();
+		$result = array(
+			'attachments' => array(),
+			'replacements' => array(),
+		);
+		$processed = array();
+		if ( empty( $assets ) ) {
+			return $result;
+		}
+
+		if ( ! function_exists( 'wp_upload_dir' ) || ! function_exists( 'wp_insert_attachment' ) || ! function_exists( 'wp_get_attachment_url' ) ) {
+			return new WP_Error( 'static_site_importer_media_api_unavailable', 'WordPress media APIs are required to materialize generated SVG attachments.' );
+		}
+
+		$uploads = wp_upload_dir();
+		if ( ! is_array( $uploads ) || ! empty( $uploads['error'] ) || empty( $uploads['basedir'] ) || empty( $uploads['baseurl'] ) ) {
+			return new WP_Error( 'static_site_importer_media_upload_directory_unavailable', is_array( $uploads ) ? (string) ( $uploads['error'] ?? 'WordPress upload directory is unavailable.' ) : 'WordPress upload directory is unavailable.' );
+		}
+
+		$directory = trailingslashit( (string) $uploads['basedir'] ) . 'static-site-importer';
+		if ( ! wp_mkdir_p( $directory ) ) {
+			return new WP_Error( 'static_site_importer_media_directory_failed', sprintf( 'Failed to create generated media directory: %s', $directory ) );
+		}
+
+		foreach ( $assets as $asset ) {
+			if ( ! is_array( $asset ) || ! self::is_sanitized_svg_asset( $asset ) ) {
+				continue;
+			}
+
+			$source_path = self::safe_source_path( (string) ( $asset['path'] ?? ( $asset['source'] ?? '' ) ) );
+			if ( '' === $source_path || isset( $processed[ $source_path ] ) || ! isset( $materialized_assets[ $source_path ] ) ) {
+				continue;
+			}
+			$processed[ $source_path ] = true;
+
+			$content = self::asset_content( $asset );
+			if ( '' === $content || ! self::is_safe_svg( $content ) ) {
+				return new WP_Error( 'static_site_importer_generated_svg_unsafe', sprintf( 'Generated SVG failed the attachment safety gate: %s', $source_path ) );
+			}
+
+			$hash     = hash( 'sha256', $content );
+			$stem     = sanitize_title( pathinfo( basename( $source_path ), PATHINFO_FILENAME ) );
+			$filename = ( '' === $stem ? 'generated-svg' : $stem ) . '-' . substr( $hash, 0, 16 ) . '.svg';
+			$file     = trailingslashit( $directory ) . $filename;
+			$url      = trailingslashit( (string) $uploads['baseurl'] ) . 'static-site-importer/' . rawurlencode( $filename );
+
+			if ( ! file_exists( $file ) ) {
+				$written = Static_Site_Importer_Theme_Materializer::write_file( $file, $content . ( str_ends_with( $content, "\n" ) ? '' : "\n" ) );
+				if ( is_wp_error( $written ) ) {
+					return $written;
+				}
+			}
+
+			$attachment_id = function_exists( 'attachment_url_to_postid' ) ? (int) attachment_url_to_postid( $url ) : 0;
+			if ( $attachment_id <= 0 ) {
+				$attachment_id = wp_insert_attachment(
+					array(
+						'post_mime_type' => 'image/svg+xml',
+						'post_title'     => sanitize_text_field( str_replace( '-', ' ', '' === $stem ? 'Generated SVG' : $stem ) ),
+						'post_status'    => 'inherit',
+					),
+					$file,
+					0,
+					true
+				);
+				if ( is_wp_error( $attachment_id ) ) {
+					return $attachment_id;
+				}
+				$attachment_id = (int) $attachment_id;
+				if ( function_exists( 'update_attached_file' ) ) {
+					update_attached_file( $attachment_id, $file );
+				}
+				if ( function_exists( 'update_post_meta' ) ) {
+					update_post_meta( $attachment_id, '_static_site_importer_asset_hash', $hash );
+					update_post_meta( $attachment_id, '_static_site_importer_source_path', $source_path );
+				}
+			}
+
+			$attachment_url = (string) wp_get_attachment_url( $attachment_id );
+			if ( '' === $attachment_url ) {
+				return new WP_Error( 'static_site_importer_attachment_url_missing', sprintf( 'Generated SVG attachment has no URL: %s', $source_path ) );
+			}
+
+			$old_url = isset( $materialized_assets[ $source_path ]['final_url'] ) && is_scalar( $materialized_assets[ $source_path ]['final_url'] ) ? (string) $materialized_assets[ $source_path ]['final_url'] : '';
+			if ( '' !== $old_url ) {
+				$result['replacements'][ $old_url ] = array(
+					'url' => $attachment_url,
+					'id'  => $attachment_id,
+				);
+			}
+			$result['attachments'][] = array(
+				'id'          => $attachment_id,
+				'url'         => $attachment_url,
+				'source_path' => $source_path,
+				'hash'        => $hash,
+				'mime_type'   => 'image/svg+xml',
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Rewrite generated media URLs in serialized block content.
+	 *
+	 * @param string                                      $markup       Serialized blocks.
+	 * @param array<string,array{url:string,id:int}>       $replacements Attachment replacements keyed by old URL.
+	 * @return string
+	 */
+	public static function rewrite_block_media( string $markup, array $replacements ): string {
+		foreach ( $replacements as $old_url => $replacement ) {
+			$markup = str_replace( $old_url, $replacement['url'], $markup );
+		}
+
+		return $markup;
+	}
+
+	/** @param array<string,mixed> $asset */
+	private static function is_sanitized_svg_asset( array $asset ): bool {
+		$mime = strtolower( (string) ( $asset['mime_type'] ?? ( $asset['media_type'] ?? '' ) ) );
+		$role = strtolower( str_replace( '-', '_', (string) ( $asset['source_role'] ?? '' ) ) );
+
+		return 'image/svg+xml' === $mime && 'importer_owned' === $role && true === ( $asset['pipeline_sanitized'] ?? false );
+	}
+
+	/** @param array<string,mixed> $asset */
+	private static function asset_content( array $asset ): string {
+		if ( isset( $asset['content'] ) && is_scalar( $asset['content'] ) ) {
+			return trim( (string) $asset['content'] );
+		}
+		if ( isset( $asset['content_base64'] ) && is_scalar( $asset['content_base64'] ) ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes trusted generated asset content.
+			$decoded = base64_decode( (string) $asset['content_base64'], true );
+			return false === $decoded ? '' : trim( $decoded );
+		}
+
+		return '';
+	}
+
+	private static function safe_source_path( string $path ): string {
+		$path = ltrim( str_replace( '\\', '/', trim( $path ) ), '/' );
+		return '' === $path || str_contains( $path, '..' ) ? '' : $path;
+	}
+
+	private static function is_safe_svg( string $svg ): bool {
+		return 1 === preg_match( '/^<svg\b[\s\S]*<\/svg>$/i', trim( $svg ) )
+			&& 0 === preg_match( '/<(?:script|foreignObject|iframe|object|embed)\b/i', $svg )
+			&& 0 === preg_match( '/\son[a-z]+\s*=/i', $svg )
+			&& 0 === preg_match( '/\b(?:href|xlink:href|src)\s*=\s*(["\'])(?!#)[^"\']+\1/i', $svg );
+	}
+}

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -597,7 +597,17 @@ class Static_Site_Importer_Page_Materializer {
 		$changed = false;
 
 		if ( $strip_header ) {
-			$index = self::first_meaningful_block_index( $blocks );
+			$index = null;
+			foreach ( $blocks as $candidate_index => $block ) {
+				if ( ! self::is_meaningful_parsed_block( $block ) ) {
+					continue;
+				}
+				if ( self::is_skip_link_block( $block ) ) {
+					continue;
+				}
+				$index = (int) $candidate_index;
+				break;
+			}
 			if ( null !== $index && self::is_template_chrome_block( $blocks[ $index ], 'header' ) ) {
 				array_splice( $blocks, $index, 1 );
 				$changed       = true;
@@ -627,6 +637,24 @@ class Static_Site_Importer_Page_Materializer {
 		}
 
 		return $changed ? trim( serialize_blocks( $blocks ) ) : $markup;
+	}
+
+	/**
+	 * Determine whether a leading block is an accessibility skip link.
+	 *
+	 * @param mixed $block Parsed block.
+	 */
+	private static function is_skip_link_block( $block ): bool {
+		if ( ! is_array( $block ) ) {
+			return false;
+		}
+
+		$attrs = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+		$class = isset( $attrs['className'] ) && is_scalar( $attrs['className'] ) ? (string) $attrs['className'] : '';
+		$html  = isset( $block['innerHTML'] ) && is_scalar( $block['innerHTML'] ) ? (string) $block['innerHTML'] : '';
+
+		return (bool) preg_match( '/(?:^|\s)skip-link(?:\s|$)/', $class )
+			|| (bool) preg_match( '/\bclass=["\'][^"\']*\bskip-link\b/i', $html );
 	}
 
 	/**

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -1078,8 +1078,10 @@ class Static_Site_Importer_Page_Materializer {
 	 * @param string                       $body        HTML body markup.
 	 * @param string                       $source_path Source path for diagnostics.
 	 * @param array<int,array<string,mixed>> $diagnostics Diagnostics, passed by reference.
+	 * @param array<string,mixed>          $options     Transformer options.
+	 * @param array<int,array<string,mixed>> $assets    Generated transformer assets, passed by reference.
 	 */
-	public static function html_to_blocks( string $body, string $source_path, array &$diagnostics ): string {
+	public static function html_to_blocks( string $body, string $source_path, array &$diagnostics, array $options = array(), array &$assets = array() ): string {
 		if ( ! function_exists( 'blocks_engine_php_transformer_convert_format' ) ) {
 			$diagnostics[] = array(
 				'type'        => 'missing_transformer_bridge',
@@ -1090,7 +1092,12 @@ class Static_Site_Importer_Page_Materializer {
 			return '';
 		}
 
-		$result = call_user_func( 'blocks_engine_php_transformer_convert_format', $body, 'html', 'blocks' );
+		$result = call_user_func( 'blocks_engine_php_transformer_convert_format', $body, 'html', 'blocks', $options );
+		foreach ( isset( $result['assets'] ) && is_array( $result['assets'] ) ? $result['assets'] : array() as $asset ) {
+			if ( is_array( $asset ) ) {
+				$assets[] = $asset;
+			}
+		}
 
 		foreach ( isset( $result['diagnostics'] ) && is_array( $result['diagnostics'] ) ? $result['diagnostics'] : array() as $diagnostic ) {
 			if ( is_array( $diagnostic ) ) {

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -114,7 +114,7 @@ class Static_Site_Importer_Page_Materializer {
 		$contents     = array();
 		$asset_writes = array();
 		$diagnostics  = array();
-		$strip_header = ! empty( $options['strip_template_header'] );
+		$strip_header = ! empty( $options['strip_template_header'] ) && empty( $template_part_writes );
 		$strip_footer = ! empty( $options['strip_template_footer'] );
 		$svg_font_faces = isset( $options['svg_font_faces'] ) && is_string( $options['svg_font_faces'] ) ? $options['svg_font_faces'] : '';
 
@@ -195,6 +195,7 @@ class Static_Site_Importer_Page_Materializer {
 		$footer_start = null;
 		$header_count = 0;
 		$footer_count = 0;
+		$header_reason = '';
 		$matched_header_part = '';
 		$matched_footer_part = '';
 		$header_candidate_start = 0;
@@ -208,6 +209,27 @@ class Static_Site_Importer_Page_Materializer {
 			if ( $count > 0 && $header_candidate_start <= count( $top_level ) - $count && self::block_sequence_matches( array_slice( $top_level, $header_candidate_start, $count ), $part_blocks ) ) {
 				$header_start         = $header_candidate_start;
 				$header_count         = $count;
+				$matched_header_part = $part['path'];
+				break;
+			}
+		}
+
+		if ( null === $header_start && isset( $top_level[ $header_candidate_start ] ) && ! self::is_header_shell_block( $top_level[ $header_candidate_start + 1 ] ?? array() ) ) {
+			$candidate_semantics = self::header_shell_semantics( $top_level[ $header_candidate_start ] );
+			foreach ( $header_parts as $part ) {
+				$part_semantics = self::header_shell_semantics(
+					array(
+						'normalized' => implode( "\n", array_column( $part['blocks'], 'normalized' ) ),
+						'original'   => implode( "\n", array_column( $part['blocks'], 'original' ) ),
+					)
+				);
+				if ( '' === $candidate_semantics || $candidate_semantics !== $part_semantics ) {
+					continue;
+				}
+
+				$header_start         = $header_candidate_start;
+				$header_count         = 1;
+				$header_reason        = 'semantic_header_identity_and_navigation_match';
 				$matched_header_part = $part['path'];
 				break;
 			}
@@ -247,7 +269,9 @@ class Static_Site_Importer_Page_Materializer {
 			'type'                         => 'template_part_shell_deduped',
 			'source'                       => 'static-site-importer/page-materializer',
 			'source_path'                  => $source_path,
-			'reason'                       => 'matching_header_footer_template_parts',
+			'reason'                       => '' !== $header_reason ? $header_reason : 'matching_header_footer_template_parts',
+			'header_removal_reason'        => $header_reason,
+			'header_match_signal'          => '' !== $header_reason ? 'stable_header_classes_and_navigation_destinations' : 'exact_block_sequence',
 			'removed_header_blocks'        => $header_count,
 			'removed_footer_blocks'        => $footer_count,
 			'matched_header_template_part' => $matched_header_part,
@@ -258,7 +282,7 @@ class Static_Site_Importer_Page_Materializer {
 				'leading_blocks'  => $header_count,
 				'trailing_blocks' => $footer_count,
 			),
-			'message'                      => 'Page body blocks matching generated header/footer template parts were removed to avoid duplicate global shell rendering.',
+			'message'                      => '' !== $header_reason ? 'A leading header with the same stable identity and navigation destinations as the generated header template part was removed.' : 'Page body blocks matching generated header/footer template parts were removed to avoid duplicate global shell rendering.',
 		);
 
 		return $deduped;
@@ -268,7 +292,7 @@ class Static_Site_Importer_Page_Materializer {
 	 * Return top-level serialized block spans and normalized markup.
 	 *
 	 * @param string $markup Serialized block markup.
-	 * @return array<int,array{start:int,end:int,normalized:string}>
+	 * @return array<int,array{start:int,end:int,normalized:string,original:string}>
 	 */
 	private static function top_level_serialized_blocks( string $markup ): array {
 		if ( ! preg_match_all( '/<!--\s+(\/)?wp:([a-zA-Z0-9_\-\/]+)([^>]*)-->/', $markup, $matches, PREG_OFFSET_CAPTURE ) ) {
@@ -294,6 +318,7 @@ class Static_Site_Importer_Page_Materializer {
 						'start'      => (int) $opened['start'],
 						'end'        => $end,
 						'normalized' => self::normalize_shell_block_markup( $original ),
+						'original'   => $original,
 					);
 				}
 				continue;
@@ -306,6 +331,7 @@ class Static_Site_Importer_Page_Materializer {
 					'start'      => $offset,
 					'end'        => $end,
 					'normalized' => self::normalize_shell_block_markup( $original ),
+					'original'   => $original,
 				);
 				continue;
 			}
@@ -330,7 +356,18 @@ class Static_Site_Importer_Page_Materializer {
 		}
 
 		$anchor = $matches[0];
-		if ( ! preg_match( '/\bclass\s*=\s*(["\'])(.*?)\1/is', $anchor, $class_matches ) || ! preg_match( '/(?:^|\s)skip-link(?:\s|$)/i', $class_matches[2] ) ) {
+		if ( ! preg_match_all( '/\bclass\s*=\s*(["\'])(.*?)\1/is', $block['normalized'], $class_matches ) ) {
+			return false;
+		}
+
+		$has_skip_link_class = false;
+		foreach ( $class_matches[2] as $classes ) {
+			if ( preg_match( '/(?:^|\s)skip-link(?:\s|$)/i', $classes ) ) {
+				$has_skip_link_class = true;
+				break;
+			}
+		}
+		if ( ! $has_skip_link_class ) {
 			return false;
 		}
 
@@ -338,11 +375,124 @@ class Static_Site_Importer_Page_Materializer {
 	}
 
 	/**
+	 * Check whether a serialized block renders a header landmark.
+	 *
+	 * @param array{normalized?:string} $block Serialized block.
+	 * @return bool
+	 */
+	private static function is_header_shell_block( array $block ): bool {
+		return 1 === preg_match( '/<header\b/i', $block['normalized'] ?? '' );
+	}
+
+	/**
+	 * Build a semantic fingerprint that tolerates route-specific header actions.
+	 *
+	 * @param array{normalized?:string,original?:string} $block Serialized block.
+	 * @return string
+	 */
+	private static function header_shell_semantics( array $block ): string {
+		$markup = $block['normalized'] ?? '';
+		if ( ! preg_match( '/<header\b([^>]*)>/i', $markup, $header_matches ) || ! preg_match( '/\bclass\s*=\s*(["\'])(.*?)\1/is', $header_matches[1], $class_matches ) ) {
+			return '';
+		}
+
+		$classes = array_values(
+			array_filter(
+				preg_split( '/\s+/', strtolower( html_entity_decode( $class_matches[2], ENT_QUOTES | ENT_HTML5 ) ) ) ?: array(),
+				static fn( string $class ): bool => '' !== $class && ! str_starts_with( $class, 'wp-' ) && ! str_starts_with( $class, 'is-layout-' ) && ! str_starts_with( $class, 'has-' ) && ! str_starts_with( $class, 'blocks-engine-' )
+			)
+		);
+		if ( empty( $classes ) ) {
+			return '';
+		}
+
+		$links = self::serialized_navigation_links( $block['original'] ?? '' );
+		if ( empty( $links ) && preg_match_all( '/<nav\b[^>]*>(.*?)<\/nav>/is', $markup, $navigation_matches ) ) {
+			foreach ( $navigation_matches[1] as $navigation ) {
+				if ( ! preg_match_all( '/<a\b[^>]*\bhref\s*=\s*(["\'])(.*?)\1[^>]*>(.*?)<\/a>/is', $navigation, $link_matches, PREG_SET_ORDER ) ) {
+					continue;
+				}
+				foreach ( $link_matches as $link ) {
+					$links[] = self::navigation_link_semantics( wp_strip_all_tags( $link[3] ), $link[2] );
+				}
+			}
+		}
+
+		return empty( $links ) ? '' : implode( ' ', $classes ) . '|' . implode( '|', $links );
+	}
+
+	/**
+	 * Extract ordered navigation-link semantics from serialized dynamic blocks.
+	 *
+	 * @param string $markup Raw serialized block markup.
+	 * @return array<int,string>
+	 */
+	private static function serialized_navigation_links( string $markup ): array {
+		if ( ! preg_match_all( '/<!--\s+wp:navigation-link\s+(.+?)\/-->/is', $markup, $matches ) ) {
+			return array();
+		}
+
+		$links = array();
+		foreach ( $matches[1] as $attributes ) {
+			$start = strpos( $attributes, '{' );
+			$end   = strrpos( $attributes, '}' );
+			if ( false === $start || false === $end || $end < $start ) {
+				continue;
+			}
+
+			$decoded = json_decode( substr( $attributes, $start, $end - $start + 1 ), true );
+			if ( ! is_array( $decoded ) || ! isset( $decoded['label'], $decoded['url'] ) ) {
+				continue;
+			}
+
+			$links[] = self::navigation_link_semantics( (string) $decoded['label'], (string) $decoded['url'] );
+		}
+
+		return $links;
+	}
+
+	/**
+	 * Normalize a navigation label and destination into a stable route identity.
+	 *
+	 * @param string $label Link label.
+	 * @param string $url   Link destination.
+	 * @return string
+	 */
+	private static function navigation_link_semantics( string $label, string $url ): string {
+		$label = strtolower( trim( preg_replace( '/\s+/', ' ', html_entity_decode( $label, ENT_QUOTES | ENT_HTML5 ) ) ?? $label ) );
+		$url   = trim( html_entity_decode( $url, ENT_QUOTES | ENT_HTML5 ) );
+		$parts = parse_url( $url );
+		$path  = is_array( $parts ) ? (string) ( $parts['path'] ?? '' ) : $url;
+
+		// Relative HTML routes may be coerced into hostnames before materialization.
+		if ( '' === $path && is_array( $parts ) && preg_match( '/\.html?$/i', (string) ( $parts['host'] ?? '' ) ) ) {
+			$path = (string) $parts['host'];
+		}
+
+		$path = preg_replace( '#/+#', '/', str_replace( '\\', '/', $path ) ) ?? $path;
+		$path = preg_replace( '#(?:^|/)index\.html?$#i', '', $path ) ?? $path;
+		$path = preg_replace( '/\.html?$/i', '', $path ) ?? $path;
+		$path = trim( $path, '/' );
+		if ( '' === $path ) {
+			$path = 'home';
+		}
+
+		if ( is_array( $parts ) && isset( $parts['query'] ) ) {
+			$path .= '?' . $parts['query'];
+		}
+		if ( is_array( $parts ) && isset( $parts['fragment'] ) ) {
+			$path .= '#' . $parts['fragment'];
+		}
+
+		return $label . '@' . strtolower( $path );
+	}
+
+	/**
 	 * Extract normalized top-level block sequences from generated template part writes.
 	 *
 	 * @param array<string,string> $template_part_writes Generated template part writes.
 	 * @param string               $area                 Template part area.
-	 * @return array<int,array{path:string,blocks:array<int,array{normalized:string}>}>
+	 * @return array<int,array{path:string,blocks:array<int,array{normalized:string,original:string}>}>
 	 */
 	private static function template_part_write_sequences( array $template_part_writes, string $area ): array {
 		$sequences = array();

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -114,7 +114,7 @@ class Static_Site_Importer_Page_Materializer {
 		$contents     = array();
 		$asset_writes = array();
 		$diagnostics  = array();
-		$strip_header = ! empty( $options['strip_template_header'] ) && empty( $template_part_writes );
+		$strip_header = ! empty( $options['strip_template_header'] );
 		$strip_footer = ! empty( $options['strip_template_footer'] );
 		$svg_font_faces = isset( $options['svg_font_faces'] ) && is_string( $options['svg_font_faces'] ) ? $options['svg_font_faces'] : '';
 

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2548,6 +2548,29 @@ class Static_Site_Importer_Report_Diagnostics {
 				$provenance['reference'] = $reference;
 			}
 		}
+		if ( method_exists( '\\Composer\\InstalledVersions', 'getInstallPath' ) ) {
+			$install_path = \Composer\InstalledVersions::getInstallPath( $package );
+			if ( is_string( $install_path ) && is_dir( $install_path ) ) {
+				$files    = array();
+				$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $install_path, FilesystemIterator::SKIP_DOTS ) );
+				foreach ( $iterator as $file ) {
+					if ( ! $file instanceof SplFileInfo || ! $file->isFile() ) {
+						continue;
+					}
+					$relative = ltrim( str_replace( '\\', '/', substr( $file->getPathname(), strlen( $install_path ) ) ), '/' );
+					if ( 'composer.json' === $relative || 'php-transformer.php' === $relative || str_starts_with( $relative, 'src/' ) ) {
+						$files[ $relative ] = hash_file( 'sha256', $file->getPathname() );
+					}
+				}
+				ksort( $files );
+				if ( ! empty( $files ) ) {
+					$provenance['source_fingerprint'] = 'sha256:' . hash( 'sha256', wp_json_encode( $files ) );
+					if ( ! isset( $provenance['reference'] ) ) {
+						$provenance['reference'] = $provenance['source_fingerprint'];
+					}
+				}
+			}
+		}
 		return $provenance;
 	}
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -309,7 +309,7 @@ class Static_Site_Importer_Theme_Generator {
 			);
 		}
 
-		$media = Static_Site_Importer_Media_Materializer::materialize_sanitized_svgs( $artifacts, $materialized['assets'] );
+		$media = Static_Site_Importer_Media_Materializer::materialize_sanitized_svgs( $artifacts, $materialized['assets'], $materialized['svg_font_faces'] );
 		if ( is_wp_error( $media ) ) {
 			return $media;
 		}
@@ -351,7 +351,7 @@ class Static_Site_Importer_Theme_Generator {
 			return $result;
 		}
 
-		$materialized_write = self::materialize_website_artifact_files_to_theme( $theme_dir, $artifacts, true, false );
+		$materialized_write = self::materialize_website_artifact_files_to_theme( $theme_dir, $artifacts, true, false, $svg_font_usage_markup );
 		if ( is_wp_error( $materialized_write ) ) {
 			return $materialized_write;
 		}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -177,10 +177,11 @@ class Static_Site_Importer_Theme_Generator {
 			return $materialized;
 		}
 
-		$template_part_writes = self::template_part_artifact_writes( $theme_dir, $artifacts, $materialized['assets'], $permalinks );
-		if ( is_wp_error( $template_part_writes ) ) {
-			return $template_part_writes;
+		$template_part_result = self::template_part_artifact_writes( $theme_dir, $artifacts, $materialized['assets'], $permalinks );
+		if ( is_wp_error( $template_part_result ) ) {
+			return $template_part_result;
 		}
+		$template_part_writes = $template_part_result['writes'];
 		$has_header_part      = isset( $template_part_writes[ $theme_dir . '/parts/header.html' ] );
 		$has_footer_part      = isset( $template_part_writes[ $theme_dir . '/parts/footer.html' ] );
 		$page_artifacts       = Static_Site_Importer_Page_Materializer::page_artifacts(
@@ -202,6 +203,12 @@ class Static_Site_Importer_Theme_Generator {
 		Static_Site_Importer_Document_Metadata_Reporter::record( self::$conversion_report, $artifacts );
 
 		$visual_repair_styles = self::visual_repair_styles_from_artifacts( $artifacts );
+		foreach ( $template_part_result['styles'] as $style ) {
+			$visual_repair_styles['frontend'][] = $style;
+			$visual_repair_styles['editor'][]   = $style;
+		}
+		$visual_repair_styles['frontend'] = array_values( array_unique( $visual_repair_styles['frontend'] ) );
+		$visual_repair_styles['editor']   = array_values( array_unique( $visual_repair_styles['editor'] ) );
 
 		$stylesheet_writes = Static_Site_Importer_Stylesheet_Materializer::stylesheet_writes(
 			$theme_dir,
@@ -301,6 +308,23 @@ class Static_Site_Importer_Theme_Generator {
 				)
 			);
 		}
+
+		$media = Static_Site_Importer_Media_Materializer::materialize_sanitized_svgs( $artifacts, $materialized['assets'] );
+		if ( is_wp_error( $media ) ) {
+			return $media;
+		}
+		if ( ! empty( $media['replacements'] ) ) {
+			foreach ( $page_artifacts['contents'] as $filename => $content ) {
+				$page_artifacts['contents'][ $filename ] = Static_Site_Importer_Media_Materializer::rewrite_block_media( (string) $content, $media['replacements'] );
+			}
+			foreach ( $writes as $path => $content ) {
+				$writes[ $path ] = Static_Site_Importer_Media_Materializer::rewrite_block_media( (string) $content, $media['replacements'] );
+			}
+		}
+		self::$conversion_report['media_library'] = array(
+			'sanitized_svg_attachment_count' => count( $media['attachments'] ),
+			'attachments'                    => $media['attachments'],
+		);
 
 		$cleanup = self::cleanup_stale_generated_theme_files( $theme_dir, $source_of_truth_manifest, $args );
 		if ( is_wp_error( $cleanup ) ) {
@@ -2091,11 +2115,11 @@ class Static_Site_Importer_Theme_Generator {
 	/**
 	 * Normalize template part artifacts into generated theme writes.
 	 *
-	 * @param string              $theme_dir Theme directory.
+	 * @param string                                  $theme_dir Theme directory.
 	 * @param array<string,mixed>                     $artifacts WordPress artifacts from Blocks Engine.
 	 * @param array<string,array<string,mixed>>       $assets Materialized assets keyed by source path.
 	 * @param array<string,string>                    $permalinks Imported page permalinks keyed by source path.
-	 * @return array<string,string>|WP_Error Absolute write paths keyed to serialized block markup.
+	 * @return array{writes:array<string,string>,reports:array<int,array<string,mixed>>,styles:array<int,string>}|WP_Error Template-part artifacts.
 	 */
 	private static function template_part_artifact_writes( string $theme_dir, array $artifacts, array $assets = array(), array $permalinks = array() ) {
 		$result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes( $theme_dir, $artifacts, $assets, $permalinks );
@@ -2107,7 +2131,7 @@ class Static_Site_Importer_Theme_Generator {
 			self::$conversion_report['generated_theme']['template_parts'][] = $report;
 		}
 
-		return $result['writes'];
+		return $result;
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -973,8 +973,6 @@ class Static_Site_Importer_Theme_Materializer {
 			$source_path = (string) strtok( $source_path, '#' );
 			$markup      = Static_Site_Importer_Page_Materializer::rewrite_materialized_asset_references( $markup, $assets, $source_path, $permalinks );
 
-			$writes[ trailingslashit( $theme_dir ) . $relative ] = $markup;
-			$reports[] = self::template_part_artifact_report_payload( $relative, $template_part, $markup );
 			foreach ( isset( $template_part['stylesheet_assets'] ) && is_array( $template_part['stylesheet_assets'] ) ? $template_part['stylesheet_assets'] : array() as $asset ) {
 				if ( ! is_array( $asset ) || ! isset( $asset['content'] ) || ! is_scalar( $asset['content'] ) ) {
 					continue;
@@ -985,7 +983,27 @@ class Static_Site_Importer_Theme_Materializer {
 				if ( '' !== $content && ( 'text/css' === $type || preg_match( '/\.css$/i', $path ) ) ) {
 					$styles[] = $content;
 				}
+
+				$target_path = isset( $asset['target_path'] ) && is_scalar( $asset['target_path'] ) ? ltrim( str_replace( '\\', '/', (string) $asset['target_path'] ), '/' ) : ltrim( str_replace( '\\', '/', $path ), '/' );
+				if (
+					'svg' === ( $asset['kind'] ?? '' )
+					&& 'importer_owned' === ( $asset['source_role'] ?? '' )
+					&& true === ( $asset['pipeline_sanitized'] ?? false )
+					&& preg_match( '#^assets/materialized-svg/[a-zA-Z0-9._-]+\.svg$#', $target_path )
+					&& preg_match( '/^<svg\b[\s\S]*<\/svg>$/i', $content )
+					&& ! preg_match( '/<(?:script|foreignObject|iframe|object|embed)\b|\son[a-z]+\s*=/i', $content )
+				) {
+					$writes[ trailingslashit( $theme_dir ) . $target_path ] = $content . "\n";
+					if ( function_exists( 'get_theme_root_uri' ) ) {
+						$theme_slug     = sanitize_key( basename( rtrim( str_replace( '\\', '/', $theme_dir ), '/' ) ) );
+						$asset_url      = trailingslashit( get_theme_root_uri( $theme_slug ) ) . $theme_slug . '/' . $target_path;
+						$reference_path = '' !== $path ? $path : $target_path;
+						$markup         = str_replace( $reference_path, $asset_url, $markup );
+					}
+				}
 			}
+			$writes[ trailingslashit( $theme_dir ) . $relative ] = $markup;
+			$reports[] = self::template_part_artifact_report_payload( $relative, $template_part, $markup );
 		}
 
 		return array(
@@ -1103,7 +1121,7 @@ class Static_Site_Importer_Theme_Materializer {
 			$diagnostics = array();
 			$assets      = array();
 			$markup      = Static_Site_Importer_Page_Materializer::html_to_blocks(
-				self::strip_inline_svg_markup( $fragment ),
+				$fragment,
 				$source_path . '#' . $slug,
 				$diagnostics,
 				'' === $static_css ? array() : array( 'static_css' => $static_css ),
@@ -1126,20 +1144,6 @@ class Static_Site_Importer_Theme_Materializer {
 		}
 
 		return $parts;
-	}
-
-	/**
-	 * Remove inline SVG from synthesized source-derived template parts.
-	 *
-	 * @param string $html HTML fragment.
-	 * @return string
-	 */
-	private static function strip_inline_svg_markup( string $html ): string {
-		if ( '' === trim( $html ) || ! str_contains( strtolower( $html ), '<svg' ) ) {
-			return $html;
-		}
-
-		return (string) preg_replace( '#<svg\b[^>]*>.*?</svg>#is', '', $html );
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -950,6 +950,7 @@ class Static_Site_Importer_Theme_Materializer {
 
 		$writes  = array();
 		$reports = array();
+		$styles  = array();
 		foreach ( $template_parts as $template_part ) {
 			if ( ! is_array( $template_part ) ) {
 				return new WP_Error( 'static_site_importer_template_part_invalid', 'Template part artifacts must be arrays.' );
@@ -974,11 +975,23 @@ class Static_Site_Importer_Theme_Materializer {
 
 			$writes[ trailingslashit( $theme_dir ) . $relative ] = $markup;
 			$reports[] = self::template_part_artifact_report_payload( $relative, $template_part, $markup );
+			foreach ( isset( $template_part['stylesheet_assets'] ) && is_array( $template_part['stylesheet_assets'] ) ? $template_part['stylesheet_assets'] : array() as $asset ) {
+				if ( ! is_array( $asset ) || ! isset( $asset['content'] ) || ! is_scalar( $asset['content'] ) ) {
+					continue;
+				}
+				$path    = isset( $asset['path'] ) && is_scalar( $asset['path'] ) ? (string) $asset['path'] : '';
+				$type    = isset( $asset['type'] ) && is_scalar( $asset['type'] ) ? (string) $asset['type'] : '';
+				$content = trim( (string) $asset['content'] );
+				if ( '' !== $content && ( 'text/css' === $type || preg_match( '/\.css$/i', $path ) ) ) {
+					$styles[] = $content;
+				}
+			}
 		}
 
 		return array(
 			'writes'  => $writes,
 			'reports' => $reports,
+			'styles'  => array_values( array_unique( $styles ) ),
 		);
 	}
 
@@ -991,6 +1004,7 @@ class Static_Site_Importer_Theme_Materializer {
 	 */
 	private static function source_file_template_parts( array $artifacts ): array {
 		$files = isset( $artifacts['source_files'] ) && is_array( $artifacts['source_files'] ) ? $artifacts['source_files'] : array();
+		$static_css = self::source_file_static_css( $files );
 		foreach ( $files as $file ) {
 			if ( ! is_array( $file ) || ! isset( $file['path'] ) || ! is_scalar( $file['path'] ) ) {
 				continue;
@@ -1015,7 +1029,7 @@ class Static_Site_Importer_Theme_Materializer {
 				continue;
 			}
 
-			$parts = self::template_parts_from_html( $content, $path );
+			$parts = self::template_parts_from_html( $content, $path, $static_css );
 			if ( ! empty( $parts ) ) {
 				return $parts;
 			}
@@ -1025,13 +1039,42 @@ class Static_Site_Importer_Theme_Materializer {
 	}
 
 	/**
+	 * Collect source stylesheets for source-derived template-part conversion.
+	 *
+	 * @param array<int,array<string,mixed>> $files Source artifact files.
+	 * @return string
+	 */
+	private static function source_file_static_css( array $files ): string {
+		$styles = array();
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) || ! isset( $file['path'] ) || ! is_scalar( $file['path'] ) || ! preg_match( '/\.css$/i', (string) $file['path'] ) ) {
+				continue;
+			}
+
+			$content = '';
+			if ( isset( $file['content'] ) && is_scalar( $file['content'] ) ) {
+				$content = (string) $file['content'];
+			} elseif ( isset( $file['content_base64'] ) && is_scalar( $file['content_base64'] ) ) {
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes trusted website artifact file content.
+				$decoded = base64_decode( (string) $file['content_base64'], true );
+				$content = false === $decoded ? '' : $decoded;
+			}
+			if ( '' !== trim( $content ) ) {
+				$styles[] = trim( $content );
+			}
+		}
+
+		return implode( "\n\n", $styles );
+	}
+
+	/**
 	 * Convert source HTML landmarks into reusable block theme parts.
 	 *
 	 * @param string $html        Source HTML document.
 	 * @param string $source_path Source file path for reports.
 	 * @return array<int,array<string,mixed>>
 	 */
-	private static function template_parts_from_html( string $html, string $source_path ): array {
+	private static function template_parts_from_html( string $html, string $source_path, string $static_css = '' ): array {
 		$document  = new Static_Site_Importer_Document( $html );
 		$fragments = $document->fragments();
 		$parts     = array();
@@ -1046,18 +1089,27 @@ class Static_Site_Importer_Theme_Materializer {
 			}
 
 			$diagnostics = array();
-			$markup      = Static_Site_Importer_Page_Materializer::html_to_blocks( self::strip_inline_svg_markup( $fragment ), $source_path . '#' . $slug, $diagnostics );
+			$assets      = array();
+			$markup      = Static_Site_Importer_Page_Materializer::html_to_blocks(
+				self::strip_inline_svg_markup( $fragment ),
+				$source_path . '#' . $slug,
+				$diagnostics,
+				'' === $static_css ? array() : array( 'static_css' => $static_css ),
+				$assets
+			);
 			if ( '' === trim( $markup ) ) {
 				continue;
 			}
 
 			$parts[] = array(
+				'origin'       => 'source_files.landmark',
 				'source_path'  => $source_path . '#' . $slug,
 				'slug'         => $slug,
 				'title'        => ucfirst( $slug ),
 				'area'         => $slug,
 				'generated'    => true,
 				'block_markup' => trim( $markup ) . "\n",
+				'stylesheet_assets' => $assets,
 			);
 		}
 
@@ -1137,6 +1189,7 @@ class Static_Site_Importer_Theme_Materializer {
 
 			$template_parts[] = array_filter(
 				array(
+					'origin'       => 'materialization_plan.template_part_writes',
 					'source_path'  => isset( $write['source_path'] ) && is_scalar( $write['source_path'] ) ? (string) $write['source_path'] : '',
 					'slug'         => isset( $write['slug'] ) && is_scalar( $write['slug'] ) ? (string) $write['slug'] : '',
 					'title'        => isset( $write['title'] ) && is_scalar( $write['title'] ) ? (string) $write['title'] : '',
@@ -1186,6 +1239,7 @@ class Static_Site_Importer_Theme_Materializer {
 
 			$template_parts[] = array_filter(
 				array(
+					'origin'       => 'materialization_plan.navigation',
 					'source_path'  => isset( $navigation['source_path'] ) && is_scalar( $navigation['source_path'] ) ? (string) $navigation['source_path'] : '',
 					'slug'         => isset( $navigation['slug'] ) && in_array( sanitize_key( (string) $navigation['slug'] ), array( 'header', 'footer' ), true ) ? sanitize_key( (string) $navigation['slug'] ) : 'header',
 					'title'        => isset( $navigation['title'] ) && is_scalar( $navigation['title'] ) ? (string) $navigation['title'] : 'Navigation',
@@ -1260,8 +1314,20 @@ class Static_Site_Importer_Theme_Materializer {
 			$source_paths = array( (string) $template_part['source_path'] );
 		}
 
+		$block_names = array();
+		if ( preg_match_all( '/<!--\s+wp:([a-z0-9-]+(?:\/[a-z0-9-]+)?)/i', $markup, $matches ) ) {
+			$block_names = array_values( array_unique( array_map(
+				static function ( string $block_name ): string {
+					$block_name = strtolower( $block_name );
+					return str_contains( $block_name, '/' ) ? $block_name : 'core/' . $block_name;
+				},
+				$matches[1]
+			) ) );
+		}
+
 		return array(
 			'path'               => $path,
+			'origin'             => isset( $template_part['origin'] ) && is_scalar( $template_part['origin'] ) ? (string) $template_part['origin'] : 'artifact.template_parts',
 			'slug'               => isset( $template_part['slug'] ) && is_scalar( $template_part['slug'] ) ? (string) $template_part['slug'] : '',
 			'area'               => isset( $template_part['area'] ) && is_scalar( $template_part['area'] ) ? (string) $template_part['area'] : '',
 			'generated'          => ! empty( $template_part['generated'] ),
@@ -1269,6 +1335,9 @@ class Static_Site_Importer_Theme_Materializer {
 			'source_hash'        => isset( $template_part['source_hash'] ) && is_scalar( $template_part['source_hash'] ) ? (string) $template_part['source_hash'] : '',
 			'block_markup_bytes' => strlen( $markup ),
 			'block_markup_hash'  => hash( 'sha256', $markup ),
+			'block_names'        => $block_names,
+			'contains_core_html' => in_array( 'core/html', $block_names, true ),
+			'control_marker_count' => substr_count( $markup, 'blocks-engine-control-' ),
 		);
 	}
 
@@ -1525,19 +1594,6 @@ class Static_Site_Importer_Theme_Materializer {
 			"/**\n" .
 			" * Generated theme bootstrap.\n" .
 			" */\n\n" .
-			"add_filter( 'upload_mimes', static function ( array \$mimes ): array {\n" .
-			"\t// Generated SVG media is sanitized by the import pipeline at build time.\n" .
-			"\t\$mimes['svg'] = 'image/svg+xml';\n" .
-			"\treturn \$mimes;\n" .
-			"} );\n\n" .
-			"add_filter( 'wp_check_filetype_and_ext', static function ( array \$data, string \$file, string \$filename, array \$mimes ): array {\n" .
-			"\tif ( 'svg' !== strtolower( pathinfo( \$filename, PATHINFO_EXTENSION ) ) ) {\n" .
-			"\t\treturn \$data;\n" .
-			"\t}\n" .
-			"\t\$data['ext'] = 'svg';\n" .
-			"\t\$data['type'] = 'image/svg+xml';\n" .
-			"\treturn \$data;\n" .
-			"}, 10, 4 );\n\n" .
 			"add_action( 'after_setup_theme', static function (): void {\n" .
 			"\tadd_theme_support( 'editor-styles' );\n" .
 			"\tadd_editor_style( 'assets/css/editor-style.css' );\n" .

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -432,15 +432,25 @@ class Static_Site_Importer_Theme_Materializer {
 	}
 
 	private static function bounded_google_font_request( string $url, int $limit ) {
-		return wp_safe_remote_get(
-			$url,
-			array(
-				'timeout'             => 15,
-				'redirection'         => 0,
-				'limit_response_size' => $limit,
-				'headers'             => array( 'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' ),
-			)
+		$args = array(
+			'timeout'             => 15,
+			'redirection'         => 0,
+			'limit_response_size' => $limit,
+			'headers'             => array( 'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' ),
 		);
+		$response = null;
+		for ( $attempt = 1; $attempt <= 3; ++$attempt ) {
+			$response = wp_safe_remote_get( $url, $args );
+			$status   = is_wp_error( $response ) ? 0 : (int) wp_remote_retrieve_response_code( $response );
+			if ( ! is_wp_error( $response ) && 0 !== $status && ! in_array( $status, array( 408, 429 ), true ) && $status < 500 ) {
+				break;
+			}
+			if ( $attempt < 3 ) {
+				usleep( 100000 * $attempt );
+			}
+		}
+
+		return $response;
 	}
 
 	/** @param array<int,string> $families @param array<int,array<string,mixed>> $diagnostics @param array<string,string> $font_payloads */

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -1005,6 +1005,18 @@ class Static_Site_Importer_Theme_Materializer {
 	private static function source_file_template_parts( array $artifacts ): array {
 		$files = isset( $artifacts['source_files'] ) && is_array( $artifacts['source_files'] ) ? $artifacts['source_files'] : array();
 		$static_css = self::source_file_static_css( $files );
+		$entry_path = '';
+		foreach ( array( $artifacts['compiled_site']['entry_path'] ?? '', $artifacts['site']['entry_path'] ?? '' ) as $candidate ) {
+			if ( is_scalar( $candidate ) && '' !== trim( (string) $candidate ) ) {
+				$entry_path = ltrim( str_replace( '\\', '/', trim( (string) $candidate ) ), '/' );
+				break;
+			}
+		}
+		if ( '' !== $entry_path ) {
+			$entry_files = array_filter( $files, static fn( $file ): bool => is_array( $file ) && $entry_path === ltrim( str_replace( '\\', '/', (string) ( $file['path'] ?? '' ) ), '/' ) );
+			$other_files = array_filter( $files, static fn( $file ): bool => ! is_array( $file ) || $entry_path !== ltrim( str_replace( '\\', '/', (string) ( $file['path'] ?? '' ) ), '/' ) );
+			$files       = array_merge( $entry_files, $other_files );
+		}
 		foreach ( $files as $file ) {
 			if ( ! is_array( $file ) || ! isset( $file['path'] ) || ! is_scalar( $file['path'] ) ) {
 				continue;

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -1022,6 +1022,7 @@ class Static_Site_Importer_Theme_Materializer {
 	 */
 	private static function source_file_template_parts( array $artifacts ): array {
 		$files = isset( $artifacts['source_files'] ) && is_array( $artifacts['source_files'] ) ? $artifacts['source_files'] : array();
+		$source_files = $files;
 		$static_css = self::source_file_static_css( $files );
 		$entry_path = '';
 		foreach ( array( $artifacts['compiled_site']['entry_path'] ?? '', $artifacts['site']['entry_path'] ?? '' ) as $candidate ) {
@@ -1059,7 +1060,10 @@ class Static_Site_Importer_Theme_Materializer {
 				continue;
 			}
 
-			$parts = self::template_parts_from_html( $content, $path, $static_css );
+			$runtime_context = function_exists( 'blocks_engine_php_transformer_runtime_context' )
+				? blocks_engine_php_transformer_runtime_context( $content, $path, $source_files )
+				: array();
+			$parts = self::template_parts_from_html( $content, $path, $static_css, is_array( $runtime_context ) ? $runtime_context : array() );
 			if ( ! empty( $parts ) ) {
 				return $parts;
 			}
@@ -1102,9 +1106,10 @@ class Static_Site_Importer_Theme_Materializer {
 	 *
 	 * @param string $html        Source HTML document.
 	 * @param string $source_path Source file path for reports.
+	 * @param array<string,mixed> $runtime_context Script-derived transformer context.
 	 * @return array<int,array<string,mixed>>
 	 */
-	private static function template_parts_from_html( string $html, string $source_path, string $static_css = '' ): array {
+	private static function template_parts_from_html( string $html, string $source_path, string $static_css = '', array $runtime_context = array() ): array {
 		$document  = new Static_Site_Importer_Document( $html );
 		$fragments = $document->fragments();
 		$parts     = array();
@@ -1124,7 +1129,7 @@ class Static_Site_Importer_Theme_Materializer {
 				$fragment,
 				$source_path . '#' . $slug,
 				$diagnostics,
-				'' === $static_css ? array() : array( 'static_css' => $static_css ),
+				array_merge( $runtime_context, '' === $static_css ? array() : array( 'static_css' => $static_css ) ),
 				$assets
 			);
 			if ( '' === trim( $markup ) ) {

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -129,10 +129,17 @@ function collectMatrixEvidence(payload) {
   const blocksEngine = objectValue(payload.blocks_engine || payload.blocksEngine || payload.import_report?.blocks_engine || payload.importReport?.blocks_engine || payload.report?.blocks_engine);
   const transformer = objectValue(blocksEngine.transformer || blocksEngine.transformer_provenance || blocksEngine.transformerProvenance);
   const plan = objectValue(blocksEngine.materialization_plan || blocksEngine.materializationPlan);
+  const importReport = objectValue(payload.import_report || payload.importReport || payload.report);
+  const generatedTheme = objectValue(importReport.generated_theme || importReport.generatedTheme || payload.generated_theme || payload.generatedTheme);
+  const templateParts = normalizeArray(generatedTheme.template_parts || generatedTheme.templateParts)
+    .map(templatePartEvidenceSummary)
+    .filter((part) => Object.keys(part).length > 0);
   const provenance = compactObject({
     package: firstString([transformer.package, transformer.name]),
     version: firstString([transformer.version, transformer.pretty_version, transformer.prettyVersion]),
-    reference: firstString([transformer.reference, transformer.commit, transformer.source_reference, transformer.sourceReference]),
+    reference: firstString([transformer.source_fingerprint, transformer.sourceFingerprint, transformer.reference, transformer.commit, transformer.source_reference, transformer.sourceReference]),
+    package_reference: firstString([transformer.reference, transformer.commit, transformer.source_reference, transformer.sourceReference]),
+    source_fingerprint: firstString([transformer.source_fingerprint, transformer.sourceFingerprint]),
   });
   const missing = [
     ...(provenance.package ? [] : ['transformer_package']),
@@ -156,7 +163,22 @@ function collectMatrixEvidence(payload) {
       asset_count: sourceAssets.length,
       assets,
     }),
+    template_parts: templateParts,
   };
+}
+
+function templatePartEvidenceSummary(part) {
+  const row = objectValue(part);
+  return compactObject({
+    path: firstString([row.path]),
+    origin: firstString([row.origin]),
+    source_paths: normalizeArray(row.source_paths || row.sourcePaths),
+    block_markup_hash: firstString([row.block_markup_hash, row.blockMarkupHash]),
+    block_markup_bytes: Number.isFinite(Number(row.block_markup_bytes ?? row.blockMarkupBytes)) ? Number(row.block_markup_bytes ?? row.blockMarkupBytes) : undefined,
+    block_names: normalizeArray(row.block_names || row.blockNames),
+    contains_core_html: typeof row.contains_core_html === 'boolean' ? row.contains_core_html : row.containsCoreHtml,
+    control_marker_count: Number.isFinite(Number(row.control_marker_count ?? row.controlMarkerCount)) ? Number(row.control_marker_count ?? row.controlMarkerCount) : undefined,
+  });
 }
 
 function materializationPlanAssetSummary(asset) {

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -262,29 +262,58 @@ function fixtureWorkflowSteps(options) {
 function svgFontEvidenceStep(fixture) {
   const code = `$root = get_stylesheet_directory();
 $files = array();
+$font_families = array();
+$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS));
+foreach ($iterator as $file) {
+	if (!$file->isFile() || 'css' !== strtolower($file->getExtension())) { continue; }
+	$content = file_get_contents($file->getPathname());
+	if (false === $content || !preg_match_all('#https://fonts\\.googleapis\\.com/(?:css|css2)\\?[^\\s"\)]+#i', $content, $urls)) { continue; }
+	foreach ($urls[0] as $url) {
+		if (!preg_match_all('/(?:[?&])family=([^&]+)/', html_entity_decode($url), $families)) { continue; }
+		foreach ($families[1] as $family) {
+			$font_families[] = trim(explode(':', urldecode($family), 2)[0]);
+		}
+	}
+}
+$font_families = array_values(array_unique(array_filter($font_families)));
 $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS));
 foreach ($iterator as $file) {
 	if (!$file->isFile() || 'svg' !== strtolower($file->getExtension())) { continue; }
 	$content = file_get_contents($file->getPathname());
 	if (false === $content) { continue; }
+	$uses_planned_font = false;
+	if (preg_match('/<text\\b/i', $content)) {
+		foreach ($font_families as $family) {
+			if (false !== stripos($content, $family)) { $uses_planned_font = true; break; }
+		}
+	}
 	$files[] = array(
 		'path' => ltrim(str_replace('\\\\', '/', substr($file->getPathname(), strlen($root))), '/'),
 		'bytes' => strlen($content),
 		'sha256' => hash('sha256', $content),
+		'uses_planned_font' => $uses_planned_font,
 		'has_font_face' => str_contains($content, '@font-face'),
 		'has_data_font' => str_contains($content, 'data:font/'),
 	);
 }
 usort($files, static fn($left, $right) => strcmp($left['path'], $right['path']));
+$expected = count(array_filter($files, static fn($file) => $file['uses_planned_font']));
+$embedded = count(array_filter($files, static fn($file) => $file['uses_planned_font'] && $file['has_data_font']));
+$complete = 0 === $expected || $expected === $embedded;
 WP_CLI::line(wp_json_encode(array(
-	'status' => 'success',
+	'status' => $complete ? 'success' : 'failed',
+	'success' => $complete,
 	'svg_font_embedding_evidence' => array(
 		'schema' => 'static-site-importer/svg-font-embedding-evidence/v1',
+		'status' => $complete ? 'complete' : 'required_fonts_missing',
+		'planned_font_families' => $font_families,
 		'svg_count' => count($files),
-		'embedded_font_svg_count' => count(array_filter($files, static fn($file) => $file['has_data_font'])),
+		'expected_font_svg_count' => $expected,
+		'embedded_font_svg_count' => $embedded,
 		'files' => $files,
 	),
-), JSON_UNESCAPED_SLASHES));`;
+), JSON_UNESCAPED_SLASHES));
+if (!$complete) { WP_CLI::error('Required self-contained SVG fonts are missing; visual parity capture is not valid.'); }`;
   const encoded = Buffer.from(code, 'utf8').toString('base64');
   return {
     command: 'wordpress.wp-cli',

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -58,6 +58,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-as
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document-metadata-reporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-page-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-materializer.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-media-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-stylesheet-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-woo-product-seeder.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-form-seeder.php';

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -65,6 +65,11 @@ const steps = [
     args: [ path.join( repoRoot, 'tests/smoke-visual-repair-css.php' ) ],
   },
   {
+    name: 'Generated media materializer smoke',
+    command: 'php',
+    args: [ path.join( repoRoot, 'tests/smoke-media-materializer.php' ) ],
+  },
+  {
     name: 'Export theme ability smoke',
     command: 'php',
     args: [ path.join( repoRoot, 'tests/smoke-export-theme-ability.php' ) ],

--- a/tests/smoke-media-materializer.php
+++ b/tests/smoke-media-materializer.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Smoke coverage for generated SVG Media Library materialization.
+ *
+ * @package StaticSiteImporter
+ */
+
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+
+$root = sys_get_temp_dir() . '/ssi-media-materializer-' . uniqid( '', true );
+$attachments = array();
+
+function trailingslashit( string $value ): string {
+	return rtrim( $value, '/\\' ) . '/';
+}
+function sanitize_title( string $value ): string {
+	return trim( preg_replace( '/[^a-z0-9]+/', '-', strtolower( $value ) ) ?? '', '-' );
+}
+function sanitize_text_field( string $value ): string {
+	return trim( strip_tags( $value ) );
+}
+function wp_mkdir_p( string $directory ): bool {
+	return is_dir( $directory ) || mkdir( $directory, 0777, true );
+}
+function wp_upload_dir(): array {
+	global $root;
+	return array(
+		'basedir' => $root,
+		'baseurl' => 'https://example.test/wp-content/uploads',
+		'error'   => false,
+	);
+}
+function attachment_url_to_postid( string $url ): int {
+	global $attachments;
+	foreach ( $attachments as $id => $attachment ) {
+		if ( $url === $attachment['url'] ) {
+			return $id;
+		}
+	}
+	return 0;
+}
+function wp_insert_attachment( array $postarr, string $file, int $parent, bool $wp_error ) {
+	global $attachments;
+	unset( $parent, $wp_error );
+	$id = count( $attachments ) + 1;
+	$attachments[ $id ] = array(
+		'file' => $file,
+		'mime' => $postarr['post_mime_type'],
+		'url'  => 'https://example.test/wp-content/uploads/static-site-importer/' . rawurlencode( basename( $file ) ),
+	);
+	return $id;
+}
+function wp_get_attachment_url( int $id ): string {
+	global $attachments;
+	return (string) ( $attachments[ $id ]['url'] ?? '' );
+}
+function update_attached_file( int $id, string $file ): void {
+	unset( $id, $file );
+}
+function update_post_meta( int $id, string $key, string $value ): void {
+	unset( $id, $key, $value );
+}
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+class WP_Error {
+	public function __construct( public string $code, public string $message ) {}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-media-materializer.php';
+
+$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/></svg>';
+$path = 'website/assets/materialized-svg/status.svg';
+$old_url = 'https://example.test/wp-content/themes/generated/assets/materialized/' . $path;
+$artifacts = array(
+	'site' => array(
+		'assets' => array(
+			array(
+				'path'               => $path,
+				'mime_type'          => 'image/svg+xml',
+				'content'            => $svg,
+				'source_role'        => 'importer_owned',
+				'pipeline_sanitized' => true,
+			),
+			array(
+				'path'               => $path,
+				'mime_type'          => 'image/svg+xml',
+				'content'            => $svg,
+				'source_role'        => 'importer_owned',
+				'pipeline_sanitized' => true,
+			),
+			array(
+				'path'        => 'website/unsafe.svg',
+				'mime_type'   => 'image/svg+xml',
+				'content'     => '<svg><script>alert(1)</script></svg>',
+				'source_role' => 'canonical',
+			),
+		),
+	),
+);
+$result = Static_Site_Importer_Media_Materializer::materialize_sanitized_svgs(
+	$artifacts,
+	array( $path => array( 'final_url' => $old_url ) )
+);
+
+$failures = array();
+$assert = static function ( bool $condition, string $label ) use ( &$failures ): void {
+	if ( ! $condition ) {
+		$failures[] = $label;
+	}
+};
+
+$assert( is_array( $result ), 'materialization-succeeds' );
+$assert( 1 === count( $result['attachments'] ?? array() ), 'only-unique-sanitized-importer-owned-svg-attached' );
+$assert( 'image/svg+xml' === ( $result['attachments'][0]['mime_type'] ?? '' ), 'attachment-mime-recorded' );
+$assert( file_exists( (string) ( $attachments[1]['file'] ?? '' ) ), 'sanitized-svg-written-to-uploads' );
+$rewritten = Static_Site_Importer_Media_Materializer::rewrite_block_media( '<!-- wp:paragraph --><p><img src="' . $old_url . '" /></p><!-- /wp:paragraph -->', $result['replacements'] ?? array() );
+$assert( str_contains( $rewritten, '/wp-content/uploads/static-site-importer/' ), 'block-url-rewritten-to-attachment' );
+$assert( ! str_contains( $rewritten, '/wp-content/themes/generated/' ), 'theme-asset-url-removed-from-block' );
+
+if ( $failures ) {
+	fwrite( STDERR, 'FAIL: ' . implode( ', ', $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo "PASS smoke-media-materializer.php (6 assertions)\n";

--- a/tests/smoke-media-materializer.php
+++ b/tests/smoke-media-materializer.php
@@ -70,7 +70,8 @@ class WP_Error {
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-media-materializer.php';
 
-$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/></svg>';
+$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><text x="2" y="12" font-family="Inter">Ready</text></svg>';
+$font_faces = '@font-face{font-family:Inter;src:url(data:font/woff2;base64,d09GMg==) format("woff2");font-weight:400;font-style:normal;}';
 $path = 'website/assets/materialized-svg/status.svg';
 $old_url = 'https://example.test/wp-content/themes/generated/assets/materialized/' . $path;
 $artifacts = array(
@@ -101,7 +102,8 @@ $artifacts = array(
 );
 $result = Static_Site_Importer_Media_Materializer::materialize_sanitized_svgs(
 	$artifacts,
-	array( $path => array( 'final_url' => $old_url ) )
+	array( $path => array( 'final_url' => $old_url ) ),
+	$font_faces
 );
 
 $failures = array();
@@ -115,6 +117,7 @@ $assert( is_array( $result ), 'materialization-succeeds' );
 $assert( 1 === count( $result['attachments'] ?? array() ), 'only-unique-sanitized-importer-owned-svg-attached' );
 $assert( 'image/svg+xml' === ( $result['attachments'][0]['mime_type'] ?? '' ), 'attachment-mime-recorded' );
 $assert( file_exists( (string) ( $attachments[1]['file'] ?? '' ) ), 'sanitized-svg-written-to-uploads' );
+$assert( str_contains( (string) file_get_contents( (string) ( $attachments[1]['file'] ?? '' ) ), $font_faces ), 'attachment-preserves-embedded-font-faces' );
 $rewritten = Static_Site_Importer_Media_Materializer::rewrite_block_media( '<!-- wp:paragraph --><p><img src="' . $old_url . '" /></p><!-- /wp:paragraph -->', $result['replacements'] ?? array() );
 $assert( str_contains( $rewritten, '/wp-content/uploads/static-site-importer/' ), 'block-url-rewritten-to-attachment' );
 $assert( ! str_contains( $rewritten, '/wp-content/themes/generated/' ), 'theme-asset-url-removed-from-block' );
@@ -124,4 +127,4 @@ if ( $failures ) {
 	exit( 1 );
 }
 
-echo "PASS smoke-media-materializer.php (6 assertions)\n";
+echo "PASS smoke-media-materializer.php (7 assertions)\n";

--- a/tests/smoke-svg-font-embedding.php
+++ b/tests/smoke-svg-font-embedding.php
@@ -150,6 +150,52 @@ $assert( 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)
 $assert( $GLOBALS['ssi_svg_font_requests'][0]['args']['headers']['User-Agent'] === ( $GLOBALS['ssi_svg_font_requests'][1]['args']['headers']['User-Agent'] ?? '' ), 'font-request-uses-browser-user-agent' );
 $assert( empty( $deprecations ), 'embedding-emits-no-deprecations' );
 
+$transient_attempts = array();
+$GLOBALS['ssi_svg_font_filters']['pre_http_request'] = array(
+	static function ( mixed $preempt, array $args, string $url ) use ( $css_url, $font_url, &$transient_attempts ): mixed {
+		$transient_attempts[ $url ] = ( $transient_attempts[ $url ] ?? 0 ) + 1;
+		if ( $css_url === $url ) {
+			return 1 === $transient_attempts[ $url ]
+				? new WP_Error( 'http_request_failed', 'Temporary stylesheet transport failure.' )
+				: array( 'body' => "@font-face{font-family:'Example Family';src:url($font_url) format('woff2')}", 'response' => array( 'code' => 200 ) );
+		}
+		if ( $font_url === $url ) {
+			return 1 === $transient_attempts[ $url ]
+				? array( 'body' => 'temporary failure', 'response' => array( 'code' => 503 ) )
+				: array( 'body' => 'woff2-payload', 'response' => array( 'code' => 200 ) );
+		}
+		return new WP_Error( 'unexpected_request' );
+	}
+);
+$before = count( $GLOBALS['ssi_svg_font_requests'] );
+$retried = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files( $theme_dir, 'https://example.test/themes/generated', $plan( array( $css_url ), $svg ), false );
+$retried = is_array( $retried ) ? $retried : array( 'diagnostics' => array(), 'svg_font_faces' => '' );
+$assert( 4 === count( $GLOBALS['ssi_svg_font_requests'] ) - $before, 'transient-stylesheet-and-font-failures-are-retried-once' );
+$assert( array( $css_url => 2, $font_url => 2 ) === $transient_attempts, 'retries-remain-scoped-to-original-allowlisted-urls' );
+$assert( str_contains( (string) ( $retried['svg_font_faces'] ?? '' ), 'data:font/woff2;base64,' ), 'transient-failures-recover-self-contained-fonts' );
+$assert( empty( $retried['diagnostics'] ), 'recovered-transient-failures-emit-no-failure-diagnostic' );
+
+$GLOBALS['ssi_svg_font_filters']['pre_http_request'] = array(
+	static fn( mixed $preempt, array $args, string $url ): WP_Error => new WP_Error( 'http_request_failed', 'Persistent transport failure.' ),
+);
+$before = count( $GLOBALS['ssi_svg_font_requests'] );
+$exhausted = Static_Site_Importer_Theme_Materializer::materialize_website_artifact_files( $theme_dir, 'https://example.test/themes/generated', $plan( array( $css_url ), $svg ), false );
+$exhausted = is_array( $exhausted ) ? $exhausted : array( 'diagnostics' => array(), 'svg_font_faces' => '' );
+$assert( 3 === count( $GLOBALS['ssi_svg_font_requests'] ) - $before, 'persistent-transport-failure-exhausts-bounded-attempts' );
+$assert( 'stylesheet_fetch_failed' === ( $exhausted['diagnostics'][0]['reason'] ?? '' ), 'exhausted-retries-retain-specific-failure-diagnostic' );
+
+$GLOBALS['ssi_svg_font_filters']['pre_http_request'] = array(
+	static function ( mixed $preempt, array $args, string $url ) use ( $css_url, $font_url ): mixed {
+		if ( $css_url === $url ) {
+			return array( 'body' => "@font-face{font-family:'Example Family';font-style:normal;src:url($font_url) format('woff2')}", 'response' => array( 'code' => 200 ) );
+		}
+		if ( $font_url === $url ) {
+			return array( 'body' => 'woff2-payload', 'response' => array( 'code' => 200 ) );
+		}
+		return new WP_Error( 'unexpected_request' );
+	}
+);
+
 $inline_svg = '<svg xmlns="http://www.w3.org/2000/svg"><text font-family="Example Family">Page label</text></svg>';
 $page_markup = '<!-- wp:html {"content":' . wp_json_encode( $inline_svg ) . '} -->' . $inline_svg . '<!-- /wp:html -->';
 $page = Static_Site_Importer_Source_Page::from_wordpress_document_artifact(

--- a/tests/smoke-template-chrome-dedupe.php
+++ b/tests/smoke-template-chrome-dedupe.php
@@ -98,6 +98,7 @@ $assert     = static function ( bool $condition, string $label, string $detail =
 $chrome_markup = implode(
 	'',
 	array(
+		'<!-- wp:paragraph {"className":"skip-link"} --><p class="skip-link"><a href="#main">Skip to content</a></p><!-- /wp:paragraph -->',
 		'<!-- wp:group {"tagName":"header","className":"site-header"} --><header class="wp-block-group site-header"><!-- wp:navigation --><!-- wp:navigation-link {"label":"Product","url":"#product"} /--><!-- /wp:navigation --></header><!-- /wp:group -->',
 		'<!-- wp:group {"className":"hero"} --><div class="wp-block-group hero"><!-- wp:heading {"level":1} --><h1 class="wp-block-heading">Every launch.</h1><!-- /wp:heading --></div><!-- /wp:group -->',
 		'<!-- wp:group {"tagName":"footer","className":"site-footer"} --><footer class="wp-block-group site-footer"><!-- wp:paragraph --><p>Relay Atlas</p><!-- /wp:paragraph --></footer><!-- /wp:group -->',
@@ -135,6 +136,7 @@ if ( ! is_wp_error( $page ) ) {
 	$content = $with_template_parts['contents']['index.html'];
 	$assert( ! str_contains( $content, 'tagName":"header' ), 'strips-leading-header-when-template-part-exists' );
 	$assert( ! str_contains( $content, 'tagName":"footer' ), 'strips-trailing-footer-when-template-part-exists' );
+	$assert( str_contains( $content, 'Skip to content' ), 'keeps-leading-accessibility-skip-link' );
 	$assert( str_contains( $content, 'Every launch.' ), 'keeps-page-body-content' );
 
 	$parts = array_values( array_filter( array_map( static fn( array $diagnostic ): string => (string) ( $diagnostic['part'] ?? '' ), $with_template_parts['diagnostics'] ) ) );

--- a/tests/smoke-template-part-shell-dedupe.php
+++ b/tests/smoke-template-part-shell-dedupe.php
@@ -63,6 +63,7 @@ $body   = '<!-- wp:paragraph --><p>Article body remains.</p><!-- /wp:paragraph -
 $article_header = '<!-- wp:group {"tagName":"header","className":"article-header"} --><header class="wp-block-group article-header"><h2>Article Header</h2></header><!-- /wp:group -->';
 $article_footer = '<!-- wp:group {"tagName":"footer","className":"article-footer"} --><footer class="wp-block-group article-footer"><p>Article Footer</p></footer><!-- /wp:group -->';
 $skip_link = '<!-- wp:html --><a class="skip-link" href="#main">Skip to content</a><!-- /wp:html -->';
+$wrapped_skip_link = '<!-- wp:paragraph {"className":"skip-link"} --><p class="skip-link wp-block-paragraph"><a href="#main">Skip to content</a></p><!-- /wp:paragraph -->';
 
 $page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
 	array(
@@ -207,6 +208,182 @@ $nonmatching_prelude_content   = (string) ( $nonmatching_prelude_artifacts['cont
 $assert( str_contains( $nonmatching_prelude_content, 'Skip to content' ), 'nonmatching-prelude-preserved' );
 $assert( str_contains( $nonmatching_prelude_content, 'Article Header' ), 'nonmatching-header-preserved' );
 $assert( ! str_contains( $nonmatching_prelude_content, 'Global Footer' ), 'nonmatching-prelude-footer-removed' );
+
+$template_semantic_header = '<!-- wp:group {"tagName":"header","className":"site-header"} --><header class="wp-block-group site-header"><nav><a href="/about">About</a></nav><a href="/back">Back home</a></header><!-- /wp:group -->';
+$different_global_header = '<!-- wp:group {"tagName":"header","className":"site-header"} --><header class="wp-block-group site-header"><nav><a href="/about">About</a></nav><a href="/try">Try the editor</a></header><!-- /wp:group -->';
+$near_global_header      = str_replace( 'href="/about"', 'href="/journal"', $different_global_header );
+$serialized_template_header = '<!-- wp:group {"tagName":"header","className":"site-header"} --><header class="wp-block-group site-header"><!-- wp:navigation --><nav class="wp-block-navigation"><!-- wp:navigation-link {"label":"Home","url":"http:\/\/index.html"} /--><!-- wp:navigation-link {"label":"The Block Editor","url":"http:\/\/blocks.html"} /--><!-- /wp:navigation --></nav><a href="/back">Back home</a></header><!-- /wp:group -->';
+$serialized_runtime_header = '<!-- wp:group {"tagName":"header","className":"site-header"} --><header class="wp-block-group site-header"><!-- wp:navigation --><nav class="wp-block-navigation"><!-- wp:navigation-link {"label":"Home","url":"http:\/\/example.test\/home\/"} /--><!-- wp:navigation-link {"label":"The Block Editor","url":"http:\/\/example.test\/blocks\/"} /--><!-- /wp:navigation --></nav><a href="/try">Try the editor</a></header><!-- /wp:group -->';
+$serialized_near_header = str_replace( 'example.test\\/blocks\\/', 'example.test\\/journal\\/', $serialized_runtime_header );
+$role_global_header      = '<!-- wp:group {"tagName":"header","className":"route-chrome"} --><header class="wp-block-group route-chrome" role="banner"><p>Route-specific masthead</p></header><!-- /wp:group -->';
+$different_local_header  = '<!-- wp:group {"tagName":"header","className":"article-header"} --><header class="wp-block-group article-header"><h1>Article title</h1></header><!-- /wp:group -->';
+$semantic_template_part_writes = array(
+	'/tmp/ssi-theme/parts/header.html' => $template_semantic_header,
+);
+
+$runtime_header_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'runtime-header.html',
+		'title'        => 'Runtime Header',
+		'block_markup' => $skip_link . "\n" . $different_global_header . "\n" . $body,
+	)
+);
+
+$runtime_header_artifacts = $runtime_header_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'runtime-header.html' => $runtime_header_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$semantic_template_part_writes,
+	array( 'strip_template_header' => true )
+) : array();
+$runtime_header_content   = (string) ( $runtime_header_artifacts['contents']['runtime-header.html'] ?? '' );
+$runtime_header_diagnostic = $runtime_header_artifacts['diagnostics'][0] ?? array();
+
+$assert( str_contains( $runtime_header_content, 'Skip to content' ), 'runtime-global-header-skip-link-preserved' );
+$assert( ! str_contains( $runtime_header_content, 'Try the editor' ), 'runtime-different-global-header-removed' );
+$assert( str_contains( $runtime_header_content, 'Article body remains.' ), 'runtime-global-header-body-preserved' );
+$assert( 'semantic_header_identity_and_navigation_match' === ( $runtime_header_diagnostic['reason'] ?? '' ), 'runtime-global-header-diagnostic-reason' );
+$assert( 1 === ( $runtime_header_diagnostic['removed_header_blocks'] ?? 0 ), 'runtime-global-header-diagnostic-count' );
+$assert( 'parts/header.html' === ( $runtime_header_diagnostic['matched_header_template_part'] ?? '' ), 'runtime-global-header-template-match' );
+$assert( 'stable_header_classes_and_navigation_destinations' === ( $runtime_header_diagnostic['header_match_signal'] ?? '' ), 'runtime-global-header-match-signal' );
+
+$serialized_header_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'serialized-header.html',
+		'title'        => 'Serialized Header',
+		'block_markup' => $wrapped_skip_link . "\n" . $serialized_runtime_header . "\n" . $body,
+	)
+);
+$serialized_header_artifacts = $serialized_header_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'serialized-header.html' => $serialized_header_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	array( '/tmp/ssi-theme/parts/header.html' => $serialized_template_header )
+) : array();
+$serialized_header_content = (string) ( $serialized_header_artifacts['contents']['serialized-header.html'] ?? '' );
+
+$assert( ! str_contains( $serialized_header_content, 'Try the editor' ), 'serialized-navigation-rewritten-routes-match' );
+$assert( str_contains( $serialized_header_content, 'Skip to content' ), 'serialized-navigation-skip-link-preserved' );
+$assert( 'semantic_header_identity_and_navigation_match' === ( $serialized_header_artifacts['diagnostics'][0]['reason'] ?? '' ), 'serialized-navigation-diagnostic-reason' );
+
+$serialized_near_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'serialized-near-header.html',
+		'title'        => 'Serialized Near Header',
+		'block_markup' => $serialized_near_header . "\n" . $body,
+	)
+);
+$serialized_near_artifacts = $serialized_near_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'serialized-near-header.html' => $serialized_near_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	array( '/tmp/ssi-theme/parts/header.html' => $serialized_template_header )
+) : array();
+$serialized_near_content = (string) ( $serialized_near_artifacts['contents']['serialized-near-header.html'] ?? '' );
+
+$assert( str_contains( $serialized_near_content, 'journal' ), 'serialized-navigation-different-route-preserved' );
+
+$wrapped_skip_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'wrapped-skip-header.html',
+		'title'        => 'Wrapped Skip Header',
+		'block_markup' => $wrapped_skip_link . "\n" . $different_global_header . "\n" . $body,
+	)
+);
+
+$wrapped_skip_artifacts = $wrapped_skip_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'wrapped-skip-header.html' => $wrapped_skip_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$semantic_template_part_writes
+) : array();
+$wrapped_skip_content = (string) ( $wrapped_skip_artifacts['contents']['wrapped-skip-header.html'] ?? '' );
+
+$assert( str_contains( $wrapped_skip_content, 'Skip to content' ), 'wrapped-skip-link-preserved' );
+$assert( ! str_contains( $wrapped_skip_content, 'Try the editor' ), 'wrapped-skip-link-followed-global-header-removed' );
+
+$role_global_header_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'role-global-header.html',
+		'title'        => 'Role Global Header',
+		'block_markup' => $role_global_header . "\n" . $body,
+	)
+);
+
+$role_global_header_artifacts = $role_global_header_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'role-global-header.html' => $role_global_header_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$semantic_template_part_writes,
+	array( 'strip_template_header' => true )
+) : array();
+$role_global_header_content = (string) ( $role_global_header_artifacts['contents']['role-global-header.html'] ?? '' );
+
+$assert( str_contains( $role_global_header_content, 'Route-specific masthead' ), 'runtime-unmatched-role-global-header-preserved' );
+
+$near_global_header_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'near-global-header.html',
+		'title'        => 'Near Global Header',
+		'block_markup' => $near_global_header . "\n" . $body,
+	)
+);
+$near_global_header_artifacts = $near_global_header_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'near-global-header.html' => $near_global_header_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$semantic_template_part_writes
+) : array();
+$near_global_header_content = (string) ( $near_global_header_artifacts['contents']['near-global-header.html'] ?? '' );
+
+$assert( str_contains( $near_global_header_content, 'href="/journal"' ), 'runtime-near-global-header-preserved' );
+
+$local_header_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'runtime-local-header.html',
+		'title'        => 'Runtime Local Header',
+		'block_markup' => $different_local_header . "\n" . $body,
+	)
+);
+
+$local_header_artifacts = $local_header_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'runtime-local-header.html' => $local_header_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$semantic_template_part_writes,
+	array( 'strip_template_header' => true )
+) : array();
+$local_header_content = (string) ( $local_header_artifacts['contents']['runtime-local-header.html'] ?? '' );
+
+$assert( str_contains( $local_header_content, 'Article title' ), 'runtime-local-header-preserved' );
+$assert( array() === ( $local_header_artifacts['diagnostics'] ?? array() ), 'runtime-local-header-no-dedupe-diagnostic' );
+
+$body_global_header_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'body-global-header.html',
+		'title'        => 'Body Global Header',
+		'block_markup' => $body . "\n" . $different_global_header,
+	)
+);
+
+$body_global_header_artifacts = $body_global_header_page instanceof Static_Site_Importer_Source_Page ? Static_Site_Importer_Page_Materializer::page_artifacts(
+	array( 'body-global-header.html' => $body_global_header_page ),
+	'ssi-theme',
+	array(),
+	array(),
+	$semantic_template_part_writes,
+	array( 'strip_template_header' => true )
+) : array();
+$body_global_header_content = (string) ( $body_global_header_artifacts['contents']['body-global-header.html'] ?? '' );
+
+$assert( str_contains( $body_global_header_content, 'Try the editor' ), 'runtime-global-header-after-body-preserved' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -80,6 +80,13 @@ if ( ! function_exists( 'trailingslashit' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_theme_root_uri' ) ) {
+	function get_theme_root_uri( string $stylesheet_or_template = '' ): string {
+		unset( $stylesheet_or_template );
+		return 'https://example.test/wp-content/themes';
+	}
+}
+
 if ( ! function_exists( 'wp_mkdir_p' ) ) {
 	function wp_mkdir_p( string $path ): bool {
 		return is_dir( $path ) || mkdir( $path, 0777, true );
@@ -263,18 +270,29 @@ $assert( array( 'website/index.html#main-nav' ) === ( $navigation_part_reports[0
 if ( ! function_exists( 'blocks_engine_php_transformer_convert_format' ) ) {
 	function blocks_engine_php_transformer_convert_format( string $content, string $from, string $to, array $options = array() ): array {
 		$GLOBALS['static_site_importer_test_transform_options'][] = $options;
+		$GLOBALS['static_site_importer_test_transform_content'][] = $content;
 		unset( $from, $to );
 		$text = trim( preg_replace( '/\s+/', ' ', wp_strip_all_tags( $content ) ) ?? '' );
+		$svg_asset = str_contains( $content, '<svg' ) ? array(
+			'source'             => 'inline-svg',
+			'path'               => 'assets/materialized-svg/inline-svg-test.svg',
+			'target_path'        => 'assets/materialized-svg/inline-svg-test.svg',
+			'kind'               => 'svg',
+			'source_role'        => 'importer_owned',
+			'pipeline_sanitized' => true,
+			'content'            => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"><path d="M0 0h1v1z" /></svg>',
+		) : null;
 		return array(
-			'serialized_blocks' => '<!-- wp:paragraph --><p>' . esc_html( $text ) . '</p><!-- /wp:paragraph -->',
+			'serialized_blocks' => '<!-- wp:paragraph --><p>' . esc_html( $text ) . ( null !== $svg_asset ? '<img src="assets/materialized-svg/inline-svg-test.svg" alt="" />' : '' ) . '</p><!-- /wp:paragraph -->',
 			'diagnostics'       => array(),
-			'assets'            => array(
+			'assets'            => array_values( array_filter( array(
 				array(
 					'path'    => 'assets/css/template-part-projection.css',
 					'type'    => 'text/css',
 					'content' => '.projected-template-part{display:flex}',
 				),
-			),
+				$svg_asset,
+			) ) ),
 		);
 	}
 }
@@ -307,7 +325,12 @@ $assert( false === ( $source_file_part_reports[0]['contains_core_html'] ?? true 
 $assert( 0 === ( $source_file_part_reports[0]['control_marker_count'] ?? -1 ), 'source-file-template-part-fallback-reports-control-marker-count' );
 $assert( array( '.projected-template-part{display:flex}' ) === ( $source_file_part_result['styles'] ?? array() ), 'source-file-template-part-fallback-retains-transformer-css-assets' );
 $transform_options = $GLOBALS['static_site_importer_test_transform_options'] ?? array();
+$transform_content = $GLOBALS['static_site_importer_test_transform_content'] ?? array();
 $assert( ':root{--brand:#2c63ff}.btn{background:var(--brand);color:#fff}' === ( $transform_options[0]['static_css'] ?? '' ), 'source-file-template-part-fallback-passes-source-css-to-transformer' );
+$assert( str_contains( (string) ( $transform_content[0] ?? '' ), '<svg>' ), 'source-file-template-part-fallback-passes-inline-svg-to-transformer' );
+$assert( isset( $source_file_part_writes['/tmp/visual-repair-smoke/assets/materialized-svg/inline-svg-test.svg'] ), 'source-file-template-part-fallback-writes-sanitized-importer-owned-svg' );
+$assert( str_contains( (string) $source_file_part_writes['/tmp/visual-repair-smoke/parts/header.html'], 'https://example.test/wp-content/themes/visual-repair-smoke/assets/materialized-svg/inline-svg-test.svg' ), 'source-file-template-part-fallback-rewrites-materialized-svg-url-once' );
+$assert( ! str_contains( (string) $source_file_part_writes['/tmp/visual-repair-smoke/parts/header.html'], '/visual-repair-smoke/https://' ), 'source-file-template-part-fallback-does-not-double-rewrite-svg-url' );
 
 $entrypoint_part_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
 	'/tmp/visual-repair-smoke',

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -262,11 +262,19 @@ $assert( array( 'website/index.html#main-nav' ) === ( $navigation_part_reports[0
 
 if ( ! function_exists( 'blocks_engine_php_transformer_convert_format' ) ) {
 	function blocks_engine_php_transformer_convert_format( string $content, string $from, string $to, array $options = array() ): array {
-		unset( $from, $to, $options );
+		$GLOBALS['static_site_importer_test_transform_options'][] = $options;
+		unset( $from, $to );
 		$text = trim( preg_replace( '/\s+/', ' ', wp_strip_all_tags( $content ) ) ?? '' );
 		return array(
 			'serialized_blocks' => '<!-- wp:paragraph --><p>' . esc_html( $text ) . '</p><!-- /wp:paragraph -->',
 			'diagnostics'       => array(),
+			'assets'            => array(
+				array(
+					'path'    => 'assets/css/template-part-projection.css',
+					'type'    => 'text/css',
+					'content' => '.projected-template-part{display:flex}',
+				),
+			),
 		);
 	}
 }
@@ -279,6 +287,10 @@ $source_file_part_result = Static_Site_Importer_Theme_Materializer::template_par
 				'path'    => 'index.html',
 				'content' => '<!doctype html><html><body><main><header><nav><a href="/news/">News</a><svg><path d="M0 0h1v1z" /></svg></nav></header><article><h1>Home</h1></article><footer><p>Footer</p></footer></main></body></html>',
 			),
+			array(
+				'path'    => 'css/style.css',
+				'content' => ':root{--brand:#2c63ff}.btn{background:var(--brand);color:#fff}',
+			),
 		),
 	)
 );
@@ -289,6 +301,13 @@ $assert( isset( $source_file_part_writes['/tmp/visual-repair-smoke/parts/header.
 $assert( isset( $source_file_part_writes['/tmp/visual-repair-smoke/parts/footer.html'] ), 'source-file-template-part-fallback-writes-footer' );
 $assert( ! str_contains( (string) $source_file_part_writes['/tmp/visual-repair-smoke/parts/header.html'], '<!-- wp:html' ), 'source-file-template-part-fallback-strips-inline-svg-html-fallback' );
 $assert( array( 'index.html#header' ) === ( $source_file_part_reports[0]['source_paths'] ?? array() ), 'source-file-template-part-fallback-reports-header-source' );
+$assert( 'source_files.landmark' === ( $source_file_part_reports[0]['origin'] ?? '' ), 'source-file-template-part-fallback-reports-origin' );
+$assert( array( 'core/paragraph' ) === ( $source_file_part_reports[0]['block_names'] ?? array() ), 'source-file-template-part-fallback-reports-block-shape' );
+$assert( false === ( $source_file_part_reports[0]['contains_core_html'] ?? true ), 'source-file-template-part-fallback-reports-core-html-absence' );
+$assert( 0 === ( $source_file_part_reports[0]['control_marker_count'] ?? -1 ), 'source-file-template-part-fallback-reports-control-marker-count' );
+$assert( array( '.projected-template-part{display:flex}' ) === ( $source_file_part_result['styles'] ?? array() ), 'source-file-template-part-fallback-retains-transformer-css-assets' );
+$transform_options = $GLOBALS['static_site_importer_test_transform_options'] ?? array();
+$assert( ':root{--brand:#2c63ff}.btn{background:var(--brand);color:#fff}' === ( $transform_options[0]['static_css'] ?? '' ), 'source-file-template-part-fallback-passes-source-css-to-transformer' );
 
 $base_theme_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes( '/tmp/visual-repair-smoke', 'visual-repair-smoke', 'Visual Repair Smoke', '', true, true );
 $assert( isset( $base_theme_writes['/tmp/visual-repair-smoke/templates/404.html'] ), 'base-theme-writes-404-template' );
@@ -677,9 +696,8 @@ $source_enq_pos  = strpos( $functions_php, "wp_enqueue_style( 'fixture-theme-ass
 $assert( false !== $font_enq_pos && false !== $source_enq_pos && $font_enq_pos < $source_enq_pos, 'font-stylesheet-enqueue-row-precedes-source-stylesheet-enqueue-row' );
 $assert( 2 === substr_count( $functions_php, "wp_enqueue_style( 'fixture-theme-asset-assets-materialized-assets-site', get_template_directory_uri() . '/assets/materialized/assets/site.css'" ), 'source-stylesheet-enqueue-row-is-emitted-in-both-enqueue-actions' );
 $assert( str_contains( $functions_php, '/assets/materialized/assets/app.js' ), 'materialization-plan-script-is-enqueued' );
-$assert( str_contains( $functions_php, "\$mimes['svg'] = 'image/svg+xml';" ), 'generated-theme-enables-svg-upload-mime' );
-$assert( str_contains( $functions_php, "add_filter( 'wp_check_filetype_and_ext'" ), 'generated-theme-corrects-svg-filetype-check' );
-$assert( str_contains( $functions_php, 'sanitized by the import pipeline at build time' ), 'generated-theme-documents-build-time-svg-sanitization' );
+$assert( ! str_contains( $functions_php, "\$mimes['svg'] = 'image/svg+xml';" ), 'generated-theme-does-not-enable-unsanitized-svg-uploads' );
+$assert( ! str_contains( $functions_php, "add_filter( 'wp_check_filetype_and_ext'" ), 'generated-theme-does-not-bypass-svg-filetype-checks' );
 $assert( str_contains( $functions_php, "wp_script_add_data( 'fixture-theme-asset-assets-materialized-assets-app', 'defer', true );" ), 'materialization-plan-script-defer-is-enqueued' );
 $assert( str_contains( $functions_php, "wp_script_add_data( 'fixture-theme-asset-assets-materialized-assets-app', 'type', 'module' );" ), 'materialization-plan-script-type-is-enqueued' );
 $assert( str_contains( $functions_php, "wp_script_add_data( 'fixture-theme-asset-assets-materialized-assets-vendor', 'async', true );" ), 'materialization-plan-script-async-is-enqueued' );

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -309,6 +309,26 @@ $assert( array( '.projected-template-part{display:flex}' ) === ( $source_file_pa
 $transform_options = $GLOBALS['static_site_importer_test_transform_options'] ?? array();
 $assert( ':root{--brand:#2c63ff}.btn{background:var(--brand);color:#fff}' === ( $transform_options[0]['static_css'] ?? '' ), 'source-file-template-part-fallback-passes-source-css-to-transformer' );
 
+$entrypoint_part_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
+	'/tmp/visual-repair-smoke',
+	array(
+		'compiled_site' => array( 'entry_path' => 'index.html' ),
+		'source_files'  => array(
+			array(
+				'path'    => 'about.html',
+				'content' => '<html><body><header><a href="/">Back home</a></header><main>About</main><footer><p>Short footer.</p></footer></body></html>',
+			),
+			array(
+				'path'    => 'index.html',
+				'content' => '<html><body><header><a href="/editor">Try the editor</a></header><main>Home</main><footer><p>Full footer — sincerely, no snark.</p></footer></body></html>',
+			),
+		),
+	)
+);
+$entrypoint_part_writes = is_array( $entrypoint_part_result ) ? $entrypoint_part_result['writes'] : array();
+$assert( str_contains( (string) ( $entrypoint_part_writes['/tmp/visual-repair-smoke/parts/header.html'] ?? '' ), 'Try the editor' ), 'source-file-template-part-fallback-prefers-entrypoint-header' );
+$assert( str_contains( (string) ( $entrypoint_part_writes['/tmp/visual-repair-smoke/parts/footer.html'] ?? '' ), 'sincerely, no snark' ), 'source-file-template-part-fallback-preserves-entrypoint-footer-content' );
+
 $base_theme_writes = Static_Site_Importer_Theme_Materializer::base_theme_writes( '/tmp/visual-repair-smoke', 'visual-repair-smoke', 'Visual Repair Smoke', '', true, true );
 $assert( isset( $base_theme_writes['/tmp/visual-repair-smoke/templates/404.html'] ), 'base-theme-writes-404-template' );
 $assert( isset( $base_theme_writes['/tmp/visual-repair-smoke/templates/archive.html'] ), 'base-theme-writes-archive-template' );

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -297,6 +297,15 @@ if ( ! function_exists( 'blocks_engine_php_transformer_convert_format' ) ) {
 	}
 }
 
+if ( ! function_exists( 'blocks_engine_php_transformer_runtime_context' ) ) {
+	function blocks_engine_php_transformer_runtime_context( string $html, string $source_path, array $files ): array {
+		unset( $html, $source_path, $files );
+		return array(
+			'runtime_dom_selectors' => array( '.theme-toggle' ),
+		);
+	}
+}
+
 $source_file_part_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
 	'/tmp/visual-repair-smoke',
 	array(
@@ -327,6 +336,7 @@ $assert( array( '.projected-template-part{display:flex}' ) === ( $source_file_pa
 $transform_options = $GLOBALS['static_site_importer_test_transform_options'] ?? array();
 $transform_content = $GLOBALS['static_site_importer_test_transform_content'] ?? array();
 $assert( ':root{--brand:#2c63ff}.btn{background:var(--brand);color:#fff}' === ( $transform_options[0]['static_css'] ?? '' ), 'source-file-template-part-fallback-passes-source-css-to-transformer' );
+$assert( array( '.theme-toggle' ) === ( $transform_options[0]['runtime_dom_selectors'] ?? array() ), 'source-file-template-part-fallback-passes-script-derived-runtime-context' );
 $assert( str_contains( (string) ( $transform_content[0] ?? '' ), '<svg>' ), 'source-file-template-part-fallback-passes-inline-svg-to-transformer' );
 $assert( isset( $source_file_part_writes['/tmp/visual-repair-smoke/assets/materialized-svg/inline-svg-test.svg'] ), 'source-file-template-part-fallback-writes-sanitized-importer-owned-svg' );
 $assert( str_contains( (string) $source_file_part_writes['/tmp/visual-repair-smoke/parts/header.html'], 'https://example.test/wp-content/themes/visual-repair-smoke/assets/materialized-svg/inline-svg-test.svg' ), 'source-file-template-part-fallback-rewrites-materialized-svg-url-once' );

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -475,7 +475,7 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   assert.deepEqual(recipe.inputs.mounts, []);
 });
 
-test('optionally captures bounded generated SVG font evidence after import', () => {
+test('gates visual capture on complete generated SVG font evidence after import', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'svg-font-evidence-recipe-test' });
   const recipe = buildFixtureMatrixRecipe({
     matrix,
@@ -491,8 +491,12 @@ test('optionally captures bounded generated SVG font evidence after import', () 
 
   assert.equal(step?.command, 'wordpress.wp-cli');
   assert.match(code, /svg-font-embedding-evidence\/v1/);
+  assert.match(code, /expected_font_svg_count/);
   assert.match(code, /has_data_font/);
+  assert.match(code, /Required self-contained SVG fonts are missing/);
   assert.doesNotMatch(code, /base64_encode/);
+  const lint = spawnSync('php', ['-l'], { input: `<?php\n${code}`, encoding: 'utf8' });
+  assert.equal(lint.status, 0, lint.stderr || lint.stdout);
 });
 
 test('retains generated SVG font evidence from runtime output', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -841,11 +841,24 @@ test('fixture matrix captures installed transformer provenance and bounded mater
       fixture_id: 'simple-site',
       status: 'passed',
       import_report: {
+        generated_theme: {
+          template_parts: [{
+            path: 'parts/header.html',
+            origin: 'source_files.landmark',
+            source_paths: ['website/index.html#header'],
+            block_markup_hash: 'header123',
+            block_markup_bytes: 512,
+            block_names: ['core/group', 'core/navigation'],
+            contains_core_html: false,
+            control_marker_count: 2,
+          }],
+        },
         blocks_engine: {
           transformer: {
             package: 'automattic/blocks-engine-php-transformer',
             version: '0.2.6',
             reference: '908c76a8d9b7679c87f59aa183f09b12ea9f89e6',
+            source_fingerprint: 'sha256:source123',
           },
           materialization_plan: {
             schema: 'blocks-engine/php-transformer/materialization-plan/v1',
@@ -883,12 +896,17 @@ test('fixture matrix captures installed transformer provenance and bounded mater
   assert.deepEqual(evidence.transformer, {
     package: 'automattic/blocks-engine-php-transformer',
     version: '0.2.6',
-    reference: '908c76a8d9b7679c87f59aa183f09b12ea9f89e6',
+    reference: 'sha256:source123',
+    package_reference: '908c76a8d9b7679c87f59aa183f09b12ea9f89e6',
+    source_fingerprint: 'sha256:source123',
   });
   assert.deepEqual(evidence.materialization_plan.assets[0], {
     path: 'assets/app.js', source: 'website/index.html', role: 'runtime', kind: 'script', type: 'application/javascript', placement: 'footer', defer: true, async: false, payload_present: true, payload_sha256: 'def456', payload_bytes: 84,
   });
   assert.equal(evidence.materialization_plan.assets[1].payload_sha256, 'abc123');
+  assert.deepEqual(evidence.template_parts[0], {
+    path: 'parts/header.html', origin: 'source_files.landmark', source_paths: ['website/index.html#header'], block_markup_hash: 'header123', block_markup_bytes: 512, block_names: ['core/group', 'core/navigation'], contains_core_html: false, control_marker_count: 2,
+  });
   assert.equal(result.summary.matrix_evidence_readiness.status, 'verified');
 });
 


### PR DESCRIPTION
## Summary

- deduplicate semantically equivalent global header and footer shells while preserving accessibility preludes, content-local lookalikes, and runtime controls
- materialize transformer-owned sanitized SVGs through the Media Library without losing template references or embedded font payloads
- resolve and embed only the Google font faces used by generated SVG text, with bounded fetching and explicit diagnostics
- retain bounded SVG/font evidence in fixture-matrix results so missing generated font payloads fail before visual capture

## Why

Transformed pages could render duplicate global chrome when the page shell and generated template part were semantically equivalent but structurally different. Generated text-bearing SVGs also lost their self-contained font payload when SSI rebuilt Media Library attachments from the original artifact content, producing a small but deterministic visual regression.

The materialization pipeline now carries the same computed font payload into generated theme files, page-level SVG writes, and Media Library attachments.

## How to test

1. Run `composer install --no-interaction --prefer-dist`.
2. Run `npm test`.
3. Run `npm run test:validation`.

## Acceptance evidence

- Full test suite passes: 184 fixture-matrix tests, 5 Figma E2E tests, 3 promotion tests, 3 PHP.wasm tests, and the canonical site-plan materializer smoke test.
- Validation harness passes all 12 steps.
- The solved `15-saas` fixture reports `solved_candidate`, 292/292 native valid blocks, zero HTML fallbacks, and zero invalid blocks.
- Full-page visual comparison at 1280x1600 reports `identical` with threshold `0`.
- Source and candidate screenshot SHA-256 are both `3e685d7e83cafd03a878fa5cc8f8c44d1143c27275e4e82278dca71bfe4b410f`.
- Source and candidate each load 18/18 images and expose 50 generated font faces.

## Compatibility

`Static_Site_Importer_Media_Materializer::materialize_sanitized_svgs()` gains an optional third argument, so existing callers remain compatible. Generated SVG attachment filenames intentionally change when embedded font content changes because filenames are content-addressed.

Closes #654.
Relates to #489.

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenCode with OpenAI GPT-5.6 Sol
- **Used for:** Runtime evidence analysis, implementation, test coverage, and exact-parity verification. Chris reviewed and owns the change.
