### PR TITLE
Require fixture matrix execution evidence

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -104,6 +104,9 @@ export default async function runFixtureMatrixBench(context = {}) {
       fixture_root: summary.fixture_root,
       output_directory: summary.output_directory,
       result_summary: summary.result_summary,
+      execution_requested: summary.metadata.execution_requested,
+      execution_status: summary.metadata.execution_status,
+      execution_evidence: summary.metadata.execution_evidence,
       runtime: summary.runtime,
       // Surface failing batches at the top level (also nested in runtime) so a
       // gate-FAIL run stays attributable without re-reading the runtime block.
@@ -302,6 +305,9 @@ export async function runFixtureMatrix(options) {
     replay,
     artifact_refs: written.artifact_refs,
     metadata: {
+      execution_requested: Boolean(options.run),
+      execution_status: collectedResult.summary.execution_status,
+      execution_evidence: executionEvidenceMetadata(options.run),
       performance,
       artifact_bytes: artifactBytes,
       source_staging: written.metadata?.source_staging,
@@ -324,6 +330,26 @@ export async function runFixtureMatrix(options) {
   writeJsonArtifact(path.join(outputDirectory, 'cli-run.json'), summary);
   progress.emit('matrix', runtimeError ? 'failed' : 'completed');
   return { summary, runtimeError, runtime };
+}
+
+function executionEvidenceMetadata(executionRequested) {
+  if (executionRequested) {
+    return {
+      status: 'requested',
+      blind_spots: [],
+    };
+  }
+
+  return {
+    status: 'plan_only',
+    gate_reason: 'execution_not_requested',
+    blind_spots: [
+      'transformer_execution',
+      'wordpress_materialization',
+      'editor_validation',
+      'visual_parity',
+    ],
+  };
 }
 
 // Provision and reconcile a single batch in its own WP Codebox sandbox. Pure with

--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -47,7 +47,8 @@
       "static_site_importer_fixture_matrix_namespace"
     ],
     "result_gates": {
-      "failed_fixture_count": { "lte": 0 }
+      "failed_fixture_count": { "lte": 0 },
+      "not_run_fixture_count": { "lte": 0 }
     }
   },
   "bench_workloads": {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -686,6 +686,12 @@ test('fixture-matrix rig preflight is declarative and checks hydrated prerequisi
   assert.deepEqual(preflightFailures(path.join(packageRoot, 'missing-hydration')), requiredFiles);
 });
 
+test('fixture-matrix rig requires executed fixtures before transformer evidence can pass', () => {
+  const rig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs', 'static-site-importer-fixture-matrix', 'rig.json'), 'utf8'));
+
+  assert.deepEqual(rig.bench.result_gates.not_run_fixture_count, { lte: 0 });
+});
+
 test('fixture-matrix WP Codebox batch runner uses Homeboy declared binary', () => {
   assert.equal(wpCodeboxBin({
     HOMEBOY_WP_CODEBOX_BIN: '/runner/wp-codebox-current',
@@ -4064,6 +4070,12 @@ test('runFixtureMatrixBench returns a partial result with survivors aggregated w
     assert.equal(benchResult.metrics.passed_fixture_count, 3);
     assert.equal(benchResult.metrics.failed_fixture_count, 1);
     assert.equal(benchResult.metrics.not_run_fixture_count, 0);
+    assert.equal(benchResult.metadata.execution_requested, true);
+    assert.equal(benchResult.metadata.execution_status, 'requested');
+    assert.deepEqual(benchResult.metadata.execution_evidence, {
+      status: 'requested',
+      blind_spots: [],
+    });
 
     // The result-gate (failed_fixture_count <= 0) will fail on this, while the
     // partial result is still emitted and the failing batch stays attributable.
@@ -4130,6 +4142,18 @@ test('runFixtureMatrixBench reads workload args from context.args when imported'
     assert.equal(benchResult.metrics.fixture_count, 1);
     assert.equal(benchResult.metadata.fixture_root, path.resolve(contextFixtureRoot));
     assert.equal(benchResult.metadata.output_directory, path.resolve(outputDirectory));
+    assert.equal(benchResult.metadata.execution_requested, false);
+    assert.equal(benchResult.metadata.execution_status, 'not_requested');
+    assert.deepEqual(benchResult.metadata.execution_evidence, {
+      status: 'plan_only',
+      gate_reason: 'execution_not_requested',
+      blind_spots: [
+        'transformer_execution',
+        'wordpress_materialization',
+        'editor_validation',
+        'visual_parity',
+      ],
+    });
     const matrix = JSON.parse(readFileSync(benchResult.artifacts.matrix.path, 'utf8'));
     assert.deepEqual(matrix.fixtures.map((fixture) => fixture.id), ['context-fixture']);
     assert.equal(existsSync(path.join(argvOutputDirectory, 'matrix.json')), false);


### PR DESCRIPTION
## Summary
- expose execution-requested, execution-status, and plan-only blind-spot metadata
- require zero not-run fixtures in the execution-required rig profile
- retain supported direct plan-only behavior while making it impossible to interpret as executed evidence

## Verification
- `node --test tools/fixture-matrix.test.mjs` (194 passed)
- `git diff --check`

Closes #716

## AI assistance
OpenCode with `openai/gpt-5.6-sol` reviewed the run evidence, drafted the execution contract and deterministic coverage, and ran verification. Chris Huber reviewed and remains responsible for the changes.