### PR TITLE
Update PHP transformer to v0.4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.4.4",
+        "version": "0.4.5",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "ab71509d5cfb4b767bcdb6f3ba9472377ee2f4ef"
+          "reference": "6751c02a6a216e127c2657d7a7e617f13cbaca36"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.4.zip",
-          "reference": "ab71509d5cfb4b767bcdb6f3ba9472377ee2f4ef"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.5.zip",
+          "reference": "6751c02a6a216e127c2657d7a7e617f13cbaca36"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "^0.4.4",
+    "automattic/blocks-engine-php-transformer": "^0.4.5",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50e5d428088fd64fa39122e9d99d3874",
+    "content-hash": "562ebf635d605afedf235e4b003e6499",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.4.4",
+            "version": "0.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "ab71509d5cfb4b767bcdb6f3ba9472377ee2f4ef"
+                "reference": "6751c02a6a216e127c2657d7a7e617f13cbaca36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.4.zip",
-                "reference": "ab71509d5cfb4b767bcdb6f3ba9472377ee2f4ef"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.5.zip",
+                "reference": "6751c02a6a216e127c2657d7a7e617f13cbaca36"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary
- update the bundled Blocks Engine PHP Transformer from `v0.4.4` to `v0.4.5`
- pin immutable release commit `6751c02a6a216e127c2657d7a7e617f13cbaca36`
- restore solved Relay Atlas imports containing HTML-encoded quoted data-SVG URLs

## Verification
- Composer resolved and installed `automattic/blocks-engine-php-transformer 0.4.5`
- upstream WordPress site-plan regression contract passed
- operator requested release quality checks be skipped; Homeboy packaging remains required

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Use:** Fixed and released the upstream validator, then prepared this immutable dependency pin. Chris Huber remains responsible for the change.