### PR TITLE
Persist fixture surface evidence lineage

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -95,6 +95,7 @@ export default async function runFixtureMatrixBench(context = {}) {
       visual_parity_evidence_report: { path: path.join(summary.output_directory, 'visual-parity-evidence-report.json') },
       visual_parity_evidence_report_markdown: { path: path.join(summary.output_directory, 'visual-parity-evidence-report.md') },
       visual_diff_classification: { path: path.join(summary.output_directory, 'visual-diff-classification.json') },
+      surface_lineage_bundles: { path: path.join(summary.output_directory, 'surface-lineage-bundles.json') },
       gutenberg_incompatibility_registry: { path: path.join(summary.output_directory, 'gutenberg-incompatibility-registry.json') },
       gutenberg_incompatibility_registry_report: { path: path.join(summary.output_directory, 'gutenberg-incompatibility-registry.md') },
       ...(summary.visual_parity_artifacts || {}),
@@ -637,9 +638,10 @@ function materializeFixtureEditorCanvasArtifacts({ fixture, outputDirectory, cod
     const persistedPath = path.join(outputDirectory, 'editor-canvas', fixtureId, path.basename(ref.path));
     fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
     fs.copyFileSync(sourcePath, persistedPath);
-    rewrites.set(ref.path, persistedPath);
     const artifactId = String(ref.artifact_id || ref.id || path.basename(ref.path, path.extname(ref.path))).replace(/[^a-z0-9_.-]+/gi, '-');
-    artifacts[`editor_canvas_${fixtureId}_${artifactId}`] = { path: persistedPath };
+    const exportedArtifactId = `editor_canvas_${fixtureId}_${artifactId}`;
+    rewrites.set(ref.path, { path: persistedPath, artifact_id: exportedArtifactId });
+    artifacts[exportedArtifactId] = { path: persistedPath };
   }
   if (rewrites.size === 0) {
     return fixture;
@@ -663,9 +665,9 @@ function rewriteEditorEvidencePaths(value, rewrites) {
     return value;
   }
   const files = value.files && typeof value.files === 'object'
-    ? Object.fromEntries(Object.entries(value.files).map(([key, filePath]) => [key, rewrites.get(filePath) || filePath]))
+    ? Object.fromEntries(Object.entries(value.files).map(([key, filePath]) => [key, rewritePath(filePath, rewrites)]))
     : undefined;
-  return { ...value, ...(files ? { files } : {}), ...(value.screenshot ? { screenshot: rewrites.get(value.screenshot) || value.screenshot } : {}) };
+  return { ...value, ...(files ? { files } : {}), ...(value.screenshot ? { screenshot: rewritePath(value.screenshot, rewrites) } : {}) };
 }
 
 export function materializeVisualCompareArtifacts(input = {}) {
@@ -737,14 +739,15 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
     const persistedPath = path.join(outputDirectory, 'visual-compare', fixtureId, fileStem.includes('.') ? fileStem : `${fileStem}.png`);
     fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
     fs.copyFileSync(sourcePath, persistedPath);
-    rewrites.set(refPath, persistedPath);
+    const exportedArtifactId = `visual_compare_${artifactKey(fixtureId)}_${fileStem}`;
+    rewrites.set(refPath, { path: persistedPath, artifact_id: exportedArtifactId });
     updatedSlots[slotName] = {
       ...slots[slotName],
       status: 'captured',
       kind: slotName,
-      ref: artifactRef(slotName, persistedPath, 'visual-parity'),
+      ref: artifactRef(exportedArtifactId, persistedPath, 'visual-parity'),
     };
-    artifacts[`visual_compare_${artifactKey(fixtureId)}_${fileStem}`] = { path: persistedPath };
+    artifacts[exportedArtifactId] = { path: persistedPath };
   }
 
   const comparisonRefPaths = new Set(arrayValue(fixture.visual_parity_comparisons).flatMap((comparison) => Object.values(
@@ -764,8 +767,9 @@ function materializeFixtureVisualCompareArtifacts({ fixture, outputDirectory, co
       const persistedPath = path.join(outputDirectory, 'visual-compare', comparisonName, fileName);
       fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
       fs.copyFileSync(sourcePath, persistedPath);
-      rewrites.set(ref.path, persistedPath);
-      artifacts[`visual_compare_${artifactKey(comparisonName)}_${artifactKey(fileName)}`] = { path: persistedPath };
+      const exportedArtifactId = `visual_compare_${artifactKey(comparisonName)}_${artifactKey(fileName)}`;
+      rewrites.set(ref.path, { path: persistedPath, artifact_id: exportedArtifactId });
+      artifacts[exportedArtifactId] = { path: persistedPath };
     }
   }
 
@@ -876,8 +880,8 @@ function materializeSecondaryVisualCompareArtifacts({ comparison, fixtureId, out
     const persistedPath = path.join(outputDirectory, 'visual-compare', fixtureId, surfaceId, fileStem.includes('.') ? fileStem : `${fileStem}.png`);
     fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
     fs.copyFileSync(sourcePath, persistedPath);
-    rewrites.set(refPath, persistedPath);
     const artifactId = `visual_compare_${artifactKey(fixtureId)}_${surfaceId}_${fileStem}`;
+    rewrites.set(refPath, { path: persistedPath, artifact_id: artifactId });
     updatedSlots[slotName] = {
       ...slots[slotName],
       status: 'captured',
@@ -904,8 +908,13 @@ function rewriteVisualEvidencePaths(value, rewrites) {
   }
   return Object.fromEntries(Object.entries(value).map(([key, entry]) => [
     key,
-    typeof entry === 'string' && rewrites.has(entry) ? rewrites.get(entry) : rewriteVisualEvidencePaths(entry, rewrites),
+    typeof entry === 'string' && rewrites.has(entry) ? rewritePath(entry, rewrites) : rewriteVisualEvidencePaths(entry, rewrites),
   ]));
+}
+
+function rewritePath(value, rewrites) {
+  const rewrite = rewrites.get(value);
+  return typeof rewrite === 'string' ? rewrite : rewrite?.path || value;
 }
 
 function materializeVisualAttribution({ fixture, fixtureId, outputDirectory, slots, normalizer, loader, homeboyExtensionPath }) {
@@ -1131,7 +1140,12 @@ function rewriteArtifactRefs(refs, rewrites, unavailablePaths = new Set()) {
   return Array.isArray(refs)
     ? refs
       .filter((ref) => !unavailablePaths.has(ref?.path))
-      .map((ref) => rewrites.has(ref?.path) ? { ...ref, path: rewrites.get(ref.path) } : ref)
+      .map((ref) => {
+        const rewrite = rewrites.get(ref?.path);
+        if (!rewrite) return ref;
+        if (typeof rewrite === 'string') return { ...ref, path: rewrite };
+        return { ...ref, path: rewrite.path, ...(rewrite.artifact_id ? { artifact_id: rewrite.artifact_id } : {}) };
+      })
     : refs;
 }
 

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -54,6 +54,12 @@ export {
   summarizeSurfaceCoverage,
 } from './fixture-matrix/steps/surfaces.mjs';
 
+export {
+  SURFACE_LINEAGE_SCHEMA,
+  buildFixtureSurfaceLineage,
+  buildSurfaceLineageArtifact,
+} from './fixture-matrix/surface-lineage.mjs';
+
 export { editorBlockValidationStep } from './fixture-matrix/steps/editor-validation-step.mjs';
 
 export {

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -69,7 +69,7 @@ export function collectFixtureMatrixRunResults(input = {}) {
     return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity, dependencyOverrides: input.dependencyOverrides || input.dependency_overrides, sidecar });
   });
 
-  return normalizeFixtureMatrixResult({ matrix, results, slow_fixtures: slowFixtures });
+  return normalizeFixtureMatrixResult({ matrix, results, slow_fixtures: slowFixtures, surfaceCoverage: input.surfaceCoverage || input.surface_coverage });
 }
 
 function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity, liveWpParity, dependencyOverrides, sidecar }) {
@@ -116,6 +116,7 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     editor_open: merged.editor_open || merged.editorOpen || null,
     visual_parity_artifacts: visualParityArtifacts,
     ...(visualParityComparisons.length ? { visual_parity_comparisons: visualParityComparisons } : {}),
+    surface_records: collectSurfaceRecords(payloads),
     visual_diff_regions: visualParityArtifacts?.visual_diff_regions || [],
     visual_diff_cause_summary: visualParityArtifacts?.visual_diff_cause_summary || null,
     visual_diff_classification: visualParityArtifacts?.visual_diff_classification || null,
@@ -123,6 +124,36 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     matrix_evidence: collectMatrixEvidence(merged, { dependencyOverrides, sidecar }),
     svg_font_embedding_evidence: merged.svg_font_embedding_evidence || merged.svgFontEmbeddingEvidence || null,
     raw: { payloads },
+  });
+}
+
+export function collectSurfaceRecords(payloads) {
+  return payloads.flatMap((payload, index) => {
+    const metadata = objectValue(payload.metadata);
+    const explicitId = firstString([metadata.surface_id, metadata.surfaceId, payload.surface_id, payload.surfaceId]);
+    const command = firstString([payload.command, metadata.command]);
+    const phase = firstString([metadata.recipe_phase, metadata.recipePhase, payload.recipe_phase, payload.recipePhase]);
+    const role = /visual-compare|visual/i.test(command) || phase === 'visual'
+      ? 'visual'
+      : /editor-(?:open|validate)|editor/i.test(command) || phase === 'editor'
+        ? 'editor'
+        : '';
+    // Import/transform payloads routinely contain a post-like value but do not
+    // identify a browser surface. They must not overwrite editor/capture lineage.
+    if (!explicitId && !role) return [];
+    return [compactObject({
+      surface_id: explicitId || 'front-page',
+      role,
+      command,
+      provenance_index: index,
+      source_url: firstString([metadata.source_url, metadata.sourceUrl, payload.source_url, payload.sourceUrl]),
+      candidate_url: firstString([metadata.candidate_url, metadata.candidateUrl, payload.candidate_url, payload.candidateUrl]),
+      post_id: firstString([metadata.post_id, metadata.postId, payload.post_id, payload.postId]),
+      post_type: firstString([metadata.post_type, metadata.postType, payload.post_type, payload.postType]),
+      post_slug: firstString([metadata.post_slug, metadata.postSlug, payload.post_slug, payload.postSlug]),
+      target: firstString([metadata.target, payload.target]),
+      artifact_refs: collectPayloadArtifactRefs(payload),
+    })];
   });
 }
 
@@ -135,6 +166,8 @@ function collectVisualParityComparisons(payloads, visualParityOptions) {
       const explicitSurfaceId = firstString([metadata.surface_id, metadata.surfaceId, payload.surface_id, payload.surfaceId]);
       return collectVisualParityArtifactComparisons(payload, visualParityOptions).map((comparison) => ({
         surface_id: visualComparisonSurfaceId({ explicitSurfaceId, comparison }),
+        source_url: firstString([metadata.source_url, metadata.sourceUrl]),
+        candidate_url: firstString([metadata.candidate_url, metadata.candidateUrl]),
         visual_parity_artifacts: comparison.visual_parity_artifacts,
       }));
     })

