### PR TITLE
Match SVG font-family fallback lists

### DIFF
--- a/includes/class-static-site-importer-font-materializer.php
+++ b/includes/class-static-site-importer-font-materializer.php
@@ -239,16 +239,98 @@ final class Static_Site_Importer_Font_Materializer {
 	}
 
 	/** @param array<int,string> $families */
-	private static function svg_uses_font_family( string $svg, array $families ): bool {
+	public static function svg_uses_font_family( string $svg, array $families ): bool {
 		if ( ! preg_match( '/<text\b/i', $svg ) ) {
 			return false;
 		}
+		$expected = array();
 		foreach ( $families as $family ) {
-			if ( preg_match( '/font-family\s*[:=]\s*(["\']?)' . preg_quote( $family, '/' ) . '\1/i', $svg ) ) {
-				return true;
+			$family = self::normalize_font_family( is_scalar( $family ) ? (string) $family : '' );
+			if ( '' !== $family ) {
+				$expected[ $family ] = true;
+			}
+		}
+		if ( empty( $expected ) ) {
+			return false;
+		}
+
+		$values = array();
+		if ( preg_match_all( '/\bfont-family\s*=\s*(["\'])(.*?)\1/is', $svg, $attributes ) ) {
+			$values = array_merge( $values, $attributes[2] );
+		}
+		if ( preg_match_all( '/\bfont-family\s*=\s*(?!["\'])([^\s>]+)/i', $svg, $attributes ) ) {
+			$values = array_merge( $values, $attributes[1] );
+		}
+		if ( preg_match_all( '/\bfont-family\s*:\s*([^;}]+)/i', $svg, $declarations ) ) {
+			$values = array_merge( $values, $declarations[1] );
+		}
+
+		foreach ( $values as $value ) {
+			foreach ( self::font_family_tokens( (string) $value ) as $family ) {
+				if ( isset( $expected[ $family ] ) ) {
+					return true;
+				}
 			}
 		}
 		return false;
+	}
+
+	/** @return array<int,string> */
+	private static function font_family_tokens( string $value ): array {
+		$value = preg_replace( '/\s*!important\s*$/i', '', html_entity_decode( $value, ENT_QUOTES | ENT_HTML5 ) ) ?? $value;
+		$tokens = array();
+		$token = '';
+		$quote = '';
+		$escaped = false;
+		$length = strlen( $value );
+		for ( $index = 0; $index < $length; ++$index ) {
+			$character = $value[ $index ];
+			if ( $escaped ) {
+				$token .= $character;
+				$escaped = false;
+				continue;
+			}
+			if ( '\\' === $character ) {
+				$token .= $character;
+				$escaped = true;
+				continue;
+			}
+			if ( '' !== $quote ) {
+				$token .= $character;
+				if ( $quote === $character ) {
+					$quote = '';
+				}
+				continue;
+			}
+			if ( '"' === $character || "'" === $character ) {
+				$quote = $character;
+				$token .= $character;
+				continue;
+			}
+			if ( ',' === $character ) {
+				$family = self::normalize_font_family( $token );
+				if ( '' !== $family ) {
+					$tokens[] = $family;
+				}
+				$token = '';
+				continue;
+			}
+			$token .= $character;
+		}
+		$family = self::normalize_font_family( $token );
+		if ( '' !== $family ) {
+			$tokens[] = $family;
+		}
+		return array_values( array_unique( $tokens ) );
+	}
+
+	private static function normalize_font_family( string $family ): string {
+		$family = trim( $family );
+		if ( 2 <= strlen( $family ) && ( ( '"' === $family[0] && '"' === $family[ strlen( $family ) - 1 ] ) || ( "'" === $family[0] && "'" === $family[ strlen( $family ) - 1 ] ) ) ) {
+			$family = substr( $family, 1, -1 );
+		}
+		$family = preg_replace( '/\s+/', ' ', trim( $family ) ) ?? '';
+		return strtolower( $family );
 	}
 
 	private static function embed_svg_font_faces( string $svg, string $font_faces ): string {

--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -809,13 +809,7 @@ class Static_Site_Importer_Page_Materializer {
 	private static function embed_svg_font_faces( string $svg, string $font_faces ): string {
 		preg_match_all( '/font-family\s*:\s*(["\']?)([^;"\']+)\1\s*;/i', $font_faces, $matches );
 		$families = array_values( array_unique( array_map( 'trim', $matches[2] ?? array() ) ) );
-		$uses_family = false;
-		foreach ( $families as $family ) {
-			if ( preg_match( '/font-family\s*[:=]\s*(["\']?)' . preg_quote( $family, '/' ) . '\\1/i', $svg ) ) {
-				$uses_family = true;
-				break;
-			}
-		}
+		$uses_family = Static_Site_Importer_Font_Materializer::svg_uses_font_family( $svg, $families );
 		if ( '' === $font_faces || ! str_contains( $svg, '<text' ) || ! $uses_family || ! preg_match( '/<svg\b[^>]*>/i', $svg, $match, PREG_OFFSET_CAPTURE ) ) {
 			return $svg;
 		}

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -136,7 +136,7 @@ $font_result = ( new ArtifactCompiler() )->compile(
 	array(
 		'entrypoint' => 'index.html',
 		'files'      => array(
-			'index.html' => '<html><head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Example+Font:wght@400&amp;display=swap"><style>body{font-family:"Example Font",sans-serif}</style></head><body><main><svg xmlns="http://www.w3.org/2000/svg"><text font-family="Example Font">Label</text></svg></main></body></html>',
+			'index.html' => '<html><head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Example+Font:wght@400&amp;display=swap"><style>body{font-family:"Example Font",sans-serif}</style></head><body><main><svg xmlns="http://www.w3.org/2000/svg"><text font-family="Example Font, sans-serif">Label</text></svg></main></body></html>',
 		),
 	)
 )->toArray();
@@ -154,6 +154,9 @@ $font_svg_files = array_values( array_filter( $font_receipt['completed']['font_m
 $assert( 1 === count( $font_svg_files ), 'matching generated SVG receives a font overlay' );
 $assert( str_contains( (string) file_get_contents( $font_root . '/' . $font_svg_files[0]['target_path'] ), 'data:font/woff2;base64,' ), 'generated SVG embeds the declared font payload' );
 $assert( 2 === count( $GLOBALS['ssi_plan_font_requests'] ), 'font materialization fetches one declared stylesheet and one unique payload' );
+$assert( Static_Site_Importer_Font_Materializer::svg_uses_font_family( '<svg><text style="font-family:\'Example Font\', serif">Label</text></svg>', array( 'Example Font' ) ), 'SVG style declarations match quoted families within fallback lists' );
+$assert( Static_Site_Importer_Font_Materializer::svg_uses_font_family( '<svg><text font-family="serif, Example Font">Label</text></svg>', array( 'example font' ) ), 'SVG presentation attributes normalize case and fallback-list position' );
+$assert( ! Static_Site_Importer_Font_Materializer::svg_uses_font_family( '<svg><text font-family="Example Font Pro, sans-serif">Label</text></svg>', array( 'Example Font' ) ), 'SVG font matching compares complete family tokens instead of prefixes' );
 
 $font_without_svg_result = ( new ArtifactCompiler() )->compile(
 	array(


### PR DESCRIPTION
## Summary

- parse SVG `font-family` presentation attributes and style declarations as CSS family lists
- normalize and compare complete family tokens instead of whole declarations or substrings
- share the matcher between canonical plan font overlays and inline SVG promotion
- cover quoted multi-word families, fallback positions, case normalization, and prefix rejection

Closes #730.

## Verification

- `npm test`
- `composer validate --strict`
- `php tests/smoke-wordpress-site-plan-materializer.php`
- PHP lint and `git diff --check`
- real eight-route `27-university-department` WP Codebox run against Blocks Engine integration commit `21ea6106f712dc9dcc157858f0136eee0258f37b`

Runtime evidence:

- SVG font status: `complete`
- expected font SVGs: 1
- embedded font SVGs: 1
- generated crest includes `@font-face` and `data:font/`
- 207/207 imported blocks are native; zero HTML fallbacks
- 269/269 post-import blocks pass `wp.blocks.validateBlock`

## Compatibility

The change only broadens matching from exact whole declarations to exact tokens within valid CSS font-family lists. Prefixes such as `Example Font Pro` do not match `Example Font`. The canonical plan and receipt schemas are unchanged.

## AI assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** cross-stack reproduction, implementation, tests, and university runtime verification with Chris Huber.