### PR TITLE
Accept bounded staged Figma sources

### DIFF
--- a/includes/class-static-site-importer-figma-import.php
+++ b/includes/class-static-site-importer-figma-import.php
@@ -323,6 +323,9 @@ class Static_Site_Importer_Figma_Import {
 	 */
 	private static function website_artifact_from_figma_file( array $figma_file, array $input ) {
 		$name = isset( $figma_file['name'] ) ? (string) $figma_file['name'] : '';
+		if ( isset( $figma_file['staged_path'] ) ) {
+			return self::website_artifact_from_staged_figma_file( (string) $figma_file['staged_path'], $name, $input );
+		}
 
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes uploaded .fig payload content.
 		$content = isset( $figma_file['content_base64'] ) ? base64_decode( (string) $figma_file['content_base64'], true ) : false;
@@ -343,6 +346,34 @@ class Static_Site_Importer_Figma_Import {
 				wp_delete_file( $tmp );
 			}
 		}
+	}
+
+	/**
+	 * Transform a Studio-staged .fig file without copying its bytes through JSON and PHP source.
+	 *
+	 * @param string              $path  Staged file path.
+	 * @param string              $name  Original file name.
+	 * @param array<string,mixed> $input Full request input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function website_artifact_from_staged_figma_file( string $path, string $name, array $input ) {
+		$staging_root = realpath( ABSPATH . '.studio-import' );
+		$resolved     = realpath( $path );
+		if ( false === $staging_root || false === $resolved ) {
+			return new WP_Error( 'static_site_importer_figma_staged_file_invalid', 'Staged Figma file could not be resolved.', array( 'status' => 400 ) );
+		}
+
+		$normalized_root = rtrim( str_replace( '\\', '/', $staging_root ), '/' ) . '/';
+		$normalized_path = str_replace( '\\', '/', $resolved );
+		if ( ! str_starts_with( $normalized_path, $normalized_root ) || is_link( $path ) || ! is_file( $resolved ) || ! is_readable( $resolved ) ) {
+			return new WP_Error( 'static_site_importer_figma_staged_file_invalid', 'Staged Figma file must be a readable regular file inside the Studio import directory.', array( 'status' => 400 ) );
+		}
+
+		if ( ! preg_match( '/\.fig$/i', $name ) || ! preg_match( '/\.fig$/i', $normalized_path ) ) {
+			return new WP_Error( 'static_site_importer_figma_file_type_invalid', 'Staged Figma files must use the .fig extension.', array( 'status' => 400 ) );
+		}
+
+		return self::website_artifact_from_figma_file_path( $resolved, $name, $input );
 	}
 
 	/**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -995,6 +995,36 @@ if ( is_wp_error( $figma_upload_artifact ) && 'static_site_importer_figma_transf
 	$assert( isset( $figma_upload_error_data['diagnostic'] ) && is_array( $figma_upload_error_data['diagnostic'] ), 'figma-empty-transform-error-exposes-diagnostic' );
 	$assert( 'Blocks Engine Figma transformer did not produce importable files.' !== $figma_upload_artifact->get_error_message(), 'figma-empty-transform-error-message-includes-diagnostic' );
 }
+$staged_figma_root = ABSPATH . '.studio-import';
+if ( ! is_dir( $staged_figma_root ) ) {
+	mkdir( $staged_figma_root );
+}
+$staged_figma_path = $staged_figma_root . '/design.fig';
+file_put_contents( $staged_figma_path, 'not-a-zip' );
+$staged_figma_artifact = Static_Site_Importer_Figma_Import::website_artifact_from_input(
+	array(
+		'source' => array(
+			'figma_file' => array(
+				'name'        => 'design.fig',
+				'staged_path' => $staged_figma_path,
+			),
+		),
+	)
+);
+$assert( 'static_site_importer_figma_staged_file_invalid' !== ( is_wp_error( $staged_figma_artifact ) ? $staged_figma_artifact->get_error_code() : '' ), 'figma-staged-file-routes-through-transformer' );
+$outside_staged_figma = Static_Site_Importer_Figma_Import::website_artifact_from_input(
+	array(
+		'source' => array(
+			'figma_file' => array(
+				'name'        => 'design.fig',
+				'staged_path' => __FILE__,
+			),
+		),
+	)
+);
+$assert( 'static_site_importer_figma_staged_file_invalid' === ( is_wp_error( $outside_staged_figma ) ? $outside_staged_figma->get_error_code() : '' ), 'figma-staged-file-rejects-outside-path' );
+unlink( $staged_figma_path );
+rmdir( $staged_figma_root );
 $generic_fig_artifact = static_site_importer_rest_source_artifact(
 	array(
 		'files' => array(


### PR DESCRIPTION
## Summary
- accept staged `.fig` paths only beneath `ABSPATH/.studio-import/`
- reject unresolved, outside-root, symlinked, unreadable, non-file, and non-`.fig` inputs
- reuse the existing path-based Figma transformer while preserving base64 compatibility for existing clients

Closes #696.

## Verification
- `php tests/smoke-importer-block.php` (329 assertions)
- `php -l includes/class-static-site-importer-figma-import.php`

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Use:** Designed and implemented the bounded staged-source contract from the reproduced Studio memory failure. Chris Huber remains responsible for the change.