### PR TITLE
Fix solved fixture corpus selection identity

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -168,6 +168,7 @@ export async function runFixtureMatrix(options) {
     complexity: options.complexity,
     max_complexity: options.maxComplexity || options.max_complexity,
     fixture_ids: options.fixtureIds,
+    fixture_corpus: options.fixtureCorpus,
   });
   const progress = createFixtureMatrixProgress(matrix, options);
   progress.emit('matrix', 'started');
@@ -1310,6 +1311,7 @@ export function optionsFromEnv(env = process.env) {
     explainSelectors: benchEnv.SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS || env.SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS,
     minNativeRate: benchEnv.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE || env.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE,
     fixtureIds: benchEnv.SSI_FIXTURE_MATRIX_FIXTURE_IDS || env.SSI_FIXTURE_MATRIX_FIXTURE_IDS,
+    fixtureCorpus: benchEnv.SSI_FIXTURE_MATRIX_FIXTURE_CORPUS || env.SSI_FIXTURE_MATRIX_FIXTURE_CORPUS,
     requireSolvedCandidate: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE) || isTruthy(env.SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE),
   };
 }

--- a/lib/fixture-matrix/fixtures.mjs
+++ b/lib/fixture-matrix/fixtures.mjs
@@ -258,11 +258,12 @@ function normalizeFixtureFilter(input = {}) {
   const tags = normalizeManifestTags(input.tag || input.tags).map((tag) => tag.toLowerCase());
   const capabilities = normalizeManifestCapabilities(input.capability || input.capabilities);
   const riskProfile = input.risk_profile || input.riskProfile ? normalizeManifestRiskProfile(input.risk_profile || input.riskProfile) : '';
+  const fixtureCorpus = String(input.fixture_corpus || input.fixtureCorpus || '').trim().toLowerCase();
   const hasComplexity = input.complexity !== undefined && input.complexity !== null && input.complexity !== '';
   const hasMaxComplexity = input.max_complexity !== undefined || input.maxComplexity !== undefined;
   const complexity = hasComplexity ? normalizeManifestComplexity(input.complexity) : null;
   const maxComplexity = hasMaxComplexity ? normalizeManifestComplexity(input.max_complexity ?? input.maxComplexity) : null;
-  if (fixtureIds.length === 0 && !fixtureClass && tags.length === 0 && capabilities.length === 0 && !riskProfile && complexity === null && maxComplexity === null) {
+  if (fixtureIds.length === 0 && !fixtureClass && tags.length === 0 && capabilities.length === 0 && !riskProfile && !fixtureCorpus && complexity === null && maxComplexity === null) {
     return null;
   }
   return {
@@ -271,6 +272,7 @@ function normalizeFixtureFilter(input = {}) {
     ...(tags.length ? { tags } : {}),
     ...(capabilities.length ? { capabilities } : {}),
     ...(riskProfile ? { risk_profile: riskProfile } : {}),
+    ...(fixtureCorpus ? { fixture_corpus: fixtureCorpus } : {}),
     ...(complexity !== null ? { complexity } : {}),
     ...(maxComplexity !== null ? { max_complexity: maxComplexity } : {}),
   };
@@ -278,6 +280,9 @@ function normalizeFixtureFilter(input = {}) {
 
 function fixtureMatchesFilter(fixture, filter) {
   if (filter.fixture_ids && !filter.fixture_ids.includes(fixture.id)) {
+    return false;
+  }
+  if (filter.fixture_corpus && fixture.fixture_corpus !== filter.fixture_corpus) {
     return false;
   }
   if (filter.fixture_class && fixture.fixture_class !== filter.fixture_class) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2410,6 +2410,7 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
     fixture_ids: ['solved-site'],
     solved_only: true,
     identity: SOLVED_ONLY_LANE_ID,
+    fixture_corpus: 'solved',
   });
   assert.ok(solvedOnlyPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_FIXTURE_IDS=solved-site'));
   assert.ok(solvedOnlyPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE=1'));
@@ -2514,10 +2515,12 @@ test('--solved-only selects exactly the valid solved fixture corpus', () => {
   const fixtureRoot = path.join(root, 'fixtures');
   mkdirSync(staticSiteImporter, { recursive: true });
   mkdirSync(path.join(fixtureRoot, 'websites', 'active-site'), { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'websites', 'solved-a'), { recursive: true });
   mkdirSync(path.join(fixtureRoot, 'solved', 'solved-b'), { recursive: true });
   mkdirSync(path.join(fixtureRoot, 'solved', 'solved-a'), { recursive: true });
   mkdirSync(path.join(fixtureRoot, 'solved', 'incomplete'), { recursive: true });
   writeFileSync(path.join(fixtureRoot, 'websites', 'active-site', 'index.html'), '<h1>Active</h1>');
+  writeFileSync(path.join(fixtureRoot, 'websites', 'solved-a', 'index.html'), '<h1>Active collision</h1>');
   writeFileSync(path.join(fixtureRoot, 'solved', 'solved-a', 'index.html'), '<h1>Solved A</h1>');
   writeFileSync(path.join(fixtureRoot, 'solved', 'solved-b', 'index.html'), '<h1>Solved B</h1>');
 
@@ -2530,8 +2533,19 @@ test('--solved-only selects exactly the valid solved fixture corpus', () => {
   });
 
   assert.deepEqual(plan.lane_filter.fixture_ids, ['solved-a', 'solved-b']);
+  assert.equal(plan.lane_filter.fixture_corpus, 'solved');
+  assert.equal(plan.solved_fixture_count, 2);
   assert.equal(plan.selected_active_fixture_count, 0);
   assert.equal(plan.selected_solved_fixture_count, 2);
+  assert.ok(plan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_FIXTURE_CORPUS=solved'));
+
+  const matrix = createFixtureMatrix({
+    fixture_root: fixtureRoot,
+    fixture_ids: plan.lane_filter.fixture_ids,
+    fixture_corpus: plan.lane_filter.fixture_corpus,
+  });
+  assert.equal(matrix.count, 2);
+  assert.ok(matrix.fixtures.every((fixture) => fixture.fixture_corpus === 'solved'));
 });
 
 test('fixture matrix operator composes typed placement only for the bench step', () => {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -96,6 +96,7 @@ export function buildFixtureMatrixRunPlan(input) {
     SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH: options.staticSiteImporter,
     SSI_FIXTURE_MATRIX_RUN: '1',
     ...(options.fixtureIds.length ? { SSI_FIXTURE_MATRIX_FIXTURE_IDS: options.fixtureIds.join(',') } : {}),
+    ...(options.solvedOnly ? { SSI_FIXTURE_MATRIX_FIXTURE_CORPUS: 'solved' } : {}),
     ...(options.requireSolvedCandidate ? { SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE: '1' } : {}),
     ...(options.blocksEnginePhpTransformerPath
       ? { SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH: options.blocksEnginePhpTransformerPath }
@@ -227,6 +228,7 @@ function laneFilterSummary(options) {
     ...(options.targetFixture ? { target_fixture: options.targetFixture } : {}),
     ...(options.promotionGate ? { promotion_gate: true } : {}),
     ...(options.solvedOnly ? { solved_only: true, identity: SOLVED_ONLY_LANE_ID } : {}),
+    ...(options.solvedOnly ? { fixture_corpus: 'solved' } : {}),
     ...(options.class ? { class: String(options.class) } : {}),
     ...(options.tag ? { tag: String(options.tag) } : {}),
     ...(options.capability ? { capability: String(options.capability) } : {}),
@@ -890,7 +892,7 @@ function countCorpusFixtureDirectories(fixtureRoot) {
     ? countTopLevelFixtureDirectories(activeRoot)
     : countTopLevelFixtureDirectories(fixtureRoot);
   const solved = fs.existsSync(solvedRoot) && fs.statSync(solvedRoot).isDirectory()
-    ? countTopLevelFixtureDirectories(solvedRoot)
+    ? fixtureDirectoryNames(solvedRoot).length
     : 0;
   return {
     active,


### PR DESCRIPTION
## Summary

- qualify solved-only fixture selection with `fixture_corpus=solved`
- forward the corpus identity through the operator, bench environment, and matrix filter
- count only valid solved fixtures that contain `index.html`
- cover duplicate IDs across active and solved corpora

## Root cause

#671 selected solved fixtures by ID alone. When an active fixture shared a solved fixture ID, matrix discovery could select both corpora during a solved-only run. The reported solved fixture count also counted incomplete directories that were not selectable fixtures.

## How to test

1. Run `npm ci`.
2. Run `composer install --no-interaction`.
3. Run `npm run test:fixture-matrix`.
4. Run `npm test`.
5. Run `git diff --check origin/main...HEAD`.

Expected: both test commands pass, the solved-only regression selects exactly the two valid solved fixtures despite an active fixture with a duplicate ID, and the diff check emits no output.

## Compatibility

This adds an optional fixture matrix filter and environment value. Existing active/default fixture selection and directory-count behavior remain unchanged; no extension path or public API is removed.

Follow-up to #671.

## AI disclosure

This change was developed with AI assistance and verified with the repository test suite.