### PR TITLE
Update PHP transformer to 0.4.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.4.8",
+        "version": "0.4.9",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "8da403712e01d7ca21d53018292e37dc530b790c"
+          "reference": "0cd65716f31ef5a0ffef84ba7415e45b0fe218d3"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.8.zip",
-          "reference": "8da403712e01d7ca21d53018292e37dc530b790c"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.9.zip",
+          "reference": "0cd65716f31ef5a0ffef84ba7415e45b0fe218d3"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "^0.4.8",
+    "automattic/blocks-engine-php-transformer": "^0.4.9",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e5896e5d54d2540760354475c13a475",
+    "content-hash": "1b054df09bbcd30ef61624dd810429d5",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "8da403712e01d7ca21d53018292e37dc530b790c"
+                "reference": "0cd65716f31ef5a0ffef84ba7415e45b0fe218d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.8.zip",
-                "reference": "8da403712e01d7ca21d53018292e37dc530b790c"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.9.zip",
+                "reference": "0cd65716f31ef5a0ffef84ba7415e45b0fe218d3"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary

- update the immutable Blocks Engine PHP transformer package from `0.4.8` to `0.4.9`
- consume the semantic template-part boundary repair from Automattic/blocks-engine#696
- preserve source presentation inside a non-landmark group while WordPress owns the template-part `header`/`footer` landmark

Fixes #745.
Unblocks Automattic/wp-codebox#1975.

## Verification

- `composer validate --strict`
- `npm test` through the 199/199 fixture-matrix suite; the aggregate command exceeded the local command timeout before later suites
- `npm run test:solved-site-promotion`
- `npm run test:fig-fixture-e2e`
- `npm run test:promote-solved-fixture`
- `npm run test:php-wasm-zstd`
- `php tests/smoke-template-part-shell-dedupe.php` (49 assertions)
- direct two-page semantic-shell compilation confirms populated header/footer parts with non-landmark inner groups

## AI Assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** cross-repository root-cause verification, dependency update, contract verification, and test execution. Chris Huber remains responsible for every line.
