### PR TITLE
Keep the Playground demo safe without zstd

### DIFF
--- a/.github/workflows/release-php-wasm-zstd.yml
+++ b/.github/workflows/release-php-wasm-zstd.yml
@@ -14,6 +14,10 @@ permissions:
   contents: write
   pages: write
 
+concurrency:
+  group: release-php-wasm-zstd-pages
+  cancel-in-progress: false
+
 jobs:
   build-and-publish:
     name: Build and publish PHP 8.5 JSPI zstd side module
@@ -30,18 +34,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh api "repos/$GITHUB_REPOSITORY/pages"
+      - name: Resolve mutable alias eligibility
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          latest_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
+          if [ "$RELEASE_TAG" = "$latest_tag" ]; then
+            echo "ADVANCE_LATEST=true" >> "$GITHUB_ENV"
+          else
+            echo "ADVANCE_LATEST=false" >> "$GITHUB_ENV"
+            echo "Publishing immutable assets only: $RELEASE_TAG is not latest ($latest_tag)."
+          fi
       - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: npm
       - run: npm ci
-      - name: Build the immutable release asset
-        env:
-          PHP_WASM_ZSTD_ASSET_BASE_URL: https://automattic.github.io/static-site-importer/playground/extensions/${{ env.RELEASE_TAG }}
-        run: npm run build:php-wasm-zstd -- dist/php-wasm-zstd
-      - name: Verify the PHP.wasm artifact contract
-        run: npm run test:php-wasm-zstd
-      - name: Publish immutable CORS-capable Pages assets
+      - name: Publish the immutable safe blueprint
         run: |
           pages_dir="$RUNNER_TEMP/static-site-importer-pages"
           if git fetch origin gh-pages; then
@@ -52,8 +61,7 @@ jobs:
             git -C "$pages_dir" rm -rf . || true
           fi
           touch "$pages_dir/.nojekyll"
-          mkdir -p "$pages_dir/playground/extensions/$RELEASE_TAG"
-          cp dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.* "$pages_dir/playground/extensions/$RELEASE_TAG/"
+          mkdir -p "$pages_dir/playground"
           # shellcheck disable=SC2016
           node -e '
             const fs = require("node:fs");
@@ -62,54 +70,146 @@ jobs:
             blueprint.steps.find((step) => step.step === "installPlugin").pluginData.url = `https://github.com/Automattic/static-site-importer/releases/download/${tag}/static-site-importer.zip`;
             fs.writeFileSync(output, JSON.stringify(blueprint, null, 2) + "\n");
           ' docs/playground/blueprint.json "$pages_dir/playground/$RELEASE_TAG.blueprint.json" "$RELEASE_TAG"
-          git -C "$pages_dir" add .nojekyll playground
+          git -C "$pages_dir" add .nojekyll "playground/$RELEASE_TAG.blueprint.json"
           if ! git -C "$pages_dir" diff --cached --quiet; then
-            git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Publish immutable Playground assets for $RELEASE_TAG"
+            git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Publish safe Playground blueprint for $RELEASE_TAG"
             git -C "$pages_dir" push origin HEAD:gh-pages
           fi
-      - name: Wait for the CORS publication contract
+      - name: Wait for the immutable safe blueprint
         run: |
-          url="https://automattic.github.io/static-site-importer/playground/extensions/$RELEASE_TAG/static-site-importer-zstd-php8.5-jspi.manifest.json"
+          blueprint_url="https://automattic.github.io/static-site-importer/playground/$RELEASE_TAG.blueprint.json"
+          expected_plugin_url="https://github.com/Automattic/static-site-importer/releases/download/$RELEASE_TAG/static-site-importer.zip"
           for attempt in $(seq 1 30); do
-            headers="$(curl --silent --show-error --location --dump-header - --output /dev/null "$url")"
-            if printf '%s' "$headers" | tr -d '\r' | grep -qi '^access-control-allow-origin: \*'; then exit 0; fi
-            echo "Waiting for immutable Pages publication ($attempt/30)"
+            if curl --silent --show-error --fail --location "$blueprint_url" | EXPECTED_PLUGIN_URL="$expected_plugin_url" node -e '
+              let body = "";
+              process.stdin.on("data", (chunk) => body += chunk);
+              process.stdin.on("end", () => {
+                const blueprint = JSON.parse(body);
+                const plugin = blueprint.steps.find((step) => step.step === "installPlugin");
+                if (plugin?.pluginData?.url !== process.env.EXPECTED_PLUGIN_URL) process.exit(1);
+              });
+            '; then exit 0; fi
+            echo "Waiting for immutable safe blueprint ($attempt/30)"
             sleep 10
           done
-          echo "GitHub Pages did not publish CORS headers for $url" >&2
+          echo "GitHub Pages did not publish the immutable safe blueprint for $RELEASE_TAG" >&2
           exit 1
-      - name: Verify the immutable Playground launch end to end
+      - name: Verify the immutable safe Playground launch
         env:
-          PLAYGROUND_EXTENSION_MANIFEST_URL: https://automattic.github.io/static-site-importer/playground/extensions/${{ env.RELEASE_TAG }}/static-site-importer-zstd-php8.5-jspi.manifest.json
           PLAYGROUND_BLUEPRINT_URL: https://automattic.github.io/static-site-importer/playground/${{ env.RELEASE_TAG }}.blueprint.json
         run: |
           npx playwright install --with-deps chromium
           npm run test:playground-launch
-      - name: Advance the verified latest aliases
+      - name: Advance the safe README blueprint alias
+        if: env.ADVANCE_LATEST == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          latest_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
+          if [ "$RELEASE_TAG" != "$latest_tag" ]; then
+            echo "Skipping safe alias: $RELEASE_TAG is no longer latest ($latest_tag)."
+            echo "ADVANCE_LATEST=false" >> "$GITHUB_ENV"
+            exit 0
+          fi
           pages_dir="$RUNNER_TEMP/static-site-importer-pages"
-          mkdir -p "$pages_dir/playground/latest" "$pages_dir/playground/extensions/latest"
-          cp dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.* "$pages_dir/playground/extensions/latest/"
+          mkdir -p "$pages_dir/playground/latest"
           cp "$pages_dir/playground/$RELEASE_TAG.blueprint.json" "$pages_dir/playground/latest/blueprint.json"
           git -C "$pages_dir" add playground
           if ! git -C "$pages_dir" diff --cached --quiet; then
