### PR TITLE
Preserve portable transformer references

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -1141,6 +1141,9 @@ function prepareDependencyOverrides(options) {
         blocks_engine_php_transformer: {
           package: 'automattic/blocks-engine-php-transformer',
           path: blocksEnginePhpTransformerPath,
+          ...(options.blocksEnginePhpTransformerReference
+            ? { reference: options.blocksEnginePhpTransformerReference }
+            : {}),
         },
       }
       : {}),
@@ -1456,6 +1459,7 @@ export function optionsFromEnv(env = process.env) {
     maxComplexity: benchEnv.SSI_FIXTURE_MATRIX_MAX_COMPLEXITY || env.SSI_FIXTURE_MATRIX_MAX_COMPLEXITY,
     artifactRoot: benchEnv.SSI_FIXTURE_MATRIX_ARTIFACT_ROOT || env.SSI_FIXTURE_MATRIX_ARTIFACT_ROOT,
     blocksEnginePhpTransformerPath: benchEnv.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH || env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH,
+    blocksEnginePhpTransformerReference: benchEnv.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE || env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE,
     wordpressVersion: benchEnv.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION || env.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION,
     batchSize: benchEnv.SSI_FIXTURE_MATRIX_BATCH_SIZE || env.SSI_FIXTURE_MATRIX_BATCH_SIZE,
     concurrency: benchEnv.SSI_FIXTURE_MATRIX_CONCURRENCY || env.SSI_FIXTURE_MATRIX_CONCURRENCY,
@@ -1644,6 +1648,8 @@ Options:
   --artifact-root <path>             Generated artifact root to normalize into fixtures.
   --blocks-engine-php-transformer-path <path>
                                      Blocks Engine repo root or php-transformer package path for Composer.
+  --blocks-engine-php-transformer-reference <ref>
+                                     Immutable 40-64 character hexadecimal package source reference.
   --entrypoint <file>                Fixture entrypoint. Defaults to index.html.
   --max-depth <n>                    Fixture discovery depth. Defaults to 2.
   --surface-coverage <n>             Capture front page plus up to n secondary HTML surfaces.

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -606,6 +606,10 @@ function buildDependencyOverrideSetup(input, importer) {
   if (packageComposer?.name !== packageName) {
     throw new Error(`SSI dependency override path must contain ${packageName}: ${packagePath}`);
   }
+  const reference = blocksEnginePhpTransformer.reference || '';
+  if (reference && !/^[a-f0-9]{40,64}$/i.test(reference)) {
+    throw new Error('SSI dependency override reference must be a 40-64 character hexadecimal immutable reference');
+  }
 
   return {
     dependencyOverlays: [
@@ -614,6 +618,7 @@ function buildDependencyOverrideSetup(input, importer) {
         package: packageName,
         consumer: importer.slug,
         source: packagePath,
+        ...(reference ? { reference } : {}),
       },
     ],
   };

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -721,6 +721,7 @@ test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () 
     name: 'automattic/blocks-engine-php-transformer',
   }));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'recipe-dependency-override-test' });
+  const reference = 'a'.repeat(40);
 
   const recipe = buildFixtureMatrixRecipe({
     matrix,
@@ -730,6 +731,7 @@ test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () 
       blocks_engine_php_transformer: {
         package: 'automattic/blocks-engine-php-transformer',
         path: transformerPath,
+        reference,
       },
     },
   });
@@ -739,6 +741,7 @@ test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () 
     package: 'automattic/blocks-engine-php-transformer',
     consumer: 'static-site-importer',
     source: transformerPath,
+    reference,
   });
   assert.equal(recipe.inputs.mounts.length, 0);
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
@@ -761,6 +764,21 @@ test('fails recipe generation for invalid SSI dependency override paths', () => 
       },
     },
   }), /composer\.json not found/);
