### PR TITLE
Fix binary artifact content-policy false positives

### DIFF
--- a/includes/class-static-site-importer-content-policy.php
+++ b/includes/class-static-site-importer-content-policy.php
@@ -45,6 +45,9 @@ final class Static_Site_Importer_Content_Policy {
 		'pdf',
 	);
 
+	/** Static formats whose source bytes are inspected for server-side code. */
+	private const TEXTUAL_EXTENSIONS = array( 'html', 'htm', 'css', 'js', 'mjs', 'json', 'map', 'xml', 'txt', 'md', 'markdown', 'svg' );
+
 	/** Assets that a compiler may carry into a generated companion plugin. */
 	private const COMPANION_ASSET_EXTENSIONS = array( 'js', 'mjs', 'css', 'json', 'svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'ico', 'woff', 'woff2', 'ttf', 'otf', 'eot' );
 
@@ -63,7 +66,7 @@ final class Static_Site_Importer_Content_Policy {
 				return new WP_Error( 'static_site_importer_executable_source_rejected', sprintf( 'Untrusted artifact file %s is not static content.', $path ), array( 'path' => $path ) );
 			}
 			$content = self::file_content( $file );
-			if ( null !== $content && self::contains_server_code( $content ) ) {
+			if ( null !== $content && self::is_textual_path( $path ) && self::contains_server_code( $content ) ) {
 				return new WP_Error( 'static_site_importer_executable_source_rejected', sprintf( 'Untrusted artifact file %s contains server-side code.', $path ), array( 'path' => $path ) );
 			}
 		}
@@ -73,6 +76,11 @@ final class Static_Site_Importer_Content_Policy {
 	public static function is_static_path( string $path ): bool {
 		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
 		return '' !== $extension && in_array( $extension, self::STATIC_EXTENSIONS, true );
+	}
+
+	public static function is_textual_path( string $path ): bool {
+		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+		return '' !== $extension && in_array( $extension, self::TEXTUAL_EXTENSIONS, true );
 	}
 
 	public static function is_companion_asset_path( string $path ): bool {

--- a/tests/smoke-content-only-policy.php
+++ b/tests/smoke-content-only-policy.php
@@ -36,6 +36,8 @@ foreach ( array( 'website/shell.php', 'website/shell.phtml', 'website/shell.jsp'
 }
 $assert( is_wp_error( Static_Site_Importer_Content_Policy::validate_artifact( $artifact( 'website/index.html', '<?php system("id");', true ) ) ), 'base64-server-code-rejected' );
 $assert( is_wp_error( Static_Site_Importer_Content_Policy::validate_artifact( $artifact( 'website/site.js', '<?php system("id");' ) ) ), 'server-code-marker-in-static-extension-rejected' );
+$assert( is_wp_error( Static_Site_Importer_Content_Policy::validate_artifact( $artifact( 'website/logo.svg', '<svg><?php system("id");</svg>', true ) ) ), 'textual-svg-server-code-rejected' );
+$assert( true === Static_Site_Importer_Content_Policy::validate_artifact( $artifact( 'website/photo.jpeg', "\xFF\xD8\xFF\xFE\x00\x07<?php\xFF\xD9", true ) ), 'binary-jpeg-php-tag-bytes-accepted' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary

Closes #920.

- Scan PHP opening tags only in explicitly textual allowed artifact formats.
- Preserve fail-closed executable-extension rejection and textual/polyglot source rejection.
- Accept valid base64 JPEG bytes that contain a PHP-tag-like byte sequence.

## Verification

- `php tests/smoke-content-only-policy.php`
- `php -l includes/class-static-site-importer-content-policy.php`
- `php -l tests/smoke-content-only-policy.php`
- `npm run test:inventory`
- `npm run test:all` (58 runnable tests passed; 14 environment-dependent lanes explicitly skipped)
- `homeboy review lint --placement local --changed-only --summary`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to inspect the policy, implement the format-aware fix, and run the listed verification. Chris Huber remains responsible for every line.