### PR TITLE
fix(fonts): preserve source stylesheet on Google Fonts cap overflow

### DIFF
--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -1,28 +1,63 @@
-# Testing Instructions: Restore Repository Lint Gate (#750)
+# Testing instructions for #732
 
-## What Changed
+## What changed
 
-1. Restored `review lint` alongside `review test` in the Homeboy CI matrix.
-2. Applied PHPCBF to current production PHP, resolving 4,021 mechanical findings introduced before the gate was restored.
-3. Recorded the remaining 237 findings in Homeboy's repository baseline so unchanged debt passes and new findings fail the gate.
-4. Removed the stale PHPStan baseline entry for the deleted transformer adapter.
-5. Dropped the unsupported second argument to `ArtifactCompiler::compile()` while retaining `compiler_options` as an explicitly diagnosed compatibility no-op.
-6. Preserved the resumable import and SVG font behavior merged after the contributor branch was opened.
+A valid compiler font plan that exceeds SSI's fixed Google Fonts byte caps (CSS > 256 KiB or aggregate woff2 > 4 MiB) used to hard-abort the entire import. Now the import falls back to a preserved `@import` of the original Google stylesheet and continues, with a diagnostic that reports the exact cap reason and observed bytes.
 
-## Verification
+## Install
+
+1. Back up your existing `wp-content/plugins/static-site-importer/` directory.
+2. Unzip `static-site-importer-fix-732.zip` over your WordPress install so the new files land at `wp-content/plugins/static-site-importer/`.
+3. Activate (or reactivate) **Static Site Importer** from **Plugins**.
+4. Make sure the **Blocks Engine** PHP transformer dependency is installed (`composer install` from the plugin root if not already).
+
+## Test 1: standalone smoke (headless)
+
+From the plugin root:
 
 ```bash
-homeboy review lint --summary
-npm test
-for file in static-site-importer.php includes/*.php; do php -l "$file" >/dev/null || exit 1; done
+php tests/smoke-google-fonts-cap-fallback.php
+php tests/smoke-webfont-producer-consumer.php
 ```
 
-Expected results:
+The first new smoke covers CSS-too-large and aggregate-too-large fallbacks. The second is the producer-path regression sentinel and must still pass.
 
-- Homeboy lint passes with no drift from the 237-finding baseline.
-- The test manifest passes 42 selected checks: 34 standalone PHP and eight Node lanes.
-- Every production PHP file passes syntax validation.
+## Test 2: full fast lane
 
-## Ratcheting
+```bash
+npm test
+npm run test:inventory
+```
 
-When existing findings are repaired, run `homeboy review lint --ratchet` to remove resolved fingerprints from `homeboy.json`. New findings fail CI without requiring the existing debt to be repaired in the same change.
+A pre-existing failure in `tests/smoke-url-batch-import.php` is unrelated to this fix.
+
+## Test 3: end-to-end repro (per issue)
+
+The issue repro is the fixture matrix against `29-multilingual-i18n`. The expected behavior changes:
+
+```sh
+node tools/run-fixture-matrix.mjs --local --static-site-importer <path-to-this-plugin> --blocks-engine <path-to-blocks-engine> --target-fixture 29-multilingual-i18n --surface-coverage 7 --wp-codebox-bin <path-to-wp-codebox/bin/wp-codebox-source.mjs> --allow-stale-override --skip-install --skip-sync
+```
+
+What to look for:
+
+- The matrix output must NOT contain `static_site_importer_font_materialization_failed`.
+- The static front page is created.
+- Browser surfaces (Chrome/SVG parity surfaces) render text using the Noto Sans JP / Noto Naskh Arabic families.
+- The Homeboy evidence run shows a `font_materialization_partial_preserved` diagnostic with one of these inner reasons: `google_fonts_stylesheet_preserved_due_to_size` (CSS > 256 KiB) or `google_fonts_payloads_partial_preserved` (aggregate woff2 > 4 MiB). The diagnostic's `details.observed_bytes`, `details.limit_bytes`, and `details.url` fields should be populated.
+
+## Test 4: happy path regression
+
+Run a small Google Fonts fixture (1 family, 1 weight) through any normal import path. Embedded font asset should still be downloaded and embedded as a `data:font/woff2;base64,…` URL inside `assets/css/embedded-fonts.css`. No `font_materialization_partial_preserved` diagnostic should appear.
+
+## Rollback
+
+If something goes wrong, deactivate the plugin and restore the backup from step 1 of Install.
+
+## Files touched in this fix
+
+- `includes/class-static-site-importer-font-materializer.php` — return shape change in `resolve_google_font_faces()` and `embed_font_sources()`; new preservation branch in `prepare_overlay()`; new `diagnostic_with_detail()` helper
+- `tests/smoke-google-fonts-cap-fallback.php` — new standalone PHP smoke
+- `test-manifest.json`, `homeboy-test-manifest.json` — registered the new smoke
+
+Producer path (`materialize_producer_faces`) is untouched.

--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -1,63 +1,28 @@
-# Testing instructions for #732
+# Testing Instructions: Restore Repository Lint Gate (#750)
 
-## What changed
+## What Changed
 
-A valid compiler font plan that exceeds SSI's fixed Google Fonts byte caps (CSS > 256 KiB or aggregate woff2 > 4 MiB) used to hard-abort the entire import. Now the import falls back to a preserved `@import` of the original Google stylesheet and continues, with a diagnostic that reports the exact cap reason and observed bytes.
+1. Restored `review lint` alongside `review test` in the Homeboy CI matrix.
+2. Applied PHPCBF to current production PHP, resolving 4,021 mechanical findings introduced before the gate was restored.
+3. Recorded the remaining 237 findings in Homeboy's repository baseline so unchanged debt passes and new findings fail the gate.
+4. Removed the stale PHPStan baseline entry for the deleted transformer adapter.
+5. Dropped the unsupported second argument to `ArtifactCompiler::compile()` while retaining `compiler_options` as an explicitly diagnosed compatibility no-op.
+6. Preserved the resumable import and SVG font behavior merged after the contributor branch was opened.
 
-## Install
-
-1. Back up your existing `wp-content/plugins/static-site-importer/` directory.
-2. Unzip `static-site-importer-fix-732.zip` over your WordPress install so the new files land at `wp-content/plugins/static-site-importer/`.
-3. Activate (or reactivate) **Static Site Importer** from **Plugins**.
-4. Make sure the **Blocks Engine** PHP transformer dependency is installed (`composer install` from the plugin root if not already).
-
-## Test 1: standalone smoke (headless)
-
-From the plugin root:
+## Verification
 
 ```bash
-php tests/smoke-google-fonts-cap-fallback.php
-php tests/smoke-webfont-producer-consumer.php
-```
-
-The first new smoke covers CSS-too-large and aggregate-too-large fallbacks. The second is the producer-path regression sentinel and must still pass.
-
-## Test 2: full fast lane
-
-```bash
+homeboy review lint --summary
 npm test
-npm run test:inventory
+for file in static-site-importer.php includes/*.php; do php -l "$file" >/dev/null || exit 1; done
 ```
 
-A pre-existing failure in `tests/smoke-url-batch-import.php` is unrelated to this fix.
+Expected results:
 
-## Test 3: end-to-end repro (per issue)
+- Homeboy lint passes with no drift from the 237-finding baseline.
+- The test manifest passes 42 selected checks: 34 standalone PHP and eight Node lanes.
+- Every production PHP file passes syntax validation.
 
-The issue repro is the fixture matrix against `29-multilingual-i18n`. The expected behavior changes:
+## Ratcheting
 
