### PR TITLE
Verify generated Playground preview packages

### DIFF
--- a/.github/workflows/release-php-wasm-zstd.yml
+++ b/.github/workflows/release-php-wasm-zstd.yml
@@ -51,6 +51,8 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Publish the immutable safe blueprint
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           pages_dir="$RUNNER_TEMP/static-site-importer-pages"
           if git fetch origin gh-pages; then
@@ -62,14 +64,27 @@ jobs:
           fi
           touch "$pages_dir/.nojekyll"
           mkdir -p "$pages_dir/playground"
+          package_digest="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.assets[] | select(.name == "static-site-importer.zip") | .digest')"
+          package_sha256="${package_digest#sha256:}"
+          if ! printf '%s' "$package_sha256" | grep -Eq '^[a-f0-9]{64}$'; then
+            echo "Release asset static-site-importer.zip must expose a SHA-256 digest." >&2
+            exit 1
+          fi
           # shellcheck disable=SC2016
           node -e '
             const fs = require("node:fs");
-            const [source, output, tag] = process.argv.slice(1);
+            const [source, output, tag, digest] = process.argv.slice(1);
             const blueprint = JSON.parse(fs.readFileSync(source, "utf8"));
-            blueprint.steps.find((step) => step.step === "installPlugin").pluginData.url = `https://github.com/Automattic/static-site-importer/releases/download/${tag}/static-site-importer.zip`;
+            const replace = (value) => value.replaceAll("{{RELEASE_TAG}}", tag).replaceAll("{{PACKAGE_SHA256}}", digest);
+            for (const step of blueprint.steps) {
+              if (step.data?.url) step.data.url = replace(step.data.url);
+              if (step.pluginData?.url) step.pluginData.url = replace(step.pluginData.url);
+              if (step.pluginData?.path) step.pluginData.path = replace(step.pluginData.path);
+              if (step.path) step.path = replace(step.path);
+              if (step.code) step.code = replace(step.code);
+            }
             fs.writeFileSync(output, JSON.stringify(blueprint, null, 2) + "\n");
-          ' docs/playground/blueprint.json "$pages_dir/playground/$RELEASE_TAG.blueprint.json" "$RELEASE_TAG"
+          ' docs/playground/blueprint.json "$pages_dir/playground/$RELEASE_TAG.blueprint.json" "$RELEASE_TAG" "$package_sha256"
           git -C "$pages_dir" add .nojekyll "playground/$RELEASE_TAG.blueprint.json"
           if ! git -C "$pages_dir" diff --cached --quiet; then
             git -C "$pages_dir" -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' commit -m "Publish safe Playground blueprint for $RELEASE_TAG"
@@ -85,8 +100,10 @@ jobs:
               process.stdin.on("data", (chunk) => body += chunk);
               process.stdin.on("end", () => {
                 const blueprint = JSON.parse(body);
+                const download = blueprint.steps.find((step) => step.step === "writeFile");
                 const plugin = blueprint.steps.find((step) => step.step === "installPlugin");
-                if (plugin?.pluginData?.url !== process.env.EXPECTED_PLUGIN_URL) process.exit(1);
+                const check = blueprint.steps.find((step) => step.step === "runPHP" && step.code.includes("hash_file"));
+                if (download?.data?.url !== process.env.EXPECTED_PLUGIN_URL || plugin?.pluginData?.resource !== "vfs" || !check) process.exit(1);
               });
             '; then exit 0; fi
             echo "Waiting for immutable safe blueprint ($attempt/30)"
