### PR TITLE
Separate lint and test CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,23 @@ permissions:
   pull-requests: write
 
 jobs:
+  homeboy-lint:
+    name: Homeboy Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: Extra-Chill/homeboy-action@31e95050206332c4ebd36894387c980c99443ecf  # v2.8.15
+        with:
+          commands: review lint
+          args: --extension wordpress
+          php-version: '8.2'
+          node-version: '24'
+          autofix: 'false'
+
   homeboy-test:
     name: Homeboy Test (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
@@ -32,7 +49,7 @@ jobs:
 
       - uses: Extra-Chill/homeboy-action@31e95050206332c4ebd36894387c980c99443ecf  # v2.8.15
         with:
-          commands: review lint,test
+          commands: review test
           args: --extension wordpress
           php-version: ${{ matrix.php-version }}
           node-version: '24'


### PR DESCRIPTION
## Summary

- report repository lint as a dedicated `Homeboy Lint` job
- run lint once on PHP 8.2 instead of duplicating the same fixed-target analysis across the PHP matrix
- retain independent `Homeboy Test` coverage on PHP 8.1, 8.2, 8.3, and 8.4

This makes GitHub status reporting accurate: lint failures no longer present as failed test jobs.

## Verification

- `actionlint .github/workflows/test.yml`
- YAML parse via Ruby
- `npm test` (44 selected checks passed)

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode diagnosed the misleading combined CI status, split the workflow jobs, reviewed the resulting diff, and ran validation. Chris Huber remains responsible for every line.