### PR TITLE
fix: keep fixture-matrix dependency-discovery failures batch-scoped

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -415,60 +415,43 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     staticSiteImporterSlug: options.staticSiteImporterSlug,
     dependencyOverrides,
   });
-  const dependencyPlan = await discoverFixtureDependencyPlan({ fixtures, outputDirectory, staticSiteImporterPath, options, dependencyOverlays, batchSuffix });
-  const resolvedDependencyPlan = await resolveHostDependencyPlan(dependencyPlan, path.join(outputDirectory, 'dependency-cache'));
-  const batchRecipe = buildFixtureMatrixRecipe({
-    matrix: batchMatrix,
-    runId: batchMatrix.id,
-    attemptId: batchSuffix,
-    artifactsDirectory: outputDirectory,
-    playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
-    wordpressVersion: options.wordpressVersion,
-    staticSiteImporterPath,
-    staticSiteImporterPlugin: options.staticSiteImporterPlugin,
-    staticSiteImporterSlug: options.staticSiteImporterSlug,
-    dependencyPlan: resolvedDependencyPlan,
-    dependencyOverrides,
-    dependencyOverlays,
-    svgFontEvidence: true,
-    ...fixtureMatrixRecipeInput(normalizeFixtureMatrixRunConfig(Object.fromEntries(Object.keys(FIXTURE_MATRIX_RUN_FIELDS).map((key) => [key, options[key]])))),
-    ...visualParityRecipeInput(options),
-    ...liveWpParityRecipeInput(options),
-    ...runtimePresentationEvidenceRecipeInput(options),
-  });
   const batchRecipeFile = path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`);
   const outputFile = path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`);
   const codeboxArtifactsDirectory = batchCodeboxArtifactsDirectory(outputDirectory, batchSuffix);
   const artifactRefs = batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile, codeboxArtifactsDirectory });
-  writeJsonArtifact(batchRecipeFile, batchRecipe);
-  progress?.emit(recovery ? 'recovery' : 'batch', 'started', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery });
-  progress?.emit('fixture', 'started', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery });
 
-  let batchRuntime = null;
+  let dependencyPlan = null;
+  let resolvedDependencyPlan = null;
+  let batchRecipe = null;
   let batchError = null;
   let childCommandFailure = null;
