### PR TITLE
Fix Playground extension hosting and browser verification

### DIFF
--- a/.github/workflows/release-php-wasm-zstd.yml
+++ b/.github/workflows/release-php-wasm-zstd.yml
@@ -6,10 +6,11 @@ on:
 
 permissions:
   contents: write
+  pages: write
 
 jobs:
-  build-and-upload:
-    name: Build PHP 8.5 JSPI zstd side module
+  build-and-publish:
+    name: Build and publish PHP 8.5 JSPI zstd side module
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
@@ -22,10 +23,71 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - run: npm run build:php-wasm-zstd -- dist/php-wasm-zstd
+      - name: Build the immutable release asset
+        env:
+          PHP_WASM_ZSTD_ASSET_BASE_URL: https://automattic.github.io/static-site-importer/playground/extensions/${{ github.event.release.tag_name }}
+        run: npm run build:php-wasm-zstd -- dist/php-wasm-zstd
       - name: Verify the PHP.wasm artifact contract
         run: npm run test:php-wasm-zstd
-      - name: Upload public Playground extension assets
+      - name: Publish immutable CORS-capable Pages assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.so dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.manifest.json
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          pages_dir="$RUNNER_TEMP/static-site-importer-pages"
+          if git fetch origin gh-pages; then
+            git worktree add --detach "$pages_dir" origin/gh-pages
+          else
+            git worktree add --detach "$pages_dir"
+            git -C "$pages_dir" checkout --orphan gh-pages
+            git -C "$pages_dir" rm -rf . || true
+          fi
+          touch "$pages_dir/.nojekyll"
+          mkdir -p "$pages_dir/playground/extensions/$RELEASE_TAG"
+          cp dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.* "$pages_dir/playground/extensions/$RELEASE_TAG/"
+          node -e '
+            const fs = require("node:fs");
+            const [source, output, tag] = process.argv.slice(1);
+            const blueprint = JSON.parse(fs.readFileSync(source, "utf8"));
+            blueprint.steps.find((step) => step.step === "installPlugin").pluginData.url = `https://github.com/Automattic/static-site-importer/releases/download/${tag}/static-site-importer.zip`;
+            fs.writeFileSync(output, JSON.stringify(blueprint, null, 2) + "\n");
+          ' docs/playground/blueprint.json "$pages_dir/playground/$RELEASE_TAG.blueprint.json" "$RELEASE_TAG"
+          git -C "$pages_dir" add playground
+          git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Publish immutable Playground assets for $RELEASE_TAG"
+          git -C "$pages_dir" push origin HEAD:gh-pages
+          if ! gh api "repos/$GITHUB_REPOSITORY/pages" >/dev/null 2>&1; then
+            gh api --method POST "repos/$GITHUB_REPOSITORY/pages" -f 'source[branch]=gh-pages' -f 'source[path]=/'
+          fi
+      - name: Wait for the CORS publication contract
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          url="https://automattic.github.io/static-site-importer/playground/extensions/$RELEASE_TAG/static-site-importer-zstd-php8.5-jspi.manifest.json"
+          for attempt in $(seq 1 30); do
+            headers="$(curl --silent --show-error --location --dump-header - --output /dev/null "$url")"
+            if printf '%s' "$headers" | tr -d '\r' | grep -qi '^access-control-allow-origin: \*'; then exit 0; fi
+            sleep 10
+          done
+          echo "GitHub Pages did not publish CORS headers for $url" >&2
+          exit 1
+      - name: Verify the immutable Playground launch end to end
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          PLAYGROUND_EXTENSION_MANIFEST_URL: https://automattic.github.io/static-site-importer/playground/extensions/${{ github.event.release.tag_name }}/static-site-importer-zstd-php8.5-jspi.manifest.json
+          PLAYGROUND_BLUEPRINT_URL: https://automattic.github.io/static-site-importer/playground/${{ github.event.release.tag_name }}.blueprint.json
+        run: |
+          npx playwright install --with-deps chromium
+          npm run test:playground-launch
+      - name: Advance the verified latest aliases
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          pages_dir="$RUNNER_TEMP/static-site-importer-pages"
+          mkdir -p "$pages_dir/playground/latest" "$pages_dir/playground/extensions/latest"
+          cp dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.* "$pages_dir/playground/extensions/latest/"
+          cp "$pages_dir/playground/$RELEASE_TAG.blueprint.json" "$pages_dir/playground/latest/blueprint.json"
+          git -C "$pages_dir" add playground
+          git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Advance Playground latest to $RELEASE_TAG"
+          git -C "$pages_dir" push origin HEAD:gh-pages
+      - name: Verify the exact README Playground launch
+        run: npm run test:playground-launch

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Import a static site or generated website artifact into WordPress pages and a companion block theme.
 
