### PR TITLE
Fix development dependency advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,28 +10,32 @@
         "pngjs": "^7.0.0"
       },
       "devDependencies": {
-        "@wordpress/block-library": "^9.45.0",
-        "@wordpress/blocks": "^15.18.0",
-        "@wordpress/element": "^6.45.0",
-        "jsdom": "^29.1.0",
-        "playwright": "^1.56.1"
+        "@wordpress/block-library": "^10.3.0",
+        "@wordpress/blocks": "^15.25.0",
+        "@wordpress/element": "^8.4.0",
+        "jsdom": "^30.0.1",
+        "playwright": "^1.62.1"
       }
     },
-    "node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+    "node_modules/@ariakit/components": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.9.tgz",
+      "integrity": "sha512-Rmj5gcdfNQ4r4z5FzHHeC9OFRu9HSCVXDCDz8ak/vNHBrGmjeZ6Q3LOup61Eh+/GsT6cc2TDIQ6i8X1aB6y0BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5"
+      }
+    },
+    "node_modules/@ariakit/react": {
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.36.tgz",
+      "integrity": "sha512-QKxSc6KvTHObB9khmaQlr6XOvjKyZSHr4JWnZTDwRFDgUAzz79a+p2vApCHFlqadqV1QeGezap5cxHrOysoNOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-components": "0.4.0"
       },
       "funding": {
         "type": "opencollective",
@@ -42,26 +46,76 @@
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
+    "node_modules/@ariakit/react-components": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.4.0.tgz",
+      "integrity": "sha512-dYymiYvAbyu6a/ehqYN2ZeieiMSYt0CMAj2BnDRUI/dZ9vLF32cv9PQMcgXXyqn0ILpqu79PQs53vVEZ+Z+0rQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
+        "@ariakit/components": "0.1.9",
+        "@ariakit/react-store": "0.1.8",
+        "@ariakit/react-utils": "0.2.3",
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5",
+        "@floating-ui/dom": "^1.0.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@ariakit/react-store": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.8.tgz",
+      "integrity": "sha512-VYZ1LTUVMrNUi4jP37Npvhe3mcAzKdznqnBSVeh1Jjsbcgw0JlN88oy6UpdoJPvLKWOZHVYr62Sqn7xE0GrsqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-utils": "0.2.3",
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-utils": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.2.3.tgz",
+      "integrity": "sha512-fDaheb/7QEusanZb2oRT7mO55GTpQUyBOdjvQF5RPh3/CM15lm0TejLKN5bl1obmU5HRuByvckQmQvSyr8n/dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/store": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.7.tgz",
+      "integrity": "sha512-/GcxscA9QTo2F+IFbFPvoyj1N8hzXBnaYsQt9UxRiJgCFPQ2jIe4i6QgPXdOZEZUuqYdyuvjcQrg7MDm9vpvCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/utils": "0.1.5"
+      }
+    },
+    "node_modules/@ariakit/utils": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.5.tgz",
+      "integrity": "sha512-BQebYH9nV1VZttZwoq/fsxcxIJjc8oW2bNV6yJDHLZ8OF8UtM15drFN0JOL8Jwn7jeeD7Ev+tIC8pUijJEditQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@arraypress/waveform-player": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@arraypress/waveform-player/-/waveform-player-1.2.1.tgz",
-      "integrity": "sha512-PsgOZStUN+1GnY0tujbwk2PYE3HMT/Vl3wEvunqH16hIJWzisf8GEngy5EbswTAjQ1aV3Tk4XBkAskc8eslY1A==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@arraypress/waveform-player/-/waveform-player-1.24.0.tgz",
+      "integrity": "sha512-0lC2ZMiWUE0GKQGblapJEvhu78kVBF/in4yRMCb89W4uHTA9+qJVUmMJ76TvmW83aEgXmBsuEDX0aOSH7C1RTg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -73,64 +127,46 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.5.tgz",
+      "integrity": "sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@csstools/css-calc": "^3.2.0",
-        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-color-parser": "^4.1.9",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.13.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.13.0 || >=24.0.0"
       }
-    },
-    "node_modules/@asamuzakjp/generational-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -139,14 +175,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -156,9 +192,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -166,23 +202,23 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -190,9 +226,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -200,13 +236,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -216,9 +252,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -226,33 +262,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -260,29 +296,82 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@base-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
+    "node_modules/@base-ui/react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+      "integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@floating-ui/utils": "^0.2.11",
-        "reselect": "^5.1.1",
+        "@base-ui/utils": "0.3.2",
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+      "integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.12",
+        "reselect": "^5.2.0",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -310,9 +399,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
       "dev": true,
       "funding": [
         {
@@ -330,9 +419,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
       "dev": true,
       "funding": [
         {
@@ -354,9 +443,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
       "dev": true,
       "funding": [
         {
@@ -370,8 +459,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.2.0"
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -405,9 +494,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
       "dev": true,
       "funding": [
         {
@@ -450,9 +539,9 @@
       }
     },
     "node_modules/@date-fns/tz": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
-      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -637,9 +726,9 @@
       "license": "MIT"
     },
     "node_modules/@exodus/bytes": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -655,24 +744,24 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -690,9 +779,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "dev": true,
       "license": "MIT"
     },
@@ -753,9 +842,9 @@
       }
     },
     "node_modules/@preact/signals-core": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
-      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -764,16 +853,16 @@
       }
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -787,9 +876,9 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -803,50 +892,27 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
-      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -864,41 +930,17 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -916,9 +958,9 @@
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
-      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -932,39 +974,15 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
-      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -982,13 +1000,13 @@
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
-      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1001,38 +1019,14 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1050,14 +1044,13 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
-      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1075,13 +1068,13 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
-      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-slot": "1.2.4"
+        "@radix-ui/react-slot": "1.3.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1098,33 +1091,14 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1137,9 +1111,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1153,14 +1127,15 @@
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
-      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1173,32 +1148,13 @@
       }
     },
     "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
-      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1211,9 +1167,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1356,6 +1312,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz",
+      "integrity": "sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/gradient-parser": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
@@ -1433,14 +1406,14 @@
       }
     },
     "node_modules/@wordpress/a11y": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.45.0.tgz",
-      "integrity": "sha512-KOgdBsZP34nAi+UfrhIAZDt2I1ZDb3DXAgIeQk7QxTIc9OlQKMNfrYwPG0jidgfKwmjFxh8vV8HbZcBzTD29Rw==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.52.0.tgz",
+      "integrity": "sha512-0KlDa/vSASriu84+z+a/XA2teaau6t6rCH6PEqMXoW5a6EbP2e/REpZRumbu0VzV5MRO5kpxfD+fVYNYz9BdlA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.45.0",
-        "@wordpress/i18n": "^6.18.0"
+        "@wordpress/dom-ready": "^4.52.0",
+        "@wordpress/i18n": "^6.25.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1448,14 +1421,15 @@
       }
     },
     "node_modules/@wordpress/api-fetch": {
-      "version": "7.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.45.0.tgz",
-      "integrity": "sha512-qAx9X8B6P6eQ/XkAnQaqnkMinBTnc+qPSQEttkaUO3QQOvMeG6oWdxnjhL846z8jw6d/xcS7V89xej4P9/+BUw==",
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.52.0.tgz",
+      "integrity": "sha512-9EPAmnYH/mEjXB3s+1iNqw7/+GvcXfwq42zjVVOxYrl4NAF77BeHS3yPHDJD87C2vDDSzLsqOCn0HZD9TWs4JA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/url": "^4.45.0"
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/url": "^4.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1463,9 +1437,9 @@
       }
     },
     "node_modules/@wordpress/autop": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.45.0.tgz",
