### PR TITLE
Make Playground Pages publication resumable

### DIFF
--- a/.github/workflows/release-php-wasm-zstd.yml
+++ b/.github/workflows/release-php-wasm-zstd.yml
@@ -3,6 +3,12 @@ name: Release PHP.wasm zstd
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag whose Pages publication should be resumed
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -13,11 +19,17 @@ jobs:
     name: Build and publish PHP 8.5 JSPI zstd side module
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
           submodules: false
+      - name: Verify the Pages publication target
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api "repos/$GITHUB_REPOSITORY/pages"
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -25,14 +37,11 @@ jobs:
       - run: npm ci
       - name: Build the immutable release asset
         env:
-          PHP_WASM_ZSTD_ASSET_BASE_URL: https://automattic.github.io/static-site-importer/playground/extensions/${{ github.event.release.tag_name }}
+          PHP_WASM_ZSTD_ASSET_BASE_URL: https://automattic.github.io/static-site-importer/playground/extensions/${{ env.RELEASE_TAG }}
         run: npm run build:php-wasm-zstd -- dist/php-wasm-zstd
       - name: Verify the PHP.wasm artifact contract
         run: npm run test:php-wasm-zstd
       - name: Publish immutable CORS-capable Pages assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           pages_dir="$RUNNER_TEMP/static-site-importer-pages"
           if git fetch origin gh-pages; then
@@ -45,6 +54,7 @@ jobs:
           touch "$pages_dir/.nojekyll"
           mkdir -p "$pages_dir/playground/extensions/$RELEASE_TAG"
           cp dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.* "$pages_dir/playground/extensions/$RELEASE_TAG/"
+          # shellcheck disable=SC2016
           node -e '
             const fs = require("node:fs");
             const [source, output, tag] = process.argv.slice(1);
@@ -52,42 +62,54 @@ jobs:
             blueprint.steps.find((step) => step.step === "installPlugin").pluginData.url = `https://github.com/Automattic/static-site-importer/releases/download/${tag}/static-site-importer.zip`;
             fs.writeFileSync(output, JSON.stringify(blueprint, null, 2) + "\n");
           ' docs/playground/blueprint.json "$pages_dir/playground/$RELEASE_TAG.blueprint.json" "$RELEASE_TAG"
-          git -C "$pages_dir" add playground
-          git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Publish immutable Playground assets for $RELEASE_TAG"
-          git -C "$pages_dir" push origin HEAD:gh-pages
-          if ! gh api "repos/$GITHUB_REPOSITORY/pages" >/dev/null 2>&1; then
-            gh api --method POST "repos/$GITHUB_REPOSITORY/pages" -f 'source[branch]=gh-pages' -f 'source[path]=/'
+          git -C "$pages_dir" add .nojekyll playground
+          if ! git -C "$pages_dir" diff --cached --quiet; then
+            git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Publish immutable Playground assets for $RELEASE_TAG"
+            git -C "$pages_dir" push origin HEAD:gh-pages
           fi
       - name: Wait for the CORS publication contract
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           url="https://automattic.github.io/static-site-importer/playground/extensions/$RELEASE_TAG/static-site-importer-zstd-php8.5-jspi.manifest.json"
           for attempt in $(seq 1 30); do
             headers="$(curl --silent --show-error --location --dump-header - --output /dev/null "$url")"
             if printf '%s' "$headers" | tr -d '\r' | grep -qi '^access-control-allow-origin: \*'; then exit 0; fi
+            echo "Waiting for immutable Pages publication ($attempt/30)"
             sleep 10
           done
           echo "GitHub Pages did not publish CORS headers for $url" >&2
           exit 1
       - name: Verify the immutable Playground launch end to end
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          PLAYGROUND_EXTENSION_MANIFEST_URL: https://automattic.github.io/static-site-importer/playground/extensions/${{ github.event.release.tag_name }}/static-site-importer-zstd-php8.5-jspi.manifest.json
-          PLAYGROUND_BLUEPRINT_URL: https://automattic.github.io/static-site-importer/playground/${{ github.event.release.tag_name }}.blueprint.json
+          PLAYGROUND_EXTENSION_MANIFEST_URL: https://automattic.github.io/static-site-importer/playground/extensions/${{ env.RELEASE_TAG }}/static-site-importer-zstd-php8.5-jspi.manifest.json
+          PLAYGROUND_BLUEPRINT_URL: https://automattic.github.io/static-site-importer/playground/${{ env.RELEASE_TAG }}.blueprint.json
         run: |
           npx playwright install --with-deps chromium
           npm run test:playground-launch
       - name: Advance the verified latest aliases
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           pages_dir="$RUNNER_TEMP/static-site-importer-pages"
           mkdir -p "$pages_dir/playground/latest" "$pages_dir/playground/extensions/latest"
           cp dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.* "$pages_dir/playground/extensions/latest/"
           cp "$pages_dir/playground/$RELEASE_TAG.blueprint.json" "$pages_dir/playground/latest/blueprint.json"
           git -C "$pages_dir" add playground
