### PR TITLE
Fix PHPStan regression in surface lineage registration

### DIFF
--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -603,7 +603,7 @@ function static_site_importer_cli_materialized_documents( array $pages ): array 
 			continue;
 		}
 		$permalink = get_permalink( $post );
-		$route     = is_string( $permalink ) ? (string) wp_parse_url( $permalink, PHP_URL_PATH ) : '';
+		$route     = (string) wp_parse_url( (string) $permalink, PHP_URL_PATH );
 		$rows[]    = array(
 			'source_path'               => (string) $source_path,
 			'route'                     => $route,


### PR DESCRIPTION
Fixes #899.

## Summary
- Remove the redundant `is_string()` check around the permalink route parse while preserving the string normalization used by `wp_parse_url()`.

## Verification
- `git diff --check`
- `php -l static-site-importer.php`
- `npm run test:inventory`
- `npm test` (56 passed, 0 failed)

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent was used to implement and verify the fix; Chris Huber remains responsible.