### PR TITLE
fix(importer): reprepare stale completed batch pages on shared plan change

### DIFF
--- a/includes/class-static-site-importer-shared-resource-plan.php
+++ b/includes/class-static-site-importer-shared-resource-plan.php
@@ -55,7 +55,7 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 				'plan'    => $plan,
 			);
 		}
-		$current = self::resources( $artifact, array_column( $existing['resources'], 'path' ) );
+		$current = self::resources( $artifact );
 		$digest  = self::digest( $current );
 		if ( hash_equals( $existing['digest'], $digest ) ) {
 			return array(
@@ -64,7 +64,7 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 				'plan'    => $existing,
 			);
 		}
-		$plan = $this->establish( $artifact, array_column( $existing['resources'], 'path' ) );
+		$plan = $this->establish( $artifact );
 		return array(
 			'digest'  => is_array( $plan ) ? $plan['digest'] : '',
 			'changed' => true,

--- a/includes/class-static-site-importer-url-batch-import.php
+++ b/includes/class-static-site-importer-url-batch-import.php
@@ -475,6 +475,16 @@ final class Static_Site_Importer_URL_Batch_Import {
 			return new WP_Error( 'static_site_importer_url_plan_shared_missing', 'The frozen URL run has no shared compiler plan.' );
 		}
 
+		$current_digest = (string) ( $shared_plan['digest'] ?? '' );
+		$compiler       = self::staged_compiler();
+		if ( is_wp_error( $compiler ) ) {
+			return $compiler;
+		}
+		$prepare_page_callable = array( $compiler, 'preparePage' );
+		if ( ! is_callable( $prepare_page_callable ) ) {
+			return new WP_Error( 'static_site_importer_missing_transformer_capability', 'The Blocks Engine php-transformer does not support staged URL batch plans.' );
+		}
+
 		$page_plans = array();
 		$snapshots  = array();
 		foreach ( $cursor as $batch ) {
@@ -484,10 +494,31 @@ final class Static_Site_Importer_URL_Batch_Import {
 			if ( ! is_array( $runtime ) || ! is_array( $runtime['staged_page_plans'] ?? null ) ) {
 				return new WP_Error( 'static_site_importer_url_plan_batch_missing', 'The frozen URL run has an incomplete staged batch.' );
 			}
-			$page_plans = array_merge( $page_plans, $runtime['staged_page_plans'] );
-			$snapshot   = $runtime['source_metadata']['snapshot']['sha256'] ?? null;
+			$snapshot = $runtime['source_metadata']['snapshot']['sha256'] ?? null;
 			if ( is_string( $snapshot ) && '' !== $snapshot ) {
 				$snapshots[] = $snapshot;
+			}
+
+			$batch_digest = (string) ( $runtime['shared_plan_digest'] ?? '' );
+			if ( '' === $batch_digest && is_array( $runtime['staged_page_plans'] ) && ! empty( $runtime['staged_page_plans'] ) ) {
+				$batch_digest = (string) ( $runtime['staged_page_plans'][0]['shared_digest'] ?? '' );
+			}
+
+			if ( '' !== $current_digest && '' !== $batch_digest && ! hash_equals( $current_digest, $batch_digest ) && is_array( $runtime['artifact']['files'] ?? null ) ) {
+				$fresh_plans = array();
+				foreach ( $runtime['artifact']['files'] as $file ) {
+					if ( ! is_array( $file ) || 'text/html' !== strtolower( (string) ( $file['mime_type'] ?? '' ) ) || '' === (string) ( $file['path'] ?? '' ) ) {
+						continue;
+					}
+					try {
+						$fresh_plans[] = call_user_func( $prepare_page_callable, $runtime['artifact'], $shared_plan, (string) $file['path'] );
+					} catch ( Throwable $error ) {
+						return new WP_Error( 'static_site_importer_staged_reprepare_failed', $error->getMessage() );
+					}
+				}
+				$page_plans = array_merge( $page_plans, $fresh_plans );
+			} else {
+				$page_plans = array_merge( $page_plans, $runtime['staged_page_plans'] );
 			}
 		}
 

--- a/tests/smoke-url-batch-import.php
+++ b/tests/smoke-url-batch-import.php
@@ -262,4 +262,35 @@ $url_plan_pages = $url_plan_final['plan']['pages'] ?? array();
 $url_plan_paths = array_map( static fn( array $page ): string => (string) ( $page['path'] ?? $page['slug'] ?? '' ), $url_plan_pages );
 $operation_mismatch = Static_Site_Importer_URL_Import_Runtime::run_operation( array( 'operation' => 'apply', 'source' => array( 'type' => 'url' ), 'url' => 'https://runtime-plan.test/', 'import_id' => $url_plan_first['import_id'] ?? '', 'slug' => 'runtime-plan' ) );
 if ( empty( $url_plan_first['continuation'] ) || empty( $url_plan_first['import_id'] ) || ! empty( $url_plan_first['plan'] ) || empty( $url_plan_final['plan'] ) || 'completed' !== ( $url_plan_final['url_batch_run']['status'] ?? '' ) || 2 !== count( $url_plan_pages ) || empty( $url_plan_paths[0] ) || empty( $url_plan_paths[1] ) || $writes_before_url_plan !== count( $runtime_imports ) || ! is_wp_error( $operation_mismatch ) || 'static_site_importer_url_import_run_mismatch' !== $operation_mismatch->get_error_code() ) { throw new RuntimeException( 'URL planning must compose every frozen batch into one plan without importer writes and bind continuation to operation intent' ); }
+
+// shared-change.test — plan-mode cross-batch shared digest change (issue #901)
+add_filter( 'static_site_importer_url_batch_import_fetcher', static function ( $fetcher, array $request ) {
+	if ( 'https://shared-change.test/' !== ( $request['url'] ?? '' ) ) {
+		return $fetcher;
+	}
+	return static function ( string $url ): array {
+		if ( 'https://shared-change.test/sitemap.xml' === $url ) {
+			return array( 'body' => '<urlset><url><loc>https://shared-change.test/</loc></url><url><loc>https://shared-change.test/page2/</loc></url></urlset>', 'metadata' => array( 'content_type' => 'application/xml', 'final_url' => $url ) );
+		}
+		if ( 'https://shared-change.test/' === $url ) {
+			return array( 'body' => '<main>page1<link rel="stylesheet" href="/theme-a.css"></main>', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) );
+		}
+		if ( 'https://shared-change.test/page2/' === $url ) {
+			return array( 'body' => '<main>page2<link rel="stylesheet" href="/theme-a.css"><link rel="stylesheet" href="/theme-b.css"></main>', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) );
+		}
+		if ( 'https://shared-change.test/theme-a.css' === $url ) {
+			return array( 'body' => 'body{color:red}', 'metadata' => array( 'content_type' => 'text/css', 'final_url' => $url ) );
+		}
+		if ( 'https://shared-change.test/theme-b.css' === $url ) {
+			return array( 'body' => 'h1{font-size:2em}', 'metadata' => array( 'content_type' => 'text/css', 'final_url' => $url ) );
+		}
+		return new WP_Error( 'not_found', 'not found' );
+	};
+} );
+$writes_before_shared = count( $runtime_imports );
+$shared_first         = static_site_importer_ability_import( array( 'operation' => 'plan', 'source' => array( 'type' => 'url', 'url' => 'https://shared-change.test/' ), 'slug' => 'shared-change' ) );
+$shared_final         = static_site_importer_ability_import( array( 'operation' => 'plan', 'source' => array( 'type' => 'url', 'url' => 'https://shared-change.test/', 'import_id' => $shared_first['import_id'] ?? '' ), 'slug' => 'shared-change' ) );
+$shared_pages         = $shared_final['plan']['pages'] ?? array();
+$shared_paths         = array_map( static fn( array $p ): string => (string) ( $p['path'] ?? $p['slug'] ?? '' ), $shared_pages );
+if ( empty( $shared_first['continuation'] ) || empty( $shared_first['import_id'] ) || ! empty( $shared_first['plan'] ) || empty( $shared_final['plan'] ) || 'completed' !== ( $shared_final['url_batch_run']['status'] ?? '' ) || 2 !== count( $shared_pages ) || empty( $shared_paths[0] ) || empty( $shared_paths[1] ) || $writes_before_shared !== count( $runtime_imports ) ) { throw new RuntimeException( 'shared plan change across batches must re-prepare stale page plans in compose_complete_plan and succeed without importer writes' ); }
 echo "URL batch import smoke passed.\n";


