### PR TITLE
Persist failed fixture import evidence

### DIFF
--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -354,6 +354,16 @@ export function collectMatrixEvidence(payload, options = {}) {
       truncation: sidecar.payload?.receipt?.truncated,
       ...(sidecar.status !== 'verified' && sidecar.status !== 'absent' ? { reason: sidecar.status } : {}),
     }),
+    import_command: compactObject({
+      status: sidecar.payload?.command_result?.status,
+      success: sidecar.payload?.command_result?.success,
+      error_code: sidecar.payload?.command_result?.error_code,
+      error_hash: sidecar.payload?.command_result?.error_hash,
+    }),
+    front_page_options: compactObject({
+      show_on_front: sidecar.payload?.front_page_options?.show_on_front,
+      page_on_front: sidecar.payload?.front_page_options?.page_on_front,
+    }),
     template_parts: templateParts,
   };
 }
@@ -672,10 +682,10 @@ function readMaterializationSidecar(directory, fixtureId, runId, attemptId) {
 
 function validSidecar(row) {
   const receipt = objectValue(row.receipt);
-  const allowed = ['schema', 'fixture_id', 'run_id', 'step_id', 'attempt_id', 'artifact_sha256', 'provenance', 'durability', 'receipt', 'content_sha256'];
+  const allowed = ['schema', 'fixture_id', 'run_id', 'step_id', 'attempt_id', 'artifact_sha256', 'provenance', 'durability', 'receipt', 'command_result', 'front_page_options', 'content_sha256'];
   if (Object.keys(row).some((key) => !allowed.includes(key))) return false;
   if (row.schema !== MATERIALIZATION_SIDECAR_SCHEMA || !safeToken(row.fixture_id, 80) || !safeToken(row.run_id, 160) || row.step_id !== 'import' || !safeToken(row.attempt_id, 80) || !sha256(row.artifact_sha256) || !sha256(row.content_sha256)) return false;
-  if (!validProvenance(row.provenance) || !validDurability(row.durability) || !validReceipt(receipt)) return false;
+  if (!validProvenance(row.provenance) || !validDurability(row.durability) || !validReceipt(receipt) || (row.command_result !== undefined && !validCommandResult(row.command_result)) || (row.front_page_options !== undefined && !validFrontPageOptions(row.front_page_options))) return false;
   return true;
 }
 
@@ -688,19 +698,37 @@ function validDurability(value) {
 
 function validProvenance(value) {
   const row = objectValue(value);
-  return Object.keys(row).length === 2 && row.provider === 'static-site-importer/current-runtime' && row.provider_status === 'completed';
+  return Object.keys(row).length === 2 && row.provider === 'static-site-importer/current-runtime' && ['completed', 'failed'].includes(row.provider_status);
 }
 
 function validReceipt(row) {
-  const allowed = ['schema', 'status', 'plan_hash', 'page_count', 'file_count', 'operation_count', 'loss_count', 'provider_totals', 'computed_layout_totals', 'operation_rows', 'loss_rows', 'truncated'];
+  const allowed = ['schema', 'status', 'plan_hash', 'page_count', 'file_count', 'operation_count', 'loss_count', 'failure_code', 'provider_totals', 'computed_layout_totals', 'operation_rows', 'loss_rows', 'truncated'];
   if (Object.keys(row).some((key) => !allowed.includes(key))) return false;
-  if (row.schema !== 'static-site-importer/materialization-receipt/v1' || row.status !== 'completed' || !sha256(row.plan_hash)) return false;
+  if (row.schema !== 'static-site-importer/materialization-receipt/v1' || !['completed', 'failed'].includes(row.status)) return false;
+  if (row.status === 'failed') return boundedCount(row.page_count) && boundedCount(row.file_count) && boundedCount(row.operation_count) && boundedCount(row.loss_count) && safeToken(row.failure_code, 80);
+  if (!sha256(row.plan_hash)) return false;
   if (!['page_count', 'file_count', 'operation_count', 'loss_count'].every((key) => boundedCount(row[key]))) return false;
   if (!validCounts(row.provider_totals, ['completed']) || !validCounts(row.computed_layout_totals, ['applied', 'losses', 'operations'])) return false;
   if (!Array.isArray(row.operation_rows) || !Array.isArray(row.loss_rows) || row.operation_rows.length > 25 || row.loss_rows.length > 25) return false;
   if (![...row.operation_rows, ...row.loss_rows].every(validSidecarRow)) return false;
   const truncated = objectValue(row.truncated);
   return Object.keys(truncated).length === 2 && typeof truncated.operation_rows === 'boolean' && typeof truncated.loss_rows === 'boolean';
+}
+
+function validCommandResult(value) {
+  const row = objectValue(value);
+  return Object.keys(row).every((key) => ['status', 'success', 'error_code', 'error_hash'].includes(key))
+    && ['completed', 'failed'].includes(row.status)
+    && typeof row.success === 'boolean'
+    && row.success === (row.status === 'completed')
+    && typeof row.error_code === 'string'
+    && (row.status === 'completed' || safeToken(row.error_code, 80))
+    && sha256(row.error_hash);
+}
+
+function validFrontPageOptions(value) {
+  const row = objectValue(value);
+  return Object.keys(row).length === 2 && safeToken(row.show_on_front, 20) && boundedCount(row.page_on_front);
 }
 
 function validCounts(value, keys) {

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -315,6 +315,12 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				if ( 'fixture-matrix' === $format ) {
 					$error_result = Static_Site_Importer_Validation_Runtime::fixture_matrix_result( $error_result );
 				}
+				if ( true === $sidecar_contract ) {
+					$sidecar_result = static_site_importer_cli_write_materialization_sidecar( $error_result, $assoc_args );
+					if ( is_wp_error( $sidecar_result ) ) {
+						WP_CLI::error( $sidecar_result->get_error_message(), 1 );
+					}
+				}
 				$json = wp_json_encode( $error_result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 				if ( false === $json ) {
 					WP_CLI::error( $result->get_error_message() );
@@ -423,31 +429,36 @@ function static_site_importer_cli_write_materialization_sidecar( array $result, 
 	if ( ! is_string( $artifact_hash ) || ! preg_match( '/^[a-f0-9]{64}$/', $artifact_hash ) ) {
 		return new WP_Error( 'static_site_importer_sidecar_artifact_hash_missing', 'Required materialization sidecar artifact hash could not be calculated.' );
 	}
-	$receipt = isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : array();
-	if ( 'static-site-importer/materialization-receipt/v1' !== ( $receipt['schema'] ?? '' ) || 'completed' !== ( $receipt['status'] ?? '' ) || ! isset( $receipt['plan_hash'] ) || ! is_string( $receipt['plan_hash'] ) || ! preg_match( '/^(?:sha256:)?[a-f0-9]{64}$/', $receipt['plan_hash'] ) ) {
-		return new WP_Error( 'static_site_importer_sidecar_receipt_invalid', 'Required materialization sidecar receipt is incomplete or invalid.' );
-	}
-	$completed = isset( $receipt['completed'] ) && is_array( $receipt['completed'] ) ? $receipt['completed'] : array();
-	if ( ! isset( $completed['pages'], $completed['files'] ) || ! is_array( $completed['pages'] ) || ! is_array( $completed['files'] ) ) {
-		return new WP_Error( 'static_site_importer_sidecar_receipt_shape_invalid', 'Required materialization sidecar receipt pages and files must be arrays.' );
-	}
-	$summary                   = static_site_importer_cli_materialization_summary( $receipt, $result );
+	$receipt                   = isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : array();
+	$completed                 = isset( $receipt['completed'] ) && is_array( $receipt['completed'] ) ? $receipt['completed'] : array();
+	$is_completed              = 'static-site-importer/materialization-receipt/v1' === ( $receipt['schema'] ?? '' ) && 'completed' === ( $receipt['status'] ?? '' ) && isset( $receipt['plan_hash'] ) && is_string( $receipt['plan_hash'] ) && preg_match( '/^(?:sha256:)?[a-f0-9]{64}$/', $receipt['plan_hash'] ) && isset( $completed['pages'], $completed['files'] ) && is_array( $completed['pages'] ) && is_array( $completed['files'] );
+	$summary                   = $is_completed ? static_site_importer_cli_materialization_summary( $receipt, $result ) : static_site_importer_cli_failed_materialization_summary( $result );
 	$sidecar                   = array(
-		'schema'          => 'static-site-importer/materialization-runtime-sidecar/v1',
-		'fixture_id'      => $fixture_id,
-		'run_id'          => $run_id,
-		'step_id'         => $step_id,
-		'attempt_id'      => $attempt_id,
-		'artifact_sha256' => $artifact_hash,
-		'provenance'      => array(
-			'provider'        => (string) ( $result['runtime']['provider'] ?? '' ),
-			'provider_status' => (string) ( $result['runtime']['status'] ?? '' ),
+		'schema'             => 'static-site-importer/materialization-runtime-sidecar/v1',
+		'fixture_id'         => $fixture_id,
+		'run_id'             => $run_id,
+		'step_id'            => $step_id,
+		'attempt_id'         => $attempt_id,
+		'artifact_sha256'    => $artifact_hash,
+		'provenance'         => array(
+			'provider'        => (string) ( $result['runtime']['provider'] ?? 'static-site-importer/current-runtime' ),
+			'provider_status' => $is_completed ? 'completed' : 'failed',
 		),
-		'durability'      => array(
+		'durability'         => array(
 			'file_fsync'      => function_exists( 'fsync' ) ? 'available' : 'unavailable',
 			'directory_fsync' => function_exists( 'fsync' ) ? 'attempted' : 'unavailable',
 		),
-		'receipt'         => $summary,
+		'receipt'            => $summary,
+		'command_result'     => array(
+			'status'     => $is_completed ? 'completed' : 'failed',
+			'success'    => $is_completed,
+			'error_code' => $is_completed ? '' : static_site_importer_cli_sidecar_token_value( $result['error']['code'] ?? $result['code'] ?? 'import_failed', 80 ),
+			'error_hash' => hash( 'sha256', (string) wp_json_encode( $result, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ),
+		),
+		'front_page_options' => array(
+			'show_on_front' => static_site_importer_cli_sidecar_token_value( get_option( 'show_on_front' ), 20 ),
+			'page_on_front' => min( 10000000, max( 0, (int) get_option( 'page_on_front' ) ) ),
+		),
 	);
 	$sidecar['content_sha256'] = hash( 'sha256', (string) wp_json_encode( $sidecar, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
 	$json                      = wp_json_encode( $sidecar, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
@@ -465,7 +476,7 @@ function static_site_importer_cli_write_materialization_sidecar( array $result, 
 	$handle = fopen( $temp, 'wb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- explicit CLI artifact publication.
 	try {
 		$bytes = strlen( $json ) + 1;
-		if ( false === $handle || $bytes !== fwrite( $handle, $json . "\n" ) || ! fflush( $handle ) || ( function_exists( 'fsync' ) && ! fsync( $handle ) ) || ! fclose( $handle ) || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite,WordPress.WP.AlternativeFunctions.file_system_operations_fclose,WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-directory publication.
+		if ( false === $handle || fwrite( $handle, $json . "\n" ) !== $bytes || ! fflush( $handle ) || ( function_exists( 'fsync' ) && ! fsync( $handle ) ) || ! fclose( $handle ) || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite,WordPress.WP.AlternativeFunctions.file_system_operations_fclose,WordPress.WP.AlternativeFunctions.rename_rename -- atomic same-directory publication.
 			if ( is_resource( $handle ) ) {
 				fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- cleanup after failed atomic publish.
 			}
@@ -478,6 +489,20 @@ function static_site_importer_cli_write_materialization_sidecar( array $result, 
 		}
 	}
 	return true;
+}
+
+/** @return array<string,mixed> */
+function static_site_importer_cli_failed_materialization_summary( array $result ): array {
+	$error_code = static_site_importer_cli_sidecar_token_value( $result['error']['code'] ?? $result['code'] ?? 'import_failed', 80 );
+	return array(
+		'schema'          => 'static-site-importer/materialization-receipt/v1',
+		'status'          => 'failed',
+		'page_count'      => 0,
+		'file_count'      => 0,
+		'operation_count' => 0,
+		'loss_count'      => 1,
+		'failure_code'    => $error_code ? $error_code : 'import_failed',
+	);
 }
 
 function static_site_importer_cli_fsync_directory( string $directory ): void {
@@ -542,7 +567,7 @@ function static_site_importer_cli_materialization_summary( array $receipt, array
 			array(
 				'applied'    => isset( $layout['applied'] ) ? (int) $layout['applied'] : null,
 				'losses'     => isset( $layout['losses'] ) ? (int) $layout['losses'] : null,
-				'operations' => count( array_filter( $operations, static fn( $operation ): bool => is_array( $operation ) && false !== strpos( wp_json_encode( $operation ), 'computed_layout' ) ) ),
+				'operations' => count( array_filter( $operations, static fn( $operation ): bool => is_array( $operation ) && false !== strpos( (string) wp_json_encode( $operation ), 'computed_layout' ) ) ),
 			),
 			static fn( $value ): bool => null !== $value
 		),

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1149,6 +1149,28 @@ test('materialization sidecars retain bounded evidence after oversized import st
   }
 });
 
+test('failure sidecars retain the bounded import result and front-page option observation', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-sidecar-failed-import-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'failed-import-evidence' });
+  const directory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(directory, { recursive: true });
+  const artifact = JSON.stringify({ fixture: 'simple-site' });
+  writeFileSync(path.join(directory, 'artifact.json'), artifact);
+  const sidecar = {
+    schema: 'static-site-importer/materialization-runtime-sidecar/v1', fixture_id: 'simple-site', run_id: matrix.id, step_id: 'import', attempt_id: 'primary', artifact_sha256: createHash('sha256').update(artifact).digest('hex'), provenance: { provider: 'static-site-importer/current-runtime', provider_status: 'failed' }, durability: { file_fsync: 'available', directory_fsync: 'attempted' },
+    receipt: { schema: 'static-site-importer/materialization-receipt/v1', status: 'failed', page_count: 0, file_count: 0, operation_count: 0, loss_count: 1, failure_code: 'artifact_invalid' },
+    command_result: { status: 'failed', success: false, error_code: 'artifact_invalid', error_hash: 'a'.repeat(64) },
+    front_page_options: { show_on_front: 'posts', page_on_front: 0 },
+  };
+  sidecar.content_sha256 = createHash('sha256').update(JSON.stringify(sidecar)).digest('hex');
+  writeFileSync(path.join(directory, 'materialization-receipt--primary.json'), JSON.stringify(sidecar));
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  assert.equal(result.fixtures[0].matrix_evidence.materialization_sidecar.status, 'verified');
+  assert.deepEqual(result.fixtures[0].matrix_evidence.import_command, { status: 'failed', success: false, error_code: 'artifact_invalid', error_hash: 'a'.repeat(64) });
+  assert.deepEqual(result.fixtures[0].matrix_evidence.front_page_options, { show_on_front: 'posts', page_on_front: 0 });
+  assert.equal(result.fixtures[0].matrix_evidence.materialization_receipt.status, 'failed');
+});
+
 test('materialization sidecars reject malformed, stale, cross-fixture, and hash-mismatched evidence', () => {
   const cases = ['missing', 'malformed', 'stale', 'cross_fixture', 'hash_mismatch'];
   for (const status of cases) {


### PR DESCRIPTION
## Summary
- Supersedes #804 because its AI disclosure named the wrong model.
- Preserves #804's exact final three-file net diff for bounded failed-import evidence and its tests.

## Tracking
Fixes #802.
Unblocks evidence-based review of #801.

## Verification
- `npm test`
- `npm run test:all`
- `php -l static-site-importer.php`
- `php tests/smoke-wordpress-site-plan-materializer.php`
- `php tests/form-materializer-smoke.php`
- No repository lint configuration is present (`npm run lint` reports no script).

## AI Assistance
AI assistance: gpt-5.6-sol via OpenCode was used to diagnose, implement, test, and verify this failure-evidence repair. Chris Huber remains responsible for every line.