### PR TITLE
Default validation dependency materialization on

### DIFF
--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -44,6 +44,7 @@ class Static_Site_Importer_Validation_Runtime {
 			'name'                      => isset( $input['name'] ) ? sanitize_text_field( (string) $input['name'] ) : $slug,
 			'activate'                  => array_key_exists( 'activate', $input ) ? (bool) $input['activate'] : true,
 			'overwrite'                 => array_key_exists( 'overwrite', $input ) ? (bool) $input['overwrite'] : true,
+			'materialize_dependencies'  => array_key_exists( 'materialize_dependencies', $input ) ? (bool) $input['materialize_dependencies'] : true,
 			'fail_on_quality'           => ! empty( $input['fail_on_quality'] ),
 			'allow_missing_woocommerce' => ! empty( $input['allow_missing_woocommerce'] ),
 			'allow_missing_jetpack'     => ! empty( $input['allow_missing_jetpack'] ),

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -29,6 +29,45 @@ if ( ! function_exists( 'sanitize_title' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ) {
+		return trim( strip_tags( (string) $value ) );
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $value ) {
+		return rtrim( (string) $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( $directory ) {
+		return is_dir( $directory ) || mkdir( $directory, 0777, true );
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return false;
+	}
+}
+
+if ( ! class_exists( 'Static_Site_Importer_Theme_Generator' ) ) {
+	class Static_Site_Importer_Theme_Generator {
+		public static array $last_args = array();
+
+		public static function import_website_artifact( array $artifact, array $args = array() ): array {
+			self::$last_args = $args;
+
+			return array(
+				'quality'    => array( 'pass' => true ),
+				'theme_slug' => 'validation-theme',
+			);
+		}
+	}
+}
+
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-validation-runtime.php';
 
@@ -122,7 +161,32 @@ $assert( ! isset( $result['fixture_diagnostics']['blocks_engine']['wordpress_sit
 $assert( 'completed' === ( $result['fixture_diagnostics']['materialization_receipt']['status'] ?? '' ), 'materialization-receipt-status-preserved' );
 $assert( 1 === ( $result['fixture_diagnostics']['materialization_receipt']['page_count'] ?? 0 ), 'materialization-receipt-counts-preserved' );
 
+$default_artifact_dir = $artifact_dir . '/default-materialization';
+$default_result       = Static_Site_Importer_Validation_Runtime::validate_artifact(
+	array(
+		'artifact'     => array( 'schema' => 'test/website-artifact/v1' ),
+		'artifact_dir' => $default_artifact_dir,
+		'slug'         => 'default-materialization',
+	)
+);
+$assert( true === ( Static_Site_Importer_Theme_Generator::$last_args['materialize_dependencies'] ?? null ), 'validation-defaults-dependency-materialization-on' );
+$assert( true === ( $default_result['request']['import_args']['materialize_dependencies'] ?? null ), 'validation-result-records-default-dependency-materialization' );
+
+$override_artifact_dir = $artifact_dir . '/disabled-materialization';
+$override_result       = Static_Site_Importer_Validation_Runtime::validate_artifact(
+	array(
+		'artifact'                 => array( 'schema' => 'test/website-artifact/v1' ),
+		'artifact_dir'             => $override_artifact_dir,
+		'slug'                     => 'disabled-materialization',
+		'materialize_dependencies' => false,
+	)
+);
+$assert( false === ( Static_Site_Importer_Theme_Generator::$last_args['materialize_dependencies'] ?? null ), 'validation-honors-disabled-dependency-materialization' );
+$assert( false === ( $override_result['request']['import_args']['materialize_dependencies'] ?? null ), 'validation-result-records-disabled-dependency-materialization' );
+
 unlink( $report_path );
+rmdir( $default_artifact_dir );
+rmdir( $override_artifact_dir );
 rmdir( $artifact_dir );
 
 if ( $failures ) {


### PR DESCRIPTION
## Summary

- default validation-runtime dependency materialization to the same enabled behavior as normal SSI imports
- preserve an explicit `materialize_dependencies: false` override
- exercise both paths through the public `validate_artifact()` entrypoint

Closes #708.

## Verification

- `php tests/smoke-validation-runtime-diagnostics.php` (15 assertions)
- PHP syntax checks for both changed files
- `git diff --check`
- `npm run test:fixture-matrix` after Homeboy dependency hydration: 192/193 passed; the remaining current-main assertion expects one fewer `wordpress.run-php` fixture setup step and is unrelated to this change
- Homeboy Lab run `60f5d4b3-7e9d-4bf2-9ff0-8ec339d92ec4` tested exact commit `9414dc69` against Blocks Engine fixture `8-local-service-business`. The original `static_site_importer_required_runtime_dependency_missing` failure is absent and execution advances to the later SVG font evidence gate (`required_fonts_missing`).

Reproduce the Lab proof with:

```sh
node tools/run-fixture-matrix.mjs --runner homeboy-lab --static-site-importer /path/to/this/checkout --blocks-engine /path/to/blocks-engine --target-fixture 8-local-service-business --batch-size 1 --concurrency 1 --run-id ssi-708-validation-dependency-materialization-9414dc69
```

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode diagnosed the validation/runtime contract mismatch, drafted the focused code and regression coverage, and ran the verification workflow. Chris Huber reviewed and remains responsible for the change.