### PR TITLE
fix: disable smilie conversion for imported static content (#780)

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -125,11 +125,12 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
-						'plan'       => array( 'type' => 'object' ),
-						'slug'       => array( 'type' => 'string' ),
-						'activate'   => array( 'type' => 'boolean' ),
-						'site_title' => array( 'type' => 'string' ),
-						'overwrite'  => array( 'type' => 'boolean' ),
+						'plan'            => array( 'type' => 'object' ),
+						'slug'            => array( 'type' => 'string' ),
+						'activate'        => array( 'type' => 'boolean' ),
+						'site_title'      => array( 'type' => 'string' ),
+						'overwrite'       => array( 'type' => 'boolean' ),
+						'disable_smilies' => array( 'type' => 'boolean' ),
 					),
 					'required'   => array( 'plan', 'slug' ),
 				),

--- a/includes/class-static-site-importer-website-artifact-import-input.php
+++ b/includes/class-static-site-importer-website-artifact-import-input.php
@@ -25,6 +25,7 @@ class Static_Site_Importer_Website_Artifact_Import_Input {
 		),
 		'activate'                             => array( 'type' => 'boolean' ),
 		'overwrite'                            => array( 'type' => 'boolean' ),
+		'disable_smilies'                      => array( 'type' => 'boolean' ),
 		'fail_on_quality'                      => array( 'type' => 'boolean' ),
 		'allow_missing_woocommerce'            => array( 'type' => 'boolean' ),
 		'allow_missing_jetpack'                => array( 'type' => 'boolean' ),
