### PR TITLE
fix: carry candidate overlays into dependency discovery

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -30,6 +30,7 @@ import {
   fixtureMatrixGateConfig,
   fixtureMatrixRecipeInput,
   fixtureMatrixRunConfigFromEnv,
+  normalizeFixtureMatrixDependencyOverlays,
   normalizeFixtureMatrixRunConfig,
 } from '../lib/fixture-matrix.mjs';
 
@@ -256,6 +257,7 @@ export async function runFixtureMatrix(options) {
       outputDirectory,
       staticSiteImporterPath,
       options,
+      dependencyOverrides,
       progress,
     }));
     performance.batch_execution_ms = elapsedMs(batchExecutionStartedAt);
@@ -393,7 +395,7 @@ function executionEvidenceMetadata(executionRequested) {
 // per-fixture artifact subdirectories, all keyed by the unique batch suffix), so
 // many of these can run concurrently without colliding. Returns a stable outcome
 // the caller folds back together in batch order.
-export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outputDirectory, staticSiteImporterPath, options, recovery = false, progress }) {
+export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outputDirectory, staticSiteImporterPath, options, dependencyOverrides = prepareDependencyOverrides(options), recovery = false, progress }) {
   const batchNumber = batchIndex + 1;
   const batchSuffix = recovery
     ? `${String(batchNumber).padStart(3, '0')}-recovery-${fixtures[0].id}`
@@ -407,7 +409,13 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
   // Discovery is deliberately a separate, short-lived Codebox runtime. It only
   // asks SSI for its registry-derived plan; package resolution happens on the
   // host while assembling the following fresh import runtime.
-  const dependencyPlan = await discoverFixtureDependencyPlan({ fixtures, outputDirectory, staticSiteImporterPath, options, batchSuffix });
+  const dependencyOverlays = normalizeFixtureMatrixDependencyOverlays({
+    staticSiteImporterPath,
+    staticSiteImporterPlugin: options.staticSiteImporterPlugin,
+    staticSiteImporterSlug: options.staticSiteImporterSlug,
+    dependencyOverrides,
+  });
+  const dependencyPlan = await discoverFixtureDependencyPlan({ fixtures, outputDirectory, staticSiteImporterPath, options, dependencyOverlays, batchSuffix });
   const resolvedDependencyPlan = await resolveHostDependencyPlan(dependencyPlan, path.join(outputDirectory, 'dependency-cache'));
   const batchRecipe = buildFixtureMatrixRecipe({
     matrix: batchMatrix,
@@ -420,7 +428,8 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     staticSiteImporterPlugin: options.staticSiteImporterPlugin,
     staticSiteImporterSlug: options.staticSiteImporterSlug,
     dependencyPlan: resolvedDependencyPlan,
-    dependencyOverrides: prepareDependencyOverrides(options),
+    dependencyOverrides,
+    dependencyOverlays,
     svgFontEvidence: true,
     ...fixtureMatrixRecipeInput(normalizeFixtureMatrixRunConfig(Object.fromEntries(Object.keys(FIXTURE_MATRIX_RUN_FIELDS).map((key) => [key, options[key]])))),
     ...visualParityRecipeInput(options),
@@ -503,7 +512,8 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     sidecarAttemptId: batchSuffix,
     visualParity: fixtureMatrixGateConfig(normalizeFixtureMatrixRunConfig(Object.fromEntries(Object.keys(FIXTURE_MATRIX_RUN_FIELDS).map((key) => [key, options[key]])))).visualParity,
     liveWpParity: liveWpParityCollectorInput(options),
-    dependencyOverrides: prepareDependencyOverrides(options),
+    dependencyOverrides,
+    dependencyOverlays: batchRecipe.inputs.dependency_overlays || [],
   });
   const visualCompare = materializeVisualCompareArtifacts({
     result: batchResult,
@@ -547,6 +557,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       outputDirectory,
       staticSiteImporterPath,
       options,
+      dependencyOverrides,
       recovery: true,
       progress,
     }));
@@ -600,7 +611,7 @@ export async function resolveHostDependencyPlan(plan, cacheDirectory, fetcher = 
   return { ...plan, entries };
 }
 
