### PR TITLE
Test immutable Playground package contracts

### DIFF
--- a/tests/smoke-import-disposition.php
+++ b/tests/smoke-import-disposition.php
@@ -86,7 +86,26 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/rest.php';
+
+add_filter(
+	'static_site_importer_playground_package',
+	static fn() => array(
+		'url'     => 'https://github.com/Automattic/static-site-importer/releases/download/v1.2.3/static-site-importer.zip',
+		'version' => 'v1.2.3',
+		'sha256'  => str_repeat( 'a', 64 ),
+	)
+);
 
 $assert(
 	function_exists( 'static_site_importer_import_website_artifact_with_disposition' ),

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -660,6 +660,14 @@ $assert( 'https://example.test/' === ( $apply_response['preview']['url'] ?? '' )
 
 Static_Site_Importer_Theme_Generator::$last_artifact = array();
 Static_Site_Importer_Theme_Generator::$last_args     = array();
+add_filter(
+	'static_site_importer_playground_package',
+	static fn() => array(
+		'url'     => 'https://github.com/Automattic/static-site-importer/releases/download/v1.2.3/static-site-importer.zip',
+		'version' => 'v1.2.3',
+		'sha256'  => str_repeat( 'a', 64 ),
+	)
+);
 $playground_response = static_site_importer_rest_create_import(
 	new WP_REST_Request(
 		array(
@@ -681,8 +689,14 @@ $playground_blueprint_json = rawurldecode( substr( (string) ( $playground_respon
 $playground_blueprint      = json_decode( $playground_blueprint_json, true );
 $assert( is_array( $playground_blueprint ), 'rest-playground-open-blueprint-decodes' );
 $playground_blueprint_code = wp_json_encode( $playground_blueprint );
-$playground_plugin_step    = $playground_blueprint['steps'][1] ?? array();
-$assert( 'https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip' === ( $playground_plugin_step['pluginData']['url'] ?? '' ), 'rest-playground-open-blueprint-installs-release-zip' );
+$playground_download_steps = array_values( array_filter( $playground_blueprint['steps'] ?? array(), static fn( array $step ): bool => 'writeFile' === ( $step['step'] ?? '' ) ) );
+$playground_plugin_steps   = array_values( array_filter( $playground_blueprint['steps'] ?? array(), static fn( array $step ): bool => 'installPlugin' === ( $step['step'] ?? '' ) ) );
+$playground_download_step  = $playground_download_steps[0] ?? array();
+$playground_plugin_step    = $playground_plugin_steps[0] ?? array();
+$assert( 'https://github.com/Automattic/static-site-importer/releases/download/v1.2.3/static-site-importer.zip' === ( $playground_download_step['data']['url'] ?? '' ), 'rest-playground-open-blueprint-downloads-pinned-release-zip' );
+$assert( 'vfs' === ( $playground_plugin_step['pluginData']['resource'] ?? '' ), 'rest-playground-open-blueprint-installs-verified-vfs-package' );
+$assert( ( $playground_download_step['path'] ?? null ) === ( $playground_plugin_step['pluginData']['path'] ?? null ), 'rest-playground-open-blueprint-installs-downloaded-package' );
+$assert( str_contains( (string) $playground_blueprint_code, str_repeat( 'a', 64 ) ), 'rest-playground-open-blueprint-verifies-package-digest' );
 $assert( str_contains( (string) $playground_blueprint_code, 'static_site_importer_ability_import' ), 'rest-playground-open-blueprint-runs-import-ability' );
 $assert( str_contains( (string) $playground_blueprint_code, "'activate' => true" ), 'rest-playground-open-blueprint-activates-generated-site' );
 $assert( str_contains( (string) $playground_blueprint_code, "'overwrite' => true" ), 'rest-playground-open-blueprint-overwrites-generated-site' );
@@ -748,7 +762,8 @@ $assert( 'test-provider' === ( $GLOBALS['ssi_last_url_provider_request']['provid
 $assert( 'playground-provider-arg' === ( $GLOBALS['ssi_last_url_provider_request']['provider_args']['token'] ?? '' ), 'rest-playground-url-only-preserves-provider-args' );
 $url_playground_blueprint_json = rawurldecode( substr( (string) ( $url_playground_response['preview']['playground']['blueprint_url'] ?? '' ), strlen( 'https://playground.wordpress.net/#' ) ) );
 $url_playground_blueprint      = json_decode( $url_playground_blueprint_json, true );
-$url_playground_import_code    = is_array( $url_playground_blueprint ) ? (string) ( $url_playground_blueprint['steps'][2]['code'] ?? '' ) : '';
+$url_playground_import_steps   = is_array( $url_playground_blueprint ) ? array_values( array_filter( $url_playground_blueprint['steps'] ?? array(), static fn( array $step ): bool => 'runPHP' === ( $step['step'] ?? '' ) && str_contains( (string) ( $step['code'] ?? '' ), 'static_site_importer_ability_import' ) ) ) : array();
+$url_playground_import_code    = (string) ( $url_playground_import_steps[0]['code'] ?? '' );
 $assert( str_contains( $url_playground_blueprint_json, 'Facebook Fixture' ), 'rest-playground-url-only-blueprint-contains-fetched-artifact' );
 $assert( str_contains( $url_playground_import_code, "'source_url' => 'https://facebook.com'" ), 'rest-playground-url-only-blueprint-preserves-source-url' );
 $assert( str_contains( $url_playground_import_code, "'provider_token' => 'playground-provider-arg'" ), 'rest-playground-url-only-blueprint-preserves-provider-arg-metadata' );
@@ -1005,9 +1020,14 @@ $assert( str_contains( $blueprint_code, '"applyToCurrentSite":false' ), 'playgro
 $assert( str_contains( $blueprint_code, '"openInPlayground":true' ), 'playground-blueprint-targets-open-in-playground' );
 $assert( ! str_contains( $blueprint_code, 'generateInCurrentRuntime' ), 'playground-blueprint-does-not-reference-current-runtime-generation' );
 $assert( str_contains( $blueprint_code, 'static_site_importer_protected_pages' ), 'playground-blueprint-protects-import-page' );
-$plugin_steps = array_values( array_filter( $blueprint['steps'] ?? array(), static fn( array $step ): bool => 'installPlugin' === ( $step['step'] ?? '' ) ) );
-$plugin_step  = $plugin_steps[0] ?? array();
-$assert( 'https://github.com/Automattic/static-site-importer/releases/download/{{RELEASE_TAG}}/static-site-importer.zip' === ( $plugin_step['pluginData']['url'] ?? '' ), 'playground-blueprint-installs-same-release-package' );
+$download_steps = array_values( array_filter( $blueprint['steps'] ?? array(), static fn( array $step ): bool => 'writeFile' === ( $step['step'] ?? '' ) ) );
+$plugin_steps   = array_values( array_filter( $blueprint['steps'] ?? array(), static fn( array $step ): bool => 'installPlugin' === ( $step['step'] ?? '' ) ) );
+$download_step  = $download_steps[0] ?? array();
+$plugin_step    = $plugin_steps[0] ?? array();
+$assert( 'https://github.com/Automattic/static-site-importer/releases/download/{{RELEASE_TAG}}/static-site-importer.zip' === ( $download_step['data']['url'] ?? '' ), 'playground-blueprint-downloads-same-release-package' );
+$assert( 'vfs' === ( $plugin_step['pluginData']['resource'] ?? '' ), 'playground-blueprint-installs-verified-vfs-package' );
+$assert( ( $download_step['path'] ?? null ) === ( $plugin_step['pluginData']['path'] ?? null ), 'playground-blueprint-installs-downloaded-package' );
+$assert( str_contains( $blueprint_code, '{{PACKAGE_SHA256}}' ), 'playground-blueprint-verifies-release-package' );
 
 $GLOBALS['ssi_test_options']['static_site_importer_protected_pages'] = array( 'import', 'tools/settings', '42' );
 $assert( Static_Site_Importer_Page_Materializer::is_protected_page( new WP_Post( 7, 'import' ) ), 'protected-page-matches-slug' );

--- a/tools/php-wasm-zstd.test.mjs
+++ b/tools/php-wasm-zstd.test.mjs
@@ -56,7 +56,7 @@ test( 'release publication keeps immutable assets and blueprints separate from t
 	assert.match( workflow, /PHP_WASM_ZSTD_ASSET_BASE_URL: https:\/\/automattic\.github\.io\/static-site-importer\/playground\/extensions\/\$\{\{ env\.RELEASE_TAG \}\}/ );
 	assert.match( workflow, /playground\/extensions\/\$RELEASE_TAG/ );
 	assert.match( workflow, /playground\/extensions\/latest/ );
-	assert.match( workflow, /releases\/download\/\$\{tag\}/ );
+	assert.match( workflow, /releases\/download\/\$RELEASE_TAG/ );
 	assert.match( workflow, /access-control-allow-origin/ );
 	assert.match( workflow, /git -C "\$pages_dir" add \.nojekyll "playground\/\$RELEASE_TAG\.blueprint\.json"/ );
 	assert.match( workflow, /git -C "\$pages_dir" diff --cached --quiet/ );


### PR DESCRIPTION
## Summary

- configure pinned package provenance in standalone Playground smokes
- assert download, checksum, and VFS installation behavior instead of the removed mutable package shape
- align the release workflow assertion with the RELEASE_TAG runtime variable

## Verification

- `php tests/smoke-import-disposition.php`
- `php tests/smoke-importer-block.php` (303 assertions)
- `node --test tools/php-wasm-zstd.test.mjs`
- `npm test -- --runInBand` (53 selected, 0 failed)

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the post-#860 test regressions, updated test contracts, and ran verification. Chris Huber remains responsible for every line.