### PR TITLE
Materialize canonical font plans

### DIFF
--- a/includes/class-static-site-importer-font-materializer.php
+++ b/includes/class-static-site-importer-font-materializer.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Materializes compiler-declared web fonts for canonical site plans.
+ *
+ * @package StaticSiteImporter
+ */
+
+final class Static_Site_Importer_Font_Materializer {
+	private const PLAN_SCHEMA = 'blocks-engine/php-transformer/font-materialization-plan/v1';
+	private const CSS_LIMIT = 262144;
+	private const FONT_LIMIT = 2097152;
+	private const TOTAL_FONT_LIMIT = 4194304;
+
+	/**
+	 * Resolve an explicit font plan into receipt-owned theme writes.
+	 *
+	 * @param array<string,mixed> $plan          Compiler font materialization plan.
+	 * @param array<string,mixed> $resolved_plan Resolved canonical WordPress site plan.
+	 * @return array{writes:array<int,array<string,string>>,diagnostics:array<int,array<string,string>>}|WP_Error
+	 */
+	public static function prepare_overlay( array $plan, array $resolved_plan ) {
+		if ( empty( $plan ) ) {
+			return array( 'writes' => array(), 'diagnostics' => array() );
+		}
+		if ( self::PLAN_SCHEMA !== (string) ( $plan['schema'] ?? '' ) ) {
+			return new WP_Error( 'static_site_importer_font_materialization_plan_invalid' );
+		}
+
+		$writes = self::stylesheet_writes( $plan );
+		if ( is_wp_error( $writes ) ) {
+			return $writes;
+		}
+		$diagnostics = array();
+		if ( 'google_fonts' !== (string) ( $plan['provider'] ?? '' ) ) {
+			return array( 'writes' => $writes, 'diagnostics' => $diagnostics );
+		}
+
+		$families = self::font_families( $plan['fonts'] ?? array() );
+		$svg_writes = self::matching_svg_writes( $resolved_plan['writes'] ?? array(), $families );
+		if ( empty( $families ) ) {
+			return array( 'writes' => $writes, 'diagnostics' => $diagnostics );
+		}
+
+		$font_faces = self::resolve_google_font_faces( $plan, $families, $diagnostics );
+		if ( '' === $font_faces ) {
+			return new WP_Error( 'static_site_importer_font_materialization_failed', '', $diagnostics );
+		}
+
+		$writes[] = self::write( 'assets/css/embedded-fonts.css', trim( $font_faces ) . "\n", 'theme.font_materialization' );
+		foreach ( $svg_writes as $svg_write ) {
+			$writes[] = self::write(
+				$svg_write['target_path'],
+				self::embed_svg_font_faces( $svg_write['content'], $font_faces ),
+				$svg_write['source_path']
+			);
+		}
+
+		$bootstrap = self::canonical_write_content( $resolved_plan['writes'] ?? array(), 'functions.php' );
+		if ( null === $bootstrap ) {
+			return new WP_Error( 'static_site_importer_font_materialization_bootstrap_target_missing' );
+		}
+		$bootstrap .= "\nadd_action( 'wp_enqueue_scripts', static function (): void {\n";
+		$bootstrap .= "    wp_enqueue_style( 'static-site-importer-embedded-fonts', get_theme_file_uri( 'assets/css/embedded-fonts.css' ), array(), null );\n";
+		$bootstrap .= "} );\n";
+		$writes[] = self::write( 'functions.php', $bootstrap, 'theme.font_materialization' );
+
+		return array( 'writes' => $writes, 'diagnostics' => $diagnostics );
+	}
+
+	/** @return array<int,array<string,string>>|WP_Error */
+	private static function stylesheet_writes( array $plan ) {
+		$rows = isset( $plan['stylesheets'] ) && is_array( $plan['stylesheets'] ) ? $plan['stylesheets'] : array();
+		if ( empty( $rows ) && isset( $plan['css'] ) && is_scalar( $plan['css'] ) && '' !== trim( (string) $plan['css'] ) ) {
+			$rows[] = array( 'path' => 'assets/css/fonts.css', 'content' => trim( (string) $plan['css'] ) . "\n" );
+		}
+		$writes = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) || ! is_scalar( $row['path'] ?? null ) || ! is_scalar( $row['content'] ?? null ) ) {
+				return new WP_Error( 'static_site_importer_font_materialization_stylesheet_invalid' );
+			}
+			$path = self::safe_path( (string) $row['path'] );
+			if ( '' === $path ) {
+				return new WP_Error( 'static_site_importer_font_materialization_stylesheet_path_invalid' );
+			}
+			$content = (string) $row['content'];
+			if ( '' !== trim( $content ) ) {
+				$writes[] = self::write( $path, $content, 'theme.font_materialization' );
+			}
+		}
+		return $writes;
+	}
+
+	/** @return array<int,string> */
+	private static function font_families( mixed $fonts ): array {
+		if ( ! is_array( $fonts ) ) {
+			return array();
+		}
+		$families = array();
+		foreach ( $fonts as $font ) {
+			$family = is_array( $font ) ? ( $font['family'] ?? $font['font_family'] ?? '' ) : $font;
+			if ( is_scalar( $family ) && '' !== trim( (string) $family ) ) {
+				$families[] = trim( (string) $family );
+			}
+		}
+		return array_values( array_unique( $families ) );
+	}
+
+	/** @param array<int,array<string,mixed>> $writes @param array<int,string> $families @return array<int,array{target_path:string,source_path:string,content:string}> */
+	private static function matching_svg_writes( array $writes, array $families ): array {
+		$matches = array();
+		foreach ( $writes as $write ) {
+			$target = is_array( $write ) && is_scalar( $write['target_path'] ?? null ) ? (string) $write['target_path'] : '';
+			if ( ! str_ends_with( strtolower( $target ), '.svg' ) ) {
+				continue;
+			}
+			$content = self::payload_content( $write );
+			if ( null !== $content && self::svg_uses_font_family( $content, $families ) ) {
+				$matches[] = array(
+					'target_path' => $target,
+					'source_path' => is_scalar( $write['source_path'] ?? null ) ? (string) $write['source_path'] : $target,
+					'content'     => $content,
+				);
+			}
+		}
+		return $matches;
+	}
+
+	/** @param array<int,string> $families @param array<int,array<string,string>> $diagnostics */
+	private static function resolve_google_font_faces( array $plan, array $families, array &$diagnostics ): string {
+		$imports = array();
+		foreach ( $plan['stylesheets'] ?? array() as $stylesheet ) {
+			$content = is_array( $stylesheet ) && is_scalar( $stylesheet['content'] ?? null ) ? (string) $stylesheet['content'] : '';
+			if ( preg_match_all( '/@import\s+(?:url\()?\s*["\']?([^"\'\s\)]+)["\']?\s*\)?/i', $content, $matches ) ) {
+				$imports = array_merge( $imports, $matches[1] );
+			}
+		}
+		$imports = array_values( array_unique( $imports ) );
+		if ( empty( $imports ) ) {
+			$diagnostics[] = self::diagnostic( 'stylesheet_import_missing' );
+			return '';
+		}
+		foreach ( $imports as $import ) {
+			if ( ! self::is_google_stylesheet_url( $import ) ) {
+				$diagnostics[] = self::diagnostic( 'untrusted_stylesheet_url' );
+				return '';
+			}
+		}
+
+		$faces = array();
+		$font_payloads = array();
+		$font_payload_bytes = 0;
+		foreach ( $imports as $import ) {
+			$response = self::request( $import, self::CSS_LIMIT );
+			$css = is_wp_error( $response ) ? '' : (string) wp_remote_retrieve_body( $response );
+			if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $css ) {
+				$diagnostics[] = self::diagnostic( 'stylesheet_fetch_failed' );
+				return '';
+			}
+			if ( strlen( $css ) > self::CSS_LIMIT ) {
+				$diagnostics[] = self::diagnostic( 'stylesheet_response_too_large' );
+				return '';
+			}
+			$embedded = self::embed_font_sources( $css, $families, $font_payloads, $font_payload_bytes, $diagnostics );
+			if ( '' === $embedded ) {
+				return '';
+			}
+			$faces[] = $embedded;
+		}
+		return implode( "\n", $faces );
+	}
+
+	/** @param array<int,string> $families @param array<string,string> $payloads @param array<int,array<string,string>> $diagnostics */
+	private static function embed_font_sources( string $css, array $families, array &$payloads, int &$payload_bytes, array &$diagnostics ): string {
+		if ( ! preg_match_all( '/@font-face\s*\{([^{}]*)\}/is', $css, $faces ) ) {
+			$diagnostics[] = self::diagnostic( 'stylesheet_font_faces_missing' );
+			return '';
+		}
+		$embedded = array();
+		foreach ( $faces[0] as $index => $face ) {
+			if ( ! preg_match( '/font-family\s*:\s*(["\']?)([^;"\']+)\1\s*;/i', $faces[1][ $index ], $family ) || ! in_array( trim( $family[2] ), $families, true ) ) {
+				continue;
+			}
+			if ( str_contains( $face, '<' ) || ! preg_match_all( '/url\(\s*(["\']?)([^"\'\s\)]+)\1\s*\)/i', $face, $urls ) ) {
+				$diagnostics[] = self::diagnostic( 'untrusted_font_url' );
+				return '';
+			}
+			$rewritten = $face;
+			foreach ( array_unique( $urls[2] ) as $url ) {
+				$parts = wp_parse_url( $url );
+				$path = is_array( $parts ) ? strtolower( (string) ( $parts['path'] ?? '' ) ) : '';
+				if ( ! is_array( $parts ) || 'https' !== strtolower( (string) ( $parts['scheme'] ?? '' ) ) || 'fonts.gstatic.com' !== strtolower( (string) ( $parts['host'] ?? '' ) ) || ( isset( $parts['port'] ) && 443 !== (int) $parts['port'] ) || isset( $parts['user'] ) || isset( $parts['pass'] ) || ! preg_match( '/\.woff2?$/', $path ) ) {
+					$diagnostics[] = self::diagnostic( 'untrusted_font_url' );
+					return '';
+				}
+				if ( ! isset( $payloads[ $url ] ) ) {
+					$response = self::request( $url, self::FONT_LIMIT );
+					$payload = is_wp_error( $response ) ? '' : (string) wp_remote_retrieve_body( $response );
+					if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $payload || strlen( $payload ) > self::FONT_LIMIT ) {
+						$diagnostics[] = self::diagnostic( 'font_payload_fetch_failed' );
+						return '';
+					}
+					if ( self::TOTAL_FONT_LIMIT < $payload_bytes + strlen( $payload ) ) {
+						$diagnostics[] = self::diagnostic( 'font_payload_total_too_large' );
+						return '';
+					}
+					$payloads[ $url ] = $payload;
+					$payload_bytes += strlen( $payload );
+				}
+				$mime = str_ends_with( $path, '.woff2' ) ? 'font/woff2' : 'font/woff';
+				$rewritten = str_replace( $url, 'data:' . $mime . ';base64,' . base64_encode( $payloads[ $url ] ), $rewritten );
+			}
+			$embedded[] = $rewritten;
+		}
+		if ( empty( $embedded ) ) {
+			$diagnostics[] = self::diagnostic( 'matching_font_faces_missing' );
+		}
+		return implode( "\n", $embedded );
+	}
+
+	private static function request( string $url, int $limit ) {
+		$args = array(
+			'timeout'             => 15,
+			'redirection'         => 0,
+			'limit_response_size' => $limit,
+			'headers'             => array( 'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' ),
+		);
+		$response = null;
+		for ( $attempt = 1; $attempt <= 3; ++$attempt ) {
+			$response = wp_safe_remote_get( $url, $args );
+			$status = is_wp_error( $response ) ? 0 : (int) wp_remote_retrieve_response_code( $response );
+			if ( ! is_wp_error( $response ) && 0 !== $status && ! in_array( $status, array( 408, 429 ), true ) && $status < 500 ) {
+				break;
+			}
+			if ( $attempt < 3 ) {
+				usleep( 100000 * $attempt );
+			}
+		}
+		return $response;
+	}
+
+	/** @param array<int,string> $families */
+	private static function svg_uses_font_family( string $svg, array $families ): bool {
+		if ( ! preg_match( '/<text\b/i', $svg ) ) {
+			return false;
+		}
+		foreach ( $families as $family ) {
+			if ( preg_match( '/font-family\s*[:=]\s*(["\']?)' . preg_quote( $family, '/' ) . '\1/i', $svg ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static function embed_svg_font_faces( string $svg, string $font_faces ): string {
+		if ( ! preg_match( '/<svg\b[^>]*>/i', $svg, $match, PREG_OFFSET_CAPTURE ) ) {
+			return $svg;
+		}
+		$offset = $match[0][1] + strlen( $match[0][0] );
+		return substr( $svg, 0, $offset ) . '<style type="text/css">' . $font_faces . '</style>' . substr( $svg, $offset );
+	}
+
+	/** @param array<int,array<string,mixed>> $writes */
+	private static function canonical_write_content( array $writes, string $target ): ?string {
+		foreach ( $writes as $write ) {
+			if ( is_array( $write ) && $target === ( $write['target_path'] ?? null ) ) {
+				return self::payload_content( $write );
+			}
+		}
+		return null;
+	}
+
+	private static function payload_content( mixed $write ): ?string {
+		if ( ! is_array( $write ) || ! is_array( $write['payload'] ?? null ) || ! is_string( $write['payload']['data'] ?? null ) ) {
+			return null;
+		}
+		if ( 'base64' === ( $write['payload']['encoding'] ?? null ) ) {
+			$decoded = base64_decode( $write['payload']['data'], true );
+			return false === $decoded ? null : $decoded;
+		}
+		return 'utf8' === ( $write['payload']['encoding'] ?? null ) ? $write['payload']['data'] : null;
+	}
+
+	private static function safe_path( string $path ): string {
+		$path = str_replace( '\\', '/', trim( $path ) );
+		if ( '' === $path || str_starts_with( $path, '/' ) || preg_match( '#(?:^|/)\.\.(?:/|$)|^[a-z][a-z0-9+.-]*:#i', $path ) || ! preg_match( '#^[A-Za-z0-9._/-]+$#', $path ) ) {
+			return '';
+		}
+		return $path;
+	}
+
+	/** @return array{target_path:string,content:string,source_path:string} */
+	private static function write( string $target, string $content, string $source ): array {
+		return array( 'target_path' => $target, 'content' => $content, 'source_path' => $source );
+	}
+
+	private static function is_google_stylesheet_url( string $url ): bool {
+		$parts = wp_parse_url( $url );
+		return is_array( $parts ) && 'https' === strtolower( (string) ( $parts['scheme'] ?? '' ) ) && 'fonts.googleapis.com' === strtolower( (string) ( $parts['host'] ?? '' ) ) && ( ! isset( $parts['port'] ) || 443 === (int) $parts['port'] ) && ! isset( $parts['user'] ) && ! isset( $parts['pass'] ) && in_array( (string) ( $parts['path'] ?? '' ), array( '/css', '/css2' ), true );
+	}
+
+	/** @return array{type:string,source:string,reason:string} */
+	private static function diagnostic( string $reason ): array {
+		return array( 'type' => 'font_materialization_failed', 'source' => 'static-site-importer/font-materializer', 'reason' => $reason );
+	}
+}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -100,6 +100,8 @@ class Static_Site_Importer_Theme_Generator {
 			return new WP_Error( 'static_site_importer_artifact_compile_failed', 'Website artifact compilation did not produce a WordPress site plan.' . ( false !== $diagnostics ? ' ' . $diagnostics : '' ), $compiled );
 		}
 		$plan = self::bridge_product_grid_findings_to_runtime_declarations( $plan );
+		$materialization_plan = isset( $compiled['source_reports']['materialization_plan'] ) && is_array( $compiled['source_reports']['materialization_plan'] ) ? $compiled['source_reports']['materialization_plan'] : array();
+		$args['font_materialization'] = isset( $materialization_plan['theme']['font_materialization'] ) && is_array( $materialization_plan['theme']['font_materialization'] ) ? $materialization_plan['theme']['font_materialization'] : array();
 		if ( ! empty( $args['fail_on_quality'] ) && empty( $plan['quality']['pass'] ) ) {
 			return new WP_Error( 'static_site_importer_quality_gate_failed', 'Website artifact did not pass the canonical plan quality gate.', array( 'quality' => $plan['quality'] ?? array(), 'diagnostics' => $plan['diagnostics'] ?? array() ) );
 		}
@@ -261,6 +263,18 @@ class Static_Site_Importer_Theme_Generator {
 			array_filter( array( 'schema' => $plan['source']['schema'] ?? null, 'source_hash' => $plan['source']['source_hash'] ?? null, 'entry_path' => $plan['source']['entry_path'] ?? null ) )
 		);
 		$artifact['hash'] = (string) ( $args['artifact_hash'] ?? $artifact['hash'] ?? $plan['source']['source_hash'] );
+		$desired_files = array_map( static fn( array $write ): array => array( 'path' => $write['target_path'], 'kind' => $write['kind'] ), $plan['writes'] );
+		$desired_file_paths = array_fill_keys( array_column( $desired_files, 'path' ), true );
+		$desired_assets = array_map( static fn( array $asset ): array => array( 'source_path' => $asset['source_path'], 'theme_path' => $asset['target_path'] ), $plan['assets'] );
+		foreach ( $receipt['completed']['font_materialization']['files'] ?? array() as $file ) {
+			$path = is_array( $file ) && is_scalar( $file['target_path'] ?? null ) ? (string) $file['target_path'] : '';
+			if ( '' === $path || isset( $desired_file_paths[ $path ] ) ) {
+				continue;
+			}
+			$desired_file_paths[ $path ] = true;
+			$desired_files[] = array( 'path' => $path, 'kind' => 'font_materialization' );
+			$desired_assets[] = array( 'source_path' => (string) ( $file['source_path'] ?? 'theme.font_materialization' ), 'theme_path' => $path );
+		}
 		$manifest = array(
 			'schema'        => 'static-site-importer/source-of-truth-manifest/v1',
 			'version'       => 1,
@@ -268,7 +282,7 @@ class Static_Site_Importer_Theme_Generator {
 			'artifact'      => array_merge( $artifact, array( 'provenance' => $plan['source']['provenance'] ) ),
 			'manifest_path' => 'static-site-importer-manifest.json',
 			'generated_theme' => array( 'slug' => $theme['slug'], 'dir' => $theme['dir'] ),
-			'desired'       => array( 'pages' => array(), 'files' => array_merge( array_map( static fn( array $write ): array => array( 'path' => $write['target_path'], 'kind' => $write['kind'] ), $plan['writes'] ), array( array( 'path' => 'static-site-importer-manifest.json', 'kind' => 'ssi_manifest' ) ) ), 'assets' => array_map( static fn( array $asset ): array => array( 'source_path' => $asset['source_path'], 'theme_path' => $asset['target_path'] ), $plan['assets'] ) ),
+			'desired'       => array( 'pages' => array(), 'files' => array_merge( $desired_files, array( array( 'path' => 'static-site-importer-manifest.json', 'kind' => 'ssi_manifest' ) ) ), 'assets' => $desired_assets ),
 		);
 		foreach ( $plan['pages'] as $page ) {
 			$source_path = $page['source_path'];

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -104,6 +104,13 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return $state['receipt'];
 		}
 		$args = $state['args'];
+		$font_overlay = Static_Site_Importer_Font_Materializer::prepare_overlay(
+			isset( $args['font_materialization'] ) && is_array( $args['font_materialization'] ) ? $args['font_materialization'] : array(),
+			$state['resolved']
+		);
+		if ( is_wp_error( $font_overlay ) ) {
+			return self::failed_receipt( $state, $font_overlay->get_error_code() );
+		}
 
 		foreach ( $state['ordered_pages'] as $page ) {
 			if ( ! empty( $page['skip_materialization'] ) ) {
@@ -138,6 +145,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		if ( is_wp_error( $publications ) ) {
 			return self::failed_receipt( $state, $publications->get_error_code() );
 		}
+		$font_materialization = self::apply_font_overlay( $state, $font_overlay );
+		if ( is_wp_error( $font_materialization ) ) {
+			return self::failed_receipt( $state, $font_materialization->get_error_code() );
+		}
+		$state['applied']['font_materialization'] = $font_materialization;
 
 		if ( ! empty( $args['activate'] ) ) {
 			foreach ( $state['resolved']['operations'] as $operation ) {
@@ -340,6 +352,44 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		return array( 'target_path' => $write['target_path'], 'hash' => self::file_hash( $path ), 'payload_hash' => $write['payload_hash'] ?? hash( 'sha256', $data ), 'reconciliation_identity' => $write['reconciliation_identity'] ?? hash( 'sha256', $write['source_path'] . "\n" . $write['target_path'] ) );
 	}
 
+	/** @param array<string,mixed> $state @param array{writes:array<int,array<string,string>>,diagnostics:array<int,array<string,string>>} $overlay */
+	private static function apply_font_overlay( array &$state, array $overlay ) {
+		$reports = array();
+		foreach ( $overlay['writes'] as $write ) {
+			$target = (string) ( $write['target_path'] ?? '' );
+			if ( ! self::safe_destination( $state['theme_dir'], $target ) ) {
+				return new WP_Error( 'static_site_importer_font_materialization_destination_invalid' );
+			}
+			$result = self::write_file(
+				$state['theme_dir'],
+				array(
+					'target_path'            => $target,
+					'source_path'            => (string) ( $write['source_path'] ?? $target ),
+					'payload'                => array( 'encoding' => 'utf8', 'data' => (string) ( $write['content'] ?? '' ) ),
+					'payload_hash'           => hash( 'sha256', (string) ( $write['content'] ?? '' ) ),
+					'reconciliation_identity' => hash( 'sha256', "font-materialization\n" . $target ),
+				)
+			);
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$result['source_path'] = (string) ( $write['source_path'] ?? $target );
+			$reports[] = $result;
+			$replaced = false;
+			foreach ( $state['applied']['files'] as $index => $file ) {
+				if ( $target === ( $file['target_path'] ?? null ) ) {
+					$state['applied']['files'][ $index ] = $result;
+					$replaced = true;
+					break;
+				}
+			}
+			if ( ! $replaced ) {
+				$state['applied']['files'][] = $result;
+			}
+		}
+		return array( 'status' => 'completed', 'files' => $reports, 'diagnostics' => $overlay['diagnostics'] );
+	}
+
 	/** Verify every canonical asset publication against its resolved write and references. */
 	private static function verify_asset_publications( array &$state ) {
 		$writes = array();
@@ -525,6 +575,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'files'      => $state['applied']['files'],
 				'operations' => $state['applied']['operations'],
 				'runtime_declarations' => $state['applied']['runtime_declarations'] ?? array( 'asset_publications' => array() ),
+				'font_materialization' => $state['applied']['font_materialization'] ?? array( 'status' => 'not_requested', 'files' => array(), 'diagnostics' => array() ),
 				'materialized_pages' => $materialized_pages,
 				'block_provenance' => $block_provenance,
 				'block_provenance_count' => $block_provenance_count,

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -66,6 +66,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-di
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-validation-runtime.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-font-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-wordpress-site-plan-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-figma-import.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-exporter.php';

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -23,6 +23,7 @@ $GLOBALS['ssi_plan_posts']      = array();
 $GLOBALS['ssi_plan_meta']       = array();
 $GLOBALS['ssi_plan_options']    = array( 'show_on_front' => 'posts', 'page_on_front' => 0, 'blogname' => 'Before' );
 $GLOBALS['ssi_plan_fail_after'] = 0;
+$GLOBALS['ssi_plan_font_requests'] = array();
 mkdir( $GLOBALS['ssi_plan_root'], 0777, true );
 
 class WP_Error {
@@ -42,6 +43,19 @@ function trailingslashit( string $path ): string { return rtrim( $path, '/' ) . 
 function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
 function wp_slash( string $value ): string { return addslashes( $value ); }
 function wp_mkdir_p( string $path ): bool { return is_dir( $path ) || mkdir( $path, 0777, true ); }
+function wp_parse_url( string $url ) { return parse_url( $url ); }
+function wp_safe_remote_get( string $url, array $args ) {
+	$GLOBALS['ssi_plan_font_requests'][] = array( 'url' => $url, 'args' => $args );
+	if ( str_starts_with( $url, 'https://fonts.googleapis.com/' ) ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => "@font-face{font-family:'Example Font';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/example/font.woff2) format('woff2')}" );
+	}
+	if ( 'https://fonts.gstatic.com/s/example/font.woff2' === $url ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => 'font-payload' );
+	}
+	return new WP_Error( 'unexpected_request' );
+}
+function wp_remote_retrieve_response_code( $response ): int { return (int) ( $response['response']['code'] ?? 0 ); }
+function wp_remote_retrieve_body( $response ): string { return (string) ( $response['body'] ?? '' ); }
 function update_option( string $key, $value ): void { $GLOBALS['ssi_plan_options'][ $key ] = $value; }
 function switch_theme( string $slug ): void { $GLOBALS['ssi_plan_options']['stylesheet'] = $slug; }
 function sanitize_text_field( string $value ): string { return $value; }
@@ -63,6 +77,7 @@ function wp_insert_post( array $post, bool $wp_error ) {
 	return $id;
 }
 
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-font-materializer.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-wordpress-site-plan-materializer.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-woo-product-seeder.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-form-seeder.php';
@@ -106,6 +121,50 @@ $unbound_provenance = $receipt['completed']['block_provenance'] ?? array();
 $assert( count( $plan['pages'] ) === count( $unbound_provenance ) && count( $plan['pages'] ) === ( $receipt['completed']['block_provenance_count'] ?? 0 ), 'ordinary resolved pages receive receipt provenance without runtime bindings' );
 $assert( 'blocks-engine/wordpress-site-plan-resolver' === ( $unbound_provenance[0]['stages'][0]['stage'] ?? '' ) && hash( 'sha256', $receipt['plan']['pages'][0]['resolved_block_markup'] ) === ( $unbound_provenance[0]['stages'][0]['output']['sha256'] ?? '' ), 'ordinary page provenance records the resolver output hash' );
 $assert( false === ( $receipt['completed']['block_provenance_truncated'] ?? true ) && ! str_contains( (string) wp_json_encode( $unbound_provenance ), (string) $receipt['plan']['pages'][0]['resolved_block_markup'] ), 'provenance uses structural evidence without raw page markup' );
+
+$font_result = ( new ArtifactCompiler() )->compile(
+	array(
+		'entrypoint' => 'index.html',
+		'files'      => array(
+			'index.html' => '<html><head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Example+Font:wght@400&amp;display=swap"><style>body{font-family:"Example Font",sans-serif}</style></head><body><main><svg xmlns="http://www.w3.org/2000/svg"><text font-family="Example Font">Label</text></svg></main></body></html>',
+		),
+	)
+)->toArray();
+$font_plan = $font_result['source_reports']['wordpress_site_plan'];
+$font_materialization = $font_result['source_reports']['materialization_plan']['theme']['font_materialization'];
+$font_plan_hash = hash( 'sha256', (string) wp_json_encode( $font_plan, JSON_UNESCAPED_SLASHES ) );
+$font_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $font_plan, array( 'slug' => 'font-site-plan', 'font_materialization' => $font_materialization ) );
+$font_root = $GLOBALS['ssi_plan_root'] . '/font-site-plan';
+$assert( 'completed' === $font_receipt['status'], 'canonical font materialization completes' );
+$assert( $font_plan_hash === $font_receipt['plan_hash'], 'font overlay leaves the canonical source plan unchanged' );
+$assert( file_exists( $font_root . '/assets/css/fonts.css' ), 'declared font stylesheet is materialized' );
+$assert( str_contains( (string) file_get_contents( $font_root . '/assets/css/embedded-fonts.css' ), 'data:font/woff2;base64,' ), 'self-contained font stylesheet is materialized' );
+$assert( str_contains( (string) file_get_contents( $font_root . '/functions.php' ), "wp_enqueue_style( 'static-site-importer-embedded-fonts'" ), 'generated theme loads self-contained font stylesheet' );
+$font_svg_files = array_values( array_filter( $font_receipt['completed']['font_materialization']['files'] ?? array(), static fn( array $file ): bool => str_ends_with( (string) ( $file['target_path'] ?? '' ), '.svg' ) ) );
+$assert( 1 === count( $font_svg_files ), 'matching generated SVG receives a font overlay' );
+$assert( str_contains( (string) file_get_contents( $font_root . '/' . $font_svg_files[0]['target_path'] ), 'data:font/woff2;base64,' ), 'generated SVG embeds the declared font payload' );
+$assert( 2 === count( $GLOBALS['ssi_plan_font_requests'] ), 'font materialization fetches one declared stylesheet and one unique payload' );
+
+$font_without_svg_result = ( new ArtifactCompiler() )->compile(
+	array(
+		'entrypoint' => 'index.html',
+		'files'      => array(
+			'index.html' => '<html><head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Example+Font:wght@400&amp;display=swap"><style>body{font-family:"Example Font",sans-serif}</style></head><body><main>Text</main></body></html>',
+		),
+	)
+)->toArray();
+$font_without_svg_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$font_without_svg_result['source_reports']['wordpress_site_plan'],
+	array(
+		'slug'                 => 'font-site-plan-without-svg',
+		'font_materialization' => $font_without_svg_result['source_reports']['materialization_plan']['theme']['font_materialization'],
+	)
+);
+$font_without_svg_root = $GLOBALS['ssi_plan_root'] . '/font-site-plan-without-svg';
+$assert( 'completed' === $font_without_svg_receipt['status'], 'canonical font materialization completes without SVG consumers' );
+$assert( str_contains( (string) file_get_contents( $font_without_svg_root . '/assets/css/embedded-fonts.css' ), 'data:font/woff2;base64,' ), 'page fonts are self-contained without SVG consumers' );
+$assert( str_contains( (string) file_get_contents( $font_without_svg_root . '/functions.php' ), "wp_enqueue_style( 'static-site-importer-embedded-fonts'" ), 'page fonts load without SVG consumers' );
+$assert( 4 === count( $GLOBALS['ssi_plan_font_requests'] ), 'each font materialization resolves its declared stylesheet and payload' );
 
 $nested_route_result = ( new ArtifactCompiler() )->compile(
 	array(


### PR DESCRIPTION
## Summary

- consume the compiler-declared `source_reports.materialization_plan.theme.font_materialization` through the canonical WordPress site-plan path
- resolve bounded stylesheet and font payloads into content-addressed local theme assets
- emit and enqueue `embedded-fonts.css`, enrich declared SVG consumers, and retain file/diagnostic evidence in the materialization receipt
- keep font materialization working when a plan has no SVG consumers

Relates to #661. This establishes canonical deterministic font materialization and evidence; #661 remains open for transient-request retry policy and exhausted-retry gate behavior.

## Exact parity evidence

The solved `15-saas` fixture remained unchanged from source introduction commit `fc948977ee8b55c1440727ebf815797265cbdbbc` (blob `95b0c823cc338a222710807fdcb9e040f8a072dc`).

- Run: `3beefde3-0d0c-4dbb-bdc5-dd92b3d4ed33`
- Result: `identical`
- Source/candidate hash: `3e685d7e83cafd03a878fa5cc8f8c44d1143c27275e4e82278dca71bfe4b410f`
- Fonts: 50 registered, 7 loaded
- Fallback blocks: 0

Reproduce against the unchanged solved fixture with the canonical fixture-matrix command and `--surface-coverage 7`; the materialization receipt must report completed font files and the visual comparison must be pixel-identical.

## Testing

- `npm test` (all suites passed)
- `npm run test:site-plan-materializer`
- PHP lint on all touched PHP files
- `git diff --check`

## AI assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** implementation, canonical boundary analysis, deterministic tests, and exact visual-parity verification with Chris Huber.