@@ -130,8 +147,10 @@ jobs:
               process.stdin.on("data", (chunk) => body += chunk);
               process.stdin.on("end", () => {
                 const blueprint = JSON.parse(body);
+                const download = blueprint.steps.find((step) => step.step === "writeFile");
                 const plugin = blueprint.steps.find((step) => step.step === "installPlugin");
-                if (plugin?.pluginData?.url !== process.env.EXPECTED_PLUGIN_URL) process.exit(1);
+                const check = blueprint.steps.find((step) => step.step === "runPHP" && step.code.includes("hash_file"));
+                if (download?.data?.url !== process.env.EXPECTED_PLUGIN_URL || plugin?.pluginData?.resource !== "vfs" || !check) process.exit(1);
               });
             '; then exit 0; fi
             echo "Waiting for safe README blueprint alias ($attempt/30)"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Static Site Importer is a WordPress plugin. It requires the [Blocks Engine PHP t
 
 The initial `website-artifact-import` profile provides the artifact import, validation, WordPress site-plan materialization, and manifest-inspection abilities. It includes SSI's WordPress/PHP runtime and the Blocks Engine PHP transformer dependency while excluding Figma, tests, tools, docs, Node dependencies, and other development-only trees. The same immutable contract is available from `static-site-importer/get-runtime-package-manifest` for runtime discovery.
 
+## Playground package integrity
+
+Generated Playground previews accept an SSI package only when it declares `url`, `version`, and a SHA-256 `sha256` (or `digest`) value. Production selection accepts either the exact GitHub release asset URL for that version or a content-addressed URL containing the declared digest. Playground downloads the archive to its virtual filesystem, verifies its SHA-256 before `installPlugin`, and records the version, digest, and URL in the preview request provenance.
+
+Hosts provide the package through the `static_site_importer_playground_package` filter or the public blueprint primitive's explicit `package` option. A bundled runtime passes `install => false`; this remains the WordPress Build content-addressed package flow and never downloads a second SSI archive. Development-only package URLs require an explicit `development => true` selection and still require a valid digest. Mutable aliases such as `releases/latest` are rejected.
+
 ## Canonical Site Plans
 
 `static-site-importer/materialize-wordpress-site-plan` is the generic plan-only boundary for a `blocks-engine/wordpress-site-plan/v2` produced by Blocks Engine 0.4.4. SSI calls the package's canonical validator and resolver, then owns WordPress/filesystem preflight, materialization, reconciliation, and the `static-site-importer/materialization-receipt/v1` response. It accepts no source HTML or transformer result envelope.

--- a/docs/playground/blueprint.json
+++ b/docs/playground/blueprint.json
@@ -13,10 +13,22 @@
       "step": "login"
     },
     {
-      "step": "installPlugin",
-      "pluginData": {
+      "step": "writeFile",
+      "path": "/tmp/static-site-importer-{{PACKAGE_SHA256}}.zip",
+      "data": {
         "resource": "url",
         "url": "https://github.com/Automattic/static-site-importer/releases/download/{{RELEASE_TAG}}/static-site-importer.zip"
+      }
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php if ( ! hash_equals( '{{PACKAGE_SHA256}}', hash_file( 'sha256', '/tmp/static-site-importer-{{PACKAGE_SHA256}}.zip' ) ) ) { throw new RuntimeException( 'Static Site Importer package integrity verification failed.' ); } ?>"
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "vfs",
+        "path": "/tmp/static-site-importer-{{PACKAGE_SHA256}}.zip"
       },
       "options": {
         "activate": true,

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -206,7 +206,14 @@ function static_site_importer_rest_import_figma_file( WP_REST_Request $request )
  * @return array<string,mixed>|WP_Error
  */
 function static_site_importer_rest_create_playground_open( array $artifact, array $input, string $source = 'upload' ) {
-	$blueprint      = static_site_importer_rest_playground_blueprint( $input );
+	$package        = static_site_importer_playground_package();
+	if ( is_wp_error( $package ) ) {
+		return $package;
+	}
+	$blueprint      = static_site_importer_playground_import_blueprint( $input, array( 'package' => $package ) );
+	if ( is_wp_error( $blueprint ) ) {
+		return $blueprint;
+	}
 	$blueprint_json = wp_json_encode( $blueprint );
 	if ( ! is_string( $blueprint_json ) ) {
 		return new WP_Error( 'static_site_importer_playground_blueprint_encode_failed', __( 'Could not encode the Playground preview blueprint.', 'static-site-importer' ), array( 'status' => 500 ) );
@@ -237,6 +244,7 @@ function static_site_importer_rest_create_playground_open( array $artifact, arra
 			'blueprint' => array(
 				'ref' => $ref,
 			),
+			'package'   => static_site_importer_playground_package_provenance( $package ),
 		),
 	);
 
@@ -259,7 +267,8 @@ function static_site_importer_rest_create_playground_open( array $artifact, arra
  *
  * The returned steps are:
  * - login
- * - installPlugin (SSI from GitHub releases) — omitted when $options['install'] is false
+ * - writeFile + runPHP checksum verification + installPlugin (SSI package) —
+ *   omitted when $options['install'] is false
  * - runPHP — runs static_site_importer_ability_import( $input )
  *
  * Pass `'install' => false` for hosts/runtimes where SSI is already present
@@ -267,11 +276,15 @@ function static_site_importer_rest_create_playground_open( array $artifact, arra
  * skips the GitHub release install step and imports against the bundled plugin.
  *
  * @param array<string,mixed> $input   Import ability input.
- * @param array<string,mixed> $options Optional. { install: bool (default true) }.
- * @return array<int,array<string,mixed>>
+ * @param array<string,mixed> $options Optional. { install: bool (default true), package: array }.
+ * @return array<int,array<string,mixed>>|WP_Error
  */
-function static_site_importer_playground_import_steps( array $input, array $options = array() ): array {
+function static_site_importer_playground_import_steps( array $input, array $options = array() ) {
 	$install = ! array_key_exists( 'install', $options ) || ! empty( $options['install'] );
+	$package = $install ? static_site_importer_playground_package( $options ) : null;
+	if ( is_wp_error( $package ) ) {
+		return $package;
+	}
 
 	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generates self-contained Playground import code.
 	$input_literal = var_export( $input, true );
@@ -298,11 +311,24 @@ update_option( "static_site_importer_playground_preview_result", $result, false 
 	);
 
 	if ( $install ) {
+		$package_path = '/tmp/static-site-importer-' . substr( $package['sha256'], 0, 16 ) . '.zip';
+		$steps[] = array(
+			'step' => 'writeFile',
+			'path' => $package_path,
+			'data' => array(
+				'resource' => 'url',
+				'url'      => $package['url'],
+			),
+		);
+		$steps[] = array(
+			'step' => 'runPHP',
+			'code' => '<?php if ( ! hash_equals( ' . var_export( $package['sha256'], true ) . ', hash_file( "sha256", ' . var_export( $package_path, true ) . ' ) ) ) { throw new RuntimeException( "Static Site Importer package integrity verification failed." ); } ?>',
+		);
 		$steps[] = array(
 			'step'       => 'installPlugin',
 			'pluginData' => array(
-				'resource' => 'url',
-				'url'      => 'https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip',
+				'resource' => 'vfs',
+				'path'     => $package_path,
 			),
 			'options'    => array(
 				'activate'         => true,
@@ -328,10 +354,15 @@ update_option( "static_site_importer_playground_preview_result", $result, false 
  * {@see static_site_importer_rest_playground_blueprint()} returns today.
  *
  * @param array<string,mixed> $input   Import ability input.
- * @param array<string,mixed> $options Optional. { install: bool (default true) }.
- * @return array<string,mixed>
+ * @param array<string,mixed> $options Optional. { install: bool (default true), package: array }.
+ * @return array<string,mixed>|WP_Error
  */
-function static_site_importer_playground_import_blueprint( array $input, array $options = array() ): array {
+function static_site_importer_playground_import_blueprint( array $input, array $options = array() ) {
+	$steps = static_site_importer_playground_import_steps( $input, $options );
+	if ( is_wp_error( $steps ) ) {
+		return $steps;
+	}
+
 	return array(
 		'$schema'           => 'https://playground.wordpress.net/blueprint-schema.json',
 		'landingPage'       => '/',
@@ -342,7 +373,7 @@ function static_site_importer_playground_import_blueprint( array $input, array $
 		'features'          => array(
 			'networking' => true,
 		),
-		'steps'             => static_site_importer_playground_import_steps( $input, $options ),
+		'steps'             => $steps,
 	);
 }
 
@@ -351,13 +382,67 @@ function static_site_importer_playground_import_blueprint( array $input, array $
  *
  * Thin REST-internal wrapper retained for backward compatibility. Delegates to
  * the public {@see static_site_importer_playground_import_blueprint()} primitive
- * with the install step enabled so the public /import preview URL is unchanged.
+ * with the install step enabled.
  *
  * @param array<string,mixed> $input Import ability input.
- * @return array<string,mixed>
+ * @return array<string,mixed>|WP_Error
  */
-function static_site_importer_rest_playground_blueprint( array $input ): array {
+function static_site_importer_rest_playground_blueprint( array $input ) {
 	return static_site_importer_playground_import_blueprint( $input );
+}
+
+/**
+ * Select an integrity-verified package for a generated Playground preview.
+ *
+ * A production package must either be a GitHub release asset pinned to its
+ * version or a URL whose path embeds the declared SHA-256. Hosts that bundle
+ * SSI (including WordPress Build) retain the install=false path and never
+ * download a second package.
+ *
+ * @param array<string,mixed> $options Blueprint options.
+ * @return array{url:string,version:string,sha256:string}|WP_Error
+ */
+function static_site_importer_playground_package( array $options = array() ) {
+	$package = isset( $options['package'] ) && is_array( $options['package'] ) ? $options['package'] : null;
+	if ( null === $package && function_exists( 'apply_filters' ) ) {
+		$package = apply_filters( 'static_site_importer_playground_package', null, $options );
+	}
+	if ( ! is_array( $package ) ) {
+		return new WP_Error( 'static_site_importer_playground_package_missing', __( 'A pinned, integrity-verified Static Site Importer package is required for Playground previews.', 'static-site-importer' ), array( 'status' => 503 ) );
+	}
+
+	$url     = isset( $package['url'] ) ? (string) $package['url'] : '';
+	$version = isset( $package['version'] ) ? (string) $package['version'] : '';
+	$sha256  = strtolower( preg_replace( '/^sha256:/i', '', (string) ( $package['sha256'] ?? $package['digest'] ?? '' ) ) );
+	$is_development = ! empty( $package['development'] );
+	if ( '' === $url || '' === $version || ! preg_match( '/^[a-f0-9]{64}$/', $sha256 ) || ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
+		return new WP_Error( 'static_site_importer_playground_package_invalid', __( 'The Static Site Importer Playground package must provide a URL, version, and SHA-256 digest.', 'static-site-importer' ), array( 'status' => 500 ) );
+	}
+
+	$release_asset = 'https://github.com/Automattic/static-site-importer/releases/download/' . rawurlencode( $version ) . '/static-site-importer.zip';
+	$content_addressed = false !== strpos( strtolower( (string) parse_url( $url, PHP_URL_PATH ) ), $sha256 );
+	if ( ! $is_development && $url !== $release_asset && ! $content_addressed ) {
+		return new WP_Error( 'static_site_importer_playground_package_mutable', __( 'Static Site Importer Playground previews require a version-pinned release asset or content-addressed package URL.', 'static-site-importer' ), array( 'status' => 500 ) );
+	}
+
+	return array(
+		'url'     => $url,
+		'version' => $version,
+		'sha256'  => $sha256,
+	);
+}
+
+/**
+ * Return package provenance for the current REST preview response.
+ *
+ * @return array<string,string>
+ */
+function static_site_importer_playground_package_provenance( array $package ): array {
+	return array(
+		'version' => $package['version'],
+		'sha256'  => $package['sha256'],
+		'url'     => $package['url'],
+	);
 }
 
 /**

--- a/tests/smoke-playground-import-primitive.php
+++ b/tests/smoke-playground-import-primitive.php
@@ -55,6 +55,24 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		return 'static_site_importer_playground_package' === $hook ? ( $GLOBALS['static_site_importer_test_playground_package'] ?? $value ) : $value;
+	}
+}
+
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/rest.php';
 
 /**
@@ -100,9 +118,15 @@ $input = array(
 		),
 	),
 );
+$package = array(
+	'url'     => 'https://github.com/Automattic/static-site-importer/releases/download/1.4.0/static-site-importer.zip',
+	'version' => '1.4.0',
+	'sha256'  => str_repeat( 'a', 64 ),
+);
+$GLOBALS['static_site_importer_test_playground_package'] = $package;
 
 // --- Case 1: default steps include installPlugin + runPHP (+ login). ---
-$default_steps = static_site_importer_playground_import_steps( $input );
+$default_steps = static_site_importer_playground_import_steps( $input, array( 'package' => $package ) );
 $default_names = $step_names( $default_steps );
 
 $assert( is_array( $default_steps ), 'default-array', 'default steps is an array' );
@@ -116,6 +140,12 @@ $assert(
 	'default-install',
 	'default steps include installPlugin'
 );
+$assert( in_array( 'writeFile', $default_names, true ), 'default-download', 'default steps download the package before installation' );
+$assert( 2 === count( array_keys( $default_names, 'runPHP', true ) ), 'default-integrity-check', 'default steps verify the package digest before importing' );
+$install_step = $default_steps[ array_search( 'installPlugin', $default_names, true ) ];
+$assert( 'vfs' === ( $install_step['pluginData']['resource'] ?? '' ), 'default-vfs-install', 'installPlugin consumes the verified VFS package' );
+$integrity_step = $default_steps[ array_search( 'runPHP', $default_names, true ) ];
+$assert( false !== strpos( $integrity_step['code'] ?? '', "hash_equals( '" . $package['sha256'] . "', hash_file" ), 'digest-mismatch-fails', 'a downloaded archive with a mismatched digest throws before installPlugin executes' );
 $assert(
 	in_array( 'runPHP', $default_names, true ),
 	'default-runphp',
@@ -168,19 +198,32 @@ $assert(
 );
 
 // --- Case 4: blueprint primitive matches the legacy REST blueprint (delegation parity). ---
-$primitive_blueprint = static_site_importer_playground_import_blueprint( $input );
+$primitive_blueprint = static_site_importer_playground_import_blueprint( $input, array( 'package' => $package ) );
 $legacy_blueprint    = static_site_importer_rest_playground_blueprint( $input );
 
 $assert(
 	$primitive_blueprint === $legacy_blueprint,
 	'delegation-parity',
-	'public blueprint is byte-identical to the legacy REST blueprint'
+	'public blueprint is deterministic for an explicit package selection'
 );
 $assert(
 	isset( $primitive_blueprint['steps'] ) && $primitive_blueprint['steps'] === $default_steps,
 	'blueprint-steps-parity',
 	'public blueprint embeds the public default steps'
 );
+
+// --- Case 5: mutable aliases and invalid digest declarations fail closed. ---
+$mutable = static_site_importer_playground_import_steps( $input, array( 'package' => array_merge( $package, array( 'url' => 'https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip' ) ) ) );
+$assert( is_wp_error( $mutable ) && 'static_site_importer_playground_package_mutable' === $mutable->code, 'mutable-rejected', 'latest release aliases cannot become preview defaults' );
+$invalid_digest = static_site_importer_playground_import_steps( $input, array( 'package' => array_merge( $package, array( 'sha256' => 'not-a-digest' ) ) ) );
+$assert( is_wp_error( $invalid_digest ) && 'static_site_importer_playground_package_invalid' === $invalid_digest->code, 'digest-rejected', 'malformed integrity declarations fail closed' );
+$content_addressed = static_site_importer_playground_import_steps( $input, array( 'package' => array( 'url' => 'https://packages.example.test/ssi/' . str_repeat( 'b', 64 ) . '/static-site-importer.zip', 'version' => 'wpbuild-20260806', 'digest' => 'sha256:' . str_repeat( 'b', 64 ) ) ) );
+$assert( ! is_wp_error( $content_addressed ), 'content-addressed-accepted', 'WordPress Build content-addressed packages remain supported' );
+$development = static_site_importer_playground_import_steps( $input, array( 'package' => array_merge( $package, array( 'url' => 'http://127.0.0.1:8080/static-site-importer.zip', 'development' => true ) ) ) );
+$assert( ! is_wp_error( $development ), 'development-override-accepted', 'an explicit development package override remains available' );
+$GLOBALS['static_site_importer_test_playground_package'] = null;
+$missing = static_site_importer_playground_import_steps( $input );
+$assert( is_wp_error( $missing ) && 'static_site_importer_playground_package_missing' === $missing->code, 'production-default-rejected', 'a mutable or unspecified production package is never emitted' );
 
 // --- Report. ---
 if ( empty( $failures ) ) {


### PR DESCRIPTION
Fixes #857

## Summary
- require an explicit versioned release asset or content-addressed SSI package plus SHA-256 for generated Playground previews
- download to VFS and verify the archive before `installPlugin`, recording package provenance in preview responses
- preserve explicit development overrides and bundled WordPress Build `install => false` flows
- publish verified digests in release blueprints

## Test evidence
- `php tests/smoke-playground-import-primitive.php` (23 assertions)
- `npm run test:runtime-package`
- `npm run test:inventory`
- `php -l includes/rest.php`
- `actionlint .github/workflows/release-php-wasm-zstd.yml`

AI assistance disclosure: OpenAI GPT-5.6 Sol via OpenCode implemented the integrity selection, tests, documentation, and release workflow update. Chris Huber is responsible for every line.