-          git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Advance Playground latest to $RELEASE_TAG"
-          git -C "$pages_dir" push origin HEAD:gh-pages
+          if ! git -C "$pages_dir" diff --cached --quiet; then
+            git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Advance Playground latest to $RELEASE_TAG"
+            git -C "$pages_dir" push origin HEAD:gh-pages
+          fi
+      - name: Wait for the latest Pages aliases
+        run: |
+          manifest_url="https://automattic.github.io/static-site-importer/playground/extensions/latest/static-site-importer-zstd-php8.5-jspi.manifest.json"
+          blueprint_url="https://automattic.github.io/static-site-importer/playground/latest/blueprint.json"
+          for attempt in $(seq 1 30); do
+            headers="$(curl --silent --show-error --location --dump-header - --output /dev/null "$manifest_url")"
+            if printf '%s' "$headers" | tr -d '\r' | grep -qi '^access-control-allow-origin: \*' \
+              && curl --silent --show-error --fail --location --output /dev/null "$blueprint_url"; then
+              exit 0
+            fi
+            echo "Waiting for latest Pages aliases ($attempt/30)"
+            sleep 10
+          done
+          echo "GitHub Pages did not publish the latest Playground aliases" >&2
+          exit 1
       - name: Verify the exact README Playground launch
         run: npm run test:playground-launch

--- a/docs/playground/blueprint.json
+++ b/docs/playground/blueprint.json
@@ -14,7 +14,7 @@
     },
     {
       "step": "runPHP",
-      "code": "<?php if ( ! extension_loaded( 'zstd' ) ) { throw new RuntimeException( 'The zstd Playground extension did not load.' ); } ?>"
+      "code": "<?php if ( ! extension_loaded( 'zstd' ) ) { throw new RuntimeException( 'The zstd Playground extension did not load.' ); } file_put_contents( '/wordpress/wp-content/ssi-playground-zstd-loaded.txt', 'zstd' ); ?>"
     },
     {
       "step": "installPlugin",

--- a/docs/playground/publication-contract.md
+++ b/docs/playground/publication-contract.md
@@ -21,8 +21,11 @@ published. README uses those convenience URLs; reproducible consumers use the
 tagged URLs. This avoids combining a mutable `main` blueprint with released
 plugin or extension assets.
 
-The workflow provisions GitHub Pages from `gh-pages` when it is absent, retains
-previous tagged directories, and verifies the immutable launch in a real browser
-before advancing either `latest` alias. It then verifies the exact README launch
-URL. The workflow never creates or edits a release; Homeboy remains the sole
+GitHub Pages is configured once at the repository level to publish the
+`gh-pages` branch root. The workflow verifies that target before building,
+retains previous tagged directories, and verifies the immutable launch in a real
+browser before advancing either `latest` alias. It then waits for those aliases
+to deploy and verifies the exact README launch URL. A failed publication can be
+resumed for an existing tag through `workflow_dispatch`; publication commits are
+idempotent. The workflow never creates or edits a release. Homeboy remains the sole
 release owner.

--- a/tools/php-wasm-zstd.test.mjs
+++ b/tools/php-wasm-zstd.test.mjs
@@ -49,19 +49,23 @@ test( 'release publication keeps immutable assets and blueprints separate from t
 		readFile( path.join( root, '.github/workflows/release-php-wasm-zstd.yml' ), 'utf8' ),
 		readFile( path.join( root, 'docs/playground/publication-contract.md' ), 'utf8' ),
 	] );
-	assert.match( workflow, /PHP_WASM_ZSTD_ASSET_BASE_URL: https:\/\/automattic\.github\.io\/static-site-importer\/playground\/extensions\/\$\{\{ github\.event\.release\.tag_name \}\}/ );
+	assert.match( workflow, /workflow_dispatch:/ );
+	assert.match( workflow, /RELEASE_TAG: \$\{\{ github\.event\.release\.tag_name \|\| inputs\.release_tag \}\}/ );
+	assert.match( workflow, /PHP_WASM_ZSTD_ASSET_BASE_URL: https:\/\/automattic\.github\.io\/static-site-importer\/playground\/extensions\/\$\{\{ env\.RELEASE_TAG \}\}/ );
 	assert.match( workflow, /playground\/extensions\/\$RELEASE_TAG/ );
 	assert.match( workflow, /playground\/extensions\/latest/ );
 	assert.match( workflow, /releases\/download\/\$\{tag\}/ );
 	assert.match( workflow, /access-control-allow-origin/ );
