### PR TITLE
Persist secondary-surface visual evidence as bench artifacts

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -602,8 +602,13 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
   const visualParityArtifacts = fixture.visual_parity_artifacts || fixture.visualParityArtifacts;
   const slots = visualParityArtifacts?.artifacts || {};
   const fixtureId = fixture.fixture_id || fixture.fixtureId || '';
-  if (!fixtureId || !slots || typeof slots !== 'object') {
+  if (!fixtureId) {
     return fixture;
+  }
+  if (!slots || typeof slots !== 'object') {
+    const secondary = arrayValue(fixture.visual_parity_comparisons).map((comparison) => materializeSecondaryVisualCompareArtifacts({ comparison, fixtureId, outputDirectory, codeboxArtifactsDirectory, artifacts }));
+    const rewrites = new Map(secondary.flatMap((entry) => [...entry.rewrites]));
+    return rewriteVisualEvidencePaths({ ...fixture, visual_parity_comparisons: secondary.map((entry) => entry.comparison) }, rewrites);
   }
 
   const rewrites = new Map();
@@ -681,7 +686,7 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
     updatedVisualParityArtifacts.visual_attribution_summary = summarizeVisualAttribution(visualAttribution.attribution, visualAttribution.path);
   }
 
-  return {
+  const materialized = {
     ...fixture,
     diagnostics: rewriteDiagnosticArtifactRefs(fixture.diagnostics, rewrites),
     artifact_refs: rewriteArtifactRefs(fixture.artifact_refs, rewrites),
@@ -697,6 +702,82 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
       visual_diff_classification: classification,
     } : {}),
   };
