### PR TITLE
Reconcile materialized form fallbacks

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -415,6 +415,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return array<string, mixed>
 	 */
 	public static function finalize_quality_report( array &$report, array $args ): array {
+		self::reconcile_provider_materialized_fallbacks( $report );
 		self::mark_active_companion_script_fallbacks_materialized( $report );
 		self::normalize_import_diagnostics( $report );
 
@@ -1215,7 +1216,6 @@ class Static_Site_Importer_Report_Diagnostics {
 					$report['diagnostics'][] = $graft['diagnostic'];
 				}
 			}
-
 			$pending = array_values( array_diff( $pending, array( $index ) ) );
 		}
 
@@ -1497,6 +1497,19 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		return $diagnostic;
+	}
+
+	/** @param array<string,mixed> $fallback */
+	public static function fallback_reconciliation_hash( array $fallback ): string {
+		$source = isset( $fallback['form'] ) || isset( $fallback['controls'] )
+			? wp_json_encode( array( 'form' => $fallback['form'] ?? array(), 'controls' => $fallback['controls'] ?? array() ) )
+			: self::first_scalar( $fallback, array( 'source_html_preview', 'html_excerpt', 'excerpt' ) );
+		return hash( 'sha256', (string) $source );
+	}
+
+	/** @param array<string,mixed> $fallback */
+	public static function fallback_reconciliation_identity( array $fallback ): string {
+		return hash( 'sha256', "static-site-importer/fallback-reconciliation/v1\n" . self::first_scalar( $fallback, array( 'source_path', 'source' ) ) . "\n" . self::first_scalar( $fallback, array( 'selector' ) ) . "\n" . self::fallback_reconciliation_hash( $fallback ) );
 	}
 
 	/**
@@ -2597,6 +2610,104 @@ class Static_Site_Importer_Report_Diagnostics {
 			$runtime_scripts = isset( $dependency['runtime_scripts'] ) && is_array( $dependency['runtime_scripts'] ) ? $dependency['runtime_scripts'] : array();
 			self::mark_companion_script_fallbacks_materialized( $report, $runtime_scripts, (string) $slug );
 		}
+	}
+
+	/**
+	 * Reconcile source form fallbacks against hash-bound provider receipts.
+	 *
+	 * The source finding remains in diagnostics for auditability. Only the final
+	 * quality count excludes a form after a completed receipt proves that exact
+	 * source fallback was replaced by the provider's persisted block markup.
+	 *
+	 * @param array<string,mixed> $report Import report.
+	 * @return void
+	 */
+	public static function reconcile_provider_materialized_fallbacks( array &$report, array $receipts = array() ): void {
+		if ( ! isset( $report['quality'] ) || ! is_array( $report['quality'] ) ) {
+			$report['quality'] = array();
+		}
+		$source_total = max(
+			(int) ( $report['quality']['source_fallback_count'] ?? 0 ),
+			(int) ( $report['quality']['fallback_count'] ?? 0 )
+		);
+		$report['quality']['source_fallback_count'] = $source_total;
+
+		if ( empty( $receipts ) ) {
+			$bindings = $report['materialization_receipt']['completed']['runtime_declarations']['entity_bindings'] ?? array();
+			foreach ( $bindings as $binding ) {
+				if ( ! is_array( $binding ) || 'completed' !== ( $binding['status'] ?? null ) || 'form' !== ( $binding['role'] ?? null ) ) {
+					continue;
+				}
+				$receipts[] = array(
+					'schema'                           => 'static-site-importer/quality-resolution-receipt/v1',
+					'status'                           => 'completed',
+					'fallback_reconciliation_identity' => $binding['fallback_reconciliation_identity'] ?? '',
+					'fallback_hash'                    => $binding['fallback_hash'] ?? '',
+					'binding_reconciliation_identity'  => $binding['reconciliation_identity'] ?? '',
+					'materialized_block_hash'          => $binding['materialized_block_hash'] ?? '',
+					'persisted_fragment_hash'          => $binding['persisted_fragment_hash'] ?? '',
+					'materialized_content_hash'        => $binding['materialized_content_hash'] ?? '',
+					'provider'                         => $binding['provider'] ?? '',
+				);
+			}
+		}
+		$receipts_by_fallback = array();
+		foreach ( $receipts as $receipt ) {
+			if ( ! is_array( $receipt ) || ! is_string( $receipt['fallback_reconciliation_identity'] ?? null ) ) {
+				continue;
+			}
+			$receipts_by_fallback[ $receipt['fallback_reconciliation_identity'] ] = $receipt;
+		}
+		$resolved = 0;
+		$resolutions = array();
+		foreach ( $report['diagnostics'] ?? array() as $index => $diagnostic ) {
+			if ( ! is_array( $diagnostic ) || 'html_form_fallback' !== (string) ( $diagnostic['diagnostic_code'] ?? '' ) ) {
+				continue;
+			}
+			$identity     = self::fallback_reconciliation_identity( $diagnostic );
+			$fallback_hash = self::fallback_reconciliation_hash( $diagnostic );
+			$receipt      = $receipts_by_fallback[ $identity ] ?? array();
+			$source_path  = self::first_scalar( $diagnostic, array( 'source_path', 'source' ) );
+			$page_receipt = $report['materialization_receipt']['completed']['materialized_pages'][ $source_path ] ?? array();
+			$page_hash    = is_array( $page_receipt ) && is_string( $page_receipt['content_hash'] ?? null ) ? $page_receipt['content_hash'] : '';
+			$resolved_by_provider = 'static-site-importer/quality-resolution-receipt/v1' === ( $receipt['schema'] ?? null )
+				&& 'completed' === ( $receipt['status'] ?? null )
+				&& $identity === ( $receipt['fallback_reconciliation_identity'] ?? null )
+				&& $fallback_hash === ( $receipt['fallback_hash'] ?? null )
+				&& 1 === preg_match( '/^[a-f0-9]{64}$/', (string) ( $receipt['binding_reconciliation_identity'] ?? '' ) )
+				&& 1 === preg_match( '/^[a-f0-9]{64}$/', (string) ( $receipt['materialized_block_hash'] ?? '' ) )
+				&& ( $receipt['materialized_block_hash'] ?? null ) === ( $receipt['persisted_fragment_hash'] ?? null )
+				&& 1 === preg_match( '/^[a-f0-9]{64}$/', (string) ( $receipt['materialized_content_hash'] ?? '' ) )
+				&& $page_hash === ( $receipt['materialized_content_hash'] ?? null );
+
+			$diagnostic['fallback_reconciliation_identity'] = $identity;
+			$diagnostic['fallback_hash']                    = $fallback_hash;
+			$diagnostic['fallback_resolution']              = array(
+				'source_state' => 'detected',
+				'state' => $resolved_by_provider ? 'resolved_by_provider' : 'unresolved',
+				'receipt' => $receipt,
+			);
+			$report['diagnostics'][ $index ]                = $diagnostic;
+			if ( $resolved_by_provider ) {
+				++$resolved;
+			}
+			$resolutions[] = array(
+				'fallback_reconciliation_identity' => $identity,
+				'fallback_hash' => $fallback_hash,
+				'state' => $resolved_by_provider ? 'resolved_by_provider' : 'unresolved',
+				'receipt' => $receipt,
+			);
+		}
+
+		$report['quality']['fallback_count'] = max( 0, $source_total - $resolved );
+		$report['quality_resolutions']        = array(
+			'schema'                  => 'static-site-importer/quality-resolutions/v1',
+			'source_fallback_count'   => $source_total,
+			'resolved_by_provider'    => $resolved,
+			'unresolved_fallback_count' => max( 0, $source_total - $resolved ),
+			'resolutions'              => $resolutions,
+		);
+		$report['fallback_reconciliation'] = $report['quality_resolutions'];
 	}
 
 	/**

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1502,7 +1502,12 @@ class Static_Site_Importer_Report_Diagnostics {
 	/** @param array<string,mixed> $fallback */
 	public static function fallback_reconciliation_hash( array $fallback ): string {
 		$source = isset( $fallback['form'] ) || isset( $fallback['controls'] )
-			? wp_json_encode( array( 'form' => $fallback['form'] ?? array(), 'controls' => $fallback['controls'] ?? array() ) )
+			? wp_json_encode(
+				array(
+					'form'     => $fallback['form'] ?? array(),
+					'controls' => $fallback['controls'] ?? array(),
+				)
+			)
 			: self::first_scalar( $fallback, array( 'source_html_preview', 'html_excerpt', 'excerpt' ) );
 		return hash( 'sha256', (string) $source );
 	}
