### PR TITLE
Fix fixture matrix evidence attribution

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -195,6 +195,7 @@ export async function runFixtureMatrix(options) {
   performance.artifact_writing_ms = elapsedMs(artifactWriteStartedAt);
   const recipe = buildFixtureMatrixRecipe({
     matrix,
+    runId: matrix.id,
     artifactsDirectory: outputDirectory,
     playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
     wordpressVersion: options.wordpressVersion,
@@ -379,6 +380,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
   });
   const batchRecipe = buildFixtureMatrixRecipe({
     matrix: batchMatrix,
+    runId: batchMatrix.id,
     artifactsDirectory: outputDirectory,
     playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
     wordpressVersion: options.wordpressVersion,

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -467,6 +467,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     codeboxError: batchError,
     visualParity: visualParityGateInput(options),
     liveWpParity: liveWpParityCollectorInput(options),
+    dependencyOverrides: prepareDependencyOverrides(options),
   });
   const visualCompare = materializeVisualCompareArtifacts({
     result: batchResult,

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -196,6 +196,7 @@ export async function runFixtureMatrix(options) {
   const recipe = buildFixtureMatrixRecipe({
     matrix,
     runId: matrix.id,
+    attemptId: 'primary',
     artifactsDirectory: outputDirectory,
     playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
     wordpressVersion: options.wordpressVersion,
@@ -381,6 +382,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
   const batchRecipe = buildFixtureMatrixRecipe({
     matrix: batchMatrix,
     runId: batchMatrix.id,
+    attemptId: batchSuffix,
     artifactsDirectory: outputDirectory,
     playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
     wordpressVersion: options.wordpressVersion,
@@ -467,6 +469,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     outputFile,
     codeboxOutput: batchRuntime?.json,
     codeboxError: batchError,
+    sidecarAttemptId: batchSuffix,
     visualParity: visualParityGateInput(options),
     liveWpParity: liveWpParityCollectorInput(options),
     dependencyOverrides: prepareDependencyOverrides(options),

--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -196,7 +196,7 @@ export async function runFixtureMatrix(options) {
   const recipe = buildFixtureMatrixRecipe({
     matrix,
     runId: matrix.id,
-    attemptId: 'primary',
+    attemptId: `plan-${matrix.id}`,
     artifactsDirectory: outputDirectory,
     playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
     wordpressVersion: options.wordpressVersion,
@@ -463,6 +463,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       batch_output: fileBytes(outputFile),
     },
   });
+  materializeMaterializationSidecars({ fixtures, outputDirectory, codeboxArtifactsDirectory, attemptId: batchSuffix });
   const batchResult = collectFixtureMatrixRunResults({
     matrix: batchMatrix,
     outputDirectory,
@@ -564,6 +565,45 @@ function createFixtureMatrixProgress(matrix, options) {
 
 function batchInactivityTimeoutMs(options) {
   return positiveInteger(options.batchInactivityTimeoutMs || options.batch_inactivity_timeout_ms, DEFAULT_RECIPE_INACTIVITY_TIMEOUT_MS);
+}
+
+// Declared typed artifacts leave the guest filesystem through WP Codebox's
+// --artifacts tree. Materialize only an identity-matching export into the
+// fixture directory consumed by run intake.
+export function materializeMaterializationSidecars({ fixtures = [], outputDirectory, codeboxArtifactsDirectory, attemptId }) {
+  const root = path.resolve(codeboxArtifactsDirectory || '');
+  const output = path.resolve(outputDirectory || '');
+  if (!root || !output || !fs.existsSync(root)) return [];
+  const exported = new Map();
+  for (const filePath of runtimeArtifactFiles(root)) {
+    if (filePath.endsWith('.json') && fs.statSync(filePath).size <= 32 * 1024) {
+      try {
+        const sidecar = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        if (sidecar?.schema === 'static-site-importer/materialization-runtime-sidecar/v1' && sidecar.attempt_id === attemptId && typeof sidecar.fixture_id === 'string') {
+          exported.set(sidecar.fixture_id, filePath);
+        }
+      } catch {
+        // Declared artifact output can include unrelated or partial JSON files.
+      }
+    }
+  }
+  for (const fixture of fixtures) {
+    const source = exported.get(fixture.id);
+    if (!source) continue;
+    const target = path.join(output, fixture.id, `materialization-receipt--${attemptId}.json`);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(source, target);
+  }
+  return [...exported.entries()].map(([fixture_id, source]) => ({ fixture_id, source }));
+}
+
+function runtimeArtifactFiles(directory, files = []) {
+  for (const entry of safeReadDirectory(directory)) {
+    const filePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) runtimeArtifactFiles(filePath, files);
+    if (entry.isFile()) files.push(filePath);
+  }
+  return files;
 }
 
 export function materializeEditorCanvasArtifacts(input = {}) {

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -63,13 +63,13 @@ export function collectFixtureMatrixRunResults(input = {}) {
       ...runtimePayloads.filter((payload) => fixtureIdentity(payload) === fixture.id),
       ...readFixturePayloadFiles(fixtureArtifactsDirectory),
     ];
-    return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity });
+    return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity, dependencyOverrides: input.dependencyOverrides || input.dependency_overrides });
   });
 
   return normalizeFixtureMatrixResult({ matrix, results, slow_fixtures: slowFixtures });
 }
 
-function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity }) {
+function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity, dependencyOverrides }) {
   const merged = mergeObjects(payloads);
   const visualParityOptions = { ...visualParity, fixtureArtifactsDirectory };
   const diagnostics = collectFixtureDiagnostics(merged, { visualParity: visualParityOptions });
@@ -117,7 +117,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     visual_diff_cause_summary: visualParityArtifacts?.visual_diff_cause_summary || null,
     visual_diff_classification: visualParityArtifacts?.visual_diff_classification || null,
     live_wp_parity: liveWpParityResult,
-    matrix_evidence: collectMatrixEvidence(merged),
+    matrix_evidence: collectMatrixEvidence(merged, { dependencyOverrides }),
     svg_font_embedding_evidence: merged.svg_font_embedding_evidence || merged.svgFontEmbeddingEvidence || null,
     raw: { payloads },
   });
@@ -168,13 +168,16 @@ const MATERIALIZATION_PLAN_ASSET_LIMIT = 50;
 
 // Keep enough runtime evidence to attribute CSS/JS behavior without retaining
 // arbitrary source payloads in matrix artifacts.
