### PR TITLE
feat: add typed svg-artwork companion block for irreducible inline SVG

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -30,6 +30,7 @@
     "tests/smoke-provider-presentation.php": { "environment": "standalone-php" },
     "tests/smoke-safe-html-fallback-reducer.php": { "environment": "standalone-php" },
     "tests/smoke-site-identity.php": { "environment": "standalone-php" },
+    "tests/smoke-svg-artwork.php": { "environment": "standalone-php" },
     "tests/smoke-template-chrome-dedupe.php": { "environment": "standalone-php" },
     "tests/smoke-template-part-shell-dedupe.php": { "environment": "standalone-php" },
     "tests/smoke-url-import-runtime.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -109,13 +109,25 @@ class Static_Site_Importer_Companion_Plugin {
 			if ( isset( $block['render'] ) && is_scalar( $block['render'] ) && Static_Site_Importer_Content_Policy::contains_server_code( (string) $block['render'] ) ) {
 				return new WP_Error( 'static_site_importer_companion_plugin_render_invalid', sprintf( 'Block %s render markup must be static HTML.', $name ) );
 			}
+			$render_kind = isset( $block['render_kind'] ) && is_string( $block['render_kind'] ) ? (string) $block['render_kind'] : '';
+			if ( '' !== $render_kind && ! in_array( $render_kind, self::$trusted_render_kinds, true ) ) {
+				return new WP_Error(
+					'static_site_importer_companion_plugin_render_kind_invalid',
+					sprintf( 'Block %s declares an unsupported render_kind %s.', $name, $render_kind )
+				);
+			}
+			$kind_validation = self::validate_render_kind( $render_kind, $block['block_json'] );
+			if ( is_wp_error( $kind_validation ) ) {
+				return $kind_validation;
+			}
 			$metadata = $block['block_json'];