-```sh
-node tools/run-fixture-matrix.mjs --local --static-site-importer <path-to-this-plugin> --blocks-engine <path-to-blocks-engine> --target-fixture 29-multilingual-i18n --surface-coverage 7 --wp-codebox-bin <path-to-wp-codebox/bin/wp-codebox-source.mjs> --allow-stale-override --skip-install --skip-sync
-```
-
-What to look for:
-
-- The matrix output must NOT contain `static_site_importer_font_materialization_failed`.
-- The static front page is created.
-- Browser surfaces (Chrome/SVG parity surfaces) render text using the Noto Sans JP / Noto Naskh Arabic families.
-- The Homeboy evidence run shows a `font_materialization_partial_preserved` diagnostic with one of these inner reasons: `google_fonts_stylesheet_preserved_due_to_size` (CSS > 256 KiB) or `google_fonts_payloads_partial_preserved` (aggregate woff2 > 4 MiB). The diagnostic's `details.observed_bytes`, `details.limit_bytes`, and `details.url` fields should be populated.
-
-## Test 4: happy path regression
-
-Run a small Google Fonts fixture (1 family, 1 weight) through any normal import path. Embedded font asset should still be downloaded and embedded as a `data:font/woff2;base64,…` URL inside `assets/css/embedded-fonts.css`. No `font_materialization_partial_preserved` diagnostic should appear.
-
-## Rollback
-
-If something goes wrong, deactivate the plugin and restore the backup from step 1 of Install.
-
-## Files touched in this fix
-
-- `includes/class-static-site-importer-font-materializer.php` — return shape change in `resolve_google_font_faces()` and `embed_font_sources()`; new preservation branch in `prepare_overlay()`; new `diagnostic_with_detail()` helper
-- `tests/smoke-google-fonts-cap-fallback.php` — new standalone PHP smoke
-- `test-manifest.json`, `homeboy-test-manifest.json` — registered the new smoke
-
-Producer path (`materialize_producer_faces`) is untouched.
+When existing findings are repaired, run `homeboy review lint --ratchet` to remove resolved fingerprints from `homeboy.json`. New findings fail CI without requiring the existing debt to be repaired in the same change.

--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -31,6 +31,7 @@
     "tests/smoke-validation-runtime-diagnostics.php": { "environment": "standalone-php" },
     "tests/smoke-visual-repair-css.php": { "environment": "standalone-php" },
     "tests/smoke-webfont-producer-consumer.php": { "environment": "standalone-php" },
+    "tests/smoke-google-fonts-cap-fallback.php": { "environment": "standalone-php" },
     "tests/smoke-website-artifact-import-input.php": { "environment": "standalone-php" },
     "tests/smoke-wordpress-site-plan-materializer.php": { "environment": "standalone-php" },
     "tests/smoke-artifact-run-primitives.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-font-materializer.php
+++ b/includes/class-static-site-importer-font-materializer.php
@@ -78,15 +78,63 @@ final class Static_Site_Importer_Font_Materializer {
 		}
 
 		$font_faces = self::resolve_google_font_faces( $plan, $families, $diagnostics );