@@ -2626,7 +2631,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		if ( ! isset( $report['quality'] ) || ! is_array( $report['quality'] ) ) {
 			$report['quality'] = array();
 		}
-		$source_total = max(
+		$source_total                               = max(
 			(int) ( $report['quality']['source_fallback_count'] ?? 0 ),
 			(int) ( $report['quality']['fallback_count'] ?? 0 )
 		);
@@ -2658,34 +2663,34 @@ class Static_Site_Importer_Report_Diagnostics {
 			}
 			$receipts_by_fallback[ $receipt['fallback_reconciliation_identity'] ] = $receipt;
 		}
-		$resolved = 0;
+		$resolved    = 0;
 		$resolutions = array();
 		foreach ( $report['diagnostics'] ?? array() as $index => $diagnostic ) {
 			if ( ! is_array( $diagnostic ) || 'html_form_fallback' !== (string) ( $diagnostic['diagnostic_code'] ?? '' ) ) {
 				continue;
 			}
-			$identity     = self::fallback_reconciliation_identity( $diagnostic );
-			$fallback_hash = self::fallback_reconciliation_hash( $diagnostic );
-			$receipt      = $receipts_by_fallback[ $identity ] ?? array();
-			$source_path  = self::first_scalar( $diagnostic, array( 'source_path', 'source' ) );
-			$page_receipt = $report['materialization_receipt']['completed']['materialized_pages'][ $source_path ] ?? array();
-			$page_hash    = is_array( $page_receipt ) && is_string( $page_receipt['content_hash'] ?? null ) ? $page_receipt['content_hash'] : '';
+			$identity             = self::fallback_reconciliation_identity( $diagnostic );
+			$fallback_hash        = self::fallback_reconciliation_hash( $diagnostic );
+			$receipt              = $receipts_by_fallback[ $identity ] ?? array();
+			$source_path          = self::first_scalar( $diagnostic, array( 'source_path', 'source' ) );
+			$page_receipt         = $report['materialization_receipt']['completed']['materialized_pages'][ $source_path ] ?? array();
+			$page_hash            = is_array( $page_receipt ) && is_string( $page_receipt['content_hash'] ?? null ) ? $page_receipt['content_hash'] : '';
 			$resolved_by_provider = 'static-site-importer/quality-resolution-receipt/v1' === ( $receipt['schema'] ?? null )
 				&& 'completed' === ( $receipt['status'] ?? null )
-				&& $identity === ( $receipt['fallback_reconciliation_identity'] ?? null )
-				&& $fallback_hash === ( $receipt['fallback_hash'] ?? null )
+				&& ( $receipt['fallback_reconciliation_identity'] ?? null ) === $identity
+				&& ( $receipt['fallback_hash'] ?? null ) === $fallback_hash
 				&& 1 === preg_match( '/^[a-f0-9]{64}$/', (string) ( $receipt['binding_reconciliation_identity'] ?? '' ) )
 				&& 1 === preg_match( '/^[a-f0-9]{64}$/', (string) ( $receipt['materialized_block_hash'] ?? '' ) )
-				&& ( $receipt['materialized_block_hash'] ?? null ) === ( $receipt['persisted_fragment_hash'] ?? null )
+				&& ( $receipt['persisted_fragment_hash'] ?? null ) === ( $receipt['materialized_block_hash'] ?? null )
 				&& 1 === preg_match( '/^[a-f0-9]{64}$/', (string) ( $receipt['materialized_content_hash'] ?? '' ) )
-				&& $page_hash === ( $receipt['materialized_content_hash'] ?? null );
+				&& ( $receipt['materialized_content_hash'] ?? null ) === $page_hash;
 
 			$diagnostic['fallback_reconciliation_identity'] = $identity;
 			$diagnostic['fallback_hash']                    = $fallback_hash;
 			$diagnostic['fallback_resolution']              = array(
 				'source_state' => 'detected',
-				'state' => $resolved_by_provider ? 'resolved_by_provider' : 'unresolved',
-				'receipt' => $receipt,
+				'state'        => $resolved_by_provider ? 'resolved_by_provider' : 'unresolved',
+				'receipt'      => $receipt,
 			);
 			$report['diagnostics'][ $index ]                = $diagnostic;
 			if ( $resolved_by_provider ) {
@@ -2693,21 +2698,21 @@ class Static_Site_Importer_Report_Diagnostics {
 			}
 			$resolutions[] = array(
 				'fallback_reconciliation_identity' => $identity,
-				'fallback_hash' => $fallback_hash,
-				'state' => $resolved_by_provider ? 'resolved_by_provider' : 'unresolved',
-				'receipt' => $receipt,
+				'fallback_hash'                    => $fallback_hash,
+				'state'                            => $resolved_by_provider ? 'resolved_by_provider' : 'unresolved',
+				'receipt'                          => $receipt,
 			);
 		}
 
 		$report['quality']['fallback_count'] = max( 0, $source_total - $resolved );
-		$report['quality_resolutions']        = array(
-			'schema'                  => 'static-site-importer/quality-resolutions/v1',
-			'source_fallback_count'   => $source_total,
-			'resolved_by_provider'    => $resolved,
+		$report['quality_resolutions']       = array(
+			'schema'                    => 'static-site-importer/quality-resolutions/v1',
+			'source_fallback_count'     => $source_total,
+			'resolved_by_provider'      => $resolved,
 			'unresolved_fallback_count' => max( 0, $source_total - $resolved ),
-			'resolutions'              => $resolutions,
+			'resolutions'               => $resolutions,
 		);
-		$report['fallback_reconciliation'] = $report['quality_resolutions'];
+		$report['fallback_reconciliation']   = $report['quality_resolutions'];
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -477,6 +477,8 @@ class Static_Site_Importer_Theme_Generator {
 			),
 		);
 		$report['source_artifact'] = array( 'hash' => (string) ( $args['artifact_hash'] ?? $plan['source']['source_hash'] ) );
+		$report['materialization_receipt'] = $receipt;
+		$quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $report, $args );
 		$artifact = array_merge(
 			isset( $args['source_artifact_reference'] ) && is_array( $args['source_artifact_reference'] ) ? $args['source_artifact_reference'] : array(),
 			array_filter(
@@ -1157,6 +1159,10 @@ class Static_Site_Importer_Theme_Generator {
 						'role'                         => $binding['role'],
 						'declaration_id'               => $declaration_id,
 						'reconciliation_identity'      => hash( 'sha256', "static-site-importer/runtime-entity-binding/v1\n{$declaration_id}\n{$binding['source_path']}\n{$binding['occurrence']}\n" . hash( 'sha256', $binding['search_block_markup'] ) ),
+						'fallback_reconciliation_identity' => 'form' === $binding['role'] ? Static_Site_Importer_Report_Diagnostics::fallback_reconciliation_identity( $entity ) : '',
+						'fallback_hash'                 => 'form' === $binding['role'] ? Static_Site_Importer_Report_Diagnostics::fallback_reconciliation_hash( $entity ) : '',
+						'materialized_block_hash'       => 'form' === $binding['role'] ? hash( 'sha256', $replacement ) : '',
+						'provider'                      => $prepared['adapter']['provider'] ?? '',
 						'superseded_runtime_selectors' => $binding['superseded_runtime_selectors'] ?? array(),
 					);
 				}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1151,19 +1151,19 @@ class Static_Site_Importer_Theme_Generator {
 				}
 				foreach ( $entity_bindings as $binding ) {
 					$bindings[] = array(
-						'schema'                       => 'static-site-importer/runtime-entity-binding/v1',
-						'source_path'                  => $binding['source_path'],
-						'search_block_markup'          => $binding['search_block_markup'],
-						'replacement_block_markup'     => $replacement,
-						'occurrence'                   => $binding['occurrence'],
-						'role'                         => $binding['role'],
-						'declaration_id'               => $declaration_id,
-						'reconciliation_identity'      => hash( 'sha256', "static-site-importer/runtime-entity-binding/v1\n{$declaration_id}\n{$binding['source_path']}\n{$binding['occurrence']}\n" . hash( 'sha256', $binding['search_block_markup'] ) ),
+						'schema'                           => 'static-site-importer/runtime-entity-binding/v1',
+						'source_path'                      => $binding['source_path'],
+						'search_block_markup'              => $binding['search_block_markup'],
+						'replacement_block_markup'         => $replacement,
+						'occurrence'                       => $binding['occurrence'],
+						'role'                             => $binding['role'],
+						'declaration_id'                   => $declaration_id,
+						'reconciliation_identity'          => hash( 'sha256', "static-site-importer/runtime-entity-binding/v1\n{$declaration_id}\n{$binding['source_path']}\n{$binding['occurrence']}\n" . hash( 'sha256', $binding['search_block_markup'] ) ),
 						'fallback_reconciliation_identity' => 'form' === $binding['role'] ? Static_Site_Importer_Report_Diagnostics::fallback_reconciliation_identity( $entity ) : '',
-						'fallback_hash'                 => 'form' === $binding['role'] ? Static_Site_Importer_Report_Diagnostics::fallback_reconciliation_hash( $entity ) : '',
-						'materialized_block_hash'       => 'form' === $binding['role'] ? hash( 'sha256', $replacement ) : '',
-						'provider'                      => $prepared['adapter']['provider'] ?? '',
-						'superseded_runtime_selectors' => $binding['superseded_runtime_selectors'] ?? array(),
+						'fallback_hash'                    => 'form' === $binding['role'] ? Static_Site_Importer_Report_Diagnostics::fallback_reconciliation_hash( $entity ) : '',
+						'materialized_block_hash'          => 'form' === $binding['role'] ? hash( 'sha256', $replacement ) : '',
+						'provider'                         => $prepared['adapter']['provider'] ?? '',
+						'superseded_runtime_selectors'     => $binding['superseded_runtime_selectors'] ?? array(),
 					);
 				}
 			}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -201,7 +201,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			);
 			foreach ( $state['applied']['runtime_declarations']['entity_bindings'] as &$binding_report ) {
 				if ( ( $binding_report['source_path'] ?? '' ) === $page['source_path'] ) {
-					$fragment = (string) ( $binding_report['replacement_block_markup'] ?? '' );
+					$fragment          = (string) ( $binding_report['replacement_block_markup'] ?? '' );
 					$persisted_content = function_exists( 'get_post_field' ) ? get_post_field( 'post_content', $post ) : null;
 					if ( ! is_string( $persisted_content ) || '' === $fragment || ! str_contains( $persisted_content, $fragment ) ) {
 						$binding_report['status'] = 'unresolved';
@@ -209,7 +209,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 					}
 					$binding_report['status']                    = 'completed';
 					$binding_report['post_id']                   = $post;
-					$binding_report['persisted_fragment_hash']  = hash( 'sha256', $fragment );
+					$binding_report['persisted_fragment_hash']   = hash( 'sha256', $fragment );
 					$binding_report['materialized_content_hash'] = hash( 'sha256', $persisted_content );
 				}
 			}
