### PR TITLE
Introduce a provider presentation seam for materialized blocks

### DIFF
--- a/includes/class-static-site-importer-commerce-presentation.php
+++ b/includes/class-static-site-importer-commerce-presentation.php
@@ -24,74 +24,39 @@ if ( ! defined( 'ABSPATH' ) ) {
  * scoped to the inline add-to-cart control so no other WooCommerce surface is
  * affected, and the CSS is only emitted when WooCommerce actually renders on
  * the page.
+ *
+ * The generic delivery pipeline — hooking, admin/active guards, stylesheet
+ * handle resolution, and inline enqueue — lives in the provider presentation
+ * base; this subclass supplies only the WooCommerce-specific active check,
+ * preferred handles, and CSS.
  */
-class Static_Site_Importer_Commerce_Presentation {
+class Static_Site_Importer_Commerce_Presentation extends Static_Site_Importer_Provider_Presentation {
 
 	/**
-	 * Register the frontend presentation hooks.
-	 *
-	 * @return void
+	 * @inheritDoc
 	 */
-	public static function register(): void {
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_add_to_cart_normalization' ), 20 );
+	protected static function provider_slug(): string {
+		return 'commerce';
 	}
 
 	/**
-	 * Whether the WooCommerce add-to-cart inline control can render in this
-	 * runtime. Only then is the normalization CSS meaningful.
+	 * The WooCommerce add-to-cart inline control can render when its shortcode is
+	 * registered or WooCommerce is loaded. Only then is the reset meaningful.
 	 *
 	 * @return bool
 	 */
-	private static function woocommerce_add_to_cart_available(): bool {
+	protected static function is_active(): bool {
 		return shortcode_exists( 'add_to_cart' ) || class_exists( 'WooCommerce' );
 	}
 
 	/**
-	 * Attach the normalization CSS to a registered frontend stylesheet handle so
-	 * it loads in document order after WooCommerce's own styles.
+	 * WooCommerce stylesheet handles, in cascade-preference order, so the reset
+	 * follows Woo's own styles.
 	 *
-	 * @return void
+	 * @return array<int, string>
 	 */
-	public static function enqueue_add_to_cart_normalization(): void {
-		if ( is_admin() || ! self::woocommerce_add_to_cart_available() ) {
-			return;
-		}
-
-		$handle = self::inline_style_handle();
-		if ( '' === $handle ) {
-			return;
-		}
-
-		wp_add_inline_style( $handle, self::add_to_cart_normalization_css() );
-	}
-
-	/**
-	 * Resolve a registered, enqueued frontend stylesheet handle to attach the
-	 * inline CSS to. Prefers a WooCommerce handle so the reset follows Woo's own
-	 * styles in the cascade, then falls back to the active theme stylesheet.
-	 *
-	 * @return string
-	 */
-	private static function inline_style_handle(): string {
-		foreach ( array( 'wc-blocks-style', 'woocommerce-general', 'woocommerce-layout', 'woocommerce-inline' ) as $handle ) {
-			if ( wp_style_is( $handle, 'enqueued' ) || wp_style_is( $handle, 'registered' ) ) {
-				return $handle;
-			}
-		}
-
-		if ( wp_style_is( 'wc-blocks-style', 'registered' ) ) {
-			return 'wc-blocks-style';
-		}
-
-		// Register a lightweight own handle so the reset still ships when no
-		// WooCommerce stylesheet is enqueued (blocks-only stores).
-		$own = 'static-site-importer-commerce';
-		if ( ! wp_style_is( $own, 'registered' ) ) {
-			wp_register_style( $own, false, array(), '0.1.0' );
-		}
-		wp_enqueue_style( $own );
-
-		return $own;
+	protected static function preferred_style_handles(): array {
+		return array( 'wc-blocks-style', 'woocommerce-general', 'woocommerce-layout', 'woocommerce-inline' );
 	}
 
 	/**
@@ -99,7 +64,7 @@ class Static_Site_Importer_Commerce_Presentation {
 	 *
 	 * @return string
 	 */
-	private static function add_to_cart_normalization_css(): string {
+	protected static function css(): string {
 		return implode(
 			'',
 			array(

--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -490,6 +490,7 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 				'materializer'    => array( 'Static_Site_Importer_Woo_Product_Seeder', 'seed' ),
 				'binding_callback' => array( 'Static_Site_Importer_Woo_Product_Seeder', 'binding_block_markup' ),
 				'report_callback' => array( 'Static_Site_Importer_Woo_Product_Seeder', 'new_report' ),
+				'presentation'    => 'Static_Site_Importer_Commerce_Presentation',
 				'dependencies'    => array(
 					array(
 						'type'                  => 'wp_org_plugin',
@@ -532,6 +533,32 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 		/** @var mixed $filtered */
 		$filtered = function_exists( 'apply_filters' ) ? apply_filters( 'static_site_importer_entity_materializers', $adapters ) : $adapters;
 		return is_array( $filtered ) ? $filtered : $adapters;
+	}
+
+	/**
+	 * Register the frontend presentation for every adapter that declares one.
+	 *
+	 * Each adapter may name a `Static_Site_Importer_Provider_Presentation`
+	 * subclass under its `presentation` key. This keeps a provider fully described
+	 * in one place — materialization, binding, reporting, and presentation — and
+	 * lets the plugin bootstrap register all of them without hardcoding each.
+	 *
+	 * @return void
+	 */
+	public static function register_presentations(): void {
+		$registered = array();
+		foreach ( self::adapters() as $adapter ) {
+			$presentation = isset( $adapter['presentation'] ) ? (string) $adapter['presentation'] : '';
+			if ( '' === $presentation || isset( $registered[ $presentation ] ) ) {
+				continue;
+			}
+			if ( ! class_exists( $presentation ) || ! is_subclass_of( $presentation, 'Static_Site_Importer_Provider_Presentation' ) ) {
+				continue;
+			}
+
+			$registered[ $presentation ] = true;
+			call_user_func( array( $presentation, 'register' ) );
+		}
 	}
 
 	/**

--- a/includes/class-static-site-importer-provider-presentation.php
+++ b/includes/class-static-site-importer-provider-presentation.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Base class for provider-block frontend presentation.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Shared frontend-presentation pipeline for materialized provider blocks.
+ *
+ * SSI materializes source entities as provider blocks (WooCommerce products,
+ * Jetpack forms, and so on). Those blocks render with the provider's own default
+ * chrome, which rarely matches the imported design. A provider presentation
+ * subclass supplies scoped CSS that reconciles that chrome with the source, and
+ * this base owns the generic delivery: it hooks `wp_enqueue_scripts`, guards on
+ * the admin context and the provider being active, resolves a stylesheet handle
+ * to attach the CSS to (preferring the provider's own handles so the reset wins
+ * document order, otherwise a lightweight own handle), and emits the inline CSS.
+ *
+ * Subclasses implement only the three things that vary per provider:
+ * `is_active()`, `preferred_style_handles()`, and `css()`.
+ */
+abstract class Static_Site_Importer_Provider_Presentation {
+
+	/**
+	 * Register the presentation's frontend hook.
+	 *
+	 * @return void
+	 */
+	final public static function register(): void {
+		add_action( 'wp_enqueue_scripts', array( static::class, 'enqueue' ), 20 );
+	}
+
+	/**
+	 * Emit the presentation CSS, attached to a resolved stylesheet handle.
+	 *
+	 * @return void
+	 */
+	final public static function enqueue(): void {
+		if ( is_admin() || ! static::is_active() ) {
+			return;
+		}
+
+		$css = static::css();
+		if ( '' === trim( $css ) ) {
+			return;
+		}
+
+		$handle = static::resolve_style_handle();
+		if ( '' === $handle ) {
+			return;
+		}
+
+		wp_add_inline_style( $handle, $css );
+	}
+
+	/**
+	 * Resolve a registered/enqueued stylesheet handle to attach the CSS to. Prefers
+	 * the provider's own handles so the reset follows the provider styles in the
+	 * cascade, then falls back to a lightweight own handle that always ships.
+	 *
+	 * @return string
+	 */
+	final protected static function resolve_style_handle(): string {
+		foreach ( static::preferred_style_handles() as $handle ) {
+			if ( '' !== $handle && ( wp_style_is( $handle, 'enqueued' ) || wp_style_is( $handle, 'registered' ) ) ) {
+				return $handle;
+			}
+		}
+
+		$own = static::own_style_handle();
+		if ( '' === $own ) {
+			return '';
+		}
+		if ( ! wp_style_is( $own, 'registered' ) ) {
+			wp_register_style( $own, false, static::own_style_dependencies(), '0.1.0' );
+		}
+		wp_enqueue_style( $own );
+
+		return $own;
+	}
+
+	/**
+	 * The handle for a self-registered fallback stylesheet, used when none of the
+	 * provider's own handles are present.
+	 *
+	 * @return string
+	 */
+	protected static function own_style_handle(): string {
+		return 'static-site-importer-' . static::provider_slug();
+	}
+
+	/**
+	 * Dependencies for the self-registered fallback stylesheet so it loads after
+	 * the listed handles in the cascade. Only present handles are kept.
+	 *
+	 * @return array<int, string>
+	 */
+	protected static function own_style_dependencies(): array {
+		$deps = array();
+		foreach ( static::preferred_style_handles() as $handle ) {
+			if ( '' !== $handle && ( wp_style_is( $handle, 'enqueued' ) || wp_style_is( $handle, 'registered' ) ) ) {
+				$deps[] = $handle;
+			}
+		}
+
+		return $deps;
+	}
+
+	/**
+	 * A short slug identifying the provider, used to name the own handle.
+	 *
+	 * @return string
+	 */
+	abstract protected static function provider_slug(): string;
+
+	/**
+	 * Whether the provider can render its blocks on this request; only then is the
+	 * presentation CSS meaningful.
+	 *
+	 * @return bool
+	 */
+	abstract protected static function is_active(): bool;
+
+	/**
+	 * Stylesheet handles, in cascade-preference order, that the presentation CSS
+	 * should attach to so it follows the provider's own styles.
+	 *
+	 * @return array<int, string>
+	 */
+	abstract protected static function preferred_style_handles(): array;
+
+	/**
+	 * The scoped presentation CSS for the provider's materialized blocks.
+	 *
+	 * @return string
+	 */
+	abstract protected static function css(): string;
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -71,13 +71,14 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-fi
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-exporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-block-document-reporter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-generator.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-provider-presentation.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-commerce-presentation.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/abilities.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/block.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/rest.php';
 
 Static_Site_Importer_Figma_Import::register_default_zstd_decoder();
-Static_Site_Importer_Commerce_Presentation::register();
+Static_Site_Importer_Entity_Materializer_Registry::register_presentations();
 
 add_action( 'init', 'static_site_importer_register_block' );
 add_action( 'rest_api_init', 'static_site_importer_register_rest_routes' );

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -40,6 +40,11 @@ const steps = [
     args: [ path.join( repoRoot, 'tests/smoke-entity-materializer-registry.php' ) ],
   },
   {
+    name: 'Provider presentation smoke',
+    command: 'php',
+    args: [ path.join( repoRoot, 'tests/smoke-provider-presentation.php' ) ],
+  },
+  {
     name: 'Visual repair CSS smoke',
     command: 'php',
     args: [ path.join( repoRoot, 'tests/smoke-visual-repair-css.php' ) ],

--- a/tests/smoke-provider-presentation.php
+++ b/tests/smoke-provider-presentation.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Smoke coverage for the provider presentation seam.
+ *
+ * Verifies the shared presentation pipeline (admin/active/empty guards, handle
+ * resolution, inline enqueue) and the registry-driven registration dispatcher.
+ *
+ * Run from the repository root:
+ * php tests/smoke-provider-presentation.php
+ *
+ * @package StaticSiteImporter
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	}
+
+	// Mutable WordPress runtime state the pipeline reads/writes.
+	$GLOBALS['ssi_test_is_admin']      = false;
+	$GLOBALS['ssi_test_registered']    = array();
+	$GLOBALS['ssi_test_enqueued']      = array();
+	$GLOBALS['ssi_test_actions']       = array();
+	$GLOBALS['ssi_test_inline_styles'] = array();
+
+	if ( ! function_exists( 'is_admin' ) ) {
+		function is_admin(): bool { return (bool) ( $GLOBALS['ssi_test_is_admin'] ?? false ); }
+	}
+	if ( ! function_exists( 'add_action' ) ) {
+		function add_action( string $hook, $callback, int $priority = 10, int $args = 1 ): void {
+			$GLOBALS['ssi_test_actions'][] = array( 'hook' => $hook, 'callback' => $callback, 'priority' => $priority );
+		}
+	}
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $tag, $value ) { unset( $tag ); return $value; }
+	}
+	if ( ! function_exists( 'shortcode_exists' ) ) {
+		function shortcode_exists( string $tag ): bool { return 'add_to_cart' === $tag; }
+	}
+	if ( ! function_exists( 'wp_style_is' ) ) {
+		function wp_style_is( string $handle, string $list = 'enqueued' ): bool {
+			if ( 'registered' === $list ) {
+				return isset( $GLOBALS['ssi_test_registered'][ $handle ] );
+			}
+			return isset( $GLOBALS['ssi_test_enqueued'][ $handle ] );
+		}
+	}
+	if ( ! function_exists( 'wp_register_style' ) ) {
+		function wp_register_style( string $handle, $src, array $deps = array(), $ver = false ): void {
+			$GLOBALS['ssi_test_registered'][ $handle ] = array( 'src' => $src, 'deps' => $deps );
+		}
+	}
+	if ( ! function_exists( 'wp_enqueue_style' ) ) {
+		function wp_enqueue_style( string $handle ): void {
+			$GLOBALS['ssi_test_enqueued'][ $handle ] = true;
+		}
+	}
+	if ( ! function_exists( 'wp_add_inline_style' ) ) {
+		function wp_add_inline_style( string $handle, string $css ): bool {
+			$GLOBALS['ssi_test_inline_styles'][ $handle ] = ( $GLOBALS['ssi_test_inline_styles'][ $handle ] ?? '' ) . $css;
+			return true;
+		}
+	}
+
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-provider-presentation.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-commerce-presentation.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-woo-product-seeder.php';
+	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
+
+	$failures   = array();
+	$assertions = 0;
+	$assert     = static function ( bool $condition, string $label ) use ( &$assertions, &$failures ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			$failures[] = 'FAIL [' . $label . ']';
+		}
+	};
+
+	$reset = static function (): void {
+		$GLOBALS['ssi_test_is_admin']      = false;
+		$GLOBALS['ssi_test_registered']    = array();
+		$GLOBALS['ssi_test_enqueued']      = array();
+		$GLOBALS['ssi_test_inline_styles'] = array();
+	};
+
+	// A test presentation with controllable active/CSS to exercise the base.
+	if ( ! class_exists( 'SSI_Test_Presentation' ) ) {
+		class SSI_Test_Presentation extends \Static_Site_Importer_Provider_Presentation {
+			public static bool $active = true;
+			public static string $out  = '.demo{color:red}';
+			protected static function provider_slug(): string { return 'demo'; }
+			protected static function is_active(): bool { return static::$active; }
+			protected static function preferred_style_handles(): array { return array( 'demo-provider-style' ); }
+			protected static function css(): string { return static::$out; }
+		}
+	}
+
+	// Registry dispatcher registers the declared presentation exactly once on
+	// wp_enqueue_scripts, and skips classes that are not presentation subclasses.
+	\Static_Site_Importer_Entity_Materializer_Registry::register_presentations();
+	$commerce_hooks = array_filter(
+		$GLOBALS['ssi_test_actions'],
+		static fn ( array $a ): bool => 'wp_enqueue_scripts' === $a['hook']
+			&& is_array( $a['callback'] )
+			&& 'Static_Site_Importer_Commerce_Presentation' === $a['callback'][0]
+	);
+	$assert( 1 === count( $commerce_hooks ), 'registry-registers-commerce-presentation-once' );
+	$assert( 'enqueue' === ( reset( $commerce_hooks )['callback'][1] ?? '' ), 'registry-hooks-shared-enqueue-entrypoint' );
+
+	// Own-handle fallback: no preferred handle present -> registers and enqueues a
+	// slugged own handle, then attaches the CSS to it.
+	$reset();
+	SSI_Test_Presentation::$active = true;
+	SSI_Test_Presentation::$out    = '.demo{color:red}';
+	SSI_Test_Presentation::enqueue();
+	$assert( isset( $GLOBALS['ssi_test_registered']['static-site-importer-demo'] ), 'own-handle-registered-when-no-provider-handle' );
+	$assert( isset( $GLOBALS['ssi_test_enqueued']['static-site-importer-demo'] ), 'own-handle-enqueued' );
+	$assert( '.demo{color:red}' === ( $GLOBALS['ssi_test_inline_styles']['static-site-importer-demo'] ?? '' ), 'css-attached-to-own-handle' );
+
+	// Preferred handle present -> CSS attaches to it, no own handle registered.
+	$reset();
+	$GLOBALS['ssi_test_registered']['demo-provider-style'] = array();
+	SSI_Test_Presentation::enqueue();
+	$assert( '.demo{color:red}' === ( $GLOBALS['ssi_test_inline_styles']['demo-provider-style'] ?? '' ), 'css-attached-to-preferred-handle' );
+	$assert( ! isset( $GLOBALS['ssi_test_registered']['static-site-importer-demo'] ), 'own-handle-not-registered-when-preferred-present' );
+
+	// Admin context is a no-op.
+	$reset();
+	$GLOBALS['ssi_test_is_admin'] = true;
+	SSI_Test_Presentation::enqueue();
+	$assert( array() === $GLOBALS['ssi_test_inline_styles'], 'admin-context-emits-nothing' );
+
+	// Inactive provider is a no-op.
+	$reset();
+	SSI_Test_Presentation::$active = false;
+	SSI_Test_Presentation::enqueue();
+	$assert( array() === $GLOBALS['ssi_test_inline_styles'], 'inactive-provider-emits-nothing' );
+	SSI_Test_Presentation::$active = true;
+
+	// Empty CSS is a no-op (never registers a handle).
+	$reset();
+	SSI_Test_Presentation::$out = '   ';
+	SSI_Test_Presentation::enqueue();
+	$assert( array() === $GLOBALS['ssi_test_registered'], 'empty-css-registers-no-handle' );
+
+	// The refactored commerce presentation preserves its own handle + CSS.
+	$reset();
+	SSI_Test_Presentation::$out = '.demo{color:red}';
+	\Static_Site_Importer_Commerce_Presentation::enqueue();
+	$assert( isset( $GLOBALS['ssi_test_inline_styles']['static-site-importer-commerce'] ), 'commerce-attaches-to-own-handle-name' );
+	$assert( false !== strpos( $GLOBALS['ssi_test_inline_styles']['static-site-importer-commerce'] ?? '', 'add_to_cart_inline' ), 'commerce-css-preserved' );
+
+	if ( $failures ) {
+		fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+		exit( 1 );
+	}
+
+	echo 'OK: provider presentation smoke passed (' . $assertions . " assertions)\n";
+}


### PR DESCRIPTION
## Summary

A small, behavior-preserving refactor that gives provider-block frontend presentation a single shared seam, so the codebase is easier to hold and extend.

### The problem

Provider-block presentation had no shared home. `Commerce_Presentation` hand-rolled the entire delivery pipeline — hook registration, `is_admin`/active guards, stylesheet-handle resolution (prefer the provider's own handles, else register a lightweight own handle), and the inline enqueue — and its registration was hardcoded in the plugin bootstrap. Any new provider (forms, and future ones) would duplicate all of that boilerplate. That missing seam is what made ad-hoc provider-styling work sprawl.

### The change

- **`Static_Site_Importer_Provider_Presentation`** (new base) owns the generic pipeline. Subclasses supply only what varies per provider: `is_active()`, `preferred_style_handles()`, `css()`, and a `provider_slug()` for the own handle.
- **`Commerce_Presentation`** becomes a thin subclass. Its resolved handle (`static-site-importer-commerce`), preferred WooCommerce handles, and reset CSS are **byte-identical** to before (`-54` lines of duplicated pipeline removed).
- **Registry-driven registration**: each entity-materializer adapter may name its presentation class under a `presentation` key, and `Entity_Materializer_Registry::register_presentations()` registers them all. A provider is now fully described in one place — materialization, binding, reporting, **and** presentation — and the bootstrap calls one dispatcher instead of hardcoding each.

### Why now

The next task is styling the materialized Jetpack form to match its source. Attempts sprawled because there was no clean place for provider presentation to live. This lands that seam first, so the form work becomes a small, focused subclass rather than another hand-rolled pipeline.

## Verification

- WooCommerce reset CSS is byte-identical to `main`; the fixture matrix shows **merch/music/tour parity unchanged** (0.66% / 0.05% / 0.03%).
- New `tests/smoke-provider-presentation.php` (12 assertions, wired into the validation harness) covers: registry dispatch registers the declared presentation once on `wp_enqueue_scripts`; own-handle fallback vs preferred-handle attachment; and the admin / inactive / empty-CSS no-op guards; plus commerce CSS preservation.
- Full validation harness green (11 steps).

## AI assistance disclosure

Drafted with **Claude (Sonnet 4.5)** via **opencode**, used to survey the presentation/registry surface and extract the shared pipeline. Every line reviewed by Chris Huber.
