### PR TITLE
Fix resolved provider lifecycle bindings

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -195,6 +195,7 @@ class Static_Site_Importer_Theme_Generator {
 			$error   = $receipt['errors'][0] ?? array();
 			return new WP_Error( (string) ( $error['code'] ?? 'static_site_importer_materialization_failed' ), (string) ( $error['message'] ?? 'WordPress site plan destination preflight failed.' ), $receipt );
 		}
+		$lifecycle = self::with_resolved_runtime_binding_manifests( $lifecycle, $prepared['resolved'] ?? array() );
 		$binding_preflight = self::preflight_runtime_entity_binding_anchors( $prepared['resolved'] ?? array(), $lifecycle, $args );
 		if ( is_wp_error( $binding_preflight ) ) {
 			return $binding_preflight;
@@ -886,6 +887,63 @@ class Static_Site_Importer_Theme_Generator {
 		} elseif ( ! empty( $lifecycle['dependencies'] ) || ! empty( $lifecycle['entities'] ) ) {
 			$lifecycle['status'] = 'runtime_declarations';
 		}
+		return $lifecycle;
+	}
+
+	/**
+	 * Project provider binding anchors through the same resolver output that writes pages.
+	 *
+	 * Canonical declarations remain in the lifecycle for audit and dependency planning.
+	 * Only their destination-dependent binding markup is replaced when the resolver
+	 * provides a declaration with the same reconciliation identity.
+	 *
+	 * @param array<string,mixed> $lifecycle Prepared canonical lifecycle.
+	 * @param array<string,mixed> $resolved Resolved WordPress site plan.
+	 * @return array<string,mixed>
+	 */
+	private static function with_resolved_runtime_binding_manifests( array $lifecycle, array $resolved ): array {
+		$declarations = isset( $resolved['runtime_declarations'] ) && is_array( $resolved['runtime_declarations'] ) ? $resolved['runtime_declarations'] : array();
+		if ( empty( $declarations ) ) {
+			return $lifecycle;
+		}
+
+		$resolved_entities = array();
+		foreach ( $declarations as $declaration ) {
+			$id = is_array( $declaration ) ? (string) ( $declaration['reconciliation_identity'] ?? '' ) : '';
+			if ( '' !== $id && 'entity_collection' === ( $declaration['kind'] ?? '' ) && isset( $declaration['payload']['entities'] ) && is_array( $declaration['payload']['entities'] ) ) {
+				$resolved_entities[ $id ] = $declaration['payload']['entities'];
+			}
+		}
+
+		foreach ( $lifecycle['entities'] as $id => &$prepared ) {
+			$entities = $resolved_entities[ $id ] ?? null;
+			if ( ! is_array( $entities ) || ! isset( $prepared['manifest'] ) || ! is_array( $prepared['manifest'] ) ) {
+				continue;
+			}
+			$key = isset( $prepared['manifest']['products'] ) ? 'products' : 'forms';
+			$canonical_entities = isset( $prepared['manifest'][ $key ] ) && is_array( $prepared['manifest'][ $key ] ) ? $prepared['manifest'][ $key ] : array();
+			$resolved_by_key = array();
+			foreach ( $entities as $entity ) {
+				if ( ! is_array( $entity ) ) {
+					continue;
+				}
+				$entity_key = 'products' === $key ? (string) ( $entity['slug'] ?? '' ) : (string) ( $entity['source_path'] ?? '' ) . "\n" . (string) ( $entity['selector'] ?? '' );
+				if ( '' !== $entity_key ) {
+					$resolved_by_key[ $entity_key ] = $entity;
+				}
+			}
+			foreach ( $canonical_entities as $index => $entity ) {
+				if ( ! is_array( $entity ) ) {
+					continue;
+				}
+				$entity_key = 'products' === $key ? (string) ( $entity['slug'] ?? '' ) : (string) ( $entity['source_path'] ?? '' ) . "\n" . (string) ( $entity['selector'] ?? '' );
+				if ( isset( $resolved_by_key[ $entity_key ]['bindings'] ) && is_array( $resolved_by_key[ $entity_key ]['bindings'] ) ) {
+					$prepared['manifest'][ $key ][ $index ]['bindings'] = $resolved_by_key[ $entity_key ]['bindings'];
+				}
+			}
+		}
+		unset( $prepared );
+
 		return $lifecycle;
 	}
 

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -319,6 +319,28 @@ $assert( 'woocommerce_simple_product' === ( $entity_lifecycle['entities'][ $enti
 $prepared_entity = reset( $entity_lifecycle['entities'] );
 $assert( 'Aero Mug' === ( $prepared_entity['manifest']['products'][0]['name'] ?? '' ) && true === ( $prepared_entity['required'] ?? false ), 'v2 product rows validate and retain their required dependency relationship' );
 
+// Provider declarations keep portable asset tokens, while resolver output carries
+// destination-specific URLs. Binding preflight must use the latter without
+// mutating the canonical declaration retained by the lifecycle.
+$token_anchor = '<!-- wp:buttons --><div><img src="{{wordpress-site-plan:asset:hero}}"></div><!-- /wp:buttons -->';
+$resolved_anchor = '<!-- wp:buttons --><div><img src="https://example.test/wp-content/themes/entity-plan/assets/hero.svg"></div><!-- /wp:buttons -->';
+$token_entity_declaration_id = (string) array_key_first( $entity_lifecycle['entities'] );
+$token_lifecycle = $entity_lifecycle;
+$token_lifecycle['entities'][ $token_entity_declaration_id ]['manifest']['products'][0]['bindings'][0]['search_block_markup'] = $token_anchor;
+$resolved_declaration = $entity_plan['runtime_declarations'][1];
+$resolved_declaration['payload']['entities'][0]['bindings'][0]['search_block_markup'] = $resolved_anchor;
+$resolved_binding_plan = array(
+	'pages' => array( array( 'source_path' => 'index.html', 'resolved_block_markup' => '<main>' . $resolved_anchor . '</main>' ) ),
+	'runtime_declarations' => array( $resolved_declaration ),
+);
+$resolve_binding_manifests = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'with_resolved_runtime_binding_manifests' );
+$preflight_bindings = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'preflight_runtime_entity_binding_anchors' );
+$assert( is_wp_error( $preflight_bindings->invoke( null, $resolved_binding_plan, $token_lifecycle, array() ) ), 'canonical token anchors fail against destination-specific resolved page URLs before projection' );
+$resolved_lifecycle = $resolve_binding_manifests->invoke( null, $token_lifecycle, $resolved_binding_plan );
+$assert( $token_anchor === ( $token_lifecycle['entities'][ $token_entity_declaration_id ]['manifest']['products'][0]['bindings'][0]['search_block_markup'] ?? '' ) && $resolved_anchor === ( $resolved_lifecycle['entities'][ $token_entity_declaration_id ]['manifest']['products'][0]['bindings'][0]['search_block_markup'] ?? '' ), 'resolved binding projection changes only lifecycle binding anchors and preserves canonical declarations' );
+$assert( true === $preflight_bindings->invoke( null, $resolved_binding_plan, $resolved_lifecycle, array() ), 'resolved provider binding anchors match the exact page markup consumed by materialization' );
+$assert( $token_lifecycle === $resolve_binding_manifests->invoke( null, $token_lifecycle, array( 'pages' => $resolved_binding_plan['pages'] ) ), 'plans without resolved runtime declarations retain canonical lifecycle behavior' );
+
 $form_declaration_id = 'form-topology-runtime';
 $topology_form = array(
 	'selector' => 'form.contact', 'source_path' => 'index.html', 'form' => array( 'class' => 'contact' ),


### PR DESCRIPTION
## Summary
- project provider binding anchors from the resolved runtime declarations before preflight and materialization
- retain canonical lifecycle declarations for dependency planning and audit
- cover token-to-runtime-URL cardinality and legacy mixed-plan fallback

## Tests
- `npm test`

Fixes #881

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented the resolved lifecycle projection and contract coverage, guided by direct fixture evidence. Chris Huber remains responsible for every line.