@@ -600,17 +600,17 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			$materialized = substr( $content, 0, $position ) . $binding['replacement_block_markup'] . substr( $content, $position + strlen( $binding['search_block_markup'] ) );
 			$plan['pages'][ $index ]['materialized_block_markup'] = $materialized;
 			$reports[ $binding['reconciliation_identity'] ]       = array(
-				'status'                       => 'prepared',
-				'reconciliation_identity'      => $binding['reconciliation_identity'],
-				'source_path'                  => $binding['source_path'],
-				'role'                         => $binding['role'] ?? '',
-				'declaration_id'               => $binding['declaration_id'] ?? '',
+				'status'                           => 'prepared',
+				'reconciliation_identity'          => $binding['reconciliation_identity'],
+				'source_path'                      => $binding['source_path'],
+				'role'                             => $binding['role'] ?? '',
+				'declaration_id'                   => $binding['declaration_id'] ?? '',
 				'fallback_reconciliation_identity' => $binding['fallback_reconciliation_identity'] ?? '',
-				'fallback_hash'                => $binding['fallback_hash'] ?? '',
-				'materialized_block_hash'      => $binding['materialized_block_hash'] ?? '',
-				'replacement_block_markup'     => $binding['replacement_block_markup'],
-				'provider'                     => $binding['provider'] ?? '',
-				'superseded_runtime_selectors' => $selectors,
+				'fallback_hash'                    => $binding['fallback_hash'] ?? '',
+				'materialized_block_hash'          => $binding['materialized_block_hash'] ?? '',
+				'replacement_block_markup'         => $binding['replacement_block_markup'],
+				'provider'                         => $binding['provider'] ?? '',
+				'superseded_runtime_selectors'     => $selectors,
 			);
 		}
 		foreach ( $reports as &$report ) {
@@ -786,7 +786,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				return $result;
 			}
 			$result['status'] = 'applied';
