### PR TITLE
Fix false-positive visual comparison evidence

### DIFF
--- a/lib/fixture-matrix/visual-evidence-report.mjs
+++ b/lib/fixture-matrix/visual-evidence-report.mjs
@@ -108,7 +108,10 @@ function fixtureEvidenceRow({ fixture, manifest, findings, outputDirectory }) {
   const blockTotal = numberValue(editorQuality.block_total ?? blockComposition.block_total, 0);
   const nativeBlockCount = numberValue(editorQuality.native_block_count ?? blockComposition.native_block_count, 0);
   const coreHtmlBlockCount = numberValue(editorQuality.core_html_block_count ?? blockComposition.core_html_block_count, 0);
-  const visualComparePresent = Object.keys(visualMetrics).length > 0 || Object.keys(visualArtifacts).length > 0 || artifactRefs.some((ref) => /visual-(compare|diff)|screenshot/i.test(`${ref.artifact_id || ''} ${ref.kind || ''} ${ref.path || ''}`));
+  const visualComparePresent = Object.keys(visualMetrics).length > 0
+    || normalizeArray(fixture.visual_parity_comparisons).length > 0
+    || Object.values(visualArtifacts).some((artifact) => objectValue(artifact).status === 'captured')
+    || artifactRefs.some((ref) => /visual[-_ ](?:compare|diff|parity)/i.test(`${ref.artifact_id || ''} ${ref.kind || ''}`));
   const importedSnapshotPresent = fileExists(fixturePath(outputDirectory, fixtureId, 'files', 'browser', 'snapshot.html')) || artifactRefs.some((ref) => /snapshot\.html|capture-html|browser.*html/i.test(`${ref.artifact_id || ''} ${ref.kind || ''} ${ref.path || ''}`));
   const risk = computeRisk({ artifactPath, sourcePath, importedSnapshotPresent, visualComparePresent, screenshotRefs, viewportRows, missingAssets, coreHtmlBlockCount, fixture });
 

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -6529,6 +6529,36 @@ test('visual parity evidence report summarizes staged output evidence and layout
   assert.ok(fixture.risk.reasons.includes('1 core/html block(s)'));
 });
 
+test('visual parity evidence report requires captured comparison evidence', () => {
+  const fixtures = [
+    {
+      fixture_id: 'editor-screenshot-only',
+      artifact_refs: [{ artifact_id: 'editor-open-screenshot', kind: 'editor-canvas', path: 'files/browser/editor-open.png' }],
+      visual_parity_artifacts: {
+        artifacts: {
+          visual_diff: { status: 'pending', capture_state: 'not_captured' },
+        },
+      },
+    },
+    { fixture_id: 'metrics', visual_parity_artifacts: { metrics: { mismatch_pixels: 0, total_pixels: 1000 } } },
+    { fixture_id: 'captured-source', visual_parity_artifacts: { artifacts: { source_screenshot: { status: 'captured' } } } },
+    { fixture_id: 'captured-candidate', visual_parity_artifacts: { artifacts: { imported_screenshot: { status: 'captured' } } } },
+    { fixture_id: 'captured-diff', visual_parity_artifacts: { artifacts: { diff_screenshot: { status: 'captured' } } } },
+    { fixture_id: 'normalized-comparison', visual_parity_comparisons: [{ source_path: '/' }] },
+    { fixture_id: 'typed-compare-ref', artifact_refs: [{ artifact_id: 'visual-compare-result', kind: 'diagnostic' }] },
+    { fixture_id: 'typed-diff-ref', artifact_refs: [{ artifact_id: 'result', kind: 'browser-visual-diff' }] },
+  ];
+  const report = buildVisualParityEvidenceReport({ result: { fixtures } });
+  const rows = new Map(report.fixtures.map((fixture) => [fixture.fixture_id, fixture]));
+
+  assert.equal(report.summary.visual_compare_fixture_count, fixtures.length - 1);
+  assert.equal(rows.get('editor-screenshot-only').evidence.visual_compare.status, 'missing');
+  assert.equal(rows.get('editor-screenshot-only').evidence.screenshots.status, 'present');
+  for (const fixture of fixtures.slice(1)) {
+    assert.equal(rows.get(fixture.fixture_id).evidence.visual_compare.status, 'present', fixture.fixture_id);
+  }
+});
+
 test('fixture matrix result artifacts include visual parity evidence JSON and markdown reports', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-evidence-artifacts-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-evidence-artifact-test' });


### PR DESCRIPTION
## Summary
Require actual visual comparison evidence before reporting visual parity as present.

## What changed
- Ignore unrelated editor screenshots and pending visual envelopes when determining visual-comparison availability.
- Recognize normalized comparisons, real metrics, captured comparison artifacts, and explicitly typed visual compare/diff references.
- Cover editor-screenshot-only and positive comparison-evidence paths with focused fixture-matrix tests.

## How to test
1. Run `npm run test:fixture-matrix`; expect The fixture-matrix suite passes, including the editor-screenshot-only regression..
2. Run `npm test`; expect The complete Static Site Importer test suite passes..

## Compatibility
No schema changes; existing captured visual-comparison evidence remains recognized while false-positive evidence is corrected.

## Evidence
- Base unchanged since verification: main remains at 7b69c8c9f129905bc73c2d121dbe9223a9249533.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/static-site-importer/issues/747
- Verified finalization base: main at 7b69c8c9f129905bc73c2d121dbe9223a9249533
- fixture-matrix: passed (npm run test:fixture-matrix) (Passed)
- full-suite: passed (npm test) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Investigated contradictory fixture evidence, isolated the false-positive predicate, implemented the minimal correction and focused regression coverage, and verified the targeted and complete suites.

## Source relationships
- Closes #747
