### PR TITLE
Bound ZIP intake before decompression

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1047,7 +1047,7 @@ function static_site_importer_rest_archive_files( array $archive ) {
 	$total_uncompressed_bytes = 0;
 	for ( $i = 0; $i < $zip->numFiles; $i++ ) {
 		$stat = $zip->statIndex( $i );
-		if ( ! is_array( $stat ) || ! isset( $stat['size'], $stat['comp_size'] ) || $stat['size'] < 0 || $stat['comp_size'] < 0 ) {
+		if ( ! is_array( $stat ) || $stat['size'] < 0 || $stat['comp_size'] < 0 ) {
 			$zip->close();
 			wp_delete_file( $tmp );
 			return new WP_Error( 'static_site_importer_archive_metadata_invalid', __( 'A ZIP archive entry has invalid metadata.', 'static-site-importer' ), array( 'status' => 400 ) );
@@ -1122,26 +1122,26 @@ function static_site_importer_rest_archive_files( array $archive ) {
  */
 function static_site_importer_rest_archive_limits(): array {
 	$hard_limits = array(
-		'max_encoded_bytes'              => 52428800,
-		'max_decoded_bytes'              => 39321600,
-		'max_entries'                    => 5000,
-		'max_entry_uncompressed_bytes'   => 26214400,
-		'max_total_uncompressed_bytes'   => 104857600,
-		'max_compression_ratio'          => 200,
+		'max_encoded_bytes'            => 52428800,
+		'max_decoded_bytes'            => 39321600,
+		'max_entries'                  => 5000,
+		'max_entry_uncompressed_bytes' => 26214400,
+		'max_total_uncompressed_bytes' => 104857600,
+		'max_compression_ratio'        => 200,
 	);
 	$defaults    = array(
-		'max_encoded_bytes'              => 26214400,
-		'max_decoded_bytes'              => 19660800,
-		'max_entries'                    => 1000,
-		'max_entry_uncompressed_bytes'   => 10485760,
-		'max_total_uncompressed_bytes'   => 52428800,
-		'max_compression_ratio'          => 100,
+		'max_encoded_bytes'            => 26214400,
+		'max_decoded_bytes'            => 19660800,
+		'max_entries'                  => 1000,
+		'max_entry_uncompressed_bytes' => 10485760,
+		'max_total_uncompressed_bytes' => 52428800,
+		'max_compression_ratio'        => 100,
 	);
 	$limits      = apply_filters( 'static_site_importer_archive_limits', $defaults );
 	$limits      = is_array( $limits ) ? $limits : $defaults;
 
 	foreach ( $hard_limits as $key => $maximum ) {
-		$candidate       = isset( $limits[ $key ] ) ? (int) $limits[ $key ] : $defaults[ $key ];
+		$candidate      = isset( $limits[ $key ] ) ? (int) $limits[ $key ] : $defaults[ $key ];
 		$limits[ $key ] = min( $maximum, max( 1, $candidate ) );
 	}
 
@@ -1157,7 +1157,14 @@ function static_site_importer_rest_archive_limits(): array {
 function static_site_importer_rest_archive_limit_error( string $reason ): WP_Error {
 	$code = 'static_site_importer_archive_' . $reason;
 
-	return new WP_Error( $code, __( 'The ZIP archive exceeds the configured safety limit.', 'static-site-importer' ), array( 'status' => 400, 'diagnostic' => array( 'code' => $code ) ) );
+	return new WP_Error(
+		$code,
+		__( 'The ZIP archive exceeds the configured safety limit.', 'static-site-importer' ),
+		array(
+			'status'     => 400,
+			'diagnostic' => array( 'code' => $code ),
+		)
+	);
 }
 
 /**

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1007,8 +1007,19 @@ function static_site_importer_rest_archive_files( array $archive ) {
 		return new WP_Error( 'static_site_importer_zip_unavailable', __( 'ZIP archive extraction is unavailable on this server.', 'static-site-importer' ), array( 'status' => 500 ) );
 	}
 
-	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes uploaded ZIP archive payload content.
-	$content = isset( $archive['content_base64'] ) ? base64_decode( (string) $archive['content_base64'], true ) : false;
+	$encoded_content = isset( $archive['content_base64'] ) ? (string) $archive['content_base64'] : '';
+	$limits          = static_site_importer_rest_archive_limits();
+	if ( strlen( $encoded_content ) > $limits['max_encoded_bytes'] ) {
+		return static_site_importer_rest_archive_limit_error( 'encoded_bytes_exceeded' );
+	}
+
+	// This upper bound is calculated without allocating the decoded archive.
+	if ( intdiv( strlen( $encoded_content ) + 3, 4 ) * 3 > $limits['max_decoded_bytes'] ) {
+		return static_site_importer_rest_archive_limit_error( 'decoded_bytes_exceeded' );
+	}
+
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes uploaded ZIP archive payload content after its encoded and decoded sizes are bounded.
+	$content = base64_decode( $encoded_content, true );
 	if ( false === $content ) {
 		return new WP_Error( 'static_site_importer_invalid_archive_content', __( 'Uploaded ZIP archive content could not be decoded.', 'static-site-importer' ), array( 'status' => 400 ) );
 	}
@@ -1025,6 +1036,43 @@ function static_site_importer_rest_archive_files( array $archive ) {
 			wp_delete_file( $tmp );
 		}
 		return new WP_Error( 'static_site_importer_archive_open_failed', __( 'Uploaded ZIP archive could not be opened.', 'static-site-importer' ), array( 'status' => 400 ) );
+	}
+
+	if ( $zip->numFiles > $limits['max_entries'] ) {
+		$zip->close();
+		wp_delete_file( $tmp );
+		return static_site_importer_rest_archive_limit_error( 'entry_count_exceeded' );
+	}
+
+	$total_uncompressed_bytes = 0;
+	for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+		$stat = $zip->statIndex( $i );
+		if ( ! is_array( $stat ) || ! isset( $stat['size'], $stat['comp_size'] ) || $stat['size'] < 0 || $stat['comp_size'] < 0 ) {
+			$zip->close();
+			wp_delete_file( $tmp );
+			return new WP_Error( 'static_site_importer_archive_metadata_invalid', __( 'A ZIP archive entry has invalid metadata.', 'static-site-importer' ), array( 'status' => 400 ) );
+		}
+
+		$entry_uncompressed_bytes = (int) $stat['size'];
+		$entry_compressed_bytes   = (int) $stat['comp_size'];
+		if ( $entry_uncompressed_bytes > $limits['max_entry_uncompressed_bytes'] ) {
+			$zip->close();
+			wp_delete_file( $tmp );
+			return static_site_importer_rest_archive_limit_error( 'entry_uncompressed_bytes_exceeded' );
+		}
+
+		$total_uncompressed_bytes += $entry_uncompressed_bytes;
+		if ( $total_uncompressed_bytes > $limits['max_total_uncompressed_bytes'] ) {
+			$zip->close();
+			wp_delete_file( $tmp );
+			return static_site_importer_rest_archive_limit_error( 'total_uncompressed_bytes_exceeded' );
+		}
+
+		if ( 0 === $entry_compressed_bytes ? $entry_uncompressed_bytes > 0 : $entry_uncompressed_bytes / $entry_compressed_bytes > $limits['max_compression_ratio'] ) {
+			$zip->close();
+			wp_delete_file( $tmp );
+			return static_site_importer_rest_archive_limit_error( 'compression_ratio_exceeded' );
+		}
 	}
 
 	$files = array();
@@ -1065,6 +1113,51 @@ function static_site_importer_rest_archive_files( array $archive ) {
 	}
 
 	return $files;
+}
+
+/**
+ * Return bounded ZIP intake limits.
+ *
+ * @return array<string,int>
+ */
+function static_site_importer_rest_archive_limits(): array {
+	$hard_limits = array(
+		'max_encoded_bytes'              => 52428800,
+		'max_decoded_bytes'              => 39321600,
+		'max_entries'                    => 5000,
+		'max_entry_uncompressed_bytes'   => 26214400,
+		'max_total_uncompressed_bytes'   => 104857600,
+		'max_compression_ratio'          => 200,
+	);
+	$defaults    = array(
+		'max_encoded_bytes'              => 26214400,
+		'max_decoded_bytes'              => 19660800,
+		'max_entries'                    => 1000,
+		'max_entry_uncompressed_bytes'   => 10485760,
+		'max_total_uncompressed_bytes'   => 52428800,
+		'max_compression_ratio'          => 100,
+	);
+	$limits      = apply_filters( 'static_site_importer_archive_limits', $defaults );
+	$limits      = is_array( $limits ) ? $limits : $defaults;
+
+	foreach ( $hard_limits as $key => $maximum ) {
+		$candidate       = isset( $limits[ $key ] ) ? (int) $limits[ $key ] : $defaults[ $key ];
+		$limits[ $key ] = min( $maximum, max( 1, $candidate ) );
+	}
+
+	return $limits;
+}
+
+/**
+ * Build a stable archive-policy error without exposing archive contents.
+ *
+ * @param string $reason Policy reason code.
+ * @return WP_Error
+ */
+function static_site_importer_rest_archive_limit_error( string $reason ): WP_Error {
+	$code = 'static_site_importer_archive_' . $reason;
+
+	return new WP_Error( $code, __( 'The ZIP archive exceeds the configured safety limit.', 'static-site-importer' ), array( 'status' => 400, 'diagnostic' => array( 'code' => $code ) ) );
 }
 
 /**

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -1189,6 +1189,49 @@ if ( class_exists( 'ZipArchive' ) ) {
 	$paths = array_column( $artifact['files'] ?? array(), 'path' );
 	$assert( in_array( 'website/site/index.html', $paths, true ), 'rest-zip-extracts-normalized-entry' );
 	$assert( in_array( 'website/escape.html', $paths, true ), 'rest-zip-strips-traversal-entry' );
+
+	$assert_archive_limit = static function ( string $label, array $limits, array $entries, string $expected_code ) use ( $assert ): void {
+		$zip_path = tempnam( sys_get_temp_dir(), 'ssi-limit-' );
+		$zip      = new ZipArchive();
+		$zip->open( $zip_path, ZipArchive::OVERWRITE );
+		foreach ( $entries as $path => $content ) {
+			$zip->addFromString( $path, $content );
+		}
+		$zip->close();
+
+		$GLOBALS['ssi_filters']['static_site_importer_archive_limits'] = array(
+			static function ( array $configured_limits ) use ( $limits ): array {
+				return array_merge( $configured_limits, $limits );
+			},
+		);
+		$result = static_site_importer_rest_archive_files(
+			array(
+				'name'           => 'adversarial.zip',
+				'content_base64' => base64_encode( file_get_contents( $zip_path ) ),
+			)
+		);
+		unset( $GLOBALS['ssi_filters']['static_site_importer_archive_limits'] );
+		@unlink( $zip_path );
+
+		$assert( is_wp_error( $result ) && $expected_code === $result->get_error_code(), $label . '-rejects-before-materialization', is_wp_error( $result ) ? $result->get_error_code() : 'archive was materialized' );
+		$assert( is_wp_error( $result ) && $expected_code === ( $result->get_error_data()['diagnostic']['code'] ?? '' ), $label . '-returns-stable-diagnostic' );
+	};
+
+	$assert_archive_limit( 'rest-zip-encoded-size', array( 'max_encoded_bytes' => 1 ), array( 'index.html' => '<main>bounded</main>' ), 'static_site_importer_archive_encoded_bytes_exceeded' );
+	$assert_archive_limit( 'rest-zip-decoded-size', array( 'max_encoded_bytes' => 1024 * 1024, 'max_decoded_bytes' => 1 ), array( 'index.html' => '<main>bounded</main>' ), 'static_site_importer_archive_decoded_bytes_exceeded' );
+	$assert_archive_limit( 'rest-zip-entry-count', array( 'max_entries' => 1 ), array( 'index.html' => '<main>one</main>', 'about.html' => '<main>two</main>' ), 'static_site_importer_archive_entry_count_exceeded' );
+	$assert_archive_limit( 'rest-zip-entry-size', array( 'max_entry_uncompressed_bytes' => 16 ), array( 'index.html' => str_repeat( 'a', 32 ) ), 'static_site_importer_archive_entry_uncompressed_bytes_exceeded' );
+	$assert_archive_limit( 'rest-zip-aggregate-size', array( 'max_entry_uncompressed_bytes' => 1024, 'max_total_uncompressed_bytes' => 32 ), array( 'index.html' => str_repeat( 'a', 20 ), 'about.html' => str_repeat( 'b', 20 ) ), 'static_site_importer_archive_total_uncompressed_bytes_exceeded' );
+	$assert_archive_limit( 'rest-zip-compression-ratio', array( 'max_entry_uncompressed_bytes' => 4096, 'max_compression_ratio' => 2 ), array( 'index.html' => str_repeat( 'a', 2048 ) ), 'static_site_importer_archive_compression_ratio_exceeded' );
+	$GLOBALS['ssi_filters']['static_site_importer_archive_limits'] = array(
+		static function ( array $limits ): array {
+			$limits['max_encoded_bytes'] = PHP_INT_MAX;
+			return $limits;
+		},
+	);
+	$hard_limited = static_site_importer_rest_archive_limits();
+	unset( $GLOBALS['ssi_filters']['static_site_importer_archive_limits'] );
+	$assert( 52428800 >= $hard_limited['max_encoded_bytes'], 'rest-zip-filter-cannot-exceed-encoded-hard-ceiling' );
 }
 
 $artifact = static_site_importer_rest_source_artifact(


### PR DESCRIPTION
## Summary
- Bound encoded Base64 and estimated decoded ZIP bytes before staging or decoding.
- Preflight every central-directory record before any `getFromIndex()` call, rejecting excessive entry counts, per-entry and aggregate uncompressed sizes, and compression ratios with stable reason-coded diagnostics.
- Keep `static_site_importer_archive_limits` filterable only down to or up to hard ceilings, and add adversarial coverage for every limit.

## Policy defaults
- 25 MiB encoded Base64, 18.75 MiB decoded ZIP, 1,000 entries, 10 MiB per entry, 50 MiB aggregate uncompressed, and 100:1 compression ratio.
- Hard ceilings are 50 MiB encoded, 37.5 MiB decoded, 5,000 entries, 25 MiB per entry, 100 MiB aggregate, and 200:1 ratio.

## Evidence
- `php tests/smoke-importer-block.php` (310 assertions)
- `npm test -- --runInBand` (50 passed, 0 failed; 7 WordPress-runtime, 1 browser-WP-Codebox, and 3 operator-only tests intentionally skipped by the manifest)
- `php -l includes/rest.php`
- `php -l tests/smoke-importer-block.php`

Fixes #854

AI assistance disclosure: OpenAI GPT-5.6 Sol via OpenCode implemented the bounded intake policy and adversarial tests. Chris Huber is responsible for every line.