-      "integrity": "sha512-BJAdQOVqMC7t5cTWxD7Q8P+EWu3JopXD/yaf0Qc6tuFzihngIDvV9Ck03jGY4uXJVeO5SXNqARmU1JFn8YHNcA==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.52.0.tgz",
+      "integrity": "sha512-BZUmljM4MFod1p01dRVsZUoW5GR9JfwIBrJ1kYG3nPtTwyVHZcgCo2An9n+oUQbXv3gA+ah/ZJ4DIZrqEFf0IQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -1474,9 +1448,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
-      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-12.0.0.tgz",
+      "integrity": "sha512-BqSA9qZrBM9FBXFmQYvYCigA8ytkmlNFZ8+H0FscEnLWXkyCRwvHm4dE6LL53lmclKUGRMKlTZOUe1l8hfBQ5g==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -1485,9 +1459,9 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.45.0.tgz",
-      "integrity": "sha512-B/3pz4aF/0lTdn7uZd6PXS5FEtBXeVS9/CLm9ECE4dtyqKPIvpMcDcLdTv4QfQeu7BoObV1KIpGIbrflyJvcQg==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.52.0.tgz",
+      "integrity": "sha512-IBC0lVXiGioaeLXlX092Xqr6WNQiNoYYf60LnE23YGMy1e4unpiCHtW3kcqBmiKuLdkrDitC55uV6EMHnUOM3g==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -1496,63 +1470,62 @@
       }
     },
     "node_modules/@wordpress/block-editor": {
-      "version": "15.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.18.0.tgz",
-      "integrity": "sha512-g1sMgapiMonuDenMK9HC6klS94SrmUsZafsd7iCI2txlZxml6QKPHIVfpk+5WW9xowEAQIteZclNflHdeYG8vA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-16.1.0.tgz",
+      "integrity": "sha512-yCvgQAMPRtWk5aqCa++hU9oe/6O7M63NqgRZNFaRdo8M7YtRMd4qPpLFW0hLibNmFlrF/46kfctGiTqWNMcqkA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.45.0",
-        "@wordpress/base-styles": "^7.0.0",
-        "@wordpress/blob": "^4.45.0",
-        "@wordpress/block-serialization-default-parser": "^5.45.0",
-        "@wordpress/blocks": "^15.18.0",
-        "@wordpress/commands": "^1.45.0",
-        "@wordpress/components": "^33.0.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/dataviews": "^14.2.0",
-        "@wordpress/date": "^5.45.0",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/dom": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/escape-html": "^3.45.0",
-        "@wordpress/global-styles-engine": "^1.12.0",
-        "@wordpress/hooks": "^4.45.0",
-        "@wordpress/html-entities": "^4.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/icons": "^13.0.0",
-        "@wordpress/image-cropper": "^1.9.0",
-        "@wordpress/interactivity": "^6.45.0",
-        "@wordpress/is-shallow-equal": "^5.45.0",
-        "@wordpress/keyboard-shortcuts": "^5.45.0",
-        "@wordpress/keycodes": "^4.45.0",
-        "@wordpress/notices": "^5.45.0",
-        "@wordpress/preferences": "^4.45.0",
-        "@wordpress/priority-queue": "^3.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/rich-text": "^7.45.0",
-        "@wordpress/style-engine": "^2.45.0",
-        "@wordpress/token-list": "^3.45.0",
-        "@wordpress/ui": "^0.12.0",
-        "@wordpress/upload-media": "^0.30.0",
-        "@wordpress/url": "^4.45.0",
-        "@wordpress/warning": "^3.45.0",
-        "@wordpress/wordcount": "^4.45.0",
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/base-styles": "^12.0.0",
+        "@wordpress/blob": "^4.52.0",
+        "@wordpress/block-serialization-default-parser": "^5.52.0",
+        "@wordpress/blocks": "^15.25.0",
+        "@wordpress/commands": "^1.52.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/dataviews": "^17.3.0",
+        "@wordpress/date": "^5.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/escape-html": "^3.52.0",
+        "@wordpress/global-styles-engine": "^1.19.0",
+        "@wordpress/hooks": "^4.52.0",
+        "@wordpress/html-entities": "^4.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/image-cropper": "^1.16.0",
+        "@wordpress/interactivity": "^6.52.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/keyboard-shortcuts": "^5.52.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/notices": "^5.52.0",
+        "@wordpress/preferences": "^4.52.0",
+        "@wordpress/priority-queue": "^3.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/rich-text": "^7.52.0",
+        "@wordpress/style-engine": "^2.52.0",
+        "@wordpress/token-list": "^3.52.0",
+        "@wordpress/ui": "^0.19.0",
+        "@wordpress/upload-media": "^0.37.0",
+        "@wordpress/url": "^4.52.0",
+        "@wordpress/warning": "^3.52.0",
+        "@wordpress/wordcount": "^4.52.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "deepmerge": "^4.3.0",
-        "diff": "^4.0.2",
+        "colord": "^2.9.3",
+        "deepmerge": "^4.3.1",
+        "diff": "^8.0.3",
         "fast-deep-equal": "^3.1.3",
-        "memize": "^2.1.0",
         "parsel-js": "^1.1.2",
-        "postcss": "^8.4.21",
+        "postcss": "^8.4.38",
         "postcss-prefix-selector": "^1.16.0",
         "postcss-urlrebase": "^1.4.0",
         "react-autosize-textarea": "^7.1.0",
-        "react-easy-crop": "^5.0.6",
+        "react-easy-crop": "^5.4.2",
         "remove-accents": "^0.5.0"
       },
       "engines": {
@@ -1560,78 +1533,92 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/block-library": {
-      "version": "9.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.45.0.tgz",
-      "integrity": "sha512-1/OipWced7itCU+2miVgMpsHIiAxxe664F5EJLZUeei7VDC4x3mFLR7pPK3xcnEJw2hf2AmLhu1F7RROqIZ7EA==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-10.3.0.tgz",
+      "integrity": "sha512-qnHVDOOcg1uOWDOWl68kmgpn1tFemtWnKIC8CLswFsT7dQMWN3swRldj6ntHModxW3H7uH7KJgRout0EqEwLPg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@arraypress/waveform-player": "1.2.1",
-        "@wordpress/a11y": "^4.45.0",
-        "@wordpress/api-fetch": "^7.45.0",
-        "@wordpress/autop": "^4.45.0",
-        "@wordpress/base-styles": "^7.0.0",
-        "@wordpress/blob": "^4.45.0",
-        "@wordpress/block-editor": "^15.18.0",
-        "@wordpress/blocks": "^15.18.0",
-        "@wordpress/components": "^33.0.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/core-data": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/date": "^5.45.0",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/dom": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/escape-html": "^3.45.0",
-        "@wordpress/hooks": "^4.45.0",
-        "@wordpress/html-entities": "^4.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/icons": "^13.0.0",
-        "@wordpress/interactivity": "^6.45.0",
-        "@wordpress/interactivity-router": "^2.45.0",
-        "@wordpress/keyboard-shortcuts": "^5.45.0",
-        "@wordpress/keycodes": "^4.45.0",
-        "@wordpress/latex-to-mathml": "^1.13.0",
-        "@wordpress/notices": "^5.45.0",
-        "@wordpress/patterns": "^2.45.0",
-        "@wordpress/primitives": "^4.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/reusable-blocks": "^5.45.0",
-        "@wordpress/rich-text": "^7.45.0",
-        "@wordpress/server-side-render": "^6.21.0",
-        "@wordpress/ui": "^0.12.0",
-        "@wordpress/upload-media": "^0.30.0",
-        "@wordpress/url": "^4.45.0",
-        "@wordpress/viewport": "^6.45.0",
-        "@wordpress/wordcount": "^4.45.0",
+        "@arraypress/waveform-player": "^1.23.0",
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/api-fetch": "^7.52.0",
+        "@wordpress/autop": "^4.52.0",
+        "@wordpress/base-styles": "^12.0.0",
+        "@wordpress/blob": "^4.52.0",
+        "@wordpress/block-editor": "^16.1.0",
+        "@wordpress/blocks": "^15.25.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/core-data": "^7.52.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/date": "^5.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/escape-html": "^3.52.0",
+        "@wordpress/global-styles-engine": "^1.19.0",
+        "@wordpress/hooks": "^4.52.0",
+        "@wordpress/html-entities": "^4.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/interactivity": "^6.52.0",
+        "@wordpress/interactivity-router": "^2.52.0",
+        "@wordpress/keyboard-shortcuts": "^5.52.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/latex-to-mathml": "^1.20.0",
+        "@wordpress/notices": "^5.52.0",
+        "@wordpress/patterns": "^2.52.0",
+        "@wordpress/primitives": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/reusable-blocks": "^5.52.0",
+        "@wordpress/rich-text": "^7.52.0",
+        "@wordpress/server-side-render": "^6.28.0",
+        "@wordpress/shortcode": "^4.52.0",
+        "@wordpress/ui": "^0.19.0",
+        "@wordpress/upload-media": "^0.37.0",
+        "@wordpress/url": "^4.52.0",
+        "@wordpress/viewport": "^6.52.0",
+        "@wordpress/wordcount": "^4.52.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
-        "colord": "^2.7.0",
+        "colord": "^2.9.3",
         "fast-average-color": "^9.1.1",
         "fast-deep-equal": "^3.1.3",
-        "html-react-parser": "5.2.11",
-        "memize": "^2.1.0",
+        "html-react-parser": "^5.2.11",
+        "memize": "^2.1.1",
         "remove-accents": "^0.5.0",
-        "uuid": "^9.0.1"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.45.0.tgz",
-      "integrity": "sha512-48Pj6o9iDGf7fCprXoXD8nvDgBigrQ6uZEb+VMrcvabn59ymKHzx/Ex9O3mpp7Ft2NMJRGpO3w0mNocoDfCksA==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.52.0.tgz",
+      "integrity": "sha512-k+kOLRTS5sYSFLC1Pe4kSwrflTfelKhAEm4+MUyjsrQL3WtewC1eUKyLcBZy/n5LOy1UoGMDtnjkVB/ZbjwGYQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -1640,64 +1627,70 @@
       }
     },
     "node_modules/@wordpress/blocks": {
-      "version": "15.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.18.0.tgz",
-      "integrity": "sha512-orpiOWWmG9qdacqMC4WIdHgZRJNLLmCqTLj/5HQcBAfOXjbUQcjOj6f4lZx9HS89kJ350KJOkqWVPWrZoJE9og==",
+      "version": "15.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.25.0.tgz",
+      "integrity": "sha512-u1QOrS1/ljWCovuJu90EAJUPfhsxgzSbF4j8eE82FiW/VglqqH2ASr60V3BhIR4GNVpZPgNiVGwVsGu5iIf9Tw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/autop": "^4.45.0",
-        "@wordpress/blob": "^4.45.0",
-        "@wordpress/block-serialization-default-parser": "^5.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/dom": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/hooks": "^4.45.0",
-        "@wordpress/html-entities": "^4.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/is-shallow-equal": "^5.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/rich-text": "^7.45.0",
-        "@wordpress/shortcode": "^4.45.0",
-        "@wordpress/warning": "^3.45.0",
+        "@wordpress/autop": "^4.52.0",
+        "@wordpress/blob": "^4.52.0",
+        "@wordpress/block-serialization-default-parser": "^5.52.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/hooks": "^4.52.0",
+        "@wordpress/html-entities": "^4.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/rich-text": "^7.52.0",
+        "@wordpress/shortcode": "^4.52.0",
+        "@wordpress/warning": "^3.52.0",
         "change-case": "^4.1.2",
-        "colord": "^2.7.0",
+        "colord": "^2.9.3",
         "fast-deep-equal": "^3.1.3",
         "hpq": "^1.3.0",
         "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
+        "marked": "^18.0.3",
+        "memize": "^2.1.1",
         "react-is": "^18.3.0",
         "remove-accents": "^0.5.0",
-        "showdown": "^1.9.1",
         "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^9.0.1"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/commands": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.45.0.tgz",
-      "integrity": "sha512-R71ZtwwqEkrQ/098HyiOeYq7Iu13770BroqtuTjBkNY2tWIR3WNUnMlK3UKDO70QhPtkLZaoz79AWKRCfVUTnw==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.52.0.tgz",
+      "integrity": "sha512-sE4djZTZwCOON2QcIkIB7wnDXY7TLu4MCGQV6MmTelNE6gU6MdjjcR3dTNZGBOYsq8gRMxxyNHCP/NDUc6QDLA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^7.0.0",
-        "@wordpress/components": "^33.0.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/icons": "^13.0.0",
-        "@wordpress/keyboard-shortcuts": "^5.45.0",
-        "@wordpress/preferences": "^4.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/warning": "^3.45.0",
+        "@wordpress/base-styles": "^12.0.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/keyboard-shortcuts": "^5.52.0",
+        "@wordpress/preferences": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/warning": "^3.52.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0"
       },
