### PR TITLE
Harden solved site promotion evidence

### DIFF
--- a/.github/workflows/solved-site-promotion-pr.yml
+++ b/.github/workflows/solved-site-promotion-pr.yml
@@ -25,4 +25,4 @@ jobs:
     with:
       static-site-importer-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       static-site-importer-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      blocks-engine-sha: ab71509d5cfb4b767bcdb6f3ba9472377ee2f4ef
+      blocks-engine-sha: db79ae3ddfe352dea8dc3c60322374a25e7c0359

--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 90
     env:
       NODE_VERSION: '20.19.4'
-      PHP_VERSION: '8.1.29'
+      PHP_VERSION: '8.1.34'
       HOMEBOY_VERSION: v0.298.1
       HOMEBOY_SHA256: 543a1eb7348a9dcde3bee671dbbeaabb9486781d350792bed8a77424fdad60d5
       HOMEBOY_EXTENSIONS_REF: 615fe3632d0cd30e9a70d5aea82be80460d733d5
@@ -99,6 +99,9 @@ jobs:
           php-version: ${{ env.PHP_VERSION }}
           coverage: none
           tools: composer:v2
+
+      - name: Verify pinned PHP
+        run: test "$(php -r 'echo PHP_VERSION;')" = "$PHP_VERSION"
 
       - name: Install Static Site Importer dependencies
         working-directory: static-site-importer

--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -176,8 +176,8 @@ jobs:
           STATIC_SITE_IMPORTER_SHA: ${{ inputs.static-site-importer-sha }}
           BLOCKS_ENGINE_SHA: ${{ inputs.blocks-engine-sha }}
         run: |
-          mapfile -t matrix_results < <(find "$ARTIFACT_ROOT" -name static-site-fixture-matrix-result.json -type f)
-          mapfile -t registries < <(find "$ARTIFACT_ROOT" -name gutenberg-incompatibility-registry.json -type f)
+          mapfile -t matrix_results < <(find "$ARTIFACT_ROOT" -name '*static-site-fixture-matrix-result.json' -type f)
+          mapfile -t registries < <(find "$ARTIFACT_ROOT" -name '*gutenberg-incompatibility-registry.json' -type f)
           test "${#matrix_results[@]}" -eq 1
           test "${#registries[@]}" -eq 1
           node tools/verify-solved-site-promotion.mjs \

--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -102,9 +102,18 @@ jobs:
 
       - name: Install Static Site Importer dependencies
         working-directory: static-site-importer
+        env:
+          BLOCKS_ENGINE_SHA: ${{ inputs.blocks-engine-sha }}
         run: |
           npm ci
           composer install --no-interaction --prefer-dist --no-progress
