### PR TITLE
fix: harden solved-site promotion corpus identity (#693)

### DIFF
--- a/.github/workflows/solved-site-promotion-pr.yml
+++ b/.github/workflows/solved-site-promotion-pr.yml
@@ -14,6 +14,7 @@ on:
       - 'composer.lock'
       - 'package.json'
       - 'package-lock.json'
+      - 'docs/contracts/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -85,7 +85,7 @@ jobs:
           mkdir -p "$ARTIFACT_ROOT" "$RUN_DIR/homeboy-shared-state"
           FIXTURE_TREE_SHA=$(git -C blocks-engine rev-parse "${BLOCKS_ENGINE_SHA}:fixtures/solved")
           SOLVED_FIXTURE_IDS=$(node static-site-importer/tools/list-solved-fixture-ids.mjs "$GITHUB_WORKSPACE/blocks-engine/fixtures")
-          SOLVED_FIXTURE_COUNT=$(printf '%s' "$SOLVED_FIXTURE_IDS" | tr ',' '\n' | wc -l | tr -d ' ')
+          SOLVED_FIXTURE_COUNT=$(printf '%s' "$SOLVED_FIXTURE_IDS" | awk -F, '{print NF}')
           {
             echo "RUN_ID=$RUN_ID"
             echo "RUN_DIR=$RUN_DIR"

--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -69,6 +69,11 @@ jobs:
           ref: ${{ inputs.blocks-engine-sha }}
           path: blocks-engine
 
+      - name: Setup pinned Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Initialize immutable run evidence
         env:
           STATIC_SITE_IMPORTER_SHA: ${{ inputs.static-site-importer-sha }}
@@ -79,20 +84,16 @@ jobs:
           ARTIFACT_ROOT="$RUN_DIR/evidence"
           mkdir -p "$ARTIFACT_ROOT" "$RUN_DIR/homeboy-shared-state"
           FIXTURE_TREE_SHA=$(git -C blocks-engine rev-parse "${BLOCKS_ENGINE_SHA}:fixtures/solved")
-          SOLVED_FIXTURE_COUNT=$(find blocks-engine/fixtures/solved -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-          test "$SOLVED_FIXTURE_COUNT" -gt 0
+          SOLVED_FIXTURE_IDS=$(node static-site-importer/tools/list-solved-fixture-ids.mjs "$GITHUB_WORKSPACE/blocks-engine/fixtures")
+          SOLVED_FIXTURE_COUNT=$(printf '%s' "$SOLVED_FIXTURE_IDS" | tr ',' '\n' | wc -l | tr -d ' ')
           {
             echo "RUN_ID=$RUN_ID"
             echo "RUN_DIR=$RUN_DIR"
             echo "ARTIFACT_ROOT=$ARTIFACT_ROOT"
             echo "FIXTURE_TREE_SHA=$FIXTURE_TREE_SHA"
             echo "SOLVED_FIXTURE_COUNT=$SOLVED_FIXTURE_COUNT"
+            echo "SOLVED_FIXTURE_IDS=$SOLVED_FIXTURE_IDS"
           } >> "$GITHUB_ENV"
-
-      - name: Setup pinned Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pinned PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
@@ -193,6 +194,7 @@ jobs:
             --blocks-engine-sha "$BLOCKS_ENGINE_SHA" \
             --fixture-tree-sha "$FIXTURE_TREE_SHA" \
             --solved-fixture-count "$SOLVED_FIXTURE_COUNT" \
+            --solved-fixture-ids "$SOLVED_FIXTURE_IDS" \
             --run-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             --artifact-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}#artifacts" \
             --output "$ARTIFACT_ROOT/solved-site-promotion-receipt.json" \

--- a/docs/contracts/solved-site-promotion-receipt-v1.md
+++ b/docs/contracts/solved-site-promotion-receipt-v1.md
@@ -14,3 +14,11 @@ The receipt is emitted only when:
 - reviewer-facing references resolve to the GitHub Actions run and artifact list.
 
 SSI owns this decision and its schema. Homeboy may consume the receipt for generic finalization after validating the candidate and artifact identity chain; it does not reinterpret solved-site policy.
+
+## Downstream build status
+
+Receipt status `accepted` records the solved-site promotion decision. It does not deploy or mark a downstream site as built. Downstream finalization owns setting `status:built` after validating this receipt and the candidate identity chain. Finalization must not reinterpret solved-site policy or replace this receipt with a separate acceptance decision.
+
+## Required branch-protection check
+
+The `solved-site-promotion` job must be configured as a required status check on the protected target branch before any post-acceptance push or downstream `status:built` transition. This workflow cannot enforce branch protection itself. Receipt validity depends on repository branch protection requiring this check for the relevant candidate ref.

--- a/tools/list-solved-fixture-ids.mjs
+++ b/tools/list-solved-fixture-ids.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { discoverFixtures } from '../lib/fixture-matrix/fixtures.mjs';
+
+const fixtureRoot = process.argv[2];
+if (!fixtureRoot) {
+  process.stderr.write('Usage: node tools/list-solved-fixture-ids.mjs <fixture-root>\n');
+  process.exitCode = 1;
+} else {
+  const ids = discoverFixtures(fixtureRoot, { maxDepth: 2 })
+    .filter((fixture) => fixture.fixture_corpus === 'solved')
+    .map((fixture) => fixture.id)
+    .sort();
+  if (!ids.length) {
+    process.stderr.write(`No solved fixtures found under ${fixtureRoot}.\n`);
+    process.exitCode = 1;
+  } else {
+    process.stdout.write(`${ids.join(',')}\n`);
+  }
+}

--- a/tools/verify-solved-site-promotion.mjs
+++ b/tools/verify-solved-site-promotion.mjs
@@ -19,7 +19,8 @@ export function verifySolvedSitePromotion(input) {
   assertSha(options.staticSiteImporterSha, 'Static Site Importer candidate SHA');
   assertSha(options.blocksEngineSha, 'Blocks Engine candidate SHA');
   assertSha(options.fixtureTreeSha, 'Fixture tree SHA');
-  assert(Number(options.solvedFixtureCount) > 0, 'Solved fixture corpus must be non-empty.');
+  assert(Number(options.solvedFixtureCount) === options.solvedFixtureIds.length,
+    `--solved-fixture-count must equal the number of --solved-fixture-ids (${options.solvedFixtureIds.length}).`);
   assert(matrix.summary?.execution_status === 'requested', 'Matrix execution was not requested.');
   assert(matrix.summary?.generation_status === 'succeeded', 'Matrix generation did not succeed.');
   assert(Array.isArray(matrix.fixtures) && matrix.fixtures.length > 0, 'Selected fixture corpus must be non-empty.');
@@ -28,8 +29,26 @@ export function verifySolvedSitePromotion(input) {
   assert(matrix.summary?.solved_candidate_gate?.enabled === true, 'Solved-candidate gate must be enabled.');
   assert(matrix.summary?.solved_candidate_gate?.failed_fixture_count === 0, 'Solved-candidate gate reported failures.');
 
+  for (const fixture of matrix.fixtures) {
+    assert(fixture.fixture_corpus === 'solved', `${fixture.fixture_id}: matrix fixture must belong to the solved corpus.`);
+  }
+  const matrixFixtureIds = matrix.fixtures.map((fixture) => String(fixture.fixture_id)).sort();
+  assert(JSON.stringify(matrixFixtureIds) === JSON.stringify(options.solvedFixtureIds),
+    `Matrix must cover the complete canonical solved corpus: expected [${options.solvedFixtureIds.join(',')}] got [${matrixFixtureIds.join(',')}]`);
+
+  assert(matrix.matrix_id, 'Matrix result is missing matrix_id.');
+  assert(registry.matrix_id === matrix.matrix_id, 'Registry matrix_id must match the matrix result matrix_id.');
+  assert(registry.generated_from?.result_schema === matrix.schema, 'Registry generated_from.result_schema must match the matrix schema.');
+  assert(Number(registry.generated_from?.fixture_count) === matrix.fixtures.length, 'Registry generated_from.fixture_count must match the matrix fixture count.');
+
   validateRuntime(runtime, options);
   const decisions = new Map((registry.fixture_decisions || []).map((row) => [row.fixture_id, row]));
+  const registrySolvedIds = (registry.fixture_decisions || [])
+    .filter((row) => row.fixture_corpus === 'solved')
+    .map((row) => String(row.fixture_id))
+    .sort();
+  assert(JSON.stringify(registrySolvedIds) === JSON.stringify(options.solvedFixtureIds),
+    `Registry must carry a solved fixture decision for every canonical solved fixture id: expected [${options.solvedFixtureIds.join(',')}] got [${registrySolvedIds.join(',')}]`);
   const requiredFiles = [options.matrixResult, options.registry];
   for (const fixture of matrix.fixtures) {
     verifyFixture(fixture, decisions.get(fixture.fixture_id), options, requiredFiles);
@@ -55,9 +74,9 @@ export function verifySolvedSitePromotion(input) {
     },
     corpus: {
       fixture_root_tree_sha: options.fixtureTreeSha,
-      solved_fixture_count: Number(options.solvedFixtureCount),
-      selected_fixture_ids: matrix.fixtures.map((fixture) => fixture.fixture_id).sort(),
-      selected_fixture_count: matrix.fixtures.length,
+      solved_fixture_count: options.solvedFixtureIds.length,
+      selected_fixture_ids: options.solvedFixtureIds,
+      selected_fixture_count: options.solvedFixtureIds.length,
     },
     gates: {
       matrix: 'passed',
@@ -86,19 +105,29 @@ function verifyFixture(fixture, decision, options, requiredFiles) {
   const quality = fixture.quality_metrics || {};
   assert(quality.pass === true, `${id}: quality gate did not pass.`);
   for (const key of ['fallback_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count']) {
-    assert(Number(quality[key] || 0) === 0, `${id}: ${key} must be zero.`);
+    assertFiniteMetric(quality, key, id);
+    assert(Number(quality[key]) === 0, `${id}: ${key} must be zero.`);
   }
   const composition = fixture.block_composition || {};
+  assertFiniteMetric(composition, 'block_total', id);
   assert(Number(composition.block_total) > 0, `${id}: imported block count must be nonzero.`);
+  assertFiniteMetric(composition, 'native_block_count', id);
   assert(Number(composition.native_block_count) === Number(composition.block_total), `${id}: every imported block must be native.`);
-  assert(Number(composition.core_html_block_count || 0) === 0, `${id}: core/html blocks are forbidden.`);
+  assertFiniteMetric(composition, 'core_html_block_count', id);
+  assert(Number(composition.core_html_block_count) === 0, `${id}: core/html blocks are forbidden.`);
   const editor = fixture.editor_validation || {};
   assert(editor.validation_method === 'wp.blocks.validateBlock', `${id}: editor validation must use wp.blocks.validateBlock.`);
+  assertFiniteMetric(editor, 'total_blocks', id);
+  assertFiniteMetric(editor, 'valid_blocks', id);
+  assertFiniteMetric(editor, 'invalid_blocks', id);
   assert(Number(editor.total_blocks) > 0 && editor.valid_blocks === editor.total_blocks && Number(editor.invalid_blocks) === 0, `${id}: editor validation is incomplete or invalid.`);
   assert(fixture.editor_canvas?.status === 'captured', `${id}: editor canvas evidence is missing.`);
   addRequiredFile(requiredFiles, fixture.editor_canvas?.screenshot, `${id}: editor screenshot`, options.artifactRoot);
   const visual = fixture.visual_parity_artifacts || {};
-  assert(Number(visual.metrics?.mismatch_ratio) === 0 && Number(visual.metrics?.mismatch_pixels) === 0, `${id}: visual mismatch must be exactly zero.`);
+  const visualMetrics = visual.metrics || {};
+  assertFiniteMetric(visualMetrics, 'mismatch_ratio', id);
+  assertFiniteMetric(visualMetrics, 'mismatch_pixels', id);
+  assert(Number(visualMetrics.mismatch_ratio) === 0 && Number(visualMetrics.mismatch_pixels) === 0, `${id}: visual mismatch must be exactly zero.`);
   for (const slot of ['source_screenshot', 'imported_screenshot', 'diff_screenshot', 'visual_diff']) {
     const artifact = visual.artifacts?.[slot];
     assert(artifact?.status === 'captured', `${id}: ${slot} evidence is missing.`);
@@ -108,7 +137,9 @@ function verifyFixture(fixture, decision, options, requiredFiles) {
   assert(evidence.readiness === 'verified' && (evidence.missing || []).length === 0, `${id}: runtime evidence is incomplete.`);
   assert(evidence.materialization_receipt?.status === 'completed' && evidence.materialization_receipt?.plan_hash, `${id}: completed materialization receipt is missing.`);
   assert(evidence.transformer?.package_reference === options.blocksEngineSha, `${id}: transformer provenance does not match the Blocks Engine candidate.`);
-  assert(Number(fixture.editor_quality?.native_conversion_rate) === 1, `${id}: native conversion rate must equal 1.`);
+  const editorQuality = fixture.editor_quality || {};
+  assertFiniteMetric(editorQuality, 'native_conversion_rate', id);
+  assert(Number(editorQuality.native_conversion_rate) === 1, `${id}: native conversion rate must equal 1.`);
 }
 
 function validateRuntime(runtime, options) {
@@ -167,9 +198,16 @@ function filesBelow(directory) {
 
 function normalizeOptions(input) {
   const options = { ...input };
-  for (const key of ['matrixResult', 'registry', 'runtimeInputs', 'artifactRoot', 'staticSiteImporterSha', 'blocksEngineSha', 'fixtureTreeSha', 'solvedFixtureCount', 'runUrl', 'artifactUrl', 'output', 'manifestOutput']) {
+  for (const key of ['matrixResult', 'registry', 'runtimeInputs', 'artifactRoot', 'staticSiteImporterSha', 'blocksEngineSha', 'fixtureTreeSha', 'solvedFixtureCount', 'solvedFixtureIds', 'runUrl', 'artifactUrl', 'output', 'manifestOutput']) {
     assert(options[key] !== undefined && options[key] !== '', `--${kebab(key)} is required.`);
   }
+  options.solvedFixtureIds = String(options.solvedFixtureIds)
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  assert(options.solvedFixtureIds.length > 0, '--solved-fixture-ids must list at least one canonical solved fixture.');
+  assert(new Set(options.solvedFixtureIds).size === options.solvedFixtureIds.length, '--solved-fixture-ids must be unique.');
+  options.solvedFixtureIds.sort();
   options.artifactRoot = path.resolve(options.artifactRoot);
   options.output = path.resolve(options.output);
   options.manifestOutput = path.resolve(options.manifestOutput);
@@ -194,12 +232,19 @@ function readJson(file, label) {
   try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { throw new Error(`Could not read ${label}: ${file}`); }
 }
 function assertSha(value, label) { assert(/^[a-f0-9]{40}$/.test(String(value || '')), `${label} must be a full commit SHA.`); }
+function assertFiniteMetric(object, key, fixtureId) {
+  assert(Object.prototype.hasOwnProperty.call(object, key), `${fixtureId}: ${key} must be present.`);
+  const value = object[key];
+  const validNumber = typeof value === 'number' && Number.isFinite(value);
+  const validNumericString = typeof value === 'string' && /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/.test(value) && Number.isFinite(Number(value));
+  assert(validNumber || validNumericString, `${fixtureId}: ${key} must be a finite number.`);
+}
 function assert(condition, message) { if (!condition) throw new Error(message); }
 function camel(value) { return value.replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase()); }
 function kebab(value) { return value.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`); }
 
 function printHelp() {
-  process.stdout.write('Usage: node tools/verify-solved-site-promotion.mjs --matrix-result <file> --registry <file> --runtime-inputs <file> --artifact-root <dir> --static-site-importer-sha <sha> --blocks-engine-sha <sha> --fixture-tree-sha <sha> --solved-fixture-count <n> --run-url <url> --artifact-url <url> --output <file> --manifest-output <file>\n');
+  process.stdout.write('Usage: node tools/verify-solved-site-promotion.mjs --matrix-result <file> --registry <file> --runtime-inputs <file> --artifact-root <dir> --static-site-importer-sha <sha> --blocks-engine-sha <sha> --fixture-tree-sha <sha> --solved-fixture-count <n> --solved-fixture-ids <id1,id2,...> --run-url <url> --artifact-url <url> --output <file> --manifest-output <file>\n');
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -13,6 +13,7 @@ function fixture() {
   for (const file of ['editor.png', 'source.png', 'candidate.png', 'diff.png', 'visual-diff.json']) fs.writeFileSync(path.join(root, file), file);
   const matrix = {
     schema: 'static-site-importer/fixture-matrix-result/v1',
+    matrix_id: 'solved-matrix',
     summary: { generation_status: 'succeeded', execution_status: 'requested', fixture_count: 1, failed: 0, not_run: 0, solved_candidate_gate: { enabled: true, failed_fixture_count: 0 } },
     fixtures: [{
       fixture_id: 'solved', status: 'passed', success: true,
@@ -27,11 +28,17 @@ function fixture() {
       editor_quality: { native_conversion_rate: 1 },
     }],
   };
-  const registry = { schema: 'static-site-importer/gutenberg-incompatibility-registry/v1', fixture_decisions: [{ fixture_id: 'solved', acceptance_status: 'solved_candidate' }] };
+  matrix.fixtures[0].fixture_corpus = 'solved';
+  const registry = {
+    schema: 'static-site-importer/gutenberg-incompatibility-registry/v1',
+    matrix_id: matrix.matrix_id,
+    generated_from: { result_schema: matrix.schema, fixture_count: matrix.fixtures.length },
+    fixture_decisions: [{ fixture_id: 'solved', fixture_corpus: 'solved', acceptance_status: 'solved_candidate' }],
+  };
   const runtime = { nodeVersion: '20.19.4', phpVersion: '8.1.29', wordpressVersion: '7.0.2', homeboyVersion: 'v0.298.1', homeboySha256: '3'.repeat(64), homeboyExtensionsRef: '4'.repeat(40), wpCodeboxVersion: 'v0.18.4', wpCodeboxSha256: '5'.repeat(64), staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA };
   const paths = { matrix: path.join(root, 'matrix.json'), registry: path.join(root, 'registry.json'), runtime: path.join(root, 'runtime.json') };
   write(paths.matrix, matrix); write(paths.registry, registry); write(paths.runtime, runtime);
-  return { root, matrix, registry, runtime, paths, options: { matrixResult: paths.matrix, registry: paths.registry, runtimeInputs: paths.runtime, artifactRoot: root, staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA, fixtureTreeSha: '6'.repeat(40), solvedFixtureCount: 1, runUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123', artifactUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123#artifacts', output: path.join(root, 'receipt.json'), manifestOutput: path.join(root, 'manifest.json') } };
+  return { root, matrix, registry, runtime, paths, options: { matrixResult: paths.matrix, registry: paths.registry, runtimeInputs: paths.runtime, artifactRoot: root, staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA, fixtureTreeSha: '6'.repeat(40), solvedFixtureCount: 1, solvedFixtureIds: 'solved', runUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123', artifactUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123#artifacts', output: path.join(root, 'receipt.json'), manifestOutput: path.join(root, 'manifest.json') } };
 }
 
 test('issues an accepted immutable promotion receipt', () => {
@@ -85,6 +92,23 @@ for (const [name, mutate, pattern] of [
   ['transformer mismatch', (input) => { input.matrix.fixtures[0].matrix_evidence.transformer.package_reference = '7'.repeat(40); }, /provenance/],
   ['unpinned runtime', (input) => { input.runtime.wordpressVersion = 'latest'; }, /pinned/],
   ['missing evidence file', (input) => { fs.unlinkSync(path.join(input.root, 'diff.png')); }, /missing/],
+  ['missing quality metric', (input) => { delete input.matrix.fixtures[0].quality_metrics.core_html_block_count; }, /present/],
+  ['null quality metric', (input) => { input.matrix.fixtures[0].quality_metrics.core_html_block_count = null; }, /finite number/],
+  ['boolean quality metric', (input) => { input.matrix.fixtures[0].quality_metrics.core_html_block_count = false; }, /finite number/],
+  ['empty quality metric', (input) => { input.matrix.fixtures[0].quality_metrics.core_html_block_count = ''; }, /finite number/],
+  ['wrong matrix corpus', (input) => { input.matrix.fixtures[0].fixture_corpus = 'active'; }, /solved corpus/],
+  ['null block total', (input) => { input.matrix.fixtures[0].block_composition.block_total = null; }, /finite number/],
+  ['boolean native block count', (input) => { input.matrix.fixtures[0].block_composition.native_block_count = true; }, /finite number/],
+  ['array total blocks', (input) => { input.matrix.fixtures[0].editor_validation.total_blocks = []; }, /finite number/],
+  ['whitespace total blocks', (input) => { input.matrix.fixtures[0].editor_validation.total_blocks = '  '; }, /finite number/],
+  ['null valid blocks', (input) => { input.matrix.fixtures[0].editor_validation.valid_blocks = null; }, /finite number/],
+  ['boolean native conversion rate', (input) => { input.matrix.fixtures[0].editor_quality.native_conversion_rate = true; }, /finite number/],
+  ['partial canonical corpus', (input) => { input.options.solvedFixtureIds = 'solved,other'; input.options.solvedFixtureCount = 2; }, /complete canonical solved corpus/],
+  ['duplicate canonical ids', (input) => { input.options.solvedFixtureIds = 'solved,solved'; }, /unique/],
+  ['registry matrix mismatch', (input) => { input.registry.matrix_id = 'other-matrix'; }, /matrix_id/],
+  ['registry source schema mismatch', (input) => { input.registry.generated_from.result_schema = 'other/schema'; }, /result_schema/],
+  ['registry fixture count mismatch', (input) => { input.registry.generated_from.fixture_count = 2; }, /fixture_count/],
+  ['registry solved decision missing', (input) => { input.registry.fixture_decisions[0].fixture_corpus = 'active'; }, /solved fixture decision/],
 ]) {
   test(`fails closed for ${name}`, () => {
     const input = fixture(); mutate(input); write(input.paths.matrix, input.matrix); write(input.paths.registry, input.registry); write(input.paths.runtime, input.runtime);


### PR DESCRIPTION
## Summary

Hardening follow-up to the solved-site promotion gate (#687/#688/#689). The accepted-receipt verifier currently takes only a bare fixture count and never binds the incompatibility registry, so a receipt could be issued for a partial or wrong corpus, a stale registry, or metrics that silently fall back to zero. This change binds the receipt to the complete canonical solved fixture corpus.

Fixes #693

## Changes

### tools/verify-solved-site-promotion.mjs
- Added required `--solved-fixture-ids` option. The fixture count must now equal the id list length, so the count and ids are consistent by construction.
- The matrix result must cover every canonical solved fixture id and nothing extra, and the receipt now emits those canonical ids and counts instead of the raw matrix list.
- The incompatibility registry is now bound to the matrix (`matrix_id`, `generated_from.result_schema`, `generated_from.fixture_count`) and must carry a solved decision for every canonical fixture id.
- Replaced every silent `Number(x || 0) === 0` coercion with an explicit presence and finite-zero check on quality, composition, editor, visual, and editor-quality metrics. A missing, null, boolean, array, or whitespace metric now fails closed instead of passing as zero.

### tools/list-solved-fixture-ids.mjs (new)
- Computes canonical solved fixture ids from the Blocks Engine checkout via `discoverFixtures`, matching the matrix fixture_id derivation exactly, so CI enumeration cannot drift from the matrix slug logic.

### .github/workflows/solved-site-promotion.yml
- Runs the pinned Node setup before id discovery, computes `SOLVED_FIXTURE_IDS` and `SOLVED_FIXTURE_COUNT` with the new helper, and passes them to the verifier.

### .github/workflows/solved-site-promotion-pr.yml
- Promotion CI now runs when receipt contract documentation changes (`docs/contracts/**`).

### docs/contracts/solved-site-promotion-receipt-v1.md
- Documented downstream `status:built` ownership (the accepted receipt is the decision artifact, not the deploy) and the required `solved-site-promotion` branch-protection check. Schema stays additive, receipt schema const unchanged.

## Testing

**Test 1: Focused promotion verifier suite**
```
npm run test:solved-site-promotion
```
Result: 31 tests pass, 0 fail. Covers 28 fail-closed cases including partial canonical corpus, duplicate ids, registry matrix/schema/count mismatch, missing solved decision, and every missing/null/boolean/array/whitespace metric.

**Test 2: Fast lane (full manifest)**
```
npm test
```
Result: 54 tests pass, 0 fail (44 standalone PHP + 10 node).

**Test 3: Whitespace / conflict markers**
```
git diff --check
```
Result: clean. Receipt schema const unchanged.

No runtime or PHP code changes; this is verifier, CI, and docs only.