@@ -1706,18 +1699,18 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/@wordpress/components": {
-      "version": "33.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
-      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "version": "38.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-38.0.0.tgz",
+      "integrity": "sha512-FdmfeLB0cUH8Vwmp1Sz0o7mnhmg0kir2oouuvkcVtPgwHfCnsOgvg1ZelYdaQz+F6MyAsCY1mKQn100A9npUDA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ariakit/react": "^0.4.22",
+        "@ariakit/react": "^0.4.32",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
@@ -1725,72 +1718,80 @@
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
         "@emotion/utils": "^1.4.2",
-        "@floating-ui/react-dom": "2.0.8",
-        "@types/gradient-parser": "1.1.0",
-        "@types/highlight-words-core": "1.2.1",
-        "@types/react": "^18.3.27",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@types/gradient-parser": "^1.1.0",
+        "@types/highlight-words-core": "^1.2.1",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.45.0",
-        "@wordpress/base-styles": "^7.0.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/date": "^5.45.0",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/dom": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/escape-html": "^3.45.0",
-        "@wordpress/hooks": "^4.45.0",
-        "@wordpress/html-entities": "^4.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/icons": "^13.0.0",
-        "@wordpress/is-shallow-equal": "^5.45.0",
-        "@wordpress/keycodes": "^4.45.0",
-        "@wordpress/primitives": "^4.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/rich-text": "^7.45.0",
-        "@wordpress/warning": "^3.45.0",
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/base-styles": "^12.0.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/date": "^5.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/escape-html": "^3.52.0",
+        "@wordpress/hooks": "^4.52.0",
+        "@wordpress/html-entities": "^4.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/primitives": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/rich-text": "^7.52.0",
+        "@wordpress/style-runtime": "^0.8.0",
+        "@wordpress/ui": "^0.19.0",
+        "@wordpress/warning": "^3.52.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
-        "colord": "^2.7.0",
+        "colord": "^2.9.3",
         "csstype": "^3.2.3",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
+        "date-fns": "^4.4.0",
+        "deepmerge": "^4.3.1",
         "fast-deep-equal": "^3.1.3",
         "framer-motion": "^11.15.0",
-        "gradient-parser": "1.1.1",
+        "gradient-parser": "^1.1.1",
         "highlight-words-core": "^1.2.2",
         "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
+        "memize": "^2.1.1",
         "path-to-regexp": "^6.2.1",
         "re-resizable": "^6.4.0",
         "react-colorful": "^5.6.1",
         "react-day-picker": "^9.7.0",
         "remove-accents": "^0.5.0",
-        "uuid": "^9.0.1"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/compose": {
-      "version": "7.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.45.0.tgz",
-      "integrity": "sha512-/keWdRFUe7bnzh2ZtOYLexknpj0K0G56WFw7RLZehl54a9EmzjYjAODBOF9DB3c07pJuNuy7c5QgqMPi0cqLlw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.5.0.tgz",
+      "integrity": "sha512-giYS22Tbhtr3Lj4lK6lxzGqV6EkM2QeVBiP7+c9r2F9rnQN3F6A8cN4gQM5sVGdgIOlps9tw+dsn9OHzIFVwIg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/dom": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/is-shallow-equal": "^5.45.0",
-        "@wordpress/keycodes": "^4.45.0",
-        "@wordpress/priority-queue": "^3.45.0",
-        "@wordpress/undo-manager": "^1.45.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/priority-queue": "^3.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/undo-manager": "^1.52.0",
         "change-case": "^4.1.2",
         "mousetrap": "^1.6.5",
         "use-memo-one": "^1.1.1"
@@ -1800,62 +1801,79 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/core-data": {
-      "version": "7.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.45.0.tgz",
-      "integrity": "sha512-aXp9K7on8wKq/PlSYdZNZRFYJjK0OUUlyrBpyyQuioSfPYav76ImGf6DAI0tJ7PCZF61KmMT9KHfQMjnK4bh4g==",
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.52.0.tgz",
+      "integrity": "sha512-TgJRNMb9Gcd7gyO1T0si4noMrjt9emZjGyod9lNK8n/YyUY+JN5gLzE7J9aOEkP/3Q6MKj6FL5MAxeOWmDK/Eg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.45.0",
-        "@wordpress/block-editor": "^15.18.0",
-        "@wordpress/blocks": "^15.18.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/html-entities": "^4.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/is-shallow-equal": "^5.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/rich-text": "^7.45.0",
-        "@wordpress/sync": "^1.45.0",
-        "@wordpress/undo-manager": "^1.45.0",
-        "@wordpress/url": "^4.45.0",
-        "@wordpress/warning": "^3.45.0",
+        "@wordpress/api-fetch": "^7.52.0",
+        "@wordpress/block-editor": "^16.1.0",
+        "@wordpress/blocks": "^15.25.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/global-styles-engine": "^1.19.0",
+        "@wordpress/html-entities": "^4.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/notices": "^5.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/rich-text": "^7.52.0",
+        "@wordpress/sync": "^1.52.0",
+        "@wordpress/undo-manager": "^1.52.0",
+        "@wordpress/url": "^4.52.0",
+        "@wordpress/warning": "^3.52.0",
         "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
         "equivalent-key-map": "^0.2.2",
         "fast-deep-equal": "^3.1.3",
