### PR TITLE
Stabilize fixture recipe working directories

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -435,6 +435,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       recipeFile: batchRecipeFile,
       artifactsDir: codeboxArtifactsDirectory,
       outputFile,
+      cwd: outputDirectory,
       wpCodeboxBin: options.wpCodeboxBin,
       inactivityTimeoutMs: batchInactivityTimeoutMs(options),
       onInactivity: ({ timeout_ms }) => {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -3843,7 +3843,10 @@ test('fixture matrix records generic child command failures for failed WP Codebo
   writeFileSync(helperPath, `
 function wpCodeboxBin() { return '/tmp/wp-codebox'; }
 function wpCodeboxCommand(bin) { return { command: bin, args: [] }; }
-async function runWpCodeboxRecipe() {
+async function runWpCodeboxRecipe(options) {
+  if (options.cwd !== require('node:path').dirname(options.outputFile)) {
+    throw new Error('recipe-run did not receive the matrix output directory as cwd');
+  }
   const error = new Error('recipe-run failed');
   error.code = 17;
   error.signal = 'SIGKILL';
@@ -3961,7 +3964,7 @@ const outputIndex = process.argv.indexOf('--output');
 const outputFile = outputIndex >= 0 ? process.argv[outputIndex + 1] : '';
 const fixtureId = process.env.SSI_TEST_FAKE_WP_CODEBOX_FIXTURE_ID || 'large-output-fixture';
 if (outputFile) {
-  writeFileSync(outputFile, JSON.stringify({ results: [{ fixture_id: fixtureId, status: 'succeeded' }] }));
+  writeFileSync(outputFile, JSON.stringify({ cwd: process.cwd(), results: [{ fixture_id: fixtureId, status: 'succeeded' }] }));
 }
 const chunk = 'stdout chunk '.padEnd(1024 * 1024, 'x');
 for (let index = 0; index < 12; index += 1) {
@@ -3983,9 +3986,9 @@ for (let index = 0; index < 12; index += 1) {
   assert.equal(runtimeError, null);
   assert.equal(summary.result_summary.succeeded, 1);
   assert.equal(summary.child_command_failures?.length || 0, 0);
-  assert.deepEqual(JSON.parse(readFileSync(path.join(outputDirectory, 'wp-codebox-output-batch-001.json'), 'utf8')), {
-    results: [{ fixture_id: fixtureId, status: 'succeeded' }],
-  });
+  const childOutput = JSON.parse(readFileSync(path.join(outputDirectory, 'wp-codebox-output-batch-001.json'), 'utf8'));
+  assert.equal(realpathSync(childOutput.cwd), realpathSync(outputDirectory));
+  assert.deepEqual(childOutput.results, [{ fixture_id: fixtureId, status: 'succeeded' }]);
 });
 
 test('WP Codebox recipe runner falls back when the CLI rejects recipe-run --output', async () => {

--- a/tools/wp-codebox/recipe.mjs
+++ b/tools/wp-codebox/recipe.mjs
@@ -62,6 +62,7 @@ export async function runWpCodeboxRecipe(options = {}) {
   }
 
   const result = spawnSync(base.command, args, {
+    cwd: options.cwd,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     maxBuffer: WP_CODEBOX_RECIPE_MAX_BUFFER,
@@ -92,7 +93,7 @@ function recipeRunArgs(base, options, { output }) {
 }
 
 async function runWpCodeboxRecipeStdoutFallback(base, options) {
-  const result = await spawnRecipeToOutputFile(base.command, recipeRunArgs(base, options, { output: false }), options.outputFile);
+  const result = await spawnRecipeToOutputFile(base.command, recipeRunArgs(base, options, { output: false }), options);
   const output = readTextFile(options.outputFile);
   const parsed = parseJsonText(output);
   if (result.status !== 0) {
@@ -133,7 +134,7 @@ function spawnRecipeWithTails(command, args, options = {}) {
   return new Promise((resolve) => {
     const stdout = new RingTextBuffer(WP_CODEBOX_RECIPE_TAIL_BYTES);
     const stderr = new RingTextBuffer(WP_CODEBOX_RECIPE_TAIL_BYTES);
-    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn(command, args, { cwd: options.cwd, stdio: ['ignore', 'pipe', 'pipe'] });
     let spawnError = null;
     const inactivityTimeoutMs = positiveInteger(options.inactivityTimeoutMs, DEFAULT_RECIPE_INACTIVITY_TIMEOUT_MS);
     let inactivityTimedOut = false;
@@ -174,12 +175,12 @@ function spawnRecipeWithTails(command, args, options = {}) {
   });
 }
 
-function spawnRecipeToOutputFile(command, args, outputFile) {
+function spawnRecipeToOutputFile(command, args, options) {
   return new Promise((resolve) => {
     const stdout = new RingTextBuffer(WP_CODEBOX_RECIPE_TAIL_BYTES);
     const stderr = new RingTextBuffer(WP_CODEBOX_RECIPE_TAIL_BYTES);
-    const output = fs.createWriteStream(outputFile, { encoding: 'utf8' });
-    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const output = fs.createWriteStream(options.outputFile, { encoding: 'utf8' });
+    const child = spawn(command, args, { cwd: options.cwd, stdio: ['ignore', 'pipe', 'pipe'] });
     let spawnError = null;
 
     child.stdout?.on('data', (chunk) => {


### PR DESCRIPTION
## Summary

- run every fixture-matrix WP Codebox child from the matrix-owned output directory
- propagate the explicit working directory through standalone async, sync, and output-fallback launch paths
- verify both the Homeboy Extensions helper seam and a real child process observe the stable directory

## Root cause

The canonical Lab matrix run `ca290b6e-6ca4-42c5-bcd1-3cfb726fb392` inherited a reclaimable bench working directory. Once that directory disappeared, 78 fixtures failed before recipe execution with `uv_cwd`/`ENOENT`, invalidating the aggregate product evidence.

Closes #811.

## Verification

- `npm run test:fixture-matrix` (248 passed)

## AI assistance

GPT-5.6-sol via OpenCode analyzed the Lab evidence, traced the child-process launch paths, implemented the stable-CWD contract, and added regression coverage. Chris Huber reviewed and is responsible for every line.