### PR TITLE
Pin solved-site promotion to WP Codebox v0.18.4

### DIFF
--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -41,8 +41,9 @@ jobs:
       HOMEBOY_VERSION: v0.298.1
       HOMEBOY_SHA256: 543a1eb7348a9dcde3bee671dbbeaabb9486781d350792bed8a77424fdad60d5
       HOMEBOY_EXTENSIONS_REF: 615fe3632d0cd30e9a70d5aea82be80460d733d5
-      WP_CODEBOX_VERSION: v0.15.0
-      WP_CODEBOX_SHA256: 7e23817be1599a24cdaddc83cdf64e28f4b6feb1e7e8827ab1de5347f6aa7879
+      WP_CODEBOX_VERSION: v0.18.4
+      WP_CODEBOX_WORKSPACE_ASSET: wp-codebox-workspace-0.18.4.tgz
+      WP_CODEBOX_SHA256: 56d8f887a7b5109aa83927fd1cee5ec665af63cb72a35dba2df70f84b7ac47eb
       WORDPRESS_VERSION: ${{ inputs.wordpress-version }}
 
     steps:
@@ -132,7 +133,7 @@ jobs:
       - name: Install pinned WP Codebox
         run: |
           mkdir -p "$RUNNER_TEMP/wp-codebox"
-          curl --fail --location --retry 3 --retry-all-errors --output "$RUNNER_TEMP/wp-codebox/workspace.tgz" "https://github.com/Automattic/wp-codebox/releases/download/${WP_CODEBOX_VERSION}/02-wp-codebox-workspace-${WP_CODEBOX_VERSION#v}.tgz"
+          curl --fail --location --retry 3 --retry-all-errors --output "$RUNNER_TEMP/wp-codebox/workspace.tgz" "https://github.com/Automattic/wp-codebox/releases/download/${WP_CODEBOX_VERSION}/${WP_CODEBOX_WORKSPACE_ASSET}"
           echo "${WP_CODEBOX_SHA256}  $RUNNER_TEMP/wp-codebox/workspace.tgz" | sha256sum --check --status
           npm install --global --prefix "$RUNNER_TEMP/wp-codebox" "$RUNNER_TEMP/wp-codebox/workspace.tgz"
           node "$RUNNER_TEMP/wp-codebox/lib/node_modules/wp-codebox-workspace/node_modules/playwright/cli.js" install --with-deps chromium

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -28,7 +28,7 @@ function fixture() {
     }],
   };
   const registry = { schema: 'static-site-importer/gutenberg-incompatibility-registry/v1', fixture_decisions: [{ fixture_id: 'solved', acceptance_status: 'solved_candidate' }] };
-  const runtime = { nodeVersion: '20.19.4', phpVersion: '8.1.29', wordpressVersion: '7.0.2', homeboyVersion: 'v0.298.1', homeboySha256: '3'.repeat(64), homeboyExtensionsRef: '4'.repeat(40), wpCodeboxVersion: 'v0.12.29', wpCodeboxSha256: '5'.repeat(64), staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA };
+  const runtime = { nodeVersion: '20.19.4', phpVersion: '8.1.29', wordpressVersion: '7.0.2', homeboyVersion: 'v0.298.1', homeboySha256: '3'.repeat(64), homeboyExtensionsRef: '4'.repeat(40), wpCodeboxVersion: 'v0.18.4', wpCodeboxSha256: '5'.repeat(64), staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA };
   const paths = { matrix: path.join(root, 'matrix.json'), registry: path.join(root, 'registry.json'), runtime: path.join(root, 'runtime.json') };
   write(paths.matrix, matrix); write(paths.registry, registry); write(paths.runtime, runtime);
   return { root, matrix, registry, runtime, paths, options: { matrixResult: paths.matrix, registry: paths.registry, runtimeInputs: paths.runtime, artifactRoot: root, staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA, fixtureTreeSha: '6'.repeat(40), solvedFixtureCount: 1, runUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123', artifactUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123#artifacts', output: path.join(root, 'receipt.json'), manifestOutput: path.join(root, 'manifest.json') } };
