### PR TITLE
Fix #661: Make fixture font materialization deterministic

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -42,6 +42,7 @@
     "tests/smoke-visual-repair-css.php": { "environment": "standalone-php" },
     "tests/smoke-webfont-producer-consumer.php": { "environment": "standalone-php" },
     "tests/smoke-google-fonts-cap-fallback.php": { "environment": "standalone-php" },
+    "tests/smoke-google-fonts-retry-determinism.php": { "environment": "standalone-php" },
     "tests/smoke-website-artifact-import-input.php": { "environment": "standalone-php" },
     "tests/smoke-wordpress-site-plan-materializer.php": { "environment": "standalone-php" },
     "tests/smoke-artifact-run-primitives.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-font-materializer.php
+++ b/includes/class-static-site-importer-font-materializer.php
@@ -10,6 +10,8 @@ final class Static_Site_Importer_Font_Materializer {
 	private const CSS_LIMIT        = 262144;
 	private const FONT_LIMIT       = 2097152;
 	private const TOTAL_FONT_LIMIT = 4194304;
+	private const REQUEST_ATTEMPTS = 3;
+	private const RETRY_DELAY      = 100000;
 
 	/**
 	 * Resolve an explicit font plan into receipt-owned theme writes.
@@ -78,6 +80,9 @@ final class Static_Site_Importer_Font_Materializer {
 		}
 
 		$font_faces = self::resolve_google_font_faces( $plan, $families, $diagnostics );
+		if ( is_wp_error( $font_faces ) ) {
+			return $font_faces;
+		}
 		if ( 'preserved' === $font_faces['state'] ) {
 			$preserved_url = (string) $font_faces['url'];
 			$fallback_url  = self::is_google_stylesheet_url( $preserved_url ) ? $preserved_url : '';
@@ -114,6 +119,8 @@ final class Static_Site_Importer_Font_Materializer {
 				$outer_detail['aggregate_bytes'] = (int) ( $font_faces['aggregate_bytes'] ?? $font_faces['observed_bytes'] );
 			} elseif ( 'google_fonts_stylesheet_preserved_due_to_size' === $outer_detail['reason'] ) {
 				$outer_detail['limit_bytes'] = self::CSS_LIMIT;
+			} elseif ( 'font_payload_preserved_due_to_size' === $outer_detail['reason'] ) {
+				$outer_detail['limit_bytes'] = self::FONT_LIMIT;
 			}
 			$diagnostics[] = self::diagnostic_with_detail( 'font_materialization_partial_preserved', $outer_detail );
 			if ( '' === $css_body ) {
@@ -645,8 +652,9 @@ final class Static_Site_Importer_Font_Materializer {
 	/** @param array<int,string> $families @param array<int,array<string,string>> $diagnostics
 	 *  @return array{state:'embedded',css:string}
 	 *          | array{state:'preserved',reason:string,observed_bytes:int,url:string,aggregate_bytes?:int}
+	 *          | WP_Error
 	 */
-	private static function resolve_google_font_faces( array $plan, array $families, array &$diagnostics ): array {
+	private static function resolve_google_font_faces( array $plan, array $families, array &$diagnostics ): array|WP_Error {
 		$imports = array();
 		foreach ( $plan['stylesheets'] ?? array() as $stylesheet ) {
 			$content = is_array( $stylesheet ) && is_scalar( $stylesheet['content'] ?? null ) ? (string) $stylesheet['content'] : '';
@@ -691,12 +699,7 @@ final class Static_Site_Importer_Font_Materializer {
 						'limit_bytes'    => self::CSS_LIMIT,
 					)
 				);
-				return array(
-					'state'          => 'preserved',
-					'reason'         => 'stylesheet_fetch_failed',
-					'observed_bytes' => strlen( $css ),
-					'url'            => $import,
-				);
+				return new WP_Error( 'static_site_importer_font_materialization_failed', '', $diagnostics );
 			}
 			if ( strlen( $css ) > self::CSS_LIMIT ) {
 				$diagnostics[] = self::diagnostic_with_detail(
@@ -715,6 +718,9 @@ final class Static_Site_Importer_Font_Materializer {
 				);
 			}
 			$embedded = self::embed_font_sources( $css, $families, $font_payloads, $font_payload_bytes, $diagnostics );
+			if ( is_wp_error( $embedded ) ) {
+				return $embedded;
+			}
 			if ( 'preserved' === $embedded['state'] ) {
 				if ( '' === (string) $embedded['url'] ) {
 					$embedded['url'] = $import;
@@ -732,8 +738,9 @@ final class Static_Site_Importer_Font_Materializer {
 	/** @param array<int,string> $families @param array<string,string> $payloads @param array<int,array<string,string>> $diagnostics
 	 *  @return array{state:'embedded',css:string}
 	 *          | array{state:'preserved',reason:string,observed_bytes:int,url:string,aggregate_bytes?:int}
+	 *          | WP_Error
 	 */
-	private static function embed_font_sources( string $css, array $families, array &$payloads, int &$payload_bytes, array &$diagnostics ): array {
+	private static function embed_font_sources( string $css, array $families, array &$payloads, int &$payload_bytes, array &$diagnostics ): array|WP_Error {
 		if ( ! preg_match_all( '/@font-face\s*\{([^{}]*)\}/is', $css, $faces ) ) {
 			$diagnostics[] = self::diagnostic_with_detail(
 				'stylesheet_font_faces_missing',
@@ -783,7 +790,7 @@ final class Static_Site_Importer_Font_Materializer {
 					$response = self::request( $url, self::FONT_LIMIT );
 					$payload  = is_wp_error( $response ) ? '' : (string) wp_remote_retrieve_body( $response );
 					$observed = strlen( $payload );
-					if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $payload || $observed > self::FONT_LIMIT ) {
+					if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $payload ) {
 						$diagnostics[] = self::diagnostic_with_detail(
 							'font_payload_fetch_failed',
 							array(
@@ -792,9 +799,20 @@ final class Static_Site_Importer_Font_Materializer {
 								'limit_bytes'    => self::FONT_LIMIT,
 							)
 						);
+						return new WP_Error( 'static_site_importer_font_materialization_failed', '', $diagnostics );
+					}
+					if ( $observed > self::FONT_LIMIT ) {
+						$diagnostics[] = self::diagnostic_with_detail(
+							'font_payload_preserved_due_to_size',
+							array(
+								'url'            => $url,
+								'observed_bytes' => $observed,
+								'limit_bytes'    => self::FONT_LIMIT,
+							)
+						);
 						return array(
 							'state'          => 'preserved',
-							'reason'         => 'font_payload_fetch_failed',
+							'reason'         => 'font_payload_preserved_due_to_size',
 							'observed_bytes' => $observed,
 							'url'            => $url,
 						);
@@ -842,14 +860,14 @@ final class Static_Site_Importer_Font_Materializer {
 			'headers'             => array( 'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' ),
 		);
 		$response = null;
-		for ( $attempt = 1; $attempt <= 3; ++$attempt ) {
+		for ( $attempt = 1; $attempt <= self::REQUEST_ATTEMPTS; ++$attempt ) {
 			$response = wp_safe_remote_get( $url, $args );
 			$status   = is_wp_error( $response ) ? 0 : (int) wp_remote_retrieve_response_code( $response );
 			if ( ! is_wp_error( $response ) && 0 !== $status && ! in_array( $status, array( 408, 429 ), true ) && $status < 500 ) {
 				break;
 			}
-			if ( $attempt < 3 ) {
-				usleep( 100000 * $attempt );
+			if ( $attempt < self::REQUEST_ATTEMPTS ) {
+				usleep( self::RETRY_DELAY * $attempt );
 			}
 		}
 		return $response;

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -48,6 +48,7 @@
     { "path": "tests/smoke-visual-repair-css.php", "environment": "standalone-php" },
     { "path": "tests/smoke-webfont-producer-consumer.php", "environment": "standalone-php" },
     { "path": "tests/smoke-google-fonts-cap-fallback.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-google-fonts-retry-determinism.php", "environment": "standalone-php" },
     { "path": "tests/smoke-website-artifact-import-input.php", "environment": "standalone-php" },
     { "path": "tests/smoke-wordpress-site-plan-materializer.php", "environment": "standalone-php" },
     { "path": "tests/smoke-artifact-run-primitives.php", "environment": "standalone-php" },

--- a/tests/smoke-google-fonts-retry-determinism.php
+++ b/tests/smoke-google-fonts-retry-determinism.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Deterministic Google Fonts retry coverage for #661.
+ *
+ * Transient stylesheet and font-payload failures are retried through the
+ * bounded request policy and must resolve to self-contained fonts. Exhausted
+ * retries fail closed with the specific diagnostic instead of preserving a
+ * remote @import fallback that would let visual parity score fallback fonts.
+ *
+ * Run: php tests/smoke-google-fonts-retry-determinism.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['ssi_retry_attempts']  = array();
+$GLOBALS['ssi_retry_responder'] = null;
+
+class WP_Error {
+	private string $code;
+	private mixed $data;
+	public function __construct( string $code, string $message = '', mixed $data = null ) { $this->code = $code; $this->data = $data; }
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_data(): mixed { return $this->data; }
+}
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+function wp_parse_url( string $url ) { return parse_url( $url ); }
+function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
+function wp_remote_retrieve_response_code( $response ): int { return is_array( $response ) ? (int) ( $response['response']['code'] ?? 0 ) : 0; }
+function wp_remote_retrieve_body( $response ): string { return is_array( $response ) ? (string) ( $response['body'] ?? '' ) : ''; }
+function wp_safe_remote_get( string $url, array $args ) {
+	$attempt                             = ( $GLOBALS['ssi_retry_attempts'][ $url ] ?? 0 ) + 1;
+	$GLOBALS['ssi_retry_attempts'][ $url ] = $attempt;
+	$responder                           = $GLOBALS['ssi_retry_responder'];
+	return is_callable( $responder ) ? $responder( $url, $attempt, $args ) : new WP_Error( 'unexpected_request' );
+}
+
+require dirname( __DIR__ ) . '/vendor/autoload.php';
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-font-materializer.php';
+
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+};
+
+$google_url    = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap';
+$woff2_url     = 'https://fonts.gstatic.com/s/inter/v1/inter-latin.woff2';
+$css_body      = "@font-face { font-family: 'Inter'; font-style: normal; font-weight: 400; src: url({$woff2_url}) format('woff2'); }\n@font-face { font-family: 'Inter'; font-style: normal; font-weight: 700; src: url({$woff2_url}) format('woff2'); }";
+$functions_php = array( 'target_path' => 'functions.php', 'payload' => array( 'encoding' => 'utf8', 'data' => '<?php' ) );
+$plan          = array(
+	'schema'      => 'blocks-engine/php-transformer/font-materialization-plan/v1',
+	'provider'    => 'google_fonts',
+	'fonts'       => array( array( 'family' => 'Inter' ) ),
+	'stylesheets' => array(
+		array(
+			'path'    => 'assets/css/fonts.css',
+			'content' => "@import url('" . $google_url . "');\n",
+		),
+	),
+);
+
+// Case 1: transient stylesheet failure (two failed attempts) followed by success embeds self-contained fonts.
+$GLOBALS['ssi_retry_attempts']  = array();
+$GLOBALS['ssi_retry_responder'] = static function ( string $url, int $attempt ) use ( $google_url, $woff2_url, $css_body ) {
+	if ( $url === $google_url ) {
+		return $attempt < 3 ? new WP_Error( 'http_request_failed' ) : array( 'response' => array( 'code' => 200 ), 'body' => $css_body );
+	}
+	if ( $url === $woff2_url ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => 'inter-font-payload' );
+	}
+	return new WP_Error( 'unexpected_request' );
+};
+$overlay_stylesheet = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan, array( 'writes' => array( $functions_php ) ) );
+$assert( ! is_wp_error( $overlay_stylesheet ), 'case 1: transient stylesheet failure recovers into embedded fonts' );
+$assert( 3 === ( $GLOBALS['ssi_retry_attempts'][ $google_url ] ?? 0 ), 'case 1: stylesheet request retries through the bounded policy before succeeding' );
+$css_writes = array_values( array_filter( $overlay_stylesheet['writes'] ?? array(), static fn( array $write ): bool => 'assets/css/embedded-fonts.css' === $write['target_path'] ) );
+$assert( 1 === count( $css_writes ), 'case 1: exactly one embedded-fonts.css write' );
+$assert( str_contains( $css_writes[0]['content'], 'data:font/woff2;base64,' ) && ! str_contains( $css_writes[0]['content'], '@import' ), 'case 1: embedded stylesheet is self-contained' );
+
+// Case 2: transient font-payload failure (two failed attempts) followed by success embeds self-contained fonts.
+$GLOBALS['ssi_retry_attempts']  = array();
+$GLOBALS['ssi_retry_responder'] = static function ( string $url, int $attempt ) use ( $google_url, $woff2_url, $css_body ) {
+	if ( $url === $google_url ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => $css_body );
+	}
+	if ( $url === $woff2_url ) {
+		return $attempt < 3 ? new WP_Error( 'http_request_failed' ) : array( 'response' => array( 'code' => 200 ), 'body' => 'inter-font-payload' );
+	}
+	return new WP_Error( 'unexpected_request' );
+};
+$overlay_payload = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan, array( 'writes' => array( $functions_php ) ) );
+$assert( ! is_wp_error( $overlay_payload ), 'case 2: transient font-payload failure recovers into embedded fonts' );
+$assert( 3 === ( $GLOBALS['ssi_retry_attempts'][ $woff2_url ] ?? 0 ), 'case 2: font payload request retries through the bounded policy before succeeding' );
+$css_writes_payload = array_values( array_filter( $overlay_payload['writes'] ?? array(), static fn( array $write ): bool => 'assets/css/embedded-fonts.css' === $write['target_path'] ) );
+$assert( 1 === count( $css_writes_payload ) && str_contains( $css_writes_payload[0]['content'], 'data:font/woff2;base64,' ), 'case 2: embedded stylesheet is self-contained after payload recovery' );
+
+// Case 3: exhausted stylesheet retries fail closed with the specific diagnostic retained.
+$GLOBALS['ssi_retry_attempts']  = array();
+$GLOBALS['ssi_retry_responder'] = static function ( string $url ) use ( $google_url ) {
+	return $url === $google_url ? new WP_Error( 'http_request_failed' ) : new WP_Error( 'unexpected_request' );
+};
+$overlay_exhausted_stylesheet = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan, array( 'writes' => array( $functions_php ) ) );
+$assert( is_wp_error( $overlay_exhausted_stylesheet ) && 'static_site_importer_font_materialization_failed' === $overlay_exhausted_stylesheet->get_error_code(), 'case 3: exhausted stylesheet retries produce an evidence failure' );
+$assert( 3 === ( $GLOBALS['ssi_retry_attempts'][ $google_url ] ?? 0 ), 'case 3: stylesheet request exhausts the bounded retry budget' );
+$stylesheet_diagnostics = $overlay_exhausted_stylesheet->get_error_data();
+$assert( is_array( $stylesheet_diagnostics ) && count( array_filter( $stylesheet_diagnostics, static fn( array $row ): bool => 'stylesheet_fetch_failed' === ( $row['reason'] ?? '' ) ) ) >= 1, 'case 3: retains the stylesheet_fetch_failed diagnostic' );
+
+// Case 4: exhausted font-payload retries fail closed with the specific diagnostic retained.
+$GLOBALS['ssi_retry_attempts']  = array();
+$GLOBALS['ssi_retry_responder'] = static function ( string $url ) use ( $google_url, $woff2_url, $css_body ) {
+	if ( $url === $google_url ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => $css_body );
+	}
+	return $url === $woff2_url ? new WP_Error( 'http_request_failed' ) : new WP_Error( 'unexpected_request' );
+};
+$overlay_exhausted_payload = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan, array( 'writes' => array( $functions_php ) ) );
+$assert( is_wp_error( $overlay_exhausted_payload ) && 'static_site_importer_font_materialization_failed' === $overlay_exhausted_payload->get_error_code(), 'case 4: exhausted font-payload retries produce an evidence failure' );
+$assert( 3 === ( $GLOBALS['ssi_retry_attempts'][ $woff2_url ] ?? 0 ), 'case 4: font-payload request exhausts the bounded retry budget' );
+$payload_diagnostics = $overlay_exhausted_payload->get_error_data();
+$assert( is_array( $payload_diagnostics ) && count( array_filter( $payload_diagnostics, static fn( array $row ): bool => 'font_payload_fetch_failed' === ( $row['reason'] ?? '' ) ) ) >= 1, 'case 4: retains the font_payload_fetch_failed diagnostic' );
+
+echo "Google Fonts retry determinism smoke passed.\n";


### PR DESCRIPTION
## Summary

Fixes the reported issue: Make fixture font materialization deterministic.

## Changes

```
c39488d Fix #661: Make fixture font materialization deterministic
 homeboy-test-manifest.json                         |   1 +
 ...lass-static-site-importer-font-materializer.php |  44 ++++---
 test-manifest.json                                 |   1 +
 tests/smoke-google-fonts-retry-determinism.php     | 126 +++++++++++++++++++++
 4 files changed, 159 insertions(+), 13 deletions(-)
```

## Testing

- `npm test`: passed

## Use of AI Tools

AI assistance: Yes

Tool(s): opencode

Used for: Repository investigation, implementation, and test suggestions; the final diff and validation were reviewed by the contributor.

Fixes #661
