### PR TITLE
Preserve resolver rejection diagnostics

### DIFF
--- a/.github/workflows/solved-site-promotion-pr.yml
+++ b/.github/workflows/solved-site-promotion-pr.yml
@@ -25,4 +25,4 @@ jobs:
     with:
       static-site-importer-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       static-site-importer-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      blocks-engine-sha: ab71509d5cfb4b767bcdb6f3ba9472377ee2f4ef
+      blocks-engine-sha: a3244dcd72373afdff92cb33247689fdd893db99

--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -175,6 +175,7 @@ jobs:
             --matrix-result "${matrix_results[0]}" \
             --registry "${registries[0]}" \
             --runtime-inputs "$ARTIFACT_ROOT/runtime-inputs.json" \
+            --artifact-index "$ARTIFACT_ROOT/homeboy-bench-result.json" \
             --artifact-root "$ARTIFACT_ROOT" \
             --static-site-importer-sha "$STATIC_SITE_IMPORTER_SHA" \
             --blocks-engine-sha "$BLOCKS_ENGINE_SHA" \

--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -167,13 +167,9 @@ jobs:
           STATIC_SITE_IMPORTER_SHA: ${{ inputs.static-site-importer-sha }}
           BLOCKS_ENGINE_SHA: ${{ inputs.blocks-engine-sha }}
         run: |
-          mapfile -t matrix_results < <(find "$ARTIFACT_ROOT" -name static-site-fixture-matrix-result.json -type f)
-          mapfile -t registries < <(find "$ARTIFACT_ROOT" -name gutenberg-incompatibility-registry.json -type f)
-          test "${#matrix_results[@]}" -eq 1
-          test "${#registries[@]}" -eq 1
           node tools/verify-solved-site-promotion.mjs \
-            --matrix-result "${matrix_results[0]}" \
-            --registry "${registries[0]}" \
+            --matrix-result artifact:result \
+            --registry artifact:gutenberg_incompatibility_registry \
             --runtime-inputs "$ARTIFACT_ROOT/runtime-inputs.json" \
             --artifact-index "$ARTIFACT_ROOT/homeboy-bench-result.json" \
             --artifact-root "$ARTIFACT_ROOT" \

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -454,7 +454,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     return {
       batchRun,
       batchResult: editorCanvas.result,
-      visualParityArtifacts: visualCompare.artifacts,
+      visualParityArtifacts: { ...visualCompare.artifacts, ...editorCanvas.artifacts },
       error: batchError,
       childCommandFailures: childCommandFailure ? [childCommandFailure] : [],
     };
@@ -523,15 +523,17 @@ export function materializeEditorCanvasArtifacts(input = {}) {
   const result = input.result || {};
   const outputDirectory = path.resolve(input.outputDirectory || input.output_directory || '');
   const codeboxArtifactsDirectory = path.resolve(input.codeboxArtifactsDirectory || input.codebox_artifacts_directory || '');
+  const artifacts = {};
   return {
     result: {
       ...result,
-      fixtures: arrayValue(result.fixtures).map((fixture) => materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory })),
+      fixtures: arrayValue(result.fixtures).map((fixture) => materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory, artifacts })),
     },
+    artifacts,
   };
 }
 