-[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fgithub.com%2FAutomattic%2Fstatic-site-importer%2Freleases%2Flatest%2Fdownload%2Fstatic-site-importer-zstd-php8.5-jspi.manifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FAutomattic%2Fstatic-site-importer%2Fmain%2Fdocs%2Fplayground%2Fblueprint.json)
+[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fautomattic.github.io%2Fstatic-site-importer%2Fplayground%2Fextensions%2Flatest%2Fstatic-site-importer-zstd-php8.5-jspi.manifest.json&blueprint-url=https%3A%2F%2Fautomattic.github.io%2Fstatic-site-importer%2Fplayground%2Flatest%2Fblueprint.json)
 
 Static Site Importer is a WordPress plugin. It requires the [Blocks Engine PHP transformer](https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer) Composer package and calls that package's canonical helper functions for generic artifact compilation and format conversion.
 
@@ -151,11 +151,11 @@ add_filter(
 
 Open Static Site Importer in a disposable WordPress Playground site:
 
-[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fgithub.com%2FAutomattic%2Fstatic-site-importer%2Freleases%2Flatest%2Fdownload%2Fstatic-site-importer-zstd-php8.5-jspi.manifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FAutomattic%2Fstatic-site-importer%2Fmain%2Fdocs%2Fplayground%2Fblueprint.json)
+[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fautomattic.github.io%2Fstatic-site-importer%2Fplayground%2Fextensions%2Flatest%2Fstatic-site-importer-zstd-php8.5-jspi.manifest.json&blueprint-url=https%3A%2F%2Fautomattic.github.io%2Fstatic-site-importer%2Fplayground%2Flatest%2Fblueprint.json)
 
 The blueprint installs and activates the packaged Static Site Importer release, logs the visitor in, and opens `/import/` with the `static-site-importer/importer` block configured to generate a WordPress website. Playground loads the PHP 8.5 JSPI `zstd` side module before PHP starts, so the existing Figma upload flow can decode zstd-compressed `.fig` canvas chunks. Testers can upload site files, choose a folder, upload a ZIP, paste HTML, or upload a Figma file.
 
-The extension manifest and side module are immutable named assets on each SSI GitHub Release. They are produced from pinned `php-ext-zstd` and vendored `libzstd` source by the release workflow. The README URL targets `releases/latest`, so it becomes usable after the first release containing these two assets has finished its upload; no unpublished branch, localhost URL, PECL installation, or host `zstd` executable is used.
+The extension manifest, side module, and launch blueprint are published to the repository's GitHub Pages site. Each release gets an immutable versioned directory; `latest` is a convenience alias updated only after that version is published. This keeps the release plugin, blueprint, manifest, and module on one release contract while GitHub Pages supplies the CORS headers required by Playground. They are produced from pinned `php-ext-zstd` and vendored `libzstd` source by the release workflow; no unpublished branch, localhost URL, PECL installation, or host `zstd` executable is used.
 
 URL intake rules:
 

--- a/docs/playground/blueprint.json
+++ b/docs/playground/blueprint.json
@@ -13,10 +13,14 @@
       "step": "login"
     },
     {
+      "step": "runPHP",
+      "code": "<?php if ( ! extension_loaded( 'zstd' ) ) { throw new RuntimeException( 'The zstd Playground extension did not load.' ); } ?>"
+    },
+    {
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip"
+        "url": "https://github.com/Automattic/static-site-importer/releases/download/{{RELEASE_TAG}}/static-site-importer.zip"
       },
       "options": {
         "activate": true,

--- a/docs/playground/extensions/zstd-php8.5-jspi.manifest.json
+++ b/docs/playground/extensions/zstd-php8.5-jspi.manifest.json
@@ -5,7 +5,7 @@
   "artifacts": [
     {
       "phpVersion": "8.5",
-      "sourcePath": "https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer-zstd-php8.5-jspi.so"
+      "sourcePath": "https://automattic.github.io/static-site-importer/playground/extensions/latest/static-site-importer-zstd-php8.5-jspi.so"
     }
   ]
 }

