### PR TITLE
Update Figma transformer to v0.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,19 +38,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-figma-transformer",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "description": "PHP primitives for transforming Figma designs into static HTML website artifacts.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "467f9f6647f41bfa9a64984b40007a8d97f1a072"
+          "reference": "66881a867595e813658cb4b844f46ba6d04cf198"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/figma-transformer-v0.1.2.zip",
-          "reference": "467f9f6647f41bfa9a64984b40007a8d97f1a072"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/figma-transformer-v0.1.3.zip",
+          "reference": "66881a867595e813658cb4b844f46ba6d04cf198"
         },
         "autoload": {
           "psr-4": {
@@ -72,7 +72,7 @@
     }
   ],
   "require": {
-    "automattic/blocks-engine-figma-transformer": "^0.1.1",
+    "automattic/blocks-engine-figma-transformer": "^0.1.3",
     "automattic/blocks-engine-php-transformer": "^0.4.4",
     "php": "^8.1"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d6c7b15b5e65d9b91eb0ee68beceb3b",
+    "content-hash": "50e5d428088fd64fa39122e9d99d3874",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "467f9f6647f41bfa9a64984b40007a8d97f1a072"
+                "reference": "66881a867595e813658cb4b844f46ba6d04cf198"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/figma-transformer-v0.1.2.zip",
-                "reference": "467f9f6647f41bfa9a64984b40007a8d97f1a072"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/figma-transformer-v0.1.3.zip",
+                "reference": "66881a867595e813658cb4b844f46ba6d04cf198"
             },
             "require": {
                 "php": ">=8.1"


### PR DESCRIPTION
## Summary
- update the bundled Blocks Engine Figma transformer from `v0.1.2` to `v0.1.3`
- pin immutable release commit `66881a867595e813658cb4b844f46ba6d04cf198`
- refresh Composer lock metadata for the release package

## Verification
- Composer resolved and installed `automattic/blocks-engine-figma-transformer 0.1.3` from the release tag
- operator requested release quality checks be skipped; Homeboy packaging remains required

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Use:** Audited the release chain and prepared the immutable dependency pin. Chris Huber remains responsible for the change.