### PR TITLE
Fix secondary editor surface materialization targets

### DIFF
--- a/lib/fixture-matrix/steps/editor-open-step.mjs
+++ b/lib/fixture-matrix/steps/editor-open-step.mjs
@@ -52,6 +52,8 @@ export function editorOpenStep(input = {}) {
     metadata: fixtureStepMetadata(fixture, 'editor-open', {
       artifact_prefix: artifactPrefix,
       ...(surface?.id ? { surface_id: surface.id } : {}),
+      ...(surface?.source_entry ? { source_entry: surface.source_entry } : {}),
+      ...(surface?.target ? { route: surface.target } : {}),
       ...(postId !== undefined ? { post_id: postId } : {}),
       ...(postSlug !== undefined ? { post_type: postType, post_slug: postSlug } : {}),
       ...(url !== undefined ? { url } : {}),

--- a/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -50,6 +50,8 @@ export function editorBlockValidationStep(input = {}) {
     args,
     metadata: fixtureStepMetadata(fixture, 'editor', {
       ...(surface?.id ? { surface_id: surface.id } : {}),
+      ...(surface?.source_entry ? { source_entry: surface.source_entry } : {}),
+      ...(surface?.target ? { route: surface.target } : {}),
       ...(postId !== undefined ? { post_id: postId } : {}),
       ...(postSlug !== undefined ? { post_type: postType, post_slug: postSlug } : {}),
       ...(url !== undefined ? { url } : {}),

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -384,6 +384,7 @@ function fixtureWorkflowSteps(options) {
     ...(input.svgFontEvidence || input.svg_font_evidence ? [svgFontEvidenceStep(fixture)] : []),
     woocommerceOnboardingSuppressionStep(fixture),
     ...surfaces.flatMap((surface, index) => [
+      materializedSurfaceIdentityStep(fixture, editorSurface(surface)),
       ...(editorOpenEnabled ? [editorOpenStep({
         fixture,
         surface: editorSurface(surface),
@@ -507,8 +508,49 @@ function editorSurface(surface) {
   if (surface.id === 'front-page') {
     return surface;
   }
-  const postSlug = String(surface.target || '').split('/').filter(Boolean).join('-');
+  const postSlug = String(surface.target || '').split('/').filter(Boolean).join('/');
   return { ...surface, post_type: 'page', post_slug: postSlug };
+}
+
+// Resolve the exact post immediately after import. The editor commands retain a
+// portable path target, while this receipt supplies the materialized post ID and
+// prevents an unavailable secondary surface from falling through to another page.
+function materializedSurfaceIdentityStep(fixture, surface) {
+  const sourceEntry = String(surface.source_entry || '');
+  const route = String(surface.target || '');
+  const postType = String(surface.post_type || 'page');
+  const postSlug = String(surface.post_slug || '');
+  const lookup = surface.id === 'front-page'
+    ? "$post_id = 'page' === get_option('show_on_front') ? (int) get_option('page_on_front') : 0; $post = $post_id > 0 ? get_post($post_id) : null;"
+    : `$post = get_page_by_path(${JSON.stringify(postSlug)}, OBJECT, ${JSON.stringify(postType)}); $post_id = $post instanceof WP_Post ? (int) $post->ID : 0;`;
+  const code = `${lookup}
+$available = $post instanceof WP_Post && (int) $post->ID > 0;
+$result = array(
+  'schema' => 'static-site-importer/materialized-surface-identity/v1',
+  'fixture_id' => ${JSON.stringify(fixture.id)},
+  'surface_id' => ${JSON.stringify(surface.id)},
+  'status' => $available ? 'available' : 'unavailable',
+  'reason' => $available ? '' : 'materialized_post_missing',
+  'source_entry' => ${JSON.stringify(sourceEntry)},
+  'route' => ${JSON.stringify(route)},
+  'post_id' => $available ? (string) $post->ID : '',
+  'post_type' => $available ? (string) $post->post_type : ${JSON.stringify(postType)},
+  'post_slug' => $available ? (string) $post->post_name : ${JSON.stringify(postSlug)},
+);
+WP_CLI::line(wp_json_encode($result, JSON_UNESCAPED_SLASHES));
+if (!$available) { WP_CLI::error('Materialized editor surface is unavailable.'); }`;
+  const encoded = Buffer.from(code, 'utf8').toString('base64');
+  return {
+    command: 'wordpress.wp-cli',
+    args: [`command=eval ${shellToken(`eval(base64_decode('${encoded}'));`)}`],
+    metadata: fixtureStepMetadata(fixture, 'materialized-surface-identity', {
+      surface_id: surface.id,
+      source_entry: sourceEntry,
+      route,
+      post_type: postType,
+      ...(postSlug ? { post_slug: postSlug } : {}),
+    }),
+  };
 }
 
 function editorArtifactPrefix(fixture, surface) {

--- a/lib/fixture-matrix/steps/surfaces.mjs
+++ b/lib/fixture-matrix/steps/surfaces.mjs
@@ -101,13 +101,16 @@ function surfaceFromHtmlPath(relativePath) {
   const extensionless = normalized.replace(/\.(?:html?)$/i, '');
   const slugPath = extensionless.endsWith('/index') ? extensionless.slice(0, -6) : extensionless;
   const slug = slugPath.split('/').filter(Boolean).join('-') || 'home';
+  const routePath = slugPath.split('/').filter(Boolean).join('/');
   const id = slug || 'front-page';
   return {
     id,
     label: normalized,
-    target: `/${slug}/`,
+    // WordPress resolves a hierarchical page by its slash-delimited page path.
+    // The flattened value remains the stable surface ID and artifact suffix only.
+    target: `/${routePath}/`,
     source_entry: normalized,
-    candidate_url: `/${slug}/`,
+    candidate_url: `/${routePath}/`,
   };
 }
 

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -517,6 +517,10 @@ function static_site_importer_cli_write_materialization_sidecar( array $result, 
 	$completed                 = isset( $receipt['completed'] ) && is_array( $receipt['completed'] ) ? $receipt['completed'] : array();
 	$is_completed              = 'static-site-importer/materialization-receipt/v1' === ( $receipt['schema'] ?? '' ) && 'completed' === ( $receipt['status'] ?? '' ) && isset( $receipt['plan_hash'] ) && is_string( $receipt['plan_hash'] ) && preg_match( '/^(?:sha256:)?[a-f0-9]{64}$/', $receipt['plan_hash'] ) && isset( $completed['pages'], $completed['files'] ) && is_array( $completed['pages'] ) && is_array( $completed['files'] );
 	$summary                   = $is_completed ? static_site_importer_cli_materialization_summary( $receipt, $result ) : static_site_importer_cli_failed_materialization_summary( $result );
+	$documents                 = $is_completed ? static_site_importer_cli_materialized_documents( $completed['pages'] ) : array(
+		'rows'      => array(),
+		'truncated' => false,
+	);
 	$sidecar                   = array(
 		'schema'             => 'static-site-importer/materialization-runtime-sidecar/v1',
 		'fixture_id'         => $fixture_id,
@@ -543,6 +547,8 @@ function static_site_importer_cli_write_materialization_sidecar( array $result, 
 			'show_on_front' => static_site_importer_cli_sidecar_token_value( get_option( 'show_on_front' ), 20 ),
 			'page_on_front' => min( 10000000, max( 0, (int) get_option( 'page_on_front' ) ) ),
 		),
+		'documents'           => $documents['rows'],
+		'documents_truncated' => $documents['truncated'],
 	);
 	$sidecar['content_sha256'] = hash( 'sha256', (string) wp_json_encode( $sidecar, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
 	$json                      = wp_json_encode( $sidecar, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
@@ -573,6 +579,38 @@ function static_site_importer_cli_write_materialization_sidecar( array $result, 
 		}
 	}
 	return true;
+}
+
+/**
+ * Project materialized posts to bounded source and route identities for matrix joins.
+ *
+ * @param array<string,mixed> $pages Materialization receipt source-path to post-id map.
+ * @return array{rows:array<int,array<string,mixed>>,truncated:bool}
+ */
+function static_site_importer_cli_materialized_documents( array $pages ): array {
+	$rows     = array();
+	$max_rows = 25;
+	foreach ( $pages as $source_path => $post_id ) {
+		$post = get_post( (int) $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			continue;
+		}
+		if ( count( $rows ) >= $max_rows ) {
+			return array( 'rows' => $rows, 'truncated' => true );
+		}
+		$permalink = get_permalink( $post );
+		$route     = is_string( $permalink ) ? (string) wp_parse_url( $permalink, PHP_URL_PATH ) : '';
+		$rows[]    = array(
+			'source_path'               => (string) $source_path,
+			'route'                     => $route,
+			'post_id'                   => (string) $post->ID,
+			'post_type'                 => (string) $post->post_type,
+			'post_slug'                 => (string) $post->post_name,
+			'serialized_content_sha256' => hash( 'sha256', (string) $post->post_content ),
+		);
+	}
+
+	return array( 'rows' => $rows, 'truncated' => false );
 }
 
 /** @return array<string,mixed> */

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -958,7 +958,7 @@ test('fixture capability metadata does not alter provider setup or execution', (
   const fixtureSteps = (id) => recipe.workflow.steps.filter((step) => step.metadata?.fixture_id === id);
 
   const plainSteps = fixtureSteps('plain-site');
-  assert.deepEqual(plainSteps.map((step) => step.command), ['wordpress.wp-cli', 'wordpress.wp-cli', 'wordpress.wp-cli']);
+  assert.deepEqual(plainSteps.map((step) => step.command), ['wordpress.wp-cli', 'wordpress.wp-cli', 'wordpress.wp-cli', 'wordpress.wp-cli']);
   assert.deepEqual(fixtureSteps('shop-site').map((step) => step.command), plainSteps.map((step) => step.command));
   assert.deepEqual(fixtureSteps('shop-forms-site').map((step) => step.command), plainSteps.map((step) => step.command));
   assert.equal(recipe.workflow.steps.some((step) => ['wordpress.plugin-setup', 'wordpress.run-php'].includes(step.command)), false);
@@ -5656,7 +5656,7 @@ test('recipe runs editor-validate-blocks against imported content after each imp
     staticSiteImporterPath: '/tmp/static-site-importer',
   });
 
-  // [activate, prepare, validate, visual-font-setup, suppress-onboarding, editor-open, editor-validate-blocks]
+  // [activate, prepare, validate, visual-font-setup, suppress-onboarding, identity, editor-open, editor-validate-blocks]
   assert.equal(recipe.workflow.steps[1].command, 'wordpress.wp-cli');
   assert.match(recipe.workflow.steps[1].args[0], /prepare-artifact-dependencies/);
   assert.equal(recipe.workflow.steps[2].command, 'wordpress.wp-cli');
@@ -5664,12 +5664,15 @@ test('recipe runs editor-validate-blocks against imported content after each imp
   assert.equal(recipe.workflow.steps[4].command, 'wordpress.wp-cli');
   assert.equal(recipe.workflow.steps[4].metadata.phase, 'editor-preflight');
   assert.match(recipe.workflow.steps[4].args[0], /woocommerce_onboarding_profile/);
-  const editorOpenStep = recipe.workflow.steps[5];
+  const identityStep = recipe.workflow.steps[5];
+  assert.equal(identityStep.command, 'wordpress.wp-cli');
+  assert.equal(identityStep.metadata.phase, 'materialized-surface-identity');
+  const editorOpenStep = recipe.workflow.steps[6];
   assert.equal(editorOpenStep.command, 'wordpress.editor-open');
   assert.ok(editorOpenStep.args.includes('target=front-page'));
   assert.ok(editorOpenStep.args.includes('capture=screenshot,editor-state,editor-validity'));
   assert.ok(editorOpenStep.args.includes('artifact-prefix=files/browser/editor-open/simple-site'));
-  const editorStep = recipe.workflow.steps[6];
+  const editorStep = recipe.workflow.steps[7];
   assert.equal(editorStep.command, EDITOR_VALIDATE_BLOCKS_COMMAND);
   assert.equal(editorStep.command, 'wordpress.editor-validate-blocks');
   assert.equal(editorStep.args.some((arg) => arg.includes('post-new.php')), false);
@@ -5718,6 +5721,7 @@ test('fixture matrix browser surfaces default to front page and opt into bounded
   writeFileSync(path.join(fixtureDirectory, 'index.html'), '<main>Home</main>');
   writeFileSync(path.join(fixtureDirectory, 'about.html'), '<main>About flat</main>');
   writeFileSync(path.join(fixtureDirectory, 'about', 'index.html'), '<main>About nested</main>');
+  writeFileSync(path.join(fixtureDirectory, 'about', 'team.html'), '<main>Team</main>');
   writeFileSync(path.join(fixtureDirectory, 'contact.html'), '<main><form><input name="email"></form></main>');
   writeFileSync(path.join(fixtureDirectory, 'faculty.html'), '<main>Faculty</main>');
   writeFileSync(path.join(fixtureDirectory, 'merch', 'index.html'), '<main><button>Add to cart</button></main>');
@@ -5728,7 +5732,7 @@ test('fixture matrix browser surfaces default to front page and opt into bounded
   const matrix = { ...discoveredMatrix, fixtures: discoveredMatrix.fixtures.filter((fixture) => fixture.id === 'artist'), count: 1 };
   assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0]).map((surface) => surface.id), ['front-page']);
   assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: { maxExtraSurfaces: 1 } }).map((surface) => surface.id), ['front-page', 'about']);
-  assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: 7 }).map((surface) => surface.id), ['front-page', 'about', 'about--2', 'contact', 'faculty', 'merch', 'news', 'programs']);
+  assert.deepEqual(selectFixtureSurfaces(matrix.fixtures[0], { surfaceCoverage: 8 }).map((surface) => surface.id), ['front-page', 'about', 'about--2', 'about-team', 'contact', 'faculty', 'merch', 'news', 'programs']);
   assert.equal(normalizeSurfaceCoverageOptions({ surfaceCoverage: 99 }).extraSurfaceCount, MAX_EXTRA_SURFACE_COUNT);
 
   const defaultRecipe = buildFixtureMatrixRecipe({
@@ -5743,15 +5747,17 @@ test('fixture matrix browser surfaces default to front page and opt into bounded
     matrix,
     artifactsDirectory: '/tmp/artifacts',
     staticSiteImporterPath: '/tmp/static-site-importer',
-    surfaceCoverage: { maxExtraSurfaces: 2 },
+    surfaceCoverage: { maxExtraSurfaces: 3 },
   });
   const editorOpenSteps = multiSurfaceRecipe.workflow.steps.filter((step) => step.command === 'wordpress.editor-open');
   const editorValidationSteps = multiSurfaceRecipe.workflow.steps.filter((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND);
+  const identitySteps = multiSurfaceRecipe.workflow.steps.filter((step) => step.metadata?.phase === 'materialized-surface-identity');
   const visualSteps = multiSurfaceRecipe.workflow.steps.filter((step) => step.command === 'wordpress.visual-compare');
 
-  assert.equal(editorOpenSteps.length, 3);
-  assert.equal(editorValidationSteps.length, 3);
-  assert.equal(visualSteps.length, 3);
+  assert.equal(editorOpenSteps.length, 4);
+  assert.equal(editorValidationSteps.length, 4);
+  assert.equal(identitySteps.length, 4);
+  assert.equal(visualSteps.length, 4);
   assert.ok(editorOpenSteps[0].args.includes('artifact-prefix=files/browser/editor-open/artist'));
   assert.ok(editorOpenSteps[1].args.includes('post-type=page'));
   assert.ok(editorOpenSteps[1].args.includes('post-slug=about'));
@@ -5764,6 +5770,13 @@ test('fixture matrix browser surfaces default to front page and opt into bounded
   assert.ok(editorValidationSteps[1].args.includes('post-slug=about'));
   assert.equal(editorValidationSteps[1].args.some((arg) => arg.startsWith('url=')), false);
 
+  assert.ok(editorOpenSteps[3].args.includes('post-slug=about/team'));
+  assert.equal(editorOpenSteps[3].metadata.route, '/about/team/');
+  assert.equal(editorOpenSteps[3].metadata.source_entry, 'about/team.html');
+  assert.ok(editorValidationSteps[3].args.includes('post-slug=about/team'));
+  assert.equal(identitySteps[3].metadata.post_slug, 'about/team');
+  assert.equal(identitySteps[3].metadata.route, '/about/team/');
+
   const aboutComparison = visualCompareMatrixComparison(visualSteps[1]);
   assert.equal(aboutComparison.name, 'artist--about');
   assert.equal(aboutComparison.sourceUrl, 'file:///tmp/artifacts/artist/source/about.html');
@@ -5772,8 +5785,10 @@ test('fixture matrix browser surfaces default to front page and opt into bounded
   assert.equal(nestedAboutComparison.name, 'artist--about--2');
   assert.equal(nestedAboutComparison.sourceUrl, 'file:///tmp/artifacts/artist/source/about/index.html');
   assert.equal(nestedAboutComparison.candidateUrl, '/about/');
-  assert.equal(multiSurfaceRecipe.metadata.surface_coverage.extra_surfaces_per_fixture, 2);
-  assert.equal(multiSurfaceRecipe.metadata.surface_coverage.total_surface_count, 3);
+  const teamComparison = visualCompareMatrixComparison(visualSteps[3]);
+  assert.equal(teamComparison.candidateUrl, '/about/team/');
+  assert.equal(multiSurfaceRecipe.metadata.surface_coverage.extra_surfaces_per_fixture, 3);
+  assert.equal(multiSurfaceRecipe.metadata.surface_coverage.total_surface_count, 4);
   assert.equal(multiSurfaceRecipe.metadata.runtime_cost_warnings[0].code, 'surface_coverage_runtime_cost');
 });
 
@@ -6664,12 +6679,12 @@ test('recipe runs a wordpress.visual-compare visual-parity step after each impor
     pixelThreshold: 0.05,
   });
 
-  // [activate, prepare, validate, visual-font-setup, suppress-onboarding, editor-open, editor-validation, visual-setup, visual-compare]
-  const visualSetupStep = recipe.workflow.steps[7];
+  // [activate, prepare, validate, visual-font-setup, suppress-onboarding, identity, editor-open, editor-validation, visual-setup, visual-compare]
+  const visualSetupStep = recipe.workflow.steps[8];
   assert.equal(visualSetupStep.command, 'wordpress.wp-cli');
   assert.equal(visualSetupStep.metadata.phase, 'visual-setup');
   assert.match(visualSetupStep.args[0], /wp_update_custom_css_post/);
-  const visualStep = recipe.workflow.steps[8];
+  const visualStep = recipe.workflow.steps[9];
   assert.equal(visualStep.command, 'wordpress.visual-compare');
   const comparison = visualCompareMatrixComparison(visualStep);
   assert.equal(comparison.sourceUrl, 'file:///tmp/artifacts/simple-site/source/index.html');


### PR DESCRIPTION
## Summary

- Preserve hierarchical routes such as `/about/team/` as WordPress editor paths instead of flattening them to `about-team`.
- Add a per-surface materialized identity preflight that emits the concrete post ID or typed `unavailable` result and terminates before editor validation when absent.
- Include source path, canonical route, post ID, type, and slug in the bounded SSI materialization sidecar.

## Verification

- `npm test`
- `php -l static-site-importer.php`

Fixes #893

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode was used to trace SSI matrix artifacts and WP Codebox editor resolution, implement the SSI-owned fix, and run the test suite. Chris Huber remains responsible for this change.