-        "memize": "^2.1.0",
-        "uuid": "^9.0.1"
+        "memize": "^2.1.1",
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/data": {
-      "version": "10.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.45.0.tgz",
-      "integrity": "sha512-OR/uMpcEbCh1aBkbzateXffNrL829M+N92qtuD+Gt08Mey129WIEVR9kBC2Tf02VtXs644OKZD6cz77KlxH8XA==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.52.0.tgz",
+      "integrity": "sha512-7Nx66TfUkYZDdXL4wn2/DjIJOYRsKdi8Gvv24Warv9rZ1pwTNoFXFDagvc3UoCOjn0pM8+pFNbd7a9TJH8oQzg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/is-shallow-equal": "^5.45.0",
-        "@wordpress/priority-queue": "^3.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/redux-routine": "^5.45.0",
-        "deepmerge": "^4.3.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/priority-queue": "^3.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/redux-routine": "^5.52.0",
+        "deepmerge": "^4.3.1",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
         "is-promise": "^4.0.0",
@@ -1868,35 +1886,43 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/dataviews": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.2.0.tgz",
-      "integrity": "sha512-jTsXH3fDEQbvtK7N/giZJtE/NdDYN/LOlf6dkbfh89GyJmvwuikQZjpX10DexqOjc8AcNPUd1hU2b1sL8d99HA==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-17.3.0.tgz",
+      "integrity": "sha512-9U50IPnaYWUbkdVl2J2eRkkT0x83nGxmsVkkNVBSGQFpnWHhCAN7TqZOOSVYM+ppMBQnVwDhml6URIc4iejZ8A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ariakit/react": "^0.4.21",
-        "@wordpress/base-styles": "^7.0.0",
-        "@wordpress/components": "^33.0.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/date": "^5.45.0",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/icons": "^13.0.0",
-        "@wordpress/keycodes": "^4.45.0",
-        "@wordpress/primitives": "^4.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/ui": "^0.12.0",
-        "@wordpress/warning": "^3.45.0",
+        "@ariakit/react": "^0.4.32",
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/base-styles": "^12.0.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/date": "^5.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/primitives": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/rich-text": "^7.52.0",
+        "@wordpress/ui": "^0.19.0",
+        "@wordpress/warning": "^3.52.0",
         "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^4.1.0",
-        "deepmerge": "4.3.1",
+        "colord": "^2.9.3",
+        "date-fns": "^4.4.0",
+        "deepmerge": "^4.3.1",
         "fast-deep-equal": "^3.1.3",
         "remove-accents": "^0.5.0"
       },
@@ -1905,29 +1931,24 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/date": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.45.0.tgz",
-      "integrity": "sha512-34v3hCxn68kYzWs8bhuAt8cfMxdFX9ukKn3a3FB+tAJXpxafnPCcZoWfJHn4I8hepCbreFrf3UiGdA+id2kQ4A==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.52.0.tgz",
+      "integrity": "sha512-JRAXv2CQwUiJq9k2n/iUqblo9rX3LUFJ03lA4zRy4+bxcSiMdpXvYrpZfUTp3W4I1Oc/fPZIYQY0HB3XNyjUWw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/deprecated": "^4.52.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -1937,13 +1958,13 @@
       }
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.45.0.tgz",
-      "integrity": "sha512-qer/fk/lgmmisb8/hj1xZtsbJbZhCoOblhyxI2k7RRul7rQDdk+fm28LJYV+eIF0ldSVX30f4dmz1pvcVHQEEg==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.52.0.tgz",
+      "integrity": "sha512-94oHBKPty4pp6L5510LWDwJwNqFhikxLfwN6VUcDOQzj3itkc0MQ4ZQhmsfBy3Y6IRxSGx+p2bjSQvA4D+M96A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.45.0"
+        "@wordpress/hooks": "^4.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1951,13 +1972,13 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.45.0.tgz",
-      "integrity": "sha512-6RObr/KEZS1FnZwpcDAsKlJ3qw2KLF5+A/LsxlM9fSWDGSO05CEaTp+VmWgx9pwjQWbPEa7N73ijEy8cCNSZWA==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.52.0.tgz",
+      "integrity": "sha512-LUY9nI9h6blk4xBuG83KgyfTnx7PMs/g6ZVzY/SOaCcOc2P3zOfzacADq/vxQydbZpcwtLM6juzgnNta6AX95w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.45.0"
+        "@wordpress/deprecated": "^4.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1965,9 +1986,9 @@
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.45.0.tgz",
-      "integrity": "sha512-0lFImpg9DGXcGCDQePdoU8haz7QYsKOFXUMTpRvi/Te38LFXzgZtOUBQbY8fRBlLxrgrj4FsAIc7bzdLn73wNQ==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.52.0.tgz",
+      "integrity": "sha512-dAsch1oeyRV4kwoQuqdr6dXisGAs09OtvGOk09Ke+QC0fTTPzxdKUw+c4M1nk0AmCeyZfqAqYYGCMm4n241QeQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -1976,19 +1997,20 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "6.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.45.0.tgz",
-      "integrity": "sha512-WFrGNPEnj8uE+XhFW9NVbxvqraYpConaEokLv9IszFYVfyg8juXSQcHOAfEnxjC08HBPfVcayr2igu/XUgGOAw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.4.0.tgz",
+      "integrity": "sha512-/LzW+0MpSmKfYiESoXUQtjBPqOPyvqUm17GigQR5c0Z8Wj2NiklP72x4XaF02uSkau1ru1Z9lP8NWEGjwBwLsA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/escape-html": "^3.52.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -1996,9 +2018,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.45.0.tgz",
-      "integrity": "sha512-IW4mnA+65XKhABuBkwrQNAlbq97luC6ZIBfdSq0Tkq+AFPqE1lJTMlLo7iBkTpsHsBLyznViPXultq40fz8L7w==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.52.0.tgz",
+      "integrity": "sha512-sW8X839Xu8aiJlCGF48MM3iYrcXspuiY0By8iTpXKpnUdd2u0SL9HRR0ALSAsOf2ujOeWm/x58ODMSchovRWGw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -2007,21 +2029,22 @@
       }
     },
     "node_modules/@wordpress/global-styles-engine": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.12.0.tgz",
-      "integrity": "sha512-4RWpN50E9OEhd3nBP9CXOc1gybSCFulDzqHQLHkNS9iCPhpn7J3tE32XcCVVMHis9atO+PAktVKkWiPzQf+0Qw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.19.0.tgz",
+      "integrity": "sha512-U0W01gdhHZp7sOwIQezjjzPGjLhgk8jBVRHhh9YYWrzLVgQWzhYRUFHhv2hAD16BSRU3yu1cJ/yBFIROTfc2AQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/blocks": "^15.18.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/style-engine": "^2.45.0",
-        "colord": "^2.9.2",
-        "deepmerge": "^4.3.0",
+        "@wordpress/blocks": "^15.25.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/style-engine": "^2.52.0",
+        "colord": "^2.9.3",
+        "deepmerge": "^4.3.1",
         "fast-deep-equal": "^3.1.3",
         "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0"
+        "memize": "^2.1.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -2029,9 +2052,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.45.0.tgz",
-      "integrity": "sha512-+gOlu8TdohqL1INQNxS/7CxhM4T4MuYnKietWV9zWDmNQV2ysM0SdamNk5pWERJ4w0yY9XhtMBcwR/piJtePZg==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.52.0.tgz",
+      "integrity": "sha512-EbV/nJTerhqwNW3DLvvGutJfNyXcmBHXuWyJpv1NypzT80k21jPGP79HBE5Z0A2oAI2kIBp6Klaa4O8uEjq/sw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -2040,9 +2063,9 @@
       }
     },
     "node_modules/@wordpress/html-entities": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.45.0.tgz",
