### PR TITLE
Fix dangling script preloads in inert imports

### DIFF
--- a/includes/class-static-site-importer-client-script-policy.php
+++ b/includes/class-static-site-importer-client-script-policy.php
@@ -117,7 +117,9 @@ class Static_Site_Importer_Client_Script_Policy {
 				$attributes = $matches[1];
 				$relation   = strtolower( trim( (string) self::attribute( $attributes, 'rel' ) ) );
 				$as         = strtolower( trim( (string) self::attribute( $attributes, 'as' ) ) );
-				$script     = in_array( 'modulepreload', preg_split( '/\s+/', $relation ) ?: array(), true ) || ( in_array( 'preload', preg_split( '/\s+/', $relation ) ?: array(), true ) && 'script' === $as );
+				$relations  = preg_split( '/\s+/', $relation );
+				$relations  = false === $relations ? array() : $relations;
+				$script     = in_array( 'modulepreload', $relations, true ) || ( in_array( 'preload', $relations, true ) && 'script' === $as );
 				if ( ! $script ) {
 					return $matches[0];
 				}

--- a/includes/class-static-site-importer-client-script-policy.php
+++ b/includes/class-static-site-importer-client-script-policy.php
@@ -87,7 +87,7 @@ class Static_Site_Importer_Client_Script_Policy {
 	}
 
 	private static function filter_html( string $html, string $path, bool $preserve, array &$report ): string {
-		return (string) preg_replace_callback(
+		$html = (string) preg_replace_callback(
 			'#<script\b([^>]*)>(.*?)</script\s*>#is',
 			static function ( array $matches ) use ( $path, $preserve, &$report ): string {
 				$attributes = $matches[1];
@@ -108,6 +108,28 @@ class Static_Site_Importer_Client_Script_Policy {
 				}
 				self::record( $report, 'data' === $row['class'] ? 'quarantined' : 'dropped', $row );
 				return '';
+			},
+			$html
+		);
+		return (string) preg_replace_callback(
+			'#<link\b([^>]*)/?>#is',
+			static function ( array $matches ) use ( $path, $preserve, &$report ): string {
+				$attributes = $matches[1];
+				$relation   = strtolower( trim( (string) self::attribute( $attributes, 'rel' ) ) );
+				$as         = strtolower( trim( (string) self::attribute( $attributes, 'as' ) ) );
+				$script     = in_array( 'modulepreload', preg_split( '/\s+/', $relation ) ?: array(), true ) || ( in_array( 'preload', preg_split( '/\s+/', $relation ) ?: array(), true ) && 'script' === $as );
+				if ( ! $script ) {
+					return $matches[0];
+				}
+				$row = array(
+					'path'   => $path,
+					'class'  => 'preload',
+					'type'   => 'modulepreload' === $relation ? 'modulepreload' : 'preload',
+					'href'   => (string) self::attribute( $attributes, 'href' ),
+					'sha256' => hash( 'sha256', $matches[0] ),
+				);
+				self::record( $report, $preserve ? 'preserved' : 'dropped', $row );
+				return $preserve ? $matches[0] : '';
 			},
 			$html
 		);

--- a/tests/smoke-client-script-policy.php
+++ b/tests/smoke-client-script-policy.php
@@ -27,7 +27,7 @@ $artifact = array(
 	'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
 	'entrypoint' => 'website/index.html',
 	'files'      => array(
-		array( 'path' => 'website/index.html', 'mime_type' => 'text/html', 'content' => '<main>Safe content</main><script>window.inline=true</script><script src="assets/app.js"></script><script src="https://cdn.example.test/app.js"></script><script type="module" src="assets/module.mjs"></script><script type="application/ld+json">{"@type":"Organization"}</script><script src="data:text/javascript,alert(1)"></script><script>window.gtag("config", "UA-test")</script>' ),
+		array( 'path' => 'website/index.html', 'mime_type' => 'text/html', 'content' => '<link rel="preload" href="assets/app.js" as="script"><link rel="modulepreload" href="assets/module.mjs"><link rel="stylesheet" href="assets/site.css"><link rel="preload" href="assets/font.woff2" as="font"><main>Safe content</main><script>window.inline=true</script><script src="assets/app.js"></script><script src="https://cdn.example.test/app.js"></script><script type="module" src="assets/module.mjs"></script><script type="application/ld+json">{"@type":"Organization"}</script><script src="data:text/javascript,alert(1)"></script><script>window.gtag("config", "UA-test")</script>' ),
 		array( 'path' => 'website/assets/app.js', 'mime_type' => 'application/javascript', 'content' => 'window.local=true;' ),
 		array( 'path' => 'website/assets/module.mjs', 'mime_type' => 'text/javascript', 'content' => 'export default true;' ),
 		array( 'path' => 'website/assets/site.css', 'mime_type' => 'text/css', 'content' => 'main{color:green}' ),
@@ -44,7 +44,8 @@ $paths = array_column( $inert['artifact']['files'], 'path' );
 $assert( 'inert' === $inert['report']['policy'], 'default-is-inert' );
 $assert( str_contains( $inert_html, 'Safe content' ) && ! str_contains( $inert_html, '<script' ), 'inert-removes-executable-and-data-markup' );
 $assert( ! in_array( 'website/assets/app.js', $paths, true ) && ! in_array( 'website/assets/module.mjs', $paths, true ) && in_array( 'website/assets/site.css', $paths, true ), 'inert-removes-local-script-assets-only' );
-$assert( array( 'data', 'data', 'inline', 'local', 'local', 'local', 'module', 'remote', 'telemetry' ) === $classes, 'inert-classifies-inline-local-remote-module-data-and-telemetry' );
+$assert( ! str_contains( $inert_html, 'modulepreload' ) && ! str_contains( $inert_html, 'as="script"' ) && str_contains( $inert_html, 'stylesheet' ) && str_contains( $inert_html, 'as="font"' ), 'inert-removes-script-preloads-only' );
+$assert( array( 'data', 'data', 'inline', 'local', 'local', 'local', 'module', 'preload', 'preload', 'remote', 'telemetry' ) === $classes, 'inert-classifies-inline-local-remote-module-data-telemetry-and-preloads' );
 $assert( 2 === count( $inert['report']['quarantined'] ) && 'data' === $inert['report']['quarantined'][0]['class'], 'data-is-quarantined-and-never-executed' );
 
 $unproven = Static_Site_Importer_Client_Script_Policy::apply( $artifact, array( 'client_script_policy' => 'isolated_preview', 'client_script_provenance' => array( 'ref' => 'upload:sha256:abc123' ) ) );
@@ -53,7 +54,7 @@ $assert( 'inert' === $unproven['report']['policy'] && empty( $unproven['report']
 $preview      = Static_Site_Importer_Client_Script_Policy::apply( $artifact, array( 'client_script_policy' => 'isolated_preview', 'client_script_isolated' => true, 'client_script_provenance' => array( 'ref' => 'upload:sha256:abc123' ) ) );
 $preview_html = (string) ( $preview['artifact']['files'][0]['content'] ?? '' );
 $assert( 'isolated_preview' === $preview['report']['policy'] && 'untrusted_imported_code' === $preview['report']['trust'] && 'upload:sha256:abc123' === $preview['report']['provenance'], 'isolated-policy-requires-and-records-provenance' );
-$assert( str_contains( $preview_html, 'window.inline=true' ) && 9 === count( $preview['report']['preserved'] ) && empty( $preview['report']['dropped'] ) && empty( $preview['report']['quarantined'] ), 'isolated-preview-preserves-scripts-without-granting-trust' );
+$assert( str_contains( $preview_html, 'window.inline=true' ) && str_contains( $preview_html, 'modulepreload' ) && 11 === count( $preview['report']['preserved'] ) && empty( $preview['report']['dropped'] ) && empty( $preview['report']['quarantined'] ), 'isolated-preview-preserves-scripts-and-preloads-without-granting-trust' );
 
 $base64_html     = '<main>Base64 content</main><script src="js/main.js"></script>';
 $base64_script   = 'window.base64Script=true;';


### PR DESCRIPTION
## Summary

- remove script preload and modulepreload declarations when inert policy drops imported JavaScript
- preserve stylesheet, font, and other non-script link declarations
- report preserved or dropped preload declarations alongside scripts

Fixes #924.

## Verification

- `composer check`
- `npm test`
- PHP syntax checks
- full selected suite: 58 PHP/Node tests plus platform checks

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the BET-19 Figma failure through the import pipeline, implemented the policy fix and coverage, and ran verification. Chris Huber reviewed and remains responsible for every line.