--- a/docs/playground/publication-contract.md
+++ b/docs/playground/publication-contract.md
@@ -1,0 +1,28 @@
+# Playground Publication Contract
+
+The GitHub Pages `gh-pages` branch is the browser-facing publication origin for
+Playground assets. GitHub Release Assets are not used by the browser because
+their redirect target does not provide the CORS response required by
+`resolvePHPExtension`.
+
+For every Homeboy-owned plugin release tag `<tag>`, the release workflow builds
+from that tag and publishes these immutable files:
+
+- `https://automattic.github.io/static-site-importer/playground/extensions/<tag>/static-site-importer-zstd-php8.5-jspi.manifest.json`
+- `https://automattic.github.io/static-site-importer/playground/extensions/<tag>/static-site-importer-zstd-php8.5-jspi.so`
+- `https://automattic.github.io/static-site-importer/playground/<tag>.blueprint.json`
+
+The versioned blueprint installs `static-site-importer.zip` from the same GitHub
+Release tag. `docs/playground/blueprint.json` is a release template: the
+workflow replaces `{{RELEASE_TAG}}` while publishing it. The
+`playground/extensions/latest/` and `playground/latest/`
+locations are convenience copies updated only after the immutable tag files are
+published. README uses those convenience URLs; reproducible consumers use the
+tagged URLs. This avoids combining a mutable `main` blueprint with released
+plugin or extension assets.
+
+The workflow provisions GitHub Pages from `gh-pages` when it is absent, retains
+previous tagged directories, and verifies the immutable launch in a real browser
+before advancing either `latest` alias. It then verifies the exact README launch
+URL. The workflow never creates or edits a release; Homeboy remains the sole
+release owner.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2607,6 +2607,19 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@wordpress/ui/node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/@wordpress/undo-manager": {
       "version": "1.45.0",
       "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.45.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@wordpress/block-library": "^9.45.0",
         "@wordpress/blocks": "^15.18.0",
         "@wordpress/element": "^6.45.0",
