### PR TITLE
Provision Jetpack Forms so seeded contact forms render on the frontend

### DIFF
--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -58,9 +58,14 @@ const CAPABILITY_PROVIDER_READINESS = {
   },
   jetpack: {
     label: 'Jetpack',
-    // The form provider is ready when the Jetpack Forms contact-form runtime is
-    // present (class or registered block), matching the SSI form seeder gate.
-    predicate: "( class_exists('Automattic\\\\Jetpack\\\\Forms\\\\ContactForm\\\\Contact_Form') || class_exists('Grunion_Contact_Form') || ( class_exists('WP_Block_Type_Registry') && WP_Block_Type_Registry::get_instance()->is_registered('jetpack/contact-form') ) )",
+    // The form provider is ready only when the `jetpack/contact-form` block is
+    // registered AND actually renders a form on the frontend. Merely finding the
+    // Contact_Form class is a false positive: the class autoloads via Composer,
+    // but Jetpack gates the block's render callback behind an active module, so an
+    // unprovisioned install renders the seeded form to an empty string. Prove the
+    // real behavior by rendering a minimal contact-form block and requiring a
+    // `<form>` in the output, so a non-rendering provider fails closed here.
+    predicate: "class_exists('WP_Block_Type_Registry') && WP_Block_Type_Registry::get_instance()->is_registered('jetpack/contact-form') && ( false !== stripos( do_blocks('<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-name {\\\"label\\\":\\\"Name\\\"} /--><!-- /wp:jetpack/contact-form -->'), '<form' ) )",
   },
 };
 
@@ -262,6 +267,7 @@ function fixtureWorkflowSteps(options) {
 
   return [
     ...fixturePluginProvisioningSteps(fixture),
+    ...jetpackFormsActivationSteps(fixture),
     ...fixtureCapabilityReadinessSteps(fixture),
     importFixtureStep(fixture, commandArtifactsDirectory),
     ...(input.svgFontEvidence || input.svg_font_evidence ? [svgFontEvidenceStep(fixture)] : []),
@@ -477,6 +483,44 @@ function fixturePluginProvisioningSteps(fixture) {
     }),
   }));
   return steps;
+}
+
+// Jetpack's contact-form block only registers its render callback when the
+// `contact-form` module is active, and Jetpack refuses to load any module on an
+// unconnected site unless it is in offline mode (Jetpack::load_modules() returns
+// early otherwise). A generated/local site has no WPCOM connection, so the block
+// would render to an empty string on the frontend and the seeded form would
+// vanish. Provision the sanctioned local/dev path — offline mode plus the active
+// module — via an mu-plugin so it applies to every subsequent frontend request,
+// matching how an unconnected Jetpack install is expected to run forms locally.
+// Only emitted when the fixture actually provisions Jetpack.
+function jetpackFormsActivationSteps(fixture) {
+  if (!fixtureCapabilityPlugins(fixture).some((plugin) => plugin.slug === 'jetpack')) {
+    return [];
+  }
+  const muPlugin = [
+    '<?php',
+    "add_filter( 'jetpack_offline_mode', '__return_true', 9 );",
+    "add_filter( 'jetpack_active_modules', function ( $modules ) {",
+    '  $modules = (array) $modules;',
+    "  if ( ! in_array( 'contact-form', $modules, true ) ) {",
+    "    $modules[] = 'contact-form';",
+    '  }',
+    '  return $modules;',
+    '}, 9 );',
+    '',
+  ].join('\n');
+  const php = `$dir = defined('WPMU_PLUGIN_DIR') ? WPMU_PLUGIN_DIR : WP_CONTENT_DIR . '/mu-plugins'; if ( ! is_dir( $dir ) ) { wp_mkdir_p( $dir ); } $ok = file_put_contents( $dir . '/ssi-fixture-jetpack-forms.php', ${phpSingleQuoted(muPlugin)} ); if ( false === $ok ) { fwrite(STDERR, 'Failed to write Jetpack Forms activation mu-plugin.'); exit(1); } echo 'jetpack-forms-activated';`;
+  return [
+    {
+      command: 'wordpress.run-php',
+      args: [`code=${php}`],
+      metadata: fixtureStepMetadata(fixture, 'provider-preflight', {
+        setup: 'activate-jetpack-forms-module',
+        provider: 'jetpack',
+      }),
+    },
+  ];
 }
 
 function woocommerceOnboardingSuppressionStep(fixture) {


### PR DESCRIPTION
## Summary

SSI seeds contact forms as `jetpack/contact-form` + `jetpack/field-*` blocks, and the block content is correct — but on the imported site the form **rendered to an empty string**: the fields were simply absent (0 `<input>`, 0 `<form>` in the served HTML).

## Root cause (Jetpack module/connection model)

1. `Contact_Form_Block::register_block()` attaches the block's **render callback** only when `can_manage_block()` is true, which requires the `contact-form` module active **or** an admin user. A public frontend request is neither → the block registers no renderer → empty output.
2. `Jetpack::load_modules()` **returns early on any unconnected site** unless it is in **offline mode**, so `modules/contact-form.php` (which calls `Jetpack_Forms::load_contact_form()` and registers the block) never loads at all.

A generated/local site has no WPCOM connection, so the seeded form vanished.

## Fix

Provision Jetpack's **sanctioned local/dev path** via an mu-plugin, emitted only for fixtures that provision Jetpack:

- `add_filter( 'jetpack_offline_mode', '__return_true' )` — lets Jetpack load modules without a WPCOM connection
- `add_filter( 'jetpack_active_modules', … )` — ensures `contact-form` is active so its module file loads and registers the block with its render callback

With this, the contact form renders: **6 form fields where there were 0**, verified via a fresh in-sandbox HTTP fetch of `/contact/`.

## Also: hardened the readiness gate (was a false positive)

The Jetpack capability readiness predicate passed on `class_exists('…Contact_Form')`, but that class autoloads via Composer even when the block renders nothing — so the gate claimed "form provider ready" while importing an empty form. It now requires the block to be **registered AND to actually render a `<form>`**, failing closed before import otherwise.

## Scope note

`jetpack_offline_mode` is applied only in the fixture-matrix test harness / local provisioning path, not forced on connected production sites.

## AI assistance disclosure

Drafted with **Claude (Sonnet 4.5)** via **opencode**, used to trace Jetpack's module-loading and block-registration gates through source and in-sandbox probes. Every line reviewed by Chris Huber.