-      "integrity": "sha512-7W95xaOv4UgMSWlEmyO7YkBsUae3QlQu3GKENVH7Pt/osbJGSPInAJ1ruO4oeUwGPygWOL7b7IzRsgTNP0M/Wg==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.52.0.tgz",
+      "integrity": "sha512-SM0XH+EgCi20Ptqv5WGkM8d2CAlThWRO/BVMeXzu6RLlcHKLMXNQZvW2waXCZtUpto8hlVZT9Dzg8z37sj4OiQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -2051,16 +2074,15 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.18.0.tgz",
-      "integrity": "sha512-6dYCih4wUwi7Csu4RNfHiAKkgWhpSQdl8YthvQUF59Sfsoia3RCdtd4K2l7W4f18ldFA/RXjShMjvSexWy6OyQ==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.25.0.tgz",
+      "integrity": "sha512-UcyUT8CJgEkhjzEGTVV6kw0Qi4OraF0I9J9FBLmTda/1Wi1o6rLAXZBm2aJrP740ezFxPneHH92aQF4Z5xZqcQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/hooks": "^4.52.0",
         "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
         "tannin": "^1.2.0"
       },
       "bin": {
@@ -2072,34 +2094,40 @@
       }
     },
     "node_modules/@wordpress/icons": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
-      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.3.0.tgz",
+      "integrity": "sha512-An7jPqTSmJpjmeSa6EYohE9m/4gUE+bkrgQekqkcOPAlOISpG/jv3Zq+pVeZXCQz206zYF+feTvmLEW+/vXAeg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/primitives": "^4.45.0",
-        "change-case": "4.1.2"
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/primitives": "^4.52.0",
+        "change-case": "^4.1.2"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/image-cropper": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.9.0.tgz",
-      "integrity": "sha512-cHkLNS/ePQIAAOnQy9lgaAWzLjDGYHHkziHXq/EOLN75FW0mxj6nmsHoa5N5YebKEVAeqc7UfyRNNp0Bbflsig==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.16.0.tgz",
+      "integrity": "sha512-js6o/AeVTN6NzIQkFM11u5jebaPHIkmww+HlLZ9qUOAS5MXIhM2jPCb2smsmhcu5OYMeXnkBPr+F2aa7dVl3WA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/components": "^33.0.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/i18n": "^6.25.0",
         "clsx": "^2.1.1",
         "dequal": "^2.0.3",
         "react-easy-crop": "^5.4.2"
@@ -2109,19 +2137,26 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/interactivity": {
-      "version": "6.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.45.0.tgz",
-      "integrity": "sha512-QL/ANMn1lO+O+E/hxHtzE3yMx2mB2MxfKwN24f58HiVgKQ8ufUSYwcZfH2gLY+n9MfDoKbnvtkSpsEdL6I7y3A==",
+      "version": "6.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.52.0.tgz",
+      "integrity": "sha512-rIX/GpfVXsY26N/dFdNmFxJ+aj/3PCJbWOFp2fCb/XBBwjFmZ6nukD6B/7dnrj0GnsbMjNiLkPSPDHH7/7Lglw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@preact/signals": "^1.3.0",
-        "preact": "^10.24.2"
+        "@preact/signals-core": "^1.7.0",
+        "preact": "^10.29.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -2129,14 +2164,14 @@
       }
     },
     "node_modules/@wordpress/interactivity-router": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.45.0.tgz",
-      "integrity": "sha512-oswqAE/IVedf1lzNfFSIRogeN4GAEUpQcEJBq6qhjuAUAff7pvxCW9N0HQWFRYiS4QWHLvCeKAq3RBvPrEf6MQ==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.52.0.tgz",
+      "integrity": "sha512-v56whKl4nYO0pCYun1GRzpOGgAzqDUQ8XyP7TijS6GQr0a7pu35HM8CLvCF8kuKFt1OuThG43DhifOow6qYR0Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.45.0",
-        "@wordpress/interactivity": "^6.45.0",
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/interactivity": "^6.52.0",
         "es-module-lexer": "^1.5.4"
       },
       "engines": {
@@ -2145,9 +2180,9 @@
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.45.0.tgz",
-      "integrity": "sha512-saamGjAuhZOiFOyznsriPGrO8GRDremImMO4q92qjQqmDqssC+FRDQnwr9D8BaedSnVvUDcriGeYBObEEnIJ2A==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.52.0.tgz",
+      "integrity": "sha512-LMIBLLTZ+vvq0DlYebL4d9XaCu16PNnhPGSn8QqsMPmBzwBYOjO0/btMLpYbs9rRc8k1QKBDWvw8eddvRVsYxA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -2156,42 +2191,56 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.45.0.tgz",
-      "integrity": "sha512-icOA81P50p1xe1LmK2epxmpXrKrq0BYrrUjDOaMQZbH+giZfGvMyvt47bvNVuZqg6BBzTLqZ4X8PUFcCiO6osQ==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.52.0.tgz",
+      "integrity": "sha512-xqHteT7/05zRLQ+mF7zsHesKkNCyiJnBVUy5LEhueCpiYJkmm5zpFgAuGI+/2BjkCrekfCNmlUQb33Nsc6yEFA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/keycodes": "^4.45.0"
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/keycodes": "^4.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
-      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.52.0.tgz",
+      "integrity": "sha512-KRvwViTTdxUDgikYaCm+qnXSH2UlFuCDjAIvtjjcen8oRviSkeMv6bPn1T2vqFRKcVgt88xTtKlvI8l5U99o2Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.18.0"
+        "@wordpress/i18n": "^6.25.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/latex-to-mathml": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.13.0.tgz",
-      "integrity": "sha512-YsGWTccjMVH3RDZGJB4Ft8+hv9RsWadLgnHia7llp0YpkB0z94UDbi7niqy5C5aKEK6MvmIlLp/nLdpuprTTmw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.20.0.tgz",
+      "integrity": "sha512-xa+XOQrZwfDH2bGOGYEFPGhich0ag/sNFXBLydk7nh3bXso+wfelYTCZsd0ZtNr4xRG1Y6Uy2Y0mopFYXudm/w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -2203,15 +2252,15 @@
       }
     },
     "node_modules/@wordpress/notices": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.45.0.tgz",
-      "integrity": "sha512-V0uRC/zMktet66jdICkr9iuZsLV2vEY/LhuWNFaJ3veIdLMBZ5EIMYwiLOGA1DagtDll0vi7/ab/xXVij7vK/Q==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.52.0.tgz",
+      "integrity": "sha512-rbOQ17DeL7RH8z3GyLWB923abO+KU1T4oQCELuey1mbVvQE99m4tjNQhTpaWlgxe3Y4eiptO+/sQMLDoqzUfrA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.45.0",
-        "@wordpress/components": "^33.0.0",
-        "@wordpress/data": "^10.45.0",
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/data": "^10.52.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -2219,58 +2268,65 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/patterns": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.45.0.tgz",
-      "integrity": "sha512-7aniq0ImCqvd7BhtxH89OZfyXPaht7sPlVzrXV76+Vioa8H84QBgS9bfzgv0dsgvDU1DEsmXIGY18xeKJ7XuHA==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.52.0.tgz",
+      "integrity": "sha512-BAZ7/6ofLwmjBaCvr79Lz/uKcpl1u0IyQn7w7owGfexiFJ+7WHTjtvW1qO2onHtawe9lts+ZEPO5umXGf/yXtQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.45.0",
-        "@wordpress/base-styles": "^7.0.0",
-        "@wordpress/block-editor": "^15.18.0",
-        "@wordpress/blocks": "^15.18.0",
-        "@wordpress/components": "^33.0.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/core-data": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/html-entities": "^4.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/icons": "^13.0.0",
-        "@wordpress/notices": "^5.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/url": "^4.45.0"
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/base-styles": "^12.0.0",
+        "@wordpress/block-editor": "^16.1.0",
+        "@wordpress/blocks": "^15.25.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/core-data": "^7.52.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/html-entities": "^4.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/notices": "^5.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/ui": "^0.19.0",
+        "@wordpress/url": "^4.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/@wordpress/preferences": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.45.0.tgz",
-      "integrity": "sha512-ZM9W7T05NeVOLc+4WhCpFsCUb6r6BqBYvWgK7KCpMRVnvYqUDAqzh9HuuTFfiLabotOJm2Hpm8G1M+iqIEehvA==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.52.0.tgz",
+      "integrity": "sha512-RAeVA0u/1hBSdrWnGDZBrkBG/bMxyLG29KqyGM32tuY8TIOaIdKIHgbjA2eNgyk2idF6cojrBnutT/NASGb0Tw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.45.0",
-        "@wordpress/base-styles": "^7.0.0",
-        "@wordpress/components": "^33.0.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/icons": "^13.0.0",
-        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/base-styles": "^12.0.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/private-apis": "^1.52.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -2278,18 +2334,24 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/primitives": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.45.0.tgz",
-      "integrity": "sha512-x+i6EKUvz96EkUb2KuBTLNGm8d5+ZS0FYjUEnIhp5dtWxjMe8dJT6LS+n363vg+K28LVvjptiTAaByccnNKc9w==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.52.0.tgz",
+      "integrity": "sha512-rgB+Q1i97AY8AECLAEhvV/bGw9sOV6CKtUaY90t7nuv6M+ZgXqwQLRRWVaXWFUsthcZ2y4sTIbKfxwVJV+JQ6g==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.45.0",
+        "@wordpress/element": "^8.4.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -2297,13 +2359,19 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.45.0.tgz",
-      "integrity": "sha512-0sIX2PRPzo5nk252f60xpPj3/BUZxEOLcabCC7FuvQDYPGZrRyS6Dy0vDDzozZxHGuUYCT65t8ubBwXx37wXCw==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.52.0.tgz",
+      "integrity": "sha512-aYnVXxV5j4D73tRld2n1D3G6cKLfSwKWcTnktJ7XlmiswW7xlaAqvn4FyBjwmIe20pZw0A7xLH5xCuQcqOM7nw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -2315,9 +2383,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.45.0.tgz",
-      "integrity": "sha512-UjhIDpoyKKUghPM0tkqd5Whsuk4kqfAfhb5VYGoEYtunDs0rB8IxgFO7hE0PhimHL74QVgaJOlprRZVRCCoQ6w==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.52.0.tgz",
+      "integrity": "sha512-gFcmBXSti73Y4uEx++5qUNDaH/o0/2ijrHEJkY5e/df4RtmxVSQOIVxftRiI4m9thCWfJMoehMMreJxhwx6Qtg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -2326,9 +2394,9 @@
       }
     },
     "node_modules/@wordpress/redux-routine": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.45.0.tgz",
