### PR TITLE
Register declared companion blocks before editor validation

### DIFF
--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -210,6 +210,11 @@ class Static_Site_Importer_Plugin_Materializer {
 		if ( false === $plan['activate'] ) {
 			// mu-plugins are always active; no activation call is required.
 			$plugin_file = (string) $descriptor['plugin_file'];
+			$registered  = self::register_generated_blocks( $descriptor, $plan );
+			if ( is_wp_error( $registered ) ) {
+				return self::failed_report( $report, $registered );
+			}
+			$report['registration'] = $registered;
 			self::replace_active_generated_companion( $plugin_file, $report );
 			if ( function_exists( 'update_option' ) ) {
 				update_option( self::ACTIVE_COMPANION_OPTION, $plugin_file, false );
@@ -247,6 +252,11 @@ class Static_Site_Importer_Plugin_Materializer {
 				)
 			);
 		}
+		$registered = self::register_generated_blocks( $descriptor, $plan );
+		if ( is_wp_error( $registered ) ) {
+			return self::failed_report( $report, $registered );
+		}
+		$report['registration'] = $registered;
 		self::replace_active_generated_companion( $plugin_file, $report );
 		if ( function_exists( 'update_option' ) ) {
 			update_option( self::ACTIVE_COMPANION_OPTION, $plugin_file, false );
@@ -254,6 +264,54 @@ class Static_Site_Importer_Plugin_Materializer {
 
 		$report['status'] = $already_available ? 'refreshed' : 'installed_activated';
 		return $report;
+	}
+
+	/**
+	 * Register a materialized companion package in the current request.
+	 *
+	 * Activation updates persistent state after the WordPress init lifecycle has
+	 * run. A compiler-declared companion owns its registration callback, so SSI
+	 * invokes that callback and verifies its declared inventory before editor
+	 * validation observes the imported content.
+	 *
+	 * @param array<string,mixed> $descriptor Generated companion descriptor.
+	 * @param array<string,mixed> $plan       Generated companion install plan.
+	 * @return true|WP_Error
+	 */
+	private static function register_generated_blocks( array $descriptor, array $plan ) {
+		$slug        = isset( $descriptor['slug'] ) && is_string( $descriptor['slug'] ) ? $descriptor['slug'] : '';
+		$plugin_file = isset( $descriptor['plugin_file'] ) && is_string( $descriptor['plugin_file'] ) ? $descriptor['plugin_file'] : '';
+		$base_dir    = isset( $plan['base_dir'] ) && is_string( $plan['base_dir'] ) ? $plan['base_dir'] : '';
+		$callback    = str_replace( '-', '_', $slug ) . '_register_blocks';
+		$path        = '' === $base_dir || '' === $plugin_file ? '' : rtrim( $base_dir, '/\\' ) . '/' . $plugin_file;
+
+		if ( '' === $slug || '' === $path || ! is_readable( $path ) ) {
+			return new WP_Error( 'static_site_importer_companion_plugin_registration_unavailable', 'Generated companion block registration file is unavailable.' );
+		}
+		if ( ! function_exists( $callback ) ) {
+			require_once $path;
+		}
+		if ( ! is_callable( $callback ) ) {
+			return new WP_Error( 'static_site_importer_companion_plugin_registration_unavailable', sprintf( 'Generated companion %s does not expose its block registration callback.', $slug ) );
+		}
+
+		call_user_func( $callback );
+		$registry = class_exists( 'WP_Block_Type_Registry' ) ? WP_Block_Type_Registry::get_instance() : null;
+		$missing  = array();
+		foreach ( $descriptor['block_names'] ?? array() as $block_name ) {
+			if ( ! is_string( $block_name ) || '' === $block_name || ! $registry || ! $registry->is_registered( $block_name ) ) {
+				$missing[] = $block_name;
+			}
+		}
+		if ( ! empty( $missing ) ) {
+			return new WP_Error(
+				'static_site_importer_companion_plugin_registration_incomplete',
+				'Generated companion blocks were not registered before editor use.',
+				array( 'missing_block_names' => $missing )
+			);
+		}
+
+		return true;
 	}
 
 	/** Preflight registered block names before generated files are written. */

--- a/lib/fixture-matrix/collectors/editor-validation.mjs
+++ b/lib/fixture-matrix/collectors/editor-validation.mjs
@@ -137,6 +137,13 @@ function isInvalidEditorBlock(block) {
   if (!block || typeof block !== 'object') {
     return false;
   }
+  // Gutenberg retains the intended name when it falls back to core/missing.
+  // The fallback is structurally valid but cannot be edited as its declared block.
+  if ((block.name === 'core/missing' || block.block_name === 'core/missing' || block.blockName === 'core/missing')
+    && typeof (block.originalName || block.original_name) === 'string'
+    && (block.originalName || block.original_name).length > 0) {
+    return true;
+  }
   if (block.isValid === false || block.is_valid === false || block.valid === false) {
     return true;
   }
@@ -148,7 +155,9 @@ function isInvalidEditorBlock(block) {
 }
 
 function editorInvalidBlockDiagnostic(block) {
-  const name = block.name || block.block_name || block.blockName || '';
+  const observedName = block.name || block.block_name || block.blockName || '';
+  const originalName = block.originalName || block.original_name || '';
+  const name = observedName === 'core/missing' && originalName ? originalName : observedName;
   const clientId = block.clientId || block.client_id || '';
   const selector = block.selector || (clientId ? `[data-block="${clientId}"]` : '');
   const detail = firstString([
@@ -161,7 +170,8 @@ function editorInvalidBlockDiagnostic(block) {
   return {
     kind: EDITOR_BLOCK_INVALID_KIND,
     block_name: name,
-    observed_block_name: name,
+    observed_block_name: observedName,
+    ...(originalName ? { original_block_name: originalName } : {}),
     selector,
     source_path: block.source_path || block.source || '',
     observed_output: firstString([block.originalContent, block.expectedContent, block.html_excerpt]),

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -18,6 +18,7 @@
     { "path": "tests/smoke-companion-plugin.php", "environment": "standalone-php" },
     { "path": "tests/smoke-contact-layout-transformer.php", "environment": "standalone-php" },
     { "path": "tests/smoke-diagnostic-loss-classes.php", "environment": "standalone-php" },
+    { "path": "tests/editor-validation-contract.test.mjs", "environment": "node" },
     { "path": "tests/smoke-empty-js-populated-container.php", "environment": "standalone-php" },
     { "path": "tests/smoke-entity-materializer-registry.php", "environment": "standalone-php" },
     { "path": "tests/smoke-external-report-destinations.php", "environment": "standalone-php" },

--- a/tests/editor-validation-contract.test.mjs
+++ b/tests/editor-validation-contract.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  collectEditorValidation,
+  collectEditorValidationDiagnostics,
+} from '../lib/fixture-matrix/collectors/editor-validation.mjs';
+
+test('fails editor validation when Gutenberg substitutes core/missing for a declared block', () => {
+  const payload = {
+    schema: 'wp-codebox/editor-validate-blocks/v1',
+    results: [
+      { name: 'example/available', isValid: true },
+      { name: 'core/missing', originalName: 'example/declared', isValid: true },
+    ],
+  };
+
+  assert.deepEqual(collectEditorValidation(payload), {
+    validation_method: 'wp.blocks.validateBlock',
+    validation_provider: 'wordpress-block-editor',
+    total_blocks: 2,
+    valid_blocks: 1,
+    invalid_blocks: 1,
+  });
+  assert.deepEqual(collectEditorValidationDiagnostics(payload), [
+    {
+      kind: 'editor_block_invalid',
+      block_name: 'example/declared',
+      observed_block_name: 'core/missing',
+      original_block_name: 'example/declared',
+      selector: '',
+      source_path: '',
+      observed_output: '',
+      message: 'Editor reported block "example/declared" as invalid: This block contains unexpected or invalid content.',
+    },
+  ]);
+});

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -150,6 +150,7 @@ if ( ! function_exists( 'activate_plugin' ) ) {
 	function activate_plugin( string $plugin_file ) {
 		$GLOBALS['ssi_companion_active'][]    = $plugin_file;
 		$GLOBALS['ssi_companion_activated'][] = $plugin_file;
+		require_once WP_PLUGIN_DIR . '/' . $plugin_file;
 		return null;
 	}
 }
@@ -436,6 +437,8 @@ $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' )
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/render.php' ), 'install-writes-render-php-to-disk' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/block.json' ), 'install-emits-block-json' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/editor.js' ), 'install-emits-declared-editor-asset' );
+$assert( in_array( 'example/custom-hero', WP_Block_Type_Registry::$registered, true ), 'install-registers-declared-block-before-editor-use' );
+$assert( isset( $GLOBALS['static_site_importer_companion_block_owners']['example/custom-hero'] ), 'install-records-declared-block-owner-before-editor-use' );
 $written_main = file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) ? (string) file_get_contents( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) : '';
 $assert( str_contains( $written_main, 'register_block_type' ), 'written-main-file-registers-blocks' );
 
@@ -443,10 +446,7 @@ $assert( str_contains( $written_main, 'register_block_type' ), 'written-main-fil
 // marked as companion-owned, so a later materialization still fails closed.
 WP_Block_Type_Registry::$registered[] = 'example/custom-hero';
 $GLOBALS['static_site_importer_companion_block_owners'] = array();
-require WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php';
-foreach ( $GLOBALS['ssi_companion_actions']['init'] ?? array() as $callback ) {
-	call_user_func( $callback );
-}
+ssi_example_site_register_blocks();
 $assert( ! isset( $GLOBALS['static_site_importer_companion_block_owners']['example/custom-hero'] ), 'foreign-registration-before-generated-init-records-no-owner' );
 $foreign_init_collision = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $payload, static fn (): bool => true );
 $assert( 'failed' === ( $foreign_init_collision['status'] ?? '' ) && 'runtime_block_name_collision' === ( $foreign_init_collision['diagnostics'][0]['reason_code'] ?? '' ), 'foreign-registration-before-generated-init-blocks-refresh' );
@@ -522,6 +522,8 @@ $assert( 1 === count( $waived_diag ), 'waived-companion-emits-warning' );
 
 // A new site replaces the previous regular companion so document-global
 // scripts from separate imports cannot execute together.
+$GLOBALS['static_site_importer_companion_block_owners'] = array();
+WP_Block_Type_Registry::$registered                   = array();
 $replacement_payload = array_merge( $payload, array( 'site_slug' => 'replacement-site' ) );
 $replacement_report  = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $replacement_payload );
 $assert( in_array( 'ssi-example-site/ssi-example-site.php', $GLOBALS['ssi_companion_deactivated'], true ), 'replacement-deactivates-previous-companion' );


### PR DESCRIPTION
## Summary

- invoke a compiler-declared companion package's own registration callback after materialization, before editor validation
- verify only the package's declared block inventory in the runtime registry
- treat Gutenberg `core/missing` blocks with `originalName` as failed editor evidence
- keep SSI free of producer- or block-specific behavior

Fixes #883.

## Relationship to #884

This is the focused successor to #884. It starts from current `main` and extracts the unique registration-before-editor-validation behavior. It intentionally excludes #884's bundled base64 policy, font materialization, provider-binding, pending-runtime, sidecar, and lifecycle-continuation changes. It also uses generic companion declarations rather than Blocks Engine control semantics.

## Verification

- `php tests/smoke-companion-plugin.php` (101 assertions)
- `node --test tests/editor-validation-contract.test.mjs`
- `npm run test:inventory`
- `npm test` (57 selected tests passed)
- `php -l includes/class-static-site-importer-plugin-materializer.php`
- `git diff --check`

## Lint

No repository PHPCS/ESLint configuration or lint dependency is declared, so no project lint command is available. PHP syntax validation and the full declared test suite pass.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode investigated #884 and its bundled predecessors against current `origin/main`, extracted the generic companion registration and editor-validation contract into this successor, and ran the listed verification. Chris Huber remains responsible for every line.