### PR TITLE
Fix generic provider form topology materialization

### DIFF
--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -284,6 +284,14 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 				(string) ( $dependency['plugin_file'] ?? '' ),
 				$dependency['availability_callback'] ?? null
 			);
+			$prepare = $dependency['preparation_callback'] ?? null;
+			if ( 'completed' === ( $reports[ $slug ]['status'] ?? '' ) && is_callable( $prepare ) ) {
+				$prepared = call_user_func( $prepare );
+				if ( function_exists( 'is_wp_error' ) && is_wp_error( $prepared ) ) {
+					$reports[ $slug ]['status'] = 'failed';
+					$reports[ $slug ]['reason'] = $prepared->get_error_code();
+				}
+			}
 		}
 
 		foreach ( self::companion_dependencies( $adapter ) as $dependency ) {
@@ -519,6 +527,7 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 						'slug'                  => 'jetpack',
 						'plugin_file'           => 'jetpack/jetpack.php',
 						'availability_callback' => array( 'Static_Site_Importer_Form_Seeder', 'jetpack_forms_available' ),
+						'preparation_callback'  => array( 'Static_Site_Importer_Form_Seeder', 'prepare_jetpack_forms_runtime' ),
 						'missing_apis'          => array( 'Automattic\\Jetpack\\Forms\\ContactForm\\Contact_Form', 'jetpack/contact-form', 'jetpack/field-text' ),
 					),
 				),
@@ -791,6 +800,22 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 				'form'        => isset( $form['form'] ) && is_array( $form['form'] ) ? $form['form'] : array(),
 				'controls'    => $controls,
 			);
