### PR TITLE
Prove persisted Gutenberg edits in solved fixture gate

### DIFF
--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -439,6 +439,14 @@ complete solved corpus. The replayable plan and operator summary identify this
 lane as `fixtures-solved-only/v1` and include active, solved, and selected corpus
 counts plus the full coverage inventory so CI artifacts prove the exact selection.
 
+The solved-candidate gate also proves persisted Gutenberg editability. After
+visual parity capture, it inserts a fixture-specific paragraph through
+`wordpress.editor-actions`, saves with `core/editor.savePost`, reloads the editor,
+and captures the reloaded state. A required runtime assertion verifies the marker
+in the persisted front-page `post_content`, then `wp.blocks.validateBlock` runs
+again against the post-save document. Any action, persistence, reload, or
+post-save block-validity failure fails the fixture.
+
 ```bash
 node tools/promote-solved-fixture.mjs \
   --fixture-id <id> \
@@ -488,16 +496,9 @@ After each fixture's import step, `buildFixtureMatrixRecipe` appends a
 `invalid_blocks`. This reuses the existing wp-codebox editor-validation command
 rather than rebuilding a validator.
 
-Live-wiring gap (verified by a real local recipe-run): the matrix currently
-passes only a bare `post-type=<type>` target. wp-codebox's
-`editorOpenTargetFromArgs` resolves a bare `post-type` to an EMPTY
-`post-new.php?post_type=<type>` editor, so the pass validates `total_blocks: 0`
-and proves nothing about the imported markup. To assert real imported-output
-block validity the step must receive a concrete target — most robustly the
-imported `post-id` surfaced out of the in-sandbox `validate-artifact` step (or
-an inline `content` snapshot of the imported post_content). See
-`lib/fixture-matrix/steps/editor-validation-step.mjs` for the target priority
-order and the remaining enablement.
+The default `front-page` target resolves at runtime to the imported
+`page_on_front`, so validation exercises real imported content even though its
+post ID is not known while the recipe is generated.
 
 `collectEditorValidationDiagnostics` reads the probe's `selectorSummary`
 (invalid-warning matches) — and, when present, per-block `isValid`/`validateBlock`

--- a/lib/fixture-matrix/run-config.mjs
+++ b/lib/fixture-matrix/run-config.mjs
@@ -9,7 +9,7 @@ export const FIXTURE_MATRIX_RUN_FIELDS = Object.freeze({
   run: { env: 'SSI_FIXTURE_MATRIX_RUN', boolean: true, always: true, projections: {} },
   fixtureIds: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_IDS', list: true, projections: {} },
   fixtureCorpus: { env: 'SSI_FIXTURE_MATRIX_FIXTURE_CORPUS', string: true, projections: {} },
-  requireSolvedCandidate: { env: 'SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE', boolean: true, projections: {} },
+  requireSolvedCandidate: { env: 'SSI_FIXTURE_MATRIX_REQUIRE_SOLVED_CANDIDATE', boolean: true, projections: { recipe: 'requireSolvedCandidate' } },
   blocksEnginePhpTransformerPath: { env: 'SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH', string: true, projections: {} },
   blocksEnginePhpTransformerReference: { env: 'SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_REFERENCE', string: true, projections: {} },
   batchSize: { env: 'SSI_FIXTURE_MATRIX_BATCH_SIZE', integer: { min: 1 }, default: 10, always: true, projections: {} },

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -386,7 +386,9 @@ function fixtureWorkflowSteps(options) {
         ...editorValidationOptions,
         artifactPrefix: editorArtifactPrefix(fixture, surface),
       })] : []),
-      ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, surface: editorSurface(surface), ...editorValidationOptions })] : []),
+      ...(editorValidationEnabled && !(editorPersistenceRequired && index === 0)
+        ? [editorBlockValidationStep({ fixture, surface: editorSurface(surface), ...editorValidationOptions })]
+        : []),
       ...(visualParityEnabled && index === 0 ? [visualParityDeterministicCssStep(fixture)] : []),
       ...(visualParityEnabled ? [visualParityCompareStep({ fixture, surface, ...visualParityRecipeOptions })] : []),
     ]),

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -222,6 +222,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
   ];
   const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
   const editorOpenEnabled = editorValidationEnabled && input.editorOpen !== false && input.editor_open !== false;
+  const editorPersistenceRequired = input.requireSolvedCandidate === true || input.require_solved_candidate === true;
   // Real-content validation options forwarded to the editor-validate-blocks step.
   // No empty-post default: when nothing concrete is provided, the step targets
   // `front-page`, which wp-codebox resolves to the imported static front page
@@ -293,6 +294,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
           attemptId,
           editorOpenEnabled,
           editorValidationEnabled,
+          editorPersistenceRequired,
           editorValidationOptions,
           visualParityEnabled,
           visualParityRecipeOptions,
@@ -340,6 +342,7 @@ function fixtureWorkflowSteps(options) {
     attemptId,
     editorOpenEnabled,
     editorValidationEnabled,
+    editorPersistenceRequired,
     editorValidationOptions,
     visualParityEnabled,
     visualParityRecipeOptions,
@@ -387,7 +390,47 @@ function fixtureWorkflowSteps(options) {
       ...(visualParityEnabled && index === 0 ? [visualParityDeterministicCssStep(fixture)] : []),
       ...(visualParityEnabled ? [visualParityCompareStep({ fixture, surface, ...visualParityRecipeOptions })] : []),
     ]),
+    ...(editorPersistenceRequired ? editorPersistenceSteps(fixture) : []),
     ...(liveWpParityCaptureEnabled ? [liveWpParityCaptureStep({ fixture, ...input })] : []),
+  ];
+}
+
+function editorPersistenceSteps(fixture) {
+  const marker = `ssi-solved-editability-${fixture.id}`;
+  const postSaveValidation = editorBlockValidationStep({ fixture, target: 'front-page' });
+  const verifyCode = `$post_id = (int) get_option('page_on_front');
+$content = $post_id > 0 ? (string) get_post_field('post_content', $post_id) : '';
+$persisted = $post_id > 0 && str_contains($content, '${marker}');
+WP_CLI::line(wp_json_encode(array('schema' => 'static-site-importer/editor-persistence/v1', 'post_id' => $post_id, 'marker' => '${marker}', 'persisted' => $persisted)));
+if (!$persisted) { WP_CLI::error('Gutenberg edit did not persist after save and reload.'); }`;
+  const encodedVerifyCode = Buffer.from(verifyCode, 'utf8').toString('base64');
+  return [
+    {
+      command: 'wordpress.editor-actions',
+      args: [
+        'target=front-page',
+        'capture=steps,errors,editor-state,editor-validity',
+        'wait-timeout=45s',
+        'step-timeout=45s',
+        'timeout=120s',
+        `steps-json=${JSON.stringify([
+          { kind: 'savePost', marker },
+          { kind: 'reload' },
+          { kind: 'inspectState' },
+        ])}`,
+      ],
+      metadata: fixtureStepMetadata(fixture, 'editor-persistence'),
+    },
+    {
+      command: 'wordpress.wp-cli',
+      args: [`command=eval ${shellToken(`eval(base64_decode('${encodedVerifyCode}'));`)}`],
+      metadata: fixtureStepMetadata(fixture, 'editor-persistence-verify'),
+    },
+    {
+      ...postSaveValidation,
+      allowFailure: false,
+      metadata: fixtureStepMetadata(fixture, 'editor-persistence-validation', { target: 'front-page' }),
+    },
   ];
 }
 

--- a/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/rigs/static-site-importer-fixture-matrix/rig.json
@@ -26,6 +26,7 @@
         "env": ["HOMEBOY_WP_CODEBOX_BIN"],
         "capabilities": [
           "wordpress.editor-open",
+          "wordpress.editor-actions",
           "wordpress.editor-validate-blocks",
           "wordpress.browser-probe",
           "wordpress.visual-compare"

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -5527,6 +5527,7 @@ test('recipe runs editor-validate-blocks against imported content after each imp
   assert.equal(persistenceValidationStep.command, EDITOR_VALIDATE_BLOCKS_COMMAND);
   assert.equal(persistenceValidationStep.allowFailure, false);
   assert.ok(persistenceValidationStep.args.includes('target=front-page'));
+  assert.equal(solvedCandidateRecipe.workflow.steps.filter((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND).length, 1);
 
   const disabled = buildFixtureMatrixRecipe({
     matrix,

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1008,6 +1008,7 @@ test('fixture-matrix rig requires env-backed WP Codebox editor and visual capabi
   assert.equal(tool.command, 'wp-codebox');
   assert.deepEqual(tool.env, ['HOMEBOY_WP_CODEBOX_BIN']);
   assert.ok(tool.capabilities.includes('wordpress.editor-open'));
+  assert.ok(tool.capabilities.includes('wordpress.editor-actions'));
   assert.ok(tool.capabilities.includes('wordpress.editor-validate-blocks'));
   assert.ok(tool.capabilities.includes('wordpress.visual-compare'));
 });
@@ -5505,6 +5506,27 @@ test('recipe runs editor-validate-blocks against imported content after each imp
   assert.ok(editorStep.args.includes('target=front-page'));
   assert.equal(editorStep.args.some((arg) => arg.startsWith('capture=')), false);
   assert.equal(editorStep.allowFailure, true);
+  assert.equal(recipe.workflow.steps.some((step) => step.command === 'wordpress.editor-actions'), false);
+
+  const solvedCandidateRecipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    requireSolvedCandidate: true,
+  });
+  const persistenceStep = solvedCandidateRecipe.workflow.steps.find((step) => step.metadata?.phase === 'editor-persistence');
+  assert.equal(persistenceStep.command, 'wordpress.editor-actions');
+  assert.ok(persistenceStep.args.includes('target=front-page'));
+  assert.ok(persistenceStep.args.some((arg) => arg.includes('"kind":"savePost"') && arg.includes('ssi-solved-editability-simple-site')));
+  assert.ok(persistenceStep.args.some((arg) => arg.includes('"kind":"reload"')));
+  assert.ok(persistenceStep.args.some((arg) => arg.includes('"kind":"inspectState"')));
+  const persistenceVerifyStep = solvedCandidateRecipe.workflow.steps.find((step) => step.metadata?.phase === 'editor-persistence-verify');
+  assert.equal(persistenceVerifyStep.command, 'wordpress.wp-cli');
+  assert.match(persistenceVerifyStep.args[0], /command=eval/);
+  const persistenceValidationStep = solvedCandidateRecipe.workflow.steps.find((step) => step.metadata?.phase === 'editor-persistence-validation');
+  assert.equal(persistenceValidationStep.command, EDITOR_VALIDATE_BLOCKS_COMMAND);
+  assert.equal(persistenceValidationStep.allowFailure, false);
+  assert.ok(persistenceValidationStep.args.includes('target=front-page'));
 
   const disabled = buildFixtureMatrixRecipe({
     matrix,


### PR DESCRIPTION
## Summary

- require solved-candidate runs to insert fixture-specific content through Gutenberg, save, reload, and verify the marker in persisted front-page `post_content`
- run `wp.blocks.validateBlock` against the post-save document and fail closed on action, persistence, reload, or validation errors
- keep ordinary development matrix runs unchanged and document the stronger solved-fixture contract

## Verification

- `npm run test:fixture-matrix` (259 tests passed)
- direct committed solved-only WP Codebox bench: 2 fixtures passed, 0 failed, 0 findings
- `15-saas`: persistence confirmed; 288/288 post-save blocks valid
- `89-static-site-importer-architecture`: persistence confirmed; 171/171 post-save blocks valid

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the fixture gate, implemented the edit/save/reload persistence proof, added tests and documentation, and ran the runtime verification. Chris Huber reviewed the work and remains responsible for every line.