### PR TITLE
Update PHP transformer to 0.4.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.4.6",
+        "version": "0.4.7",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "533e6c3f76f9b439232ddc441f6e544331c5de59"
+          "reference": "d74fefaf6ebdb4e5cb50e9b53aed2e07d0e7428d"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.6.zip",
-          "reference": "533e6c3f76f9b439232ddc441f6e544331c5de59"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.7.zip",
+          "reference": "d74fefaf6ebdb4e5cb50e9b53aed2e07d0e7428d"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "^0.4.6",
+    "automattic/blocks-engine-php-transformer": "^0.4.7",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fabb7f047253a3d6d84aae9c5b1f603d",
+    "content-hash": "e1285ed66f6874ff1b1726a29f6082d1",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.4.6",
+            "version": "0.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "533e6c3f76f9b439232ddc441f6e544331c5de59"
+                "reference": "d74fefaf6ebdb4e5cb50e9b53aed2e07d0e7428d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.6.zip",
-                "reference": "533e6c3f76f9b439232ddc441f6e544331c5de59"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.7.zip",
+                "reference": "d74fefaf6ebdb4e5cb50e9b53aed2e07d0e7428d"
             },
             "require": {
                 "league/commonmark": "^2.5",

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -107,6 +107,19 @@ $assert( count( $plan['pages'] ) === count( $unbound_provenance ) && count( $pla
 $assert( 'blocks-engine/wordpress-site-plan-resolver' === ( $unbound_provenance[0]['stages'][0]['stage'] ?? '' ) && hash( 'sha256', $receipt['plan']['pages'][0]['resolved_block_markup'] ) === ( $unbound_provenance[0]['stages'][0]['output']['sha256'] ?? '' ), 'ordinary page provenance records the resolver output hash' );
 $assert( false === ( $receipt['completed']['block_provenance_truncated'] ?? true ) && ! str_contains( (string) wp_json_encode( $unbound_provenance ), (string) $receipt['plan']['pages'][0]['resolved_block_markup'] ), 'provenance uses structural evidence without raw page markup' );
 
+$nested_route_result = ( new ArtifactCompiler() )->compile(
+	array(
+		'entrypoint' => 'website/index.html',
+		'files'      => array(
+			'website/api/index.html'       => '<main><h1>API</h1></main>',
+			'website/lifecycle/index.html' => '<main><h1>Lifecycle</h1></main>',
+			'website/index.html'           => '<main><h1>Home</h1></main>',
+		),
+	)
+)->toArray();
+$nested_routes = array_column( $nested_route_result['source_reports']['wordpress_site_plan']['routes'], 'target_path', 'source_path' );
+$assert( 3 === count( $nested_routes ) && '/' === ( $nested_routes['website/index.html'] ?? '' ) && '/api' === ( $nested_routes['website/api/index.html'] ?? '' ) && '/lifecycle' === ( $nested_routes['website/lifecycle/index.html'] ?? '' ), 'nested index documents retain distinct routes when the declared root entrypoint is ordered last' );
+
 $product_grid_artifact = array(
 	'entrypoint' => 'index.html',
 	'files'      => array(
@@ -124,7 +137,7 @@ $bridged_lifecycle = ( new ReflectionMethod( Static_Site_Importer_Theme_Generato
 $assert( 'runtime_declarations' === ( $bridged_lifecycle['status'] ?? '' ) && true === ( reset( $bridged_lifecycle['entities'] )['required'] ?? false ), 'bridged product entities enter the required canonical seeding lifecycle' );
 
 $entity_artifact = $artifact;
-$entity_search = '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Add</a></div><!-- /wp:button --></div><!-- /wp:buttons -->';
+$entity_search = '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button {"tagName":"button","text":"Add"} --><div class="wp-block-button"><button type="button" class="wp-block-button__link wp-element-button">Add</button></div><!-- /wp:button --></div><!-- /wp:buttons -->';
 $entity_artifact['files']['index.html'] = '<main><h1>Home</h1><div class="wp-block-buttons"><button>Add</button></div></main>';
 $entity_artifact['runtime_declarations'] = array(
 	array( 'kind' => 'dependency', 'capability' => 'shop', 'source_path' => 'index.html', 'required_for' => array( 'entity_collection:products' ) ),


### PR DESCRIPTION
## Summary

- pin the published Blocks Engine PHP Transformer `0.4.7` release and immutable release commit
- prove nested `*/index.html` documents retain distinct routes when the artifact root entrypoint is ordered last
- align the synthetic runtime-binding fixture with `0.4.7` canonical button markup

Upstream repair: https://github.com/Automattic/blocks-engine/pull/693
Release: https://github.com/Automattic/blocks-engine/releases/tag/php-transformer-v0.4.7
Downstream: https://github.com/Automattic/wp-codebox/pull/2013

## Testing

- `composer validate --strict`
- `npm test`
- 195 fixture-matrix tests passed, plus runtime-package, site-plan materialization, solved-site promotion, Fig workflow, promotion, and PHP-WASM zstd contracts

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode helped trace the dependency compatibility failure, update the immutable package pin, draft nested-route regression coverage, and run the complete suite. Chris Huber reviewed and is responsible for the change.