+			if ( array_key_exists( 'control_topology', $form ) ) {
+				$topology = self::normalize_form_control_topology( $form['control_topology'], count( $controls ) );
+				if ( isset( $topology['error'] ) ) {
+					$errors[] = array( 'path' => $path_prefix . '.control_topology', 'message' => $topology['error'] );
+					continue;
+				}
+				$row['control_topology'] = $topology['topology'];
+			}
+			if ( array_key_exists( 'layout_graph', $form ) ) {
+				$graph = self::normalize_form_layout_graph( $form['layout_graph'] );
+				if ( isset( $graph['error'] ) ) {
+					$errors[] = array( 'path' => $path_prefix . '.layout_graph', 'message' => $graph['error'] );
+					continue;
+				}
+				$row['layout_graph'] = $graph['graph'];
+			}
 			$form_key = $row['source_path'] . "\n" . $row['selector'];
 			if ( isset( $seen_forms[ $form_key ] ) ) {
 				$errors[] = array(
@@ -834,6 +859,69 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 			'forms'  => $forms,
 			'errors' => $errors,
 		);
+	}
+
+	/** @return array{topology?:array<string,mixed>,error?:string} */
+	private static function normalize_form_control_topology( mixed $candidate, int $control_count ): array {
+		if ( ! is_array( $candidate ) || 'generic/form-control-topology/v1' !== ( $candidate['schema'] ?? null ) || true === ( $candidate['truncated'] ?? false ) || ! is_int( $candidate['max_depth'] ?? null ) || ! is_int( $candidate['max_nodes'] ?? null ) || ! is_array( $candidate['nodes'] ?? null ) || ! array_is_list( $candidate['nodes'] ) || count( $candidate['nodes'] ) > $candidate['max_nodes'] || $candidate['max_depth'] < 0 || $candidate['max_depth'] > 8 || $candidate['max_nodes'] < 1 || $candidate['max_nodes'] > 128 ) {
+			return array( 'error' => 'control_topology must be a complete bounded generic/form-control-topology/v1 tree.' );
+		}
+		$seen = array();
+		$controls = array();
+		$orders = array();
+		$nodes = array();
+		foreach ( $candidate['nodes'] as $node ) {
+			if ( ! is_array( $node ) || ! is_string( $node['id'] ?? null ) || ! preg_match( '/^(?:wrapper|control)-[0-9]+$/D', $node['id'] ) || isset( $seen[ $node['id'] ] ) || ! in_array( $node['kind'] ?? null, array( 'wrapper', 'control' ), true ) || ! is_int( $node['order'] ?? null ) || ! is_int( $node['depth'] ?? null ) || $node['order'] < 0 || $node['depth'] < 0 || $node['depth'] > $candidate['max_depth'] ) {
+				return array( 'error' => 'control_topology contains an invalid node.' );
+			}
+			$parent = $node['parent'] ?? null;
+			if ( null !== $parent && ( ! is_string( $parent ) || ! isset( $seen[ $parent ] ) || 'wrapper' !== $seen[ $parent ]['kind'] || $node['depth'] !== $seen[ $parent ]['depth'] + 1 ) ) {
+				return array( 'error' => 'control_topology parentage must be an ordered wrapper tree.' );
+			}
+			$key = $parent ?? '$root';
+			if ( isset( $orders[ $key ][ $node['order'] ] ) || ( null === $parent && 0 !== $node['depth'] ) ) {
+				return array( 'error' => 'control_topology sibling order or depth is invalid.' );
+			}
+			$clean = array( 'id' => $node['id'], 'kind' => $node['kind'], 'parent' => $parent, 'order' => $node['order'], 'depth' => $node['depth'] );
+			if ( 'control' === $node['kind'] ) {
+				if ( ! is_int( $node['control'] ?? null ) || $node['control'] < 0 || $node['control'] >= $control_count || isset( $controls[ $node['control'] ] ) ) {
+					return array( 'error' => 'control_topology control references must preserve every source control once.' );
+				}
+				$clean['control'] = $node['control'];
+				$controls[ $node['control'] ] = true;
+			} else {
+				foreach ( array( 'tag', 'class', 'source_id' ) as $field ) {
+					if ( isset( $node[ $field ] ) && ( ! is_string( $node[ $field ] ) || ! preg_match( '/^[A-Za-z][A-Za-z0-9 _-]{0,159}$/D', $node[ $field ] ) ) ) {
+						return array( 'error' => 'control_topology wrapper hooks must be bounded identifiers.' );
+					}
+					if ( isset( $node[ $field ] ) ) {
+						$clean[ $field ] = $node[ $field ];
+					}
+				}
+			}
+			$seen[ $node['id'] ] = $clean;
+			$orders[ $key ][ $node['order'] ] = true;
+			$nodes[] = $clean;
+		}
+		return count( $controls ) === $control_count ? array( 'topology' => array( 'schema' => 'generic/form-control-topology/v1', 'max_depth' => $candidate['max_depth'], 'max_nodes' => $candidate['max_nodes'], 'truncated' => false, 'nodes' => $nodes ) ) : array( 'error' => 'control_topology must preserve every source control once.' );
+	}
+
+	/** @return array{graph?:array<string,mixed>,error?:string} */
+	private static function normalize_form_layout_graph( mixed $candidate ): array {
+		if ( ! is_array( $candidate ) || 'generic/computed-layout-graph/v1' !== ( $candidate['schema'] ?? null ) || 'source_css_cascade' !== ( $candidate['basis'] ?? null ) || true === ( $candidate['truncated'] ?? false ) || ! is_array( $candidate['nodes'] ?? null ) || ! array_is_list( $candidate['nodes'] ) || count( $candidate['nodes'] ) > 128 || ! is_array( $candidate['variants'] ?? null ) || ! empty( $candidate['variants'] ) ) {
+			return array( 'error' => 'layout_graph must be a complete bounded generic/computed-layout-graph/v1 graph.' );
+		}
+		$allowed = array( 'display', 'columns', 'rows', 'gap', 'row_gap', 'column_gap', 'direction', 'wrap', 'column', 'row', 'area' );
+		$nodes = array();
+		$seen = array();
+		foreach ( $candidate['nodes'] as $node ) {
+			if ( ! is_array( $node ) || ! is_string( $node['id'] ?? null ) || ! preg_match( '/^(?:form|wrapper-[0-9]+|control-[0-9]+)$/D', $node['id'] ) || isset( $seen[ $node['id'] ] ) || ! is_array( $node['layout'] ?? null ) || array_diff( array_keys( $node['layout'] ), $allowed ) || array_filter( $node['layout'], static fn( $value ): bool => ! is_scalar( $value ) ) ) {
+				return array( 'error' => 'layout_graph contains unsupported layout facts.' );
+			}
+			$seen[ $node['id'] ] = true;
+			$nodes[] = array( 'id' => $node['id'], 'layout' => $node['layout'] );
+		}
+		return array( 'graph' => array( 'schema' => 'generic/computed-layout-graph/v1', 'basis' => 'source_css_cascade', 'truncated' => false, 'nodes' => $nodes, 'variants' => array() ) );
 	}
 
 	/** @return array<string,mixed>|null */

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/class-static-site-importer-provider-layout-overlay.php';
+
 /**
  * Turns preserved <form> fallback metadata into working Jetpack Form blocks.
  *
@@ -145,6 +147,25 @@ class Static_Site_Importer_Form_Seeder {
 		return ! empty( $availability['available'] );
 	}
 
+	/** Activate and register Jetpack Forms after the plugin dependency is active. */
+	public static function prepare_jetpack_forms_runtime() {
+		if ( ! class_exists( 'Jetpack' ) || ! class_exists( 'Automattic\\Jetpack\\Modules' ) ) {
+			return new WP_Error( 'static_site_importer_jetpack_forms_runtime_missing' );
+		}
+		$modules = new Automattic\Jetpack\Modules();
+		if ( ! $modules->is_active( 'contact-form' ) && method_exists( 'Jetpack', 'activate_module' ) ) {
+			Jetpack::activate_module( 'contact-form', false, false );
+		}
+		$block = 'Automattic\\Jetpack\\Extensions\\Contact_Form\\Contact_Form_Block';
+		if ( class_exists( $block ) && method_exists( $block, 'register_block' ) ) {
+			$block::register_block();
+			if ( method_exists( $block, 'register_child_blocks' ) ) {
+				$block::register_child_blocks();
+			}
+		}
+		return self::jetpack_forms_available() ? true : new WP_Error( 'static_site_importer_jetpack_forms_blocks_missing' );
+	}
+
 	/**
 	 * Return the specific Jetpack Forms APIs present in the current runtime.
 	 *
@@ -200,12 +221,13 @@ class Static_Site_Importer_Form_Seeder {
 		$selector    = isset( $form['selector'] ) && is_scalar( $form['selector'] ) ? (string) $form['selector'] : '';
 		$source_path = isset( $form['source_path'] ) && is_scalar( $form['source_path'] ) ? (string) $form['source_path'] : '';
 
+		$scope        = self::layout_scope( $form );
 		$field_blocks = array();
 		$mapped_types = array();
 		$submit_text  = 'Submit';
 		$skipped      = array();
 
-		foreach ( $controls as $control ) {
+		foreach ( $controls as $control_index => $control ) {
 			if ( ! is_array( $control ) ) {
 				continue;
 			}
@@ -225,7 +247,8 @@ class Static_Site_Importer_Form_Seeder {
 				continue;
 			}
 
-			$field_blocks[] = $field_block;
+			$field_block['attrs']['className'] = self::layout_node_class( $scope, 'control-' . $control_index );
+			$field_blocks[ $control_index ] = $field_block;
 			$mapped_types[] = $field_block['name'];
 		}
 
@@ -242,9 +265,18 @@ class Static_Site_Importer_Form_Seeder {
 			);
 		}
 
-		$inner_blocks   = $field_blocks;
-		$inner_blocks[] = self::submit_button_block( $submit_text );
-		$form_attrs     = self::contact_form_attributes( $form );
+		$topology = self::topology_blocks( $form, $field_blocks, $controls, $scope );
+		if ( null === $topology ) {
+			return array( 'selector' => $selector, 'source_path' => $source_path, 'provider' => self::PROVIDER_ID, 'block_name' => 'jetpack/contact-form', 'status' => 'skipped', 'reason' => 'unsupported_control_topology', 'runtime_mapped' => false );
+		}
+		$inner_blocks = $topology['blocks'];
+		if ( ! $topology['has_submit'] ) {
+			$inner_blocks[] = self::submit_button_block( $submit_text, self::layout_node_class( $scope, 'control-submit' ) );
+		}
+		$target_map = self::provider_layout_target_map( $form, $scope );
+		$overlay = Static_Site_Importer_Provider_Layout_Overlay::compile( is_array( $form['layout_graph'] ?? null ) ? $form['layout_graph'] : array( 'nodes' => array() ), $target_map );
+		$receipt = array( 'schema' => 'static-site-importer/computed-layout-receipt/v1', 'status' => empty( $overlay['operations'] ) ? ( empty( $overlay['losses'] ) ? 'skipped' : 'deferred' ) : 'applied', 'operation_count' => count( $overlay['operations'] ), 'loss_count' => count( $overlay['losses'] ), 'operations' => $overlay['operations'], 'losses' => $overlay['losses'] );
+		$form_attrs     = self::contact_form_attributes( $form, $scope );
 		$markup         = self::serialize_block( 'jetpack/contact-form', $form_attrs, $inner_blocks );
 
 		return array(
@@ -260,7 +292,48 @@ class Static_Site_Importer_Form_Seeder {
 			'runtime_mapped'  => true,
 			'runtime_carried' => $available,
 			'block_markup'    => $markup,
+			'computed_layout_receipt' => $receipt,
+			'provider_layout_target_map' => $target_map,
+			'provider_layout_overlay_css' => $overlay['overlay'],
 		);
+	}
+
+	/** @return array{blocks:array<int,array<string,mixed>>,has_submit:bool}|null */
+	private static function topology_blocks( array $form, array $field_blocks, array $controls, string $scope ): ?array {
+		if ( ! isset( $form['control_topology'] ) ) {
+			return array( 'blocks' => array_values( $field_blocks ), 'has_submit' => false );
+		}
+		$nodes = $form['control_topology']['nodes'] ?? null;
+		if ( ! is_array( $nodes ) ) {
+			return null;
+		}
+		$wrappers = array();
+		foreach ( $nodes as $node ) {
+			if ( is_array( $node ) && 'wrapper' === ( $node['kind'] ?? null ) && is_string( $node['id'] ?? null ) ) {
+				$wrappers[ $node['id'] ] = $node;
+			}
+		}
+		$blocks = array();
+		$has_submit = false;
+		foreach ( $nodes as $node ) {
+			if ( ! is_array( $node ) || 'control' !== ( $node['kind'] ?? null ) || ! is_int( $node['control'] ?? null ) || ! isset( $field_blocks[ $node['control'] ] ) ) {
+				continue;
+			}
+			$block = $field_blocks[ $node['control'] ];
+			$classes = array( self::layout_node_class( $scope, (string) $node['id'] ) );
+			$parent = $node['parent'] ?? null;
+			if ( is_string( $parent ) && isset( $wrappers[ $parent ] ) ) {
+				$classes[] = self::layout_node_class( $scope, $parent );
+				if ( ! empty( $wrappers[ $parent ]['class'] ) ) {
+					$classes[] = (string) $wrappers[ $parent ]['class'];
+				}
+			}
+			$block['attrs']['className'] = trim( (string) ( $block['attrs']['className'] ?? '' ) . ' ' . implode( ' ', $classes ) );
+			$blocks[] = $block;
+			$control = $controls[ $node['control'] ] ?? array();
+			$has_submit = $has_submit || ( is_array( $control ) && 'submit' === (string) ( $control['type'] ?? '' ) );
+		}
+		return count( $blocks ) === count( $field_blocks ) ? array( 'blocks' => $blocks, 'has_submit' => $has_submit ) : null;
 	}
 
 	/**
@@ -373,12 +446,13 @@ class Static_Site_Importer_Form_Seeder {
 	 * @param string $text Submit button label.
 	 * @return array<string, mixed>
 	 */
