### PR TITLE
Retain secondary fixture surface evidence

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -651,9 +651,12 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
     artifacts[`visual_compare_${artifactKey(fixtureId)}_${fileStem}`] = { path: persistedPath };
   }
 
+  const comparisonRefPaths = new Set(arrayValue(fixture.visual_parity_comparisons).flatMap((comparison) => Object.values(
+    comparison?.visual_parity_artifacts?.artifacts || comparison?.visualParityArtifacts?.artifacts || {},
+  ).map((slot) => slot?.ref?.path).filter(Boolean)));
   for (const diagnostic of arrayValue(fixture.diagnostics)) {
     for (const ref of arrayValue(diagnostic?.artifact_refs)) {
-      if (ref?.kind !== 'visual-parity' || !ref.path || rewrites.has(ref.path)) {
+      if (ref?.kind !== 'visual-parity' || !ref.path || rewrites.has(ref.path) || comparisonRefPaths.has(ref.path)) {
         continue;
       }
       const sourcePath = resolveCodeboxArtifactPath(ref.path, codeboxArtifactsDirectory);

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -651,6 +651,25 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
     artifacts[`visual_compare_${artifactKey(fixtureId)}_${fileStem}`] = { path: persistedPath };
   }
 
+  for (const diagnostic of arrayValue(fixture.diagnostics)) {
+    for (const ref of arrayValue(diagnostic?.artifact_refs)) {
+      if (ref?.kind !== 'visual-parity' || !ref.path || rewrites.has(ref.path)) {
+        continue;
+      }
+      const sourcePath = resolveCodeboxArtifactPath(ref.path, codeboxArtifactsDirectory);
+      if (!sourcePath || !fs.existsSync(sourcePath)) {
+        continue;
+      }
+      const comparisonName = path.basename(path.dirname(ref.path));
+      const fileName = path.basename(ref.path);
+      const persistedPath = path.join(outputDirectory, 'visual-compare', comparisonName, fileName);
+      fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
+      fs.copyFileSync(sourcePath, persistedPath);
+      rewrites.set(ref.path, persistedPath);
+      artifacts[`visual_compare_${artifactKey(comparisonName)}_${artifactKey(fileName)}`] = { path: persistedPath };
+    }
+  }
+
   if (rewrites.size === 0) {
     return fixture;
   }
@@ -1584,7 +1603,7 @@ Options:
   --wordpress-version <version>      WP Codebox WordPress version. Defaults to latest.
   --batch-size <n>                   Fixtures per WP Codebox run when --run is used. Defaults to 10.
   --concurrency <n>                  Batches (WP Codebox sandboxes) to run in parallel. Defaults to ${DEFAULT_BATCH_CONCURRENCY}, hard-capped at ${MAX_BATCH_CONCURRENCY}.
-  --surface-coverage <n>             Opt into bounded secondary page browser evidence per fixture. Hard-capped at 5 extra surfaces.
+  --surface-coverage <n>             Opt into bounded secondary page browser evidence per fixture. Hard-capped at 10 extra surfaces.
   --no-editor-validation            Skip browser editor block validation.
   --no-visual-parity                Skip wordpress.visual-compare recipe steps. Same as SSI_FIXTURE_MATRIX_VISUAL_PARITY=0.
   --visual-parity-block-external-requests <bool>

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -420,6 +420,7 @@ function injectDeterministicSourceCss(filePath, fixtureId) {
       if (svg.hasAttribute(name)) image.setAttribute(name, svg.getAttribute(name));
     }
     const computed = getComputedStyle(svg);
+    clone.style.setProperty('color', computed.color);
     image.style.cssText = svg.getAttribute('style') || '';
     image.style.setProperty('display', computed.display);
     image.style.setProperty('vertical-align', computed.verticalAlign);

--- a/lib/fixture-matrix/steps/surfaces.mjs
+++ b/lib/fixture-matrix/steps/surfaces.mjs
@@ -17,7 +17,7 @@ const FRONT_PAGE_SURFACE = Object.freeze({
 });
 
 export const DEFAULT_EXTRA_SURFACE_COUNT = 2;
-export const MAX_EXTRA_SURFACE_COUNT = 5;
+export const MAX_EXTRA_SURFACE_COUNT = 10;
 
 export function selectFixtureSurfaces(fixture, options = {}) {
   const config = normalizeSurfaceCoverageOptions(options);

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -4380,7 +4380,7 @@ test('editorBlockValidationStep emits editor-validate-blocks against real import
     fixture: { id: 'shop' },
     surface: { post_slug: 'contact', post_type: 'page' },
   });
-  assert.deepEqual(byPostSlug.args, ['post-slug=contact', 'post-type=page']);
+  assert.deepEqual(byPostSlug.args, ['post-type=page', 'post-slug=contact']);
   assert.equal(byPostSlug.metadata.post_slug, 'contact');
 
   // Wait passthrough stays available.

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -4215,13 +4215,16 @@ test('fixture matrix browser surfaces default to front page and opt into bounded
   writeFileSync(path.join(fixtureDirectory, 'about.html'), '<main>About flat</main>');
   writeFileSync(path.join(fixtureDirectory, 'about', 'index.html'), '<main>About nested</main>');
   writeFileSync(path.join(fixtureDirectory, 'contact.html'), '<main><form><input name="email"></form></main>');
+  writeFileSync(path.join(fixtureDirectory, 'faculty.html'), '<main>Faculty</main>');
   writeFileSync(path.join(fixtureDirectory, 'merch', 'index.html'), '<main><button>Add to cart</button></main>');
+  writeFileSync(path.join(fixtureDirectory, 'news.html'), '<main>News</main>');
+  writeFileSync(path.join(fixtureDirectory, 'programs.html'), '<main>Programs</main>');
 
   const discoveredMatrix = createFixtureMatrix({ fixture_root: root, id: 'surface-recipe-test' });
   const matrix = { ...discoveredMatrix, fixtures: discoveredMatrix.fixtures.filter((fixture) => fixture.id === 'artist'), count: 1 };
   assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0]).map((surface) => surface.id), ['front-page']);
   assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: { maxExtraSurfaces: 1 } }).map((surface) => surface.id), ['front-page', 'about']);
