### PR TITLE
Bound WP Codebox fixture matrix evidence

### DIFF
--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -282,6 +282,86 @@ class Static_Site_Importer_Diagnostic_Contract {
 		foreach ( $keys as $key ) {
 			$counts[ $key ] = isset( $quality[ $key ] ) && is_numeric( $quality[ $key ] ) ? (int) $quality[ $key ] : 0;
 		}
+		if ( $counts['block_count'] <= 0 ) {
+			$document_counts = self::block_document_quality_counts( $import_report );
+			if ( $document_counts['block_count'] > 0 ) {
+				$counts = array_merge( $counts, $document_counts );
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Derive bounded composition counts when a report carries documents but no aggregate.
+	 *
+	 * @param array<string,mixed> $import_report Import report.
+	 * @return array<string,int>
+	 */
+	private static function block_document_quality_counts( array $import_report ): array {
+		$materialized = isset( $import_report['materialized_content']['block_documents'] ) && is_array( $import_report['materialized_content']['block_documents'] )
+			? $import_report['materialized_content']['block_documents']
+			: array();
+		$documents    = ! empty( $materialized )
+			? $materialized
+			: ( isset( $import_report['generated_theme']['block_documents'] ) && is_array( $import_report['generated_theme']['block_documents'] ) ? $import_report['generated_theme']['block_documents'] : array() );
+		$counts       = array(
+			'block_count'           => 0,
+			'core_html_block_count' => 0,
+			'freeform_block_count'  => 0,
+		);
+
+		foreach ( $documents as $document ) {
+			if ( ! is_array( $document ) ) {
+				continue;
+			}
+			$document_count = isset( $document['block_count'] ) && is_numeric( $document['block_count'] ) ? (int) $document['block_count'] : 0;
+			if ( $document_count > 0 ) {
+				$counts['block_count']           += $document_count;
+				$counts['core_html_block_count'] += isset( $document['core_html_block_count'] ) && is_numeric( $document['core_html_block_count'] ) ? (int) $document['core_html_block_count'] : 0;
+				$counts['freeform_block_count']  += isset( $document['freeform_block_count'] ) && is_numeric( $document['freeform_block_count'] ) ? (int) $document['freeform_block_count'] : 0;
+				continue;
+			}
+
+			foreach ( array( 'content', 'post_content', 'block_markup', 'serialized_blocks' ) as $field ) {
+				if ( isset( $document[ $field ] ) && is_string( $document[ $field ] ) && '' !== trim( $document[ $field ] ) ) {
+					$parsed = self::serialized_block_quality_counts( $document[ $field ] );
+					foreach ( $counts as $key => $value ) {
+						$counts[ $key ] = $value + $parsed[ $key ];
+					}
+					break;
+				}
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Count named Gutenberg block comments without retaining serialized content.
+	 *
+	 * @param string $content Serialized block document.
+	 * @return array<string,int>
+	 */
+	private static function serialized_block_quality_counts( string $content ): array {
+		$counts = array(
+			'block_count'           => 0,
+			'core_html_block_count' => 0,
+			'freeform_block_count'  => 0,
+		);
+		if ( ! preg_match_all( '/<!--\s+wp:([a-z][a-z0-9-]*(?:\/[a-z][a-z0-9-]*)?)/i', $content, $matches ) ) {
+			return $counts;
+		}
+
+		foreach ( $matches[1] as $name ) {
+			$normalized = strtolower( (string) $name );
+			++$counts['block_count'];
+			if ( 'html' === $normalized || 'core/html' === $normalized ) {
+				++$counts['core_html_block_count'];
+			} elseif ( 'freeform' === $normalized || 'core/freeform' === $normalized ) {
+				++$counts['freeform_block_count'];
+			}
+		}
 
 		return $counts;
 	}

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -276,7 +276,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 	 */
 	private static function quality_counts( array $import_report, array $summary ): array {
 		$quality = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
-		$keys    = array( 'fallback_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
+		$keys    = array( 'block_count', 'fallback_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
 
 		$counts = array();
 		foreach ( $keys as $key ) {

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -48,6 +48,7 @@ class Static_Site_Importer_Validation_Runtime {
 			'fixture_id'          => isset( $result['fixture_id'] ) && is_scalar( $result['fixture_id'] ) ? (string) $result['fixture_id'] : '',
 			'status'              => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : '',
 			'success'             => ! empty( $result['success'] ),
+			'quality'             => array( 'pass' => ! empty( $result['success'] ) ),
 			'diagnostics'         => $diagnostics,
 			'fixture_diagnostics' => $fixture_diagnostics,
 			'artifacts'           => isset( $result['artifacts'] ) && is_array( $result['artifacts'] ) ? $result['artifacts'] : array(),

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -15,6 +15,44 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Static_Site_Importer_Validation_Runtime {
 
 	public const RESULT_SCHEMA = 'static-site-importer/import-validation-result/v1';
+	public const FIXTURE_MATRIX_RESULT_SCHEMA = 'static-site-importer/fixture-matrix-validation-result/v1';
+
+	/**
+	 * Project the full validation result into the bounded fixture-matrix contract.
+	 *
+	 * The full import report can exceed runtime command-capture limits. Matrix
+	 * consumers need actionable diagnostics and attribution evidence, not the raw
+	 * materialized documents carried by that report.
+	 *
+	 * @param array<string,mixed> $result Full validation result.
+	 * @return array<string,mixed>
+	 */
+	public static function fixture_matrix_result( array $result ): array {
+		$fixture_diagnostics = isset( $result['fixture_diagnostics'] ) && is_array( $result['fixture_diagnostics'] )
+			? $result['fixture_diagnostics']
+			: Static_Site_Importer_Diagnostic_Contract::build( $result );
+
+		$diagnostics = isset( $fixture_diagnostics['diagnostics'] ) && is_array( $fixture_diagnostics['diagnostics'] )
+			? $fixture_diagnostics['diagnostics']
+			: array();
+		unset(
+			$fixture_diagnostics['diagnostics'],
+			$fixture_diagnostics['runtime_dependency_target_gaps'],
+			$fixture_diagnostics['asset_diagnostics'],
+			$fixture_diagnostics['svg_diagnostics'],
+			$fixture_diagnostics['button_style_loss_hints']
+		);
+
+		return array(
+			'schema'              => self::FIXTURE_MATRIX_RESULT_SCHEMA,
+			'fixture_id'          => isset( $result['fixture_id'] ) && is_scalar( $result['fixture_id'] ) ? (string) $result['fixture_id'] : '',
+			'status'              => isset( $result['status'] ) && is_scalar( $result['status'] ) ? (string) $result['status'] : '',
+			'success'             => ! empty( $result['success'] ),
+			'diagnostics'         => $diagnostics,
+			'fixture_diagnostics' => $fixture_diagnostics,
+			'artifacts'           => isset( $result['artifacts'] ) && is_array( $result['artifacts'] ) ? $result['artifacts'] : array(),
+		);
+	}
 
 	/**
 	 * Validate a website artifact in the current runtime.

--- a/lib/fixture-matrix/collectors/editor-validation.mjs
+++ b/lib/fixture-matrix/collectors/editor-validation.mjs
@@ -116,9 +116,9 @@ export function collectEditorValidation(payload) {
   const results = normalizeArray(source.results).filter((entry) => entry && typeof entry === 'object');
   const totalFromResults = results.length;
   const invalidFromResults = results.filter((block) => isInvalidEditorBlock(block)).length;
-  const total = pickCount(source.total_blocks ?? source.totalBlocks, totalFromResults);
-  const invalid = pickCount(source.invalid_blocks ?? source.invalidBlocks, invalidFromResults);
-  const valid = pickCount(source.valid_blocks ?? source.validBlocks, Math.max(0, total - invalid));
+  const total = totalFromResults > 0 ? totalFromResults : pickCount(source.total_blocks ?? source.totalBlocks, 0);
+  const invalid = totalFromResults > 0 ? invalidFromResults : pickCount(source.invalid_blocks ?? source.invalidBlocks, 0);
+  const valid = totalFromResults > 0 ? Math.max(0, total - invalid) : pickCount(source.valid_blocks ?? source.validBlocks, Math.max(0, total - invalid));
   return compactObject({
     validation_method: firstString([source.validation_method, source.validationMethod, EDITOR_VALIDATION_METHOD]),
     validation_provider: firstString([source.validation_provider, source.validationProvider, EDITOR_VALIDATION_PROVIDER]),

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -331,7 +331,7 @@ function importFixtureStep(fixture, commandArtifactsDirectory) {
   return {
     command: 'wordpress.wp-cli',
     args: [
-      `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-failure`,
+      `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --format=fixture-matrix --allow-failure`,
     ],
     metadata: fixtureStepMetadata(fixture, 'import', {
       artifact: path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'),

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -216,6 +216,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 		static function ( array $args, array $assoc_args ): void {
 			unset( $args );
 			$halt_on_failure = ! isset( $assoc_args['allow-failure'] ) && false !== ( $assoc_args['error-on-fail'] ?? true ) && ! isset( $assoc_args['no-error-on-fail'] );
+			$format          = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'full';
+			if ( ! in_array( $format, array( 'full', 'fixture-matrix' ), true ) ) {
+				WP_CLI::error( 'The --format value must be full or fixture-matrix.' );
+			}
 
 			$input  = array(
 				'slug'                      => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
@@ -251,6 +255,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			$result = Static_Site_Importer_Validation_Runtime::validate_artifact( $input );
 			if ( is_wp_error( $result ) ) {
 				$error_result = Static_Site_Importer_Validation_Runtime::error_result_from_wp_error( $result, $input );
+				if ( 'fixture-matrix' === $format ) {
+					$error_result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $error_result );
+				}
 				$json         = wp_json_encode( $error_result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 				if ( false === $json ) {
 					WP_CLI::error( $result->get_error_message() );
@@ -264,6 +271,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				return;
 			}
 
+			if ( 'fixture-matrix' === $format ) {
+				$result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $result );
+			}
 			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 			if ( false === $json ) {
 				WP_CLI::error( 'Failed to encode validation result.' );

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -89,8 +89,13 @@ file_put_contents(
 	json_encode(
 		array(
 			'quality'       => array(
-				'block_count'                    => 12,
 				'semantic_parity_failure_count' => 1,
+			),
+			'generated_theme' => array(
+				'block_documents' => array(
+					array( 'content' => '<!-- wp:group --><!-- wp:paragraph --><p>One</p><!-- /wp:paragraph --><!-- wp:html --><div>Fallback</div><!-- /wp:html --><!-- /wp:group -->' ),
+					array( 'block_count' => 2, 'core_html_block_count' => 0, 'freeform_block_count' => 1 ),
+				),
 			),
 			'blocks_engine' => array(
 				'transformer'         => array(
@@ -166,7 +171,9 @@ $assert( Static_Site_Importer_Validation_Runtime::FIXTURE_MATRIX_RESULT_SCHEMA =
 $assert( ! isset( $matrix_result['import_report'] ), 'fixture-matrix-omits-full-import-report' );
 $assert( 1 === count( $matrix_result['diagnostics'] ?? array() ), 'fixture-matrix-keeps-actionable-diagnostics' );
 $assert( ! isset( $matrix_result['fixture_diagnostics']['diagnostics'] ), 'fixture-matrix-does-not-duplicate-diagnostics' );
-$assert( 12 === ( $matrix_result['fixture_diagnostics']['quality_counts']['block_count'] ?? 0 ), 'fixture-matrix-keeps-block-count' );
+$assert( 5 === ( $matrix_result['fixture_diagnostics']['quality_counts']['block_count'] ?? 0 ), 'fixture-matrix-derives-block-count' );
+$assert( 1 === ( $matrix_result['fixture_diagnostics']['quality_counts']['core_html_block_count'] ?? 0 ), 'fixture-matrix-derives-core-html-count' );
+$assert( 1 === ( $matrix_result['fixture_diagnostics']['quality_counts']['freeform_block_count'] ?? 0 ), 'fixture-matrix-derives-freeform-count' );
 $assert( str_repeat( 'a', 40 ) === ( $matrix_result['fixture_diagnostics']['blocks_engine']['transformer']['reference'] ?? '' ), 'fixture-matrix-keeps-transformer-reference' );
 $assert( 'blocks-engine/wordpress-site-plan/v2' === ( $matrix_result['fixture_diagnostics']['blocks_engine']['wordpress_site_plan']['schema'] ?? '' ), 'fixture-matrix-keeps-site-plan' );
 $assert( 'completed' === ( $matrix_result['fixture_diagnostics']['materialization_receipt']['status'] ?? '' ), 'fixture-matrix-keeps-materialization-receipt' );

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -169,6 +169,7 @@ $assert( 1 === ( $result['fixture_diagnostics']['materialization_receipt']['page
 $matrix_result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $result );
 $assert( Static_Site_Importer_Validation_Runtime::FIXTURE_MATRIX_RESULT_SCHEMA === ( $matrix_result['schema'] ?? '' ), 'fixture-matrix-schema' );
 $assert( ! isset( $matrix_result['import_report'] ), 'fixture-matrix-omits-full-import-report' );
+$assert( false === ( $matrix_result['quality']['pass'] ?? true ), 'fixture-matrix-keeps-quality-pass' );
 $assert( 1 === count( $matrix_result['diagnostics'] ?? array() ), 'fixture-matrix-keeps-actionable-diagnostics' );
 $assert( ! isset( $matrix_result['fixture_diagnostics']['diagnostics'] ), 'fixture-matrix-does-not-duplicate-diagnostics' );
 $assert( 5 === ( $matrix_result['fixture_diagnostics']['quality_counts']['block_count'] ?? 0 ), 'fixture-matrix-derives-block-count' );

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -161,6 +161,16 @@ $assert( ! isset( $result['fixture_diagnostics']['blocks_engine']['wordpress_sit
 $assert( 'completed' === ( $result['fixture_diagnostics']['materialization_receipt']['status'] ?? '' ), 'materialization-receipt-status-preserved' );
 $assert( 1 === ( $result['fixture_diagnostics']['materialization_receipt']['page_count'] ?? 0 ), 'materialization-receipt-counts-preserved' );
 
+$matrix_result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $result );
+$assert( Static_Site_Importer_Validation_Runtime::FIXTURE_MATRIX_RESULT_SCHEMA === ( $matrix_result['schema'] ?? '' ), 'fixture-matrix-schema' );
+$assert( ! isset( $matrix_result['import_report'] ), 'fixture-matrix-omits-full-import-report' );
+$assert( 1 === count( $matrix_result['diagnostics'] ?? array() ), 'fixture-matrix-keeps-actionable-diagnostics' );
+$assert( ! isset( $matrix_result['fixture_diagnostics']['diagnostics'] ), 'fixture-matrix-does-not-duplicate-diagnostics' );
+$assert( 12 === ( $matrix_result['fixture_diagnostics']['quality_counts']['block_count'] ?? 0 ), 'fixture-matrix-keeps-block-count' );
+$assert( str_repeat( 'a', 40 ) === ( $matrix_result['fixture_diagnostics']['blocks_engine']['transformer']['reference'] ?? '' ), 'fixture-matrix-keeps-transformer-reference' );
+$assert( 'blocks-engine/wordpress-site-plan/v2' === ( $matrix_result['fixture_diagnostics']['blocks_engine']['wordpress_site_plan']['schema'] ?? '' ), 'fixture-matrix-keeps-site-plan' );
+$assert( 'completed' === ( $matrix_result['fixture_diagnostics']['materialization_receipt']['status'] ?? '' ), 'fixture-matrix-keeps-materialization-receipt' );
+
 $default_artifact_dir = $artifact_dir . '/default-materialization';
 $default_result       = Static_Site_Importer_Validation_Runtime::validate_artifact(
 	array(

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -81,6 +81,7 @@ import {
   writeFixtureMatrixArtifacts,
 } from '../lib/fixture-matrix.mjs';
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
+import { collectQualityMetrics } from '../lib/fixture-matrix/collectors/quality-metrics.mjs';
 import { runWpCodeboxRecipe, wpCodeboxBin } from './wp-codebox/recipe.mjs';
 
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
@@ -152,6 +153,15 @@ test('block composition uses nested runtime quality metrics and diagnostic fallb
     fixture_diagnostics: { quality_counts: { core_html_block_count: 0, freeform_block_count: 0 } },
   });
   assert.deepEqual(composition, { block_total: 318, native_block_count: 318, core_html_block_count: 0, block_type_counts: null, source: 'quality_counts' });
+});
+
+test('bounded runtime quality retains the promotion gate pass signal', () => {
+  const quality = collectQualityMetrics({
+    quality: { pass: true },
+    fixture_diagnostics: { quality_counts: { block_count: 318, fallback_count: 0 } },
+  });
+  assert.equal(quality.pass, true);
+  assert.equal(quality.block_count, 318);
 });
 
 test('Homeboy component assigns runtime and dependency capabilities to WordPress', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -553,6 +553,7 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   assert.equal(recipe.workflow.steps[0].command, 'wordpress.wp-cli');
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
+  assert.match(recipe.workflow.steps[1].args[0], /--format=fixture-matrix/);
   assert.match(recipe.workflow.steps[1].args[0], /--allow-failure/);
   assert.doesNotMatch(recipe.workflow.steps[1].args[0], /--allow-missing-woocommerce/);
   assert.deepEqual(recipe.inputs.stagedFiles[0], {
@@ -4654,6 +4655,26 @@ test('collectEditorValidation reads the editor-validate-blocks shape into headli
   assert.equal(metrics.valid_blocks, 3);
   assert.equal(metrics.invalid_blocks, 0);
   assert.equal(collectEditorValidation({ unrelated: true }), null);
+});
+
+test('collectEditorValidation derives cross-surface totals from authoritative block results', () => {
+  const metrics = collectEditorValidation({
+    validation_method: 'wp.blocks.validateBlock',
+    validation_provider: 'wordpress-block-editor',
+    total_blocks: 1,
+    valid_blocks: 1,
+    invalid_blocks: 0,
+    results: [
+      { name: 'core/separator', isValid: false, issues: ['Invalid separator'] },
+      { name: 'core/heading', isValid: true, issues: [] },
+      { name: 'core/column', isValid: false, issues: ['Invalid column'] },
+      { name: 'core/paragraph', isValid: true, issues: [] },
+    ],
+  });
+
+  assert.equal(metrics.total_blocks, 4);
+  assert.equal(metrics.valid_blocks, 2);
+  assert.equal(metrics.invalid_blocks, 2);
 });
 
 test('editor-validate-blocks all-valid output reports a 1.0 valid-block rate with zero invalid and no findings', () => {


### PR DESCRIPTION
## Summary
- add an explicit bounded `fixture-matrix` validation-result schema for runtime command capture
- preserve actionable diagnostics, quality-gate status, transformer identity, WordPress site-plan evidence, materialization receipt, quality counts, and artifact refs without duplicating the full import report
- derive bounded block-composition counts from serialized report documents when the importer does not provide a usable aggregate
- derive editor totals from authoritative per-block results when summary counts disagree
- make fixture recipes request the bounded contract explicitly

Fixes #751

## Evidence

The pre-fix WP Codebox 0.18.0 run exposed two contradictions:

- command capture bounded an approximately 11 MiB import result, causing missing provenance
- editor findings reported invalid `core/separator`/`core/column` blocks while headline counts claimed every block was valid

The final fixture 37 Lab run used `--surface-coverage 7` and verified:

- matrix evidence readiness `verified` with no missing provenance fields
- transformer reference `1956227b1abb05d824ac9e586eee6e006e22590c`
- materialization receipt completed for seven pages
- editor validity `2485 total / 2485 valid / 0 invalid` via `wp.blocks.validateBlock`
- block composition `1593 total / 1577 native / 16 core/html`
- native conversion rate `99%`; core/html fallback ratio `1%`

The fixture still has seven visual-parity failures routed to Blocks Engine. Those downstream quality findings do not indicate a missing or incomplete SSI evidence contract.

Homeboy run: `6e9aa29e-2258-484a-86d7-aefe95fd516c`

The solved-site promotion workflow independently verifies the bounded contract against `15-saas`; it passes at head `6b77f14d`.

## Verification
- `npm run test:fixture-matrix` (202 passed)
- `npm run test:solved-site-promotion` (13 passed)
- `php tests/smoke-validation-runtime-diagnostics.php` (26 assertions passed)
- PHP syntax checks for changed runtime classes
- `git diff --check`
- GitHub: Homeboy Test on PHP 8.1, 8.2, 8.3, and 8.4 passed
- GitHub: solved-site promotion gate passed

PHPCS is not installed by this repository and no PHPCS configuration is present, so that optional local command was unavailable.

## AI assistance
- Model: OpenAI `openai/gpt-5.6-sol`
- Tool: OpenCode
- Used for: WP Codebox reproduction, evidence-contract implementation, editor-count correction, bounded block-composition derivation, promotion-contract repair, tests, and control-plane diagnosis. Chris Huber reviewed and remains responsible for every line.