-  let childRecipeRunMs = 0;
-  const childRecipeRunStartedAt = nowMs();
+
   try {
-    batchRuntime = await runWpCodeboxRecipe({
-      recipeFile: batchRecipeFile,
-      artifactsDir: codeboxArtifactsDirectory,
-      outputFile,
-      cwd: outputDirectory,
-      wpCodeboxBin: options.wpCodeboxBin,
-      inactivityTimeoutMs: batchInactivityTimeoutMs(options),
-      onInactivity: ({ timeout_ms }) => {
-        progress?.emit('batch', 'timeout', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery, timeout_ms });
-        if (recovery) progress?.emit('fixture', 'timeout', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery, timeout_ms });
-      },
+    dependencyPlan = await discoverFixtureDependencyPlan({ fixtures, outputDirectory, staticSiteImporterPath, options, dependencyOverlays, batchSuffix });
+    resolvedDependencyPlan = await resolveHostDependencyPlan(dependencyPlan, path.join(outputDirectory, 'dependency-cache'));
+    batchRecipe = buildFixtureMatrixRecipe({
+      matrix: batchMatrix,
+      runId: batchMatrix.id,
+      attemptId: batchSuffix,
+      artifactsDirectory: outputDirectory,
+      playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
+      wordpressVersion: options.wordpressVersion,
+      staticSiteImporterPath,
+      staticSiteImporterPlugin: options.staticSiteImporterPlugin,
+      staticSiteImporterSlug: options.staticSiteImporterSlug,
+      dependencyPlan: resolvedDependencyPlan,
+      dependencyOverrides,
+      dependencyOverlays,
+      svgFontEvidence: true,
+      ...fixtureMatrixRecipeInput(normalizeFixtureMatrixRunConfig(Object.fromEntries(Object.keys(FIXTURE_MATRIX_RUN_FIELDS).map((key) => [key, options[key]])))),
+      ...visualParityRecipeInput(options),
+      ...liveWpParityRecipeInput(options),
+      ...runtimePresentationEvidenceRecipeInput(options),
     });
+    writeJsonArtifact(batchRecipeFile, batchRecipe);
   } catch (error) {
+    const failureStage = !dependencyPlan ? 'dependency_discovery' : !resolvedDependencyPlan ? 'dependency_resolution' : 'recipe_build';
     batchError = error;
-    batchRuntime = {
-      exitCode: error?.code ?? 1,
-      outputFile,
-      json: parseJsonText(error?.stdout),
-    };
     childCommandFailure = buildWpCodeboxChildCommandFailure({
       error,
       fixtures,
@@ -480,9 +463,54 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       artifactsDir: codeboxArtifactsDirectory,
       wpCodeboxBin: options.wpCodeboxBin,
       artifactRefs,
+      failureStage,
     });
-  } finally {
-    childRecipeRunMs = elapsedMs(childRecipeRunStartedAt);
+  }
+
+  progress?.emit(recovery ? 'recovery' : 'batch', batchError ? 'failed' : 'started', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery, ...(batchError ? { failure_stage: childCommandFailure?.failure_stage } : {}) });
+  if (!batchError) {
+    progress?.emit('fixture', 'started', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery });
+  }
+
+  let batchRuntime = null;
+  let childRecipeRunMs = 0;
+  const childRecipeRunStartedAt = nowMs();
+  if (!batchError) {
+    try {
+      batchRuntime = await runWpCodeboxRecipe({
+        recipeFile: batchRecipeFile,
+        artifactsDir: codeboxArtifactsDirectory,
+        outputFile,
+        cwd: outputDirectory,
+        wpCodeboxBin: options.wpCodeboxBin,
+        inactivityTimeoutMs: batchInactivityTimeoutMs(options),
+        onInactivity: ({ timeout_ms }) => {
+          progress?.emit('batch', 'timeout', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery, timeout_ms });
+          if (recovery) progress?.emit('fixture', 'timeout', { fixture_id: fixtures[0]?.id || '', batch: batchNumber, recovery, timeout_ms });
+        },
+      });
+    } catch (error) {
+      batchError = error;
+      batchRuntime = {
+        exitCode: error?.code ?? 1,
+        outputFile,
+        json: parseJsonText(error?.stdout),
+      };
+      childCommandFailure = buildWpCodeboxChildCommandFailure({
+        error,
+        fixtures,
+        batchNumber,
+        batchSuffix,
+        batchId: `batch-${String(batchNumber).padStart(3, '0')}`,
+        batchRecipeFile,
+        outputFile,
+        artifactsDir: codeboxArtifactsDirectory,
+        wpCodeboxBin: options.wpCodeboxBin,
+        artifactRefs,
+      });
+    } finally {
+      childRecipeRunMs = elapsedMs(childRecipeRunStartedAt);
+    }
   }
 
   const batchRun = fixtureMatrixBatchRunSummary({
@@ -494,6 +522,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     codeboxArtifactsDirectory,
     batchRuntime,
     batchError,
+    exitCode: childCommandFailure?.exit_status,
     performance: {
       child_recipe_run_ms: childRecipeRunMs,
     },
@@ -513,7 +542,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     visualParity: fixtureMatrixGateConfig(normalizeFixtureMatrixRunConfig(Object.fromEntries(Object.keys(FIXTURE_MATRIX_RUN_FIELDS).map((key) => [key, options[key]])))).visualParity,
     liveWpParity: liveWpParityCollectorInput(options),
     dependencyOverrides,
-    dependencyOverlays: batchRecipe.inputs.dependency_overlays || [],
+    dependencyOverlays: batchRecipe?.inputs?.dependency_overlays || [],
   });
   const visualCompare = materializeVisualCompareArtifacts({
     result: batchResult,
@@ -544,6 +573,20 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       editorCanvasArtifacts: editorCanvas.artifacts,
       error: batchError,
       childCommandFailures: childCommandFailure ? [childCommandFailure] : [],
+    };
+  }
+
+  // Dependency discovery, host resolution, and recipe build failures are
+  // planning failures, not sandbox corruption. Re-running each fixture
+  // individually would fail identically — return the typed failure directly.
+  if (childCommandFailure?.failure_stage && childCommandFailure.failure_stage !== 'recipe_run') {
+    return {
+      batchRun,
+      batchResult: editorCanvas.result,
+      visualParityArtifacts: visualCompare.artifacts,
+      editorCanvasArtifacts: editorCanvas.artifacts,
+      error: batchError,
+      childCommandFailures: [childCommandFailure],
     };
   }
 
@@ -1411,7 +1454,7 @@ export function fixtureMatrixBatchRunSummary(input = {}) {
     recipe_file: input.batchRecipeFile || '',
     output_file: input.outputFile || '',
     codebox_artifacts_directory: input.codeboxArtifactsDirectory || '',
-    exit_code: batchRuntime?.exitCode ?? 0,
+    exit_code: batchRuntime?.exitCode ?? input.exitCode ?? 0,
     error: batchError ? batchError.message : '',
     stderr_tail: batchError ? textTail(batchError.stderr) : '',
     stdout_tail: batchError ? textTail(batchError.stdout) : '',
@@ -1447,17 +1490,18 @@ function runtimeSummary(runtime, runtimeError) {
   };
 }
 
