### PR TITLE
Fix fixture matrix empty-root planning

### DIFF
--- a/lib/fixture-matrix/fixtures.mjs
+++ b/lib/fixture-matrix/fixtures.mjs
@@ -30,10 +30,11 @@ import {
 
 export function discoverFixtures(root, options = {}) {
   const requestedRoot = root || options.fixtureRoot || options.fixture_root;
-  if (isSymlink(requestedRoot)) {
-    throw new Error(`fixtureRoot must not be a symbolic link: ${requestedRoot}`);
+  const fixtureRoot = path.resolve(requestedRoot || '.');
+  const rootInspection = inspectFixtureDirectories(fixtureRoot, options);
+  if (rootInspection.exclusions[0]?.reason && ['root_missing', 'root_not_directory', 'root_symlink'].includes(rootInspection.exclusions[0].reason)) {
+    return [];
   }
-  const fixtureRoot = requiredDirectory(requestedRoot, 'fixtureRoot');
   const searchRoots = resolveFixtureSearchRoots(fixtureRoot);
   const entrypoint = options.entrypoint || 'index.html';
   const maxDepth = finiteNumber(options.maxDepth ?? options.max_depth, 2);
@@ -199,14 +200,6 @@ function isRealDirectory(directory) {
   }
 }
 
-function isSymlink(target) {
-  try {
-    return fs.lstatSync(target).isSymbolicLink();
-  } catch {
-    return false;
-  }
-}
-
 function corpusLabelForSearchRoot(searchRoot, fixtureRoot) {
   const normalizedSearchRoot = path.resolve(searchRoot);
   const normalizedFixtureRoot = path.resolve(fixtureRoot);
@@ -248,7 +241,16 @@ export function createFixtureMatrix(input = {}) {
 // directories and their authored metadata rather than a separately maintained
 // fixture count.
 export function buildFixtureCoverage(root, options = {}, selectedFixtures = [], filter = null) {
-  const fixtureRoot = requiredDirectory(root, 'fixtureRoot');
+  const fixtureRoot = path.resolve(root || '.');
+  const rootInspection = inspectFixtureDirectories(fixtureRoot, options);
+  if (rootInspection.exclusions[0]?.reason && ['root_missing', 'root_not_directory', 'root_symlink'].includes(rootInspection.exclusions[0].reason)) {
+    return {
+      schema: 'static-site-importer/fixture-matrix-coverage/v1',
+      active: coverageInventoryFromInspection('active', rootInspection, options),
+      solved: emptyCoverageInventory('solved', path.join(fixtureRoot, 'solved'), options),
+      gate: { status: 'passed', reasons: [] },
+    };
+  }
   const searchRoots = resolveFixtureSearchRoots(fixtureRoot);
   const selectedIds = new Set(selectedFixtures.map((fixture) => fixture.id));
   const inventories = searchRoots.map((searchRoot) => {
@@ -274,18 +276,7 @@ export function buildFixtureCoverage(root, options = {}, selectedFixtures = [], 
       ...eligible.filter((fixture) => !selectedIds.has(fixture.id)).map(({ id }) => ({ id, reason: filter ? 'filter_mismatch' : 'omitted' })),
       ...inspection.exclusions.map(({ id, reason }) => ({ id, reason })),
     ].sort((left, right) => left.id.localeCompare(right.id) || left.reason.localeCompare(right.reason));
-    return {
-      corpus,
-      root: inspection.root,
-      entrypoint: inspection.entrypoint,
-      discovered_fixture_ids: inspection.selected_ids,
-      eligible_fixture_ids: eligible.map((fixture) => fixture.id),
-      selected,
-      skipped,
-      malformed: inspection.malformed.map((fixture) => coverageRow({ corpus, root: inspection.root, fixture })),
-      duplicates: [...inspection.duplicates.map((fixture) => coverageRow({ corpus, root: inspection.root, fixture })), ...crossCorpusDuplicates]
-        .sort((left, right) => left.id.localeCompare(right.id) || left.corpus.localeCompare(right.corpus) || left.path.localeCompare(right.path)),
-    };
+    return coverageInventoryFromInspection(corpus, inspection, options, { eligible, selected, skipped, crossCorpusDuplicates });
   });
   const active = coverageInventories.find((inventory) => inventory.corpus === 'active') || emptyCoverageInventory('active', fixtureRoot, options);
   const solved = coverageInventories.find((inventory) => inventory.corpus === 'solved') || emptyCoverageInventory('solved', path.join(fixtureRoot, 'solved'), options);
@@ -299,6 +290,22 @@ export function buildFixtureCoverage(root, options = {}, selectedFixtures = [], 
       status: invalid.length || omitted.length ? 'failed' : 'passed',
       reasons: [...invalid, ...omitted].map((row) => row.reason).sort(),
     },
+  };
+}
+
+function coverageInventoryFromInspection(corpus, inspection, options, overrides = {}) {
+  const eligible = overrides.eligible || inspection.eligible;
+  return {
+    corpus,
+    root: inspection.root,
+    entrypoint: inspection.entrypoint || options.entrypoint || 'index.html',
+    discovered_fixture_ids: inspection.selected_ids,
+    eligible_fixture_ids: eligible.map((fixture) => fixture.id),
+    selected: overrides.selected || [],
+    skipped: overrides.skipped || inspection.exclusions.map(({ id, reason }) => ({ id, reason })),
+    malformed: inspection.malformed.map((fixture) => coverageRow({ corpus, root: inspection.root, fixture })),
+    duplicates: [...inspection.duplicates.map((fixture) => coverageRow({ corpus, root: inspection.root, fixture })), ...(overrides.crossCorpusDuplicates || [])]
+      .sort((left, right) => left.id.localeCompare(right.id) || left.corpus.localeCompare(right.corpus) || left.path.localeCompare(right.path)),
   };
 }
 

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -3592,6 +3592,24 @@ test('fixture selection fails closed for execution and keeps empty dry-run plann
   assert.equal(JSON.parse(dryRun.stdout).fixture_selection.status, 'planning_empty');
 });
 
+test('missing and top-level symlink roots retain planning-empty selection semantics', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-invalid-root-planning-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const externalRoot = path.join(root, 'external-fixtures');
+  const symlinkRoot = path.join(root, 'symlinked-fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(externalRoot, 'site'), { recursive: true });
+  writeFileSync(path.join(externalRoot, 'site', 'index.html'), '<h1>External</h1>');
+  symlinkSync(externalRoot, symlinkRoot);
+
+  for (const [fixtureRoot, reason] of [[path.join(root, 'missing-fixtures'), 'root_missing'], [symlinkRoot, 'root_symlink']]) {
+    const plan = buildFixtureMatrixRunPlan({ staticSiteImporter, fixtureRoot });
+    assert.equal(plan.execution_eligible, false);
+    assert.equal(plan.fixture_selection.status, 'planning_empty');
+    assert.equal(plan.fixture_selection.exclusions[0].reason, reason);
+  }
+});
+
 test('fixture selection reports one executable fixture and rejects typoed targets', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-one-selection-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -3573,7 +3573,7 @@ test('fixture selection fails closed for execution and keeps empty dry-run plann
   assert.equal(planned.summary.fixture_count, 0);
   await assert.rejects(
     runFixtureMatrix({ fixtureRoot, outputDirectory: path.join(root, 'executed'), staticSiteImporterPath: staticSiteImporter, tag: 'absent', run: true }),
-    /requires at least one executable fixture/,
+    /requires a complete eligible fixture inventory/,
   );
 
   const nonDirectoryRoot = path.join(root, 'not-a-directory');
@@ -3708,7 +3708,7 @@ test('top-level symlink fixture roots stay planning-empty and never stage an ext
   assert.equal(existsSync(path.join(outputDirectory, 'external-site', 'artifact.json')), false);
   await assert.rejects(
     runFixtureMatrix({ fixtureRoot, outputDirectory, staticSiteImporterPath: staticSiteImporter, run: true }),
-    /requires at least one executable fixture/,
+    /requires a complete eligible fixture inventory/,
   );
 });
 


### PR DESCRIPTION
## Summary
- restore `planning_empty` for missing, non-directory, and top-level symlink fixture roots before discovery
- preserve derived fixture coverage validation for real executable roots
- align invalid-root direct-bench assertions with #834's authoritative `requires a complete eligible fixture inventory` execution error
- follow up the premature merge of #834, which omitted this isolated compatibility fix

## Evidence
- `composer install --no-interaction --prefer-dist` hydrated the PHP dependencies.
- `node --test tools/fixture-matrix.test.mjs`: 255 passed, 0 failed.
- `node --test --test-name-pattern="fixture selection fails closed|top-level symlink fixture roots|missing and top-level symlink roots" tools/fixture-matrix.test.mjs`: 3 passed, 0 failed.
- PHP lane-equivalent manifest selection: 37 standalone-PHP tests passed.
- `node --check lib/fixture-matrix/fixtures.mjs && node --check lib/fixture-matrix/result.mjs && node --check tools/run-fixture-matrix.mjs && node --check bench/static-site-fixture-matrix.bench.mjs && node --check tools/fixture-matrix.test.mjs`
- `git diff --check origin/main...HEAD`
- The aggregate `npm test` runner has an unrelated timing-sensitive failure in the existing runner-progress test at `tools/fixture-matrix.test.mjs:5134` when it executes its Node suite alongside the manifest; the same full file passes standalone as above.
- No fixture matrix execution was run.

## Compatibility
- Existing invalid-root dry-run behavior is restored rather than throwing before the planner can report exclusions.
- The wrapper CLI continues to report its established planning-empty handoff message. Direct bench execution consistently reports the eligible-inventory contract.
- Real fixture roots retain malformed-metadata, duplicate-ID, and omission validation from #834.
- The change is limited to fixture discovery and focused test-contract coverage.

Refs #833
Follow-up to #834

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode rebased/cherry-picked the isolated fix, aligned the stale assertions, hydrated dependencies, ran focused/full Node and PHP-equivalent validation, and drafted this PR update. Chris Huber reviewed and owns every line.