-		if ( '' === $font_faces ) {
+		if ( is_array( $font_faces ) && isset( $font_faces['state'] ) && 'preserved' === $font_faces['state'] ) {
+			$preserved_url  = (string) ( $font_faces['url'] ?? '' );
+			$fallback_url   = self::is_google_stylesheet_url( $preserved_url ) ? $preserved_url : '';
+			$imports        = array();
+			foreach ( $plan['stylesheets'] ?? array() as $stylesheet ) {
+				$content = is_array( $stylesheet ) && is_scalar( $stylesheet['content'] ?? null ) ? (string) $stylesheet['content'] : '';
+				if ( preg_match_all( '/@import\s+(?:url\()?\s*["\']?([^"\'\s\)]+)["\']?\s*\)?/i', $content, $matches ) ) {
+					foreach ( $matches[1] as $candidate ) {
+						if ( self::is_google_stylesheet_url( $candidate ) ) {
+							$imports[] = $candidate;
+						}
+					}
+				}
+			}
+			$imports = array_values( array_unique( $imports ) );
+			if ( '' === $fallback_url && ! empty( $imports ) ) {
+				$fallback_url = $imports[0];
+			}
+			$css_lines = array();
+			foreach ( $imports as $import_url ) {
+				$css_lines[] = '@import "' . addcslashes( $import_url, "\"\\\n" ) . '";';
+			}
+			if ( empty( $css_lines ) && '' !== $fallback_url ) {
+				$css_lines[] = '@import "' . addcslashes( $fallback_url, "\"\\\n" ) . '";';
+			}
+			$css_body = empty( $css_lines ) ? '' : trim( implode( "\n", $css_lines ) ) . "\n";
+			$outer_detail = array(
+				'reason'         => (string) ( $font_faces['reason'] ?? '' ),
+				'observed_bytes' => (int) ( $font_faces['observed_bytes'] ?? 0 ),
+				'url'            => $preserved_url,
+			);
+			if ( 'google_fonts_payloads_partial_preserved' === $outer_detail['reason'] ) {
+				$outer_detail['limit_bytes']     = self::TOTAL_FONT_LIMIT;
+				$outer_detail['aggregate_bytes'] = (int) ( $font_faces['aggregate_bytes'] ?? $font_faces['observed_bytes'] );
+			} elseif ( 'google_fonts_stylesheet_preserved_due_to_size' === $outer_detail['reason'] ) {
+				$outer_detail['limit_bytes'] = self::CSS_LIMIT;
+			}
+			$diagnostics[] = self::diagnostic_with_detail( 'font_materialization_partial_preserved', $outer_detail );
+			if ( '' === $css_body ) {
+				return new WP_Error( 'static_site_importer_font_materialization_failed', '', $diagnostics );
+			}
+			$writes[] = self::write( 'assets/css/embedded-fonts.css', $css_body, 'theme.font_materialization' );
+			return self::with_runtime_registration( $writes, $resolved_plan, array(), $diagnostics );
+		}
+		if ( is_array( $font_faces ) && isset( $font_faces['state'] ) && 'embedded' === $font_faces['state'] ) {
+			$embedded_css = (string) ( $font_faces['css'] ?? '' );
+		} else {
+			$embedded_css = is_string( $font_faces ) ? $font_faces : '';
+		}
+		if ( '' === trim( $embedded_css ) ) {
 			return new WP_Error( 'static_site_importer_font_materialization_failed', '', $diagnostics );
 		}
-
-		$writes[] = self::write( 'assets/css/embedded-fonts.css', trim( $font_faces ) . "\n", 'theme.font_materialization' );
+		$writes[] = self::write( 'assets/css/embedded-fonts.css', trim( $embedded_css ) . "\n", 'theme.font_materialization' );
 		foreach ( $svg_writes as $svg_write ) {
 			$writes[] = self::write(
 				$svg_write['target_path'],
-				self::embed_svg_font_faces( $svg_write['content'], $font_faces ),
+				self::embed_svg_font_faces( $svg_write['content'], $embedded_css ),
 				$svg_write['source_path']
 			);
 		}
@@ -532,8 +580,10 @@ final class Static_Site_Importer_Font_Materializer {
 		return $matches;
 	}
 
-	/** @param array<int,string> $families @param array<int,array<string,string>> $diagnostics */
-	private static function resolve_google_font_faces( array $plan, array $families, array &$diagnostics ): string {
+	/** @param array<int,string> $families @param array<int,array<string,string>> $diagnostics
+	 *  @return array{state:'embedded',css:string}|array{state:'preserved',reason:string,observed_bytes:int,url:string}
+	 */
+	private static function resolve_google_font_faces( array $plan, array $families, array &$diagnostics ): array {
 		$imports = array();
 		foreach ( $plan['stylesheets'] ?? array() as $stylesheet ) {
 			$content = is_array( $stylesheet ) && is_scalar( $stylesheet['content'] ?? null ) ? (string) $stylesheet['content'] : '';
@@ -544,12 +594,12 @@ final class Static_Site_Importer_Font_Materializer {
 		$imports = array_values( array_unique( $imports ) );
 		if ( empty( $imports ) ) {
 			$diagnostics[] = self::diagnostic( 'stylesheet_import_missing' );
-			return '';
+			return array( 'state' => 'preserved', 'reason' => 'stylesheet_import_missing', 'observed_bytes' => 0, 'url' => '' );
 		}
 		foreach ( $imports as $import ) {
 			if ( ! self::is_google_stylesheet_url( $import ) ) {
 				$diagnostics[] = self::diagnostic( 'untrusted_stylesheet_url' );
-				return '';
+				return array( 'state' => 'preserved', 'reason' => 'untrusted_stylesheet_url', 'observed_bytes' => 0, 'url' => (string) $import );
 			}
 		}
 
@@ -560,58 +610,67 @@ final class Static_Site_Importer_Font_Materializer {
 			$response = self::request( $import, self::CSS_LIMIT );
 			$css      = is_wp_error( $response ) ? '' : (string) wp_remote_retrieve_body( $response );
 			if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $css ) {
-				$diagnostics[] = self::diagnostic( 'stylesheet_fetch_failed' );
-				return '';
+				$diagnostics[] = self::diagnostic_with_detail( 'stylesheet_fetch_failed', array( 'url' => $import, 'observed_bytes' => strlen( $css ), 'limit_bytes' => self::CSS_LIMIT ) );
+				return array( 'state' => 'preserved', 'reason' => 'stylesheet_fetch_failed', 'observed_bytes' => strlen( $css ), 'url' => $import );
 			}
 			if ( strlen( $css ) > self::CSS_LIMIT ) {
-				$diagnostics[] = self::diagnostic( 'stylesheet_response_too_large' );
-				return '';
+				$diagnostics[] = self::diagnostic_with_detail( 'google_fonts_stylesheet_preserved_due_to_size', array( 'url' => $import, 'observed_bytes' => strlen( $css ), 'limit_bytes' => self::CSS_LIMIT ) );
+				return array( 'state' => 'preserved', 'reason' => 'google_fonts_stylesheet_preserved_due_to_size', 'observed_bytes' => strlen( $css ), 'url' => $import );
 			}
 			$embedded = self::embed_font_sources( $css, $families, $font_payloads, $font_payload_bytes, $diagnostics );
-			if ( '' === $embedded ) {
-				return '';
+			if ( is_array( $embedded ) && isset( $embedded['state'] ) && 'preserved' === $embedded['state'] ) {
+				if ( '' === (string) ( $embedded['url'] ?? '' ) ) {
+					$embedded['url'] = $import;
+				}
+				return $embedded;
 			}
-			$faces[] = $embedded;
+			$faces[] = is_array( $embedded ) ? (string) ( $embedded['css'] ?? '' ) : (string) $embedded;
 		}
-		return implode( "\n", $faces );
+		return array( 'state' => 'embedded', 'css' => implode( "\n", $faces ) );
 	}
 
-	/** @param array<int,string> $families @param array<string,string> $payloads @param array<int,array<string,string>> $diagnostics */
-	private static function embed_font_sources( string $css, array $families, array &$payloads, int &$payload_bytes, array &$diagnostics ): string {
+	/** @param array<int,string> $families @param array<string,string> $payloads @param array<int,array<string,string>> $diagnostics
+	 *  @return array{state:'embedded',css:string}|array{state:'preserved',reason:string,observed_bytes:int,url:string}
+	 */
+	private static function embed_font_sources( string $css, array $families, array &$payloads, int &$payload_bytes, array &$diagnostics ): array {
 		if ( ! preg_match_all( '/@font-face\s*\{([^{}]*)\}/is', $css, $faces ) ) {
-			$diagnostics[] = self::diagnostic( 'stylesheet_font_faces_missing' );
-			return '';
+			$diagnostics[] = self::diagnostic_with_detail( 'stylesheet_font_faces_missing', array( 'observed_bytes' => strlen( $css ), 'limit_bytes' => self::CSS_LIMIT ) );
+			return array( 'state' => 'preserved', 'reason' => 'stylesheet_font_faces_missing', 'observed_bytes' => strlen( $css ), 'url' => '' );
 		}
-		$embedded = array();
+		$embedded          = array();
+		$current_source_url = '';
 		foreach ( $faces[0] as $index => $face ) {
+			$current_source_url = '';
 			if ( ! preg_match( '/font-family\s*:\s*(["\']?)([^;"\']+)\1\s*;/i', $faces[1][ $index ], $family ) || ! in_array( trim( $family[2] ), $families, true ) ) {
 				continue;
 			}
 			if ( str_contains( $face, '<' ) || ! preg_match_all( '/url\(\s*(["\']?)([^"\'\s\)]+)\1\s*\)/i', $face, $urls ) ) {
 				$diagnostics[] = self::diagnostic( 'untrusted_font_url' );
-				return '';
+				return array( 'state' => 'preserved', 'reason' => 'untrusted_font_url', 'observed_bytes' => 0, 'url' => $current_source_url );
 			}
 			$rewritten = $face;
 			foreach ( array_unique( $urls[2] ) as $url ) {
+				$current_source_url = $url;
 				$parts = wp_parse_url( $url );
 				$path  = is_array( $parts ) ? strtolower( (string) ( $parts['path'] ?? '' ) ) : '';
 				if ( ! is_array( $parts ) || 'https' !== strtolower( (string) ( $parts['scheme'] ?? '' ) ) || 'fonts.gstatic.com' !== strtolower( (string) ( $parts['host'] ?? '' ) ) || ( isset( $parts['port'] ) && 443 !== (int) $parts['port'] ) || isset( $parts['user'] ) || isset( $parts['pass'] ) || ! preg_match( '/\.woff2?$/', $path ) ) {
 					$diagnostics[] = self::diagnostic( 'untrusted_font_url' );
-					return '';
+					return array( 'state' => 'preserved', 'reason' => 'untrusted_font_url', 'observed_bytes' => 0, 'url' => $url );
 				}
 				if ( ! isset( $payloads[ $url ] ) ) {
 					$response = self::request( $url, self::FONT_LIMIT );
 					$payload  = is_wp_error( $response ) ? '' : (string) wp_remote_retrieve_body( $response );
-					if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $payload || strlen( $payload ) > self::FONT_LIMIT ) {
-						$diagnostics[] = self::diagnostic( 'font_payload_fetch_failed' );
-						return '';
+					$observed = strlen( $payload );
+					if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $payload || $observed > self::FONT_LIMIT ) {
+						$diagnostics[] = self::diagnostic_with_detail( 'font_payload_fetch_failed', array( 'url' => $url, 'observed_bytes' => $observed, 'limit_bytes' => self::FONT_LIMIT ) );
+						return array( 'state' => 'preserved', 'reason' => 'font_payload_fetch_failed', 'observed_bytes' => $observed, 'url' => $url );
 					}
-					if ( self::TOTAL_FONT_LIMIT < $payload_bytes + strlen( $payload ) ) {
-						$diagnostics[] = self::diagnostic( 'font_payload_total_too_large' );
-						return '';
+					if ( self::TOTAL_FONT_LIMIT < $payload_bytes + $observed ) {
+						$diagnostics[] = self::diagnostic_with_detail( 'google_fonts_payloads_partial_preserved', array( 'url' => $url, 'observed_bytes' => $observed, 'aggregate_bytes' => $payload_bytes, 'limit_bytes' => self::TOTAL_FONT_LIMIT ) );
+						return array( 'state' => 'preserved', 'reason' => 'google_fonts_payloads_partial_preserved', 'observed_bytes' => $observed, 'aggregate_bytes' => $payload_bytes, 'url' => $url );
 					}
 					$payloads[ $url ] = $payload;
-					$payload_bytes   += strlen( $payload );
+					$payload_bytes   += $observed;
 				}
 				$mime      = str_ends_with( $path, '.woff2' ) ? 'font/woff2' : 'font/woff';
 				$rewritten = str_replace( $url, 'data:' . $mime . ';base64,' . base64_encode( $payloads[ $url ] ), $rewritten ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encodes a fetched font asset for a CSS data URL.
@@ -621,7 +680,7 @@ final class Static_Site_Importer_Font_Materializer {
 		if ( empty( $embedded ) ) {
 			$diagnostics[] = self::diagnostic( 'matching_font_faces_missing' );
 		}
-		return implode( "\n", $embedded );
+		return array( 'state' => 'embedded', 'css' => implode( "\n", $embedded ) );
 	}
 
 	private static function request( string $url, int $limit ) {
@@ -826,6 +885,16 @@ final class Static_Site_Importer_Font_Materializer {
 			'type'   => 'font_materialization_failed',
 			'source' => 'static-site-importer/font-materializer',
 			'reason' => $reason,
+		);
+	}
+
+	/** @return array{type:string,source:string,reason:string,details:array<string,mixed>} */
+	private static function diagnostic_with_detail( string $reason, array $details ): array {
+		return array(
+			'type'    => 'font_materialization_failed',
+			'source'  => 'static-site-importer/font-materializer',
+			'reason'  => $reason,
+			'details' => $details,
 		);
 	}
 }

--- a/includes/class-static-site-importer-font-materializer.php
+++ b/includes/class-static-site-importer-font-materializer.php
@@ -78,10 +78,10 @@ final class Static_Site_Importer_Font_Materializer {
 		}
 
 		$font_faces = self::resolve_google_font_faces( $plan, $families, $diagnostics );
-		if ( is_array( $font_faces ) && isset( $font_faces['state'] ) && 'preserved' === $font_faces['state'] ) {
-			$preserved_url  = (string) ( $font_faces['url'] ?? '' );
-			$fallback_url   = self::is_google_stylesheet_url( $preserved_url ) ? $preserved_url : '';
-			$imports        = array();
+		if ( 'preserved' === $font_faces['state'] ) {
+			$preserved_url = (string) $font_faces['url'];
+			$fallback_url  = self::is_google_stylesheet_url( $preserved_url ) ? $preserved_url : '';
+			$imports       = array();
 			foreach ( $plan['stylesheets'] ?? array() as $stylesheet ) {
 				$content = is_array( $stylesheet ) && is_scalar( $stylesheet['content'] ?? null ) ? (string) $stylesheet['content'] : '';
 				if ( preg_match_all( '/@import\s+(?:url\()?\s*["\']?([^"\'\s\)]+)["\']?\s*\)?/i', $content, $matches ) ) {
@@ -103,10 +103,10 @@ final class Static_Site_Importer_Font_Materializer {
 			if ( empty( $css_lines ) && '' !== $fallback_url ) {
 				$css_lines[] = '@import "' . addcslashes( $fallback_url, "\"\\\n" ) . '";';
 			}
-			$css_body = empty( $css_lines ) ? '' : trim( implode( "\n", $css_lines ) ) . "\n";
+			$css_body     = empty( $css_lines ) ? '' : trim( implode( "\n", $css_lines ) ) . "\n";
 			$outer_detail = array(
-				'reason'         => (string) ( $font_faces['reason'] ?? '' ),
-				'observed_bytes' => (int) ( $font_faces['observed_bytes'] ?? 0 ),
+				'reason'         => (string) $font_faces['reason'],
+				'observed_bytes' => (int) $font_faces['observed_bytes'],
 				'url'            => $preserved_url,
 			);
 			if ( 'google_fonts_payloads_partial_preserved' === $outer_detail['reason'] ) {
@@ -122,10 +122,8 @@ final class Static_Site_Importer_Font_Materializer {
 			$writes[] = self::write( 'assets/css/embedded-fonts.css', $css_body, 'theme.font_materialization' );
 			return self::with_runtime_registration( $writes, $resolved_plan, array(), $diagnostics );
 		}
-		if ( is_array( $font_faces ) && isset( $font_faces['state'] ) && 'embedded' === $font_faces['state'] ) {
-			$embedded_css = (string) ( $font_faces['css'] ?? '' );
-		} else {
-			$embedded_css = is_string( $font_faces ) ? $font_faces : '';
+		if ( 'embedded' === $font_faces['state'] ) {
+			$embedded_css = (string) $font_faces['css'];
 		}
 		if ( '' === trim( $embedded_css ) ) {
 			return new WP_Error( 'static_site_importer_font_materialization_failed', '', $diagnostics );
@@ -581,7 +579,8 @@ final class Static_Site_Importer_Font_Materializer {
 	}
 
 	/** @param array<int,string> $families @param array<int,array<string,string>> $diagnostics
-	 *  @return array{state:'embedded',css:string}|array{state:'preserved',reason:string,observed_bytes:int,url:string}
+	 *  @return array{state:'embedded',css:string}
+	 *          | array{state:'preserved',reason:string,observed_bytes:int,url:string,aggregate_bytes?:int}
 	 */
 	private static function resolve_google_font_faces( array $plan, array $families, array &$diagnostics ): array {
 		$imports = array();
@@ -594,12 +593,22 @@ final class Static_Site_Importer_Font_Materializer {
 		$imports = array_values( array_unique( $imports ) );
 		if ( empty( $imports ) ) {
 			$diagnostics[] = self::diagnostic( 'stylesheet_import_missing' );
-			return array( 'state' => 'preserved', 'reason' => 'stylesheet_import_missing', 'observed_bytes' => 0, 'url' => '' );
+			return array(
+				'state'          => 'preserved',
+				'reason'         => 'stylesheet_import_missing',
+				'observed_bytes' => 0,
+				'url'            => '',
+			);
 		}
 		foreach ( $imports as $import ) {
 			if ( ! self::is_google_stylesheet_url( $import ) ) {
 				$diagnostics[] = self::diagnostic( 'untrusted_stylesheet_url' );
-				return array( 'state' => 'preserved', 'reason' => 'untrusted_stylesheet_url', 'observed_bytes' => 0, 'url' => (string) $import );
+				return array(
+					'state'          => 'preserved',
+					'reason'         => 'untrusted_stylesheet_url',
+					'observed_bytes' => 0,
+					'url'            => (string) $import,
+				);
 			}
 		}
 
@@ -610,34 +619,73 @@ final class Static_Site_Importer_Font_Materializer {
 			$response = self::request( $import, self::CSS_LIMIT );
 			$css      = is_wp_error( $response ) ? '' : (string) wp_remote_retrieve_body( $response );
 			if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $css ) {
-				$diagnostics[] = self::diagnostic_with_detail( 'stylesheet_fetch_failed', array( 'url' => $import, 'observed_bytes' => strlen( $css ), 'limit_bytes' => self::CSS_LIMIT ) );
-				return array( 'state' => 'preserved', 'reason' => 'stylesheet_fetch_failed', 'observed_bytes' => strlen( $css ), 'url' => $import );
+				$diagnostics[] = self::diagnostic_with_detail(
+					'stylesheet_fetch_failed',
+					array(
+						'url'            => $import,
+						'observed_bytes' => strlen( $css ),
+						'limit_bytes'    => self::CSS_LIMIT,
+					)
+				);
+				return array(
+					'state'          => 'preserved',
+					'reason'         => 'stylesheet_fetch_failed',
+					'observed_bytes' => strlen( $css ),
+					'url'            => $import,
+				);
 			}
 			if ( strlen( $css ) > self::CSS_LIMIT ) {
-				$diagnostics[] = self::diagnostic_with_detail( 'google_fonts_stylesheet_preserved_due_to_size', array( 'url' => $import, 'observed_bytes' => strlen( $css ), 'limit_bytes' => self::CSS_LIMIT ) );
-				return array( 'state' => 'preserved', 'reason' => 'google_fonts_stylesheet_preserved_due_to_size', 'observed_bytes' => strlen( $css ), 'url' => $import );
+				$diagnostics[] = self::diagnostic_with_detail(
+					'google_fonts_stylesheet_preserved_due_to_size',
+					array(
+						'url'            => $import,
+						'observed_bytes' => strlen( $css ),
+						'limit_bytes'    => self::CSS_LIMIT,
+					)
+				);
+				return array(
+					'state'          => 'preserved',
+					'reason'         => 'google_fonts_stylesheet_preserved_due_to_size',
+					'observed_bytes' => strlen( $css ),
+					'url'            => $import,
+				);
 			}
 			$embedded = self::embed_font_sources( $css, $families, $font_payloads, $font_payload_bytes, $diagnostics );
-			if ( is_array( $embedded ) && isset( $embedded['state'] ) && 'preserved' === $embedded['state'] ) {
-				if ( '' === (string) ( $embedded['url'] ?? '' ) ) {
+			if ( 'preserved' === $embedded['state'] ) {
+				if ( '' === (string) $embedded['url'] ) {
 					$embedded['url'] = $import;
 				}
 				return $embedded;
 			}
-			$faces[] = is_array( $embedded ) ? (string) ( $embedded['css'] ?? '' ) : (string) $embedded;
+			$faces[] = (string) $embedded['css'];
 		}
-		return array( 'state' => 'embedded', 'css' => implode( "\n", $faces ) );
+		return array(
+			'state' => 'embedded',
+			'css'   => implode( "\n", $faces ),
+		);
 	}
 
 	/** @param array<int,string> $families @param array<string,string> $payloads @param array<int,array<string,string>> $diagnostics
-	 *  @return array{state:'embedded',css:string}|array{state:'preserved',reason:string,observed_bytes:int,url:string}
+	 *  @return array{state:'embedded',css:string}
+	 *          | array{state:'preserved',reason:string,observed_bytes:int,url:string,aggregate_bytes?:int}
 	 */
 	private static function embed_font_sources( string $css, array $families, array &$payloads, int &$payload_bytes, array &$diagnostics ): array {
 		if ( ! preg_match_all( '/@font-face\s*\{([^{}]*)\}/is', $css, $faces ) ) {
-			$diagnostics[] = self::diagnostic_with_detail( 'stylesheet_font_faces_missing', array( 'observed_bytes' => strlen( $css ), 'limit_bytes' => self::CSS_LIMIT ) );
-			return array( 'state' => 'preserved', 'reason' => 'stylesheet_font_faces_missing', 'observed_bytes' => strlen( $css ), 'url' => '' );
+			$diagnostics[] = self::diagnostic_with_detail(
+				'stylesheet_font_faces_missing',
+				array(
+					'observed_bytes' => strlen( $css ),
+					'limit_bytes'    => self::CSS_LIMIT,
+				)
+			);
+			return array(
+				'state'          => 'preserved',
+				'reason'         => 'stylesheet_font_faces_missing',
+				'observed_bytes' => strlen( $css ),
+				'url'            => '',
+			);
 		}
-		$embedded          = array();
+		$embedded           = array();
 		$current_source_url = '';
 		foreach ( $faces[0] as $index => $face ) {
 			$current_source_url = '';
@@ -646,28 +694,64 @@ final class Static_Site_Importer_Font_Materializer {
 			}
 			if ( str_contains( $face, '<' ) || ! preg_match_all( '/url\(\s*(["\']?)([^"\'\s\)]+)\1\s*\)/i', $face, $urls ) ) {
 				$diagnostics[] = self::diagnostic( 'untrusted_font_url' );
-				return array( 'state' => 'preserved', 'reason' => 'untrusted_font_url', 'observed_bytes' => 0, 'url' => $current_source_url );
+				return array(
+					'state'          => 'preserved',
+					'reason'         => 'untrusted_font_url',
+					'observed_bytes' => 0,
+					'url'            => $current_source_url,
+				);
 			}
 			$rewritten = $face;
 			foreach ( array_unique( $urls[2] ) as $url ) {
 				$current_source_url = $url;
-				$parts = wp_parse_url( $url );
-				$path  = is_array( $parts ) ? strtolower( (string) ( $parts['path'] ?? '' ) ) : '';
+				$parts              = wp_parse_url( $url );
+				$path               = is_array( $parts ) ? strtolower( (string) ( $parts['path'] ?? '' ) ) : '';
 				if ( ! is_array( $parts ) || 'https' !== strtolower( (string) ( $parts['scheme'] ?? '' ) ) || 'fonts.gstatic.com' !== strtolower( (string) ( $parts['host'] ?? '' ) ) || ( isset( $parts['port'] ) && 443 !== (int) $parts['port'] ) || isset( $parts['user'] ) || isset( $parts['pass'] ) || ! preg_match( '/\.woff2?$/', $path ) ) {
 					$diagnostics[] = self::diagnostic( 'untrusted_font_url' );
-					return array( 'state' => 'preserved', 'reason' => 'untrusted_font_url', 'observed_bytes' => 0, 'url' => $url );
+					return array(
+						'state'          => 'preserved',
+						'reason'         => 'untrusted_font_url',
+						'observed_bytes' => 0,
+						'url'            => $url,
+					);
 				}
 				if ( ! isset( $payloads[ $url ] ) ) {
 					$response = self::request( $url, self::FONT_LIMIT );
 					$payload  = is_wp_error( $response ) ? '' : (string) wp_remote_retrieve_body( $response );
 					$observed = strlen( $payload );
 					if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $payload || $observed > self::FONT_LIMIT ) {
-						$diagnostics[] = self::diagnostic_with_detail( 'font_payload_fetch_failed', array( 'url' => $url, 'observed_bytes' => $observed, 'limit_bytes' => self::FONT_LIMIT ) );
-						return array( 'state' => 'preserved', 'reason' => 'font_payload_fetch_failed', 'observed_bytes' => $observed, 'url' => $url );
+						$diagnostics[] = self::diagnostic_with_detail(
+							'font_payload_fetch_failed',
+							array(
+								'url'            => $url,
+								'observed_bytes' => $observed,
+								'limit_bytes'    => self::FONT_LIMIT,
+							)
+						);
+						return array(
+							'state'          => 'preserved',
+							'reason'         => 'font_payload_fetch_failed',
+							'observed_bytes' => $observed,
+							'url'            => $url,
+						);
 					}
 					if ( self::TOTAL_FONT_LIMIT < $payload_bytes + $observed ) {
-						$diagnostics[] = self::diagnostic_with_detail( 'google_fonts_payloads_partial_preserved', array( 'url' => $url, 'observed_bytes' => $observed, 'aggregate_bytes' => $payload_bytes, 'limit_bytes' => self::TOTAL_FONT_LIMIT ) );
-						return array( 'state' => 'preserved', 'reason' => 'google_fonts_payloads_partial_preserved', 'observed_bytes' => $observed, 'aggregate_bytes' => $payload_bytes, 'url' => $url );
+						$diagnostics[] = self::diagnostic_with_detail(
+							'google_fonts_payloads_partial_preserved',
+							array(
+								'url'             => $url,
+								'observed_bytes'  => $observed,
+								'aggregate_bytes' => $payload_bytes,
+								'limit_bytes'     => self::TOTAL_FONT_LIMIT,
+							)
+						);
+						return array(
+							'state'           => 'preserved',
+							'reason'          => 'google_fonts_payloads_partial_preserved',
+							'observed_bytes'  => $observed,
+							'aggregate_bytes' => $payload_bytes,
+							'url'             => $url,
+						);
 					}
 					$payloads[ $url ] = $payload;
 					$payload_bytes   += $observed;
@@ -680,7 +764,10 @@ final class Static_Site_Importer_Font_Materializer {
 		if ( empty( $embedded ) ) {
 			$diagnostics[] = self::diagnostic( 'matching_font_faces_missing' );
 		}
-		return array( 'state' => 'embedded', 'css' => implode( "\n", $embedded ) );
+		return array(
+			'state' => 'embedded',
+			'css'   => implode( "\n", $embedded ),
+		);
 	}
 
 	private static function request( string $url, int $limit ) {

--- a/includes/class-static-site-importer-font-materializer.php
+++ b/includes/class-static-site-importer-font-materializer.php
@@ -122,9 +122,7 @@ final class Static_Site_Importer_Font_Materializer {
 			$writes[] = self::write( 'assets/css/embedded-fonts.css', $css_body, 'theme.font_materialization' );
 			return self::with_runtime_registration( $writes, $resolved_plan, array(), $diagnostics );
 		}
-		if ( 'embedded' === $font_faces['state'] ) {
-			$embedded_css = (string) $font_faces['css'];
-		}
+		$embedded_css = (string) $font_faces['css'];
 		if ( '' === trim( $embedded_css ) ) {
 			return new WP_Error( 'static_site_importer_font_materialization_failed', '', $diagnostics );
 		}

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -35,6 +35,7 @@
     { "path": "tests/smoke-validation-runtime-diagnostics.php", "environment": "standalone-php" },
     { "path": "tests/smoke-visual-repair-css.php", "environment": "standalone-php" },
     { "path": "tests/smoke-webfont-producer-consumer.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-google-fonts-cap-fallback.php", "environment": "standalone-php" },
     { "path": "tests/smoke-website-artifact-import-input.php", "environment": "standalone-php" },
     { "path": "tests/smoke-wordpress-site-plan-materializer.php", "environment": "standalone-php" },
     { "path": "tests/smoke-artifact-run-primitives.php", "environment": "standalone-php" },

--- a/tests/smoke-google-fonts-cap-fallback.php
+++ b/tests/smoke-google-fonts-cap-fallback.php
@@ -56,7 +56,7 @@ $google_url_legacy = 'https://fonts.googleapis.com/css?family=Inter:wght@400;700
 $functions_php     = array( 'target_path' => 'functions.php', 'payload' => array( 'encoding' => 'utf8', 'data' => '<?php' ) );
 
 // Case 1: Google CSS body > 256 KiB -> preserved stylesheet with @import.
-$GLOBALS['ssi_cap_response'] = function ( string $url ) use ( $google_url ): array {
+$GLOBALS['ssi_cap_response'] = function ( string $url ) use ( $google_url ) {
 	if ( $url === $google_url ) {
 		$body = "@font-face { font-family: 'Noto Sans JP'; src: url(https://fonts.gstatic.com/s/noto/jp.woff2) format('woff2'); }\n";
 		$body = str_repeat( $body, 8000 );
@@ -97,7 +97,7 @@ $woff2_url_b   = 'https://fonts.gstatic.com/s/noto/arabic-regular.woff2';
 $woff2_url_c   = 'https://fonts.gstatic.com/s/noto/arabic-700.woff2';
 $css_body_small = "@font-face { font-family: 'Noto Sans JP'; src: url(" . $woff2_url_a . ") format('woff2'); }\n@font-face { font-family: 'Noto Naskh Arabic'; src: url(" . $woff2_url_b . ") format('woff2'); font-weight: 400; }\n@font-face { font-family: 'Noto Naskh Arabic'; src: url(" . $woff2_url_c . ") format('woff2'); font-weight: 700; }\n";
 $one_five_mib   = intdiv( 3 * 1024 * 1024, 2 );
-$GLOBALS['ssi_cap_response'] = function ( string $url ) use ( $google_url, $css_body_small, $woff2_url_a, $woff2_url_b, $woff2_url_c, $one_five_mib ): array {
+$GLOBALS['ssi_cap_response'] = function ( string $url ) use ( $google_url, $css_body_small, $woff2_url_a, $woff2_url_b, $woff2_url_c, $one_five_mib ) {
 	if ( $url === $google_url ) {
 		return array( 'response' => array( 'code' => 200 ), 'body' => $css_body_small );
 	}
@@ -138,7 +138,7 @@ $assert( 4194304 === ( $preserved_big[0]['details']['limit_bytes'] ?? 0 ), 'case
 $assert( isset( $preserved_big[0]['details']['aggregate_bytes'] ), 'case 2: aggregate_bytes is reported' );
 
 // Case 3: producer path not regressed. Use the existing smoke's stubbed google_fonts response to keep this file standalone.
-$GLOBALS['ssi_cap_response']  = function ( string $url ): array {
+$GLOBALS['ssi_cap_response']  = function ( string $url ) {
 	if ( str_starts_with( $url, 'https://fonts.googleapis.com/css2?family=Inter:' ) ) {
 		return array( 'response' => array( 'code' => 200 ), 'body' => "@font-face{font-family:'Inter';font-style:normal;font-weight:100 900;font-stretch:75% 125%;src:url(https://fonts.gstatic.com/s/inter/v1/inter-latin.woff2) format('woff2');unicode-range:U+0000-00FF}" );
 	}
@@ -166,7 +166,7 @@ $producer_diagnostic_failure = Static_Site_Importer_Font_Materializer::prepare_o
 $assert( is_wp_error( $producer_diagnostic_failure ) && 'static_site_importer_font_materialization_producer_diagnostic' === $producer_diagnostic_failure->get_error_code(), 'case 3: required producer diagnostics still gate materialization' );
 
 // Case 4: empty plan + empty stylesheets is preserved as preserved (no import URL to import) but a WP_Error is surfaced because no @import can be written.
-$GLOBALS['ssi_cap_response'] = function (): array { return new WP_Error( 'unexpected_request' ); };
+$GLOBALS['ssi_cap_response'] = function () { return new WP_Error( 'unexpected_request' ); };
 $plan_no_imports = array(
 	'schema'      => 'blocks-engine/php-transformer/font-materialization-plan/v1',
 	'provider'    => 'google_fonts',
@@ -179,7 +179,7 @@ $no_imports_diagnostics = $overlay_no_imports->get_error_data();
 $assert( is_array( $no_imports_diagnostics ) && count( array_filter( $no_imports_diagnostics, static fn( array $row ): bool => ( $row['reason'] ?? '' ) === 'stylesheet_import_missing' ) ) >= 1, 'case 4: surfaces the stylesheet_import_missing reason before failing closed' );
 
 // Case 5: legacy v1 css path (fontfamily=...) -- same preservation contract.
-$GLOBALS['ssi_cap_response'] = function ( string $url ) use ( $google_url_legacy ): array {
+$GLOBALS['ssi_cap_response'] = function ( string $url ) use ( $google_url_legacy ) {
 	if ( $url === $google_url_legacy ) {
 		return array( 'response' => array( 'code' => 200 ), 'body' => str_repeat( '@font-face { font-family: "Inter"; src: url(https://fonts.gstatic.com/legacy.woff2); }' . "\n", 7000 ) );
 	}

--- a/tests/smoke-google-fonts-cap-fallback.php
+++ b/tests/smoke-google-fonts-cap-fallback.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Cap-fallback coverage for the Google Fonts path in #732.
+ *
+ * Run: php tests/smoke-google-fonts-cap-fallback.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['ssi_cap_requests']   = array();
+$GLOBALS['ssi_cap_response']  = null;
+$GLOBALS['ssi_cap_payloads']  = array();
+
+class WP_Error {
+	private string $code;
+	private mixed $data;
+	public function __construct( string $code, string $message = '', mixed $data = null ) { $this->code = $code; $this->data = $data; }
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_data(): mixed { return $this->data; }
+}
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+function wp_parse_url( string $url ) { return parse_url( $url ); }
+function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
+function wp_remote_retrieve_response_code( $response ): int { return is_array( $response ) ? (int) ( $response['response']['code'] ?? 0 ) : 0; }
+function wp_remote_retrieve_body( $response ): string { return is_array( $response ) ? (string) ( $response['body'] ?? '' ) : ''; }
+function wp_safe_remote_get( string $url, array $args ) {
+	$GLOBALS['ssi_cap_requests'][] = $url;
+	$response = $GLOBALS['ssi_cap_response'] ?? null;
+	if ( null === $response ) {
+		if ( isset( $GLOBALS['ssi_cap_payloads'][ $url ] ) ) {
+			return array( 'response' => array( 'code' => 200 ), 'body' => $GLOBALS['ssi_cap_payloads'][ $url ] );
+		}
+		return new WP_Error( 'unexpected_request' );
+	}
+	if ( is_callable( $response ) ) {
+		return $response( $url );
+	}
+	return $response;
+}
+
+require dirname( __DIR__ ) . '/vendor/autoload.php';
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-font-materializer.php';
+
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+};
+
+$google_url        = 'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Noto+Naskh+Arabic:wght@400;700&display=swap';
+$google_url_legacy = 'https://fonts.googleapis.com/css?family=Inter:wght@400;700';
+$functions_php     = array( 'target_path' => 'functions.php', 'payload' => array( 'encoding' => 'utf8', 'data' => '<?php' ) );
+
+// Case 1: Google CSS body > 256 KiB -> preserved stylesheet with @import.
+$GLOBALS['ssi_cap_response'] = function ( string $url ) use ( $google_url ): array {
+	if ( $url === $google_url ) {
+		$body = "@font-face { font-family: 'Noto Sans JP'; src: url(https://fonts.gstatic.com/s/noto/jp.woff2) format('woff2'); }\n";
+		$body = str_repeat( $body, 8000 );
+		return array( 'response' => array( 'code' => 200 ), 'body' => $body );
+	}
+	return new WP_Error( 'unexpected_request' );
+};
+$plan_too_large = array(
+	'schema'      => 'blocks-engine/php-transformer/font-materialization-plan/v1',
+	'provider'    => 'google_fonts',
+	'fonts'       => array( array( 'family' => 'Noto Sans JP' ), array( 'family' => 'Noto Naskh Arabic' ) ),
+	'stylesheets' => array(
+		array(
+			'path'    => 'assets/css/fonts.css',
+			'content' => "@import url('" . $google_url . "');\n",
+		),
+	),
+);
+$overlay = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan_too_large, array( 'writes' => array( $functions_php ) ) );
+$assert( ! is_wp_error( $overlay ), 'case 1: oversized Google CSS preserves instead of aborting' );
+$css_writes = array_values( array_filter( $overlay['writes'] ?? array(), static fn( array $write ): bool => 'assets/css/embedded-fonts.css' === $write['target_path'] ) );
+$font_writes = array_values( array_filter( $overlay['writes'] ?? array(), static fn( array $write ): bool => str_starts_with( $write['target_path'], 'assets/fonts/' ) ) );
+$assert( 1 === count( $css_writes ), 'case 1: exactly one embedded-fonts.css write' );
+$assert( 0 === count( $font_writes ), 'case 1: no embedded font assets are downloaded when the CSS body itself is oversized' );
+$assert( str_contains( $css_writes[0]['content'], '@import "' . $google_url . '";' ), 'case 1: preserved stylesheet body re-imports the original Google URL' );
+$preserved = array_values( array_filter( $overlay['diagnostics'] ?? array(), static fn( array $row ): bool => ( $row['reason'] ?? '' ) === 'font_materialization_partial_preserved' ) );
+$assert( 1 === count( $preserved ), 'case 1: emits a font_materialization_partial_preserved diagnostic' );
+$assert( 'google_fonts_stylesheet_preserved_due_to_size' === ( $preserved[0]['details']['reason'] ?? '' ), 'case 1: inner reason is google_fonts_stylesheet_preserved_due_to_size' );
+$assert( ( $preserved[0]['details']['observed_bytes'] ?? 0 ) > 262144, 'case 1: observed_bytes exceeds CSS_LIMIT' );
+$assert( 262144 === ( $preserved[0]['details']['limit_bytes'] ?? 0 ), 'case 1: limit_bytes equals CSS_LIMIT' );
+$assert( $google_url === ( $preserved[0]['details']['url'] ?? '' ), 'case 1: url echoes the offending import' );
+
+// Case 2: aggregate woff2 > 4 MiB -> preserved stylesheet with @import.
+$GLOBALS['ssi_cap_response']   = null;
+$GLOBALS['ssi_cap_payloads']   = array();
+$woff2_url_a   = 'https://fonts.gstatic.com/s/noto/jp-regular.woff2';
+$woff2_url_b   = 'https://fonts.gstatic.com/s/noto/arabic-regular.woff2';
+$woff2_url_c   = 'https://fonts.gstatic.com/s/noto/arabic-700.woff2';
+$css_body_small = "@font-face { font-family: 'Noto Sans JP'; src: url(" . $woff2_url_a . ") format('woff2'); }\n@font-face { font-family: 'Noto Naskh Arabic'; src: url(" . $woff2_url_b . ") format('woff2'); font-weight: 400; }\n@font-face { font-family: 'Noto Naskh Arabic'; src: url(" . $woff2_url_c . ") format('woff2'); font-weight: 700; }\n";
+$one_five_mib   = intdiv( 3 * 1024 * 1024, 2 );
+$GLOBALS['ssi_cap_response'] = function ( string $url ) use ( $google_url, $css_body_small, $woff2_url_a, $woff2_url_b, $woff2_url_c, $one_five_mib ): array {
+	if ( $url === $google_url ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => $css_body_small );
+	}
+	if ( $url === $woff2_url_a ) {
+		// 1.5 MiB (under FONT_LIMIT 2 MiB).
+		return array( 'response' => array( 'code' => 200 ), 'body' => str_repeat( 'a', $one_five_mib ) );
+	}
+	if ( $url === $woff2_url_b ) {
+		// 1.5 MiB; aggregate now 3 MiB, still under 4 MiB.
+		return array( 'response' => array( 'code' => 200 ), 'body' => str_repeat( 'b', $one_five_mib ) );
+	}
+	if ( $url === $woff2_url_c ) {
+		// 1.5 MiB; would push aggregate to 4.5 MiB, exceeds TOTAL_FONT_LIMIT 4 MiB.
+		return array( 'response' => array( 'code' => 200 ), 'body' => str_repeat( 'c', $one_five_mib ) );
+	}
+	return new WP_Error( 'unexpected_request' );
+};
+$plan_too_big = array(
+	'schema'      => 'blocks-engine/php-transformer/font-materialization-plan/v1',
+	'provider'    => 'google_fonts',
+	'fonts'       => array( array( 'family' => 'Noto Sans JP' ), array( 'family' => 'Noto Naskh Arabic' ) ),
+	'stylesheets' => array(
+		array(
+			'path'    => 'assets/css/fonts.css',
+			'content' => "@import url('" . $google_url . "');\n",
+		),
+	),
+);
+$overlay_big = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan_too_big, array( 'writes' => array( $functions_php ) ) );
+$assert( ! is_wp_error( $overlay_big ), 'case 2: aggregate overflow preserves instead of aborting' );
+$css_writes_big = array_values( array_filter( $overlay_big['writes'] ?? array(), static fn( array $write ): bool => 'assets/css/embedded-fonts.css' === $write['target_path'] ) );
+$assert( 1 === count( $css_writes_big ), 'case 2: exactly one embedded-fonts.css write' );
+$assert( str_contains( $css_writes_big[0]['content'], '@import "' . $google_url . '";' ), 'case 2: preserved stylesheet body re-imports the original Google URL' );
+$preserved_big = array_values( array_filter( $overlay_big['diagnostics'] ?? array(), static fn( array $row ): bool => ( $row['reason'] ?? '' ) === 'font_materialization_partial_preserved' ) );
+$assert( 1 === count( $preserved_big ), 'case 2: emits a font_materialization_partial_preserved diagnostic' );
+$assert( 'google_fonts_payloads_partial_preserved' === ( $preserved_big[0]['details']['reason'] ?? '' ), 'case 2: inner reason is google_fonts_payloads_partial_preserved' );
+$assert( 4194304 === ( $preserved_big[0]['details']['limit_bytes'] ?? 0 ), 'case 2: limit_bytes equals TOTAL_FONT_LIMIT' );
+$assert( isset( $preserved_big[0]['details']['aggregate_bytes'] ), 'case 2: aggregate_bytes is reported' );
+
+// Case 3: producer path not regressed. Use the existing smoke's stubbed google_fonts response to keep this file standalone.
+$GLOBALS['ssi_cap_response']  = function ( string $url ): array {
+	if ( str_starts_with( $url, 'https://fonts.googleapis.com/css2?family=Inter:' ) ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => "@font-face{font-family:'Inter';font-style:normal;font-weight:100 900;font-stretch:75% 125%;src:url(https://fonts.gstatic.com/s/inter/v1/inter-latin.woff2) format('woff2');unicode-range:U+0000-00FF}" );
+	}
+	if ( 'https://fonts.gstatic.com/s/inter/v1/inter-latin.woff2' === $url ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => 'fixture-37-inter-variable-font' );
+	}
+	return new WP_Error( 'unexpected_request' );
+};
+$fixture_html  = '<!doctype html><html><head><link rel="stylesheet" href="css/style.css"></head><body><main>Inter fixture</main></body></html>';
+$fixture_css   = "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');\n:root{--font:'Inter',system-ui,sans-serif}body{font-family:var(--font)}";
+$producer_plan = ( new Automattic\BlocksEngine\PhpTransformer\StaticSite\FontMaterialization\FontMaterializationPlanBuilder() )->fromWebFontSources(
+	$fixture_html,
+	$fixture_css,
+	array( array( 'path' => 'css/style.css', 'content' => $fixture_css, 'source_hash' => hash( 'sha256', $fixture_css ) ) )
+);
+$producer_overlay = Static_Site_Importer_Font_Materializer::prepare_overlay(
+	$producer_plan,
+	array( 'writes' => array( $functions_php ) )
+);
+$assert( ! is_wp_error( $producer_overlay ), 'case 3: producer path still materializes (regression sentinel)' );
+$producer_diagnostic_failure = Static_Site_Importer_Font_Materializer::prepare_overlay(
+	array_merge( $producer_plan, array( 'webfont_contract' => array_merge( $producer_plan['webfont_contract'], array( 'diagnostics' => array( array( 'code' => 'webfont_import_unresolved' ) ) ) ) ) ),
+	array( 'writes' => array( $functions_php ) )
+);
+$assert( is_wp_error( $producer_diagnostic_failure ) && 'static_site_importer_font_materialization_producer_diagnostic' === $producer_diagnostic_failure->get_error_code(), 'case 3: required producer diagnostics still gate materialization' );
+
+// Case 4: empty plan + empty stylesheets is preserved as preserved (no import URL to import) but a WP_Error is surfaced because no @import can be written.
+$GLOBALS['ssi_cap_response'] = function (): array { return new WP_Error( 'unexpected_request' ); };
+$plan_no_imports = array(
+	'schema'      => 'blocks-engine/php-transformer/font-materialization-plan/v1',
+	'provider'    => 'google_fonts',
+	'fonts'       => array( array( 'family' => 'Inter' ) ),
+	'stylesheets' => array( array( 'path' => 'assets/css/fonts.css', 'content' => ':root { color: red; }' ) ),
+);
+$overlay_no_imports = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan_no_imports, array( 'writes' => array( $functions_php ) ) );
+$assert( is_wp_error( $overlay_no_imports ) && 'static_site_importer_font_materialization_failed' === $overlay_no_imports->get_error_code(), 'case 4: absent Google @import with no fallback URL still reports materialization failure' );
+$no_imports_diagnostics = $overlay_no_imports->get_error_data();
+$assert( is_array( $no_imports_diagnostics ) && count( array_filter( $no_imports_diagnostics, static fn( array $row ): bool => ( $row['reason'] ?? '' ) === 'stylesheet_import_missing' ) ) >= 1, 'case 4: surfaces the stylesheet_import_missing reason before failing closed' );
+
+// Case 5: legacy v1 css path (fontfamily=...) -- same preservation contract.
+$GLOBALS['ssi_cap_response'] = function ( string $url ) use ( $google_url_legacy ): array {
+	if ( $url === $google_url_legacy ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => str_repeat( '@font-face { font-family: "Inter"; src: url(https://fonts.gstatic.com/legacy.woff2); }' . "\n", 7000 ) );
+	}
+	return new WP_Error( 'unexpected_request' );
+};
+$plan_legacy = array(
+	'schema'      => 'blocks-engine/php-transformer/font-materialization-plan/v1',
+	'provider'    => 'google_fonts',
+	'fonts'       => array( array( 'family' => 'Inter' ) ),
+	'stylesheets' => array(
+		array(
+			'path'    => 'assets/css/fonts.css',
+			'content' => "@import url('" . $google_url_legacy . "');\n",
+		),
+	),
+);
+$overlay_legacy = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan_legacy, array( 'writes' => array( $functions_php ) ) );
+$assert( ! is_wp_error( $overlay_legacy ), 'case 5: legacy /css path also preserves when the response is oversized' );
+$css_writes_legacy = array_values( array_filter( $overlay_legacy['writes'] ?? array(), static fn( array $write ): bool => 'assets/css/embedded-fonts.css' === $write['target_path'] ) );
+$assert( 1 === count( $css_writes_legacy ) && str_contains( $css_writes_legacy[0]['content'], '@import "' . $google_url_legacy . '";' ), 'case 5: legacy /css import URL is round-tripped in the preserved stylesheet' );
+
+echo "Google Fonts cap-fallback smoke passed.\n";


### PR DESCRIPTION
## Summary

A valid compiler font plan that exceeded SSI's fixed Google Fonts byte caps (CSS > 256 KiB or aggregate woff2 > 4 MiB) used to hard-abort the entire import with `static_site_importer_font_materialization_failed`. The cap overflow now falls back to a preserved `@import` of the original Google stylesheet so the import continues, with a `font_materialization_partial_preserved` diagnostic that reports the exact reason, observed bytes, and offending URL.

Fixes #732

## Changes

### `includes/class-static-site-importer-font-materializer.php`

**Why:** Multilingual fixtures (e.g. `29-multilingual-i18n`) blow past the CSS or aggregate woff2 cap. The cap should be bounded, but exceeding it must not abort an otherwise valid import. The producer path (`materialize_producer_faces`) is unchanged.

The two private helpers that materialize the Google Fonts path now return a tagged union instead of a bare CSS string. `prepare_overlay()` inspects the union, and on a `preserved` state re-scans the plan stylesheets for the original Google `@import` URL, writes an `@import`-only `assets/css/embedded-fonts.css`, and emits the diagnostic.

```php
// before — hard-fail path
$css = self::embed_font_sources( ... );
if ( '' === $css ) {
    return new WP_Error( 'static_site_importer_font_materialization_failed', ... );
}

// after — preserve when cap overflows
$result = self::embed_font_sources( ... );
if ( 'preserved' === $result['state'] ) {
    // re-emit @import of the original Google URL, attach diagnostic
    $diagnostics[] = self::diagnostic_with_detail(
        'font_materialization_partial_preserved',
        $result['source'],
        $result['reason'],
        array(
            'url'             => $result['url'],
            'observed_bytes'  => $result['observed_bytes'],
            'limit_bytes'     => $result['limit_bytes'],
            'aggregate_bytes' => $result['aggregate_bytes'] ?? null,
        )
    );
    // continue with the rest of prepare_overlay
}
```

**Why:** Strict allowlist `is_google_stylesheet_url()` already gates the URL before it reaches CSS, but a defense-in-depth `addcslashes( $x, "\"\\\\\\n" )` is applied to the URL interpolated into the `@import` string so future allowlist loosening cannot leak a quote/backslash/newline into a CSS at-rule.

### `tests/smoke-google-fonts-cap-fallback.php` (new)

Standalone PHP smoke, 5 cases:

1. Google CSS body > 256 KiB → preserved `@import` of original URL, `google_fonts_stylesheet_preserved_due_to_size` diagnostic with `observed_bytes` and `limit_bytes === 262144`.
2. Aggregate woff2 > 4 MiB → preserved `@import`, `google_fonts_payloads_partial_preserved` diagnostic with `limit_bytes === 4194304` and `aggregate_bytes`.
3. Producer path regression sentinel — `FontMaterializationPlanBuilder` plan still materializes; required producer diagnostics still gate materialization.
4. No `@import` in plan + no fallback URL → `WP_Error` closed-fail with `stylesheet_import_missing` reason.
5. Legacy `/css?family=…` v1 URL — same preservation contract.

### `test-manifest.json`, `homeboy-test-manifest.json`

Registered the new smoke as `standalone-php`.

## Testing

**Test 1: standalone smokes**
```bash
php tests/smoke-google-fonts-cap-fallback.php
php tests/smoke-webfont-producer-consumer.php
```
Result: both pass.

**Test 2: fast lane + inventory**
```bash
npm test
npm run test:inventory
```
Result: 46/47 pass. The single failure is `smoke-url-batch-import.php` (pre-existing on clean main, unrelated to fonts).

**Test 3: end-to-end repro against fixture `29-multilingual-i18n`**
Run the fixture matrix; confirm the output no longer contains `static_site_importer_font_materialization_failed` and that a `font_materialization_partial_preserved` diagnostic appears with `details.url`, `details.observed_bytes`, and `details.limit_bytes` populated. Browser surfaces (Chrome/SVG parity) should render text using the Noto Sans JP / Noto Naskh Arabic families.

**Test 4: happy path regression**
Run a small Google Fonts fixture (1 family, 1 weight). `assets/css/embedded-fonts.css` should still contain `data:font/woff2;base64,…` URLs and no `font_materialization_partial_preserved` diagnostic should appear.