### PR TITLE
Scope generated companion runtime assets

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -102,7 +102,7 @@ class Static_Site_Importer_Companion_Plugin {
 		$main_file = $plugin_slug . '/' . $plugin_slug . '.php';
 		$files     = array_merge(
 			array(
-				$main_file => self::main_plugin_file( $plugin_slug, $block_namespace, $site_name, $block_specs, $preserved ),
+				$main_file => self::main_plugin_file( $plugin_slug, $block_namespace, $site_name, $block_specs, $preserved, $main_file ),
 			),
 			$files
 		);
@@ -480,6 +480,7 @@ class Static_Site_Importer_Companion_Plugin {
 	 * @param string                          $site_name       Human-readable site name.
 	 * @param array<int,array<string,mixed>>  $block_specs     PHP-only block registration specs.
 	 * @param array<int,array<string,string>> $preserved       Preserved island descriptors.
+	 * @param string                          $plugin_file     Generated plugin basename.
 	 * @return string
 	 */
 	private static function main_plugin_file(
@@ -487,7 +488,8 @@ class Static_Site_Importer_Companion_Plugin {
 		string $block_namespace,
 		string $site_name,
 		array $block_specs,
-		array $preserved
+		array $preserved,
+		string $plugin_file
 	): string {
 		$header_name  = sprintf( 'SSI Companion: %s', $site_name );
 		$fn_prefix    = str_replace( '-', '_', $plugin_slug );
@@ -606,6 +608,9 @@ class Static_Site_Importer_Companion_Plugin {
 		$lines[] = '/** Enqueue preserved scripts that apply to the rendered frontend document. */';
 		$lines[] = sprintf( 'function %s_enqueue_global_islands() {', $fn_prefix );
 		$lines[] = "\tif ( ! function_exists( 'wp_enqueue_script' ) ) {";
+		$lines[] = "\t\treturn;";
+		$lines[] = "\t}";
+		$lines[] = sprintf( "\tif ( function_exists( 'get_option' ) && %s !== (string) get_option( 'static_site_importer_active_companion_plugin', '' ) ) {", var_export( $plugin_file, true ) );
 		$lines[] = "\t\treturn;";
 		$lines[] = "\t}";
 		$lines[] = sprintf( "\tforeach ( %s_islands() as \$island ) {", $fn_prefix );

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -14,6 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Static_Site_Importer_Plugin_Materializer {
 
+	/** Option identifying the generated companion that owns document-global runtime assets. */
+	public const ACTIVE_COMPANION_OPTION = 'static_site_importer_active_companion_plugin';
+
 	/**
 	 * Ensure a WordPress.org plugin is installed, active, and exposes expected APIs.
 	 *
@@ -130,6 +133,11 @@ class Static_Site_Importer_Plugin_Materializer {
 
 		if ( false === $plan['activate'] ) {
 			// mu-plugins are always active; no activation call is required.
+			$plugin_file = (string) $descriptor['plugin_file'];
+			self::replace_active_generated_companion( $plugin_file, $report );
+			if ( function_exists( 'update_option' ) ) {
+				update_option( self::ACTIVE_COMPANION_OPTION, $plugin_file, false );
+			}
 			$report['active'] = true;
 			$report['status'] = 'installed_activated';
 			return $report;
@@ -154,7 +162,6 @@ class Static_Site_Importer_Plugin_Materializer {
 				)
 			);
 		}
-
 		if ( null !== $availability_check && ! self::available( $availability_check ) ) {
 			return self::failed_report(
 				$report,
@@ -164,9 +171,35 @@ class Static_Site_Importer_Plugin_Materializer {
 				)
 			);
 		}
+		self::replace_active_generated_companion( $plugin_file, $report );
+		if ( function_exists( 'update_option' ) ) {
+			update_option( self::ACTIVE_COMPANION_OPTION, $plugin_file, false );
+		}
 
 		$report['status'] = $already_available ? 'refreshed' : 'installed_activated';
 		return $report;
+	}
+
+	/**
+	 * Deactivate the regular generated companion replaced by this import.
+	 *
+	 * @param string               $plugin_file New generated companion basename.
+	 * @param array<string, mixed> $report      Materialization report.
+	 */
+	private static function replace_active_generated_companion( string $plugin_file, array &$report ): void {
+		if ( ! function_exists( 'get_option' ) ) {
+			return;
+		}
+
+		$previous = (string) get_option( self::ACTIVE_COMPANION_OPTION, '' );
+		if ( '' === $previous || $plugin_file === $previous || ! function_exists( 'deactivate_plugins' ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) || is_plugin_active( $previous ) ) {
+			deactivate_plugins( $previous );
+			$report['actions'][] = 'replaced:' . $previous;
+		}
 	}
 
 	/**

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -135,6 +135,7 @@ if ( is_array( $script_only_descriptor ) ) {
 	$script_only_main = $script_only_descriptor['files']['ssi-example-site/ssi-example-site.php'] ?? '';
 	$assert( str_contains( $script_only_main, "add_action( 'wp_enqueue_scripts'" ), 'script-only-companion-enqueues-on-frontend' );
 	$assert( str_contains( $script_only_main, "'' !== ( \$island['block'] ?? '' )" ), 'global-enqueue-is-limited-to-unscoped-scripts' );
+	$assert( str_contains( $script_only_main, "get_option( 'static_site_importer_active_companion_plugin', '' )" ), 'global-enqueue-is-limited-to-current-site-companion' );
 }
 
 // 2. Gate/diagnostics account for the JS as companion-plugin-carried.

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -24,8 +24,10 @@ if ( ! defined( 'WPMU_PLUGIN_DIR' ) ) {
 // Controllable plugin-activation stubs so the install path is exercised without
 // a WordPress runtime. is_plugin_active reports inactive until activate_plugin
 // records the activation intent.
-$GLOBALS['ssi_companion_active']    = array();
-$GLOBALS['ssi_companion_activated'] = array();
+$GLOBALS['ssi_companion_active']      = array();
+$GLOBALS['ssi_companion_activated']   = array();
+$GLOBALS['ssi_companion_deactivated'] = array();
+$GLOBALS['ssi_companion_options']     = array();
 
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
@@ -85,6 +87,26 @@ if ( ! function_exists( 'activate_plugin' ) ) {
 		$GLOBALS['ssi_companion_active'][]    = $plugin_file;
 		$GLOBALS['ssi_companion_activated'][] = $plugin_file;
 		return null;
+	}
+}
+
+if ( ! function_exists( 'deactivate_plugins' ) ) {
+	function deactivate_plugins( string $plugin_file ): void {
+		$GLOBALS['ssi_companion_active']        = array_values( array_diff( $GLOBALS['ssi_companion_active'], array( $plugin_file ) ) );
+		$GLOBALS['ssi_companion_deactivated'][] = $plugin_file;
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $name, mixed $default = false ): mixed {
+		return $GLOBALS['ssi_companion_options'][ $name ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $name, mixed $value, bool $autoload = false ): bool {
+		$GLOBALS['ssi_companion_options'][ $name ] = $value;
+		return true;
 	}
 }
 
@@ -291,6 +313,7 @@ $assert( true === ( $report['active'] ?? false ), 'install-reports-active' );
 $assert( in_array( 'installed', $report['actions'] ?? array(), true ), 'install-records-installed-action' );
 $assert( in_array( 'activated', $report['actions'] ?? array(), true ), 'install-records-activated-action' );
 $assert( in_array( 'ssi-example-site/ssi-example-site.php', $GLOBALS['ssi_companion_activated'], true ), 'install-activates-companion-plugin' );
+$assert( 'ssi-example-site/ssi-example-site.php' === get_option( Static_Site_Importer_Plugin_Materializer::ACTIVE_COMPANION_OPTION ), 'install-records-current-companion-plugin' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ), 'install-writes-main-file-to-disk' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/render.php' ), 'install-writes-render-php-to-disk' );
 $assert( ! file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/block.json' ), 'install-emits-no-block-json' );
@@ -348,6 +371,14 @@ Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( $wa
 $assert( 0 === (int) ( $waived_report['quality']['companion_plugin_dependency_failures'] ?? 0 ), 'waived-companion-no-quality-failure' );
 $waived_diag = array_values( array_filter( $waived_report['diagnostics'] ?? array(), static fn ( array $d ): bool => 'companion_plugin_waived' === ( $d['code'] ?? '' ) ) );
 $assert( 1 === count( $waived_diag ), 'waived-companion-emits-warning' );
+
+// A new site replaces the previous regular companion so document-global
+// scripts from separate imports cannot execute together.
+$replacement_payload = array_merge( $payload, array( 'site_slug' => 'replacement-site' ) );
+$replacement_report  = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $replacement_payload );
+$assert( in_array( 'ssi-example-site/ssi-example-site.php', $GLOBALS['ssi_companion_deactivated'], true ), 'replacement-deactivates-previous-companion' );
+$assert( in_array( 'replaced:ssi-example-site/ssi-example-site.php', $replacement_report['actions'] ?? array(), true ), 'replacement-reports-previous-companion' );
+$assert( 'ssi-replacement-site/ssi-replacement-site.php' === get_option( Static_Site_Importer_Plugin_Materializer::ACTIVE_COMPANION_OPTION ), 'replacement-records-current-companion-plugin' );
 
 // Cleanup generated fixtures.
 $cleanup = static function ( string $dir ) use ( &$cleanup ): void {


### PR DESCRIPTION
## Summary
- record the generated companion that owns document-global runtime assets
- activate replacements before deactivating the previous regular companion
- gate global island enqueueing to the current companion, including persistent mu-plugin configurations
- preserve existing block-owned render-time island scoping

## Evidence
- `php tests/smoke-companion-plugin.php`: 73 assertions pass
- `npm test`: passes
- release-baseline Lab matrix: SaaS remains exact; University improves from 26.21% to 16.53%; position-offset findings drop to zero
- run: `a3ef3d05-f346-49fb-98a8-07bf34a75fae`
- DOM proof: https://homeboy-artifacts-tunnel.dev.chubes.net/a3ef3d05-f346-49fb-98a8-07bf34a75fae/00f663c9-8574-4ae4-ad4b-4d6dfe7e89f4-candidate-dom-snapshot.json

## Base limitation
`tests/smoke-companion-plugin-js.php` currently fatals unchanged on clean `origin/main` because `Static_Site_Importer_Report_Diagnostics::is_script_runtime_fallback_diagnostic()` is missing. The new generated-code assertion executes before that pre-existing fatal.

Fixes the runtime-scoping requirement in #491.