-      "integrity": "sha512-6ShpBns4jIBFXrYFBcKA5pnFm/kjr1SqFvLj5DwLgMV61eI3Rr9LyZwIzNR2BGg067ryxu4W172Uqjke/mZjcQ==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.52.0.tgz",
+      "integrity": "sha512-MpyNAKpfQAk8IWJ3Cwzc/p1dVEUl/iYxL6GCTX/y7K3c8qYd7csU4o5kuK9lfeqgVVI+d0y6rzBZiTaL2Z6Ojw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -2345,96 +2413,108 @@
       }
     },
     "node_modules/@wordpress/reusable-blocks": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.45.0.tgz",
-      "integrity": "sha512-TlpqOrheSRv2PnZtNdJtMDmK7lkn4ikjpIMtHiWp1lfr/bf5O92VHg0gocEL4tatu2otz7otyMzJyRkyBgBmhg==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.52.0.tgz",
+      "integrity": "sha512-MTnhn5pnYOCMeBWm4JGfl0DY1YskUztcbHzjvVwEsnz1j5smxY39EVg6SlDXsWzPhoV7Wa7M4BAJOCA2yr0DcA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^7.0.0",
-        "@wordpress/block-editor": "^15.18.0",
-        "@wordpress/blocks": "^15.18.0",
-        "@wordpress/components": "^33.0.0",
-        "@wordpress/core-data": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/icons": "^13.0.0",
-        "@wordpress/notices": "^5.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/url": "^4.45.0"
+        "@wordpress/base-styles": "^12.0.0",
+        "@wordpress/block-editor": "^16.1.0",
+        "@wordpress/blocks": "^15.25.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/core-data": "^7.52.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/notices": "^5.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/url": "^4.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/@wordpress/rich-text": {
-      "version": "7.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.45.0.tgz",
-      "integrity": "sha512-C5+JQqNzA3fiQq0hN9pQPKsjcwO/fczouHqubq3847kAUrClROqqI1GJHE34WLl1Vp+/tWQuBkIjQ/95olKteA==",
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.52.0.tgz",
+      "integrity": "sha512-zyd7w4hs8TV+nWrC/hbULg4lKJQyxpd5AolFfOHAJmKM2LrU/Lvlobz9oyGuTrZ/HXdkFs3wzPMwS/VGydSjHw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.45.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/dom": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/escape-html": "^3.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/keycodes": "^4.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "colord": "2.9.3",
-        "memize": "^2.1.0"
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/escape-html": "^3.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "colord": "^2.9.3"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/server-side-render": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.21.0.tgz",
-      "integrity": "sha512-hhewUyFy5KKHgWjDNAUKjj0i6rBFdLKln7LlCm4rWbZiWhS1uHOOhkyO1GJiwCL+gQjZjY0QBhNGmTfDFetvEg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.28.0.tgz",
+      "integrity": "sha512-xKLsj4B9gy7gXj/2G6LwP3Vm610fClNk9ZZvkqEPkFAbhhKUKvzylxx33RAaUTrhFIFa9OzcLHBbiYNCkMAfww==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.45.0",
-        "@wordpress/blocks": "^15.18.0",
-        "@wordpress/components": "^33.0.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/deprecated": "^4.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/url": "^4.45.0"
+        "@wordpress/api-fetch": "^7.52.0",
+        "@wordpress/blocks": "^15.25.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/url": "^4.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/shortcode": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.45.0.tgz",
-      "integrity": "sha512-lHuE3BOOV6hWieDCW0pRUk/jP+qEKjhZs/G5EAko5t7IcNmaihmBBos8RpvZDEzkK8CoH8vfoAQAmYW0xP146A==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.52.0.tgz",
+      "integrity": "sha512-6vTLq3WxPMaE6pvxvvUzbcSeNzvqcghF4ngX1bXlSVIwMXVDgwsTFA4yc6LoI9BFBDZt9UZ+KN22wcdqnDr9Ug==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "memize": "^2.0.1"
+        "memize": "^2.1.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -2442,9 +2522,9 @@
       }
     },
     "node_modules/@wordpress/style-engine": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.45.0.tgz",
-      "integrity": "sha512-TQZbdLiDsQL1EATq4HKkmKCn99+l6eK3fmBpwOgXeOscQB9ta/Na64KYLoilZBuXnAelmFOXsWpz0c8ijRRniw==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.52.0.tgz",
+      "integrity": "sha512-VZkJ1VO8h+lZNfoqURgd5VM4LXSu6I88ThMYM4C5hG7su/pK47mjOE/K39KW9eLt4KFuBcKKrwsOvgYLOJClig==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -2453,71 +2533,53 @@
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/sync": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.45.0.tgz",
-      "integrity": "sha512-K+js/65DPrkNNVNg871C6HROm4BYt5iHY5HRBXfrErnoeXesDG9I1RrfqHu1mHn+JTn5nX1wJVlKDlCimY/B6g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/api-fetch": "^7.45.0",
-        "@wordpress/hooks": "^4.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/undo-manager": "^1.45.0",
-        "diff": "^8.0.3",
-        "fast-deep-equal": "^3.1.3",
-        "lib0": "0.2.99",
-        "y-protocols": "^1.0.7",
-        "yjs": "13.6.29"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/sync/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@wordpress/theme": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.12.0.tgz",
-      "integrity": "sha512-AmEVO0B+kI9tsxkLnna/S+7yi+EPCMTuaPqagje7pnlXeDfykVQfeDeWJfU+QvhcqHXCySn89vvw1Ihep0rj7w==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "colorjs.io": "^0.6.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2"
+        "@types/react": "^18 || ^19"
       },
       "peerDependenciesMeta": {
-        "stylelint": {
+        "@types/react": {
           "optional": true
         }
       }
     },
