### PR TITLE
Derive route identity for secondary visual artifacts

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -713,7 +713,9 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
     codeboxArtifactsDirectory,
     artifacts,
   }));
-  const secondaryRewrites = new Map(secondary.flatMap((entry) => [...entry.rewrites]));
+  // Nested front-page comparisons share the primary route's stable artifact IDs.
+  // Apply those rewrites too so every result-level visual reference is retained.
+  const secondaryRewrites = new Map([...rewrites, ...secondary.flatMap((entry) => [...entry.rewrites])]);
   return rewriteVisualEvidencePaths({
     ...materialized,
     visual_parity_comparisons: secondary.map((entry) => entry.comparison),

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -33,6 +33,7 @@ import { collectEditorValidationDiagnostics, collectEditorValidation } from './e
 import {
   collectVisualParityDiagnostics,
   collectVisualParityArtifacts,
+  collectVisualParityArtifactComparisons,
   normalizeVisualParityGateOptions,
 } from './visual-parity.mjs';
 import { VISUAL_TIMEOUT_KIND } from '../shared/constants.mjs';
@@ -126,18 +127,40 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
 // fixture status, but it otherwise discards secondary route visual evidence.
 function collectVisualParityComparisons(payloads, visualParityOptions) {
   return payloads
-    .map((payload) => {
-      const artifacts = collectVisualParityArtifacts(payload, visualParityOptions);
-      if (!artifacts) {
-        return null;
-      }
+    .flatMap((payload) => {
       const metadata = objectValue(payload.metadata);
-      return {
-        surface_id: firstString([metadata.surface_id, metadata.surfaceId, payload.surface_id, payload.surfaceId]) || 'front-page',
-        visual_parity_artifacts: artifacts,
-      };
+      const explicitSurfaceId = firstString([metadata.surface_id, metadata.surfaceId, payload.surface_id, payload.surfaceId]);
+      return collectVisualParityArtifactComparisons(payload, visualParityOptions).map((comparison) => ({
+        surface_id: visualComparisonSurfaceId({ explicitSurfaceId, comparison }),
+        visual_parity_artifacts: comparison.visual_parity_artifacts,
+      }));
     })
-    .filter(Boolean);
+    .filter((comparison) => comparison.visual_parity_artifacts);
+}
+
+function visualComparisonSurfaceId({ explicitSurfaceId, comparison }) {
+  return explicitSurfaceId
+    || surfaceIdFromSourcePath(comparison.source_path)
+    || surfaceIdFromVisualArtifacts(comparison.visual_parity_artifacts)
+    || 'front-page';
+}
+
+function surfaceIdFromSourcePath(sourcePath) {
+  const fileName = String(sourcePath || '').split(/[?#]/, 1)[0].split('/').pop() || '';
+  const stem = fileName.replace(/\.html?$/i, '');
+  return stem && stem !== 'index' ? stem : '';
+}
+
+function surfaceIdFromVisualArtifacts(artifacts) {
+  for (const slot of Object.values(objectValue(artifacts?.artifacts))) {
+    const refPath = firstString([slot?.ref?.path, slot?.ref?.file, slot?.path]);
+    const directory = refPath.split('/').filter(Boolean).at(-2) || '';
+    const match = directory.match(/--([^/]+)$/);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return '';
 }
 
 const WORDPRESS_SITE_PLAN_SCHEMA = 'blocks-engine/wordpress-site-plan/v2';

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -236,10 +236,27 @@ function dedupeVisualParityComparisons(comparisons) {
       comparison.dimension_delta_pixels,
       comparison.dimension_mismatch,
     ].join('\u0000');
-    const existing = byMetrics.get(key);
-    byMetrics.set(key, existing ? mergeVisualParityComparison(existing, comparison) : comparison);
+    const records = byMetrics.get(key) || [];
+    const index = records.findIndex((existing) => visualComparisonEvidenceMatches(existing, comparison));
+    if (index >= 0) {
+      records[index] = mergeVisualParityComparison(records[index], comparison);
+    } else {
+      records.push(comparison);
+    }
+    byMetrics.set(key, records);
   }
-  return [...byMetrics.values()];
+  return [...byMetrics.values()].flat();
+}
+
+function visualComparisonEvidenceMatches(left, right) {
+  return [
+    'source_path',
+    'source_screenshot',
+    'candidate_screenshot',
+    'diff_screenshot',
+    'visual_diff',
+    'visual_explanation_ref',
+  ].every((key) => !left[key] || !right[key] || left[key] === right[key]);
 }
 
 function mergeVisualParityComparison(left, right) {
@@ -626,7 +643,19 @@ export function collectVisualParityArtifacts(payload, options = {}) {
   if (comparisons.length === 0) {
     return null;
   }
-  const comparison = selectBestVisualParityArtifactComparison(comparisons);
+  return visualParityArtifactsForComparison(selectBestVisualParityArtifactComparison(comparisons));
+}
+
+// Keep route-level records available to intake callers. A single runtime payload
+// can contain every visual comparison from a fixture, not just one command result.
+export function collectVisualParityArtifactComparisons(payload, options = {}) {
+  return collectVisualParityComparisons(payload, options).map((comparison) => ({
+    source_path: comparison.source_path,
+    visual_parity_artifacts: visualParityArtifactsForComparison(comparison),
+  }));
+}
+
+function visualParityArtifactsForComparison(comparison) {
   const slot = (ref, kind, reason) => (ref
     ? { status: 'captured', kind, ref: artifactRef(kind, ref, 'visual-parity') }
     : { status: 'pending', kind, capture_state: 'not_captured', reason });

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -5670,6 +5670,60 @@ test('visual-compare materialization retains non-colliding fixture and surface a
   assert.equal(normalized.visual_parity_comparisons[1].visual_parity_artifacts.artifacts.source_screenshot.ref.path, secondaryArtifacts.source_screenshot.ref.path);
 });
 
+test('visual-compare aggregate intake retains source-path-identified routes without surface metadata', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-aggregate-output-'));
+  const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-aggregate-codebox-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-aggregate-intake-test' });
+  const makeComparison = (sourcePath, artifactDirectory) => {
+    const runtimeDirectory = path.join(codeboxArtifactsDirectory, 'runtime-123', artifactDirectory);
+    mkdirSync(runtimeDirectory, { recursive: true });
+    const files = {};
+    for (const [key, fileName] of Object.entries({ sourceScreenshot: 'source.png', candidateScreenshot: 'candidate.png', diffScreenshot: 'diff.png' })) {
+      writeFileSync(path.join(runtimeDirectory, fileName), `${sourcePath}:${fileName}`);
+      files[key] = `${artifactDirectory}/${fileName}`;
+    }
+    return {
+      source: { path: sourcePath },
+      summary: { mismatchPixels: 20, totalPixels: 100, mismatchRatio: 0.2 },
+      files,
+    };
+  };
+  const frontPage = makeComparison('index.html', 'files/browser/visual-compare/3-artist-music');
+  const music = makeComparison('music.html', 'files/browser/visual-compare/3-artist-music--music');
+  const collected = collectFixtureMatrixRunResults({
+    matrix,
+    outputDirectory,
+    codeboxOutput: {
+      fixture_id: 'simple-site',
+      status: 'completed',
+      comparisons: [frontPage, music],
+    },
+    visualParity: { threshold: 0.1, gate: true },
+  });
+  const persisted = materializeVisualCompareArtifacts({ result: collected, outputDirectory, codeboxArtifactsDirectory });
+  const fixture = persisted.result.fixtures[0];
+  const comparisons = fixture.visual_parity_comparisons;
+  const bySurface = Object.fromEntries(comparisons.map((comparison) => [comparison.surface_id, comparison]));
+  const retainedRefs = comparisons.flatMap((comparison) => Object.values(comparison.visual_parity_artifacts.artifacts)
+    .filter((slot) => slot.status === 'captured')
+    .map((slot) => slot.ref?.path)
+    .filter(Boolean));
+
+  assert.deepEqual(comparisons.map((comparison) => comparison.surface_id).sort(), ['front-page', 'music']);
+  assert.equal(bySurface.music.visual_parity_artifacts.artifacts.diff_screenshot.ref.artifact_id, 'visual_compare_simple-site_music_diff');
+  assert.ok(retainedRefs.every((ref) => ref.startsWith(path.join(outputDirectory, 'visual-compare', 'simple-site'))));
+  assert.equal(new Set(retainedRefs).size, retainedRefs.length, 'route artifact refs must not collide');
+  assert.deepEqual(Object.keys(persisted.artifacts).sort(), [
+    'visual_compare_simple-site_candidate',
+    'visual_compare_simple-site_diff',
+    'visual_compare_simple-site_music_candidate',
+    'visual_compare_simple-site_music_diff',
+    'visual_compare_simple-site_music_source',
+    'visual_compare_simple-site_source',
+  ]);
+  assert.ok(fixture.diagnostics.every((diagnostic) => diagnostic.artifact_refs.every((ref) => ref.path.startsWith(path.join(outputDirectory, 'visual-compare', 'simple-site')))));
+});
+
 test('visual-compare attribution degrades explicitly when sidecars or the extension normalizer are unavailable', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-degraded-output-'));
   const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-attribution-degraded-codebox-'));


### PR DESCRIPTION
## Summary
Derive route identity for secondary visual artifacts

## What changed
- Task objective: Patch forward from merged PR #683 for Automattic/static-site-importer issue #681. The merged implementation depends on metadata.surface\_id/payload.surface\_id and defaults missing identity to front-page, but real fixture-matrix route comparisons do not expose surface\_id. Existing runtime evidence uses source\_path values ending in contact.html, merch.html, music.html, and tour.html plus artifact paths such as files/browser/visual-compare/3-artist-music--music/diff.png. Inspect the actual visual collector normalization and payload shapes. Derive deterministic route identity from authoritative normalized comparison evidence such as source\_path and artifact paths when explicit metadata is absent, while keeping front-page compatibility. Prove that multiple comparisons arriving in one aggregate payload are not lost; expose or add an owning collector primitive rather than relying on payload boundaries if necessary. Add an intake-level multipage regression matching the real shape: no explicit surface\_id, at least front page plus music.html, unique --music artifact paths, and assertions that both artifact sets are retained, declared, non-colliding, and all diagnostic/result refs are rewritten. Keep it generic and do not edit CHANGELOG.md. Run npm run test:fixture-matrix and git diff --check, inspect the complete diff, then commit, push, and open a follow-up PR linked to issue #681.
- Verified candidate changed 4 file(s): bench/static-site-fixture-matrix.bench.mjs, lib/fixture-matrix/collectors/run-intake.mjs, lib/fixture-matrix/collectors/visual-parity.mjs, tools/fixture-matrix.test.mjs.
- Cook completed 1 deterministic verification gate(s) before finalization.
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.

## How to test
1. Run `npm run test:fixture-matrix && git diff --check`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Compatibility impact is unknown from durable task and promotion evidence. The candidate is bounded to 4 changed file(s): bench/static-site-fixture-matrix.bench.mjs, lib/fixture-matrix/collectors/run-intake.mjs, lib/fixture-matrix/collectors/visual-parity.mjs, tools/fixture-matrix.test.mjs; review externally consumed interfaces in this scope.

## Evidence
- Base unchanged since verification: main remains at 08e1c677c38444e5c8a5b480d855d084b7418e5b.
- CI expected: Homeboy CI after push
- Cook deterministic verification: 1 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable source evidence: https://github.com/Automattic/static-site-importer/issues/681
- Verified candidate scope: 4 changed file(s): bench/static-site-fixture-matrix.bench.mjs, lib/fixture-matrix/collectors/run-intake.mjs, lib/fixture-matrix/collectors/visual-parity.mjs, tools/fixture-matrix.test.mjs.
- Verified finalization base: main at 08e1c677c38444e5c8a5b480d855d084b7418e5b
- gate-1: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** AI-assisted
- **Model:** openai/gpt-5.6-terra
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.
