### PR TITLE
Emit canonical Figma acceptance evidence

### DIFF
--- a/docs/fig-acceptance-provider.md
+++ b/docs/fig-acceptance-provider.md
@@ -1,0 +1,82 @@
+# Figma Acceptance Provider
+
+`tools/fig-acceptance-provider.mjs` adapts a completed Blocks Engine
+`figma-fixture-matrix.php` summary and the SSI fixture-matrix result. It copies
+the Figma-owned stages from `acceptance_readiness.stage_paths`, validates their
+fixture/source identities, and re-homes every reference under the evaluator
+artifact root. It does not consume `acceptance_evidence` or reinterpret metrics.
+
+Run `npm run fig-fixture-e2e -- --blocks-engine /path/to/blocks-engine --fixture /fixtures/a.fig --fixture /fixtures/b.fig --fixture /fixtures/c.fig --run` first. For each completed fixture, compose the provider with the paths emitted by that command:
+
+```sh
+npm run fig-acceptance-provider -- \
+  --fig /fixtures/a.fig --fixture-id a \
+  --fixture-output /artifacts/acceptance/fixtures/a \
+  --transform-summary /artifacts/fig-fixture-e2e/figma-transform/summary.json \
+  --matrix-result /artifacts/fig-fixture-e2e/ssi-matrix/static-site-fixture-matrix-result.json \
+  --matrix-output /artifacts/fig-fixture-e2e/ssi-matrix \
+  --site-plan /artifacts/site-plans/a.json \
+  --provider-identity static-site-importer@COMMIT \
+  --runtime-identity wp-codebox@VERSION \
+  --html-wordpress-mobile-parity html-wordpress-mobile.json \
+  --figma-wordpress-desktop-parity figma-wordpress-desktop.json \
+  --figma-wordpress-mobile-parity figma-wordpress-mobile.json
+```
+
+The adapter owns the `.fig`, transform summary, matrix result, and matrix output
+arguments above; `run-fig-fixture-e2e.mjs` emits all of those locations in its
+summary. The deployable site plan remains an explicit input because the bounded
+matrix result is not the deployable artifact. Provider/runtime identities and
+the three named downstream parity inputs are external because current workflows
+do not emit them.
+
+Each named parity file must use this schema. It identifies the unavailable stage
+rather than disguising it as aggregate acceptance evidence.
+
+```json
+{
+  "schema": "static-site-importer/fig-acceptance-parity-input/v1",
+  "stage": "html_wordpress_mobile_parity",
+  "source_screenshot": "/absolute/source.png",
+  "rendered_screenshot": "/absolute/rendered.png",
+  "diff_report": {
+    "metrics": { "pixel_difference_count": 0, "geometry_difference_count": 0 }
+  }
+}
+```
+
+Blocks Engine supplies both Figma-to-HTML stages and responsive selection
+directly from its versioned acceptance-readiness projection. SSI supplies
+`html_wordpress_desktop_parity` directly from each fixture's
+`visual_parity_artifacts`: `source_screenshot`, `imported_screenshot`,
+`visual_diff`, and `metrics`. Mobile HTML-to-WordPress and both end-to-end stages
+are unavailable from current SSI output, so omission fails with the exact stage.
+
+The emitted stage files use
+`blocks-engine/figma-wordpress-stage-evidence/v1`, with `fixture_id`, `stage`,
+`source_sha256`, `status: "passed"`, and stage-specific metrics/references.
+
+## Direct three-Fig run
+
+Pass `--acceptance-config=/path/to/config.json` to `fig-fixture-e2e` to compose
+all fixture fragments and run Blocks Engine's production evaluator without
+`--no-run-providers`. The config shape is:
+
+```json
+{
+  "provider_identity": "static-site-importer@COMMIT",
+  "runtime_identity": "wp-codebox@VERSION",
+  "fixtures": {
+    "fisiostetic": {
+      "site_plan": "/absolute/fisiostetic-site-plan.json",
+      "html_wordpress_mobile_parity": "/absolute/html-wordpress-mobile.json",
+      "figma_wordpress_desktop_parity": "/absolute/figma-wordpress-desktop.json",
+      "figma_wordpress_mobile_parity": "/absolute/figma-wordpress-mobile.json"
+    }
+  }
+}
+```
+
+Provide one entry for each selected fixture. Outputs are written under
+`<output-directory>/production-acceptance`, including `manifest.json`, each
+fixture's 13 stage files, copied evidence artifacts, and evaluator `summary.json`.

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -104,6 +104,46 @@ metrics are under `import_matrix` and `metrics.import_matrix_*`. Use these field
 for performance and quality regression gates instead of treating `.fig -> blocks`
 as one opaque operation.
 
+### Blocks Engine Acceptance Provider
+
+SSI owns the adapter from concrete three-Fig E2E artifacts to Blocks Engine's
+`blocks-engine/figma-wordpress-stage-evidence/v1` contract. It does not treat an
+aggregate matrix status as evidence. It validates and copies Blocks Engine's Figma-owned
+acceptance stage files, then combines them with SSI import/editor/fallback facts,
+a deployable `wordpress-site-plan/v2`, isolated WordPress identities, and the
+remaining downstream parity artifacts.
+
+Run the provider after a real E2E run, choosing the evaluator output directory
+up front so every reference is evaluator-relative:
+
+```bash
+node tools/fig-acceptance-provider.mjs \
+  --fig /path/to/Fisiostetic.fig \
+  --fixture-id fisiostetic \
+  --fixture-output /tmp/figma-wordpress-acceptance/fixtures/fisiostetic \
+  --transform-summary /path/to/artifacts/fig-fixture-e2e/figma-transform/summary.json \
+  --matrix-result /path/to/artifacts/fig-fixture-e2e/ssi-matrix/static-site-fixture-matrix-result.json \
+  --matrix-output /path/to/artifacts/fig-fixture-e2e/ssi-matrix \
+  --site-plan /path/to/fisiostetic-site-plan.json
+```
+
+For the canonical run, supply the full provider config documented in
+[`fig-acceptance-provider.md`](fig-acceptance-provider.md). The E2E command then
+writes the combined manifest and invokes the evaluator directly:
+
+```bash
+node tools/run-fig-fixture-e2e.mjs \
+  --blocks-engine /path/to/blocks-engine \
+  --fixture /path/to/a.fig --fixture /path/to/b.fig --fixture /path/to/c.fig \
+  --acceptance-config /path/to/acceptance-config.json \
+  --run
+```
+
+Reviewer-facing artifacts are under
+`/tmp/figma-wordpress-acceptance/fixtures/<fixture-id>/ssi-acceptance-provider/`:
+`stages/*.json` are the 13 contract records, `artifacts/` contains copied
+resolvable evidence, and `manifest-fragment.json` is the exact provider output.
+
 To compare a candidate run to a saved baseline summary, pass the previous
 `summary.json` and an allowed regression ratio:
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "fig-intent-parity": "node tools/fig-intent-parity-report.mjs",
     "fig-fixture-e2e": "node tools/run-fig-fixture-e2e.mjs",
