### PR TITLE
fix(importer): preserve shared resources across URL batch plans

### DIFF
--- a/includes/class-static-site-importer-shared-resource-plan.php
+++ b/includes/class-static-site-importer-shared-resource-plan.php
@@ -55,7 +55,7 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 				'plan'    => $plan,
 			);
 		}
-		$current = self::resources( $artifact, array_column( $existing['resources'], 'path' ) );
+		$current = self::resources( $artifact );
 		$digest  = self::digest( $current );
 		if ( hash_equals( $existing['digest'], $digest ) ) {
 			return array(
@@ -64,7 +64,7 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 				'plan'    => $existing,
 			);
 		}
-		$plan = $this->establish( $artifact, array_column( $existing['resources'], 'path' ) );
+		$plan = $this->establish( $artifact );
 		return array(
 			'digest'  => is_array( $plan ) ? $plan['digest'] : '',
 			'changed' => true,

--- a/includes/class-static-site-importer-shared-resource-plan.php
+++ b/includes/class-static-site-importer-shared-resource-plan.php
@@ -29,6 +29,11 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 	/** @return array<string,mixed>|WP_Error */
 	public function establish( array $artifact, ?array $paths = null ): array|WP_Error {
 		$resources = self::resources( $artifact, $paths );
+		return $this->store( $resources );
+	}
+
+	/** @return array<string,mixed>|WP_Error */
+	private function store( array $resources ): array|WP_Error {
 		$plan      = array(
 			'schema'     => self::SCHEMA,
 			'digest'     => self::digest( $resources ),
@@ -55,7 +60,7 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 				'plan'    => $plan,
 			);
 		}
-		$current = self::resources( $artifact );
+		$current = self::merge_resources( $existing['resources'], self::resources( $artifact ) );
 		$digest  = self::digest( $current );
 		if ( hash_equals( $existing['digest'], $digest ) ) {
 			return array(
@@ -64,7 +69,7 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 				'plan'    => $existing,
 			);
 		}
-		$plan = $this->establish( $artifact );
+		$plan = $this->store( $current );
 		return array(
 			'digest'  => is_array( $plan ) ? $plan['digest'] : '',
 			'changed' => true,
@@ -95,6 +100,18 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 		}
 		usort( $resources, static fn( array $left, array $right ): int => strcmp( $left['path'], $right['path'] ) );
 		return $resources;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function merge_resources( array $existing, array $current ): array {
+		$resources = array();
+		foreach ( array_merge( $existing, $current ) as $resource ) {
+			if ( is_array( $resource ) && '' !== (string) ( $resource['path'] ?? '' ) ) {
+				$resources[ $resource['path'] ] = $resource;
+			}
+		}
+		ksort( $resources, SORT_STRING );
+		return array_values( $resources );
 	}
 
 	private static function digest( array $resources ): string {

--- a/includes/class-static-site-importer-url-batch-import.php
+++ b/includes/class-static-site-importer-url-batch-import.php
@@ -521,11 +521,14 @@ final class Static_Site_Importer_URL_Batch_Import {
 			}
 
 			$batch_digest = (string) ( $runtime['shared_plan_digest'] ?? '' );
-			if ( '' === $batch_digest && is_array( $runtime['staged_page_plans'] ) && ! empty( $runtime['staged_page_plans'] ) ) {
+			if ( '' === $batch_digest && ! empty( $runtime['staged_page_plans'] ) ) {
 				$batch_digest = (string) ( $runtime['staged_page_plans'][0]['shared_digest'] ?? '' );
 			}
 
-			if ( '' !== $current_digest && '' !== $batch_digest && ! hash_equals( $current_digest, $batch_digest ) && is_array( $runtime['artifact']['files'] ?? null ) ) {
+			if ( '' !== $current_digest && ! hash_equals( $current_digest, $batch_digest ) ) {
+				if ( ! is_array( $runtime['artifact']['files'] ?? null ) ) {
+					return new WP_Error( 'static_site_importer_url_plan_batch_artifact_missing', 'The frozen URL run cannot reprepare a stale staged batch without its retained artifact.' );
+				}
 				$fresh_plans = array();
 				foreach ( $runtime['artifact']['files'] as $file ) {
 					if ( ! is_array( $file ) || 'text/html' !== strtolower( (string) ( $file['mime_type'] ?? '' ) ) || '' === (string) ( $file['path'] ?? '' ) ) {

--- a/includes/class-static-site-importer-url-batch-import.php
+++ b/includes/class-static-site-importer-url-batch-import.php
@@ -496,6 +496,16 @@ final class Static_Site_Importer_URL_Batch_Import {
 			return new WP_Error( 'static_site_importer_url_plan_shared_missing', 'The frozen URL run has no shared compiler plan.' );
 		}
 
+		$current_digest = (string) ( $shared_plan['digest'] ?? '' );
+		$compiler       = self::staged_compiler();
+		if ( is_wp_error( $compiler ) ) {
+			return $compiler;
+		}
+		$prepare_page_callable = array( $compiler, 'preparePage' );
+		if ( ! is_callable( $prepare_page_callable ) ) {
+			return new WP_Error( 'static_site_importer_missing_transformer_capability', 'The Blocks Engine php-transformer does not support staged URL batch plans.' );
+		}
+
 		$page_plans = array();
 		$snapshots  = array();
 		foreach ( $cursor as $batch ) {
@@ -505,10 +515,31 @@ final class Static_Site_Importer_URL_Batch_Import {
 			if ( ! is_array( $runtime ) || ! is_array( $runtime['staged_page_plans'] ?? null ) ) {
 				return new WP_Error( 'static_site_importer_url_plan_batch_missing', 'The frozen URL run has an incomplete staged batch.' );
 			}
-			$page_plans = array_merge( $page_plans, $runtime['staged_page_plans'] );
-			$snapshot   = $runtime['source_metadata']['snapshot']['sha256'] ?? null;
+			$snapshot = $runtime['source_metadata']['snapshot']['sha256'] ?? null;
 			if ( is_string( $snapshot ) && '' !== $snapshot ) {
 				$snapshots[] = $snapshot;
+			}
+
+			$batch_digest = (string) ( $runtime['shared_plan_digest'] ?? '' );
+			if ( '' === $batch_digest && is_array( $runtime['staged_page_plans'] ) && ! empty( $runtime['staged_page_plans'] ) ) {
+				$batch_digest = (string) ( $runtime['staged_page_plans'][0]['shared_digest'] ?? '' );
+			}
+
+			if ( '' !== $current_digest && '' !== $batch_digest && ! hash_equals( $current_digest, $batch_digest ) && is_array( $runtime['artifact']['files'] ?? null ) ) {
+				$fresh_plans = array();
+				foreach ( $runtime['artifact']['files'] as $file ) {
+					if ( ! is_array( $file ) || 'text/html' !== strtolower( (string) ( $file['mime_type'] ?? '' ) ) || '' === (string) ( $file['path'] ?? '' ) ) {
+						continue;
+					}
+					try {
+						$fresh_plans[] = call_user_func( $prepare_page_callable, $runtime['artifact'], $shared_plan, (string) $file['path'] );
+					} catch ( Throwable $error ) {
+						return new WP_Error( 'static_site_importer_staged_reprepare_failed', $error->getMessage() );
+					}
+				}
+				$page_plans = array_merge( $page_plans, $fresh_plans );
+			} else {
+				$page_plans = array_merge( $page_plans, $runtime['staged_page_plans'] );
 			}
 		}
 

--- a/tests/smoke-shared-resource-plan.php
+++ b/tests/smoke-shared-resource-plan.php
@@ -14,5 +14,8 @@ $first = $plan->reconcile( $artifact( 'body{color:red}', 'first' ) );
 $second = ( new Static_Site_Importer_Shared_Resource_Plan( $workspace ) )->reconcile( $artifact( 'body{color:red}', 'second' ) );
 $changed = $plan->reconcile( $artifact( 'body{color:blue}', 'third' ) );
 if ( is_wp_error( $first['plan'] ) || $first['changed'] || is_wp_error( $second['plan'] ) || $second['changed'] || $first['digest'] !== $second['digest'] || is_wp_error( $changed['plan'] ) || ! $changed['changed'] || $changed['digest'] === $first['digest'] || ! is_file( $workspace->directory() . '/shared-resource-plan.json' ) ) { throw new RuntimeException( 'shared plans must survive restart, ignore page-only changes, and deterministically invalidate changed shared content' ); }
+$expanded = $plan->reconcile( array( 'files' => array( array( 'path' => 'website/extra.css', 'mime_type' => 'text/css', 'content' => 'h1{color:blue}' ) ) ) );
+$preserved = $plan->reconcile( $artifact( 'body{color:blue}', 'fourth' ) );
+if ( is_wp_error( $expanded['plan'] ) || ! $expanded['changed'] || is_wp_error( $preserved['plan'] ) || $preserved['changed'] || 3 !== count( $preserved['plan']['resources'] ?? array() ) ) { throw new RuntimeException( 'shared plans must retain resources discovered only in an earlier batch' ); }
 $workspace->purge(); @rmdir( $root );
 echo "Shared resource plan smoke passed.\n";

--- a/tests/smoke-url-batch-import.php
+++ b/tests/smoke-url-batch-import.php
@@ -266,4 +266,35 @@ $url_plan_pages = $url_plan_final['plan']['pages'] ?? array();
 $url_plan_paths = array_map( static fn( array $page ): string => (string) ( $page['path'] ?? $page['slug'] ?? '' ), $url_plan_pages );
 $operation_mismatch = Static_Site_Importer_URL_Import_Runtime::run_operation( array( 'operation' => 'apply', 'source' => array( 'type' => 'url' ), 'url' => 'https://runtime-plan.test/', 'import_id' => $url_plan_first['import_id'] ?? '', 'slug' => 'runtime-plan' ) );
 if ( empty( $url_plan_first['continuation'] ) || empty( $url_plan_first['import_id'] ) || ! empty( $url_plan_first['plan'] ) || empty( $url_plan_final['plan'] ) || 'completed' !== ( $url_plan_final['url_batch_run']['status'] ?? '' ) || 2 !== count( $url_plan_pages ) || empty( $url_plan_paths[0] ) || empty( $url_plan_paths[1] ) || $writes_before_url_plan !== count( $runtime_imports ) || ! is_wp_error( $operation_mismatch ) || 'static_site_importer_url_import_run_mismatch' !== $operation_mismatch->get_error_code() ) { throw new RuntimeException( 'URL planning must compose every frozen batch into one plan without importer writes and bind continuation to operation intent' ); }
+
+// shared-change.test — plan-mode cross-batch shared digest change (issue #901)
+add_filter( 'static_site_importer_url_batch_import_fetcher', static function ( $fetcher, array $request ) {
+	if ( 'https://shared-change.test/' !== ( $request['url'] ?? '' ) ) {
+		return $fetcher;
+	}
+	return static function ( string $url ): array {
+		if ( 'https://shared-change.test/sitemap.xml' === $url ) {
+			return array( 'body' => '<urlset><url><loc>https://shared-change.test/</loc></url><url><loc>https://shared-change.test/page2/</loc></url></urlset>', 'metadata' => array( 'content_type' => 'application/xml', 'final_url' => $url ) );
+		}
+		if ( 'https://shared-change.test/' === $url ) {
+			return array( 'body' => '<main>page1<link rel="stylesheet" href="/theme-a.css"></main>', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) );
+		}
+		if ( 'https://shared-change.test/page2/' === $url ) {
+			return array( 'body' => '<main>page2<link rel="stylesheet" href="/theme-a.css"><link rel="stylesheet" href="/theme-b.css"></main>', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) );
+		}
+		if ( 'https://shared-change.test/theme-a.css' === $url ) {
+			return array( 'body' => 'body{color:red}', 'metadata' => array( 'content_type' => 'text/css', 'final_url' => $url ) );
+		}
+		if ( 'https://shared-change.test/theme-b.css' === $url ) {
+			return array( 'body' => 'h1{font-size:2em}', 'metadata' => array( 'content_type' => 'text/css', 'final_url' => $url ) );
+		}
+		return new WP_Error( 'not_found', 'not found' );
+	};
+} );
+$writes_before_shared = count( $runtime_imports );
+$shared_first         = static_site_importer_ability_import( array( 'operation' => 'plan', 'source' => array( 'type' => 'url', 'url' => 'https://shared-change.test/' ), 'slug' => 'shared-change' ) );
+$shared_final         = static_site_importer_ability_import( array( 'operation' => 'plan', 'source' => array( 'type' => 'url', 'url' => 'https://shared-change.test/', 'import_id' => $shared_first['import_id'] ?? '' ), 'slug' => 'shared-change' ) );
+$shared_pages         = $shared_final['plan']['pages'] ?? array();
+$shared_paths         = array_map( static fn( array $p ): string => (string) ( $p['path'] ?? $p['slug'] ?? '' ), $shared_pages );
+if ( empty( $shared_first['continuation'] ) || empty( $shared_first['import_id'] ) || ! empty( $shared_first['plan'] ) || empty( $shared_final['plan'] ) || 'completed' !== ( $shared_final['url_batch_run']['status'] ?? '' ) || 2 !== count( $shared_pages ) || empty( $shared_paths[0] ) || empty( $shared_paths[1] ) || $writes_before_shared !== count( $runtime_imports ) ) { throw new RuntimeException( 'shared plan change across batches must re-prepare stale page plans in compose_complete_plan and succeed without importer writes' ); }
 echo "URL batch import smoke passed.\n";


### PR DESCRIPTION
## Summary

Supersedes #903 without closing it. This maintainer-owned successor preserves Faisal Ahammad’s original implementation as an authored cherry-pick (`3c1c68e0`) and adds the follow-up required for correct cumulative shared-resource planning.

Fixes #901.

When a later URL batch expands the shared plan, previously prepared batch page plans are re-prepared from their immutable retained artifacts before terminal composition. Shared resource reconciliation now retains the cumulative path-keyed union across batches, with the current batch authoritative for resources it contains. This prevents a later partial artifact from dropping resources that appeared only in an earlier batch.

## Commits and Credit

- `3c1c68e0` `Faisal Ahammad <faisalahammad24@gmail.com>`: original stale-digest detection, terminal reprepare flow, and cross-batch URL smoke coverage from #903.
- `10e072cc` `Chris Huber <chris.huber@automattic.com>`: retain cumulative shared resources, treat absent stored batch digests as stale, and add regression coverage for earlier-batch-only resources.

## Verification

- `php -l includes/class-static-site-importer-shared-resource-plan.php`
- `php -l includes/class-static-site-importer-url-batch-import.php`
- `php -l tests/smoke-shared-resource-plan.php`
- `php -l tests/smoke-url-batch-import.php`
- `php tests/smoke-shared-resource-plan.php`
- `php tests/smoke-url-batch-import.php`
- `npm run test:inventory`
- `npm test` (56 passed, 0 failed)
- `git diff --check origin/main...HEAD`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding subagent implemented and verified; Chris Huber remains responsible.