### PR TITLE
Centralize fixture matrix run configuration

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -23,9 +23,14 @@ import {
   writeFixtureMatrixArtifacts,
   writeFixtureMatrixResultArtifacts,
   normalizeVisualAttributionOptions,
+  FIXTURE_MATRIX_RUN_FIELDS,
+  fixtureMatrixBenchOptions,
+  fixtureMatrixGateConfig,
+  fixtureMatrixRecipeInput,
+  fixtureMatrixRunConfigFromEnv,
+  normalizeFixtureMatrixRunConfig,
 } from '../lib/fixture-matrix.mjs';
 
-const DEFAULT_BATCH_SIZE = 10;
 // Each batch provisions its own WP Codebox sandbox, so batches are independent
 // and safe to fan out in parallel. A single live sandbox costs ~3.3GB host RSS,
 // but RSS grows superlinearly when several overlap (a measured `--concurrency 4`
@@ -148,6 +153,8 @@ function elapsedMs(startedAt) {
 }
 
 export async function runFixtureMatrix(options) {
+  const runConfig = normalizeFixtureMatrixRunConfig(Object.fromEntries(Object.keys(FIXTURE_MATRIX_RUN_FIELDS).map((key) => [key, options[key]])));
+  options = { ...options, ...fixtureMatrixBenchOptions(runConfig) };
   const performance = {};
   const outputDirectory = path.resolve(options.outputDirectory || path.join(process.cwd(), 'artifacts', 'static-site-importer-fixture-matrix'));
   const intake = options.artifactRoot
@@ -207,10 +214,7 @@ export async function runFixtureMatrix(options) {
     staticSiteImporterSlug: options.staticSiteImporterSlug,
     dependencyOverrides,
     svgFontEvidence: true,
-    surfaceCoverage: options.surfaceCoverage,
-    maxExtraSurfaces: options.maxExtraSurfaces,
-    ...editorValidationRecipeInput(options),
-    ...surfaceCoverageRecipeInput(options),
+    ...fixtureMatrixRecipeInput(runConfig),
     ...visualParityRecipeInput(options),
     ...liveWpParityRecipeInput(options),
   });
@@ -229,8 +233,8 @@ export async function runFixtureMatrix(options) {
   let editorCanvasArtifacts = {};
   let surfaceLineageArtifacts = collectSurfaceLineageArtifacts(collectedResult);
   if (options.run) {
-    const batchSize = positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE);
-    const concurrency = boundedConcurrency(options.concurrency, DEFAULT_BATCH_CONCURRENCY, MAX_BATCH_CONCURRENCY);
+    const batchSize = options.batchSize;
+    const concurrency = options.concurrency;
     const batches = chunk(matrix.fixtures, batchSize);
     // Each batch spins up its own isolated WP Codebox sandbox, so batches can run
     // concurrently. `mapWithConcurrency` bounds how many sandboxes are live at
@@ -271,7 +275,7 @@ export async function runFixtureMatrix(options) {
       matrix,
       results: attributeChildCommandFailures(batchResults.flatMap((result) => result.fixtures), childCommandFailures),
       // Editor-quality scoring is always on; the native-rate gate is opt-in.
-      editorQuality: editorQualityGateInput(options),
+      editorQuality: fixtureMatrixGateConfig(runConfig).editorQuality,
       requireSolvedCandidate: options.requireSolvedCandidate,
     });
     performance.result_assembly_ms = elapsedMs(resultAssemblyStartedAt);
@@ -402,10 +406,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     staticSiteImporterSlug: options.staticSiteImporterSlug,
     dependencyOverrides: prepareDependencyOverrides(options),
     svgFontEvidence: true,
-    surfaceCoverage: options.surfaceCoverage,
-    maxExtraSurfaces: options.maxExtraSurfaces,
-    ...editorValidationRecipeInput(options),
-    ...surfaceCoverageRecipeInput(options),
+    ...fixtureMatrixRecipeInput(normalizeFixtureMatrixRunConfig(Object.fromEntries(Object.keys(FIXTURE_MATRIX_RUN_FIELDS).map((key) => [key, options[key]])))),
     ...visualParityRecipeInput(options),
     ...liveWpParityRecipeInput(options),
   });
@@ -482,7 +483,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     codeboxOutput: batchRuntime?.json,
     codeboxError: batchError,
     sidecarAttemptId: batchSuffix,