-  assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: 99 }).map((surface) => surface.id), ['front-page', 'about', 'about--2', 'contact', 'merch']);
+  assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: 7 }).map((surface) => surface.id), ['front-page', 'about', 'about--2', 'contact', 'faculty', 'merch', 'news', 'programs']);
   assert.equal(normalizeSurfaceCoverageOptions({ surfaceCoverage: 99 }).extraSurfaceCount, MAX_EXTRA_SURFACE_COUNT);
 
   const defaultRecipe = buildFixtureMatrixRecipe({
@@ -4372,6 +4375,13 @@ test('editorBlockValidationStep emits editor-validate-blocks against real import
   // An imported post id is preferred over a URL.
   const byPostId = editorBlockValidationStep({ fixture: { id: 'shop', post_id: 99 } });
   assert.ok(byPostId.args.includes('post-id=99'));
+
+  const byPostSlug = editorBlockValidationStep({
+    fixture: { id: 'shop' },
+    surface: { post_slug: 'contact', post_type: 'page' },
+  });
+  assert.deepEqual(byPostSlug.args, ['post-slug=contact', 'post-type=page']);
+  assert.equal(byPostSlug.metadata.post_slug, 'contact');
 
   // Wait passthrough stays available.
   const withWait = editorBlockValidationStep({
@@ -5358,6 +5368,7 @@ test('stageFixtureSource copies the raw fixture source into the served source/ s
   assert.match(stagedHtml, /animation-duration: 0\.001ms !important/);
   assert.ok(stagedHtml.includes(VISUAL_PARITY_DETERMINISTIC_CSS.trim()));
   assert.match(stagedHtml, /data-ssi-visual-parity-svg-normalization/);
+  assert.match(stagedHtml, /clone\.style\.setProperty\('color', computed\.color\)/);
   assert.match(stagedHtml, /new XMLSerializer\(\)\.serializeToString\(clone\)/);
   // The import payload (artifact.json) is still written alongside, unchanged.
   assert.ok(existsSync(path.join(outputDirectory, 'simple-site', 'artifact.json')), 'artifact.json should still be written');
@@ -5662,6 +5673,9 @@ test('visual-compare sidecars are normalized and retained under the bench artifa
       snapshot: { elementCount: 3, capturedElements: [{ path: '0.1' }], truncated: false },
     }));
   }
+  const secondaryRuntimeDirectory = path.join(codeboxArtifactsDirectory, 'runtime-123', 'files', 'browser', 'visual-compare', 'simple-site--contact');
+  mkdirSync(secondaryRuntimeDirectory, { recursive: true });
+  writeFileSync(path.join(secondaryRuntimeDirectory, 'candidate.png'), 'secondary candidate');
 
   const result = {
     fixtures: [
@@ -5675,6 +5689,12 @@ test('visual-compare sidecars are normalized and retained under the bench artifa
               { schema: 'homeboy/artifact-ref/v1', artifact_id: 'source_screenshot', kind: 'visual-parity', path: 'files/browser/visual-compare/simple-site/source.png' },
               { schema: 'homeboy/artifact-ref/v1', artifact_id: 'candidate_screenshot', kind: 'visual-parity', path: 'files/browser/visual-compare/simple-site/candidate.png' },
               { schema: 'homeboy/artifact-ref/v1', artifact_id: 'diff_screenshot', kind: 'visual-parity', path: 'files/browser/visual-compare/simple-site/diff.png' },
+            ],
+          },
+          {
+            kind: VISUAL_PARITY_MISMATCH_KIND,
+            artifact_refs: [
+              { schema: 'homeboy/artifact-ref/v1', artifact_id: 'candidate_screenshot', kind: 'visual-parity', path: 'files/browser/visual-compare/simple-site--contact/candidate.png' },
             ],
           },
         ],
@@ -5717,6 +5737,7 @@ test('visual-compare sidecars are normalized and retained under the bench artifa
   const fixture = persisted.result.fixtures[0];
 
   assert.deepEqual(Object.keys(persisted.artifacts).sort(), [
+    'visual_compare_simple-site--contact_candidate.png',
     'visual_compare_simple-site_candidate',
     'visual_compare_simple-site_candidate-dom-snapshot.json',
     'visual_compare_simple-site_diff',
@@ -5737,6 +5758,7 @@ test('visual-compare sidecars are normalized and retained under the bench artifa
   assert.equal(fixture.visual_parity_artifacts.artifacts.imported_screenshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'candidate.png'));
   assert.equal(fixture.visual_parity_artifacts.artifacts.diff_screenshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'diff.png'));
   assert.equal(fixture.diagnostics[0].artifact_refs.find((ref) => ref.artifact_id === 'diff_screenshot').path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'diff.png'));
+  assert.equal(fixture.diagnostics[1].artifact_refs[0].path, path.join(outputDirectory, 'visual-compare', 'simple-site--contact', 'candidate.png'));
   assert.equal(fixture.visual_parity_artifacts.artifacts.visual_diff.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'visual-diff.json'));
   assert.equal(fixture.visual_parity_artifacts.artifacts.source_dom_snapshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'source-dom-snapshot.json'));
   assert.equal(fixture.visual_parity_artifacts.artifacts.visual_attribution.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'visual-attribution.json'));


### PR DESCRIPTION
## Summary

- retain visual-parity diagnostic artifacts that are not already represented by normalized route comparisons
- avoid duplicate artifacts when aggregate comparison intake already owns a route
- raise bounded secondary coverage from five to ten routes
- preserve computed SVG `currentColor` during deterministic source capture

Fixes #681.

## Evidence

The university fixture exposed the loss on Lab runs: secondary routes produced mismatch metrics but their screenshots and DOM evidence disappeared after the sandbox was cleaned up. With this materialization path, the narrowed contact run retained route-specific visual artifacts and editor evidence under Homeboy run `a071e387-3af1-418c-8003-525e63b71b99`.

This PR improves evidence retention; it does not claim that the university fixture has reached solved-site parity. The latest diagnostic run remained at `197,685 / 4,908,800` mismatched pixels (`4.03%`) for contact.

## Testing

- `npm test`
- fixture matrix: 193 passed
- solved-site promotion: 13 passed
- Fig fixture E2E: 11 passed
- solved-fixture promotion: 3 passed

## AI assistance

- **AI assistance:** Yes
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** investigation, implementation, conflict resolution against current `main`, test execution, and evidence analysis
