### PR TITLE
test: cover fixture run config projections

### DIFF
--- a/lib/fixture-matrix/run-config.mjs
+++ b/lib/fixture-matrix/run-config.mjs
@@ -4,42 +4,42 @@
  * camelCase so recipe and gate builders never need to parse environment values.
  */
 export const FIXTURE_MATRIX_RUN_FIELDS = Object.freeze({
-  fixtureRoot: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_ROOT', required: true, string: true },
-  staticSiteImporterPath: { env: 'SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH', required: true, string: true },
-  run: { env: 'SSI_FIXTURE_MATRIX_RUN', boolean: true, always: true },
-  fixtureIds: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_IDS', list: true },
-  fixtureCorpus: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_CORPUS', string: true },
-  requireSolvedCandidate: { env: 'SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE', boolean: true },
-  blocksEnginePhpTransformerPath: { env: 'SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH', string: true },
-  blocksEnginePhpTransformerReference: { env: 'SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE', string: true },
-  batchSize: { env: 'SSI_FIXTURE_MATRIX_BATCH_SIZE', integer: { min: 1 }, default: 10 },
-  concurrency: { env: 'SSI_FIXTURE_MATRIX_CONCURRENCY', integer: { min: 1, max: 16 }, default: 2 },
-  batchInactivityTimeoutMs: { env: 'SSI_FIXTURE_MATRIX_BATCH_INACTIVITY_TIMEOUT_MS', integer: { min: 1 } },
-  wordpressVersion: { env: 'SSI_FIXTURE_MATRIX_WORDPRESS_VERSION', string: true },
-  wpCodeboxBin: { env: 'SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN', string: true },
-  surfaceCoverage: { env: 'SSI_FIXTURE_MATRIX_SURFACE_COVERAGE', integer: { min: 0 } },
-  maxExtraSurfaces: { env: 'SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES', integer: { min: 0 } },
-  editorValidation: { env: 'SSI_FIXTURE_MATRIX_EDITOR_VALIDATION', boolean: true, default: true },
-  visualParity: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY', boolean: true, default: true },
-  visualParityGate: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE', boolean: true, default: true, always: true },
-  pixelThreshold: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD', number: true },
-  visualParityAlignment: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT', boolean: true },
-  visualParityMaxVerticalShift: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT', number: true },
-  visualParityMaxHorizontalShift: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT', number: true },
-  visualParityOffsetTolerance: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE', number: true },
-  visualParityPixelmatchThreshold: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD', number: true },
-  maxExplanationElements: { env: 'SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS', integer: { min: 1 } },
-  maxExplanationCandidates: { env: 'SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES', integer: { min: 1 } },
-  explainSelectors: { env: 'SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS', list: true },
-  liveWpParity: { env: 'SSI_FIXTURE_MATRIX_LIVE_WP_PARITY', boolean: true },
-  minNativeRate: { env: 'SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE', number: true },
-  fixtureClass: { env: 'SSI_FIXTURE_MATRIX_CLASS', string: true },
-  tag: { env: 'SSI_FIXTURE_MATRIX_TAG', string: true },
-  capabilities: { env: 'SSI_FIXTURE_MATRIX_CAPABILITIES', string: true },
-  capability: { env: 'SSI_FIXTURE_MATRIX_CAPABILITY', string: true },
-  riskProfile: { env: 'SSI_FIXTURE_MATRIX_RISK_PROFILE', string: true },
-  complexity: { env: 'SSI_FIXTURE_MATRIX_COMPLEXITY', string: true },
-  maxComplexity: { env: 'SSI_FIXTURE_MATRIX_MAX_COMPLEXITY', string: true },
+  fixtureRoot: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_ROOT', required: true, string: true, projections: {} },
+  staticSiteImporterPath: { env: 'SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH', required: true, string: true, projections: {} },
+  run: { env: 'SSI_FIXTURE_MATRIX_RUN', boolean: true, always: true, projections: {} },
+  fixtureIds: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_IDS', list: true, projections: {} },
+  fixtureCorpus: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_CORPUS', string: true, projections: {} },
+  requireSolvedCandidate: { env: 'SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE', boolean: true, projections: {} },
+  blocksEnginePhpTransformerPath: { env: 'SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH', string: true, projections: {} },
+  blocksEnginePhpTransformerReference: { env: 'SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE', string: true, projections: {} },
+  batchSize: { env: 'SSI_FIXTURE_MATRIX_BATCH_SIZE', integer: { min: 1 }, default: 10, always: true, projections: {} },
+  concurrency: { env: 'SSI_FIXTURE_MATRIX_CONCURRENCY', integer: { min: 1, max: 16 }, default: 2, always: true, projections: {} },
+  batchInactivityTimeoutMs: { env: 'SSI_FIXTURE_MATRIX_BATCH_INACTIVITY_TIMEOUT_MS', integer: { min: 1 }, projections: {} },
+  wordpressVersion: { env: 'SSI_FIXTURE_MATRIX_WORDPRESS_VERSION', string: true, projections: {} },
+  wpCodeboxBin: { env: 'SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN', string: true, projections: {} },
+  surfaceCoverage: { env: 'SSI_FIXTURE_MATRIX_SURFACE_COVERAGE', integer: { min: 0 }, projections: { recipe: 'surfaceCoverage' } },
+  maxExtraSurfaces: { env: 'SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES', integer: { min: 0 }, projections: { recipe: 'maxExtraSurfaces' } },
+  editorValidation: { env: 'SSI_FIXTURE_MATRIX_EDITOR_VALIDATION', boolean: true, default: true, always: true, projections: { recipe: 'editorValidation' } },
+  visualParity: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY', boolean: true, default: true, always: true, projections: { recipe: 'visualParity' } },
+  visualParityGate: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE', boolean: true, default: true, always: true, projections: { gate: 'visualParity.gate' } },
+  pixelThreshold: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD', number: true, projections: { recipe: 'pixelThreshold', gate: 'visualParity.threshold' } },
+  visualParityAlignment: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT', boolean: true, projections: { gate: 'visualParity.alignment' } },
+  visualParityMaxVerticalShift: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT', number: true, projections: { gate: 'visualParity.maxVerticalShift' } },
+  visualParityMaxHorizontalShift: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT', number: true, projections: { gate: 'visualParity.maxHorizontalShift' } },
+  visualParityOffsetTolerance: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE', number: true, projections: { gate: 'visualParity.offsetTolerance' } },
+  visualParityPixelmatchThreshold: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD', number: true, projections: { gate: 'visualParity.pixelmatchThreshold' } },
+  maxExplanationElements: { env: 'SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS', integer: { min: 1 }, projections: { recipe: 'maxExplanationElements' } },
+  maxExplanationCandidates: { env: 'SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES', integer: { min: 1 }, projections: { recipe: 'maxExplanationCandidates' } },
+  explainSelectors: { env: 'SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS', list: true, projections: { recipe: 'explainSelectors' } },
+  liveWpParity: { env: 'SSI_FIXTURE_MATRIX_LIVE_WP_PARITY', boolean: true, projections: { recipe: 'liveWpParity' } },
+  minNativeRate: { env: 'SSI_FIXTURE_MATRIX_MIN_NATIVE_RATE', number: true, projections: { gate: 'editorQuality.minNativeRate' } },
+  fixtureClass: { env: 'SSI_FIXTURE_MATRIX_CLASS', string: true, projections: {} },
+  tag: { env: 'SSI_FIXTURE_MATRIX_TAG', string: true, projections: {} },
+  capabilities: { env: 'SSI_FIXTURE_MATRIX_CAPABILITIES', string: true, projections: {} },
+  capability: { env: 'SSI_FIXTURE_MATRIX_CAPABILITY', string: true, projections: {} },
+  riskProfile: { env: 'SSI_FIXTURE_MATRIX_RISK_PROFILE', string: true, projections: {} },
+  complexity: { env: 'SSI_FIXTURE_MATRIX_COMPLEXITY', string: true, projections: {} },
+  maxComplexity: { env: 'SSI_FIXTURE_MATRIX_MAX_COMPLEXITY', string: true, projections: {} },
 });
 
 export function normalizeFixtureMatrixRunConfig(input = {}) {
@@ -68,32 +68,23 @@ export function fixtureMatrixBenchOptions(config) {
 }
 
 export function fixtureMatrixRecipeInput(config) {
-  return {
-    surfaceCoverage: config.surfaceCoverage,
-    maxExtraSurfaces: config.maxExtraSurfaces,
-    editorValidation: config.editorValidation,
-    visualParity: config.visualParity,
-    pixelThreshold: config.pixelThreshold,
-    maxExplanationElements: config.maxExplanationElements,
-    maxExplanationCandidates: config.maxExplanationCandidates,
-    explainSelectors: config.explainSelectors,
-    liveWpParity: config.liveWpParity,
-  };
+  return projectRunConfig(config, 'recipe');
 }
 
 export function fixtureMatrixGateConfig(config) {
-  return {
-    visualParity: {
-      threshold: config.pixelThreshold,
-      gate: config.visualParityGate,
-      alignment: config.visualParityAlignment,
-      maxVerticalShift: config.visualParityMaxVerticalShift,
-      maxHorizontalShift: config.visualParityMaxHorizontalShift,
-      offsetTolerance: config.visualParityOffsetTolerance,
-      pixelmatchThreshold: config.visualParityPixelmatchThreshold,
-    },
-    editorQuality: { minNativeRate: config.minNativeRate },
-  };
+  return projectRunConfig(config, 'gate');
+}
+
+function projectRunConfig(config, projection) {
+  return Object.entries(FIXTURE_MATRIX_RUN_FIELDS).reduce((output, [key, field]) => {
+    const target = field.projections[projection];
+    if (!target) return output;
+    const segments = target.split('.');
+    const leaf = segments.pop();
+    const parent = segments.reduce((value, segment) => (value[segment] ||= {}), output);
+    parent[leaf] = config[key];
+    return output;
+  }, {});
 }
 
 function normalizeField(key, value, field) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -84,6 +84,7 @@ import {
   fixtureMatrixHomeboySettings,
   fixtureMatrixRecipeInput,
   fixtureMatrixRunConfigFromEnv,
+  FIXTURE_MATRIX_RUN_FIELDS,
   normalizeFixtureMatrixRunConfig,
   resolveFixtureSearchRoots,
   wordpressServedPath,
@@ -3161,44 +3162,55 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.ok(visualGateOptOutPlan.steps.at(-1).args.includes('bench_env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=0'));
 });
 