-			$reports[]  = $result;
+			$reports[]        = $result;
 			foreach ( $state['applied']['files'] as $index => $file ) {
 				if ( ( $file['target_path'] ?? null ) === $target ) {
 					$state['applied']['files'][ $index ] = self::canonical_file_receipt( $path, $file );

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -201,8 +201,16 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			);
 			foreach ( $state['applied']['runtime_declarations']['entity_bindings'] as &$binding_report ) {
 				if ( ( $binding_report['source_path'] ?? '' ) === $page['source_path'] ) {
-					$binding_report['status']  = 'completed';
-					$binding_report['post_id'] = $post;
+					$fragment = (string) ( $binding_report['replacement_block_markup'] ?? '' );
+					$persisted_content = function_exists( 'get_post_field' ) ? get_post_field( 'post_content', $post ) : null;
+					if ( ! is_string( $persisted_content ) || '' === $fragment || ! str_contains( $persisted_content, $fragment ) ) {
+						$binding_report['status'] = 'unresolved';
+						continue;
+					}
+					$binding_report['status']                    = 'completed';
+					$binding_report['post_id']                   = $post;
+					$binding_report['persisted_fragment_hash']  = hash( 'sha256', $fragment );
+					$binding_report['materialized_content_hash'] = hash( 'sha256', $persisted_content );
 				}
 			}
 			unset( $binding_report );
@@ -593,9 +601,15 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			$plan['pages'][ $index ]['materialized_block_markup'] = $materialized;
 			$reports[ $binding['reconciliation_identity'] ]       = array(
 				'status'                       => 'prepared',
+				'reconciliation_identity'      => $binding['reconciliation_identity'],
 				'source_path'                  => $binding['source_path'],
 				'role'                         => $binding['role'] ?? '',
 				'declaration_id'               => $binding['declaration_id'] ?? '',
+				'fallback_reconciliation_identity' => $binding['fallback_reconciliation_identity'] ?? '',
+				'fallback_hash'                => $binding['fallback_hash'] ?? '',
+				'materialized_block_hash'      => $binding['materialized_block_hash'] ?? '',
+				'replacement_block_markup'     => $binding['replacement_block_markup'],
+				'provider'                     => $binding['provider'] ?? '',
 				'superseded_runtime_selectors' => $selectors,
 			);
 		}

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -95,6 +95,7 @@ function wp_insert_post( array $post, bool $wp_error ) {
 	$GLOBALS['ssi_plan_posts'][ $id ] = $post;
 	return $id;
 }
