### PR TITLE
Emit editor-valid Jetpack form block trees

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -1,0 +1,8 @@
+{
+  "schema": "homeboy/test-manifest/v1",
+  "tests": {
+    "tests/form-materializer-smoke.php": {
+      "environment": "standalone-php"
+    }
+  }
+}

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -37,13 +37,14 @@ class Static_Site_Importer_Form_Seeder {
 	 * @return array<string,string>
 	 */
 	private static function field_block_map(): array {
+		// field-telephone rewrites its valid input child to an editor-invalid phone-input block.
 		return array(
 			'text'     => 'jetpack/field-text',
 			'search'   => 'jetpack/field-text',
 			'password' => 'jetpack/field-text',
-			'number'   => 'jetpack/field-text',
+			'number'   => 'jetpack/field-number',
 			'email'    => 'jetpack/field-email',
-			'tel'      => 'jetpack/field-telephone',
+			'tel'      => 'jetpack/field-text',
 			'url'      => 'jetpack/field-url',
 			'date'     => 'jetpack/field-date',
 			'textarea' => 'jetpack/field-textarea',
@@ -284,16 +285,14 @@ class Static_Site_Importer_Form_Seeder {
 
 		$attrs = array();
 		$label = self::control_text( $control );
-		if ( '' !== $label ) {
-			$attrs['label'] = $label;
-		}
 		if ( ! empty( $control['required'] ) ) {
 			$attrs['required'] = true;
 		}
-		$placeholder = isset( $control['placeholder'] ) && is_scalar( $control['placeholder'] ) ? trim( (string) $control['placeholder'] ) : '';
-		if ( '' !== $placeholder ) {
-			$attrs['placeholder'] = $placeholder;
+		$id = isset( $control['id'] ) && is_scalar( $control['id'] ) ? trim( (string) $control['id'] ) : '';
+		if ( '' !== $id ) {
+			$attrs['id'] = $id;
 		}
+		$placeholder = isset( $control['placeholder'] ) && is_scalar( $control['placeholder'] ) ? trim( (string) $control['placeholder'] ) : '';
 
 		if ( in_array( $lookup, array( 'select', 'radio', 'checkbox' ), true ) ) {
 			$options = self::option_labels( $control );
@@ -302,9 +301,69 @@ class Static_Site_Importer_Form_Seeder {
 			}
 		}
 
+		$inner_blocks = array();
+		if ( 'checkbox' === $lookup ) {
+			$inner_blocks[] = array(
+				'name'  => 'jetpack/option',
+				'attrs' => array(
+					'label'        => $label,
+					'isStandalone' => true,
+				),
+			);
+		} elseif ( '' !== $label ) {
+			$label_attrs = array( 'label' => $label );
+			if ( ! empty( $control['required'] ) ) {
+				$label_attrs['requiredText'] = '*';
+			}
+			$inner_blocks[] = array(
+				'name'  => 'jetpack/label',
+				'attrs' => $label_attrs,
+			);
+		}
+		if ( 'radio' === $lookup ) {
+			$options = $attrs['options'] ?? array();
+			if ( empty( $options ) && '' !== $label ) {
+				$options = array( $label );
+			}
+			$option_blocks = array();
+			foreach ( $options as $option ) {
+				$option_blocks[] = array(
+					'name'  => 'jetpack/option',
+					'attrs' => array( 'label' => $option ),
+				);
+			}
+			$inner_blocks[] = array(
+				'name'        => 'jetpack/options',
+				'attrs'       => array( 'type' => 'radio' ),
+				'innerBlocks' => $option_blocks,
+				'wrapper'     => 'ul',
+			);
+		}
+
+		$input_attrs = array();
+		if ( '' !== $placeholder ) {
+			$input_attrs['placeholder'] = $placeholder;
+		}
+		if ( 'textarea' === $lookup ) {
+			$input_attrs['type'] = 'textarea';
+		} elseif ( 'select' === $lookup ) {
+			$input_attrs['type'] = 'dropdown';
+		} elseif ( ! in_array( $lookup, array( 'checkbox', 'radio' ), true ) ) {
+			$input_attrs['type'] = $type;
+		}
+
+		if ( ! in_array( $lookup, array( 'checkbox', 'radio' ), true ) ) {
+			$inner_blocks[] = array(
+				'name'  => 'jetpack/input',
+				'attrs' => $input_attrs,
+			);
+		}
+
 		return array(
-			'name'  => $map[ $lookup ],
-			'attrs' => $attrs,
+			'name'        => $map[ $lookup ],
+			'attrs'       => $attrs,
+			'innerBlocks' => $inner_blocks,
+			'wrapper'     => 'div',
 		);
 	}
 
@@ -338,6 +397,11 @@ class Static_Site_Importer_Form_Seeder {
 		$attrs    = array();
 		$metadata = isset( $form['form'] ) && is_array( $form['form'] ) ? $form['form'] : array();
 		$action   = isset( $metadata['action'] ) && is_scalar( $metadata['action'] ) ? trim( (string) $metadata['action'] ) : '';
+		$class    = isset( $metadata['class'] ) && is_scalar( $metadata['class'] ) ? trim( (string) $metadata['class'] ) : '';
+
+		if ( '' !== $class ) {
+			$attrs['className'] = $class;
+		}
 
 		if ( '' !== $action && 0 === stripos( $action, 'mailto:' ) ) {
 			$recipient = trim( substr( $action, 7 ) );
@@ -400,9 +464,10 @@ class Static_Site_Importer_Form_Seeder {
 	 * @param string                          $name        Block name.
 	 * @param array<string, mixed>            $attrs       Block attributes.
 	 * @param array<int, array<string,mixed>> $inner_blocks Child block definitions.
+	 * @param string                          $wrapper     Persisted inner-block wrapper element.
 	 * @return string
 	 */
-	private static function serialize_block( string $name, array $attrs, array $inner_blocks = array() ): string {
+	private static function serialize_block( string $name, array $attrs, array $inner_blocks = array(), string $wrapper = '' ): string {
 		$attr_json = '';
 		if ( ! empty( $attrs ) ) {
 			$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $attrs ) : json_encode( $attrs ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
@@ -423,11 +488,33 @@ class Static_Site_Importer_Form_Seeder {
 			$inner[] = self::serialize_block(
 				(string) $block['name'],
 				isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array(),
-				isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : array()
+				isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : array(),
+				isset( $block['wrapper'] ) && is_string( $block['wrapper'] ) ? $block['wrapper'] : ''
 			);
 		}
 
-		return '<!-- wp:' . $name . $attr_json . ' -->' . "\n" . implode( "\n", $inner ) . "\n" . '<!-- /wp:' . $name . ' -->';
+		$inner_markup = implode( "\n", $inner );
+		if ( 'jetpack/contact-form' === $name ) {
+			$classes = 'wp-block-jetpack-contact-form';
+			if ( isset( $attrs['className'] ) && is_scalar( $attrs['className'] ) && '' !== trim( (string) $attrs['className'] ) ) {
+				$classes .= ' ' . trim( (string) $attrs['className'] );
+			}
+			$inner_markup = '<div class="' . self::escape_attribute( $classes ) . '">' . $inner_markup . '</div>';
+		} elseif ( in_array( $wrapper, array( 'div', 'ul' ), true ) ) {
+			$inner_markup = '<' . $wrapper . '>' . $inner_markup . '</' . $wrapper . '>';
+		}
+
+		return '<!-- wp:' . $name . $attr_json . ' -->' . "\n" . $inner_markup . "\n" . '<!-- /wp:' . $name . ' -->';
+	}
+
+	/**
+	 * Escape a block wrapper attribute without requiring WordPress to be loaded.
+	 *
+	 * @param string $value Raw attribute value.
+	 * @return string
+	 */
+	private static function escape_attribute( string $value ): string {
+		return htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
 	}
 
 	/**

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -3,7 +3,7 @@
  * Smoke coverage for the configurable form provider layer and Jetpack form adapter.
  *
  * Run from the repository root:
- * php tests/smoke-form-materializer.php
+ * php tests/form-materializer-smoke.php
  *
  * @package StaticSiteImporter
  */
@@ -465,7 +465,7 @@ namespace {
 	$assert( 'woocommerce' === Static_Site_Importer_Entity_Materializer_Registry::provider_for( 'shop' ), 'shop-provider-unaffected-by-form-override' );
 
 	if ( empty( $failures ) ) {
-		echo 'PASS smoke-form-materializer.php (' . $assertions . " assertions)\n";
+		echo 'PASS form-materializer-smoke.php (' . $assertions . " assertions)\n";
 		exit( 0 );
 	}
 

--- a/tests/smoke-form-materializer.php
+++ b/tests/smoke-form-materializer.php
@@ -106,12 +106,15 @@ namespace {
 		'forms' => array(
 			array(
 				'selector' => 'form.contact',
-				'form'     => array( 'action' => 'mailto:hello@example.com', 'method' => 'post' ),
+				'form'     => array( 'action' => 'mailto:hello@example.com', 'method' => 'post', 'class' => 'form contact' ),
 				'controls' => array(
-					array( 'tag' => 'input', 'type' => 'text', 'name' => 'name', 'label' => 'Your name', 'required' => true ),
+					array( 'tag' => 'input', 'type' => 'text', 'id' => 'contact-name', 'name' => 'name', 'label' => 'Your name', 'required' => true ),
 					array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email', 'required' => true ),
 					array( 'tag' => 'input', 'type' => 'tel', 'name' => 'phone', 'label' => 'Phone' ),
+					array( 'tag' => 'input', 'type' => 'number', 'name' => 'attendees', 'label' => 'Attendees' ),
 					array( 'tag' => 'select', 'type' => 'select', 'name' => 'topic', 'label' => 'Topic', 'options' => array( array( 'label' => 'Sales' ), array( 'label' => 'Support' ) ) ),
+					array( 'tag' => 'input', 'type' => 'radio', 'name' => 'format', 'label' => 'In person', 'options' => array( 'In person', 'Online' ) ),
+					array( 'tag' => 'input', 'type' => 'checkbox', 'name' => 'updates', 'label' => 'Send me updates' ),
 					array( 'tag' => 'textarea', 'type' => 'textarea', 'name' => 'message', 'label' => 'Message' ),
 					array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send message' ),
 				),
@@ -124,16 +127,29 @@ namespace {
 	$row    = $seed['forms'][0] ?? array();
 	$markup = (string) ( $row['block_markup'] ?? '' );
 	$assert( true === ( $row['runtime_mapped'] ?? false ), 'seed-form-runtime-mapped' );
-	$assert( 5 === ( $row['field_count'] ?? 0 ), 'seed-five-fields-mapped' );
+	$assert( 8 === ( $row['field_count'] ?? 0 ), 'seed-eight-fields-mapped' );
 	$assert( str_contains( $markup, 'wp:jetpack/contact-form' ), 'markup-contact-form' );
 	$assert( str_contains( $markup, 'wp:jetpack/field-text' ), 'markup-field-text' );
 	$assert( str_contains( $markup, 'wp:jetpack/field-email' ), 'markup-field-email' );
-	$assert( str_contains( $markup, 'wp:jetpack/field-telephone' ), 'markup-field-telephone' );
+	$assert( ! str_contains( $markup, 'wp:jetpack/field-telephone' ), 'markup-avoids-unstable-field-telephone-template' );
+	$assert( str_contains( $markup, 'wp:jetpack/field-number' ), 'markup-field-number' );
 	$assert( str_contains( $markup, 'wp:jetpack/field-select' ), 'markup-field-select' );
+	$assert( str_contains( $markup, 'wp:jetpack/field-radio' ), 'markup-field-radio' );
+	$assert( str_contains( $markup, 'wp:jetpack/field-checkbox' ), 'markup-field-checkbox' );
 	$assert( str_contains( $markup, 'wp:jetpack/field-textarea' ), 'markup-field-textarea' );
 	$assert( str_contains( $markup, 'wp:jetpack/button' ), 'markup-submit-button' );
 	$assert( str_contains( $markup, 'hello@example.com' ), 'markup-mailto-recipient' );
 	$assert( str_contains( $markup, '"options":["Sales","Support"]' ), 'markup-select-options' );
+	$assert( str_contains( $markup, '<div class="wp-block-jetpack-contact-form form contact">' ), 'markup-contact-form-wrapper-and-source-classes' );
+	$assert( str_contains( $markup, '<!-- wp:jetpack/field-text {"required":true,"id":"contact-name"} -->' ), 'markup-field-wrapper-open' );
+	$assert( str_contains( $markup, '<div><!-- wp:jetpack/label {"label":"Your name","requiredText":"*"} /-->' ), 'markup-field-label-child' );
+	$assert( str_contains( $markup, '<!-- wp:jetpack/input {"type":"text"} /--></div>' ), 'markup-field-input-child-and-wrapper-close' );
+	$assert( str_contains( $markup, '<!-- wp:jetpack/input {"type":"dropdown"} /-->' ), 'markup-select-input-child' );
+	$assert( str_contains( $markup, '<!-- wp:jetpack/input {"type":"textarea"} /-->' ), 'markup-textarea-input-child' );
+	$assert( str_contains( $markup, '<!-- wp:jetpack/input {"type":"tel"} /-->' ), 'markup-telephone-input-child' );
+	$assert( str_contains( $markup, '<!-- wp:jetpack/options {"type":"radio"} -->' ), 'markup-radio-options-child' );
+	$assert( str_contains( $markup, '<ul><!-- wp:jetpack/option {"label":"In person"} /-->' ), 'markup-radio-option-wrapper' );
+	$assert( str_contains( $markup, '<!-- wp:jetpack/option {"label":"Send me updates","isStandalone":true} /-->' ), 'markup-checkbox-option-child' );
 
 	// --- Provider blocks are never claimed without the provider runtime --------
 	$GLOBALS['ssi_jetpack_form_blocks_available'] = false;


### PR DESCRIPTION
## Summary

- serialize Jetpack forms with their canonical contact-form and field wrappers
- emit label, input, option, and options inner blocks for mapped controls
- preserve source form classes and stable control IDs
- route telephone controls through the valid text-field/input path instead of Jetpack's editor-invalid phone template rewrite

Fixes #737.

## Verification

- `php tests/smoke-form-materializer.php` (101 assertions)
- `npm test`
- Fixture 37 Homeboy proof `2cf1340a-84b1-4c8a-8124-5422a58a91c8`: 188/189 blocks valid, zero Jetpack-invalid blocks; sole remaining invalid block is the unrelated Blocks Engine `core/separator` style mismatch

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode investigated the malformed block trees, drafted the implementation and tests, and ran the fixture-matrix verification. Chris Huber reviewed and directed the architecture and remains responsible for the change.