### PR TITLE
Preserve canonical nested index page identities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.4.5",
+        "version": "0.4.6",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "6751c02a6a216e127c2657d7a7e617f13cbaca36"
+          "reference": "533e6c3f76f9b439232ddc441f6e544331c5de59"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.5.zip",
-          "reference": "6751c02a6a216e127c2657d7a7e617f13cbaca36"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.6.zip",
+          "reference": "533e6c3f76f9b439232ddc441f6e544331c5de59"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "^0.4.5",
+    "automattic/blocks-engine-php-transformer": "^0.4.6",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "562ebf635d605afedf235e4b003e6499",
+    "content-hash": "fabb7f047253a3d6d84aae9c5b1f603d",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.4.5",
+            "version": "0.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "6751c02a6a216e127c2657d7a7e617f13cbaca36"
+                "reference": "533e6c3f76f9b439232ddc441f6e544331c5de59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.5.zip",
-                "reference": "6751c02a6a216e127c2657d7a7e617f13cbaca36"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.6.zip",
+                "reference": "533e6c3f76f9b439232ddc441f6e544331c5de59"
             },
             "require": {
                 "league/commonmark": "^2.5",

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -235,6 +235,27 @@ $dynamic_plan = ( new ArtifactCompiler() )->compile( $dynamic_artifact )->toArra
 $dynamic_completed = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $dynamic_plan, array( 'slug' => 'dynamic-plan' ) );
 $assert( 'completed' === $dynamic_completed['status'], 'declared static local scripts are proven and materialize' );
 
+$GLOBALS['ssi_plan_posts'] = array();
+$GLOBALS['ssi_plan_meta']  = array();
+$nested_index_artifact = array(
+	'entrypoint' => 'website/index.html',
+	'files'      => array(
+		'website/index.html'            => '<main><h1>Home</h1></main>',
+		'website/about/index.html'      => '<main><h1>About</h1></main>',
+		'website/about/team/index.html' => '<main><h1>Team</h1></main>',
+	),
+);
+$nested_index_plan    = ( new ArtifactCompiler() )->compile( $nested_index_artifact )->toArray()['source_reports']['wordpress_site_plan'];
+$nested_index_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $nested_index_plan, array( 'slug' => 'nested-index-plan' ) );
+$nested_index_ids     = $nested_index_receipt['completed']['pages'] ?? array();
+$home_id              = (int) ( $nested_index_ids['website/index.html'] ?? 0 );
+$about_id             = (int) ( $nested_index_ids['website/about/index.html'] ?? 0 );
+$team_id              = (int) ( $nested_index_ids['website/about/team/index.html'] ?? 0 );
+$assert( 'completed' === $nested_index_receipt['status'] && 3 === count( array_unique( array( $home_id, $about_id, $team_id ) ) ), 'wrapper-root nested index pages materialize as distinct WordPress posts' );
+$assert( 'index' === ( $GLOBALS['ssi_plan_posts'][ $home_id ]['post_name'] ?? null ) && 0 === ( $GLOBALS['ssi_plan_posts'][ $home_id ]['post_parent'] ?? null ), 'wrapper entrypoint preserves its root page identity' );
+$assert( 'about' === ( $GLOBALS['ssi_plan_posts'][ $about_id ]['post_name'] ?? null ) && 0 === ( $GLOBALS['ssi_plan_posts'][ $about_id ]['post_parent'] ?? null ), 'nested index page slug matches its top-level canonical route' );
+$assert( 'team' === ( $GLOBALS['ssi_plan_posts'][ $team_id ]['post_name'] ?? null ) && $about_id === ( $GLOBALS['ssi_plan_posts'][ $team_id ]['post_parent'] ?? null ), 'deeper nested index page preserves canonical slug and WordPress parent identity' );
+
 $GLOBALS['ssi_plan_posts']      = array();
 $GLOBALS['ssi_plan_meta']       = array();
 $GLOBALS['ssi_plan_fail_after'] = 1;


### PR DESCRIPTION
## Summary

- pin Blocks Engine PHP Transformer `0.4.6` by released commit and tag archive
- regenerate the Composer lockfile against the immutable release
- prove wrapper-root nested index pages materialize as distinct WordPress posts with canonical slugs and parents

## Why

Transformer `0.4.5` emitted `slug: index` for both `website/index.html` and nested documents such as `website/about/index.html`. SSI correctly materialized that plan, but hierarchical Markdown persistence collapsed both posts into one identity. Blocks Engine #680 and #682 repair the route and slug contract; this PR consumes their Homeboy-published release.

Fixes #702.
Unblocks Automattic/wp-codebox#1975.

## Verification

- `composer validate --strict`
- `npm run test:site-plan-materializer`
- `npm run test:fixture-matrix`
- `composer show automattic/blocks-engine-php-transformer --format=json` resolves `0.4.6` at `533e6c3f76f9b439232ddc441f6e544331c5de59`

The first full `npm test` run encountered one existing timing-sensitive fixture-matrix assertion; its complete suite passed immediately on targeted rerun.

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode traced the downstream canonical identity collision, coordinated the upstream release handoff, updated the immutable dependency pin, drafted the WordPress materializer regression, and ran validation. Chris Huber reviewed and remains responsible for the change.