+
+  writeFileSync(path.join(root, 'composer.json'), JSON.stringify({
+    name: 'automattic/blocks-engine-php-transformer',
+  }));
+  assert.throws(() => buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    dependencyOverrides: {
+      blocks_engine_php_transformer: {
+        path: root,
+        reference: 'not-an-immutable-reference',
+      },
+    },
+  }), /reference must be a 40-64 character hexadecimal immutable reference/);
 });
 
 test('normalizes SSI diagnostics into product repair groups', () => {
@@ -3323,6 +3341,7 @@ test('code freshness guard lets fresh and diverged overrides through with accura
   mkdirSync(staticSiteImporter, { recursive: true });
   mkdirSync(path.join(freshFixtureRoot, 'fixture-a'), { recursive: true });
 
+  const transformerReference = 'b'.repeat(40);
   const freshPlan = buildFixtureMatrixRunPlan({
     staticSiteImporter,
     blocksEngine,
@@ -3330,7 +3349,7 @@ test('code freshness guard lets fresh and diverged overrides through with accura
     skipInstall: true,
     skipSync: true,
     gitRunner: fakeGitRunner({
-      [path.resolve(blocksEngine)]: { branch: 'trunk', upstream: 'origin/trunk', behind: 0, ahead: 2, commit: 'aheadcommit' },
+      [path.resolve(blocksEngine)]: { branch: 'trunk', upstream: 'origin/trunk', behind: 0, ahead: 2, commit: transformerReference },
       [path.resolve(staticSiteImporter)]: { branch: 'main', upstream: 'origin/main', behind: 0, ahead: 0, commit: 'freshcommit' },
     }),
   });
@@ -3338,6 +3357,8 @@ test('code freshness guard lets fresh and diverged overrides through with accura
   assert.equal(freshPlan.code_freshness.would_block, false);
   assert.deepEqual(freshPlan.code_freshness.stale_overrides, []);
   assert.equal(freshPlan.code_freshness.paths.blocks_engine_php_transformer_path.status, 'ahead');
+  assert.equal(freshPlan.dependency_overrides.blocks_engine_php_transformer.reference, transformerReference);
+  assert.ok(freshPlan.steps.at(-1).args.includes(`bench_env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE=${transformerReference}`));
   assert.equal(freshPlan.warnings.some((warning) => warning.code === 'stale_override'), false);
 
   const diverged = resolvePathFreshness(
@@ -5283,6 +5304,13 @@ test('fixture matrix maps visual attribution environment settings', () => {
   assert.equal(options.maxExplanationElements, '500');
   assert.equal(options.maxExplanationCandidates, '600');
   assert.equal(options.explainSelectors, '.hero, #footer');
+});
+
+test('fixture matrix maps the portable transformer reference setting', () => {
+  const reference = 'c'.repeat(40);
+  assert.equal(optionsFromEnv({
+    SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE: reference,
+  }).blocksEnginePhpTransformerReference, reference);
 });
 
 test('fixture matrix maps visual parity external request isolation', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -3342,16 +3342,18 @@ test('code freshness guard lets fresh and diverged overrides through with accura
   mkdirSync(path.join(freshFixtureRoot, 'fixture-a'), { recursive: true });
 
   const transformerReference = 'b'.repeat(40);
+  const gitRunner = fakeGitRunner({
+    [path.resolve(blocksEngine)]: { branch: 'trunk', upstream: 'origin/trunk', behind: 0, ahead: 2, commit: transformerReference },
+    [path.resolve(staticSiteImporter)]: { branch: 'main', upstream: 'origin/main', behind: 0, ahead: 0, commit: 'freshcommit' },
+  });
   const freshPlan = buildFixtureMatrixRunPlan({
     staticSiteImporter,
     blocksEngine,
     runId: 'ssi-freshness-fresh',
     skipInstall: true,
     skipSync: true,
-    gitRunner: fakeGitRunner({
-      [path.resolve(blocksEngine)]: { branch: 'trunk', upstream: 'origin/trunk', behind: 0, ahead: 2, commit: transformerReference },
-      [path.resolve(staticSiteImporter)]: { branch: 'main', upstream: 'origin/main', behind: 0, ahead: 0, commit: 'freshcommit' },
-    }),
+    dependencyOverlayReferences: true,
+    gitRunner,
   });
 
   assert.equal(freshPlan.code_freshness.would_block, false);
@@ -3360,6 +3362,17 @@ test('code freshness guard lets fresh and diverged overrides through with accura
   assert.equal(freshPlan.dependency_overrides.blocks_engine_php_transformer.reference, transformerReference);
   assert.ok(freshPlan.steps.at(-1).args.includes(`bench_env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE=${transformerReference}`));
   assert.equal(freshPlan.warnings.some((warning) => warning.code === 'stale_override'), false);
+
+  const compatiblePlan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    blocksEngine,
+    runId: 'ssi-freshness-compatible',
+    skipInstall: true,
+    skipSync: true,
+    gitRunner,
+  });
+  assert.equal(compatiblePlan.dependency_overrides.blocks_engine_php_transformer.reference, undefined);
+  assert.equal(compatiblePlan.steps.at(-1).args.some((arg) => arg.includes('SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE')), false);
 
   const diverged = resolvePathFreshness(
     'blocks_engine_php_transformer_path',

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -92,7 +92,7 @@ async function main() {
 export function buildFixtureMatrixRunPlan(input) {
   const options = normalizeOptions(input);
   const codeFreshness = buildCodeFreshness(options, options.gitRunner || defaultGitRunner);
-  const transformerReference = resolveTransformerReference(codeFreshness);
+  const transformerReference = options.dependencyOverlayReferences ? resolveTransformerReference(codeFreshness) : '';
   const settings = {
     SSI_FIXTURE_MATRIX_FIXTURE_ROOT: options.fixtureRoot,
     SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH: options.staticSiteImporter,
@@ -883,7 +883,7 @@ function parseArgs(args) {
     if (arg.startsWith('--')) {
       const [rawKey, rawValue] = arg.slice(2).split('=');
       const key = camelCase(rawKey);
-      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'visualParityAlignment', 'liveWpParity', 'promotionGate', 'solvedOnly']);
+      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate', 'visualParityAlignment', 'liveWpParity', 'promotionGate', 'solvedOnly', 'dependencyOverlayReferences']);
       if (booleanKeys.has(key)) {
         options[key] = true;
         continue;
@@ -1008,11 +1008,16 @@ function printHelp() {
   process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Passes --placement local to homeboy bench.\n  --runner <id>                       Passes --runner <id> to homeboy bench (implies Lab placement).\n  --lab-only                          Passes --placement lab without selecting a runner.\n  --allow-local-fallback              Passes --placement lab-or-local to homeboy bench.\n  no routing flags                    Passes --placement auto to homeboy bench.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote>, --lab-only, or --allow-local-fallback.\n  --lab-only cannot be combined with --allow-local-fallback.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n    --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures, which discovers both fixtures/websites and fixtures/solved.
 \n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 2, hard-capped at 16.\n  --target-fixture <id>               Run one active fixture for the fast inner loop.\n  --promotion-gate                    Run the target plus every solved fixture, one per batch, and require solved_candidate for all.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind upstream.\n  --allow-local-fallback              Permit selected Lab runner fallback to local execution.\n  --allow-dirty-lab-workspace         Permit reusing/overwriting a dirty Lab workspace.\n  --detach-after-handoff              Return after runner daemon accepts the job.\n  --dry-run                           Print the plan without running Homeboy.\n  --skip-install                      Skip rig install.\n  --skip-sync                         Skip rig sync.\n  --no-editor-validation              Omit editor block validation.\n  --no-visual-parity                  Omit visual parity capture.\n  --no-visual-parity-gate             Capture visual parity without gating.\n  --help                              Show this help.\n`);
   printSolvedOnlyHelp();
+  printDependencyOverlayReferenceHelp();
   printVisualAttributionHelp();
 }
 
 function printSolvedOnlyHelp() {
   process.stdout.write('  --solved-only                       Run every valid fixtures/solved fixture, one per batch, and require solved_candidate for all.\n');
+}
+
+function printDependencyOverlayReferenceHelp() {
+  process.stdout.write('  --dependency-overlay-references    Declare immutable references when the selected WP Codebox supports them.\n');
 }
 
 // Visual attribution controls are separate so the main usage text remains

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -91,6 +91,8 @@ async function main() {
 
 export function buildFixtureMatrixRunPlan(input) {
   const options = normalizeOptions(input);
+  const codeFreshness = buildCodeFreshness(options, options.gitRunner || defaultGitRunner);
+  const transformerReference = resolveTransformerReference(codeFreshness);
   const settings = {
     SSI_FIXTURE_MATRIX_FIXTURE_ROOT: options.fixtureRoot,
     SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH: options.staticSiteImporter,
@@ -100,6 +102,9 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.requireSolvedCandidate ? { SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE: '1' } : {}),
     ...(options.blocksEnginePhpTransformerPath
       ? { SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH: options.blocksEnginePhpTransformerPath }
+      : {}),
+    ...(transformerReference
+      ? { SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE: transformerReference }
       : {}),
     ...(options.batchSize ? { SSI_FIXTURE_MATRIX_BATCH_SIZE: String(options.batchSize) } : {}),
     ...(options.concurrency ? { SSI_FIXTURE_MATRIX_CONCURRENCY: String(options.concurrency) } : {}),
@@ -143,7 +148,6 @@ export function buildFixtureMatrixRunPlan(input) {
   const fixtureCount = options.fixtureIds.length || corpusCounts.total;
   const activeFixtureCount = corpusCounts.active;
   const solvedFixtureCount = corpusCounts.solved;
-  const codeFreshness = buildCodeFreshness(options, options.gitRunner || defaultGitRunner);
   const warnings = [
     ...buildWarnings(options),
     ...buildSurfaceCoverageWarnings(options, fixtureCount),
@@ -216,7 +220,12 @@ export function buildFixtureMatrixRunPlan(input) {
     transformer_commit: resolveTransformerCommit(codeFreshness),
     warnings,
     dependency_overrides: options.blocksEnginePhpTransformerPath
-      ? { blocks_engine_php_transformer: { path: options.blocksEnginePhpTransformerPath } }
+      ? {
+        blocks_engine_php_transformer: {
+          path: options.blocksEnginePhpTransformerPath,
+          ...(transformerReference ? { reference: transformerReference } : {}),
+        },
+      }
       : {},
     steps: buildSteps(options, settings),
   };
@@ -648,6 +657,11 @@ function buildFreshnessWarnings(codeFreshness, options) {
 function resolveTransformerCommit(codeFreshness) {
   const entry = codeFreshness?.paths?.blocks_engine_php_transformer_path || codeFreshness?.paths?.blocks_engine;
   return entry?.commit || '';
+}
+
+function resolveTransformerReference(codeFreshness) {
+  const entry = codeFreshness?.paths?.blocks_engine_php_transformer_path || codeFreshness?.paths?.blocks_engine;
+  return entry?.in_git_repo && !entry.dirty && /^[a-f0-9]{40,64}$/i.test(entry.commit || '') ? entry.commit : '';
 }
 
 function freshnessGuardBanner(codeFreshness, options) {


### PR DESCRIPTION
## Summary

- propagate the controller-resolved clean transformer commit through fixture-matrix bench settings
- declare that immutable revision on the generated Composer dependency overlay
- omit references for dirty, non-Git, or malformed source identities

## Root cause

Lab run `50eadcfc-23c9-450a-929f-cb47f08f2a65` retained every bounded provenance field except `transformer_reference`. The controller had already recorded the transformer commit, but forwarded only the package path. Portable Lab sync excludes `.git/`, so the bench could not infer the revision later.

Direct probes against the exact materialized source path failed with `fatal: not a git repository`:

- `runner-exec-git-homeboy-lab-c96977e2-da47-482b-b201-84c7a8559e5d`
- `runner-exec-git-homeboy-lab-3b27a7a2-2457-4c1f-b8a0-b849b55d10ad`

This PR carries SSI’s existing freshness identity across that portability boundary. It uses the generic explicit overlay reference contract from Automattic/wp-codebox#2059.

## Verification

- `npm run test:fixture-matrix`: 196 passed
- targeted provenance tests: 3 passed
- `git diff --check`

The first full matrix test invocation had one unrelated timing-sensitive runner-progress assertion fail; an immediate complete rerun passed all 196 tests.

Fixes #724.

## AI assistance

OpenCode using `openai/gpt-5.6-sol` investigated the Lab materialization boundary, implemented the propagation contract and tests, and performed verification and PR preparation. Chris Huber reviewed and remains responsible for every line.