### PR TITLE
Expose materialization preflight errors

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -116,7 +116,9 @@ class Static_Site_Importer_Theme_Generator {
 		$args['report_destinations'] = $report_destinations;
 		$prepared = Static_Site_Importer_WordPress_Site_Plan_Materializer::prepare( $plan, $args );
 		if ( 'prepared' !== ( $prepared['status'] ?? '' ) ) {
-			return new WP_Error( 'static_site_importer_materialization_failed', 'WordPress site plan destination preflight failed.', $prepared['receipt'] ?? array() );
+			$receipt = isset( $prepared['receipt'] ) && is_array( $prepared['receipt'] ) ? $prepared['receipt'] : array();
+			$error   = $receipt['errors'][0] ?? array();
+			return new WP_Error( (string) ( $error['code'] ?? 'static_site_importer_materialization_failed' ), (string) ( $error['message'] ?? 'WordPress site plan destination preflight failed.' ), $receipt );
 		}
 		$dependencies = self::materialize_prepared_dependencies( $lifecycle, $args );
 		if ( is_wp_error( $dependencies ) ) {


### PR DESCRIPTION
## Summary
- preserve the rejected materialization receipt as WP_Error data
- project its first concrete reason code and message instead of collapsing every preflight rejection into one generic error
- align prepare-time failures with the existing materialize-time error projection

## Validation
- `npm test`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `git diff --check`

Follow-up to #688; required to diagnose the immutable solved-site gate from its reviewer artifacts.

Refs #687.