-            git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Advance Playground latest to $RELEASE_TAG"
+            git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Advance safe Playground blueprint to $RELEASE_TAG"
             git -C "$pages_dir" push origin HEAD:gh-pages
           fi
-      - name: Wait for the latest Pages aliases
+      - name: Wait for the safe README blueprint alias
+        if: env.ADVANCE_LATEST == 'true'
         run: |
-          manifest_url="https://automattic.github.io/static-site-importer/playground/extensions/latest/static-site-importer-zstd-php8.5-jspi.manifest.json"
           blueprint_url="https://automattic.github.io/static-site-importer/playground/latest/blueprint.json"
+          expected_plugin_url="https://github.com/Automattic/static-site-importer/releases/download/$RELEASE_TAG/static-site-importer.zip"
           for attempt in $(seq 1 30); do
-            headers="$(curl --silent --show-error --location --dump-header - --output /dev/null "$manifest_url")"
-            if printf '%s' "$headers" | tr -d '\r' | grep -qi '^access-control-allow-origin: \*' \
-              && curl --silent --show-error --fail --location --output /dev/null "$blueprint_url"; then
-              exit 0
-            fi
-            echo "Waiting for latest Pages aliases ($attempt/30)"
+            if curl --silent --show-error --fail --location "$blueprint_url" | EXPECTED_PLUGIN_URL="$expected_plugin_url" node -e '
+              let body = "";
+              process.stdin.on("data", (chunk) => body += chunk);
+              process.stdin.on("end", () => {
+                const blueprint = JSON.parse(body);
+                const plugin = blueprint.steps.find((step) => step.step === "installPlugin");
+                if (plugin?.pluginData?.url !== process.env.EXPECTED_PLUGIN_URL) process.exit(1);
+              });
+            '; then exit 0; fi
+            echo "Waiting for safe README blueprint alias ($attempt/30)"
             sleep 10
           done
-          echo "GitHub Pages did not publish the latest Playground aliases" >&2
+          echo "GitHub Pages did not publish the safe README blueprint alias" >&2
           exit 1
       - name: Verify the exact README Playground launch
+        if: env.ADVANCE_LATEST == 'true'
         run: npm run test:playground-launch
+      - name: Build the optional immutable zstd asset
+        env:
+          PHP_WASM_ZSTD_ASSET_BASE_URL: https://automattic.github.io/static-site-importer/playground/extensions/${{ env.RELEASE_TAG }}
+        run: npm run build:php-wasm-zstd -- dist/php-wasm-zstd
+      - name: Verify the PHP.wasm artifact contract
+        run: npm run test:php-wasm-zstd
+      - name: Publish immutable CORS-capable extension assets
+        run: |
+          pages_dir="$RUNNER_TEMP/static-site-importer-pages"
+          mkdir -p "$pages_dir/playground/extensions/$RELEASE_TAG"
+          cp dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.* "$pages_dir/playground/extensions/$RELEASE_TAG/"
+          git -C "$pages_dir" add "playground/extensions/$RELEASE_TAG"
+          if ! git -C "$pages_dir" diff --cached --quiet; then
+            git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Publish immutable Playground extension for $RELEASE_TAG"
+            git -C "$pages_dir" push origin HEAD:gh-pages
+          fi
+      - name: Wait for the CORS extension publication contract
+        run: |
+          url="https://automattic.github.io/static-site-importer/playground/extensions/$RELEASE_TAG/static-site-importer-zstd-php8.5-jspi.manifest.json"
+          for attempt in $(seq 1 30); do
+            headers="$(curl --silent --show-error --fail --location --dump-header - --output /dev/null "$url" || true)"
+            if printf '%s' "$headers" | tr -d '\r' | grep -qi '^access-control-allow-origin: \*' \
+              && curl --silent --show-error --fail --location "$url" | node -e '
+                let body = "";
+                process.stdin.on("data", (chunk) => body += chunk);
+                process.stdin.on("end", () => {
+                  const manifest = JSON.parse(body);
+                  if (manifest.name !== "zstd" || !Array.isArray(manifest.artifacts)) process.exit(1);
+                });
+              '; then exit 0; fi
+            echo "Waiting for immutable extension publication ($attempt/30)"
+            sleep 10
+          done
+          echo "GitHub Pages did not publish a valid extension manifest at $url" >&2
+          exit 1
+      - name: Verify the optional zstd Playground launch end to end
+        env:
+          PLAYGROUND_EXTENSION_MANIFEST_URL: https://automattic.github.io/static-site-importer/playground/extensions/${{ env.RELEASE_TAG }}/static-site-importer-zstd-php8.5-jspi.manifest.json
+          PLAYGROUND_BLUEPRINT_URL: https://automattic.github.io/static-site-importer/playground/${{ env.RELEASE_TAG }}.blueprint.json
+        run: npm run test:playground-launch
+      - name: Advance the verified extension aliases
+        if: env.ADVANCE_LATEST == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          latest_tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
+          if [ "$RELEASE_TAG" != "$latest_tag" ]; then
+            echo "Skipping extension alias: $RELEASE_TAG is no longer latest ($latest_tag)."
+            echo "ADVANCE_LATEST=false" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          pages_dir="$RUNNER_TEMP/static-site-importer-pages"
+          mkdir -p "$pages_dir/playground/extensions/latest"
+          cp dist/php-wasm-zstd/static-site-importer-zstd-php8.5-jspi.* "$pages_dir/playground/extensions/latest/"
+          git -C "$pages_dir" add playground/extensions/latest
+          if ! git -C "$pages_dir" diff --cached --quiet; then
+            git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Advance Playground extension latest to $RELEASE_TAG"
+            git -C "$pages_dir" push origin HEAD:gh-pages
+          fi
+      - name: Wait for the latest extension aliases
+        if: env.ADVANCE_LATEST == 'true'
+        run: |
+          manifest_url="https://automattic.github.io/static-site-importer/playground/extensions/latest/static-site-importer-zstd-php8.5-jspi.manifest.json"
+          for attempt in $(seq 1 30); do
+            headers="$(curl --silent --show-error --fail --location --dump-header - --output /dev/null "$manifest_url" || true)"
+            if printf '%s' "$headers" | tr -d '\r' | grep -qi '^access-control-allow-origin: \*'; then exit 0; fi
+            echo "Waiting for latest extension aliases ($attempt/30)"
+            sleep 10
+          done
+          echo "GitHub Pages did not publish the latest extension aliases" >&2
+          exit 1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Import a static site or generated website artifact into WordPress pages and a companion block theme.
 