-export function collectMatrixEvidence(payload) {
+export function collectMatrixEvidence(payload, options = {}) {
   const fixtureDiagnostics = objectValue(payload.fixture_diagnostics || payload.fixtureDiagnostics);
   const blocksEngine = objectValue(payload.blocks_engine || payload.blocksEngine || payload.import_report?.blocks_engine || payload.importReport?.blocks_engine || payload.report?.blocks_engine || fixtureDiagnostics.blocks_engine || fixtureDiagnostics.blocksEngine);
   const transformer = objectValue(blocksEngine.transformer || blocksEngine.transformer_provenance || blocksEngine.transformerProvenance);
   const plan = objectValue(blocksEngine.wordpress_site_plan || blocksEngine.wordpressSitePlan);
   const importReport = objectValue(payload.import_report || payload.importReport || payload.report);
   const materializationReceipt = objectValue(payload.materialization_receipt || payload.materializationReceipt || importReport.materialization_receipt || importReport.materializationReceipt || fixtureDiagnostics.materialization_receipt || fixtureDiagnostics.materializationReceipt);
+  const providerAdapter = objectValue(payload.provider_adapter || payload.providerAdapter || importReport.provider_adapter || importReport.providerAdapter || fixtureDiagnostics.provider_adapter || fixtureDiagnostics.providerAdapter);
+  const captureContract = objectValue(payload.capture_contract || payload.captureContract || payload.visual_capture || payload.visualCapture || fixtureDiagnostics.capture_contract || fixtureDiagnostics.captureContract);
+  const override = objectValue(options.dependencyOverrides || options.dependency_overrides).blocks_engine_php_transformer || objectValue(options.dependencyOverrides || options.dependency_overrides).blocksEnginePhpTransformer || {};
   const completedMaterialization = objectValue(materializationReceipt.completed);
   const generatedTheme = objectValue(importReport.generated_theme || importReport.generatedTheme || payload.generated_theme || payload.generatedTheme);
   const templateParts = normalizeArray(generatedTheme.template_parts || generatedTheme.templateParts)
@@ -207,6 +210,24 @@ export function collectMatrixEvidence(payload) {
     readiness: missing.length === 0 ? 'verified' : 'legacy_evidence_missing',
     missing,
     transformer: provenance,
+    lineage: compactObject({
+      development_override: Object.keys(override).length > 0 ? compactObject({
+        package: firstString([override.package]),
+        reference: firstString([override.reference]),
+      }) : undefined,
+      artifact: plan.schema === WORDPRESS_SITE_PLAN_SCHEMA ? { schema: plan.schema } : undefined,
+      provider_adapter: Object.keys(providerAdapter).length > 0 ? compactObject({
+        schema: firstString([providerAdapter.schema]),
+        status: firstString([providerAdapter.status, providerAdapter.result]),
+        provider: firstString([providerAdapter.provider, providerAdapter.name]),
+      }) : undefined,
+      capture: Object.keys(captureContract).length > 0 ? compactObject({
+        schema: firstString([captureContract.schema]),
+        status: firstString([captureContract.status, captureContract.result]),
+        source: firstString([captureContract.source]),
+        candidate: firstString([captureContract.candidate]),
+      }) : undefined,
+    }),
     wordpress_site_plan: compactObject({
       schema: plan.schema,
       asset_count: assetCount,

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -190,8 +190,8 @@ function correlationIdentity(value) {
 
 function sameCorrelation(left, right) {
   if (!left || !right) return false;
-  const shared = ['run_id', 'step_id', 'diagnostic_id'].filter((key) => left[key] && right[key]);
-  return shared.length > 0 && shared.every((key) => left[key] === right[key]);
+  const keys = ['run_id', 'step_id', 'diagnostic_id'].filter((key) => left[key] || right[key]);
+  return keys.length > 0 && keys.every((key) => left[key] && right[key] && left[key] === right[key]);
 }
 
 function lineageStatus(value) {
@@ -928,7 +928,7 @@ function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen) {
 }
 
 function hasPayloadData(value) {
-  return ['status', 'success', 'ok', 'passed', 'error', 'diagnostics', 'findings', 'summary', 'artifacts', 'upstream_gaps', 'runtime_target_gaps', 'blocks_engine', 'import_report', 'editor_canvas', 'editorCanvas', 'editor_open', 'editorOpen']
+  return ['status', 'success', 'ok', 'passed', 'error', 'diagnostics', 'findings', 'summary', 'artifacts', 'upstream_gaps', 'runtime_target_gaps', 'blocks_engine', 'import_report', 'provider_adapter', 'providerAdapter', 'capture_contract', 'captureContract', 'visual_capture', 'visualCapture', 'editor_canvas', 'editorCanvas', 'editor_open', 'editorOpen']
     .some((key) => Object.hasOwn(value, key));
 }
 

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -639,11 +639,18 @@ function readMaterializationSidecar(directory, fixtureId, runId, attemptId) {
 
 function validSidecar(row) {
   const receipt = objectValue(row.receipt);
-  const allowed = ['schema', 'fixture_id', 'run_id', 'step_id', 'attempt_id', 'artifact_sha256', 'provenance', 'receipt', 'content_sha256'];
+  const allowed = ['schema', 'fixture_id', 'run_id', 'step_id', 'attempt_id', 'artifact_sha256', 'provenance', 'durability', 'receipt', 'content_sha256'];
   if (Object.keys(row).some((key) => !allowed.includes(key))) return false;
   if (row.schema !== MATERIALIZATION_SIDECAR_SCHEMA || !safeToken(row.fixture_id, 80) || !safeToken(row.run_id, 160) || row.step_id !== 'import' || !safeToken(row.attempt_id, 80) || !sha256(row.artifact_sha256) || !sha256(row.content_sha256)) return false;
-  if (!validProvenance(row.provenance) || !validReceipt(receipt)) return false;
+  if (!validProvenance(row.provenance) || !validDurability(row.durability) || !validReceipt(receipt)) return false;
   return true;
+}
+
+function validDurability(value) {
+  const row = objectValue(value);
+  return Object.keys(row).length === 2
+    && ['available', 'unavailable'].includes(row.file_fsync)
+    && ['attempted', 'unavailable'].includes(row.directory_fsync);
 }
 
 function validProvenance(value) {

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -9,6 +9,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 
 /**
  * Internal dependencies
@@ -59,17 +60,19 @@ export function collectFixtureMatrixRunResults(input = {}) {
   const liveWpParity = normalizeLiveWpParityCollectorOptions(input.liveWpParity || input.live_wp_parity);
   const results = matrix.fixtures.map((fixture) => {
     const fixtureArtifactsDirectory = path.join(outputDirectory, fixture.id);
+    const sidecar = readMaterializationSidecar(fixtureArtifactsDirectory, fixture.id, matrix.id);
     const payloads = [
       ...runtimePayloads.filter((payload) => fixtureIdentity(payload) === fixture.id),
       ...readFixturePayloadFiles(fixtureArtifactsDirectory),
+      ...(sidecar.status === 'verified' ? [{ fixture_id: fixture.id, materialization_runtime_sidecar: sidecar.payload, materialization_receipt: sidecar.payload.receipt }] : []),
     ];
-    return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity, dependencyOverrides: input.dependencyOverrides || input.dependency_overrides });
+    return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity, dependencyOverrides: input.dependencyOverrides || input.dependency_overrides, sidecar });
   });
 
   return normalizeFixtureMatrixResult({ matrix, results, slow_fixtures: slowFixtures });
 }
 
-function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity, dependencyOverrides }) {
+function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity, dependencyOverrides, sidecar }) {
   const merged = mergeObjects(payloads);
   const visualParityOptions = { ...visualParity, fixtureArtifactsDirectory };
   const diagnostics = attachDiagnosticLineage(collectFixtureDiagnostics(merged, { visualParity: visualParityOptions }), payloads);
@@ -117,7 +120,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     visual_diff_cause_summary: visualParityArtifacts?.visual_diff_cause_summary || null,
     visual_diff_classification: visualParityArtifacts?.visual_diff_classification || null,
     live_wp_parity: liveWpParityResult,
-    matrix_evidence: collectMatrixEvidence(merged, { dependencyOverrides }),
+    matrix_evidence: collectMatrixEvidence(merged, { dependencyOverrides, sidecar }),
     svg_font_embedding_evidence: merged.svg_font_embedding_evidence || merged.svgFontEmbeddingEvidence || null,
     raw: { payloads },
   });
@@ -238,6 +241,7 @@ export function collectMatrixEvidence(payload, options = {}) {
   const materializationReceipt = objectValue(payload.materialization_receipt || payload.materializationReceipt || importReport.materialization_receipt || importReport.materializationReceipt || fixtureDiagnostics.materialization_receipt || fixtureDiagnostics.materializationReceipt);
   const providerAdapter = objectValue(payload.provider_adapter || payload.providerAdapter || importReport.provider_adapter || importReport.providerAdapter || fixtureDiagnostics.provider_adapter || fixtureDiagnostics.providerAdapter);
   const captureContract = objectValue(payload.capture_contract || payload.captureContract || payload.visual_capture || payload.visualCapture || fixtureDiagnostics.capture_contract || fixtureDiagnostics.captureContract);
+  const sidecar = options.sidecar || { status: 'absent' };
   const override = objectValue(options.dependencyOverrides || options.dependency_overrides).blocks_engine_php_transformer || objectValue(options.dependencyOverrides || options.dependency_overrides).blocksEnginePhpTransformer || {};
   const completedMaterialization = objectValue(materializationReceipt.completed);
   const generatedTheme = objectValue(importReport.generated_theme || importReport.generatedTheme || payload.generated_theme || payload.generatedTheme);
@@ -305,6 +309,17 @@ export function collectMatrixEvidence(payload, options = {}) {
       ...(materializationReceipt.block_provenance_count !== undefined || materializationReceipt.blockProvenanceCount !== undefined ? { block_provenance_count: Number.isFinite(Number(materializationReceipt.block_provenance_count ?? materializationReceipt.blockProvenanceCount)) ? Number(materializationReceipt.block_provenance_count ?? materializationReceipt.blockProvenanceCount) : blockProvenance.length } : {}),
       ...(materializationReceipt.block_provenance_truncated !== undefined || materializationReceipt.blockProvenanceTruncated !== undefined ? { block_provenance_truncated: Boolean(materializationReceipt.block_provenance_truncated ?? materializationReceipt.blockProvenanceTruncated) } : {}),
       ...(blockProvenance.length > 0 ? { block_provenance: blockProvenance } : {}),
+    }),
+    materialization_sidecar: compactObject({
+      status: sidecar.status,
+      schema: sidecar.payload?.schema,
+      content_sha256: sidecar.payload?.content_sha256,
+      artifact_sha256: sidecar.payload?.artifact_sha256,
+      provenance: sidecar.payload?.provenance,
+      provider_totals: sidecar.payload?.receipt?.provider_totals,
+      computed_layout_totals: sidecar.payload?.receipt?.computed_layout_totals,
+      truncation: sidecar.payload?.receipt?.truncated,
+      ...(sidecar.status !== 'verified' && sidecar.status !== 'absent' ? { reason: sidecar.status } : {}),
     }),
     template_parts: templateParts,
   };
@@ -584,13 +599,47 @@ function findingPacketDiagnostic(packet) {
 
 function collectFixtureArtifactRefs(payloads, fixtureArtifactsDirectory) {
   const refs = normalizeArray(payloads).flatMap(collectPayloadArtifactRefs);
-  for (const fileName of ['artifact.json', 'validation-result.json', 'import-report.json']) {
+  for (const fileName of ['artifact.json', 'validation-result.json', 'import-report.json', 'materialization-receipt.json']) {
     const filePath = path.join(fixtureArtifactsDirectory, fileName);
     if (fs.existsSync(filePath)) {
       refs.push(artifactRef(fileName.replace(/\.json$/, ''), filePath, fileName === 'artifact.json' ? 'input' : 'diagnostic'));
     }
   }
   return dedupeArtifactRefs(refs);
+}
+
+const MATERIALIZATION_SIDECAR_SCHEMA = 'static-site-importer/materialization-runtime-sidecar/v1';
+
+// Sidecars are written by the import command before its verbose JSON reaches a
+// capped transport. Validate both correlation and immutable fixture input before
+// allowing this compact evidence to replace any truncated command output.
+function readMaterializationSidecar(directory, fixtureId, runId) {
+  const filePath = path.join(directory, 'materialization-receipt.json');
+  if (!fs.existsSync(filePath)) return { status: 'missing', path: filePath };
+  let payload;
+  try {
+    payload = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return { status: 'malformed', path: filePath };
+  }
+  const row = objectValue(payload);
+  if (row.schema !== MATERIALIZATION_SIDECAR_SCHEMA || !objectValue(row.receipt).schema) return { status: 'malformed', path: filePath };
+  if (row.fixture_id !== fixtureId) return { status: 'cross_fixture', path: filePath };
+  if (row.run_id !== runId || row.step_id !== 'import') return { status: 'stale', path: filePath };
+  const artifactPath = path.join(directory, 'artifact.json');
+  if (!fs.existsSync(artifactPath) || row.artifact_sha256 !== fileSha256(artifactPath)) return { status: 'hash_mismatch', path: filePath };
+  const expectedContentHash = sidecarContentHash(row);
+  if (!row.content_sha256 || row.content_sha256 !== expectedContentHash) return { status: 'hash_mismatch', path: filePath };
+  return { status: 'verified', path: filePath, payload: row };
+}
+
+function sidecarContentHash(sidecar) {
+  const { content_sha256: _contentHash, ...unsigned } = sidecar;
+  return createHash('sha256').update(JSON.stringify(unsigned)).digest('hex');
+}
+
+function fileSha256(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
 }
 
 function collectPayloadArtifactRefs(payload) {

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -190,8 +190,8 @@ function correlationIdentity(value) {
 
 function sameCorrelation(left, right) {
   if (!left || !right) return false;
-  if (left.run_id && right.run_id) return left.run_id === right.run_id;
-  return ['step_id', 'diagnostic_id'].some((key) => left[key] && right[key] && left[key] === right[key]);
+  const shared = ['run_id', 'step_id', 'diagnostic_id'].filter((key) => left[key] && right[key]);
+  return shared.length > 0 && shared.every((key) => left[key] === right[key]);
 }
 
 function lineageStatus(value) {

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -72,7 +72,7 @@ export function collectFixtureMatrixRunResults(input = {}) {
 function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity, dependencyOverrides }) {
   const merged = mergeObjects(payloads);
   const visualParityOptions = { ...visualParity, fixtureArtifactsDirectory };
-  const diagnostics = collectFixtureDiagnostics(merged, { visualParity: visualParityOptions });
+  const diagnostics = attachDiagnosticLineage(collectFixtureDiagnostics(merged, { visualParity: visualParityOptions }), payloads);
   const visualParityArtifacts = collectVisualParityArtifacts(merged, visualParityOptions);
   const visualParityComparisons = collectVisualParityComparisons(payloads, visualParityOptions);
   // Best-effort live-WP parity (opt-in). Returns null when disabled or when the
@@ -136,6 +136,67 @@ function collectVisualParityComparisons(payloads, visualParityOptions) {
       }));
     })
     .filter((comparison) => comparison.visual_parity_artifacts);
+}
+
+// Provider and capture results can be retried within one fixture run. Only join
+// them to a diagnostic when their bounded run/step/diagnostic identity matches.
+function attachDiagnosticLineage(diagnostics, payloads) {
+  return diagnostics.map((diagnostic) => {
+    const row = objectValue(diagnostic);
+    const correlation = correlationIdentity(row);
+    const evidence = payloads.flatMap((payload) => correlatedLineage(payload, correlation));
+    const lineage = evidence.reduce((result, item) => ({ ...result, ...item }), {});
+    const boundary = firstString([row.attribution_boundary, row.attributionBoundary, inferredDiagnosticBoundary(row)]);
+    return {
+      ...row,
+      ...(boundary ? { attribution_boundary: boundary } : {}),
+      ...(Object.keys(lineage).length > 0 ? { attribution_evidence: lineage } : {}),
+    };
+  });
+}
+
+function inferredDiagnosticBoundary(diagnostic) {
+  const kind = String(diagnostic.kind || diagnostic.code || '').toLowerCase();
+  const lossClass = String(diagnostic.loss_class || diagnostic.lossClass || '').toLowerCase();
+  if (['editor_block_invalid', 'invalid_block_content', 'low_native_conversion', 'runtime_target_gap'].includes(kind) || ['editor_block_invalid', 'invalid_block_content', 'low_native_conversion', 'runtime_target_gap'].includes(lossClass)) return 'transform';
+  if (['importer_materialization_bug', 'missing_asset', 'dropped_images'].includes(kind) || ['importer_materialization_bug', 'missing_asset'].includes(lossClass)) return 'materialization';
+  return '';
+}
+
+function correlatedLineage(payload, correlation) {
+  if (!correlation) return [];
+  const row = objectValue(payload);
+  const payloadCorrelation = correlationIdentity(row);
+  if (!sameCorrelation(correlation, payloadCorrelation)) return [];
+  const importReport = objectValue(row.import_report || row.importReport || row.report);
+  const provider = objectValue(row.provider_adapter || row.providerAdapter || importReport.provider_adapter || importReport.providerAdapter);
+  const capture = objectValue(row.capture_contract || row.captureContract || row.visual_capture || row.visualCapture);
+  const result = compactObject({
+    provider_adapter: Object.keys(provider).length > 0 ? lineageStatus(provider) : undefined,
+    capture: Object.keys(capture).length > 0 ? lineageStatus(capture) : undefined,
+    correlation,
+  });
+  return Object.keys(result).length > 1 ? [result] : [];
+}
+
+function correlationIdentity(value) {
+  const row = objectValue(value);
+  const metadata = objectValue(row.metadata);
+  const runId = firstString([row.run_id, row.runId, metadata.run_id, metadata.runId]);
+  const stepId = firstString([row.step_id, row.stepId, row.recipe_step_index, row.recipeStepIndex, metadata.step_id, metadata.stepId, metadata.recipe_step_index, metadata.recipeStepIndex]);
+  const diagnosticId = firstString([row.diagnostic_id, row.diagnosticId, row.id]);
+  return runId || stepId || diagnosticId ? compactObject({ run_id: runId, step_id: stepId, diagnostic_id: diagnosticId }) : null;
+}
+
+function sameCorrelation(left, right) {
+  if (!left || !right) return false;
+  if (left.run_id && right.run_id) return left.run_id === right.run_id;
+  return ['step_id', 'diagnostic_id'].some((key) => left[key] && right[key] && left[key] === right[key]);
+}
+
+function lineageStatus(value) {
+  const row = objectValue(value);
+  return compactObject({ schema: firstString([row.schema]), status: firstString([row.status, row.result]), provider: firstString([row.provider, row.name]) });
 }
 
 function visualComparisonSurfaceId({ explicitSurfaceId, comparison }) {

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -60,7 +60,7 @@ export function collectFixtureMatrixRunResults(input = {}) {
   const liveWpParity = normalizeLiveWpParityCollectorOptions(input.liveWpParity || input.live_wp_parity);
   const results = matrix.fixtures.map((fixture) => {
     const fixtureArtifactsDirectory = path.join(outputDirectory, fixture.id);
-    const sidecar = readMaterializationSidecar(fixtureArtifactsDirectory, fixture.id, matrix.id);
+    const sidecar = readMaterializationSidecar(fixtureArtifactsDirectory, fixture.id, matrix.id, input.sidecarAttemptId || input.sidecar_attempt_id || 'primary');
     const payloads = [
       ...runtimePayloads.filter((payload) => fixtureIdentity(payload) === fixture.id),
       ...readFixturePayloadFiles(fixtureArtifactsDirectory),
@@ -599,7 +599,10 @@ function findingPacketDiagnostic(packet) {
 
 function collectFixtureArtifactRefs(payloads, fixtureArtifactsDirectory) {
   const refs = normalizeArray(payloads).flatMap(collectPayloadArtifactRefs);
-  for (const fileName of ['artifact.json', 'validation-result.json', 'import-report.json', 'materialization-receipt.json']) {
+  const sidecars = fs.existsSync(fixtureArtifactsDirectory)
+    ? fs.readdirSync(fixtureArtifactsDirectory).filter((fileName) => /^materialization-receipt--[A-Za-z0-9][A-Za-z0-9._-]{0,79}\.json$/.test(fileName))
+    : [];
+  for (const fileName of ['artifact.json', 'validation-result.json', 'import-report.json', ...sidecars]) {
     const filePath = path.join(fixtureArtifactsDirectory, fileName);
     if (fs.existsSync(filePath)) {
       refs.push(artifactRef(fileName.replace(/\.json$/, ''), filePath, fileName === 'artifact.json' ? 'input' : 'diagnostic'));
@@ -613,9 +616,10 @@ const MATERIALIZATION_SIDECAR_SCHEMA = 'static-site-importer/materialization-run
 // Sidecars are written by the import command before its verbose JSON reaches a
 // capped transport. Validate both correlation and immutable fixture input before
 // allowing this compact evidence to replace any truncated command output.
-function readMaterializationSidecar(directory, fixtureId, runId) {
-  const filePath = path.join(directory, 'materialization-receipt.json');
+function readMaterializationSidecar(directory, fixtureId, runId, attemptId) {
+  const filePath = path.join(directory, `materialization-receipt--${attemptId}.json`);
   if (!fs.existsSync(filePath)) return { status: 'missing', path: filePath };
+  if (fs.statSync(filePath).size > 32 * 1024) return { status: 'malformed', path: filePath };
   let payload;
   try {
     payload = JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -623,14 +627,64 @@ function readMaterializationSidecar(directory, fixtureId, runId) {
     return { status: 'malformed', path: filePath };
   }
   const row = objectValue(payload);
-  if (row.schema !== MATERIALIZATION_SIDECAR_SCHEMA || !objectValue(row.receipt).schema) return { status: 'malformed', path: filePath };
+  if (!validSidecar(row)) return { status: 'malformed', path: filePath };
   if (row.fixture_id !== fixtureId) return { status: 'cross_fixture', path: filePath };
-  if (row.run_id !== runId || row.step_id !== 'import') return { status: 'stale', path: filePath };
+  if (row.run_id !== runId || row.step_id !== 'import' || row.attempt_id !== attemptId) return { status: 'stale', path: filePath };
   const artifactPath = path.join(directory, 'artifact.json');
   if (!fs.existsSync(artifactPath) || row.artifact_sha256 !== fileSha256(artifactPath)) return { status: 'hash_mismatch', path: filePath };
   const expectedContentHash = sidecarContentHash(row);
   if (!row.content_sha256 || row.content_sha256 !== expectedContentHash) return { status: 'hash_mismatch', path: filePath };
   return { status: 'verified', path: filePath, payload: row };
+}
+
+function validSidecar(row) {
+  const receipt = objectValue(row.receipt);
+  const allowed = ['schema', 'fixture_id', 'run_id', 'step_id', 'attempt_id', 'artifact_sha256', 'provenance', 'receipt', 'content_sha256'];
+  if (Object.keys(row).some((key) => !allowed.includes(key))) return false;
+  if (row.schema !== MATERIALIZATION_SIDECAR_SCHEMA || !safeToken(row.fixture_id, 80) || !safeToken(row.run_id, 160) || row.step_id !== 'import' || !safeToken(row.attempt_id, 80) || !sha256(row.artifact_sha256) || !sha256(row.content_sha256)) return false;
+  if (!validProvenance(row.provenance) || !validReceipt(receipt)) return false;
+  return true;
+}
+
+function validProvenance(value) {
+  const row = objectValue(value);
+  return Object.keys(row).length === 2 && row.provider === 'static-site-importer/current-runtime' && row.provider_status === 'completed';
+}
+
+function validReceipt(row) {
+  const allowed = ['schema', 'status', 'plan_hash', 'page_count', 'file_count', 'operation_count', 'loss_count', 'provider_totals', 'computed_layout_totals', 'operation_rows', 'loss_rows', 'truncated'];
+  if (Object.keys(row).some((key) => !allowed.includes(key))) return false;
+  if (row.schema !== 'static-site-importer/materialization-receipt/v1' || row.status !== 'completed' || !sha256(row.plan_hash)) return false;
+  if (!['page_count', 'file_count', 'operation_count', 'loss_count'].every((key) => boundedCount(row[key]))) return false;
+  if (!validCounts(row.provider_totals, ['completed']) || !validCounts(row.computed_layout_totals, ['applied', 'losses', 'operations'])) return false;
+  if (!Array.isArray(row.operation_rows) || !Array.isArray(row.loss_rows) || row.operation_rows.length > 25 || row.loss_rows.length > 25) return false;
+  if (![...row.operation_rows, ...row.loss_rows].every(validSidecarRow)) return false;
+  const truncated = objectValue(row.truncated);
+  return Object.keys(truncated).length === 2 && typeof truncated.operation_rows === 'boolean' && typeof truncated.loss_rows === 'boolean';
+}
+
+function validCounts(value, keys) {
+  const row = objectValue(value);
+  return Object.keys(row).every((key) => keys.includes(key)) && Object.values(row).every(boundedCount);
+}
+
+function validSidecarRow(value) {
+  const row = objectValue(value);
+  return Object.keys(row).every((key) => ['kind', 'status', 'reason_code', 'hash'].includes(key))
+    && safeToken(row.kind, 80) && (!Object.hasOwn(row, 'status') || safeToken(row.status, 40))
+    && (!Object.hasOwn(row, 'reason_code') || safeToken(row.reason_code, 80)) && sha256(row.hash);
+}
+
+function safeToken(value, maximum) {
+  return typeof value === 'string' && value.length > 0 && value.length <= maximum && /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/.test(value);
+}
+
+function sha256(value) {
+  return typeof value === 'string' && /^(?:sha256:)?[a-f0-9]{64}$/.test(value);
+}
+
+function boundedCount(value) {
+  return Number.isInteger(value) && value >= 0 && value <= 10000000;
 }
 
 function sidecarContentHash(sidecar) {

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -224,19 +224,19 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
 
 function applyEvidenceAttribution(finding, raw, result) {
   const evidence = objectValue(result.matrix_evidence || result.matrixEvidence);
-  const lineage = objectValue(evidence.lineage);
   const missing = normalizeArray(evidence.missing).map(String);
-  const requestedBoundary = String(raw.attribution_boundary || raw.attributionBoundary || '').toLowerCase();
+  const requestedBoundary = attributionBoundary(raw, finding);
   const transformReady = evidence.readiness === 'verified' && ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan'].every((key) => !missing.includes(key));
   const materializationReady = transformReady && !missing.includes('materialization_receipt');
-  const provider = objectValue(lineage.provider_adapter || lineage.providerAdapter);
-  const capture = objectValue(lineage.capture);
+  const diagnosticEvidence = objectValue(raw.attribution_evidence || raw.attributionEvidence);
+  const provider = objectValue(diagnosticEvidence.provider_adapter || diagnosticEvidence.providerAdapter);
+  const capture = objectValue(diagnosticEvidence.capture);
   const candidates = [
-    attributionCandidate('transform', 'blocks-engine', transformReady && boundaryMatches(requestedBoundary, 'transform'), ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan'].filter((key) => missing.includes(key))),
-    attributionCandidate('materialization', 'static-site-importer', materializationReady && boundaryMatches(requestedBoundary, 'materialization'), ['wordpress_site_plan', 'materialization_receipt'].filter((key) => missing.includes(key))),
-    attributionCandidate('provider', 'static-site-importer', provider.status === 'failed' && boundaryMatches(requestedBoundary, 'provider'), provider.status ? [] : ['provider_adapter_result']),
-    attributionCandidate('capture', 'static-site-importer', capture.status === 'failed' && boundaryMatches(requestedBoundary, 'capture'), capture.status ? [] : ['capture_contract']),
-    attributionCandidate('unknown', '', !requestedBoundary || !['transform', 'materialization', 'provider', 'capture'].includes(requestedBoundary), missing),
+    attributionCandidate('transform', 'blocks-engine', transformReady && boundaryMatches(requestedBoundary, 'transform'), boundaryMissing(requestedBoundary, 'transform', ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan'].filter((key) => missing.includes(key)))),
+    attributionCandidate('materialization', 'static-site-importer', materializationReady && boundaryMatches(requestedBoundary, 'materialization'), boundaryMissing(requestedBoundary, 'materialization', ['wordpress_site_plan', 'materialization_receipt'].filter((key) => missing.includes(key)))),
+    attributionCandidate('provider', 'static-site-importer', provider.status === 'failed' && boundaryMatches(requestedBoundary, 'provider'), boundaryMissing(requestedBoundary, 'provider', provider.status ? [] : ['provider_adapter_result'])),
+    attributionCandidate('capture', 'static-site-importer', capture.status === 'failed' && boundaryMatches(requestedBoundary, 'capture'), boundaryMissing(requestedBoundary, 'capture', capture.status ? [] : ['capture_contract'])),
+    attributionCandidate('unknown', '', !requestedBoundary, requestedBoundary ? [] : ['attribution_boundary']),
   ];
   const supported = candidates.filter((candidate) => candidate.supported && candidate.repository);
   const blindSpots = [...new Set(candidates.flatMap((candidate) => candidate.missing))].sort();
@@ -246,6 +246,24 @@ function applyEvidenceAttribution(finding, raw, result) {
     attribution_candidates: candidates,
     ...(blindSpots.length > 0 ? { diagnostic_blind_spots: blindSpots } : {}),
   };
+}
+
+function attributionBoundary(raw, finding) {
+  const explicit = String(raw.attribution_boundary || raw.attributionBoundary || '').toLowerCase();
+  if (['transform', 'materialization', 'provider', 'capture'].includes(explicit)) {
+    return explicit;
+  }
+  if (['editor_block_invalid', 'invalid_block_content', 'low_native_conversion', 'runtime_target_gap'].includes(finding.loss_class)) {
+    return 'transform';
+  }
+  if (['importer_materialization_bug', 'missing_asset'].includes(finding.loss_class)) {
+    return 'materialization';
+  }
+  return '';
+}
+
+function boundaryMissing(requested, boundary, missing) {
+  return requested === boundary ? missing : [];
 }
 
 function boundaryMatches(requested, boundary) {

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -152,7 +152,7 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
   const observedBlockName = raw.block_name || rawObserved.block_name || derivedContext.observed_block_name || '';
   const sourceSnippet = raw.source_html_preview || raw.html_excerpt || rawSource.snippet || rawSelectorEvidence.source_text || rawSelectorEvidence.sourceText || derivedContext.source_snippet || '';
   const observedOutput = raw.emitted_block_preview || rawObserved.output || rawSelectorEvidence.target_text || rawSelectorEvidence.targetText || derivedContext.observed_output || '';
-  return {
+  const finding = {
     id: raw.id || `${result.fixture_id || 'fixture'}:${group.group_key}:${index + 1}`,
     kind,
     category: raw.category || group.group_key,
@@ -218,6 +218,46 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     // duplicates the (already-bounded) classified fields and can carry raw
     // serialized markup. All classification above is computed from `raw` before
     // this point; downstream consumers read the bounded top-level fields.
+  };
+  return applyEvidenceAttribution(finding, raw, result);
+}
+
+function applyEvidenceAttribution(finding, raw, result) {
+  const evidence = objectValue(result.matrix_evidence || result.matrixEvidence);
+  const lineage = objectValue(evidence.lineage);
+  const missing = normalizeArray(evidence.missing).map(String);
+  const requestedBoundary = String(raw.attribution_boundary || raw.attributionBoundary || '').toLowerCase();
+  const transformReady = evidence.readiness === 'verified' && ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan'].every((key) => !missing.includes(key));
+  const materializationReady = transformReady && !missing.includes('materialization_receipt');
+  const provider = objectValue(lineage.provider_adapter || lineage.providerAdapter);
+  const capture = objectValue(lineage.capture);
+  const candidates = [
+    attributionCandidate('transform', 'blocks-engine', transformReady && boundaryMatches(requestedBoundary, 'transform'), ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan'].filter((key) => missing.includes(key))),
+    attributionCandidate('materialization', 'static-site-importer', materializationReady && boundaryMatches(requestedBoundary, 'materialization'), ['wordpress_site_plan', 'materialization_receipt'].filter((key) => missing.includes(key))),
+    attributionCandidate('provider', 'static-site-importer', provider.status === 'failed' && boundaryMatches(requestedBoundary, 'provider'), provider.status ? [] : ['provider_adapter_result']),
+    attributionCandidate('capture', 'static-site-importer', capture.status === 'failed' && boundaryMatches(requestedBoundary, 'capture'), capture.status ? [] : ['capture_contract']),
+    attributionCandidate('unknown', '', !requestedBoundary || !['transform', 'materialization', 'provider', 'capture'].includes(requestedBoundary), missing),
+  ];
+  const supported = candidates.filter((candidate) => candidate.supported && candidate.repository);
+  const blindSpots = [...new Set(candidates.flatMap((candidate) => candidate.missing))].sort();
+  return {
+    ...finding,
+    candidate_repo: supported.length === 1 ? supported[0].repository : '',
+    attribution_candidates: candidates,
+    ...(blindSpots.length > 0 ? { diagnostic_blind_spots: blindSpots } : {}),
+  };
+}
+
+function boundaryMatches(requested, boundary) {
+  return requested === boundary;
+}
+
+function attributionCandidate(boundary, repository, supported, missing) {
+  return {
+    boundary,
+    ...(repository ? { repository } : {}),
+    supported,
+    missing: [...new Set(missing)].sort(),
   };
 }
 

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -232,11 +232,12 @@ function applyEvidenceAttribution(finding, raw, result) {
   const diagnosticEvidence = objectValue(raw.attribution_evidence || raw.attributionEvidence);
   const provider = objectValue(diagnosticEvidence.provider_adapter || diagnosticEvidence.providerAdapter);
   const capture = objectValue(diagnosticEvidence.capture);
+  const correlationMatches = evidenceCorrelationMatches(raw, diagnosticEvidence);
   const candidates = [
     attributionCandidate('transform', 'blocks-engine', transformReady && boundaryMatches(requestedBoundary, 'transform'), boundaryMissing(requestedBoundary, 'transform', ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan'].filter((key) => missing.includes(key)))),
     attributionCandidate('materialization', 'static-site-importer', materializationReady && boundaryMatches(requestedBoundary, 'materialization'), boundaryMissing(requestedBoundary, 'materialization', ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan', 'materialization_receipt'].filter((key) => missing.includes(key)))),
-    attributionCandidate('provider', 'static-site-importer', provider.status === 'failed' && boundaryMatches(requestedBoundary, 'provider'), boundaryMissing(requestedBoundary, 'provider', provider.status ? [] : ['provider_adapter_result'])),
-    attributionCandidate('capture', 'static-site-importer', capture.status === 'failed' && boundaryMatches(requestedBoundary, 'capture'), boundaryMissing(requestedBoundary, 'capture', capture.status ? [] : ['capture_contract'])),
+    attributionCandidate('provider', 'static-site-importer', provider.status === 'failed' && correlationMatches && boundaryMatches(requestedBoundary, 'provider'), boundaryMissing(requestedBoundary, 'provider', provider.status ? (correlationMatches ? [] : ['provider_adapter_correlation']) : ['provider_adapter_result'])),
+    attributionCandidate('capture', 'static-site-importer', capture.status === 'failed' && correlationMatches && boundaryMatches(requestedBoundary, 'capture'), boundaryMissing(requestedBoundary, 'capture', capture.status ? (correlationMatches ? [] : ['capture_contract_correlation']) : ['capture_contract'])),
     attributionCandidate('unknown', '', !requestedBoundary, requestedBoundary ? [] : ['attribution_boundary']),
   ];
   const supported = candidates.filter((candidate) => candidate.supported && candidate.repository);
@@ -246,6 +247,22 @@ function applyEvidenceAttribution(finding, raw, result) {
     candidate_repo: supported.length === 1 ? supported[0].repository : (strictContract ? '' : (raw.candidate_repo || '')),
     attribution_candidates: candidates,
     ...(blindSpots.length > 0 ? { diagnostic_blind_spots: blindSpots } : {}),
+  };
+}
+
+function evidenceCorrelationMatches(raw, evidence) {
+  const diagnostic = correlationIdentity(objectValue(raw.correlation || raw.correlation_identity || raw.correlationIdentity || raw));
+  const source = correlationIdentity(objectValue(evidence.correlation || evidence.correlation_identity || evidence.correlationIdentity));
+  const keys = ['run_id', 'step_id', 'diagnostic_id'].filter((key) => diagnostic[key] || source[key]);
+  return keys.length > 0 && keys.every((key) => diagnostic[key] && source[key] && diagnostic[key] === source[key]);
+}
+
+function correlationIdentity(value) {
+  const row = objectValue(value);
+  return {
+    run_id: row.run_id || row.runId || '',
+    step_id: row.step_id || row.stepId || row.recipe_step_index || row.recipeStepIndex || '',
+    diagnostic_id: row.diagnostic_id || row.diagnosticId || row.id || '',
   };
 }
 

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -225,6 +225,7 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
 function applyEvidenceAttribution(finding, raw, result) {
   const evidence = objectValue(result.matrix_evidence || result.matrixEvidence);
   const missing = normalizeArray(evidence.missing).map(String);
+  const strictContract = evidence.schema === 'static-site-importer/fixture-matrix-runtime-evidence/v1';
   const requestedBoundary = attributionBoundary(raw, finding);
   const transformReady = evidence.readiness === 'verified' && ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan'].every((key) => !missing.includes(key));
   const materializationReady = transformReady && !missing.includes('materialization_receipt');
@@ -233,7 +234,7 @@ function applyEvidenceAttribution(finding, raw, result) {
   const capture = objectValue(diagnosticEvidence.capture);
   const candidates = [
     attributionCandidate('transform', 'blocks-engine', transformReady && boundaryMatches(requestedBoundary, 'transform'), boundaryMissing(requestedBoundary, 'transform', ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan'].filter((key) => missing.includes(key)))),
-    attributionCandidate('materialization', 'static-site-importer', materializationReady && boundaryMatches(requestedBoundary, 'materialization'), boundaryMissing(requestedBoundary, 'materialization', ['wordpress_site_plan', 'materialization_receipt'].filter((key) => missing.includes(key)))),
+    attributionCandidate('materialization', 'static-site-importer', materializationReady && boundaryMatches(requestedBoundary, 'materialization'), boundaryMissing(requestedBoundary, 'materialization', ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan', 'materialization_receipt'].filter((key) => missing.includes(key)))),
     attributionCandidate('provider', 'static-site-importer', provider.status === 'failed' && boundaryMatches(requestedBoundary, 'provider'), boundaryMissing(requestedBoundary, 'provider', provider.status ? [] : ['provider_adapter_result'])),
     attributionCandidate('capture', 'static-site-importer', capture.status === 'failed' && boundaryMatches(requestedBoundary, 'capture'), boundaryMissing(requestedBoundary, 'capture', capture.status ? [] : ['capture_contract'])),
     attributionCandidate('unknown', '', !requestedBoundary, requestedBoundary ? [] : ['attribution_boundary']),
@@ -242,7 +243,7 @@ function applyEvidenceAttribution(finding, raw, result) {
   const blindSpots = [...new Set(candidates.flatMap((candidate) => candidate.missing))].sort();
   return {
     ...finding,
-    candidate_repo: supported.length === 1 ? supported[0].repository : '',
+    candidate_repo: supported.length === 1 ? supported[0].repository : (strictContract ? '' : (raw.candidate_repo || '')),
     attribution_candidates: candidates,
     ...(blindSpots.length > 0 ? { diagnostic_blind_spots: blindSpots } : {}),
   };

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -773,6 +773,7 @@ function diagnosticBlindSpots(findings) {
   const genericFindings = findings.filter((finding) => isGenericFinding(finding));
   const missingSourceContext = findings.filter((finding) => !finding.selector && !finding.source_snippet && !finding.observed_output);
   const missingRuntimeContext = findings.filter((finding) => finding.loss_class === 'runtime_execution_failed' && !finding.command && !finding.batch_id && !finding.stderr_tail && !finding.stdout_tail && normalizeArray(finding.artifact_refs).length === 0);
+  const missingLineage = findings.filter((finding) => normalizeArray(finding.diagnostic_blind_spots).length > 0);
   if (genericFindings.length > 0) {
     spots.push(blindSpot('generic_finding_family', genericFindings, 'Findings need a specific type, repair bucket, or reason code before fanout.'));
   }
@@ -781,6 +782,9 @@ function diagnosticBlindSpots(findings) {
   }
   if (missingRuntimeContext.length > 0) {
     spots.push(blindSpot('missing_runtime_failure_context', missingRuntimeContext, 'Runtime failures need batch id, command, bounded stdout/stderr tails, artifact refs, or replay command for direct reproduction.'));
+  }
+  if (missingLineage.length > 0) {
+    spots.push(blindSpot('missing_required_lineage', missingLineage, 'Capture the listed transform, materialization, provider, or capture evidence before assigning repair ownership.'));
   }
   return spots;
 }

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -9,6 +9,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { randomUUID } from 'node:crypto';
 
 /**
  * Internal dependencies
@@ -117,6 +118,8 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const artifactsDirectory = input.artifactsDirectory || input.artifacts_directory || '/artifacts/static-site-importer-fixture-matrix';
   const playgroundArtifactsDirectory = input.playgroundArtifactsDirectory || input.playground_artifacts_directory;
   const commandArtifactsDirectory = playgroundArtifactsDirectory || artifactsDirectory;
+  const runId = input.runId || input.run_id || `${matrix.id}-${randomUUID()}`;
+  const attemptId = input.attemptId || input.attempt_id || randomUUID();
   const importer = normalizeStaticSiteImporterPlugin(input);
   const dependencyOverrideSetup = buildDependencyOverrideSetup(input, importer);
   const mounts = normalizeArray(input.mounts);
@@ -190,8 +193,8 @@ export function buildFixtureMatrixRecipe(input = {}) {
           fixture,
           input,
           commandArtifactsDirectory,
-          runId: input.runId || input.run_id || matrix.id,
-          attemptId: input.attemptId || input.attempt_id || 'primary',
+          runId,
+          attemptId,
           editorOpenEnabled,
           editorValidationEnabled,
           editorValidationOptions,
@@ -203,6 +206,16 @@ export function buildFixtureMatrixRecipe(input = {}) {
     },
     artifacts: {
       directory: artifactsDirectory,
+      typed: matrix.fixtures.map((fixture) => ({
+        name: `ssi-materialization-sidecar-${fixture.id}-${sidecarToken(attemptId)}`,
+        type: 'static-site-importer/materialization-runtime-sidecar',
+        path: path.join(commandArtifactsDirectory, fixture.id, `materialization-receipt--${sidecarToken(attemptId)}.json`),
+        required: false,
+        parseJson: true,
+        contentType: 'application/json',
+        payloadSchema: 'static-site-importer/materialization-runtime-sidecar/v1',
+        metadata: { fixture_id: fixture.id, run_id: runId, step_id: 'import', attempt_id: attemptId },
+      })),
     },
     metadata: {
       surface_coverage: surfaceCoverage,

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -190,6 +190,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
           fixture,
           input,
           commandArtifactsDirectory,
+          runId: input.runId || input.run_id || matrix.id,
           editorOpenEnabled,
           editorValidationEnabled,
           editorValidationOptions,
@@ -221,6 +222,7 @@ function fixtureWorkflowSteps(options) {
     fixture,
     input,
     commandArtifactsDirectory,
+    runId,
     editorOpenEnabled,
     editorValidationEnabled,
     editorValidationOptions,
@@ -231,7 +233,7 @@ function fixtureWorkflowSteps(options) {
   const surfaces = selectFixtureSurfaces(fixture, input);
 
   return [
-    importFixtureStep(fixture, commandArtifactsDirectory),
+    importFixtureStep(fixture, commandArtifactsDirectory, runId),
     ...(input.svgFontEvidence || input.svg_font_evidence ? [svgFontEvidenceStep(fixture)] : []),
     woocommerceOnboardingSuppressionStep(fixture),
     ...surfaces.flatMap((surface, index) => [
@@ -327,11 +329,12 @@ function editorArtifactPrefix(fixture, surface) {
   return `files/browser/editor-open/${fixture.id}/${surface.id}`;
 }
 
-function importFixtureStep(fixture, commandArtifactsDirectory) {
+function importFixtureStep(fixture, commandArtifactsDirectory, runId) {
+  const fixtureDirectory = path.join(commandArtifactsDirectory, fixture.id);
   return {
     command: 'wordpress.wp-cli',
     args: [
-      `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --format=fixture-matrix --allow-failure`,
+      `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(fixtureDirectory, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --format=fixture-matrix --receipt-sidecar=${shellToken(path.join(fixtureDirectory, 'materialization-receipt.json'))} --receipt-run-id=${shellToken(runId)} --receipt-step-id=import --allow-failure`,
     ],
     metadata: fixtureStepMetadata(fixture, 'import', {
       artifact: path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'),

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -191,6 +191,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
           input,
           commandArtifactsDirectory,
           runId: input.runId || input.run_id || matrix.id,
+          attemptId: input.attemptId || input.attempt_id || 'primary',
           editorOpenEnabled,
           editorValidationEnabled,
           editorValidationOptions,
@@ -223,6 +224,7 @@ function fixtureWorkflowSteps(options) {
     input,
     commandArtifactsDirectory,
     runId,
+    attemptId,
     editorOpenEnabled,
     editorValidationEnabled,
     editorValidationOptions,
@@ -233,7 +235,7 @@ function fixtureWorkflowSteps(options) {
   const surfaces = selectFixtureSurfaces(fixture, input);
 
   return [
-    importFixtureStep(fixture, commandArtifactsDirectory, runId),
+    importFixtureStep(fixture, commandArtifactsDirectory, runId, attemptId),
     ...(input.svgFontEvidence || input.svg_font_evidence ? [svgFontEvidenceStep(fixture)] : []),
     woocommerceOnboardingSuppressionStep(fixture),
     ...surfaces.flatMap((surface, index) => [
@@ -329,17 +331,24 @@ function editorArtifactPrefix(fixture, surface) {
   return `files/browser/editor-open/${fixture.id}/${surface.id}`;
 }
 
-function importFixtureStep(fixture, commandArtifactsDirectory, runId) {
+function importFixtureStep(fixture, commandArtifactsDirectory, runId, attemptId) {
   const fixtureDirectory = path.join(commandArtifactsDirectory, fixture.id);
+  const sidecarName = `materialization-receipt--${sidecarToken(attemptId)}.json`;
   return {
     command: 'wordpress.wp-cli',
     args: [
-      `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(fixtureDirectory, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --format=fixture-matrix --receipt-sidecar=${shellToken(path.join(fixtureDirectory, 'materialization-receipt.json'))} --receipt-run-id=${shellToken(runId)} --receipt-step-id=import --allow-failure`,
+      `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(fixtureDirectory, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --format=fixture-matrix --receipt-sidecar=${shellToken(path.join(fixtureDirectory, sidecarName))} --receipt-run-id=${shellToken(runId)} --receipt-step-id=import --receipt-attempt-id=${shellToken(attemptId)} --allow-failure`,
     ],
     metadata: fixtureStepMetadata(fixture, 'import', {
       artifact: path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'),
     }),
   };
+}
+
+function sidecarToken(value) {
+  const token = String(value || '').trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(token)) throw new Error('Fixture matrix sidecar attempt id must be a 1-80 character safe token.');
+  return token;
 }
 
 function visualParityDeterministicCssStep(fixture) {

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -255,7 +255,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			$result = Static_Site_Importer_Validation_Runtime::validate_artifact( $input );
 			if ( is_wp_error( $result ) ) {
 				$error_result = Static_Site_Importer_Validation_Runtime::error_result_from_wp_error( $result, $input );
-				static_site_importer_cli_write_materialization_sidecar( $error_result, $assoc_args );
+				$sidecar_result = static_site_importer_cli_write_materialization_sidecar( $error_result, $assoc_args );
+				if ( is_wp_error( $sidecar_result ) ) {
+					WP_CLI::error( $sidecar_result->get_error_message(), 1 );
+				}
 				if ( 'fixture-matrix' === $format ) {
 					$error_result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $error_result );
 				}
@@ -272,7 +275,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				return;
 			}
 
-			static_site_importer_cli_write_materialization_sidecar( $result, $assoc_args );
+			$sidecar_result = static_site_importer_cli_write_materialization_sidecar( $result, $assoc_args );
+			if ( is_wp_error( $sidecar_result ) ) {
+				WP_CLI::error( $sidecar_result->get_error_message(), 1 );
+			}
 			if ( 'fixture-matrix' === $format ) {
 				$result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $result );
 			}
@@ -329,31 +335,63 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
  * @param array<string,mixed> $result Validation result.
  * @param array<string,mixed> $args CLI arguments.
  */
-function static_site_importer_cli_write_materialization_sidecar( array $result, array $args ): void {
+function static_site_importer_cli_write_materialization_sidecar( array $result, array $args ) {
 	$path = isset( $args['receipt-sidecar'] ) ? (string) $args['receipt-sidecar'] : '';
-	if ( '' === $path ) {
-		return;
-	}
 	$fixture_id = isset( $result['fixture_id'] ) ? (string) $result['fixture_id'] : ( isset( $args['slug'] ) ? (string) $args['slug'] : '' );
+	$run_id = isset( $args['receipt-run-id'] ) ? (string) $args['receipt-run-id'] : '';
+	$step_id = isset( $args['receipt-step-id'] ) ? (string) $args['receipt-step-id'] : '';
+	$attempt_id = isset( $args['receipt-attempt-id'] ) ? (string) $args['receipt-attempt-id'] : '';
+	if ( '' === $path || ! static_site_importer_cli_sidecar_token( $fixture_id, 80 ) || ! static_site_importer_cli_sidecar_token( $run_id, 160 ) || 'import' !== $step_id || ! static_site_importer_cli_sidecar_token( $attempt_id, 80 ) ) {
+		return new WP_Error( 'static_site_importer_sidecar_identity_invalid', 'Required materialization sidecar identity is missing or invalid.' );
+	}
 	$artifact_path = isset( $args['artifact'] ) ? (string) $args['artifact'] : '';
 	$artifact_hash = is_readable( $artifact_path ) ? hash_file( 'sha256', $artifact_path ) : '';
+	if ( ! is_string( $artifact_hash ) || ! preg_match( '/^[a-f0-9]{64}$/', $artifact_hash ) ) {
+		return new WP_Error( 'static_site_importer_sidecar_artifact_hash_missing', 'Required materialization sidecar artifact hash could not be calculated.' );
+	}
 	$receipt = isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : array();
+	if ( 'static-site-importer/materialization-receipt/v1' !== ( $receipt['schema'] ?? '' ) || 'completed' !== ( $receipt['status'] ?? '' ) || ! isset( $receipt['plan_hash'] ) || ! is_string( $receipt['plan_hash'] ) || ! preg_match( '/^(?:sha256:)?[a-f0-9]{64}$/', $receipt['plan_hash'] ) ) {
+		return new WP_Error( 'static_site_importer_sidecar_receipt_invalid', 'Required materialization sidecar receipt is incomplete or invalid.' );
+	}
 	$summary = static_site_importer_cli_materialization_summary( $receipt, $result );
 	$sidecar = array(
 		'schema'          => 'static-site-importer/materialization-runtime-sidecar/v1',
 		'fixture_id'      => $fixture_id,
-		'run_id'          => isset( $args['receipt-run-id'] ) ? (string) $args['receipt-run-id'] : '',
-		'step_id'         => isset( $args['receipt-step-id'] ) ? (string) $args['receipt-step-id'] : '',
+		'run_id'          => $run_id,
+		'step_id'         => $step_id,
+		'attempt_id'      => $attempt_id,
 		'artifact_sha256' => $artifact_hash,
 		'provenance'      => array( 'provider' => (string) ( $result['runtime']['provider'] ?? '' ), 'provider_status' => (string) ( $result['runtime']['status'] ?? '' ) ),
 		'receipt'         => $summary,
 	);
 	$sidecar['content_sha256'] = hash( 'sha256', (string) wp_json_encode( $sidecar, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+	$json = wp_json_encode( $sidecar, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+	if ( false === $json || strlen( $json ) > 32768 ) {
+		return new WP_Error( 'static_site_importer_sidecar_too_large', 'Required materialization sidecar exceeds its 32 KiB bound.' );
+	}
 	$directory = dirname( $path );
 	if ( ! wp_mkdir_p( $directory ) ) {
-		return;
+		return new WP_Error( 'static_site_importer_sidecar_directory_failed', 'Required materialization sidecar directory could not be created.' );
 	}
-	wp_json_encode( $sidecar, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) && file_put_contents( $path, wp_json_encode( $sidecar, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . "\n", LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- CLI writes an explicit operator artifact.
+	$temp = tempnam( $directory, '.ssi-sidecar-' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_tempnam -- same-directory temporary file is required for atomic rename.
+	if ( false === $temp ) {
+		return new WP_Error( 'static_site_importer_sidecar_temp_failed', 'Required materialization sidecar temporary file could not be created.' );
+	}
+	$handle = fopen( $temp, 'wb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- explicit CLI artifact publication.
+	try {
+		$bytes = strlen( $json ) + 1;
+		if ( false === $handle || $bytes !== fwrite( $handle, $json . "\n" ) || ! fflush( $handle ) || ( function_exists( 'fsync' ) && ! fsync( $handle ) ) || ! fclose( $handle ) || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite,WordPress.WP.AlternativeFunctions.file_system_operations_fclose,WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-directory publication.
+			if ( is_resource( $handle ) ) {
+				fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- cleanup after failed atomic publish.
+			}
+			return new WP_Error( 'static_site_importer_sidecar_persist_failed', 'Required materialization sidecar could not be atomically persisted.' );
+		}
+	} finally {
+		if ( file_exists( $temp ) ) {
+			unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- removes only this bounded temporary sidecar.
+		}
+	}
+	return true;
 }
 
 /** @return array<string,mixed> */
@@ -365,30 +403,46 @@ function static_site_importer_cli_materialization_summary( array $receipt, array
 	$loss_rows = array();
 	foreach ( array_slice( $operations, 0, 25 ) as $operation ) {
 		if ( is_array( $operation ) ) {
-			$operation_rows[] = array_filter( array(
-				'kind'        => (string) ( $operation['kind'] ?? $operation['type'] ?? $operation['operation'] ?? '' ),
-				'status'      => (string) ( $operation['status'] ?? '' ),
-				'reason_code' => (string) ( $operation['reason_code'] ?? '' ),
+			$row = array_filter( array(
+				'kind'        => static_site_importer_cli_sidecar_token_value( $operation['kind'] ?? $operation['type'] ?? $operation['operation'] ?? '', 80 ),
+				'status'      => static_site_importer_cli_sidecar_token_value( $operation['status'] ?? '', 40 ),
+				'reason_code' => static_site_importer_cli_sidecar_token_value( $operation['reason_code'] ?? '', 80 ),
 				'hash'        => hash( 'sha256', (string) wp_json_encode( $operation ) ),
 			) );
+			if ( ! empty( $row['kind'] ) ) {
+				$operation_rows[] = $row;
+			}
 		}
 	}
 	foreach ( array_slice( $diagnostics, 0, 25 ) as $diagnostic ) {
 		if ( is_array( $diagnostic ) ) {
-			$loss_rows[] = array_filter( array(
-				'kind'        => (string) ( $diagnostic['kind'] ?? $diagnostic['code'] ?? $diagnostic['type'] ?? '' ),
-				'reason_code' => (string) ( $diagnostic['reason_code'] ?? '' ),
+			$row = array_filter( array(
+				'kind'        => static_site_importer_cli_sidecar_token_value( $diagnostic['kind'] ?? $diagnostic['code'] ?? $diagnostic['type'] ?? '', 80 ),
+				'reason_code' => static_site_importer_cli_sidecar_token_value( $diagnostic['reason_code'] ?? '', 80 ),
 				'hash'        => hash( 'sha256', (string) wp_json_encode( $diagnostic ) ),
 			) );
+			if ( ! empty( $row['kind'] ) ) {
+				$loss_rows[] = $row;
+			}
 		}
 	}
 	$layout = isset( $receipt['computed_layout'] ) && is_array( $receipt['computed_layout'] ) ? $receipt['computed_layout'] : array();
+	$plan_hash = isset( $receipt['plan_hash'] ) && is_string( $receipt['plan_hash'] ) && preg_match( '/^(?:sha256:)?[a-f0-9]{64}$/', $receipt['plan_hash'] ) ? $receipt['plan_hash'] : '';
 	return array(
-		'schema' => (string) ( $receipt['schema'] ?? '' ), 'status' => (string) ( $receipt['status'] ?? '' ), 'plan_hash' => (string) ( $receipt['plan_hash'] ?? '' ),
-		'page_count' => count( $completed['pages'] ?? array() ), 'file_count' => count( $completed['files'] ?? array() ), 'operation_count' => count( $operations ), 'loss_count' => count( $diagnostics ),
+		'schema' => 'static-site-importer/materialization-receipt/v1', 'status' => 'completed', 'plan_hash' => $plan_hash,
+		'page_count' => min( 10000000, count( $completed['pages'] ?? array() ) ), 'file_count' => min( 10000000, count( $completed['files'] ?? array() ) ), 'operation_count' => min( 10000000, count( $operations ) ), 'loss_count' => min( 10000000, count( $diagnostics ) ),
 		'provider_totals' => array( 'completed' => ! empty( $result['runtime']['provider'] ) ? 1 : 0 ),
 		'computed_layout_totals' => array_filter( array( 'applied' => isset( $layout['applied'] ) ? (int) $layout['applied'] : null, 'losses' => isset( $layout['losses'] ) ? (int) $layout['losses'] : null, 'operations' => count( array_filter( $operations, static fn( $operation ): bool => is_array( $operation ) && false !== strpos( wp_json_encode( $operation ), 'computed_layout' ) ) ) ), static fn( $value ): bool => null !== $value ),
 		'operation_rows' => $operation_rows, 'loss_rows' => $loss_rows,
 		'truncated' => array( 'operation_rows' => count( $operations ) > 25, 'loss_rows' => count( $diagnostics ) > 25 ),
 	);
+}
+
+function static_site_importer_cli_sidecar_token( $value, int $maximum ): bool {
+	return is_string( $value ) && 0 < strlen( $value ) && $maximum >= strlen( $value ) && 1 === preg_match( '/^[A-Za-z0-9][A-Za-z0-9._:\/-]*$/', $value );
+}
+
+function static_site_importer_cli_sidecar_token_value( $value, int $maximum ): string {
+	$value = is_scalar( $value ) ? (string) $value : '';
+	return static_site_importer_cli_sidecar_token( $value, $maximum ) ? $value : '';
 }

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -251,6 +251,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			if ( isset( $assoc_args['theme-archive-ref'] ) ) {
 				$input['theme_archive_ref'] = array( 'artifact_ref' => (string) $assoc_args['theme-archive-ref'] );
 			}
+			$sidecar_contract = static_site_importer_cli_materialization_sidecar_contract( $assoc_args );
+			if ( is_wp_error( $sidecar_contract ) ) {
+				WP_CLI::error( $sidecar_contract->get_error_message(), 1 );
+			}
 
 			$result = Static_Site_Importer_Validation_Runtime::validate_artifact( $input );
 			if ( is_wp_error( $result ) ) {
@@ -271,9 +275,11 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				return;
 			}
 
-			$sidecar_result = static_site_importer_cli_write_materialization_sidecar( $result, $assoc_args );
-			if ( is_wp_error( $sidecar_result ) ) {
-				WP_CLI::error( $sidecar_result->get_error_message(), 1 );
+			if ( true === $sidecar_contract ) {
+				$sidecar_result = static_site_importer_cli_write_materialization_sidecar( $result, $assoc_args );
+				if ( is_wp_error( $sidecar_result ) ) {
+					WP_CLI::error( $sidecar_result->get_error_message(), 1 );
+				}
 			}
 			if ( 'fixture-matrix' === $format ) {
 				$result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $result );
@@ -323,6 +329,25 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			WP_CLI::line( $json );
 		}
 	);
+}
+
+/**
+ * A sidecar is an opt-in CLI contract. Legacy validate-artifact callers retain
+ * their prior result and exit behavior; partial receipt identities fail early.
+ *
+ * @param array<string,mixed> $args CLI arguments.
+ * @return bool|WP_Error True when required, false when absent.
+ */
+function static_site_importer_cli_materialization_sidecar_contract( array $args ) {
+	$keys = array( 'receipt-sidecar', 'receipt-run-id', 'receipt-step-id', 'receipt-attempt-id' );
+	$present = array_filter( $keys, static fn( string $key ): bool => array_key_exists( $key, $args ) );
+	if ( empty( $present ) ) {
+		return false;
+	}
+	if ( count( $present ) !== count( $keys ) ) {
+		return new WP_Error( 'static_site_importer_sidecar_contract_partial', 'Materialization sidecar requires --receipt-sidecar, --receipt-run-id, --receipt-step-id, and --receipt-attempt-id together.' );
+	}
+	return true;
 }
 
 /**

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -255,6 +255,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			$result = Static_Site_Importer_Validation_Runtime::validate_artifact( $input );
 			if ( is_wp_error( $result ) ) {
 				$error_result = Static_Site_Importer_Validation_Runtime::error_result_from_wp_error( $result, $input );
+				static_site_importer_cli_write_materialization_sidecar( $error_result, $assoc_args );
 				if ( 'fixture-matrix' === $format ) {
 					$error_result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $error_result );
 				}
@@ -271,6 +272,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				return;
 			}
 
+			static_site_importer_cli_write_materialization_sidecar( $result, $assoc_args );
 			if ( 'fixture-matrix' === $format ) {
 				$result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $result );
 			}
@@ -318,5 +320,75 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 
 			WP_CLI::line( $json );
 		}
+	);
+}
+
+/**
+ * Persist compact matrix evidence before verbose WP-CLI output can be truncated.
+ *
+ * @param array<string,mixed> $result Validation result.
+ * @param array<string,mixed> $args CLI arguments.
+ */
+function static_site_importer_cli_write_materialization_sidecar( array $result, array $args ): void {
+	$path = isset( $args['receipt-sidecar'] ) ? (string) $args['receipt-sidecar'] : '';
+	if ( '' === $path ) {
+		return;
+	}
+	$fixture_id = isset( $result['fixture_id'] ) ? (string) $result['fixture_id'] : ( isset( $args['slug'] ) ? (string) $args['slug'] : '' );
+	$artifact_path = isset( $args['artifact'] ) ? (string) $args['artifact'] : '';
+	$artifact_hash = is_readable( $artifact_path ) ? hash_file( 'sha256', $artifact_path ) : '';
+	$receipt = isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : array();
+	$summary = static_site_importer_cli_materialization_summary( $receipt, $result );
+	$sidecar = array(
+		'schema'          => 'static-site-importer/materialization-runtime-sidecar/v1',
+		'fixture_id'      => $fixture_id,
+		'run_id'          => isset( $args['receipt-run-id'] ) ? (string) $args['receipt-run-id'] : '',
+		'step_id'         => isset( $args['receipt-step-id'] ) ? (string) $args['receipt-step-id'] : '',
+		'artifact_sha256' => $artifact_hash,
+		'provenance'      => array( 'provider' => (string) ( $result['runtime']['provider'] ?? '' ), 'provider_status' => (string) ( $result['runtime']['status'] ?? '' ) ),
+		'receipt'         => $summary,
+	);
+	$sidecar['content_sha256'] = hash( 'sha256', (string) wp_json_encode( $sidecar, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+	$directory = dirname( $path );
+	if ( ! wp_mkdir_p( $directory ) ) {
+		return;
+	}
+	wp_json_encode( $sidecar, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) && file_put_contents( $path, wp_json_encode( $sidecar, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . "\n", LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- CLI writes an explicit operator artifact.
+}
+
+/** @return array<string,mixed> */
+function static_site_importer_cli_materialization_summary( array $receipt, array $result ): array {
+	$completed = isset( $receipt['completed'] ) && is_array( $receipt['completed'] ) ? $receipt['completed'] : array();
+	$operations = isset( $completed['operations'] ) && is_array( $completed['operations'] ) ? $completed['operations'] : array();
+	$diagnostics = isset( $result['diagnostics'] ) && is_array( $result['diagnostics'] ) ? $result['diagnostics'] : array();
+	$operation_rows = array();
+	$loss_rows = array();
+	foreach ( array_slice( $operations, 0, 25 ) as $operation ) {
+		if ( is_array( $operation ) ) {
+			$operation_rows[] = array_filter( array(
+				'kind'        => (string) ( $operation['kind'] ?? $operation['type'] ?? $operation['operation'] ?? '' ),
+				'status'      => (string) ( $operation['status'] ?? '' ),
+				'reason_code' => (string) ( $operation['reason_code'] ?? '' ),
+				'hash'        => hash( 'sha256', (string) wp_json_encode( $operation ) ),
+			) );
+		}
+	}
+	foreach ( array_slice( $diagnostics, 0, 25 ) as $diagnostic ) {
+		if ( is_array( $diagnostic ) ) {
+			$loss_rows[] = array_filter( array(
+				'kind'        => (string) ( $diagnostic['kind'] ?? $diagnostic['code'] ?? $diagnostic['type'] ?? '' ),
+				'reason_code' => (string) ( $diagnostic['reason_code'] ?? '' ),
+				'hash'        => hash( 'sha256', (string) wp_json_encode( $diagnostic ) ),
+			) );
+		}
+	}
+	$layout = isset( $receipt['computed_layout'] ) && is_array( $receipt['computed_layout'] ) ? $receipt['computed_layout'] : array();
+	return array(
+		'schema' => (string) ( $receipt['schema'] ?? '' ), 'status' => (string) ( $receipt['status'] ?? '' ), 'plan_hash' => (string) ( $receipt['plan_hash'] ?? '' ),
+		'page_count' => count( $completed['pages'] ?? array() ), 'file_count' => count( $completed['files'] ?? array() ), 'operation_count' => count( $operations ), 'loss_count' => count( $diagnostics ),
+		'provider_totals' => array( 'completed' => ! empty( $result['runtime']['provider'] ) ? 1 : 0 ),
+		'computed_layout_totals' => array_filter( array( 'applied' => isset( $layout['applied'] ) ? (int) $layout['applied'] : null, 'losses' => isset( $layout['losses'] ) ? (int) $layout['losses'] : null, 'operations' => count( array_filter( $operations, static fn( $operation ): bool => is_array( $operation ) && false !== strpos( wp_json_encode( $operation ), 'computed_layout' ) ) ) ), static fn( $value ): bool => null !== $value ),
+		'operation_rows' => $operation_rows, 'loss_rows' => $loss_rows,
+		'truncated' => array( 'operation_rows' => count( $operations ) > 25, 'loss_rows' => count( $diagnostics ) > 25 ),
 	);
 }

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -255,10 +255,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			$result = Static_Site_Importer_Validation_Runtime::validate_artifact( $input );
 			if ( is_wp_error( $result ) ) {
 				$error_result = Static_Site_Importer_Validation_Runtime::error_result_from_wp_error( $result, $input );
-				$sidecar_result = static_site_importer_cli_write_materialization_sidecar( $error_result, $assoc_args );
-				if ( is_wp_error( $sidecar_result ) ) {
-					WP_CLI::error( $sidecar_result->get_error_message(), 1 );
-				}
 				if ( 'fixture-matrix' === $format ) {
 					$error_result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $error_result );
 				}
@@ -353,6 +349,10 @@ function static_site_importer_cli_write_materialization_sidecar( array $result, 
 	if ( 'static-site-importer/materialization-receipt/v1' !== ( $receipt['schema'] ?? '' ) || 'completed' !== ( $receipt['status'] ?? '' ) || ! isset( $receipt['plan_hash'] ) || ! is_string( $receipt['plan_hash'] ) || ! preg_match( '/^(?:sha256:)?[a-f0-9]{64}$/', $receipt['plan_hash'] ) ) {
 		return new WP_Error( 'static_site_importer_sidecar_receipt_invalid', 'Required materialization sidecar receipt is incomplete or invalid.' );
 	}
+	$completed = isset( $receipt['completed'] ) && is_array( $receipt['completed'] ) ? $receipt['completed'] : array();
+	if ( ! isset( $completed['pages'], $completed['files'] ) || ! is_array( $completed['pages'] ) || ! is_array( $completed['files'] ) ) {
+		return new WP_Error( 'static_site_importer_sidecar_receipt_shape_invalid', 'Required materialization sidecar receipt pages and files must be arrays.' );
+	}
 	$summary = static_site_importer_cli_materialization_summary( $receipt, $result );
 	$sidecar = array(
 		'schema'          => 'static-site-importer/materialization-runtime-sidecar/v1',
@@ -362,6 +362,7 @@ function static_site_importer_cli_write_materialization_sidecar( array $result, 
 		'attempt_id'      => $attempt_id,
 		'artifact_sha256' => $artifact_hash,
 		'provenance'      => array( 'provider' => (string) ( $result['runtime']['provider'] ?? '' ), 'provider_status' => (string) ( $result['runtime']['status'] ?? '' ) ),
+		'durability'      => array( 'file_fsync' => function_exists( 'fsync' ) ? 'available' : 'unavailable', 'directory_fsync' => function_exists( 'fsync' ) ? 'attempted' : 'unavailable' ),
 		'receipt'         => $summary,
 	);
 	$sidecar['content_sha256'] = hash( 'sha256', (string) wp_json_encode( $sidecar, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
@@ -386,12 +387,24 @@ function static_site_importer_cli_write_materialization_sidecar( array $result, 
 			}
 			return new WP_Error( 'static_site_importer_sidecar_persist_failed', 'Required materialization sidecar could not be atomically persisted.' );
 		}
+		static_site_importer_cli_fsync_directory( $directory );
 	} finally {
 		if ( file_exists( $temp ) ) {
 			unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- removes only this bounded temporary sidecar.
 		}
 	}
 	return true;
+}
+
+function static_site_importer_cli_fsync_directory( string $directory ): void {
+	if ( ! function_exists( 'fsync' ) ) {
+		return;
+	}
+	$handle = @fopen( $directory, 'r' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- best-effort directory durability on supported platforms.
+	if ( false !== $handle ) {
+		@fsync( $handle ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- unsupported directory fsync remains non-fatal.
+		fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- closes the best-effort directory handle.
+	}
 }
 
 /** @return array<string,mixed> */

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -566,8 +566,8 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
   assert.match(recipe.workflow.steps[1].args[0], /--format=fixture-matrix/);
-  assert.match(recipe.workflow.steps[1].args[0], /--receipt-sidecar=\/wordpress\/wp-content\/uploads\/static-site-importer-fixture-matrix\/simple-site\/materialization-receipt\.json/);
-  assert.match(recipe.workflow.steps[1].args[0], /--receipt-run-id=recipe-test --receipt-step-id=import/);
+  assert.match(recipe.workflow.steps[1].args[0], /--receipt-sidecar=\/wordpress\/wp-content\/uploads\/static-site-importer-fixture-matrix\/simple-site\/materialization-receipt--primary\.json/);
+  assert.match(recipe.workflow.steps[1].args[0], /--receipt-run-id=recipe-test --receipt-step-id=import --receipt-attempt-id=primary/);
   assert.match(recipe.workflow.steps[1].args[0], /--allow-failure/);
   assert.doesNotMatch(recipe.workflow.steps[1].args[0], /--allow-missing-woocommerce/);
   assert.deepEqual(recipe.inputs.stagedFiles[0], {
@@ -1079,7 +1079,7 @@ test('materialization sidecars retain bounded evidence after oversized import st
     assert.equal(fixture.matrix_evidence.materialization_receipt.page_count, 2);
     assert.deepEqual(fixture.matrix_evidence.materialization_sidecar.computed_layout_totals, { applied: 7, losses: 2, operations: 9 });
     assert.deepEqual(fixture.matrix_evidence.materialization_sidecar.provider_totals, { completed: 1 });
-    assert.ok(fixture.artifact_refs.some((ref) => ref.artifact_id === 'materialization-receipt'));
+    assert.ok(fixture.artifact_refs.some((ref) => ref.artifact_id === 'materialization-receipt--primary'));
   }
 });
 
@@ -1091,7 +1091,7 @@ test('materialization sidecars reject malformed, stale, cross-fixture, and hash-
     const directory = path.join(outputDirectory, 'simple-site');
     mkdirSync(directory, { recursive: true });
     writeFileSync(path.join(directory, 'artifact.json'), JSON.stringify({ fixture: 'simple-site' }));
-    if (status === 'malformed') writeFileSync(path.join(directory, 'materialization-receipt.json'), '{');
+    if (status === 'malformed') writeFileSync(path.join(directory, 'materialization-receipt--primary.json'), '{');
     if (status === 'stale') writeMaterializationSidecar({ directory, fixtureId: 'simple-site', runId: 'old-run', receipt: boundedSidecarReceipt() });
     if (status === 'cross_fixture') writeMaterializationSidecar({ directory, fixtureId: 'other-site', runId: matrix.id, receipt: boundedSidecarReceipt() });
     if (status === 'hash_mismatch') writeMaterializationSidecar({ directory, fixtureId: 'simple-site', runId: matrix.id, receipt: boundedSidecarReceipt(), artifactHash: '0'.repeat(64) });
@@ -1100,20 +1100,59 @@ test('materialization sidecars reject malformed, stale, cross-fixture, and hash-
   }
 });
 
+test('materialization sidecars isolate concurrent attempts for the same fixture', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-sidecar-concurrent-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'sidecar-concurrent-run' });
+  const directory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(path.join(directory, 'artifact.json'), JSON.stringify({ fixture: 'simple-site' }));
+  writeMaterializationSidecar({ directory, fixtureId: 'simple-site', runId: matrix.id, attemptId: 'attempt-a', receipt: { ...boundedSidecarReceipt(), operation_count: 1 } });
+  writeMaterializationSidecar({ directory, fixtureId: 'simple-site', runId: matrix.id, attemptId: 'attempt-b', receipt: { ...boundedSidecarReceipt(), operation_count: 2 } });
+
+  const first = collectFixtureMatrixRunResults({ matrix, outputDirectory, sidecarAttemptId: 'attempt-a' });
+  const second = collectFixtureMatrixRunResults({ matrix, outputDirectory, sidecarAttemptId: 'attempt-b' });
+  assert.equal(first.fixtures[0].matrix_evidence.materialization_receipt.operation_count, 1);
+  assert.equal(second.fixtures[0].matrix_evidence.materialization_receipt.operation_count, 2);
+});
+
+test('materialization sidecars reject partial, oversized, and semantically invalid content', () => {
+  const invalid = [
+    ['partial', (sidecar) => '{'],
+    ['oversized', (sidecar) => JSON.stringify({ ...sidecar, padding: 'x'.repeat(32 * 1024) })],
+    ['wrong-sidecar-schema', (sidecar) => JSON.stringify({ ...sidecar, schema: 'wrong/v1' })],
+    ['wrong-receipt-schema', (sidecar) => JSON.stringify({ ...sidecar, receipt: { ...sidecar.receipt, schema: 'wrong/v1' } })],
+    ['wrong-receipt-status', (sidecar) => JSON.stringify({ ...sidecar, receipt: { ...sidecar.receipt, status: 'partial' } })],
+    ['raw-string', (sidecar) => JSON.stringify({ ...sidecar, receipt: { ...sidecar.receipt, operation_rows: [{ kind: '<script>\nraw</script>', hash: 'a'.repeat(64) }] } })],
+  ];
+  for (const [name, encode] of invalid) {
+    const outputDirectory = mkdtempSync(path.join(tmpdir(), `ssi-sidecar-invalid-${name}-`));
+    const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'sidecar-invalid-run' });
+    const directory = path.join(outputDirectory, 'simple-site');
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, 'artifact.json'), JSON.stringify({ fixture: 'simple-site' }));
+    writeMaterializationSidecar({ directory, fixtureId: 'simple-site', runId: matrix.id, receipt: boundedSidecarReceipt() });
+    const sidecarPath = path.join(directory, 'materialization-receipt--primary.json');
+    const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf8'));
+    writeFileSync(sidecarPath, encode(sidecar));
+    const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+    assert.equal(result.fixtures[0].matrix_evidence.materialization_sidecar.status, 'malformed', name);
+  }
+});
+
 function boundedSidecarReceipt() {
   return {
-    schema: 'static-site-importer/materialization-receipt/v1', status: 'completed', plan_hash: 'plan-hash', page_count: 2, file_count: 4, operation_count: 99, loss_count: 3,
+    schema: 'static-site-importer/materialization-receipt/v1', status: 'completed', plan_hash: 'a'.repeat(64), page_count: 2, file_count: 4, operation_count: 99, loss_count: 3,
     provider_totals: { completed: 1 }, computed_layout_totals: { applied: 7, losses: 2, operations: 9 }, operation_rows: [{ kind: 'computed_layout', status: 'completed', hash: 'a'.repeat(64) }], loss_rows: [{ kind: 'computed_layout_loss', reason_code: 'missing_measurement', hash: 'b'.repeat(64) }], truncated: { operation_rows: true, loss_rows: false },
   };
 }
 
-function writeMaterializationSidecar({ directory, fixtureId, runId, receipt, artifactHash }) {
+function writeMaterializationSidecar({ directory, fixtureId, runId, receipt, artifactHash, attemptId = 'primary', fileName }) {
   const artifact = readFileSync(path.join(directory, 'artifact.json'));
   const sidecar = {
-    schema: 'static-site-importer/materialization-runtime-sidecar/v1', fixture_id: fixtureId, run_id: runId, step_id: 'import', artifact_sha256: artifactHash || createHash('sha256').update(artifact).digest('hex'), provenance: { provider: 'static-site-importer/current-runtime', provider_status: 'completed' }, receipt,
+    schema: 'static-site-importer/materialization-runtime-sidecar/v1', fixture_id: fixtureId, run_id: runId, step_id: 'import', attempt_id: attemptId, artifact_sha256: artifactHash || createHash('sha256').update(artifact).digest('hex'), provenance: { provider: 'static-site-importer/current-runtime', provider_status: 'completed' }, receipt,
   };
   sidecar.content_sha256 = createHash('sha256').update(JSON.stringify(sidecar)).digest('hex');
-  writeFileSync(path.join(directory, 'materialization-receipt.json'), JSON.stringify(sidecar));
+  writeFileSync(path.join(directory, fileName || `materialization-receipt--${attemptId}.json`), JSON.stringify(sidecar));
 }
 
 test('fixture attribution assigns a transform loss only with complete transformer lineage', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1054,6 +1054,102 @@ test('fixture matrix labels reports without runtime provenance and materializati
   assert.equal(result.summary.matrix_evidence_readiness.counts.legacy_evidence_missing, 1);
 });
 
+test('fixture attribution assigns a transform loss only with complete transformer lineage', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'transform-attribution-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      matrix_evidence: verifiedMatrixEvidence(),
+      diagnostics: [{ kind: 'missing_output', attribution_boundary: 'transform', message: 'Transformer omitted a source block.' }],
+    }],
+  });
+
+  assert.equal(result.findings[0].candidate_repo, 'blocks-engine');
+  assert.equal(result.findings[0].attribution_candidates.find((candidate) => candidate.boundary === 'transform').supported, true);
+});
+
+test('fixture attribution assigns adapter loss only with a failed provider result', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'provider-attribution-test' });
+  const evidence = verifiedMatrixEvidence();
+  evidence.lineage.provider_adapter = { schema: 'static-site-importer/provider-adapter/v1', status: 'failed', provider: 'test-adapter' };
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      matrix_evidence: evidence,
+      diagnostics: [{ kind: 'recipe_step_failure', attribution_boundary: 'provider', message: 'Provider adapter dropped the import result.' }],
+    }],
+  });
+
+  assert.equal(result.findings[0].candidate_repo, 'static-site-importer');
+  assert.equal(result.findings[0].attribution_candidates.find((candidate) => candidate.boundary === 'provider').supported, true);
+});
+
+test('fixture attribution keeps capture-only mismatches distinct from transform ownership', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'capture-attribution-test' });
+  const evidence = verifiedMatrixEvidence();
+  evidence.lineage.capture = { schema: 'wp-codebox/visual-capture/v1', status: 'failed', source: 'source.png', candidate: 'candidate.png' };
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      matrix_evidence: evidence,
+      diagnostics: [{ kind: 'visual_parity_mismatch', attribution_boundary: 'capture', message: 'Capture contract mismatched source and candidate screenshots.' }],
+    }],
+  });
+
+  assert.equal(result.findings[0].candidate_repo, 'static-site-importer');
+  assert.equal(result.findings[0].attribution_candidates.find((candidate) => candidate.boundary === 'transform').supported, false);
+});
+
+test('fixture attribution records missing lineage as a blind spot instead of defaulting to Blocks Engine', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'missing-lineage-attribution-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      matrix_evidence: { readiness: 'legacy_evidence_missing', missing: ['transformer_reference', 'wordpress_site_plan', 'materialization_receipt'] },
+      diagnostics: [{ kind: 'visual_parity_mismatch', message: 'Visual mismatch has no lineage.' }],
+    }],
+  });
+
+  assert.equal(result.findings[0].candidate_repo, '');
+  assert.deepEqual(result.findings[0].diagnostic_blind_spots, ['capture_contract', 'materialization_receipt', 'provider_adapter_result', 'transformer_reference', 'wordpress_site_plan']);
+  assert.ok(result.summary.diagnostic_blind_spots.some((spot) => spot.kind === 'missing_required_lineage'));
+});
+
+test('fixture lineage retains the development transformer override identity', () => {
+  const evidence = collectMatrixEvidence({
+    import_report: {
+      blocks_engine: {
+        transformer: { package: 'automattic/blocks-engine-php-transformer', version: 'dev-main', reference: 'a'.repeat(40) },
+        wordpress_site_plan: { schema: 'blocks-engine/wordpress-site-plan/v2' },
+      },
+      materialization_receipt: { schema: 'static-site-importer/materialization-receipt/v1', status: 'completed' },
+    },
+  }, {
+    dependencyOverrides: { blocks_engine_php_transformer: { package: 'automattic/blocks-engine-php-transformer', reference: 'b'.repeat(40) } },
+  });
+
+  assert.deepEqual(evidence.lineage.development_override, { package: 'automattic/blocks-engine-php-transformer', reference: 'b'.repeat(40) });
+});
+
+function verifiedMatrixEvidence() {
+  return {
+    readiness: 'verified',
+    missing: [],
+    transformer: { package: 'automattic/blocks-engine-php-transformer', version: '1.0.0', reference: 'a'.repeat(40) },
+    wordpress_site_plan: { schema: 'blocks-engine/wordpress-site-plan/v2' },
+    materialization_receipt: { schema: 'static-site-importer/materialization-receipt/v1', status: 'completed' },
+    lineage: { artifact: { schema: 'blocks-engine/wordpress-site-plan/v2' } },
+  };
+}
+
 test('fixture matrix rejects placeholder transformer provenance', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-matrix-placeholder-provenance-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'placeholder-provenance-test' });