--- a/lib/fixture-matrix/findings.mjs
+++ b/lib/fixture-matrix/findings.mjs
@@ -162,6 +162,7 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     reason_code: reasonCode,
     severity: raw.severity || (result.status === 'failed' ? 'error' : 'warning'),
     fixture_id: result.fixture_id || '',
+    surface_id: raw.surface_id || raw.surfaceId || 'front-page',
     fixture_class: result.fixture_class || result.taxonomy?.fixture_class || 'unknown',
     fixture_capabilities: result.capabilities || result.taxonomy?.capabilities || [],
     fixture_risk_profile: result.risk_profile || result.taxonomy?.risk_profile || 'unknown',

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -63,6 +63,7 @@ import {
   finalizeEditorQuality,
 } from './collectors/quality-metrics.mjs';
 import { buildFixtureArtifact, stageFixtureSource } from './steps/recipe-builder.mjs';
+import { buildFixtureSurfaceLineage, buildSurfaceLineageArtifact, surfaceLineageArtifactRef } from './surface-lineage.mjs';
 
 export function normalizeFixtureMatrixResult(input = {}) {
   const matrix = input.matrix || createFixtureMatrix(input);
@@ -71,10 +72,13 @@ export function normalizeFixtureMatrixResult(input = {}) {
   const executionRequested = executionStatus !== 'not_requested';
   const results = normalizeArray(input.results || input.fixture_results || input.fixtureResults).map(normalizeFixtureResult);
   const resultByFixture = new Map(results.map((result) => [result.fixture_id, result]));
-  const fixtureResults = matrix.fixtures.map((fixture) => attachFixtureTaxonomy(
-    resultByFixture.get(fixture.id) || normalizeFixtureResult({ fixture_id: fixture.id, fixture_path: fixture.fixture_path, status: 'not_run' }),
-    fixture,
-  ));
+  const fixtureResults = matrix.fixtures.map((fixture) => {
+    const normalized = attachFixtureTaxonomy(
+      resultByFixture.get(fixture.id) || normalizeFixtureResult({ fixture_id: fixture.id, fixture_path: fixture.fixture_path, status: 'not_run' }),
+      fixture,
+    );
+    return { ...normalized, surface_lineage: buildFixtureSurfaceLineage(fixture, normalized, input) };
+  });
   const baseFindings = dedupeFindings(fixtureResults.flatMap((result) => findingsForFixtureResult(result, { matrix, executionRequested })));
   // Editor-quality metrics are computed from generic block-composition data plus
   // the #537 editor-invalid findings. Scoring always runs; gating is opt-in.
@@ -528,6 +532,7 @@ export function normalizeFixtureResult(input) {
     editor_open: boundBlob(input.editor_open || input.editorOpen || null),
     visual_parity_artifacts: input.visual_parity_artifacts || input.visualParityArtifacts || null,
     visual_parity_comparisons: input.visual_parity_comparisons || input.visualParityComparisons || [],
+    surface_records: input.surface_records || input.surfaceRecords || [],
     visual_diff_regions: normalizeArray(input.visual_diff_regions || input.visualDiffRegions),
     visual_diff_cause_summary: input.visual_diff_cause_summary || input.visualDiffCauseSummary || null,
     visual_diff_classification: input.visual_diff_classification || input.visualDiffClassification || null,
@@ -581,6 +586,7 @@ export function writeFixtureMatrixArtifacts(input = {}) {
     'gutenberg-incompatibility-registry.md',
     'visual-parity-evidence-report.json',
     'visual-parity-evidence-report.md',
+    'surface-lineage-bundles.json',
   ].reduce((total, fileName) => total + fileBytes(path.join(outputDirectory, fileName)), 0);
   artifactBytes.total = artifactBytes.fixture_artifacts + artifactBytes.staged_source + artifactBytes.matrix + artifactBytes.result_artifacts;
 
@@ -605,6 +611,7 @@ export function writeFixtureMatrixArtifacts(input = {}) {
       artifactRef('visual-diff-classification', path.join(outputDirectory, 'visual-diff-classification.json'), 'diagnostic'),
       artifactRef('visual-parity-evidence-report', path.join(outputDirectory, 'visual-parity-evidence-report.json'), 'diagnostic'),
       artifactRef('visual-parity-evidence-report-markdown', path.join(outputDirectory, 'visual-parity-evidence-report.md'), 'summary'),
+      artifactRef('surface-lineage-bundles', path.join(outputDirectory, 'surface-lineage-bundles.json'), 'surface-lineage'),
       artifactRef('gutenberg-incompatibility-registry', path.join(outputDirectory, 'gutenberg-incompatibility-registry.json'), 'diagnostic'),
       artifactRef('gutenberg-incompatibility-registry-report', path.join(outputDirectory, 'gutenberg-incompatibility-registry.md'), 'summary'),
     ],
@@ -615,6 +622,18 @@ export function writeFixtureMatrixResultArtifacts(input = {}) {
   const outputDirectory = requiredString(input.outputDirectory || input.output_directory, 'outputDirectory');
   const matrix = input.matrix || createFixtureMatrix(input);
   const result = input.result || normalizeFixtureMatrixResult({ ...input, matrix });
+  const surfaceLineage = buildSurfaceLineageArtifact(result);
+  writeJsonFile(path.join(outputDirectory, 'surface-lineage-bundles.json'), surfaceLineage);
+  for (const fixture of normalizeArray(result.fixtures)) {
+    for (const surface of normalizeArray(fixture.surface_lineage)) {
+      const file = path.join(outputDirectory, fixture.fixture_id, `surface-lineage--${surface.surface.artifact_slug}.json`);
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      writeJsonFile(file, surface);
+      const refs = normalizeArray(fixture.artifact_refs);
+      pushUnique(refs, surfaceLineageArtifactRef(outputDirectory, fixture.fixture_id, surface.surface.id), Infinity);
+      fixture.artifact_refs = refs;
+    }
+  }
   writeJsonFile(path.join(outputDirectory, 'static-site-fixture-matrix-result.json'), result);
   writeJsonFile(path.join(outputDirectory, 'summary.json'), result.summary);
   writeJsonFile(path.join(outputDirectory, 'finding-packets.json'), result.findings);

--- a/lib/fixture-matrix/surface-lineage.mjs
+++ b/lib/fixture-matrix/surface-lineage.mjs
@@ -1,0 +1,131 @@
+/**
+ * External dependencies
+ */
+import { createHash } from 'node:crypto';
+
+/**
+ * Internal dependencies
+ */
+import { selectFixtureSurfaces } from './steps/surfaces.mjs';
+import { normalizeArray, objectValue, firstString, compactObject, artifactRef } from './shared/utils.mjs';
+
+export const SURFACE_LINEAGE_SCHEMA = 'static-site-importer/fixture-surface-lineage/v1';
+
+// A surface bundle is deliberately a small, transportable index. The referenced
+// artifacts stay first-class files rather than being embedded in the receipt.
+export function buildFixtureSurfaceLineage(fixture, result = {}, options = {}) {
+  const selected = selectFixtureSurfaces(fixture, options);
+  const payloads = normalizeArray(result.surface_records);
+  const observedIds = [
+    ...normalizeArray(result.visual_parity_comparisons).map((comparison) => comparison.surface_id),
+    ...payloads.map((payload) => payload.surface_id),
+  ].filter(Boolean);
+  const surfaceById = new Map(selected.map((surface) => [surface.id, surface]));
+  for (const id of observedIds) {
+    if (!surfaceById.has(id)) surfaceById.set(id, { id, source_entry: '', candidate_url: '' });
+  }
+  const surfaces = [...surfaceById.values()];
+  return surfaces.map((surface) => buildSurfaceLineage({ fixture, result, surface, payloads }));
+}
+
+export function buildSurfaceLineageArtifact(result = {}) {
+  return {
+    schema: SURFACE_LINEAGE_SCHEMA,
+    matrix_id: result.matrix_id || '',
+    fixtures: normalizeArray(result.fixtures).map((fixture) => ({
+      fixture_id: fixture.fixture_id,
+      surfaces: normalizeArray(fixture.surface_lineage),
+    })),
+  };
+}
+
+function buildSurfaceLineage({ fixture, result, surface, payloads }) {
+  const scoped = payloads.filter((payload) => surfaceId(payload) === surface.id);
+  const comparison = normalizeArray(result.visual_parity_comparisons).find((row) => row.surface_id === surface.id) || {};
+  const artifacts = objectValue(comparison.visual_parity_artifacts);
+  const visual = objectValue(preferredSurfaceRecord(scoped, 'visual'));
+  const editor = objectValue(preferredSurfaceRecord(scoped, 'editor'));
+  const runtime = Object.keys(editor).length > 0 ? editor : Object.keys(visual).length > 0 ? visual : objectValue(scoped.at(-1));
+  const sourceUrl = firstString([comparison.source_url, visual.source_url, runtime.source_url, sourceUrlFor(fixture, surface)]);
+  const candidateUrl = firstString([comparison.candidate_url, visual.candidate_url, runtime.candidate_url, surface.candidate_url]);
+  const refs = refsForSurface({ result, scoped, artifacts });
+  const selectorEvidence = objectValue(artifacts.visual_explanation || artifacts.visualExplanation);
+  const domCaptured = refs.some((ref) => /(?:source|candidate)[-_]dom/i.test(`${ref.artifact_id} ${ref.kind}`));
+  const selectorCaptured = Boolean(selectorEvidence.selector || selectorEvidence.selectors || selectorEvidence.regions || selectorEvidence.elements);
+  return {
+    schema: SURFACE_LINEAGE_SCHEMA,
+    surface_id: `${fixture.id}:${surface.id}`,
+    fixture_id: fixture.id,
+    surface: {
+      id: surface.id,
+      artifact_slug: surfaceArtifactSlug(surface.id),
+      source_entry: surface.source_entry,
+      source_url: sourceUrl,
+      candidate_url: candidateUrl,
+    },
+    imported_post: compactObject({
+      id: firstString([runtime.post_id]),
+      type: firstString([runtime.post_type, surface.post_type]),
+      slug: firstString([runtime.post_slug, surface.post_slug]),
+      editor_target: firstString([runtime.target, surface.target]),
+    }),
+    artifacts: refs,
+    materialization: compactObject({
+      receipt: objectValue(result.matrix_evidence).materialization_receipt,
+      refs: normalizeArray(result.artifact_refs).filter((ref) => /materialization|receipt|sidecar/i.test(`${ref.artifact_id} ${ref.kind}`)),
+    }),
+    capture: compactObject({
+      viewport: objectValue(artifacts.metrics).viewport,
+      full_page: objectValue(artifacts.metrics).full_page,
+    }),
+    blind_spots: [
+      ...(!domCaptured ? [{ kind: 'dom_attribution_absent', message: 'No source/candidate DOM snapshot is registered for this surface.' }] : []),
+      ...(!selectorCaptured ? [{ kind: 'css_selector_attribution_absent', message: 'No bounded CSS selector or region attribution is registered for this surface.' }] : []),
+    ],
+  };
+}
+
+function preferredSurfaceRecord(records, role) {
+  return [...records].reverse().find((record) => record.role === role) || null;
+}
+
+function refsForSurface({ result, scoped, artifacts }) {
+  const refs = [
+    ...normalizeArray(result.artifact_refs).filter((ref) => isSurfaceVisualRef(ref, artifacts)),
+    ...scoped.flatMap((payload) => normalizeArray(payload.artifact_refs || payload.artifactRefs)),
+    ...Object.entries(objectValue(artifacts.artifacts)).map(([id, slot]) => ({ artifact_id: id, kind: slot?.kind || 'visual-parity', ...(objectValue(slot?.ref)) })),
+  ].filter((ref) => ref && (ref.path || ref.file || ref.href));
+  const seen = new Set();
+  return refs.filter((ref) => {
+    const key = `${ref.artifact_id || ''}\u0000${ref.path || ref.file || ref.href || ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function isSurfaceVisualRef(ref, artifacts) {
+  const slots = Object.values(objectValue(artifacts.artifacts));
+  return slots.some((slot) => (slot?.ref?.path || slot?.ref?.file || slot?.ref?.href) === (ref.path || ref.file || ref.href));
+}
+
+function surfaceId(payload) {
+  return firstString([payload?.surface_id, payload?.surfaceId]) || 'front-page';
+}
+
+function sourceUrlFor(fixture, surface) {
+  return `source/${fixture.id}/${surface.source_entry}`;
+}
+
+export function surfaceLineageArtifactRef(outputDirectory, fixtureId, surfaceId) {
+  const slug = surfaceArtifactSlug(surfaceId);
+  return artifactRef(`surface-lineage--${slug}`, `${outputDirectory}/${fixtureId}/surface-lineage--${slug}.json`, 'surface-lineage');
+}
+
+// Keep logical surface IDs lossless in the JSON while preventing a runner-provided
+// route name from affecting artifact paths. The hash disambiguates equivalent slugs.
+export function surfaceArtifactSlug(surfaceId) {
+  const logicalId = String(surfaceId || 'surface');
+  const stem = logicalId.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48) || 'surface';
+  return `${stem}-${createHash('sha256').update(logicalId).digest('hex').slice(0, 12)}`;
+}

--- a/lib/fixture-matrix/surface-lineage.mjs
+++ b/lib/fixture-matrix/surface-lineage.mjs
@@ -63,6 +63,11 @@ function buildSurfaceLineage({ fixture, result, surface, payloads }) {
       source_url: sourceUrl,
       candidate_url: candidateUrl,
     },
+    fixture: compactObject({
+      corpus: fixture.fixture_corpus || result.fixture_corpus,
+      path: fixture.fixture_path || result.fixture_path,
+      entrypoint: fixture.entrypoint,
+    }),
     imported_post: compactObject({
       id: firstString([runtime.post_id]),
       type: firstString([runtime.post_type, surface.post_type]),
@@ -75,9 +80,19 @@ function buildSurfaceLineage({ fixture, result, surface, payloads }) {
       refs: normalizeArray(result.artifact_refs).filter((ref) => /materialization|receipt|sidecar/i.test(`${ref.artifact_id} ${ref.kind}`)),
     }),
     capture: compactObject({
-      viewport: objectValue(artifacts.metrics).viewport,
-      full_page: objectValue(artifacts.metrics).full_page,
+      viewport: artifacts.metrics?.viewport || artifacts.viewport,
+      full_page: artifacts.metrics?.full_page ?? artifacts.metrics?.fullPage,
+      wait_for: artifacts.metrics?.wait_for || artifacts.metrics?.waitFor,
+      duration_ms: artifacts.metrics?.duration_ms ?? artifacts.metrics?.durationMs,
+      block_external_requests: artifacts.metrics?.block_external_requests ?? artifacts.metrics?.blockExternalRequests,
+      threshold: artifacts.metrics?.threshold,
     }),
+    replay_inputs: {
+      matrix: { artifact_id: 'matrix', kind: 'matrix', path: 'matrix.json' },
+      recipe: { artifact_id: 'fixture-matrix-recipe', kind: 'recipe', path: 'wp-codebox-static-site-fixture-matrix-recipe.json' },
+      fixture: { artifact_id: `fixture-${fixture.id}`, kind: 'fixture', path: `${fixture.id}/artifact.json` },
+      source: { artifact_id: `fixture-source-${fixture.id}-${surface.artifact_slug}`, kind: 'fixture-source', path: `${fixture.id}/source/${surface.source_entry}` },
+    },
     blind_spots: [
       ...(!domCaptured ? [{ kind: 'dom_attribution_absent', message: 'No source/candidate DOM snapshot is registered for this surface.' }] : []),
       ...(!selectorCaptured ? [{ kind: 'css_selector_attribution_absent', message: 'No bounded CSS selector or region attribution is registered for this surface.' }] : []),

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -82,9 +82,11 @@ import {
   resolveFixtureSearchRoots,
   wordpressServedPath,
   writeFixtureMatrixArtifacts,
+  writeFixtureMatrixResultArtifacts,
 } from '../lib/fixture-matrix.mjs';
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
 import { collectQualityMetrics } from '../lib/fixture-matrix/collectors/quality-metrics.mjs';
+import { collectSurfaceRecords } from '../lib/fixture-matrix/collectors/run-intake.mjs';
 import { runWpCodeboxRecipe, wpCodeboxBin } from './wp-codebox/recipe.mjs';
 
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
@@ -6363,6 +6365,81 @@ test('visual-compare artifacts collected from fixture files gate the matrix when
   assert.ok(capturedFinding, 'expected the mismatch to still be captured');
   assert.equal(capturedFinding.loss_acceptance, 'acceptable');
   assert.equal(captured.fixtures[0].status, 'passed');
+});
+
+test('surface lineage persists reviewer-facing visual refs and explicit absent-attribution blind spots', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-surface-lineage-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'surface-lineage-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{
+      fixture_id: 'simple-site',
+      status: 'passed',
+      surface_records: [{
+          surface_id: 'front-page', source_url: 'https://source.test/', candidate_url: 'https://candidate.test/', post_id: 42, post_type: 'page', post_slug: 'home',
+          artifact_refs: [{ artifact_id: 'editor-state', kind: 'editor-canvas', path: 'files/browser/editor/state.json' }],
+      }],
+      artifact_refs: [{ artifact_id: 'materialization-receipt--primary', kind: 'materialization-sidecar', path: 'materialization-receipt--primary.json' }],
+      matrix_evidence: { materialization_receipt: { schema: 'static-site-importer/materialization-receipt/v1', status: 'completed' } },
+      visual_parity_comparisons: [{
+        surface_id: 'front-page',
+        source_url: 'https://source.test/',
+        candidate_url: 'https://candidate.test/',
+        visual_parity_artifacts: { artifacts: {
+          source_screenshot: { kind: 'source_screenshot', ref: { path: 'files/browser/source.png' } },
+          imported_screenshot: { kind: 'imported_screenshot', ref: { path: 'files/browser/candidate.png' } },
+          diff_screenshot: { kind: 'diff_screenshot', ref: { path: 'files/browser/diff.png' } },
+        } },
+      }],
+    }],
+  });
+
+  writeFixtureMatrixResultArtifacts({ outputDirectory, matrix, result });
+  const surface = JSON.parse(readFileSync(path.join(outputDirectory, 'simple-site', 'surface-lineage--front-page-d365228668b8.json'), 'utf8'));
+  assert.equal(surface.surface_id, 'simple-site:front-page');
+  assert.equal(surface.surface.source_url, 'https://source.test/');
+  assert.equal(surface.surface.candidate_url, 'https://candidate.test/');
+  assert.equal(surface.imported_post.id, '42');
+  assert.deepEqual(surface.artifacts.map((ref) => ref.path).sort(), ['files/browser/candidate.png', 'files/browser/diff.png', 'files/browser/editor/state.json', 'files/browser/source.png']);
+  assert.deepEqual(surface.blind_spots.map((spot) => spot.kind), ['dom_attribution_absent', 'css_selector_attribution_absent']);
+  const persisted = JSON.parse(readFileSync(path.join(outputDirectory, 'static-site-fixture-matrix-result.json'), 'utf8'));
+  assert.ok(persisted.fixtures[0].artifact_refs.some((ref) => ref.artifact_id === 'surface-lineage--front-page-d365228668b8'));
+});
+
+test('surface lineage slugs hostile route IDs without changing their logical identity', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-hostile-surface-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'hostile-surface-test' });
+  const hostileId = '../../editor?surface=<script>';
+  const result = normalizeFixtureMatrixResult({ matrix, results: [{
+    fixture_id: 'simple-site', status: 'passed',
+    surface_records: [{ surface_id: hostileId, role: 'visual', source_url: 'https://source.test/', artifact_refs: [{ artifact_id: 'diff', path: 'diff.png' }] }],
+  }] });
+  writeFixtureMatrixResultArtifacts({ outputDirectory, matrix, result });
+  const bundle = result.fixtures[0].surface_lineage.find((surface) => surface.surface.id === hostileId);
+  const ref = result.fixtures[0].artifact_refs.find((item) => item.artifact_id === `surface-lineage--${bundle.surface.artifact_slug}`);
+  assert.match(bundle.surface.artifact_slug, /^[a-z0-9-]+-[a-f0-9]{12}$/);
+  assert.equal(ref.path.includes(hostileId), false);
+  assert.equal(path.dirname(ref.path), path.join(outputDirectory, 'simple-site'));
+  assert.equal(existsSync(ref.path), true);
+});
+
+test('surface records ignore unrelated import payloads and prefer editor identity over visual capture', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'surface-record-selection-test' });
+  const records = collectSurfaceRecords([
+    { fixture_id: 'simple-site', command: 'wordpress.wp-cli', post_id: 'wrong-import-post', target: 'wrong-import-target' },
+    { fixture_id: 'simple-site', command: 'wordpress.visual-compare', metadata: { surface_id: 'front-page', source_url: 'https://source.test/', candidate_url: 'https://candidate.test/', post_id: 'visual-post' } },
+    { fixture_id: 'simple-site', command: 'wordpress.editor-validate-blocks', metadata: { surface_id: 'front-page', post_id: 'editor-post', post_type: 'page', post_slug: 'home', target: '/wp-admin/post.php?post=editor-post' } },
+  ]);
+  assert.equal(records.length, 2);
+  assert.deepEqual(records.map((record) => record.role), ['visual', 'editor']);
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'passed', surface_records: records }],
+  });
+  const surface = result.fixtures[0].surface_lineage[0];
+  assert.equal(surface.imported_post.id, 'editor-post');
+  assert.equal(surface.imported_post.editor_target, '/wp-admin/post.php?post=editor-post');
+  assert.equal(surface.surface.source_url, 'https://source.test/');
 });
 
 test('visual evidence report infers viewport evidence from visual-compare metrics', () => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -2745,6 +2745,10 @@ test('editor canvas artifacts are persisted in the matrix artifact root and refs
   assert.equal(fixture.editor_open.files.editorState, statePath);
   assert.equal(fixture.surfaces[0].editor_open.files.screenshot, screenshotPath);
   assert.deepEqual(fixture.artifact_refs.map((ref) => ref.path), [screenshotPath, statePath]);
+  assert.deepEqual(fixture.artifact_refs.map((ref) => ref.artifact_id), [
+    'editor_canvas_simple-site_editor-open-screenshot',
+    'editor_canvas_simple-site_editor-open-editorState',
+  ]);
   assert.deepEqual(result.artifacts, {
     'editor_canvas_simple-site_editor-open-screenshot': { path: screenshotPath },
     'editor_canvas_simple-site_editor-open-editorState': { path: statePath },
@@ -6595,9 +6599,11 @@ test('visual-compare sidecars are normalized and retained under the bench artifa
   assert.equal(readFileSync(path.join(outputDirectory, 'visual-compare', 'simple-site', 'source.png'), 'utf8'), 'fake source.png');
   assert.equal(fixture.visual_parity_artifacts.owner, 'bench_artifact_root');
   assert.equal(fixture.visual_parity_artifacts.artifacts.source_screenshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'source.png'));
+  assert.equal(fixture.visual_parity_artifacts.artifacts.source_screenshot.ref.artifact_id, 'visual_compare_simple-site_source');
   assert.equal(fixture.visual_parity_artifacts.artifacts.imported_screenshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'candidate.png'));
   assert.equal(fixture.visual_parity_artifacts.artifacts.diff_screenshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'diff.png'));
-  assert.equal(fixture.diagnostics[0].artifact_refs.find((ref) => ref.artifact_id === 'diff_screenshot').path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'diff.png'));
+  assert.equal(fixture.visual_parity_artifacts.artifacts.diff_screenshot.ref.artifact_id, 'visual_compare_simple-site_diff');
+  assert.equal(fixture.diagnostics[0].artifact_refs.find((ref) => ref.artifact_id === 'visual_compare_simple-site_diff').path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'diff.png'));
   assert.equal(fixture.diagnostics[1].artifact_refs[0].path, path.join(outputDirectory, 'visual-compare', 'simple-site--contact', 'candidate.png'));
   assert.equal(fixture.visual_parity_artifacts.artifacts.visual_diff.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'visual-diff.json'));
   assert.equal(fixture.visual_parity_artifacts.artifacts.source_dom_snapshot.ref.path, path.join(outputDirectory, 'visual-compare', 'simple-site', 'source-dom-snapshot.json'));


### PR DESCRIPTION
## Summary
- emit per-surface lineage bundles with route identity, URLs, editor target, materialization evidence, capture settings, corpus metadata, and replayable matrix-relative inputs
- preserve source, candidate, diff, DOM, attribution, and editor evidence in the matrix artifact root and reference the exact typed artifact keys exported to Homeboy
- expose the aggregate lineage bundle as a first-class bench artifact

Fixes #766

## Reproducible evidence
The reported run `2d788144-6209-4b5c-b39e-d6798e2b49fe` for `89-static-site-importer-architecture` (Blocks Engine `fe130c1b15c0cfa7e57dddde90b40ab4e7f7d152`) demonstrated that runner-local paths expired after completion. The durable capture tokens are now the refs retained in surface lineage, including:
- `visual_compare_89-static-site-importer-architecture_source`
- `visual_compare_89-static-site-importer-architecture_candidate`
- `visual_compare_89-static-site-importer-architecture_diff`

Validate locally with:
```sh
npm run test:fixture-matrix
npm test
```

## AI assistance
OpenAI GPT-5.6 Sol, using OpenCode, drafted the durable surface-lineage and artifact-reference wiring plus focused regression tests. Chris reviewed and remains responsible for the change.