+    "fig-acceptance-provider": "node tools/fig-acceptance-provider.mjs",
     "test": "npm run test:site-plan-materializer && npm run test:fixture-matrix && npm run test:solved-site-promotion && npm run test:fig-fixture-e2e && npm run test:promote-solved-fixture && npm run test:php-wasm-zstd",
     "test:site-plan-materializer": "php tests/smoke-wordpress-site-plan-materializer.php",
     "test:fig-fixture-e2e": "node --test tools/run-fig-fixture-e2e.test.mjs",

--- a/tools/fig-acceptance-provider.mjs
+++ b/tools/fig-acceptance-provider.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+/**
+ * Adapt versioned Blocks Engine transform and SSI matrix records to Blocks
+ * Engine's acceptance provider contract.  It never treats aggregate status as
+ * evidence: every stage is backed by an artifact or a named provider input.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const STAGES = ['decode', 'normalize', 'emit', 'figma_html_desktop_parity', 'figma_html_mobile_parity', 'import', 'editor_validity', 'fallback', 'html_wordpress_desktop_parity', 'html_wordpress_mobile_parity', 'figma_wordpress_desktop_parity', 'figma_wordpress_mobile_parity', 'responsive_selection'];
+const PARITY = { figma_html_desktop_parity: 'figma_html', figma_html_mobile_parity: 'figma_html', html_wordpress_desktop_parity: 'html_wordpress', html_wordpress_mobile_parity: 'html_wordpress', figma_wordpress_desktop_parity: 'figma_wordpress', figma_wordpress_mobile_parity: 'figma_wordpress' };
+const FIGMA_STAGES = new Set(['decode', 'normalize', 'emit', 'figma_html_desktop_parity', 'figma_html_mobile_parity', 'responsive_selection']);
+const EXTERNAL_PARITY = new Set(['html_wordpress_mobile_parity', 'figma_wordpress_desktop_parity', 'figma_wordpress_mobile_parity']);
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try { process.stdout.write(`${JSON.stringify(buildFigAcceptanceProvider(parseArgs(process.argv.slice(2))), null, 2)}\n`); } catch (error) { process.stderr.write(`${error.message}\n`); process.exitCode = 1; }
+}
+
+export function buildFigAcceptanceProvider(input = {}) {
+  const fig = requiredFile(input.fig, '--fig');
+  const fixtureId = requiredSlug(input.fixtureId || input.fixture_id, '--fixture-id');
+  const fixtureOutput = path.resolve(requiredString(input.fixtureOutput || input.fixture_output, '--fixture-output'));
+  const matrixOutput = requiredDirectory(input.matrixOutput || input.matrix_output, '--matrix-output');
+  const transformSummary = readJson(requiredFile(input.transformSummary || input.transform_summary, '--transform-summary'));
+  const transform = fixtureRecord(transformSummary, fixtureId, 'transform');
+  const matrix = fixtureRecord(readJson(requiredFile(input.matrixResult || input.matrix_result, '--matrix-result')), fixtureId, 'matrix');
+  if (transform.status !== 'completed') fail('transform fixture is not completed');
+  if (matrix.status !== 'passed') fail('matrix fixture is not passed');
+  const root = acceptanceRoot(fixtureOutput);
+  const directory = path.join(fixtureOutput, 'ssi-acceptance-provider');
+  const transformRoot = requiredDirectory(transformSummary.output_dir, 'transform output_dir');
+  requiredFile(transform.result_path, 'transform result_path');
+  requiredDirectory(transform.artifact_dir, 'transform artifact_dir');
+  const sourceHash = sha256(fig);
+  const source = copyEvidence(fig, directory, root, 'source-artifact.fig');
+  const emitted = copyEvidence(transform.result_path, directory, root, 'transform-result.json');
+  const sitePlanValue = readJson(requiredFile(input.sitePlan || input.site_plan, '--site-plan'));
+  validateSitePlan(sitePlanValue);
+  const sitePlan = writeArtifact(sitePlanValue, directory, root, 'site-plan.json');
+  const importReport = writeArtifact(matrix, directory, root, 'matrix-fixture-result.json');
+  const editorReport = writeArtifact(requiredObject(matrix.editor_validation, 'matrix editor_validation'), directory, root, 'editor-report.json');
+  const figmaRecords = figmaStageRecords(transform, transformRoot, directory, root, fixtureId, sourceHash);
+  const composition = requiredObject(matrix.block_composition, 'matrix block_composition');
+  const editor = requiredObject(matrix.editor_validation, 'matrix editor_validation');
+  const imported = { imported_route_count: positiveInteger(matrix.matrix_evidence?.materialization_receipt?.page_count, 'imported route count') };
+  const editorMetrics = { parsed_block_count: positiveInteger(editor.total_blocks, 'editor total_blocks'), native_editable_block_count: positiveInteger(composition.native_block_count, 'native block count'), invalid_block_count: integer(editor.invalid_blocks, 'editor invalid_blocks') };
+  zeroMetrics(editorMetrics, ['invalid_block_count'], 'editor validity');
+  const fallbackCount = fallbackCountFrom(matrix); if (fallbackCount !== 0) fail('fallback count must be zero');
+  const providerIdentity = requiredString(input.providerIdentity || input.provider_identity, '--provider-identity');
+  const runtimeIdentity = requiredString(input.runtimeIdentity || input.runtime_identity, '--runtime-identity');
+  const records = {
+    import: { metrics: imported, references: [importReport, sitePlan], isolated_fresh_wordpress_import: true, provider_identity: providerIdentity, runtime_identity: runtimeIdentity },
+    editor_validity: { metrics: editorMetrics, references: [editorReport] }, fallback: { fallback_count: fallbackCount, references: [importReport] },
+  };
+  for (const stage of Object.keys(PARITY)) if (!FIGMA_STAGES.has(stage)) records[stage] = parityRecord(stage, matrix, input, directory, root, matrixOutput);
+  const stages = {};
+  for (const stage of STAGES) {
+    const file = path.join(directory, 'stages', `${stage}.json`);
+    writeJson(file, figmaRecords[stage] || { schema: 'blocks-engine/figma-wordpress-stage-evidence/v1', fixture_id: fixtureId, stage, source_sha256: sourceHash, status: 'passed', ...records[stage] });
+    stages[stage] = file;
+  }
+  const manifest = { id: fixtureId, fig, evidence: stages, site_plan: path.join(root, sitePlan), provider_artifacts: { source, emitted, importReport, editorReport, sitePlan } };
+  writeJson(path.join(directory, 'manifest-fragment.json'), manifest);
+  return manifest;
+}
+
+function figmaStageRecords(transform, transformRoot, directory, root, fixtureId, sourceHash) {
+  const readiness = requiredObject(transform.acceptance_readiness, 'transform acceptance_readiness');
+  if (readiness.schema !== 'blocks-engine/figma-transformer/acceptance-readiness/v1') fail('transform acceptance_readiness has an invalid schema');
+  const paths = requiredObject(readiness.stage_paths, 'transform acceptance_readiness stage_paths');
+  const records = {};
+  for (const stage of FIGMA_STAGES) {
+    const evidencePath = resolveArtifact(paths[stage], transformRoot, `transform ${stage} stage path`);
+    const evidence = readJson(evidencePath);
+    if (evidence.schema !== 'blocks-engine/figma-wordpress-stage-evidence/v1' || evidence.fixture_id !== fixtureId || evidence.stage !== stage) fail(`transform ${stage} evidence identity is invalid`);
+    if (evidence.source_sha256 !== sourceHash) fail(`transform ${stage} evidence does not match --fig`);
+    if (evidence.status !== 'passed') fail(`transform ${stage} evidence is not passed`);
+    const references = Array.isArray(evidence.references) ? evidence.references : fail(`transform ${stage} evidence references are required`);
+    const rewritten = new Map();
+    for (const [index, reference] of references.entries()) {
+      const sourceFile = resolveArtifact(reference, transformRoot, `transform ${stage} reference`);
+      rewritten.set(reference, copyEvidence(sourceFile, directory, root, path.join('figma', stage, `${index}-${path.basename(sourceFile)}`)));
+    }
+    records[stage] = { ...evidence, references: references.map((reference) => rewritten.get(reference)) };
+    for (const key of ['source_screenshot', 'rendered_screenshot', 'diff_report']) if (typeof evidence[key] === 'string') records[stage][key] = rewritten.get(evidence[key]) || fail(`transform ${stage} ${key} is not a declared reference`);
+  }
+  return records;
+}
+
+function parityRecord(stage, matrix, input, directory, root, matrixOutput) {
+  const supplied = input[camel(stage)] || input[stage];
+  const item = EXTERNAL_PARITY.has(stage) ? readExternalParity(supplied, stage) : htmlWordpressParity(matrix, matrixOutput);
+  const source = copyEvidence(item.source_screenshot, directory, root, `${stage}-source.png`);
+  const rendered = copyEvidence(item.rendered_screenshot, directory, root, `${stage}-rendered.png`);
+  const report = writeArtifact(item.diff_report, directory, root, `${stage}-diff.json`);
+  const checked = requiredMetrics(item.diff_report.metrics || item.diff_report, ['pixel_difference_count', 'geometry_difference_count'], stage);
+  zeroMetrics(checked, ['pixel_difference_count', 'geometry_difference_count'], stage);
+  return { comparison: PARITY[stage], metrics: checked, source_screenshot: source, rendered_screenshot: rendered, diff_report: report, references: [source, rendered, report] };
+}
+function htmlWordpressParity(matrix, root) {
+  const visual = requiredObject(matrix.visual_parity_artifacts, 'matrix visual_parity_artifacts');
+  const slots = requiredObject(visual.artifacts, 'matrix visual parity artifacts');
+  const source = artifactPath(slots.source_screenshot, root, 'html_wordpress_desktop_parity source screenshot');
+  const rendered = artifactPath(slots.imported_screenshot, root, 'html_wordpress_desktop_parity rendered screenshot');
+  artifactPath(slots.visual_diff, root, 'html_wordpress_desktop_parity diff report');
+  const metrics = requiredObject(visual.metrics, 'matrix visual parity metrics');
+  return { source_screenshot: source, rendered_screenshot: rendered, diff_report: { metrics: { pixel_difference_count: integer(metrics.mismatch_pixels, 'html_wordpress_desktop_parity mismatch_pixels'), geometry_difference_count: metrics.dimension_mismatch ? 1 : 0 } } };
+}
+function readExternalParity(value, stage) {
+  if (!value) fail(`${stage} is unavailable from current workflows; supply --${stage.replaceAll('_', '-')}`);
+  const item = readJson(requiredFile(value, `${stage} provider input`));
+  if (item.schema !== 'static-site-importer/fig-acceptance-parity-input/v1' || item.stage !== stage) fail(`${stage} provider input has an invalid schema or stage`);
+  requiredFile(item.source_screenshot, `${stage} source screenshot`); requiredFile(item.rendered_screenshot, `${stage} rendered screenshot`);
+  return { source_screenshot: item.source_screenshot, rendered_screenshot: item.rendered_screenshot, diff_report: requiredObject(item.diff_report, `${stage} diff_report`) };
+}
+function validateSitePlan(plan) { if (plan.schema !== 'blocks-engine/wordpress-site-plan/v2' || !Array.isArray(plan.pages) || !plan.pages.some((page) => page && typeof page === 'object') || !Array.isArray(plan.routes) || !plan.routes.some((route) => route && typeof route === 'object')) fail('site plan is not a structurally valid non-empty blocks-engine/wordpress-site-plan/v2 artifact'); }
+function fallbackCountFrom(matrix) { const quality = requiredObject(matrix.quality_metrics, 'matrix quality_metrics'); const count = integer(quality.fallback_count, 'matrix fallback_count'); if (integer(matrix.block_composition?.core_html_block_count || 0, 'core html block count') !== 0) fail('core/html fallback count must be zero'); return count; }
+function fixtureRecord(document, id, label) { const record = (Array.isArray(document.fixtures) ? document.fixtures : []).find((item) => item?.id === id || item?.fixture_id === id); if (!record) fail(`${label} evidence has no fixture ${id}`); return record; }
+function artifactPath(slot, root, label) { const value = slot?.ref?.path || slot?.path; const file = path.resolve(root, requiredString(value, label)); return requiredFile(file, label); }
+function resolveArtifact(value, root, label) { const reference = requiredString(value, label); const file = path.isAbsolute(reference) ? reference : path.join(root, reference); return requiredFile(file, label); }
+function copyEvidence(value, directory, root, name) { const target = path.join(directory, 'artifacts', name); fs.mkdirSync(path.dirname(target), { recursive: true }); fs.copyFileSync(requiredFile(value, 'evidence file'), target); return relativeReference(root, target); }
+function writeArtifact(value, directory, root, name) { const target = path.join(directory, 'artifacts', name); writeJson(target, value); return relativeReference(root, target); }
+function requiredMetrics(value, keys, label) { const metrics = requiredObject(value, `${label} metrics`); for (const key of keys) integer(metrics[key], `${label} ${key}`); return Object.fromEntries(keys.map((key) => [key, metrics[key]])); }
+function zeroMetrics(metrics, keys, label) { for (const key of keys) if (integer(metrics[key], `${label} ${key}`) !== 0) fail(`${label} ${key} must be zero`); }
+function acceptanceRoot(output) { const root = path.dirname(path.dirname(output)); if (path.basename(path.dirname(output)) !== 'fixtures') fail('fixture output must be under an acceptance fixtures/<id> directory'); return root; }
+function relativeReference(root, file) { const ref = path.relative(root, file); if (!ref || ref.startsWith('..') || path.isAbsolute(ref)) fail('evidence cannot be resolved relative to the acceptance output'); return ref.split(path.sep).join('/'); }
+function requiredFile(value, label) { const file = path.resolve(requiredString(value, label)); if (!fs.existsSync(file) || !fs.statSync(file).isFile()) fail(`${label} is missing or unreadable: ${file}`); return file; }
+function requiredDirectory(value, label) { const directory = path.resolve(requiredString(value, label)); if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) fail(`${label} is missing or unreadable: ${directory}`); return directory; }
+function readJson(file) { try { const value = JSON.parse(fs.readFileSync(file, 'utf8')); return requiredObject(value, 'JSON evidence'); } catch { fail(`invalid JSON evidence: ${file}`); } }
+function writeJson(file, value) { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`); }
+function requiredObject(value, label) { if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} is required`); return value; }
+function integer(value, label) { if (!Number.isInteger(value)) fail(`${label} must be an integer`); return value; }
+function positiveInteger(value, label) { const number = integer(value, label); if (number <= 0) fail(`${label} must be positive`); return number; }
+function requiredString(value, label) { if (typeof value !== 'string' || value.trim() === '') fail(`${label} is required`); return value; }
+function requiredSlug(value, label) { const id = requiredString(value, label); if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) fail(`${label} must be a lowercase slug`); return id; }
+function sha256(file) { return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex'); }
+function camel(value) { return value.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase()); }
+function fail(message) { throw new Error(`SSI acceptance provider: ${message}`); }
+function parseArgs(args) { const options = {}; for (let i = 0; i < args.length; i += 1) { const [key, inline] = args[i].replace(/^--/, '').split(/=(.*)/s, 2); if (!key || args[i][0] !== '-') fail(`unknown argument: ${args[i]}`); const value = inline === undefined ? args[++i] : inline; if (value === undefined) fail(`missing value for --${key}`); options[key.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())] = value; } return options; }

--- a/tools/run-fig-fixture-e2e.mjs
+++ b/tools/run-fig-fixture-e2e.mjs
@@ -12,6 +12,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { buildFigAcceptanceProvider } from './fig-acceptance-provider.mjs';
+
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const DEFAULT_EXPECTED_FIXTURE_COUNT = 3;
 const SUMMARY_SCHEMA = 'static-site-importer/fig-fixture-e2e-summary/v1';
@@ -57,6 +59,25 @@ export function runFigFixtureE2E(input = {}) {
   const transformStatus = runCommand(plan.steps.transform);
   const matrixStatus = transformStatus.status === 0 ? runCommand(plan.steps.import_matrix) : null;
   const summary = summarizeRun({ plan, transformStatus, matrixStatus });
+  if (summary.status === 'passed' && plan.acceptance.enabled) {
+    try {
+      const manifest = writeFigAcceptanceManifest(plan);
+      const acceptanceStatus = runCommand(plan.steps.acceptance_matrix);
+      summary.acceptance = {
+        enabled: true,
+        manifest_path: manifest.path,
+        summary_path: path.join(plan.acceptance.output_directory, 'summary.json'),
+        exit_code: acceptanceStatus.status,
+      };
+      if (acceptanceStatus.status !== 0) {
+        summary.status = 'failed';
+        summary.failures.push(`production acceptance matrix exited ${acceptanceStatus.status}`);
+      }
+    } catch (error) {
+      summary.status = 'failed';
+      summary.failures.push(`acceptance provider failed: ${error.message}`);
+    }
+  }
   writeJson(plan.artifacts.summary, summary);
   return { plan, summary };
 }
@@ -68,7 +89,10 @@ export function buildFigFixtureE2EPlan(input = {}) {
   const matrixSummary = path.join(matrixOutputDirectory, 'summary.json');
   const matrixResult = path.join(matrixOutputDirectory, 'static-site-fixture-matrix-result.json');
   const summaryPath = path.join(options.outputDirectory, 'summary.json');
+  const acceptanceOutput = path.join(options.outputDirectory, 'production-acceptance');
+  const acceptanceManifest = path.join(acceptanceOutput, 'manifest.json');
   const transformScript = path.join(options.blocksEngine, 'figma-transformer', 'scripts', 'figma-fixture-matrix.php');
+  const acceptanceScript = path.join(options.blocksEngine, 'scripts', 'production-acceptance-matrix.php');
   const benchScript = path.join(options.staticSiteImporter, 'bench', 'static-site-fixture-matrix.bench.mjs');
 
   const transformArgv = [
@@ -117,6 +141,12 @@ export function buildFigFixtureE2EPlan(input = {}) {
       matrix_result: matrixResult,
       matrix_output_directory: matrixOutputDirectory,
     },
+    acceptance: {
+      enabled: Boolean(options.acceptanceConfig),
+      config_path: options.acceptanceConfig || null,
+      output_directory: acceptanceOutput,
+      manifest_path: acceptanceManifest,
+    },
     thresholds: {
       max_transform_failures: 0,
       max_import_failures: 0,
@@ -129,9 +159,42 @@ export function buildFigFixtureE2EPlan(input = {}) {
     steps: {
       transform: commandStep('figma-transform', transformArgv, { cwd: path.join(options.blocksEngine, 'figma-transformer') }),
       import_matrix: commandStep('ssi-import-matrix', matrixArgv, { cwd: options.staticSiteImporter }),
+      ...(options.acceptanceConfig ? {
+        acceptance_matrix: commandStep('production-acceptance-matrix', [options.phpBin, acceptanceScript, `--profile=${options.expectedFixtureCount === 3 ? 'production' : 'manifest'}`, `--manifest=${acceptanceManifest}`, `--output=${acceptanceOutput}`], { cwd: options.blocksEngine }),
+      } : {}),
     },
-    warnings: buildPlanWarnings(options, transformScript, benchScript),
+    warnings: buildPlanWarnings(options, transformScript, benchScript, acceptanceScript),
   };
+}
+
+export function writeFigAcceptanceManifest(plan) {
+  const config = readJsonIfExists(plan.acceptance.config_path);
+  if (!config) throw new Error(`acceptance config is missing or invalid: ${plan.acceptance.config_path}`);
+  const transformSummary = readJsonIfExists(plan.artifacts.transform_summary);
+  const fixtures = Array.isArray(transformSummary?.fixtures) ? transformSummary.fixtures : [];
+  const configuredFixtures = config.fixtures && typeof config.fixtures === 'object' && !Array.isArray(config.fixtures) ? config.fixtures : {};
+  const fragments = fixtures.map((fixture) => {
+    const id = requiredString(fixture?.id, 'transform fixture id');
+    const configured = configuredFixtures[id];
+    if (!configured || typeof configured !== 'object' || Array.isArray(configured)) throw new Error(`acceptance config has no fixture ${id}`);
+    return buildFigAcceptanceProvider({
+      fig: fixture.path,
+      fixtureId: id,
+      fixtureOutput: path.join(plan.acceptance.output_directory, 'fixtures', id),
+      transformSummary: plan.artifacts.transform_summary,
+      matrixResult: plan.artifacts.matrix_result,
+      matrixOutput: plan.artifacts.matrix_output_directory,
+      providerIdentity: config.provider_identity,
+      runtimeIdentity: config.runtime_identity,
+      sitePlan: configured.site_plan,
+      htmlWordpressMobileParity: configured.html_wordpress_mobile_parity,
+      figmaWordpressDesktopParity: configured.figma_wordpress_desktop_parity,
+      figmaWordpressMobileParity: configured.figma_wordpress_mobile_parity,
+    });
+  });
+  if (fragments.length !== plan.expected_fixture_count) throw new Error(`acceptance provider completed ${fragments.length}/${plan.expected_fixture_count} fixtures`);
+  writeJson(plan.acceptance.manifest_path, { fixtures: fragments });
+  return { path: plan.acceptance.manifest_path, fixtures: fragments };
 }
 
 export function summarizeRun({ plan, transformStatus, matrixStatus }) {
@@ -246,6 +309,7 @@ function normalizeOptions(input) {
     blocksEnginePhpTransformerPath: path.resolve(input.blocksEnginePhpTransformerPath || input.blocks_engine_php_transformer_path || process.env.SSI_FIG_E2E_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH || blocksEngine),
     fixtures,
     outputDirectory,
+    acceptanceConfig: input.acceptanceConfig || input.acceptance_config || process.env.SSI_FIG_E2E_ACCEPTANCE_CONFIG || '',
     baselineSummary: input.baselineSummary || input.baseline_summary || process.env.SSI_FIG_E2E_BASELINE_SUMMARY || '',
     expectedFixtureCount: positiveInteger(input.expectedFixtureCount || input.expected_fixture_count || process.env.SSI_FIG_E2E_EXPECTED_FIXTURE_COUNT, DEFAULT_EXPECTED_FIXTURE_COUNT),
     maxPages: positiveInteger(input.maxPages || input.max_pages || process.env.SSI_FIG_E2E_MAX_PAGES, 3),
@@ -318,7 +382,7 @@ function parseArgs(args, env = process.env) {
   return options;
 }
 
-function buildPlanWarnings(options, transformScript, benchScript) {
+function buildPlanWarnings(options, transformScript, benchScript, acceptanceScript) {
   const warnings = [];
   if (options.fixtures.length !== options.expectedFixtureCount) {
     warnings.push(`Expected ${options.expectedFixtureCount} fixture paths; received ${options.fixtures.length}.`);
@@ -333,6 +397,12 @@ function buildPlanWarnings(options, transformScript, benchScript) {
   }
   if (!fs.existsSync(benchScript)) {
     warnings.push(`SSI fixture matrix bench script not found: ${benchScript}`);
+  }
+  if (options.acceptanceConfig && !fs.existsSync(options.acceptanceConfig)) {
+    warnings.push(`Acceptance config does not exist: ${options.acceptanceConfig}`);
+  }
+  if (options.acceptanceConfig && !fs.existsSync(acceptanceScript)) {
+    warnings.push(`Blocks Engine production acceptance script not found: ${acceptanceScript}`);
   }
   if (!options.run) {
     warnings.push('Import/parity matrix is planned only; pass --run or SSI_FIG_E2E_RUN=1 to launch WP Codebox.');
@@ -559,5 +629,6 @@ function shellQuote(value) {
 }
 
 function printHelp() {
+  process.stdout.write('Acceptance mode: --acceptance-config <path> supplies provider identities, site plans, and downstream parity inputs, then runs the production evaluator.\n\n');
   process.stdout.write(`Usage: node tools/run-fig-fixture-e2e.mjs --blocks-engine <path> --fixture <file.fig> --fixture <file.fig> --fixture <file.fig> [options]\n\nRuns Blocks Engine Figma transforms and feeds the generated artifacts into the SSI WP Codebox fixture matrix.\n\nOptions:\n  --fixture <path>                         .fig fixture path. Repeat exactly three times for the release gate.\n  --blocks-engine <path>                   Blocks Engine checkout containing figma-transformer/. Required.\n  --static-site-importer <path>            SSI checkout. Defaults to this repo.\n  --blocks-engine-php-transformer-path <path>\n                                           Composer path override for SSI import. Defaults to --blocks-engine.\n  --output-directory <path>                Artifact root. Defaults to ./artifacts/fig-fixture-e2e.\n  --baseline-summary <path>                Previous summary.json to compare staged metrics against.\n  --max-baseline-regression-ratio <n>      Fail if compared numeric metrics regress by more than this ratio.\n  --run                                    Launch SSI import/parity through WP Codebox. Without this, writes transform artifacts and a replayable matrix recipe only.\n  --dry-run                                Write plan/summary without running transform or import.\n  --expected-fixture-count <n>             Defaults to 3.\n  --min-native-rate <n>                    Defaults to 1.\n  --max-transform-vector-placeholders <n>  Defaults to 0.\n  --max-transform-missing-assets <n>       Defaults to 0.\n  --max-import-findings <n>                Optional SSI finding count budget.\n  --batch-size <n>                         Defaults to 3.\n  --concurrency <n>                        Defaults to 1.\n  --wp-codebox-bin <path>                  WP Codebox binary override for the SSI matrix.\n  --no-editor-validation                   Skip editor block validation.\n  --no-visual-parity                       Skip visual compare.\n  --live-wp-parity                         Enable live WP HTML parity capture.\n\nEnvironment equivalents:\n  SSI_FIG_E2E_BLOCKS_ENGINE=/path/to/blocks-engine\n  SSI_FIG_E2E_FIXTURES=/path/Fisiostetic.fig:${path.join('<path>', 'FSE Pilot Build Theme.fig')}:/path/Twenty Twenty-Five.fig\n  SSI_FIG_E2E_RUN=1\n`);
 }

--- a/tools/run-fig-fixture-e2e.test.mjs
+++ b/tools/run-fig-fixture-e2e.test.mjs
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -10,21 +11,26 @@ import test from 'node:test';
 /**
  * Internal dependencies
  */
