### PR TITLE
fix: dedupe leading semantic nav group when header template part exists (#645)

### DIFF
--- a/includes/class-static-site-importer-page-materializer.php
+++ b/includes/class-static-site-importer-page-materializer.php
@@ -754,7 +754,7 @@ class Static_Site_Importer_Page_Materializer {
 			return true;
 		}
 
-		if ( 'header' === $part && 'core/navigation' === $name ) {
+		if ( 'header' === $part && ( 'core/navigation' === $name || 'nav' === $tag ) ) {
 			return true;
 		}
 

--- a/tests/smoke-template-chrome-dedupe.php
+++ b/tests/smoke-template-chrome-dedupe.php
@@ -104,6 +104,78 @@ $chrome_markup = implode(
 	)
 );
 
+$nav_group_markup = implode(
+	'',
+	array(
+		'<!-- wp:group {"tagName":"nav","className":"site-nav"} --><nav class="wp-block-group site-nav"><!-- wp:navigation-link {"label":"Product","url":"#product"} /--></nav><!-- /wp:group -->',
+		'<!-- wp:group {"className":"hero"} --><div class="wp-block-group hero"><!-- wp:heading {"level":1} --><h1 class="wp-block-heading">Every launch.</h1><!-- /wp:heading --></div><!-- /wp:group -->',
+	)
+);
+
+$nav_group_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'nav-lead.html',
+		'title'        => 'Nav Lead',
+		'slug'         => 'nav-lead',
+		'block_markup' => $nav_group_markup,
+	)
+);
+
+$assert( ! is_wp_error( $nav_group_page ), 'nav-group-page-created', is_wp_error( $nav_group_page ) ? $nav_group_page->get_error_message() : '' );
+
+if ( ! is_wp_error( $nav_group_page ) ) {
+	$nav_without_template_parts = Static_Site_Importer_Page_Materializer::page_artifacts( array( 'nav-lead.html' => $nav_group_page ), 'relay-atlas' );
+	$assert( str_contains( $nav_without_template_parts['contents']['nav-lead.html'], 'tagName":"nav' ), 'keeps-leading-nav-group-without-template-part' );
+
+	$nav_with_template_parts = Static_Site_Importer_Page_Materializer::page_artifacts(
+		array( 'nav-lead.html' => $nav_group_page ),
+		'relay-atlas',
+		array(),
+		array(),
+		array(),
+		array(
+			'strip_template_header' => true,
+			'strip_template_footer' => true,
+		)
+	);
+
+	$nav_content = $nav_with_template_parts['contents']['nav-lead.html'];
+	$assert( ! str_contains( $nav_content, 'tagName":"nav' ), 'strips-leading-nav-group-when-template-part-exists' );
+	$assert( str_contains( $nav_content, 'Every launch.' ), 'keeps-page-body-content-after-nav-strip' );
+}
+
+$non_leading_nav_markup = implode(
+	'',
+	array(
+		'<!-- wp:group {"className":"hero"} --><div class="wp-block-group hero"><!-- wp:group {"tagName":"nav","className":"local-nav"} --><nav class="wp-block-group local-nav"><!-- wp:navigation-link {"label":"Section","url":"#section"} /--></nav><!-- /wp:group --><!-- wp:heading {"level":1} --><h1 class="wp-block-heading">Local nav.</h1><!-- /wp:heading --></div><!-- /wp:group -->',
+	)
+);
+
+$non_leading_nav_page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
+	array(
+		'source_path'  => 'nav-local.html',
+		'title'        => 'Nav Local',
+		'slug'         => 'nav-local',
+		'block_markup' => $non_leading_nav_markup,
+	)
+);
+
+$assert( ! is_wp_error( $non_leading_nav_page ), 'non-leading-nav-page-created', is_wp_error( $non_leading_nav_page ) ? $non_leading_nav_page->get_error_message() : '' );
+
+if ( ! is_wp_error( $non_leading_nav_page ) ) {
+	$non_leading_stripped = Static_Site_Importer_Page_Materializer::page_artifacts(
+		array( 'nav-local.html' => $non_leading_nav_page ),
+		'relay-atlas',
+		array(),
+		array(),
+		array(),
+		array(
+			'strip_template_header' => true,
+		)
+	);
+	$assert( str_contains( $non_leading_stripped['contents']['nav-local.html'], 'tagName":"nav' ), 'keeps-non-leading-nav-group-as-page-content' );
+}
+
 $page = Static_Site_Importer_Source_Page::from_materialization_plan_page(
 	array(
 		'source_path'  => 'index.html',


### PR DESCRIPTION
## Summary

A generated theme with a header template part could render duplicate global navigation when the page body began with a `core/group` block using `tagName: "nav"`. The header-chrome predicate recognized `tagName: "header"`, `core/navigation`, and header-like classes, but not a bare `nav` tag, so the leading nav group survived and overlapped the generated header template part.

Fixes #645

## Changes

### includes/class-static-site-importer-page-materializer.php
**Before:**
```php
if ( 'header' === $part && 'core/navigation' === $name ) {
    return true;
}
```
**After:**
```php
if ( 'header' === $part && ( 'core/navigation' === $name || 'nav' === $tag ) ) {
    return true;
}
```
**Why:** A leading semantic `nav` group is now treated as header chrome, mirroring the existing `core/navigation` branch. The strip loop is already leading-only, so nav groups deeper in content are untouched. The footer path is unaffected because this is gated by `'header' === $part`.

### tests/smoke-template-chrome-dedupe.php
Added coverage for the three contract cases against a leading `tagName: "nav"` group:
- stripped when a header template part exists,
- retained when no template part exists,
- a non-leading nav group nested in the body stays as page content.

## Testing
1. Ran `php tests/smoke-template-chrome-dedupe.php` -> 14 assertions pass.
2. Ran `npm test` -> 54 tests pass, 0 failures.
3. Ran `npm run test:inventory` -> manifest integrity clean.

Result: duplicate top-level nav no longer renders; local nav deeper in content is preserved.

## Screenshots
No UI changed; behavior-only fix, reported via the leading-only boundary contract.