### PR TITLE
Consolidate URL imports behind one resumable contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ PHP consumers can build the same blueprint with `static_site_importer_playground
 
 URL intake rules:
 
-- Fetches one URL by default and does not execute JavaScript.
-- `provider_args.collect_site=true` or CLI `--collect-site` enables bounded collection. It reads the origin's `/sitemap.xml`, follows same-origin HTML links, collects directly referenced page assets and nested CSS assets, and emits one canonical website artifact.
-- Collection defaults to 20 pages, 200 assets, 50 MiB total, 5 MiB per response, and 100 ms between requests. Limits can be configured with `max_pages`, `max_assets`, `max_total_bytes`, `max_bytes`, and `request_delay_ms` up to the collector's hard caps.
-- URL collection defaults to the frozen static artifact policy: executable and data scripts are omitted with reason-coded provenance because the server-rendered output does not require them. Select `include_scripts=true` or CLI `--retain-scripts` for full legacy script retention when the caller provides the runtime-preservation contract; use `include_scripts=false` or `--skip-scripts` to explicitly omit every script.
+- Every built-in URL import collects the bounded site through the resumable batch engine. It reads the origin's `/sitemap.xml`, follows same-origin HTML links, and collects directly referenced page assets and nested CSS assets.
+- SSI owns collection, batch, deadline, asset, byte, pacing, and script-policy defaults. Hosts can adjust this policy with the `static_site_importer_url_batch_import_args` filter.
+- The first `static-site-importer/import-url` call returns an opaque `import_id`. To continue a pending run, call the same ability with the normalized URL and import intent plus that ID. SSI resolves the server-owned workspace and validates the URL, import options, and current user; no filesystem path is accepted or returned.
+- URL collection uses the frozen static artifact policy: executable and data scripts are omitted with reason-coded provenance because the server-rendered output does not require them.
 - Registered source-exclusion rules remove non-authored platform chrome before asset discovery and compilation. Each removal records selector, provider, reason, and before/after hashes under `source_metadata.collection.source_exclusions`; set `exclude_platform_chrome=false` to preserve the raw source.
 - Extensions can add or replace source-exclusion rules with the `static_site_importer_source_exclusion_rules` filter. Rules use stable ID selectors and reason-coded categories so removals remain explicit and auditable.
 - External assets must be directly referenced by fetched HTML or CSS and pass the same public-IP and redirect validation as page URLs.
@@ -271,9 +271,6 @@ wp static-site-importer import-url https://example.com/ \
   --report=report.json
 
 wp static-site-importer import-url https://example.com/ \
-  --collect-site \
-  --max-pages=20 \
-  --max-assets=100 \
   --slug=example-site \
   --activate \
   --overwrite

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -163,16 +163,14 @@ if ( ! function_exists( 'static_site_importer_register_abilities' ) ) {
 			'static-site-importer/import-url',
 			array(
 				'label'               => __( 'Import URL', 'static-site-importer' ),
-				'description'         => __( 'Import one public HTML URL or collect a bounded public static site through a URL extraction provider.', 'static-site-importer' ),
+				'description'         => __( 'Import a public static site from a URL. The importer manages bounded resumable collection; pass import_id to continue a prior run.', 'static-site-importer' ),
 				'category'            => STATIC_SITE_IMPORTER_ABILITY_CATEGORY,
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array_merge(
 						array(
-							'url'           => array( 'type' => 'string' ),
-							'provider'      => array( 'type' => 'string' ),
-							'provider_args' => array( 'type' => 'object' ),
-							'work_dir'      => array( 'type' => 'string' ),
+							'url'       => array( 'type' => 'string' ),
+							'import_id' => array( 'type' => 'string' ),
 						),
 						$import_properties
 					),
@@ -372,6 +370,10 @@ if ( ! function_exists( 'static_site_importer_ability_import_url' ) ) {
 			'success'               => true,
 			'result'                => $result,
 			'import_report_summary' => isset( $result['import_report_summary'] ) && is_array( $result['import_report_summary'] ) ? $result['import_report_summary'] : array(),
+			'import_id'             => isset( $result['import_id'] ) ? (string) $result['import_id'] : '',
+			'continuation'          => ! empty( $result['continuation'] ),
+			'continuation_reason'   => isset( $result['continuation_reason'] ) ? (string) $result['continuation_reason'] : '',
+			'url_batch_run'         => isset( $result['url_batch_run'] ) && is_array( $result['url_batch_run'] ) ? $result['url_batch_run'] : array(),
 		);
 	}
 }

--- a/includes/class-static-site-importer-url-import-runtime.php
+++ b/includes/class-static-site-importer-url-import-runtime.php
@@ -43,6 +43,9 @@ class Static_Site_Importer_URL_Import_Runtime {
 			return new WP_Error( 'static_site_importer_missing_url', 'The url input is required.' );
 		}
 		$input['url']    = $url;
+		if ( ! empty( $input['import_id'] ) ) {
+			return self::continue_batch_import( $url, $input );
+		}
 		$request         = self::provider_request( $url, $input );
 		$provider_output = self::provider_output( $request );
 		if ( is_wp_error( $provider_output ) ) {
@@ -50,10 +53,8 @@ class Static_Site_Importer_URL_Import_Runtime {
 		}
 		if ( is_array( $provider_output ) ) {
 			$runtime = $provider_output;
-		} elseif ( ! empty( $request['provider_args']['collect_site'] ) && array_key_exists( 'batch_pages', $request['provider_args'] ) ) {
-			return Static_Site_Importer_URL_Batch_Import::import( $request, $input );
 		} else {
-			$runtime = self::fetch_public_url_provider( $request );
+			return self::start_batch_import( $url, $input );
 		}
 		if ( is_wp_error( $runtime ) ) {
 			return $runtime;
@@ -107,7 +108,7 @@ class Static_Site_Importer_URL_Import_Runtime {
 			'url'             => $url,
 			'provider'        => isset( $input['provider'] ) ? (string) $input['provider'] : '',
 			'provider_args'   => isset( $input['provider_args'] ) && is_array( $input['provider_args'] ) ? $input['provider_args'] : array(),
-			'work_dir'        => ! empty( $input['work_dir'] ) ? (string) $input['work_dir'] : self::default_work_dir(),
+			'work_dir'        => self::default_work_dir(),
 			'source_metadata' => isset( $input['source_metadata'] ) && is_array( $input['source_metadata'] ) ? $input['source_metadata'] : array(),
 		);
 	}
@@ -213,6 +214,127 @@ class Static_Site_Importer_URL_Import_Runtime {
 	/** @return array<string,mixed> */
 	public static function batch_import_args( array $input, array $runtime ): array {
 		return self::import_args( $input, $runtime );
+	}
+
+	/** @return array<string,mixed>|WP_Error */
+	private static function start_batch_import( string $url, array $input ) {
+		$identity = bin2hex( random_bytes( 32 ) );
+		$contract = self::batch_contract( $url, $input );
+		$registry = self::run_registry_path( $identity );
+		$record   = array(
+			'schema'    => 'static-site-importer/url-import-run/v1',
+			'identity'  => $identity,
+			'contract'  => $contract,
+			'workspace' => self::run_workspace( $identity ),
+		);
+		if ( ! wp_mkdir_p( dirname( $registry ) ) || false === file_put_contents( $registry, wp_json_encode( $record ) ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writes an importer-owned opaque run registry.
+			return new WP_Error( 'static_site_importer_url_import_run_unavailable', 'The URL import run workspace is unavailable.' );
+		}
+
+		return self::run_batch_import( $record, $input );
+	}
+
+	/** @return array<string,mixed>|WP_Error */
+	private static function continue_batch_import( string $url, array $input ) {
+		$identity = (string) $input['import_id'];
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $identity ) ) {
+			return new WP_Error( 'static_site_importer_invalid_url_import_id', 'The import_id is invalid.' );
+		}
+		$registry = self::run_registry_path( $identity );
+		$raw      = is_file( $registry ) ? file_get_contents( $registry ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads an importer-owned opaque run registry.
+		$record   = is_string( $raw ) ? json_decode( $raw, true ) : null;
+		if ( ! is_array( $record ) || 'static-site-importer/url-import-run/v1' !== ( $record['schema'] ?? '' ) || $identity !== ( $record['identity'] ?? '' ) || self::run_workspace( $identity ) !== ( $record['workspace'] ?? '' ) ) {
+			return new WP_Error( 'static_site_importer_url_import_run_not_found', 'The URL import run was not found.' );
+		}
+		if ( self::canonical( self::batch_contract( $url, $input ) ) !== self::canonical( $record['contract'] ?? array() ) ) {
+			return new WP_Error( 'static_site_importer_url_import_run_mismatch', 'The URL import identity does not match this URL, import options, or user.' );
+		}
+
+		return self::run_batch_import( $record, $input );
+	}
+
+	/** @param array<string,mixed> $record @return array<string,mixed>|WP_Error */
+	private static function run_batch_import( array $record, array $input ) {
+		$request = self::provider_request( (string) $record['contract']['url'], $input );
+		$request['work_dir']      = (string) $record['workspace'];
+		$request['provider_args'] = self::batch_args();
+		$fetcher = apply_filters( 'static_site_importer_url_batch_import_fetcher', null, $request, $input );
+		$importer = apply_filters( 'static_site_importer_url_batch_importer', null, $request, $input );
+		$result = Static_Site_Importer_URL_Batch_Import::import( $request, $input, is_callable( $fetcher ) ? $fetcher : null, is_callable( $importer ) ? $importer : null );
+		if ( is_wp_error( $result ) ) {
+			$data = $result->get_error_data();
+			if ( is_array( $data ) ) {
+				unset( $data['expired_manifest'], $data['archived_manifest'], $data['cleanup'] );
+			}
+			return new WP_Error( $result->get_error_code(), $result->get_error_message(), $data );
+		}
+		$result['import_id'] = (string) $record['identity'];
+		if ( isset( $result['url_batch_run'] ) && is_array( $result['url_batch_run'] ) ) {
+			unset( $result['url_batch_run']['run_manifest'] );
+			unset( $result['url_batch_run']['cleanup'], $result['url_batch_run']['legacy_cache_cleanup'] );
+			$result['url_batch_run']['import_id'] = (string) $record['identity'];
+		}
+
+		return $result;
+	}
+
+	/** @return array<string,mixed> */
+	private static function batch_contract( string $url, array $input ): array {
+		$options = Static_Site_Importer_Website_Artifact_Import_Input::normalize( $input );
+		return self::canonical(
+			array(
+				'url'     => $url,
+				'options' => $options,
+				'user_id' => function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0,
+			)
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function batch_args(): array {
+		$args = array(
+			'collect_site'                       => true,
+			'batch_pages'                        => 20,
+			'max_effective_batches_per_invocation' => 1,
+			'max_invocation_seconds'              => 20,
+			'max_pages'                           => 20,
+			'max_assets'                          => 2000,
+			'max_total_bytes'                     => 268435456,
+			'max_bytes'                           => 5242880,
+			'timeout'                             => 10,
+			'request_delay_ms'                    => 100,
+			'include_scripts'                     => false,
+		);
+		/** @param array<string,mixed> $args Server-owned URL batch policy. */
+		return apply_filters( 'static_site_importer_url_batch_import_args', $args );
+	}
+
+	private static function run_registry_path( string $identity ): string {
+		return trailingslashit( self::url_import_root() ) . 'runs/' . $identity . '.json';
+	}
+
+	private static function run_workspace( string $identity ): string {
+		return trailingslashit( self::url_import_root() ) . 'workspaces/' . $identity;
+	}
+
+	private static function url_import_root(): string {
+		$upload_dir = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
+		$base_dir   = isset( $upload_dir['basedir'] ) ? (string) $upload_dir['basedir'] : sys_get_temp_dir();
+		return trailingslashit( $base_dir ) . 'static-site-importer/url-imports';
+	}
+
+	/** @param array<string,mixed> $value @return array<string,mixed> */
+	private static function canonical( array $value ): array {
+		foreach ( $value as &$item ) {
+			if ( is_array( $item ) ) {
+				$item = self::canonical( $item );
+			}
+		}
+		unset( $item );
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value, SORT_STRING );
+		}
+		return $value;
 	}
 
 	/**

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -231,25 +231,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				WP_CLI::error( 'Provide a public source URL.' );
 			}
 
-			$provider_args = array();
-			if ( isset( $assoc_args['collect-site'] ) ) {
-				$provider_args['collect_site'] = true;
-			}
-			if ( isset( $assoc_args['skip-scripts'] ) ) {
-				$provider_args['include_scripts'] = false;
-			}
-			if ( isset( $assoc_args['retain-scripts'] ) ) {
-				$provider_args['include_scripts'] = true;
-			}
-			foreach ( array( 'batch-pages', 'max-pages', 'max-assets', 'max-total-bytes', 'request-delay-ms', 'timeout', 'max-bytes' ) as $key ) {
-				if ( isset( $assoc_args[ $key ] ) ) {
-					$provider_args[ str_replace( '-', '_', $key ) ] = (int) $assoc_args[ $key ];
-				}
-			}
-
 			$input  = array(
 				'url'                       => $url,
-				'provider_args'             => $provider_args,
 				'slug'                      => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
 				'name'                      => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
 				'site_title'                => isset( $assoc_args['site-title'] ) ? (string) $assoc_args['site-title'] : '',
@@ -259,9 +242,12 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				'fail_on_quality'           => isset( $assoc_args['fail-on-quality'] ),
 				'allow_missing_woocommerce' => isset( $assoc_args['allow-missing-woocommerce'] ),
 				'report'                    => isset( $assoc_args['report'] ) ? (string) $assoc_args['report'] : '',
-				'work_dir'                  => isset( $assoc_args['work-dir'] ) ? (string) $assoc_args['work-dir'] : '',
 			);
 			$result = static_site_importer_ability_import_url( $input );
+			while ( ! empty( $result['success'] ) && ! empty( $result['continuation'] ) ) {
+				$input['import_id'] = (string) ( $result['import_id'] ?? '' );
+				$result             = static_site_importer_ability_import_url( $input );
+			}
 			if ( empty( $result['success'] ) ) {
 				$error = isset( $result['error'] ) && is_array( $result['error'] ) ? $result['error'] : array();
 				WP_CLI::error( (string) ( $error['message'] ?? 'Static site URL import failed.' ) );

--- a/tests/smoke-ability-registration-idempotent.php
+++ b/tests/smoke-ability-registration-idempotent.php
@@ -72,6 +72,9 @@ foreach ( array( 'static-site-importer/import-website-artifact', 'static-site-im
 	assert( 'string' === $properties['site_title']['type'] );
 	assert( array( 'report_only', 'draft' ) === $properties['stale_page_action']['enum'] );
 }
+$url_properties = $GLOBALS['ssi_abilities']['static-site-importer/import-url']['input_schema']['properties'];
+assert( isset( $url_properties['import_id'] ) );
+assert( ! isset( $url_properties['provider'] ) && ! isset( $url_properties['provider_args'] ) && ! isset( $url_properties['work_dir'] ) );
 $manifest_result = static_site_importer_ability_get_runtime_package_manifest();
 assert( true === $manifest_result['success'] );
 assert( 'static-site-importer/runtime-package-manifest/v1' === $manifest_result['manifest']['schema'] );

--- a/tests/smoke-url-batch-import.php
+++ b/tests/smoke-url-batch-import.php
@@ -8,12 +8,22 @@ function trailingslashit( string $path ): string { return rtrim( $path, '/' ) . 
 function wp_mkdir_p( string $path ): bool { return is_dir( $path ) || mkdir( $path, 0777, true ); }
 function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
 function wp_delete_file( string $path ): bool { return false; }
+function wp_generate_uuid4(): string { return bin2hex( random_bytes( 16 ) ); }
+function get_current_user_id(): int { return (int) ( $GLOBALS['ssi_test_user_id'] ?? 1 ); }
+function wp_upload_dir(): array { return array( 'basedir' => sys_get_temp_dir() . '/ssi-url-runtime' ); }
+$GLOBALS['ssi_test_filters'] = array();
+function add_filter( string $hook, callable $callback ): void { $GLOBALS['ssi_test_filters'][ $hook ][] = $callback; }
+function add_action( string $hook, callable $callback ): void { $GLOBALS['ssi_test_filters'][ $hook ][] = $callback; }
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed { foreach ( $GLOBALS['ssi_test_filters'][ $hook ] ?? array() as $callback ) { $value = $callback( $value, ...$args ); } return $value; }
+function did_action( string $hook ): int { return 0; }
+function doing_action( string $hook ): bool { return false; }
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 function wp_parse_url( string $url, int $component = -1 ) { return parse_url( $url, $component ); }
 function wp_strip_all_tags( string $text ): string { return strip_tags( $text ); }
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-fetcher.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-site-collector.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-import-runtime.php';
+require_once dirname( __DIR__ ) . '/includes/abilities.php';
 
 $legacy_path = tempnam( sys_get_temp_dir(), 'ssi-legacy-' ); $delete_legacy_file = new ReflectionMethod( Static_Site_Importer_URL_Batch_Import::class, 'delete_legacy_file' ); if ( ! $delete_legacy_file->invoke( null, $legacy_path ) || is_file( $legacy_path ) ) { throw new RuntimeException( 'legacy cache cleanup must unlink its verified exact path without wp_delete_file filters' ); }
 
@@ -211,4 +221,23 @@ $negative_fetcher = static function ( string $url, array $args ) use ( &$negativ
 $negative_result = Static_Site_Importer_URL_Batch_Import::import( $negative_request, array(), $negative_fetcher, static fn() => array( 'theme_slug' => 'negative', 'import_report_summary' => array( 'status' => 'completed' ) ) );
 $negative_resume = Static_Site_Importer_URL_Batch_Import::import( $negative_request, array(), $negative_fetcher, static fn() => array() );
 if ( is_wp_error( $negative_result ) || is_wp_error( $negative_resume ) || 2 !== $negative_asset_calls || 1 > ( $negative_result['url_batch_run']['fetch_cache']['negative_writes'] ?? 0 ) || 2 !== ( $negative_result['url_batch_run']['external_asset_retained']['count'] ?? 0 ) ) { throw new RuntimeException( 'negative cache failures must retain optional singleton assets without exposing internal cache hooks' ); }
+
+$runtime_imports = array();
+add_filter( 'static_site_importer_url_batch_import_args', static fn(): array => array( 'collect_site' => true, 'batch_pages' => 1, 'max_effective_batches_per_invocation' => 1, 'request_delay_ms' => 0, 'max_assets' => 10, 'max_total_bytes' => 1024 * 1024, 'include_scripts' => false ) );
+add_filter( 'static_site_importer_url_batch_import_fetcher', static fn() => static function ( string $url ): array { if ( 'https://runtime.test/sitemap.xml' === $url ) { return array( 'body' => '<urlset><url><loc>https://runtime.test/</loc></url><url><loc>https://runtime.test/about/</loc></url></urlset>', 'metadata' => array( 'content_type' => 'application/xml', 'final_url' => $url ) ); } if ( 'https://runtime-one.test/sitemap.xml' === $url ) { return array( 'body' => '<urlset><url><loc>https://runtime-one.test/</loc></url></urlset>', 'metadata' => array( 'content_type' => 'application/xml', 'final_url' => $url ) ); } return array( 'body' => '<main>' . $url . '</main>', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) ); } );
+add_filter( 'static_site_importer_url_batch_importer', static function () use ( &$runtime_imports ) { return static function ( array $artifact, array $args ) use ( &$runtime_imports ): array { $runtime_imports[] = $args; return array( 'theme_slug' => 'runtime', 'import_report_summary' => array( 'status' => 'completed' ) ); }; } );
+$runtime_input = array( 'url' => 'https://runtime.test/', 'slug' => 'runtime', 'activate' => true );
+$runtime_first = Static_Site_Importer_URL_Import_Runtime::import_url( $runtime_input );
+if ( is_wp_error( $runtime_first ) || empty( $runtime_first['continuation'] ) || ! preg_match( '/^[a-f0-9]{64}$/', (string) ( $runtime_first['import_id'] ?? '' ) ) || isset( $runtime_first['url_batch_run']['run_manifest'] ) || 1 !== ( $runtime_first['url_batch_run']['completed_routes'] ?? 0 ) ) { throw new RuntimeException( 'public URL imports must use opaque, path-free resumable batch runs without caller mode flags' ); }
+$runtime_input['import_id'] = $runtime_first['import_id'];
+$runtime_second = Static_Site_Importer_URL_Import_Runtime::import_url( $runtime_input );
+if ( is_wp_error( $runtime_second ) || 'completed' !== ( $runtime_second['url_batch_run']['status'] ?? '' ) || $runtime_first['import_id'] !== ( $runtime_second['import_id'] ?? '' ) || 2 !== count( $runtime_imports ) || true !== ( $runtime_imports[1]['activate'] ?? false ) ) { throw new RuntimeException( 'opaque continuation must resume the server-owned workspace and preserve terminal activation' ); }
+$changed_url = $runtime_input; $changed_url['url'] = 'https://other.test/';
+$changed_options = $runtime_input; $changed_options['activate'] = false;
+$GLOBALS['ssi_test_user_id'] = 2; $changed_user = Static_Site_Importer_URL_Import_Runtime::import_url( $runtime_input ); $GLOBALS['ssi_test_user_id'] = 1;
+if ( ! is_wp_error( Static_Site_Importer_URL_Import_Runtime::import_url( $changed_url ) ) || ! is_wp_error( Static_Site_Importer_URL_Import_Runtime::import_url( $changed_options ) ) || ! is_wp_error( $changed_user ) ) { throw new RuntimeException( 'opaque identities must reject URL, import-option, and user changes' ); }
+$runtime_one = Static_Site_Importer_URL_Import_Runtime::import_url( array( 'url' => 'https://runtime-one.test/', 'slug' => 'runtime-one' ) );
+$runtime_replay = Static_Site_Importer_URL_Import_Runtime::import_url( array( 'url' => 'https://runtime.test/', 'slug' => 'runtime', 'activate' => true, 'import_id' => $runtime_first['import_id'] ) );
+$ability_replay = static_site_importer_ability_import_url( array( 'url' => 'https://runtime.test/', 'slug' => 'runtime', 'activate' => true, 'import_id' => $runtime_first['import_id'] ) );
+if ( is_wp_error( $runtime_one ) || 'completed' !== ( $runtime_one['url_batch_run']['status'] ?? '' ) || empty( $runtime_one['import_id'] ) || is_wp_error( $runtime_replay ) || 'completed' !== ( $runtime_replay['url_batch_run']['status'] ?? '' ) || $runtime_first['import_id'] !== ( $ability_replay['import_id'] ?? '' ) || 'completed' !== ( $ability_replay['import_report_summary']['status'] ?? '' ) || 'completed' !== ( $ability_replay['url_batch_run']['status'] ?? '' ) ) { throw new RuntimeException( 'single-route imports, completed-run replays, and ability envelopes must preserve the opaque batch contract' ); }
 echo "URL batch import smoke passed.\n";

--- a/tests/smoke-url-import-runtime.php
+++ b/tests/smoke-url-import-runtime.php
@@ -181,8 +181,8 @@ $assert( 'external-caller' === ( Static_Site_Importer_Theme_Generator::$last_arg
 $assert( 'private' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['visibility'] ?? '' ), 'provider-metadata-merged' );
 $assert( 'test-private-runtime' === ( Static_Site_Importer_Theme_Generator::$last_args['source_metadata']['url_import_provider'] ?? '' ), 'provider-recorded' );
 
-$batch_provider_result = Static_Site_Importer_URL_Import_Runtime::import_url( array( 'url' => 'private.example.test/', 'slug' => 'private-batch-request', 'provider_args' => array( 'collect_site' => true, 'batch_pages' => 2 ) ) );
-$assert( ! is_wp_error( $batch_provider_result ) && 'private-batch-request' === ( $batch_provider_result['theme_slug'] ?? '' ) && empty( $batch_provider_result['url_batch_run'] ), 'external-provider-keeps-normal-import-contract-for-batch-request' );
+$provider_result = Static_Site_Importer_URL_Import_Runtime::import_url( array( 'url' => 'private.example.test/', 'slug' => 'private-provider-request' ) );
+$assert( ! is_wp_error( $provider_result ) && 'private-provider-request' === ( $provider_result['theme_slug'] ?? '' ) && empty( $provider_result['url_batch_run'] ), 'external-provider-keeps-normal-artifact-import-contract' );
 
 $runtime_artifact = Static_Site_Importer_URL_Import_Runtime::website_artifact_from_url(
 	array(


### PR DESCRIPTION
## Summary
- route built-in public URL imports through one canonical resumable batch engine
- expose opaque URL/options/user-bound import identity and path-free progress
- keep provider artifacts on the normal artifact importer and simplify CLI projection

## Verification
- changed-PHP syntax checks
- `php tests/smoke-url-import-runtime.php`
- `php tests/smoke-url-batch-import.php`
- `php tests/smoke-url-site-collector.php`
- `php tests/smoke-importer-block.php`
- `npm run test:runtime-package`

Closes #832.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode traced the split runtime, implemented the consolidated contract, and ran focused verification. Chris Huber remains responsible for every line.