### PR TITLE
Fix current-site materialization capability matrix

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -16,6 +16,7 @@
     "tests/smoke-import-diagnostic-contract.php": { "environment": "standalone-php" },
     "tests/smoke-import-disposition.php": { "environment": "standalone-php" },
     "tests/smoke-import-permission-filter.php": { "environment": "standalone-php" },
+    "tests/smoke-current-site-capabilities.php": { "environment": "standalone-php" },
     "tests/smoke-importer-block.php": { "environment": "standalone-php" },
     "tests/smoke-inline-svg-materialization.php": { "environment": "standalone-php" },
     "tests/smoke-materialized-block-content-validation.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-current-site-capabilities.php
+++ b/includes/class-static-site-importer-current-site-capabilities.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Current-site materialization capability checks.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class Static_Site_Importer_Current_Site_Capabilities {
+	/** @return true|WP_Error */
+	public static function check_plan( array $state ): true|WP_Error {
+		if ( self::is_cli() ) {
+			return true;
+		}
+
+		$required = array();
+		foreach ( $state['resolved']['writes'] ?? array() as $write ) {
+			if ( is_array( $write ) ) {
+				if ( function_exists( 'wp_is_file_mod_allowed' ) && ! wp_is_file_mod_allowed( 'static_site_importer_theme_materialization' ) ) {
+					return new WP_Error( 'static_site_importer_file_modification_forbidden', 'WordPress file modification policy does not allow theme materialization.' );
+				}
+				$required[] = array( 'capability' => 'install_themes' );
+				break;
+			}
+		}
+		foreach ( $state['ordered_pages'] ?? array() as $page ) {
+			if ( ! is_array( $page ) || ! empty( $page['skip_materialization'] ) ) {
+				continue;
+			}
+			$existing_id = (int) ( $page['planned_existing_id'] ?? 0 );
+			if ( $existing_id > 0 ) {
+				$required[] = array( 'capability' => 'edit_post', 'args' => array( $existing_id ) );
+				continue;
+			}
+			$type = function_exists( 'get_post_type_object' ) ? get_post_type_object( (string) ( $page['post_type'] ?? 'page' ) ) : null;
+			if ( ! $type ) {
+				return new WP_Error( 'static_site_importer_capability_plan_invalid', 'The materialization plan has an unknown post type.' );
+			}
+			$cap = $type->cap ?? null;
+			if ( ! is_object( $cap ) || ! isset( $cap->create_posts, $cap->publish_posts ) ) {
+				return new WP_Error( 'static_site_importer_capability_plan_invalid', 'The materialization plan has incomplete post type capabilities.' );
+			}
+			$required[] = array( 'capability' => (string) $cap->create_posts );
+			$required[] = array( 'capability' => (string) $cap->publish_posts );
+		}
+
+		$args = is_array( $state['args'] ?? null ) ? $state['args'] : array();
+		if ( ! empty( $args['activate'] ) ) {
+			$required[] = array( 'capability' => 'switch_themes' );
+			if ( ! empty( $state['resolved']['operations'] ) || '' !== trim( (string) ( $args['site_title'] ?? '' ) ) || ! isset( $args['disable_smilies'] ) || false !== (bool) $args['disable_smilies'] ) {
+				$required[] = array( 'capability' => 'manage_options' );
+			}
+		}
+
+		return self::check( $required );
+	}
+
+	/** @return true|WP_Error */
+	public static function check_plugin_install( bool $activate, bool $install = true ): true|WP_Error {
+		if ( self::is_cli() ) {
+			return true;
+		}
+		if ( $install && function_exists( 'wp_is_file_mod_allowed' ) && ! wp_is_file_mod_allowed( 'static_site_importer_plugin_materialization' ) ) {
+			return new WP_Error( 'static_site_importer_file_modification_forbidden', 'WordPress file modification policy does not allow plugin materialization.' );
+		}
+		$required = $install ? array( array( 'capability' => 'install_plugins' ) ) : array();
+		if ( $activate ) {
+			$required[] = array( 'capability' => 'activate_plugins' );
+		}
+		return self::check( $required );
+	}
+
+	/** @param array<int,array{capability:string,args?:array<int,mixed>}> $required @return true|WP_Error */
+	private static function check( array $required ): true|WP_Error {
+		if ( ! function_exists( 'current_user_can' ) ) {
+			return true;
+		}
+		foreach ( $required as $requirement ) {
+			$capability = $requirement['capability'];
+			$args       = $requirement['args'] ?? array();
+			if ( '' !== $capability && ! current_user_can( $capability, ...$args ) ) {
+				return new WP_Error( 'static_site_importer_capability_forbidden', sprintf( 'Current-site materialization requires the %s capability.', $capability ), array( 'capability' => $capability ) );
+			}
+		}
+		return true;
+	}
+
+	private static function is_cli(): bool {
+		return defined( 'WP_CLI' ) && WP_CLI;
+	}
+}

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Current_Site_Capabilities' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-current-site-capabilities.php';
+}
+
 /**
  * Installs and activates declared WordPress.org plugins before entity seeding.
  */