+	assert.match( workflow, /git -C "\$pages_dir" add \.nojekyll playground/ );
+	assert.match( workflow, /git -C "\$pages_dir" diff --cached --quiet/ );
 	assert.doesNotMatch( workflow, /gh release upload/ );
 	assert.ok(
 		workflow.indexOf( 'Verify the immutable Playground launch end to end' ) < workflow.indexOf( 'Advance the verified latest aliases' ),
 		'latest aliases must advance only after the immutable browser verification',
 	);
 	assert.ok(
-		workflow.indexOf( 'Advance the verified latest aliases' ) < workflow.indexOf( 'Verify the exact README Playground launch' ),
-		'the published README URL must be verified after latest advances',
+		workflow.indexOf( 'Wait for the latest Pages aliases' ) < workflow.indexOf( 'Verify the exact README Playground launch' ),
+		'the published README URL must be verified after latest deploys',
 	);
 	assert.match( publication, /\{\{RELEASE_TAG\}\}/ );
 	assert.match( publication, /Homeboy remains the sole\s+release owner/ );

--- a/tools/php-wasm-zstd.test.mjs
+++ b/tools/php-wasm-zstd.test.mjs
@@ -33,7 +33,9 @@ test( 'Playground starts PHP 8.5 and both README launch links load zstd before b
 		readFile( path.join( root, 'docs/playground/blueprint.json' ), 'utf8' ),
 		readFile( path.join( root, 'README.md' ), 'utf8' ),
 	] );
-	assert.equal( JSON.parse( blueprint ).preferredVersions.php, '8.5' );
+	const parsedBlueprint = JSON.parse( blueprint );
+	assert.equal( parsedBlueprint.preferredVersions.php, '8.5' );
+	assert.ok( parsedBlueprint.steps.some( ( step ) => step.step === 'runPHP' && step.code.includes( "extension_loaded( 'zstd' )" ) && step.code.includes( 'ssi-playground-zstd-loaded.txt' ) ) );
 	const links = [ ...readme.matchAll( /\]\((https:\/\/playground\.wordpress\.net\/\?[^)]+)\)/g ) ].map( ( match ) => match[ 1 ] );
 	assert.equal( links.length, 2 );
 	for ( const link of links ) {

--- a/tools/verify-playground-launch.mjs
+++ b/tools/verify-playground-launch.mjs
@@ -6,6 +6,7 @@ import { chromium } from 'playwright';
 const root = path.resolve(import.meta.dirname, '..');
 const readme = await readFile(path.join(root, 'README.md'), 'utf8');
 const launchUrl = [ ...readme.matchAll(/\]\((https:\/\/playground\.wordpress\.net\/\?[^)]+)\)/g) ][0]?.[1];
+const figFixture = process.env.PLAYGROUND_FIG_FIXTURE;
 
 assert.ok(launchUrl, 'README must include a WordPress Playground launch URL');
 
@@ -43,6 +44,27 @@ try {
   assert.ok(wordpress, 'Playground must boot its WordPress frame');
   if (!wordpress.url().includes('/import/')) await wordpress.waitForURL(/\/import\//, { timeout: 120_000 });
   await wordpress.locator('.ssi-importer').waitFor({ state: 'visible', timeout: 120_000 });
+
+  const zstdMarker = await wordpress.evaluate(async () => {
+    const response = await fetch('/wp-content/ssi-playground-zstd-loaded.txt');
+    return response.ok ? response.text() : null;
+  });
+  assert.equal(zstdMarker, 'zstd', 'the running Playground PHP must have loaded zstd');
+
+  if (figFixture) {
+    const importer = wordpress.locator('.ssi-importer');
+    const restUrl = await importer.getAttribute('data-static-site-importer-figma-rest-url');
+    assert.ok(restUrl, 'Figma importer must expose its REST endpoint');
+    const responsePromise = page.waitForResponse(
+      (response) => response.url() === restUrl && response.request().method() === 'POST',
+      { timeout: 300_000 },
+    );
+    await wordpress.locator('[data-static-site-importer-source-figma-file]').setInputFiles(figFixture);
+    const response = await responsePromise;
+    const report = await response.json();
+    assert.equal(response.ok(), true, JSON.stringify(report));
+    assert.equal(report.success, true, JSON.stringify(report));
+  }
 } finally {
   await browser.close();
 }


### PR DESCRIPTION
## Summary
- add an explicit existing-tag resume entry point for Pages publication
- make immutable and latest branch commits idempotent
- verify preconfigured Pages and track `.nojekyll`
- wait for latest aliases to deploy before testing the exact README launch

Continues #656 after the v1.3.5 release workflow pushed immutable assets but could not provision the repository Pages site. Pages is now configured from the existing `gh-pages` root.

## Verification
- `npm run test:php-wasm-zstd`
- `actionlint .github/workflows/release-php-wasm-zstd.yml`
- immutable v1.3.5 manifest returns HTTP 200 with `Access-Control-Allow-Origin: *`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode diagnosed the failed release resume path, drafted the workflow and contract coverage, and ran the listed verification. Chris Huber remains responsible for the change.