### PR TITLE
Retain Playground boot failure diagnostics

### DIFF
--- a/tools/verify-playground-launch.mjs
+++ b/tools/verify-playground-launch.mjs
@@ -22,6 +22,10 @@ assert.ok(manifestUrl, 'README launch URL must provide a PHP extension manifest'
 
 const browser = await chromium.launch({ headless: true });
 const page = await browser.newPage();
+const diagnostics = [];
+page.on('console', (message) => diagnostics.push(`console.${message.type()}: ${message.text()}`));
+page.on('pageerror', (error) => diagnostics.push(`pageerror: ${error.message}`));
+page.on('requestfailed', (request) => diagnostics.push(`requestfailed: ${request.url()} (${request.failure()?.errorText})`));
 
 try {
   // This is deliberately a browser fetch from Playground's origin: Node fetch
@@ -41,7 +45,10 @@ try {
     if (wordpress) break;
     await page.waitForTimeout(1_000);
   }
-  assert.ok(wordpress, 'Playground must boot its WordPress frame');
+  assert.ok(
+    wordpress,
+    `Playground must boot its WordPress frame; frames=${JSON.stringify(page.frames().map((frame) => frame.url()))}; diagnostics=${JSON.stringify(diagnostics.slice(-20))}`,
+  );
   if (!wordpress.url().includes('/import/')) await wordpress.waitForURL(/\/import\//, { timeout: 120_000 });
   await wordpress.locator('.ssi-importer').waitFor({ state: 'visible', timeout: 120_000 });
 


### PR DESCRIPTION
## Summary
- retain bounded browser console, page-error, failed-request, and frame URL diagnostics
- include those diagnostics when WordPress fails to boot

This made the v1.3.5 failure actionable: the manifest/CORS contract passed, while deployed PHP 8.5 crashed loading the side module with `TypeError: n is not a function`. That evidence is attached to WordPress/wordpress-playground#4107 and PR #4108.

## Verification
- `npm run test:php-wasm-zstd`
- reproduced the immutable v1.3.5 launch and captured the missing MAIN_MODULE ABI failure

## AI assistance
OpenAI gpt-5.6-sol via OpenCode added the bounded browser diagnostics and used them to isolate the upstream PHP.wasm ABI blocker. Chris Huber remains responsible for the change.