### PR TITLE
Bootstrap Jetpack Forms on fresh requests

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -37,6 +37,31 @@ class Static_Site_Importer_Form_Seeder {
 	 */
 	public const PROVIDER_ID = 'jetpack';
 
+	/** Register the provider bootstrap needed on every WordPress request. */
+	public static function register_runtime_bootstrap(): void {
+		if ( function_exists( 'add_action' ) ) {
+			add_action( 'jetpack_loaded', array( __CLASS__, 'bootstrap_jetpack_forms_runtime' ) );
+		}
+	}
+
+	/**
+	 * Load Forms after Jetpack's autoloader is ready and before WordPress init.
+	 *
+	 * Jetpack 16 skips its normal after_setup_theme module loader for disconnected
+	 * sites. Its persisted contact-form module flag therefore needs this adapter
+	 * bootstrap on later frontend requests as well as during import preparation.
+	 */
+	public static function bootstrap_jetpack_forms_runtime(): void {
+		if ( ! self::runtime_static_method_exists( 'Jetpack', 'is_module_active' ) || ! self::invoke_runtime_static_method( 'Jetpack', 'is_module_active', array( 'contact-form' ) ) ) {
+			return;
+		}
+
+		$loader = 'Automattic\\Jetpack\\Forms\\Jetpack_Forms';
+		if ( self::runtime_static_method_exists( $loader, 'load_contact_form' ) ) {
+			self::invoke_runtime_static_method( $loader, 'load_contact_form' );
+		}
+	}
+
 	/**
 	 * Map a source control type to a Jetpack field block name.
 	 *

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -89,6 +89,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/rest.php';
 
 Static_Site_Importer_Figma_Import::register_default_zstd_decoder();
 Static_Site_Importer_Entity_Materializer_Registry::register_presentations();
+Static_Site_Importer_Form_Seeder::register_runtime_bootstrap();
 
 add_action( 'init', 'static_site_importer_register_block' );
 add_action( 'rest_api_init', 'static_site_importer_register_rest_routes' );

--- a/tests/provider-adapter-runtime-smoke.php
+++ b/tests/provider-adapter-runtime-smoke.php
@@ -9,7 +9,7 @@ namespace {
 	$case = $argv[1] ?? '';
 	if ( '' === $case ) {
 		$failures = array();
-		foreach ( array( 'supported-late', 'already-active-late', 'init-pending', 'activation-failed', 'missing-lifecycle', 'missing-loader', 'missing-init', 'partial-blocks' ) as $child_case ) {
+		foreach ( array( 'supported-late', 'already-active-late', 'fresh-frontend', 'init-pending', 'activation-failed', 'missing-lifecycle', 'missing-loader', 'missing-init', 'partial-blocks' ) as $child_case ) {
 			$command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( __FILE__ ) . ' ' . escapeshellarg( $child_case );
 			exec( $command, $output, $status );
 			if ( 0 !== $status ) {
@@ -38,19 +38,25 @@ namespace {
 	}
 	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
 	function did_action( string $hook ): int { return 'init' === $hook ? $GLOBALS['ssi_init_actions'] : 0; }
-	function add_action( string $hook, $callback ): void { $GLOBALS['ssi_hooks'][ $hook ][] = $callback; }
+	function add_action( string $hook, $callback, int $priority = 10 ): void { $GLOBALS['ssi_hooks'][ $hook ][ $priority ][] = $callback; }
 	function has_action( string $hook, $callback = false ) {
-		foreach ( $GLOBALS['ssi_hooks'][ $hook ] ?? array() as $registered ) {
-			if ( $registered === $callback || ltrim( (string) $registered, '\\' ) === ltrim( (string) $callback, '\\' ) ) {
-				return 9;
+		foreach ( $GLOBALS['ssi_hooks'][ $hook ] ?? array() as $priority => $callbacks ) {
+			foreach ( $callbacks as $registered ) {
+				if ( $registered === $callback || ltrim( (string) $registered, '\\' ) === ltrim( (string) $callback, '\\' ) ) {
+					return $priority;
+				}
 			}
 		}
 		return false;
 	}
-	function ssi_run_init(): void {
-		$GLOBALS['ssi_init_actions'] = 1;
-		foreach ( $GLOBALS['ssi_hooks']['init'] ?? array() as $callback ) {
-			call_user_func( $callback );
+	function ssi_run_hook( string $hook ): void {
+		if ( 'init' === $hook ) {
+			$GLOBALS['ssi_init_actions'] = 1;
+		}
+		foreach ( $GLOBALS['ssi_hooks'][ $hook ] ?? array() as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				call_user_func( $callback );
+			}
 		}
 	}
 
@@ -124,8 +130,14 @@ namespace {
 	if ( 'already-active-late' === $case ) {
 		Jetpack::$contact_form_active = true;
 	}
+	if ( 'fresh-frontend' === $case ) {
+		Jetpack::$contact_form_active = true;
+		Static_Site_Importer_Form_Seeder::register_runtime_bootstrap();
+		ssi_run_hook( 'jetpack_loaded' );
+		ssi_run_hook( 'init' );
+	}
 
-	$result = Static_Site_Importer_Form_Seeder::prepare_jetpack_forms_runtime();
+	$result = 'fresh-frontend' === $case ? Static_Site_Importer_Form_Seeder::jetpack_forms_available() : Static_Site_Importer_Form_Seeder::prepare_jetpack_forms_runtime();
 	$assert = static function ( bool $condition, string $message ): void {
 		if ( ! $condition ) {
 			echo 'FAIL ' . $message . "\n";
@@ -146,9 +158,15 @@ namespace {
 		$assert( 0 === Jetpack::$default_activations, 'active module is not reactivated' );
 		$assert( 1 === \Automattic\Jetpack\Forms\Jetpack_Forms::$loads, 'missing package hook is installed once' );
 	}
+	if ( 'fresh-frontend' === $case ) {
+		$assert( true === $result, 'fresh frontend request registers the persisted Forms runtime' );
+		$assert( 0 === Jetpack::$default_activations, 'fresh frontend request does not reactivate the persisted module' );
+		$assert( 1 === \Automattic\Jetpack\Forms\Jetpack_Forms::$loads, 'fresh frontend request loads Forms through Jetpack lifecycle' );
+		$assert( 1 === \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::$initializations, 'fresh frontend request initializes dynamic field rendering' );
+	}
 	if ( 'init-pending' === $case ) {
 		$assert( is_wp_error( $result ) && 'static_site_importer_jetpack_forms_init_pending' === $result->get_error_code(), 'pre-init preparation is bounded' );
-		ssi_run_init();
+		ssi_run_hook( 'init' );
 		$assert( true === Static_Site_Importer_Form_Seeder::prepare_jetpack_forms_runtime(), 'normal init hook completes readiness' );
 		$assert( 1 === Jetpack::$default_activations && 1 === \Automattic\Jetpack\Forms\Jetpack_Forms::$loads, 'init completion does not replay lifecycle work' );
 	}


### PR DESCRIPTION
## Summary

- bootstrap Jetpack Forms during `jetpack_loaded` on every fresh WordPress request
- keep the provider-owned bootstrap idempotent when Jetpack has already initialized Forms
- cover separate-request activation and block registration instead of relying on import-request state

Addresses #848.

## Verification

- `php tests/provider-adapter-runtime-smoke.php`
- `php tests/form-materializer-smoke.php` (147 assertions)
- `npm run test:fixture-matrix` (259 passing)
- `npm test` (53 manifest tests passing)

The full immutable fixture 87 proof is currently blocked before materialization by [WP Codebox #2232](https://github.com/Automattic/wp-codebox/issues/2232). Homeboy runs `7da07802-58d7-4cc9-a402-947552ed26dc` and `722c1623-c523-4808-b884-3bc3dd3eded4` both stop in dependency discovery before producing fixture metrics. The preserved diagnostic reports `unresolved_local_url` for `website/index.html` -> `js/site.js`; direct compilation of the identical artifact succeeds through both Blocks Engine trunk and SSI's hydrated pinned vendor package. This PR does not claim the blocked visual proof.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode and Homeboy diagnosed the fresh-request lifecycle defect, implemented the provider bootstrap, expanded cross-request coverage, ran deterministic tests, and investigated the blocked fixture proof. Chris Huber directed the architecture and remains responsible for every line.