-    visualParity: visualParityGateInput(options),
+    visualParity: fixtureMatrixGateConfig(normalizeFixtureMatrixRunConfig(Object.fromEntries(Object.keys(FIXTURE_MATRIX_RUN_FIELDS).map((key) => [key, options[key]])))).visualParity,
     liveWpParity: liveWpParityCollectorInput(options),
     dependencyOverrides: prepareDependencyOverrides(options),
   });
@@ -1518,75 +1519,21 @@ function parseArgs(args) {
 
 export function optionsFromEnv(env = process.env) {
   const benchEnv = settingsBenchEnv(env);
+  const config = fixtureMatrixRunConfigFromEnv(env);
   return {
-    fixtureRoot: benchEnv.SSI_FIXTURE_MATRIX_FIXTURE_ROOT || env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT,
+    ...fixtureMatrixBenchOptions(config),
     outputDirectory: benchEnv.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY || env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY || env.HOMEBOY_BENCH_ARTIFACTS_DIR,
-    staticSiteImporterPath: benchEnv.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH || env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH,
     staticSiteImporterSlug: benchEnv.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_SLUG || env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_SLUG,
     staticSiteImporterPlugin: benchEnv.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PLUGIN || env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PLUGIN,
     entrypoint: benchEnv.SSI_FIXTURE_MATRIX_ENTRYPOINT || env.SSI_FIXTURE_MATRIX_ENTRYPOINT,
     maxDepth: benchEnv.SSI_FIXTURE_MATRIX_MAX_DEPTH || env.SSI_FIXTURE_MATRIX_MAX_DEPTH,
-    surfaceCoverage: benchEnv.SSI_FIXTURE_MATRIX_SURFACE_COVERAGE || env.SSI_FIXTURE_MATRIX_SURFACE_COVERAGE,
-    maxExtraSurfaces: benchEnv.SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES || env.SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES,
-    // Lane selection from authored manifest taxonomy.
-    fixtureClass: benchEnv.SSI_FIXTURE_MATRIX_CLASS || env.SSI_FIXTURE_MATRIX_CLASS,
-    tag: benchEnv.SSI_FIXTURE_MATRIX_TAG || env.SSI_FIXTURE_MATRIX_TAG,
-    capabilities: benchEnv.SSI_FIXTURE_MATRIX_CAPABILITY || env.SSI_FIXTURE_MATRIX_CAPABILITY || benchEnv.SSI_FIXTURE_MATRIX_CAPABILITIES || env.SSI_FIXTURE_MATRIX_CAPABILITIES,
-    riskProfile: benchEnv.SSI_FIXTURE_MATRIX_RISK_PROFILE || env.SSI_FIXTURE_MATRIX_RISK_PROFILE,
-    complexity: benchEnv.SSI_FIXTURE_MATRIX_COMPLEXITY || env.SSI_FIXTURE_MATRIX_COMPLEXITY,
-    maxComplexity: benchEnv.SSI_FIXTURE_MATRIX_MAX_COMPLEXITY || env.SSI_FIXTURE_MATRIX_MAX_COMPLEXITY,
     artifactRoot: benchEnv.SSI_FIXTURE_MATRIX_ARTIFACT_ROOT || env.SSI_FIXTURE_MATRIX_ARTIFACT_ROOT,
-    blocksEnginePhpTransformerPath: benchEnv.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH || env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH,
-    blocksEnginePhpTransformerReference: benchEnv.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE || env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE,
-    wordpressVersion: benchEnv.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION || env.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION,
-    batchSize: benchEnv.SSI_FIXTURE_MATRIX_BATCH_SIZE || env.SSI_FIXTURE_MATRIX_BATCH_SIZE,
-    concurrency: benchEnv.SSI_FIXTURE_MATRIX_CONCURRENCY || env.SSI_FIXTURE_MATRIX_CONCURRENCY,
-    batchInactivityTimeoutMs: benchEnv.SSI_FIXTURE_MATRIX_BATCH_INACTIVITY_TIMEOUT_MS || env.SSI_FIXTURE_MATRIX_BATCH_INACTIVITY_TIMEOUT_MS,
-    run: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_RUN) || isTruthy(env.SSI_FIXTURE_MATRIX_RUN),
-    wpCodeboxBin: benchEnv.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN || env.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN,
-    editorValidation: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION ?? env.SSI_FIXTURE_MATRIX_EDITOR_VALIDATION),
-    visualParity: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY),
-    visualParityGate: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE ?? true),
     visualParityFullPage: optionalBoolean(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_FULL_PAGE),
     visualParityBlockExternalRequests: optionalBoolean(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_BLOCK_EXTERNAL_REQUESTS ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_BLOCK_EXTERNAL_REQUESTS),