@@ -41,6 +41,14 @@ test('issues an accepted immutable promotion receipt', () => {
   assert.equal(receipt.candidate.blocks_engine_sha, BE_SHA);
   assert.equal(receipt.corpus.selected_fixture_count, 1);
   assert.ok(receipt.evidence.artifacts.every((row) => /^[a-f0-9]{64}$/.test(row.sha256)));
+});
+
+test('pins the published WP Codebox workspace asset and checksum together', () => {
+  const workflow = fs.readFileSync(path.resolve('.github/workflows/solved-site-promotion.yml'), 'utf8');
+  assert.match(workflow, /WP_CODEBOX_VERSION: v0\.18\.4/);
+  assert.match(workflow, /WP_CODEBOX_WORKSPACE_ASSET: wp-codebox-workspace-0\.18\.4\.tgz/);
+  assert.match(workflow, /WP_CODEBOX_SHA256: 56d8f887a7b5109aa83927fd1cee5ec665af63cb72a35dba2df70f84b7ac47eb/);
+  assert.match(workflow, /releases\/download\/\$\{WP_CODEBOX_VERSION\}\/\$\{WP_CODEBOX_WORKSPACE_ASSET\}/);
 });
 
 test('resolves uniquely named durable copies of transient runtime evidence', () => {


### PR DESCRIPTION
Closes #799

## Root cause

The reusable solved-site promotion workflow still installed the pre-deterministic-visual-capture WP Codebox v0.15.0 workspace artifact. Its historical `02-wp-codebox-workspace-<version>.tgz` release path no longer identifies the published workspace asset.

## Boundary evidence

- Blocks Engine [#779](https://github.com/Automattic/blocks-engine/pull/779) failed on the v0.15 runtime in [run 30751245433](https://github.com/Automattic/blocks-engine/actions/runs/30751245433) and [run 30749601388](https://github.com/Automattic/blocks-engine/actions/runs/30749601388).
- v0.18.0 remained failing; v0.18.3 is the first passing deterministic visual-capture boundary.
- [WP Codebox commit ac64df48d87000f39a84155c18965bd7b138d3bb](https://github.com/Automattic/wp-codebox/commit/ac64df48d87000f39a84155c18965bd7b138d3bb) introduced the deterministic visual capture contract.

## Release provenance

Pins the v0.18.4 published asset [`wp-codebox-workspace-0.18.4.tgz`](https://github.com/Automattic/wp-codebox/releases/download/v0.18.4/wp-codebox-workspace-0.18.4.tgz) from [WP Codebox v0.18.4](https://github.com/Automattic/wp-codebox/releases/tag/v0.18.4), verified locally as SHA-256 `56d8f887a7b5109aa83927fd1cee5ec665af63cb72a35dba2df70f84b7ac47eb`. This follows SSI [#726](https://github.com/Automattic/static-site-importer/issues/726) and [#727](https://github.com/Automattic/static-site-importer/issues/727).

## Changes

- Pins the version, explicit published asset name, and SHA-256 together.
- Keeps the existing fail-closed `sha256sum --check --status` verification and immutable candidate-SHA recording unchanged.
- Adds a focused workflow source contract test for the version, checksum, and download URL/name.
- Leaves exact-zero visual parity and all promotion thresholds unchanged.

## Tests

- `npm run test:solved-site-promotion`
- `actionlint .github/workflows/solved-site-promotion.yml .github/workflows/solved-site-promotion-pr.yml`
- `npm test`
- `npm run test:all` (42 selected passed; 10 documented environment/operator skips)

AI assistance: gpt-5.6-sol via OpenCode was used to diagnose, implement, test, and verify this runtime upgrade. Chris Huber remains responsible for every line.