### PR TITLE
Bridge product-grid findings into Woo declarations

### DIFF
--- a/docs/product-handoff-contract.md
+++ b/docs/product-handoff-contract.md
@@ -16,6 +16,10 @@ Static Site Importer's product handoff uses four machine-readable envelopes. The
 - Codebox owns optional WordPress validation and artifact references.
 - Product callers consume these outputs directly; they should not depend on legacy SSI wrapper history.
 
+## Commerce Findings
+
+When the canonical plan contains a Blocks Engine `html_product_grid_fallback`, SSI converts only its extracted product rows into a required `shop` dependency and `products` entity collection before the v2 lifecycle runs. Those declarations use the existing WooCommerce simple-product adapter and seeder. The finding does not itself provide canonical replacement-block anchors, so SSI does not infer cart-control bindings from selectors; provider bindings require explicit source anchors in the entity declaration.
+
 ## Boundary
 
 Blocks Engine stays out of Codebox details. If a caller wants Codebox validation, it asks Codebox after SSI materializes WordPress and passes SSI output or runtime references through the Codebox-owned envelope.

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2166,7 +2166,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				continue;
 			}
 
-			$code = (string) ( $diagnostic['diagnostic_code'] ?? '' );
+			$code = (string) ( $diagnostic['diagnostic_code'] ?? $diagnostic['code'] ?? '' );
 			if ( '' === $code ) {
 				$code = (string) ( $diagnostic['kind'] ?? '' );
 			}
@@ -2177,6 +2177,39 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		return $indexes;
+	}
+
+	/**
+	 * Normalize active product-grid findings into the Woo manifest row contract.
+	 *
+	 * This is intentionally limited to the Blocks Engine product-grid discriminator.
+	 * Callers own how the rows are declared or materialized; this helper owns only
+	 * the source-finding to validated-product data bridge.
+	 *
+	 * @param array<int,mixed> $diagnostics Plan or report diagnostics.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function product_grid_manifest_products( array $diagnostics ): array {
+		$products = array();
+		foreach ( self::product_grid_finding_indexes( $diagnostics ) as $index ) {
+			$finding = $diagnostics[ $index ] ?? array();
+			if ( ! is_array( $finding ) ) {
+				continue;
+			}
+			$container = isset( $finding['container_selector'] ) && is_scalar( $finding['container_selector'] )
+				? (string) $finding['container_selector']
+				: ( isset( $finding['selector'] ) && is_scalar( $finding['selector'] ) ? (string) $finding['selector'] : '' );
+			foreach ( is_array( $finding['products'] ?? null ) ? $finding['products'] : array() as $product ) {
+				if ( ! is_array( $product ) ) {
+					continue;
+				}
+				$row = self::product_finding_manifest_row( $product, $container );
+				if ( null !== $row ) {
+					$products[] = $row;
+				}
+			}
+		}
+		return $products;
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -19,6 +19,10 @@ if ( ! class_exists( 'Static_Site_Importer_Block_Document_Reporter' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-block-document-reporter.php';
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Report_Diagnostics' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-report-diagnostics.php';
+}
+
 /**
  * Generates a block theme from a static HTML document.
  */
@@ -95,6 +99,7 @@ class Static_Site_Importer_Theme_Generator {
 			$diagnostics = isset( $compiled['source_reports']['wordpress_site_plan_diagnostics'] ) && is_array( $compiled['source_reports']['wordpress_site_plan_diagnostics'] ) ? wp_json_encode( $compiled['source_reports']['wordpress_site_plan_diagnostics'] ) : '';
 			return new WP_Error( 'static_site_importer_artifact_compile_failed', 'Website artifact compilation did not produce a WordPress site plan.' . ( false !== $diagnostics ? ' ' . $diagnostics : '' ), $compiled );
 		}
+		$plan = self::bridge_product_grid_findings_to_runtime_declarations( $plan );
 		if ( ! empty( $args['fail_on_quality'] ) && empty( $plan['quality']['pass'] ) ) {
 			return new WP_Error( 'static_site_importer_quality_gate_failed', 'Website artifact did not pass the canonical plan quality gate.', array( 'quality' => $plan['quality'] ?? array(), 'diagnostics' => $plan['diagnostics'] ?? array() ) );
 		}