+  const comparisons = arrayValue(fixture.visual_parity_comparisons);
+  if (comparisons.length === 0) {
+    return materialized;
+  }
+  const secondary = comparisons.map((comparison) => materializeSecondaryVisualCompareArtifacts({
+    comparison,
+    fixtureId,
+    outputDirectory,
+    codeboxArtifactsDirectory,
+    artifacts,
+  }));
+  const secondaryRewrites = new Map(secondary.flatMap((entry) => [...entry.rewrites]));
+  return rewriteVisualEvidencePaths({
+    ...materialized,
+    visual_parity_comparisons: secondary.map((entry) => entry.comparison),
+  }, secondaryRewrites);
+}
+
+function materializeSecondaryVisualCompareArtifacts({ comparison, fixtureId, outputDirectory, codeboxArtifactsDirectory, artifacts }) {
+  const visualParityArtifacts = comparison?.visual_parity_artifacts || comparison?.visualParityArtifacts;
+  const slots = visualParityArtifacts?.artifacts || {};
+  const surfaceId = artifactKey(comparison?.surface_id || comparison?.surfaceId || 'front-page');
+  // The primary route keeps its long-standing IDs and location. Every additional
+  // route is fixture/surface-scoped so identical runtime filenames cannot collide.
+  if (surfaceId === 'front-page' || !slots || typeof slots !== 'object') {
+    return { comparison, rewrites: new Map() };
+  }
+  const rewrites = new Map();
+  const updatedSlots = { ...slots };
+  for (const [slotName, fileStem] of [
+    ['source_screenshot', 'source'],
+    ['imported_screenshot', 'candidate'],
+    ['diff_screenshot', 'diff'],
+    ['visual_diff', 'visual-diff.json'],
+    ['visual_explanation', 'visual-explanation.json'],
+    ['source_dom_snapshot', 'source-dom-snapshot.json'],
+    ['candidate_dom_snapshot', 'candidate-dom-snapshot.json'],
+  ]) {
+    const refPath = slots[slotName]?.ref?.path;
+    const sourcePath = resolveCodeboxArtifactPath(refPath, codeboxArtifactsDirectory);
+    if (!sourcePath || !fs.existsSync(sourcePath)) {
+      continue;
+    }
+    const persistedPath = path.join(outputDirectory, 'visual-compare', fixtureId, surfaceId, fileStem.includes('.') ? fileStem : `${fileStem}.png`);
+    fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
+    fs.copyFileSync(sourcePath, persistedPath);
+    rewrites.set(refPath, persistedPath);
+    const artifactId = `visual_compare_${artifactKey(fixtureId)}_${surfaceId}_${fileStem}`;
+    updatedSlots[slotName] = {
+      ...slots[slotName],
+      status: 'captured',
+      kind: slotName,
+      ref: artifactRef(artifactId, persistedPath, 'visual-parity'),
+    };
+    artifacts[artifactId] = { path: persistedPath };
+  }
+  return {
+    rewrites,
+    comparison: rewriteVisualEvidencePaths({
+      ...comparison,
+      visual_parity_artifacts: { ...visualParityArtifacts, owner: 'bench_artifact_root', artifacts: updatedSlots },
+    }, rewrites),
+  };
+}
+
+function rewriteVisualEvidencePaths(value, rewrites) {
+  if (!value || typeof value !== 'object' || rewrites.size === 0) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => rewriteVisualEvidencePaths(entry, rewrites));
+  }
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => [
+    key,
+    typeof entry === 'string' && rewrites.has(entry) ? rewrites.get(entry) : rewriteVisualEvidencePaths(entry, rewrites),
+  ]));
 }
 
 function materializeVisualAttribution({ fixture, fixtureId, outputDirectory, slots, normalizer, loader, homeboyExtensionPath }) {

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -73,6 +73,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
   const visualParityOptions = { ...visualParity, fixtureArtifactsDirectory };
   const diagnostics = collectFixtureDiagnostics(merged, { visualParity: visualParityOptions });
   const visualParityArtifacts = collectVisualParityArtifacts(merged, visualParityOptions);
+  const visualParityComparisons = collectVisualParityComparisons(payloads, visualParityOptions);
   // Best-effort live-WP parity (opt-in). Returns null when disabled or when the
   // capture/source/comparator is unavailable, keeping the lane isolated.
   const liveWpParityResult = collectLiveWpParity({
@@ -110,6 +111,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     editor_canvas: merged.editor_canvas || merged.editorCanvas || merged.editor_canvas_summary || merged.editorCanvasSummary || null,
     editor_open: merged.editor_open || merged.editorOpen || null,
     visual_parity_artifacts: visualParityArtifacts,
+    ...(visualParityComparisons.length ? { visual_parity_comparisons: visualParityComparisons } : {}),
     visual_diff_regions: visualParityArtifacts?.visual_diff_regions || [],
     visual_diff_cause_summary: visualParityArtifacts?.visual_diff_cause_summary || null,
     visual_diff_classification: visualParityArtifacts?.visual_diff_classification || null,
@@ -118,6 +120,24 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     svg_font_embedding_evidence: merged.svg_font_embedding_evidence || merged.svgFontEmbeddingEvidence || null,
     raw: { payloads },
   });
+}
+
+// Keep each command result separate: merging runtime payloads is appropriate for
+// fixture status, but it otherwise discards secondary route visual evidence.
+function collectVisualParityComparisons(payloads, visualParityOptions) {
+  return payloads
+    .map((payload) => {
+      const artifacts = collectVisualParityArtifacts(payload, visualParityOptions);
+      if (!artifacts) {
+        return null;
+      }
+      const metadata = objectValue(payload.metadata);
+      return {
+        surface_id: firstString([metadata.surface_id, metadata.surfaceId, payload.surface_id, payload.surfaceId]) || 'front-page',
+        visual_parity_artifacts: artifacts,
+      };
+    })
+    .filter(Boolean);
 }
 
 const WORDPRESS_SITE_PLAN_SCHEMA = 'blocks-engine/wordpress-site-plan/v2';

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -527,6 +527,7 @@ export function normalizeFixtureResult(input) {
     editor_canvas: boundBlob(input.editor_canvas || input.editorCanvas || null),
     editor_open: boundBlob(input.editor_open || input.editorOpen || null),
     visual_parity_artifacts: input.visual_parity_artifacts || input.visualParityArtifacts || null,
+    visual_parity_comparisons: input.visual_parity_comparisons || input.visualParityComparisons || [],
     visual_diff_regions: normalizeArray(input.visual_diff_regions || input.visualDiffRegions),
     visual_diff_cause_summary: input.visual_diff_cause_summary || input.visualDiffCauseSummary || null,
     visual_diff_classification: input.visual_diff_classification || input.visualDiffClassification || null,

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -5612,6 +5612,64 @@ test('visual-compare sidecars are normalized and retained under the bench artifa
   });
 });
 
