### PR TITLE
fix: remove obsolete Homeboy autofix inputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
           args: --extension wordpress
           php-version: '8.2'
           node-version: '24'
-          autofix: 'false'
 
   homeboy-test:
     name: Homeboy Test (PHP ${{ matrix.php-version }})
@@ -53,4 +52,3 @@ jobs:
           args: --extension wordpress
           php-version: ${{ matrix.php-version }}
           node-version: '24'
-          autofix: 'false'


### PR DESCRIPTION
## Summary
Removes the obsolete `autofix` input from both Homeboy Action invocations in the test workflow.

Fixes #877

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/test.yml'); puts 'YAML valid'"`\n- `actionlint .github/workflows/test.yml`\n- `git diff --check`\n\n## AI assistance\nOpenAI gpt-5.6-sol via OpenCode removed the obsolete workflow inputs and verified the YAML and workflow diff. Chris Huber remains responsible for the change.