### PR TITLE
Fix absent provider overlay collection

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -296,7 +296,7 @@ class Static_Site_Importer_Theme_Generator {
 		$overlays = array();
 		foreach ( $reports as $report ) {
 			foreach ( is_array( $report['forms'] ?? null ) ? $report['forms'] : array() as $form ) {
-				if ( is_array( $form['provider_layout_overlay_css'] ?? null ) ) {
+				if ( is_array( $form['provider_layout_overlay_css'] ?? null ) && ! empty( $form['provider_layout_overlay_css'] ) ) {
 					$overlays[] = $form['provider_layout_overlay_css'];
 				}
 			}

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -170,6 +170,9 @@ $assert( false === ( $receipt['completed']['block_provenance_truncated'] ?? true
 
 $overlay_css = "/* Static Site Importer provider layout overlay: abcdef123456 */\n.ssi-form-123456789abc > form.jetpack-contact-form__form{display:flex;gap:1rem}\n";
 $overlay = array( 'schema' => Static_Site_Importer_Provider_Layout_Overlay::OVERLAY_SCHEMA, 'css' => $overlay_css, 'sha256' => hash( 'sha256', $overlay_css ), 'bytes' => strlen( $overlay_css ) );
+$collect_overlays = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'provider_layout_overlays_from_entity_reports' );
+$collected_overlays = $collect_overlays->invoke( null, array( array( 'forms' => array( array( 'provider_layout_overlay_css' => array() ), array( 'provider_layout_overlay_css' => $overlay ), array( 'provider_layout_overlay_css' => array( 'malformed' => true ) ) ) ) ) );
+$assert( array( $overlay, array( 'malformed' => true ) ) === $collected_overlays, 'provider layout collection omits empty absence sentinels without hiding non-empty overlays from strict validation' );
 $overlay_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'provider-overlay-plan', 'provider_layout_overlays' => array( $overlay, $overlay ) ) );
 $overlay_root = $GLOBALS['ssi_plan_root'] . '/provider-overlay-plan';
 $assert( 'completed' === $overlay_receipt['status'] && 'completed' === ( $overlay_receipt['completed']['provider_layout_overlays']['status'] ?? '' ), 'provider layout receipt is applied only after stylesheet writes complete' );


### PR DESCRIPTION
## Summary

- omit empty provider-layout overlay absence sentinels emitted by form reports
- preserve non-empty malformed overlays for strict materializer validation
- cover empty, valid, and malformed collection in the existing overlay contract test

Fixes #933.

## Root cause

The frozen BET-19 Squarespace retry contained 26 `provider_layout_overlay_css: []` values and zero produced overlays. The theme-generator collector treated every array as a requested overlay, so materializer preflight correctly rejected the empty arrays as malformed. Empty arrays represent `not_requested` and must not enter the requested-overlay list.

## Verification

- `npm test`: 59 selected manifest tests passed, including 267 Node tests and supporting suites
- `npm run test:inventory`
- `php tests/smoke-wordpress-site-plan-materializer.php`
- PHP syntax checks for both changed files
- unchanged frozen Squarespace retry completed with 575 generated files
- second unchanged retry completed with 25 `reconciliation_identity_match` page matches, zero errors, and no duplicate `index` page
- generated theme and Jetpack were active

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol traced the preserved BET-19 receipt, identified the empty-sentinel collector boundary, implemented the focused fix and regression coverage, ran repository tests, and reran the frozen Squarespace acceptance workflow. Chris Huber reviewed and is responsible for the change.