### PR TITLE
Fix content-only static artifact boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The conversion stack is split by responsibility:
 - **Static Site Importer** owns WordPress intake, safety checks, page/theme creation, asset placement, import reports, quality gates, and block-theme materialization.
 - **Blocks Engine PHP transformer** owns the generic `ArtifactCompiler`, its diagnostics, and the `source_reports.wordpress_site_plan` v2 output. SSI materializes that plan into WordPress and returns the receipt and import report.
 
+## Content-Only Security Boundary
+
+All HTML, folders, ZIPs, URLs, and website artifact objects are untrusted static content. SSI accepts only explicit static asset extensions and rejects server-side source markers before compilation. Compiler-produced companion payloads are independently revalidated before any generated plugin file is written or activated. Companion block renders accept static HTML only; SSI emits its own fixed PHP wrapper to output that markup, so source PHP cannot be preserved or executed. Existing payloads that relied on PHP render templates or PHP companion assets must migrate their behavior to blocks, data bindings, or client-side JavaScript.
+
 When a generated artifact contains full-document HTML, Static Site Importer routes document metadata, head content, styles, scripts, and page body fragments to the right WordPress destinations before calling the conversion stack. A `core/html` block in imported page content is therefore a materialization/conversion quality issue to fix in this stack, not a product-layer workaround to hide upstream.
 
 ## What It Does

--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -7,6 +7,7 @@
     "tests/smoke-ability-import-success-diagnostics.php": { "environment": "standalone-php" },
     "tests/smoke-ability-registration-idempotent.php": { "environment": "standalone-php" },
     "tests/smoke-canonical-import-ability.php": { "environment": "standalone-php" },
+    "tests/smoke-content-only-policy.php": { "environment": "standalone-php" },
     "tests/smoke-companion-plugin-js.php": { "environment": "standalone-php" },
     "tests/smoke-companion-plugin.php": { "environment": "standalone-php" },
     "tests/smoke-contact-layout-transformer.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -30,6 +30,10 @@ if ( ! class_exists( 'Static_Site_Importer_Site_Identity' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-site-identity.php';
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Content_Policy' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-content-policy.php';
+}
+
 /**
  * Scaffolds a one-per-site companion plugin from a generated block payload.
  */
@@ -94,13 +98,16 @@ class Static_Site_Importer_Companion_Plugin {
 			}
 			$block_names[ $effective_name ] = true;
 			$assets                         = $block['assets'] ?? array();
