### PR TITLE
Normalize image MIME before runtime presentation evidence binding

### DIFF
--- a/lib/fixture-matrix/runtime-presentation-evidence.mjs
+++ b/lib/fixture-matrix/runtime-presentation-evidence.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { shellToken } from './shared/utils.mjs';
+import { isImagePath, shellToken } from './shared/utils.mjs';
 import { fixtureStepMetadata } from './steps/shared.mjs';
 
 export const RUNTIME_PRESENTATION_EVIDENCE_SCHEMA = 'blocks-engine/php-transformer/runtime-presentation-evidence/v1';
@@ -34,7 +34,7 @@ export function runtimePresentationEvidenceProbeStep({ fixture = {}, surface = {
   }
   const sourceRootUrl = normalizedSourceUrl.slice(0, -entrypoint.length);
   const assets = Object.fromEntries((artifact?.files || [])
-    .filter((file) => /^image\//.test(file.type || ''))
+    .filter((file) => isImagePath(file.path))
     .map((file) => [String(file.path).replace(/^website\//, ''), createHash('sha256').update(file.content_base64 || '').digest('hex')]));
   const script = `const assets=${JSON.stringify(assets)}; const sourceRoot=new URL(${JSON.stringify(sourceRootUrl)},location.href).pathname; const selector=(n)=>{const p=n.parentElement;if(!p)return n.tagName.toLowerCase();const s=[...p.children].filter(x=>x.tagName===n.tagName);return selector(p)+' > '+n.tagName.toLowerCase()+':nth-of-type('+(s.indexOf(n)+1)+')'}; const clip=(n)=>{let p=n.parentElement;while(p){const s=getComputedStyle(p);if(/(hidden|clip|scroll|auto)/.test(s.overflow+s.overflowX+s.overflowY)){const r=p.getBoundingClientRect();return {x:r.x,y:r.y,width:r.width,height:r.height}}p=p.parentElement}const r=n.getBoundingClientRect();return {x:r.x,y:r.y,width:r.width,height:r.height}}; const browserVersion=(navigator.userAgent.match(/(?:HeadlessChrome|Chrome)\\/([^\\s]+)/)||[])[1]||'unknown'; return {schema:'${RUNTIME_PRESENTATION_EVIDENCE_SCHEMA}',provenance:{browser:{name:'Chromium',version:browserVersion},viewport:{width:innerWidth,height:innerHeight,device_scale_factor:devicePixelRatio},lifecycle:{phase:'network-idle'}},observations:[...document.images].map(n=>{const r=n.getBoundingClientRect(),s=getComputedStyle(n),m=(s.transform.match(/-?[\\d.]+/g)||[]).map(Number),pathname=new URL(n.currentSrc||n.src,location.href).pathname,path=pathname.startsWith(sourceRoot)?decodeURIComponent(pathname.slice(sourceRoot.length)).replace(/^\\/+/, ''):'';return {element:{source_path:'website/${entrypoint}',selector:selector(n)},asset_hash:assets[path]||'',intrinsic:{width:n.naturalWidth,height:n.naturalHeight},rendered:{width:r.width,height:r.height},transform:{matrix:m.length===6?m:[1,0,0,1,0,0],origin:{x:parseFloat(s.transformOrigin)||0,y:parseFloat(s.transformOrigin.split(' ')[1])||0}},clip:clip(n)}}).filter(x=>x.asset_hash&&x.intrinsic.width>0&&x.intrinsic.height>0&&x.rendered.width>0&&x.rendered.height>0)};`;
   const probeScript = script

--- a/lib/fixture-matrix/shared/utils.mjs
+++ b/lib/fixture-matrix/shared/utils.mjs
@@ -82,11 +82,17 @@ export function fileType(filePath) {
   if (extension === '.webp') {
     return 'image/webp';
   }
+  if (extension === '.gif') {
+    return 'image/gif';
+  }
+  if (extension === '.avif') {
+    return 'image/avif';
+  }
   return 'application/octet-stream';
 }
 
 export function isImagePath(filePath) {
-  return /\.(png|jpe?g|gif|webp|svg)$/i.test(filePath);
+  return /\.(png|jpe?g|gif|avif|webp|svg)$/i.test(filePath);
 }
 
 export function isTextPayloadType(type) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -742,6 +742,29 @@ test('runtime presentation evidence binds staged URLs to artifact paths and payl
   assert.doesNotMatch(script, /version:navigator\.userAgent/);
 });
 
+test('runtime presentation evidence binds images with generic MIME but excludes unrelated binary files', () => {
+  const gifBytes = Buffer.from('animated image bytes');
+  const avifBytes = Buffer.from('avif payload');
+  const zipBytes = Buffer.from('binary payload');
+  const gifHash = createHash('sha256').update(gifBytes.toString('base64')).digest('hex');
+  const avifHash = createHash('sha256').update(avifBytes.toString('base64')).digest('hex');
+  const probe = runtimePresentationEvidenceProbeStep({
+    fixture: { id: 'media-site', entrypoint: 'pages/team.html' },
+    sourceUrl: '/wp-content/uploads/fixtures/media-site/source/pages/team.html',
+    artifact: {
+      files: [
+        { path: 'website/images/team.gif', type: 'application/octet-stream', content_base64: gifBytes.toString('base64') },
+        { path: 'website/images/team.avif', type: 'image/avif', content_base64: avifBytes.toString('base64') },
+        { path: 'website/downloads/archive.zip', type: 'application/octet-stream', content_base64: zipBytes.toString('base64') },
+      ],
+    },
+  });
+  const script = probe.args.find((arg) => arg.startsWith('script='));
+  assert.match(script, new RegExp(`images/team\\.gif":\\"${gifHash}\\"`));
+  assert.match(script, new RegExp(`images/team\\.avif":\\"${avifHash}\\"`));
+  assert.doesNotMatch(script, /downloads\/archive\.zip/);
+});
+
 test('runtime presentation evidence intake preserves a typed envelope and diagnoses an unmerged probe', () => {
   const unavailable = collectRuntimePresentationEvidence([{ command: 'wordpress.browser-probe', metadata: { phase: 'runtime-presentation-evidence' } }]);
   assert.equal(unavailable.evidence, null);


### PR DESCRIPTION
Fixes #821.

## Summary
- Classify runtime presentation evidence assets by path extension via the existing `isImagePath()` instead of MIME prefix (`/^image\//`), so images with a generic MIME declaration (e.g. `.gif` typed as `application/octet-stream`) are still bound into the browser asset hash map.
- Add `.gif` → `image/gif` and `.avif` → `image/avif` to `fileType()` and add `.avif` to `isImagePath()`, matching the extension map used downstream by blocks-engine's `ArtifactNormalizer`.
- Add coverage for generic-MIME `.gif`/`.avif` inclusion and unrelated-binary exclusion in `tools/fixture-matrix.test.mjs`.

## Test Plan
- `npm run test:fixture-matrix` — 249/249 pass.
- `npm test` — 45/45 on changed scope. One remaining failure (`smoke-url-batch-import.php`) also fails on clean `main` and is unrelated.