-    // Opt-in live-WP parity capture + comparison. Off by default; mirrors the
-    // visual-parity-gate truthy env mapping. When on, the recipe appends the
-    // capture-html step and the result collector runs the live-wp-parity comparator.
-    liveWpParity: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_LIVE_WP_PARITY) || isTruthy(env.SSI_FIXTURE_MATRIX_LIVE_WP_PARITY),
-    pixelThreshold: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD,
-    visualParityAlignment: optionalBoolean(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT),
-    visualParityMaxVerticalShift: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT,
-    visualParityMaxHorizontalShift: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT,
-    visualParityOffsetTolerance: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE,
-    visualParityPixelmatchThreshold: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD,
     visualParityCandidateUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_CANDIDATE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_CANDIDATE_URL,
     visualParitySourceBaseUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL,
     visualParityWaitFor: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_WAIT_FOR || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_WAIT_FOR,
     visualParityDurationMs: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_DURATION_MS || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_DURATION_MS,
-    maxExplanationElements: benchEnv.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS || env.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS,
-    maxExplanationCandidates: benchEnv.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES || env.SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES,
-    explainSelectors: benchEnv.SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS || env.SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS,
-    minNativeRate: benchEnv.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE || env.SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE,
-    fixtureIds: benchEnv.SSI_FIXTURE_MATRIX_FIXTURE_IDS || env.SSI_FIXTURE_MATRIX_FIXTURE_IDS,
-    fixtureCorpus: benchEnv.SSI_FIXTURE_MATRIX_FIXTURE_CORPUS || env.SSI_FIXTURE_MATRIX_FIXTURE_CORPUS,
-    requireSolvedCandidate: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE) || isTruthy(env.SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE),
-  };
-}
-
-// Editor-validation recipe option. The wordpress.editor-validate-blocks step
-// launches a browser per imported site and is the slowest per-fixture step, so
-// --no-editor-validation (SSI_FIXTURE_MATRIX_EDITOR_VALIDATION=0) skips it while
-// leaving native-rate/loss-classes/findings intact. Enabled by default.
-function editorValidationRecipeInput(options) {
-  return {
-    editorValidation: options.editorValidation !== false,
-  };
-}
-
-function surfaceCoverageRecipeInput(options) {
-  return {
-    surfaceCoverage: options.surfaceCoverage,
-    maxExtraSurfaces: options.maxExtraSurfaces,
   };
 }
 
@@ -1602,18 +1549,6 @@ function visualParityRecipeInput(options) {
     visualParityWaitFor: options.visualParityWaitFor,
     visualParityDurationMs: options.visualParityDurationMs,
     ...normalizeVisualAttributionOptions(options),
-  };
-}
-
-function visualParityGateInput(options) {
-  return {
-    threshold: options.pixelThreshold,
-    gate: options.visualParityGate !== false,
-    alignment: options.visualParityAlignment,
-    maxVerticalShift: options.visualParityMaxVerticalShift,
-    maxHorizontalShift: options.visualParityMaxHorizontalShift,
-    offsetTolerance: options.visualParityOffsetTolerance,
-    pixelmatchThreshold: options.visualParityPixelmatchThreshold,
   };
 }
 
@@ -1643,14 +1578,6 @@ function liveWpParityCollectorInput(options) {
   };
 }
 
