### PR TITLE
Use released PHP Transformer v0.4.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,36 +7,6 @@
     {
       "type": "package",
       "package": {
-        "name": "automattic/blocks-engine-php-transformer",
-        "version": "0.4.16-dev",
-        "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
-        "type": "library",
-        "license": "GPL-3.0-or-later",
-        "source": {
-          "type": "git",
-          "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-          "reference": "f16ca299bf97d28eede5b7cbd7746ff2df1d0349"
-        },
-        "dist": {
-          "type": "zip",
-          "url": "https://github.com/Automattic/blocks-engine-php-transformer/archive/f16ca299bf97d28eede5b7cbd7746ff2df1d0349.zip",
-          "reference": "f16ca299bf97d28eede5b7cbd7746ff2df1d0349"
-        },
-        "autoload": {
-          "psr-4": {
-            "Automattic\\BlocksEngine\\PhpTransformer\\": "src/"
-          }
-        },
-        "require": {
-          "league/commonmark": "^2.5",
-          "league/html-to-markdown": "^5.1",
-          "php": ">=8.1"
-        }
-      }
-    },
-    {
-      "type": "package",
-      "package": {
         "name": "automattic/blocks-engine-figma-transformer",
         "version": "0.1.3",
         "description": "PHP primitives for transforming Figma designs into static HTML website artifacts.",
@@ -73,7 +43,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "0.4.16-dev",
+    "automattic/blocks-engine-php-transformer": "0.4.16",
     "php": "^8.1"
   },
   "minimum-stability": "dev",
@@ -83,8 +53,5 @@
       "php": "8.1.0"
     },
     "sort-packages": true
-  },
-  "extra": {
-    "static-site-importer-temporary-dependency": "Blocks Engine PHP Transformer mirror commit f16ca299; replace this package reference with the released 0.4.16 version."
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2f16c79bfad42743aa0e7cbb37bbb10",
+    "content-hash": "dcc272fbb6a743ddd32048ef43431b24",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,21 +43,26 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.4.16-dev",
+            "version": "v0.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "f16ca299bf97d28eede5b7cbd7746ff2df1d0349"
+                "reference": "8871be064be55bb22b6c8bea10d19809d51a8c5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/Automattic/blocks-engine-php-transformer/archive/f16ca299bf97d28eede5b7cbd7746ff2df1d0349.zip",
-                "reference": "f16ca299bf97d28eede5b7cbd7746ff2df1d0349"
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/8871be064be55bb22b6c8bea10d19809d51a8c5d",
+                "reference": "8871be064be55bb22b6c8bea10d19809d51a8c5d",
+                "shasum": ""
             },
             "require": {
                 "league/commonmark": "^2.5",
                 "league/html-to-markdown": "^5.1",
                 "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6",
+                "yoast/phpunit-polyfills": "^3.0"
             },
             "type": "library",
             "autoload": {
@@ -65,10 +70,28 @@
                     "Automattic\\BlocksEngine\\PhpTransformer\\": "src/"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-3.0-or-later"
             ],
-            "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs."
+            "authors": [
+                {
+                    "name": "Automattic"
+                }
+            ],
+            "description": "PHP primitives for transforming HTML, Markdown, and website artifacts into WordPress block outputs.",
+            "homepage": "https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer",
+            "keywords": [
+                "blocks",
+                "html",
+                "markdown",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Automattic/blocks-engine/issues",
+                "source": "https://github.com/Automattic/blocks-engine-php-transformer"
+            },
+            "time": "2026-08-12T11:31:58+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -788,9 +811,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "automattic/blocks-engine-php-transformer": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## Summary

- replace the temporary `0.4.16-dev` inline package definition with stable `0.4.16`
- resolve the dependency through Packagist at mirror commit `8871be064be55bb22b6c8bea10d19809d51a8c5d`
- remove the completed temporary-dependency migration marker

Closes #918.

## Verification

- `composer validate --strict`
- `composer audit`
- `composer install --no-interaction --prefer-dist --dry-run`
- `composer show automattic/blocks-engine-php-transformer --format=json`
- `npm test` (58 passed, 0 failed)
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to inspect the release chain, update Composer metadata, and run verification. Chris Huber reviewed and remains responsible for the change.