### PR TITLE
Record bounded block provenance

### DIFF
--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -19,6 +19,8 @@ if ( ! class_exists( 'Static_Site_Importer_Diagnostic_Loss_Classes' ) ) {
 class Static_Site_Importer_Diagnostic_Contract {
 
 	public const IMPORT_DIAGNOSTICS_SCHEMA = 'static-site-importer/import-diagnostics/v1';
+	private const BLOCK_PROVENANCE_LIMIT = 50;
+	private const BLOCK_PROVENANCE_STAGE_LIMIT = 2;
 
 	/**
 	 * Build an importer-owned diagnostics envelope from a validation/import result.
@@ -325,7 +327,98 @@ class Static_Site_Importer_Diagnostic_Contract {
 			'file_count'        => isset( $completed['files'] ) && is_array( $completed['files'] ) ? count( $completed['files'] ) : 0,
 			'operation_count'   => isset( $completed['operations'] ) && is_array( $completed['operations'] ) ? count( $completed['operations'] ) : 0,
 			'declaration_count' => isset( $completed['declaration_ids'] ) && is_array( $completed['declaration_ids'] ) ? count( $completed['declaration_ids'] ) : 0,
+			'block_provenance'  => self::block_provenance_summary( isset( $completed['block_provenance'] ) && is_array( $completed['block_provenance'] ) ? $completed['block_provenance'] : array() ),
+			'block_provenance_count' => isset( $completed['block_provenance_count'] ) ? (int) $completed['block_provenance_count'] : 0,
+			'block_provenance_truncated' => ! empty( $completed['block_provenance_truncated'] ),
 		);
+	}
+
+	/**
+	 * Project provider-supplied provenance to immutable attribution metadata.
+	 *
+	 * @param array<int|string,mixed> $provenance Provider receipt provenance.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function block_provenance_summary( array $provenance ): array {
+		$summary = array();
+		foreach ( array_slice( array_values( $provenance ), 0, self::BLOCK_PROVENANCE_LIMIT ) as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$source = isset( $row['source'] ) && is_array( $row['source'] ) ? $row['source'] : array();
+			$entry  = array(
+				'source' => self::provenance_source_summary( $source ),
+				'stages' => self::provenance_stage_summary( isset( $row['stages'] ) && is_array( $row['stages'] ) ? $row['stages'] : array() ),
+			);
+			if ( ! empty( $entry['source'] ) || ! empty( $entry['stages'] ) ) {
+				$summary[] = $entry;
+			}
+		}
+
+		return $summary;
+	}
+
+	/** @param array<string,mixed> $source @return array<string,string> */
+	private static function provenance_source_summary( array $source ): array {
+		$summary = array();
+		foreach ( array( 'schema', 'source_path', 'reconciliation_identity' ) as $field ) {
+			$value = isset( $source[ $field ] ) ? self::bounded_provenance_string( $source[ $field ], 1024 ) : '';
+			if ( '' !== $value ) {
+				$summary[ $field ] = $value;
+			}
+		}
+
+		return $summary;
+	}
+
+	/** @param array<int|string,mixed> $stages @return array<int,array<string,mixed>> */
+	private static function provenance_stage_summary( array $stages ): array {
+		$summary = array();
+		foreach ( array_slice( array_values( $stages ), 0, self::BLOCK_PROVENANCE_STAGE_LIMIT ) as $stage ) {
+			if ( ! is_array( $stage ) ) {
+				continue;
+			}
+
+			$entry = array();
+			$name = isset( $stage['stage'] ) ? self::bounded_provenance_string( $stage['stage'], 1024 ) : '';
+			if ( '' !== $name ) {
+				$entry['stage'] = $name;
+			}
+			foreach ( array( 'input_sha256', 'input_bytes', 'input_count' ) as $field ) {
+				if ( isset( $stage[ $field ] ) && is_scalar( $stage[ $field ] ) ) {
+					$value = 'input_sha256' === $field ? self::bounded_provenance_string( $stage[ $field ], 128 ) : (int) $stage[ $field ];
+					if ( '' !== $value ) {
+						$entry[ $field ] = $value;
+					}
+				}
+			}
+			$output = isset( $stage['output'] ) && is_array( $stage['output'] ) ? $stage['output'] : array();
+			foreach ( array( 'sha256', 'bytes', 'count' ) as $field ) {
+				if ( isset( $output[ $field ] ) && is_scalar( $output[ $field ] ) ) {
+					$value = 'sha256' === $field ? self::bounded_provenance_string( $output[ $field ], 128 ) : (int) $output[ $field ];
+					if ( '' !== $value ) {
+						$entry['output'][ $field ] = $value;
+					}
+				}
+			}
+			if ( ! empty( $entry ) ) {
+				$summary[] = $entry;
+			}
+		}
+
+		return $summary;
+	}
+
+	/** @param mixed $value */
+	private static function bounded_provenance_string( $value, int $limit ): string {
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
+		$value = substr( (string) $value, 0, $limit );
+
+		return str_contains( $value, '<' ) || str_contains( $value, '>' ) ? '' : $value;
 	}
 
 	/**

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -11,6 +11,7 @@ use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanRe
 final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	public const RECEIPT_SCHEMA = 'static-site-importer/materialization-receipt/v1';
 	private const RECONCILIATION_META_KEY = '_static_site_importer_reconciliation_identity';
+	private const BLOCK_PROVENANCE_LIMIT = 50;
 
 	/**
 	 * Materialize a fully canonical v2 plan. Compilation and plan validation belong to Blocks Engine.
@@ -487,12 +488,21 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$plan = $state['plan'];
 		$resolved_plan = $state['resolved'] ?? $plan;
 		$materialized_pages = array();
+		$block_provenance = array();
+		$block_provenance_count = 0;
 		$written_sources = array_fill_keys( array_filter( array_column( $state['applied']['posts'] ?? array(), 'source_path' ), 'is_string' ), true );
 		foreach ( $resolved_plan['pages'] as &$page ) {
-			if ( isset( $page['materialized_block_markup'] ) ) {
-				if ( isset( $written_sources[ $page['source_path'] ] ) ) {
+			if ( isset( $written_sources[ $page['source_path'] ] ) ) {
+				$materialized_markup = (string) ( $page['materialized_block_markup'] ?? $page['resolved_block_markup'] ?? '' );
+				++$block_provenance_count;
+				if ( count( $block_provenance ) < self::BLOCK_PROVENANCE_LIMIT ) {
+					$block_provenance[] = self::block_provenance( $page, $materialized_markup );
+				}
+				if ( isset( $page['materialized_block_markup'] ) ) {
 					$materialized_pages[ $page['source_path'] ] = array( 'block_markup' => $page['materialized_block_markup'], 'content_hash' => hash( 'sha256', $page['materialized_block_markup'] ) );
 				}
+			}
+			if ( isset( $page['materialized_block_markup'] ) ) {
 				unset( $page['materialized_block_markup'] );
 			}
 		}
@@ -516,6 +526,9 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'operations' => $state['applied']['operations'],
 				'runtime_declarations' => $state['applied']['runtime_declarations'] ?? array( 'asset_publications' => array() ),
 				'materialized_pages' => $materialized_pages,
+				'block_provenance' => $block_provenance,
+				'block_provenance_count' => $block_provenance_count,
+				'block_provenance_truncated' => $block_provenance_count > count( $block_provenance ),
 				'declaration_ids' => array_keys( $state['applied']['runtime_declarations']['asset_publications'] ?? array() ),
 			),
 			'reconciliation_identities' => array_merge( array_column( $plan['pages'] ?? array(), 'reconciliation_identity' ), array_column( $plan['writes'] ?? array(), 'reconciliation_identity' ), array_column( $plan['runtime_declarations'] ?? array(), 'reconciliation_identity' ) ),
@@ -526,6 +539,46 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			'existing_matches'          => $state['existing_matches'],
 			'diagnostics'               => $state['diagnostics'],
 			'errors'                    => $errors,
+		);
+	}
+
+	/**
+	 * Record bounded stage evidence for one WordPress page without retaining markup.
+	 *
+	 * @param array<string,mixed> $page              Resolved compiler page.
+	 * @param string              $materialized_markup WordPress post-content markup.
+	 * @return array<string,mixed>
+	 */
+	private static function block_provenance( array $page, string $materialized_markup ): array {
+		$resolved_markup = (string) ( $page['resolved_block_markup'] ?? '' );
+		$resolved_evidence = self::bounded_block_markup_evidence( $resolved_markup );
+		$stages = array(
+			array( 'stage' => 'blocks-engine/wordpress-site-plan-resolver', 'output' => $resolved_evidence ),
+		);
+		if ( $resolved_markup !== $materialized_markup ) {
+			$stages[] = array(
+				'stage' => 'static-site-importer/runtime-entity-bindings',
+				'input_sha256' => $resolved_evidence['sha256'],
+				'output' => self::bounded_block_markup_evidence( $materialized_markup ),
+			);
+		}
+
+		return array(
+			// This mirrors the page meta provenance written during materialization.
+			'source' => array(
+				'schema' => 'static-site-importer/page-provenance/v1',
+				'source_path' => (string) ( $page['source_path'] ?? '' ),
+				'reconciliation_identity' => (string) ( $page['reconciliation_identity'] ?? '' ),
+			),
+			'stages' => $stages,
+		);
+	}
+
+	/** @return array{sha256:string,bytes:int} */
+	private static function bounded_block_markup_evidence( string $markup ): array {
+		return array(
+			'sha256'  => hash( 'sha256', $markup ),
+			'bytes'   => strlen( $markup ),
 		);
 	}
 

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -195,6 +195,7 @@ export function collectMatrixEvidence(payload) {
     ...(materializationReceipt.schema === 'static-site-importer/materialization-receipt/v1' && materializationReceipt.status === 'completed' ? [] : ['materialization_receipt']),
   ];
   const sourceAssets = normalizeArray(plan.assets);
+  const blockProvenance = normalizeArray(materializationReceipt.block_provenance || materializationReceipt.blockProvenance || completedMaterialization.block_provenance || completedMaterialization.blockProvenance).slice(0, 50).map(blockProvenanceSummary);
   const assetCount = Number.isFinite(Number(plan.asset_count ?? plan.assetCount)) ? Number(plan.asset_count ?? plan.assetCount) : sourceAssets.length;
   const assets = sourceAssets
     .map(materializationPlanAssetSummary)
@@ -219,9 +220,29 @@ export function collectMatrixEvidence(payload) {
       file_count: Number.isFinite(Number(materializationReceipt.file_count ?? materializationReceipt.fileCount)) ? Number(materializationReceipt.file_count ?? materializationReceipt.fileCount) : normalizeArray(completedMaterialization.files).length,
       operation_count: Number.isFinite(Number(materializationReceipt.operation_count ?? materializationReceipt.operationCount)) ? Number(materializationReceipt.operation_count ?? materializationReceipt.operationCount) : normalizeArray(completedMaterialization.operations).length,
       declaration_count: Number.isFinite(Number(materializationReceipt.declaration_count ?? materializationReceipt.declarationCount)) ? Number(materializationReceipt.declaration_count ?? materializationReceipt.declarationCount) : normalizeArray(completedMaterialization.declaration_ids || completedMaterialization.declarationIds).length,
+      ...(materializationReceipt.block_provenance_count !== undefined || materializationReceipt.blockProvenanceCount !== undefined ? { block_provenance_count: Number.isFinite(Number(materializationReceipt.block_provenance_count ?? materializationReceipt.blockProvenanceCount)) ? Number(materializationReceipt.block_provenance_count ?? materializationReceipt.blockProvenanceCount) : blockProvenance.length } : {}),
+      ...(materializationReceipt.block_provenance_truncated !== undefined || materializationReceipt.blockProvenanceTruncated !== undefined ? { block_provenance_truncated: Boolean(materializationReceipt.block_provenance_truncated ?? materializationReceipt.blockProvenanceTruncated) } : {}),
+      ...(blockProvenance.length > 0 ? { block_provenance: blockProvenance } : {}),
     }),
     template_parts: templateParts,
   };
