### PR TITLE
Update Jetpack Forms fixture expectation

### DIFF
--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -607,7 +607,7 @@ test('fixture capability manifests drive per-fixture plugin provisioning without
   // Each capability provider gets a best-effort install followed by a fail-closed
   // readiness assertion (wordpress.run-php) before the import runs.
   assert.deepEqual(fixtureSteps('shop-site').map((step) => step.command), ['wordpress.plugin-setup', 'wordpress.run-php', 'wordpress.wp-cli', 'wordpress.wp-cli']);
-  assert.deepEqual(fixtureSteps('shop-forms-site').map((step) => step.command), ['wordpress.plugin-setup', 'wordpress.plugin-setup', 'wordpress.run-php', 'wordpress.run-php', 'wordpress.wp-cli', 'wordpress.wp-cli']);
+  assert.deepEqual(fixtureSteps('shop-forms-site').map((step) => step.command), ['wordpress.plugin-setup', 'wordpress.plugin-setup', 'wordpress.run-php', 'wordpress.run-php', 'wordpress.run-php', 'wordpress.wp-cli', 'wordpress.wp-cli']);
   assert.deepEqual(fixtureSteps('shop-site')[0].args, ['action=install', 'plugin=woocommerce', 'activate=true']);
   assert.deepEqual(fixtureSteps('shop-forms-site')[0].args, ['action=install', 'plugin=woocommerce', 'activate=true']);
   assert.deepEqual(fixtureSteps('shop-forms-site')[1].args, ['action=install', 'plugin=jetpack', 'activate=true']);


### PR DESCRIPTION
## Summary

- include the Jetpack Forms activation preflight in the fixture command-sequence expectation
- restore the full npm test suite on current main

## Tests

- node --test --test-name-pattern=fixture-capability tools/fixture-matrix.test.mjs
- npm test

Closes #711

## AI assistance

OpenCode using openai/gpt-5.6-sol diagnosed the current-main failure, made the one-line assertion update, and ran the focused and full test suites. Chris Huber remains responsible for the change.