### PR TITLE
Use invocation identity for persistent-worker lifecycle resume

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -81,10 +81,12 @@ class Static_Site_Importer_Theme_Generator {
 				'status'            => 'dependencies_prepared',
 				'runtime_lifecycle' => $lifecycle,
 				'dependencies'      => $dependencies,
-				'fresh_runtime'     => array( 'request_id' => self::runtime_request_id() ),
+				'fresh_runtime'     => array( 'request_id' => (string) ( $args['runtime_lifecycle_invocation_id'] ?? '' ) ),
 			);
 		}
-		if ( 'resume' === ( $args['runtime_lifecycle_phase'] ?? '' ) && (string) ( $args['runtime_lifecycle_request_id'] ?? '' ) === self::runtime_request_id() ) {
+		$prepared_invocation = (string) ( $args['runtime_lifecycle_request_id'] ?? '' );
+		$current_invocation  = (string) ( $args['runtime_lifecycle_invocation_id'] ?? '' );
+		if ( 'resume' === ( $args['runtime_lifecycle_phase'] ?? '' ) && '' !== $prepared_invocation && $prepared_invocation === $current_invocation ) {
 			return new WP_Error( 'static_site_importer_fresh_runtime_required', 'Provider validation must resume in a fresh WordPress request after dependency preparation.' );
 		}
 
@@ -885,11 +887,6 @@ class Static_Site_Importer_Theme_Generator {
 			$lifecycle['status'] = 'runtime_declarations';
 		}
 		return $lifecycle;
-	}
-
-	/** A CLI process id is sufficient to reject same-request phase resumes. */
-	private static function runtime_request_id(): string {
-		return (string) ( function_exists( 'getmypid' ) ? getmypid() : spl_object_id( new stdClass() ) );
 	}
 
 	private static function runtime_declaration_is_required( array $declaration, array $declarations ): bool {

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -62,10 +62,11 @@ class Static_Site_Importer_Validation_Runtime {
 	/**
 	 * Validate a website artifact in the current runtime.
 	 *
-	 * @param array<string,mixed> $input Validation input.
+	 * @param array<string,mixed> $input         Validation input.
+	 * @param string              $invocation_id Server-owned identity for this invocation.
 	 * @return array<string,mixed>|WP_Error
 	 */
-	public static function validate_artifact( array $input ) {
+	public static function validate_artifact( array $input, string $invocation_id = '' ) {
 		$artifact = isset( $input['artifact'] ) && is_array( $input['artifact'] ) ? $input['artifact'] : array();
 		if ( empty( $artifact ) ) {
 			return new WP_Error( 'static_site_importer_validation_artifact_missing', 'Validation requires an artifact JSON object.' );
@@ -104,6 +105,7 @@ class Static_Site_Importer_Validation_Runtime {
 		if ( isset( $input['runtime_lifecycle_request_id'] ) ) {
 			$import_args['runtime_lifecycle_request_id'] = (string) $input['runtime_lifecycle_request_id'];
 		}
+		$import_args['runtime_lifecycle_invocation_id'] = self::invocation_id( $invocation_id );
 
 		$result = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $import_args );
 		if ( is_wp_error( $result ) ) {
@@ -113,8 +115,14 @@ class Static_Site_Importer_Validation_Runtime {
 		return self::result_from_import( $result, $artifact_dir, $import_args );
 	}
 
-	/** Prepare plugin dependencies in this request; callers resume validation in another request. */
-	public static function prepare_artifact_dependencies( array $input ) {
+	/**
+	 * Prepare plugin dependencies in this request; callers resume validation in another request.
+	 *
+	 * @param array<string,mixed> $input         Validation input.
+	 * @param string              $invocation_id Server-owned identity for this invocation.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function prepare_artifact_dependencies( array $input, string $invocation_id = '' ) {
 		$input['runtime_lifecycle_phase']  = 'prepare';
 		$input['materialize_dependencies'] = true;
 		$artifact                          = isset( $input['artifact'] ) && is_array( $input['artifact'] ) ? $input['artifact'] : array();
@@ -133,7 +141,8 @@ class Static_Site_Importer_Validation_Runtime {
 			)
 		);
 		$import_args['runtime_lifecycle_phase'] = 'prepare';
-		$result                                 = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $import_args );
+		$import_args['runtime_lifecycle_invocation_id'] = self::invocation_id( $invocation_id );
+		$result = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $import_args );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
@@ -147,6 +156,11 @@ class Static_Site_Importer_Validation_Runtime {
 			'dependencies'      => $result['dependencies'] ?? array(),
 			'runtime_lifecycle' => $result['runtime_lifecycle'] ?? array(),
 		);
+	}
+
+	/** Resolve the server-owned identity for one validation invocation. */
+	private static function invocation_id( string $invocation_id ): string {
+		return '' !== $invocation_id ? $invocation_id : wp_generate_uuid4();
 	}
 
 	/** Build a registry-derived dependency plan without installing packages. */

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -47,9 +47,38 @@ if ( ! function_exists( 'wp_mkdir_p' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4() {
+		static $sequence = 0;
+		++$sequence;
+
+		return '00000000-0000-4000-8000-' . str_pad( (string) $sequence, 12, '0', STR_PAD_LEFT );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+
+		public function __construct( string $code ) {
+			$this->code = $code;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+	}
+}
+
 if ( ! function_exists( 'is_wp_error' ) ) {
 	function is_wp_error( $value ) {
-		return false;
+		return $value instanceof WP_Error;
 	}
 }
 
@@ -57,8 +86,17 @@ if ( ! class_exists( 'Static_Site_Importer_Theme_Generator' ) ) {
 	class Static_Site_Importer_Theme_Generator {
 		public static array $last_args = array();
 
-		public static function import_website_artifact( array $artifact, array $args = array() ): array {
+		public static function import_website_artifact( array $artifact, array $args = array() ) {
 			self::$last_args = $args;
+			if ( 'prepare' === ( $args['runtime_lifecycle_phase'] ?? '' ) ) {
+				return array(
+					'status'        => 'dependencies_prepared',
+					'fresh_runtime' => array( 'request_id' => $args['runtime_lifecycle_invocation_id'] ?? '' ),
+				);
+			}
+			if ( 'resume' === ( $args['runtime_lifecycle_phase'] ?? '' ) && ( $args['runtime_lifecycle_request_id'] ?? '' ) === ( $args['runtime_lifecycle_invocation_id'] ?? '' ) ) {
+				return new WP_Error( 'static_site_importer_fresh_runtime_required' );
+			}
 
 			return array(
 				'quality'    => array( 'pass' => true ),
@@ -202,9 +240,47 @@ $override_result       = Static_Site_Importer_Validation_Runtime::validate_artif
 $assert( false === ( Static_Site_Importer_Theme_Generator::$last_args['materialize_dependencies'] ?? null ), 'validation-honors-disabled-dependency-materialization' );
 $assert( false === ( $override_result['request']['import_args']['materialize_dependencies'] ?? null ), 'validation-result-records-disabled-dependency-materialization' );
 
+$lifecycle_artifact = array( 'schema' => 'test/website-artifact/v1' );
+$prepare_receipt    = Static_Site_Importer_Validation_Runtime::prepare_artifact_dependencies(
+	array(
+		'artifact' => $lifecycle_artifact,
+		'slug'     => 'persistent-worker',
+	)
+);
+$prepared_invocation = (string) ( $prepare_receipt['fresh_runtime']['request_id'] ?? '' );
+$assert( '' !== $prepared_invocation, 'prepare-receipt-carries-invocation' );
+
+$resume_artifact_dir = $artifact_dir . '/persistent-worker-resume';
+$resume_result       = Static_Site_Importer_Validation_Runtime::validate_artifact(
+	array(
+		'artifact'                     => $lifecycle_artifact,
+		'artifact_dir'                 => $resume_artifact_dir,
+		'slug'                         => 'persistent-worker',
+		'runtime_lifecycle_phase'      => 'resume',
+		'runtime_lifecycle_request_id' => $prepare_receipt['fresh_runtime']['request_id'],
+	)
+);
+$assert( ! is_wp_error( $resume_result ), 'distinct-invocation-resume-proceeds-in-one-process' );
+$assert( $prepared_invocation !== ( Static_Site_Importer_Theme_Generator::$last_args['runtime_lifecycle_invocation_id'] ?? '' ), 'separate-runtime-calls-receive-distinct-invocations' );
+
+$same_invocation_artifact_dir = $artifact_dir . '/same-invocation-resume';
+$same_invocation_result       = Static_Site_Importer_Validation_Runtime::validate_artifact(
+	array(
+		'artifact'                     => $lifecycle_artifact,
+		'artifact_dir'                 => $same_invocation_artifact_dir,
+		'slug'                         => 'same-invocation',
+		'runtime_lifecycle_phase'      => 'resume',
+		'runtime_lifecycle_request_id' => $prepare_receipt['fresh_runtime']['request_id'],
+	),
+	$prepared_invocation
+);
+$assert( is_wp_error( $same_invocation_result ) && 'static_site_importer_fresh_runtime_required' === $same_invocation_result->get_error_code(), 'same-invocation-resume-rejected' );
+
 unlink( $report_path );
 rmdir( $default_artifact_dir );
 rmdir( $override_artifact_dir );
+rmdir( $resume_artifact_dir );
+rmdir( $same_invocation_artifact_dir );
 rmdir( $artifact_dir );
 
 if ( $failures ) {

--- a/tests/smoke-website-artifact-import-input.php
+++ b/tests/smoke-website-artifact-import-input.php
@@ -42,6 +42,12 @@ if ( ! function_exists( 'wp_mkdir_p' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4(): string {
+		return '00000000-0000-4000-8000-000000000001';
+	}
+}
+
 if ( ! function_exists( 'is_wp_error' ) ) {
 	function is_wp_error( $value ) {
 		return $value instanceof WP_Error;


### PR DESCRIPTION
## Summary

- replace PID-based lifecycle freshness with explicit server-owned validation invocation identities
- persist the prepare invocation in the existing lifecycle receipt and compare it with the resume invocation
- preserve rejection of a genuine same-invocation resume while allowing distinct commands in one persistent PHP worker
- add deterministic persistent-worker and same-invocation coverage

Fixes #866.

## Verification

- `homeboy review --placement local --path /Users/chubes/Developer/static-site-importer@fix-866-lifecycle-invocation-identity --changed-since origin/main --summary`
- `npm run test:fixture-matrix` (259 passing)
- `npm test` (50 manifest tests passing)
- focused lifecycle smoke tests (168 assertions passing)

Fixture 87 passed through the real host-staged WP Codebox path:

```sh
node tools/run-fixture-matrix.mjs \
  --local \
  --static-site-importer /Users/chubes/Developer/static-site-importer@fix-866-lifecycle-invocation-identity \
  --blocks-engine /Users/chubes/Developer/blocks-engine \
  --target-fixture 87-travel-tours \
  --artifact-root /tmp/ssi-866-fixture87-proof \
  --run-id ssi-866-fixture87-proof \
  --batch-size 1 \
  --concurrency 1 \
  --no-visual-parity
```

Homeboy run `20584cec-a1c1-4259-89d7-540fc6774998`: 1/1 fixture passed, zero findings, zero gate failures. This advances the same runtime that previously stopped at `static_site_importer_fresh_runtime_required` through materialization and front-page editor validation.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode and Homeboy implemented the invocation identity contract, added persistent-worker coverage, ran deterministic review gates, and verified fixture 87 in WP Codebox. Chris Huber directed the architecture and remains responsible for every line.
