### PR TITLE
Reconcile final import quality counts

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -694,6 +694,13 @@ if ( ! function_exists( 'static_site_importer_success_diagnostics_contract' ) ) 
 		$import_validation_result = isset( $result['import_validation_result'] ) && is_array( $result['import_validation_result'] ) ? $result['import_validation_result'] : array();
 		$quality                  = isset( $result['quality'] ) && is_array( $result['quality'] ) ? $result['quality'] : array();
 		$validation_diagnostics   = isset( $import_validation_result['diagnostics'] ) && is_array( $import_validation_result['diagnostics'] ) ? $import_validation_result['diagnostics'] : array();
+		$import_report            = isset( $result['import_report'] ) && is_array( $result['import_report'] ) ? $result['import_report'] : array();
+		if ( empty( $import_report ) ) {
+			$import_report = array(
+				'quality'     => $quality,
+				'diagnostics' => $validation_diagnostics,
+			);
+		}
 
 		$contract_input = array(
 			'success'                  => true,
@@ -701,10 +708,8 @@ if ( ! function_exists( 'static_site_importer_success_diagnostics_contract' ) ) 
 			'slug'                     => isset( $result['theme_slug'] ) ? (string) $result['theme_slug'] : '',
 			'name'                     => isset( $result['theme_name'] ) ? (string) $result['theme_name'] : '',
 			'import_validation_result' => $import_validation_result,
-			'import_report'            => array(
-				'quality'     => $quality,
-				'diagnostics' => $validation_diagnostics,
-			),
+			'import_report'            => $import_report,
+			'materialization_receipt'  => isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : array(),
 		);
 
 		return class_exists( 'Static_Site_Importer_Diagnostic_Contract' ) ? Static_Site_Importer_Diagnostic_Contract::build( $contract_input ) : array( 'diagnostics' => $validation_diagnostics );

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -35,17 +35,18 @@ class Static_Site_Importer_Diagnostic_Contract {
 		$summary       = isset( $result['summary'] ) && is_array( $result['summary'] ) ? $result['summary'] : array();
 		$artifacts     = isset( $result['artifacts'] ) && is_array( $result['artifacts'] ) ? $result['artifacts'] : array();
 
+		$quality_counts = self::quality_counts( $import_report, $summary, $result );
+
 		$diagnostics = array_merge(
 			self::diagnostic_rows_from_result( $result ),
 			self::diagnostic_rows_from_import_report( $import_report ),
 			self::blocks_engine_conversion_diagnostics( $import_report ),
 			self::runtime_dependency_target_gaps( $import_report ),
 			self::semantic_parity_diagnostics( $import_report ),
-			self::gutenberg_gap_diagnostics( $import_report )
+			self::gutenberg_gap_diagnostics( $import_report ),
+			self::quality_count_consistency_diagnostics( $quality_counts )
 		);
 		$diagnostics = self::dedupe_diagnostics( $diagnostics );
-
-		$quality_counts = self::quality_counts( $import_report, $summary );
 
 		return array(
 			'schema'                         => self::IMPORT_DIAGNOSTICS_SCHEMA,
@@ -268,19 +269,69 @@ class Static_Site_Importer_Diagnostic_Contract {
 	}
 
 	/**
-	 * Return quality counts from import report first, then compact summaries.
+	 * Reconcile canonical compiler quality evidence with explicit materialization resolutions.
 	 *
 	 * @param array<string,mixed> $import_report Import report.
 	 * @param array<string,mixed> $summary Provider summary.
-	 * @return array<string,int>
+	 * @param array<string,mixed> $result  Provider result.
+	 * @return array<string,mixed>
 	 */
-	private static function quality_counts( array $import_report, array $summary ): array {
-		$quality = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
-		$keys    = array( 'block_count', 'fallback_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
+	private static function quality_counts( array $import_report, array $summary, array $result ): array {
+		$keys = array( 'block_count', 'fallback_count', 'diagnostic_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
+		$compiler_quality = isset( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) && is_array( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) ? $import_report['blocks_engine']['wordpress_site_plan']['quality'] : array();
+		$report_quality   = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
+		$source_counts    = self::quality_metric_values( $compiler_quality, $keys );
+		$report_counts    = self::quality_metric_values( $report_quality, $keys );
+		$compiler_fallback_count_available = isset( $source_counts['fallback_count'] );
+		$provenance       = array();
+
+		foreach ( $keys as $key ) {
+			if ( ! isset( $source_counts[ $key ] ) && isset( $report_counts[ $key ] ) ) {
+				$source_counts[ $key ] = $report_counts[ $key ];
+			}
+		}
+		if ( ! empty( $compiler_quality ) ) {
+			$provenance['source_detected'] = array(
+				'owner'   => 'blocks-engine',
+				'path'    => 'blocks_engine.wordpress_site_plan.quality',
+				'schema'  => isset( $import_report['blocks_engine']['wordpress_site_plan']['schema'] ) ? (string) $import_report['blocks_engine']['wordpress_site_plan']['schema'] : '',
+				'metrics' => 'blocks_engine.wordpress_site_plan.quality.metrics',
+			);
+		} elseif ( ! empty( $report_quality ) ) {
+			$provenance['source_detected'] = array( 'owner' => 'static-site-importer', 'path' => 'quality', 'schema' => isset( $import_report['schema'] ) ? (string) $import_report['schema'] : '', 'metrics' => 'quality' );
+		}
+
+		$receipt = isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : ( isset( $import_report['materialization_receipt'] ) && is_array( $import_report['materialization_receipt'] ) ? $import_report['materialization_receipt'] : array() );
+		$reconciliation = isset( $import_report['quality_resolutions'] ) && is_array( $import_report['quality_resolutions'] )
+			? $import_report['quality_resolutions']
+			: ( isset( $import_report['fallback_reconciliation'] ) && is_array( $import_report['fallback_reconciliation'] ) ? $import_report['fallback_reconciliation'] : array() );
+		$resolved_counts = array();
+		$source_fallback_count_available = isset( $reconciliation['source_fallback_count'] ) && is_numeric( $reconciliation['source_fallback_count'] );
+		if ( ! $compiler_fallback_count_available && $source_fallback_count_available ) {
+			$source_counts['fallback_count'] = max( 0, (int) $reconciliation['source_fallback_count'] );
+			$provenance['source_detected'] = array(
+				'owner'   => 'static-site-importer',
+				'path'    => 'quality_resolutions.source_fallback_count',
+				'schema'  => isset( $reconciliation['schema'] ) ? (string) $reconciliation['schema'] : '',
+				'metrics' => 'quality_resolutions',
+			);
+		}
+		$verified_resolutions = self::verified_provider_resolution_count( $reconciliation );
+		if ( ( $compiler_fallback_count_available || $source_fallback_count_available ) && null !== $verified_resolutions ) {
+			$resolved_counts['fallback_count'] = $verified_resolutions;
+			$provenance['materialized'] = array(
+				'owner'   => 'static-site-importer',
+				'path'    => 'quality_resolutions',
+				'schema'  => isset( $reconciliation['schema'] ) ? (string) $reconciliation['schema'] : '',
+				'receipt' => isset( $receipt['schema'] ) ? (string) $receipt['schema'] : '',
+			);
+		}
 
 		$counts = array();
 		foreach ( $keys as $key ) {
-			$counts[ $key ] = isset( $quality[ $key ] ) && is_numeric( $quality[ $key ] ) ? (int) $quality[ $key ] : 0;
+			$source = $source_counts[ $key ] ?? 0;
+			$resolved = min( $source, $resolved_counts[ $key ] ?? 0 );
+			$counts[ $key ] = $source - $resolved;
 		}
 		if ( $counts['block_count'] <= 0 ) {
 			$document_counts = self::block_document_quality_counts( $import_report );
@@ -289,7 +340,91 @@ class Static_Site_Importer_Diagnostic_Contract {
 			}
 		}
 
+		$counts['source_detected'] = array_merge( array_fill_keys( $keys, 0 ), $source_counts );
+		$counts['materialized']    = array_merge( array_fill_keys( $keys, 0 ), $resolved_counts );
+		$counts['unresolved']      = array_intersect_key( $counts, array_flip( $keys ) );
+		$counts['provenance']      = $provenance;
+		$counts['consistent']      = empty( $compiler_quality ) || empty( $report_quality ) || self::quality_metrics_agree( $source_counts, $report_counts );
+
 		return $counts;
+	}
+
+	/**
+	 * Verify the public shape of #937 resolution evidence without repeating its
+	 * materializer-level page and binding verification.
+	 */
+	private static function verified_provider_resolution_count( array $reconciliation ): ?int {
+		if ( 'static-site-importer/quality-resolutions/v1' !== ( $reconciliation['schema'] ?? null ) || ! isset( $reconciliation['source_fallback_count'], $reconciliation['resolved_by_provider'], $reconciliation['unresolved_fallback_count'], $reconciliation['resolutions'] ) || ! is_numeric( $reconciliation['source_fallback_count'] ) || ! is_numeric( $reconciliation['resolved_by_provider'] ) || ! is_numeric( $reconciliation['unresolved_fallback_count'] ) || ! is_array( $reconciliation['resolutions'] ) ) {
+			return null;
+		}
+
+		$source     = max( 0, (int) $reconciliation['source_fallback_count'] );
+		$resolved   = max( 0, (int) $reconciliation['resolved_by_provider'] );
+		$unresolved = max( 0, (int) $reconciliation['unresolved_fallback_count'] );
+		if ( $source - $resolved !== $unresolved ) {
+			return null;
+		}
+
+		$identities = array();
+		foreach ( $reconciliation['resolutions'] as $resolution ) {
+			if ( ! is_array( $resolution ) || 'resolved_by_provider' !== ( $resolution['state'] ?? null ) || ! is_string( $resolution['fallback_reconciliation_identity'] ?? null ) || ! is_string( $resolution['fallback_hash'] ?? null ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $resolution['fallback_reconciliation_identity'] ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $resolution['fallback_hash'] ) ) {
+				return null;
+			}
+			$receipt = isset( $resolution['receipt'] ) && is_array( $resolution['receipt'] ) ? $resolution['receipt'] : array();
+			if ( 'static-site-importer/quality-resolution-receipt/v1' !== ( $receipt['schema'] ?? null ) || 'completed' !== ( $receipt['status'] ?? null ) || $resolution['fallback_reconciliation_identity'] !== ( $receipt['fallback_reconciliation_identity'] ?? null ) || $resolution['fallback_hash'] !== ( $receipt['fallback_hash'] ?? null ) ) {
+				return null;
+			}
+			foreach ( array( 'binding_reconciliation_identity', 'materialized_block_hash', 'materialized_content_hash' ) as $field ) {
+				if ( ! is_string( $receipt[ $field ] ?? null ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $receipt[ $field ] ) ) {
+					return null;
+				}
+			}
+			if ( isset( $identities[ $resolution['fallback_reconciliation_identity'] ] ) ) {
+				return null;
+			}
+			$identities[ $resolution['fallback_reconciliation_identity'] ] = true;
+		}
+
+		return $resolved === count( $identities ) ? $resolved : null;
+	}
+
+	/** @return array<string,int> */
+	private static function quality_metric_values( array $quality, array $keys ): array {
+		$metrics = isset( $quality['metrics'] ) && is_array( $quality['metrics'] ) ? $quality['metrics'] : $quality;
+		$counts  = array();
+		foreach ( $keys as $key ) {
+			if ( isset( $metrics[ $key ] ) && is_numeric( $metrics[ $key ] ) ) {
+				$counts[ $key ] = max( 0, (int) $metrics[ $key ] );
+			}
+		}
+		return $counts;
+	}
+
+	private static function quality_metrics_agree( array $left, array $right ): bool {
+		foreach ( $left as $key => $value ) {
+			if ( isset( $right[ $key ] ) && $value !== $right[ $key ] ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function quality_count_consistency_diagnostics( array $quality_counts ): array {
+		if ( ! empty( $quality_counts['consistent'] ) ) {
+			return array();
+		}
+		return array(
+			array(
+				'type'        => 'quality_count_consistency_failure',
+				'severity'    => 'error',
+				'code'        => 'static_site_importer_quality_count_consistency_failure',
+				'stage'       => 'quality_reconciliation',
+				'owner'       => 'static-site-importer',
+				'message'     => 'Canonical compiler quality counts disagree with the importer report; unresolved counts retain compiler evidence.',
+				'constraints' => 'gating',
+			)
+		);
 	}
 
 	/**

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -277,8 +277,8 @@ class Static_Site_Importer_Diagnostic_Contract {
 	 * @return array<string,mixed>
 	 */
 	private static function quality_counts( array $import_report, array $summary, array $result ): array {
-		$keys = array( 'block_count', 'fallback_count', 'diagnostic_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
-		$compiler_quality = isset( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) && is_array( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) ? $import_report['blocks_engine']['wordpress_site_plan']['quality'] : array();
+		$keys                              = array( 'block_count', 'fallback_count', 'diagnostic_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
+		$compiler_quality                  = isset( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) && is_array( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) ? $import_report['blocks_engine']['wordpress_site_plan']['quality'] : array();
 		$report_quality   = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
 		$source_counts    = self::quality_metric_values( $compiler_quality, $keys );
 		$report_counts    = self::quality_metric_values( $report_quality, $keys );
@@ -298,14 +298,19 @@ class Static_Site_Importer_Diagnostic_Contract {
 				'metrics' => 'blocks_engine.wordpress_site_plan.quality.metrics',
 			);
 		} elseif ( ! empty( $report_quality ) ) {
-			$provenance['source_detected'] = array( 'owner' => 'static-site-importer', 'path' => 'quality', 'schema' => isset( $import_report['schema'] ) ? (string) $import_report['schema'] : '', 'metrics' => 'quality' );
+			$provenance['source_detected'] = array(
+				'owner'   => 'static-site-importer',
+				'path'    => 'quality',
+				'schema'  => isset( $import_report['schema'] ) ? (string) $import_report['schema'] : '',
+				'metrics' => 'quality',
+			);
 		}
 
-		$receipt = isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : ( isset( $import_report['materialization_receipt'] ) && is_array( $import_report['materialization_receipt'] ) ? $import_report['materialization_receipt'] : array() );
-		$reconciliation = isset( $import_report['quality_resolutions'] ) && is_array( $import_report['quality_resolutions'] )
+		$receipt                        = isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : ( isset( $import_report['materialization_receipt'] ) && is_array( $import_report['materialization_receipt'] ) ? $import_report['materialization_receipt'] : array() );
+		$reconciliation                 = isset( $import_report['quality_resolutions'] ) && is_array( $import_report['quality_resolutions'] )
 			? $import_report['quality_resolutions']
 			: ( isset( $import_report['fallback_reconciliation'] ) && is_array( $import_report['fallback_reconciliation'] ) ? $import_report['fallback_reconciliation'] : array() );
-		$resolved_counts = array();
+		$resolved_counts                = array();
 		$source_fallback_count_available = isset( $reconciliation['source_fallback_count'] ) && is_numeric( $reconciliation['source_fallback_count'] );
 		if ( ! $compiler_fallback_count_available && $source_fallback_count_available ) {
 			$source_counts['fallback_count'] = max( 0, (int) $reconciliation['source_fallback_count'] );
@@ -316,7 +321,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 				'metrics' => 'quality_resolutions',
 			);
 		}
-		$verified_resolutions = self::verified_provider_resolution_count( $reconciliation );
+		$verified_resolutions            = self::verified_provider_resolution_count( $reconciliation );
 		if ( ( $compiler_fallback_count_available || $source_fallback_count_available ) && null !== $verified_resolutions ) {
 			$resolved_counts['fallback_count'] = $verified_resolutions;
 			$provenance['materialized'] = array(
@@ -329,8 +334,8 @@ class Static_Site_Importer_Diagnostic_Contract {
 
 		$counts = array();
 		foreach ( $keys as $key ) {
-			$source = $source_counts[ $key ] ?? 0;
-			$resolved = min( $source, $resolved_counts[ $key ] ?? 0 );
+			$source         = $source_counts[ $key ] ?? 0;
+			$resolved       = min( $source, $resolved_counts[ $key ] ?? 0 );
 			$counts[ $key ] = $source - $resolved;
 		}
 		if ( $counts['block_count'] <= 0 ) {
@@ -371,7 +376,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 				return null;
 			}
 			$receipt = isset( $resolution['receipt'] ) && is_array( $resolution['receipt'] ) ? $resolution['receipt'] : array();
-			if ( 'static-site-importer/quality-resolution-receipt/v1' !== ( $receipt['schema'] ?? null ) || 'completed' !== ( $receipt['status'] ?? null ) || $resolution['fallback_reconciliation_identity'] !== ( $receipt['fallback_reconciliation_identity'] ?? null ) || $resolution['fallback_hash'] !== ( $receipt['fallback_hash'] ?? null ) ) {
+			if ( 'static-site-importer/quality-resolution-receipt/v1' !== ( $receipt['schema'] ?? null ) || 'completed' !== ( $receipt['status'] ?? null ) || ( $receipt['fallback_reconciliation_identity'] ?? null ) !== $resolution['fallback_reconciliation_identity'] || ( $receipt['fallback_hash'] ?? null ) !== $resolution['fallback_hash'] ) {
 				return null;
 			}
 			foreach ( array( 'binding_reconciliation_identity', 'materialized_block_hash', 'materialized_content_hash' ) as $field ) {
@@ -385,7 +390,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 			$identities[ $resolution['fallback_reconciliation_identity'] ] = true;
 		}
 
-		return $resolved === count( $identities ) ? $resolved : null;
+		return count( $identities ) === $resolved ? $resolved : null;
 	}
 
 	/** @return array<string,int> */
@@ -423,7 +428,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 				'owner'       => 'static-site-importer',
 				'message'     => 'Canonical compiler quality counts disagree with the importer report; unresolved counts retain compiler evidence.',
 				'constraints' => 'gating',
-			)
+			),
 		);
 	}
 

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -918,6 +918,8 @@ function static_site_importer_rest_route_url_import( array $source, array $input
 		'success'               => true,
 		'import_id'             => isset( $result['import_id'] ) ? (string) $result['import_id'] : '',
 		'result'                => isset( $result['result'] ) && is_array( $result['result'] ) ? $result['result'] : array(),
+		'diagnostics'           => isset( $result['diagnostics'] ) && is_array( $result['diagnostics'] ) ? $result['diagnostics'] : array(),
+		'fixture_diagnostics'   => isset( $result['fixture_diagnostics'] ) && is_array( $result['fixture_diagnostics'] ) ? $result['fixture_diagnostics'] : array(),
 		'import_report_summary' => isset( $result['import_report_summary'] ) && is_array( $result['import_report_summary'] ) ? $result['import_report_summary'] : array(),
 		'terminal_batch_result' => isset( $result['url_batch_run']['terminal_batch_result'] ) && is_array( $result['url_batch_run']['terminal_batch_result'] )
 			? $result['url_batch_run']['terminal_batch_result']

--- a/tests/fixtures/diagnostic-contract/quality-reconciliation.json
+++ b/tests/fixtures/diagnostic-contract/quality-reconciliation.json
@@ -1,0 +1,35 @@
+{
+  "source_evidence": {
+    "schema": "blocks-engine/wordpress-site-plan/v2",
+    "quality": {
+      "status": "success_with_warnings",
+      "metrics": {
+        "block_count": 331,
+        "fallback_count": 458,
+        "diagnostic_count": 537
+      }
+    }
+  },
+  "importer_report_evidence": {
+    "quality": {
+      "block_count": 0,
+      "fallback_count": 0,
+      "diagnostic_count": 0
+    }
+  },
+  "quality_resolutions_evidence": {
+    "schema": "static-site-importer/quality-resolutions/v1",
+    "source_fallback_count": 458,
+    "resolved_by_provider": 8,
+    "unresolved_fallback_count": 450
+  },
+  "materialization_receipt_evidence": {
+    "schema": "static-site-importer/materialization-receipt/v1",
+    "status": "completed"
+  },
+  "expected_unresolved_quality": {
+    "block_count": 331,
+    "fallback_count": 450,
+    "diagnostic_count": 537
+  }
+}

--- a/tests/smoke-ability-import-success-diagnostics.php
+++ b/tests/smoke-ability-import-success-diagnostics.php
@@ -130,6 +130,61 @@ $assert( ( $fired[0]['args'][0] ?? null ) === $contract, 'hook-arg-contract' );
 $assert( ( $fired[0]['args'][1] ?? null ) === $result, 'hook-arg-result' );
 $assert( ( $fired[0]['args'][2] ?? null ) === $input, 'hook-arg-input' );
 
+$provider_resolutions = array();
+for ( $index = 1; $index <= 8; ++$index ) {
+	$fallback_identity = hash( 'sha256', 'ability-fallback-' . $index );
+	$fallback_hash     = hash( 'sha256', 'ability-source-' . $index );
+	$provider_resolutions[] = array(
+		'fallback_reconciliation_identity' => $fallback_identity,
+		'fallback_hash'                    => $fallback_hash,
+		'state'                            => 'resolved_by_provider',
+		'receipt'                          => array(
+			'schema'                           => 'static-site-importer/quality-resolution-receipt/v1',
+			'status'                           => 'completed',
+			'fallback_reconciliation_identity' => $fallback_identity,
+			'fallback_hash'                    => $fallback_hash,
+			'binding_reconciliation_identity'  => hash( 'sha256', 'ability-binding-' . $index ),
+			'materialized_block_hash'          => hash( 'sha256', 'ability-block-' . $index ),
+			'materialized_content_hash'        => hash( 'sha256', 'ability-content-' . $index ),
+		),
+	);
+}
+$reconciled_result = array(
+	'theme_slug'   => 'compiler-quality-site',
+	'theme_name'   => 'Compiler Quality Site',
+	'quality'      => array( 'block_count' => 0, 'fallback_count' => 0, 'diagnostic_count' => 0 ),
+	'import_report' => array(
+		'schema'                  => 'static-site-importer/import-report/v1',
+		'quality'                 => array( 'block_count' => 0, 'fallback_count' => 0, 'diagnostic_count' => 0 ),
+		'blocks_engine'           => array(
+			'wordpress_site_plan' => array(
+				'schema'  => 'blocks-engine/wordpress-site-plan/v2',
+				'quality' => array( 'metrics' => array( 'block_count' => 331, 'fallback_count' => 458, 'diagnostic_count' => 537 ) ),
+			),
+		),
+		'quality_resolutions' => array(
+			'schema'                    => 'static-site-importer/quality-resolutions/v1',
+			'source_fallback_count'     => 458,
+			'resolved_by_provider'      => 8,
+			'unresolved_fallback_count' => 450,
+			'resolutions'               => $provider_resolutions,
+		),
+	),
+	'materialization_receipt' => array(
+		'schema' => 'static-site-importer/materialization-receipt/v1',
+		'status' => 'completed',
+	),
+);
+$reconciled_envelope = static_site_importer_ability_import_success( $reconciled_result, array( 'slug' => 'compiler-quality-site' ) );
+$reconciled_contract = $reconciled_envelope['fixture_diagnostics'] ?? array();
+$assert( 331 === ( $reconciled_contract['quality_counts']['block_count'] ?? null ), 'success-envelope-retains-compiler-block-count' );
+$assert( 450 === ( $reconciled_contract['quality_counts']['fallback_count'] ?? null ), 'success-envelope-emits-unresolved-fallback-count' );
+$assert( 8 === ( $reconciled_contract['quality_counts']['materialized']['fallback_count'] ?? null ), 'success-envelope-uses-provider-reconciliation' );
+$assert( 'blocks_engine.wordpress_site_plan.quality' === ( $reconciled_contract['quality_counts']['provenance']['source_detected']['path'] ?? '' ), 'success-envelope-identifies-compiler-provenance' );
+$assert( 'static-site-importer/materialization-receipt/v1' === ( $reconciled_contract['quality_counts']['provenance']['materialized']['receipt'] ?? '' ), 'success-envelope-identifies-materialization-receipt' );
+$assert( false === ( $reconciled_contract['quality_counts']['consistent'] ?? true ), 'success-envelope-flags-contradictory-quality-layers' );
+$assert( 'quality_count_consistency_failure' === ( $reconciled_contract['diagnostics'][0]['type'] ?? '' ), 'success-envelope-emits-consistency-diagnostic' );
+
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
 	exit( 1 );

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -156,6 +156,135 @@ $assert( '#canvas' === ( $diagnostics['runtime_dependency_target_gaps'][0]['sele
 $assert( 'header nav' === ( $diagnostics['by_repair_bucket']['semantic_parity'][0]['selector'] ?? '' ), 'semantic-selector' );
 $assert( array() === ( $diagnostics['artifact_refs'] ?? null ), 'no-runtime-artifact-requirement' );
 
+$quality_fixture = json_decode( (string) file_get_contents( dirname( __DIR__ ) . '/tests/fixtures/diagnostic-contract/quality-reconciliation.json' ), true );
+$verified_resolutions = array();
+for ( $index = 1; $index <= 8; ++$index ) {
+	$fallback_identity = hash( 'sha256', 'fallback-' . $index );
+	$fallback_hash     = hash( 'sha256', 'source-' . $index );
+	$verified_resolutions[] = array(
+		'fallback_reconciliation_identity' => $fallback_identity,
+		'fallback_hash'                    => $fallback_hash,
+		'state'                            => 'resolved_by_provider',
+		'receipt'                          => array(
+			'schema'                           => 'static-site-importer/quality-resolution-receipt/v1',
+			'status'                           => 'completed',
+			'fallback_reconciliation_identity' => $fallback_identity,
+			'fallback_hash'                    => $fallback_hash,
+			'binding_reconciliation_identity'  => hash( 'sha256', 'binding-' . $index ),
+			'materialized_block_hash'          => hash( 'sha256', 'block-' . $index ),
+			'materialized_content_hash'        => hash( 'sha256', 'content-' . $index ),
+		),
+	);
+}
+$quality_fixture['quality_resolutions_evidence']['resolutions'] = $verified_resolutions;
+$quality_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'import_report' => array(
+			'schema'        => 'static-site-importer/import-report/v1',
+			'quality'       => $quality_fixture['importer_report_evidence']['quality'],
+			'blocks_engine' => array( 'wordpress_site_plan' => $quality_fixture['source_evidence'] ),
+			'quality_resolutions' => $quality_fixture['quality_resolutions_evidence'],
+		),
+		'materialization_receipt' => $quality_fixture['materialization_receipt_evidence'],
+	)
+);
+$expected_unresolved = $quality_fixture['expected_unresolved_quality'];
+$assert( $expected_unresolved['block_count'] === ( $quality_contract['quality_counts']['block_count'] ?? null ), 'quality-reconciliation-retains-compiler-block-count' );
+$assert( $expected_unresolved['fallback_count'] === ( $quality_contract['quality_counts']['fallback_count'] ?? null ), 'quality-reconciliation-subtracts-explicit-resolution' );
+$assert( $expected_unresolved['diagnostic_count'] === ( $quality_contract['quality_counts']['diagnostic_count'] ?? null ), 'quality-reconciliation-retains-compiler-diagnostics' );
+$assert( 458 === ( $quality_contract['quality_counts']['source_detected']['fallback_count'] ?? null ), 'quality-reconciliation-preserves-source-evidence' );
+$assert( 8 === ( $quality_contract['quality_counts']['materialized']['fallback_count'] ?? null ), 'quality-reconciliation-preserves-provider-resolution-evidence' );
+$assert( $expected_unresolved['fallback_count'] === ( $quality_contract['quality_counts']['unresolved']['fallback_count'] ?? null ), 'quality-reconciliation-exposes-unresolved-evidence' );
+$assert( 'blocks_engine.wordpress_site_plan.quality' === ( $quality_contract['quality_counts']['provenance']['source_detected']['path'] ?? '' ), 'quality-reconciliation-identifies-compiler-provenance' );
+$assert( false === ( $quality_contract['quality_counts']['consistent'] ?? true ), 'quality-reconciliation-detects-contradictory-layers' );
+$assert( 'quality_count_consistency_failure' === ( $quality_contract['diagnostics'][0]['type'] ?? '' ), 'quality-reconciliation-emits-gating-diagnostic' );
+
+$absent_quality_contract = Static_Site_Importer_Diagnostic_Contract::build( array( 'import_report' => array( 'blocks_engine' => array( 'wordpress_site_plan' => array( 'schema' => 'blocks-engine/wordpress-site-plan/v2' ) ) ) ) );
+$assert( 0 === ( $absent_quality_contract['quality_counts']['fallback_count'] ?? null ), 'quality-reconciliation-keeps-absent-fields-zero' );
+$assert( array() === ( $absent_quality_contract['quality_counts']['provenance'] ?? null ), 'quality-reconciliation-does-not-invent-absent-provenance' );
+$assert( true === ( $absent_quality_contract['quality_counts']['consistent'] ?? false ), 'quality-reconciliation-keeps-absent-layers-consistent' );
+
+$clean_quality_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'import_report' => array(
+			'quality'       => array( 'block_count' => 2, 'fallback_count' => 0, 'diagnostic_count' => 0 ),
+			'blocks_engine' => array( 'wordpress_site_plan' => array( 'schema' => 'blocks-engine/wordpress-site-plan/v2', 'quality' => array( 'metrics' => array( 'block_count' => 2, 'fallback_count' => 0, 'diagnostic_count' => 0 ) ) ) ),
+		),
+	)
+);
+$assert( 0 === ( $clean_quality_contract['quality_counts']['fallback_count'] ?? null ), 'quality-reconciliation-keeps-clean-fallbacks-zero' );
+$assert( true === ( $clean_quality_contract['quality_counts']['consistent'] ?? false ), 'quality-reconciliation-keeps-clean-layers-consistent' );
+$assert( 0 === ( $clean_quality_contract['diagnostic_summary']['total'] ?? null ), 'quality-reconciliation-does-not-diagnose-clean-layers' );
+
+$importer_only_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'import_report' => array(
+			'schema'              => 'static-site-importer/import-report/v1',
+			'quality'             => array( 'fallback_count' => 450 ),
+			'quality_resolutions' => array(
+				'schema'                    => 'static-site-importer/quality-resolutions/v1',
+				'source_fallback_count'     => 458,
+				'resolved_by_provider'      => 8,
+				'unresolved_fallback_count' => 450,
+				'resolutions'               => $verified_resolutions,
+			),
+		),
+	)
+);
+$assert( 450 === ( $importer_only_contract['quality_counts']['fallback_count'] ?? null ), 'quality-reconciliation-does-not-double-subtract-importer-unresolved-count' );
+$assert( 458 === ( $importer_only_contract['quality_counts']['source_detected']['fallback_count'] ?? null ), 'quality-reconciliation-uses-importer-source-fallback-baseline' );
+$assert( 8 === ( $importer_only_contract['quality_counts']['materialized']['fallback_count'] ?? null ), 'quality-reconciliation-preserves-importer-provider-resolution' );
+$assert( 'quality_resolutions.source_fallback_count' === ( $importer_only_contract['quality_counts']['provenance']['source_detected']['path'] ?? '' ), 'quality-reconciliation-identifies-importer-source-baseline' );
+
+$legacy_importer_only_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'import_report' => array(
+			'schema'                  => 'static-site-importer/import-report/v1',
+			'quality'                 => array( 'fallback_count' => 450 ),
+			'fallback_reconciliation' => array( 'schema' => 'static-site-importer/quality-resolutions/v1', 'resolved_by_provider' => 8 ),
+		),
+	)
+);
+$assert( 450 === ( $legacy_importer_only_contract['quality_counts']['fallback_count'] ?? null ), 'quality-reconciliation-keeps-legacy-importer-quality-as-unresolved' );
+$assert( 0 === ( $legacy_importer_only_contract['quality_counts']['materialized']['fallback_count'] ?? null ), 'quality-reconciliation-does-not-apply-resolution-without-source-baseline' );
+$assert( 'quality' === ( $legacy_importer_only_contract['quality_counts']['provenance']['source_detected']['path'] ?? '' ), 'quality-reconciliation-preserves-legacy-importer-provenance' );
+
+$forged_resolution_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'import_report' => array(
+			'quality'             => array( 'fallback_count' => 0 ),
+			'blocks_engine'       => array( 'wordpress_site_plan' => array( 'quality' => array( 'metrics' => array( 'fallback_count' => 458 ) ) ) ),
+			'quality_resolutions' => array_merge( $quality_fixture['quality_resolutions_evidence'], array( 'resolutions' => array() ) ),
+		),
+	)
+);
+$assert( 458 === ( $forged_resolution_contract['quality_counts']['fallback_count'] ?? null ), 'quality-reconciliation-rejects-forged-aggregate-without-receipts' );
+$assert( 0 === ( $forged_resolution_contract['quality_counts']['materialized']['fallback_count'] ?? null ), 'quality-reconciliation-does-not-credit-forged-aggregate' );
+
+$stale_resolution_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'import_report' => array(
+			'quality'             => array( 'fallback_count' => 0 ),
+			'blocks_engine'       => array( 'wordpress_site_plan' => array( 'quality' => array( 'metrics' => array( 'fallback_count' => 458 ) ) ) ),
+			'quality_resolutions' => array_merge( $quality_fixture['quality_resolutions_evidence'], array( 'resolutions' => array_slice( $verified_resolutions, 0, 7 ) ) ),
+		),
+	)
+);
+$assert( 458 === ( $stale_resolution_contract['quality_counts']['fallback_count'] ?? null ), 'quality-reconciliation-rejects-stale-aggregate-count-mismatch' );
+
+$mismatched_resolution_entries = $verified_resolutions;
+$mismatched_resolution_entries[0]['receipt']['fallback_hash'] = hash( 'sha256', 'other-source' );
+$mismatched_resolution_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'import_report' => array(
+			'quality'             => array( 'fallback_count' => 0 ),
+			'blocks_engine'       => array( 'wordpress_site_plan' => array( 'quality' => array( 'metrics' => array( 'fallback_count' => 458 ) ) ) ),
+			'quality_resolutions' => array_merge( $quality_fixture['quality_resolutions_evidence'], array( 'resolutions' => $mismatched_resolution_entries ) ),
+		),
+	)
+);
+$assert( 458 === ( $mismatched_resolution_contract['quality_counts']['fallback_count'] ?? null ), 'quality-reconciliation-rejects-mismatched-receipt-hash' );
+
 $quality_gate_error = static_site_importer_ability_error(
 	'static_site_importer_quality_gate_failed',
 	'Import failed quality gates; materialization was not completed.',


### PR DESCRIPTION
## Summary
- preserve compiler and materialization evidence through ability and REST success contracts
- report source, materialized, and final unresolved quality counts with provenance
- require identity/hash-bound resolution receipts before reducing fallback counts

Closes #936

## Verification
- `npm test` (59 selected entries, 0 failures)
- ability success, diagnostic contract, and validation runtime smokes

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed this change with parallel coding and review agents. Chris Huber reviewed and remains responsible for every line.