### PR TITLE
Fix fixture matrix controller-local setup routing

### DIFF
--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -3908,8 +3908,8 @@ test('fixture matrix deterministic dry-run phase plans route setup locally and w
     fixtureRoot,
   });
   assert.deepEqual(setupPlan.steps.slice(0, -1).map((step) => step.args), [
-    ['rig', 'install', path.dirname(path.dirname(fileURLToPath(import.meta.url))), '--id', 'static-site-importer-fixture-matrix', '--reinstall'],
-    ['rig', 'sync', 'static-site-importer-fixture-matrix'],
+    ['--placement', 'local', 'rig', 'install', path.dirname(path.dirname(fileURLToPath(import.meta.url))), '--id', 'static-site-importer-fixture-matrix', '--reinstall'],
+    ['--placement', 'local', 'rig', 'sync', 'static-site-importer-fixture-matrix'],
   ]);
   assert.deepEqual(setupPlan.phase_plan, {
     schema: FIXTURE_MATRIX_PHASE_PLAN_SCHEMA,
@@ -3922,6 +3922,7 @@ test('fixture matrix deterministic dry-run phase plans route setup locally and w
     })),
   });
   assert.ok(setupPlan.steps.slice(0, -1).every((step) => step.phase === 'controller-setup' && step.placement === 'auto' && step.resolved_placement === 'controller-local'));
+  assert.ok(setupPlan.steps.slice(0, -1).every((step) => step.args[0] === '--placement' && step.args[1] === 'local'));
   assert.equal(setupPlan.steps.at(-1).phase, 'fixture-workload');
   assert.equal(setupPlan.steps.at(-1).resolved_placement, 'lab:homeboy-lab');
 

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -699,7 +699,7 @@ function buildSteps(options, settings) {
       reason: 'Rig source installation remains on the controller and does not inherit fixture workload routing.',
       label: `Refresh installed SSI fixture matrix rig (${options.executionTarget})`,
       command: options.homeboyBin,
-      args: ['rig', 'install', packageRoot, '--id', RIG_ID, '--reinstall'],
+      args: ['--placement', 'local', 'rig', 'install', packageRoot, '--id', RIG_ID, '--reinstall'],
     }));
   }
   if (!options.skipSync) {
@@ -710,7 +710,7 @@ function buildSteps(options, settings) {
       reason: 'Rig component synchronization remains on the controller and does not inherit fixture workload routing.',
       label: `Sync/materialize rig components (${options.executionTarget})`,
       command: options.homeboyBin,
-      args: ['rig', 'sync', RIG_ID],
+      args: ['--placement', 'local', 'rig', 'sync', RIG_ID],
     }));
   }
 


### PR DESCRIPTION
## Summary

- enforce `--placement local` for fixture-matrix `rig install` and `rig sync` setup phases
- preserve `--runner` routing exclusively for the fixture workload
- extend deterministic phase-plan coverage to assert executable local placement

Closes #850.

## Verification

- `npm run test:fixture-matrix` (259 passed)
- canonical 88-fixture dry-run selected 88 executable fixtures
- live canonical invocation completed both setup phases and advanced to Lab workload staging; it then exposed a separate upstream Homeboy `workspace_owner_request: null` admission defect

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode investigated the failure, implemented the fix, and ran verification. Chris Huber reviewed and remains responsible for every line.