+}
+
+function blockProvenanceSummary(provenance) {
+  const row = objectValue(provenance);
+  const source = objectValue(row.source);
+  return compactObject({
+    source: compactObject({
+      schema: firstString([source.schema]),
+      source_path: firstString([source.source_path, source.sourcePath]),
+      reconciliation_identity: firstString([source.reconciliation_identity, source.reconciliationIdentity]),
+    }),
+    stages: normalizeArray(row.stages).slice(0, 2).map((stage) => {
+      const record = objectValue(stage);
+      const output = objectValue(record.output);
+      return compactObject({ stage: firstString([record.stage]), input_sha256: firstString([record.input_sha256, record.inputSha256]), output: compactObject({ sha256: firstString([output.sha256]), bytes: Number.isFinite(Number(output.bytes)) ? Number(output.bytes) : undefined }) });
+    }),
+  });
 }
 
 function isConcreteTransformerValue(value) {

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -68,6 +68,7 @@ require dirname( __DIR__ ) . '/includes/class-static-site-importer-woo-product-s
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-form-seeder.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php';
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
 
 $assert = static function ( bool $condition, string $message ): void {
 	if ( ! $condition ) {
@@ -101,6 +102,10 @@ $assert( str_contains( file_get_contents( $GLOBALS['ssi_plan_root'] . '/site-pla
 $assert( 'posts' === $GLOBALS['ssi_plan_options']['show_on_front'], 'plan-only materialization does not change reading settings by default' );
 $assert( $receipt['plan']['pages'][0]['document_metadata']['links'][0]['resolved_url'] === 'https://example.test/wp-content/themes/site-plan/assets/assets/site.css', 'resolved metadata retains the declared stylesheet destination' );
 $assert( array() === $receipt['completed']['runtime_declarations']['asset_publications'], 'plans without publication declarations retain an explicit empty receipt collection' );
+$unbound_provenance = $receipt['completed']['block_provenance'] ?? array();
+$assert( count( $plan['pages'] ) === count( $unbound_provenance ) && count( $plan['pages'] ) === ( $receipt['completed']['block_provenance_count'] ?? 0 ), 'ordinary resolved pages receive receipt provenance without runtime bindings' );
+$assert( 'blocks-engine/wordpress-site-plan-resolver' === ( $unbound_provenance[0]['stages'][0]['stage'] ?? '' ) && hash( 'sha256', $receipt['plan']['pages'][0]['resolved_block_markup'] ) === ( $unbound_provenance[0]['stages'][0]['output']['sha256'] ?? '' ), 'ordinary page provenance records the resolver output hash' );
+$assert( false === ( $receipt['completed']['block_provenance_truncated'] ?? true ) && ! str_contains( (string) wp_json_encode( $unbound_provenance ), (string) $receipt['plan']['pages'][0]['resolved_block_markup'] ), 'provenance uses structural evidence without raw page markup' );
 
 $entity_artifact = $artifact;
 $entity_search = '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Add</a></div><!-- /wp:button --></div><!-- /wp:buttons -->';
@@ -131,6 +136,11 @@ $binding_replacement = '<!-- wp:shortcode -->[add_to_cart id="42"]<!-- /wp:short
 $binding_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $binding_plan, array( 'slug' => 'binding-plan', 'runtime_entity_bindings' => array( array( 'schema' => 'static-site-importer/runtime-entity-binding/v1', 'source_path' => 'index.html', 'search_block_markup' => $binding_search, 'replacement_block_markup' => $binding_replacement, 'occurrence' => 1, 'role' => 'commerce_controls', 'declaration_id' => $entity_declaration_id, 'reconciliation_identity' => hash( 'sha256', 'binding-test' ), 'superseded_runtime_selectors' => array( '.add-to-cart' ) ) ) ) );
 $assert( str_contains( $binding_receipt['completed']['materialized_pages']['index.html']['block_markup'] ?? '', '[add_to_cart id="42"]' ) && ! isset( $binding_receipt['plan']['pages'][0]['materialized_block_markup'] ), 'runtime binding is receipt-owned without mutating the canonical resolved plan' );
 $assert( hash( 'sha256', $binding_receipt['completed']['materialized_pages']['index.html']['block_markup'] ) === ( $binding_receipt['completed']['materialized_pages']['index.html']['content_hash'] ?? '' ), 'materialized page receipt owns the final provider-bound content hash' );
+$binding_provenance = $binding_receipt['completed']['block_provenance'][0] ?? array();
+$assert( 'static-site-importer/page-provenance/v1' === ( $binding_provenance['source']['schema'] ?? '' ) && 'index.html' === ( $binding_provenance['source']['source_path'] ?? '' ) && ! isset( $binding_provenance['source']['compiler_node_id'] ), 'receipt uses existing sanitized page provenance without fabricating compiler identities' );
+$assert( 'blocks-engine/wordpress-site-plan-resolver' === ( $binding_provenance['stages'][0]['stage'] ?? '' ) && hash( 'sha256', $binding_receipt['plan']['pages'][0]['resolved_block_markup'] ) === ( $binding_provenance['stages'][0]['output']['sha256'] ?? '' ), 'receipt records the resolver output before runtime binding' );
+$assert( 'static-site-importer/runtime-entity-bindings' === ( $binding_provenance['stages'][1]['stage'] ?? '' ) && ( $binding_provenance['stages'][0]['output']['sha256'] ?? '' ) === ( $binding_provenance['stages'][1]['input_sha256'] ?? '' ) && hash( 'sha256', $binding_receipt['completed']['materialized_pages']['index.html']['block_markup'] ) === ( $binding_provenance['stages'][1]['output']['sha256'] ?? '' ), 'receipt distinguishes the runtime-binding output from resolver output' );
+$assert( ! str_contains( (string) wp_json_encode( $binding_provenance ), '[add_to_cart id="42"]' ), 'runtime-bound provenance does not leak provider markup' );
 $binding_post_id = (int) ( $binding_receipt['completed']['pages']['index.html'] ?? 0 );
 $assert( str_contains( $GLOBALS['ssi_plan_posts'][ $binding_post_id ]['post_content'] ?? '', '[add_to_cart id=\"42\"]' ), 'page write uses provider-bound markup rather than the static fallback' );
 $assert( 'completed' === ( reset( $binding_receipt['completed']['runtime_declarations']['entity_bindings'] )['status'] ?? '' ), 'receipt proves canonical runtime entity binding completion' );
@@ -234,6 +244,42 @@ $dynamic_artifact['files']['assets/site.js'] = 'window.sitePlan = true;';
 $dynamic_plan = ( new ArtifactCompiler() )->compile( $dynamic_artifact )->toArray()['source_reports']['wordpress_site_plan'];
 $dynamic_completed = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $dynamic_plan, array( 'slug' => 'dynamic-plan' ) );
 $assert( 'completed' === $dynamic_completed['status'], 'declared static local scripts are proven and materialize' );
+
+$many_files = array( 'index.html' => '<main><h1>Index</h1></main>' );
+for ( $index = 1; $index <= 50; ++$index ) {
+	$many_files[ 'page-' . $index . '.html' ] = '<main><h1>Page ' . $index . '</h1></main>';
+}
+$many_plan = ( new ArtifactCompiler() )->compile( array( 'entrypoint' => 'index.html', 'files' => $many_files ) )->toArray()['source_reports']['wordpress_site_plan'];
+$many_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $many_plan, array( 'slug' => 'many-pages-plan' ) );
+$assert( 51 === ( $many_receipt['completed']['block_provenance_count'] ?? 0 ) && 50 === count( $many_receipt['completed']['block_provenance'] ?? array() ) && true === ( $many_receipt['completed']['block_provenance_truncated'] ?? false ), 'receipt enforces the provenance cap before downstream projection' );
+
+$provider_receipt_diagnostics = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'materialization_receipt' => array(
+			'schema'    => 'static-site-importer/materialization-receipt/v1',
+			'status'    => 'completed',
+			'plan_hash' => 'provider-plan-hash',
+			'completed' => array(
+				'block_provenance_count' => 1,
+				'block_provenance'       => array(
+					array(
+						'source'   => array( 'schema' => 'static-site-importer/page-provenance/v1', 'source_path' => 'index.html', 'reconciliation_identity' => 'page-index', 'raw_source_html' => '<main>provider source markup</main>', 'unknown_source_key' => 'provider payload' ),
+						'stages'   => array(
+							array( 'stage' => 'blocks-engine/wordpress-site-plan-resolver', 'output' => array( 'sha256' => 'resolved-hash', 'bytes' => 18, 'preview' => '<p>provider preview</p>' ), 'provider_html' => '<p>provider HTML</p>' ),
+							array( 'stage' => 'static-site-importer/runtime-entity-bindings', 'input_sha256' => 'resolved-hash', 'output' => array( 'sha256' => 'bound-hash', 'bytes' => 21, 'count' => 1, 'raw_markup' => '<p>bound markup</p>' ), 'unknown_stage_key' => 'provider value' ),
+							array( 'stage' => 'provider-extra-stage', 'output' => array( 'sha256' => 'must-not-survive' ) ),
+						),
+						'unknown_row_key' => array( 'provider' => 'payload' ),
+					),
+				),
+			),
+		),
+	)
+);
+$projected_provider_provenance = $provider_receipt_diagnostics['materialization_receipt']['block_provenance'] ?? array();
+$projected_provider_json        = (string) wp_json_encode( $projected_provider_provenance );
+$assert( array( array( 'source' => array( 'schema' => 'static-site-importer/page-provenance/v1', 'source_path' => 'index.html', 'reconciliation_identity' => 'page-index' ), 'stages' => array( array( 'stage' => 'blocks-engine/wordpress-site-plan-resolver', 'output' => array( 'sha256' => 'resolved-hash', 'bytes' => 18 ) ), array( 'stage' => 'static-site-importer/runtime-entity-bindings', 'input_sha256' => 'resolved-hash', 'output' => array( 'sha256' => 'bound-hash', 'bytes' => 21, 'count' => 1 ) ) ) ) ) === $projected_provider_provenance, 'fixture diagnostics project only bounded provenance identity and stage metadata' );
+$assert( ! str_contains( $projected_provider_json, 'provider source markup' ) && ! str_contains( $projected_provider_json, 'provider HTML' ) && ! str_contains( $projected_provider_json, 'provider preview' ) && ! str_contains( $projected_provider_json, 'unknown_source_key' ) && ! str_contains( $projected_provider_json, 'unknown_row_key' ) && ! str_contains( $projected_provider_json, 'unknown_stage_key' ) && ! str_contains( $projected_provider_json, 'provider-extra-stage' ), 'fixture diagnostics reject provider markup, previews, nested payloads, and unknown provenance keys' );
 
 $GLOBALS['ssi_plan_posts'] = array();
 $GLOBALS['ssi_plan_meta']  = array();

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -127,13 +127,23 @@ test('matrix evidence consumes the bounded fixture diagnostic contract', () => {
         file_count: 2,
         operation_count: 3,
         declaration_count: 4,
+        block_provenance_count: 1,
+        block_provenance: [{ source: { schema: 'static-site-importer/page-provenance/v1', source_path: 'contact.html', reconciliation_identity: 'page-id' }, stages: [{ stage: 'blocks-engine/wordpress-site-plan-resolver', output: { sha256: 'resolved-hash', bytes: 18 } }, { stage: 'static-site-importer/runtime-entity-bindings', input_sha256: 'resolved-hash', output: { sha256: 'bound-hash', bytes: 21 } }] }],
       },
     },
   });
   assert.equal(evidence.readiness, 'verified');
   assert.equal(evidence.transformer.package_reference, reference);
   assert.equal(evidence.wordpress_site_plan.asset_count, 1);