+    "node_modules/@wordpress/style-runtime": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.8.0.tgz",
+      "integrity": "sha512-gqe5cnsDLwH2NQ//VyUtzS4pcht0iR64hP+3u6p5/pPvwA2ySGn71mJ/7+O2X7sUG5drxNp6+4Kl3LWOzkKYng==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@wordpress/sync": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.52.0.tgz",
+      "integrity": "sha512-5Al3xPAzB7719zz38eJlbKD9rm1AwWpnjtyGeZxu6O3VFLZQa+i2hS+vE67NWJo6/1+SqSiOcFaFY2NGSf0Kww==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/api-fetch": "^7.52.0",
+        "@wordpress/hooks": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/undo-manager": "^1.52.0",
+        "diff": "^8.0.3",
+        "fast-deep-equal": "^3.1.3",
+        "lib0": "^0.2.99",
+        "y-protocols": "^1.0.7",
+        "yjs": "^13.6.29"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/token-list": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.45.0.tgz",
-      "integrity": "sha512-4BT2u4/M88h7IvoLC0yswbOPpf7UcsKWh7XXdsDdQc3aWJ1q6dDZB7jQ7tJ8WGQGgztKMcweo3bkZULgzJkECw==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.52.0.tgz",
+      "integrity": "sha512-+q60OFp/1zoT2AbDW/aVqI1Ez7DfgeBCjuW5KCTtsgyS0esqCZG9EJW9887oh5MF9rNDQ6X5kS7mC8d1NKhP7Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -2526,108 +2588,95 @@
       }
     },
     "node_modules/@wordpress/ui": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.12.0.tgz",
-      "integrity": "sha512-n/xfyagM90CcikLtlvNcjsFZtpt1wTpboOZPyCp9wqF6akAyJ4SUg9hXb/UA7pC8JqGe1Dg/hXJnFn/td8pvRA==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.19.0.tgz",
+      "integrity": "sha512-ck0BcuWu96vbpim0rFUI0kDLaUgLyRmbhkgfhgYFyHm2klzyRxhbakNTc6qqj7xCQ0Wsy9SwCqDCuCHltZpXkA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@base-ui/react": "^1.4.1",
-        "@wordpress/a11y": "^4.45.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/icons": "^13.0.0",
-        "@wordpress/keycodes": "^4.45.0",
-        "@wordpress/primitives": "^4.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/theme": "^0.12.0",
+        "@base-ui/react": "^1.6.0",
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/primitives": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/style-runtime": "^0.8.0",
+        "@wordpress/theme": "^1.1.0",
         "clsx": "^2.1.1",
         "tabbable": "^6.4.0"
       },
       "engines": {
-        "node": ">=20.10.0",
+        "node": "^20.19.0 || >=22.13.0",
         "npm": ">=10.2.3"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/ui/node_modules/@base-ui/react": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
-      "integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.2.8",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       },
       "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
         "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
           "optional": true
         }
       }
     },
-    "node_modules/@wordpress/ui/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@wordpress/ui/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@wordpress/undo-manager": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.45.0.tgz",
-      "integrity": "sha512-BqclZIPjzBYIjLqLZFihs+Ce+w+yBQuj44VYSrRDOj56AbMtwmClIUqgIVBZAe2En/2ncixTTWOZG9KluvEXfA==",
+    "node_modules/@wordpress/ui/node_modules/@wordpress/theme": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-1.1.0.tgz",
+      "integrity": "sha512-SWEGYY/HnSzmKDJnDhWVfxUDyLlJkz9EtpfAWhgPcCLSaZVc/pp99Fxr+/ueB2mHlQ9gpaWCPAMBxq8knDCbXw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/is-shallow-equal": "^5.45.0"
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/style-runtime": "^0.8.0",
+        "colorjs.io": "^0.7.1",
+        "memize": "^2.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.13.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "esbuild": ">=0.27.2 <1.0.0",
+        "postcss": "^8.0.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "stylelint": "^16 || ^17",
+        "vite": "^7 || ^8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "stylelint": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/undo-manager": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.52.0.tgz",
+      "integrity": "sha512-6hI0WWDOtLLVEkWqQokCoQRz5Pba9UNtgt5MV4hHGe5x0mzsowj+GWHedppf8UCVZ2ex3cde7fThaRKMCackrQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.52.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -2635,36 +2684,43 @@
       }
     },
     "node_modules/@wordpress/upload-media": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.30.0.tgz",
-      "integrity": "sha512-8KjMTNY/6j0x2bQ799KGGfFhvlGP7OCw1ZGdNDK5q4y5ABDmVrv/dVPQywUavnFs5epQxG9vDXjN4lcD2rgtkQ==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.37.0.tgz",
+      "integrity": "sha512-EMVwOsuA+gloz0VeQFm5B+unmVqYArTs6TMYvCCWf0VjhcJnTITqX+/Iz81tROvgThHB1I/SYzucD1Y2QJhUaA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/blob": "^4.45.0",
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/element": "^6.45.0",
-        "@wordpress/i18n": "^6.18.0",
-        "@wordpress/preferences": "^4.45.0",
-        "@wordpress/private-apis": "^1.45.0",
-        "@wordpress/url": "^4.45.0",
-        "@wordpress/vips": "^1.5.0",
-        "uuid": "^9.0.1"
+        "@wordpress/blob": "^4.52.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/preferences": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/url": "^4.52.0",
+        "@wordpress/video-conversion": "^0.3.0",
+        "@wordpress/vips": "^3.0.0",
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.45.0.tgz",
-      "integrity": "sha512-Uh29Th3EEAK/6wsBy7d9hNj2UhDzV0H7cT7xi3s4uAKOUYsIx7scawZakVRa73d3z+lnAkk0lyneIQPPosFHaQ==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.52.0.tgz",
+      "integrity": "sha512-4cSo0dUHiOQB2DiiPkoVIqP5aoGJdIj32LD9XgG41yeh7xG6ALdDA1I/883WFRoX2JIYySFj208MzopURDH7Yg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -2675,34 +2731,55 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/viewport": {
-      "version": "6.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.45.0.tgz",
-      "integrity": "sha512-eyhtP13CxaQzLxlfhVDYvuJoEkHfPQCvUimzGT0fygi6be01g+/r27e8xjVo6C00Ot3vPzKz4Gt8RfEgGzvw1g==",
+    "node_modules/@wordpress/video-conversion": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/video-conversion/-/video-conversion-0.3.0.tgz",
+      "integrity": "sha512-jHFOgfxlj9wjstJ5AlpozReAru4uGua30Y72Ifg2vrFv/xEQSd4pdTtfZ7Xg7o+NQyMx92Wxea/yFdn7IQpETA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.45.0",
-        "@wordpress/data": "^10.45.0",
-        "@wordpress/element": "^6.45.0"
+        "@wordpress/worker-threads": "^1.12.0",
+        "mediabunny": "^1.45.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/viewport": {
+      "version": "6.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.52.0.tgz",
+      "integrity": "sha512-QEnSm9x4EgtPms/mwI+jNRuYwj5s73mQJXJe+QLNLPMwcpKKZdUKDRlVcvqxPdE8aCou6PE5wefFysP9C6LQ1Q==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/element": "^8.4.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/vips": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-1.5.0.tgz",
-      "integrity": "sha512-BxTy86EHy3pXYkpJtMZGMhxipC2YQqN9xKDGlL3GZPIBjJ5A+/Xe3ZlVvGaQRc9qWz3ifOgMF4ElKpc6RK8giA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-3.0.0.tgz",
+      "integrity": "sha512-pzCho1/ZfLkmHX9kd2KuCix0nKQK9sD+gaC2zi8pz355j25ARJJEWJOwstjNWgmDHHzOwnUDAfj67Z/K7643kw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/worker-threads": "^1.5.0",
-        "wasm-vips": "^0.0.16"
+        "@wordpress/worker-threads": "^1.12.0",
+        "wasm-vips": "^0.0.18"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -2710,9 +2787,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.45.0.tgz",
-      "integrity": "sha512-NQ9tAhPdwhfceVIzWra1rbumvgAFAEDTgZlWsX880zLiq1F8JTwBouwW6wfIhA3XLcY6Yj7cBBYLa8vnNiDZDw==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.52.0.tgz",
+      "integrity": "sha512-BjJ+Jte1g2nMITI1IHq0NwMpm/qlFOV1L+gNe0vFQmGKEcXiQ0DjrHQNtA8hV+Mgt9zSWRNS71Fgonht3r72Ew==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -2721,9 +2798,9 @@
       }
     },
     "node_modules/@wordpress/wordcount": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.45.0.tgz",
-      "integrity": "sha512-pv81+OANhvWSkMKD6QP429drE1GT4MQnoqAFcQItJyPSMJ58sO731Xui1wWKLkrwh9s/QhokAnyo+eRasjY7LQ==",
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.52.0.tgz",
+      "integrity": "sha512-aMrmu/9LZK4hzKpekWjuapKubRS0KSHsg/0DZQ5CYZ63lLRrXA96dulM6p1I75CubWcwZR6U0MrPaICmUXtbtw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -2732,9 +2809,9 @@
       }
     },
     "node_modules/@wordpress/worker-threads": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.5.0.tgz",
