### PR TITLE
Verify published asset receipt integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Static Site Importer is a WordPress plugin. It requires the [Blocks Engine PHP t
 
 ## Canonical Site Plans
 
-`static-site-importer/materialize-wordpress-site-plan` is the generic plan-only boundary for a `blocks-engine/wordpress-site-plan/v2` produced by Blocks Engine 0.4.3. SSI calls the package's canonical validator and resolver, then owns WordPress/filesystem preflight, materialization, reconciliation, and the `static-site-importer/materialization-receipt/v1` response. It accepts no source HTML or transformer result envelope.
+`static-site-importer/materialize-wordpress-site-plan` is the generic plan-only boundary for a `blocks-engine/wordpress-site-plan/v2` produced by Blocks Engine 0.4.4. SSI calls the package's canonical validator and resolver, then owns WordPress/filesystem preflight, materialization, reconciliation, and the `static-site-importer/materialization-receipt/v1` response. It accepts no source HTML or transformer result envelope.
 
 For an isolated runtime matrix, invoke the ability with `plan`, `slug`, and optional `overwrite`, or use:
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -137,7 +137,7 @@ class Static_Site_Importer_Theme_Generator {
 			$error = $entity_result['error'];
 			$receipt['status'] = 'partial';
 			$receipt['errors'][] = $error;
-			$receipt['completed']['declaration_ids'] = array_keys( array_filter( array_merge( $dependencies, $entities ), static fn( $report ): bool => 'waived' !== ( $report['status'] ?? '' ) ) );
+			$receipt['completed']['declaration_ids'] = array_values( array_unique( array_merge( $receipt['completed']['declaration_ids'] ?? array(), array_keys( array_filter( array_merge( $dependencies, $entities ), static fn( $report ): bool => 'waived' !== ( $report['status'] ?? '' ) ) ) ) ) );
 			$receipt['completed']['action_ids'] = array_values( array_filter( array_column( $receipt['completed']['operations'], 'reconciliation_identity' ) ) );
 			return new WP_Error( $error['code'], $error['message'], $receipt );
 		}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -274,7 +274,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			}
 			return new WP_Error( 'theme_write_failed' );
 		}
-		return array( 'target_path' => $write['target_path'], 'hash' => hash( 'sha256', $data ), 'payload_hash' => $write['payload_hash'] ?? hash( 'sha256', $data ), 'reconciliation_identity' => $write['reconciliation_identity'] ?? hash( 'sha256', $write['source_path'] . "\n" . $write['target_path'] ) );
+		return array( 'target_path' => $write['target_path'], 'hash' => self::file_hash( $path ), 'payload_hash' => $write['payload_hash'] ?? hash( 'sha256', $data ), 'reconciliation_identity' => $write['reconciliation_identity'] ?? hash( 'sha256', $write['source_path'] . "\n" . $write['target_path'] ) );
 	}
 
 	/** Verify every canonical asset publication against its resolved write and references. */
@@ -310,9 +310,13 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				&& $write['payload_hash'] === $applied['hash'];
 			foreach ( $references[ $id ] ?? array() as $reference ) {
 				$target = $writes[ $reference['write_reconciliation_identity'] ] ?? null;
+				$target_path = is_array( $target ) ? $state['theme_dir'] . '/' . $target['target_path'] : '';
+				$target_content = '' !== $target_path && is_file( $target_path ) ? file_get_contents( $target_path ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Verifies the final declared theme write.
 				$valid = $valid && is_array( $target )
 					&& $reference['target_path'] === $target['target_path']
-					&& $reference['count'] === substr_count( (string) ( $target['payload']['data'] ?? '' ), $reference['expected_resolved_url'] );
+					&& is_string( $target_content )
+					&& $target['payload_hash'] === hash( 'sha256', $target_content )
+					&& $reference['count'] === substr_count( $target_content, $reference['expected_resolved_url'] );
 			}
 			$state['applied']['runtime_declarations']['asset_publications'][ $id ] = array(
 				'status'                  => $valid ? 'completed' : 'failed',


### PR DESCRIPTION
## Summary

Follow-up to #684 after its automatic merge raced the final review fix.

- hash final asset publication bytes from disk after the atomic rename
- verify reference-bearing target files and resolved URL counts from disk
- preserve completed asset publication IDs when a later entity declaration fails
- correct the documented Blocks Engine version to `0.4.4`

## Verification

- `php tests/smoke-wordpress-site-plan-materializer.php`
- `composer validate --strict`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** final defect review and integrity repair