### PR TITLE
Keep fixture capabilities metadata-only

### DIFF
--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -34,41 +34,6 @@ import { liveWpParityCaptureStep, liveWpParityEnabled } from './live-wp-parity-s
 import { fixtureStepMetadata } from './shared.mjs';
 import { selectFixtureSurfaces, summarizeSurfaceCoverage } from './surfaces.mjs';
 
-const CAPABILITY_PLUGIN_PROVISIONING = {
-  'commerce-products': [
-    { slug: 'woocommerce', label: 'WooCommerce' },
-  ],
-  forms: [
-    { slug: 'jetpack', label: 'Jetpack' },
-  ],
-};
-
-// A capability-required provider must be actually usable before import, not just
-// installed. Plugin installation stays best-effort (it can flake or retry), but a
-// silently-missing provider previously degraded a required capability into a
-// fallback finding (e.g. a `forms` fixture emitting `html_form_fallback` because
-// Jetpack never activated). Each provider declares the PHP runtime predicate that
-// proves its capability is materializable so the readiness gate can fail closed.
-const CAPABILITY_PROVIDER_READINESS = {
-  woocommerce: {
-    label: 'WooCommerce',
-    // The commerce provider is ready when its plugin is active and the
-    // `[add_to_cart]` shortcode SSI seeds products through is registered.
-    predicate: "is_plugin_active('woocommerce/woocommerce.php') && shortcode_exists('add_to_cart')",
-  },
-  jetpack: {
-    label: 'Jetpack',
-    // The form provider is ready only when the `jetpack/contact-form` block is
-    // registered AND actually renders a form on the frontend. Merely finding the
-    // Contact_Form class is a false positive: the class autoloads via Composer,
-    // but Jetpack gates the block's render callback behind an active module, so an
-    // unprovisioned install renders the seeded form to an empty string. Prove the
-    // real behavior by rendering a minimal contact-form block and requiring a
-    // `<form>` in the output, so a non-rendering provider fails closed here.
-    predicate: "class_exists('WP_Block_Type_Registry') && WP_Block_Type_Registry::get_instance()->is_registered('jetpack/contact-form') && ( false !== stripos( do_blocks('<!-- wp:jetpack/contact-form --><!-- wp:jetpack/field-name {\\\"label\\\":\\\"Name\\\"} /--><!-- /wp:jetpack/contact-form -->'), '<form' ) )",
-  },
-};
-
 export function buildFixtureArtifact(fixture, options = {}) {
   const normalized = normalizeFixture(fixture);
   const files = collectFixtureFiles(normalized.directory, options);
@@ -266,9 +231,6 @@ function fixtureWorkflowSteps(options) {
   const surfaces = selectFixtureSurfaces(fixture, input);
 
   return [
-    ...fixturePluginProvisioningSteps(fixture),
-    ...jetpackFormsActivationSteps(fixture),
-    ...fixtureCapabilityReadinessSteps(fixture),
     importFixtureStep(fixture, commandArtifactsDirectory),
     ...(input.svgFontEvidence || input.svg_font_evidence ? [svgFontEvidenceStep(fixture)] : []),
     woocommerceOnboardingSuppressionStep(fixture),
@@ -467,63 +429,6 @@ function themeSlug(value) {
   return String(value || 'fixture').toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'fixture';
 }
 
-function fixturePluginProvisioningSteps(fixture) {
-  const plugins = fixtureCapabilityPlugins(fixture);
-  const steps = plugins.map((plugin) => ({
-    command: 'wordpress.plugin-setup',
-    allowFailure: true,
-    args: [
-      'action=install',
-      `plugin=${shellToken(plugin.slug)}`,
-      'activate=true',
-    ],
-    metadata: fixtureStepMetadata(fixture, 'provision-plugin', {
-      capability: plugin.capability,
-      plugin_slug: plugin.slug,
-      plugin_label: plugin.label,
-    }),
-  }));
-  return steps;
-}
-
-// Jetpack's contact-form block only registers its render callback when the
-// `contact-form` module is active, and Jetpack refuses to load any module on an
-// unconnected site unless it is in offline mode (Jetpack::load_modules() returns
-// early otherwise). A generated/local site has no WPCOM connection, so the block
-// would render to an empty string on the frontend and the seeded form would
-// vanish. Provision the sanctioned local/dev path — offline mode plus the active
-// module — via an mu-plugin so it applies to every subsequent frontend request,
-// matching how an unconnected Jetpack install is expected to run forms locally.
-// Only emitted when the fixture actually provisions Jetpack.
-function jetpackFormsActivationSteps(fixture) {
-  if (!fixtureCapabilityPlugins(fixture).some((plugin) => plugin.slug === 'jetpack')) {
-    return [];
-  }
-  const muPlugin = [
-    '<?php',
-    "add_filter( 'jetpack_offline_mode', '__return_true', 9 );",
-    "add_filter( 'jetpack_active_modules', function ( $modules ) {",
-    '  $modules = (array) $modules;',
-    "  if ( ! in_array( 'contact-form', $modules, true ) ) {",
-    "    $modules[] = 'contact-form';",
-    '  }',
-    '  return $modules;',
-    '}, 9 );',
-    '',
-  ].join('\n');
-  const php = `$dir = defined('WPMU_PLUGIN_DIR') ? WPMU_PLUGIN_DIR : WP_CONTENT_DIR . '/mu-plugins'; if ( ! is_dir( $dir ) ) { wp_mkdir_p( $dir ); } $ok = file_put_contents( $dir . '/ssi-fixture-jetpack-forms.php', ${phpSingleQuoted(muPlugin)} ); if ( false === $ok ) { fwrite(STDERR, 'Failed to write Jetpack Forms activation mu-plugin.'); exit(1); } echo 'jetpack-forms-activated';`;
-  return [
-    {
-      command: 'wordpress.run-php',
-      args: [`code=${php}`],
-      metadata: fixtureStepMetadata(fixture, 'provider-preflight', {
-        setup: 'activate-jetpack-forms-module',
-        provider: 'jetpack',
-      }),
-    },
-  ];
-}
-
 function woocommerceOnboardingSuppressionStep(fixture) {
   return {
     command: 'wordpress.wp-cli',
@@ -535,54 +440,6 @@ function woocommerceOnboardingSuppressionStep(fixture) {
       setup: 'suppress-onboarding-redirect',
     }),
   };
-}
-
-function fixtureCapabilityPlugins(fixture) {
-  const seen = new Set();
-  const plugins = [];
-  for (const capability of normalizeArray(fixture.capabilities).map((item) => String(item || '').trim().toLowerCase()).filter(Boolean)) {
-    for (const plugin of CAPABILITY_PLUGIN_PROVISIONING[capability] || []) {
-      if (seen.has(plugin.slug)) {
-        continue;
-      }
-      seen.add(plugin.slug);
-      plugins.push({ ...plugin, capability });
-    }
-  }
-  return plugins;
-}
-
-// Emit a fail-closed readiness assertion per capability-required provider so a
-// silently-missing provider (e.g. a Jetpack install that flaked under
-// `allowFailure`) surfaces as a hard, visible error before import instead of
-// degrading the required capability into a fallback finding. The install step
-// keeps `allowFailure`; this gate does not.
-function fixtureCapabilityReadinessSteps(fixture) {
-  const steps = [];
-  for (const plugin of fixtureCapabilityPlugins(fixture)) {
-    const readiness = CAPABILITY_PROVIDER_READINESS[plugin.slug];
-    if (!readiness) {
-      continue;
-    }
-    const message = `${readiness.label} is required for the "${plugin.capability}" capability but its runtime is not available after provisioning. Install/activate ${readiness.label} on this WordPress version before running the fixture matrix, or remove the "${plugin.capability}" capability from ${fixture.id}.`;
-    const php = `if ( ! function_exists('is_plugin_active') ) { require_once ABSPATH . 'wp-admin/includes/plugin.php'; } if ( ! ( ${readiness.predicate} ) ) { fwrite(STDERR, ${phpSingleQuoted(message)}); exit(1); } echo ${phpSingleQuoted(`${plugin.slug}-ready`)};`;
-    steps.push({
-      command: 'wordpress.run-php',
-      args: [`code=${php}`],
-      metadata: fixtureStepMetadata(fixture, 'capability-readiness', {
-        capability: plugin.capability,
-        plugin_slug: plugin.slug,
-        plugin_label: readiness.label,
-      }),
-    });
-  }
-  return steps;
-}
-
-// Wrap a literal string as a single-quoted PHP string, escaping backslashes and
-// single quotes per PHP single-quote rules.
-function phpSingleQuoted(value) {
-  return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 }
 
 function buildDependencyOverrideSetup(input, importer) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -6026,6 +6026,7 @@ test('visual-compare attribution degrades explicitly when sidecars or the extens
   const persisted = materializeVisualCompareArtifacts({
     outputDirectory,
     codeboxArtifactsDirectory,
+    visualAttributionLoader: () => null,
     result: {
       fixtures: [{
         fixture_id: 'simple-site',

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -608,7 +608,7 @@ test('retains generated SVG font evidence from runtime output', () => {
   assert.equal(result.fixtures[0].svg_font_embedding_evidence.files[0].has_data_font, true);
 });
 
-test('fixture capability manifests drive per-fixture plugin provisioning without waivers', () => {
+test('fixture capability metadata does not alter provider setup or execution', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-recipe-capabilities-'));
   const plain = path.join(root, 'plain-site');
   const shop = path.join(root, 'shop-site');
@@ -631,39 +631,11 @@ test('fixture capability manifests drive per-fixture plugin provisioning without
   });
   const fixtureSteps = (id) => recipe.workflow.steps.filter((step) => step.metadata?.fixture_id === id);
 
-  assert.deepEqual(fixtureSteps('plain-site').map((step) => step.command), ['wordpress.wp-cli', 'wordpress.wp-cli']);
-  // Each capability provider gets a best-effort install followed by a fail-closed
-  // readiness assertion (wordpress.run-php) before the import runs.
-  assert.deepEqual(fixtureSteps('shop-site').map((step) => step.command), ['wordpress.plugin-setup', 'wordpress.run-php', 'wordpress.wp-cli', 'wordpress.wp-cli']);
-  assert.deepEqual(fixtureSteps('shop-forms-site').map((step) => step.command), ['wordpress.plugin-setup', 'wordpress.plugin-setup', 'wordpress.run-php', 'wordpress.run-php', 'wordpress.run-php', 'wordpress.wp-cli', 'wordpress.wp-cli']);
-  assert.deepEqual(fixtureSteps('shop-site')[0].args, ['action=install', 'plugin=woocommerce', 'activate=true']);
-  assert.deepEqual(fixtureSteps('shop-forms-site')[0].args, ['action=install', 'plugin=woocommerce', 'activate=true']);
-  assert.deepEqual(fixtureSteps('shop-forms-site')[1].args, ['action=install', 'plugin=jetpack', 'activate=true']);
-  assert.equal(fixtureSteps('shop-site')[0].allowFailure, true);
-  assert.equal(recipe.workflow.steps.some((step) => /--allow-missing-woocommerce/.test(step.args?.[0] || '')), false);
-
-  // The readiness gate is fail-closed: it must not allow failure and must assert
-  // the provider runtime is present so a silently-missing provider (e.g. a flaked
-  // Jetpack install) is a hard error rather than a degraded fallback finding.
-  const shopReadiness = fixtureSteps('shop-site').filter((step) => step.metadata?.phase === 'capability-readiness');
-  assert.equal(shopReadiness.length, 1);
-  assert.equal(shopReadiness[0].command, 'wordpress.run-php');
-  assert.notEqual(shopReadiness[0].allowFailure, true);
-  assert.equal(shopReadiness[0].metadata.plugin_slug, 'woocommerce');
-  assert.match(shopReadiness[0].args[0], /shortcode_exists\('add_to_cart'\)/);
-  assert.match(shopReadiness[0].args[0], /exit\(1\)/);
-
-  const formsReadiness = fixtureSteps('shop-forms-site').filter((step) => step.metadata?.phase === 'capability-readiness');
-  assert.deepEqual(formsReadiness.map((step) => step.metadata.plugin_slug), ['woocommerce', 'jetpack']);
-  assert.ok(formsReadiness.every((step) => step.command === 'wordpress.run-php' && step.allowFailure !== true));
-  const jetpackReadiness = formsReadiness.find((step) => step.metadata.plugin_slug === 'jetpack');
-  assert.match(jetpackReadiness.args[0], /jetpack\/contact-form/);
-  assert.match(jetpackReadiness.args[0], /exit\(1\)/);
-  // The readiness gate for a capability runs before that fixture's import step.
-  const shopFormsCommands = fixtureSteps('shop-forms-site');
-  const lastReadinessIndex = shopFormsCommands.map((step) => step.metadata?.phase).lastIndexOf('capability-readiness');
-  const importIndex = shopFormsCommands.findIndex((step) => String(step.args?.[0] || '').includes('validate-artifact'));
-  assert.ok(lastReadinessIndex >= 0 && importIndex > lastReadinessIndex, 'readiness gates precede the import');
+  const plainSteps = fixtureSteps('plain-site');
+  assert.deepEqual(plainSteps.map((step) => step.command), ['wordpress.wp-cli', 'wordpress.wp-cli']);
+  assert.deepEqual(fixtureSteps('shop-site').map((step) => step.command), plainSteps.map((step) => step.command));
+  assert.deepEqual(fixtureSteps('shop-forms-site').map((step) => step.command), plainSteps.map((step) => step.command));
+  assert.equal(recipe.workflow.steps.some((step) => ['wordpress.plugin-setup', 'wordpress.run-php'].includes(step.command)), false);
 });
 
 test('fixture-matrix rig requires env-backed WP Codebox editor and visual capabilities', () => {


### PR DESCRIPTION
## Summary

- remove fixture capability-to-plugin provisioning from the matrix recipe
- remove fixture-owned Jetpack module activation and provider readiness setup
- enforce that fixture capability metadata cannot alter execution steps
- exercise SSI's existing arbitrary-HTML inference and provider materialization path directly

Fixes #738.

## Stack

This PR is stacked on #739 so fixture 37 can validate the corrected Jetpack serialization while proving provider inference. After #739 merges, this PR can be retargeted to `main`.

## Verification

- `npm run test:fixture-matrix` (199 tests)
- Homeboy run `0e7f3aab-18b7-4746-a428-1b0f6c8084a2` used fixture 37 with no declared capabilities and a recipe containing no Jetpack setup step
- SSI imported the arbitrary HTML and materialized valid Jetpack forms; 188/189 editor blocks valid, with only the unrelated Blocks Engine `core/separator` style mismatch remaining

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode traced the fixture/product dependency boundary, drafted the matrix cleanup and regression test, and ran the clean-sandbox proof. Chris Huber reviewed and directed the architecture and remains responsible for the change.