@@ -154,6 +159,56 @@ class Static_Site_Importer_Theme_Generator {
 			$receipt['errors'][] = array( 'code' => 'static_site_importer_projection_write_failed', 'message' => $error->getMessage() );
 			return new WP_Error( 'static_site_importer_projection_write_failed', 'Website materialization completed partially because a public projection could not be written.', $receipt );
 		}
+	}
+
+	/**
+	 * Declare detected Blocks Engine product grids for the canonical v2 lifecycle.
+	 *
+	 * Product-grid findings carry product data but no canonical block replacement
+	 * anchors, so this bridge seeds only the explicit commerce entities. Provider
+	 * bindings remain limited to declarations that include their own exact anchors.
+	 *
+	 * @param array<string,mixed> $plan Compiled WordPress site plan.
+	 * @return array<string,mixed>
+	 */
+	private static function bridge_product_grid_findings_to_runtime_declarations( array $plan ): array {
+		$diagnostics = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
+		$products    = Static_Site_Importer_Report_Diagnostics::product_grid_manifest_products( $diagnostics );
+		if ( empty( $products ) ) {
+			return $plan;
+		}
+
+		$adapter    = Static_Site_Importer_Entity_Materializer_Registry::product_adapter();
+		$validation = Static_Site_Importer_Entity_Materializer_Registry::validate_manifest_generic( $adapter, array( 'schema_version' => 1, 'products' => $products ) );
+		if ( ! empty( $validation['errors'] ) || empty( $validation['products'] ) ) {
+			return $plan;
+		}
+
+		$declarations = isset( $plan['runtime_declarations'] ) && is_array( $plan['runtime_declarations'] ) ? $plan['runtime_declarations'] : array();
+		foreach ( $declarations as $declaration ) {
+			if ( is_array( $declaration ) && 'entity_collection' === ( $declaration['kind'] ?? null ) && 'products' === ( $declaration['type'] ?? null ) ) {
+				return $plan;
+			}
+		}
+
+		$source_path = (string) ( $plan['source']['entry_path'] ?? '' );
+		$identity    = hash( 'sha256', "static-site-importer/product-grid-bridge/v1\n" . wp_json_encode( $validation['products'] ) );
+		$declarations[] = array(
+			'kind'                    => 'dependency',
+			'capability'              => 'shop',
+			'source_path'             => $source_path,
+			'required_for'            => array( 'entity_collection:products' ),
+			'reconciliation_identity' => hash( 'sha256', $identity . "\ndependency" ),
+		);
+		$declarations[] = array(
+			'kind'                    => 'entity_collection',
+			'type'                    => 'products',
+			'source_path'             => $source_path,
+			'payload'                 => array( 'schema' => 'generic/products/v1', 'entities' => $validation['products'] ),
+			'reconciliation_identity' => hash( 'sha256', $identity . "\nentities" ),
+		);
+		$plan['runtime_declarations'] = $declarations;
+		return $plan;
 	}
 
 	/**

--- a/tests/run-validation-harness.cjs
+++ b/tests/run-validation-harness.cjs
@@ -65,6 +65,11 @@ const steps = [
     args: [ path.join( repoRoot, 'tests/smoke-product-handoff-contract.php' ) ],
   },
   {
+    name: 'Woo product finding materialization smoke',
+    command: 'php',
+    args: [ path.join( repoRoot, 'tests/smoke-product-materializer.php' ) ],
+  },
+  {
     name: 'Website artifact document metadata smoke',
     command: wpCli[ 0 ],
     args: [

--- a/tests/smoke-product-materializer.php
+++ b/tests/smoke-product-materializer.php
@@ -350,15 +350,16 @@ namespace {
 	$assert( 'skipped' === ( $empty_seed['status'] ?? '' ), 'no-findings-skipped' );
 	$assert( 'no_product_findings' === ( $empty_seed['reason'] ?? '' ), 'no-findings-reason' );
 
-	// --- product_grid_finding_indexes detects both `kind` and `diagnostic_code`
+	// --- product_grid_finding_indexes detects plan and fallback discriminator fields
 	$indexes = Static_Site_Importer_Report_Diagnostics::product_grid_finding_indexes(
 		array(
 			array( 'diagnostic_code' => 'html_form_fallback' ),
 			array( 'kind' => 'html_product_grid_fallback' ),
 			array( 'diagnostic_code' => 'html_product_grid_fallback' ),
+			array( 'code' => 'html_product_grid_fallback' ),
 		)
 	);
-	$assert( array( 1, 2 ) === $indexes, 'finding-indexes-detect-kind-and-code' );
+	$assert( array( 1, 2, 3 ) === $indexes, 'finding-indexes-detect-plan-and-fallback-codes' );
 
 	if ( empty( $failures ) ) {
 		echo 'PASS smoke-product-materializer.php (' . $assertions . " assertions)\n";

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -102,6 +102,22 @@ $assert( 'posts' === $GLOBALS['ssi_plan_options']['show_on_front'], 'plan-only m
 $assert( $receipt['plan']['pages'][0]['document_metadata']['links'][0]['resolved_url'] === 'https://example.test/wp-content/themes/site-plan/assets/assets/site.css', 'resolved metadata retains the declared stylesheet destination' );
 $assert( array() === $receipt['completed']['runtime_declarations']['asset_publications'], 'plans without publication declarations retain an explicit empty receipt collection' );
 
+$product_grid_artifact = array(
+	'entrypoint' => 'index.html',
+	'files'      => array(
+		'index.html' => '<main><ul class="products"><li><article class="product-card"><h3>Tour Tee</h3><p>Heavy cotton shirt.</p><div class="price">$30</div><button class="add-to-cart">Add to cart</button></article></li><li><article class="product-card"><h3>Signed CD</h3><p>Hand-signed disc.</p><div class="price">$15</div><button class="add-to-cart">Add to cart</button></article></li></ul></main>',
+	),
+);
+$product_grid_plan = ( new ArtifactCompiler() )->compile( $product_grid_artifact )->toArray()['source_reports']['wordpress_site_plan'];
+$bridge_product_grid = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'bridge_product_grid_findings_to_runtime_declarations' );
+$bridged_product_grid_plan = $bridge_product_grid->invoke( null, $product_grid_plan );
+$bridged_declarations = $bridged_product_grid_plan['runtime_declarations'] ?? array();
+$assert( 2 === count( $bridged_declarations ) && 'shop' === ( $bridged_declarations[0]['capability'] ?? '' ) && 'products' === ( $bridged_declarations[1]['type'] ?? '' ), 'active Blocks Engine product-grid findings bridge into explicit v2 commerce declarations' );
+$assert( true === in_array( 'entity_collection:products', $bridged_declarations[0]['required_for'] ?? array(), true ), 'bridged product entities retain the required commerce dependency relationship' );
+$assert( array( 'tour-tee', 'signed-cd' ) === array_column( $bridged_declarations[1]['payload']['entities'] ?? array(), 'slug' ), 'bridge preserves product-grid evidence as normalized Woo entity rows' );
+$bridged_lifecycle = ( new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'prepare_wordpress_site_plan_lifecycle' ) )->invoke( null, $bridged_product_grid_plan, array() );
+$assert( 'runtime_declarations' === ( $bridged_lifecycle['status'] ?? '' ) && true === ( reset( $bridged_lifecycle['entities'] )['required'] ?? false ), 'bridged product entities enter the required canonical seeding lifecycle' );
+
 $entity_artifact = $artifact;
 $entity_search = '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Add</a></div><!-- /wp:button --></div><!-- /wp:buttons -->';
 $entity_artifact['files']['index.html'] = '<main><h1>Home</h1><div class="wp-block-buttons"><button>Add</button></div></main>';


### PR DESCRIPTION
## Summary
Bridge active product-grid findings into canonical WooCommerce runtime declarations.

## What changed
- Normalize product-grid diagnostics into validated product manifest rows.
- Declare the existing shop dependency and products entity collection before the v2 lifecycle.
- Cover the active Blocks Engine finding path in the validation harness.

## How to test
1. Run `npm run test:validation`; expect passes all 12 validation steps.
2. Run `npm test`; expect passes the full repository suite.

## Compatibility
Existing explicit product declarations remain authoritative; plans without product-grid findings are unchanged.

## Evidence
- Base unchanged since verification: main remains at f787424c3d8f7dca4d75658e324a4568a969f83f.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/static-site-importer/issues/510
- Verified finalization base: main at f787424c3d8f7dca4d75658e324a4568a969f83f
- npm run test:validation: passed (12 validation steps passed, including 63 Woo assertions and 249 generated blocks) (Passed)
- npm test: passed (full repository suite passed) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** OpenCode with openai/gpt-5.6-terra implemented the recovered patch; Franklin with openai/gpt-5.6-sol recovered, rebased, and verified it.

## Source relationships
- Closes #510
