### PR TITLE
Align materialization sidecar lineage intake

### DIFF
--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -672,6 +672,8 @@ const MATERIALIZATION_SIDECAR_SCHEMAS = new Set([
   'static-site-importer/materialization-runtime-sidecar/v1',
   'static-site-importer/materialization-runtime-sidecar/v2',
 ]);
+const MATERIALIZED_DOCUMENT_IDENTITY_FIELDS = ['post_id', 'post_type', 'post_slug', 'serialized_content_sha256'];
+const MATERIALIZED_DOCUMENT_LINEAGE_FIELDS = ['source_path', 'route', ...MATERIALIZED_DOCUMENT_IDENTITY_FIELDS];
 
 // Sidecars are written by the import command before its verbose JSON reaches a
 // capped transport. Validate both correlation and immutable fixture input before
@@ -713,14 +715,37 @@ function validSidecar(row) {
 function validDocuments(documents, truncated, total) {
   return Array.isArray(documents) && documents.length <= 25 && typeof truncated === 'boolean' && boundedCount(total)
     && total >= documents.length && truncated === (total > documents.length)
-    && documents.every((document) => {
-      const row = objectValue(document);
-      return Object.keys(row).length === 4
-        && safeToken(row.post_id, 20)
-        && safeToken(row.post_type, 80)
-        && safeToken(row.post_slug, 200)
-        && sha256(row.serialized_content_sha256);
-    });
+    && documents.every(validMaterializedDocument);
+}
+
+// Runtime sidecars record source and route joins alongside the post identity.
+// Four-field rows were persisted before that complete contract reached intake.
+function validMaterializedDocument(document) {
+  const row = objectValue(document);
+  const identity = safeToken(row.post_id, 20)
+    && safeToken(row.post_type, 80)
+    && safeToken(row.post_slug, 200)
+    && sha256(row.serialized_content_sha256);
+  if (!identity) return false;
+
+  const fields = Object.keys(row);
+  if (fields.length === 4) {
+    return fields.every((field) => MATERIALIZED_DOCUMENT_IDENTITY_FIELDS.includes(field));
+  }
+  return fields.length === 6
+    && fields.every((field) => MATERIALIZED_DOCUMENT_LINEAGE_FIELDS.includes(field))
+    && validMaterializedDocumentLineageValue(row.source_path)
+    && validMaterializedDocumentRoute(row.route);
+}
+
+// Match the PHP sidecar writer: printable ASCII, 500-byte maximum, and an
+// absolute path for routes returned from wp_parse_url().
+function validMaterializedDocumentLineageValue(value) {
+  return typeof value === 'string' && value.length > 0 && value.length <= 500 && /^[\x20-\x7e]+$/.test(value);
+}
+
+function validMaterializedDocumentRoute(value) {
+  return validMaterializedDocumentLineageValue(value) && value.startsWith('/');
 }
 
 function validDurability(value) {

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -599,14 +599,18 @@ function static_site_importer_cli_materialized_documents( array $pages ): array 
 		if ( ! $post instanceof WP_Post ) {
 			continue;
 		}
+		$permalink = get_permalink( $post );
+		$source_path = static_site_importer_cli_sidecar_lineage_value( $source_path );
+		$route       = static_site_importer_cli_sidecar_route_value( wp_parse_url( (string) $permalink, PHP_URL_PATH ) );
+		if ( '' === $source_path || '' === $route ) {
+			continue;
+		}
 		++$total;
 		if ( count( $rows ) >= $max_rows ) {
 			continue;
 		}
-		$permalink = get_permalink( $post );
-		$route     = (string) wp_parse_url( (string) $permalink, PHP_URL_PATH );
 		$rows[]    = array(
-			'source_path'               => (string) $source_path,
+			'source_path'               => $source_path,
 			'route'                     => $route,
 			'post_id'                   => (string) $post->ID,
 			'post_type'                 => (string) $post->post_type,
@@ -718,4 +722,23 @@ function static_site_importer_cli_sidecar_token( $value, int $maximum ): bool {
 function static_site_importer_cli_sidecar_token_value( $value, int $maximum ): string {
 	$value = is_scalar( $value ) ? (string) $value : '';
 	return static_site_importer_cli_sidecar_token( $value, $maximum ) ? $value : '';
+}
+
+/**
+ * The matrix sidecar keeps source lineage printable and bounded so its compact
+ * transport can retain it without accepting control characters.
+ *
+ * @param mixed $value Source path from the materialization receipt.
+ */
+function static_site_importer_cli_sidecar_lineage_value( $value ): string {
+	$value = is_string( $value ) ? $value : '';
+	return 0 < strlen( $value ) && 500 >= strlen( $value ) && 1 === preg_match( '/^[\x20-\x7E]+$/', $value ) ? $value : '';
+}
+
+/**
+ * @param mixed $value URL path returned by wp_parse_url().
+ */
+function static_site_importer_cli_sidecar_route_value( $value ): string {
+	$value = static_site_importer_cli_sidecar_lineage_value( $value );
+	return '/' === substr( $value, 0, 1 ) ? $value : '';
 }

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -1497,7 +1497,8 @@ test('typed WP Codebox sidecar export materializes into the host intake path', (
   const artifact = JSON.stringify({ fixture: 'simple-site' });
   writeFileSync(path.join(fixtureDirectory, 'artifact.json'), artifact);
   writeFileSync(path.join(guestDirectory, 'artifact.json'), artifact);
-  const documents = [{ post_id: '42', post_type: 'page', post_slug: 'home', serialized_content_sha256: 'c'.repeat(64) }];
+  // This is the complete row emitted by static_site_importer_cli_materialized_documents().
+  const documents = [{ source_path: 'index.html', route: '/', post_id: '42', post_type: 'page', post_slug: 'home', serialized_content_sha256: 'c'.repeat(64) }];
   writeMaterializationSidecar({ directory: guestDirectory, fixtureId: 'simple-site', runId: matrix.id, attemptId: 'batch-001', receipt: boundedSidecarReceipt(), fileName: 'exported-sidecar.json', schema: 'static-site-importer/materialization-runtime-sidecar/v2', documents, documentsTruncated: false, documentsTotal: 1 });
 
   const exports = materializeMaterializationSidecars({ fixtures: matrix.fixtures, outputDirectory, codeboxArtifactsDirectory, attemptId: 'batch-001' });
@@ -1516,7 +1517,7 @@ test('typed WP Codebox sidecar export materializes into the host intake path', (
   assert.deepEqual(result.fixtures[0].surface_lineage.find((surface) => surface.surface.id === 'front-page').materialized_document, { status: 'available', post_id: '42', post_type: 'page', post_slug: 'home', serialized_content_sha256: 'c'.repeat(64) });
 });
 
-test('v1 sidecars remain compatible while truncated v2 documents make absent identities indeterminate', () => {
+test('persisted v1 and four-field v2 sidecars remain compatible while truncated documents make absent identities indeterminate', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-sidecar-v1-v2-lineage-'));
   const base = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'sidecar-v1-v2-lineage' });
   const matrix = { ...base, fixtures: [{ ...base.fixtures[0] }, { ...base.fixtures[0], id: 'truncated-site' }, { ...base.fixtures[0], id: 'missing-site' }] };
@@ -1540,6 +1541,47 @@ test('v1 sidecars remain compatible while truncated v2 documents make absent ide
   assert.deepEqual(byFixture.get('truncated-site').surface_lineage.find((surface) => surface.surface.id === 'front-page').materialized_document, { status: 'indeterminate', post_id: '42', truncated: true, documents_total: 26 });
   assert.deepEqual(byFixture.get('missing-site').surface_lineage.find((surface) => surface.surface.id === 'front-page').materialized_document, { status: 'missing', post_id: '42' });
   assert.equal(byFixture.get('missing-site').surface_lineage.find((surface) => surface.surface.id === 'front-page').lanes.editor.status, 'disabled');
+});
+
+test('materialization sidecars reject malformed canonical and mixed document rows', () => {
+  const invalidDocuments = [
+    ['empty-source-path', { source_path: '', route: '/', post_id: '42', post_type: 'page', post_slug: 'home', serialized_content_sha256: 'c'.repeat(64) }],
+    ['oversized-source-path', { source_path: `website/${'x'.repeat(493)}`, route: '/', post_id: '42', post_type: 'page', post_slug: 'home', serialized_content_sha256: 'c'.repeat(64) }],
+    ['control-character-route', { source_path: 'index.html', route: '/\n', post_id: '42', post_type: 'page', post_slug: 'home', serialized_content_sha256: 'c'.repeat(64) }],
+    ['relative-route', { source_path: 'index.html', route: 'home', post_id: '42', post_type: 'page', post_slug: 'home', serialized_content_sha256: 'c'.repeat(64) }],
+    ['mixed-row', { source_path: 'index.html', post_id: '42', post_type: 'page', post_slug: 'home', serialized_content_sha256: 'c'.repeat(64) }],
+  ];
+  for (const [name, document] of invalidDocuments) {
+    const outputDirectory = mkdtempSync(path.join(tmpdir(), `ssi-sidecar-invalid-document-${name}-`));
+    const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'sidecar-invalid-document-run' });
+    const directory = path.join(outputDirectory, 'simple-site');
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, 'artifact.json'), JSON.stringify({ fixture: 'simple-site' }));
+    writeMaterializationSidecar({ directory, fixtureId: 'simple-site', runId: matrix.id, receipt: boundedSidecarReceipt(), schema: 'static-site-importer/materialization-runtime-sidecar/v2', documents: [document], documentsTruncated: false, documentsTotal: 1 });
+
+    const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+    assert.equal(result.fixtures[0].matrix_evidence.materialization_sidecar.status, 'malformed', name);
+  }
+});
+
+test('invalid writer-skipped lineage rows do not make a complete sidecar indeterminate', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-sidecar-skipped-lineage-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'sidecar-skipped-lineage-run' });
+  const directory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(path.join(directory, 'artifact.json'), JSON.stringify({ fixture: 'simple-site' }));
+  // The PHP writer excludes an invalid source/route candidate before calculating
+  // documents_total and documents_truncated.
+  writeMaterializationSidecar({ directory, fixtureId: 'simple-site', runId: matrix.id, receipt: boundedSidecarReceipt(), schema: 'static-site-importer/materialization-runtime-sidecar/v2', documents: [], documentsTruncated: false, documentsTotal: 0 });
+
+  const result = collectFixtureMatrixRunResults({
+    matrix,
+    outputDirectory,
+    codeboxOutput: { fixture_id: 'simple-site', surface_id: 'front-page', command: 'wordpress.editor-open', status: 'completed', post_id: '42' },
+  });
+  const fixture = result.fixtures[0];
+  assert.equal(fixture.matrix_evidence.materialization_sidecar.status, 'verified');
+  assert.deepEqual(fixture.surface_lineage.find((surface) => surface.surface.id === 'front-page').materialized_document, { status: 'missing', post_id: '42' });
 });
 
 test('direct recipe builders generate distinct run and attempt identities', () => {


### PR DESCRIPTION
## Summary
- emit bounded `source_path` and absolute `route` lineage alongside materialized post identity
- accept the complete six-field sidecar contract while preserving persisted four-field rows
- reject malformed, mixed, control-character, oversized, and relative-route document rows

## Verification
- 267 fixture-matrix tests pass
- `git diff --check`

## Tracking
Closes #909.

## Cross-Repo Context
- Blocks Engine crop recognition PR: https://github.com/Automattic/blocks-engine/pull/848
- Homeboy Lab control-plane PR: https://github.com/Extra-Chill/homeboy/pull/12199

The canonical Lab visual/editor matrix remains a downstream integration gate across these candidates; no fixture is promoted by this PR.

## AI Assistance
OpenAI GPT-5.6 Sol was used through OpenCode to investigate the sidecar contract mismatch, implement and test the fix, and prepare this PR. Chris Huber reviewed and is responsible for the changes.