-  assert.deepEqual(evidence.materialization_receipt, { schema: 'static-site-importer/materialization-receipt/v1', status: 'completed', plan_hash: 'plan-hash', page_count: 1, file_count: 2, operation_count: 3, declaration_count: 4 });
+  assert.equal(evidence.materialization_receipt.schema, 'static-site-importer/materialization-receipt/v1');
+  assert.equal(evidence.materialization_receipt.status, 'completed');
+  assert.equal(evidence.materialization_receipt.plan_hash, 'plan-hash');
+  assert.deepEqual(evidence.materialization_receipt.block_provenance, [{
+    source: { schema: 'static-site-importer/page-provenance/v1', source_path: 'contact.html', reconciliation_identity: 'page-id' },
+    stages: [{ stage: 'blocks-engine/wordpress-site-plan-resolver', output: { sha256: 'resolved-hash', bytes: 18 } }, { stage: 'static-site-importer/runtime-entity-bindings', input_sha256: 'resolved-hash', output: { sha256: 'bound-hash', bytes: 21 } }],
+  }]);
+  assert.equal(evidence.materialization_receipt.block_provenance_count, 1);
+  assert.equal(JSON.stringify(evidence.materialization_receipt.block_provenance).includes('preview'), false);
 });
 
 test('block composition uses nested runtime quality metrics and diagnostic fallback counts', () => {


### PR DESCRIPTION
## Summary
- record resolver and runtime-binding stage hashes and byte counts in materialization receipts
- cap provenance at 50 pages and project only allowlisted identity and structural evidence
- carry bounded stage provenance into fixture-matrix evidence without retaining provider markup or previews

## Verification
- `node --test tools/fixture-matrix.test.mjs` (193 passed)
- `php tests/smoke-wordpress-site-plan-materializer.php`
- `git diff --check`

Closes #717

## AI assistance
OpenCode with `openai/gpt-5.6-sol` analyzed the attribution gap, drafted the bounded provenance contract and end-to-end coverage, and ran verification. Chris Huber reviewed and remains responsible for the changes.