@@ -1760,11 +1856,11 @@ test('splits acceptable and unacceptable pattern rollups for minion fanout', () 
   assert.equal(result.summary.top_acceptable_pattern_families[0].key, 'static_site_import_quality:native_block_conversion:(none)');
   assert.equal(result.summary.top_unacceptable_pattern_families[0].key, 'static_site_import_quality:layout_shift:(none)');
   assert.equal(result.summary.top_unacceptable_pattern_families[0].count, 2);
-  assert.equal(result.summary.unacceptable_candidate_repos[0].candidate_repo, 'blocks-engine');
-  assert.equal(result.summary.unacceptable_candidate_repos[0].count, 2);
+  assert.equal(result.summary.unacceptable_candidate_repos[0].candidate_repo, 'unknown');
+  assert.equal(result.summary.unacceptable_candidate_repos[0].count, 3);
   assert.equal(result.summary.unacceptable_candidate_repos[0].top_pattern_families[0].key, 'static_site_import_quality:layout_shift:(none)');
   assert.equal(result.fanout_groups[0].acceptance, 'unacceptable');
-  assert.equal(result.fanout_groups[0].candidate_repo, 'blocks-engine');
+  assert.equal(result.fanout_groups[0].candidate_repo, 'unknown');
   assert.equal(result.fanout_groups[0].pattern_family, 'static_site_import_quality:layout_shift:(none)');
   assert.equal(result.fanout_groups[0].count, 2);
   assert.notEqual(result.fanout_groups[0].group_key, 'static_site_import_quality');
@@ -4695,7 +4791,7 @@ test('editor-canvas-probe invalid-block warnings become gating editor_block_inva
   assert.equal(finding.kind, 'editor_block_invalid');
   assert.equal(finding.group_key, 'editor_block_invalid');
   assert.equal(finding.repair_bucket, 'editor_block_invalid');
-  assert.equal(finding.candidate_repo, 'blocks-engine');
+  assert.equal(finding.candidate_repo, '');
   assert.equal(finding.loss_class, 'editor_block_invalid');
   assert.equal(finding.loss_acceptance, 'unacceptable');
   assert.equal(finding.selector, '.block-editor-warning');
@@ -5785,7 +5881,7 @@ test('(b) visual-compare mismatch over threshold with gate on becomes a gating u
   assert.ok(finding, 'expected a visual_parity_mismatch finding');
   assert.equal(finding.group_key, 'visual_parity_mismatch');
   assert.equal(finding.repair_bucket, 'visual_parity_mismatch');
-  assert.equal(finding.candidate_repo, 'blocks-engine');
+  assert.equal(finding.candidate_repo, '');
   assert.equal(finding.loss_class, 'visual_parity_mismatch');
   assert.equal(finding.loss_acceptance, 'unacceptable');
   assert.equal(result.summary.unacceptable_finding_count, 1);

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1241,6 +1241,44 @@ test('fixture lineage rejects same-run evidence from a different step', () => {
   assert.equal(finding.diagnostic_blind_spots, undefined);
 });
 
+test('fixture lineage requires complete matching correlation identities', () => {
+  const cases = [
+    ['matching run', { run_id: 'run-a' }, { run_id: 'run-a' }, true],
+    ['matching run and step', { run_id: 'run-a', step_id: 'step-a' }, { run_id: 'run-a', step_id: 'step-a' }, true],
+    ['matching full identity', { run_id: 'run-a', step_id: 'step-a', diagnostic_id: 'diagnostic-a' }, { run_id: 'run-a', step_id: 'step-a', diagnostic_id: 'diagnostic-a' }, true],
+    ['same run with evidence-only step', { run_id: 'run-a' }, { run_id: 'run-a', step_id: 'step-a' }, false],
+    ['same step with diagnostic-only run', { run_id: 'run-a', step_id: 'step-a' }, { step_id: 'step-a' }, false],
+    ['same run with conflicting step', { run_id: 'run-a', step_id: 'step-a' }, { run_id: 'run-a', step_id: 'step-b' }, false],
+    ['same run and step with conflicting diagnostic', { run_id: 'run-a', step_id: 'step-a', diagnostic_id: 'diagnostic-a' }, { run_id: 'run-a', step_id: 'step-a', diagnostic_id: 'diagnostic-b' }, false],
+    ['absent identities', {}, {}, false],
+  ];
+
+  for (const [name, diagnosticIdentity, evidenceIdentity, expected] of cases) {
+    const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-attribution-identity-'));
+    const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: `attribution-identity-${name}` });
+    const result = collectFixtureMatrixRunResults({
+      matrix,
+      outputDirectory,
+      codeboxOutput: [
+        {
+          fixture_id: 'simple-site',
+          status: 'failed',
+          import_report: verifiedImportReport(),
+          diagnostics: [{ ...diagnosticIdentity, kind: 'recipe_step_failure', attribution_boundary: 'provider', message: 'Provider operation failed.' }],
+        },
+        {
+          fixture_id: 'simple-site',
+          ...evidenceIdentity,
+          provider_adapter: { schema: 'static-site-importer/provider-adapter/v1', status: 'failed', provider: 'correlation-test' },
+        },
+      ],
+    });
+
+    const finding = result.findings.find((item) => item.kind === 'recipe_step_failure');
+    assert.equal(finding.candidate_repo === 'static-site-importer', expected, name);
+  }
+});
+
 test('fixture attribution infers transform ownership for verified editor-invalid diagnostics', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'inferred-transform-attribution-test' });
   const result = normalizeFixtureMatrixResult({

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -115,6 +115,18 @@ test('matrix evidence fails closed when the materialization receipt is absent', 
   assert.ok(evidence.missing.includes('materialization_receipt'));
 });
 
+test('legacy validation payloads without a receipt contract remain consumable', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-legacy-no-sidecar-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'legacy-no-sidecar' });
+  const result = collectFixtureMatrixRunResults({
+    matrix,
+    outputDirectory,
+    codeboxOutput: { fixture_id: 'simple-site', status: 'passed', success: true, import_report: { blocks_engine: { available: true } } },
+  });
+  assert.equal(result.fixtures[0].status, 'passed');
+  assert.equal(result.fixtures[0].matrix_evidence.materialization_sidecar.status, 'missing');
+});
+
 test('matrix evidence consumes the bounded fixture diagnostic contract', () => {
   const reference = 'b'.repeat(40);
   const evidence = collectMatrixEvidence({
@@ -577,6 +589,26 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
     target: '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix/simple-site/artifact.json',
   });
   assert.deepEqual(recipe.inputs.mounts, []);
+});
+
+test('matrix import recipes declare the complete required sidecar contract', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'complete-sidecar-contract' });
+  const recipe = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', runId: 'run-1', attemptId: 'attempt-1' });
+  const command = recipe.workflow.steps[1].args[0];
+  for (const flag of ['--receipt-sidecar=', '--receipt-run-id=run-1', '--receipt-step-id=import', '--receipt-attempt-id=attempt-1']) {
+    assert.match(command, new RegExp(flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});
+
+test('validate-artifact sidecar contract preserves legacy calls and rejects partial arguments', () => {
+  const plugin = readFileSync(path.join(packageRoot, 'static-site-importer.php'), 'utf8');
+  const start = plugin.indexOf('function static_site_importer_cli_materialization_sidecar_contract');
+  const end = plugin.indexOf('\n}\n\n/**', start) + 2;
+  const contract = plugin.slice(start, end);
+  const code = `class WP_Error { public $code; function __construct($code) { $this->code = $code; } } function is_wp_error($value) { return $value instanceof WP_Error; } ${contract} $cases = array(static_site_importer_cli_materialization_sidecar_contract(array()), static_site_importer_cli_materialization_sidecar_contract(array('receipt-sidecar' => '/tmp/sidecar.json', 'receipt-run-id' => 'run', 'receipt-step-id' => 'import', 'receipt-attempt-id' => 'attempt')), static_site_importer_cli_materialization_sidecar_contract(array('receipt-sidecar' => '/tmp/sidecar.json'))); echo json_encode(array($cases[0], $cases[1], is_wp_error($cases[2]) ? $cases[2]->code : 'not-error'));`;
+  const result = spawnSync('php', ['-r', code], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [false, true, 'static_site_importer_sidecar_contract_partial']);
 });
 
 test('gates visual capture on complete generated SVG font evidence after import', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1071,7 +1071,7 @@ test('fixture attribution assigns a transform loss only with complete transforme
   assert.equal(result.findings[0].diagnostic_blind_spots, undefined);
 });
 
-test('fixture attribution assigns adapter loss only with a failed provider result', () => {
+test('fixture attribution assigns adapter loss only with correlated failed provider evidence', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'provider-attribution-test' });
   const evidence = verifiedMatrixEvidence();
   const result = normalizeFixtureMatrixResult({
@@ -1080,7 +1080,7 @@ test('fixture attribution assigns adapter loss only with a failed provider resul
       fixture_id: 'simple-site',
       status: 'failed',
       matrix_evidence: evidence,
-      diagnostics: [{ kind: 'recipe_step_failure', attribution_boundary: 'provider', attribution_evidence: { provider_adapter: { schema: 'static-site-importer/provider-adapter/v1', status: 'failed', provider: 'test-adapter' } }, message: 'Provider adapter dropped the import result.' }],
+      diagnostics: [{ kind: 'recipe_step_failure', run_id: 'provider-run', attribution_boundary: 'provider', attribution_evidence: { correlation: { run_id: 'provider-run' }, provider_adapter: { schema: 'static-site-importer/provider-adapter/v1', status: 'failed', provider: 'test-adapter' } }, message: 'Provider adapter dropped the import result.' }],
     }],
   });
 
@@ -1097,12 +1097,42 @@ test('fixture attribution keeps capture-only mismatches distinct from transform 
       fixture_id: 'simple-site',
       status: 'failed',
       matrix_evidence: evidence,
-      diagnostics: [{ kind: 'visual_parity_mismatch', attribution_boundary: 'capture', attribution_evidence: { capture: { schema: 'wp-codebox/visual-capture/v1', status: 'failed', source: 'source.png', candidate: 'candidate.png' } }, message: 'Capture contract mismatched source and candidate screenshots.' }],
+      diagnostics: [{ kind: 'visual_parity_mismatch', run_id: 'capture-run', attribution_boundary: 'capture', attribution_evidence: { correlation: { run_id: 'capture-run' }, capture: { schema: 'wp-codebox/visual-capture/v1', status: 'failed', source: 'source.png', candidate: 'candidate.png' } }, message: 'Capture contract mismatched source and candidate screenshots.' }],
     }],
   });
 
   assert.equal(result.findings[0].candidate_repo, 'static-site-importer');
   assert.equal(result.findings[0].attribution_candidates.find((candidate) => candidate.boundary === 'transform').supported, false);