+test('visual-compare materialization retains non-colliding fixture and surface artifact sets', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-multi-surface-output-'));
+  const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-multi-surface-codebox-'));
+  const makeComparison = (surfaceId) => {
+    const relative = `files/browser/visual-compare/simple-site--${surfaceId}`;
+    const runtimeDirectory = path.join(codeboxArtifactsDirectory, 'runtime-123', relative);
+    mkdirSync(runtimeDirectory, { recursive: true });
+    for (const fileName of ['source.png', 'candidate.png', 'diff.png']) {
+      writeFileSync(path.join(runtimeDirectory, fileName), `${surfaceId}:${fileName}`);
+    }
+    return {
+      surface_id: surfaceId,
+      visual_parity_artifacts: {
+        artifacts: Object.fromEntries([
+          ['source_screenshot', 'source.png'],
+          ['imported_screenshot', 'candidate.png'],
+          ['diff_screenshot', 'diff.png'],
+        ].map(([slot, fileName]) => [slot, { status: 'captured', ref: { path: `${relative}/${fileName}` } }])),
+      },
+    };
+  };
+  const primary = makeComparison('front-page');
+  const secondary = makeComparison('about');
+  const persisted = materializeVisualCompareArtifacts({
+    outputDirectory,
+    codeboxArtifactsDirectory,
+    result: {
+      fixtures: [{
+        fixture_id: 'simple-site',
+        diagnostics: [{ artifact_refs: [{ artifact_id: 'diff_screenshot', path: 'files/browser/visual-compare/simple-site--about/diff.png' }] }],
+        visual_parity_artifacts: primary.visual_parity_artifacts,
+        visual_parity_comparisons: [primary, secondary],
+      }],
+    },
+  });
+  const fixture = persisted.result.fixtures[0];
+  const secondaryArtifacts = fixture.visual_parity_comparisons[1].visual_parity_artifacts.artifacts;
+  const normalized = normalizeFixtureMatrixResult({
+    matrix: { id: 'multi-surface-materialization', fixture_root: '/tmp', fixtures: [{ id: 'simple-site', fixture_path: '/tmp/simple-site' }] },
+    results: persisted.result.fixtures,
+  }).fixtures[0];
+
+  assert.ok(existsSync(path.join(outputDirectory, 'visual-compare', 'simple-site', 'source.png')));
+  assert.ok(existsSync(path.join(outputDirectory, 'visual-compare', 'simple-site', 'about', 'source.png')));
+  assert.deepEqual(Object.keys(persisted.artifacts).sort(), [
+    'visual_compare_simple-site_about_candidate',
+    'visual_compare_simple-site_about_diff',
+    'visual_compare_simple-site_about_source',
+    'visual_compare_simple-site_candidate',
+    'visual_compare_simple-site_diff',
+    'visual_compare_simple-site_source',
+  ]);
+  assert.notEqual(fixture.visual_parity_artifacts.artifacts.source_screenshot.ref.path, secondaryArtifacts.source_screenshot.ref.path);
+  assert.equal(secondaryArtifacts.diff_screenshot.ref.artifact_id, 'visual_compare_simple-site_about_diff');
+  assert.equal(fixture.diagnostics[0].artifact_refs[0].path, secondaryArtifacts.diff_screenshot.ref.path);
+  assert.equal(normalized.visual_parity_comparisons[1].visual_parity_artifacts.artifacts.source_screenshot.ref.path, secondaryArtifacts.source_screenshot.ref.path);
+});
+
 test('visual-compare attribution degrades explicitly when sidecars or the extension normalizer are unavailable', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-degraded-output-'));
   const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-degraded-codebox-'));


### PR DESCRIPTION
## Summary
Persist secondary-surface visual evidence as bench artifacts

## What changed
- Task objective: Fix Automattic/static-site-importer issue #681 at its owning workload layer. Inspect the fixture-matrix collection and artifact materialization contracts before editing. Extend the generic visual artifact materializer and bench artifact export so every captured route/surface comparison is copied into the bench artifact root, receives deterministic collision-safe artifact IDs containing fixture and surface identity, and has all nested diagnostic/evidence refs rewritten to retained paths. Preserve the existing fixture-level artifact IDs for the primary route when possible unless the contract requires a deliberate migration. Add high-signal deterministic coverage with at least two route comparisons proving both artifact sets are retained, declared, non-colliding, and referenced from normalized results. Keep the implementation fixture-agnostic and do not edit CHANGELOG.md. Run npm run test:fixture-matrix and git diff --check. Review the final diff for unrelated changes, then commit, push, and open a PR linked to issue #681 through normal cook finalization.
- Verified candidate changed 4 file(s): bench/static-site-fixture-matrix.bench.mjs, lib/fixture-matrix/collectors/run-intake.mjs, lib/fixture-matrix/result.mjs, tools/fixture-matrix.test.mjs.
- Cook completed 1 deterministic verification gate(s) before finalization.
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.

## How to test
1. Run `npm run test:fixture-matrix && git diff --check`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Compatibility impact is unknown from durable task and promotion evidence. The candidate is bounded to 4 changed file(s): bench/static-site-fixture-matrix.bench.mjs, lib/fixture-matrix/collectors/run-intake.mjs, lib/fixture-matrix/result.mjs, tools/fixture-matrix.test.mjs; review externally consumed interfaces in this scope.

## Evidence
- Base unchanged since verification: main remains at 133666c8bdce292ab15004301a52c88c0a3ed2e9.
- CI expected: Homeboy CI after push
- Cook deterministic verification: 1 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable source evidence: https://github.com/Automattic/static-site-importer/issues/681
- Verified candidate scope: 4 changed file(s): bench/static-site-fixture-matrix.bench.mjs, lib/fixture-matrix/collectors/run-intake.mjs, lib/fixture-matrix/result.mjs, tools/fixture-matrix.test.mjs.
- Verified finalization base: main at 133666c8bdce292ab15004301a52c88c0a3ed2e9
- gate-1: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** AI-assisted
- **Model:** openai/gpt-5.6-terra
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.
