### PR TITLE
Restore Jetpack 16 Forms provider readiness

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -162,29 +162,52 @@ class Static_Site_Importer_Form_Seeder {
 
 	/** Activate and prepare Jetpack Forms through its canonical module lifecycle. */
 	public static function prepare_jetpack_forms_runtime() {
-		if ( ! class_exists( 'Jetpack' ) || ! class_exists( 'Automattic\\Jetpack\\Modules' ) ) {
-			return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_runtime_missing', array( 'Jetpack', 'Automattic\\Jetpack\\Modules' ) );
+		$availability = self::jetpack_forms_availability_details();
+		if ( ! empty( $availability['available'] ) ) {
+			return true;
 		}
 
-		$modules = new Automattic\Jetpack\Modules();
-		if ( ! $modules->is_active( 'contact-form' ) ) {
-			$activated = Jetpack::activate_module( 'contact-form', false, false );
-			if ( false === $activated ) {
+		$lifecycle_apis = array(
+			'Jetpack::is_module_active'       => class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'is_module_active' ),
+			'Jetpack::activate_default_modules' => class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'activate_default_modules' ),
+			'WP_Block_Type_Registry::get_instance' => class_exists( 'WP_Block_Type_Registry' ) && method_exists( 'WP_Block_Type_Registry', 'get_instance' ),
+		);
+		$missing_lifecycle_apis = array_keys( array_filter( $lifecycle_apis, static fn ( bool $available ): bool => ! $available ) );
+		if ( ! empty( $missing_lifecycle_apis ) ) {
+			return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_lifecycle_missing', $missing_lifecycle_apis );
+		}
+
+		if ( ! Jetpack::is_module_active( 'contact-form' ) ) {
+			// Jetpack uses this inverted range to activate only explicitly supplied defaults.
+			Jetpack::activate_default_modules( 999, 1, array( 'contact-form' ), false, false );
+			if ( ! Jetpack::is_module_active( 'contact-form' ) ) {
 				return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_activation_failed', array( 'contact-form' ) );
 			}
 		}
 
 		$loader = 'Automattic\\Jetpack\\Forms\\Jetpack_Forms';
-		if ( ! class_exists( $loader ) ) {
+		if ( ! class_exists( $loader ) || ! method_exists( $loader, 'load_contact_form' ) ) {
 			return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_loader_missing', array( $loader . '::load_contact_form' ) );
 		}
-		$loader::load_contact_form();
 
 		$initializer = 'Automattic\\Jetpack\\Forms\\ContactForm\\Contact_Form_Plugin';
-		if ( function_exists( 'did_action' ) && did_action( 'init' ) && ! self::$jetpack_forms_initialized ) {
-			if ( ! class_exists( $initializer ) ) {
-				return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_init_missing', array( $initializer . '::init' ) );
-			}
+		if ( ! class_exists( $initializer ) || ! method_exists( $initializer, 'init' ) ) {
+			return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_init_missing', array( $initializer . '::init' ) );
+		}
+
+		$init_callback_loaded = function_exists( 'has_action' ) && (
+			false !== has_action( 'init', '\\' . $initializer . '::init' )
+			|| false !== has_action( 'init', $initializer . '::init' )
+		);
+		if ( ! $init_callback_loaded ) {
+			$loader::load_contact_form();
+		}
+
+		if ( ! function_exists( 'did_action' ) || ! did_action( 'init' ) ) {
+			return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_init_pending', array( 'init' ) );
+		}
+
+		if ( ! self::$jetpack_forms_initialized ) {
 			$initializer::init();
 			self::$jetpack_forms_initialized = true;
 		}

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -167,31 +167,30 @@ class Static_Site_Importer_Form_Seeder {
 			return true;
 		}
 
-		$lifecycle_apis = array(
-			'Jetpack::is_module_active'       => class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'is_module_active' ),
-			'Jetpack::activate_default_modules' => class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'activate_default_modules' ),
-			'WP_Block_Type_Registry::get_instance' => class_exists( 'WP_Block_Type_Registry' ) && method_exists( 'WP_Block_Type_Registry', 'get_instance' ),
+		$lifecycle_apis         = array(
+			'Jetpack::is_module_active'         => self::runtime_static_method_exists( 'Jetpack', 'is_module_active' ),
+			'Jetpack::activate_default_modules' => self::runtime_static_method_exists( 'Jetpack', 'activate_default_modules' ),
 		);
 		$missing_lifecycle_apis = array_keys( array_filter( $lifecycle_apis, static fn ( bool $available ): bool => ! $available ) );
 		if ( ! empty( $missing_lifecycle_apis ) ) {
 			return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_lifecycle_missing', $missing_lifecycle_apis );
 		}
 
-		if ( ! Jetpack::is_module_active( 'contact-form' ) ) {
+		if ( ! self::invoke_runtime_static_method( 'Jetpack', 'is_module_active', array( 'contact-form' ) ) ) {
 			// Jetpack uses this inverted range to activate only explicitly supplied defaults.
-			Jetpack::activate_default_modules( 999, 1, array( 'contact-form' ), false, false );
-			if ( ! Jetpack::is_module_active( 'contact-form' ) ) {
+			self::invoke_runtime_static_method( 'Jetpack', 'activate_default_modules', array( 999, 1, array( 'contact-form' ), false, false ) );
+			if ( ! self::invoke_runtime_static_method( 'Jetpack', 'is_module_active', array( 'contact-form' ) ) ) {
 				return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_activation_failed', array( 'contact-form' ) );
 			}
 		}
 
 		$loader = 'Automattic\\Jetpack\\Forms\\Jetpack_Forms';
-		if ( ! class_exists( $loader ) || ! method_exists( $loader, 'load_contact_form' ) ) {
+		if ( ! self::runtime_static_method_exists( $loader, 'load_contact_form' ) ) {
 			return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_loader_missing', array( $loader . '::load_contact_form' ) );
 		}
 
 		$initializer = 'Automattic\\Jetpack\\Forms\\ContactForm\\Contact_Form_Plugin';
-		if ( ! class_exists( $initializer ) || ! method_exists( $initializer, 'init' ) ) {
+		if ( ! self::runtime_static_method_exists( $initializer, 'init' ) ) {
 			return self::jetpack_forms_runtime_error( 'static_site_importer_jetpack_forms_init_missing', array( $initializer . '::init' ) );
 		}
 
@@ -200,7 +199,7 @@ class Static_Site_Importer_Form_Seeder {
 			|| false !== has_action( 'init', $initializer . '::init' )
 		);
 		if ( ! $init_callback_loaded ) {
-			$loader::load_contact_form();
+			self::invoke_runtime_static_method( $loader, 'load_contact_form' );
 		}
 
 		if ( ! function_exists( 'did_action' ) || ! did_action( 'init' ) ) {
@@ -208,7 +207,7 @@ class Static_Site_Importer_Form_Seeder {
 		}
 
 		if ( ! self::$jetpack_forms_initialized ) {
-			$initializer::init();
+			self::invoke_runtime_static_method( $initializer, 'init' );
 			self::$jetpack_forms_initialized = true;
 		}
 
@@ -222,6 +221,20 @@ class Static_Site_Importer_Form_Seeder {
 			array_keys( array_filter( $availability['required_blocks'], static fn ( bool $registered ): bool => ! $registered ) ),
 			$availability
 		);
+	}
+
+	/** Check an extension-owned static API without binding analysis to that extension's stubs. */
+	private static function runtime_static_method_exists( string $class_name, string $method ): bool {
+		return class_exists( $class_name ) && method_exists( $class_name, $method );
+	}
+
+	/**
+	 * Invoke an extension-owned static API after runtime_static_method_exists() succeeds.
+	 *
+	 * @phpstan-impure
+	 */
+	private static function invoke_runtime_static_method( string $class_name, string $method, array $args = array() ) {
+		return ( new ReflectionMethod( $class_name, $method ) )->invokeArgs( null, $args );
 	}
 
 	/** Build a bounded provider-readiness error. */

--- a/tests/form-materializer-topology.test.mjs
+++ b/tests/form-materializer-topology.test.mjs
@@ -37,9 +37,6 @@ test( 'shared-row topology materializes through the PHP provider adapter', () =>
 test( 'Jetpack runtime preparation reports the missing canonical forms loader', () => {
 	const code = String.raw`
 namespace Automattic\Jetpack {
-	class Modules {
-		public function is_active( $module ) { return true; }
-	}
 }
 namespace {
 	define( 'ABSPATH', getcwd() . '/' );
@@ -47,7 +44,12 @@ namespace {
 		public function __construct( public $code, public $message = '', public $data = null ) {}
 	}
 	class Jetpack {
-		public static function activate_module( $module, $silent, $redirect ) {}
+		public static function is_module_active( $module ) { return true; }
+		public static function activate_default_modules( $min, $max, $modules, $network, $reactivate ) {}
+	}
+	class WP_Block_Type_Registry {
+		public static function get_instance() { return new self(); }
+		public function is_registered( $name ) { return false; }
 	}
 	function update_option( $name, $value, $autoload = null ) {}
 	require 'includes/class-static-site-importer-form-seeder.php';

--- a/tests/provider-adapter-runtime-smoke.php
+++ b/tests/provider-adapter-runtime-smoke.php
@@ -9,7 +9,7 @@ namespace {
 	$case = $argv[1] ?? '';
 	if ( '' === $case ) {
 		$failures = array();
-		foreach ( array( 'init-before-after', 'missing-loader', 'missing-init', 'partial-blocks' ) as $child_case ) {
+		foreach ( array( 'supported-late', 'already-active-late', 'init-pending', 'activation-failed', 'missing-lifecycle', 'missing-loader', 'missing-init', 'partial-blocks' ) as $child_case ) {
 			$command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( __FILE__ ) . ' ' . escapeshellarg( $child_case );
 			exec( $command, $output, $status );
 			if ( 0 !== $status ) {
@@ -27,7 +27,8 @@ namespace {
 
 	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 	$GLOBALS['ssi_provider_adapter_case'] = $case;
-	$GLOBALS['ssi_init_actions']          = 'init-before-after' === $case ? 0 : 1;
+	$GLOBALS['ssi_init_actions']          = 'init-pending' === $case ? 0 : 1;
+	$GLOBALS['ssi_hooks']                 = array();
 	$GLOBALS['ssi_missing_blocks']        = 'partial-blocks' === $case ? array( 'jetpack/field-email' ) : array();
 
 	class WP_Error {
@@ -37,25 +38,53 @@ namespace {
 	}
 	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
 	function did_action( string $hook ): int { return 'init' === $hook ? $GLOBALS['ssi_init_actions'] : 0; }
-
-	class Jetpack {
-		public static int $activations = 0;
-		public static function activate_module( string $module, bool $redirect, bool $options ): bool {
-			unset( $redirect, $options );
-			++self::$activations;
-			$GLOBALS['ssi_contact_form_active'] = 'contact-form' === $module;
-			return true;
+	function add_action( string $hook, $callback ): void { $GLOBALS['ssi_hooks'][ $hook ][] = $callback; }
+	function has_action( string $hook, $callback = false ) {
+		foreach ( $GLOBALS['ssi_hooks'][ $hook ] ?? array() as $registered ) {
+			if ( $registered === $callback || ltrim( (string) $registered, '\\' ) === ltrim( (string) $callback, '\\' ) ) {
+				return 9;
+			}
+		}
+		return false;
+	}
+	function ssi_run_init(): void {
+		$GLOBALS['ssi_init_actions'] = 1;
+		foreach ( $GLOBALS['ssi_hooks']['init'] ?? array() as $callback ) {
+			call_user_func( $callback );
 		}
 	}
-	class WP_Block_Type_Registry {
-		public static function get_instance(): self { return new self(); }
-		public function is_registered( string $name ): bool { return ! in_array( $name, $GLOBALS['ssi_missing_blocks'], true ); }
-	}
-}
 
-namespace Automattic\Jetpack {
-	class Modules {
-		public function is_active( string $module ): bool { return 'contact-form' === $module && ! empty( $GLOBALS['ssi_contact_form_active'] ); }
+	if ( 'missing-lifecycle' === $case ) {
+		class Jetpack {
+			public static function is_module_active( string $module ): bool { return false; }
+		}
+	} else {
+		class Jetpack {
+			public static int $default_activations = 0;
+			public static bool $contact_form_active = false;
+			public static function is_module_active( string $module ): bool {
+				return 'contact-form' === $module && self::$contact_form_active;
+			}
+			public static function activate_default_modules( int $min, int $max, array $modules, bool $network_wide, bool $reactivate ): void {
+				unset( $network_wide, $reactivate );
+				++self::$default_activations;
+				if ( 'activation-failed' === $GLOBALS['ssi_provider_adapter_case'] ) {
+					return;
+				}
+				self::$contact_form_active = 999 === $min && 1 === $max && array( 'contact-form' ) === $modules;
+				if ( self::$contact_form_active && class_exists( 'Automattic\\Jetpack\\Forms\\Jetpack_Forms' ) ) {
+					\Automattic\Jetpack\Forms\Jetpack_Forms::load_contact_form();
+				}
+			}
+		}
+	}
+
+	class WP_Block_Type_Registry {
+		private static ?self $instance = null;
+		private array $registered = array();
+		public static function get_instance(): self { return self::$instance ??= new self(); }
+		public function register( string $name ): void { $this->registered[ $name ] = true; }
+		public function is_registered( string $name ): bool { return isset( $this->registered[ $name ] ) && ! in_array( $name, $GLOBALS['ssi_missing_blocks'], true ); }
 	}
 }
 
@@ -63,7 +92,10 @@ namespace Automattic\Jetpack\Forms {
 	if ( 'missing-loader' !== $GLOBALS['ssi_provider_adapter_case'] ) {
 		class Jetpack_Forms {
 			public static int $loads = 0;
-			public static function load_contact_form(): void { ++self::$loads; }
+			public static function load_contact_form(): void {
+				++self::$loads;
+				\add_action( 'init', '\\Automattic\\Jetpack\\Forms\\ContactForm\\Contact_Form_Plugin::init' );
+			}
 		}
 	}
 }
@@ -73,13 +105,25 @@ namespace Automattic\Jetpack\Forms\ContactForm {
 	if ( 'missing-init' !== $GLOBALS['ssi_provider_adapter_case'] ) {
 		class Contact_Form_Plugin {
 			public static int $initializations = 0;
-			public static function init(): void { ++self::$initializations; }
+			public static function init(): void {
+				if ( self::$initializations ) {
+					return;
+				}
+				++self::$initializations;
+				foreach ( \Static_Site_Importer_Form_Seeder::required_block_types() as $block_name ) {
+					\WP_Block_Type_Registry::get_instance()->register( $block_name );
+				}
+			}
 		}
 	}
 }
 
 namespace {
 	require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-form-seeder.php';
+
+	if ( 'already-active-late' === $case ) {
+		Jetpack::$contact_form_active = true;
+	}
 
 	$result = Static_Site_Importer_Form_Seeder::prepare_jetpack_forms_runtime();
 	$assert = static function ( bool $condition, string $message ): void {
@@ -89,18 +133,32 @@ namespace {
 		}
 	};
 
-	if ( 'init-before-after' === $case ) {
-		$assert( true === $result, 'initial preparation succeeds' );
-		$assert( 1 === Jetpack::$activations, 'contact-form activates once without a connection' );
-		$assert( 1 === \Automattic\Jetpack\Forms\Jetpack_Forms::$loads, 'canonical loader runs before init' );
-		$assert( 0 === \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::$initializations, 'init hook remains deferred before init' );
-		$GLOBALS['ssi_init_actions'] = 1;
-		$assert( true === Static_Site_Importer_Form_Seeder::prepare_jetpack_forms_runtime(), 'late preparation succeeds' );
-		$assert( 1 === \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::$initializations, 'late canonical init runs once' );
+	if ( 'supported-late' === $case ) {
+		$assert( true === $result, 'late preparation succeeds' );
+		$assert( 1 === Jetpack::$default_activations, 'only the explicit default module is activated' );
+		$assert( 1 === \Automattic\Jetpack\Forms\Jetpack_Forms::$loads, 'module lifecycle loads Forms once' );
+		$assert( 1 === \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::$initializations, 'late singleton init runs once' );
 		$assert( true === Static_Site_Importer_Form_Seeder::prepare_jetpack_forms_runtime(), 'repeated preparation succeeds' );
-		$assert( 1 === \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::$initializations, 'late canonical init is idempotent' );
+		$assert( 1 === Jetpack::$default_activations && 1 === \Automattic\Jetpack\Forms\Jetpack_Forms::$loads, 'repeated preparation does not replay lifecycle work' );
 	}
-
+	if ( 'already-active-late' === $case ) {
+		$assert( true === $result, 'active module is prepared' );
+		$assert( 0 === Jetpack::$default_activations, 'active module is not reactivated' );
+		$assert( 1 === \Automattic\Jetpack\Forms\Jetpack_Forms::$loads, 'missing package hook is installed once' );
+	}
+	if ( 'init-pending' === $case ) {
+		$assert( is_wp_error( $result ) && 'static_site_importer_jetpack_forms_init_pending' === $result->get_error_code(), 'pre-init preparation is bounded' );
+		ssi_run_init();
+		$assert( true === Static_Site_Importer_Form_Seeder::prepare_jetpack_forms_runtime(), 'normal init hook completes readiness' );
+		$assert( 1 === Jetpack::$default_activations && 1 === \Automattic\Jetpack\Forms\Jetpack_Forms::$loads, 'init completion does not replay lifecycle work' );
+	}
+	if ( 'activation-failed' === $case ) {
+		$assert( is_wp_error( $result ) && 'static_site_importer_jetpack_forms_activation_failed' === $result->get_error_code(), 'failed default activation is specific' );
+	}
+	if ( 'missing-lifecycle' === $case ) {
+		$assert( is_wp_error( $result ) && 'static_site_importer_jetpack_forms_lifecycle_missing' === $result->get_error_code(), 'missing lifecycle API is bounded' );
+		$assert( array( 'Jetpack::activate_default_modules' ) === $result->get_error_data()['missing'], 'missing lifecycle API is identified' );
+	}
 	if ( 'missing-loader' === $case ) {
 		$assert( is_wp_error( $result ) && 'static_site_importer_jetpack_forms_loader_missing' === $result->get_error_code(), 'missing loader is bounded' );
 	}


### PR DESCRIPTION
## Summary

- replace the obsolete `Jetpack::activate_module( 'contact-form' )` readiness path with Jetpack 16's public explicit-default module lifecycle
- load and initialize Jetpack Forms idempotently when invoked after WordPress `init`
- return bounded provider-readiness errors for missing lifecycle APIs, failed activation, pending init, and incomplete block registration
- update provider lifecycle coverage for active, inactive, delayed-init, unsupported, and partial-registration runtimes

Addresses #848.

## Verification

- `homeboy review lint static-site-importer --placement local --path /Users/chubes/Developer/static-site-importer@fix-848-jetpack-forms-readiness --changed-since origin/main`
- `php tests/provider-adapter-runtime-smoke.php`
- `node --test tests/form-materializer-topology.test.mjs`
- `npm run test:fixture-matrix` (259 passing)
- `npm test` (50 manifest tests passing)

Fixture 87 Homeboy run `06b327d8-269a-4de4-9280-0da490e5e07b` proves:

- immutable Jetpack 16.0.1 and SSI plugin activation succeed
- dependency preparation succeeds without a WordPress.com connection
- provider readiness returns `ready: true`
- all 17 required Jetpack Forms block types are registered
- no required classes, block types, or preparation errors are missing

The fixture then reaches the next independent lifecycle defect: WP Codebox reuses a PHP PID across separate WP CLI invocations, so SSI incorrectly returns `static_site_importer_fresh_runtime_required` and cannot materialize a front page for render/submission validation. That owning-layer blocker is tracked with reproduction evidence in #866. This PR does not claim the blocked render/submission proof.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode and Homeboy inspected Jetpack 16.0.1 source, implemented the provider lifecycle update, expanded tests, ran deterministic gates, and captured fixture evidence. Chris Huber directed the architecture and remains responsible for every line.
