### PR TITLE
Consume runtime region-effect ownership modules

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -212,10 +212,10 @@ class Static_Site_Importer_Companion_Plugin {
 			),
 			'runtime_scripts' => array_map(
 				static fn ( array $island ): array => array(
-					'handle'      => (string) $island['handle'],
-					'block'       => (string) $island['block'],
-					'selector'    => (string) $island['selector'],
-					'source_path' => (string) $island['source_path'],
+					'handle'          => (string) $island['handle'],
+					'block'           => (string) $island['block'],
+					'selector'        => (string) $island['selector'],
+					'source_path'     => (string) $island['source_path'],
 					'superseded_unit' => (string) ( $island['superseded_unit'] ?? '' ),
 				),
 				$preserved
@@ -561,13 +561,13 @@ class Static_Site_Importer_Companion_Plugin {
 			}
 
 			++$index;
-			$handle_raw   = isset( $entry['handle'] ) && is_scalar( $entry['handle'] ) ? self::sanitize_slug( (string) $entry['handle'] ) : '';
-			$handle       = '' !== $handle_raw ? $handle_raw : $block_namespace . '-island-' . $index;
-			$relative_raw = isset( $entry['src'] ) && is_scalar( $entry['src'] ) ? self::sanitize_relative_path( (string) $entry['src'] ) : '';
-			$relative     = '' !== $relative_raw ? $relative_raw : 'islands/' . $handle . '.js';
-			$block        = isset( $entry['block'] ) && is_scalar( $entry['block'] ) ? (string) $entry['block'] : '';
-			$selector     = isset( $entry['selector'] ) && is_scalar( $entry['selector'] ) ? (string) $entry['selector'] : '';
-			$source_path  = isset( $entry['source_path'] ) && is_scalar( $entry['source_path'] ) ? (string) $entry['source_path'] : '';
+			$handle_raw      = isset( $entry['handle'] ) && is_scalar( $entry['handle'] ) ? self::sanitize_slug( (string) $entry['handle'] ) : '';
+			$handle          = '' !== $handle_raw ? $handle_raw : $block_namespace . '-island-' . $index;
+			$relative_raw    = isset( $entry['src'] ) && is_scalar( $entry['src'] ) ? self::sanitize_relative_path( (string) $entry['src'] ) : '';
+			$relative        = '' !== $relative_raw ? $relative_raw : 'islands/' . $handle . '.js';
+			$block           = isset( $entry['block'] ) && is_scalar( $entry['block'] ) ? (string) $entry['block'] : '';
+			$selector        = isset( $entry['selector'] ) && is_scalar( $entry['selector'] ) ? (string) $entry['selector'] : '';
+			$source_path     = isset( $entry['source_path'] ) && is_scalar( $entry['source_path'] ) ? (string) $entry['source_path'] : '';
 			$superseded_unit = isset( $entry['superseded_unit'] ) && is_scalar( $entry['superseded_unit'] ) ? (string) $entry['superseded_unit'] : '';
 
 			$islands[] = array(
@@ -594,7 +594,7 @@ class Static_Site_Importer_Companion_Plugin {
 	 */
 	private static function runtime_effects( array $payload ): array {
 		$effects = isset( $payload['runtime_effects'] ) && is_array( $payload['runtime_effects'] ) ? $payload['runtime_effects'] : array();
-		$units = array();
+		$units   = array();
 		foreach ( $effects['units'] ?? array() as $unit ) {
 			if ( is_array( $unit ) && isset( $unit['id'] ) && is_scalar( $unit['id'] ) ) {
 				$units[ (string) $unit['id'] ] = $unit;
@@ -719,7 +719,7 @@ class Static_Site_Importer_Companion_Plugin {
 		$lines[] = "\t\t\tif ( ! isset( \$GLOBALS['static_site_importer_companion_block_owners'] ) || ! is_array( \$GLOBALS['static_site_importer_companion_block_owners'] ) ) {";
 		$lines[] = "\t\t\t\t\$GLOBALS['static_site_importer_companion_block_owners'] = array();";
 		$lines[] = "\t\t\t}";
-		$lines[] = sprintf( "\t\t\t\$GLOBALS['static_site_importer_companion_block_owners'][ (string) \$spec['name'] ] = array( 'plugin_file' => %s, 'plugin_path' => __FILE__ );", var_export( $plugin_file, true ) );
+		$lines[] = sprintf( "\t\t\t\$GLOBALS['static_site_importer_companion_block_owners'][ (string) \$spec['name'] ] = array( 'plugin_file' => '%s', 'plugin_path' => __FILE__ );", self::php_single_quote( $plugin_file ) );
 		$lines[] = "\t\t}";
 		$lines[] = "\t}";
 		$lines[] = '}';
@@ -763,7 +763,7 @@ class Static_Site_Importer_Companion_Plugin {
 		$lines[] = "\tif ( ! function_exists( 'wp_enqueue_script' ) ) {";
 		$lines[] = "\t\treturn;";
 		$lines[] = "\t}";
-		$lines[] = sprintf( "\tif ( function_exists( 'get_option' ) && %s !== (string) get_option( 'static_site_importer_active_companion_plugin', '' ) ) {", var_export( $plugin_file, true ) );
+		$lines[] = sprintf( "\tif ( function_exists( 'get_option' ) && '%s' !== (string) get_option( 'static_site_importer_active_companion_plugin', '' ) ) {", self::php_single_quote( $plugin_file ) );
 		$lines[] = "\t\treturn;";
 		$lines[] = "\t}";
 		$lines[] = sprintf( "\tforeach ( %s_islands() as \$island ) {", $fn_prefix );
@@ -895,8 +895,14 @@ class Static_Site_Importer_Companion_Plugin {
 		}
 
 		if ( is_float( $value ) ) {
-			// var_export keeps a parseable float literal (e.g. trailing .0).
-			return var_export( $value, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generating a deterministic PHP literal for the scaffolded plugin file.
+			if ( is_nan( $value ) ) {
+				return 'NAN';
+			}
+			if ( is_infinite( $value ) ) {
+				return $value > 0 ? 'INF' : '-INF';
+			}
+
+			return (string) wp_json_encode( $value, JSON_PRESERVE_ZERO_FRACTION );
 		}
 
 		return "'" . self::php_single_quote( (string) $value ) . "'";

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -122,6 +122,13 @@ class Static_Site_Importer_Companion_Plugin {
 				return new WP_Error( 'static_site_importer_companion_plugin_asset_path_invalid', 'Companion-plugin preserved script has an unsafe asset path.' );
 			}
 		}
+		$effects = self::runtime_effects( $payload );
+		foreach ( $effects['retained_modules'] as $module ) {
+			$unit = $effects['units'][ $module['unit_id'] ] ?? array();
+			if ( 'independently_suppressible' !== ( $unit['status'] ?? '' ) || ! hash_equals( (string) ( $unit['source']['hash'] ?? '' ), hash( 'sha256', (string) $module['content'] ) ) ) {
+				return new WP_Error( 'static_site_importer_runtime_effect_invalid', 'Retained runtime modules must map to hash-verified independently suppressible units.' );
+			}
+		}
 		return true;
 	}
 
@@ -209,6 +216,7 @@ class Static_Site_Importer_Companion_Plugin {
 					'block'       => (string) $island['block'],
 					'selector'    => (string) $island['selector'],
 					'source_path' => (string) $island['source_path'],
+					'superseded_unit' => (string) ( $island['superseded_unit'] ?? '' ),
 				),
 				$preserved
 			),
@@ -529,6 +537,17 @@ class Static_Site_Importer_Companion_Plugin {
 	 */
 	private static function preserved_js( array $payload, string $block_namespace ): array {
 		$entries = isset( $payload['preserved_js'] ) && is_array( $payload['preserved_js'] ) ? $payload['preserved_js'] : array();
+		$effects = self::runtime_effects( $payload );
+		foreach ( $effects['retained_modules'] as $module ) {
+			$entries[] = array(
+				'handle'          => 'runtime-unit-' . $module['unit_id'],
+				'content'         => $module['content'],
+				'block'            => $module['block'],
+				'selector'         => $module['selector'],
+				'source_path'      => $module['source_path'],
+				'superseded_unit'  => $module['unit_id'],
+			);
+		}
 		$islands = array();
 		$index   = 0;
 
@@ -549,6 +568,7 @@ class Static_Site_Importer_Companion_Plugin {
 			$block        = isset( $entry['block'] ) && is_scalar( $entry['block'] ) ? (string) $entry['block'] : '';
 			$selector     = isset( $entry['selector'] ) && is_scalar( $entry['selector'] ) ? (string) $entry['selector'] : '';
 			$source_path  = isset( $entry['source_path'] ) && is_scalar( $entry['source_path'] ) ? (string) $entry['source_path'] : '';
+			$superseded_unit = isset( $entry['superseded_unit'] ) && is_scalar( $entry['superseded_unit'] ) ? (string) $entry['superseded_unit'] : '';
 
 			$islands[] = array(
 				'handle'       => $handle,
@@ -559,10 +579,40 @@ class Static_Site_Importer_Companion_Plugin {
 				'block'        => $block,
 				'selector'     => $selector,
 				'source_path'  => $source_path,
+				'superseded_unit' => $superseded_unit,
 			);
 		}
 
 		return $islands;
+	}
+
+	/**
+	 * Normalize the generic Blocks Engine AST ownership contract. Malformed
+	 * contracts yield no retained assets; validate_payload() rejects them.
+	 *
+	 * @return array{units:array<string,array<string,mixed>>,retained_modules:array<int,array<string,string>>}
+	 */
+	private static function runtime_effects( array $payload ): array {
+		$effects = isset( $payload['runtime_effects'] ) && is_array( $payload['runtime_effects'] ) ? $payload['runtime_effects'] : array();
+		$units = array();
+		foreach ( $effects['units'] ?? array() as $unit ) {
+			if ( is_array( $unit ) && isset( $unit['id'] ) && is_scalar( $unit['id'] ) ) {
+				$units[ (string) $unit['id'] ] = $unit;
+			}
+		}
+		$modules = array();
+		foreach ( $effects['retained_modules'] ?? array() as $module ) {
+			if ( ! is_array( $module ) || ! isset( $module['unit_id'], $module['content'] ) || ! is_scalar( $module['unit_id'] ) || ! is_scalar( $module['content'] ) ) {
+				continue;
+			}
+			$modules[] = array(
+				'unit_id' => (string) $module['unit_id'], 'content' => (string) $module['content'],
+				'block' => isset( $module['block'] ) && is_scalar( $module['block'] ) ? (string) $module['block'] : '',
+				'selector' => isset( $module['selector'] ) && is_scalar( $module['selector'] ) ? (string) $module['selector'] : '',
+				'source_path' => isset( $module['source_path'] ) && is_scalar( $module['source_path'] ) ? (string) $module['source_path'] : '',
+			);
+		}
+		return array( 'units' => $units, 'retained_modules' => $modules );
 	}
 
 	/**

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -98,7 +98,7 @@ class Static_Site_Importer_Companion_Plugin {
 				return new WP_Error( 'static_site_importer_companion_plugin_assets_invalid', sprintf( 'Block %s assets must be an object.', $name ) );
 			}
 			foreach ( $assets as $path => $content ) {
-				if ( ! is_string( $path ) || $path !== self::sanitize_relative_path( $path ) || ! is_scalar( $content ) ) {
+				if ( ! is_string( $path ) || self::sanitize_relative_path( $path ) !== $path || ! is_scalar( $content ) ) {
 					return new WP_Error( 'static_site_importer_companion_plugin_asset_path_invalid', sprintf( 'Block %s has an unsafe asset path.', $name ) );
 				}
 			}
@@ -118,7 +118,7 @@ class Static_Site_Importer_Companion_Plugin {
 				continue;
 			}
 			$src = is_string( $entry['src'] ) ? $entry['src'] : '';
-			if ( $src !== self::sanitize_relative_path( $src ) ) {
+			if ( self::sanitize_relative_path( $src ) !== $src ) {
 				return new WP_Error( 'static_site_importer_companion_plugin_asset_path_invalid', 'Companion-plugin preserved script has an unsafe asset path.' );
 			}
 		}
@@ -542,10 +542,10 @@ class Static_Site_Importer_Companion_Plugin {
 			$entries[] = array(
 				'handle'          => 'runtime-unit-' . $module['unit_id'],
 				'content'         => $module['content'],
-				'block'            => $module['block'],
-				'selector'         => $module['selector'],
-				'source_path'      => $module['source_path'],
-				'superseded_unit'  => $module['unit_id'],
+				'block'           => $module['block'],
+				'selector'        => $module['selector'],
+				'source_path'     => $module['source_path'],
+				'superseded_unit' => $module['unit_id'],
 			);
 		}
 		$islands = array();
@@ -571,14 +571,14 @@ class Static_Site_Importer_Companion_Plugin {
 			$superseded_unit = isset( $entry['superseded_unit'] ) && is_scalar( $entry['superseded_unit'] ) ? (string) $entry['superseded_unit'] : '';
 
 			$islands[] = array(
-				'handle'       => $handle,
-				'relative_src' => $relative,
-				'content'      => $content,
+				'handle'          => $handle,
+				'relative_src'    => $relative,
+				'content'         => $content,
 				// Scope: enqueue only when this block renders. Empty block means
 				// the island is unscoped, but slice 1 only emits scoped islands.
-				'block'        => $block,
-				'selector'     => $selector,
-				'source_path'  => $source_path,
+				'block'           => $block,
+				'selector'        => $selector,
+				'source_path'     => $source_path,
 				'superseded_unit' => $superseded_unit,
 			);
 		}
@@ -606,13 +606,17 @@ class Static_Site_Importer_Companion_Plugin {
 				continue;
 			}
 			$modules[] = array(
-				'unit_id' => (string) $module['unit_id'], 'content' => (string) $module['content'],
-				'block' => isset( $module['block'] ) && is_scalar( $module['block'] ) ? (string) $module['block'] : '',
-				'selector' => isset( $module['selector'] ) && is_scalar( $module['selector'] ) ? (string) $module['selector'] : '',
+				'unit_id'     => (string) $module['unit_id'],
+				'content'     => (string) $module['content'],
+				'block'       => isset( $module['block'] ) && is_scalar( $module['block'] ) ? (string) $module['block'] : '',
+				'selector'    => isset( $module['selector'] ) && is_scalar( $module['selector'] ) ? (string) $module['selector'] : '',
 				'source_path' => isset( $module['source_path'] ) && is_scalar( $module['source_path'] ) ? (string) $module['source_path'] : '',
 			);
 		}
-		return array( 'units' => $units, 'retained_modules' => $modules );
+		return array(
+			'units'            => $units,
+			'retained_modules' => $modules,
+		);
 	}
 
 	/**

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -100,6 +100,25 @@ $payload     = array(
 			'source_path' => 'index.html',
 		),
 	),
+	'runtime_effects' => array(
+		'units' => array(
+			array(
+				'id' => 'effect_carousel',
+				'status' => 'independently_suppressible',
+				'source' => array( 'hash' => hash( 'sha256', 'document.querySelector(".carousel").classList.add("active");' ) ),
+			),
+			array( 'id' => 'effect_shared', 'status' => 'shared_or_unsplittable', 'source' => array( 'hash' => hash( 'sha256', 'shared' ) ) ),
+		),
+		'retained_modules' => array(
+			array(
+				'unit_id' => 'effect_carousel',
+				'content' => 'document.querySelector(".carousel").classList.add("active");',
+				'block' => 'ssi-example-site/custom-hero',
+				'selector' => '.carousel',
+				'source_path' => 'js/site.js',
+			),
+		),
+	),
 );
 
 // 1. Companion plugin consumes preserved_js: scoped enqueue + island file +
@@ -108,7 +127,7 @@ $descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $payload );
 $assert( is_array( $descriptor ), 'scaffold-returns-descriptor', is_array( $descriptor ) ? '' : 'WP_Error returned' );
 
 if ( is_array( $descriptor ) ) {
-	$assert( array( 'hero-island' ) === ( $descriptor['island_handles'] ?? null ), 'descriptor-exposes-island-handles' );
+	$assert( array( 'hero-island', 'runtime-unit-effect-carousel' ) === ( $descriptor['island_handles'] ?? null ), 'descriptor-exposes-island-handles' );
 	$assert( 'script:nth-of-type(1)' === ( $descriptor['runtime_scripts'][0]['selector'] ?? '' ), 'descriptor-exposes-runtime-selector' );
 
 	$files = $descriptor['files'];
@@ -122,9 +141,14 @@ if ( is_array( $descriptor ) ) {
 		static fn ( string $content, string $path ): bool => str_contains( $path, '/islands/' ) && str_ends_with( $path, '.js' ),
 		ARRAY_FILTER_USE_BOTH
 	);
-	$assert( 1 === count( $island_files ), 'companion-emits-one-island-js-file' );
+	$assert( 2 === count( $island_files ), 'companion-emits-retained-island-js-files' );
 	$assert( in_array( $island_body, array_values( $island_files ), true ), 'companion-island-file-carries-js-body' );
+	$assert( 'effect_carousel' === ( $descriptor['runtime_scripts'][1]['superseded_unit'] ?? '' ), 'descriptor-records-superseded-runtime-unit' );
 }
+
+$unsafe_effect = $payload;
+$unsafe_effect['runtime_effects']['retained_modules'][0]['unit_id'] = 'effect_shared';
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $unsafe_effect ) ), 'shared-runtime-unit-fails-closed' );
 
 $script_only = $payload;
 $script_only['blocks'] = array();
@@ -148,7 +172,7 @@ if ( ! function_exists( 'is_plugin_active' ) ) {
 
 $dependency = Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_dependency( $payload );
 $row        = Static_Site_Importer_Entity_Materializer_Registry::companion_dependency_row( $dependency, false );
-$assert( array( 'hero-island' ) === ( $row['island_handles'] ?? null ), 'dependency-row-carries-island-handles' );
+$assert( array( 'hero-island', 'runtime-unit-effect-carousel' ) === ( $row['island_handles'] ?? null ), 'dependency-row-carries-island-handles' );
 
 // Active companion: present diagnostic flags JS as runtime-carried theme-independently.
 $GLOBALS['ssi_companion_js_active'] = true;
@@ -165,7 +189,7 @@ $report['diagnostics'][] = array(
 Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( $report, $dependency, false );
 $present = array_values( array_filter( $report['diagnostics'] ?? array(), static fn ( array $d ): bool => 'companion_plugin_present' === ( $d['code'] ?? '' ) ) );
 $assert( 1 === count( $present ), 'present-diagnostic-emitted-when-active' );
-$assert( array( 'hero-island' ) === ( $present[0]['island_handles'] ?? null ), 'present-diagnostic-carries-island-handles' );
+$assert( array( 'hero-island', 'runtime-unit-effect-carousel' ) === ( $present[0]['island_handles'] ?? null ), 'present-diagnostic-carries-island-handles' );
 $assert( true === ( $present[0]['runtime_carried'] ?? false ), 'present-diagnostic-flags-runtime-carried' );
 $materialized = array_values( array_filter( $report['diagnostics'] ?? array(), static fn ( array $d ): bool => 'runtime_script_materialized' === ( $d['code'] ?? '' ) ) );
 $assert( 1 === count( $materialized ), 'companion-materialization-resolves-script-fallback' );
@@ -183,7 +207,7 @@ Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $report, array
 $unresolved = array_filter( $report['diagnostics'], static fn ( array $d ): bool => 'html_script_fallback' === ( $d['code'] ?? '' ) );
 $assert( empty( $unresolved ), 'finalization-reconciles-late-script-fallback-rows' );
 $stored = $report['companion_plugins']['dependencies']['ssi-example-site']['island_handles'] ?? null;
-$assert( array( 'hero-island' ) === $stored, 'report-stores-companion-island-handles' );
+$assert( array( 'hero-island', 'runtime-unit-effect-carousel' ) === $stored, 'report-stores-companion-island-handles' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- accept hash-verified AST ownership units as retained page-scoped companion assets
- reject shared or unverified units before materialization
- record each superseded source unit in the companion runtime descriptor

## Evidence
- `php tests/smoke-companion-plugin-js.php`
- `php tests/smoke-companion-plugin.php`
- `npm run test:all`

Depends on Automattic/blocks-engine#792. Closes #734.

AI assistance: gpt-5.6-sol via OpenCode was used to diagnose, implement, test, and verify this runtime ownership contract. Chris Huber remains responsible for every line.