+function get_post_field( string $field, int $id ): string { return stripslashes( (string) ( $GLOBALS['ssi_plan_posts'][ $id ][ $field ] ?? '' ) ); }
 class WP_Post_Type {
 	public string $name;
 	public bool $public;
@@ -114,6 +115,7 @@ function get_post_type_object( string $post_type ): ?object {
 
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-font-materializer.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-document-type-classifier.php';
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-wordpress-site-plan-materializer.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-woo-product-seeder.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-form-seeder.php';
@@ -461,6 +463,62 @@ $assert( str_contains( $duplicate_markup, '[add_to_cart id="42"]' ) && str_conta
 $invalid_binding = array( 'schema' => 'static-site-importer/runtime-entity-binding/v1', 'source_path' => 'index.html', 'search_block_markup' => '<!-- wp:paragraph --><p>Missing</p><!-- /wp:paragraph -->', 'replacement_block_markup' => $binding_replacement, 'occurrence' => 1, 'role' => 'commerce_controls', 'declaration_id' => $entity_declaration_id, 'reconciliation_identity' => hash( 'sha256', 'invalid-binding-test' ) );
 $invalid_binding_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $binding_plan, array( 'slug' => 'invalid-binding-plan', 'runtime_entity_bindings' => array( $invalid_binding ) ) );
 $assert( 'rejected' === $invalid_binding_receipt['status'] && 'runtime_entity_binding_cardinality_mismatch' === ( $invalid_binding_receipt['errors'][0]['code'] ?? '' ), 'missing or ambiguous provider anchors fail before page writes' );
+
+// A form fallback resolves only from the persisted runtime-binding receipt. The
+// quality report never trusts a provider result before the replacement page write.
+$form_fallback = array(
+	'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'source_path' => 'index.html', 'selector' => 'form.newsletter',
+	'form' => array( 'class' => 'newsletter' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ) ),
+);
+$form_fallback_identity = Static_Site_Importer_Report_Diagnostics::fallback_reconciliation_identity( $form_fallback );
+$form_fallback_hash = Static_Site_Importer_Report_Diagnostics::fallback_reconciliation_hash( $form_fallback );
+$form_binding = array(
+	'schema' => 'static-site-importer/runtime-entity-binding/v1', 'source_path' => 'index.html', 'search_block_markup' => $binding_search,
+	'replacement_block_markup' => '<!-- wp:jetpack/contact-form -->newsletter<!-- /wp:jetpack/contact-form -->', 'occurrence' => 1, 'role' => 'form',
+	'declaration_id' => 'forms', 'reconciliation_identity' => hash( 'sha256', 'form-fallback-binding' ),
+	'fallback_reconciliation_identity' => $form_fallback_identity, 'fallback_hash' => $form_fallback_hash,
+	'materialized_block_hash' => hash( 'sha256', '<!-- wp:jetpack/contact-form -->newsletter<!-- /wp:jetpack/contact-form -->' ), 'provider' => 'jetpack',
+);
+$form_binding_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $binding_plan, array( 'slug' => 'form-fallback-binding-plan', 'runtime_entity_bindings' => array( $form_binding ) ) );
+$form_binding_report = reset( $form_binding_receipt['completed']['runtime_declarations']['entity_bindings'] );
+$form_quality_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+$form_quality_report['quality']['fallback_count'] = 1;
+$form_quality_report['diagnostics'] = array( $form_fallback );
+$form_quality_report['materialization_receipt'] = $form_binding_receipt;
+Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $form_quality_report );
+$assert( 'completed' === ( $form_binding_report['status'] ?? '' ) && ( $form_binding_report['materialized_content_hash'] ?? '' ) === hash( 'sha256', $form_binding_receipt['completed']['materialized_pages']['index.html']['block_markup'] ?? '' ), 'form quality receipt is emitted after the persisted page replacement' );
+$assert( 0 === ( $form_quality_report['quality']['fallback_count'] ?? -1 ) && 1 === ( $form_quality_report['quality']['source_fallback_count'] ?? 0 ) && 'resolved_by_provider' === ( $form_quality_report['quality_resolutions']['resolutions'][0]['state'] ?? '' ), 'persisted form receipt resolves only its identity-and-hash-bound source fallback' );
+$resolved_form_quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $form_quality_report, array( 'fail_on_quality' => true ) );
+$resolved_form_validation = Static_Site_Importer_Report_Diagnostics::import_validation_result( $form_quality_report, $resolved_form_quality );
+$assert( true === ( $resolved_form_quality['pass'] ?? false ) && false === ( $resolved_form_quality['fail_import'] ?? true ) && array() === ( $resolved_form_quality['failure_reasons'] ?? null ) && 'passed' === ( $resolved_form_validation['status'] ?? '' ), 'receipt-resolved form fallback clears derived quality gates and validation status' );
+$other_failure_report = $form_quality_report;
+$other_failure_report['quality']['core_html_block_count'] = 1;
+$other_failure_quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $other_failure_report, array( 'fail_on_quality' => true ) );
+$other_failure_validation = Static_Site_Importer_Report_Diagnostics::import_validation_result( $other_failure_report, $other_failure_quality );
+$assert( 0 === ( $other_failure_quality['fallback_count'] ?? -1 ) && false === ( $other_failure_quality['pass'] ?? true ) && true === ( $other_failure_quality['fail_import'] ?? false ) && array( 'core_html_block' ) === ( $other_failure_quality['failure_reasons'] ?? null ) && 'failed' === ( $other_failure_validation['status'] ?? '' ), 'receipt reconciliation preserves unrelated quality failures and validation status' );
+$tampered_fragment_receipt = $form_binding_receipt;
+$tampered_fragment_receipt['completed']['runtime_declarations']['entity_bindings'][ hash( 'sha256', 'form-fallback-binding' ) ]['persisted_fragment_hash'] = hash( 'sha256', 'tampered fragment' );
+$tampered_fragment_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+$tampered_fragment_report['quality']['fallback_count'] = 1;
+$tampered_fragment_report['diagnostics'] = array( $form_fallback );
+$tampered_fragment_report['materialization_receipt'] = $tampered_fragment_receipt;
+Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $tampered_fragment_report );
+$assert( 1 === ( $tampered_fragment_report['quality']['fallback_count'] ?? 0 ) && 'unresolved' === ( $tampered_fragment_report['quality_resolutions']['resolutions'][0]['state'] ?? '' ), 'tampered persisted fragment digest cannot resolve a fallback' );
+$tampered_content_receipt = $form_binding_receipt;
+$tampered_content_receipt['completed']['runtime_declarations']['entity_bindings'][ hash( 'sha256', 'form-fallback-binding' ) ]['materialized_content_hash'] = hash( 'sha256', 'tampered page' );
+$tampered_content_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+$tampered_content_report['quality']['fallback_count'] = 1;
+$tampered_content_report['diagnostics'] = array( $form_fallback );
+$tampered_content_report['materialization_receipt'] = $tampered_content_receipt;
+Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $tampered_content_report );
+$assert( 1 === ( $tampered_content_report['quality']['fallback_count'] ?? 0 ) && 'unresolved' === ( $tampered_content_report['quality_resolutions']['resolutions'][0]['state'] ?? '' ), 'tampered persisted page digest cannot resolve a fallback' );
+$resumed_form_binding_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $binding_plan, array( 'slug' => 'form-fallback-binding-plan', 'runtime_entity_bindings' => array( $form_binding ) ) );
+$resumed_form_quality_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+$resumed_form_quality_report['quality']['fallback_count'] = 1;
+$resumed_form_quality_report['diagnostics'] = array( $form_fallback );
+$resumed_form_quality_report['materialization_receipt'] = $resumed_form_binding_receipt;
+Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $resumed_form_quality_report );
+$assert( $form_quality_report['quality_resolutions'] === $resumed_form_quality_report['quality_resolutions'], 'form quality resolution receipts remain deterministic on retry' );
 
 $publication_svg = '<svg xmlns="http://www.w3.org/2000/svg"><text style="font-family:Example">Example</text></svg>';
 $publication_css = '@font-face{font-family:Example;src:url(font.woff2)}';


### PR DESCRIPTION
## Summary
- emit persisted, identity-bound form replacement receipts from the production materializer
- reconcile only verified replacements from final fallback quality counts
- recompute final quality gate state after reconciliation while preserving unrelated failures

Closes #937

## Verification
- `npm test` (59 selected entries, 0 failures)
- production materializer, form, tamper, retry, and quality-status regressions

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed this change with parallel coding and review agents. Chris Huber reviewed and remains responsible for every line.