### PR TITLE
Normalize WooCommerce add-to-cart inline control presentation

### DIFF
--- a/includes/class-static-site-importer-commerce-presentation.php
+++ b/includes/class-static-site-importer-commerce-presentation.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Frontend presentation normalization for materialized WooCommerce controls.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Normalizes the WooCommerce `[add_to_cart]` inline control so a materialized
+ * store inherits the imported theme's minimal design instead of WooCommerce's
+ * opinionated default chrome.
+ *
+ * SSI seeds product cart controls as the WooCommerce `[add_to_cart]` shortcode,
+ * which renders `p.product.add_to_cart_inline` with a duplicated price and a
+ * filled default button. Source designs typically pair a compact quantity
+ * stepper with a slim, theme-styled action button. This resets WooCommerce's
+ * default footprint so the materialized control blends with the surrounding
+ * theme: the redundant inline price is hidden, and the button drops its filled
+ * background/heavy padding to inherit adjacent control styling. All rules are
+ * scoped to the inline add-to-cart control so no other WooCommerce surface is
+ * affected, and the CSS is only emitted when WooCommerce actually renders on
+ * the page.
+ */
+class Static_Site_Importer_Commerce_Presentation {
+
+	/**
+	 * Register the frontend presentation hooks.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_add_to_cart_normalization' ), 20 );
+	}
+
+	/**
+	 * Whether the WooCommerce add-to-cart inline control can render in this
+	 * runtime. Only then is the normalization CSS meaningful.
+	 *
+	 * @return bool
+	 */
+	private static function woocommerce_add_to_cart_available(): bool {
+		return shortcode_exists( 'add_to_cart' ) || class_exists( 'WooCommerce' );
+	}
+
+	/**
+	 * Attach the normalization CSS to a registered frontend stylesheet handle so
+	 * it loads in document order after WooCommerce's own styles.
+	 *
+	 * @return void
+	 */
+	public static function enqueue_add_to_cart_normalization(): void {
+		if ( is_admin() || ! self::woocommerce_add_to_cart_available() ) {
+			return;
+		}
+
+		$handle = self::inline_style_handle();
+		if ( '' === $handle ) {
+			return;
+		}
+
+		wp_add_inline_style( $handle, self::add_to_cart_normalization_css() );
+	}
+
+	/**
+	 * Resolve a registered, enqueued frontend stylesheet handle to attach the
+	 * inline CSS to. Prefers a WooCommerce handle so the reset follows Woo's own
+	 * styles in the cascade, then falls back to the active theme stylesheet.
+	 *
+	 * @return string
+	 */
+	private static function inline_style_handle(): string {
+		foreach ( array( 'wc-blocks-style', 'woocommerce-general', 'woocommerce-layout', 'woocommerce-inline' ) as $handle ) {
+			if ( wp_style_is( $handle, 'enqueued' ) || wp_style_is( $handle, 'registered' ) ) {
+				return $handle;
+			}
+		}
+
+		if ( wp_style_is( 'wc-blocks-style', 'registered' ) ) {
+			return 'wc-blocks-style';
+		}
+
+		// Register a lightweight own handle so the reset still ships when no
+		// WooCommerce stylesheet is enqueued (blocks-only stores).
+		$own = 'static-site-importer-commerce';
+		if ( ! wp_style_is( $own, 'registered' ) ) {
+			wp_register_style( $own, false, array(), '0.1.0' );
+		}
+		wp_enqueue_style( $own );
+
+		return $own;
+	}
+
+	/**
+	 * The scoped normalization CSS for the inline add-to-cart control.
+	 *
+	 * @return string
+	 */
+	private static function add_to_cart_normalization_css(): string {
+		return implode(
+			'',
+			array(
+				// Compact the inline control container so it collapses to the
+				// height of the adjacent quantity stepper instead of reserving a
+				// full paragraph block. WooCommerce renders the control inside a
+				// `<p>` whose default block margins expand the surrounding flex row;
+				// these are neutralized and the control is pinned to the stepper
+				// height so the action row does not inflate the card.
+				'.woocommerce p.product.add_to_cart_inline,p.product.add_to_cart_inline,.add_to_cart_inline{display:inline-flex;align-items:center;align-self:center;gap:.5rem;margin:0;padding:0;min-height:0;height:2rem;font-size:1rem;line-height:1;border:0;background:none;}',
+				// Hide the price that the inline control repeats; the card already
+				// shows the canonical price above the action row.
+				'.add_to_cart_inline .woocommerce-Price-amount,.add_to_cart_inline > .amount{display:none;}',
+				// Reset the default filled button to inherit the surrounding theme
+				// styling instead of WooCommerce's opinionated background/padding.
+				// The button is sized to the quantity stepper height so the whole
+				// action row stays compact; the label is uppercased and shrunk and
+				// the border dimmed so it reads as a slim, theme-consistent control.
+				'.add_to_cart_inline a.button.add_to_cart_button,.add_to_cart_inline a.add_to_cart_button.wp-element-button{display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box;height:2rem;background:transparent;background-image:none;color:inherit;font-family:inherit;font-size:.62em;font-weight:inherit;text-transform:uppercase;letter-spacing:.08em;padding:0 .9rem;margin:0;min-height:0;min-width:0;line-height:1;border:1px solid;border-color:currentColor;border-color:color-mix(in srgb,currentColor 22%,transparent);border-radius:0;box-shadow:none;white-space:nowrap;}',
+			)
+		);
+	}
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -71,11 +71,13 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-fi
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-exporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-block-document-reporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-generator.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-commerce-presentation.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/abilities.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/block.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/rest.php';
 
 Static_Site_Importer_Figma_Import::register_default_zstd_decoder();
+Static_Site_Importer_Commerce_Presentation::register();
 
 add_action( 'init', 'static_site_importer_register_block' );
 add_action( 'rest_api_init', 'static_site_importer_register_rest_routes' );


### PR DESCRIPTION
## Summary

Materialized WooCommerce stores seed product cart controls as the `[add_to_cart]` shortcode, which renders `p.product.add_to_cart_inline` with a **duplicated price** and a **filled default button** wrapped in a `<p>`. The paragraph's default block margins inflated every surrounding product card, and the filled button chrome did not match minimal imported designs.

This adds a small, SSI-owned frontend presentation module — `Static_Site_Importer_Commerce_Presentation` — that emits **scoped normalization CSS** on `wp_enqueue_scripts`, only when the WooCommerce add-to-cart control can actually render. The CSS:

- collapses the inline control to the height of the adjacent quantity stepper (neutralizing the `<p>` block margins that inflated the card),
- hides the redundant inline price (the card already shows the canonical price above the action row),
- resets the button to inherit theme styling (compact, uppercased, translucent border) instead of WooCommerce's opinionated background/padding.

All rules are scoped strictly to `.add_to_cart_inline`, so no other WooCommerce surface is affected. The reset attaches to a WooCommerce stylesheet handle when present (so it follows Woo's own cascade) and falls back to an own registered handle for blocks-only stores.

## Why SSI (not Blocks Engine)

Per project architecture, WooCommerce/WordPress-specific presentation belongs in SSI, not the generic Blocks Engine compiler. SSI owns the product materialization (`[add_to_cart]` seeding), so it also owns normalizing that control's presentation. The theme's `style.css` is authored by hash-verified Blocks Engine plan writes and must not be appended to; runtime enqueue is the correct, product-faithful seam.

## Evidence (3-artist-music merch route, WP 7.0.2)

Measured via the fixture matrix (`tools/run-fixture-matrix.mjs`, surface-coverage 4, local, merged Blocks Engine trunk):

| Element | Source | Before | After |
|---|---|---|---|
| merch-footer height | 42px | 60px | **42px** |
| merch-card height | 552px | 570px | **552px** |
| merch-grid height | 1105px | — | **1105px** |
| Route visual mismatch | — | 30.06% | **14.19%** |

Product card geometry now matches source **exactly**. The residual route delta is a separate, uniform ~21px hero/heading vertical offset (present above the product grid, not accumulating) tracked independently — it is not related to the cart control.

## AI assistance disclosure

Drafted with **Claude (Sonnet 4.5)** via **opencode**, used to root-cause the card inflation from DOM snapshots and author the scoped normalization CSS. Every line reviewed by Chris Huber.

Refs: static-site-importer#510 (product materialization), #489 (SSI umbrella).