-import { buildFigFixtureE2EPlan, summarizeRun } from './run-fig-fixture-e2e.mjs';
+import { buildFigFixtureE2EPlan, summarizeRun, writeFigAcceptanceManifest } from './run-fig-fixture-e2e.mjs';
+import { buildFigAcceptanceProvider, STAGES } from './fig-acceptance-provider.mjs';
 
 test('builds deterministic fig transform and SSI import matrix commands for three fixtures', () => {
   const root = fs.mkdtempSync(path.join(tmpdir(), 'ssi-fig-e2e-plan-'));
   const blocksEngine = path.join(root, 'blocks-engine');
   const staticSiteImporter = path.join(root, 'static-site-importer');
   fs.mkdirSync(path.join(blocksEngine, 'figma-transformer', 'scripts'), { recursive: true });
+  fs.mkdirSync(path.join(blocksEngine, 'scripts'), { recursive: true });
   fs.mkdirSync(path.join(staticSiteImporter, 'bench'), { recursive: true });
   fs.writeFileSync(path.join(blocksEngine, 'figma-transformer', 'scripts', 'figma-fixture-matrix.php'), '<?php');
+  fs.writeFileSync(path.join(blocksEngine, 'scripts', 'production-acceptance-matrix.php'), '<?php');
   fs.writeFileSync(path.join(staticSiteImporter, 'bench', 'static-site-fixture-matrix.bench.mjs'), '');
 
   const fixtures = ['Fisiostetic.fig', 'FSE Pilot Build Theme.fig', 'Twenty Twenty-Five.fig'].map((name) => path.join(root, name));
   for (const fixture of fixtures) {
     fs.writeFileSync(fixture, 'fig');
   }
+  const acceptanceConfig = path.join(root, 'acceptance-config.json');
+  fs.writeFileSync(acceptanceConfig, '{}');
 
   const plan = buildFigFixtureE2EPlan({
     blocksEngine,
@@ -35,6 +41,7 @@ test('builds deterministic fig transform and SSI import matrix commands for thre
     wpCodeboxBin: '/usr/local/bin/wp-codebox',
     maxTransformVectorPlaceholders: 2,
     maxImportFindings: 5,
+    acceptanceConfig,
   });
 
   assert.equal(plan.fixture_count, 3);
@@ -45,6 +52,8 @@ test('builds deterministic fig transform and SSI import matrix commands for thre
   assert.ok(plan.steps.import_matrix.argv.includes('--run'));
   assert.ok(plan.steps.import_matrix.argv.includes('--wp-codebox-bin'));
   assert.ok(plan.steps.import_matrix.command.includes('static-site-fixture-matrix.bench.mjs'));
+  assert.ok(plan.steps.acceptance_matrix.command.includes('production-acceptance-matrix.php'));
+  assert.equal(plan.steps.acceptance_matrix.argv.includes('--no-run-providers'), false);
   assert.equal(plan.thresholds.max_transform_vector_placeholders, 2);
   assert.equal(plan.thresholds.max_import_findings, 5);
 });
@@ -199,6 +208,139 @@ test('summary fails closed when fixture accounting is absent or incomplete', () 
   assert.equal(summary.status, 'failed');
   assert.ok(summary.failures.includes('SSI matrix summary is missing fixture result accounting'));
 });
+
+test('adapts a complete concrete three-Fig fixture bundle to all Blocks Engine acceptance stages', () => {
+  const bundle = acceptanceBundle();
+  const manifest = buildFigAcceptanceProvider(bundle.input);
+
+  assert.equal(manifest.id, 'fisiostetic');
+  assert.equal(Object.keys(manifest.evidence).length, 13);
+  assert.deepEqual(Object.keys(manifest.evidence), STAGES);
+  for (const stage of STAGES) {
+    const evidence = JSON.parse(fs.readFileSync(manifest.evidence[stage], 'utf8'));
+    assert.equal(evidence.schema, 'blocks-engine/figma-wordpress-stage-evidence/v1');
+    assert.equal(evidence.fixture_id, 'fisiostetic');
+    assert.equal(evidence.stage, stage);
+    assert.equal(evidence.status, 'passed');
+    assert.ok(evidence.references.every((ref) => !path.isAbsolute(ref) && fs.existsSync(path.join(bundle.acceptanceRoot, ref))));
+  }
+  assert.equal(JSON.parse(fs.readFileSync(manifest.evidence.fallback, 'utf8')).fallback_count, 0);
+  assert.equal(JSON.parse(fs.readFileSync(manifest.evidence.figma_html_desktop_parity, 'utf8')).comparison, 'figma_html');
+  assert.equal(JSON.parse(fs.readFileSync(manifest.evidence.html_wordpress_desktop_parity, 'utf8')).comparison, 'html_wordpress');
+  assert.equal(JSON.parse(fs.readFileSync(manifest.evidence.figma_wordpress_desktop_parity, 'utf8')).comparison, 'figma_wordpress');
+});
+
+test('acceptance provider fails closed for missing parity proof and mismatched fixture evidence', () => {
+  const missing = acceptanceBundle();
+  fs.rmSync(missing.paths.parity.htmlWordpressMobileParity);
+  assert.throws(() => buildFigAcceptanceProvider(missing.input), /provider input is missing or unreadable/);
+
+  const mismatch = acceptanceBundle();
+  const matrix = JSON.parse(fs.readFileSync(mismatch.input.matrixResult, 'utf8'));
+  matrix.fixtures[0].fixture_id = 'another-fixture';
+  fs.writeFileSync(mismatch.input.matrixResult, JSON.stringify(matrix));
+  assert.throws(() => buildFigAcceptanceProvider(mismatch.input), /matrix evidence has no fixture fisiostetic/);
+});
+
+test('acceptance provider rejects the invented acceptance_evidence-only shape', () => {
+  const bundle = acceptanceBundle();
+  fs.writeFileSync(bundle.input.transformSummary, JSON.stringify({ fixtures: [{ id: 'fisiostetic', status: 'completed', acceptance_evidence: {} }] }));
+  assert.throws(() => buildFigAcceptanceProvider(bundle.input), /transform output_dir is required/);
+});
+
+test('acceptance provider rejects Figma stage evidence for another source file', () => {
+  const bundle = acceptanceBundle();
+  const summary = JSON.parse(fs.readFileSync(bundle.input.transformSummary, 'utf8'));
+  const decodePath = summary.fixtures[0].acceptance_readiness.stage_paths.decode;
+  const decode = JSON.parse(fs.readFileSync(decodePath, 'utf8'));
+  decode.source_sha256 = '0'.repeat(64);
+  fs.writeFileSync(decodePath, JSON.stringify(decode));
+  assert.throws(() => buildFigAcceptanceProvider(bundle.input), /decode evidence does not match --fig/);
+});
+
+test('provider bundle conforms to the documented Blocks Engine stage schema', () => {
+  const bundle = acceptanceBundle();
+  const manifest = buildFigAcceptanceProvider(bundle.input);
+  for (const stage of STAGES) {
+    const evidence = JSON.parse(fs.readFileSync(manifest.evidence[stage], 'utf8'));
+    assert.ok(['schema', 'fixture_id', 'stage', 'source_sha256', 'status', 'references'].every((key) => Object.hasOwn(evidence, key)));
+    assert.equal(Object.hasOwn(evidence, 'acceptance_evidence'), false);
+    assert.equal(evidence.schema, 'blocks-engine/figma-wordpress-stage-evidence/v1');
+    assert.equal(evidence.status, 'passed');
+  }
+});
+
+test('three-Fig workflow writes a combined evaluator manifest from provider config', () => {
+  const bundle = acceptanceBundle();
+  const config = {
+    provider_identity: bundle.input.providerIdentity,
+    runtime_identity: bundle.input.runtimeIdentity,
+    fixtures: {
+      fisiostetic: {
+        site_plan: bundle.input.sitePlan,
+        html_wordpress_mobile_parity: bundle.input.htmlWordpressMobileParity,
+        figma_wordpress_desktop_parity: bundle.input.figmaWordpressDesktopParity,
+        figma_wordpress_mobile_parity: bundle.input.figmaWordpressMobileParity,
+      },
+    },
+  };
+  const configPath = path.join(bundle.acceptanceRoot, 'config.json');
+  fs.mkdirSync(bundle.acceptanceRoot, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(config));
+  const manifestPath = path.join(bundle.acceptanceRoot, 'manifest.json');
+  const manifest = writeFigAcceptanceManifest({
+    expected_fixture_count: 1,
+    artifacts: { transform_summary: bundle.input.transformSummary, matrix_result: bundle.input.matrixResult, matrix_output_directory: bundle.input.matrixOutput },
+    acceptance: { config_path: configPath, output_directory: bundle.acceptanceRoot, manifest_path: manifestPath },
+  });
+  assert.equal(manifest.fixtures.length, 1);
+  assert.equal(Object.keys(manifest.fixtures[0].evidence).length, 13);
+  assert.deepEqual(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).fixtures.map((fixture) => fixture.id), ['fisiostetic']);
+});
+
+function acceptanceBundle() {
+  const root = fs.mkdtempSync(path.join(tmpdir(), 'ssi-acceptance-provider-'));
+  const inputRoot = path.join(root, 'input');
+  const acceptanceRoot = path.join(root, 'acceptance');
+  const fixtureOutput = path.join(acceptanceRoot, 'fixtures', 'fisiostetic');
+  fs.mkdirSync(inputRoot, { recursive: true });
+  const write = (name, payload) => {
+    const file = path.join(inputRoot, name);
+    fs.writeFileSync(file, typeof payload === 'string' ? payload : JSON.stringify(payload));
+    return file;
+  };
+  const fig = write('fixture.fig', 'fig bytes');
+  const figHash = crypto.createHash('sha256').update(fs.readFileSync(fig)).digest('hex');
+  const sitePlan = { schema: 'blocks-engine/wordpress-site-plan/v2', pages: [{ slug: 'home', title: 'Home', content: '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->' }], routes: [{ path: '/', page_slug: 'home' }] };
+  const sitePlanPath = write('site-plan.json', sitePlan);
+  const transformResult = write('transform-result.json', { schema: 'blocks-engine/figma-transform-result/v1', document: { name: 'Fisiostetic' } });
+  const visualSource = write('html-source.png', 'png');
+  const visualRendered = write('html-rendered.png', 'png');
+  const visualDiff = write('html-diff.json', { mismatch_pixels: 0 });
+  const parity = {};
+  for (const stage of ['html_wordpress_mobile_parity', 'figma_wordpress_desktop_parity', 'figma_wordpress_mobile_parity']) {
+    parity[stage.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase())] = write(`${stage}.json`, { schema: 'static-site-importer/fig-acceptance-parity-input/v1', stage, source_screenshot: write(`${stage}-source.png`, 'png'), rendered_screenshot: write(`${stage}-rendered.png`, 'png'), diff_report: { metrics: { pixel_difference_count: 0, geometry_difference_count: 0 } } });
+  }
+  const figmaReference = write('figma-result-reference.json', { status: 'completed' });
+  const stagePaths = {};
+  for (const stage of ['decode', 'normalize', 'emit', 'figma_html_desktop_parity', 'figma_html_mobile_parity', 'responsive_selection']) {
+    const evidence = { schema: 'blocks-engine/figma-wordpress-stage-evidence/v1', fixture_id: 'fisiostetic', stage, source_sha256: figHash, status: 'passed', references: [path.basename(figmaReference)] };
+    if (stage === 'decode') evidence.metrics = { missing_text_count: 0, missing_asset_count: 0, vector_placeholder_count: 0 };
+    if (stage === 'normalize') evidence.metrics = { normalized_node_count: 1 };
+    if (stage === 'emit') evidence.metrics = { emitted_route_count: 1, missing_emitted_asset_count: 0, missing_emitted_text_count: 0 };
+    if (stage === 'responsive_selection') Object.assign(evidence, { selection_source: 'dev_status', responsive_routes: [{ output_route: '/', desktop_source_frame: 'Desktop', mobile_source_frame: 'Mobile', breakpoint_min_width: 375, breakpoint_max_width: 1440 }] });
+    if (stage.includes('parity')) {
+      const source = write(`${stage}-source.png`, 'png');
+      const rendered = write(`${stage}-rendered.png`, 'png');
+      const diff = write(`${stage}-diff.json`, { metrics: { pixel_difference_count: 0, geometry_difference_count: 0 } });
+      Object.assign(evidence, { comparison: 'figma_html', metrics: { pixel_difference_count: 0, geometry_difference_count: 0 }, source_screenshot: path.basename(source), rendered_screenshot: path.basename(rendered), diff_report: path.basename(diff), references: [path.basename(figmaReference), path.basename(source), path.basename(rendered), path.basename(diff)] });
+    }
+    stagePaths[stage] = write(`${stage}-evidence.json`, evidence);
+  }
+  const transformSummary = write('transform-summary.json', { output_dir: inputRoot, fixtures: [{ id: 'fisiostetic', path: fig, status: 'completed', result_path: transformResult, artifact_dir: inputRoot, acceptance_readiness: { schema: 'blocks-engine/figma-transformer/acceptance-readiness/v1', status: 'passed', stage_paths: stagePaths } }] });
+  const matrixResult = write('matrix-result.json', { fixtures: [{ fixture_id: 'fisiostetic', status: 'passed', block_composition: { block_total: 1, native_block_count: 1, core_html_block_count: 0 }, editor_validation: { validation_method: 'wp.blocks.validateBlock', total_blocks: 1, valid_blocks: 1, invalid_blocks: 0 }, quality_metrics: { fallback_count: 0 }, import_report: { blocks_engine: { wordpress_site_plan: sitePlan } }, matrix_evidence: { readiness: 'verified', materialization_receipt: { status: 'completed', page_count: 1 } }, visual_parity_artifacts: { metrics: { mismatch_pixels: 0, dimension_mismatch: false }, artifacts: { source_screenshot: { status: 'captured', ref: { path: visualSource } }, imported_screenshot: { status: 'captured', ref: { path: visualRendered } }, visual_diff: { status: 'captured', ref: { path: visualDiff } } } } }] });
+  return { acceptanceRoot, paths: { parity }, input: { fig, fixtureId: 'fisiostetic', fixtureOutput, transformSummary, matrixResult, matrixOutput: inputRoot, sitePlan: sitePlanPath, providerIdentity: 'static-site-importer@test', runtimeIdentity: 'wp-codebox:test', ...parity } };
+}
 
 function summaryPlan(root, matrixSummary) {
   return {


### PR DESCRIPTION
## Summary
- consume the Figma-owned stage files introduced by Automattic/blocks-engine#678 without reinterpreting their metrics
- validate source and fixture identities, copy all referenced artifacts under the evaluator root, and preserve relative reviewer-resolvable references
- compose SSI import, editor-validity, fallback, desktop parity, and explicit downstream parity inputs into all 13 canonical stages
- add `--acceptance-config` to the three-Fig E2E workflow so it writes a combined manifest and runs Blocks Engine production acceptance without `--no-run-providers`
- fail closed for incomplete Figma readiness, mismatched source hashes, missing parity, invalid editor/import metrics, fallback blocks, and missing deployable site plans

## Verification
- `npm test`
- `node --test tools/run-fig-fixture-e2e.test.mjs`
- `node --check tools/fig-acceptance-provider.mjs`
- `node --check tools/run-fig-fixture-e2e.mjs`
- generated a canonical `wordpress-site-plan/v2` with Blocks Engine `ArtifactCompiler`, composed the SSI provider bundle, and ran `php scripts/production-acceptance-matrix.php --profile=manifest` from Blocks Engine trunk; all 13 stages and the site plan passed

Real production runs still fail closed until operators provide authoritative downstream mobile/end-to-end screenshots and exact diff reports.

Closes #700
Related: #673
Upstream producer: Automattic/blocks-engine#678

## AI assistance
Homeboy/OpenCode with `openai/gpt-5.6-terra` drafted the initial adapter. OpenCode with `openai/gpt-5.6-sol` reviewed it against retained real artifacts, replaced synthetic metric derivation with the merged producer contract, wired the direct evaluator workflow, and expanded verification. Chris Huber remains responsible for every line.