+});
+
+test('versioned fixture evidence rejects uncorrelated direct provider evidence', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'strict-direct-provider-correlation-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      matrix_evidence: { schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1', readiness: 'verified', missing: [] },
+      diagnostics: [{ kind: 'recipe_step_failure', attribution_boundary: 'provider', attribution_evidence: { provider_adapter: { status: 'failed' } }, message: 'Uncorrelated direct provider evidence.' }],
+    }],
+  });
+
+  assert.equal(result.findings[0].candidate_repo, '');
+  assert.deepEqual(result.findings[0].diagnostic_blind_spots, ['provider_adapter_correlation']);
+});
+
+test('unversioned callers retain explicit provider ownership without correlation evidence', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'legacy-direct-provider-correlation-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      diagnostics: [{ kind: 'recipe_step_failure', attribution_boundary: 'provider', candidate_repo: 'static-site-importer', attribution_evidence: { provider_adapter: { status: 'failed' } }, message: 'Legacy provider ownership.' }],
+    }],
+  });
+
+  assert.equal(result.findings[0].candidate_repo, 'static-site-importer');
 });
 
 test('fixture attribution records missing lineage as a blind spot instead of defaulting to Blocks Engine', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -21,6 +21,7 @@ import runFixtureMatrixBench, {
   FIXTURE_MATRIX_PROGRESS_SCHEMA,
   fixtureMatrixBatchRunSummary,
   mapWithConcurrency,
+  materializeMaterializationSidecars,
   materializeVisualCompareArtifacts,
   materializeEditorCanvasArtifacts,
   optionsFromEnv,
@@ -566,8 +567,9 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
   assert.match(recipe.workflow.steps[1].args[0], /--format=fixture-matrix/);
-  assert.match(recipe.workflow.steps[1].args[0], /--receipt-sidecar=\/wordpress\/wp-content\/uploads\/static-site-importer-fixture-matrix\/simple-site\/materialization-receipt--primary\.json/);
-  assert.match(recipe.workflow.steps[1].args[0], /--receipt-run-id=recipe-test --receipt-step-id=import --receipt-attempt-id=primary/);
+  assert.match(recipe.workflow.steps[1].args[0], /--receipt-sidecar=\/wordpress\/wp-content\/uploads\/static-site-importer-fixture-matrix\/simple-site\/materialization-receipt--[A-Za-z0-9-]+\.json/);
+  assert.match(recipe.workflow.steps[1].args[0], /--receipt-run-id=recipe-test-[A-Za-z0-9-]+ --receipt-step-id=import --receipt-attempt-id=[A-Za-z0-9-]+/);
+  assert.equal(recipe.artifacts.typed[0].path, recipe.workflow.steps[1].args[0].match(/--receipt-sidecar=([^ ]+)/)?.[1]);
   assert.match(recipe.workflow.steps[1].args[0], /--allow-failure/);
   assert.doesNotMatch(recipe.workflow.steps[1].args[0], /--allow-missing-woocommerce/);
   assert.deepEqual(recipe.inputs.stagedFiles[0], {
@@ -1115,6 +1117,35 @@ test('materialization sidecars isolate concurrent attempts for the same fixture'
   assert.equal(second.fixtures[0].matrix_evidence.materialization_receipt.operation_count, 2);
 });
 
+test('typed WP Codebox sidecar export materializes into the host intake path', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-sidecar-host-output-'));
+  const codeboxArtifactsDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-sidecar-codebox-artifacts-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'sidecar-export-run' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  const guestDirectory = path.join(codeboxArtifactsDirectory, 'runtime-123', 'files', 'runtime-evidence', 'typed-artifacts', 'guest-simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  mkdirSync(guestDirectory, { recursive: true });
+  const artifact = JSON.stringify({ fixture: 'simple-site' });
+  writeFileSync(path.join(fixtureDirectory, 'artifact.json'), artifact);
+  writeFileSync(path.join(guestDirectory, 'artifact.json'), artifact);
+  writeMaterializationSidecar({ directory: guestDirectory, fixtureId: 'simple-site', runId: matrix.id, attemptId: 'batch-001', receipt: boundedSidecarReceipt(), fileName: 'exported-sidecar.json' });
+
+  const exports = materializeMaterializationSidecars({ fixtures: matrix.fixtures, outputDirectory, codeboxArtifactsDirectory, attemptId: 'batch-001' });
+  const expected = path.join(fixtureDirectory, 'materialization-receipt--batch-001.json');
+  assert.deepEqual(exports.map((entry) => entry.fixture_id), ['simple-site']);
+  assert.equal(existsSync(expected), true);
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory, sidecarAttemptId: 'batch-001' });
+  assert.equal(result.fixtures[0].matrix_evidence.materialization_sidecar.status, 'verified');
+});
+
+test('direct recipe builders generate distinct run and attempt identities', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'direct-recipe' });
+  const first = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi' });
+  const second = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi' });
+  assert.notEqual(first.workflow.steps[1].args[0], second.workflow.steps[1].args[0]);
+  assert.notEqual(first.artifacts.typed[0].path, second.artifacts.typed[0].path);
+});
+
 test('materialization sidecars reject partial, oversized, and semantically invalid content', () => {
   const invalid = [
     ['partial', (sidecar) => '{'],
@@ -1149,7 +1180,7 @@ function boundedSidecarReceipt() {
 function writeMaterializationSidecar({ directory, fixtureId, runId, receipt, artifactHash, attemptId = 'primary', fileName }) {
   const artifact = readFileSync(path.join(directory, 'artifact.json'));
   const sidecar = {
-    schema: 'static-site-importer/materialization-runtime-sidecar/v1', fixture_id: fixtureId, run_id: runId, step_id: 'import', attempt_id: attemptId, artifact_sha256: artifactHash || createHash('sha256').update(artifact).digest('hex'), provenance: { provider: 'static-site-importer/current-runtime', provider_status: 'completed' }, receipt,
+    schema: 'static-site-importer/materialization-runtime-sidecar/v1', fixture_id: fixtureId, run_id: runId, step_id: 'import', attempt_id: attemptId, artifact_sha256: artifactHash || createHash('sha256').update(artifact).digest('hex'), provenance: { provider: 'static-site-importer/current-runtime', provider_status: 'completed' }, durability: { file_fsync: 'available', directory_fsync: 'attempted' }, receipt,
   };
   sidecar.content_sha256 = createHash('sha256').update(JSON.stringify(sidecar)).digest('hex');
   writeFileSync(path.join(directory, fileName || `materialization-receipt--${attemptId}.json`), JSON.stringify(sidecar));
@@ -7392,8 +7423,9 @@ test('live-WP parity toggle adds the capture step + invokes the collector when O
 
   // RECIPE: OFF is byte-identical to the same recipe with no live-WP input, and
   // emits no capture-html step. ON appends exactly one capture-html step.
-  const recipeBaseline = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi' });
-  const recipeOff = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', liveWpParity: false });
+  const invocation = { runId: 'live-wp-toggle-run', attemptId: 'live-wp-toggle-attempt' };
+  const recipeBaseline = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', ...invocation });
+  const recipeOff = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', liveWpParity: false, ...invocation });
   assert.deepEqual(recipeOff, recipeBaseline, 'liveWpParity:false leaves the recipe byte-identical to today');
   assert.equal(recipeOff.workflow.steps.some((step) => step.command === 'wordpress.capture-html'), false);
   const recipeOn = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', liveWpParity: true });

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -3,6 +3,7 @@
  */
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -565,6 +566,8 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
   assert.match(recipe.workflow.steps[1].args[0], /--format=fixture-matrix/);
+  assert.match(recipe.workflow.steps[1].args[0], /--receipt-sidecar=\/wordpress\/wp-content\/uploads\/static-site-importer-fixture-matrix\/simple-site\/materialization-receipt\.json/);
+  assert.match(recipe.workflow.steps[1].args[0], /--receipt-run-id=recipe-test --receipt-step-id=import/);
   assert.match(recipe.workflow.steps[1].args[0], /--allow-failure/);
   assert.doesNotMatch(recipe.workflow.steps[1].args[0], /--allow-missing-woocommerce/);
   assert.deepEqual(recipe.inputs.stagedFiles[0], {
@@ -1053,6 +1056,65 @@ test('fixture matrix labels reports without runtime provenance and materializati
   assert.equal(result.summary.matrix_evidence_readiness.status, 'incomplete');
   assert.equal(result.summary.matrix_evidence_readiness.counts.legacy_evidence_missing, 1);
 });
+
+test('materialization sidecars retain bounded evidence after oversized import stdout', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-sidecar-oversized-output-'));
+  const base = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'sidecar-run' });
+  const matrix = { ...base, fixtures: [{ ...base.fixtures[0] }, { ...base.fixtures[0], id: 'second-site' }] };
+  for (const fixture of matrix.fixtures) {
+    const directory = path.join(outputDirectory, fixture.id);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, 'artifact.json'), JSON.stringify({ fixture: fixture.id }));
+    writeMaterializationSidecar({ directory, fixtureId: fixture.id, runId: matrix.id, receipt: boundedSidecarReceipt() });
+  }
+  const result = collectFixtureMatrixRunResults({
+    matrix,
+    outputDirectory,
+    codeboxOutput: { executions: matrix.fixtures.map((fixture) => ({ metadata: { fixture_id: fixture.id }, stdout: 'x'.repeat(1024 * 1024 + 1) })) },
+  });
+
+  for (const fixture of result.fixtures) {
+    assert.equal(fixture.matrix_evidence.materialization_sidecar.status, 'verified');
+    assert.equal(fixture.matrix_evidence.materialization_receipt.operation_count, 99);
+    assert.equal(fixture.matrix_evidence.materialization_receipt.page_count, 2);
+    assert.deepEqual(fixture.matrix_evidence.materialization_sidecar.computed_layout_totals, { applied: 7, losses: 2, operations: 9 });
+    assert.deepEqual(fixture.matrix_evidence.materialization_sidecar.provider_totals, { completed: 1 });
+    assert.ok(fixture.artifact_refs.some((ref) => ref.artifact_id === 'materialization-receipt'));
+  }
+});
+
+test('materialization sidecars reject malformed, stale, cross-fixture, and hash-mismatched evidence', () => {
+  const cases = ['missing', 'malformed', 'stale', 'cross_fixture', 'hash_mismatch'];
+  for (const status of cases) {
+    const outputDirectory = mkdtempSync(path.join(tmpdir(), `ssi-sidecar-${status}-`));
+    const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'sidecar-validation-run' });
+    const directory = path.join(outputDirectory, 'simple-site');
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, 'artifact.json'), JSON.stringify({ fixture: 'simple-site' }));
+    if (status === 'malformed') writeFileSync(path.join(directory, 'materialization-receipt.json'), '{');
+    if (status === 'stale') writeMaterializationSidecar({ directory, fixtureId: 'simple-site', runId: 'old-run', receipt: boundedSidecarReceipt() });
+    if (status === 'cross_fixture') writeMaterializationSidecar({ directory, fixtureId: 'other-site', runId: matrix.id, receipt: boundedSidecarReceipt() });
+    if (status === 'hash_mismatch') writeMaterializationSidecar({ directory, fixtureId: 'simple-site', runId: matrix.id, receipt: boundedSidecarReceipt(), artifactHash: '0'.repeat(64) });
+    const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+    assert.equal(result.fixtures[0].matrix_evidence.materialization_sidecar.status, status === 'missing' ? 'missing' : status, status);
+  }
+});
+
+function boundedSidecarReceipt() {
+  return {
+    schema: 'static-site-importer/materialization-receipt/v1', status: 'completed', plan_hash: 'plan-hash', page_count: 2, file_count: 4, operation_count: 99, loss_count: 3,
+    provider_totals: { completed: 1 }, computed_layout_totals: { applied: 7, losses: 2, operations: 9 }, operation_rows: [{ kind: 'computed_layout', status: 'completed', hash: 'a'.repeat(64) }], loss_rows: [{ kind: 'computed_layout_loss', reason_code: 'missing_measurement', hash: 'b'.repeat(64) }], truncated: { operation_rows: true, loss_rows: false },
+  };
+}
+
+function writeMaterializationSidecar({ directory, fixtureId, runId, receipt, artifactHash }) {
+  const artifact = readFileSync(path.join(directory, 'artifact.json'));
+  const sidecar = {
+    schema: 'static-site-importer/materialization-runtime-sidecar/v1', fixture_id: fixtureId, run_id: runId, step_id: 'import', artifact_sha256: artifactHash || createHash('sha256').update(artifact).digest('hex'), provenance: { provider: 'static-site-importer/current-runtime', provider_status: 'completed' }, receipt,
+  };
+  sidecar.content_sha256 = createHash('sha256').update(JSON.stringify(sidecar)).digest('hex');
+  writeFileSync(path.join(directory, 'materialization-receipt.json'), JSON.stringify(sidecar));
+}
 
 test('fixture attribution assigns a transform loss only with complete transformer lineage', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'transform-attribution-test' });

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1112,7 +1112,7 @@ test('fixture attribution records missing lineage as a blind spot instead of def
     results: [{
       fixture_id: 'simple-site',
       status: 'failed',
-      matrix_evidence: { readiness: 'legacy_evidence_missing', missing: ['transformer_reference', 'wordpress_site_plan', 'materialization_receipt'] },
+      matrix_evidence: { schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1', readiness: 'legacy_evidence_missing', missing: ['transformer_reference', 'wordpress_site_plan', 'materialization_receipt'] },
       diagnostics: [{ kind: 'visual_parity_mismatch', message: 'Visual mismatch has no lineage.' }],
     }],
   });