-function materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory }) {
+function materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory, artifacts }) {
   const fixtureId = fixture.fixture_id || fixture.fixtureId || '';
   if (!fixtureId) {
     return fixture;
@@ -547,8 +549,11 @@ function materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, cod
     }
     const persistedPath = path.join(outputDirectory, 'editor-canvas', fixtureId, path.basename(ref.path));
     fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
-    fs.copyFileSync(sourcePath, persistedPath);
+    if (sourcePath !== persistedPath) {
+      fs.copyFileSync(sourcePath, persistedPath);
+    }
     rewrites.set(ref.path, persistedPath);
+    artifacts[`editor_canvas_${artifactKey(fixtureId)}_${artifactKey(path.basename(ref.path))}`] = { path: persistedPath };
   }
   if (rewrites.size === 0) {
     return fixture;

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -151,12 +151,15 @@ class Static_Site_Importer_Validation_Runtime {
 				'theme_slug'       => (string) ( $import_result['theme_slug'] ?? '' ),
 			),
 			'import_report' => $import_report,
-			'blocks_engine' => array(
-				'transformer'         => $transformer,
-				'wordpress_site_plan' => array_filter(
-					array(
-						'schema' => isset( $wordpress_site_plan['schema'] ) ? (string) $wordpress_site_plan['schema'] : '',
-					)
+			'runtime_evidence' => array(
+				'schema'        => 'static-site-importer/runtime-evidence/v1',
+				'blocks_engine' => array(
+					'transformer'         => $transformer,
+					'wordpress_site_plan' => array_filter(
+						array(
+							'schema' => isset( $wordpress_site_plan['schema'] ) ? (string) $wordpress_site_plan['schema'] : '',
+						)
+					),
 				),
 			),
 			'materialization_receipt' => array(

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -127,6 +127,11 @@ class Static_Site_Importer_Validation_Runtime {
 		if ( empty( $import_report ) && isset( $import_result['import_report'] ) && is_array( $import_result['import_report'] ) ) {
 			$import_report = $import_result['import_report'];
 		}
+		$blocks_engine          = isset( $import_report['blocks_engine'] ) && is_array( $import_report['blocks_engine'] ) ? $import_report['blocks_engine'] : array();
+		$transformer            = isset( $blocks_engine['transformer'] ) && is_array( $blocks_engine['transformer'] ) ? $blocks_engine['transformer'] : array();
+		$wordpress_site_plan    = isset( $blocks_engine['wordpress_site_plan'] ) && is_array( $blocks_engine['wordpress_site_plan'] ) ? $blocks_engine['wordpress_site_plan'] : array();
+		$receipt                = isset( $import_result['materialization_receipt'] ) && is_array( $import_result['materialization_receipt'] ) ? $import_result['materialization_receipt'] : array();
+		$completed              = isset( $receipt['completed'] ) && is_array( $receipt['completed'] ) ? $receipt['completed'] : array();
 
 		$result                        = array(
 			'success'       => $quality_pass,
@@ -146,6 +151,25 @@ class Static_Site_Importer_Validation_Runtime {
 				'theme_slug'       => (string) ( $import_result['theme_slug'] ?? '' ),
 			),
 			'import_report' => $import_report,
+			'blocks_engine' => array(
+				'transformer'         => $transformer,
+				'wordpress_site_plan' => array_filter(
+					array(
+						'schema' => isset( $wordpress_site_plan['schema'] ) ? (string) $wordpress_site_plan['schema'] : '',
+					)
+				),
+			),
+			'materialization_receipt' => array(
+				'schema'    => isset( $receipt['schema'] ) ? (string) $receipt['schema'] : '',
+				'status'    => isset( $receipt['status'] ) ? (string) $receipt['status'] : '',
+				'plan_hash' => isset( $receipt['plan_hash'] ) ? (string) $receipt['plan_hash'] : '',
+				'completed' => array(
+					'pages'           => isset( $completed['pages'] ) && is_array( $completed['pages'] ) ? $completed['pages'] : array(),
+					'files'           => isset( $completed['files'] ) && is_array( $completed['files'] ) ? $completed['files'] : array(),
+					'operations'      => isset( $completed['operations'] ) && is_array( $completed['operations'] ) ? $completed['operations'] : array(),
+					'declaration_ids' => isset( $completed['declaration_ids'] ) && is_array( $completed['declaration_ids'] ) ? $completed['declaration_ids'] : array(),
+				),
+			),
 			'artifacts'     => array(
 				'generated_theme'         => array(
 					'artifact_ref' => (string) ( $import_result['theme_slug'] ?? '' ),

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -51,7 +51,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		try {
 			WordPressSitePlan::assertValid( $plan );
 		} catch ( InvalidArgumentException $error ) {
-			$state['diagnostics'][] = array( 'reason_code' => 'canonical_plan_rejected' );
+			$state['diagnostics'][] = array( 'reason_code' => 'canonical_plan_rejected', 'message' => $error->getMessage() );
 			return array( 'status' => 'rejected', 'receipt' => self::receipt( 'rejected', $state ) );
 		}
 
@@ -73,7 +73,8 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				// Resolver proof is canonical semantics, not an inference from copied files.
 				$resolved = ( new WordPressSitePlanResolver() )->resolve( $plan, array( 'theme_uri' => $theme_uri, 'require_proven_dynamic_client_assets' => true, 'runtime_capabilities' => array( 'asset_materialization' ) ) );
 			} catch ( InvalidArgumentException $error ) {
-				throw new InvalidArgumentException( 'canonical_destination_rejected' );
+				$state['diagnostics'][] = array( 'reason_code' => 'canonical_destination_rejected', 'message' => $error->getMessage() );
+				return array( 'status' => 'rejected', 'receipt' => self::receipt( 'rejected', $state ) );
 			}
 			$state['resolved'] = $resolved;
 			$state['theme_dir'] = $theme_dir;
@@ -427,7 +428,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$pages  = isset( $state['source_ids'] ) && is_array( $state['source_ids'] ) ? $state['source_ids'] : array();
 		foreach ( $state['diagnostics'] as $diagnostic ) {
 			if ( isset( $diagnostic['reason_code'] ) && is_string( $diagnostic['reason_code'] ) ) {
-				$errors[] = array( 'code' => $diagnostic['reason_code'], 'message' => $diagnostic['reason_code'] );
+				$errors[] = array( 'code' => $diagnostic['reason_code'], 'message' => is_string( $diagnostic['message'] ?? null ) ? $diagnostic['message'] : $diagnostic['reason_code'] );
 			}
 		}
 		return array(

--- a/lib/fixture-matrix/collectors/quality-metrics.mjs
+++ b/lib/fixture-matrix/collectors/quality-metrics.mjs
@@ -296,6 +296,7 @@ function blockDocumentList(value) {
 function blockCompositionFromQualityCounts(payload) {
   const object = objectValue(payload);
   const quality = collectQualityMetrics(object);
+  const metrics = objectValue(quality.metrics);
   const importReport = objectValue(object.import_report || object.importReport || object.report);
   const blocksEngine = objectValue(importReport.blocks_engine || importReport.blocksEngine || object.blocks_engine || object.blocksEngine);
   const conversionReport = objectValue(blocksEngine.conversion_report || blocksEngine.conversionReport);
@@ -303,6 +304,9 @@ function blockCompositionFromQualityCounts(payload) {
     quality.block_count,
     quality.total_block_count,
     quality.blockCount,
+    metrics.block_count,
+    metrics.total_block_count,
+    metrics.blockCount,
     object.block_count,
     object.blockCount,
     conversionReport.block_count,
@@ -310,8 +314,9 @@ function blockCompositionFromQualityCounts(payload) {
   if (!Number.isFinite(total) || total <= 0) {
     return null;
   }
-  const coreHtml = numberValue(quality.core_html_block_count ?? quality.coreHtmlBlockCount ?? object.core_html_block_count);
-  const freeform = numberValue(quality.freeform_block_count ?? quality.freeformBlockCount ?? object.freeform_block_count);
+  const coreHtml = numberValue(quality.core_html_block_count ?? quality.coreHtmlBlockCount ?? metrics.core_html_block_count ?? metrics.coreHtmlBlockCount ?? object.core_html_block_count);
+  const aggregateFallback = firstNumber([quality.fallback_count, quality.fallbackCount, metrics.fallback_count, metrics.fallbackCount]);
+  const freeform = numberValue(quality.freeform_block_count ?? quality.freeformBlockCount ?? metrics.freeform_block_count ?? metrics.freeformBlockCount ?? object.freeform_block_count ?? (Number.isFinite(aggregateFallback) ? Math.max(0, aggregateFallback - coreHtml) : 0));
   return {
     block_total: total,
     native_block_count: Math.max(0, total - coreHtml - freeform),

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -169,7 +169,8 @@ const MATERIALIZATION_PLAN_ASSET_LIMIT = 50;
 // Keep enough runtime evidence to attribute CSS/JS behavior without retaining
 // arbitrary source payloads in matrix artifacts.
 export function collectMatrixEvidence(payload) {
-  const blocksEngine = objectValue(payload.blocks_engine || payload.blocksEngine || payload.import_report?.blocks_engine || payload.importReport?.blocks_engine || payload.report?.blocks_engine);
+  const runtimeEvidence = objectValue(payload.runtime_evidence || payload.runtimeEvidence);
+  const blocksEngine = objectValue(runtimeEvidence.blocks_engine || runtimeEvidence.blocksEngine || payload.blocks_engine || payload.blocksEngine || payload.import_report?.blocks_engine || payload.importReport?.blocks_engine || payload.report?.blocks_engine);
   const transformer = objectValue(blocksEngine.transformer || blocksEngine.transformer_provenance || blocksEngine.transformerProvenance);
   const plan = objectValue(blocksEngine.wordpress_site_plan || blocksEngine.wordpressSitePlan);
   const importReport = objectValue(payload.import_report || payload.importReport || payload.report);

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -109,9 +109,11 @@ $assert( 1 === count( $result['diagnostics'] ?? array() ), 'top-level-diagnostic
 $assert( 'semantic_parity_navigation_missing' === ( $result['diagnostics'][0]['type'] ?? '' ), 'top-level-diagnostic-type-preserved' );
 $assert( 'footer nav' === ( $result['diagnostics'][0]['selector'] ?? '' ), 'top-level-diagnostic-selector-preserved' );
 $assert( 1 === ( $result['diagnostic_summary']['total'] ?? 0 ), 'top-level-diagnostic-summary-present' );
-$assert( str_repeat( 'a', 40 ) === ( $result['blocks_engine']['transformer']['reference'] ?? '' ), 'transformer-provenance-exported' );
-$assert( 'blocks-engine/wordpress-site-plan/v2' === ( $result['blocks_engine']['wordpress_site_plan']['schema'] ?? '' ), 'site-plan-schema-exported' );
-$assert( ! isset( $result['blocks_engine']['wordpress_site_plan']['pages'] ), 'site-plan-payload-remains-private' );
+$assert( 'static-site-importer/runtime-evidence/v1' === ( $result['runtime_evidence']['schema'] ?? '' ), 'runtime-evidence-schema-exported' );
+$assert( str_repeat( 'a', 40 ) === ( $result['runtime_evidence']['blocks_engine']['transformer']['reference'] ?? '' ), 'transformer-provenance-exported' );
+$assert( 'blocks-engine/wordpress-site-plan/v2' === ( $result['runtime_evidence']['blocks_engine']['wordpress_site_plan']['schema'] ?? '' ), 'site-plan-schema-exported' );
+$assert( ! isset( $result['runtime_evidence']['blocks_engine']['wordpress_site_plan']['pages'] ), 'site-plan-payload-remains-private' );
+$assert( ! isset( $result['blocks_engine'] ), 'diagnostic-key-remains-unclaimed' );
 $assert( 'plan-hash' === ( $result['materialization_receipt']['plan_hash'] ?? '' ), 'materialization-receipt-exported' );
 $assert( array( 'website/index.html' => 4 ) === ( $result['materialization_receipt']['completed']['pages'] ?? array() ), 'materialization-completion-exported' );
 

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -49,7 +49,18 @@ file_put_contents(
 	$report_path,
 	json_encode(
 		array(
-			'quality'     => array(
+			'blocks_engine' => array(
+				'transformer' => array(
+					'package'   => 'automattic/blocks-engine-php-transformer',
+					'version'   => 'dev-main',
+					'reference' => str_repeat( 'a', 40 ),
+				),
+				'wordpress_site_plan' => array(
+					'schema' => 'blocks-engine/wordpress-site-plan/v2',
+					'pages'  => array( array( 'canonical_block_markup' => '<!-- wp:paragraph --><p>Private plan payload</p><!-- /wp:paragraph -->' ) ),
+				),
+			),
+			'quality'       => array(
 				'semantic_parity_failure_count' => 1,
 			),
 			'diagnostics' => array(
@@ -73,6 +84,17 @@ $result = $method->invoke(
 		'external_report_path' => $report_path,
 		'quality'              => array( 'pass' => false ),
 		'theme_slug'           => 'ssi-fixture-theme',
+		'materialization_receipt' => array(
+			'schema'    => 'static-site-importer/materialization-receipt/v1',
+			'status'    => 'completed',
+			'plan_hash' => 'plan-hash',
+			'completed' => array(
+				'pages'           => array( 'website/index.html' => 4 ),
+				'files'           => array( 'parts/header.html' ),
+				'operations'      => array(),
+				'declaration_ids' => array( 'declaration-1' ),
+			),
+		),
 	),
 	$artifact_dir,
 	array(
@@ -87,6 +109,11 @@ $assert( 1 === count( $result['diagnostics'] ?? array() ), 'top-level-diagnostic
 $assert( 'semantic_parity_navigation_missing' === ( $result['diagnostics'][0]['type'] ?? '' ), 'top-level-diagnostic-type-preserved' );
 $assert( 'footer nav' === ( $result['diagnostics'][0]['selector'] ?? '' ), 'top-level-diagnostic-selector-preserved' );
 $assert( 1 === ( $result['diagnostic_summary']['total'] ?? 0 ), 'top-level-diagnostic-summary-present' );
+$assert( str_repeat( 'a', 40 ) === ( $result['blocks_engine']['transformer']['reference'] ?? '' ), 'transformer-provenance-exported' );
+$assert( 'blocks-engine/wordpress-site-plan/v2' === ( $result['blocks_engine']['wordpress_site_plan']['schema'] ?? '' ), 'site-plan-schema-exported' );
+$assert( ! isset( $result['blocks_engine']['wordpress_site_plan']['pages'] ), 'site-plan-payload-remains-private' );
+$assert( 'plan-hash' === ( $result['materialization_receipt']['plan_hash'] ?? '' ), 'materialization-receipt-exported' );
+$assert( array( 'website/index.html' => 4 ) === ( $result['materialization_receipt']['completed']['pages'] ?? array() ), 'materialization-completion-exported' );
 
 unlink( $report_path );
 rmdir( $artifact_dir );

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -159,12 +159,14 @@ $dynamic_before_options = $GLOBALS['ssi_plan_options'];
 $dynamic_prepared = Static_Site_Importer_WordPress_Site_Plan_Materializer::prepare( $external_dynamic_plan, array( 'slug' => 'external-dynamic-plan' ) );
 $assert( 'rejected' === $dynamic_prepared['status'], 'external dynamic scripts reject during preparation' );
 $assert( 'canonical_destination_rejected' === $dynamic_prepared['receipt']['diagnostics'][0]['reason_code'], 'preparation reports canonical destination rejection' );
+$assert( 'WordPress site plan cannot prove dynamic client asset references.' === $dynamic_prepared['receipt']['errors'][0]['message'], 'preparation preserves the exact resolver rejection message' );
 $assert( $dynamic_before_posts === $GLOBALS['ssi_plan_posts'] && $dynamic_before_meta === $GLOBALS['ssi_plan_meta'] && $dynamic_before_options === $GLOBALS['ssi_plan_options'], 'preparation rejects external dynamic scripts before page or option mutation' );
 $assert( ! is_dir( $GLOBALS['ssi_plan_root'] . '/external-dynamic-plan' ), 'preparation rejects external dynamic scripts before file mutation' );
 
 $dynamic_rejected = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $external_dynamic_plan, array( 'slug' => 'external-dynamic-plan' ) );
 $assert( 'rejected' === $dynamic_rejected['status'], 'external dynamic scripts reject during materialization' );
 $assert( 'canonical_destination_rejected' === $dynamic_rejected['diagnostics'][0]['reason_code'], 'materialization reports canonical destination rejection' );
+$assert( 'WordPress site plan cannot prove dynamic client asset references.' === $dynamic_rejected['errors'][0]['message'], 'materialization preserves the exact resolver rejection message' );
 $assert( $dynamic_before_posts === $GLOBALS['ssi_plan_posts'] && $dynamic_before_meta === $GLOBALS['ssi_plan_meta'] && $dynamic_before_options === $GLOBALS['ssi_plan_options'], 'materialization rejects external dynamic scripts before page or option mutation' );
 $assert( ! is_dir( $GLOBALS['ssi_plan_root'] . '/external-dynamic-plan' ), 'materialization rejects external dynamic scripts before file mutation' );
 

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2173,6 +2173,10 @@ test('editor canvas artifacts are persisted in the matrix artifact root and refs
   assert.equal(fixture.editor_open.files.editorState, statePath);
   assert.equal(fixture.surfaces[0].editor_open.files.screenshot, screenshotPath);
   assert.deepEqual(fixture.artifact_refs.map((ref) => ref.path), [screenshotPath, statePath]);
+  assert.deepEqual(result.artifacts, {
+    'editor_canvas_simple-site_editor-screenshot.png': { path: screenshotPath },
+    'editor_canvas_simple-site_editor-state.json': { path: statePath },
+  });
 });
 
 test('collects SSI finding packet source and observed context from fixture artifacts', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -954,10 +954,14 @@ test('fixture matrix consumes bounded evidence from the public validation envelo
     codeboxOutput: {
       fixture_id: 'simple-site',
       status: 'passed',
-      blocks_engine: {
-        transformer: { package: 'automattic/blocks-engine-php-transformer', version: 'dev-trunk', reference: 'a'.repeat(40) },
-        wordpress_site_plan: { schema: 'blocks-engine/wordpress-site-plan/v2' },
+      runtime_evidence: {
+        schema: 'static-site-importer/runtime-evidence/v1',
+        blocks_engine: {
+          transformer: { package: 'automattic/blocks-engine-php-transformer', version: 'dev-trunk', reference: 'a'.repeat(40) },
+          wordpress_site_plan: { schema: 'blocks-engine/wordpress-site-plan/v2' },
+        },
       },
+      blocks_engine: { diagnostics: [{ code: 'conversion-warning' }] },
       materialization_receipt: {
         schema: 'static-site-importer/materialization-receipt/v1',
         status: 'completed',

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -962,6 +962,7 @@ test('fixture matrix consumes bounded evidence from the public validation envelo
         },
       },
       blocks_engine: { diagnostics: [{ code: 'conversion-warning' }] },
+      quality_metrics: { status: 'success', pass: true, metrics: { block_count: 315, fallback_count: 0 } },
       materialization_receipt: {
         schema: 'static-site-importer/materialization-receipt/v1',
         status: 'completed',
@@ -975,6 +976,7 @@ test('fixture matrix consumes bounded evidence from the public validation envelo
   assert.equal(evidence.readiness, 'verified');
   assert.equal(evidence.transformer.package_reference, 'a'.repeat(40));
   assert.equal(evidence.wordpress_site_plan.schema, 'blocks-engine/wordpress-site-plan/v2');
+  assert.deepEqual(result.fixtures[0].block_composition, { block_total: 315, native_block_count: 315, core_html_block_count: 0, block_type_counts: null, source: 'quality_counts' });
   assert.deepEqual(evidence.materialization_receipt, {
     schema: 'static-site-importer/materialization-receipt/v1', status: 'completed', plan_hash: 'plan-hash', page_count: 1, file_count: 1, operation_count: 0, declaration_count: 1,
   });

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -945,6 +945,37 @@ test('fixture matrix captures installed transformer provenance and bounded mater
   assert.equal(result.summary.matrix_evidence_readiness.status, 'verified');
 });
 
+test('fixture matrix consumes bounded evidence from the public validation envelope', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-matrix-validation-envelope-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'validation-envelope-test' });
+  const result = collectFixtureMatrixRunResults({
+    matrix,
+    outputDirectory,
+    codeboxOutput: {
+      fixture_id: 'simple-site',
+      status: 'passed',
+      blocks_engine: {
+        transformer: { package: 'automattic/blocks-engine-php-transformer', version: 'dev-trunk', reference: 'a'.repeat(40) },
+        wordpress_site_plan: { schema: 'blocks-engine/wordpress-site-plan/v2' },
+      },
+      materialization_receipt: {
+        schema: 'static-site-importer/materialization-receipt/v1',
+        status: 'completed',
+        plan_hash: 'plan-hash',
+        completed: { pages: { 'website/index.html': 4 }, files: ['parts/header.html'], operations: [], declaration_ids: ['declaration-1'] },
+      },
+    },
+  });
+
+  const evidence = result.fixtures[0].matrix_evidence;
+  assert.equal(evidence.readiness, 'verified');
+  assert.equal(evidence.transformer.package_reference, 'a'.repeat(40));
+  assert.equal(evidence.wordpress_site_plan.schema, 'blocks-engine/wordpress-site-plan/v2');
+  assert.deepEqual(evidence.materialization_receipt, {
+    schema: 'static-site-importer/materialization-receipt/v1', status: 'completed', plan_hash: 'plan-hash', page_count: 1, file_count: 1, operation_count: 0, declaration_count: 1,
+  });
+});
+
 test('fixture matrix labels reports without runtime provenance and materialization evidence as legacy', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-matrix-legacy-evidence-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'legacy-runtime-evidence-test' });

--- a/tools/verify-solved-site-promotion.mjs
+++ b/tools/verify-solved-site-promotion.mjs
@@ -11,10 +11,13 @@ const REGISTRY_SCHEMA = 'static-site-importer/gutenberg-incompatibility-registry
 
 export function verifySolvedSitePromotion(input) {
   const options = normalizeOptions(input);
-  const matrix = readJson(options.matrixResult, 'matrix result');
-  const registry = readJson(options.registry, 'registry');
-  const runtime = readJson(options.runtimeInputs, 'runtime inputs');
   const artifactIndex = readJson(options.artifactIndex, 'artifact index');
+  const registeredArtifacts = indexRegisteredArtifacts(artifactIndex, options.artifactRoot);
+  const matrixResult = resolveInputFile(options.matrixResult, registeredArtifacts, 'matrix result');
+  const registryFile = resolveInputFile(options.registry, registeredArtifacts, 'registry');
+  const matrix = readJson(matrixResult, 'matrix result');
+  const registry = readJson(registryFile, 'registry');
+  const runtime = readJson(options.runtimeInputs, 'runtime inputs');
   assert(matrix.schema === MATRIX_SCHEMA, `Matrix schema must be ${MATRIX_SCHEMA}.`);
   assert(registry.schema === REGISTRY_SCHEMA, `Registry schema must be ${REGISTRY_SCHEMA}.`);
   assertSha(options.staticSiteImporterSha, 'Static Site Importer candidate SHA');
@@ -30,9 +33,8 @@ export function verifySolvedSitePromotion(input) {
   assert(matrix.summary?.solved_candidate_gate?.failed_fixture_count === 0, 'Solved-candidate gate reported failures.');
 
   validateRuntime(runtime, options);
-  const registeredArtifacts = indexRegisteredArtifacts(artifactIndex, options.artifactRoot);
   const decisions = new Map((registry.fixture_decisions || []).map((row) => [row.fixture_id, row]));
-  const requiredFiles = [options.matrixResult, options.registry, options.artifactIndex];
+  const requiredFiles = [matrixResult, registryFile, options.artifactIndex];
   for (const fixture of matrix.fixtures) {
     verifyFixture(fixture, decisions.get(fixture.fixture_id), options, requiredFiles, registeredArtifacts);
   }
@@ -175,6 +177,14 @@ function filesWithin(directory) {
 function isFileWithinRoot(file, root) {
   const relative = path.relative(root, file);
   return relative && !relative.startsWith('..') && !path.isAbsolute(relative) && fs.existsSync(file) && fs.statSync(file).isFile();
+}
+
+function resolveInputFile(value, registeredArtifacts, label) {
+  if (!value.startsWith('artifact:')) return value;
+  const name = value.slice('artifact:'.length);
+  const matches = registeredArtifacts.get(name) || [];
+  assert(matches.length === 1, `${label} must have exactly one registered artifact named ${name}.`);
+  return matches[0];
 }
 
 function addRegisteredArtifact(files, registeredArtifacts, name, label) {

--- a/tools/verify-solved-site-promotion.mjs
+++ b/tools/verify-solved-site-promotion.mjs
@@ -14,6 +14,7 @@ export function verifySolvedSitePromotion(input) {
   const matrix = readJson(options.matrixResult, 'matrix result');
   const registry = readJson(options.registry, 'registry');
   const runtime = readJson(options.runtimeInputs, 'runtime inputs');
+  const artifactIndex = readJson(options.artifactIndex, 'artifact index');
   assert(matrix.schema === MATRIX_SCHEMA, `Matrix schema must be ${MATRIX_SCHEMA}.`);
   assert(registry.schema === REGISTRY_SCHEMA, `Registry schema must be ${REGISTRY_SCHEMA}.`);
   assertSha(options.staticSiteImporterSha, 'Static Site Importer candidate SHA');
@@ -29,10 +30,11 @@ export function verifySolvedSitePromotion(input) {
   assert(matrix.summary?.solved_candidate_gate?.failed_fixture_count === 0, 'Solved-candidate gate reported failures.');
 
   validateRuntime(runtime, options);
+  const registeredArtifacts = indexRegisteredArtifacts(artifactIndex, options.artifactRoot);
   const decisions = new Map((registry.fixture_decisions || []).map((row) => [row.fixture_id, row]));
-  const requiredFiles = [options.matrixResult, options.registry];
+  const requiredFiles = [options.matrixResult, options.registry, options.artifactIndex];
   for (const fixture of matrix.fixtures) {
-    verifyFixture(fixture, decisions.get(fixture.fixture_id), options, requiredFiles);
+    verifyFixture(fixture, decisions.get(fixture.fixture_id), options, requiredFiles, registeredArtifacts);
   }
 
   const artifacts = artifactManifest(requiredFiles, options.artifactRoot);
@@ -79,8 +81,9 @@ export function verifySolvedSitePromotion(input) {
   return receipt;
 }
 
-function verifyFixture(fixture, decision, options, requiredFiles) {
+function verifyFixture(fixture, decision, options, requiredFiles, registeredArtifacts) {
   const id = String(fixture.fixture_id || 'unknown');
+  const fixtureKey = artifactKey(id);
   assert(fixture.status === 'passed' && fixture.success === true, `${id}: fixture did not pass.`);
   assert(decision?.acceptance_status === 'solved_candidate', `${id}: acceptance status is not solved_candidate.`);
   const quality = fixture.quality_metrics || {};
@@ -96,13 +99,16 @@ function verifyFixture(fixture, decision, options, requiredFiles) {
   assert(editor.validation_method === 'wp.blocks.validateBlock', `${id}: editor validation must use wp.blocks.validateBlock.`);
   assert(Number(editor.total_blocks) > 0 && editor.valid_blocks === editor.total_blocks && Number(editor.invalid_blocks) === 0, `${id}: editor validation is incomplete or invalid.`);
   assert(fixture.editor_canvas?.status === 'captured', `${id}: editor canvas evidence is missing.`);
-  addRequiredFile(requiredFiles, fixture.editor_canvas?.screenshot, `${id}: editor screenshot`);
+  const editorScreenshot = fixture.editor_canvas?.screenshot;
+  assert(typeof editorScreenshot === 'string' && editorScreenshot, `${id}: editor screenshot path is missing.`);
+  addRegisteredArtifact(requiredFiles, registeredArtifacts, `editor_canvas_${fixtureKey}_${artifactKey(path.basename(editorScreenshot))}`, `${id}: editor screenshot`);
   const visual = fixture.visual_parity_artifacts || {};
   assert(Number(visual.metrics?.mismatch_ratio) === 0 && Number(visual.metrics?.mismatch_pixels) === 0, `${id}: visual mismatch must be exactly zero.`);
-  for (const slot of ['source_screenshot', 'imported_screenshot', 'diff_screenshot', 'visual_diff']) {
+  for (const [slot, artifactName] of Object.entries({ source_screenshot: 'source', imported_screenshot: 'candidate', diff_screenshot: 'diff', visual_diff: 'visual-diff.json' })) {
     const artifact = visual.artifacts?.[slot];
     assert(artifact?.status === 'captured', `${id}: ${slot} evidence is missing.`);
-    addRequiredFile(requiredFiles, artifact?.ref?.path, `${id}: ${slot}`);
+    assert(typeof artifact?.ref?.path === 'string' && artifact.ref.path, `${id}: ${slot} path is missing.`);
+    addRegisteredArtifact(requiredFiles, registeredArtifacts, `visual_compare_${fixtureKey}_${artifactName}`, `${id}: ${slot}`);
   }
   const evidence = fixture.matrix_evidence || {};
   assert(evidence.readiness === 'verified' && (evidence.missing || []).length === 0, `${id}: runtime evidence is incomplete.`);
@@ -135,14 +141,51 @@ function artifactManifest(files, root) {
   }).sort((left, right) => left.path.localeCompare(right.path));
 }
 
-function addRequiredFile(files, value, label) {
-  assert(typeof value === 'string' && value, `${label} path is missing.`);
-  files.push(value);
+function indexRegisteredArtifacts(index, root) {
+  assert(index.schema === 'homeboy/command-result/v3', 'Artifact index must be a Homeboy command result.');
+  const artifacts = index.data?.payload?.artifacts;
+  assert(Array.isArray(artifacts), 'Artifact index does not contain a registered artifact inventory.');
+  const registered = new Map();
+  const harvestedFiles = filesWithin(root);
+  for (const artifact of artifacts) {
+    if (!artifact?.name || !artifact?.path) continue;
+    const entries = registered.get(artifact.name) || [];
+    entries.push(resolveRegisteredPath(artifact.path, root, harvestedFiles));
+    registered.set(artifact.name, entries);
+  }
+  return registered;
+}
+
+function resolveRegisteredPath(value, root, harvestedFiles) {
+  const registeredPath = path.resolve(path.isAbsolute(value) ? value : path.join(root, value));
+  if (isFileWithinRoot(registeredPath, root)) return registeredPath;
+  const basename = path.basename(registeredPath);
+  const matches = harvestedFiles.filter((file) => path.basename(file) === basename);
+  assert(matches.length === 1, `Registered artifact path could not be resolved uniquely under artifact root: ${value}`);
+  return matches[0];
+}
+
+function filesWithin(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? filesWithin(entryPath) : entry.isFile() ? [entryPath] : [];
+  });
+}
+
+function isFileWithinRoot(file, root) {
+  const relative = path.relative(root, file);
+  return relative && !relative.startsWith('..') && !path.isAbsolute(relative) && fs.existsSync(file) && fs.statSync(file).isFile();
+}
+
+function addRegisteredArtifact(files, registeredArtifacts, name, label) {
+  const matches = registeredArtifacts.get(name) || [];
+  assert(matches.length === 1, `${label} must have exactly one registered artifact named ${name}.`);
+  files.push(matches[0]);
 }
 
 function normalizeOptions(input) {
   const options = { ...input };
-  for (const key of ['matrixResult', 'registry', 'runtimeInputs', 'artifactRoot', 'staticSiteImporterSha', 'blocksEngineSha', 'fixtureTreeSha', 'solvedFixtureCount', 'runUrl', 'artifactUrl', 'output', 'manifestOutput']) {
+  for (const key of ['matrixResult', 'registry', 'runtimeInputs', 'artifactIndex', 'artifactRoot', 'staticSiteImporterSha', 'blocksEngineSha', 'fixtureTreeSha', 'solvedFixtureCount', 'runUrl', 'artifactUrl', 'output', 'manifestOutput']) {
     assert(options[key] !== undefined && options[key] !== '', `--${kebab(key)} is required.`);
   }
   options.artifactRoot = path.resolve(options.artifactRoot);
@@ -170,11 +213,12 @@ function readJson(file, label) {
 }
 function assertSha(value, label) { assert(/^[a-f0-9]{40}$/.test(String(value || '')), `${label} must be a full commit SHA.`); }
 function assert(condition, message) { if (!condition) throw new Error(message); }
+function artifactKey(value) { return String(value || 'fixture').toLowerCase().replace(/[^a-z0-9._-]+/g, '_').replace(/^_+|_+$/g, '') || 'fixture'; }
 function camel(value) { return value.replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase()); }
 function kebab(value) { return value.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`); }
 
 function printHelp() {
-  process.stdout.write('Usage: node tools/verify-solved-site-promotion.mjs --matrix-result <file> --registry <file> --runtime-inputs <file> --artifact-root <dir> --static-site-importer-sha <sha> --blocks-engine-sha <sha> --fixture-tree-sha <sha> --solved-fixture-count <n> --run-url <url> --artifact-url <url> --output <file> --manifest-output <file>\n');
+  process.stdout.write('Usage: node tools/verify-solved-site-promotion.mjs --matrix-result <file> --registry <file> --runtime-inputs <file> --artifact-index <file> --artifact-root <dir> --static-site-importer-sha <sha> --blocks-engine-sha <sha> --fixture-tree-sha <sha> --solved-fixture-count <n> --run-url <url> --artifact-url <url> --output <file> --manifest-output <file>\n');
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -50,6 +50,18 @@ test('issues an accepted immutable promotion receipt', () => {
   assert.ok(receipt.evidence.artifacts.every((row) => /^[a-f0-9]{64}$/.test(row.sha256)));
 });
 
+test('resolves matrix and registry inputs from the registered artifact inventory', () => {
+  const input = fixture();
+  input.artifactIndex.data.payload.artifacts.push(
+    { name: 'result', path: `/relocated/${path.basename(input.paths.matrix)}` },
+    { name: 'gutenberg_incompatibility_registry', path: `/relocated/${path.basename(input.paths.registry)}` },
+  );
+  write(input.paths.artifactIndex, input.artifactIndex);
+  input.options.matrixResult = 'artifact:result';
+  input.options.registry = 'artifact:gutenberg_incompatibility_registry';
+  assert.equal(verifySolvedSitePromotion(input.options).status, 'accepted');
+});
+
 for (const [name, mutate, pattern] of [
   ['empty corpus', (input) => { input.matrix.fixtures = []; input.matrix.summary.fixture_count = 0; }, /non-empty/],
   ['failed decision', (input) => { input.registry.fixture_decisions[0].acceptance_status = 'visual_only_blocker'; }, /solved_candidate/],

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -10,7 +10,11 @@ const BE_SHA = '2'.repeat(40);
 
 function fixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ssi-promotion-'));
-  for (const file of ['editor.png', 'source.png', 'candidate.png', 'diff.png', 'visual-diff.json']) fs.writeFileSync(path.join(root, file), file);
+  const artifactFiles = Object.fromEntries([
+    ['editor', 'a1111111-editor.png'], ['source', 'b2222222-source.png'], ['candidate', 'c3333333-candidate.png'], ['diff', 'd4444444-diff.png'], ['visualDiff', 'e5555555-visual-diff.json'],
+  ].map(([key, file]) => [key, path.join(root, 'harvested', file)]));
+  fs.mkdirSync(path.join(root, 'harvested'));
+  for (const file of Object.values(artifactFiles)) fs.writeFileSync(file, path.basename(file));
   const matrix = {
     schema: 'static-site-importer/fixture-matrix-result/v1',
     summary: { generation_status: 'succeeded', execution_status: 'requested', fixture_count: 1, failed: 0, not_run: 0, solved_candidate_gate: { enabled: true, failed_fixture_count: 0 } },
@@ -19,19 +23,22 @@ function fixture() {
       quality_metrics: { pass: true, fallback_count: 0, core_html_block_count: 0, freeform_block_count: 0, invalid_block_count: 0 },
       block_composition: { block_total: 4, native_block_count: 4, core_html_block_count: 0 },
       editor_validation: { validation_method: 'wp.blocks.validateBlock', total_blocks: 4, valid_blocks: 4, invalid_blocks: 0 },
-      editor_canvas: { status: 'captured', screenshot: path.join(root, 'editor.png') },
+      editor_canvas: { status: 'captured', screenshot: '/producer/editor.png' },
       visual_parity_artifacts: { metrics: { mismatch_ratio: 0, mismatch_pixels: 0 }, artifacts: Object.fromEntries([
         ['source_screenshot', 'source.png'], ['imported_screenshot', 'candidate.png'], ['diff_screenshot', 'diff.png'], ['visual_diff', 'visual-diff.json'],
-      ].map(([slot, file]) => [slot, { status: 'captured', ref: { path: path.join(root, file) } }])) },
+      ].map(([slot, file]) => [slot, { status: 'captured', ref: { path: `/producer/${file}` } }])) },
       matrix_evidence: { readiness: 'verified', missing: [], transformer: { package_reference: BE_SHA }, materialization_receipt: { status: 'completed', plan_hash: 'abc' } },
       editor_quality: { native_conversion_rate: 1 },
     }],
   };
   const registry = { schema: 'static-site-importer/gutenberg-incompatibility-registry/v1', fixture_decisions: [{ fixture_id: 'solved', acceptance_status: 'solved_candidate' }] };
   const runtime = { nodeVersion: '20.19.4', phpVersion: '8.1.29', wordpressVersion: '7.0.2', homeboyVersion: 'v0.298.1', homeboySha256: '3'.repeat(64), homeboyExtensionsRef: '4'.repeat(40), wpCodeboxVersion: 'v0.12.29', wpCodeboxSha256: '5'.repeat(64), staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA };
-  const paths = { matrix: path.join(root, 'matrix.json'), registry: path.join(root, 'registry.json'), runtime: path.join(root, 'runtime.json') };
-  write(paths.matrix, matrix); write(paths.registry, registry); write(paths.runtime, runtime);
-  return { root, matrix, registry, runtime, paths, options: { matrixResult: paths.matrix, registry: paths.registry, runtimeInputs: paths.runtime, artifactRoot: root, staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA, fixtureTreeSha: '6'.repeat(40), solvedFixtureCount: 1, runUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123', artifactUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123#artifacts', output: path.join(root, 'receipt.json'), manifestOutput: path.join(root, 'manifest.json') } };
+  const artifactIndex = { schema: 'homeboy/command-result/v3', data: { payload: { artifacts: [
+    ['editor_canvas_solved_editor.png', artifactFiles.editor], ['visual_compare_solved_source', artifactFiles.source], ['visual_compare_solved_candidate', artifactFiles.candidate], ['visual_compare_solved_diff', artifactFiles.diff], ['visual_compare_solved_visual-diff.json', artifactFiles.visualDiff],
+  ].map(([name, file]) => ({ name, path: `/relocated/${path.basename(file)}` })) } } };
+  const paths = { matrix: path.join(root, 'matrix.json'), registry: path.join(root, 'registry.json'), runtime: path.join(root, 'runtime.json'), artifactIndex: path.join(root, 'homeboy-bench-result.json') };
+  write(paths.matrix, matrix); write(paths.registry, registry); write(paths.runtime, runtime); write(paths.artifactIndex, artifactIndex);
+  return { root, artifactFiles, matrix, registry, runtime, artifactIndex, paths, options: { matrixResult: paths.matrix, registry: paths.registry, runtimeInputs: paths.runtime, artifactIndex: paths.artifactIndex, artifactRoot: root, staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA, fixtureTreeSha: '6'.repeat(40), solvedFixtureCount: 1, runUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123', artifactUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123#artifacts', output: path.join(root, 'receipt.json'), manifestOutput: path.join(root, 'manifest.json') } };
 }
 
 test('issues an accepted immutable promotion receipt', () => {
@@ -53,10 +60,12 @@ for (const [name, mutate, pattern] of [
   ['non-native conversion', (input) => { input.matrix.fixtures[0].editor_quality.native_conversion_rate = 0.99; }, /native conversion rate/],
   ['transformer mismatch', (input) => { input.matrix.fixtures[0].matrix_evidence.transformer.package_reference = '7'.repeat(40); }, /provenance/],
   ['unpinned runtime', (input) => { input.runtime.wordpressVersion = 'latest'; }, /pinned/],
-  ['missing evidence file', (input) => { fs.unlinkSync(path.join(input.root, 'diff.png')); }, /missing/],
+  ['unregistered evidence', (input) => { input.artifactIndex.data.payload.artifacts = input.artifactIndex.data.payload.artifacts.filter((artifact) => artifact.name !== 'visual_compare_solved_diff'); }, /exactly one registered artifact/],
+  ['duplicate registration', (input) => { input.artifactIndex.data.payload.artifacts.push({ ...input.artifactIndex.data.payload.artifacts[0] }); }, /exactly one registered artifact/],
+  ['missing evidence file', (input) => { fs.unlinkSync(input.artifactFiles.diff); }, /could not be resolved uniquely/],
 ]) {
   test(`fails closed for ${name}`, () => {
-    const input = fixture(); mutate(input); write(input.paths.matrix, input.matrix); write(input.paths.registry, input.registry); write(input.paths.runtime, input.runtime);
+    const input = fixture(); mutate(input); write(input.paths.matrix, input.matrix); write(input.paths.registry, input.registry); write(input.paths.runtime, input.runtime); write(input.paths.artifactIndex, input.artifactIndex);
     assert.throws(() => verifySolvedSitePromotion(input.options), pattern);
   });
 }


### PR DESCRIPTION
## Summary
- preserve the stable canonical rejection code while retaining the exact Blocks Engine resolver message
- project diagnostic messages into materialization receipt errors
- cover preparation and direct materialization rejection receipts

## Evidence
- `php tests/smoke-wordpress-site-plan-materializer.php`
- exposed by Automattic/blocks-engine#667 promotion run: https://github.com/Automattic/blocks-engine/actions/runs/29851109790

Tracks Automattic/static-site-importer#489.