### PR TITLE
Synthesize template parts only from separable chrome

### DIFF
--- a/includes/class-static-site-importer-document.php
+++ b/includes/class-static-site-importer-document.php
@@ -228,12 +228,12 @@ class Static_Site_Importer_Document {
 		$body = $this->first_element( 'body' );
 		$root = $body instanceof DOMElement ? $body : $this->dom->documentElement;
 
-		$footer             = $this->first_element( 'footer' );
 		$main               = $this->first_element( 'main' );
+		$footer             = $this->first_separable_landmark( 'footer', $main );
 		$effective_children = $this->effective_root_children( $root, $main );
 
 		$header       = $this->first_plausible_global_header( $effective_children );
-		$nav          = $this->first_plausible_global_nav( $effective_children, $header );
+		$nav          = $this->first_plausible_global_nav( $effective_children, $header, $main );
 		$body_headers = $this->body_content_headers( $effective_children, $header, $nav );
 
 		if ( $header instanceof DOMElement && $this->contains_same_node( $body_headers, $header ) ) {
@@ -425,12 +425,21 @@ class Static_Site_Importer_Document {
 	/**
 	 * Find a nav that is plausible reusable site chrome.
 	 *
+	 * Navs embedded inside the page body (`<main>`) are page content, not
+	 * separable global chrome: extracting them duplicates the markup because the
+	 * body keeps its own copy.
+	 *
 	 * @param DOMElement[]    $effective_children Effective body-level direct children.
 	 * @param DOMElement|null $header             Selected header element.
+	 * @param DOMElement|null $main               Main landmark element if present.
 	 * @return DOMElement|null
 	 */
-	private function first_plausible_global_nav( array $effective_children, ?DOMElement $header ): ?DOMElement {
+	private function first_plausible_global_nav( array $effective_children, ?DOMElement $header, ?DOMElement $main = null ): ?DOMElement {
 		foreach ( $this->dom->getElementsByTagName( 'nav' ) as $nav ) {
+			if ( $main instanceof DOMElement && $this->is_descendant_of( $nav, $main ) ) {
+				continue;
+			}
+
 			if ( $header instanceof DOMElement && $this->is_descendant_of( $nav, $header ) ) {
 				return $nav;
 			}
@@ -438,6 +447,32 @@ class Static_Site_Importer_Document {
 			if ( $this->contains_same_node( $effective_children, $nav ) || $this->has_global_chrome_signal( $nav ) ) {
 				return $nav;
 			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Find the first landmark that is separable from the page body.
+	 *
+	 * Landmarks nested inside `<main>` stay in the page body fragment, so
+	 * extracting them as shared chrome would duplicate their markup.
+	 *
+	 * @param string          $tag  Landmark tag name.
+	 * @param DOMElement|null $main Main landmark element if present.
+	 * @return DOMElement|null
+	 */
+	private function first_separable_landmark( string $tag, ?DOMElement $main ): ?DOMElement {
+		foreach ( $this->dom->getElementsByTagName( $tag ) as $node ) {
+			if ( ! $node instanceof DOMElement ) {
+				continue;
+			}
+
+			if ( $main instanceof DOMElement && $this->is_descendant_of( $node, $main ) ) {
+				continue;
+			}
+
+			return $node;
 		}
 
 		return null;

--- a/includes/class-static-site-importer-theme-materializer.php
+++ b/includes/class-static-site-importer-theme-materializer.php
@@ -991,6 +991,7 @@ class Static_Site_Importer_Theme_Materializer {
 	 */
 	private static function source_file_template_parts( array $artifacts ): array {
 		$files = isset( $artifacts['source_files'] ) && is_array( $artifacts['source_files'] ) ? $artifacts['source_files'] : array();
+		$files = self::entrypoint_first_source_files( $files, $artifacts );
 		foreach ( $files as $file ) {
 			if ( ! is_array( $file ) || ! isset( $file['path'] ) || ! is_scalar( $file['path'] ) ) {
 				continue;
@@ -1022,6 +1023,43 @@ class Static_Site_Importer_Theme_Materializer {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Order source files so the site entrypoint is scanned first.
+	 *
+	 * The entrypoint page is the imported front page, so its chrome is the
+	 * authoritative candidate for shared template parts. Without this ordering
+	 * the fallback synthesizes parts from whichever file happens to sort first.
+	 *
+	 * @param array<int,mixed>    $files     Source files.
+	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
+	 * @return array<int,mixed>
+	 */
+	private static function entrypoint_first_source_files( array $files, array $artifacts ): array {
+		$entrypoint = '';
+		foreach ( array( 'entry_path', 'entrypoint' ) as $key ) {
+			if ( isset( $artifacts[ $key ] ) && is_scalar( $artifacts[ $key ] ) && '' !== trim( (string) $artifacts[ $key ] ) ) {
+				$entrypoint = ltrim( str_replace( '\\', '/', trim( (string) $artifacts[ $key ] ) ), '/' );
+				break;
+			}
+		}
+		if ( '' === $entrypoint ) {
+			return $files;
+		}
+
+		$leading  = array();
+		$trailing = array();
+		foreach ( $files as $file ) {
+			$path = is_array( $file ) && isset( $file['path'] ) && is_scalar( $file['path'] ) ? ltrim( str_replace( '\\', '/', (string) $file['path'] ), '/' ) : '';
+			if ( '' !== $path && ( $path === $entrypoint || str_ends_with( $path, '/' . $entrypoint ) ) ) {
+				$leading[] = $file;
+				continue;
+			}
+			$trailing[] = $file;
+		}
+
+		return array_merge( $leading, $trailing );
 	}
 
 	/**
@@ -1079,7 +1117,11 @@ class Static_Site_Importer_Theme_Materializer {
 	}
 
 	/**
-	 * Return the first matching landmark's outer HTML.
+	 * Return the first separable landmark's outer HTML.
+	 *
+	 * Landmarks nested inside `<main>` remain part of the page body markup, so
+	 * synthesizing a shared template part from them would render the same chrome
+	 * twice. Only landmarks outside the page body are reusable site chrome.
 	 *
 	 * @param string $html Source HTML document.
 	 * @param string $tag  Landmark tag name.
@@ -1099,9 +1141,42 @@ class Static_Site_Importer_Theme_Materializer {
 			return '';
 		}
 
-		$nodes = $dom->getElementsByTagName( $tag );
-		$node  = $nodes->length > 0 ? $nodes->item( 0 ) : null;
-		return $node instanceof DOMElement ? trim( (string) $dom->saveHTML( $node ) ) : '';
+		$mains = $dom->getElementsByTagName( 'main' );
+		$main  = $mains->length > 0 ? $mains->item( 0 ) : null;
+
+		foreach ( $dom->getElementsByTagName( $tag ) as $node ) {
+			if ( ! $node instanceof DOMElement ) {
+				continue;
+			}
+
+			if ( $main instanceof DOMElement && self::dom_is_descendant_of( $node, $main ) ) {
+				continue;
+			}
+
+			return trim( (string) $dom->saveHTML( $node ) );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Check whether a DOM node is contained by another element.
+	 *
+	 * @param DOMElement $candidate Candidate element.
+	 * @param DOMElement $ancestor  Ancestor element.
+	 * @return bool
+	 */
+	private static function dom_is_descendant_of( DOMElement $candidate, DOMElement $ancestor ): bool {
+		$node = $candidate->parentNode;
+		while ( $node instanceof DOMNode ) {
+			if ( $node->isSameNode( $ancestor ) ) {
+				return true;
+			}
+
+			$node = $node->parentNode;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-static-site-importer-transformer-adapter.php
+++ b/includes/class-static-site-importer-transformer-adapter.php
@@ -95,6 +95,7 @@ class Static_Site_Importer_Transformer_Adapter {
 		$artifacts['documents']         = ! empty( $view['documents'] ) && is_array( $view['documents'] ) ? $view['documents'] : ( isset( $result['documents'] ) && is_array( $result['documents'] ) ? $result['documents'] : array() );
 		$artifacts['files']             = $this->artifact_files_from_site_report( $materialization_plan, ! empty( $view ) ? $view : $result );
 		$artifacts['source_files']      = $this->source_files_from_artifact( $artifact );
+		$artifacts['entry_path']        = $this->entry_path_from_artifact( $artifact );
 		$artifacts['site']              = $materialization_plan;
 		$artifacts['compiled_site']     = ! empty( $view['compiled_site'] ) && is_array( $view['compiled_site'] ) ? $view['compiled_site'] : array();
 		$artifacts['template_parts']    = isset( $materialization_plan['template_parts'] ) && is_array( $materialization_plan['template_parts'] ) ? $materialization_plan['template_parts'] : array();
@@ -114,6 +115,22 @@ class Static_Site_Importer_Transformer_Adapter {
 		}
 
 		return $compiled;
+	}
+
+	/**
+	 * Read the declared website entrypoint from an artifact bundle.
+	 *
+	 * @param array<string,mixed> $artifact Website artifact bundle.
+	 * @return string
+	 */
+	private function entry_path_from_artifact( array $artifact ): string {
+		foreach ( array( 'entry_path', 'entrypoint' ) as $key ) {
+			if ( isset( $artifact[ $key ] ) && is_scalar( $artifact[ $key ] ) && '' !== trim( (string) $artifact[ $key ] ) ) {
+				return ltrim( str_replace( '\\', '/', trim( (string) $artifact[ $key ] ) ), '/' );
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/tests/smoke-embedded-chrome-template-parts.php
+++ b/tests/smoke-embedded-chrome-template-parts.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Smoke coverage for embedded-chrome template part separability.
+ *
+ * Landmarks nested inside the page body root (`<main>`) stay in the page
+ * markup, so synthesizing shared header/footer template parts from them
+ * renders the same chrome twice. Only separable body-level landmarks are
+ * reusable site chrome, and the entrypoint page is the authoritative source
+ * for the synthesized fallback parts.
+ *
+ * Run from the repository root:
+ * php tests/smoke-embedded-chrome-template-parts.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( string $value ): string {
+		return htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key ) ?? '' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		$title = strtolower( trim( $title ) );
+		return trim( preg_replace( '/[^a-z0-9_\-]+/', '-', $title ) ?? '', '-' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( string $value ): string {
+		return trim( preg_replace( '/\s+/', ' ', wp_strip_all_tags( $value ) ) ?? '' );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( string $value ): string {
+		return strip_tags( $value );
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $value ): string {
+		return rtrim( $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '' ) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'blocks_engine_php_transformer_convert_format' ) ) {
+	/**
+	 * Deterministic converter stub: wraps the fragment in a core/html block so
+	 * part synthesis can be asserted without the Blocks Engine transformer.
+	 *
+	 * @param string $body HTML markup.
+	 * @param string $from Source format.
+	 * @param string $to   Target format.
+	 * @return array{serialized_blocks:string}
+	 */
+	function blocks_engine_php_transformer_convert_format( string $body, string $from, string $to ): array {
+		return array( 'serialized_blocks' => '<!-- wp:html -->' . $body . '<!-- /wp:html -->' );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-source-page.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-materializer.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-page-materializer.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+// 1. Single-root page (Figma-transformer shape): every landmark lives inside
+// `<main class="figma-root">`. Nothing is separable, so no fragments and no
+// synthesized template parts may be produced.
+$embedded_chrome_html = '<!DOCTYPE html><html><head><title>Embedded</title></head><body>'
+	. '<main class="figma-root">'
+	. '<header class="figma-node-1-header"><nav class="figma-node-1-navigation"><a href="#news">News</a></nav><p>Logo</p></header>'
+	. '<section class="hero"><h1>Hero</h1></section>'
+	. '<footer class="figma-node-1-footer"><p>Footer</p></footer>'
+	. '</main>'
+	. '</body></html>';
+
+$embedded_fragments = ( new Static_Site_Importer_Document( $embedded_chrome_html ) )->fragments();
+$assert( '' === $embedded_fragments['header'], 'embedded_header_not_extracted', $embedded_fragments['header'] );
+$assert( '' === $embedded_fragments['footer'], 'embedded_footer_not_extracted', $embedded_fragments['footer'] );
+$assert( str_contains( $embedded_fragments['main'], 'figma-node-1-header' ), 'embedded_header_stays_in_page_body' );
+$assert( str_contains( $embedded_fragments['main'], 'figma-node-1-footer' ), 'embedded_footer_stays_in_page_body' );
+
+$embedded_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
+	'/tmp/theme',
+	array(
+		'entry_path'   => 'index.html',
+		'source_files' => array(
+			array(
+				'path'    => 'website/index.html',
+				'content' => $embedded_chrome_html,
+			),
+		),
+	)
+);
+$assert( ! is_wp_error( $embedded_result ), 'embedded_result_not_error', is_wp_error( $embedded_result ) ? $embedded_result->get_error_message() : '' );
+$assert( is_array( $embedded_result ) && array() === $embedded_result['writes'], 'embedded_chrome_produces_no_template_parts', is_array( $embedded_result ) ? implode( ',', array_keys( $embedded_result['writes'] ) ) : '' );
+
+// 2. Classic page shape: body-level header/nav/footer siblings of `<main>` are
+// separable shared chrome and must keep producing template parts.
+$classic_html = '<!DOCTYPE html><html><head><title>Classic</title></head><body>'
+	. '<header class="site-header"><nav class="site-nav"><a href="/">Home</a></nav></header>'
+	. '<main><h1>Welcome</h1><p>Body copy.</p></main>'
+	. '<footer class="site-footer"><p>Classic Footer</p></footer>'
+	. '</body></html>';
+
+$classic_fragments = ( new Static_Site_Importer_Document( $classic_html ) )->fragments();
+$assert( str_contains( $classic_fragments['header'], 'site-header' ), 'classic_header_extracted', $classic_fragments['header'] );
+$assert( str_contains( $classic_fragments['footer'], 'site-footer' ), 'classic_footer_extracted', $classic_fragments['footer'] );
+$assert( ! str_contains( $classic_fragments['main'], 'site-header' ), 'classic_page_body_excludes_header' );
+
+$classic_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
+	'/tmp/theme',
+	array(
+		'entry_path'   => 'index.html',
+		'source_files' => array(
+			array(
+				'path'    => 'website/index.html',
+				'content' => $classic_html,
+			),
+		),
+	)
+);
+$assert( ! is_wp_error( $classic_result ), 'classic_result_not_error', is_wp_error( $classic_result ) ? $classic_result->get_error_message() : '' );
+$classic_writes = is_array( $classic_result ) ? $classic_result['writes'] : array();
+$assert( isset( $classic_writes['/tmp/theme/parts/header.html'] ), 'classic_header_part_written', implode( ',', array_keys( $classic_writes ) ) );
+$assert( isset( $classic_writes['/tmp/theme/parts/footer.html'] ), 'classic_footer_part_written', implode( ',', array_keys( $classic_writes ) ) );
+
+// 3. Entrypoint priority: when multiple classic pages carry separable headers,
+// the entrypoint page wins over alphabetically-earlier files.
+$archive_html = str_replace( 'site-header', 'archive-header', str_replace( 'site-footer', 'archive-footer', $classic_html ) );
+$entrypoint_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
+	'/tmp/theme',
+	array(
+		'entry_path'   => 'index.html',
+		'source_files' => array(
+			array(
+				'path'    => 'website/archive.html',
+				'content' => $archive_html,
+			),
+			array(
+				'path'    => 'website/index.html',
+				'content' => $classic_html,
+			),
+		),
+	)
+);
+$assert( ! is_wp_error( $entrypoint_result ), 'entrypoint_result_not_error', is_wp_error( $entrypoint_result ) ? $entrypoint_result->get_error_message() : '' );
+$entrypoint_writes = is_array( $entrypoint_result ) ? $entrypoint_result['writes'] : array();
+$entrypoint_header = (string) ( $entrypoint_writes['/tmp/theme/parts/header.html'] ?? '' );
+$assert( str_contains( $entrypoint_header, 'site-header' ), 'entrypoint_header_preferred', $entrypoint_header );
+$assert( ! str_contains( $entrypoint_header, 'archive-header' ), 'non_entrypoint_header_skipped' );
+
+// 4. Nested-chrome entrypoint with a separable-chrome secondary page: the
+// entrypoint yields nothing, so the fallback continues to the next source page.
+$mixed_result = Static_Site_Importer_Theme_Materializer::template_part_artifact_writes(
+	'/tmp/theme',
+	array(
+		'entry_path'   => 'index.html',
+		'source_files' => array(
+			array(
+				'path'    => 'website/index.html',
+				'content' => $embedded_chrome_html,
+			),
+			array(
+				'path'    => 'website/about.html',
+				'content' => $classic_html,
+			),
+		),
+	)
+);
+$assert( ! is_wp_error( $mixed_result ), 'mixed_result_not_error', is_wp_error( $mixed_result ) ? $mixed_result->get_error_message() : '' );
+$mixed_writes = is_array( $mixed_result ) ? $mixed_result['writes'] : array();
+$mixed_header = (string) ( $mixed_writes['/tmp/theme/parts/header.html'] ?? '' );
+$assert( str_contains( $mixed_header, 'site-header' ), 'mixed_fallback_uses_separable_page', $mixed_header );
+
+if ( ! empty( $failures ) ) {
+	echo implode( "\n", $failures ) . "\n";
+	echo 'FAILED: ' . count( $failures ) . ' of ' . $assertions . " assertions\n";
+	exit( 1 );
+}
+
+echo 'PASS: ' . $assertions . " assertions\n";


### PR DESCRIPTION
## Summary

When the Blocks Engine plan emits no template parts, SSI synthesizes header/footer parts from source HTML landmarks. That fallback previously:

- accepted a nested `<nav>` as the global header purely via class-name signal, producing a nav-only header part while the page body kept its full embedded header (duplicate chrome)
- fell back to `first_landmark_html`, which grabbed **any** `<header>`/`<footer>` regardless of nesting — including chrome embedded inside `<main>` that the page body always renders itself
- scanned source files in array order, so an alphabetically-earlier archive page could define the global header instead of the entrypoint

Single-root documents (e.g. Figma-transformer output, where every landmark lives inside `main.figma-root`) therefore rendered chrome **twice**: once from the synthesized part and once from the page body — and the part could come from the wrong page variant entirely.

## Changes

- A landmark is only extractable as shared chrome when it is **separable** — not a descendant of `<main>`. Applies to the document fragment decomposition (header, nav, footer) and the `first_landmark_html` fallback.
- Source files are scanned **entrypoint-first** so the imported front page is the authoritative source for synthesized parts; the transformer adapter now passes `entry_path` through to materializer artifacts.
- Classic static sites with body-level landmarks keep today's behavior (regression-tested).

## Measured impact

Three-fixture production matrix (Fisiostetic, FSE Pilot Build Theme, Twenty Twenty-Five Community `.fig` transforms), front-page visual mismatch vs the served static source at threshold 0:

| Fixture | Before | After |
|---|---|---|
| FSE Pilot Build Theme | 45.55% | **16.54%** |
| Twenty Twenty-Five Community | 42.22% | **28.73%** |
| Fisiostetic | 32.15% | 32.15% (unrelated cause, tracked separately) |

Editor gate unchanged and fully green in the same runs: 727/727 native blocks, 0 `core/html`, 0 invalid, 365/365 browser-validated blocks.

## How to test

1. `php tests/smoke-embedded-chrome-template-parts.php` — 17 assertions: embedded chrome produces no parts and stays in the page body; classic body-level chrome still produces parts; entrypoint page wins over alphabetically-earlier files; nested-chrome entrypoint falls through to the next separable page.
2. `php tests/smoke-template-part-shell-dedupe.php`
3. `php tests/smoke-template-chrome-dedupe.php`
4. `php tests/smoke-theme-materializer-dry-run.php`
5. `php tests/smoke-semantic-parity-diagnostics.php`
6. `php tests/smoke-wordpress-site-plan-materializer.php`

All pass locally.

## AI disclosure

Implemented with OpenCode using `openai/gpt-5.6-sol`; all listed tests were run locally.