### PR TITLE
Add trusted URL resolver provider

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -36,6 +36,7 @@
     "tests/smoke-url-import-runtime.php": { "environment": "standalone-php" },
     "tests/smoke-rest-url-import-helpers.php": { "environment": "standalone-php" },
     "tests/smoke-url-concurrent-fetcher.php": { "environment": "standalone-php" },
+    "tests/smoke-url-resolver-provider.php": { "environment": "standalone-php" },
     "tests/smoke-validation-runtime-diagnostics.php": { "environment": "standalone-php" },
     "tests/smoke-visual-repair-css.php": { "environment": "standalone-php" },
     "tests/smoke-webfont-producer-consumer.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-url-fetcher.php
+++ b/includes/class-static-site-importer-url-fetcher.php
@@ -774,9 +774,17 @@ class Static_Site_Importer_URL_Fetcher {
 			return array( $host );
 		}
 
-		$ips = array();
-		if ( function_exists( 'dns_get_record' ) ) {
-			$records = dns_get_record( $host, DNS_A + DNS_AAAA );
+		$provided = function_exists( 'apply_filters' ) ? apply_filters( 'static_site_importer_url_resolved_ips', null, $host ) : null;
+		if ( is_wp_error( $provided ) ) {
+			return $provided;
+		}
+		if ( null !== $provided && ! is_array( $provided ) ) {
+			return new WP_Error( 'static_site_importer_url_dns_provider_invalid', 'The URL host resolver returned an invalid response.' );
+		}
+
+		$ips = is_array( $provided ) ? $provided : array();
+		if ( null === $provided && function_exists( 'dns_get_record' ) ) {
+			$records = @dns_get_record( $host, DNS_A + DNS_AAAA ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Unsupported runtimes may expose dns_get_record() while warning and returning no records; the fail-closed fallback handles that outcome.
 			if ( is_array( $records ) ) {
 				foreach ( $records as $record ) {
 					if ( isset( $record['ip'] ) ) {
@@ -789,8 +797,8 @@ class Static_Site_Importer_URL_Fetcher {
 			}
 		}
 
-		if ( ! $ips ) {
-			$records = gethostbynamel( $host );
+		if ( null === $provided && ! $ips ) {
+			$records = @gethostbynamel( $host ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- DNS failure is converted to a reason-coded, fail-closed URL error below.
 			if ( is_array( $records ) ) {
 				$ips = $records;
 			}

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -42,6 +42,7 @@
     { "path": "tests/smoke-url-import-runtime.php", "environment": "standalone-php" },
     { "path": "tests/smoke-rest-url-import-helpers.php", "environment": "standalone-php" },
     { "path": "tests/smoke-url-concurrent-fetcher.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-url-resolver-provider.php", "environment": "standalone-php" },
     { "path": "tests/smoke-validation-runtime-diagnostics.php", "environment": "standalone-php" },
     { "path": "tests/smoke-visual-repair-css.php", "environment": "standalone-php" },
     { "path": "tests/smoke-webfont-producer-consumer.php", "environment": "standalone-php" },

--- a/tests/smoke-url-resolver-provider.php
+++ b/tests/smoke-url-resolver-provider.php
@@ -1,0 +1,35 @@
+<?php
+/** Run: php tests/smoke-url-resolver-provider.php */
+if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', dirname( __DIR__ ) . '/' ); }
+class WP_Error { public function __construct( private string $code, private string $message = '' ) {} public function get_error_code(): string { return $this->code; } public function get_error_message(): string { return $this->message; } }
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+function wp_parse_url( string $url ) { return parse_url( $url ); }
+$GLOBALS['ssi_resolver_provider'] = null;
+function apply_filters( string $hook, $value, ...$args ) {
+	if ( 'static_site_importer_url_resolved_ips' !== $hook || ! is_callable( $GLOBALS['ssi_resolver_provider'] ) ) { return $value; }
+	return $GLOBALS['ssi_resolver_provider']( $value, ...$args );
+}
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-fetcher.php';
+
+$GLOBALS['ssi_resolver_provider'] = static fn( $value, string $host ) => 'public.test' === $host ? array( '1.1.1.1', '2606:4700:4700::1111' ) : $value;
+$public = Static_Site_Importer_URL_Fetcher::validate_url( 'https://public.test/path' );
+if ( is_wp_error( $public ) || array( '1.1.1.1', '2606:4700:4700::1111' ) !== $public['ips'] ) { throw new RuntimeException( 'provider public addresses must be retained for IP-pinned transport' ); }
+
+$GLOBALS['ssi_resolver_provider'] = static fn() => array( '127.0.0.1' );
+$private = Static_Site_Importer_URL_Fetcher::validate_url( 'https://private.test/' );
+if ( ! is_wp_error( $private ) || 'static_site_importer_url_private_ip' !== $private->get_error_code() ) { throw new RuntimeException( 'provider addresses must pass the existing public-IP policy' ); }
+
+$GLOBALS['ssi_resolver_provider'] = static fn() => '1.1.1.1';
+$malformed = Static_Site_Importer_URL_Fetcher::validate_url( 'https://malformed.test/' );
+if ( ! is_wp_error( $malformed ) || 'static_site_importer_url_dns_provider_invalid' !== $malformed->get_error_code() ) { throw new RuntimeException( 'malformed provider responses must fail closed' ); }
+
+$GLOBALS['ssi_resolver_provider'] = static fn() => array();
+$empty = Static_Site_Importer_URL_Fetcher::validate_url( 'https://empty.test/' );
+if ( ! is_wp_error( $empty ) || 'static_site_importer_url_dns_failed' !== $empty->get_error_code() ) { throw new RuntimeException( 'empty provider responses must fail closed without native fallback' ); }
+
+$provider_error = new WP_Error( 'runtime_resolver_unavailable', 'resolver unavailable' );
+$GLOBALS['ssi_resolver_provider'] = static fn() => $provider_error;
+$unavailable = Static_Site_Importer_URL_Fetcher::validate_url( 'https://unavailable.test/' );
+if ( $provider_error !== $unavailable ) { throw new RuntimeException( 'provider errors must retain their identity' ); }
+
+fwrite( STDOUT, "OK: URL resolver provider remains fail closed\n" );


### PR DESCRIPTION
## Summary

- add a generic URL host resolver provider boundary
- preserve native DNS as the default when no provider responds
- validate all provider addresses through the existing public-IP policy
- fail closed for malformed, empty, or explicitly unavailable provider results

Fixes #915. Supports the tracked Lab workflow in #768 without weakening SSRF or DNS-rebinding protection.

## Verification

- `npm test` (58 selected tests passed)
- `npm run test:inventory`
- `php tests/smoke-url-resolver-provider.php`
- `php tests/smoke-url-concurrent-fetcher.php`
- `php -l includes/class-static-site-importer-url-fetcher.php`
- `php -l tests/smoke-url-resolver-provider.php`
- `git diff --check`

PHPCS was not available from this repository's production Composer install (`vendor/bin/phpcs` absent).

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to reproduce the PHP.wasm DNS failure, design the fail-closed provider boundary, implement tests, and run verification. Chris Huber reviewed and remains responsible for every line.
