### PR TITLE
test: structure canonical manifest commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ npm run test:validation -- --json
 
 ### Test Inventory
 
-`test-manifest.json` is the canonical repository-wide test inventory. It classifies every executable test as standalone PHP, WordPress runtime, Node, browser/WP Codebox, or operator-only acceptance. `npm test` runs the fast standalone PHP and Node projection; it reports the environment-heavy lanes as skipped. `npm run test:all` is the complete CI/reviewer command and runs configured runtime lanes while reporting operator-only acceptance commands explicitly. `npm run test:inventory` verifies that every executable test is declared once and that `homeboy-test-manifest.json` remains the deterministic standalone-PHP projection used by Homeboy.
+`test-manifest.json` is the canonical repository-wide test inventory. It classifies every executable test as standalone PHP, WordPress runtime, Node, browser/WP Codebox, or operator-only acceptance. Explicit `command` values are arrays of executable and argument strings. `npm test` runs the fast standalone PHP and Node projection; it reports the environment-heavy lanes as skipped. `npm run test:all` is the complete CI/reviewer command and runs configured runtime lanes while reporting operator-only acceptance commands explicitly. `npm run test:inventory` verifies that every executable test is declared once and that `homeboy-test-manifest.json` remains the deterministic standalone-PHP projection used by Homeboy.
 
 ### PHP Smokes
 

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -38,17 +38,18 @@
     { "path": "tests/smoke-import-source-of-truth-manifest.php", "environment": "wordpress-runtime" },
     { "path": "tests/smoke-static-interactive-artifact.php", "environment": "wordpress-runtime" },
     { "path": "tests/smoke-website-artifact-document-metadata.php", "environment": "wordpress-runtime" },
-    { "path": "tests/StaticSiteImporterFallbackDiagnosticsTest.php", "environment": "wordpress-runtime", "command": "phpunit tests/StaticSiteImporterFallbackDiagnosticsTest.php" },
+    { "path": "tests/StaticSiteImporterFallbackDiagnosticsTest.php", "environment": "wordpress-runtime", "command": ["phpunit", "tests/StaticSiteImporterFallbackDiagnosticsTest.php"] },
     { "path": "tools/fig-intent-parity-report.test.mjs", "environment": "node" },
     { "path": "tools/fixture-matrix.test.mjs", "environment": "node" },
     { "path": "tools/php-wasm-zstd.test.mjs", "environment": "node" },
     { "path": "tools/promote-solved-fixture.test.mjs", "environment": "node" },
+    { "path": "tools/run-test-manifest.test.mjs", "environment": "node" },
     { "path": "tools/run-fig-fixture-e2e.test.mjs", "environment": "node" },
     { "path": "tools/runtime-package-manifest.test.mjs", "environment": "node" },
     { "path": "tools/verify-solved-site-promotion.test.mjs", "environment": "node" },
     { "path": "tests/smoke-generated-theme-block-validation.cjs", "environment": "browser-wp-codebox" },
-    { "path": "tests/run-validation-harness.cjs", "environment": "operator-only", "command": "node tests/run-validation-harness.cjs" },
-    { "path": "tools/run-fixture-matrix.mjs", "environment": "operator-only", "command": "node tools/run-fixture-matrix.mjs" },
-    { "path": "tools/fig-acceptance-provider.mjs", "environment": "operator-only", "command": "node tools/fig-acceptance-provider.mjs" }
+    { "path": "tests/run-validation-harness.cjs", "environment": "operator-only", "command": ["node", "tests/run-validation-harness.cjs"] },
+    { "path": "tools/run-fixture-matrix.mjs", "environment": "operator-only", "command": ["node", "tools/run-fixture-matrix.mjs"] },
+    { "path": "tools/fig-acceptance-provider.mjs", "environment": "operator-only", "command": ["node", "tools/fig-acceptance-provider.mjs"] }
   ]
 }

--- a/tools/run-test-manifest.mjs
+++ b/tools/run-test-manifest.mjs
@@ -10,56 +10,70 @@ const args = new Set(process.argv.slice(2))
 const manifest = JSON.parse(readFileSync(manifestPath, "utf8"))
 const environments = new Set(["standalone-php", "wordpress-runtime", "node", "browser-wp-codebox", "operator-only"])
 