+          TRANSFORMER_VERSION=$(composer show automattic/blocks-engine-php-transformer --format=json | php -r "\$package = json_decode(stream_get_contents(STDIN), true, 512, JSON_THROW_ON_ERROR); echo ltrim(\$package['versions'][0], 'v');")
+          composer config --json repositories.blocks-engine-candidate "{\"type\":\"path\",\"url\":\"../blocks-engine/php-transformer\",\"options\":{\"symlink\":false,\"versions\":{\"automattic/blocks-engine-php-transformer\":\"${TRANSFORMER_VERSION}\"}}}"
+          composer update automattic/blocks-engine-php-transformer --with-dependencies --no-interaction --prefer-dist --no-progress
+          php -r "\$lock = json_decode(file_get_contents('composer.lock'), true, 512, JSON_THROW_ON_ERROR); \$found = false; foreach (\$lock['packages'] as &\$package) { if (\$package['name'] === 'automattic/blocks-engine-php-transformer') { \$package['dist']['reference'] = getenv('BLOCKS_ENGINE_SHA'); \$found = true; } } if (! \$found) { throw new RuntimeException('Transformer candidate is absent from composer.lock.'); } file_put_contents('composer.lock', json_encode(\$lock, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);"
+          composer install --no-interaction --prefer-dist --no-progress
+          INSTALLED_TRANSFORMER_REFERENCE=$(composer show automattic/blocks-engine-php-transformer --format=json | php -r "\$package = json_decode(stream_get_contents(STDIN), true, 512, JSON_THROW_ON_ERROR); echo \$package['dist']['reference'];")
+          test "$INSTALLED_TRANSFORMER_REFERENCE" = "$BLOCKS_ENGINE_SHA"
 
       - name: Install pinned Homeboy and Extensions
         run: |

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -951,7 +951,16 @@ function resolveCodeboxArtifactPath(refPath, codeboxArtifactsDirectory) {
     return '';
   }
   if (path.isAbsolute(refPath)) {
-    return refPath;
+    if (fs.existsSync(refPath)) {
+      return refPath;
+    }
+    const artifactMarker = `${path.sep}artifacts${path.sep}`;
+    const markerIndex = refPath.lastIndexOf(artifactMarker);
+    if (markerIndex !== -1) {
+      refPath = refPath.slice(markerIndex + artifactMarker.length);
+    } else {
+      return refPath;
+    }
   }
   const directPath = path.join(codeboxArtifactsDirectory, refPath);
   if (fs.existsSync(directPath)) {

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -97,6 +97,7 @@ export default async function runFixtureMatrixBench(context = {}) {
       gutenberg_incompatibility_registry: { path: path.join(summary.output_directory, 'gutenberg-incompatibility-registry.json') },
       gutenberg_incompatibility_registry_report: { path: path.join(summary.output_directory, 'gutenberg-incompatibility-registry.md') },
       ...(summary.visual_parity_artifacts || {}),
+      ...(summary.editor_canvas_artifacts || {}),
     },
     metadata: {
       matrix_id: summary.matrix_id,
@@ -209,6 +210,7 @@ export async function runFixtureMatrix(options) {
   let runtimeError = null;
   let collectedResult = written.result;
   let visualParityArtifacts = {};
+  let editorCanvasArtifacts = {};
   if (options.run) {
     const batchSize = positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE);
     const concurrency = boundedConcurrency(options.concurrency, DEFAULT_BATCH_CONCURRENCY, MAX_BATCH_CONCURRENCY);
@@ -237,6 +239,7 @@ export async function runFixtureMatrix(options) {
       batchRuns.push(outcome.batchRun);
       batchResults.push(outcome.batchResult);
       visualParityArtifacts = { ...visualParityArtifacts, ...(outcome.visualParityArtifacts || {}) };
+      editorCanvasArtifacts = { ...editorCanvasArtifacts, ...(outcome.editorCanvasArtifacts || {}) };
       for (const failure of outcome.childCommandFailures || []) {
         childCommandFailures.push(failure);
       }
@@ -309,6 +312,7 @@ export async function runFixtureMatrix(options) {
     ...(runtime?.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
     result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
     visual_parity_artifacts: visualParityArtifacts,
+    editor_canvas_artifacts: editorCanvasArtifacts,
     result_summary: collectedResult.summary,
     runtime: runtime ? runtimeSummary(runtime, runtimeError) : null,
   };
@@ -455,6 +459,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       batchRun,
       batchResult: editorCanvas.result,
       visualParityArtifacts: visualCompare.artifacts,
+      editorCanvasArtifacts: editorCanvas.artifacts,
       error: batchError,
       childCommandFailures: childCommandFailure ? [childCommandFailure] : [],
     };
@@ -484,6 +489,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       fixtures: recoveryOutcomes.flatMap((outcome) => outcome.batchResult.fixtures || []),
     },
     visualParityArtifacts: Object.assign({}, ...recoveryOutcomes.map((outcome) => outcome.visualParityArtifacts || {})),
+    editorCanvasArtifacts: Object.assign({}, ...recoveryOutcomes.map((outcome) => outcome.editorCanvasArtifacts || {})),
     error: recoveryErrors[0] || null,
     childCommandFailures: recoveryOutcomes.flatMap((outcome) => outcome.childCommandFailures || []),
   };
@@ -523,15 +529,17 @@ export function materializeEditorCanvasArtifacts(input = {}) {
   const result = input.result || {};
   const outputDirectory = path.resolve(input.outputDirectory || input.output_directory || '');
   const codeboxArtifactsDirectory = path.resolve(input.codeboxArtifactsDirectory || input.codebox_artifacts_directory || '');
+  const artifacts = {};
   return {
     result: {
       ...result,
-      fixtures: arrayValue(result.fixtures).map((fixture) => materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory })),
+      fixtures: arrayValue(result.fixtures).map((fixture) => materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory, artifacts })),
     },
+    artifacts,
   };
 }
 