-// Editor-quality gate options for the result collector. Scoring always runs;
-// `minNativeRate` defaults to absent (off) so gating is opt-in.
-function editorQualityGateInput(options) {
-  return {
-    minNativeRate: options.minNativeRate,
-  };
-}
-
 function settingsBenchEnv(env = process.env) {
   try {
     const settings = JSON.parse(env.HOMEBOY_SETTINGS_JSON || '{}');
@@ -1660,10 +1587,6 @@ function settingsBenchEnv(env = process.env) {
   } catch {
     return {};
   }
-}
-
-function isTruthy(value) {
-  return value === true || value === '1' || value === 'true';
 }
 
 function isFalsy(value) {

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -55,6 +55,16 @@ export {
 } from './fixture-matrix/steps/surfaces.mjs';
 
 export {
+  FIXTURE_MATRIX_RUN_FIELDS,
+  normalizeFixtureMatrixRunConfig,
+  fixtureMatrixRunConfigFromEnv,
+  fixtureMatrixHomeboySettings,
+  fixtureMatrixBenchOptions,
+  fixtureMatrixRecipeInput,
+  fixtureMatrixGateConfig,
+} from './fixture-matrix/run-config.mjs';
+
+export {
   SURFACE_LINEAGE_SCHEMA,
   buildFixtureSurfaceLineage,
   buildSurfaceLineageArtifact,

--- a/lib/fixture-matrix/run-config.mjs
+++ b/lib/fixture-matrix/run-config.mjs
@@ -1,0 +1,125 @@
+/**
+ * The fixture-matrix's operator, Homeboy, and bench boundary all use this map.
+ * Environment names remain the public Homeboy contract; internal projections use
+ * camelCase so recipe and gate builders never need to parse environment values.
+ */
+export const FIXTURE_MATRIX_RUN_FIELDS = Object.freeze({
+  fixtureRoot: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_ROOT', required: true, string: true },
+  staticSiteImporterPath: { env: 'SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH', required: true, string: true },
+  run: { env: 'SSI_FIXTURE_MATRIX_RUN', boolean: true, always: true },
+  fixtureIds: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_IDS', list: true },
+  fixtureCorpus: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_CORPUS', string: true },
+  requireSolvedCandidate: { env: 'SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE', boolean: true },
+  blocksEnginePhpTransformerPath: { env: 'SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH', string: true },
+  blocksEnginePhpTransformerReference: { env: 'SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE', string: true },
+  batchSize: { env: 'SSI_FIXTURE_MATRIX_BATCH_SIZE', integer: { min: 1 }, default: 10 },
+  concurrency: { env: 'SSI_FIXTURE_MATRIX_CONCURRENCY', integer: { min: 1, max: 16 }, default: 2 },
+  batchInactivityTimeoutMs: { env: 'SSI_FIXTURE_MATRIX_BATCH_INACTIVITY_TIMEOUT_MS', integer: { min: 1 } },
+  wordpressVersion: { env: 'SSI_FIXTURE_MATRIX_WORDPRESS_VERSION', string: true },
+  wpCodeboxBin: { env: 'SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN', string: true },
+  surfaceCoverage: { env: 'SSI_FIXTURE_MATRIX_SURFACE_COVERAGE', integer: { min: 0 } },
+  maxExtraSurfaces: { env: 'SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES', integer: { min: 0 } },
+  editorValidation: { env: 'SSI_FIXTURE_MATRIX_EDITOR_VALIDATION', boolean: true, default: true },
+  visualParity: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY', boolean: true, default: true },
+  visualParityGate: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE', boolean: true, default: true, always: true },
+  pixelThreshold: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD', number: true },
+  visualParityAlignment: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT', boolean: true },
+  visualParityMaxVerticalShift: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT', number: true },
+  visualParityMaxHorizontalShift: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT', number: true },
+  visualParityOffsetTolerance: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE', number: true },
+  visualParityPixelmatchThreshold: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD', number: true },
+  maxExplanationElements: { env: 'SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS', integer: { min: 1 } },
+  maxExplanationCandidates: { env: 'SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES', integer: { min: 1 } },
+  explainSelectors: { env: 'SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS', list: true },
+  liveWpParity: { env: 'SSI_FIXTURE_MATRIX_LIVE_WP_PARITY', boolean: true },
+  minNativeRate: { env: 'SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE', number: true },
+  fixtureClass: { env: 'SSI_FIXTURE_MATRIX_CLASS', string: true },
+  tag: { env: 'SSI_FIXTURE_MATRIX_TAG', string: true },
+  capabilities: { env: 'SSI_FIXTURE_MATRIX_CAPABILITIES', string: true },
+  capability: { env: 'SSI_FIXTURE_MATRIX_CAPABILITY', string: true },
+  riskProfile: { env: 'SSI_FIXTURE_MATRIX_RISK_PROFILE', string: true },
+  complexity: { env: 'SSI_FIXTURE_MATRIX_COMPLEXITY', string: true },
+  maxComplexity: { env: 'SSI_FIXTURE_MATRIX_MAX_COMPLEXITY', string: true },
+});
+
+export function normalizeFixtureMatrixRunConfig(input = {}) {
+  const unknown = Object.keys(input).filter((key) => !Object.hasOwn(FIXTURE_MATRIX_RUN_FIELDS, key));
+  if (unknown.length) throw new Error(`Unknown fixture matrix run configuration: ${unknown.join(', ')}`);
+  return Object.fromEntries(Object.entries(FIXTURE_MATRIX_RUN_FIELDS).map(([key, field]) => [key, normalizeField(key, input[key], field)]));
+}
+
+export function fixtureMatrixRunConfigFromEnv(env = process.env) {
+  const settings = settingsBenchEnv(env);
+  const input = Object.fromEntries(Object.entries(FIXTURE_MATRIX_RUN_FIELDS).map(([key, field]) => [key, settings[field.env] ?? env[field.env]]));
+  return normalizeFixtureMatrixRunConfig(input);
+}
+
+export function fixtureMatrixHomeboySettings(config) {
+  return Object.fromEntries(Object.entries(FIXTURE_MATRIX_RUN_FIELDS).flatMap(([key, field]) => {
+    const value = config[key];
+    if (value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) return [];
+    if (!field.always && value === field.default) return [];
+    return [[field.env, field.boolean ? (value ? '1' : '0') : Array.isArray(value) ? value.join(',') : String(value)]];
+  }));
+}
+
+export function fixtureMatrixBenchOptions(config) {
+  return { ...config, fixtureIds: config.fixtureIds.join(',') };
+}
+
+export function fixtureMatrixRecipeInput(config) {
+  return {
+    surfaceCoverage: config.surfaceCoverage,
+    maxExtraSurfaces: config.maxExtraSurfaces,
+    editorValidation: config.editorValidation,
+    visualParity: config.visualParity,
+    pixelThreshold: config.pixelThreshold,
+    maxExplanationElements: config.maxExplanationElements,
+    maxExplanationCandidates: config.maxExplanationCandidates,
+    explainSelectors: config.explainSelectors,
+    liveWpParity: config.liveWpParity,
+  };
+}
+
+export function fixtureMatrixGateConfig(config) {
+  return {
+    visualParity: {
+      threshold: config.pixelThreshold,
+      gate: config.visualParityGate,
+      alignment: config.visualParityAlignment,
+      maxVerticalShift: config.visualParityMaxVerticalShift,
+      maxHorizontalShift: config.visualParityMaxHorizontalShift,
+      offsetTolerance: config.visualParityOffsetTolerance,
+      pixelmatchThreshold: config.visualParityPixelmatchThreshold,
+    },
+    editorQuality: { minNativeRate: config.minNativeRate },
+  };
+}
+
+function normalizeField(key, value, field) {
+  if (value === undefined || value === null || value === '') return field.list ? [] : field.default;
+  if (field.boolean) return booleanValue(key, value);
+  if (field.list) return [...new Set((Array.isArray(value) ? value : String(value).split(',')).map((item) => String(item).trim()).filter(Boolean))];
+  if (field.string) return String(value);
+  const number = Number(value);
+  if (!Number.isFinite(number)) throw new Error(`Fixture matrix ${key} must be a finite number.`);
+  if (field.integer && !Number.isInteger(number)) throw new Error(`Fixture matrix ${key} must be an integer.`);
+  if (field.integer?.min !== undefined && number < field.integer.min) throw new Error(`Fixture matrix ${key} must be at least ${field.integer.min}.`);
+  if (field.integer?.max !== undefined && number > field.integer.max) throw new Error(`Fixture matrix ${key} must be at most ${field.integer.max}.`);
+  return number;
+}
+
+function booleanValue(key, value) {
+  if (value === true || value === '1' || value === 'true') return true;
+  if (value === false || value === '0' || value === 'false' || value === 'no' || value === 'off') return false;
+  throw new Error(`Fixture matrix ${key} must be a boolean.`);
+}
+
+function settingsBenchEnv(env) {
+  try {
+    const settings = JSON.parse(env.HOMEBOY_SETTINGS_JSON || '{}');
+    return settings && typeof settings.bench_env === 'object' && !Array.isArray(settings.bench_env) ? settings.bench_env : {};
+  } catch {
+    return {};
+  }
+}

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -79,6 +79,12 @@ import {
   VISUAL_PARITY_MISMATCH_KIND,
   visualParityCompareStep,
   normalizeVisualAttributionOptions,
+  fixtureMatrixBenchOptions,
+  fixtureMatrixGateConfig,
+  fixtureMatrixHomeboySettings,
+  fixtureMatrixRecipeInput,
+  fixtureMatrixRunConfigFromEnv,
+  normalizeFixtureMatrixRunConfig,
   resolveFixtureSearchRoots,
   wordpressServedPath,
   writeFixtureMatrixArtifacts,
@@ -3155,6 +3161,45 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.ok(visualGateOptOutPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=0'));
 });
 
+test('fixture matrix run configuration round-trips settings into bench recipes and gates', () => {
+  const config = normalizeFixtureMatrixRunConfig({
+    fixtureRoot: '/fixtures',
+    staticSiteImporterPath: '/static-site-importer',
+    run: true,
+    fixtureIds: 'one,two',
+    batchSize: '3',
+    concurrency: '4',
+    surfaceCoverage: '2',
+    maxExtraSurfaces: '2',
+    editorValidation: false,
+    visualParity: true,
+    visualParityGate: false,
+    pixelThreshold: '0.15',
+    minNativeRate: '0.9',
+  });
+  const settings = fixtureMatrixHomeboySettings(config);
+  const bench = fixtureMatrixBenchOptions(fixtureMatrixRunConfigFromEnv({ HOMEBOY_SETTINGS_JSON: JSON.stringify({ bench_env: settings }) }));
+
+  assert.deepEqual(bench.fixtureIds, 'one,two');
+  assert.equal(bench.concurrency, 4);
+  assert.deepEqual(fixtureMatrixRecipeInput(bench), {
+    surfaceCoverage: 2,
+    maxExtraSurfaces: 2,
+    editorValidation: false,
+    visualParity: true,
+    pixelThreshold: 0.15,
+    maxExplanationElements: undefined,
+    maxExplanationCandidates: undefined,
+    explainSelectors: [],
+    liveWpParity: undefined,
+  });
+  assert.deepEqual(fixtureMatrixGateConfig(bench), {
+    visualParity: { threshold: 0.15, gate: false, alignment: undefined, maxVerticalShift: undefined, maxHorizontalShift: undefined, offsetTolerance: undefined, pixelmatchThreshold: undefined },
+    editorQuality: { minNativeRate: 0.9 },
+  });
+  assert.throws(() => normalizeFixtureMatrixRunConfig({ fixtureRoot: '/fixtures', unknown: true }), /Unknown fixture matrix run configuration/);
+});
+
 test('fixture selection fails closed for execution and keeps empty dry-run planning explicit', async () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-empty-selection-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
@@ -6001,9 +6046,9 @@ test('fixture matrix maps visual attribution environment settings', () => {
     SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES: '600',
     SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS: '.hero, #footer',
   });
-  assert.equal(options.maxExplanationElements, '500');
-  assert.equal(options.maxExplanationCandidates, '600');
-  assert.equal(options.explainSelectors, '.hero, #footer');
+  assert.equal(options.maxExplanationElements, 500);
+  assert.equal(options.maxExplanationCandidates, 600);
+  assert.deepEqual(options.explainSelectors, ['.hero', '#footer']);
 });
 
 test('fixture matrix maps the portable transformer reference setting', () => {

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 /**
  * Internal dependencies
  */
-import { MAX_EXTRA_SURFACE_COUNT, createFixtureMatrix, discoverFixtures, inspectFixtureDirectories, normalizeSurfaceCoverageOptions, normalizeVisualAttributionOptions, resolveFixtureSearchRoots } from '../lib/fixture-matrix.mjs';
+import { FIXTURE_MATRIX_RUN_FIELDS, MAX_EXTRA_SURFACE_COUNT, createFixtureMatrix, discoverFixtures, fixtureMatrixHomeboySettings, inspectFixtureDirectories, normalizeFixtureMatrixRunConfig, normalizeSurfaceCoverageOptions, normalizeVisualAttributionOptions, resolveFixtureSearchRoots } from '../lib/fixture-matrix.mjs';
 
 export const RIG_ID = 'static-site-importer-fixture-matrix';
 export const SOLVED_ONLY_LANE_ID = 'fixtures-solved-only/v1';
@@ -99,57 +99,10 @@ export function buildFixtureMatrixRunPlan(input) {
   const options = normalizeOptions(input);
   const codeFreshness = buildCodeFreshness(options, options.gitRunner || defaultGitRunner);
   const transformerReference = options.dependencyOverlayReferences ? resolveTransformerReference(codeFreshness) : '';
-  const settings = {
-    SSI_FIXTURE_MATRIX_FIXTURE_ROOT: options.fixtureRoot,
-    SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH: options.staticSiteImporter,
-    SSI_FIXTURE_MATRIX_RUN: '1',
-    ...(options.fixtureIds.length ? { SSI_FIXTURE_MATRIX_FIXTURE_IDS: options.fixtureIds.join(',') } : {}),
-    ...(options.solvedOnly ? { SSI_FIXTURE_MATRIX_FIXTURE_CORPUS: 'solved' } : {}),
-    ...(options.requireSolvedCandidate ? { SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE: '1' } : {}),
-    ...(options.blocksEnginePhpTransformerPath
-      ? { SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH: options.blocksEnginePhpTransformerPath }
-      : {}),
-    ...(transformerReference
-      ? { SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE: transformerReference }
-      : {}),
-    ...(options.batchSize ? { SSI_FIXTURE_MATRIX_BATCH_SIZE: String(options.batchSize) } : {}),
-    ...(options.concurrency ? { SSI_FIXTURE_MATRIX_CONCURRENCY: String(options.concurrency) } : {}),
-    ...(options.batchInactivityTimeoutMs ? { SSI_FIXTURE_MATRIX_BATCH_INACTIVITY_TIMEOUT_MS: String(options.batchInactivityTimeoutMs) } : {}),
-    ...(options.wordpressVersion ? { SSI_FIXTURE_MATRIX_WORDPRESS_VERSION: options.wordpressVersion } : {}),
-    ...(options.wpCodeboxBin ? { SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN: options.wpCodeboxBin } : {}),
-    ...(options.surfaceCoverage !== undefined ? { SSI_FIXTURE_MATRIX_SURFACE_COVERAGE: String(options.surfaceCoverage) } : {}),
-    ...(options.maxExtraSurfaces ? { SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES: String(options.maxExtraSurfaces) } : {}),
-    ...(options.editorValidation === false ? { SSI_FIXTURE_MATRIX_EDITOR_VALIDATION: '0' } : {}),
-    ...(options.visualParity === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY: '0' } : {}),
-    ...(options.visualParityGate === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '0' } : { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '1' }),
-    ...(options.pixelThreshold !== undefined ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD: String(options.pixelThreshold) } : {}),
-    ...(options.visualParityAlignment === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT: '0' } : {}),
-    ...(options.visualParityMaxVerticalShift !== undefined ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT: String(options.visualParityMaxVerticalShift) } : {}),
-    ...(options.visualParityMaxHorizontalShift !== undefined ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT: String(options.visualParityMaxHorizontalShift) } : {}),
-    ...(options.visualParityOffsetTolerance !== undefined ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE: String(options.visualParityOffsetTolerance) } : {}),
-    ...(options.visualParityPixelmatchThreshold !== undefined ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD: String(options.visualParityPixelmatchThreshold) } : {}),
-    ...(options.maxExplanationElements ? { SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS: String(options.maxExplanationElements) } : {}),
-    ...(options.maxExplanationCandidates ? { SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES: String(options.maxExplanationCandidates) } : {}),
-    ...(options.explainSelectors.length ? { SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS: options.explainSelectors.join(',') } : {}),
-    ...(options.surfaceCoverage ? { SSI_FIXTURE_MATRIX_SURFACE_COVERAGE: String(options.surfaceCoverage) } : {}),
-    ...(options.maxExtraSurfaces ? { SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES: String(options.maxExtraSurfaces) } : {}),
-    // Opt-in live-WP parity capture (off by default). When set, the bench appends
-    // the deterministic `wordpress.capture-html` step per fixture and runs the
-    // blocks-engine live-wp-parity comparator host-side. Absent => byte-identical
-    // to today (no setting emitted, render-free static gate stays primary).
-    ...(options.liveWpParity ? { SSI_FIXTURE_MATRIX_LIVE_WP_PARITY: '1' } : {}),
-    ...(options.minNativeRate ? { SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE: String(options.minNativeRate) } : {}),
-    // Lane/tag selection driven by the per-fixture manifest classification: run a
-    // single class lane (e.g. marketing/static) and/or only fixtures carrying a
-    // given manifest tag.
-    ...(options.class ? { SSI_FIXTURE_MATRIX_CLASS: String(options.class) } : {}),
-    ...(options.tag ? { SSI_FIXTURE_MATRIX_TAG: String(options.tag) } : {}),
-    ...(options.capability ? { SSI_FIXTURE_MATRIX_CAPABILITY: String(options.capability) } : {}),
-    ...(options.capabilities ? { SSI_FIXTURE_MATRIX_CAPABILITIES: String(options.capabilities) } : {}),
-    ...(options.riskProfile ? { SSI_FIXTURE_MATRIX_RISK_PROFILE: String(options.riskProfile) } : {}),
-    ...(options.complexity ? { SSI_FIXTURE_MATRIX_COMPLEXITY: String(options.complexity) } : {}),
-    ...(options.maxComplexity ? { SSI_FIXTURE_MATRIX_MAX_COMPLEXITY: String(options.maxComplexity) } : {}),
-  };
+  const settings = fixtureMatrixHomeboySettings({
+    ...options.runConfig,
+    blocksEnginePhpTransformerReference: transformerReference || options.runConfig.blocksEnginePhpTransformerReference,
+  });
   const corpusCounts = inspectCorpusFixtures(options.fixtureRoot);
   let matrix = { fixtures: [], count: 0 };
   if (corpusCounts.inspections.active.exclusions[0]?.reason !== 'root_symlink') {
@@ -323,6 +276,20 @@ function normalizeOptions(input) {
     artifactRoot = path.join(tempRoot, 'artifacts');
   }
 
+  const batchSize = input.batchSize || (selection.isolatedBatches ? 1 : input.batchSize);
+  const runConfig = normalizeFixtureMatrixRunConfig(Object.fromEntries(Object.keys(FIXTURE_MATRIX_RUN_FIELDS).map((key) => [key, ({
+    ...input,
+    fixtureRoot,
+    staticSiteImporterPath: path.resolve(input.staticSiteImporter),
+    fixtureIds: selection.fixtureIds,
+    fixtureCorpus: selection.solvedOnly ? 'solved' : undefined,
+    requireSolvedCandidate: selection.requireSolvedCandidate,
+    blocksEnginePhpTransformerPath,
+    fixtureClass: input.class,
+    batchSize,
+    run: true,
+  })[key]])));
+
   return {
     ...input,
     ...executionTarget,
@@ -340,7 +307,7 @@ function normalizeOptions(input) {
     requireSolvedCandidate: selection.requireSolvedCandidate,
     selectedActiveFixtureCount: selection.selectedActiveFixtureCount,
     selectedSolvedFixtureCount: selection.selectedSolvedFixtureCount,
-    batchSize: input.batchSize || (selection.isolatedBatches ? 1 : input.batchSize),
+    batchSize,
     blocksEngine,
     blocksEnginePhpTransformerPath,
     passthrough: Array.isArray(input.passthrough) ? input.passthrough : [],
@@ -350,6 +317,7 @@ function normalizeOptions(input) {
     sharedStateExplicit,
     artifactRootExplicit,
     homeboyBin: input.homeboyBin || process.env.HOMEBOY_BIN || 'homeboy',
+    runConfig,
     ...normalizeVisualAttributionOptions(input),
   };
 }


### PR DESCRIPTION
## Summary

- centralize typed fixture-matrix run configuration and field mapping
- derive Homeboy settings, bench options, recipe input, and gate configuration from one normalized source
- remove duplicate `surfaceCoverage` and `maxExtraSurfaces` emission
- add configuration round-trip coverage without changing public environment names or acceptance policy

Closes #775.

## Verification

- Node syntax checks passed
- direct config/settings/bench/recipe/gate round trip passed
- `git diff --check` passed

The complete `tools/fixture-matrix.test.mjs` suite remains unverified because this bare disk-constrained worktree has no `pngjs` installation.

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenCode general coding subagent
- **Model:** `openai/gpt-5.6-sol`
- **Used for:** Centralized configuration ownership, added round-trip coverage, and ran available verification. Chris Huber owns and reviewed the submitted change.