-function buildWpCodeboxChildCommandFailure({ error, fixtures, batchNumber, batchSuffix, batchId, batchRecipeFile, outputFile, artifactsDir, wpCodeboxBin: bin, artifactRefs }) {
-  const command = wpCodeboxRecipeRunCommand({ recipeFile: batchRecipeFile, artifactsDir, outputFile, wpCodeboxBin: bin });
+function buildWpCodeboxChildCommandFailure({ error, fixtures, batchNumber, batchSuffix, batchId, batchRecipeFile, outputFile, artifactsDir, wpCodeboxBin: bin, artifactRefs, failureStage = 'recipe_run' }) {
+  const isRecipeRun = failureStage === 'recipe_run';
+  const command = isRecipeRun ? wpCodeboxRecipeRunCommand({ recipeFile: batchRecipeFile, artifactsDir, outputFile, wpCodeboxBin: bin }) : null;
   return {
     schema: 'homeboy/child-command-failure/v1',
     kind: 'child_command_failed',
-    label: `WP Codebox recipe-run batch ${batchSuffix}`,
+    label: isRecipeRun ? `WP Codebox recipe-run batch ${batchSuffix}` : `Dependency ${failureStage} batch ${batchSuffix}`,
     batch: batchNumber,
     batch_id: batchId || `batch-${batchSuffix}`,
     fixture_ids: normalizeFixtureIds(fixtures),
-    command: command.command,
-    command_argv: command.argv,
+    ...(command ? { command: command.command } : {}),
+    ...(command ? { command_argv: command.argv } : {}),
     exit_status: exitStatus(error),
     error_code: error?.code,
     error_signal: error?.signal,
@@ -1466,9 +1510,10 @@ function buildWpCodeboxChildCommandFailure({ error, fixtures, batchNumber, batch
     recipe_file: batchRecipeFile,
     output_file: outputFile,
     artifacts_directory: artifactsDir,
-    replay_command: wpCodeboxReplayCommand({ recipeFile: batchRecipeFile, artifactsDir, wpCodeboxBin: bin }),
+    ...(isRecipeRun ? { replay_command: wpCodeboxReplayCommand({ recipeFile: batchRecipeFile, artifactsDir, wpCodeboxBin: bin }) } : {}),
     artifact_refs: artifactRefs,
-    message: error?.message || 'WP Codebox recipe-run failed',
+    failure_stage: failureStage,
+    message: error?.message || (isRecipeRun ? 'WP Codebox recipe-run failed' : `Dependency ${failureStage} failed`),
   };
 }
 

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -902,6 +902,7 @@ function childCommandFailureDiagnostic(failure) {
     artifacts_directory: failure.artifacts_directory || failure.artifactsDirectory,
     replay_command: failure.replay_command || failure.replayCommand,
     artifact_refs: failure.artifact_refs || failure.artifactRefs,
+    failure_stage: failure.failure_stage,
     reason: diagnosticMessage(failure) || 'WP Codebox child command failed.',
     message: diagnosticMessage(failure) || 'WP Codebox child command failed.',
   });

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -5009,6 +5009,24 @@ async function runWpCodeboxRecipe(options = {}) {
     fs.writeFileSync(capturedRecipes, JSON.stringify(captured));
   }
   if (recipe.includes('plan-artifact-dependencies')) {
+    // Parse batch number from the discovery artifacts path (e.g. .../discovery/001-fixture-01/).
+    const discoveryMatch = String(options.recipeFile).match(/discovery\\/(\\d{3})/);
+    const discoveryBatch = discoveryMatch ? Number(discoveryMatch[1]) : 0;
+    inFlight += 1;
+    peakInFlight = Math.max(peakInFlight, inFlight);
+    recordPeak();
+    const unit = Number(process.env.SSI_TEST_RECIPE_UNIT_MS || '15');
+    const delay = discoveryBatch * unit;
+    await new Promise((resolve) => setTimeout(resolve, Math.max(1, delay)));
+    inFlight -= 1;
+    const throwDiscoveryBatch = Number(process.env.SSI_TEST_RECIPE_DISCOVERY_THROW_BATCH || '0');
+    if (throwDiscoveryBatch && throwDiscoveryBatch === discoveryBatch) {
+      const error = new Error('discovery failed for batch ' + discoveryBatch);
+      error.code = 19;
+      error.stdout = '';
+      error.stderr = 'discovery boom';
+      throw error;
+    }
     fs.mkdirSync(options.artifactsDir, { recursive: true });
     fs.writeFileSync(require('node:path').join(options.artifactsDir, 'dependency-plan.json'), JSON.stringify({ schema: 'static-site-importer/runtime-dependency-plan/v1', artifact_sha256: 'a'.repeat(64), entries: [] }));
     return { exitCode: 0, outputFile: options.outputFile, json: {} };
@@ -5076,6 +5094,7 @@ const CONCURRENCY_ENV_KEYS = [
   'SSI_TEST_RECIPE_BATCH_COUNT',
   'SSI_TEST_RECIPE_UNIT_MS',
   'SSI_TEST_RECIPE_THROW_BATCH',
+  'SSI_TEST_RECIPE_DISCOVERY_THROW_BATCH',
   'SSI_TEST_RECIPE_CAPTURE_FILE',
 ];
 
@@ -5258,6 +5277,49 @@ test('runFixtureMatrix isolates a throwing batch so sibling batches still comple
 
     // All four batches still ran; the three non-throwing siblings succeeded,
     // proving one batch's failure did not sink the others.
+    assert.equal(summary.runtime.batches.length, 4);
+    assert.equal(summary.result_summary.succeeded, 3);
+    assert.equal(summary.result_summary.failed, 1);
+  } finally {
+    restoreConcurrencyEnv(snapshot);
+  }
+});
+
+test('runFixtureMatrix isolates a dependency-discovery failure so sibling batches still complete', async () => {
+  const snapshot = snapshotConcurrencyEnv();
+  const workspace = setupConcurrencyWorkspace('ssi-discovery-isolation-', 4);
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = workspace.helperPath;
+  process.env.SSI_TEST_RECIPE_BATCH_COUNT = '4';
+  process.env.SSI_TEST_RECIPE_UNIT_MS = '5';
+  process.env.SSI_TEST_RECIPE_DISCOVERY_THROW_BATCH = '2';
+
+  try {
+    const { summary, runtimeError } = await runFixtureMatrix({
+      id: 'discovery-isolation-matrix',
+      fixtureRoot: workspace.fixtureRoot,
+      outputDirectory: workspace.outputDirectory,
+      staticSiteImporterPath: workspace.staticSiteImporter,
+      run: true,
+      batchSize: 1,
+      concurrency: 4,
+      visualParity: false,
+    });
+
+    // The discovery failure surfaces as the runtime error + exit code, but the
+    // run still produced a full summary rather than rejecting.
+    assert.ok(runtimeError);
+    assert.match(runtimeError.message, /discovery failed/);
+    assert.equal(summary.runtime.exit_code, 19);
+
+    // Exactly one child-command failure with the correct stage.
+    const failures = summary.runtime.child_command_failures;
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].batch_id, 'batch-002');
+    assert.equal(failures[0].failure_stage, 'dependency_discovery');
+    assert.equal(failures[0].exit_status, 19);
+
+    // All four batches still ran; the three non-throwing siblings succeeded,
+    // proving one batch's discovery failure did not sink the others.
     assert.equal(summary.runtime.batches.length, 4);
     assert.equal(summary.result_summary.succeeded, 3);
     assert.equal(summary.result_summary.failed, 1);


### PR DESCRIPTION
## Summary
A dependency-discovery or host-resolution failure in a fixture-matrix batch used to throw out of `runFixtureMatrixBatch()` before the batch's error boundary. That rejection escaped `mapWithConcurrency()`'s `Promise.all`, so it discarded every sibling batch and aborted the whole lane before aggregate scoring ran.

Now discovery, resolution, and recipe build run inside the batch error boundary. A failure produces a typed `child_command_failed` receipt with a `failure_stage` field, siblings keep running, and the aggregate matrix result still emits. Each affected fixture is attributed to the preparation stage that failed.

Fixes #876

## Changes
### bench/static-site-fixture-matrix.bench.mjs
**Before:** discovery/resolution/build ran before the batch try/catch. A throw escaped and rejected `Promise.all`, dropping sibling batches.
**After:** the preparation phase is wrapped in the same error boundary as the recipe run. The catch block maps the failure to `dependency_discovery`, `dependency_resolution`, or `recipe_build` and builds a typed child-command failure. Batch paths are deterministic, so they are built before discovery and stay available for the receipt.

Discovery and resolution failures are planning failures, not sandbox corruption, so they bypass the per-fixture recovery re-runs. Global fixture inventory and dependency hydration failures stay lane-fatal.

### lib/fixture-matrix/collectors/run-intake.mjs
**After:** `childCommandFailureDiagnostic()` now carries `failure_stage`. It is additive; existing receipts without the field are unchanged.

### tools/fixture-matrix.test.mjs
Added a regression test that throws a discovery failure on batch 2 and asserts batches 1/3/4 still succeed, the aggregate emits with `succeeded: 3` / `failed: 1`, and the failure is typed `failure_stage: dependency_discovery` with `batch_id: batch-002`.

## Testing
1. Ran `npm run test:fixture-matrix` -> 262 tests pass, including the new regression test.
2. Ran `npm test` -> 54 tests pass, 0 failures.

Result: no existing behavior regressed; the new test confirms sibling batches are no longer discarded on a discovery failure.