@@ -1120,6 +1120,51 @@ test('fixture attribution records missing lineage as a blind spot instead of def
   assert.equal(result.findings[0].candidate_repo, '');
   assert.deepEqual(result.findings[0].diagnostic_blind_spots, ['attribution_boundary']);
   assert.ok(result.summary.diagnostic_blind_spots.some((spot) => spot.kind === 'missing_required_lineage'));
+});
+
+test('materialization attribution reports missing transformer provenance as a boundary blind spot', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'materialization-lineage-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      matrix_evidence: { schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1', readiness: 'legacy_evidence_missing', missing: ['transformer_package', 'transformer_version', 'transformer_reference'] },
+      diagnostics: [{ kind: 'missing_asset', attribution_boundary: 'materialization', candidate_repo: 'static-site-importer', message: 'Materialization omitted a stylesheet.' }],
+    }],
+  });
+
+  assert.equal(result.findings[0].candidate_repo, '');
+  assert.deepEqual(result.findings[0].diagnostic_blind_spots, ['transformer_package', 'transformer_reference', 'transformer_version']);
+});
+
+test('unversioned fixture results retain caller-supplied ownership when attribution evidence is absent', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'legacy-owner-compatibility-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      diagnostics: [{ kind: 'layout_shift', candidate_repo: 'blocks-engine', message: 'Legacy caller ownership.' }],
+    }],
+  });
+
+  assert.equal(result.findings[0].candidate_repo, 'blocks-engine');
+});
+
+test('versioned fixture evidence replaces an unproven caller-supplied owner', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'strict-owner-compatibility-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      matrix_evidence: { schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1', readiness: 'legacy_evidence_missing', missing: ['transformer_reference'] },
+      diagnostics: [{ kind: 'layout_shift', candidate_repo: 'blocks-engine', message: 'Strict contract lacks ownership evidence.' }],
+    }],
+  });
+
+  assert.equal(result.findings[0].candidate_repo, '');
 });
 
 test('fixture lineage retains the development transformer override identity', () => {
@@ -1165,6 +1210,35 @@ test('fixture lineage does not correlate a retried provider failure to a transfo
   assert.equal(finding.candidate_repo, 'blocks-engine');
   assert.equal(finding.diagnostic_blind_spots, undefined);
   assert.equal(finding.attribution_candidates.find((candidate) => candidate.boundary === 'provider').missing.length, 0);
+});
+
+test('fixture lineage rejects same-run evidence from a different step', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-attribution-step-correlation-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'attribution-step-correlation-test' });
+  const result = collectFixtureMatrixRunResults({
+    matrix,
+    outputDirectory,
+    codeboxOutput: [
+      {
+        fixture_id: 'simple-site',
+        run_id: 'shared-run',
+        step_id: 'transform-step',
+        status: 'failed',
+        import_report: verifiedImportReport(),
+        diagnostics: [{ id: 'transform-diagnostic', run_id: 'shared-run', step_id: 'transform-step', kind: 'missing_output', attribution_boundary: 'transform', message: 'Transform failed.' }],
+      },
+      {
+        fixture_id: 'simple-site',
+        run_id: 'shared-run',
+        step_id: 'provider-step',
+        provider_adapter: { schema: 'static-site-importer/provider-adapter/v1', status: 'failed', provider: 'other-step-provider' },
+      },
+    ],
+  });
+
+  const finding = result.findings.find((item) => item.kind === 'missing_output');
+  assert.equal(finding.candidate_repo, 'blocks-engine');
+  assert.equal(finding.diagnostic_blind_spots, undefined);
 });
 
 test('fixture attribution infers transform ownership for verified editor-invalid diagnostics', () => {
@@ -1910,11 +1984,11 @@ test('splits acceptable and unacceptable pattern rollups for minion fanout', () 
   assert.equal(result.summary.top_acceptable_pattern_families[0].key, 'static_site_import_quality:native_block_conversion:(none)');
   assert.equal(result.summary.top_unacceptable_pattern_families[0].key, 'static_site_import_quality:layout_shift:(none)');
   assert.equal(result.summary.top_unacceptable_pattern_families[0].count, 2);
-  assert.equal(result.summary.unacceptable_candidate_repos[0].candidate_repo, 'unknown');
-  assert.equal(result.summary.unacceptable_candidate_repos[0].count, 3);
+  assert.equal(result.summary.unacceptable_candidate_repos[0].candidate_repo, 'blocks-engine');
+  assert.equal(result.summary.unacceptable_candidate_repos[0].count, 2);
   assert.equal(result.summary.unacceptable_candidate_repos[0].top_pattern_families[0].key, 'static_site_import_quality:layout_shift:(none)');
   assert.equal(result.fanout_groups[0].acceptance, 'unacceptable');
-  assert.equal(result.fanout_groups[0].candidate_repo, 'unknown');
+  assert.equal(result.fanout_groups[0].candidate_repo, 'blocks-engine');
   assert.equal(result.fanout_groups[0].pattern_family, 'static_site_import_quality:layout_shift:(none)');
   assert.equal(result.fanout_groups[0].count, 2);
   assert.notEqual(result.fanout_groups[0].group_key, 'static_site_import_quality');

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1068,19 +1068,19 @@ test('fixture attribution assigns a transform loss only with complete transforme
 
   assert.equal(result.findings[0].candidate_repo, 'blocks-engine');
   assert.equal(result.findings[0].attribution_candidates.find((candidate) => candidate.boundary === 'transform').supported, true);
+  assert.equal(result.findings[0].diagnostic_blind_spots, undefined);
 });
 
 test('fixture attribution assigns adapter loss only with a failed provider result', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'provider-attribution-test' });
   const evidence = verifiedMatrixEvidence();
-  evidence.lineage.provider_adapter = { schema: 'static-site-importer/provider-adapter/v1', status: 'failed', provider: 'test-adapter' };
   const result = normalizeFixtureMatrixResult({
     matrix,
     results: [{
       fixture_id: 'simple-site',
       status: 'failed',
       matrix_evidence: evidence,
-      diagnostics: [{ kind: 'recipe_step_failure', attribution_boundary: 'provider', message: 'Provider adapter dropped the import result.' }],
+      diagnostics: [{ kind: 'recipe_step_failure', attribution_boundary: 'provider', attribution_evidence: { provider_adapter: { schema: 'static-site-importer/provider-adapter/v1', status: 'failed', provider: 'test-adapter' } }, message: 'Provider adapter dropped the import result.' }],
     }],
   });
 
@@ -1091,14 +1091,13 @@ test('fixture attribution assigns adapter loss only with a failed provider resul
 test('fixture attribution keeps capture-only mismatches distinct from transform ownership', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'capture-attribution-test' });
   const evidence = verifiedMatrixEvidence();
-  evidence.lineage.capture = { schema: 'wp-codebox/visual-capture/v1', status: 'failed', source: 'source.png', candidate: 'candidate.png' };
   const result = normalizeFixtureMatrixResult({
     matrix,
     results: [{
       fixture_id: 'simple-site',
       status: 'failed',
       matrix_evidence: evidence,
-      diagnostics: [{ kind: 'visual_parity_mismatch', attribution_boundary: 'capture', message: 'Capture contract mismatched source and candidate screenshots.' }],
+      diagnostics: [{ kind: 'visual_parity_mismatch', attribution_boundary: 'capture', attribution_evidence: { capture: { schema: 'wp-codebox/visual-capture/v1', status: 'failed', source: 'source.png', candidate: 'candidate.png' } }, message: 'Capture contract mismatched source and candidate screenshots.' }],
     }],
   });
 
@@ -1119,7 +1118,7 @@ test('fixture attribution records missing lineage as a blind spot instead of def
   });
 
   assert.equal(result.findings[0].candidate_repo, '');