@@ -61,6 +62,7 @@ class Static_Site_Importer_Website_Artifact_Import_Input {
 				'stale_page_action'                    => '',
 				'activate'                             => false,
 				'overwrite'                            => false,
+				'disable_smilies'                      => true,
 				'fail_on_quality'                      => false,
 				'allow_missing_woocommerce'            => false,
 				'allow_missing_jetpack'                => false,
@@ -89,7 +91,7 @@ class Static_Site_Importer_Website_Artifact_Import_Input {
 		foreach ( array( 'slug', 'name', 'site_title', 'stale_page_action', 'report', 'asset_materialization_policy' ) as $field ) {
 			$values[ $field ] = is_scalar( $values[ $field ] ) ? (string) $values[ $field ] : '';
 		}
-		foreach ( array( 'activate', 'overwrite', 'fail_on_quality', 'allow_missing_woocommerce', 'allow_missing_jetpack', 'materialize_dependencies', 'require_proven_dynamic_client_assets', 'seed_entities', 'write_theme_report_artifacts' ) as $field ) {
+		foreach ( array( 'activate', 'overwrite', 'disable_smilies', 'fail_on_quality', 'allow_missing_woocommerce', 'allow_missing_jetpack', 'materialize_dependencies', 'require_proven_dynamic_client_assets', 'seed_entities', 'write_theme_report_artifacts' ) as $field ) {
 			$values[ $field ] = (bool) $values[ $field ];
 		}
 		foreach ( array( 'products_manifest', 'commerce_context', 'asset_map', 'compiler_options', 'source_metadata', 'validation_artifacts' ) as $field ) {

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -262,8 +262,12 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'theme_slug' => $state['theme']['slug'],
 			);
 			if ( ! isset( $args['disable_smilies'] ) || false !== (bool) $args['disable_smilies'] ) {
-				if ( false === update_option( 'use_smilies', false ) ) {
-					return self::failed_receipt( $state, 'disable_smilies_not_applied' );
+				// update_option( 'use_smilies', false ) returns false both on failure and
+				// when the stored value is already false, so the existing value is the oracle.
+				if ( false !== get_option( 'use_smilies', false ) ) {
+					if ( false === update_option( 'use_smilies', false ) ) {
+						return self::failed_receipt( $state, 'disable_smilies_not_applied' );
+					}
 				}
 				$state['applied']['runtime_policy']['disable_smilies'] = true;
 			}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -261,6 +261,12 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'kind'       => 'activate_theme',
 				'theme_slug' => $state['theme']['slug'],
 			);
+			if ( ! isset( $args['disable_smilies'] ) || false !== (bool) $args['disable_smilies'] ) {
+				if ( false === update_option( 'use_smilies', false ) ) {
+					return self::failed_receipt( $state, 'disable_smilies_not_applied' );
+				}
+				$state['applied']['runtime_policy']['disable_smilies'] = true;
+			}
 			if ( '' !== trim( (string) ( $args['site_title'] ?? '' ) ) ) {
 				update_option( 'blogname', sanitize_text_field( (string) $args['site_title'] ) );
 				$state['applied']['operations'][] = array( 'kind' => 'site_title' );
@@ -1098,6 +1104,12 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'provider_layout_overlays'   => $state['applied']['provider_layout_overlays'] ?? array(
 					'status' => 'not_requested',
 					'files'  => array(),
+				),
+				'runtime_policy'             => array(
+					'disable_smilies' => array(
+						'requested' => isset( $state['args']['disable_smilies'] ) ? (bool) $state['args']['disable_smilies'] : true,
+						'applied'   => isset( $state['applied']['runtime_policy']['disable_smilies'] ) && true === $state['applied']['runtime_policy']['disable_smilies'],
+					),
 				),
 				'materialized_pages'         => $materialized_pages,
 				'block_provenance'           => $block_provenance,

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -139,9 +139,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			}
 			$receipt = static_site_importer_ability_materialize_wordpress_site_plan(
 				array(
-					'plan'      => $plan,
-					'slug'      => (string) $assoc_args['slug'],
-					'overwrite' => isset( $assoc_args['overwrite'] ),
+					'plan'            => $plan,
+					'slug'            => (string) $assoc_args['slug'],
+					'overwrite'       => isset( $assoc_args['overwrite'] ),
+					'disable_smilies' => ! isset( $assoc_args['no-disable-smilies'] ),
 				)
 			);
 			WP_CLI::line( (string) wp_json_encode( $receipt, JSON_UNESCAPED_SLASHES ) );
@@ -203,6 +204,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				'name'                         => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
 				'activate'                     => isset( $assoc_args['activate'] ),
 				'overwrite'                    => isset( $assoc_args['overwrite'] ),
+				'disable_smilies'              => ! isset( $assoc_args['no-disable-smilies'] ),
 				'fail_on_quality'              => isset( $assoc_args['fail-on-quality'] ),
 				'allow_missing_woocommerce'    => isset( $assoc_args['allow-missing-woocommerce'] ),
 				'materialize_dependencies'     => ! isset( $assoc_args['skip-dependency-materialization'] ),
@@ -252,6 +254,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				'site_title'                => isset( $assoc_args['site-title'] ) ? (string) $assoc_args['site-title'] : '',
 				'activate'                  => isset( $assoc_args['activate'] ),
 				'overwrite'                 => isset( $assoc_args['overwrite'] ),
+				'disable_smilies'           => ! isset( $assoc_args['no-disable-smilies'] ),
 				'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
 				'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
 				'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',

--- a/tests/smoke-website-artifact-import-input.php
+++ b/tests/smoke-website-artifact-import-input.php
@@ -106,6 +106,7 @@ $input = array(
 	'stale_page_action'            => 'draft',
 	'activate'                     => true,
 	'overwrite'                    => true,
+	'disable_smilies'              => true,
 	'fail_on_quality'              => true,
 	'allow_missing_woocommerce'    => true,
 		'allow_missing_jetpack'        => true,
@@ -123,6 +124,12 @@ $input = array(
 	'validation_artifacts'         => array( 'visual_diff' => array( 'path' => '/tmp/diff.png' ) ),
 );
 $direct = Static_Site_Importer_Website_Artifact_Import_Input::normalize( $input );
+
+// disable_smilies (issue #780) defaults on so ordinary imports keep literal text.
+$default_input = Static_Site_Importer_Website_Artifact_Import_Input::normalize( array( 'slug' => 'default-theme' ) );
+$assert( true === $default_input['disable_smilies'], 'disable-smilies-defaults-true' );
+$assert( true === Static_Site_Importer_Website_Artifact_Import_Input::normalize( array( 'disable_smilies' => '1' ) )['disable_smilies'], 'disable-smilies-coerces-true-string' );
+$assert( false === Static_Site_Importer_Website_Artifact_Import_Input::normalize( array( 'disable_smilies' => '0' ) )['disable_smilies'], 'disable-smilies-coerces-false-string' );
 
 static_site_importer_ability_import_website_artifact( array_merge( $input, array( 'artifact' => array( 'schema' => 'test/artifact/v1' ) ) ) );
 $direct_entrypoint = Static_Site_Importer_Theme_Generator::$last_args;

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -21,7 +21,7 @@ define( 'OBJECT', 'OBJECT' );
 $GLOBALS['ssi_plan_root']       = sys_get_temp_dir() . '/ssi-plan-' . bin2hex( random_bytes( 4 ) );
 $GLOBALS['ssi_plan_posts']      = array();
 $GLOBALS['ssi_plan_meta']       = array();
-$GLOBALS['ssi_plan_options']    = array( 'show_on_front' => 'posts', 'page_on_front' => 0, 'blogname' => 'Before' );
+$GLOBALS['ssi_plan_options']    = array( 'show_on_front' => 'posts', 'page_on_front' => 0, 'blogname' => 'Before', 'use_smilies' => true );
 $GLOBALS['ssi_plan_fail_after'] = 0;
 $GLOBALS['ssi_plan_font_requests'] = array();
 mkdir( $GLOBALS['ssi_plan_root'], 0777, true );
@@ -64,8 +64,9 @@ function wp_safe_remote_get( string $url, array $args ) {
 }
 function wp_remote_retrieve_response_code( $response ): int { return (int) ( $response['response']['code'] ?? 0 ); }
 function wp_remote_retrieve_body( $response ): string { return (string) ( $response['body'] ?? '' ); }
-function update_option( string $key, $value ): void { $GLOBALS['ssi_plan_options'][ $key ] = $value; }
+function update_option( string $key, $value ): bool { $GLOBALS['ssi_plan_options'][ $key ] = $value; return true; }
 function switch_theme( string $slug ): void { $GLOBALS['ssi_plan_options']['stylesheet'] = $slug; }
+function convert_smilies( string $content, string $which = 'content' ): string { return ( $GLOBALS['ssi_plan_options']['use_smilies'] ?? true ) ? 'smilied-' . $which : $content; }
 function sanitize_text_field( string $value ): string { return $value; }
 function update_post_meta( int $id, string $key, string $value ): void { $GLOBALS['ssi_plan_meta'][ $id ][ $key ] = $value; }
 function get_post_meta( int $id, string $key, bool $single = true ): string { return (string) ( $GLOBALS['ssi_plan_meta'][ $id ][ $key ] ?? '' ); }
@@ -406,13 +407,36 @@ $assert( 'completed' === $publication_receipt['status'] && 'completed' === ( $pu
 $assert( hash_file( 'sha256', $publication_file ) === ( $publication_report['actual_content_hash'] ?? '' ) && $publication_plan['runtime_declarations'][0]['expected_content_hash'] === ( $publication_report['expected_content_hash'] ?? '' ), 'publication receipt proves canonical and resolved content integrity' );
 $assert( str_contains( file_get_contents( $publication_file ), 'https://example.test/wp-content/themes/publication-plan/assets/assets/font.woff2' ), 'font-bearing SVG resolves only its declared local font URL' );
 
-$GLOBALS['ssi_plan_options'] = array( 'show_on_front' => 'posts', 'page_on_front' => 0, 'blogname' => 'Before' );
+$GLOBALS['ssi_plan_options'] = array( 'show_on_front' => 'posts', 'page_on_front' => 0, 'blogname' => 'Before', 'use_smilies' => true );
 $preview = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan', 'overwrite' => true ) );
 $assert( 'completed' === $preview['status'], 'preview materialization completes' );
 $assert( array( 'canonical_validations' => 1, 'plan_resolutions' => 1, 'destination_preflights' => 2, 'immutable_projection_reused' => true ) === ( $preview['preparation'] ?? array() ), 'materialization reuses one immutable projection while repeating destination preflight' );
 $assert( 'posts' === $GLOBALS['ssi_plan_options']['show_on_front'] && ! isset( $GLOBALS['ssi_plan_options']['stylesheet'] ), 'activate=false preserves runtime options' );
 $activated = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan', 'overwrite' => true, 'activate' => true, 'site_title' => 'Activated Plan' ) );
 $assert( 'site-plan' === $GLOBALS['ssi_plan_options']['stylesheet'] && 'page' === $GLOBALS['ssi_plan_options']['show_on_front'] && 'Activated Plan' === $GLOBALS['ssi_plan_options']['blogname'], 'activate=true applies theme title and reading policy' );
+
+// disable_smilies (issue #780): non-activating import must not touch the global option.
+$GLOBALS['ssi_plan_options'] = array( 'show_on_front' => 'posts', 'page_on_front' => 0, 'blogname' => 'Before', 'use_smilies' => true );
+$receipt_default = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan', 'overwrite' => true ) );
+$assert( true === ( $receipt_default['completed']['runtime_policy']['disable_smilies']['requested'] ?? null ), 'disable-smilies-defaults-requested-true' );
+$assert( false === ( $receipt_default['completed']['runtime_policy']['disable_smilies']['applied'] ?? null ), 'disable-smilies-not-applied-without-activate' );
+$assert( true === $GLOBALS['ssi_plan_options']['use_smilies'], 'non-activating-import-preserves-use-smilies' );
+
+// Explicit opt-out, non-activating: requested and applied both false.
+$receipt_off = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan', 'overwrite' => true, 'disable_smilies' => false ) );
+$assert( false === ( $receipt_off['completed']['runtime_policy']['disable_smilies']['requested'] ?? null ) && false === ( $receipt_off['completed']['runtime_policy']['disable_smilies']['applied'] ?? null ), 'disable-smilies-false-requested-and-applied-false' );
+
+// Activating import with default policy flips the option so literal :) stays text.
+$activated_smilies = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan', 'overwrite' => true, 'activate' => true, 'site_title' => 'Activated Plan' ) );
+$assert( false === $GLOBALS['ssi_plan_options']['use_smilies'], 'activating-import-sets-use-smilies-false' );
+$assert( 'Hello :)' === convert_smilies( 'Hello :)' ), 'convert-smilies-output-unchanged-when-disabled' );
+$assert( true === ( $activated_smilies['completed']['runtime_policy']['disable_smilies']['requested'] ?? null ) && true === ( $activated_smilies['completed']['runtime_policy']['disable_smilies']['applied'] ?? null ), 'activating-import-records-requested-and-applied' );
+
+// Explicit opt-out, activating: option untouched, policy not applied.
+$GLOBALS['ssi_plan_options'] = array( 'show_on_front' => 'posts', 'page_on_front' => 0, 'blogname' => 'Before', 'use_smilies' => true );
+$activated_off = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan', 'overwrite' => true, 'activate' => true, 'disable_smilies' => false, 'site_title' => 'Activated Off' ) );
+$assert( true === $GLOBALS['ssi_plan_options']['use_smilies'], 'activate-with-disable-smilies-false-keeps-smilies' );
+$assert( false === ( $activated_off['completed']['runtime_policy']['disable_smilies']['requested'] ?? null ) && false === ( $activated_off['completed']['runtime_policy']['disable_smilies']['applied'] ?? null ), 'disable-smilies-false-not-applied-on-activate' );
 
 $repeat = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan' ) );
 $assert( 'completed' === $repeat['status'], 'reconciliation repeat completes' );

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -64,7 +64,14 @@ function wp_safe_remote_get( string $url, array $args ) {
 }
 function wp_remote_retrieve_response_code( $response ): int { return (int) ( $response['response']['code'] ?? 0 ); }
 function wp_remote_retrieve_body( $response ): string { return (string) ( $response['body'] ?? '' ); }
-function update_option( string $key, $value ): bool { $GLOBALS['ssi_plan_options'][ $key ] = $value; return true; }
+function get_option( string $key, mixed $default = false ): mixed { return $GLOBALS['ssi_plan_options'][ $key ] ?? $default; }
+function update_option( string $key, $value ): bool {
+	if ( array_key_exists( $key, $GLOBALS['ssi_plan_options'] ) && $GLOBALS['ssi_plan_options'][ $key ] === $value ) {
+		return false; // Core semantics: unchanged value writes no row and returns false.
+	}
+	$GLOBALS['ssi_plan_options'][ $key ] = $value;
+	return true;
+}
 function switch_theme( string $slug ): void { $GLOBALS['ssi_plan_options']['stylesheet'] = $slug; }
 function convert_smilies( string $content, string $which = 'content' ): string { return ( $GLOBALS['ssi_plan_options']['use_smilies'] ?? true ) ? 'smilied-' . $which : $content; }
 function sanitize_text_field( string $value ): string { return $value; }
@@ -437,6 +444,13 @@ $GLOBALS['ssi_plan_options'] = array( 'show_on_front' => 'posts', 'page_on_front
 $activated_off = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan', 'overwrite' => true, 'activate' => true, 'disable_smilies' => false, 'site_title' => 'Activated Off' ) );
 $assert( true === $GLOBALS['ssi_plan_options']['use_smilies'], 'activate-with-disable-smilies-false-keeps-smilies' );
 $assert( false === ( $activated_off['completed']['runtime_policy']['disable_smilies']['requested'] ?? null ) && false === ( $activated_off['completed']['runtime_policy']['disable_smilies']['applied'] ?? null ), 'disable-smilies-false-not-applied-on-activate' );
+
+// Repeated activating import: use_smilies already false, update_option returns false (unchanged value).
+$GLOBALS['ssi_plan_options']['use_smilies'] = false;
+$receipt_repeat_policy = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan', 'overwrite' => true, 'activate' => true, 'site_title' => 'Repeat Policy' ) );
+$assert( 'completed' === $receipt_repeat_policy['status'], 'repeated-activating-import-completes' );
+$assert( true === ( $receipt_repeat_policy['completed']['runtime_policy']['disable_smilies']['requested'] ?? null ) && true === ( $receipt_repeat_policy['completed']['runtime_policy']['disable_smilies']['applied'] ?? null ), 'repeated-activating-import-records-requested-and-applied' );
+$assert( false === $GLOBALS['ssi_plan_options']['use_smilies'], 'repeated-activating-import-keeps-use-smilies-false' );
 
 $repeat = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan' ) );
 $assert( 'completed' === $repeat['status'], 'reconciliation repeat completes' );


### PR DESCRIPTION
## Summary

Imported static sites lose literal text because WordPress core maps emoticons like `:)` to an external emoji image (`wp-includes/images/smilies`). That shifts heading geometry, breaks offline visual capture, and makes the imported page no longer match the source.

This adds a `disable_smilies` boolean option (default `true`) to the import and site-plan materialization contracts. When materialization activates the imported theme and the option is enabled, the plugin sets the core `use_smilies` option to `false`, so imported literal `:)` stays text and no external emoji image is requested. The materialization receipt records the policy under `completed.runtime_policy.disable_smilies` as a `{ requested, applied }` pair, so the requested policy is explicit and the applied policy is only reported when the runtime mutation actually ran.

Fixes #780

## Changes

### includes/class-static-site-importer-website-artifact-import-input.php
Declares `disable_smilies` in `SCHEMA_PROPERTIES`, defaults it to `true` in `normalize()`, and adds it to the bool-cast list. The default is part of the normalized input contract, so CLI, REST, and ability entrypoints that build import input get it through `normalize()`.

### includes/abilities.php
Adds `disable_smilies` (boolean) to the `materialize-wordpress-site-plan` ability input schema. The `import-website-artifact` ability inherits it from `SCHEMA_PROPERTIES`.

### includes/class-static-site-importer-wordpress-site-plan-materializer.php
When the `activate` arg is set and `disable_smilies` is not explicitly `false`, sets `update_option( 'use_smilies', false )`. The call is guarded by the activate block, so a non-activating import never mutates the currently active site's global option. If the write fails, materialization fails closed (`disable_smilies_not_applied`) instead of claiming the policy was applied.

The receipt records the policy under `completed.runtime_policy.disable_smilies`:
- `requested` is the caller's flag, defaulting to `true`.
- `applied` is only `true` when the activation-time `update_option( 'use_smilies', false )` actually ran.

### Why the site option instead of a companion-plugin filter
The previous approach emitted a `remove_filter( 'the_content', 'convert_smilies', 20 )` call from the generated companion plugin. That only touches the `the_content` filter, and the companion plugin is only scaffolded when a site has custom blocks or preserved JS. A plain static site with literal `:)` can emit no companion payload, produce no plugin, and still return a receipt claiming the policy was applied. Core gates every `convert_smilies()` call on the `use_smilies` option, so the site option is the owning primitive: setting it to `false` is honored everywhere the conversion would otherwise run, and the receipt only reports `applied` when the mutation actually happened.

### CLI
`--no-disable-smilies` is accepted by `import-website-artifact`, `import-url`, and `materialize-wordpress-site-plan` to opt out of the default-on policy.

### Tests
- `smoke-wordpress-site-plan-materializer.php`: activating import sets `use_smilies` to `false` and leaves `convert_smilies( 'Hello :)' )` unchanged; non-activating import leaves the option untouched; receipt reports `{ requested, applied }` for default-on, explicit opt-out, and activating cases.
- `smoke-website-artifact-import-input.php`: `disable_smilies` defaults to `true`, and `'1'` / `'0'` coerce to bool.

## Testing

**Test 1: Default (flag on)**
1. Import a static site containing literal `:)` (for example `<p>Hello :)</p>`) with an activating import (`wp static-site-importer import-url https://example.com --activate`).
2. Load the imported page on the frontend.
3. Expected: page shows `Hello :)` as text, with no `<img src=".../wp-includes/images/smilies/...">` markup in the rendered HTML.

**Test 2: Opt out**
1. Repeat the same import with `--no-disable-smilies`.
2. Expected: `:)` renders as the external emoji image, core default behavior unchanged.

**Automated:** all smokes pass under `npm test` (42 passed, 0 failed; wordpress-runtime tests require a live WP and are skipped in the fast lane). `npm run test:inventory` is clean.
