### PR TITLE
fix: fail closed on empty fixture matrix selection

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -158,7 +158,6 @@ export async function runFixtureMatrix(options) {
   const fixtureRoot = path.resolve(intake?.fixture_root || options.fixtureRoot || path.join(packageRoot, 'tests', 'fixtures', 'fixture-matrix'));
   const staticSiteImporterPath = options.staticSiteImporterPath || process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH || process.cwd();
   const dependencyOverrides = prepareDependencyOverrides(options);
-  validateHydratedComposerDependencies(packageRoot);
   const matrix = createFixtureMatrix({
     id: options.id || `static-site-importer-fixture-matrix-${Date.now()}`,
     fixture_root: fixtureRoot,
@@ -175,6 +174,10 @@ export async function runFixtureMatrix(options) {
     fixture_ids: options.fixtureIds,
     fixture_corpus: options.fixtureCorpus,
   });
+  if (options.run && matrix.count === 0) {
+    throw new Error(`Fixture matrix execution requires at least one executable fixture under ${fixtureRoot}. Inspect the fixture root, entrypoint, and lane filters before retrying.`);
+  }
+  validateHydratedComposerDependencies(packageRoot);
   const progress = createFixtureMatrixProgress(matrix, options);
   progress.emit('matrix', 'started');
   const artifactWriteStartedAt = nowMs();

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -18,6 +18,7 @@ import {
   classifyVisualDiffRegions,
   collectFixtureMatrixRunResults,
   createFixtureMatrix,
+  inspectFixtureDirectories,
   normalizeFixtureMatrixResult,
   writeFixtureMatrixArtifacts,
   writeFixtureMatrixResultArtifacts,
@@ -158,7 +159,8 @@ export async function runFixtureMatrix(options) {
   const fixtureRoot = path.resolve(intake?.fixture_root || options.fixtureRoot || path.join(packageRoot, 'tests', 'fixtures', 'fixture-matrix'));
   const staticSiteImporterPath = options.staticSiteImporterPath || process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH || process.cwd();
   const dependencyOverrides = prepareDependencyOverrides(options);
-  const matrix = createFixtureMatrix({
+  const fixtureInspection = inspectFixtureDirectories(fixtureRoot, { maxDepth: options.maxDepth });
+  const matrixInput = {
     id: options.id || `static-site-importer-fixture-matrix-${Date.now()}`,
     fixture_root: fixtureRoot,
     entrypoint: options.entrypoint || 'index.html',
@@ -173,7 +175,10 @@ export async function runFixtureMatrix(options) {
     max_complexity: options.maxComplexity || options.max_complexity,
     fixture_ids: options.fixtureIds,
     fixture_corpus: options.fixtureCorpus,
-  });
+  };
+  const matrix = fixtureInspection.exclusions[0]?.reason === 'root_symlink'
+    ? createFixtureMatrix({ ...matrixInput, fixtures: [] })
+    : createFixtureMatrix(matrixInput);
   if (options.run && matrix.count === 0) {
     throw new Error(`Fixture matrix execution requires at least one executable fixture under ${fixtureRoot}. Inspect the fixture root, entrypoint, and lane filters before retrying.`);
   }

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -689,10 +689,11 @@ Notes:
   (`<ssi>/static-site-importer.php`). If the checkout/worktree was removed (e.g.
   by workspace hygiene), the bench fails with `rig.pipeline_failed` on the
   `check` step — recreate the checkout before running.
-- Fixture roots must contain real fixture subdirectories. Symlinked fixture dirs
-  are skipped by discovery (`Dirent.isDirectory()` is false for symlinks), so the
-  matrix silently finds zero fixtures and the gate falsely "passes" with
-  `fixture_count: 0`. Copy fixtures in rather than symlinking.
+- Fixture roots must contain real fixture subdirectories with `index.html`.
+   Symlinked fixture directories are excluded. Execution and promotion lanes fail
+   closed when selection is empty; `--dry-run` instead prints an explicit
+   `planning_empty` fixture-selection report with bounded exclusion reasons and
+   selected IDs. Copy fixtures in rather than symlinking.
 
 ## Editor-Quality Metrics
 

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -32,6 +32,7 @@ export {
   discoverFixtures,
   inspectFixtureDirectories,
   isExecutableFixtureDirectory,
+  resolveFixtureSearchRoots,
   createFixtureMatrix,
   classifyFixture,
   fixtureManifestCoverage,

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -30,6 +30,8 @@ export {
 
 export {
   discoverFixtures,
+  inspectFixtureDirectories,
+  isExecutableFixtureDirectory,
   createFixtureMatrix,
   classifyFixture,
   fixtureManifestCoverage,

--- a/lib/fixture-matrix/fixtures.mjs
+++ b/lib/fixture-matrix/fixtures.mjs
@@ -63,6 +63,7 @@ export function isExecutableFixtureDirectory(directory, entrypoint = 'index.html
 export function inspectFixtureDirectories(root, options = {}) {
   const entrypoint = options.entrypoint || 'index.html';
   const limit = finiteNumber(options.limit, 50);
+  const maxDepth = finiteNumber(options.maxDepth ?? options.max_depth, 2);
   const requestedRoot = path.resolve(root || '.');
   const selected_ids = [];
   const exclusions = [];
@@ -71,7 +72,11 @@ export function inspectFixtureDirectories(root, options = {}) {
     if (exclusions.length < limit) exclusions.push({ id, reason });
   };
   try {
-    if (!fs.statSync(requestedRoot).isDirectory()) {
+    if (fs.lstatSync(requestedRoot).isSymbolicLink()) {
+      addExclusion('', 'root_symlink');
+      return { root: requestedRoot, entrypoint, selected_ids, executable_count: 0, exclusions, diagnostics };
+    }
+    if (!fs.lstatSync(requestedRoot).isDirectory()) {
       addExclusion('', 'root_not_directory');
       return { root: requestedRoot, entrypoint, selected_ids, executable_count: 0, exclusions, diagnostics };
     }
@@ -79,33 +84,34 @@ export function inspectFixtureDirectories(root, options = {}) {
     addExclusion('', 'root_missing');
     return { root: requestedRoot, entrypoint, selected_ids, executable_count: 0, exclusions, diagnostics };
   }
-  for (const entry of fs.readdirSync(requestedRoot, { withFileTypes: true })) {
-    if (entry.name.startsWith('.')) continue;
-    const directory = path.join(requestedRoot, entry.name);
-    if (entry.isSymbolicLink()) addExclusion(entry.name, 'symlink');
-    else if (!entry.isDirectory()) addExclusion(entry.name, 'not_directory');
-    else if (!isExecutableFixtureDirectory(directory, entrypoint)) {
-      const entrypointPath = path.join(directory, entrypoint);
-      let reason = 'missing_entrypoint';
-      try {
-        if (fs.lstatSync(entrypointPath).isSymbolicLink()) reason = 'symlink_entrypoint';
-      } catch {
-        // The missing-entrypoint reason is already the correct diagnostic.
-      }
-      addExclusion(entry.name, reason);
-    }
-    else {
-      selected_ids.push(slug(entry.name));
+  const inspect = (directory, depth) => {
+    const id = slug(path.relative(requestedRoot, directory));
+    if (isExecutableFixtureDirectory(directory, entrypoint)) {
+      selected_ids.push(id);
       const manifestPath = path.join(directory, FIXTURE_MANIFEST_FILENAME);
       if (fs.existsSync(manifestPath)) {
         try {
           JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
         } catch {
-          if (diagnostics.length < limit) diagnostics.push({ id: slug(entry.name), reason: 'malformed_metadata' });
+          if (diagnostics.length < limit) diagnostics.push({ id, reason: 'malformed_metadata' });
         }
       }
     }
-  }
+    const entries = fs.readdirSync(directory, { withFileTypes: true }).filter((entry) => !entry.name.startsWith('.'));
+    const childDirectories = entries.filter((entry) => entry.isDirectory());
+    for (const entry of entries) {
+      const child = path.join(directory, entry.name);
+      const childId = slug(path.relative(requestedRoot, child));
+      if (entry.isSymbolicLink()) addExclusion(childId, 'symlink');
+      else if (!entry.isDirectory()) continue;
+      else if (depth < maxDepth) inspect(child, depth + 1);
+      else if (!isExecutableFixtureDirectory(child, entrypoint)) addExclusion(childId, 'missing_entrypoint');
+    }
+    if (directory !== requestedRoot && !isExecutableFixtureDirectory(directory, entrypoint) && childDirectories.length === 0) {
+      addExclusion(id, 'missing_entrypoint');
+    }
+  };
+  inspect(requestedRoot, 0);
   return { root: requestedRoot, entrypoint, selected_ids: selected_ids.sort(), executable_count: selected_ids.length, exclusions, diagnostics };
 }
 
@@ -116,15 +122,23 @@ export function inspectFixtureDirectories(root, options = {}) {
 // solved regression fixtures automatically. Any other root is searched as-is.
 export function resolveFixtureSearchRoots(fixtureRoot) {
   const websitesRoot = path.join(fixtureRoot, 'websites');
-  if (!fs.existsSync(websitesRoot) || !fs.statSync(websitesRoot).isDirectory()) {
+  if (!isRealDirectory(websitesRoot)) {
     return [fixtureRoot];
   }
   const roots = [websitesRoot];
   const solvedRoot = path.join(fixtureRoot, 'solved');
-  if (fs.existsSync(solvedRoot) && fs.statSync(solvedRoot).isDirectory()) {
+  if (isRealDirectory(solvedRoot)) {
     roots.push(solvedRoot);
   }
   return roots;
+}
+
+function isRealDirectory(directory) {
+  try {
+    return fs.lstatSync(directory).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 function corpusLabelForSearchRoot(searchRoot, fixtureRoot) {

--- a/lib/fixture-matrix/fixtures.mjs
+++ b/lib/fixture-matrix/fixtures.mjs
@@ -36,8 +36,7 @@ export function discoverFixtures(root, options = {}) {
 
   for (const searchRoot of searchRoots) {
     visitFixtureDirectory(searchRoot, 0, maxDepth, (directory) => {
-      const entryPath = path.join(directory, entrypoint);
-      if (!fs.existsSync(entryPath) || !fs.statSync(entryPath).isFile()) {
+      if (!isExecutableFixtureDirectory(directory, entrypoint)) {
         return;
       }
 
@@ -46,6 +45,59 @@ export function discoverFixtures(root, options = {}) {
   }
 
   return fixtures.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+// This is the executable-fixture predicate used by discovery and operator
+// preflight: a real directory with a real file entrypoint. Symlinked fixture
+// directories are intentionally excluded because recursive discovery skips them.
+export function isExecutableFixtureDirectory(directory, entrypoint = 'index.html') {
+  try {
+    return fs.lstatSync(directory).isDirectory() && fs.statSync(path.join(directory, entrypoint)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+// Inspect one corpus level without throwing so operator dry-runs can explain an
+// empty plan before an execution lane is rejected.
+export function inspectFixtureDirectories(root, options = {}) {
+  const entrypoint = options.entrypoint || 'index.html';
+  const limit = finiteNumber(options.limit, 50);
+  const requestedRoot = path.resolve(root || '.');
+  const selected_ids = [];
+  const exclusions = [];
+  const diagnostics = [];
+  const addExclusion = (id, reason) => {
+    if (exclusions.length < limit) exclusions.push({ id, reason });
+  };
+  try {
+    if (!fs.statSync(requestedRoot).isDirectory()) {
+      addExclusion('', 'root_not_directory');
+      return { root: requestedRoot, entrypoint, selected_ids, executable_count: 0, exclusions, diagnostics };
+    }
+  } catch {
+    addExclusion('', 'root_missing');
+    return { root: requestedRoot, entrypoint, selected_ids, executable_count: 0, exclusions, diagnostics };
+  }
+  for (const entry of fs.readdirSync(requestedRoot, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const directory = path.join(requestedRoot, entry.name);
+    if (entry.isSymbolicLink()) addExclusion(entry.name, 'symlink');
+    else if (!entry.isDirectory()) addExclusion(entry.name, 'not_directory');
+    else if (!isExecutableFixtureDirectory(directory, entrypoint)) addExclusion(entry.name, 'missing_entrypoint');
+    else {
+      selected_ids.push(slug(entry.name));
+      const manifestPath = path.join(directory, FIXTURE_MANIFEST_FILENAME);
+      if (fs.existsSync(manifestPath)) {
+        try {
+          JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        } catch {
+          if (diagnostics.length < limit) diagnostics.push({ id: slug(entry.name), reason: 'malformed_metadata' });
+        }
+      }
+    }
+  }
+  return { root: requestedRoot, entrypoint, selected_ids: selected_ids.sort(), executable_count: selected_ids.length, exclusions, diagnostics };
 }
 
 // Resolve the actual directories to search for fixtures. If the requested root

--- a/lib/fixture-matrix/fixtures.mjs
+++ b/lib/fixture-matrix/fixtures.mjs
@@ -28,7 +28,11 @@ import {
 } from './shared/utils.mjs';
 
 export function discoverFixtures(root, options = {}) {
-  const fixtureRoot = requiredDirectory(root || options.fixtureRoot || options.fixture_root, 'fixtureRoot');
+  const requestedRoot = root || options.fixtureRoot || options.fixture_root;
+  if (isSymlink(requestedRoot)) {
+    throw new Error(`fixtureRoot must not be a symbolic link: ${requestedRoot}`);
+  }
+  const fixtureRoot = requiredDirectory(requestedRoot, 'fixtureRoot');
   const searchRoots = resolveFixtureSearchRoots(fixtureRoot);
   const entrypoint = options.entrypoint || 'index.html';
   const maxDepth = finiteNumber(options.maxDepth ?? options.max_depth, 2);
@@ -141,6 +145,14 @@ function isRealDirectory(directory) {
   }
 }
 
+function isSymlink(target) {
+  try {
+    return fs.lstatSync(target).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
 function corpusLabelForSearchRoot(searchRoot, fixtureRoot) {
   const normalizedSearchRoot = path.resolve(searchRoot);
   const normalizedFixtureRoot = path.resolve(fixtureRoot);
@@ -177,6 +189,9 @@ export function createFixtureMatrix(input = {}) {
 
 function detectCorpusLayout(fixtureRoot) {
   const resolvedRoot = path.resolve(fixtureRoot);
+  if (!isRealDirectory(resolvedRoot)) {
+    return null;
+  }
   const websitesRoot = path.join(resolvedRoot, 'websites');
   if (!fs.existsSync(websitesRoot) || !fs.statSync(websitesRoot).isDirectory()) {
     return null;

--- a/lib/fixture-matrix/fixtures.mjs
+++ b/lib/fixture-matrix/fixtures.mjs
@@ -52,7 +52,7 @@ export function discoverFixtures(root, options = {}) {
 // directories are intentionally excluded because recursive discovery skips them.
 export function isExecutableFixtureDirectory(directory, entrypoint = 'index.html') {
   try {
-    return fs.lstatSync(directory).isDirectory() && fs.statSync(path.join(directory, entrypoint)).isFile();
+    return fs.lstatSync(directory).isDirectory() && fs.lstatSync(path.join(directory, entrypoint)).isFile();
   } catch {
     return false;
   }
@@ -84,7 +84,16 @@ export function inspectFixtureDirectories(root, options = {}) {
     const directory = path.join(requestedRoot, entry.name);
     if (entry.isSymbolicLink()) addExclusion(entry.name, 'symlink');
     else if (!entry.isDirectory()) addExclusion(entry.name, 'not_directory');
-    else if (!isExecutableFixtureDirectory(directory, entrypoint)) addExclusion(entry.name, 'missing_entrypoint');
+    else if (!isExecutableFixtureDirectory(directory, entrypoint)) {
+      const entrypointPath = path.join(directory, entrypoint);
+      let reason = 'missing_entrypoint';
+      try {
+        if (fs.lstatSync(entrypointPath).isSymbolicLink()) reason = 'symlink_entrypoint';
+      } catch {
+        // The missing-entrypoint reason is already the correct diagnostic.
+      }
+      addExclusion(entry.name, reason);
+    }
     else {
       selected_ids.push(slug(entry.name));
       const manifestPath = path.join(directory, FIXTURE_MANIFEST_FILENAME);

--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -47,6 +47,7 @@
       "static_site_importer_fixture_matrix_namespace"
     ],
     "result_gates": {
+      "fixture_count": { "gte": 1 },
       "failed_fixture_count": { "lte": 0 },
       "not_run_fixture_count": { "lte": 0 }
     }

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2706,6 +2706,21 @@ test('fixture selection fails closed for execution and keeps empty dry-run plann
     runFixtureMatrix({ fixtureRoot, outputDirectory: path.join(root, 'executed'), staticSiteImporterPath: staticSiteImporter, tag: 'absent', run: true }),
     /requires at least one executable fixture/,
   );
+
+  const nonDirectoryRoot = path.join(root, 'not-a-directory');
+  writeFileSync(nonDirectoryRoot, 'fixture root file');
+  const nonDirectoryPlan = buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot: nonDirectoryRoot });
+  assert.equal(nonDirectoryPlan.execution_eligible, false);
+  assert.equal(nonDirectoryPlan.fixture_selection.status, 'planning_empty');
+  assert.equal(nonDirectoryPlan.fixture_selection.exclusions[0].reason, 'root_not_directory');
+  const dryRun = spawnSync(process.execPath, [
+    path.join(packageRoot, 'tools', 'run-fixture-matrix.mjs'),
+    '--static-site-importer', staticSiteImporter,
+    '--fixture-root', nonDirectoryRoot,
+    '--dry-run',
+  ], { encoding: 'utf8' });
+  assert.equal(dryRun.status, 0, dryRun.stderr);
+  assert.equal(JSON.parse(dryRun.stdout).fixture_selection.status, 'planning_empty');
 });
 
 test('fixture selection reports one executable fixture and rejects typoed targets', () => {
@@ -2715,11 +2730,15 @@ test('fixture selection reports one executable fixture and rejects typoed target
   mkdirSync(staticSiteImporter, { recursive: true });
   mkdirSync(path.join(fixtureRoot, 'websites', 'valid-one'), { recursive: true });
   writeFileSync(path.join(fixtureRoot, 'websites', 'valid-one', 'index.html'), '<h1>Fixture</h1>');
+  mkdirSync(path.join(fixtureRoot, 'websites', 'nested', 'valid-two'), { recursive: true });
+  writeFileSync(path.join(fixtureRoot, 'websites', 'nested', 'valid-two', 'index.html'), '<h1>Nested fixture</h1>');
 
   const plan = buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot });
   assert.equal(plan.execution_eligible, true);
-  assert.equal(plan.fixture_count, 1);
-  assert.deepEqual(plan.fixture_selection.selected_fixture_ids, ['valid-one']);
+  assert.equal(plan.fixture_count, 2);
+  assert.deepEqual(plan.fixture_selection.selected_fixture_ids, ['nested-valid-two', 'valid-one']);
+  const nestedTargetPlan = buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot, targetFixture: 'nested-valid-two' });
+  assert.deepEqual(nestedTargetPlan.fixture_selection.selected_fixture_ids, ['nested-valid-two']);
   assert.throws(
     () => buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot, targetFixture: 'typo' }),
     /--target-fixture "typo" was not found/,
@@ -2727,6 +2746,21 @@ test('fixture selection reports one executable fixture and rejects typoed target
   const badRootPlan = buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot: path.join(root, 'missing') });
   assert.equal(badRootPlan.execution_eligible, false);
   assert.equal(badRootPlan.fixture_selection.exclusions[0].reason, 'root_missing');
+});
+
+test('fixture discovery rejects symlinked entrypoints and wrapper help explains empty selection behavior', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-symlink-entrypoint-'));
+  const fixtureRoot = path.join(root, 'fixtures');
+  const fixtureDirectory = path.join(fixtureRoot, 'linked-entrypoint');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(root, 'source.html'), '<h1>Source</h1>');
+  symlinkSync(path.join(root, 'source.html'), path.join(fixtureDirectory, 'index.html'));
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot });
+  assert.equal(matrix.count, 0);
+  const help = spawnSync(process.execPath, [path.join(packageRoot, 'tools', 'run-fixture-matrix.mjs'), '--help'], { encoding: 'utf8' });
+  assert.equal(help.status, 0, help.stderr);
+  assert.match(help.stdout, /Empty selections\s+Execution is refused; --dry-run prints bounded selection diagnostics/);
 });
 
 test('fixture matrix operator rejects contradictory local and Lab routing', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -77,6 +77,7 @@ import {
   VISUAL_PARITY_MISMATCH_KIND,
   visualParityCompareStep,
   normalizeVisualAttributionOptions,
+  resolveFixtureSearchRoots,
   wordpressServedPath,
   writeFixtureMatrixArtifacts,
 } from '../lib/fixture-matrix.mjs';
@@ -2761,6 +2762,38 @@ test('fixture discovery rejects symlinked entrypoints and wrapper help explains 
   const help = spawnSync(process.execPath, [path.join(packageRoot, 'tools', 'run-fixture-matrix.mjs'), '--help'], { encoding: 'utf8' });
   assert.equal(help.status, 0, help.stderr);
   assert.match(help.stdout, /Empty selections\s+Execution is refused; --dry-run prints bounded selection diagnostics/);
+});
+
+test('fixture discovery rejects symlinked corpus roots and planning recursively counts nested fixtures', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-corpus-root-selection-'));
+  const externalRoot = path.join(root, 'external-fixtures');
+  const symlinkedCorpus = path.join(root, 'symlinked-corpus');
+  mkdirSync(path.join(externalRoot, 'site'), { recursive: true });
+  writeFileSync(path.join(externalRoot, 'site', 'index.html'), '<h1>External</h1>');
+  mkdirSync(symlinkedCorpus, { recursive: true });
+  symlinkSync(externalRoot, path.join(symlinkedCorpus, 'websites'));
+
+  assert.deepEqual(resolveFixtureSearchRoots(symlinkedCorpus), [symlinkedCorpus]);
+  assert.equal(createFixtureMatrix({ fixture_root: symlinkedCorpus }).count, 0);
+
+  const fixtureRoot = path.join(root, 'fixtures');
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  for (let index = 1; index <= CANONICAL_FIXTURE_COUNT; index += 1) {
+    const fixture = path.join(fixtureRoot, 'websites', 'nested', `fixture-${String(index).padStart(2, '0')}`);
+    mkdirSync(fixture, { recursive: true });
+    writeFileSync(path.join(fixture, 'index.html'), '<h1>Nested</h1>');
+  }
+  symlinkSync(externalRoot, path.join(fixtureRoot, 'solved'));
+
+  assert.deepEqual(resolveFixtureSearchRoots(fixtureRoot), [path.join(fixtureRoot, 'websites')]);
+  const plan = buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot });
+  assert.equal(plan.active_fixture_count, CANONICAL_FIXTURE_COUNT);
+  assert.equal(plan.solved_fixture_count, 0);
+  assert.equal(plan.fixture_count_matches_canonical, true);
+  assert.equal(plan.warnings.some((warning) => warning.code === 'canonical_fixture_count_drift'), false);
+  assert.equal(plan.fixture_selection.exclusions.some((row) => row.reason === 'missing_entrypoint'), false);
+  assert.ok(plan.fixture_selection.exclusions.some((row) => row.reason === 'root_symlink'));
 });
 
 test('fixture matrix operator rejects contradictory local and Lab routing', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2796,6 +2796,37 @@ test('fixture discovery rejects symlinked corpus roots and planning recursively 
   assert.ok(plan.fixture_selection.exclusions.some((row) => row.reason === 'root_symlink'));
 });
 
+test('top-level symlink fixture roots stay planning-empty and never stage an external corpus', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-top-level-symlink-root-'));
+  const externalRoot = path.join(root, 'external-fixtures');
+  const fixtureRoot = path.join(root, 'fixture-root');
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const outputDirectory = path.join(root, 'artifacts');
+  mkdirSync(path.join(externalRoot, 'external-site'), { recursive: true });
+  mkdirSync(staticSiteImporter, { recursive: true });
+  writeFileSync(path.join(externalRoot, 'external-site', 'index.html'), '<h1>External</h1>');
+  symlinkSync(externalRoot, fixtureRoot);
+
+  const plan = buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot });
+  assert.equal(plan.execution_eligible, false);
+  assert.equal(plan.fixture_selection.status, 'planning_empty');
+  assert.equal(plan.fixture_selection.exclusions[0].reason, 'root_symlink');
+  const dryRun = spawnSync(process.execPath, [path.join(packageRoot, 'tools', 'run-fixture-matrix.mjs'), '--static-site-importer', staticSiteImporter, '--fixture-root', fixtureRoot, '--dry-run'], { encoding: 'utf8' });
+  assert.equal(dryRun.status, 0, dryRun.stderr);
+  assert.equal(JSON.parse(dryRun.stdout).fixture_selection.exclusions[0].reason, 'root_symlink');
+  const execution = spawnSync(process.execPath, [path.join(packageRoot, 'tools', 'run-fixture-matrix.mjs'), '--static-site-importer', staticSiteImporter, '--fixture-root', fixtureRoot, '--skip-install', '--skip-sync'], { encoding: 'utf8' });
+  assert.equal(execution.status, 1);
+  assert.match(execution.stderr, /requires at least one executable fixture/);
+
+  const planned = await runFixtureMatrix({ fixtureRoot, outputDirectory, staticSiteImporterPath: staticSiteImporter, run: false });
+  assert.equal(planned.summary.fixture_count, 0);
+  assert.equal(existsSync(path.join(outputDirectory, 'external-site', 'artifact.json')), false);
+  await assert.rejects(
+    runFixtureMatrix({ fixtureRoot, outputDirectory, staticSiteImporterPath: staticSiteImporter, run: true }),
+    /requires at least one executable fixture/,
+  );
+});
+
 test('fixture matrix operator rejects contradictory local and Lab routing', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-routing-conflict-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -3,7 +3,7 @@
  */
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -2514,6 +2514,7 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   mkdirSync(staticSiteImporter, { recursive: true });
   for (let index = 1; index <= CANONICAL_FIXTURE_COUNT; index += 1) {
     mkdirSync(path.join(canonicalFixtureRoot, `fixture-${String(index).padStart(2, '0')}`), { recursive: true });
+    writeFileSync(path.join(canonicalFixtureRoot, `fixture-${String(index).padStart(2, '0')}`, 'index.html'), '<h1>Fixture</h1>');
   }
   writeFileSync(path.join(canonicalFixtureRoot, 'fixture-01', 'index.html'), '<h1>Target</h1>');
   const solvedFixtureRoot = path.join(corpusRoot, 'solved', 'solved-site');
@@ -2678,6 +2679,54 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   });
   assert.equal(visualGateOptOutPlan.visual_parity.gate, false);
   assert.ok(visualGateOptOutPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=0'));
+});
+
+test('fixture selection fails closed for execution and keeps empty dry-run planning explicit', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-empty-selection-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'missing-entrypoint'), { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'metadata-warning'), { recursive: true });
+  writeFileSync(path.join(fixtureRoot, 'metadata-warning', 'index.html'), '<h1>Fixture</h1>');
+  writeFileSync(path.join(fixtureRoot, 'metadata-warning', 'fixture.json'), '{');
+  symlinkSync(path.join(fixtureRoot, 'metadata-warning'), path.join(fixtureRoot, 'linked-fixture'));
+
+  const plan = buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot, tag: 'absent' });
+  assert.equal(plan.execution_eligible, false);
+  assert.equal(plan.fixture_selection.status, 'planning_empty');
+  assert.ok(plan.fixture_selection.exclusions.some((row) => row.reason === 'missing_entrypoint'));
+  assert.ok(plan.fixture_selection.exclusions.some((row) => row.reason === 'symlink'));
+  assert.ok(plan.fixture_selection.exclusions.some((row) => row.reason === 'filter_mismatch'));
+  assert.ok(plan.fixture_selection.diagnostics.some((row) => row.reason === 'malformed_metadata'));
+
+  const planned = await runFixtureMatrix({ fixtureRoot, outputDirectory: path.join(root, 'planned'), staticSiteImporterPath: staticSiteImporter, tag: 'absent', run: false });
+  assert.equal(planned.summary.fixture_count, 0);
+  await assert.rejects(
+    runFixtureMatrix({ fixtureRoot, outputDirectory: path.join(root, 'executed'), staticSiteImporterPath: staticSiteImporter, tag: 'absent', run: true }),
+    /requires at least one executable fixture/,
+  );
+});
+
+test('fixture selection reports one executable fixture and rejects typoed targets', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-one-selection-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'websites', 'valid-one'), { recursive: true });
+  writeFileSync(path.join(fixtureRoot, 'websites', 'valid-one', 'index.html'), '<h1>Fixture</h1>');
+
+  const plan = buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot });
+  assert.equal(plan.execution_eligible, true);
+  assert.equal(plan.fixture_count, 1);
+  assert.deepEqual(plan.fixture_selection.selected_fixture_ids, ['valid-one']);
+  assert.throws(
+    () => buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot, targetFixture: 'typo' }),
+    /--target-fixture "typo" was not found/,
+  );
+  const badRootPlan = buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot: path.join(root, 'missing') });
+  assert.equal(badRootPlan.execution_eligible, false);
+  assert.equal(badRootPlan.fixture_selection.exclusions[0].reason, 'root_missing');
 });
 
 test('fixture matrix operator rejects contradictory local and Lab routing', () => {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 /**
  * Internal dependencies
  */
-import { MAX_EXTRA_SURFACE_COUNT, normalizeSurfaceCoverageOptions, normalizeVisualAttributionOptions } from '../lib/fixture-matrix.mjs';
+import { MAX_EXTRA_SURFACE_COUNT, createFixtureMatrix, inspectFixtureDirectories, normalizeSurfaceCoverageOptions, normalizeVisualAttributionOptions } from '../lib/fixture-matrix.mjs';
 
 export const RIG_ID = 'static-site-importer-fixture-matrix';
 export const SOLVED_ONLY_LANE_ID = 'fixtures-solved-only/v1';
@@ -56,6 +56,12 @@ async function main() {
 
   if (options.dryRun) {
     process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return;
+  }
+
+  if (!plan.execution_eligible) {
+    process.stderr.write(`${plan.fixture_selection.message}\n`);
+    process.exitCode = 1;
     return;
   }
 
@@ -144,8 +150,24 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.complexity ? { SSI_FIXTURE_MATRIX_COMPLEXITY: String(options.complexity) } : {}),
     ...(options.maxComplexity ? { SSI_FIXTURE_MATRIX_MAX_COMPLEXITY: String(options.maxComplexity) } : {}),
   };
-  const corpusCounts = countCorpusFixtureDirectories(options.fixtureRoot);
-  const fixtureCount = options.fixtureIds.length || corpusCounts.total;
+  const corpusCounts = inspectCorpusFixtures(options.fixtureRoot);
+  let matrix = { fixtures: [], count: 0 };
+  try {
+    matrix = createFixtureMatrix({
+      fixture_root: options.fixtureRoot,
+      fixture_ids: options.fixtureIds,
+      fixture_corpus: options.solvedOnly ? 'solved' : undefined,
+      class: options.class,
+      tag: options.tag,
+      capabilities: options.capability || options.capabilities,
+      risk_profile: options.riskProfile,
+      complexity: options.complexity,
+      max_complexity: options.maxComplexity,
+    });
+  } catch (error) {
+    if (corpusCounts.inspections.active.exclusions[0]?.reason !== 'root_missing') throw error;
+  }
+  const fixtureCount = matrix.count;
   const activeFixtureCount = corpusCounts.active;
   const solvedFixtureCount = corpusCounts.solved;
   const warnings = [
@@ -171,9 +193,11 @@ export function buildFixtureMatrixRunPlan(input) {
     fixture_count: fixtureCount,
     active_fixture_count: activeFixtureCount,
     solved_fixture_count: solvedFixtureCount,
-    selected_active_fixture_count: options.selectedActiveFixtureCount,
-    selected_solved_fixture_count: options.selectedSolvedFixtureCount,
+    selected_active_fixture_count: matrix.fixtures.filter((fixture) => fixture.fixture_corpus === 'active').length,
+    selected_solved_fixture_count: matrix.fixtures.filter((fixture) => fixture.fixture_corpus === 'solved').length,
     selected_fixture_count: fixtureCount,
+    execution_eligible: fixtureCount > 0,
+    fixture_selection: fixtureSelectionSummary({ matrix, corpusCounts, options }),
     ...(options.laneIdentity ? { lane_identity: options.laneIdentity } : {}),
     canonical_fixture_count: CANONICAL_FIXTURE_COUNT,
     fixture_count_matches_canonical: activeFixtureCount === CANONICAL_FIXTURE_COUNT,
@@ -332,7 +356,7 @@ function resolveFixtureSelection({ fixtureRoot, targetFixture, promotionGate, so
   const target = String(targetFixture || '').trim();
   if (solvedOnly) {
     assertSolvedOnlySelectionIsCompatible(input);
-    const solvedFixtureIds = fixtureDirectoryNames(path.join(fixtureRoot, 'solved'));
+    const solvedFixtureIds = inspectFixtureDirectories(path.join(fixtureRoot, 'solved')).selected_ids;
     if (!solvedFixtureIds.length) {
       throw new Error(`--solved-only requires at least one valid fixture under ${path.join(fixtureRoot, 'solved')}.`);
     }
@@ -364,10 +388,10 @@ function resolveFixtureSelection({ fixtureRoot, targetFixture, promotionGate, so
   }
 
   const activeRoot = path.join(fixtureRoot, 'websites');
-  if (!fs.existsSync(path.join(activeRoot, target, 'index.html'))) {
+  if (!inspectFixtureDirectories(activeRoot).selected_ids.includes(target)) {
     throw new Error(`--target-fixture "${target}" was not found under ${activeRoot}.`);
   }
-  const solvedFixtureIds = promotionGate ? fixtureDirectoryNames(path.join(fixtureRoot, 'solved')) : [];
+  const solvedFixtureIds = promotionGate ? inspectFixtureDirectories(path.join(fixtureRoot, 'solved')).selected_ids : [];
   return {
     fixtureIds: [...new Set([target, ...solvedFixtureIds])].sort(),
     targetFixture: target,
@@ -394,17 +418,6 @@ function assertSolvedOnlySelectionIsCompatible(input) {
   ].filter(([key]) => input[key] !== undefined && input[key] !== false).map(([, flag]) => flag);
   if (incompatible.length) {
     throw new Error(`--solved-only selects the complete fixtures/solved corpus and cannot be combined with ${incompatible.join(', ')}.`);
-  }
-}
-
-function fixtureDirectoryNames(fixtureRoot) {
-  try {
-    return fs.readdirSync(fixtureRoot, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.') && fs.existsSync(path.join(fixtureRoot, entry.name, 'index.html')))
-      .map((entry) => entry.name)
-      .sort();
-  } catch {
-    return [];
   }
 }
 
@@ -899,31 +912,41 @@ function parseArgs(args) {
   return options;
 }
 
-function countCorpusFixtureDirectories(fixtureRoot) {
+function inspectCorpusFixtures(fixtureRoot) {
   const activeRoot = path.join(fixtureRoot, 'websites');
   const solvedRoot = path.join(fixtureRoot, 'solved');
-  const active = fs.existsSync(activeRoot) && fs.statSync(activeRoot).isDirectory()
-    ? countTopLevelFixtureDirectories(activeRoot)
-    : countTopLevelFixtureDirectories(fixtureRoot);
-  const solved = fs.existsSync(solvedRoot) && fs.statSync(solvedRoot).isDirectory()
-    ? fixtureDirectoryNames(solvedRoot).length
-    : 0;
+  const activeInspection = inspectFixtureDirectories(fs.existsSync(activeRoot) && fs.statSync(activeRoot).isDirectory() ? activeRoot : fixtureRoot);
+  const solvedInspection = inspectFixtureDirectories(solvedRoot);
   return {
-    active,
-    solved,
-    total: active + solved,
-    active_root: fs.existsSync(activeRoot) && fs.statSync(activeRoot).isDirectory() ? activeRoot : fixtureRoot,
+    active: activeInspection.executable_count,
+    solved: solvedInspection.executable_count,
+    total: activeInspection.executable_count + solvedInspection.executable_count,
+    active_root: activeInspection.root,
+    inspections: { active: activeInspection, solved: solvedInspection },
   };
 }
 
-function countTopLevelFixtureDirectories(fixtureRoot) {
-  try {
-    return fs.readdirSync(fixtureRoot, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
-      .length;
-  } catch {
-    return 0;
+function fixtureSelectionSummary({ matrix, corpusCounts, options }) {
+  const selectedIds = matrix.fixtures.map((fixture) => fixture.id).sort();
+  const exclusions = Object.values(corpusCounts.inspections)
+    .flatMap((inspection) => inspection.exclusions.map((exclusion) => ({ ...exclusion, root: inspection.root })))
+    .slice(0, 50);
+  const diagnostics = Object.values(corpusCounts.inspections)
+    .flatMap((inspection) => (inspection.diagnostics || []).map((diagnostic) => ({ ...diagnostic, root: inspection.root })))
+    .slice(0, 50);
+  if (matrix.count === 0 && (options.class || options.tag || options.capability || options.capabilities || options.riskProfile || options.complexity || options.maxComplexity || options.fixtureIds.length)) {
+    exclusions.push({ id: '', reason: 'filter_mismatch' });
   }
+  return {
+    status: matrix.count > 0 ? 'executable' : 'planning_empty',
+    selected_fixture_ids: selectedIds.slice(0, 50),
+    selected_fixture_ids_truncated: selectedIds.length > 50,
+    exclusions: exclusions.slice(0, 50),
+    diagnostics,
+    message: matrix.count > 0
+      ? `Selected ${matrix.count} executable fixture${matrix.count === 1 ? '' : 's'} before Homeboy handoff.`
+      : 'Fixture matrix execution requires at least one executable fixture; this is an explicit empty planning result and cannot be handed to Homeboy.',
+  };
 }
 
 function readJson(file) {
@@ -1008,12 +1031,17 @@ function printHelp() {
   process.stdout.write(`Usage: node tools/run-fixture-matrix.mjs --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nExecution modes:\n  --local                             Passes --placement local to homeboy bench.\n  --runner <id>                       Passes --runner <id> to homeboy bench (implies Lab placement).\n  --lab-only                          Passes --placement lab without selecting a runner.\n  --allow-local-fallback              Passes --placement lab-or-local to homeboy bench.\n  no routing flags                    Passes --placement auto to homeboy bench.\n\nRules:\n  --runner local                      Alias for --local.\n  --local cannot be combined with --runner <remote>, --lab-only, or --allow-local-fallback.\n  --lab-only cannot be combined with --allow-local-fallback.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n    --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures, which discovers both fixtures/websites and fixtures/solved.
 \n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 2, hard-capped at 16.\n  --target-fixture <id>               Run one active fixture for the fast inner loop.\n  --promotion-gate                    Run the target plus every solved fixture, one per batch, and require solved_candidate for all.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind upstream.\n  --allow-local-fallback              Permit selected Lab runner fallback to local execution.\n  --allow-dirty-lab-workspace         Permit reusing/overwriting a dirty Lab workspace.\n  --detach-after-handoff              Return after runner daemon accepts the job.\n  --dry-run                           Print the plan without running Homeboy.\n  --skip-install                      Skip rig install.\n  --skip-sync                         Skip rig sync.\n  --no-editor-validation              Omit editor block validation.\n  --no-visual-parity                  Omit visual parity capture.\n  --no-visual-parity-gate             Capture visual parity without gating.\n  --help                              Show this help.\n`);
   printSolvedOnlyHelp();
+  printSurfaceCoverageHelp();
   printDependencyOverlayReferenceHelp();
   printVisualAttributionHelp();
 }
 
 function printSolvedOnlyHelp() {
   process.stdout.write('  --solved-only                       Run every valid fixtures/solved fixture, one per batch, and require solved_candidate for all.\n');
+}
+
+function printSurfaceCoverageHelp() {
+  process.stdout.write('  --surface-coverage <n>              Capture front page plus up to n secondary HTML surfaces per fixture.\n  --max-extra-surfaces <n>            Cap secondary surfaces when coverage is boolean/object-driven.\n');
 }
 
 function printDependencyOverlayReferenceHelp() {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -152,7 +152,8 @@ export function buildFixtureMatrixRunPlan(input) {
   };
   const corpusCounts = inspectCorpusFixtures(options.fixtureRoot);
   let matrix = { fixtures: [], count: 0 };
-  try {
+  if (corpusCounts.inspections.active.exclusions[0]?.reason !== 'root_symlink') {
+    try {
     matrix = createFixtureMatrix({
       fixture_root: options.fixtureRoot,
       fixture_ids: options.fixtureIds,
@@ -164,8 +165,9 @@ export function buildFixtureMatrixRunPlan(input) {
       complexity: options.complexity,
       max_complexity: options.maxComplexity,
     });
-  } catch (error) {
-    if (!['root_missing', 'root_not_directory'].includes(corpusCounts.inspections.active.exclusions[0]?.reason)) throw error;
+    } catch (error) {
+      if (!['root_missing', 'root_not_directory'].includes(corpusCounts.inspections.active.exclusions[0]?.reason)) throw error;
+    }
   }
   const fixtureCount = matrix.count;
   const activeFixtureCount = corpusCounts.active;

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -154,17 +154,17 @@ export function buildFixtureMatrixRunPlan(input) {
   let matrix = { fixtures: [], count: 0 };
   if (corpusCounts.inspections.active.exclusions[0]?.reason !== 'root_symlink') {
     try {
-    matrix = createFixtureMatrix({
-      fixture_root: options.fixtureRoot,
-      fixture_ids: options.fixtureIds,
-      fixture_corpus: options.solvedOnly ? 'solved' : undefined,
-      class: options.class,
-      tag: options.tag,
-      capabilities: options.capability || options.capabilities,
-      risk_profile: options.riskProfile,
-      complexity: options.complexity,
-      max_complexity: options.maxComplexity,
-    });
+      matrix = createFixtureMatrix({
+        fixture_root: options.fixtureRoot,
+        fixture_ids: options.fixtureIds,
+        fixture_corpus: options.solvedOnly ? 'solved' : undefined,
+        class: options.class,
+        tag: options.tag,
+        capabilities: options.capability || options.capabilities,
+        risk_profile: options.riskProfile,
+        complexity: options.complexity,
+        max_complexity: options.maxComplexity,
+      });
     } catch (error) {
       if (!['root_missing', 'root_not_directory'].includes(corpusCounts.inspections.active.exclusions[0]?.reason)) throw error;
     }

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 /**
  * Internal dependencies
  */
-import { MAX_EXTRA_SURFACE_COUNT, createFixtureMatrix, inspectFixtureDirectories, normalizeSurfaceCoverageOptions, normalizeVisualAttributionOptions } from '../lib/fixture-matrix.mjs';
+import { MAX_EXTRA_SURFACE_COUNT, createFixtureMatrix, discoverFixtures, inspectFixtureDirectories, normalizeSurfaceCoverageOptions, normalizeVisualAttributionOptions } from '../lib/fixture-matrix.mjs';
 
 export const RIG_ID = 'static-site-importer-fixture-matrix';
 export const SOLVED_ONLY_LANE_ID = 'fixtures-solved-only/v1';
@@ -165,7 +165,7 @@ export function buildFixtureMatrixRunPlan(input) {
       max_complexity: options.maxComplexity,
     });
   } catch (error) {
-    if (corpusCounts.inspections.active.exclusions[0]?.reason !== 'root_missing') throw error;
+    if (!['root_missing', 'root_not_directory'].includes(corpusCounts.inspections.active.exclusions[0]?.reason)) throw error;
   }
   const fixtureCount = matrix.count;
   const activeFixtureCount = corpusCounts.active;
@@ -356,7 +356,7 @@ function resolveFixtureSelection({ fixtureRoot, targetFixture, promotionGate, so
   const target = String(targetFixture || '').trim();
   if (solvedOnly) {
     assertSolvedOnlySelectionIsCompatible(input);
-    const solvedFixtureIds = inspectFixtureDirectories(path.join(fixtureRoot, 'solved')).selected_ids;
+    const solvedFixtureIds = discoverExecutableFixtureIds(path.join(fixtureRoot, 'solved'));
     if (!solvedFixtureIds.length) {
       throw new Error(`--solved-only requires at least one valid fixture under ${path.join(fixtureRoot, 'solved')}.`);
     }
@@ -388,10 +388,10 @@ function resolveFixtureSelection({ fixtureRoot, targetFixture, promotionGate, so
   }
 
   const activeRoot = path.join(fixtureRoot, 'websites');
-  if (!inspectFixtureDirectories(activeRoot).selected_ids.includes(target)) {
+  if (!discoverExecutableFixtureIds(activeRoot).includes(target)) {
     throw new Error(`--target-fixture "${target}" was not found under ${activeRoot}.`);
   }
-  const solvedFixtureIds = promotionGate ? inspectFixtureDirectories(path.join(fixtureRoot, 'solved')).selected_ids : [];
+  const solvedFixtureIds = promotionGate ? discoverExecutableFixtureIds(path.join(fixtureRoot, 'solved')) : [];
   return {
     fixtureIds: [...new Set([target, ...solvedFixtureIds])].sort(),
     targetFixture: target,
@@ -418,6 +418,14 @@ function assertSolvedOnlySelectionIsCompatible(input) {
   ].filter(([key]) => input[key] !== undefined && input[key] !== false).map(([, flag]) => flag);
   if (incompatible.length) {
     throw new Error(`--solved-only selects the complete fixtures/solved corpus and cannot be combined with ${incompatible.join(', ')}.`);
+  }
+}
+
+function discoverExecutableFixtureIds(fixtureRoot) {
+  try {
+    return discoverFixtures(fixtureRoot, { maxDepth: 2 }).map((fixture) => fixture.id);
+  } catch {
+    return [];
   }
 }
 
@@ -1041,7 +1049,7 @@ function printSolvedOnlyHelp() {
 }
 
 function printSurfaceCoverageHelp() {
-  process.stdout.write('  --surface-coverage <n>              Capture front page plus up to n secondary HTML surfaces per fixture.\n  --max-extra-surfaces <n>            Cap secondary surfaces when coverage is boolean/object-driven.\n');
+  process.stdout.write('  --surface-coverage <n>              Capture front page plus up to n secondary HTML surfaces per fixture.\n  --max-extra-surfaces <n>            Cap secondary surfaces when coverage is boolean/object-driven.\n  Empty selections                    Execution is refused; --dry-run prints bounded selection diagnostics.\n');
 }
 
 function printDependencyOverlayReferenceHelp() {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 /**
  * Internal dependencies
  */
-import { MAX_EXTRA_SURFACE_COUNT, createFixtureMatrix, discoverFixtures, inspectFixtureDirectories, normalizeSurfaceCoverageOptions, normalizeVisualAttributionOptions } from '../lib/fixture-matrix.mjs';
+import { MAX_EXTRA_SURFACE_COUNT, createFixtureMatrix, discoverFixtures, inspectFixtureDirectories, normalizeSurfaceCoverageOptions, normalizeVisualAttributionOptions, resolveFixtureSearchRoots } from '../lib/fixture-matrix.mjs';
 
 export const RIG_ID = 'static-site-importer-fixture-matrix';
 export const SOLVED_ONLY_LANE_ID = 'fixtures-solved-only/v1';
@@ -921,10 +921,15 @@ function parseArgs(args) {
 }
 
 function inspectCorpusFixtures(fixtureRoot) {
-  const activeRoot = path.join(fixtureRoot, 'websites');
-  const solvedRoot = path.join(fixtureRoot, 'solved');
-  const activeInspection = inspectFixtureDirectories(fs.existsSync(activeRoot) && fs.statSync(activeRoot).isDirectory() ? activeRoot : fixtureRoot);
-  const solvedInspection = inspectFixtureDirectories(solvedRoot);
+  const resolvedRoot = path.resolve(fixtureRoot);
+  const searchRoots = resolveFixtureSearchRoots(resolvedRoot);
+  const websitesRoot = path.join(resolvedRoot, 'websites');
+  const solvedRoot = path.join(resolvedRoot, 'solved');
+  const activeRoot = searchRoots.includes(websitesRoot) ? websitesRoot : resolvedRoot;
+  const activeInspection = inspectFixtureDirectories(activeRoot, { maxDepth: 2 });
+  const solvedInspection = activeRoot === websitesRoot
+    ? inspectFixtureDirectories(solvedRoot, { maxDepth: 2 })
+    : { root: solvedRoot, selected_ids: [], executable_count: 0, exclusions: [], diagnostics: [] };
   return {
     active: activeInspection.executable_count,
     solved: solvedInspection.executable_count,


### PR DESCRIPTION
## Summary
- fail execution and promotion lanes closed when no executable fixtures are selected
- report bounded selected IDs, exclusions, metadata diagnostics, and browser-surface counts before Homeboy/Lab handoff
- align wrapper counts with discovery and expose surface coverage flags in wrapper help

Closes #759

## Tests
- `npm run test:fixture-matrix`
- `npm test`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent drafted substantive portions of this change. Chris remains responsible for every line.