### PR TITLE
Preserve unresolved source references during URL imports

### DIFF
--- a/includes/class-static-site-importer-url-batch-import.php
+++ b/includes/class-static-site-importer-url-batch-import.php
@@ -182,6 +182,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 				if ( empty( $ready_runtime ) ) {
 					$ready_args                                = $args;
 					$ready_args['_route_set']                  = array_values( array_unique( $routes ) );
+					$ready_args['_known_route_set']            = $manifest['routes'];
 					$ready_args['max_pages']                   = min( self::MAX_BATCH_PAGES + 1, count( $ready_args['_route_set'] ) + 1 );
 					$ready_args['require_complete_collection'] = true;
 					$ready_args['asset_failure_policy']        = count( $routes ) > 1 ? 'preserve_failed_external_assets' : 'preserve_external';
@@ -251,6 +252,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 			if ( empty( $runtime ) ) {
 				$collect_args                                = $args;
 				$collect_args['_route_set']                  = array_values( array_unique( $routes ) );
+				$collect_args['_known_route_set']            = $manifest['routes'];
 				$collect_args['max_pages']                   = min( self::MAX_BATCH_PAGES + 1, count( $collect_args['_route_set'] ) + 1 );
 				$collect_args['require_complete_collection'] = true;
 				$collect_args['asset_failure_policy']        = count( $routes ) > 1 ? 'preserve_failed_external_assets' : 'preserve_external';

--- a/includes/class-static-site-importer-url-site-collector.php
+++ b/includes/class-static-site-importer-url-site-collector.php
@@ -66,6 +66,7 @@ class Static_Site_Importer_URL_Site_Collector {
 		$total_bytes            = 0;
 		$truncated              = array();
 		$external_assets        = array();
+		$external_pages         = array();
 		$asset_failure_policy   = $args['asset_failure_policy'] ?? '';
 		$preserve_failed_assets = in_array( $asset_failure_policy, array( 'preserve_external', 'preserve_failed_external_assets' ), true );
 		$preserve_asset_limits  = 'preserve_external' === $asset_failure_policy;
@@ -293,6 +294,12 @@ class Static_Site_Importer_URL_Site_Collector {
 		ksort( $resources, SORT_STRING );
 		ksort( $aliases, SORT_STRING );
 		ksort( $external_assets, SORT_STRING );
+		$known_pages = array_fill_keys( isset( $args['_known_route_set'] ) && is_array( $args['_known_route_set'] ) ? $args['_known_route_set'] : array(), true );
+		foreach ( $resources as $resource_url => $resource ) {
+			if ( 'html' === $resource['kind'] ) {
+				$known_pages[ $resource_url ] = true;
+			}
+		}
 		usort( $script_exclusions, static fn ( array $left, array $right ): int => strcmp( implode( '|', $left ), implode( '|', $right ) ) );
 		$paths           = self::artifact_paths( $resources, $site_url );
 		$route_paths     = self::route_paths( $resources );
@@ -308,7 +315,7 @@ class Static_Site_Importer_URL_Site_Collector {
 			$path = $paths[ $resource_url ];
 			$body = (string) $resource['body'];
 			if ( 'html' === $resource['kind'] ) {
-				$body = self::rewrite_html( $body, self::html_base_url( $body, $resource_url ), $path, $reference_paths, $aliases, $site_url, $external_assets );
+				$body = self::rewrite_html( $body, self::html_base_url( $body, $resource_url ), $path, $reference_paths, $aliases, $site_url, $external_assets, $external_pages, $known_pages );
 			} elseif ( 'text/css' === $resource['content_type'] || str_ends_with( strtolower( $path ), '.css' ) ) {
 				$body = self::rewrite_css( $body, $resource_url, $path, $reference_paths, $external_assets );
 			}
@@ -397,6 +404,20 @@ class Static_Site_Importer_URL_Site_Collector {
 								),
 								array_keys( $external_assets ),
 								$external_assets
+							),
+							0,
+							50
+						),
+					),
+					'external_page_retained'  => array(
+						'count'   => count( $external_pages ),
+						'samples' => array_slice(
+							array_map(
+								static fn ( string $url ): array => array(
+									'url'    => $url,
+									'reason' => 'uncollected_page',
+								),
+								array_keys( $external_pages )
 							),
 							0,
 							50
@@ -778,10 +799,10 @@ class Static_Site_Importer_URL_Site_Collector {
 	}
 
 	/** @param array<string,string> $paths */
-	private static function rewrite_html( string $html, string $base_url, string $source_path, array $paths, array $aliases, string $site_url, array $external_assets = array() ): string {
+	private static function rewrite_html( string $html, string $base_url, string $source_path, array $paths, array $aliases, string $site_url, array $external_assets = array(), array &$external_pages = array(), array $known_pages = array() ): string {
 		$html = preg_replace_callback(
 			'#\b(src|href|poster)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))#is',
-			static function ( array $matches ) use ( $base_url, $source_path, $paths, $aliases, $site_url, $external_assets ): string {
+			static function ( array $matches ) use ( $base_url, $source_path, $paths, $aliases, $site_url, $external_assets, &$external_pages, $known_pages ): string {
 				$value = self::matched_attribute_value( $matches );
 				$url   = self::resolve_url( $value, $base_url );
 				if ( isset( $paths[ $url ] ) && preg_match( '/\.html?$/i', $paths[ $url ] ) ) {
@@ -796,7 +817,14 @@ class Static_Site_Importer_URL_Site_Collector {
 				if ( isset( $external_assets[ $url ] ) ) {
 					return $matches[1] . '="' . self::external_asset_url( $url, $value ) . '"';
 				}
-				return '' !== $url && self::same_origin( $url, $site_url ) && self::is_page_url( $url ) ? $matches[1] . '="' . self::route_url( $url, $value ) . '"' : $matches[0];
+				if ( '' !== $url && self::same_origin( $url, $site_url ) && self::is_page_url( $url ) ) {
+					if ( isset( $known_pages[ $url ] ) ) {
+						return $matches[1] . '="' . self::route_url( $url, $value ) . '"';
+					}
+					$external_pages[ $url ] = true;
+					return $matches[1] . '="' . htmlspecialchars( $url, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) . '"';
+				}
+				return $matches[0];
 			},
 			$html
 		);

--- a/includes/class-static-site-importer-url-site-collector.php
+++ b/includes/class-static-site-importer-url-site-collector.php
@@ -203,8 +203,19 @@ class Static_Site_Importer_URL_Site_Collector {
 				if ( 'static_site_importer_invocation_deadline_exceeded' === $response->get_error_code() ) {
 					return $response;
 				}
-				if ( $preserve_failed_assets && ! $critical ) {
-					$external_assets[ $asset_url ] = $response->get_error_code();
+				$source_status = self::source_broken_asset_status( $response );
+				$source_broken = 0 !== $source_status;
+				if ( $preserve_failed_assets && ( ! $critical || $source_broken ) ) {
+					$external_assets[ $asset_url ] = $source_broken ? 'source_http_' . $source_status : $response->get_error_code();
+					if ( $source_broken ) {
+						$diagnostics[] = array(
+							'code'     => 'source_broken_asset_reference',
+							'severity' => 'warning',
+							'url'      => $asset_url,
+							'status'   => $source_status,
+							'critical' => $critical,
+						);
+					}
 					continue;
 				}
 				$failures[] = self::failure( $asset_url, $response, 'asset' );
@@ -400,6 +411,12 @@ class Static_Site_Importer_URL_Site_Collector {
 				),
 			),
 		);
+	}
+
+	private static function source_broken_asset_status( WP_Error $error ): int {
+		$data   = $error->get_error_data();
+		$status = is_array( $data ) ? (int) ( $data['status'] ?? 0 ) : 0;
+		return 'static_site_importer_url_http_status' === $error->get_error_code() && in_array( $status, array( 404, 410 ), true ) ? $status : 0;
 	}
 
 	/**

--- a/tests/smoke-url-site-collector.php
+++ b/tests/smoke-url-site-collector.php
@@ -401,6 +401,22 @@ $critical_timeout_result = Static_Site_Importer_URL_Site_Collector::collect(
 );
 $assert( is_wp_error( $critical_timeout_result ) && 'asset_timeout' === ( $critical_timeout_result->get_error_data()['collection']['failures'][0]['code'] ?? '' ), 'critical-asset-timeouts-remain-terminal' );
 
+$uncollected_page_result = Static_Site_Importer_URL_Site_Collector::collect(
+	'https://uncollected.test/',
+	array( '_route_set' => array( 'https://uncollected.test/', 'https://uncollected.test/about.html' ), 'max_pages' => 3, 'max_assets' => 0, 'request_delay_ms' => 0 ),
+	static function ( string $url, array $args ) {
+		unset( $args );
+		$body = 'https://uncollected.test/' === $url ? '<a href="about.html">About</a><a href="missing.html">Missing</a>' : '<main>About</main>';
+		return array( 'body' => $body, 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) );
+	}
+);
+$uncollected_files = is_wp_error( $uncollected_page_result ) ? array() : array_column( $uncollected_page_result['artifact']['files'], null, 'path' );
+$uncollected_html = (string) ( $uncollected_files['website/index.html']['content'] ?? '' );
+$uncollected_metadata = is_wp_error( $uncollected_page_result ) ? array() : $uncollected_page_result['source_metadata']['collection']['external_page_retained'];
+$assert( str_contains( $uncollected_html, 'href="about.html"' ), 'collected-page-links-remain-route-rewritable' );
+$assert( str_contains( $uncollected_html, 'href="https://uncollected.test/missing.html"' ), 'uncollected-page-links-remain-external' );
+$assert( 1 === ( $uncollected_metadata['count'] ?? 0 ) && 'uncollected_page' === ( $uncollected_metadata['samples'][0]['reason'] ?? '' ), 'uncollected-page-links-record-provenance' );
+
 $redirect_responses = array(
 	'https://redirect.test/sitemap.xml' => array( 'content_type' => 'application/xml', 'body' => '<urlset><url><loc>https://redirect.test/</loc></url><url><loc>https://redirect.test/go</loc></url></urlset>' ),
 	'https://redirect.test/' => array( 'content_type' => 'text/html', 'body' => '<base href=/static/><link rel=stylesheet href=style.css><main><h1>Home</h1><a href=/go>Docs</a><img src=/hero.png></main>' ),

--- a/tests/smoke-url-site-collector.php
+++ b/tests/smoke-url-site-collector.php
@@ -371,6 +371,36 @@ $incomplete_fetcher = static function ( string $url, array $args ) use ( $incomp
 $incomplete_result = Static_Site_Importer_URL_Site_Collector::collect( 'https://example.test/', array( 'max_pages' => 10, 'max_assets' => 20, 'request_delay_ms' => 0, 'require_complete_collection' => true ), $incomplete_fetcher );
 $assert( is_wp_error( $incomplete_result ) && 'missing_fixture' === ( $incomplete_result->get_error_data()['collection']['failures'][0]['code'] ?? null ), 'complete-collection-rejects-fetch-failures' );
 
+$source_broken_fetcher = static function ( string $url, array $args ) {
+	unset( $args );
+	if ( 'https://source-broken.test/' === $url ) {
+		return array( 'body' => '<link rel="stylesheet" href="/style.css"><main>Ready</main>', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) );
+	}
+	if ( 'https://source-broken.test/style.css' === $url ) {
+		return array( 'body' => '@font-face{src:url(/missing.woff2)}', 'metadata' => array( 'content_type' => 'text/css', 'final_url' => $url ) );
+	}
+	return new WP_Error( 'static_site_importer_url_http_status', 'The URL returned HTTP status 404.', array( 'status' => 404 ) );
+};
+$source_broken_result = Static_Site_Importer_URL_Site_Collector::collect(
+	'https://source-broken.test/',
+	array( '_route_set' => array( 'https://source-broken.test/' ), 'asset_failure_policy' => 'preserve_failed_external_assets', 'hydration_mode' => 'page_ready', 'max_pages' => 2, 'max_assets' => 10, 'request_delay_ms' => 0, 'require_complete_collection' => true ),
+	$source_broken_fetcher
+);
+$source_broken_collection = is_wp_error( $source_broken_result ) ? array() : $source_broken_result['source_metadata']['collection'];
+$source_broken_diagnostics = array_values( array_filter( $source_broken_collection['diagnostics'] ?? array(), static fn ( array $diagnostic ): bool => 'source_broken_asset_reference' === ( $diagnostic['code'] ?? '' ) ) );
+$source_broken_detail = wp_json_encode( is_wp_error( $source_broken_result ) ? array( 'code' => $source_broken_result->get_error_code(), 'data' => $source_broken_result->get_error_data() ) : $source_broken_collection );
+$assert( ! is_wp_error( $source_broken_result ) && 1 === ( $source_broken_collection['external_asset_retained']['count'] ?? 0 ), 'source-broken-critical-assets-are-retained', $source_broken_detail );
+$assert( 'source_http_404' === ( $source_broken_collection['external_asset_retained']['samples'][0]['reason'] ?? '' ) && true === ( $source_broken_diagnostics[0]['critical'] ?? false ), 'source-broken-critical-assets-record-provenance', $source_broken_detail );
+
+$critical_timeout_result = Static_Site_Importer_URL_Site_Collector::collect(
+	'https://source-broken.test/',
+	array( '_route_set' => array( 'https://source-broken.test/' ), 'asset_failure_policy' => 'preserve_failed_external_assets', 'hydration_mode' => 'page_ready', 'max_pages' => 2, 'max_assets' => 10, 'request_delay_ms' => 0, 'require_complete_collection' => true ),
+	static function ( string $url, array $args ) use ( $source_broken_fetcher ) {
+		return 'https://source-broken.test/missing.woff2' === $url ? new WP_Error( 'asset_timeout', 'Timed out.' ) : $source_broken_fetcher( $url, $args );
+	}
+);
+$assert( is_wp_error( $critical_timeout_result ) && 'asset_timeout' === ( $critical_timeout_result->get_error_data()['collection']['failures'][0]['code'] ?? '' ), 'critical-asset-timeouts-remain-terminal' );
+
 $redirect_responses = array(
 	'https://redirect.test/sitemap.xml' => array( 'content_type' => 'application/xml', 'body' => '<urlset><url><loc>https://redirect.test/</loc></url><url><loc>https://redirect.test/go</loc></url></urlset>' ),
 	'https://redirect.test/' => array( 'content_type' => 'text/html', 'body' => '<base href=/static/><link rel=stylesheet href=style.css><main><h1>Home</h1><a href=/go>Docs</a><img src=/hero.png></main>' ),


### PR DESCRIPTION
## Summary

- preserves critical URL assets only when the source proves they are already gone with HTTP 404 or 410
- retains those external references and records warning provenance
- keeps timeouts and other critical acquisition failures terminal
- retains same-origin page links as absolute source URLs when the complete discovered manifest proves those pages were not collected
- keeps collected cross-batch routes local and records uncollected-page provenance

Closes #895.
Closes #897.

## Verification

- `php tests/smoke-url-site-collector.php` (65 assertions)
- `php tests/smoke-url-batch-import.php`
- `npm test` (56 selected tests passed before the second focused change; runtime/browser/operator lanes intentionally skipped by the standard command)
- live Studio import advanced past source-owned 404 assets and unresolved same-origin links into runtime entity validation

## AI assistance

OpenAI gpt-5.6-sol via OpenCode reproduced both live URL failures, implemented the bounded reference-preservation policies and deterministic coverage, and ran verification. Chris Huber reviewed and remains responsible for the change.