-	private static function submit_button_block( string $text ): array {
+	private static function submit_button_block( string $text, string $class_name = '' ): array {
 		return array(
 			'name'  => 'jetpack/button',
 			'attrs' => array(
 				'element' => 'button',
 				'text'    => '' !== trim( $text ) ? trim( $text ) : 'Submit',
+				'className' => $class_name,
 				'lock'    => array(
 					'remove' => true,
 					'move'   => false,
@@ -393,15 +467,13 @@ class Static_Site_Importer_Form_Seeder {
 	 * @param array<string, mixed> $form Validated form row.
 	 * @return array<string, mixed>
 	 */
-	private static function contact_form_attributes( array $form ): array {
+	private static function contact_form_attributes( array $form, string $scope = '' ): array {
 		$attrs    = array();
 		$metadata = isset( $form['form'] ) && is_array( $form['form'] ) ? $form['form'] : array();
 		$action   = isset( $metadata['action'] ) && is_scalar( $metadata['action'] ) ? trim( (string) $metadata['action'] ) : '';
 		$class    = isset( $metadata['class'] ) && is_scalar( $metadata['class'] ) ? trim( (string) $metadata['class'] ) : '';
 
-		if ( '' !== $class ) {
-			$attrs['className'] = $class;
-		}
+		$attrs['className'] = trim( $class . ' ' . $scope );
 
 		if ( '' !== $action && 0 === stripos( $action, 'mailto:' ) ) {
 			$recipient = trim( substr( $action, 7 ) );
@@ -412,6 +484,31 @@ class Static_Site_Importer_Form_Seeder {
 		}
 
 		return $attrs;
+	}
+
+	private static function layout_scope( array $form ): string {
+		return 'ssi-form-' . substr( hash( 'sha256', (string) ( $form['source_path'] ?? '' ) . "\n" . (string) ( $form['selector'] ?? '' ) ), 0, 12 );
+	}
+
+	private static function layout_node_class( string $scope, string $node ): string {
+		return 'ssi-node-' . substr( hash( 'sha256', $scope . "\n" . $node ), 0, 12 );
+	}
+
+	/** @return array<string,mixed> */
+	private static function provider_layout_target_map( array $form, string $scope ): array {
+		$targets = array();
+		foreach ( $form['layout_graph']['nodes'] ?? array() as $node ) {
+			if ( ! is_array( $node ) || ! is_string( $node['id'] ?? null ) ) {
+				continue;
+			}
+			$id = $node['id'];
+			if ( 'form' === $id ) {
+				$targets[] = array( 'node' => $id, 'selector' => '.' . $scope . ' > form.jetpack-contact-form__form', 'capabilities' => array( 'container_layout' ) );
+			} elseif ( preg_match( '/^(?:control|wrapper)-[0-9]+$/D', $id ) ) {
+				$targets[] = array( 'node' => $id, 'selector' => '.' . $scope . ' .' . self::layout_node_class( $scope, $id ), 'capabilities' => array( 'container_layout', 'direct_child_layout', 'item_layout' ) );
+			}
+		}
+		return array( 'schema' => Static_Site_Importer_Provider_Layout_Overlay::MAP_SCHEMA, 'provider' => self::PROVIDER_ID, 'scope' => '.' . $scope, 'targets' => $targets );
 	}
 
 	/**

--- a/includes/class-static-site-importer-provider-layout-overlay.php
+++ b/includes/class-static-site-importer-provider-layout-overlay.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Validates provider-owned layout targets and compiles their bounded CSS overlay.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Static_Site_Importer_Provider_Layout_Overlay {
+	public const MAP_SCHEMA = 'generic/provider-layout-target-map/v1';
+	public const OVERLAY_SCHEMA = 'static-site-importer/provider-layout-overlay/v1';
+
+	/** @return array{css:string,operations:array<int,array<string,mixed>>,losses:array<int,array<string,mixed>>,overlay:array<string,mixed>} */
+	public static function compile( array $graph, array $map ): array {
+		$targets = self::targets( $graph, $map );
+		if ( null === $targets ) {
+			return self::result( '', array(), array( self::loss( 'provider_structure_mismatch', '' ) ) );
+		}
+		$rules = array();
+		$operations = array();
+		$losses = array();
+		foreach ( $graph['nodes'] ?? array() as $node ) {
+			if ( ! is_array( $node ) || empty( $node['layout'] ) ) {
+				continue;
+			}
+			$id = (string) ( $node['id'] ?? '' );
+			if ( ! isset( $targets[ $id ] ) ) {
+				$losses[] = self::loss( 'provider_structure_mismatch', $id );
+				continue;
+			}
+			$declarations = self::declarations( $node['layout'], $targets[ $id ]['capabilities'], $id, $losses );
+			if ( ! empty( $declarations ) ) {
+				$rules[] = $targets[ $id ]['selector'] . '{' . implode( ';', $declarations ) . '}';
+				$operations[] = array( 'dimension' => 'layout', 'strategy' => 'provider_selector_transposition', 'node_hash' => hash( 'sha256', $id ), 'target_hash' => hash( 'sha256', $targets[ $id ]['selector'] ) );
+			}
+		}
+		$css = empty( $rules ) ? '' : "/* Static Site Importer provider layout overlay */\n" . implode( "\n", array_unique( $rules ) ) . "\n";
+		return self::result( $css, $operations, $losses );
+	}
+
+	/** Accept only the compiler's bounded, content-addressed overlay shape. */
+	public static function valid_overlay( mixed $overlay ): bool {
+		return is_array( $overlay ) && self::OVERLAY_SCHEMA === ( $overlay['schema'] ?? null ) && is_string( $overlay['css'] ?? null ) && is_string( $overlay['sha256'] ?? null ) && is_int( $overlay['bytes'] ?? null ) && $overlay['bytes'] === strlen( $overlay['css'] ) && $overlay['bytes'] <= 16384 && hash_equals( $overlay['sha256'], hash( 'sha256', $overlay['css'] ) ) && str_starts_with( $overlay['css'], "/* Static Site Importer provider layout overlay */\n" );
+	}
+
+	/** @return array<string,array{selector:string,capabilities:array<int,string>}>|null */
+	private static function targets( array $graph, array $map ): ?array {
+		if ( self::MAP_SCHEMA !== ( $map['schema'] ?? null ) || 'jetpack' !== ( $map['provider'] ?? null ) || ! is_string( $map['scope'] ?? null ) || ! preg_match( '/^\.ssi-form-[a-f0-9]{12}$/D', $map['scope'] ) || ! is_array( $map['targets'] ?? null ) || ! array_is_list( $map['targets'] ) ) {
+			return null;
+		}
+		$nodes = array();
+		foreach ( $graph['nodes'] ?? array() as $node ) {
+			if ( is_array( $node ) && is_string( $node['id'] ?? null ) ) {
+				$nodes[ $node['id'] ] = true;
+			}
+		}
+		$targets = array();
+		foreach ( $map['targets'] as $target ) {
+			if ( ! is_array( $target ) || ! is_string( $target['node'] ?? null ) || ! isset( $nodes[ $target['node'] ] ) || isset( $targets[ $target['node'] ] ) || ! is_string( $target['selector'] ?? null ) || ! preg_match( '/^' . preg_quote( $map['scope'], '/' ) . '(?: > form\.jetpack-contact-form__form| \.ssi-node-[a-f0-9]{12})$/D', $target['selector'] ) || ! is_array( $target['capabilities'] ?? null ) ) {
+				return null;
+			}
+			$capabilities = array_values( array_unique( $target['capabilities'] ) );
+			if ( array_diff( $capabilities, array( 'container_layout', 'direct_child_layout', 'item_layout' ) ) ) {
+				return null;
+			}
+			$targets[ $target['node'] ] = array( 'selector' => $target['selector'], 'capabilities' => $capabilities );
+		}
+		return $targets;
+	}
+
+	/** @param array<int,string> $capabilities @param array<int,array<string,mixed>> $losses @return array<int,string> */
+	private static function declarations( array $layout, array $capabilities, string $node, array &$losses ): array {
+		$properties = array( 'display' => 'display', 'columns' => 'grid-template-columns', 'rows' => 'grid-template-rows', 'gap' => 'gap', 'row_gap' => 'row-gap', 'column_gap' => 'column-gap', 'direction' => 'flex-direction', 'wrap' => 'flex-wrap', 'column' => 'grid-column', 'row' => 'grid-row', 'area' => 'grid-area' );
+		$declarations = array();
+		foreach ( $layout as $fact => $value ) {
+			if ( ! isset( $properties[ $fact ] ) || ! self::safe_value( $fact, $value ) ) {
+				$losses[] = self::loss( 'unsafe_layout_value', $node );
+				continue;
+			}
+			$is_item = in_array( $fact, array( 'column', 'row', 'area' ), true );
+			if ( $is_item && ( ! in_array( 'item_layout', $capabilities, true ) || ! in_array( 'direct_child_layout', $capabilities, true ) ) ) {
+				$losses[] = self::loss( 'direct_child_relationship_unrepresentable', $node );
+				continue;
+			}
+			if ( ! $is_item && ! in_array( 'container_layout', $capabilities, true ) ) {
+				$losses[] = self::loss( 'provider_structure_mismatch', $node );
+				continue;
+			}
+			$declarations[] = $properties[ $fact ] . ':' . $value;
+		}
+		return $declarations;
+	}
+
+	private static function safe_value( string $fact, mixed $value ): bool {
+		$value = is_scalar( $value ) ? (string) $value : '';
+		if ( '' === $value || strlen( $value ) > 120 || preg_match( '/(?:url\(|[;{}\\\\]|!important|expression\()/i', $value ) ) {
+			return false;
+		}
+		if ( 'display' === $fact ) {
+			return in_array( $value, array( 'grid', 'flex', 'block' ), true );
+		}
+		if ( in_array( $fact, array( 'direction', 'wrap' ), true ) ) {
+			return in_array( $value, array( 'row', 'column', 'wrap', 'nowrap' ), true );
+		}
+		return (bool) preg_match( '/^(?:auto|span [1-9][0-9]*|[1-9][0-9]*(?: \/ [1-9][0-9]*)?|(?:[0-9]+(?:\.[0-9]+)?)(?:px|rem|em|%|fr)|repeat\([1-9][0-9]*, ?1fr\)|(?:1fr ?){1,8})$/D', $value );
+	}
+
+	/** @return array{css:string,operations:array<int,array<string,mixed>>,losses:array<int,array<string,mixed>>,overlay:array<string,mixed>} */
+	private static function result( string $css, array $operations, array $losses ): array {
+		return array( 'css' => $css, 'operations' => $operations, 'losses' => $losses, 'overlay' => '' === $css ? array() : array( 'schema' => self::OVERLAY_SCHEMA, 'css' => $css, 'sha256' => hash( 'sha256', $css ), 'bytes' => strlen( $css ) ) );
+	}
+
+	/** @return array<string,mixed> */
+	private static function loss( string $reason, string $node ): array {
+		return array( 'dimension' => 'layout', 'reason_code' => $reason, 'node_hash' => hash( 'sha256', $node ) );
+	}
+}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1136,6 +1136,12 @@ class Static_Site_Importer_Report_Diagnostics {
 				'form'        => $form,
 				'controls'    => $controls,
 			);
+			if ( isset( $diagnostic['control_topology'] ) ) {
+				$manifest_forms[ array_key_last( $manifest_forms ) ]['control_topology'] = $diagnostic['control_topology'];
+			}
+			if ( isset( $diagnostic['layout_graph'] ) ) {
+				$manifest_forms[ array_key_last( $manifest_forms ) ]['layout_graph'] = $diagnostic['layout_graph'];
+			}
 		}
 
 		$validation = Static_Site_Importer_Entity_Materializer_Registry::validate_manifest_generic( $adapter, array( 'forms' => $manifest_forms ) );
@@ -1435,14 +1441,23 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return array<string,mixed>
 	 */
 	private static function mark_form_finding_mapped( array $diagnostic, array $row, string $provider ): array {
-		$diagnostic['runtime_mapped']  = true;
+		$receipt_losses = isset( $row['computed_layout_receipt']['losses'] ) && is_array( $row['computed_layout_receipt']['losses'] ) ? $row['computed_layout_receipt']['losses'] : array();
+		$unaccepted = array_values( array_filter( $receipt_losses, static fn( $loss ): bool => is_array( $loss ) && in_array( $loss['reason_code'] ?? '', array( 'provider_structure_mismatch', 'direct_child_relationship_unrepresentable', 'unsafe_layout_value' ), true ) ) );
+		$diagnostic['runtime_mapped']  = empty( $unaccepted );
 		$diagnostic['runtime_carried'] = ! empty( $row['runtime_carried'] );
 		$diagnostic['mapped_provider'] = isset( $row['provider'] ) && is_scalar( $row['provider'] ) && '' !== (string) $row['provider'] ? (string) $row['provider'] : $provider;
-		$diagnostic['acceptability']   = 'acceptable_preservation';
+		$diagnostic['acceptability']   = empty( $unaccepted ) ? 'acceptable_preservation' : 'unacceptable_imported_output_defect';
 		$diagnostic['block_name']      = isset( $row['block_name'] ) && is_scalar( $row['block_name'] ) ? (string) $row['block_name'] : 'jetpack/contact-form';
 
 		if ( isset( $row['block_markup'] ) && is_scalar( $row['block_markup'] ) ) {
 			$diagnostic['emitted_block_preview'] = self::diagnostic_excerpt( (string) $row['block_markup'] );
+		}
+		if ( ! empty( $receipt_losses ) ) {
+			$diagnostic['form_receipt_losses'] = $receipt_losses;
+		}
+		if ( ! empty( $unaccepted ) ) {
+			$diagnostic['form_receipt_unaccepted_losses'] = $unaccepted;
+			$diagnostic['reason_code'] = 'form_receipt_loss_unaccepted';
 		}
 
 		return $diagnostic;

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -205,6 +205,7 @@ class Static_Site_Importer_Theme_Generator {
 			);
 		}
 		$prepared['args']['runtime_entity_bindings'] = $bindings;
+		$prepared['args']['provider_layout_overlays'] = self::provider_layout_overlays( $entities );
 		$receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize_prepared( $prepared );
 		$receipt['completed']['companion_plugin'] = $companion_materialization;
 		$receipt['extensions']['gutenberg_gaps'] = self::project_gutenberg_gaps( $gutenberg_gaps, (string) ( $companion_materialization['status'] ?? 'not_materialized' ) );
@@ -225,6 +226,19 @@ class Static_Site_Importer_Theme_Generator {
 			);
 			return new WP_Error( 'static_site_importer_projection_write_failed', 'Website materialization completed partially because a public projection could not be written.', $receipt );
 		}
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function provider_layout_overlays( array $reports ): array {
+		$overlays = array();
+		foreach ( $reports as $report ) {
+			foreach ( is_array( $report['forms'] ?? null ) ? $report['forms'] : array() as $form ) {
+				if ( is_array( $form['provider_layout_overlay_css'] ?? null ) ) {
+					$overlays[] = $form['provider_layout_overlay_css'];
+				}
+			}
+		}
+		return $overlays;
 	}
 
 	/** Project compiler gap rows into stable materialization diagnostics. */

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -215,6 +215,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			}
 			$state['applied']['files'][] = $result;
 		}
+		$overlay_result = self::apply_provider_layout_overlays( $state, $args['provider_layout_overlays'] ?? array() );
+		if ( is_wp_error( $overlay_result ) ) {
+			return self::failed_receipt( $state, $overlay_result->get_error_code() );
+		}
+		$state['applied']['provider_layout_overlays'] = $overlay_result;
 		$publications = self::verify_asset_publications( $state );
 		if ( is_wp_error( $publications ) ) {
 			return self::failed_receipt( $state, $publications->get_error_code() );
@@ -258,6 +263,34 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		}
 
 		return self::receipt( 'completed', $state );
+	}
+
+	/** Append only validated overlays to the generated frontend and editor CSS. */
+	private static function apply_provider_layout_overlays( array &$state, mixed $overlays ) {
+		if ( ! is_array( $overlays ) || empty( $overlays ) ) {
+			return array( 'status' => 'not_requested', 'files' => array() );
+		}
+		$css = array();
+		foreach ( $overlays as $overlay ) {
+			if ( ! Static_Site_Importer_Provider_Layout_Overlay::valid_overlay( $overlay ) ) {
+				return new WP_Error( 'provider_layout_overlay_rejected' );
+			}
+			$css[] = $overlay['css'];
+		}
+		$files = array();
+		foreach ( array( 'style.css', 'assets/css/editor-style.css' ) as $target ) {
+			$path = $state['theme_dir'] . '/' . $target;
+			$content = is_readable( $path ) ? file_get_contents( $path ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- reads the generated stylesheet just written above.
+			if ( false === $content ) {
+				return new WP_Error( 'provider_layout_stylesheet_missing' );
+			}
+			$result = self::write_file( $state['theme_dir'], array( 'target_path' => $target, 'source_path' => $target, 'payload' => array( 'encoding' => 'utf8', 'data' => rtrim( $content ) . "\n" . implode( "\n", $css ) ) ) );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$files[] = $result;
+		}
+		return array( 'status' => 'completed', 'files' => $files );
 	}
 
 	/**

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -283,14 +283,23 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				return null;
 			}
 		}
+		$candidate = null;
 		foreach ( $state['resolved']['pages'] as $page ) {
+			if ( null === $candidate ) {
+				$candidate = $page;
+			}
 			$route = (string) ( $page['route']['path'] ?? '' );
 			$id = $state['page_ids'][ $page['reconciliation_identity'] ?? '' ] ?? 0;
 			if ( $id > 0 && ( '' === trim( $route, '/' ) ) ) {
-				update_option( 'show_on_front', 'page' );
-				update_option( 'page_on_front', $id );
-				return array( 'kind' => 'site_reading', 'reconciliation_identity' => $page['reconciliation_identity'], 'inferred' => true );
+				$candidate = $page;
+				break;
 			}
+		}
+		$id = $state['page_ids'][ $candidate['reconciliation_identity'] ?? '' ] ?? 0;
+		if ( $id > 0 ) {
+			update_option( 'show_on_front', 'page' );
+			update_option( 'page_on_front', $id );
+			return array( 'kind' => 'site_reading', 'reconciliation_identity' => $candidate['reconciliation_identity'], 'inferred' => true );
 		}
 		return new WP_Error( 'static_site_importer_front_page_missing' );
 	}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -241,6 +241,13 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		}
 
 		if ( ! empty( $args['activate'] ) ) {
+			$front_page = self::ensure_static_front_page( $state );
+			if ( is_wp_error( $front_page ) ) {
+				return self::failed_receipt( $state, $front_page->get_error_code() );
+			}
+			if ( is_array( $front_page ) ) {
+				$state['applied']['operations'][] = $front_page;
+			}
 			foreach ( $state['resolved']['operations'] as $operation ) {
 				if ( 'create_page' === $operation['kind'] ) {
 					continue;
@@ -263,6 +270,29 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		}
 
 		return self::receipt( 'completed', $state );
+	}
+
+	/**
+	 * Canonical plans may omit a site-reading operation when the source root is
+	 * implicit. An activated static-site import still needs that root page as the
+	 * front page for editor and browser contracts.
+	 */
+	private static function ensure_static_front_page( array $state ) {
+		foreach ( $state['resolved']['operations'] as $operation ) {
+			if ( 'site_reading' === ( $operation['kind'] ?? '' ) ) {
+				return null;
+			}
+		}
+		foreach ( $state['resolved']['pages'] as $page ) {
+			$route = (string) ( $page['route']['path'] ?? '' );
+			$id = $state['page_ids'][ $page['reconciliation_identity'] ?? '' ] ?? 0;
+			if ( $id > 0 && ( '' === trim( $route, '/' ) ) ) {
+				update_option( 'show_on_front', 'page' );
+				update_option( 'page_on_front', $id );
+				return array( 'kind' => 'site_reading', 'reconciliation_identity' => $page['reconciliation_identity'], 'inferred' => true );
+			}
+		}
+		return new WP_Error( 'static_site_importer_front_page_missing' );
 	}
 
 	/** Append only validated overlays to the generated frontend and editor CSS. */

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -6,6 +6,7 @@
   },
   "tests": [
     { "path": "tests/form-materializer-smoke.php", "environment": "standalone-php" },
+    { "path": "tests/form-materializer-topology.test.mjs", "environment": "node" },
     { "path": "tests/smoke-ability-error-report-summary.php", "environment": "standalone-php" },
     { "path": "tests/smoke-ability-import-success-diagnostics.php", "environment": "standalone-php" },
     { "path": "tests/smoke-ability-registration-idempotent.php", "environment": "standalone-php" },

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -140,8 +140,8 @@ namespace {
 	$assert( str_contains( $markup, 'wp:jetpack/button' ), 'markup-submit-button' );
 	$assert( str_contains( $markup, 'hello@example.com' ), 'markup-mailto-recipient' );
 	$assert( str_contains( $markup, '"options":["Sales","Support"]' ), 'markup-select-options' );
-	$assert( str_contains( $markup, '<div class="wp-block-jetpack-contact-form form contact">' ), 'markup-contact-form-wrapper-and-source-classes' );
-	$assert( str_contains( $markup, '<!-- wp:jetpack/field-text {"required":true,"id":"contact-name"} -->' ), 'markup-field-wrapper-open' );
+	$assert( 1 === preg_match( '/<div class="wp-block-jetpack-contact-form form contact ssi-form-[a-f0-9]{12}">/', $markup ), 'markup-contact-form-wrapper-and-source-classes' );
+	$assert( 1 === preg_match( '/<!-- wp:jetpack\/field-text \{"required":true,"id":"contact-name","className":"ssi-node-[a-f0-9]{12}"\} -->/', $markup ), 'markup-field-wrapper-open' );
 	$assert( str_contains( $markup, '<div><!-- wp:jetpack/label {"label":"Your name","requiredText":"*"} /-->' ), 'markup-field-label-child' );
 	$assert( str_contains( $markup, '<!-- wp:jetpack/input {"type":"text"} /--></div>' ), 'markup-field-input-child-and-wrapper-close' );
 	$assert( str_contains( $markup, '<!-- wp:jetpack/input {"type":"dropdown"} /-->' ), 'markup-select-input-child' );
@@ -150,6 +150,47 @@ namespace {
 	$assert( str_contains( $markup, '<!-- wp:jetpack/options {"type":"radio"} -->' ), 'markup-radio-options-child' );
 	$assert( str_contains( $markup, '<ul><!-- wp:jetpack/option {"label":"In person"} /-->' ), 'markup-radio-option-wrapper' );
 	$assert( str_contains( $markup, '<!-- wp:jetpack/option {"label":"Send me updates","isStandalone":true} /-->' ), 'markup-checkbox-option-child' );
+
+	// The generic topology is source-order only. Layout is projected onto provider
+	// wrappers through the validated map rather than inventing fixture selectors.
+	$topology_manifest = array(
+		'forms' => array(
+			array(
+				'selector' => 'form.request',
+				'form' => array( 'class' => 'request-form' ),
+				'controls' => array(
+					array( 'tag' => 'input', 'type' => 'text', 'label' => 'First name' ),
+					array( 'tag' => 'input', 'type' => 'email', 'label' => 'Email' ),
+					array( 'tag' => 'textarea', 'type' => 'textarea', 'label' => 'Message' ),
+					array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send request' ),
+				),
+				'control_topology' => array( 'schema' => 'generic/form-control-topology/v1', 'max_depth' => 4, 'max_nodes' => 8, 'truncated' => false, 'nodes' => array(
+					array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 0, 'depth' => 0, 'class' => 'field' ),
+					array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'control' => 0 ),
+					array( 'id' => 'wrapper-1', 'kind' => 'wrapper', 'parent' => null, 'order' => 1, 'depth' => 0, 'class' => 'field' ),
+					array( 'id' => 'control-1', 'kind' => 'control', 'parent' => 'wrapper-1', 'order' => 0, 'depth' => 1, 'control' => 1 ),
+					array( 'id' => 'wrapper-2', 'kind' => 'wrapper', 'parent' => null, 'order' => 2, 'depth' => 0, 'class' => 'field' ),
+					array( 'id' => 'control-2', 'kind' => 'control', 'parent' => 'wrapper-2', 'order' => 0, 'depth' => 1, 'control' => 2 ),
+					array( 'id' => 'control-3', 'kind' => 'control', 'parent' => null, 'order' => 3, 'depth' => 0, 'control' => 3 ),
+				) ),
+				'layout_graph' => array( 'schema' => 'generic/computed-layout-graph/v1', 'basis' => 'source_css_cascade', 'truncated' => false, 'nodes' => array(
+					array( 'id' => 'form', 'layout' => array( 'display' => 'grid', 'columns' => 'repeat(2, 1fr)', 'gap' => '1rem' ) ),
+					array( 'id' => 'control-2', 'layout' => array( 'column' => 'span 2' ) ),
+					array( 'id' => 'control-3', 'layout' => array( 'column' => 'span 2' ) ),
+				), 'variants' => array() ),
+			)
+		)
+	);
+	$topology_validated = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $topology_manifest );
+	$topology_seed = Static_Site_Importer_Form_Seeder::seed( $topology_validated );
+	$topology_row = $topology_seed['forms'][0] ?? array();
+	$topology_css = (string) ( $topology_row['provider_layout_overlay_css']['css'] ?? '' );
+	$assert( empty( $topology_validated['errors'] ) && 3 === ( $topology_row['field_count'] ?? 0 ), 'topology-manifest-validates-and-preserves-control-order' );
+	$assert( str_contains( $topology_css, '> form.jetpack-contact-form__form{display:grid;grid-template-columns:repeat(2, 1fr);gap:1rem}' ) && 2 === substr_count( $topology_css, 'grid-column:span 2' ), 'topology-projects-grid-root-and-full-span-provider-wrappers' );
+	$assert( 'applied' === ( $topology_row['computed_layout_receipt']['status'] ?? '' ) && 3 === ( $topology_row['computed_layout_receipt']['operation_count'] ?? 0 ), 'topology-records-provider-transposition-receipt' );
+	$invalid_topology = $topology_manifest;
+	$invalid_topology['forms'][0]['control_topology']['truncated'] = true;
+	$assert( empty( Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $invalid_topology )['forms'] ), 'topology-truncation-fails-closed' );
 
 	// --- Provider blocks are never claimed without the provider runtime --------
 	$GLOBALS['ssi_jetpack_form_blocks_available'] = false;

--- a/tests/form-materializer-topology.test.mjs
+++ b/tests/form-materializer-topology.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+
+test( 'PHP materializer validates and projects generic provider form topology', () => {
+	const output = execFileSync( 'php', [ 'tests/form-materializer-smoke.php' ], {
+		cwd: process.cwd(),
+		encoding: 'utf8',
+	} );
+
+	assert.match( output, /PASS form-materializer-smoke\.php \(\d+ assertions\)/ );
+} );


### PR DESCRIPTION
## Summary
- Validate and materialize `generic/form-control-topology/v1` through canonical Jetpack field blocks and submit controls.
- Project bounded source grid layout facts through `generic/provider-layout-target-map/v1` onto Jetpack's rendered form and provider wrappers.
- Persist validated overlays into frontend and editor stylesheets and fail closed on unsupported provider structure or unsafe layout facts.
- Prepare Jetpack Forms after dependency activation and add the static-entry front-page fallback for activated imports.

## Tracking
Replacement for #760. Refs #765 and #757. #760 remains unchanged.

## Verification
- `npm test`
- `php tests/smoke-wordpress-site-plan-materializer.php`
- `php tests/form-materializer-smoke.php`
- Fixture87 matrix against Blocks Engine trunk `772dcb9a`: Homeboy runs `2c5ba708-ccd5-4ae4-b326-c4e0fcc3286c` and `6fdbc629-3094-4e07-b6b9-41e7fcd8bc4c`.

Fixture87 generation completed, but the WP Codebox runtime still reports no static front page, so editor/rendered-DOM evidence is unavailable. Visual evidence is non-acceptance only: aligned mismatch 93.77% (raw 96.16%); no parity claim.

## AI Assistance
AI assistance: gpt-5.6-sol via OpenCode was used to diagnose, implement, test, and verify this provider-form repair. Chris Huber remains responsible for every line.