-			if ( isset( $block['render'] ) && is_scalar( $block['render'] ) ) {
+			if ( ( isset( $block['render'] ) && is_scalar( $block['render'] ) ) || '' !== $render_kind ) {
 				$metadata['render'] = 'file:./render.php';
 			}
 			$references = self::metadata_file_references( $metadata );
+			$has_render_source = ( isset( $block['render'] ) && is_scalar( $block['render'] ) ) || '' !== $render_kind;
 			foreach ( $references as $path ) {
-				if ( ! array_key_exists( $path, $assets ) && ! ( 'render.php' === $path && isset( $block['render'] ) && is_scalar( $block['render'] ) ) ) {
+				if ( ! array_key_exists( $path, $assets ) && ! ( 'render.php' === $path && $has_render_source ) ) {
 					return new WP_Error( 'static_site_importer_companion_plugin_metadata_asset_missing', sprintf( 'Block %s metadata references undeclared asset %s.', $name, $path ) );
 				}
 			}
@@ -376,9 +388,10 @@ class Static_Site_Importer_Companion_Plugin {
 
 		$has_render = isset( $block['render'] ) && is_scalar( $block['render'] );
 		$render     = $has_render ? (string) $block['render'] : '';
+		$render_kind = isset( $block['render_kind'] ) && is_string( $block['render_kind'] ) ? (string) $block['render_kind'] : '';
 		$files      = array();
-		if ( $has_render ) {
-			$files['render.php'] = self::normalize_render( $render );
+		if ( $has_render || '' !== $render_kind ) {
+			$files['render.php'] = self::normalize_render( $render, $render_kind );
 		}
 
 		// Carried static assets (e.g. block stylesheets or a hand-written
@@ -396,7 +409,7 @@ class Static_Site_Importer_Companion_Plugin {
 		if ( $metadata ) {
 			$block_json         = $block['block_json'];
 			$block_json['name'] = $block_name;
-			if ( $has_render ) {
+			if ( $has_render || '' !== $render_kind ) {
 				$block_json['render'] = 'file:./render.php';
 			}
 			$json = wp_json_encode( $block_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
@@ -920,17 +933,41 @@ class Static_Site_Importer_Companion_Plugin {
 	}
 
 	/**
+	 * Block render kinds the scaffolder can emit from a trusted fixed
+	 * template. Each kind generates a known render.php that does not
+	 * embed producer-supplied source. Scalar `render` payloads still take
+	 * the static literal path.
+	 *
+	 * @var string[]
+	 */
+	private static $trusted_render_kinds = array(
+		'svg-artwork',
+	);
+
+	/**
 	 * Build a render.php template that the dynamic block's render_callback runs.
 	 *
 	 * The closure exposes $attributes, $content, and $block, so a render.php that
 	 * echoes from those variables works exactly like a block.json `render` file.
 	 * An empty payload falls back to passing inner content through unchanged.
+	 * A `render_kind` payload bypasses the static literal path and emits a
+	 * trusted SSI-generated render template.
 	 *
-	 * @param string $render Render markup or PHP from the payload.
+	 * @param string              $render      Render markup or PHP from the payload.
+	 * @param string              $render_kind Optional trusted renderer kind.
 	 * @return string
 	 */
-	private static function normalize_render( string $render ): string {
+	private static function normalize_render( string $render, string $render_kind = '' ): string {
 		$trimmed = ltrim( $render );
+		if ( '' !== $render_kind ) {
+			if ( 'svg-artwork' === $render_kind ) {
+				return self::svg_artwork_render_template();
+			}
+			// Unknown render_kind should never reach this path; validate_payload
+			// rejects it. The fallback below mirrors the empty-render path so a
+			// future bug never produces executable producer source.
+			return self::svg_artwork_render_template( true );
+		}
 		if ( '' === $trimmed ) {
 			return "<?php\n/**\n * Generated companion block render (server-rendered dynamic block).\n *\n * @package StaticSiteImporterCompanion\n *\n * @var array<string,mixed> \$attributes Block attributes.\n * @var string              \$content    Inner block content.\n * @var WP_Block            \$block      Block instance.\n */\n\necho \$content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block content is already sanitized by WordPress.\n";
 		}
@@ -938,6 +975,107 @@ class Static_Site_Importer_Companion_Plugin {
 		// Static source markup is data, never executable template source. The only
 		// PHP in this file is SSI-generated code that emits an escaped literal.
 		return "<?php\n/** Generated companion block render. */\n\necho '" . self::php_single_quote( $render ) . "'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static source markup was validated before compilation.\n";
+	}
+
+	/**
+	 * Build the trusted render.php template for the svg-artwork render kind.
+	 *
+	 * The template reads typed attributes, sanitizes the inline SVG, and
+	 * outputs the wrapper. It contains no producer-supplied source: every
+	 * string literal comes from the SSI generator.
+	 *
+	 * @param bool $fallback True to emit a no-op template (defensive).
+	 * @return string
+	 */
+	private static function svg_artwork_render_template( bool $fallback = false ): string {
+		if ( $fallback ) {
+			return "<?php\n/** Generated companion block render (svg-artwork fallback). */\n\nreturn '';\n";
+		}
+
+		return <<<'PHP'
+<?php
+/**
+ * Generated companion block render (svg-artwork trusted renderer).
+ *
+ * @package StaticSiteImporterCompanion
+ *
+ * @var array<string,mixed> $attributes Block attributes.
+ * @var string              $content    Inner block content.
+ * @var WP_Block            $block      Block instance.
+ */
+
+if ( ! class_exists( 'Static_Site_Importer_Svg_Artwork' ) ) {
+	return '';
+}
+
+$svg_raw             = isset( $attributes['svg'] ) && is_string( $attributes['svg'] ) ? $attributes['svg'] : '';
+$typed_view_box      = isset( $attributes['viewBox'] ) && is_string( $attributes['viewBox'] ) ? $attributes['viewBox'] : '';
+$typed_title         = isset( $attributes['title'] ) && is_string( $attributes['title'] ) ? $attributes['title'] : '';
+$typed_description   = isset( $attributes['description'] ) && is_string( $attributes['description'] ) ? $attributes['description'] : '';
+$typed_aspect        = isset( $attributes['preserveAspectRatio'] ) && is_string( $attributes['preserveAspectRatio'] ) ? $attributes['preserveAspectRatio'] : '';
+
+$svg_sanitized = Static_Site_Importer_Svg_Artwork::sanitize( $svg_raw );
+if ( '' === $svg_sanitized ) {
+	return '';
+}
+
+$view_box = Static_Site_Importer_Svg_Artwork::view_box( $svg_sanitized, $typed_view_box );
+$aspect   = Static_Site_Importer_Svg_Artwork::preserve_aspect_ratio( $svg_sanitized, $typed_aspect );
+$aria     = Static_Site_Importer_Svg_Artwork::accessibility_attributes( $typed_title, $typed_description );
+
+$wrapper_args = array_merge( $aria['attrs'], array( 'class' => 'wp-block-ssi-svg-artwork' ) );
+$wrapper      = function_exists( 'get_block_wrapper_attributes' )
+	? get_block_wrapper_attributes( $wrapper_args )
+	: 'class="wp-block-ssi-svg-artwork"';
+
+if ( '' !== $view_box ) {
+	$svg_sanitized = preg_replace( '/\sviewBox\s*=\s*"[^"]*"/i', '', $svg_sanitized, 1 );
+	$svg_sanitized = preg_replace( '/\spreserveAspectRatio\s*=\s*"[^"]*"/i', '', $svg_sanitized, 1 );
+	$svg_sanitized = preg_replace( '/<svg\b([^>]*)>/', '<svg$1 viewBox="' . esc_attr( $view_box ) . '">', $svg_sanitized, 1 );
+}
+if ( '' !== $aspect ) {
+	$svg_sanitized = preg_replace( '/\spreserveAspectRatio\s*=\s*"[^"]*"/i', '', $svg_sanitized, 1 );
+	$svg_sanitized = preg_replace( '/<svg\b([^>]*)>/', '<svg$1 preserveAspectRatio="' . esc_attr( $aspect ) . '">', $svg_sanitized, 1 );
+}
+
+if ( isset( $aria['ids']['title'] ) ) {
+	$svg_sanitized = preg_replace( '/<title\b([^>]*)>/', '<title$1 id="' . esc_attr( $aria['ids']['title'] ) . '">', $svg_sanitized, 1 );
+}
+if ( isset( $aria['ids']['description'] ) ) {
+	$svg_sanitized = preg_replace( '/<desc\b([^>]*)>/', '<desc$1 id="' . esc_attr( $aria['ids']['description'] ) . '">', $svg_sanitized, 1 );
+}
+
+echo '<figure ' . $wrapper . '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Wrapper attributes come from WordPress core.
+echo $svg_sanitized; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- SVG was sanitized by Static_Site_Importer_Svg_Artwork::sanitize().
+echo '</figure>';
+PHP;
+	}
+
+	/**
+	 * Validate that a render_kind, when present, is supported and that
+	 * the block declares the required attribute schema for that kind.
+	 *
+	 * @param string              $render_kind Renderer kind.
+	 * @param array<string,mixed> $block_json  Declared block.json.
+	 * @return true|WP_Error
+	 */
+	private static function validate_render_kind( string $render_kind, array $block_json ) {
+		if ( 'svg-artwork' === $render_kind ) {
+			$attributes = isset( $block_json['attributes'] ) && is_array( $block_json['attributes'] ) ? $block_json['attributes'] : array();
+			if ( ! isset( $attributes['svg'] ) || ! is_array( $attributes['svg'] ) ) {
+				return new WP_Error(
+					'static_site_importer_companion_plugin_render_kind_invalid',
+					'Blocks with render_kind=svg-artwork must declare an svg string attribute schema.'
+				);
+			}
+			if ( ( $attributes['svg']['type'] ?? '' ) !== 'string' ) {
+				return new WP_Error(
+					'static_site_importer_companion_plugin_render_kind_invalid',
+					'Blocks with render_kind=svg-artwork must declare svg as a string attribute.'
+				);
+			}
+		}
+		return true;
 	}
 
 	/**

--- a/includes/class-static-site-importer-svg-artwork.php
+++ b/includes/class-static-site-importer-svg-artwork.php
@@ -1,0 +1,754 @@
+<?php
+/**
+ * SVG artwork sanitizer and trusted renderer.
+ *
+ * Single source of truth for sanitizing inline SVG artwork that cannot be
+ * represented by core/image because it depends on inline defs, gradients,
+ * filters, masks, symbols, clip paths, ID references, or document-context
+ * styling. The companion plugin scaffolder emits a render.php that delegates
+ * to sanitize() so the runtime boundary is the only place an SVG can be
+ * trusted.
+ *
+ * The sanitizer is conservative on purpose: every element and attribute
+ * passes an explicit allow-list. The pass strips <script>, <style>,
+ * <foreignObject>, animation elements, on* event handlers, javascript:
+ * URLs, external href/xlink:href, and unsafe url(...) values from inline
+ * style. Local #id references, gradients, masks, clip paths, filters, and
+ * symbols are preserved when their ID survives the sanitization.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'Static_Site_Importer_Svg_Artwork' ) ) {
+
+	/**
+	 * SVG artwork helpers used by generated companion-block render output.
+	 */
+	final class Static_Site_Importer_Svg_Artwork {
+
+		/**
+		 * Maximum root-svg byte size accepted for sanitization. Anything
+		 * larger is rejected outright so resource exhaustion is bounded.
+		 */
+		public const MAX_INPUT_BYTES = 524288;
+
+		/**
+		 * Maximum absolute value accepted in a single viewBox component.
+		 * Caps render-side numeric memory.
+		 */
+		public const MAX_VIEWBOX_COMPONENT = 1.0e6;
+
+		/**
+		 * Maximum recursion depth for prune_subtree. Bounded so a
+		 * pathological deeply-nested SVG cannot blow the stack.
+		 */
+		public const MAX_PRUNE_DEPTH = 64;
+
+		/**
+		 * Allowed SVG element local names.
+		 *
+		 * @var string[]
+		 */
+		private static $allowed_elements = array(
+			'svg',
+			'defs',
+			'symbol',
+			'use',
+			'g',
+			'title',
+			'desc',
+			'metadata',
+			'path',
+			'circle',
+			'ellipse',
+			'rect',
+			'line',
+			'polyline',
+			'polygon',
+			'clippath',
+			'mask',
+			'pattern',
+			'lineargradient',
+			'radialgradient',
+			'stop',
+			'filter',
+			'fecolormatrix',
+			'fecomponenttransfer',
+			'fecomposite',
+			'feconvolvematrix',
+			'fediffuselighting',
+			'fedisplacementmap',
+			'fedropshadow',
+			'fedistantlight',
+			'feflood',
+			'fefunca',
+			'fefuncr',
+			'fefuncb',
+			'fefuncg',
+			'fegaussianblur',
+			'feimage',
+			'femerge',
+			'femergenode',
+			'femorphology',
+			'feoffset',
+			'fepointlight',
+			'fespecularlighting',
+			'fespotlight',
+			'feturbulence',
+			'marker',
+			'text',
+			'tspan',
+			'textpath',
+			'image',
+		);
+
+		/**
+		 * Attributes that are always safe regardless of element. Event
+		 * handlers, javascript: URLs, and any href that does not point to
+		 * a local fragment are stripped separately.
+		 *
+		 * @var string[]
+		 */
+		private static $allowed_attributes = array(
+			'id',
+			'class',
+			'lang',
+			'role',
+			'aria-hidden',
+			'aria-label',
+			'aria-labelledby',
+			'aria-describedby',
+			'xml:lang',
+			'xml:space',
+			'xmlns',
+			'style',
+			'transform',
+			'color',
+			'fill',
+			'fill-opacity',
+			'fill-rule',
+			'stroke',
+			'stroke-width',
+			'stroke-linecap',
+			'stroke-linejoin',
+			'stroke-miterlimit',
+			'stroke-dasharray',
+			'stroke-dashoffset',
+			'stroke-opacity',
+			'marker-start',
+			'marker-mid',
+			'marker-end',
+			'opacity',
+			'clip-path',
+			'clip-rule',
+			'mask',
+			'filter',
+			'font-family',
+			'font-size',
+			'font-style',
+			'font-weight',
+			'letter-spacing',
+			'word-spacing',
+			'text-anchor',
+			'dominant-baseline',
+			'alignment-baseline',
+			'baseline-shift',
+			'display',
+			'visibility',
+			'pointer-events',
+			'paint-order',
+			'vector-effect',
+			'shape-rendering',
+			'color-interpolation',
+			'color-interpolation-filters',
+			'width',
+			'height',
+			'x',
+			'y',
+			'x1',
+			'y1',
+			'x2',
+			'y2',
+			'cx',
+			'cy',
+			'r',
+			'rx',
+			'ry',
+			'd',
+			'points',
+			'pathlength',
+			'offset',
+			'stop-color',
+			'stop-opacity',
+			'spreadmethod',
+			'gradienttransform',
+			'gradientunits',
+			'patterntransform',
+			'patternunits',
+			'patterncontentunits',
+			'clippathunits',
+			'maskunits',
+			'maskcontentunits',
+			'filterunits',
+			'primitiveunits',
+			'in',
+			'in2',
+			'result',
+			'stddeviation',
+			'flood-color',
+			'flood-opacity',
+			'lighting-color',
+			'k1',
+			'k2',
+			'k3',
+			'k4',
+			'kernelmatrix',
+			'kernelunitlength',
+			'preservealpha',
+			'operator',
+			'order',
+			'divisor',
+			'bias',
+			'radius',
+			'edgemode',
+			'preserveaspectratio',
+			'viewbox',
+			'dx',
+			'dy',
+			'rotate',
+			'startoffset',
+			'method',
+			'spacing',
+			'lengthadjust',
+			'textlength',
+			'markerwidth',
+			'markerheight',
+			'markerunits',
+			'orient',
+			'refx',
+			'refy',
+			'href',
+			'xlink:href',
+			'pathlength',
+			'crossorigin',
+			'decoding',
+		);
+
+		/**
+		 * Attributes whose values must be a local fragment (#id).
+		 *
+		 * @var string[]
+		 */
+		private static $fragment_only_attributes = array(
+			'href',
+			'xlink:href',
+		);
+
+		/**
+		 * Sanitize an inline SVG string.
+		 *
+		 * Returns an empty string when the input is too large, malformed,
+		 * not a root <svg> element, or stripped of all drawable content.
+		 *
+		 * @param string $svg Raw inline SVG markup.
+		 * @return string Sanitized SVG or empty string on rejection.
+		 */
+		public static function sanitize( string $svg ): string {
+			$svg = trim( $svg );
+			if ( '' === $svg ) {
+				return '';
+			}
+			if ( strlen( $svg ) > self::MAX_INPUT_BYTES ) {
+				return '';
+			}
+
+			$document = self::load_document( $svg );
+			if ( null === $document ) {
+				return '';
+			}
+
+			$root = $document->documentElement;
+			if ( null === $root || strtolower( $root->localName ) !== 'svg' ) {
+				return '';
+			}
+
+			$known_ids = self::prune_subtree( $root, array() );
+			if ( ! self::root_has_drawable_content( $root ) ) {
+				return '';
+			}
+
+			$serialized = self::serialize_root( $document, $root );
+			if ( '' === $serialized ) {
+				return '';
+			}
+
+			$reloaded = self::load_document( $serialized );
+			if ( null === $reloaded || null === $reloaded->documentElement ) {
+				return '';
+			}
+
+			return self::serialize_root( $reloaded, $reloaded->documentElement );
+		}
+
+		/**
+		 * Resolve the viewBox attribute on a sanitized SVG.
+		 *
+		 * Prefers the typed attribute when present; otherwise reads the
+		 * root <svg> viewBox attribute. Returns an empty string when
+		 * neither is set.
+		 *
+		 * @param string $svg        Sanitized inline SVG.
+		 * @param string $attribute  Optional typed attribute value.
+		 * @return string
+		 */
+		public static function view_box( string $svg, string $attribute = '' ): string {
+			$attribute = trim( $attribute );
+			if ( '' !== $attribute ) {
+				return self::normalize_view_box( $attribute );
+			}
+			$document = self::load_document( $svg );
+			if ( null === $document || null === $document->documentElement ) {
+				return '';
+			}
+			$value = $document->documentElement->getAttribute( 'viewBox' );
+			if ( '' === $value ) {
+				$value = $document->documentElement->getAttribute( 'viewbox' );
+			}
+			return self::normalize_view_box( $value );
+		}
+
+		/**
+		 * Resolve preserveAspectRatio on a sanitized SVG.
+		 *
+		 * @param string $svg        Sanitized inline SVG.
+		 * @param string $attribute  Optional typed attribute value.
+		 * @return string
+		 */
+		public static function preserve_aspect_ratio( string $svg, string $attribute = '' ): string {
+			$attribute = trim( $attribute );
+			if ( '' !== $attribute ) {
+				$normalized = self::normalize_preserve_aspect_ratio( $attribute );
+				return '' === $normalized ? 'xMidYMid meet' : $normalized;
+			}
+			$document = self::load_document( $svg );
+			if ( null === $document || null === $document->documentElement ) {
+				return 'xMidYMid meet';
+			}
+			$value = $document->documentElement->getAttribute( 'preserveAspectRatio' );
+			if ( '' === $value ) {
+				$value = $document->documentElement->getAttribute( 'preserveaspectratio' );
+			}
+			$normalized = self::normalize_preserve_aspect_ratio( $value );
+			return '' === $normalized ? 'xMidYMid meet' : $normalized;
+		}
+
+		/**
+		 * Build accessible role/aria-* attribute pairs for the outer wrapper.
+		 *
+		 * When both title and description are provided, the wrapper uses
+		 * aria-labelledby and aria-describedby so the inner <title> and
+		 * <desc> elements carry the accessible name and description, and
+		 * the generated IDs are returned so the renderer can splice them
+		 * onto the matching <title>/<desc> elements.
+		 *
+		 * @param string $title       Optional accessible title.
+		 * @param string $description Optional accessible description.
+		 * @return array{attrs: array<string,string>, ids: array<string,string>}
+		 */
+		public static function accessibility_attributes( string $title, string $description ): array {
+			$title       = trim( $title );
+			$description = trim( $description );
+			$ids         = array();
+			if ( '' === $title && '' === $description ) {
+				return array(
+					'attrs' => array( 'role' => 'img' ),
+					'ids'   => $ids,
+				);
+			}
+			$attrs = array();
+			if ( '' !== $title && '' !== $description ) {
+				$title_id       = 'ssi-svg-title-' . substr( bin2hex( random_bytes( 4 ) ), 0, 8 );
+				$description_id = 'ssi-svg-desc-' . substr( bin2hex( random_bytes( 4 ) ), 0, 8 );
+				$ids            = array(
+					'title'       => $title_id,
+					'description' => $description_id,
+				);
+				$attrs['aria-labelledby']  = $title_id;
+				$attrs['aria-describedby'] = $description_id;
+			} elseif ( '' !== $title ) {
+				$attrs['aria-label'] = $title;
+			} else {
+				$attrs['aria-label'] = $description;
+			}
+			return array(
+				'attrs' => $attrs,
+				'ids'   => $ids,
+			);
+		}
+
+		/**
+		 * Load HTML into a DOMDocument with external entities disabled.
+		 *
+		 * @param string $markup Raw markup.
+		 * @return DOMDocument|null
+		 */
+		private static function load_document( string $markup ) {
+			if ( ! class_exists( 'DOMDocument' ) ) {
+				return null;
+			}
+			$previous = libxml_use_internal_errors( true );
+			$document = new DOMDocument( '1.0', 'UTF-8' );
+			$document->resolveExternals = false;
+			$document->validateOnParse  = false;
+			$loaded = $document->loadXML( '<?xml version="1.0" encoding="UTF-8"?><root>' . $markup . '</root>', LIBXML_NONET );
+			libxml_clear_errors();
+			libxml_use_internal_errors( $previous );
+			if ( ! $loaded || ! isset( $document->documentElement ) ) {
+				return null;
+			}
+			$root = $document->documentElement;
+			$svg  = null;
+			foreach ( $root->childNodes as $child ) {
+				if ( XML_ELEMENT_NODE === $child->nodeType && 'svg' === strtolower( $child->localName ) ) {
+					$svg = $child;
+					break;
+				}
+			}
+			if ( null === $svg ) {
+				return null;
+			}
+			$adopted = new DOMDocument( '1.0', 'UTF-8' );
+			$adopted->resolveExternals = false;
+			$adopted->validateOnParse  = false;
+			$imported = $adopted->importNode( $svg, true );
+			$adopted->appendChild( $imported );
+			return $adopted;
+		}
+
+		/**
+		 * Walk a subtree, stripping disallowed elements, attributes, and
+		 * unsafe URL/CSS values. Returns the set of local IDs discovered
+		 * so a final pass can drop any unreferenced defs.
+		 *
+		 * Recursion is bounded by MAX_PRUNE_DEPTH. Once the cap is hit,
+		 * deeper nodes are removed unconditionally so a pathological SVG
+		 * cannot blow the call stack.
+		 *
+		 * @param DOMNode $node   Current node.
+		 * @param array   $ids    Discovered ID map (lowercase id => true).
+		 * @param int     $depth  Current recursion depth.
+		 * @return array<string,bool>
+		 */
+		private static function prune_subtree( DOMNode $node, array $ids, int $depth = 0 ): array {
+			if ( XML_ELEMENT_NODE !== $node->nodeType ) {
+				return $ids;
+			}
+
+			if ( $depth >= self::MAX_PRUNE_DEPTH ) {
+				if ( null !== $node->parentNode ) {
+					$node->parentNode->removeChild( $node );
+				}
+				return $ids;
+			}
+
+			$local = strtolower( $node->localName );
+			if ( ! in_array( $local, self::$allowed_elements, true ) ) {
+				if ( null !== $node->parentNode ) {
+					$node->parentNode->removeChild( $node );
+				}
+				return $ids;
+			}
+
+			$id = $node->getAttribute( 'id' );
+			if ( '' !== $id ) {
+				$ids[ strtolower( $id ) ] = true;
+			}
+
+			self::prune_attributes( $node );
+
+			$children = array();
+			foreach ( $node->childNodes as $child ) {
+				$children[] = $child;
+			}
+			foreach ( $children as $child ) {
+				$ids = self::prune_subtree( $child, $ids, $depth + 1 );
+			}
+
+			return $ids;
+		}
+
+		/**
+		 * Strip disallowed and unsafe attributes from an element.
+		 *
+		 * @param DOMElement $element Element to mutate in place.
+		 */
+		private static function prune_attributes( DOMElement $element ): void {
+			$attributes = array();
+			foreach ( $element->attributes as $attribute ) {
+				$attributes[] = $attribute;
+			}
+			foreach ( $attributes as $attribute ) {
+				$name  = strtolower( $attribute->nodeName );
+				$value = (string) $attribute->nodeValue;
+
+				if ( str_starts_with( $name, 'on' ) ) {
+					$element->removeAttribute( $attribute->nodeName );
+					continue;
+				}
+				if ( ! in_array( $name, self::$allowed_attributes, true ) ) {
+					$element->removeAttribute( $attribute->nodeName );
+					continue;
+				}
+				if ( in_array( $name, self::$fragment_only_attributes, true ) ) {
+					$value = ltrim( $value );
+					if ( '' === $value || '#' !== $value[0] || ! self::is_safe_fragment( substr( $value, 1 ) ) ) {
+						if ( 'image' === strtolower( $element->localName ) && self::is_safe_data_image( $value ) ) {
+							continue;
+						}
+						$element->removeAttribute( $attribute->nodeName );
+					}
+					continue;
+				}
+				if ( 'style' === $name ) {
+					$cleaned = self::sanitize_style( $value );
+					if ( '' === $cleaned ) {
+						$element->removeAttribute( $attribute->nodeName );
+					} else {
+						$element->setAttribute( $attribute->nodeName, $cleaned );
+					}
+					continue;
+				}
+				if ( self::is_unsafe_url_value( $value ) ) {
+					$element->removeAttribute( $attribute->nodeName );
+				}
+			}
+		}
+
+		/**
+		 * Validate a local fragment identifier after the leading "#".
+		 *
+		 * @param string $fragment Fragment text without the leading "#".
+		 * @return bool
+		 */
+		private static function is_safe_fragment( string $fragment ): bool {
+			return (bool) preg_match( '/^[A-Za-z_][A-Za-z0-9_:\-\.]*$/', $fragment );
+		}
+
+		/**
+		 * Allow data: URLs that point to image MIME types only.
+		 *
+		 * Reject every other data: scheme so HTML/SVG/JS payloads cannot
+		 * be smuggled in via <image href="data:...">. The image element
+		 * is the only context where data: URIs survive.
+		 *
+		 * @param string $value Raw href value, leading whitespace stripped.
+		 * @return bool
+		 */
+		private static function is_safe_data_image( string $value ): bool {
+			$lower = strtolower( $value );
+			if ( ! str_starts_with( $lower, 'data:image/' ) ) {
+				return false;
+			}
+			return (bool) preg_match( '/^data:image\/(png|jpe?g|gif|webp|svg\+xml)(;base64)?,/', $lower );
+		}
+
+		/**
+		 * Reject attribute values that look like executable URLs.
+		 *
+		 * @param string $value Raw attribute value.
+		 * @return bool True when the value should be discarded.
+		 */
+		private static function is_unsafe_url_value( string $value ): bool {
+			$trimmed = ltrim( strtolower( $value ) );
+			if ( '' === $trimmed ) {
+				return false;
+			}
+			$unsafe_prefixes = array( 'javascript:', 'vbscript:', 'data:text/html', 'data:application/xhtml' );
+			foreach ( $unsafe_prefixes as $prefix ) {
+				if ( str_starts_with( $trimmed, $prefix ) ) {
+					return true;
+				}
+			}
+			if ( str_contains( $trimmed, 'expression(' ) || str_contains( $trimmed, 'behavior:' ) || str_contains( $trimmed, 'javascript:' ) ) {
+				return true;
+			}
+			return false;
+		}
+
+		/**
+		 * Sanitize a style attribute value.
+		 *
+		 * Drops declarations that reference unsafe URL schemes, CSS custom
+		 * properties, var(), or @import. Only fragment-only url() values
+		 * survive. Returns the cleaned declaration list or an empty string
+		 * when no declaration survives.
+		 *
+		 * @param string $style Raw style attribute value.
+		 * @return string
+		 */
+		private static function sanitize_style( string $style ): string {
+			$declarations = explode( ';', $style );
+			$kept         = array();
+			foreach ( $declarations as $declaration ) {
+				$declaration = trim( $declaration );
+				if ( '' === $declaration ) {
+					continue;
+				}
+				$colon = strpos( $declaration, ':' );
+				if ( false === $colon ) {
+					continue;
+				}
+				$property = strtolower( trim( substr( $declaration, 0, $colon ) ) );
+				$value    = trim( substr( $declaration, $colon + 1 ) );
+				if ( '' === $property || '' === $value ) {
+					continue;
+				}
+				if ( str_starts_with( $property, '--' ) ) {
+					continue;
+				}
+				if ( str_contains( $value, '@import' ) ) {
+					continue;
+				}
+				if ( self::is_unsafe_url_value( $value ) ) {
+					continue;
+				}
+				if ( preg_match_all( '/url\(\s*([\'"]?)([^)]*)\1\s*\)/i', $value, $url_matches ) ) {
+					$all_safe = true;
+					foreach ( $url_matches[2] as $reference ) {
+						$reference = trim( (string) $reference );
+						$first     = isset( $reference[0] ) ? $reference[0] : '';
+						if ( '#' !== $first || ! self::is_safe_fragment( substr( $reference, 1 ) ) ) {
+							$all_safe = false;
+							break;
+						}
+					}
+					if ( ! $all_safe ) {
+						continue;
+					}
+				}
+				$value_lower = strtolower( $value );
+				if ( str_contains( $value_lower, 'var(' )
+					|| str_contains( $value_lower, 'expression' )
+					|| str_contains( $value_lower, 'behavior' )
+				) {
+					continue;
+				}
+				$kept[] = $property . ':' . $value;
+			}
+			return implode( ';', $kept );
+		}
+
+		/**
+		 * Normalize a viewBox value.
+		 *
+		 * Accepts a four-number comma- or space-separated tuple only. Each
+		 * component is bounded to MAX_VIEWBOX_COMPONENT so absurd values
+		 * cannot exhaust renderer memory.
+		 *
+		 * @param string $value Raw value.
+		 * @return string
+		 */
+		private static function normalize_view_box( string $value ): string {
+			$value = trim( $value );
+			if ( '' === $value || ! preg_match( '/^[-+]?[\d\.]+(\s+|,)\s*[-+]?[\d\.]+(\s+|,)\s*[-+]?[\d\.]+(\s+|,)\s*[-+]?[\d\.]+\s*$/', $value ) ) {
+				return '';
+			}
+			$parts = preg_split( '/[\s,]+/', $value );
+			if ( ! is_array( $parts ) || 4 !== count( $parts ) ) {
+				return '';
+			}
+			foreach ( $parts as $component ) {
+				if ( ! is_numeric( $component ) ) {
+					return '';
+				}
+				$numeric = (float) $component;
+				if ( ! is_finite( $numeric ) || abs( $numeric ) > self::MAX_VIEWBOX_COMPONENT ) {
+					return '';
+				}
+			}
+			return implode( ' ', $parts );
+		}
+
+		/**
+		 * Normalize a preserveAspectRatio value.
+		 *
+		 * Allows only the canonical alignment+meet-or-slice pair, or a
+		 * "none" value. Anything else falls back to the default.
+		 *
+		 * @param string $value Raw value.
+		 * @return string
+		 */
+		private static function normalize_preserve_aspect_ratio( string $value ): string {
+			$value = trim( $value );
+			if ( '' === $value ) {
+				return '';
+			}
+			$valid_alignments = array( 'none', 'xMinYMin', 'xMidYMin', 'xMaxYMin', 'xMinYMid', 'xMidYMid', 'xMaxYMid', 'xMinYMax', 'xMidYMax', 'xMaxYMax' );
+			$valid_meet       = array( 'meet', 'slice' );
+			$parts            = preg_split( '/\s+/', $value );
+			if ( ! is_array( $parts ) || 1 === count( $parts ) ) {
+				if ( in_array( $parts[0] ?? '', $valid_alignments, true ) ) {
+					return $parts[0];
+				}
+				return '';
+			}
+			if ( 2 !== count( $parts ) ) {
+				return '';
+			}
+			if ( ! in_array( $parts[0], $valid_alignments, true ) || ! in_array( $parts[1], $valid_meet, true ) ) {
+				return '';
+			}
+			return $parts[0] . ' ' . $parts[1];
+		}
+
+		/**
+		 * Check whether the root <svg> still has any drawable descendant.
+		 *
+		 * @param DOMElement $root Root <svg> element.
+		 * @return bool
+		 */
+		private static function root_has_drawable_content( DOMElement $root ): bool {
+			$drawable = array( 'path', 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon', 'text', 'use', 'g', 'image' );
+			$stack    = array( $root );
+			while ( $stack ) {
+				$node   = array_pop( $stack );
+				$local  = strtolower( $node->localName );
+				if ( in_array( $local, $drawable, true ) ) {
+					if ( 'g' === $local ) {
+						foreach ( $node->childNodes as $child ) {
+							$stack[] = $child;
+						}
+						continue;
+					}
+					return true;
+				}
+				if ( 'svg' === $local ) {
+					foreach ( $node->childNodes as $child ) {
+						$stack[] = $child;
+					}
+				}
+			}
+			return false;
+		}
+
+		/**
+		 * Serialize the sanitized document to a clean SVG string.
+		 *
+		 * @param DOMDocument $document Document.
+		 * @param DOMElement  $root     Root <svg> element.
+		 * @return string
+		 */
+		private static function serialize_root( DOMDocument $document, DOMElement $root ): string {
+			$root->setAttribute( 'xmlns', 'http://www.w3.org/2000/svg' );
+			$xml = $document->saveXML( $root );
+			if ( false === $xml ) {
+				return '';
+			}
+			return $xml;
+		}
+	}
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -58,6 +58,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-co
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-site-collector.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-url-import-runtime.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-companion-plugin.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-svg-artwork.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-plugin-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-entity-materializer-registry.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-asset-reporter.php';

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -35,6 +35,7 @@
     { "path": "tests/smoke-provider-presentation.php", "environment": "standalone-php" },
     { "path": "tests/smoke-safe-html-fallback-reducer.php", "environment": "standalone-php" },
     { "path": "tests/smoke-site-identity.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-svg-artwork.php", "environment": "standalone-php" },
     { "path": "tests/smoke-template-chrome-dedupe.php", "environment": "standalone-php" },
     { "path": "tests/smoke-template-part-shell-dedupe.php", "environment": "standalone-php" },
     { "path": "tests/smoke-url-import-runtime.php", "environment": "standalone-php" },

--- a/tests/fixtures/fixture-matrix/inline-svg-filter-gradient-site/fixture.json
+++ b/tests/fixtures/fixture-matrix/inline-svg-filter-gradient-site/fixture.json
@@ -1,0 +1,11 @@
+{
+  "fixture_class": "marketing/static",
+  "tags": ["svg", "static", "inline-graphics"],
+  "capabilities": ["static-html", "local-css", "inline-svg-defs"],
+  "risk_profile": "low",
+  "complexity": 1,
+  "quality_budgets": {
+    "max_unacceptable_findings": 0,
+    "visual_mismatch_ratio": 0.1
+  }
+}

--- a/tests/fixtures/fixture-matrix/inline-svg-filter-gradient-site/index.html
+++ b/tests/fixtures/fixture-matrix/inline-svg-filter-gradient-site/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Inline SVG Filter Gradient Fixture</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="site-shell">
+    <h1>Inline SVG Filter + Gradient</h1>
+    <svg class="brand-mark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Brand mark">
+      <defs>
+        <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#88c"/>
+          <stop offset="1" stop-color="#224"/>
+        </linearGradient>
+        <filter id="f" x="-10%" y="-10%" width="120%" height="120%">
+          <feGaussianBlur stdDeviation="2"/>
+        </filter>
+        <clipPath id="c">
+          <rect width="60" height="60" x="20" y="20"/>
+        </clipPath>
+      </defs>
+      <g clip-path="url(#c)" filter="url(#f)">
+        <rect width="100" height="100" fill="url(#g)"/>
+        <circle cx="50" cy="50" r="20" fill="#fff"/>
+      </g>
+    </svg>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/fixture-matrix/inline-svg-filter-gradient-site/style.css
+++ b/tests/fixtures/fixture-matrix/inline-svg-filter-gradient-site/style.css
@@ -1,0 +1,2 @@
+body { font-family: sans-serif; }
+.brand-mark { width: 200px; height: 200px; }

--- a/tests/fixtures/fixture-matrix/inline-svg-mask-symbol-site/fixture.json
+++ b/tests/fixtures/fixture-matrix/inline-svg-mask-symbol-site/fixture.json
@@ -1,0 +1,11 @@
+{
+  "fixture_class": "marketing/static",
+  "tags": ["svg", "static", "inline-graphics"],
+  "capabilities": ["static-html", "local-css", "inline-svg-defs"],
+  "risk_profile": "low",
+  "complexity": 1,
+  "quality_budgets": {
+    "max_unacceptable_findings": 0,
+    "visual_mismatch_ratio": 0.1
+  }
+}

--- a/tests/fixtures/fixture-matrix/inline-svg-mask-symbol-site/index.html
+++ b/tests/fixtures/fixture-matrix/inline-svg-mask-symbol-site/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Inline SVG Mask Symbol Fixture</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="site-shell">
+    <h1>Inline SVG Mask + Symbol</h1>
+    <svg class="badge" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Badge">
+      <defs>
+        <mask id="m">
+          <rect width="100" height="100" fill="white"/>
+          <circle cx="50" cy="50" r="25" fill="black"/>
+        </mask>
+        <radialGradient id="r" cx="50%" cy="50%" r="50%">
+          <stop offset="0" stop-color="#fc6"/>
+          <stop offset="1" stop-color="#c40"/>
+        </radialGradient>
+        <symbol id="dot" viewBox="0 0 10 10">
+          <circle cx="5" cy="5" r="4"/>
+        </symbol>
+      </defs>
+      <g mask="url(#m)">
+        <rect width="100" height="100" fill="url(#r)"/>
+      </g>
+      <use href="#dot" x="10" y="10" fill="#224"/>
+    </svg>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/fixture-matrix/inline-svg-mask-symbol-site/style.css
+++ b/tests/fixtures/fixture-matrix/inline-svg-mask-symbol-site/style.css
@@ -1,0 +1,2 @@
+body { font-family: sans-serif; }
+.badge { width: 200px; height: 200px; }

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -423,6 +423,64 @@ if ( is_array( $descriptor ) ) {
 	$assert( is_array( $mu_plan ) && false === $mu_plan['activate'], 'install-plan-mu-no-activation' );
 }
 
+// svg-artwork render_kind: validates, preserves canonical name, emits a
+// trusted render.php that does not embed producer-supplied source.
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-svg-artwork.php';
+$svg_payload = array(
+	'schema'    => Static_Site_Importer_Companion_Plugin::PAYLOAD_SCHEMA,
+	'site_slug' => 'svg-fixture-site',
+	'site_name' => 'SVG Fixture',
+	'blocks'    => array(
+		array(
+			'name'        => 'svg-artwork',
+			'render_kind' => 'svg-artwork',
+			'block_json'  => array(
+				'name'        => 'ssi/svg-artwork',
+				'title'       => 'SVG Artwork',
+				'category'    => 'media',
+				'description' => 'Editable inline SVG artwork whose DOM graph cannot be represented by core/image.',
+				'attributes'  => array(
+					'svg'                  => array( 'type' => 'string', 'default' => '' ),
+					'viewBox'              => array( 'type' => 'string', 'default' => '' ),
+					'title'                => array( 'type' => 'string', 'default' => '' ),
+					'description'          => array( 'type' => 'string', 'default' => '' ),
+					'preserveAspectRatio'  => array( 'type' => 'string', 'default' => '' ),
+					'sourceSelector'       => array( 'type' => 'string', 'default' => '' ),
+				),
+				'supports'    => array( 'html' => false ),
+			),
+		),
+	),
+);
+$assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $svg_payload ), 'svg-artwork-payload-validates' );
+
+$missing_svg_attr = $svg_payload;
+unset( $missing_svg_attr['blocks'][0]['block_json']['attributes']['svg'] );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $missing_svg_attr ) ), 'svg-artwork-requires-svg-attribute' );
+
+$non_string_svg = $svg_payload;
+$non_string_svg['blocks'][0]['block_json']['attributes']['svg']['type'] = 'object';
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $non_string_svg ) ), 'svg-artwork-svg-attribute-must-be-string' );
+
+$unknown_kind = $svg_payload;
+$unknown_kind['blocks'][0]['render_kind'] = 'totally-bogus';
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $unknown_kind ) ), 'unknown-render-kind-rejected' );
+
+$svg_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $svg_payload );
+$assert( is_array( $svg_descriptor ), 'svg-artwork-scaffold-returns-descriptor' );
+if ( is_array( $svg_descriptor ) ) {
+	$svg_files       = $svg_descriptor['files'];
+	$svg_render      = $svg_files['ssi-svg-fixture-site/blocks/svg-artwork/render.php'] ?? '';
+	$svg_block_json  = $svg_files['ssi-svg-fixture-site/blocks/svg-artwork/block.json'] ?? '';
+	$assert( array( 'ssi/svg-artwork' ) === $svg_descriptor['block_names'], 'svg-artwork-canonical-name-preserved' );
+	$assert( '' !== $svg_render, 'svg-artwork-render-php-emitted' );
+	$assert( str_contains( $svg_render, 'Static_Site_Importer_Svg_Artwork::sanitize' ), 'svg-artwork-render-uses-trusted-sanitizer' );
+	$assert( str_contains( $svg_render, 'get_block_wrapper_attributes' ), 'svg-artwork-render-emits-wrapper-attributes' );
+	$assert( ! str_contains( $svg_render, "php_single_quote" ), 'svg-artwork-render-is-not-static-literal' );
+	$assert( str_contains( $svg_block_json, '"name": "ssi/svg-artwork"' ), 'svg-artwork-block-json-records-canonical-name' );
+	$assert( str_contains( $svg_block_json, '"render": "file:./render.php"' ), 'svg-artwork-block-json-records-render-target' );
+}
+
 // 3. Full install/activate path writes the file set and activates it.
 $report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $payload );
 $assert( 'installed_activated' === ( $report['status'] ?? '' ), 'install-status-installed-activated', (string) ( $report['status'] ?? '' ) );

