### PR TITLE
Filter scripts from base64 website artifacts

### DIFF
--- a/includes/class-static-site-importer-client-script-policy.php
+++ b/includes/class-static-site-importer-client-script-policy.php
@@ -156,6 +156,7 @@ class Static_Site_Importer_Client_Script_Policy {
 			return (string) $file['content'];
 		}
 		if ( isset( $file['content_base64'] ) && is_scalar( $file['content_base64'] ) ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes declared artifact content before applying the script policy.
 			$decoded = base64_decode( (string) $file['content_base64'], true );
 			return false === $decoded ? '' : $decoded;
 		}
@@ -164,6 +165,7 @@ class Static_Site_Importer_Client_Script_Policy {
 
 	private static function with_file_content( array $file, string $content ): array {
 		if ( array_key_exists( 'content_base64', $file ) && ! array_key_exists( 'content', $file ) ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Restores filtered declared artifact content to its original representation.
 			$file['content_base64'] = base64_encode( $content );
 			return $file;
 		}

--- a/includes/class-static-site-importer-client-script-policy.php
+++ b/includes/class-static-site-importer-client-script-policy.php
@@ -44,7 +44,10 @@ class Static_Site_Importer_Client_Script_Policy {
 				}
 			}
 			if ( self::is_html_file( $file ) ) {
-				$file['content'] = self::filter_html( (string) ( $file['content'] ?? '' ), $path, $preserve, $report );
+				$content = self::filter_html( self::file_content( $file ), $path, $preserve, $report );
+				if ( ! $preserve ) {
+					$file = self::with_file_content( $file, $content );
+				}
 			}
 			$filtered[] = $file;
 		}
@@ -144,8 +147,29 @@ class Static_Site_Importer_Client_Script_Policy {
 			'path'   => $path,
 			'class'  => 'local',
 			'type'   => 'asset',
-			'sha256' => hash( 'sha256', (string) ( $file['content'] ?? '' ) ),
+			'sha256' => hash( 'sha256', self::file_content( $file ) ),
 		);
+	}
+
+	private static function file_content( array $file ): string {
+		if ( isset( $file['content'] ) && is_scalar( $file['content'] ) ) {
+			return (string) $file['content'];
+		}
+		if ( isset( $file['content_base64'] ) && is_scalar( $file['content_base64'] ) ) {
+			$decoded = base64_decode( (string) $file['content_base64'], true );
+			return false === $decoded ? '' : $decoded;
+		}
+		return '';
+	}
+
+	private static function with_file_content( array $file, string $content ): array {
+		if ( array_key_exists( 'content_base64', $file ) && ! array_key_exists( 'content', $file ) ) {
+			$file['content_base64'] = base64_encode( $content );
+			return $file;
+		}
+		$file['content'] = $content;
+		unset( $file['content_base64'] );
+		return $file;
 	}
 
 	private static function record( array &$report, string $disposition, array $row ): void {

--- a/tests/smoke-client-script-policy.php
+++ b/tests/smoke-client-script-policy.php
@@ -55,6 +55,28 @@ $preview_html = (string) ( $preview['artifact']['files'][0]['content'] ?? '' );
 $assert( 'isolated_preview' === $preview['report']['policy'] && 'untrusted_imported_code' === $preview['report']['trust'] && 'upload:sha256:abc123' === $preview['report']['provenance'], 'isolated-policy-requires-and-records-provenance' );
 $assert( str_contains( $preview_html, 'window.inline=true' ) && 9 === count( $preview['report']['preserved'] ) && empty( $preview['report']['dropped'] ) && empty( $preview['report']['quarantined'] ), 'isolated-preview-preserves-scripts-without-granting-trust' );
 
+$base64_html     = '<main>Base64 content</main><script src="js/main.js"></script>';
+$base64_script   = 'window.base64Script=true;';
+$base64_artifact = array(
+	'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+	'entrypoint' => 'website/index.html',
+	'files'      => array(
+		array( 'path' => 'website/index.html', 'mime_type' => 'text/html', 'content_base64' => base64_encode( $base64_html ) ),
+		array( 'path' => 'website/js/main.js', 'mime_type' => 'application/javascript', 'content_base64' => base64_encode( $base64_script ) ),
+	),
+);
+$base64_inert    = Static_Site_Importer_Client_Script_Policy::apply( $base64_artifact, array() );
+$base64_files    = array_column( $base64_inert['artifact']['files'], null, 'path' );
+$base64_dropped  = array_column( $base64_inert['report']['dropped'], null, 'path' );
+$base64_filtered = base64_decode( (string) ( $base64_files['website/index.html']['content_base64'] ?? '' ), true );
+
+$assert( is_string( $base64_filtered ) && str_contains( $base64_filtered, 'Base64 content' ) && ! str_contains( $base64_filtered, '<script' ) && ! isset( $base64_files['website/index.html']['content'] ), 'inert-filters-base64-html-in-place' );
+$assert( ! isset( $base64_files['website/js/main.js'] ), 'inert-removes-base64-script-assets' );
+$assert( hash( 'sha256', $base64_script ) === ( $base64_dropped['website/js/main.js']['sha256'] ?? '' ), 'base64-script-report-hashes-decoded-bytes' );
+
+$base64_preview = Static_Site_Importer_Client_Script_Policy::apply( $base64_artifact, array( 'client_script_policy' => 'isolated_preview', 'client_script_isolated' => true, 'client_script_provenance' => 'fixture:base64' ) );
+$assert( $base64_artifact['files'] === $base64_preview['artifact']['files'], 'isolated-preview-preserves-base64-artifact-bytes' );
+
 if ( $failures ) {
 	fwrite( STDERR, implode( PHP_EOL, $failures ) . PHP_EOL );
 	exit( 1 );


### PR DESCRIPTION
## Summary

- decode base64-only HTML before applying the inert client-script policy
- write filtered bytes back in the artifact's original representation
- hash decoded script bytes in policy reports and preserve isolated-preview artifacts byte-for-byte

Fixes #874.

This unblocks the combined fixture matrix for Automattic/blocks-engine#688 and Automattic/blocks-engine#822: canonical fixture `10-nonprofit` no longer retains `js/main.js` markup after the corresponding script asset is dropped.

## Verification

- `php tests/smoke-client-script-policy.php` (12 assertions)
- `npm test` (54 selected commands passed; fixture-matrix suite 261/261)
- fixture `10-nonprofit` through patched SSI policy plus combined Blocks Engine commit `598c6898`: valid WordPress site plan, zero diagnostics
- `php -l includes/class-static-site-importer-client-script-policy.php`
- `php -l tests/smoke-client-script-policy.php`
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced the WP Codebox fixture-matrix failure, isolated the base64 policy mismatch, implemented the fix and contract coverage, and ran verification. Chris Huber directed the work and remains responsible for every line.