-  assert.deepEqual(result.findings[0].diagnostic_blind_spots, ['capture_contract', 'materialization_receipt', 'provider_adapter_result', 'transformer_reference', 'wordpress_site_plan']);
+  assert.deepEqual(result.findings[0].diagnostic_blind_spots, ['attribution_boundary']);
   assert.ok(result.summary.diagnostic_blind_spots.some((spot) => spot.kind === 'missing_required_lineage'));
 });
 
@@ -1139,6 +1138,51 @@ test('fixture lineage retains the development transformer override identity', ()
   assert.deepEqual(evidence.lineage.development_override, { package: 'automattic/blocks-engine-php-transformer', reference: 'b'.repeat(40) });
 });
 
+test('fixture lineage does not correlate a retried provider failure to a transform diagnostic', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-attribution-correlation-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'attribution-correlation-test' });
+  const result = collectFixtureMatrixRunResults({
+    matrix,
+    outputDirectory,
+    codeboxOutput: [
+      {
+        fixture_id: 'simple-site',
+        run_id: 'current-run',
+        status: 'failed',
+        import_report: verifiedImportReport(),
+        diagnostics: [{ id: 'current-transform', run_id: 'current-run', step_id: 'shared-step', kind: 'missing_output', attribution_boundary: 'transform', message: 'Current transform omitted a source block.' }],
+      },
+      {
+        fixture_id: 'simple-site',
+        run_id: 'prior-run',
+        step_id: 'shared-step',
+        provider_adapter: { schema: 'static-site-importer/provider-adapter/v1', status: 'failed', provider: 'retried-provider' },
+      },
+    ],
+  });
+
+  const finding = result.findings.find((item) => item.kind === 'missing_output');
+  assert.equal(finding.candidate_repo, 'blocks-engine');
+  assert.equal(finding.diagnostic_blind_spots, undefined);
+  assert.equal(finding.attribution_candidates.find((candidate) => candidate.boundary === 'provider').missing.length, 0);
+});
+
+test('fixture attribution infers transform ownership for verified editor-invalid diagnostics', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'inferred-transform-attribution-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'failed',
+      matrix_evidence: verifiedMatrixEvidence(),
+      diagnostics: [{ kind: 'editor_block_invalid', message: 'Editor rejected transformed block markup.' }],
+    }],
+  });
+
+  assert.equal(result.findings[0].candidate_repo, 'blocks-engine');
+  assert.equal(result.findings[0].attribution_candidates.find((candidate) => candidate.boundary === 'transform').supported, true);
+});
+
 function verifiedMatrixEvidence() {
   return {
     readiness: 'verified',
@@ -1147,6 +1191,16 @@ function verifiedMatrixEvidence() {
     wordpress_site_plan: { schema: 'blocks-engine/wordpress-site-plan/v2' },
     materialization_receipt: { schema: 'static-site-importer/materialization-receipt/v1', status: 'completed' },
     lineage: { artifact: { schema: 'blocks-engine/wordpress-site-plan/v2' } },
+  };
+}
+
+function verifiedImportReport() {
+  return {
+    materialization_receipt: { schema: 'static-site-importer/materialization-receipt/v1', status: 'completed' },
+    blocks_engine: {
+      transformer: { package: 'automattic/blocks-engine-php-transformer', version: '1.0.0', reference: 'a'.repeat(40) },
+      wordpress_site_plan: { schema: 'blocks-engine/wordpress-site-plan/v2' },
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- carry bounded transformer override, artifact/site-plan, materialization, provider, and capture lineage into fixture evidence
- assign ownership only for evidence-backed transform, materialization, provider, or capture boundaries; otherwise retain unknown and report missing lineage
- retain a verified, bounded materialization/runtime sidecar before oversized WP-CLI output is truncated, with fixture/run/step correlation and artifact/content hashes
- reject malformed, stale, cross-fixture, and hash-mismatched sidecars while preserving legacy runs as legacy evidence

Fixes #758.
Fixes #764.

Evidence reviewed: Homeboy run `4aaea4b6-af4f-4d10-992b-66b38a7a4ee7`.

## Testing
- `npm run test:fixture-matrix`
- `npm test`
- `php -l static-site-importer.php`

## AI Assistance
Meaningful AI assistance: OpenAI GPT-5.6 Terra via OpenCode drafted the sidecar implementation and regression coverage; earlier PR work used OpenAI GPT-5.6 Sol via an OpenCode general coding subagent. Chris remains responsible for every line.