-test('fixture matrix run configuration round-trips settings into bench recipes and gates', () => {
-  const config = normalizeFixtureMatrixRunConfig({
-    fixtureRoot: '/fixtures',
-    staticSiteImporterPath: '/static-site-importer',
-    run: true,
-    fixtureIds: 'one,two',
-    batchSize: '3',
-    concurrency: '4',
-    surfaceCoverage: '2',
-    maxExtraSurfaces: '2',
-    editorValidation: false,
-    visualParity: true,
-    visualParityGate: false,
-    pixelThreshold: '0.15',
-    minNativeRate: '0.9',
-  });
+test('fixture matrix run configuration covers every declared environment, bench, recipe, and gate projection', () => {
+  const input = Object.fromEntries(Object.entries(FIXTURE_MATRIX_RUN_FIELDS).map(([key, field]) => [key, fixtureMatrixRunConfigTestValue(key, field)]));
+  const config = normalizeFixtureMatrixRunConfig(input);
   const settings = fixtureMatrixHomeboySettings(config);
-  const bench = fixtureMatrixBenchOptions(fixtureMatrixRunConfigFromEnv({ HOMEBOY_SETTINGS_JSON: JSON.stringify({ bench_env: settings }) }));
+  const directEnv = Object.fromEntries(Object.entries(FIXTURE_MATRIX_RUN_FIELDS).map(([key, field]) => [field.env, fixtureMatrixRunConfigFallbackValue(key, field)]));
+  const fromSettings = fixtureMatrixRunConfigFromEnv({
+    ...directEnv,
+    HOMEBOY_SETTINGS_JSON: JSON.stringify({ bench_env: settings }),
+  });
+  const bench = fixtureMatrixBenchOptions(fromSettings);
 
-  assert.deepEqual(bench.fixtureIds, 'one,two');
-  assert.equal(bench.concurrency, 4);
-  assert.deepEqual(fixtureMatrixRecipeInput(bench), {
-    surfaceCoverage: 2,
-    maxExtraSurfaces: 2,
-    editorValidation: false,
-    visualParity: true,
-    pixelThreshold: 0.15,
-    maxExplanationElements: undefined,
-    maxExplanationCandidates: undefined,
-    explainSelectors: [],
-    liveWpParity: undefined,
-  });
-  assert.deepEqual(fixtureMatrixGateConfig(bench), {
-    visualParity: { threshold: 0.15, gate: false, alignment: undefined, maxVerticalShift: undefined, maxHorizontalShift: undefined, offsetTolerance: undefined, pixelmatchThreshold: undefined },
-    editorQuality: { minNativeRate: 0.9 },
-  });
+  assert.deepEqual(fromSettings, config, 'Homeboy bench settings override direct environment values for every declared field');
+  assert.deepEqual(bench, { ...config, fixtureIds: config.fixtureIds.join(',') }, 'every normalized field reaches the bench');
+  assert.deepEqual(fixtureMatrixRecipeInput(config), fixtureMatrixExpectedProjection(config, 'recipe'));
+  assert.deepEqual(fixtureMatrixGateConfig(config), fixtureMatrixExpectedProjection(config, 'gate'));
+  for (const [key, field] of Object.entries(FIXTURE_MATRIX_RUN_FIELDS)) {
+    assert.ok(Object.hasOwn(field, 'projections'), `${key} must explicitly declare its projection contract`);
+  }
   assert.throws(() => normalizeFixtureMatrixRunConfig({ fixtureRoot: '/fixtures', unknown: true }), /Unknown fixture matrix run configuration/);
 });
+
+function fixtureMatrixRunConfigTestValue(key, field) {
+  if (field.boolean) return key === 'editorValidation' || key === 'visualParityGate' ? 'false' : 'true';
+  if (field.list) return [`${key}-one`, ` ${key}-two `, `${key}-one`];
+  if (field.string) return `/${key}`;
+  if (field.integer) return String(field.integer.min === 0 ? 2 : 3);
+  return '1.5';
+}
+
+function fixtureMatrixRunConfigFallbackValue(key, field) {
+  if (field.boolean) return 'false';
+  if (field.list) return `${key}-fallback`;
+  if (field.string) return `/fallback-${key}`;
+  if (field.integer) return String(field.integer.min === 0 ? 1 : 2);
+  return '2.5';
+}
+
+function fixtureMatrixExpectedProjection(config, projection) {
+  const output = {};
+  for (const [key, field] of Object.entries(FIXTURE_MATRIX_RUN_FIELDS)) {
+    const target = field.projections?.[projection];
+    if (!target) continue;
+    const segments = target.split('.');
+    const leaf = segments.pop();
+    const parent = segments.reduce((value, segment) => (value[segment] ||= {}), output);
+    parent[leaf] = config[key];
+  }
+  return output;
+}
 
 test('fixture selection fails closed for execution and keeps empty dry-run planning explicit', async () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-empty-selection-'));


### PR DESCRIPTION
## Summary
- derive recipe and gate projection metadata from the centralized fixture run-config field map
- exercise every declared field through normalization, Homeboy settings precedence, and bench options
- preserve default execution settings at the Homeboy boundary so ambient environment values cannot override them

Closes #782.

## Verification
- `npm run test:fixture-matrix` (235 passing)
- `npm test` (34 passing, 3 unrelated standalone-PHP failures: missing `wp_generate_uuid4` test stub, missing `Static_Site_Importer_Font_Materializer` bootstrap, and stale `analyze_imported_page_content_documents` reflection target)

## AI assistance
OpenCode using `openai/gpt-5.6-sol` drafted the centralized projection metadata and table-driven tests. Chris Huber remains responsible for every line.