-        "jsdom": "^29.1.0"
+        "jsdom": "^29.1.0",
+        "playwright": "^1.56.1"
       }
     },
     "node_modules/@ariakit/core": {
@@ -2606,19 +2607,6 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@wordpress/ui/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
     "node_modules/@wordpress/undo-manager": {
       "version": "1.45.0",
       "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.45.0.tgz",
@@ -3348,6 +3336,21 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -4096,6 +4099,38 @@
       },
       "bin": {
         "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:solved-site-promotion": "node --test tools/verify-solved-site-promotion.test.mjs",
     "test:promote-solved-fixture": "node --test tools/promote-solved-fixture.test.mjs",
     "test:php-wasm-zstd": "node --test tools/php-wasm-zstd.test.mjs",
+    "test:playground-launch": "node tools/verify-playground-launch.mjs",
     "build:php-wasm-zstd": "bash tools/build-php-wasm-zstd.sh",
     "test:js-block-validation": "node tests/smoke-generated-theme-block-validation.cjs",
     "test:validation": "node tests/run-validation-harness.cjs"
@@ -22,7 +23,8 @@
     "@wordpress/block-library": "^9.45.0",
     "@wordpress/blocks": "^15.18.0",
     "@wordpress/element": "^6.45.0",
-    "jsdom": "^29.1.0"
+    "jsdom": "^29.1.0",
+    "playwright": "^1.56.1"
   },
   "dependencies": {
     "pixelmatch": "^7.2.0",

--- a/tools/build-php-wasm-zstd.sh
+++ b/tools/build-php-wasm-zstd.sh
@@ -8,7 +8,7 @@ readonly LIBZSTD_REF='63779c798237346c2b245c546c40b72a5a5913fe'
 readonly PHP_WASM_COMPILE_EXTENSION_VERSION='3.1.45'
 readonly ARTIFACT_NAME='static-site-importer-zstd-php8.5-jspi.so'
 readonly MANIFEST_NAME='static-site-importer-zstd-php8.5-jspi.manifest.json'
-readonly RELEASE_BASE_URL='https://github.com/Automattic/static-site-importer/releases/latest/download'
+readonly PAGES_BASE_URL='https://automattic.github.io/static-site-importer/playground/extensions'
 
 root="$(git rev-parse --show-toplevel)"
 out_dir="${1:-$root/dist/php-wasm-zstd}"
@@ -43,16 +43,16 @@ mv "$module_path" "$out_dir/$ARTIFACT_NAME"
 
 node -e '
 const fs = require("node:fs");
-const [output, manifestName, artifactName, releaseBase] = process.argv.slice(1);
+const [output, manifestName, artifactName, assetBase] = process.argv.slice(1);
 const manifest = {
   name: "zstd",
   version: "0.13.3",
   mode: "php-extension",
-  artifacts: [{ phpVersion: "8.5", sourcePath: `${releaseBase}/${artifactName}` }],
+  artifacts: [{ phpVersion: "8.5", sourcePath: `${assetBase}/${artifactName}` }],
 };
 fs.writeFileSync(`${output}/${manifestName}`, JSON.stringify(manifest, null, 2) + "\n");
 manifest.artifacts[0].sourcePath = artifactName;
 fs.writeFileSync(`${output}/manifest.json`, JSON.stringify(manifest, null, 2) + "\n");
-' "$out_dir" "$MANIFEST_NAME" "$ARTIFACT_NAME" "$RELEASE_BASE_URL"
+' "$out_dir" "$MANIFEST_NAME" "$ARTIFACT_NAME" "${PHP_WASM_ZSTD_ASSET_BASE_URL:-$PAGES_BASE_URL/latest}"
 
 printf 'Built %s and %s in %s\n' "$ARTIFACT_NAME" "$MANIFEST_NAME" "$out_dir"

--- a/tools/php-wasm-zstd.test.mjs
+++ b/tools/php-wasm-zstd.test.mjs
@@ -4,8 +4,8 @@ import path from 'node:path';
 import test from 'node:test';
 
 const root = path.resolve( import.meta.dirname, '..' );
-const releaseBase = 'https://github.com/Automattic/static-site-importer/releases/latest/download';
-const manifestUrl = `${ releaseBase }/static-site-importer-zstd-php8.5-jspi.manifest.json`;
+const pagesBase = 'https://automattic.github.io/static-site-importer/playground/extensions';
+const manifestUrl = `${ pagesBase }/latest/static-site-importer-zstd-php8.5-jspi.manifest.json`;
 
 test( 'PHP.wasm zstd build uses pinned JSPI-compatible upstream sources', async () => {
 	const build = await readFile( path.join( root, 'tools/build-php-wasm-zstd.sh' ), 'utf8' );
@@ -18,13 +18,13 @@ test( 'PHP.wasm zstd build uses pinned JSPI-compatible upstream sources', async 
 	assert.doesNotMatch( build, /pecl|zstd -d|\/usr\/bin\/zstd/i );
 } );
 
-test( 'manifest publishes a PHP 8.5 JSPI zstd artifact through the release contract', async () => {
+test( 'manifest publishes a PHP 8.5 JSPI zstd artifact through the CORS-capable Pages contract', async () => {
 	const manifest = JSON.parse( await readFile( path.join( root, 'docs/playground/extensions/zstd-php8.5-jspi.manifest.json' ), 'utf8' ) );
 	assert.equal( manifest.name, 'zstd' );
 	assert.equal( manifest.mode, 'php-extension' );
 	assert.deepEqual( manifest.artifacts, [ {
 		phpVersion: '8.5',
-		sourcePath: `${ releaseBase }/static-site-importer-zstd-php8.5-jspi.so`,
+		sourcePath: `${ pagesBase }/latest/static-site-importer-zstd-php8.5-jspi.so`,
 	} ] );
 } );
 
@@ -40,6 +40,29 @@ test( 'Playground starts PHP 8.5 and both README launch links load zstd before b
 		const url = new URL( link );
 		assert.equal( url.searchParams.get( 'php' ), '8.5' );
 		assert.equal( url.searchParams.get( 'php-extension' ), manifestUrl );
-		assert.equal( url.searchParams.get( 'blueprint-url' ), 'https://raw.githubusercontent.com/Automattic/static-site-importer/main/docs/playground/blueprint.json' );
+		assert.equal( url.searchParams.get( 'blueprint-url' ), 'https://automattic.github.io/static-site-importer/playground/latest/blueprint.json' );
 	}
+} );
+
+test( 'release publication keeps immutable assets and blueprints separate from the latest convenience paths', async () => {
+	const [ workflow, publication ] = await Promise.all( [
+		readFile( path.join( root, '.github/workflows/release-php-wasm-zstd.yml' ), 'utf8' ),
+		readFile( path.join( root, 'docs/playground/publication-contract.md' ), 'utf8' ),
+	] );
+	assert.match( workflow, /PHP_WASM_ZSTD_ASSET_BASE_URL: https:\/\/automattic\.github\.io\/static-site-importer\/playground\/extensions\/\$\{\{ github\.event\.release\.tag_name \}\}/ );
+	assert.match( workflow, /playground\/extensions\/\$RELEASE_TAG/ );
+	assert.match( workflow, /playground\/extensions\/latest/ );
+	assert.match( workflow, /releases\/download\/\$\{tag\}/ );
+	assert.match( workflow, /access-control-allow-origin/ );
+	assert.doesNotMatch( workflow, /gh release upload/ );
+	assert.ok(
+		workflow.indexOf( 'Verify the immutable Playground launch end to end' ) < workflow.indexOf( 'Advance the verified latest aliases' ),
+		'latest aliases must advance only after the immutable browser verification',
+	);
+	assert.ok(
+		workflow.indexOf( 'Advance the verified latest aliases' ) < workflow.indexOf( 'Verify the exact README Playground launch' ),
+		'the published README URL must be verified after latest advances',
+	);
+	assert.match( publication, /\{\{RELEASE_TAG\}\}/ );
+	assert.match( publication, /Homeboy remains the sole\s+release owner/ );
 } );

--- a/tools/verify-playground-launch.mjs
+++ b/tools/verify-playground-launch.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { chromium } from 'playwright';
+
+const root = path.resolve(import.meta.dirname, '..');
+const readme = await readFile(path.join(root, 'README.md'), 'utf8');
+const launchUrl = [ ...readme.matchAll(/\]\((https:\/\/playground\.wordpress\.net\/\?[^)]+)\)/g) ][0]?.[1];
+
+assert.ok(launchUrl, 'README must include a WordPress Playground launch URL');
+
+const launch = new URL(launchUrl);
+if (process.env.PLAYGROUND_EXTENSION_MANIFEST_URL) {
+  launch.searchParams.set('php-extension', process.env.PLAYGROUND_EXTENSION_MANIFEST_URL);
+}
+if (process.env.PLAYGROUND_BLUEPRINT_URL) {
+  launch.searchParams.set('blueprint-url', process.env.PLAYGROUND_BLUEPRINT_URL);
+}
+const manifestUrl = launch.searchParams.get('php-extension');
+assert.ok(manifestUrl, 'README launch URL must provide a PHP extension manifest');
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+
+try {
+  // This is deliberately a browser fetch from Playground's origin: Node fetch
+  // cannot detect the CORS regression that broke the launch link.
+  await page.goto('https://playground.wordpress.net/', { waitUntil: 'domcontentloaded' });
+  const manifest = await page.evaluate(async (url) => {
+    const response = await fetch(url);
+    return { ok: response.ok, manifest: await response.json() };
+  }, manifestUrl);
+  assert.equal(manifest.ok, true, 'Playground must be able to CORS-fetch the extension manifest');
+  assert.equal(manifest.manifest.name, 'zstd');
+
+  await page.goto(launch.toString(), { waitUntil: 'domcontentloaded', timeout: 120_000 });
+  let wordpress;
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    wordpress = page.frames().find((candidate) => candidate.url().includes('/wp-admin/') || candidate.url().includes('/import/'));
+    if (wordpress) break;
+    await page.waitForTimeout(1_000);
+  }
+  assert.ok(wordpress, 'Playground must boot its WordPress frame');
+  if (!wordpress.url().includes('/import/')) await wordpress.waitForURL(/\/import\//, { timeout: 120_000 });
+  await wordpress.locator('.ssi-importer').waitFor({ state: 'visible', timeout: 120_000 });
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## Summary
Publish the Playground zstd extension and release-pinned blueprint from a CORS-capable GitHub Pages origin so the README demo boots instead of failing during extension fetch.

## What changed
- Publish immutable versioned extension assets and blueprint before transactionally advancing latest aliases.
- Exercise both the immutable release launch and exact README URL in Chromium, including zstd loading, plugin activation, and the importer UI.
- Document the release-owned publication contract and remove the broken GitHub Release Asset browser dependency.

## How to test
1. Run `npm ci`; expect Dependencies install from the lockfile..
2. Run `npm test`; expect All deterministic SSI suites pass, including the publication ordering contract..
3. Run `npm run test:playground-launch`; expect The released README launch boots Playground with zstd and renders the SSI importer..

## Compatibility
The plugin runtime and import APIs are unchanged. Existing native zstd fallback behavior remains; only browser asset transport and release publication change.

## Evidence
- Base unchanged since verification: main remains at 9e267972b563a86fa94a5f5dd8a1122c854a1e01.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/static-site-importer/issues/656
- Verified finalization base: main at 9e267972b563a86fa94a5f5dd8a1122c854a1e01
- npm ci: passed (Passed)
- npm test: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode with Homeboy)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Traced browser CORS behavior, designed the release publication contract, reviewed and corrected publication ordering, and verified deterministic tests.

## Source relationships
- Closes #656