-			if ( ! is_array( $assets ) || array_is_list( $assets ) ) {
+			if ( ! is_array( $assets ) || ( ! empty( $assets ) && array_is_list( $assets ) ) ) {
 				return new WP_Error( 'static_site_importer_companion_plugin_assets_invalid', sprintf( 'Block %s assets must be an object.', $name ) );
 			}
 			foreach ( $assets as $path => $content ) {
-				if ( ! is_string( $path ) || self::sanitize_relative_path( $path ) !== $path || ! is_scalar( $content ) ) {
+				if ( ! is_string( $path ) || self::sanitize_relative_path( $path ) !== $path || ! Static_Site_Importer_Content_Policy::is_companion_asset_path( $path ) || ! is_scalar( $content ) || Static_Site_Importer_Content_Policy::contains_server_code( (string) $content ) ) {
 					return new WP_Error( 'static_site_importer_companion_plugin_asset_path_invalid', sprintf( 'Block %s has an unsafe asset path.', $name ) );
 				}
+			}
+			if ( isset( $block['render'] ) && is_scalar( $block['render'] ) && Static_Site_Importer_Content_Policy::contains_server_code( (string) $block['render'] ) ) {
+				return new WP_Error( 'static_site_importer_companion_plugin_render_invalid', sprintf( 'Block %s render markup must be static HTML.', $name ) );
 			}
 			$metadata = $block['block_json'];
 			if ( isset( $block['render'] ) && is_scalar( $block['render'] ) ) {
@@ -143,6 +150,10 @@ class Static_Site_Importer_Companion_Plugin {
 	 * @return array<string,mixed>|WP_Error
 	 */
 	public static function scaffold( array $payload ) {
+		$validation = self::validate_payload( $payload );
+		if ( is_wp_error( $validation ) ) {
+			return $validation;
+		}
 		$site_slug = self::site_slug( $payload );
 		if ( '' === $site_slug ) {
 			return new WP_Error(
@@ -924,11 +935,9 @@ class Static_Site_Importer_Companion_Plugin {
 			return "<?php\n/**\n * Generated companion block render (server-rendered dynamic block).\n *\n * @package StaticSiteImporterCompanion\n *\n * @var array<string,mixed> \$attributes Block attributes.\n * @var string              \$content    Inner block content.\n * @var WP_Block            \$block      Block instance.\n */\n\necho \$content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block content is already sanitized by WordPress.\n";
 		}
 
-		if ( str_starts_with( $trimmed, '<?php' ) || str_starts_with( $trimmed, '<?=' ) ) {
-			return $render;
-		}
-
-		return "<?php\n/**\n * Generated companion block render (server-rendered dynamic block).\n *\n * @package StaticSiteImporterCompanion\n *\n * @var array<string,mixed> \$attributes Block attributes.\n * @var string              \$content    Inner block content.\n * @var WP_Block            \$block      Block instance.\n */\n?>\n" . $render;
+		// Static source markup is data, never executable template source. The only
+		// PHP in this file is SSI-generated code that emits an escaped literal.
+		return "<?php\n/** Generated companion block render. */\n\necho '" . self::php_single_quote( $render ) . "'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static source markup was validated before compilation.\n";
 	}
 
 	/**

--- a/includes/class-static-site-importer-content-policy.php
+++ b/includes/class-static-site-importer-content-policy.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Content-only boundary for untrusted website artifacts.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+final class Static_Site_Importer_Content_Policy {
+	/** Files that can be copied from an untrusted static-site artifact. */
+	private const STATIC_EXTENSIONS = array(
+		'html', 'htm', 'css', 'js', 'mjs', 'json', 'map', 'xml', 'txt', 'md', 'markdown',
+		'svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'ico', 'bmp',
+		'woff', 'woff2', 'ttf', 'otf', 'eot', 'mp3', 'mp4', 'webm', 'ogg', 'wav', 'pdf',
+	);
+
+	/** Assets that a compiler may carry into a generated companion plugin. */
+	private const COMPANION_ASSET_EXTENSIONS = array( 'js', 'mjs', 'css', 'json', 'svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'ico', 'woff', 'woff2', 'ttf', 'otf', 'eot' );
+
+	/** @return true|WP_Error */
+	public static function validate_artifact( array $artifact ) {
+		$files = $artifact['files'] ?? null;
+		if ( ! is_array( $files ) ) {
+			return new WP_Error( 'static_site_importer_artifact_files_invalid', 'Website artifacts must declare files as an array.' );
+		}
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) || ! isset( $file['path'] ) || ! is_scalar( $file['path'] ) ) {
+				return new WP_Error( 'static_site_importer_artifact_file_invalid', 'Website artifacts must declare a path for every file.' );
+			}
+			$path = (string) $file['path'];
+			if ( ! self::is_static_path( $path ) ) {
+				return new WP_Error( 'static_site_importer_executable_source_rejected', sprintf( 'Untrusted artifact file %s is not static content.', $path ), array( 'path' => $path ) );
+			}
+			$content = self::file_content( $file );
+			if ( null !== $content && self::contains_server_code( $content ) ) {
+				return new WP_Error( 'static_site_importer_executable_source_rejected', sprintf( 'Untrusted artifact file %s contains server-side code.', $path ), array( 'path' => $path ) );
+			}
+		}
+		return true;
+	}
+
+	public static function is_static_path( string $path ): bool {
+		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+		return '' !== $extension && in_array( $extension, self::STATIC_EXTENSIONS, true );
+	}
+
+	public static function is_companion_asset_path( string $path ): bool {
+		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+		return '' !== $extension && in_array( $extension, self::COMPANION_ASSET_EXTENSIONS, true );
+	}
+
+	public static function contains_server_code( string $content ): bool {
+		return preg_match( '/<\?(?:php|=|[[:space:]])/i', $content ) === 1;
+	}
+
+	/** @param array<string,mixed> $file */
+	private static function file_content( array $file ): ?string {
+		if ( isset( $file['content'] ) && is_scalar( $file['content'] ) ) {
+			return (string) $file['content'];
+		}
+		if ( ! isset( $file['content_base64'] ) || ! is_scalar( $file['content_base64'] ) ) {
+			return null;
+		}
+		$decoded = base64_decode( (string) $file['content_base64'], true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Validates untrusted artifact bytes.
+		return false === $decoded ? null : $decoded;
+	}
+}

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -151,15 +151,12 @@ class Static_Site_Importer_Plugin_Materializer {
 		array $payload,
 		?callable $availability_check = null
 	): array {
-		// Canonical compiler payloads are validated before deriving an install plan
-		// or touching the filesystem. Schema-less callers retain the legacy
-		// PHP-only scaffold compatibility path.
-		if ( array_key_exists( 'schema', $payload ) ) {
-			$validation = Static_Site_Importer_Companion_Plugin::validate_payload( $payload );
-			if ( is_wp_error( $validation ) ) {
-				$report = self::new_generated_report( '', '' );
-				return self::failed_report( $report, $validation );
-			}
+		// All compiler output is untrusted until the complete canonical payload has
+		// passed the content-only boundary. Schema-less PHP scaffold input is gone.
+		$validation = Static_Site_Importer_Companion_Plugin::validate_payload( $payload );
+		if ( is_wp_error( $validation ) ) {
+			$report = self::new_generated_report( '', '' );
+			return self::failed_report( $report, $validation );
 		}
 		$descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $payload );
 		if ( is_wp_error( $descriptor ) ) {

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -15,6 +15,10 @@ if ( ! class_exists( 'Static_Site_Importer_Site_Identity' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-site-identity.php';
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Content_Policy' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-content-policy.php';
+}
+
 if ( ! class_exists( 'Static_Site_Importer_Block_Document_Reporter' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-block-document-reporter.php';
 }
@@ -86,6 +90,10 @@ class Static_Site_Importer_Theme_Generator {
 
 	/** Compile an artifact into its immutable canonical WordPress site plan. */
 	public static function compile_website_artifact( array $artifact, array $args = array() ) {
+		$source_policy = Static_Site_Importer_Content_Policy::validate_artifact( $artifact );
+		if ( is_wp_error( $source_policy ) ) {
+			return $source_policy;
+		}
 		$compiler_class = 'Automattic\\BlocksEngine\\PhpTransformer\\ArtifactCompiler\\ArtifactCompiler';
 		if ( ! class_exists( $compiler_class ) ) {
 			return new WP_Error( 'static_site_importer_missing_transformer', 'Blocks Engine php-transformer is required to import a website artifact.' );

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -13,6 +13,10 @@ if ( ! class_exists( 'Static_Site_Importer_Site_Identity' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-site-identity.php';
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Content_Policy' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-content-policy.php';
+}
+
 if ( ! class_exists( 'Static_Site_Importer_URL_Import_Runtime' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-url-import-runtime.php';
 }
@@ -899,15 +903,21 @@ function static_site_importer_source_runtime( array $source, array $input = arra
 
 	$metadata = isset( $source['metadata'] ) && is_array( $source['metadata'] ) ? $source['metadata'] : array();
 
-	return array(
-		'artifact'        => array_merge(
+	$artifact = array_merge(
 			$metadata,
 			array(
 				'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
 				'entrypoint' => $entrypoint,
 				'files'      => $files,
 			)
-		),
+		);
+	$source_policy = Static_Site_Importer_Content_Policy::validate_artifact( $artifact );
+	if ( is_wp_error( $source_policy ) ) {
+		return $source_policy;
+	}
+
+	return array(
+		'artifact'        => $artifact,
 		'source_metadata' => array(),
 		'provider'        => 'rest-source',
 	);
@@ -1041,6 +1051,14 @@ function static_site_importer_rest_archive_files( array $archive ) {
 
 		if ( ! static_site_importer_rest_should_include_artifact_file( $path ) ) {
 			continue;
+		}
+
+		if ( ! Static_Site_Importer_Content_Policy::is_static_path( $path ) ) {
+			$zip->close();
+			if ( file_exists( $tmp ) ) {
+				wp_delete_file( $tmp );
+			}
+			return new WP_Error( 'static_site_importer_executable_source_rejected', __( 'ZIP archives may contain static content only.', 'static-site-importer' ), array( 'status' => 400, 'path' => $path ) );
 		}
 
 		$file_content = $zip->getFromIndex( $i );

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:all": "node tools/run-test-manifest.mjs --all",
     "test:inventory": "node tools/run-test-manifest.mjs --check",
     "test:runtime-package": "node --test tools/runtime-package-manifest.test.mjs && php tests/smoke-ability-registration-idempotent.php",
-    "test:companion-plugin": "php tests/smoke-companion-plugin.php && php tests/smoke-companion-plugin-js.php",
+    "test:companion-plugin": "php tests/smoke-content-only-policy.php && php tests/smoke-companion-plugin.php && php tests/smoke-companion-plugin-js.php",
     "test:site-plan-materializer": "php tests/smoke-wordpress-site-plan-materializer.php",
     "test:webfont-producer-consumer": "php tests/smoke-webfont-producer-consumer.php",
     "test:fig-fixture-e2e": "node --test tools/run-fig-fixture-e2e.test.mjs",

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -53,6 +53,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-so
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-fetcher.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-run.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-source-normalizer.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-content-policy.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-site-collector.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-import-runtime.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-companion-plugin.php';

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -12,6 +12,7 @@
     { "path": "tests/smoke-ability-import-success-diagnostics.php", "environment": "standalone-php" },
     { "path": "tests/smoke-ability-registration-idempotent.php", "environment": "standalone-php" },
     { "path": "tests/smoke-canonical-import-ability.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-content-only-policy.php", "environment": "standalone-php" },
     { "path": "tests/smoke-companion-plugin-js.php", "environment": "standalone-php" },
     { "path": "tests/smoke-companion-plugin.php", "environment": "standalone-php" },
     { "path": "tests/smoke-contact-layout-transformer.php", "environment": "standalone-php" },

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -83,12 +83,12 @@ $payload     = array(
 	'site_name'    => 'Example Site',
 	'blocks'       => array(
 		array(
-			'name'       => 'Custom Hero',
+			'name'       => 'custom-hero',
 			'block_json' => array(
 				'title'    => 'Custom Hero',
 				'category' => 'design',
 			),
-			'render'     => '<div class="ssi-hero"><?php echo esc_html( $attributes["heading"] ?? "" ); ?></div>',
+			'render'     => '<div class="ssi-hero">Example hero</div>',
 		),
 	),
 	'preserved_js' => array(

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -176,6 +176,7 @@ if ( ! function_exists( 'update_option' ) ) {
 
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-content-policy.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-companion-plugin.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-plugin-materializer.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
@@ -236,9 +237,9 @@ $payload = array(
 				'viewScript'   => array( 'file:./view.js' ),
 				'viewScriptModule' => array( 'file:./view-module.js' ),
 				'viewStyle'       => array( 'file:./view.css' ),
-				'variations'      => 'file:./variations.php',
+				'variations'      => 'file:./variations.json',
 			),
-			'render'     => '<div class="ssi-hero"><?php echo esc_html( $attributes["heading"] ?? "" ); ?></div>',
+			'render'     => '<div class="ssi-hero">Example hero</div>',
 			'assets'     => array(
 				'editor.js'  => 'window.SSIEditor = true;',
 				'script.js'  => 'window.SSIScript = true;',
@@ -247,7 +248,7 @@ $payload = array(
 				'view.js'    => 'window.SSIView = true;',
 				'view-module.js' => 'export const SSIView = true;',
 				'view.css' => '.ssi-hero { display: block; }',
-				'variations.php' => '<?php return array();',
+				'variations.json' => '[]',
 			),
 		),
 	),
@@ -269,7 +270,7 @@ $missing_render['blocks'][0]['render'] = null;
 $missing_render['blocks'][0]['block_json']['render'] = 'file:./render.php';
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $missing_render ) ), 'supplied-render-file-requires-declared-asset' );
 $missing_variations = $payload;
-unset( $missing_variations['blocks'][0]['assets']['variations.php'] );
+unset( $missing_variations['blocks'][0]['assets']['variations.json'] );
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $missing_variations ) ), 'variations-file-reference-requires-declared-asset' );
 $generated_render = $payload;
 $generated_render['blocks'][0]['block_json']['render'] = 'file:./missing-upstream-render.php';
@@ -287,6 +288,14 @@ $assert( is_wp_error( $invalid_result ), 'invalid-payload-rejected-before-materi
 $invalid_report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $invalid_payload );
 $assert( 'failed' === ( $invalid_report['status'] ?? '' ), 'invalid-payload-prevents-file-mutations' );
 $assert( ! file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/escape.js' ), 'invalid-payload-writes-no-unsafe-file' );
+$php_asset = $payload;
+$php_asset['blocks'][0]['assets']['exploit.php'] = '<?php touch( "/tmp/owned" );';
+$php_asset_report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $php_asset );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $php_asset ) ), 'php-companion-asset-rejected' );
+$assert( 'failed' === ( $php_asset_report['status'] ?? '' ) && empty( $GLOBALS['ssi_companion_activated'] ), 'php-companion-asset-cannot-reach-activation-sink' );
+$php_render = $payload;
+$php_render['blocks'][0]['render'] = '<?php system( "id" );';
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $php_render ) ), 'php-render-template-rejected' );
 
 // 1. Scaffolder emits a valid plugin file set.
 $descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $payload );
@@ -321,12 +330,13 @@ if ( is_array( $descriptor ) ) {
 	$assert( str_contains( $block_json, '"editorScript": "file:./editor.js"' ), 'metadata-block-json-declares-editor-script' );
 	$assert( str_contains( $block_json, '"viewScript"' ) && str_contains( $block_json, '"file:./view.js"' ), 'metadata-block-json-declares-view-script' );
 	$assert( str_contains( $block_json, '"viewScriptModule"' ) && str_contains( $block_json, '"viewStyle"' ) && str_contains( $block_json, '"script"' ), 'metadata-block-json-retains-all-core-metadata-fields' );
-	$assert( isset( $files['ssi-example-site/blocks/custom-hero/editor.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/script.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/style.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/editor.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view-module.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/variations.php'] ), 'metadata-block-assets-emitted' );
+	$assert( isset( $files['ssi-example-site/blocks/custom-hero/editor.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/script.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/style.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/editor.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view-module.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/variations.json'] ), 'metadata-block-assets-emitted' );
 
 	// The render.php is the server-rendered template the render_callback runs.
 	$render = $files['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
 	$assert( '' !== $render, 'render-php-emitted' );
 	$assert( str_starts_with( ltrim( $render ), '<?php' ), 'render-php-opens-with-php-tag' );
+	$assert( str_contains( $render, "echo '<div class=\"ssi-hero\">Example hero</div>';" ) && ! str_contains( $render, 'system(' ), 'render-php-emits-static-source-markup-only' );
 
 	// Preserved island JS (#496) is separate carried JS and still rides along.
 	$island_files = array_filter( array_keys( $files ), static fn ( string $path ): bool => str_contains( $path, '/islands/' ) && str_ends_with( $path, '.js' ) );
@@ -365,7 +375,7 @@ $render_variants = Static_Site_Importer_Companion_Plugin::scaffold(
 		),
 	)
 );
-$assert( is_array( $render_variants ), 'render-variants-scaffold-returns-descriptor', is_array( $render_variants ) ? '' : 'WP_Error returned' );
+$assert( is_array( $render_variants ), 'render-variants-scaffold-returns-descriptor', is_array( $render_variants ) ? '' : $render_variants->get_error_code() );
 
 if ( is_array( $render_variants ) ) {
 	$variant_files = $render_variants['files'];

--- a/tests/smoke-content-only-policy.php
+++ b/tests/smoke-content-only-policy.php
@@ -1,0 +1,44 @@
+<?php
+/** Adversarial coverage for the static artifact content-only boundary. */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code, private string $message, private mixed $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $value ): bool { return $value instanceof WP_Error; }
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-content-policy.php';
+
+$failures = array();
+$assert = static function ( bool $condition, string $label ) use ( &$failures ): void {
+	if ( ! $condition ) {
+		$failures[] = $label;
+	}
+};
+$artifact = static function ( string $path, string $content, bool $encoded = false ): array {
+	return array(
+		'schema' => 'blocks-engine/php-transformer/site-artifact/v1',
+		'entrypoint' => 'website/index.html',
+		'files' => array( $encoded ? array( 'path' => $path, 'content_base64' => base64_encode( $content ) ) : array( 'path' => $path, 'content' => $content ) ),
+	);
+};
+
+$assert( true === Static_Site_Importer_Content_Policy::validate_artifact( $artifact( 'website/index.html', '<main>Safe</main>' ) ), 'html-source-accepted' );
+foreach ( array( 'website/shell.php', 'website/shell.phtml', 'website/shell.jsp', 'website/shell.cgi' ) as $path ) {
+	$assert( is_wp_error( Static_Site_Importer_Content_Policy::validate_artifact( $artifact( $path, 'payload' ) ) ), 'executable-extension-rejected:' . $path );
+}
+$assert( is_wp_error( Static_Site_Importer_Content_Policy::validate_artifact( $artifact( 'website/index.html', '<?php system("id");', true ) ) ), 'base64-server-code-rejected' );
+$assert( is_wp_error( Static_Site_Importer_Content_Policy::validate_artifact( $artifact( 'website/site.js', '<?php system("id");' ) ) ), 'server-code-marker-in-static-extension-rejected' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+echo "OK: content-only policy smoke passed\n";


### PR DESCRIPTION
Fixes #853

## Summary
- Add an explicit allowlist for untrusted static artifact files and reject server-side code markers before compilation.
- Revalidate compiler companion payloads before scaffolding, writing, or activation; companion assets and render templates are content-only.
- Generate render.php from SSI-owned literal-output code, preserving static dynamic-block registration while preventing source PHP execution.

## Tests
- `npm test` (51 passed; WordPress-runtime, browser-WP-Codebox, and operator-only suites skipped by manifest without their configured runtime env)
- `npm run test:companion-plugin`
- `composer validate --no-check-publish`

## Migration / Compatibility
Existing compiler payloads using PHP render templates, PHP companion assets, or schema-less companion payloads now fail closed. Migrate server-side behavior to native blocks/data bindings or client-side JavaScript; static markup remains supported in generated dynamic blocks.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the content-only intake and companion-plugin boundary, updated tests and documentation, and ran the listed verification. Chris Huber remains responsible for every line.