### PR TITLE
Use released PHP Transformer 0.4.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
       "type": "package",
       "package": {
         "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.4.11-dev",
-        "description": "Temporary Blocks Engine PR 801 reference; replace with the released php-transformer package version.",
+        "version": "0.4.11",
+        "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
         "type": "library",
         "license": "GPL-3.0-or-later",
         "source": {
           "type": "git",
           "url": "https://github.com/Automattic/blocks-engine.git",
-          "reference": "59fb67556237bed001b11e9272cbeb81a240d2ba"
+          "reference": "c97c53b14d6c14faadc780be0fbc0e7e4010c2a0"
         },
         "dist": {
           "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine/archive/59fb67556237bed001b11e9272cbeb81a240d2ba.zip",
-          "reference": "59fb67556237bed001b11e9272cbeb81a240d2ba"
+          "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.11.zip",
+          "reference": "c97c53b14d6c14faadc780be0fbc0e7e4010c2a0"
         },
         "autoload": {
           "psr-4": {
@@ -73,7 +73,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "0.4.11-dev",
+    "automattic/blocks-engine-php-transformer": "^0.4.11",
     "php": "^8.1"
   },
   "minimum-stability": "dev",
@@ -83,8 +83,5 @@
       "php": "8.2.0"
     },
     "sort-packages": true
-  },
-  "extra": {
-    "static-site-importer-temporary-dependency": "Blocks Engine PR 801 commit 59fb6755; replace this package reference with the released php-transformer version."
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca00ed1e044fd3cbe9fb9eb9da141192",
+    "content-hash": "bf96a24a7de0b7dbb284240386cc9fbd",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.4.11-dev",
+            "version": "0.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "59fb67556237bed001b11e9272cbeb81a240d2ba"
+                "reference": "c97c53b14d6c14faadc780be0fbc0e7e4010c2a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine/archive/59fb67556237bed001b11e9272cbeb81a240d2ba.zip",
-                "reference": "59fb67556237bed001b11e9272cbeb81a240d2ba"
+                "url": "https://github.com/Automattic/blocks-engine/archive/refs/tags/php-transformer-v0.4.11.zip",
+                "reference": "c97c53b14d6c14faadc780be0fbc0e7e4010c2a0"
             },
             "require": {
                 "league/commonmark": "^2.5",
@@ -68,7 +68,7 @@
             "license": [
                 "GPL-3.0-or-later"
             ],
-            "description": "Temporary Blocks Engine PR 801 reference; replace with the released php-transformer package version."
+            "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs."
         },
         {
             "name": "dflydev/dot-access-data",
@@ -790,9 +790,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "automattic/blocks-engine-php-transformer": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## Summary

- replace the temporary Blocks Engine PR 801 commit package with released `php-transformer-v0.4.11`
- remove the temporary dependency marker and Composer dev stability flag
- retain the staged-source implementation SSI already exercised from the pre-release commit

## Verification

- `composer update automattic/blocks-engine-php-transformer --with-dependencies --no-interaction`
- `composer validate --strict`
- verified the released tag contains the temporary commit implementation plus packaging metadata

Homeboy Lab verification is pending because the managed runner remains stale after the approved binary refresh/reconnect; repository CI is the authoritative matrix for this dependency-only change.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode compared the release and temporary revisions, updated Composer metadata, validated installation, and drafted this PR. Chris Huber remains responsible for every line.