@@ -49,9 +53,14 @@ class Static_Site_Importer_Plugin_Materializer {
 			return self::failed_report( $report, $deps );
 		}
 
-		if ( file_exists( trailingslashit( WP_PLUGIN_DIR ) . $plugin_file ) ) {
+		$needs_install = ! file_exists( trailingslashit( WP_PLUGIN_DIR ) . $plugin_file );
+		if ( ! $needs_install ) {
 			$report['installed'] = true;
 		} else {
+			$capabilities = Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( true );
+			if ( is_wp_error( $capabilities ) ) {
+				return self::failed_report( $report, $capabilities );
+			}
 			$install = self::install_wp_org_plugin( $slug );
 			if ( is_wp_error( $install ) ) {
 				return self::failed_report( $report, $install );
@@ -68,6 +77,10 @@ class Static_Site_Importer_Plugin_Materializer {
 				return self::failed_report( $report, $preparation );
 			}
 		} else {
+			$capabilities = Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( true, false );
+			if ( is_wp_error( $capabilities ) ) {
+				return self::failed_report( $report, $capabilities );
+			}
 			$lifecycle = self::prepare_activation_lifecycle_replay();
 			try {
 				$activate = activate_plugin( $plugin_file );
@@ -185,6 +198,10 @@ class Static_Site_Importer_Plugin_Materializer {
 		$already_available = self::available( $availability_check );
 
 		$report['attempted'] = true;
+		$capabilities       = Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( (bool) $plan['activate'] );
+		if ( is_wp_error( $capabilities ) ) {
+			return self::failed_report( $report, $capabilities );
+		}
 
 		$written = self::write_generated_files( $plan );
 		if ( is_wp_error( $written ) ) {

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -9,6 +9,9 @@ use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlan;
 use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver;
 
 require_once __DIR__ . '/class-static-site-importer-stylesheet-materializer.php';
+if ( ! class_exists( 'Static_Site_Importer_Current_Site_Capabilities' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-current-site-capabilities.php';
+}
 
 final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	public const RECEIPT_SCHEMA           = 'static-site-importer/materialization-receipt/v1';
@@ -151,6 +154,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$state = self::refresh_prepared_destination( $prepared );
 		if ( 'prepared' !== ( $state['status'] ?? '' ) ) {
 			return $state['receipt'];
+		}
+		$capabilities = Static_Site_Importer_Current_Site_Capabilities::check_plan( $state );
+		if ( is_wp_error( $capabilities ) ) {
+			return self::failed_receipt_from_error( $state, $capabilities );
 		}
 		$args         = $state['args'];
 		$font_overlay = Static_Site_Importer_Font_Materializer::prepare_overlay(

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -73,6 +73,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-va
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-font-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document-type-classifier.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-current-site-capabilities.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-wordpress-site-plan-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-figma-import.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-exporter.php';

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -21,6 +21,7 @@
     { "path": "tests/smoke-import-diagnostic-contract.php", "environment": "standalone-php" },
     { "path": "tests/smoke-import-disposition.php", "environment": "standalone-php" },
     { "path": "tests/smoke-import-permission-filter.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-current-site-capabilities.php", "environment": "standalone-php" },
     { "path": "tests/smoke-importer-block.php", "environment": "standalone-php" },
     { "path": "tests/smoke-inline-svg-materialization.php", "environment": "standalone-php" },
     { "path": "tests/smoke-materialized-block-content-validation.php", "environment": "standalone-php" },

--- a/tests/smoke-current-site-capabilities.php
+++ b/tests/smoke-current-site-capabilities.php
@@ -1,0 +1,64 @@
+<?php
+/** Current-site materialization capability matrix regression coverage. */
+
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+$GLOBALS['ssi_caps']             = array();
+$GLOBALS['ssi_file_mod_allowed'] = true;
+
+class WP_Error {
+	public function __construct( private string $code, private string $message = '', private mixed $data = null ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_data(): mixed { return $this->data; }
+}
+class SSI_Test_Post_Type {
+	public object $cap;
+	public function __construct( string $type ) {
+		$this->cap = (object) array(
+			'create_posts'  => 'page' === $type ? 'edit_pages' : 'edit_posts',
+			'publish_posts' => 'page' === $type ? 'publish_pages' : 'publish_posts',
+		);
+	}
+}
+function current_user_can( string $capability, mixed ...$args ): bool { return ! empty( $GLOBALS['ssi_caps'][ $capability ] ); }
+function get_post_type_object( string $type ): ?object { return in_array( $type, array( 'page', 'post' ), true ) ? new SSI_Test_Post_Type( $type ) : null; }
+function wp_is_file_mod_allowed( string $context ): bool { return $GLOBALS['ssi_file_mod_allowed']; }
+function is_wp_error( mixed $value ): bool { return $value instanceof WP_Error; }
+
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-current-site-capabilities.php';
+
+$assertions = 0;
+$assert = static function ( bool $condition, string $label ) use ( &$assertions ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		throw new RuntimeException( $label );
+	}
+};
+$state = array(
+	'resolved' => array( 'writes' => array( array( 'target_path' => 'style.css' ) ), 'operations' => array( array( 'kind' => 'site_reading' ) ) ),
+	'ordered_pages' => array( array( 'post_type' => 'page' ) ),
+	'args' => array( 'activate' => true, 'site_title' => 'Built Site' ),
+);
+
+// WordPress Build-style product roles can be allowed to build, but cannot gain file or plugin authority.
+$GLOBALS['ssi_caps'] = array( 'edit_pages' => true, 'publish_pages' => true, 'switch_themes' => true, 'manage_options' => true, 'install_themes' => true );
+$assert( true === Static_Site_Importer_Current_Site_Capabilities::check_plan( $state ), 'trusted site materializer has every plan capability' );
+$assert( is_wp_error( Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( true ) ), 'restricted WordPress Build role cannot install or activate plugins' );
+
+$GLOBALS['ssi_caps']['install_plugins'] = true;
+$assert( is_wp_error( Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( true ) ), 'plugin installation alone cannot grant activation authority' );
+$GLOBALS['ssi_caps']['activate_plugins'] = true;
+$assert( true === Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( true ), 'regular generated plugins require install and activation authority' );
+$assert( true === Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( false ), 'must-use generated plugins require install authority without activation' );
+
+$GLOBALS['ssi_file_mod_allowed'] = false;
+$denied = Static_Site_Importer_Current_Site_Capabilities::check_plan( $state );
+$assert( is_wp_error( $denied ) && 'static_site_importer_file_modification_forbidden' === $denied->get_error_code(), 'theme writes honor WordPress file-modification policy' );
+$denied = Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( false );
+$assert( is_wp_error( $denied ) && 'static_site_importer_file_modification_forbidden' === $denied->get_error_code(), 'plugin writes honor WordPress file-modification policy' );
+$assert( true === Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( true, false ), 'activating an existing plugin follows WordPress capability semantics without a file write' );
+
+$GLOBALS['ssi_file_mod_allowed'] = true;
+$GLOBALS['ssi_caps']['manage_options'] = false;
+$assert( is_wp_error( Static_Site_Importer_Current_Site_Capabilities::check_plan( $state ) ), 'site setting changes require manage_options' );
+
+echo "Current-site capability smoke passed ({$assertions} assertions).\n";

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -98,7 +98,15 @@ function wp_insert_post( array $post, bool $wp_error ) {
 class WP_Post_Type {
 	public string $name;
 	public bool $public;
-	public function __construct( string $name, bool $public = true ) { $this->name = $name; $this->public = $public; }
+	public object $cap;
+	public function __construct( string $name, bool $public = true ) {
+		$this->name = $name;
+		$this->public = $public;
+		$this->cap = (object) array(
+			'create_posts'  => 'page' === $name ? 'edit_pages' : 'edit_posts',
+			'publish_posts' => 'page' === $name ? 'publish_pages' : 'publish_posts',
+		);
+	}
 }
 function get_post_type_object( string $post_type ): ?object {
 	return in_array( $post_type, array( 'page', 'post' ), true ) ? new WP_Post_Type( $post_type ) : null;


### PR DESCRIPTION
Fixes #852

## Summary
Enforces explicit WordPress capabilities for current-site theme writes, post creation/updates, theme activation, site settings, and plugin installation/activation. Generated regular and must-use plugin writes now honor WordPress file-modification policy.

## Tests
- `npm test` (51 selected checks passed; external WordPress-runtime/browser lanes intentionally skipped by the manifest)
- `php tests/smoke-current-site-capabilities.php`
- `php tests/smoke-plugin-materializer-lifecycle.php`
- `php tests/smoke-wordpress-site-plan-materializer.php`

## Compatibility
Planning and Playground/disposable preview paths are unchanged. WP-CLI remains permitted. Existing plugin activation requires only `activate_plugins`, matching WordPress core; plugin and theme writes honor core file-mod policy and multisite capability mapping through `current_user_can()`.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode was used to implement the capability matrix, add regression coverage, run tests, and prepare this pull request. Chris Huber remains responsible for every line.