-validateManifest()
-if (args.has("--check")) process.exit(0)
-
-const selectedEnvironments = args.has("--all")
-  ? environments
-  : new Set(["standalone-php", "node"])
-const selected = manifest.tests.filter((test) => selectedEnvironments.has(test.environment))
-const results = { passed: [], failed: [], skipped: [] }
-
-for (const test of selected) {
-  if (test.environment === "operator-only") {
-    results.skipped.push(`${test.path} (operator-only acceptance: ${commandFor(test).join(" ")})`)
-    continue
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    run()
+  } catch (error) {
+    console.error(error.message)
+    process.exitCode = 1
   }
-  if (test.environment === "wordpress-runtime" && !process.env.STATIC_SITE_IMPORTER_WP_CLI) {
-    results.skipped.push(`${test.path} (set STATIC_SITE_IMPORTER_WP_CLI to run WordPress runtime tests)`)
-    continue
-  }
-  if (test.environment === "browser-wp-codebox" && !process.env.STATIC_SITE_IMPORTER_THEME_DIR) {
-    results.skipped.push(`${test.path} (set STATIC_SITE_IMPORTER_THEME_DIR after a WP Codebox or WordPress import)`)
-    continue
-  }
-
-  const command = commandFor(test)
-  const result = spawnSync(command[0], command.slice(1), { cwd: root, stdio: "inherit", env: process.env })
-  if (result.status === 0) results.passed.push(test.path)
-  else results.failed.push(test.path)
 }
 