-async function discoverFixtureDependencyPlan({ fixtures, outputDirectory, staticSiteImporterPath, options, batchSuffix }) {
+async function discoverFixtureDependencyPlan({ fixtures, outputDirectory, staticSiteImporterPath, options, dependencyOverlays = [], batchSuffix }) {
   const plans = [];
   for (const fixture of fixtures) {
     const fixtureDirectory = path.join(outputDirectory, fixture.id);
@@ -616,6 +627,7 @@ async function discoverFixtureDependencyPlan({ fixtures, outputDirectory, static
       inputs: {
         stagedFiles: [{ source: path.join(fixtureDirectory, 'artifact.json'), target: path.join(runtimeDirectory, 'artifact.json') }],
         extra_plugins: [{ source: staticSiteImporterPath, slug: options.staticSiteImporterSlug || 'static-site-importer', activate: true }],
+        ...(dependencyOverlays.length ? { dependency_overlays: dependencyOverlays } : {}),
       },
       workflow: { steps: [
         { command: 'wordpress.wp-cli', args: [`command=plugin activate ${(options.staticSiteImporterPlugin || 'static-site-importer/static-site-importer.php')}`] },
@@ -627,10 +639,10 @@ async function discoverFixtureDependencyPlan({ fixtures, outputDirectory, static
     const discovery = await runWpCodeboxRecipe({ recipeFile, artifactsDir, outputFile, wpCodeboxBin: options.wpCodeboxBin, inactivityTimeoutMs: batchInactivityTimeoutMs(options) });
     const plan = findDependencyPlan(artifactsDir);
     if (!plan) throw new Error(`Dependency discovery did not persist a valid plan for fixture ${fixture.id}.`);
-    // Discovery only mounts SSI. Provider packages are resolved and activated by
-    // the final recipe's extra_plugins setup, before its workflow begins; asking
-    // this runtime for a provider receipt would incorrectly require Jetpack/Woo
-    // to be installed during planning.
+    // Discovery only mounts SSI and its declared transformer overlays. Provider
+    // packages are resolved and activated by the final recipe's extra_plugins
+    // setup, before its workflow begins; asking this runtime for a provider
+    // receipt would incorrectly require Jetpack/Woo during planning.
     plans.push(plan);
   }
   const entries = new Map();

--- a/lib/fixture-matrix.mjs
+++ b/lib/fixture-matrix.mjs
@@ -42,6 +42,7 @@ export {
 export {
   buildFixtureArtifact,
   buildFixtureMatrixRecipe,
+  normalizeFixtureMatrixDependencyOverlays,
   stageFixtureSource,
   wordpressServedPath,
   normalizeStaticSiteImporterPlugin,

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -278,7 +278,10 @@ export function collectMatrixEvidence(payload, options = {}) {
   const providerAdapter = objectValue(payload.provider_adapter || payload.providerAdapter || importReport.provider_adapter || importReport.providerAdapter || fixtureDiagnostics.provider_adapter || fixtureDiagnostics.providerAdapter);
   const captureContract = objectValue(payload.capture_contract || payload.captureContract || payload.visual_capture || payload.visualCapture || fixtureDiagnostics.capture_contract || fixtureDiagnostics.captureContract);
   const sidecar = options.sidecar || { status: 'absent' };
-  const override = objectValue(options.dependencyOverrides || options.dependency_overrides).blocks_engine_php_transformer || objectValue(options.dependencyOverrides || options.dependency_overrides).blocksEnginePhpTransformer || {};
+  const declaredOverlays = options.dependencyOverlays || options.dependency_overlays;
+  const override = Array.isArray(declaredOverlays)
+    ? objectValue(declaredOverlays.find((overlay) => overlay?.kind === 'composer-package' && overlay?.package === 'automattic/blocks-engine-php-transformer' && overlay?.consumer === 'static-site-importer'))
+    : objectValue(options.dependencyOverrides || options.dependency_overrides).blocks_engine_php_transformer || objectValue(options.dependencyOverrides || options.dependency_overrides).blocksEnginePhpTransformer || {};
   const completedMaterialization = objectValue(materializationReceipt.completed);
   const generatedTheme = objectValue(importReport.generated_theme || importReport.generatedTheme || payload.generated_theme || payload.generatedTheme);
   const templateParts = normalizeArray(generatedTheme.template_parts || generatedTheme.templateParts)

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -212,7 +212,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const runId = input.runId || input.run_id || `${matrix.id}-${randomUUID()}`;
   const attemptId = input.attemptId || input.attempt_id || randomUUID();
   const importer = normalizeStaticSiteImporterPlugin(input);
-  const dependencyOverrideSetup = buildDependencyOverrideSetup(input, importer);
+  const dependencyOverlays = input.dependencyOverlays || input.dependency_overlays || buildDependencyOverrideSetup(input, importer).dependencyOverlays;
   const mounts = normalizeArray(input.mounts);
   const stagedFiles = normalizeArray(input.stagedFiles || input.staged_files);
   const extraPlugins = [
@@ -279,8 +279,8 @@ export function buildFixtureMatrixRecipe(input = {}) {
       mounts,
       stagedFiles,
       extra_plugins: extraPlugins,
-      ...(dependencyOverrideSetup.dependencyOverlays.length
-        ? { dependency_overlays: dependencyOverrideSetup.dependencyOverlays }
+      ...(dependencyOverlays.length
+        ? { dependency_overlays: dependencyOverlays }
         : {}),
     },
     workflow: {
@@ -324,6 +324,10 @@ export function buildFixtureMatrixRecipe(input = {}) {
       provider_dependency_setup: [],
     },
   };
+}
+
+export function normalizeFixtureMatrixDependencyOverlays(input = {}) {
+  return buildDependencyOverrideSetup(input, normalizeStaticSiteImporterPlugin(input)).dependencyOverlays;
 }
 
 function surfaceCoverageRuntimeWarning(surfaceCoverage) {

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1713,6 +1713,26 @@ test('fixture lineage retains the development transformer override identity', ()
   assert.deepEqual(evidence.lineage.development_override, { package: 'automattic/blocks-engine-php-transformer', reference: 'b'.repeat(40) });
 });
 
+test('fixture lineage only claims a transformer candidate declared by the effective recipe', () => {
+  const reference = 'b'.repeat(40);
+  const payload = {
+    import_report: {
+      blocks_engine: {
+        transformer: { package: 'automattic/blocks-engine-php-transformer', version: 'dev-main', reference },
+        wordpress_site_plan: { schema: 'blocks-engine/wordpress-site-plan/v2' },
+      },
+      materialization_receipt: { schema: 'static-site-importer/materialization-receipt/v1', status: 'completed' },
+    },
+  };
+  const dependencyOverrides = { blocks_engine_php_transformer: { package: 'automattic/blocks-engine-php-transformer', reference } };
+
+  assert.equal(collectMatrixEvidence(payload, { dependencyOverrides, dependencyOverlays: [] }).lineage.development_override, undefined);
+  assert.deepEqual(collectMatrixEvidence(payload, {
+    dependencyOverrides,
+    dependencyOverlays: [{ kind: 'composer-package', package: 'automattic/blocks-engine-php-transformer', consumer: 'static-site-importer', source: '/candidate', reference }],
+  }).lineage.development_override, { package: 'automattic/blocks-engine-php-transformer', reference });
+});
+
 test('fixture lineage does not correlate a retried provider failure to a transform diagnostic', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-attribution-correlation-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'attribution-correlation-test' });
@@ -4982,6 +5002,12 @@ function wpCodeboxCommand(bin) { return { command: bin, args: [] }; }
 
 async function runWpCodeboxRecipe(options = {}) {
   const recipe = fs.readFileSync(options.recipeFile, 'utf8');
+  const capturedRecipes = process.env.SSI_TEST_RECIPE_CAPTURE_FILE;
+  if (capturedRecipes) {
+    const captured = fs.existsSync(capturedRecipes) ? JSON.parse(fs.readFileSync(capturedRecipes, 'utf8')) : [];
+    captured.push(JSON.parse(recipe));
+    fs.writeFileSync(capturedRecipes, JSON.stringify(captured));
+  }
   if (recipe.includes('plan-artifact-dependencies')) {
     fs.mkdirSync(options.artifactsDir, { recursive: true });
     fs.writeFileSync(require('node:path').join(options.artifactsDir, 'dependency-plan.json'), JSON.stringify({ schema: 'static-site-importer/runtime-dependency-plan/v1', artifact_sha256: 'a'.repeat(64), entries: [] }));
@@ -5050,6 +5076,7 @@ const CONCURRENCY_ENV_KEYS = [
   'SSI_TEST_RECIPE_BATCH_COUNT',
   'SSI_TEST_RECIPE_UNIT_MS',
   'SSI_TEST_RECIPE_THROW_BATCH',
+  'SSI_TEST_RECIPE_CAPTURE_FILE',
 ];
 
 function snapshotConcurrencyEnv() {
@@ -5098,6 +5125,50 @@ test('runFixtureMatrix caps WP Codebox batches in flight at the configured concu
     // reached the cap (proves real parallelism, not accidental serialization).
     assert.ok(stats.peak_in_flight <= 2, `peak ${stats.peak_in_flight} exceeded concurrency 2`);
     assert.equal(stats.peak_in_flight, 2);
+  } finally {
+    restoreConcurrencyEnv(snapshot);
+  }
+});
+
+test('runFixtureMatrix uses the same candidate transformer overlay for dependency discovery and final import', async () => {
+  const snapshot = snapshotConcurrencyEnv();
+  const workspace = setupConcurrencyWorkspace('ssi-discovery-overlay-', 1);
+  const transformerPath = path.join(workspace.root, 'blocks-engine', 'php-transformer');
+  const reference = 'c'.repeat(40);
+  const captureFile = path.join(workspace.root, 'recipes.json');
+  mkdirSync(transformerPath, { recursive: true });
+  writeFileSync(path.join(transformerPath, 'composer.json'), JSON.stringify({ name: 'automattic/blocks-engine-php-transformer' }));
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = workspace.helperPath;
+  process.env.SSI_TEST_RECIPE_CAPTURE_FILE = captureFile;
+
+  try {
+    const { summary, runtimeError } = await runFixtureMatrix({
+      id: 'discovery-overlay-matrix',
+      fixtureRoot: workspace.fixtureRoot,
+      outputDirectory: workspace.outputDirectory,
+      staticSiteImporterPath: workspace.staticSiteImporter,
+      blocksEnginePhpTransformerPath: transformerPath,
+      blocksEnginePhpTransformerReference: reference,
+      run: true,
+      batchSize: 1,
+      concurrency: 1,
+      visualParity: false,
+    });
+
+    assert.equal(runtimeError, null);
+    const recipes = JSON.parse(readFileSync(captureFile, 'utf8'));
+    const discoveryRecipe = recipes.find((recipe) => recipe.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('plan-artifact-dependencies'))));
+    const importRecipe = JSON.parse(readFileSync(summary.runtime.batches[0].recipe_file, 'utf8'));
+    const expectedOverlay = {
+      kind: 'composer-package',
+      package: 'automattic/blocks-engine-php-transformer',
+      consumer: 'static-site-importer',
+      source: transformerPath,
+      reference,
+    };
+
+    assert.deepEqual(discoveryRecipe.inputs.dependency_overlays, [expectedOverlay]);
+    assert.deepEqual(importRecipe.inputs.dependency_overlays, [expectedOverlay]);
   } finally {
     restoreConcurrencyEnv(snapshot);
   }


### PR DESCRIPTION
## Summary
- normalize the candidate transformer overlay once and apply it to dependency discovery and the final import recipe
- retain exact package path and immutable reference in both effective recipes
- derive candidate lineage from the final recipe declared overlays, preventing claims for absent candidates

Fixes #872.

Refs #870 and #819.

## Tests
- `npm run test:fixture-matrix`
- `npm test` (54 selected checks passed, including 44 standalone PHP checks)

## AI assistance
OpenAI gpt-5.6-sol via OpenCode implemented the overlay propagation, provenance guard, and contract coverage. Chris remains responsible for every line.