-[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fautomattic.github.io%2Fstatic-site-importer%2Fplayground%2Fextensions%2Flatest%2Fstatic-site-importer-zstd-php8.5-jspi.manifest.json&blueprint-url=https%3A%2F%2Fautomattic.github.io%2Fstatic-site-importer%2Fplayground%2Flatest%2Fblueprint.json)
+[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?php=8.5&blueprint-url=https%3A%2F%2Fautomattic.github.io%2Fstatic-site-importer%2Fplayground%2Flatest%2Fblueprint.json)
 
 Static Site Importer is a WordPress plugin. It requires the [Blocks Engine PHP transformer](https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer) Composer package and calls that package's canonical helper functions for generic artifact compilation and format conversion.
 
@@ -151,11 +151,11 @@ add_filter(
 
 Open Static Site Importer in a disposable WordPress Playground site:
 
-[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fautomattic.github.io%2Fstatic-site-importer%2Fplayground%2Fextensions%2Flatest%2Fstatic-site-importer-zstd-php8.5-jspi.manifest.json&blueprint-url=https%3A%2F%2Fautomattic.github.io%2Fstatic-site-importer%2Fplayground%2Flatest%2Fblueprint.json)
+[![Try Static Site Importer in WordPress Playground](https://img.shields.io/badge/Try_Static_Site_Importer_in-WordPress_Playground-3858e9?style=for-the-badge&logo=wordpress&logoColor=white)](https://playground.wordpress.net/?php=8.5&blueprint-url=https%3A%2F%2Fautomattic.github.io%2Fstatic-site-importer%2Fplayground%2Flatest%2Fblueprint.json)
 
-The blueprint installs and activates the packaged Static Site Importer release, logs the visitor in, and opens `/import/` with the `static-site-importer/importer` block configured to generate a WordPress website. Playground loads the PHP 8.5 JSPI `zstd` side module before PHP starts, so the existing Figma upload flow can decode zstd-compressed `.fig` canvas chunks. Testers can upload site files, choose a folder, upload a ZIP, paste HTML, or upload a Figma file.
+The blueprint installs and activates the packaged Static Site Importer release, logs the visitor in, and opens `/import/` with the `static-site-importer/importer` block configured to generate a WordPress website. The canonical demo boots without optional PHP side modules, so testers can always upload site files, choose a folder, upload a ZIP, or paste HTML. Figma upload is enabled only when the active runtime provides a zstd decoder; otherwise the importer explains that the capability is unavailable while keeping every other source type usable.
 
-The extension manifest, side module, and launch blueprint are published to the repository's GitHub Pages site. Each release gets an immutable versioned directory; `latest` is a convenience alias updated only after that version is published. This keeps the release plugin, blueprint, manifest, and module on one release contract while GitHub Pages supplies the CORS headers required by Playground. They are produced from pinned `php-ext-zstd` and vendored `libzstd` source by the release workflow; no unpublished branch, localhost URL, PECL installation, or host `zstd` executable is used.
+The optional extension manifest, side module, and safe launch blueprint are published to the repository's GitHub Pages site. Each release gets immutable versioned assets. The safe `playground/latest/blueprint.json` alias advances and is browser-verified independently; optional extension aliases advance only after their own runtime proof passes. This keeps an experimental side module from taking down the canonical demo while GitHub Pages supplies the CORS headers required by Playground. The extension is produced from pinned `php-ext-zstd` and vendored `libzstd` source by the release workflow; no unpublished branch, localhost URL, PECL installation, or host `zstd` executable is used.
 
 URL intake rules:
 

--- a/blocks/importer/style.css
+++ b/blocks/importer/style.css
@@ -166,6 +166,17 @@
 	background: var(--ssi-importer-accent-hover);
 }
 
+.ssi-importer__upload-button:disabled {
+	cursor: not-allowed;
+	opacity: 0.5;
+}
+
+.ssi-importer__capability-notice {
+	margin: 0.65rem 0 0;
+	color: var(--ssi-importer-fg-muted);
+	font-size: 0.875rem;
+}
+
 .ssi-importer__field summary {
 	cursor: pointer;
 }

--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -263,6 +263,11 @@
 	};
 
 	const submitFigmaFile = async function ( root, file ) {
+		if ( root.getAttribute( 'data-static-site-importer-figma-available' ) !== '1' ) {
+			showStatus( root, 'Figma import requires zstd support in this runtime.' );
+			return;
+		}
+
 		const restUrl = root.getAttribute( 'data-static-site-importer-figma-rest-url' );
 		const nonce = root.getAttribute( 'data-static-site-importer-nonce' );
 		const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';

--- a/docs/playground/blueprint.json
+++ b/docs/playground/blueprint.json
@@ -13,10 +13,6 @@
       "step": "login"
     },
     {
-      "step": "runPHP",
-      "code": "<?php if ( ! extension_loaded( 'zstd' ) ) { throw new RuntimeException( 'The zstd Playground extension did not load.' ); } file_put_contents( '/wordpress/wp-content/ssi-playground-zstd-loaded.txt', 'zstd' ); ?>"
-    },
-    {
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",

--- a/docs/playground/publication-contract.md
+++ b/docs/playground/publication-contract.md
@@ -14,18 +14,17 @@ from that tag and publishes these immutable files:
 
 The versioned blueprint installs `static-site-importer.zip` from the same GitHub
 Release tag. `docs/playground/blueprint.json` is a release template: the
-workflow replaces `{{RELEASE_TAG}}` while publishing it. The
-`playground/extensions/latest/` and `playground/latest/`
-locations are convenience copies updated only after the immutable tag files are
-published. README uses those convenience URLs; reproducible consumers use the
-tagged URLs. This avoids combining a mutable `main` blueprint with released
-plugin or extension assets.
+workflow replaces `{{RELEASE_TAG}}` while publishing it. README uses the safe
+`playground/latest/blueprint.json` convenience URL without loading an optional
+side module. Reproducible consumers use the tagged blueprint URL.
 
 GitHub Pages is configured once at the repository level to publish the
 `gh-pages` branch root. The workflow verifies that target before building,
-retains previous tagged directories, and verifies the immutable launch in a real
-browser before advancing either `latest` alias. It then waits for those aliases
-to deploy and verifies the exact README launch URL. A failed publication can be
+retains previous tagged directories, and validates successful HTTP responses
+before treating Pages as ready. It advances and browser-verifies the safe
+blueprint alias independently. The optional extension is then verified in a real
+browser before `playground/extensions/latest/` advances. A failed extension
+verification therefore cannot take down the README demo. Publication can be
 resumed for an existing tag through `workflow_dispatch`; publication commits are
 idempotent. The workflow never creates or edits a release. Homeboy remains the sole
 release owner.

--- a/includes/block.php
+++ b/includes/block.php
@@ -30,13 +30,17 @@ function static_site_importer_register_block(): void {
  * @return string
  */
 function static_site_importer_render_block( array $attributes = array() ): string {
-	$title       = isset( $attributes['title'] ) && '' !== trim( (string) $attributes['title'] ) ? (string) $attributes['title'] : __( 'Bring a site into WordPress.', 'static-site-importer' );
-	$intro       = isset( $attributes['intro'] ) && '' !== trim( (string) $attributes['intro'] ) ? (string) $attributes['intro'] : __( 'Upload a static site, ZIP, folder, Figma file, or paste HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' );
-	$provider    = isset( $attributes['provider'] ) ? sanitize_key( (string) $attributes['provider'] ) : '';
-	$default_url = isset( $attributes['defaultUrl'] ) ? esc_url_raw( (string) $attributes['defaultUrl'] ) : '';
-	$apply       = ! empty( $attributes['applyToCurrentSite'] );
-	$playground  = ! empty( $attributes['openInPlayground'] );
-	$button_text = $apply ? __( 'Import to this site', 'static-site-importer' ) : __( 'Generate WordPress Website', 'static-site-importer' );
+	$figma_available = Static_Site_Importer_Figma_Import::zstd_decoder_available();
+	$title           = isset( $attributes['title'] ) && '' !== trim( (string) $attributes['title'] ) ? (string) $attributes['title'] : __( 'Bring a site into WordPress.', 'static-site-importer' );
+	$default_intro   = $figma_available
+		? __( 'Upload a static site, ZIP, folder, Figma file, or paste HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' )
+		: __( 'Upload a static site, ZIP, folder, or paste HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' );
+	$intro           = isset( $attributes['intro'] ) && '' !== trim( (string) $attributes['intro'] ) ? (string) $attributes['intro'] : $default_intro;
+	$provider        = isset( $attributes['provider'] ) ? sanitize_key( (string) $attributes['provider'] ) : '';
+	$default_url     = isset( $attributes['defaultUrl'] ) ? esc_url_raw( (string) $attributes['defaultUrl'] ) : '';
+	$apply           = ! empty( $attributes['applyToCurrentSite'] );
+	$playground      = ! empty( $attributes['openInPlayground'] );
+	$button_text     = $apply ? __( 'Import to this site', 'static-site-importer' ) : __( 'Generate WordPress Website', 'static-site-importer' );
 
 	/**
 	 * Filters the importer block wrapper CSS classes.
@@ -84,7 +88,7 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 
 	ob_start();
 	?>
-	<div class="<?php echo esc_attr( $wrapper_classes ); ?>"<?php echo $extra_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Name sanitized, value escaped with esc_attr() above. ?> data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-figma-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/import-figma-file' ) ); ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>" data-static-site-importer-apply-to-current-site="<?php echo $apply ? '1' : '0'; ?>" data-static-site-importer-open-in-playground="<?php echo $playground ? '1' : '0'; ?>">
+	<div class="<?php echo esc_attr( $wrapper_classes ); ?>"<?php echo $extra_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Name sanitized, value escaped with esc_attr() above. ?> data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-figma-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/import-figma-file' ) ); ?>" data-static-site-importer-figma-available="<?php echo $figma_available ? '1' : '0'; ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>" data-static-site-importer-apply-to-current-site="<?php echo $apply ? '1' : '0'; ?>" data-static-site-importer-open-in-playground="<?php echo $playground ? '1' : '0'; ?>">
 		<section class="ssi-importer__panel" aria-labelledby="ssi-importer-title">
 			<p class="ssi-importer__eyebrow"><?php esc_html_e( 'Static Site Importer', 'static-site-importer' ); ?></p>
 			<h1 id="ssi-importer-title" class="ssi-importer__title"><?php echo esc_html( $title ); ?></h1>
@@ -101,11 +105,14 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 					<div class="ssi-importer__upload-row" role="group" aria-label="<?php echo esc_attr( __( 'Upload source type', 'static-site-importer' ) ); ?>">
 						<button type="button" class="ssi-importer__upload-button" data-static-site-importer-upload-files><?php esc_html_e( 'File(s)', 'static-site-importer' ); ?></button>
 						<button type="button" class="ssi-importer__upload-button" data-static-site-importer-upload-folder><?php esc_html_e( 'Folder', 'static-site-importer' ); ?></button>
-						<button type="button" class="ssi-importer__upload-button" data-static-site-importer-upload-figma><?php esc_html_e( 'Figma', 'static-site-importer' ); ?></button>
+						<button type="button" class="ssi-importer__upload-button" data-static-site-importer-upload-figma<?php echo $figma_available ? '' : ' disabled aria-disabled="true"'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static attributes. ?>><?php esc_html_e( 'Figma', 'static-site-importer' ); ?></button>
 						<input type="file" name="ssi_static_upload[]" accept=".zip,application/zip,.html,.htm,text/html,text/css,text/javascript,application/javascript,application/json,application/xml,text/xml,image/*,font/*" multiple hidden data-static-site-importer-source-files>
 						<input type="file" name="ssi_static_directory[]" multiple webkitdirectory hidden data-static-site-importer-source-directory>
-						<input type="file" name="ssi_figma_file" accept=".fig" hidden data-static-site-importer-source-figma-file>
+						<input type="file" name="ssi_figma_file" accept=".fig" hidden data-static-site-importer-source-figma-file<?php echo $figma_available ? '' : ' disabled'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static attribute. ?>>
 					</div>
+					<?php if ( ! $figma_available ) : ?>
+						<p class="ssi-importer__capability-notice" data-static-site-importer-figma-unavailable><?php esc_html_e( 'Figma import requires zstd support, which is unavailable in this runtime. Other source types remain available.', 'static-site-importer' ); ?></p>
+					<?php endif; ?>
 				</fieldset>
 
 				<details class="ssi-importer__field">

--- a/includes/class-static-site-importer-figma-import.php
+++ b/includes/class-static-site-importer-figma-import.php
@@ -14,6 +14,25 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Static_Site_Importer_Figma_Import {
 	/**
+	 * Whether this runtime can decode zstd-compressed Figma chunks.
+	 */
+	public static function zstd_decoder_available(): bool {
+		$command   = self::zstd_command();
+		$available = function_exists( 'zstd_uncompress' )
+			|| ( class_exists( '\\Automattic\\BlocksEngine\\FigmaTransformer\\Compression\\ZstdCommandDecoder' ) && self::zstd_command_decodes_probe( $command ) );
+
+		/**
+		 * Filters whether direct .fig intake is available in this runtime.
+		 *
+		 * Hosts that register a custom transformer decoder may advertise that
+		 * capability here without requiring the native extension or command adapter.
+		 *
+		 * @param bool $available Whether a zstd decoder is available.
+		 */
+		return (bool) apply_filters( 'static_site_importer_figma_zstd_available', $available );
+	}
+
+	/**
 	 * Register the default Zstandard decoder for .fig uploads.
 	 */
 	public static function register_default_zstd_decoder(): void {
@@ -388,6 +407,9 @@ class Static_Site_Importer_Figma_Import {
 		if ( ! function_exists( 'blocks_engine_figma_transformer_transform_file' ) ) {
 			return new WP_Error( 'static_site_importer_figma_transformer_unavailable', 'Blocks Engine Figma transformer is not available.', array( 'status' => 501 ) );
 		}
+		if ( ! self::zstd_decoder_available() ) {
+			return new WP_Error( 'static_site_importer_figma_zstd_unavailable', 'Figma file import requires zstd support in this runtime.', array( 'status' => 501 ) );
+		}
 
 		if ( ! preg_match( '/\.fig$/i', $name ) ) {
 			return new WP_Error( 'static_site_importer_figma_file_type_invalid', 'Figma file uploads must use a .fig file.', array( 'status' => 400 ) );
@@ -698,7 +720,7 @@ class Static_Site_Importer_Figma_Import {
 		}
 
 		if ( '' !== $configured ) {
-			return array( $configured, '-dc' );
+			return is_executable( $configured ) ? array( $configured, '-dc' ) : array();
 		}
 
 		foreach ( array( '/opt/homebrew/bin/zstd', '/usr/local/bin/zstd', '/usr/bin/zstd' ) as $candidate ) {
@@ -708,6 +730,40 @@ class Static_Site_Importer_Figma_Import {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Prove a command can decode a bounded known zstd frame before advertising it.
+	 *
+	 * @param array<int,string> $command Command argv.
+	 */
+	private static function zstd_command_decodes_probe( array $command ): bool {
+		if ( empty( $command ) || ! function_exists( 'proc_open' ) ) {
+			return false;
+		}
+
+		static $results = array();
+		$key = md5( serialize( $command ) );
+		if ( array_key_exists( $key, $results ) ) {
+			return $results[ $key ];
+		}
+
+		$compressed = base64_decode( 'KLUv/QRYcQAAc3NpLXpzdGQtcHJvYmVUFxFH', true );
+		if ( ! is_string( $compressed ) ) {
+			$results[ $key ] = false;
+			return false;
+		}
+
+		try {
+			$decoder = new \Automattic\BlocksEngine\FigmaTransformer\Compression\ZstdCommandDecoder( $command );
+			$result  = $decoder( $compressed, array( 'max_decoded_bytes' => 64 ) );
+		} catch ( \Throwable ) {
+			$results[ $key ] = false;
+			return false;
+		}
+
+		$results[ $key ] = 'ssi-zstd-probe' === ( $result['data'] ?? null );
+		return $results[ $key ];
 	}
 
 	/**

--- a/tests/figma-zstd-decoder.php
+++ b/tests/figma-zstd-decoder.php
@@ -5,12 +5,14 @@
  * Run from the repository root:
  * php tests/figma-zstd-decoder.php native
  * php -n tests/figma-zstd-decoder.php command
+ * php -n tests/figma-zstd-decoder.php unavailable
+ * php -n -d disable_functions=proc_open tests/figma-zstd-decoder.php disabled
  *
  * @package StaticSiteImporter
  */
 
-if ( 2 !== $argc || ! in_array( $argv[1], array( 'native', 'command' ), true ) ) {
-	fwrite( STDERR, "Usage: php tests/figma-zstd-decoder.php <native|command>\n" );
+if ( 2 !== $argc || ! in_array( $argv[1], array( 'native', 'command', 'unavailable', 'disabled' ), true ) ) {
+	fwrite( STDERR, "Usage: php tests/figma-zstd-decoder.php <native|command|unavailable|disabled>\n" );
 	exit( 2 );
 }
 
@@ -39,10 +41,25 @@ if ( 'native' === $argv[1] ) {
 	}
 
 	putenv( 'STATIC_SITE_IMPORTER_FIGMA_ZSTD_COMMAND=/definitely-not-a-zstd-command' );
-} else {
+} elseif ( in_array( $argv[1], array( 'command', 'disabled' ), true ) ) {
 	$command = tempnam( sys_get_temp_dir(), 'ssi-zstd-command-' );
 	if ( false === $command ) {
 		fwrite( STDERR, "Could not create zstd command fixture.\n" );
+		exit( 1 );
+	}
+	file_put_contents(
+		$command,
+		'#!' . PHP_BINARY . "\n<?php\n"
+		. '$input = stream_get_contents( STDIN );' . "\n"
+		. '$probe = base64_decode( \'KLUv/QRYcQAAc3NpLXpzdGQtcHJvYmVUFxFH\', true );' . "\n"
+		. 'fwrite( STDOUT, $input === $probe ? \'ssi-zstd-probe\' : $input );' . "\n"
+	);
+	chmod( $command, 0700 );
+	putenv( 'STATIC_SITE_IMPORTER_FIGMA_ZSTD_COMMAND=' . $command );
+} else {
+	$command = tempnam( sys_get_temp_dir(), 'ssi-not-zstd-command-' );
+	if ( false === $command ) {
+		fwrite( STDERR, "Could not create invalid zstd command fixture.\n" );
 		exit( 1 );
 	}
 	file_put_contents( $command, "#!/bin/sh\ncat\n" );
@@ -56,13 +73,26 @@ require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-figma-im
 Static_Site_Importer_Figma_Import::register_default_zstd_decoder();
 $decoder = apply_filters( 'blocks_engine_figma_transformer_zstd_decoder', null );
 
-if ( 'native' === $argv[1] ) {
+if ( in_array( $argv[1], array( 'unavailable', 'disabled' ), true ) ) {
+	try {
+		if ( Static_Site_Importer_Figma_Import::zstd_decoder_available() ) {
+			fwrite( STDERR, "Unavailable zstd command was advertised as available.\n" );
+			exit( 1 );
+		}
+	} finally {
+		unlink( $command );
+	}
+} elseif ( 'native' === $argv[1] ) {
 	if ( ! is_callable( $decoder ) || ( ! extension_loaded( 'zstd' ) && 'native:compressed' !== $decoder( 'compressed' ) ) ) {
 		fwrite( STDERR, "Native zstd decoder was not preferred.\n" );
 		exit( 1 );
 	}
 } else {
 	try {
+		if ( ! Static_Site_Importer_Figma_Import::zstd_decoder_available() ) {
+			fwrite( STDERR, "Working zstd command was not advertised as available.\n" );
+			exit( 1 );
+		}
 		$result = is_callable( $decoder ) ? $decoder( 'compressed', array() ) : null;
 	} finally {
 		unlink( $command );

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -427,6 +427,13 @@ if ( is_readable( $figma_transformer_bootstrap ) ) {
 }
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-figma-import.php';
 Static_Site_Importer_Figma_Import::register_default_zstd_decoder();
+$GLOBALS['ssi_figma_zstd_available'] = true;
+add_filter(
+	'static_site_importer_figma_zstd_available',
+	static function (): bool {
+		return (bool) $GLOBALS['ssi_figma_zstd_available'];
+	}
+);
 require_once dirname( __DIR__ ) . '/includes/abilities.php';
 require_once dirname( __DIR__ ) . '/includes/rest.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document.php';
@@ -450,6 +457,14 @@ $zstd_command_output = array();
 $zstd_command_status = 0;
 exec( escapeshellarg( PHP_BINARY ) . ' -n ' . $zstd_decoder_test . ' command 2>&1', $zstd_command_output, $zstd_command_status );
 $assert( 0 === $zstd_command_status, 'figma-zstd-decoder-falls-back-to-command', implode( "\n", $zstd_command_output ) );
+$zstd_unavailable_output = array();
+$zstd_unavailable_status = 0;
+exec( escapeshellarg( PHP_BINARY ) . ' -n ' . $zstd_decoder_test . ' unavailable 2>&1', $zstd_unavailable_output, $zstd_unavailable_status );
+$assert( 0 === $zstd_unavailable_status, 'figma-zstd-decoder-rejects-invalid-command', implode( "\n", $zstd_unavailable_output ) );
+$zstd_disabled_output = array();
+$zstd_disabled_status = 0;
+exec( escapeshellarg( PHP_BINARY ) . ' -n -d disable_functions=proc_open ' . $zstd_decoder_test . ' disabled 2>&1', $zstd_disabled_output, $zstd_disabled_status );
+$assert( 0 === $zstd_disabled_status, 'figma-zstd-decoder-fails-closed-without-proc-open', implode( "\n", $zstd_disabled_output ) );
 
 $rest_source = file_get_contents( dirname( __DIR__ ) . '/includes/rest.php' );
 $assert( is_string( $rest_source ), 'rest-source-readable' );
@@ -487,6 +502,7 @@ $html = static_site_importer_render_block(
 $assert( str_contains( $html, 'data-static-site-importer' ), 'render-has-root-hook' );
 $assert( str_contains( $html, 'data-static-site-importer-rest-url="https://example.test/wp-json/static-site-importer/v1/imports"' ), 'render-exposes-import-rest-route' );
 $assert( str_contains( $html, 'data-static-site-importer-figma-rest-url="https://example.test/wp-json/static-site-importer/v1/import-figma-file"' ), 'render-exposes-figma-file-rest-route' );
+$assert( str_contains( $html, 'data-static-site-importer-figma-available="1"' ), 'render-advertises-available-figma-capability' );
 $assert( str_contains( $html, 'data-static-site-importer-provider="privateprovider"' ), 'render-sanitizes-provider' );
 $assert( str_contains( $html, 'data-static-site-importer-apply-to-current-site="1"' ), 'render-exposes-current-site-apply-flag' );
 $assert( str_contains( $html, 'data-static-site-importer-open-in-playground="0"' ), 'render-exposes-open-in-playground-flag' );
@@ -532,6 +548,14 @@ $assert( str_contains( $playground_html, 'data-static-site-importer-apply-to-cur
 $assert( str_contains( $playground_html, 'data-static-site-importer-open-in-playground="1"' ), 'render-can-target-playground-with-generate-label' );
 $assert( str_contains( $playground_html, 'Generate WordPress Website' ), 'render-playground-button-generates-wordpress-website' );
 $assert( ! str_contains( $playground_html, 'Import to this site' ), 'render-playground-button-does-not-say-import-to-this-site' );
+
+$GLOBALS['ssi_figma_zstd_available'] = false;
+$safe_playground_html                = static_site_importer_render_block( array( 'openInPlayground' => true ) );
+$assert( str_contains( $safe_playground_html, 'data-static-site-importer-figma-available="0"' ), 'render-advertises-unavailable-figma-capability' );
+$assert( str_contains( $safe_playground_html, 'data-static-site-importer-upload-figma disabled aria-disabled="true"' ), 'render-disables-figma-without-zstd' );
+$assert( str_contains( $safe_playground_html, 'data-static-site-importer-figma-unavailable' ), 'render-explains-unavailable-figma-capability' );
+$assert( str_contains( $safe_playground_html, 'Other source types remain available.' ), 'render-keeps-safe-import-paths-actionable' );
+$GLOBALS['ssi_figma_zstd_available'] = true;
 
 /*
  * Theming seam: the block ships a host-overridable `--ssi-importer-*` custom
@@ -632,6 +656,7 @@ $assert( str_contains( $view_js, 'input.click()' ), 'view-opens-selected-hidden-
 $assert( str_contains( $view_js, 'webkitGetAsEntry' ), 'view-supports-dropped-directory-entries' );
 $assert( str_contains( $view_js, 'archive: await buildArchive( uploadInputs, root )' ), 'view-sends-zip-from-combined-upload-as-archive-payload' );
 $assert( str_contains( $view_js, "formData.append( 'figma_file', file )" ), 'view-sends-figma-file-as-multipart-upload' );
+$assert( str_contains( $view_js, "data-static-site-importer-figma-available' ) !== '1'" ), 'view-guards-figma-submit-by-runtime-capability' );
 $assert( ! str_contains( $view_js, 'buildFigmaFile' ), 'view-does-not-build-figma-file-payload' );
 $assert( str_contains( $view_js, '/\\.zip$/i' ), 'view-excludes-zip-files-from-generic-static-upload' );
 $assert( str_contains( $view_js, 'data-static-site-importer-source-figma-file' ), 'view-reads-separate-figma-file-input' );
@@ -1001,6 +1026,11 @@ if ( ! is_dir( $staged_figma_root ) ) {
 }
 $staged_figma_path = $staged_figma_root . '/design.fig';
 file_put_contents( $staged_figma_path, 'not-a-zip' );
+$GLOBALS['ssi_figma_zstd_available'] = false;
+$unavailable_figma_artifact          = Static_Site_Importer_Figma_Import::website_artifact_from_figma_upload( $staged_figma_path, 'design.fig', array() );
+$assert( 'static_site_importer_figma_zstd_unavailable' === ( is_wp_error( $unavailable_figma_artifact ) ? $unavailable_figma_artifact->get_error_code() : '' ), 'figma-upload-fails-explicitly-without-zstd' );
+$assert( 501 === ( is_wp_error( $unavailable_figma_artifact ) ? ( $unavailable_figma_artifact->get_error_data()['status'] ?? 0 ) : 0 ), 'figma-upload-unavailable-status-is-actionable' );
+$GLOBALS['ssi_figma_zstd_available'] = true;
 $staged_figma_artifact = Static_Site_Importer_Figma_Import::website_artifact_from_input(
 	array(
 		'source' => array(
@@ -1153,8 +1183,9 @@ $assert( str_contains( $blueprint_code, '"applyToCurrentSite":false' ), 'playgro
 $assert( str_contains( $blueprint_code, '"openInPlayground":true' ), 'playground-blueprint-targets-open-in-playground' );
 $assert( ! str_contains( $blueprint_code, 'generateInCurrentRuntime' ), 'playground-blueprint-does-not-reference-current-runtime-generation' );
 $assert( str_contains( $blueprint_code, 'static_site_importer_protected_pages' ), 'playground-blueprint-protects-import-page' );
-$plugin_step = $blueprint['steps'][1] ?? array();
-$assert( 'https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip' === ( $plugin_step['pluginData']['url'] ?? '' ), 'playground-blueprint-installs-packaged-release' );
+$plugin_steps = array_values( array_filter( $blueprint['steps'] ?? array(), static fn( array $step ): bool => 'installPlugin' === ( $step['step'] ?? '' ) ) );
+$plugin_step  = $plugin_steps[0] ?? array();
+$assert( 'https://github.com/Automattic/static-site-importer/releases/download/{{RELEASE_TAG}}/static-site-importer.zip' === ( $plugin_step['pluginData']['url'] ?? '' ), 'playground-blueprint-installs-same-release-package' );
 
 $GLOBALS['ssi_test_options']['static_site_importer_protected_pages'] = array( 'import', 'tools/settings', '42' );
 $assert( Static_Site_Importer_Page_Materializer::is_protected_page( new WP_Post( 7, 'import' ) ), 'protected-page-matches-slug' );

--- a/tools/php-wasm-zstd.test.mjs
+++ b/tools/php-wasm-zstd.test.mjs
@@ -28,20 +28,20 @@ test( 'manifest publishes a PHP 8.5 JSPI zstd artifact through the CORS-capable 
 	} ] );
 } );
 
-test( 'Playground starts PHP 8.5 and both README launch links load zstd before boot', async () => {
+test( 'Playground starts PHP 8.5 and both README launch links boot without an optional extension', async () => {
 	const [ blueprint, readme ] = await Promise.all( [
 		readFile( path.join( root, 'docs/playground/blueprint.json' ), 'utf8' ),
 		readFile( path.join( root, 'README.md' ), 'utf8' ),
 	] );
 	const parsedBlueprint = JSON.parse( blueprint );
 	assert.equal( parsedBlueprint.preferredVersions.php, '8.5' );
-	assert.ok( parsedBlueprint.steps.some( ( step ) => step.step === 'runPHP' && step.code.includes( "extension_loaded( 'zstd' )" ) && step.code.includes( 'ssi-playground-zstd-loaded.txt' ) ) );
+	assert.ok( ! parsedBlueprint.steps.some( ( step ) => step.step === 'runPHP' && step.code.includes( "extension_loaded( 'zstd' )" ) ) );
 	const links = [ ...readme.matchAll( /\]\((https:\/\/playground\.wordpress\.net\/\?[^)]+)\)/g ) ].map( ( match ) => match[ 1 ] );
 	assert.equal( links.length, 2 );
 	for ( const link of links ) {
 		const url = new URL( link );
 		assert.equal( url.searchParams.get( 'php' ), '8.5' );
-		assert.equal( url.searchParams.get( 'php-extension' ), manifestUrl );
+		assert.equal( url.searchParams.get( 'php-extension' ), null );
 		assert.equal( url.searchParams.get( 'blueprint-url' ), 'https://automattic.github.io/static-site-importer/playground/latest/blueprint.json' );
 	}
 } );
@@ -58,16 +58,20 @@ test( 'release publication keeps immutable assets and blueprints separate from t
 	assert.match( workflow, /playground\/extensions\/latest/ );
 	assert.match( workflow, /releases\/download\/\$\{tag\}/ );
 	assert.match( workflow, /access-control-allow-origin/ );
-	assert.match( workflow, /git -C "\$pages_dir" add \.nojekyll playground/ );
+	assert.match( workflow, /git -C "\$pages_dir" add \.nojekyll "playground\/\$RELEASE_TAG\.blueprint\.json"/ );
 	assert.match( workflow, /git -C "\$pages_dir" diff --cached --quiet/ );
 	assert.doesNotMatch( workflow, /gh release upload/ );
 	assert.ok(
-		workflow.indexOf( 'Verify the immutable Playground launch end to end' ) < workflow.indexOf( 'Advance the verified latest aliases' ),
-		'latest aliases must advance only after the immutable browser verification',
+		workflow.indexOf( 'Verify the immutable safe Playground launch' ) < workflow.indexOf( 'Advance the safe README blueprint alias' ),
+		'the mutable README alias must advance only after immutable browser verification',
 	);
 	assert.ok(
-		workflow.indexOf( 'Wait for the latest Pages aliases' ) < workflow.indexOf( 'Verify the exact README Playground launch' ),
-		'the published README URL must be verified after latest deploys',
+		workflow.indexOf( 'Verify the exact README Playground launch' ) < workflow.indexOf( 'Verify the optional zstd Playground launch end to end' ),
+		'the safe README launch must be independent of optional extension verification',
+	);
+	assert.ok(
+		workflow.indexOf( 'Verify the optional zstd Playground launch end to end' ) < workflow.indexOf( 'Advance the verified extension aliases' ),
+		'extension aliases must advance only after their browser verification',
 	);
 	assert.match( publication, /\{\{RELEASE_TAG\}\}/ );
 	assert.match( publication, /Homeboy remains the sole\s+release owner/ );

--- a/tools/verify-playground-launch.mjs
+++ b/tools/verify-playground-launch.mjs
@@ -18,7 +18,6 @@ if (process.env.PLAYGROUND_BLUEPRINT_URL) {
   launch.searchParams.set('blueprint-url', process.env.PLAYGROUND_BLUEPRINT_URL);
 }
 const manifestUrl = launch.searchParams.get('php-extension');
-assert.ok(manifestUrl, 'README launch URL must provide a PHP extension manifest');
 
 const browser = await chromium.launch({ headless: true });
 const page = await browser.newPage();
@@ -28,15 +27,17 @@ page.on('pageerror', (error) => diagnostics.push(`pageerror: ${error.message}`))
 page.on('requestfailed', (request) => diagnostics.push(`requestfailed: ${request.url()} (${request.failure()?.errorText})`));
 
 try {
-  // This is deliberately a browser fetch from Playground's origin: Node fetch
-  // cannot detect the CORS regression that broke the launch link.
-  await page.goto('https://playground.wordpress.net/', { waitUntil: 'domcontentloaded' });
-  const manifest = await page.evaluate(async (url) => {
-    const response = await fetch(url);
-    return { ok: response.ok, manifest: await response.json() };
-  }, manifestUrl);
-  assert.equal(manifest.ok, true, 'Playground must be able to CORS-fetch the extension manifest');
-  assert.equal(manifest.manifest.name, 'zstd');
+  if (manifestUrl) {
+    // This is deliberately a browser fetch from Playground's origin: Node fetch
+    // cannot detect the CORS regression that broke the extension launch.
+    await page.goto('https://playground.wordpress.net/', { waitUntil: 'domcontentloaded' });
+    const manifest = await page.evaluate(async (url) => {
+      const response = await fetch(url);
+      return { ok: response.ok, manifest: await response.json() };
+    }, manifestUrl);
+    assert.equal(manifest.ok, true, 'Playground must be able to CORS-fetch the extension manifest');
+    assert.equal(manifest.manifest.name, 'zstd');
+  }
 
   await page.goto(launch.toString(), { waitUntil: 'domcontentloaded', timeout: 120_000 });
   let wordpress;
@@ -52,13 +53,13 @@ try {
   if (!wordpress.url().includes('/import/')) await wordpress.waitForURL(/\/import\//, { timeout: 120_000 });
   await wordpress.locator('.ssi-importer').waitFor({ state: 'visible', timeout: 120_000 });
 
-  const zstdMarker = await wordpress.evaluate(async () => {
-    const response = await fetch('/wp-content/ssi-playground-zstd-loaded.txt');
-    return response.ok ? response.text() : null;
-  });
-  assert.equal(zstdMarker, 'zstd', 'the running Playground PHP must have loaded zstd');
+  const figmaAvailable = await wordpress.locator('.ssi-importer').getAttribute('data-static-site-importer-figma-available');
+  const figmaButton = wordpress.locator('[data-static-site-importer-upload-figma]');
+  assert.equal(figmaAvailable, manifestUrl ? '1' : '0', 'Figma availability must match the optional zstd runtime capability');
+  assert.equal(await figmaButton.isDisabled(), !manifestUrl, 'Figma control must fail open without zstd');
 
   if (figFixture) {
+    assert.ok(manifestUrl, 'Figma fixture verification requires a PHP extension manifest');
     const importer = wordpress.locator('.ssi-importer');
     const restUrl = await importer.getAttribute('data-static-site-importer-figma-rest-url');
     assert.ok(restUrl, 'Figma importer must expose its REST endpoint');


### PR DESCRIPTION
## Summary
- remove the optional zstd side module from the canonical README launch so HTML, ZIP, folder, file, and paste imports always boot
- advertise Figma runtime capability in the importer, disable and explain the control when no proven decoder exists, and fail direct `.fig` intake with an actionable 501
- probe configured zstd commands with a bounded known frame and fail closed when process execution is unavailable
- publish and browser-verify immutable safe blueprints before advancing `latest`, independently of optional extension build/runtime proof
- validate exact alias identity, serialize Pages publication, and prevent old or overtaken release jobs from rolling mutable aliases backward

This advances #656 without claiming its optional zstd acceptance is complete. Figma can be re-enabled in hosted Playground after WordPress/wordpress-playground#4108 is merged and deployed; the canonical demo no longer depends on that timeline.

## Verification
- `npm test` (all suites passed except the publication assertion changed by this PR; that assertion was updated and rerun successfully)
- `npm run test:php-wasm-zstd`
- `php tests/smoke-importer-block.php` (339 assertions)
- `php -n tests/figma-zstd-decoder.php native`
- `php -n tests/figma-zstd-decoder.php command`
- `php -n tests/figma-zstd-decoder.php unavailable`
- `php -n -d disable_functions=proc_open tests/figma-zstd-decoder.php disabled`
- PHP lint across all tracked PHP files
- `actionlint .github/workflows/release-php-wasm-zstd.yml`
- `git diff --check`
- independent review found no remaining findings

## Follow-up
A new Homeboy release is required after merge so the release-tagged safe blueprint can be published to `playground/latest/blueprint.json`; until then the current README alias remains absent.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode diagnosed the publication/runtime coupling, implemented the safe capability and publication boundaries, added regression coverage, and ran verification. Chris Huber reviewed and owns the change.