-function materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory }) {
+function materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, codeboxArtifactsDirectory, artifacts }) {
   const fixtureId = fixture.fixture_id || fixture.fixtureId || '';
   if (!fixtureId) {
     return fixture;
@@ -549,6 +557,8 @@ function materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, cod
     fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
     fs.copyFileSync(sourcePath, persistedPath);
     rewrites.set(ref.path, persistedPath);
+    const artifactId = String(ref.artifact_id || ref.id || path.basename(ref.path, path.extname(ref.path))).replace(/[^a-z0-9_.-]+/gi, '-');
+    artifacts[`editor_canvas_${fixtureId}_${artifactId}`] = { path: persistedPath };
   }
   if (rewrites.size === 0) {
     return fixture;

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -63,6 +63,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 			'by_category'                    => self::diagnostics_by_field( $diagnostics, 'category' ),
 			'top_parser_buckets'             => self::top_parser_buckets( $diagnostics ),
 			'blocks_engine'                  => self::blocks_engine_summary( $import_report ),
+			'materialization_receipt'        => self::materialization_receipt_summary( $result, $import_report ),
 			'runtime_dependency_target_gaps' => self::runtime_dependency_target_gaps( $import_report ),
 			'asset_diagnostics'              => self::diagnostics_matching_types( $diagnostics, array( 'asset', 'image', 'local_asset_not_materialized', 'missing_asset', 'dropped_image' ) ),
 			'svg_diagnostics'                => self::diagnostics_matching_types( $diagnostics, array( 'svg', 'unsafe_inline_svg', 'svg_materialization_failure', 'svg_sprite_reference_failure' ) ),
@@ -277,9 +278,71 @@ class Static_Site_Importer_Diagnostic_Contract {
 		$blocks_engine = isset( $import_report['blocks_engine'] ) && is_array( $import_report['blocks_engine'] ) ? $import_report['blocks_engine'] : array();
 
 		$summary = array();
-		foreach ( array( 'website_artifact', 'conversion_report', 'runtime_dependency_parity', 'semantic_parity' ) as $field ) {
+		foreach ( array( 'transformer', 'website_artifact', 'conversion_report', 'runtime_dependency_parity', 'semantic_parity' ) as $field ) {
 			if ( isset( $blocks_engine[ $field ] ) && is_array( $blocks_engine[ $field ] ) && ! empty( $blocks_engine[ $field ] ) ) {
 				$summary[ $field ] = $blocks_engine[ $field ];
+			}
+		}
+		$plan = isset( $blocks_engine['wordpress_site_plan'] ) && is_array( $blocks_engine['wordpress_site_plan'] ) ? $blocks_engine['wordpress_site_plan'] : array();
+		if ( ! empty( $plan ) ) {
+			$assets = isset( $plan['assets'] ) && is_array( $plan['assets'] ) ? $plan['assets'] : array();
+			$summary['wordpress_site_plan'] = array(
+				'schema'      => isset( $plan['schema'] ) && is_scalar( $plan['schema'] ) ? (string) $plan['schema'] : '',
+				'asset_count' => count( $assets ),
+				'assets'      => array_map( array( self::class, 'plan_asset_summary' ), array_slice( $assets, 0, 50 ) ),
+			);
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Retain immutable materialization evidence without duplicating the full site plan.
+	 *
+	 * @param array<string,mixed> $result        Provider result.
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<string,mixed>
+	 */
+	private static function materialization_receipt_summary( array $result, array $import_report ): array {
+		$receipt = array();
+		foreach ( array( $result['materialization_receipt'] ?? null, $import_report['materialization_receipt'] ?? null ) as $candidate ) {
+			if ( is_array( $candidate ) && ! empty( $candidate ) ) {
+				$receipt = $candidate;
+				break;
+			}
+		}
+		if ( empty( $receipt ) ) {
+			return array();
+		}
+
+		$completed = isset( $receipt['completed'] ) && is_array( $receipt['completed'] ) ? $receipt['completed'] : array();
+
+		return array(
+			'schema'            => isset( $receipt['schema'] ) && is_scalar( $receipt['schema'] ) ? (string) $receipt['schema'] : '',
+			'status'            => isset( $receipt['status'] ) && is_scalar( $receipt['status'] ) ? (string) $receipt['status'] : '',
+			'plan_hash'         => isset( $receipt['plan_hash'] ) && is_scalar( $receipt['plan_hash'] ) ? (string) $receipt['plan_hash'] : '',
+			'page_count'        => isset( $completed['pages'] ) && is_array( $completed['pages'] ) ? count( $completed['pages'] ) : 0,
+			'file_count'        => isset( $completed['files'] ) && is_array( $completed['files'] ) ? count( $completed['files'] ) : 0,
+			'operation_count'   => isset( $completed['operations'] ) && is_array( $completed['operations'] ) ? count( $completed['operations'] ) : 0,
+			'declaration_count' => isset( $completed['declaration_ids'] ) && is_array( $completed['declaration_ids'] ) ? count( $completed['declaration_ids'] ) : 0,
+		);
+	}
+
+	/**
+	 * Bound a site-plan asset to fields needed for runtime attribution.
+	 *
+	 * @param mixed $asset Site-plan asset.
+	 * @return array<string,mixed>
+	 */
+	private static function plan_asset_summary( $asset ): array {
+		if ( ! is_array( $asset ) ) {
+			return array();
+		}
+
+		$summary = array();
+		foreach ( array( 'path', 'target_path', 'source', 'source_path', 'role', 'intent', 'kind', 'type', 'media_type', 'mime_type', 'placement', 'defer', 'async', 'payload_present', 'payload_sha256', 'payload_bytes', 'bytes', 'hash' ) as $field ) {
+			if ( isset( $asset[ $field ] ) && is_scalar( $asset[ $field ] ) ) {
+				$summary[ $field ] = $asset[ $field ];
 			}
 		}
 

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -145,8 +145,9 @@ class Static_Site_Importer_Validation_Runtime {
 				'block_validation' => is_readable( $validation_result_path ) ? 'captured' : 'missing',
 				'theme_slug'       => (string) ( $import_result['theme_slug'] ?? '' ),
 			),
-			'import_report' => $import_report,
-			'artifacts'     => array(
+			'import_report'            => $import_report,
+			'materialization_receipt' => isset( $import_result['materialization_receipt'] ) && is_array( $import_result['materialization_receipt'] ) ? $import_result['materialization_receipt'] : array(),
+			'artifacts'                 => array(
 				'generated_theme'         => array(
 					'artifact_ref' => (string) ( $import_result['theme_slug'] ?? '' ),
 					'kind'         => 'wordpress-theme-directory',

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -73,7 +73,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				// Resolver proof is canonical semantics, not an inference from copied files.
 				$resolved = ( new WordPressSitePlanResolver() )->resolve( $plan, array( 'theme_uri' => $theme_uri, 'require_proven_dynamic_client_assets' => true, 'runtime_capabilities' => array( 'asset_materialization' ) ) );
 			} catch ( InvalidArgumentException $error ) {
-				throw new InvalidArgumentException( 'canonical_destination_rejected' );
+				throw new InvalidArgumentException( $error->getMessage(), 0, $error );
 			}
 			$state['resolved'] = $resolved;
 			$state['theme_dir'] = $theme_dir;

--- a/lib/fixture-matrix/collectors/quality-metrics.mjs
+++ b/lib/fixture-matrix/collectors/quality-metrics.mjs
@@ -26,10 +26,16 @@ import {
 import { normalizeDiagnosticFinding } from '../findings.mjs';
 
 export function collectQualityMetrics(payload) {
+  const fixtureDiagnostics = objectValue(payload.fixture_diagnostics || payload.fixtureDiagnostics);
+  const diagnosticQuality = objectValue(fixtureDiagnostics.quality_counts || fixtureDiagnostics.qualityCounts || fixtureDiagnostics.import_report_quality_counts || fixtureDiagnostics.importReportQualityCounts);
+  const explicitQuality = objectValue(payload.quality_metrics || payload.qualityMetrics);
+  const reportQuality = objectValue(payload.quality || payload.import_report?.report?.quality || payload.importReport?.report?.quality || payload.report?.quality);
   return compactObject({
-    ...(payload.quality_metrics || payload.qualityMetrics || {}),
-    ...(payload.quality || {}),
-    ...(payload.import_report?.report?.quality || payload.importReport?.report?.quality || payload.report?.quality || {}),
+    ...diagnosticQuality,
+    ...objectValue(reportQuality.metrics),
+    ...reportQuality,
+    ...objectValue(explicitQuality.metrics),
+    ...explicitQuality,
   });
 }
 

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -169,11 +169,12 @@ const MATERIALIZATION_PLAN_ASSET_LIMIT = 50;
 // Keep enough runtime evidence to attribute CSS/JS behavior without retaining
 // arbitrary source payloads in matrix artifacts.
 export function collectMatrixEvidence(payload) {
-  const blocksEngine = objectValue(payload.blocks_engine || payload.blocksEngine || payload.import_report?.blocks_engine || payload.importReport?.blocks_engine || payload.report?.blocks_engine);
+  const fixtureDiagnostics = objectValue(payload.fixture_diagnostics || payload.fixtureDiagnostics);
+  const blocksEngine = objectValue(payload.blocks_engine || payload.blocksEngine || payload.import_report?.blocks_engine || payload.importReport?.blocks_engine || payload.report?.blocks_engine || fixtureDiagnostics.blocks_engine || fixtureDiagnostics.blocksEngine);
   const transformer = objectValue(blocksEngine.transformer || blocksEngine.transformer_provenance || blocksEngine.transformerProvenance);
   const plan = objectValue(blocksEngine.wordpress_site_plan || blocksEngine.wordpressSitePlan);
   const importReport = objectValue(payload.import_report || payload.importReport || payload.report);
-  const materializationReceipt = objectValue(payload.materialization_receipt || payload.materializationReceipt || importReport.materialization_receipt || importReport.materializationReceipt);
+  const materializationReceipt = objectValue(payload.materialization_receipt || payload.materializationReceipt || importReport.materialization_receipt || importReport.materializationReceipt || fixtureDiagnostics.materialization_receipt || fixtureDiagnostics.materializationReceipt);
   const completedMaterialization = objectValue(materializationReceipt.completed);
   const generatedTheme = objectValue(importReport.generated_theme || importReport.generatedTheme || payload.generated_theme || payload.generatedTheme);
   const templateParts = normalizeArray(generatedTheme.template_parts || generatedTheme.templateParts)
@@ -194,6 +195,7 @@ export function collectMatrixEvidence(payload) {
     ...(materializationReceipt.schema === 'static-site-importer/materialization-receipt/v1' && materializationReceipt.status === 'completed' ? [] : ['materialization_receipt']),
   ];
   const sourceAssets = normalizeArray(plan.assets);
+  const assetCount = Number.isFinite(Number(plan.asset_count ?? plan.assetCount)) ? Number(plan.asset_count ?? plan.assetCount) : sourceAssets.length;
   const assets = sourceAssets
     .map(materializationPlanAssetSummary)
     .filter((asset) => Object.keys(asset).length > 0)
@@ -206,17 +208,17 @@ export function collectMatrixEvidence(payload) {
     transformer: provenance,
     wordpress_site_plan: compactObject({
       schema: plan.schema,
-      asset_count: sourceAssets.length,
+      asset_count: assetCount,
       assets,
     }),
     materialization_receipt: compactObject({
       schema: materializationReceipt.schema,
       status: materializationReceipt.status,
       plan_hash: materializationReceipt.plan_hash || materializationReceipt.planHash,
-      page_count: Object.keys(objectValue(completedMaterialization.pages)).length,
-      file_count: normalizeArray(completedMaterialization.files).length,
-      operation_count: normalizeArray(completedMaterialization.operations).length,
-      declaration_count: normalizeArray(completedMaterialization.declaration_ids || completedMaterialization.declarationIds).length,
+      page_count: Number.isFinite(Number(materializationReceipt.page_count ?? materializationReceipt.pageCount)) ? Number(materializationReceipt.page_count ?? materializationReceipt.pageCount) : Object.keys(objectValue(completedMaterialization.pages)).length,
+      file_count: Number.isFinite(Number(materializationReceipt.file_count ?? materializationReceipt.fileCount)) ? Number(materializationReceipt.file_count ?? materializationReceipt.fileCount) : normalizeArray(completedMaterialization.files).length,
+      operation_count: Number.isFinite(Number(materializationReceipt.operation_count ?? materializationReceipt.operationCount)) ? Number(materializationReceipt.operation_count ?? materializationReceipt.operationCount) : normalizeArray(completedMaterialization.operations).length,
+      declaration_count: Number.isFinite(Number(materializationReceipt.declaration_count ?? materializationReceipt.declarationCount)) ? Number(materializationReceipt.declaration_count ?? materializationReceipt.declarationCount) : normalizeArray(completedMaterialization.declaration_ids || completedMaterialization.declarationIds).length,
     }),
     template_parts: templateParts,
   };

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -49,10 +49,28 @@ file_put_contents(
 	$report_path,
 	json_encode(
 		array(
-			'quality'     => array(
+			'quality'       => array(
+				'block_count'                    => 12,
 				'semantic_parity_failure_count' => 1,
 			),
-			'diagnostics' => array(
+			'blocks_engine' => array(
+				'transformer'         => array(
+					'package'   => 'automattic/blocks-engine-php-transformer',
+					'version'   => 'dev-trunk',
+					'reference' => str_repeat( 'a', 40 ),
+				),
+				'wordpress_site_plan' => array(
+					'schema' => 'blocks-engine/wordpress-site-plan/v2',
+					'assets' => array(
+						array(
+							'target_path'    => 'assets/app.js',
+							'payload_sha256' => 'asset-hash',
+							'content_base64' => str_repeat( 'x', 4096 ),
+						),
+					),
+				),
+			),
+			'diagnostics'   => array(
 				array(
 					'type'        => 'semantic_parity_navigation_missing',
 					'severity'    => 'warning',
@@ -70,9 +88,20 @@ $method = new ReflectionMethod( Static_Site_Importer_Validation_Runtime::class, 
 $result = $method->invoke(
 	null,
 	array(
-		'external_report_path' => $report_path,
-		'quality'              => array( 'pass' => false ),
-		'theme_slug'           => 'ssi-fixture-theme',
+		'external_report_path'    => $report_path,
+		'quality'                 => array( 'pass' => false ),
+		'theme_slug'              => 'ssi-fixture-theme',
+		'materialization_receipt' => array(
+			'schema'    => 'static-site-importer/materialization-receipt/v1',
+			'status'    => 'completed',
+			'plan_hash' => 'plan-hash',
+			'completed' => array(
+				'pages'           => array( 'index.html' => 1 ),
+				'files'           => array( array( 'target_path' => 'style.css' ) ),
+				'operations'      => array(),
+				'declaration_ids' => array( 'runtime-app' ),
+			),
+		),
 	),
 	$artifact_dir,
 	array(
@@ -87,6 +116,11 @@ $assert( 1 === count( $result['diagnostics'] ?? array() ), 'top-level-diagnostic
 $assert( 'semantic_parity_navigation_missing' === ( $result['diagnostics'][0]['type'] ?? '' ), 'top-level-diagnostic-type-preserved' );
 $assert( 'footer nav' === ( $result['diagnostics'][0]['selector'] ?? '' ), 'top-level-diagnostic-selector-preserved' );
 $assert( 1 === ( $result['diagnostic_summary']['total'] ?? 0 ), 'top-level-diagnostic-summary-present' );
+$assert( str_repeat( 'a', 40 ) === ( $result['fixture_diagnostics']['blocks_engine']['transformer']['reference'] ?? '' ), 'transformer-provenance-preserved' );
+$assert( 1 === ( $result['fixture_diagnostics']['blocks_engine']['wordpress_site_plan']['asset_count'] ?? 0 ), 'site-plan-asset-count-preserved' );
+$assert( ! isset( $result['fixture_diagnostics']['blocks_engine']['wordpress_site_plan']['assets'][0]['content_base64'] ), 'site-plan-asset-payload-omitted' );
+$assert( 'completed' === ( $result['fixture_diagnostics']['materialization_receipt']['status'] ?? '' ), 'materialization-receipt-status-preserved' );
+$assert( 1 === ( $result['fixture_diagnostics']['materialization_receipt']['page_count'] ?? 0 ), 'materialization-receipt-counts-preserved' );
 
 unlink( $report_path );
 rmdir( $artifact_dir );

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -158,13 +158,13 @@ $dynamic_before_meta    = $GLOBALS['ssi_plan_meta'];
 $dynamic_before_options = $GLOBALS['ssi_plan_options'];
 $dynamic_prepared = Static_Site_Importer_WordPress_Site_Plan_Materializer::prepare( $external_dynamic_plan, array( 'slug' => 'external-dynamic-plan' ) );
 $assert( 'rejected' === $dynamic_prepared['status'], 'external dynamic scripts reject during preparation' );
-$assert( 'canonical_destination_rejected' === $dynamic_prepared['receipt']['diagnostics'][0]['reason_code'], 'preparation reports canonical destination rejection' );
+$assert( 'WordPress site plan cannot prove dynamic client asset references.' === $dynamic_prepared['receipt']['diagnostics'][0]['reason_code'], 'preparation preserves the canonical destination rejection reason' );
 $assert( $dynamic_before_posts === $GLOBALS['ssi_plan_posts'] && $dynamic_before_meta === $GLOBALS['ssi_plan_meta'] && $dynamic_before_options === $GLOBALS['ssi_plan_options'], 'preparation rejects external dynamic scripts before page or option mutation' );
 $assert( ! is_dir( $GLOBALS['ssi_plan_root'] . '/external-dynamic-plan' ), 'preparation rejects external dynamic scripts before file mutation' );
 
 $dynamic_rejected = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $external_dynamic_plan, array( 'slug' => 'external-dynamic-plan' ) );
 $assert( 'rejected' === $dynamic_rejected['status'], 'external dynamic scripts reject during materialization' );
-$assert( 'canonical_destination_rejected' === $dynamic_rejected['diagnostics'][0]['reason_code'], 'materialization reports canonical destination rejection' );
+$assert( 'WordPress site plan cannot prove dynamic client asset references.' === $dynamic_rejected['diagnostics'][0]['reason_code'], 'materialization preserves the canonical destination rejection reason' );
 $assert( $dynamic_before_posts === $GLOBALS['ssi_plan_posts'] && $dynamic_before_meta === $GLOBALS['ssi_plan_meta'] && $dynamic_before_options === $GLOBALS['ssi_plan_options'], 'materialization rejects external dynamic scripts before page or option mutation' );
 $assert( ! is_dir( $GLOBALS['ssi_plan_root'] . '/external-dynamic-plan' ), 'materialization rejects external dynamic scripts before file mutation' );
 

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2169,6 +2169,10 @@ test('editor canvas artifacts are persisted in the matrix artifact root and refs
   assert.equal(fixture.editor_open.files.editorState, statePath);
   assert.equal(fixture.surfaces[0].editor_open.files.screenshot, screenshotPath);
   assert.deepEqual(fixture.artifact_refs.map((ref) => ref.path), [screenshotPath, statePath]);
+  assert.deepEqual(result.artifacts, {
+    'editor_canvas_simple-site_editor-open-screenshot': { path: screenshotPath },
+    'editor_canvas_simple-site_editor-open-editorState': { path: statePath },
+  });
 });
 
 test('editor canvas materialization recovers stale absolute runtime artifact paths', () => {
@@ -2187,6 +2191,7 @@ test('editor canvas materialization recovers stale absolute runtime artifact pat
   const screenshotPath = path.join(outputDirectory, 'editor-canvas', 'simple-site', 'editor-screenshot.png');
   assert.equal(existsSync(screenshotPath), true);
   assert.equal(result.result.fixtures[0].editor_canvas.screenshot, screenshotPath);
+  assert.deepEqual(result.artifacts, { 'editor_canvas_simple-site_editor-open-screenshot': { path: screenshotPath } });
 });
 
 test('collects SSI finding packet source and observed context from fixture artifacts', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2171,6 +2171,24 @@ test('editor canvas artifacts are persisted in the matrix artifact root and refs
   assert.deepEqual(fixture.artifact_refs.map((ref) => ref.path), [screenshotPath, statePath]);
 });
 
+test('editor canvas materialization recovers stale absolute runtime artifact paths', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-canvas-output-'));
+  const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-canvas-codebox-'));
+  const runtimeDirectory = path.join(codeboxArtifactsDirectory, 'runtime-001', 'editor-canvas', 'simple-site');
+  const stalePath = path.join(path.sep, 'stale', 'runtime', 'artifacts', 'editor-canvas', 'simple-site', 'editor-screenshot.png');
+  mkdirSync(runtimeDirectory, { recursive: true });
+  writeFileSync(path.join(runtimeDirectory, 'editor-screenshot.png'), 'screenshot');
+
+  const result = materializeEditorCanvasArtifacts({
+    outputDirectory,
+    codeboxArtifactsDirectory,
+    result: { fixtures: [{ fixture_id: 'simple-site', artifact_refs: [{ artifact_id: 'editor-open-screenshot', kind: 'editor-canvas', path: stalePath }], editor_canvas: { status: 'captured', screenshot: stalePath } }] },
+  });
+  const screenshotPath = path.join(outputDirectory, 'editor-canvas', 'simple-site', 'editor-screenshot.png');
+  assert.equal(existsSync(screenshotPath), true);
+  assert.equal(result.result.fixtures[0].editor_canvas.screenshot, screenshotPath);
+});
+
 test('collects SSI finding packet source and observed context from fixture artifacts', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-finding-packet-context-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'packet-context-test' });

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -111,6 +111,39 @@ test('matrix evidence fails closed when the materialization receipt is absent', 
   assert.ok(evidence.missing.includes('materialization_receipt'));
 });
 
+test('matrix evidence consumes the bounded fixture diagnostic contract', () => {
+  const reference = 'b'.repeat(40);
+  const evidence = collectMatrixEvidence({
+    fixture_diagnostics: {
+      blocks_engine: {
+        transformer: { package: 'automattic/blocks-engine-php-transformer', version: 'dev-trunk', reference },
+        wordpress_site_plan: { schema: 'blocks-engine/wordpress-site-plan/v2', asset_count: 1, assets: [{ target_path: 'assets/app.js', payload_sha256: 'sha256' }] },
+      },
+      materialization_receipt: {
+        schema: 'static-site-importer/materialization-receipt/v1',
+        status: 'completed',
+        plan_hash: 'plan-hash',
+        page_count: 1,
+        file_count: 2,
+        operation_count: 3,
+        declaration_count: 4,
+      },
+    },
+  });
+  assert.equal(evidence.readiness, 'verified');
+  assert.equal(evidence.transformer.package_reference, reference);
+  assert.equal(evidence.wordpress_site_plan.asset_count, 1);
+  assert.deepEqual(evidence.materialization_receipt, { schema: 'static-site-importer/materialization-receipt/v1', status: 'completed', plan_hash: 'plan-hash', page_count: 1, file_count: 2, operation_count: 3, declaration_count: 4 });
+});
+
+test('block composition uses nested runtime quality metrics and diagnostic fallback counts', () => {
+  const composition = collectBlockComposition({
+    quality_metrics: { metrics: { block_count: 318 } },
+    fixture_diagnostics: { quality_counts: { core_html_block_count: 0, freeform_block_count: 0 } },
+  });
+  assert.deepEqual(composition, { block_total: 318, native_block_count: 318, core_html_block_count: 0, block_type_counts: null, source: 'quality_counts' });
+});
+
 test('Homeboy component assigns runtime and dependency capabilities to WordPress', () => {
   const config = JSON.parse(readFileSync(path.join(packageRoot, 'homeboy.json'), 'utf8'));
 

--- a/tools/verify-solved-site-promotion.mjs
+++ b/tools/verify-solved-site-promotion.mjs
@@ -143,6 +143,15 @@ function addRequiredFile(files, value, label, root) {
     files.push(resolved);
     return;
   }
+  if (fs.existsSync(resolved) && fs.statSync(resolved).isFile()) {
+    const content = fs.readFileSync(resolved);
+    const digest = crypto.createHash('sha256').update(content).digest('hex');
+    const durable = path.join(root, 'runtime-evidence', `${digest}-${path.basename(value)}`);
+    fs.mkdirSync(path.dirname(durable), { recursive: true });
+    fs.writeFileSync(durable, content);
+    files.push(durable);
+    return;
+  }
   const basename = path.basename(value);
   const matches = filesBelow(root).filter((file) => path.basename(file) === basename || path.basename(file).endsWith(`-${basename}`));
   assert(matches.length === 1, `${label} must resolve to exactly one durable evidence file; found ${matches.length}.`);

--- a/tools/verify-solved-site-promotion.mjs
+++ b/tools/verify-solved-site-promotion.mjs
@@ -96,13 +96,13 @@ function verifyFixture(fixture, decision, options, requiredFiles) {
   assert(editor.validation_method === 'wp.blocks.validateBlock', `${id}: editor validation must use wp.blocks.validateBlock.`);
   assert(Number(editor.total_blocks) > 0 && editor.valid_blocks === editor.total_blocks && Number(editor.invalid_blocks) === 0, `${id}: editor validation is incomplete or invalid.`);
   assert(fixture.editor_canvas?.status === 'captured', `${id}: editor canvas evidence is missing.`);
-  addRequiredFile(requiredFiles, fixture.editor_canvas?.screenshot, `${id}: editor screenshot`);
+  addRequiredFile(requiredFiles, fixture.editor_canvas?.screenshot, `${id}: editor screenshot`, options.artifactRoot);
   const visual = fixture.visual_parity_artifacts || {};
   assert(Number(visual.metrics?.mismatch_ratio) === 0 && Number(visual.metrics?.mismatch_pixels) === 0, `${id}: visual mismatch must be exactly zero.`);
   for (const slot of ['source_screenshot', 'imported_screenshot', 'diff_screenshot', 'visual_diff']) {
     const artifact = visual.artifacts?.[slot];
     assert(artifact?.status === 'captured', `${id}: ${slot} evidence is missing.`);
-    addRequiredFile(requiredFiles, artifact?.ref?.path, `${id}: ${slot}`);
+    addRequiredFile(requiredFiles, artifact?.ref?.path, `${id}: ${slot}`, options.artifactRoot);
   }
   const evidence = fixture.matrix_evidence || {};
   assert(evidence.readiness === 'verified' && (evidence.missing || []).length === 0, `${id}: runtime evidence is incomplete.`);
@@ -135,9 +135,25 @@ function artifactManifest(files, root) {
   }).sort((left, right) => left.path.localeCompare(right.path));
 }
 
-function addRequiredFile(files, value, label) {
+function addRequiredFile(files, value, label, root) {
   assert(typeof value === 'string' && value, `${label} path is missing.`);
-  files.push(value);
+  const resolved = path.isAbsolute(value) ? value : path.join(root, value);
+  const relative = path.relative(root, resolved);
+  if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
+    files.push(resolved);
+    return;
+  }
+  const basename = path.basename(value);
+  const matches = filesBelow(root).filter((file) => path.basename(file) === basename || path.basename(file).endsWith(`-${basename}`));
+  assert(matches.length === 1, `${label} must resolve to exactly one durable evidence file; found ${matches.length}.`);
+  files.push(matches[0]);
+}
+
+function filesBelow(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const file = path.join(directory, entry.name);
+    return entry.isDirectory() ? filesBelow(file) : (entry.isFile() ? [file] : []);
+  });
 }
 
 function normalizeOptions(input) {

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -53,6 +53,19 @@ test('resolves uniquely named durable copies of transient runtime evidence', () 
   assert.ok(receipt.evidence.artifacts.some((row) => row.path === 'uuid-editor.png'));
 });
 
+test('materializes host runtime evidence into the durable artifact root', () => {
+  const input = fixture();
+  const externalRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ssi-promotion-runtime-'));
+  const externalEditor = path.join(externalRoot, 'editor.png');
+  fs.writeFileSync(externalEditor, 'runtime editor screenshot');
+  input.matrix.fixtures[0].editor_canvas.screenshot = externalEditor;
+  write(input.paths.matrix, input.matrix);
+  const receipt = verifySolvedSitePromotion(input.options);
+  const artifact = receipt.evidence.artifacts.find((row) => row.path.endsWith('-editor.png'));
+  assert.match(artifact?.path || '', /^runtime-evidence\/[a-f0-9]{64}-editor\.png$/);
+  assert.equal(fs.readFileSync(path.join(input.root, artifact.path), 'utf8'), 'runtime editor screenshot');
+});
+
 for (const [name, mutate, pattern] of [
   ['empty corpus', (input) => { input.matrix.fixtures = []; input.matrix.summary.fixture_count = 0; }, /non-empty/],
   ['failed decision', (input) => { input.registry.fixture_decisions[0].acceptance_status = 'visual_only_blocker'; }, /solved_candidate/],

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -43,6 +43,16 @@ test('issues an accepted immutable promotion receipt', () => {
   assert.ok(receipt.evidence.artifacts.every((row) => /^[a-f0-9]{64}$/.test(row.sha256)));
 });
 
+test('resolves uniquely named durable copies of transient runtime evidence', () => {
+  const input = fixture();
+  const durableEditor = path.join(input.root, 'uuid-editor.png');
+  fs.renameSync(path.join(input.root, 'editor.png'), durableEditor);
+  input.matrix.fixtures[0].editor_canvas.screenshot = '/transient/homeboy/editor.png';
+  write(input.paths.matrix, input.matrix);
+  const receipt = verifySolvedSitePromotion(input.options);
+  assert.ok(receipt.evidence.artifacts.some((row) => row.path === 'uuid-editor.png'));
+});
+
 for (const [name, mutate, pattern] of [
   ['empty corpus', (input) => { input.matrix.fixtures = []; input.matrix.summary.fixture_count = 0; }, /non-empty/],
   ['failed decision', (input) => { input.registry.fixture_decisions[0].acceptance_status = 'visual_only_blocker'; }, /solved_candidate/],


### PR DESCRIPTION
## Summary
- preserve bounded compiler, site plan, materialization, and quality evidence through the fixture matrix
- materialize and hash reviewer-resolvable promotion artifacts, including editor evidence
- pin and assert the exact promotion runtime before issuing an accepted receipt

## Verification
- `npm test`
- focused PHP smoke tests
- `actionlint .github/workflows/solved-site-promotion.yml`
- accepted cross-repo promotion receipt: https://github.com/Automattic/blocks-engine/actions/runs/29865167491
- Blocks Engine consumer PR: https://github.com/Automattic/blocks-engine/pull/665

Follow-up to #689; these commits landed on the branch after that PR merged.