### PR DESCRIPTION
## Summary

Completed batch pages prepared against an old shared-plan digest fail terminal composition when a later batch adds new shared resources and changes the digest. This happens because `SharedResourcePlan::reconcile()` filtered resources to known paths only, so new shared files never changed the digest and never entered the stored plan. `compose_complete_plan()` then received stale page plans and Blocks Engine rejected the mixed-digest composition.

This fix resolves both sides: the shared plan now correctly detects and stores new resources, and terminal composition re-prepares any stale batch pages from their retained immutable artifacts before final compose.

Fixes #901

## Changes

### `includes/class-static-site-importer-shared-resource-plan.php`

**Before:**
```php
$current = self::resources( $artifact, array_column( $existing['resources'], 'path' ) );
// ...
$plan = $this->establish( $artifact, array_column( $existing['resources'], 'path' ) );
```

**After:**
```php
$current = self::resources( $artifact );
// ...
$plan = $this->establish( $artifact );
```

**Why:** `resources()` skipped any file not already in the existing plan. When a later batch brought a new shared CSS/JS file alongside previously known ones, that new file was invisible in the digest comparison. The digest matched, `changed` returned false, and the stored plan never grew to include the new resource. Removing the path filter ensures the full current resource set is compared and stored on change.

### `includes/class-static-site-importer-url-batch-import.php` — `compose_complete_plan()`

Adds a staleness check before merging each batch's page plans. If the batch's `shared_plan_digest` (or fallback first page plan's `shared_digest`) does not match the current shared plan's digest, the retained artifact is used to re-run `preparePage` against the current shared plan. Stale batches get fresh page plans; fresh batches are used as-is.

No batch JSONs are mutated. Re-preparation is deterministic from the immutable artifact snapshot and the current shared plan.

### `tests/smoke-url-batch-import.php`

Adds `shared-change.test` scenario: batch 1 collects one page referencing `theme-a.css` only; batch 2 adds `page2` referencing both `theme-a.css` and `theme-b.css`. Two plan-mode invocations are driven. The test asserts continuation on the first call, `completed` status on the second, two pages in the final plan, and zero importer writes for the second batch (proving no materialization side effects).

## Testing

**Test 1: Shared resource plan smoke**
```bash
php tests/smoke-shared-resource-plan.php
```
Result: passes — confirms same-content re-conciliation returns unchanged, and modified content correctly triggers re-establishment with full resource set.

**Test 2: URL batch import smoke (includes new shared-change scenario)**
```bash
php tests/smoke-url-batch-import.php
```
Result: passes — new shared-change scenario completes cleanly, existing plan-mode scenario unaffected.

**Test 3: Fast lane**
```bash
npm test
```
Result: 56/56 pass, 0 fail.