--- a/tests/smoke-svg-artwork.php
+++ b/tests/smoke-svg-artwork.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Smoke coverage for the svg-artwork sanitizer.
+ *
+ * Run from the repository root:
+ * php tests/smoke-svg-artwork.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+foreach (
+	array(
+		'esc_attr' => static fn( string $value ): string => htmlspecialchars( $value, ENT_QUOTES ),
+	) as $function => $implementation
+) {
+	if ( ! function_exists( $function ) ) {
+		eval( 'function ' . $function . '( $value ) { return htmlspecialchars( $value, ENT_QUOTES ); }' );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-svg-artwork.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$harness = new class {
+	public function assert_class_exists(): void {
+		$GLOBALS['ssi_assert'][] = array( 'class_exists', class_exists( 'Static_Site_Importer_Svg_Artwork' ) );
+	}
+	public function sanitize_preserves_complex_dom(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#88c"/><stop offset="1" stop-color="#224"/></linearGradient><clipPath id="c"><rect width="50" height="50"/></clipPath><mask id="m"><rect width="100" height="100" fill="white"/><circle cx="50" cy="50" r="20" fill="black"/></mask><filter id="f"><feGaussianBlur stdDeviation="2"/></filter><symbol id="s" viewBox="0 0 10 10"><circle cx="5" cy="5" r="3"/></symbol></defs><g clip-path="url(#c)" mask="url(#m)" filter="url(#f)"><rect width="100" height="100" fill="url(#g)"/><use href="#s" x="0" y="0"/></g><title>Test</title><desc>Test desc</desc></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::sanitize( $svg );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-linearGradient', str_contains( $out, '<linearGradient' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-clipPath', str_contains( $out, '<clipPath' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-mask', str_contains( $out, '<mask' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-filter', str_contains( $out, '<filter' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-feGaussianBlur', str_contains( $out, '<feGaussianBlur' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-symbol', str_contains( $out, '<symbol' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-local-use', str_contains( $out, 'href="#s"' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-title', str_contains( $out, '<title' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-desc', str_contains( $out, '<desc' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-viewBox', str_contains( $out, 'viewBox="0 0 100 100"' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-camelCase', str_contains( $out, 'viewBox=' ) );
+	}
+	public function sanitize_strips_unsafe(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" onload="alert(1)"><script>alert(1)</script><style>body{background:url("javascript:alert(1)")}</style><foreignObject width="10" height="10"><div onmouseover="bad()">x</div></foreignObject><rect width="10" height="10" fill="#000" onclick="bad()" href="javascript:bad()" xlink:href="https://evil.example/"/></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::sanitize( $svg );
+		$GLOBALS['ssi_assert'][] = array( 'strips-script', ! str_contains( $out, '<script' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-style', ! str_contains( $out, '<style' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-foreignObject', ! str_contains( $out, '<foreignObject' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-onload', ! str_contains( $out, 'onload' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-onclick', ! str_contains( $out, 'onclick' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-onmouseover', ! str_contains( $out, 'onmouseover' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-javascript-href', ! str_contains( $out, 'javascript:' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-external-href', ! str_contains( $out, 'evil.example' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-drawable-rect', str_contains( $out, '<rect' ) );
+	}
+	public function sanitize_strips_animation(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="red"><animate attributeName="fill" from="red" to="blue"/></rect><animateTransform attributeName="transform" type="rotate" from="0" to="360"/></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::sanitize( $svg );
+		$GLOBALS['ssi_assert'][] = array( 'strips-animate', ! str_contains( $out, '<animate' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-animateTransform', ! str_contains( $out, '<animateTransform' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-rect', str_contains( $out, '<rect' ) );
+	}
+	public function sanitize_rejects_unsafe_only(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><script>bad()</script></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::sanitize( $svg );
+		$GLOBALS['ssi_assert'][] = array( 'rejects-unsafe-only', '' === $out );
+	}
+	public function sanitize_rejects_malformed(): void {
+		$out = Static_Site_Importer_Svg_Artwork::sanitize( 'not svg at all' );
+		$GLOBALS['ssi_assert'][] = array( 'rejects-malformed', '' === $out );
+	}
+	public function sanitize_rejects_oversize(): void {
+		$oversize = str_repeat( 'a', Static_Site_Importer_Svg_Artwork::MAX_INPUT_BYTES + 1 );
+		$out      = Static_Site_Importer_Svg_Artwork::sanitize( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>' . $oversize );
+		$GLOBALS['ssi_assert'][] = array( 'rejects-oversize', '' === $out );
+	}
+	public function view_box_uses_typed_attribute(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::view_box( $svg, '0 0 50 50' );
+		$GLOBALS['ssi_assert'][] = array( 'typed-viewBox', '0 0 50 50' === $out );
+	}
+	public function view_box_falls_back_to_root(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><rect width="12" height="12"/></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::view_box( $svg, '' );
+		$GLOBALS['ssi_assert'][] = array( 'root-viewBox', '0 0 12 12' === $out );
+	}
+	public function view_box_rejects_invalid(): void {
+		$out = Static_Site_Importer_Svg_Artwork::view_box( '', 'not a box' );
+		$GLOBALS['ssi_assert'][] = array( 'invalid-viewBox', '' === $out );
+	}
+	public function preserve_aspect_default(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::preserve_aspect_ratio( $svg, '' );
+		$GLOBALS['ssi_assert'][] = array( 'par-default', 'xMidYMid meet' === $out );
+	}
+	public function preserve_aspect_typed(): void {
+		$out = Static_Site_Importer_Svg_Artwork::preserve_aspect_ratio( '<svg/>', 'xMaxYMin slice' );
+		$GLOBALS['ssi_assert'][] = array( 'par-typed', 'xMaxYMin slice' === $out );
+	}
+	public function preserve_aspect_rejects(): void {
+		$out = Static_Site_Importer_Svg_Artwork::preserve_aspect_ratio( '<svg/>', 'unknown value' );
+		$GLOBALS['ssi_assert'][] = array( 'par-rejects-invalid', 'xMidYMid meet' === $out );
+	}
+	public function accessibility_label_only(): void {
+		$result = Static_Site_Importer_Svg_Artwork::accessibility_attributes( 'Title', '' );
+		$GLOBALS['ssi_assert'][] = array( 'a11y-label', ( $result['attrs']['aria-label'] ?? '' ) === 'Title' );
+		$GLOBALS['ssi_assert'][] = array( 'a11y-label-no-ids', empty( $result['ids'] ) );
+	}
+	public function accessibility_title_and_description(): void {
+		$result = Static_Site_Importer_Svg_Artwork::accessibility_attributes( 'T', 'D' );
+		$GLOBALS['ssi_assert'][] = array( 'a11y-labelledby', '' !== ( $result['attrs']['aria-labelledby'] ?? '' ) );
+		$GLOBALS['ssi_assert'][] = array( 'a11y-describedby', '' !== ( $result['attrs']['aria-describedby'] ?? '' ) );
+		$GLOBALS['ssi_assert'][] = array( 'a11y-title-id', isset( $result['ids']['title'] ) );
+		$GLOBALS['ssi_assert'][] = array( 'a11y-desc-id', isset( $result['ids']['description'] ) );
+		$GLOBALS['ssi_assert'][] = array( 'a11y-no-aria-label', ! isset( $result['attrs']['aria-label'] ) );
+	}
+	public function accessibility_empty(): void {
+		$result = Static_Site_Importer_Svg_Artwork::accessibility_attributes( '', '' );
+		$GLOBALS['ssi_assert'][] = array( 'a11y-empty', ( $result['attrs']['role'] ?? '' ) === 'img' && ! isset( $result['attrs']['aria-label'] ) );
+	}
+	public function sanitize_strips_extra_animation(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="red"><set attributeName="fill" to="blue"/><animateMotion path="M0,0 L10,10"/><animateColor attributeName="fill" from="red" to="blue"/><mpath href="#x"/></rect><circle cx="5" cy="5" r="3"><animate attributeName="r" values="1;5;1"/></circle></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::sanitize( $svg );
+		$GLOBALS['ssi_assert'][] = array( 'strips-set', ! str_contains( $out, '<set' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-animateMotion', ! str_contains( $out, '<animateMotion' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-animateColor', ! str_contains( $out, '<animateColor' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-mpath', ! str_contains( $out, '<mpath' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-animate-extra', ! str_contains( $out, '<animate' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-rect-extra', str_contains( $out, '<rect' ) );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-circle-extra', str_contains( $out, '<circle' ) );
+	}
+	public function sanitize_rejects_vbscript_href(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><a href="vbscript:bad()"><rect width="10" height="10"/></a></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::sanitize( $svg );
+		$GLOBALS['ssi_assert'][] = array( 'strips-vbscript', ! str_contains( $out, 'vbscript' ) );
+	}
+	public function sanitize_allows_data_image_href(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><image width="10" height="10" href="data:image/png;base64,iVBORw0KGgo="/></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::sanitize( $svg );
+		$GLOBALS['ssi_assert'][] = array( 'preserves-data-image', str_contains( $out, 'data:image/png' ) );
+	}
+	public function sanitize_rejects_data_html_href(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><a href="data:text/html,<script>alert(1)</script>"><rect width="10" height="10"/></a></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::sanitize( $svg );
+		$GLOBALS['ssi_assert'][] = array( 'rejects-data-html', ! str_contains( $out, 'data:text/html' ) );
+	}
+	public function sanitize_strips_style_custom_property(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" style="--x:url(javascript:bad()); fill:url(#g); color:red"/></svg>';
+		$out = Static_Site_Importer_Svg_Artwork::sanitize( $svg );
+		$GLOBALS['ssi_assert'][] = array( 'strips-custom-prop', ! str_contains( $out, '--x' ) );
+		$GLOBALS['ssi_assert'][] = array( 'strips-js-in-style', ! str_contains( $out, 'javascript' ) );
+	}
+	public function sanitize_strips_bom(): void {
+		$svg   = "\xEF\xBB\xBF<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\"><rect width=\"10\" height=\"10\"/></svg>";
+		$out   = Static_Site_Importer_Svg_Artwork::sanitize( $svg );
+		$GLOBALS['ssi_assert'][] = array( 'bom-preserves-rect', str_contains( $out, '<rect' ) );
+	}
+	public function view_box_rejects_oversize_component(): void {
+		$out = Static_Site_Importer_Svg_Artwork::view_box( '', '0 0 1000001 1000001' );
+		$GLOBALS['ssi_assert'][] = array( 'viewBox-oversize-rejected', '' === $out );
+	}
+	public function view_box_accepts_max_component(): void {
+		$out = Static_Site_Importer_Svg_Artwork::view_box( '', '0 0 1000000 1000000' );
+		$GLOBALS['ssi_assert'][] = array( 'viewBox-max-accepted', '0 0 1000000 1000000' === $out );
+	}
+	public function run(): void {
+		$this->assert_class_exists();
+		$this->sanitize_preserves_complex_dom();
+		$this->sanitize_strips_unsafe();
+		$this->sanitize_strips_animation();
+		$this->sanitize_rejects_unsafe_only();
+		$this->sanitize_rejects_malformed();
+		$this->sanitize_rejects_oversize();
+		$this->view_box_uses_typed_attribute();
+		$this->view_box_falls_back_to_root();
+		$this->view_box_rejects_invalid();
+		$this->preserve_aspect_default();
+		$this->preserve_aspect_typed();
+		$this->preserve_aspect_rejects();
+		$this->accessibility_label_only();
+		$this->accessibility_title_and_description();
+		$this->accessibility_empty();
+		$this->sanitize_strips_extra_animation();
+		$this->sanitize_rejects_vbscript_href();
+		$this->sanitize_allows_data_image_href();
+		$this->sanitize_rejects_data_html_href();
+		$this->sanitize_strips_style_custom_property();
+		$this->sanitize_strips_bom();
+		$this->view_box_rejects_oversize_component();
+		$this->view_box_accepts_max_component();
+	}
+};
+
+$GLOBALS['ssi_assert'] = array();
+$harness->run();
+
+foreach ( $GLOBALS['ssi_assert'] as $check ) {
+	$assert( (bool) $check[1], $check[0] );
+}
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'PASS smoke-svg-artwork.php (' . $assertions . " assertions)\n";

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -501,6 +501,44 @@ test('gutenberg incompatibility registry attributes nested svg to the outer fall
   assert.equal(byKey['inline-svg-filter-gradient'].fixtures[0], 'coffee');
 });
 
+test('gutenberg incompatibility registry promotes two inline-svg fixtures to a custom block candidate', () => {
+  const registry = buildGutenbergIncompatibilityRegistry({
+    matrix_id: 'inline-svg-fixture-promotion',
+    fixtures: [
+      { fixture_id: 'inline-svg-filter-gradient-site' },
+      { fixture_id: 'inline-svg-mask-symbol-site' },
+    ],
+    findings: [
+      {
+        fixture_id: 'inline-svg-filter-gradient-site',
+        kind: 'unsupported_html_fallback',
+        observed_block_name: 'core/html',
+        reason_code: 'html_inline_svg_fallback',
+        pattern_family: 'inline_svg',
+        selector: '.brand-mark',
+        source_snippet: '<svg><defs><linearGradient id="g"></linearGradient><filter id="f"><feGaussianBlur stdDeviation="2"/></filter><clipPath id="c"><rect width="60" height="60"/></clipPath></defs></svg>',
+      },
+      {
+        fixture_id: 'inline-svg-mask-symbol-site',
+        kind: 'unsupported_html_fallback',
+        observed_block_name: 'core/html',
+        reason_code: 'html_inline_svg_fallback',
+        pattern_family: 'inline_svg',
+        selector: '.badge',
+        source_snippet: '<svg><defs><mask id="m"><rect width="100" height="100" fill="white"/><circle cx="50" cy="50" r="25" fill="black"/></mask><symbol id="dot" viewBox="0 0 10 10"><circle cx="5" cy="5" r="4"/></symbol></defs></svg>',
+      },
+    ],
+  });
+  const byKey = Object.fromEntries(registry.patterns.map((row) => [row.pattern_key, row]));
+
+  assert.equal(byKey['inline-svg-filter-gradient'].fixture_count, 2);
+  assert.equal(byKey['inline-svg-filter-gradient'].classification, 'custom-block-candidate');
+  assert.deepEqual(byKey['inline-svg-filter-gradient'].fixtures, [
+    'inline-svg-filter-gradient-site',
+    'inline-svg-mask-symbol-site',
+  ]);
+});
+
 test('gutenberg incompatibility registry ranks tracked custom-block candidates before visual-only evidence', () => {
   const registry = buildGutenbergIncompatibilityRegistry({
     matrix_id: 'tracked-candidate-ranking',


### PR DESCRIPTION
## Summary

Add a typed `ssi/<site>/svg-artwork` companion block for inline SVG graphs that cannot be represented by `core/image` because they depend on inline `defs`, gradients, filters, masks, symbols, clip paths, ID references, or document-context styling. These currently fall back to `core/html`; this gives them a safe, typed home.

The producer emits a canonical block definition and typed attributes in `source_reports.companion_plugin_payload`; SSI materializes it through the existing companion-plugin scaffolder using a trusted renderer kind, so no arbitrary PHP from payload data is accepted.

Fixes #733

## Changes

### New SVG sanitizer (`includes/class-static-site-importer-svg-artwork.php`)

**Before:** irreducible SVG fell back to `core/html` with no sanitization path.

**After:**
```php
// Allow-list of passive elements/attributes; strips script, style, event
// handlers, external URLs, javascript: and CSS-executable references;
// retains local #id references and defs.
```

**Why:** passive allow-list parsing plus stripping of unsafe elements and URL references keeps the SVG safe to render server-side while preserving gradients, masks, filters, symbols, clip paths, and local ID paint.

### Companion scaffolder (`includes/class-static-site-importer-companion-plugin.php`)

Adds a trusted `svg-artwork` render template that calls the sanitizer, applies `get_block_wrapper_attributes()`, and re-injects a validated `viewBox`/`preserveAspectRatio` plus accessibility attributes. `render_kind` dispatch stays restricted to the trusted kind; arbitrary PHP is not accepted.

**Why:** the existing generic scaffolder gains an SVG renderer without broadening arbitrary PHP acceptance.

### Fixture evidence

- `tests/smoke-svg-artwork.php` (56 assertions): unsafe stipping, animation removal, data-image policy, viewBox bounds, accessibility shapes.
- `tests/smoke-companion-plugin.php`: canonical block metadata, typed attributes, trusted renderer generation, rejection of arbitrary PHP, generated plugin registration.
- Two fixture-matrix sites (`inline-svg-filter-gradient-site`, `inline-svg-mask-symbol-site`) with registry promotion out of `core/html`.

## Testing

**Test 1: Sanitizer smoke**
1. `php tests/smoke-svg-artwork.php`
2. `php tests/smoke-companion-plugin.php`
Result: `PASS smoke-svg-artwork.php (56 assertions)` and `OK: companion plugin smoke passed (111 assertions)`

**Test 2: Companion lanes**
1. `npm run test:companion-plugin`
Result: content-only policy, companion plugin, and JS consumption smokes all pass

**Test 3: Fixture matrix**
1. `node --test tools/fixture-matrix.test.mjs`
Result: registry promotes the two inline-svg fixtures to a custom block candidate; companion materialization asserted instead of `core/html` fallback