### PR TITLE
Export fixture surface lineage artifacts

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -96,6 +96,7 @@ export default async function runFixtureMatrixBench(context = {}) {
       visual_parity_evidence_report_markdown: { path: path.join(summary.output_directory, 'visual-parity-evidence-report.md') },
       visual_diff_classification: { path: path.join(summary.output_directory, 'visual-diff-classification.json') },
       surface_lineage_bundles: { path: path.join(summary.output_directory, 'surface-lineage-bundles.json') },
+      ...(summary.surface_lineage_artifacts || {}),
       gutenberg_incompatibility_registry: { path: path.join(summary.output_directory, 'gutenberg-incompatibility-registry.json') },
       gutenberg_incompatibility_registry_report: { path: path.join(summary.output_directory, 'gutenberg-incompatibility-registry.md') },
       ...(summary.visual_parity_artifacts || {}),
@@ -226,6 +227,7 @@ export async function runFixtureMatrix(options) {
   let collectedResult = written.result;
   let visualParityArtifacts = {};
   let editorCanvasArtifacts = {};
+  let surfaceLineageArtifacts = collectSurfaceLineageArtifacts(collectedResult);
   if (options.run) {
     const batchSize = positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE);
     const concurrency = boundedConcurrency(options.concurrency, DEFAULT_BATCH_CONCURRENCY, MAX_BATCH_CONCURRENCY);
@@ -282,6 +284,7 @@ export async function runFixtureMatrix(options) {
     };
     const resultArtifactRewriteStartedAt = nowMs();
     writeFixtureMatrixResultArtifacts({ outputDirectory, matrix, result: collectedResult });
+    surfaceLineageArtifacts = collectSurfaceLineageArtifacts(collectedResult);
     performance.result_artifact_writing_ms = elapsedMs(resultArtifactRewriteStartedAt);
   }
 
@@ -315,7 +318,7 @@ export async function runFixtureMatrix(options) {
     output_directory: outputDirectory,
     recipe_file: recipeFile,
     replay,
-    artifact_refs: written.artifact_refs,
+    artifact_refs: [...written.artifact_refs, ...Object.entries(surfaceLineageArtifacts).map(([artifact_id, artifact]) => ({ artifact_id, kind: 'surface-lineage', path: artifact.path }))],
     metadata: {
       execution_requested: Boolean(options.run),
       execution_status: collectedResult.summary.execution_status,
@@ -331,6 +334,7 @@ export async function runFixtureMatrix(options) {
     result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
     visual_parity_artifacts: visualParityArtifacts,
     editor_canvas_artifacts: editorCanvasArtifacts,
+    surface_lineage_artifacts: surfaceLineageArtifacts,
     result_summary: collectedResult.summary,
     runtime: runtime ? runtimeSummary(runtime, runtimeError) : null,
   };
@@ -342,6 +346,12 @@ export async function runFixtureMatrix(options) {
   writeJsonArtifact(path.join(outputDirectory, 'cli-run.json'), summary);
   progress.emit('matrix', runtimeError ? 'failed' : 'completed');
   return { summary, runtimeError, runtime };
+}
+
+function collectSurfaceLineageArtifacts(result) {
+  return Object.fromEntries(arrayValue(result?.fixtures).flatMap((fixture) => arrayValue(fixture.artifact_refs)
+    .filter((ref) => ref?.kind === 'surface-lineage' && ref.artifact_id && ref.path)
+    .map((ref) => [ref.artifact_id, { path: ref.path }])));
 }
 
 function executionEvidenceMetadata(executionRequested) {

--- a/lib/fixture-matrix/surface-lineage.mjs
+++ b/lib/fixture-matrix/surface-lineage.mjs
@@ -134,7 +134,9 @@ function sourceUrlFor(fixture, surface) {
 
 export function surfaceLineageArtifactRef(outputDirectory, fixtureId, surfaceId) {
   const slug = surfaceArtifactSlug(surfaceId);
-  return artifactRef(`surface-lineage--${slug}`, `${outputDirectory}/${fixtureId}/surface-lineage--${slug}.json`, 'surface-lineage');
+  // Surface IDs repeat across fixtures (most commonly `front-page`), so the
+  // artifact identity must include the fixture to remain resolvable globally.
+  return artifactRef(`surface_lineage_${surfaceArtifactSlug(fixtureId)}_${slug}`, `${outputDirectory}/${fixtureId}/surface-lineage--${slug}.json`, 'surface-lineage');
 }
 
 // Keep logical surface IDs lossless in the JSON while preventing a runner-provided

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -6407,7 +6407,27 @@ test('surface lineage persists reviewer-facing visual refs and explicit absent-a
   assert.deepEqual(surface.artifacts.map((ref) => ref.path).sort(), ['files/browser/candidate.png', 'files/browser/diff.png', 'files/browser/editor/state.json', 'files/browser/source.png']);
   assert.deepEqual(surface.blind_spots.map((spot) => spot.kind), ['dom_attribution_absent', 'css_selector_attribution_absent']);
   const persisted = JSON.parse(readFileSync(path.join(outputDirectory, 'static-site-fixture-matrix-result.json'), 'utf8'));
-  assert.ok(persisted.fixtures[0].artifact_refs.some((ref) => ref.artifact_id === 'surface-lineage--front-page-d365228668b8'));
+  assert.ok(persisted.fixtures[0].artifact_refs.some((ref) => ref.kind === 'surface-lineage' && ref.artifact_id.startsWith('surface_lineage_simple-site-') && ref.artifact_id.endsWith('_front-page-d365228668b8')));
+});
+
+test('surface lineage artifact refs are fixture-scoped for globally resolvable export', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-surface-lineage-refs-'));
+  const baseMatrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'surface-lineage-ref-test' });
+  const fixture = baseMatrix.fixtures[0];
+  const matrix = {
+    ...baseMatrix,
+    fixtures: [fixture, { ...fixture, id: '89-static-site-importer-architecture' }],
+    count: 2,
+  };
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: matrix.fixtures.map((entry) => ({ fixture_id: entry.id, status: 'passed' })),
+  });
+
+  writeFixtureMatrixResultArtifacts({ outputDirectory, matrix, result });
+  const refs = result.fixtures.slice(0, 2).flatMap((fixture) => fixture.artifact_refs.filter((ref) => ref.kind === 'surface-lineage'));
+  assert.equal(new Set(refs.map((ref) => ref.artifact_id)).size, refs.length);
+  assert.ok(refs.every((ref) => existsSync(ref.path)));
 });
 
 test('surface lineage slugs hostile route IDs without changing their logical identity', () => {
@@ -6420,7 +6440,7 @@ test('surface lineage slugs hostile route IDs without changing their logical ide
   }] });
   writeFixtureMatrixResultArtifacts({ outputDirectory, matrix, result });
   const bundle = result.fixtures[0].surface_lineage.find((surface) => surface.surface.id === hostileId);
-  const ref = result.fixtures[0].artifact_refs.find((item) => item.artifact_id === `surface-lineage--${bundle.surface.artifact_slug}`);
+  const ref = result.fixtures[0].artifact_refs.find((item) => item.kind === 'surface-lineage' && item.path.endsWith(`surface-lineage--${bundle.surface.artifact_slug}.json`));
   assert.match(bundle.surface.artifact_slug, /^[a-z0-9-]+-[a-f0-9]{12}$/);
   assert.equal(ref.path.includes(hostileId), false);
   assert.equal(path.dirname(ref.path), path.join(outputDirectory, 'simple-site'));


### PR DESCRIPTION
## Summary\n- export each fixture-surface lineage JSON as a first-class bench artifact\n- scope lineage artifact IDs by fixture so repeated surface IDs cannot collide\n- cover the fixture-89-shaped duplicate-front-page lineage case\n\n## Verification\n- node --test --test-name-pattern="surface lineage" tools/fixture-matrix.test.mjs\n- npm run test:fixture-matrix\n- npm test\n\n## AI assistance\nGPT-5.6-terra via OpenCode identified the unpublished per-surface lineage files from the #769 promotion artifact, implemented the SSI-only export/identity fix, and added the regression coverage. Chris remains responsible for the change.