### PR TITLE
Update PHP transformer to 0.4.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.4.9",
+        "version": "0.4.10",
         "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "0cd65716f31ef5a0ffef84ba7415e45b0fe218d3"
+          "reference": "f332f05d39f9f3461dd9e027350633a1c28985ed"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.9.zip",
-          "reference": "0cd65716f31ef5a0ffef84ba7415e45b0fe218d3"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.10.zip",
+          "reference": "f332f05d39f9f3461dd9e027350633a1c28985ed"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "^0.4.9",
+    "automattic/blocks-engine-php-transformer": "^0.4.10",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b054df09bbcd30ef61624dd810429d5",
+    "content-hash": "4d3b4b92a59449a975fc33ed967f5a76",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.4.9",
+            "version": "0.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "0cd65716f31ef5a0ffef84ba7415e45b0fe218d3"
+                "reference": "f332f05d39f9f3461dd9e027350633a1c28985ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.9.zip",
-                "reference": "0cd65716f31ef5a0ffef84ba7415e45b0fe218d3"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.10.zip",
+                "reference": "f332f05d39f9f3461dd9e027350633a1c28985ed"
             },
             "require": {
                 "league/commonmark": "^2.5",


### PR DESCRIPTION
## Summary

- pin Blocks Engine PHP transformer 0.4.10
- consume synthetic paragraph margin and row geometry fixes
- preserve the immutable release tag and commit reference in Composer metadata

## Verification

- `composer validate --strict`
- `npm test`
- php-transformer `composer test` (255 parity fixtures)

Supports Automattic/wp-codebox#1975.

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol updated the dependency metadata, regenerated the Composer lockfile, and ran the verification commands. Chris Huber remains responsible for the change.