-for (const environment of environments) {
-  const count = manifest.tests.filter((test) => test.environment === environment).length
-  const selectedCount = selected.filter((test) => test.environment === environment).length
-  console.log(`${environment}: ${selectedCount ? `selected ${selectedCount}` : `skipped ${count}`}`)
-}
-console.log(`passed: ${results.passed.length}; failed: ${results.failed.length}; intentionally skipped: ${results.skipped.length}`)
-for (const skipped of results.skipped) console.log(`SKIP ${skipped}`)
-process.exit(results.failed.length ? 1 : 0)
+function run() {
+  validateManifest()
+  if (args.has("--check")) return
 
-function commandFor(test) {
-  if (test.command) return test.command.split(" ")
+  const selectedEnvironments = args.has("--all")
+    ? environments
+    : new Set(["standalone-php", "node"])
+  const selected = manifest.tests.filter((test) => selectedEnvironments.has(test.environment))
+  const results = { passed: [], failed: [], skipped: [] }
+
+  for (const test of selected) {
+    if (test.environment === "operator-only") {
+      results.skipped.push(`${test.path} (operator-only acceptance: ${commandFor(test).join(" ")})`)
+      continue
+    }
+    if (test.environment === "wordpress-runtime" && !process.env.STATIC_SITE_IMPORTER_WP_CLI) {
+      results.skipped.push(`${test.path} (set STATIC_SITE_IMPORTER_WP_CLI to run WordPress runtime tests)`)
+      continue
+    }
+    if (test.environment === "browser-wp-codebox" && !process.env.STATIC_SITE_IMPORTER_THEME_DIR) {
+      results.skipped.push(`${test.path} (set STATIC_SITE_IMPORTER_THEME_DIR after a WP Codebox or WordPress import)`)
+      continue
+    }
+
+    const command = commandFor(test)
+    const result = spawnSync(command[0], command.slice(1), { cwd: root, stdio: "inherit", env: process.env })
+    if (result.status === 0) results.passed.push(test.path)
+    else results.failed.push(test.path)
+  }
+
+  for (const environment of environments) {
+    const count = manifest.tests.filter((test) => test.environment === environment).length
+    const selectedCount = selected.filter((test) => test.environment === environment).length
+    console.log(`${environment}: ${selectedCount ? `selected ${selectedCount}` : `skipped ${count}`}`)
+  }
+  console.log(`passed: ${results.passed.length}; failed: ${results.failed.length}; intentionally skipped: ${results.skipped.length}`)
+  for (const skipped of results.skipped) console.log(`SKIP ${skipped}`)
+  if (results.failed.length) process.exitCode = 1
+}
+
+export function commandFor(test) {
+  if (test.command) return test.command
   if (test.environment === "standalone-php") return ["php", test.path]
   if (test.environment === "node") return ["node", "--test", test.path]
   if (test.environment === "wordpress-runtime") return [...process.env.STATIC_SITE_IMPORTER_WP_CLI.split(" "), "eval-file", test.path]
   return ["node", test.path]
 }
 
-function validateManifest() {
-  if (manifest.schema !== "static-site-importer/test-manifest/v1") fail("unexpected manifest schema")
+export function validateManifest(candidate = manifest) {
+  if (candidate.schema !== "static-site-importer/test-manifest/v1") fail("unexpected manifest schema")
   const declared = new Set()
-  for (const test of manifest.tests) {
+  for (const test of candidate.tests) {
+    if ("command" in test && (!Array.isArray(test.command) || !test.command.length || test.command.some((argument) => typeof argument !== "string" || !argument.trim()))) {
+      fail(`command for ${test.path} must be a non-empty array of non-empty strings`)
+    }
     if (!environments.has(test.environment)) fail(`unknown environment for ${test.path}: ${test.environment}`)
     if (declared.has(test.path)) fail(`test is declared more than once: ${test.path}`)
     if (!existsSync(resolve(root, test.path))) fail(`declared test does not exist: ${test.path}`)
@@ -69,13 +83,13 @@ function validateManifest() {
   const executable = execFileSync("git", ["ls-files", "--cached", "--others", "--exclude-standard", "--", "tests", "tools"], { cwd: root, encoding: "utf8" })
     .trim().split("\n").filter(Boolean)
     .filter(isExecutableTest)
-  const exclusions = Object.keys(manifest.exclusions || {})
+  const exclusions = Object.keys(candidate.exclusions || {})
   for (const path of executable) {
     if (!declared.has(path) && !exclusions.some((pattern) => matches(pattern, path))) fail(`undeclared executable test: ${path}`)
   }
 
   const homeboy = JSON.parse(readFileSync(homeboyPath, "utf8"))
-  const projected = Object.fromEntries(manifest.tests
+  const projected = Object.fromEntries(candidate.tests
     .filter((test) => test.environment === "standalone-php")
     .map((test) => [test.path, { environment: test.environment }]))
   if (JSON.stringify(homeboy.tests) !== JSON.stringify(projected)) fail("homeboy-test-manifest.json is not the standalone PHP projection of test-manifest.json")
@@ -90,6 +104,5 @@ function matches(pattern, path) {
 }
 
 function fail(message) {
-  console.error(`Test manifest error: ${message}`)
-  process.exit(1)
+  throw new Error(`Test manifest error: ${message}`)
 }

--- a/tools/run-test-manifest.test.mjs
+++ b/tools/run-test-manifest.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import test from "node:test"
+import { commandFor, validateManifest } from "./run-test-manifest.mjs"
+
+test("explicit command arguments retain spaces", () => {
+  const command = ["node", "-e", "process.stdout.write(process.argv[1])", "argument with spaces"]
+
+  assert.deepEqual(commandFor({ command }), command)
+  const result = spawnSync(command[0], command.slice(1), { encoding: "utf8" })
+  assert.equal(result.status, 0)
+  assert.equal(result.stdout, "argument with spaces")
+})
+
+test("implicit commands retain their environment defaults", () => {
+  assert.deepEqual(commandFor({ path: "tests/example.php", environment: "standalone-php" }), ["php", "tests/example.php"])
+  assert.deepEqual(commandFor({ path: "tools/example.test.mjs", environment: "node" }), ["node", "--test", "tools/example.test.mjs"])
+})
+
+test("manifest rejects invalid explicit command declarations", () => {
+  for (const command of ["node script.mjs", [], ["node", ""], ["node", " "]]) {
+    assert.throws(
+      () => validateManifest({
+        schema: "static-site-importer/test-manifest/v1",
+        tests: [{ path: "tools/run-test-manifest.mjs", environment: "node", command }],
+      }),
+      /command for tools\/run-test-manifest\.mjs must be a non-empty array of non-empty strings/,
+    )
+  }
+})


### PR DESCRIPTION
## Summary
- represent explicit canonical test-manifest commands as executable/argument arrays
- reject empty command arrays and empty or non-string command arguments
- retain implicit command derivation and the standalone-PHP Homeboy projection

Closes #781

## Verification
- `node --test tools/run-test-manifest.test.mjs`
- `npm run test:inventory`
- `npm run test:all` (35 passed; 3 existing standalone-PHP failures: unavailable `wp_generate_uuid4()`, missing `Static_Site_Importer_Font_Materializer`, and an absent reflected `analyze_imported_page_content_documents()` method. WordPress runtime, browser, and operator-only lanes are skipped without their configured environments.)

## AI assistance
OpenCode using `openai/gpt-5.6-sol` drafted the structured command schema change and focused tests. Chris Huber remains responsible for every line.