-      "integrity": "sha512-X4jVjyy6k2cbXzrXN7tcqYDBRiEV8DfFGdbDJrglrA/yAtKKe4l+h/yjyEfjzMJQNcwxKmwzFnzkW0ZJQILFTg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.12.0.tgz",
+      "integrity": "sha512-d5UiIbA7t1PDL19+cxNy2l61QOCI9Z2FQlSZAWVFNOGm7EHHoRFYYNV7CVSm3AdS7UGij+nKUoWir8fNe7KCEQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -2743,29 +2820,6 @@
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/aria-hidden": {
@@ -2835,16 +2889,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/capital-case": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
@@ -2878,18 +2922,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2917,23 +2949,6 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/colord": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -2942,9 +2957,9 @@
       "license": "MIT"
     },
     "node_modules/colorjs.io": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
-      "integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.7.1.tgz",
+      "integrity": "sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2953,9 +2968,9 @@
       }
     },
     "node_modules/comctx": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/comctx/-/comctx-1.6.1.tgz",
-      "integrity": "sha512-ZMRGAYASYRdVfEoB7oxH8Nqu5Ay8I+YvAsQni+td0pYV9eww/PrtSFVyvc2JkNQyHXGDknCB4wJfxFYP6fuqZg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/comctx/-/comctx-1.7.5.tgz",
+      "integrity": "sha512-0fsxsxr1Hg2T99wOIteUbsJOX6jMmnhAJepcVRqNRMWpcbxRhbm2+0R8qEuQEaE4gWjfdXaKeAGYAn0yeElylQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3037,9 +3052,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3070,16 +3085,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -3117,9 +3122,9 @@
       "license": "MIT"
     },
     "node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3208,13 +3213,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -3310,19 +3308,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/framer-motion": {
       "version": "11.18.2",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
@@ -3376,16 +3361,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -3417,9 +3392,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3582,29 +3557,19 @@
       "license": "MIT"
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/is-plain-object": {
@@ -3650,44 +3615,59 @@
       "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
-      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.11",
-        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-        "@exodus/bytes": "^1.15.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.3.5",
+        "lru-cache": "^11.5.2",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.25.0",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
+        "whatwg-url": "^17.1.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "canvas": "^3.0.0"
+        "canvas": "^3.2.3"
       },
       "peerDependenciesMeta": {
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -3711,9 +3691,9 @@
       "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3752,20 +3732,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3790,13 +3756,26 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+      "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdn-data": {
@@ -3805,6 +3784,25 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mediabunny": {
+      "version": "1.52.3",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.52.3.tgz",
+      "integrity": "sha512-rMGwH5fykDCSA55LG9aWkE433wwHrycq3J5mRf+djBnHBZzmJGvIwg6Qfcfr4rRkzkmrdmewxQozLkOM1H1C6Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "0.1.13"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      }
     },
     "node_modules/memize": {
       "version": "2.1.1",
@@ -3868,9 +3866,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -3912,45 +3910,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/param-case": {
@@ -4023,9 +3982,9 @@
       }
     },
     "node_modules/parsel-js": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.2.2.tgz",
-      "integrity": "sha512-AVJMlwQ4bL2Y0VvYJGk+Fp7eX4SCH2uFoNApmn4yKWACUewZ+alwW3tyoe1r5Z3aLYQTuAuPZIyGghMfO/Tlxw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.2.3.tgz",
+      "integrity": "sha512-kJHFmSNnujpusFfVEXjNaoJ09VYHF8Ih0aVUn7Clu+Ug8AFoA2wx7Ezh17JfW4+vhm/lauAd9A+//uFkmydZtQ==",
       "dev": true,
       "funding": [
         {
@@ -4059,16 +4018,6 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/path-parse": {
@@ -4115,13 +4064,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
-      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4134,9 +4083,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
-      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4156,9 +4105,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4176,7 +4125,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4215,14 +4164,22 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.29.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
-      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {
@@ -4295,9 +4252,9 @@
       }
     },
     "node_modules/react-colorful": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
-      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.8.0.tgz",
+      "integrity": "sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -4326,17 +4283,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/react-day-picker/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/react-dom": {
@@ -4482,16 +4428,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4502,17 +4438,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4618,26 +4547,6 @@
         "upper-case-first": "^2.0.2"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/showdown": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
-      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "yargs": "^14.2"
-      },
-      "bin": {
-        "showdown": "bin/showdown.js"
-      }
-    },
     "node_modules/simple-html-tokenizer": {
       "version": "0.5.11",
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
@@ -4674,34 +4583,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/style-to-js": {
@@ -4752,9 +4633,9 @@
       "license": "MIT"
     },
     "node_modules/tabbable": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4779,29 +4660,29 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.29",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
-      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.29"
+        "tldts-core": "^7.4.10"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.29",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
-      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4832,13 +4713,13 @@
       "license": "0BSD"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/upper-case": {
@@ -4927,10 +4808,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -4938,7 +4818,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -4955,13 +4835,13 @@
       }
     },
     "node_modules/wasm-vips": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.16.tgz",
-      "integrity": "sha512-4/bEq8noAFt7DX3VT+Vt5AgNtnnOLwvmrDbduWfiv9AV+VYkbUU4f9Dam9e6khRqPinyClFHCqiwATTTJEiGwA==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.18.tgz",
+      "integrity": "sha512-AJyCvxZj/3qceKNnh+YyEobu/IaJFoPN7x7SxyyHmYBS3kASMqJqxQEuN0ZHKQDWsCJ8armfx4Tq3uKrNc+nMA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16.4.0"
+        "node": ">=17.0.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -4997,28 +4877,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/xml-name-validator": {
@@ -5059,13 +4917,6 @@
         "yjs": "^13.0.0"
       }
     },
-    "node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/yaml": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
@@ -5076,41 +4927,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/yargs": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-      "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^5.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^15.0.1"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
-      "integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
     "node_modules/yjs": {
-      "version": "13.6.29",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
-      "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
+      "version": "13.6.32",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.32.tgz",
+      "integrity": "sha512-lfiJIIC4Xayt5ItynE407ehlE03pCjeOc4hkR4yxxvvNJ4kuiN25B0g+Qp8XagYz361LLL7DCzR5bvFJ81QKtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "test:form-materializer-topology": "node --test tests/form-materializer-topology.test.mjs"
   },
   "devDependencies": {
-    "@wordpress/block-library": "^9.45.0",
-    "@wordpress/blocks": "^15.18.0",
-    "@wordpress/element": "^6.45.0",
-    "jsdom": "^29.1.0",
-    "playwright": "^1.56.1"
+    "@wordpress/block-library": "^10.3.0",
+    "@wordpress/blocks": "^15.25.0",
+    "@wordpress/element": "^8.4.0",
+    "jsdom": "^30.0.1",
+    "playwright": "^1.62.1"
   },
   "dependencies": {
     "pixelmatch": "^7.2.0",


### PR DESCRIPTION
## Summary
- Upgrade the direct WordPress validation packages to the aligned supported releases: `@wordpress/block-library` 10.3.0, `@wordpress/blocks` 15.25.0, and `@wordpress/element` 8.4.0.
- Upgrade `jsdom` to 30.0.1 and Playwright to 1.62.1; the resolved graph uses PostCSS 8.5.26, Undici 8.10.0, and UUID 14.0.1, with no Showdown package.
- Regenerate the lockfile from supported direct dependency upgrades, without `overrides` or lockfile-only pins.

Fixes #858

## Verification
- `npm ci --registry=https://registry.npmjs.org --ignore-scripts` completed successfully.
- `npm audit --omit=dev --json`: 0 vulnerabilities (0 info, 0 low, 0 moderate, 0 high, 0 critical).
- `npm audit --json`: 0 vulnerabilities (0 info, 0 low, 0 moderate, 0 high, 0 critical).
- `npm test`: 50 passed, 0 failed.
- `npm run test:js-block-validation -- /Users/chubes/Studio/intelligence-chubes4/wp-content/themes/wordpress-is-dead`: passed, validating 249 blocks across 15 files.
- `npx playwright --version`: 1.62.1.

## Residual Risk
`npm audit` reports no remaining lower-severity advisories or other advisories in the committed production or development graph.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode analyzed the dependency graph, selected supported direct upgrades, regenerated the lockfile, and ran the listed verification. Chris Huber remains responsible for every line.