### PR TITLE
Fix generated companion registration refresh

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -197,10 +197,12 @@ class Static_Site_Importer_Companion_Plugin {
 			$files[ $plugin_slug . '/' . $island['relative_src'] ] = $island['content'];
 		}
 
-		$main_file = $plugin_slug . '/' . $plugin_slug . '.php';
+		$inventory_hash        = substr( hash( 'sha256', (string) wp_json_encode( array( $block_specs, $preserved ) ) ), 0, 16 );
+		$registration_callback = str_replace( '-', '_', $plugin_slug ) . '_' . $inventory_hash . '_register_blocks';
+		$main_file             = $plugin_slug . '/' . $plugin_slug . '.php';
 		$files     = array_merge(
 			array(
-				$main_file => self::main_plugin_file( $plugin_slug, $block_namespace, $site_name, $block_specs, $preserved, $main_file ),
+				$main_file => self::main_plugin_file( $plugin_slug, $block_namespace, $site_name, $block_specs, $preserved, $main_file, $inventory_hash ),
 			),
 			$files
 		);
@@ -211,6 +213,7 @@ class Static_Site_Importer_Companion_Plugin {
 			'namespace'       => $block_namespace,
 			'site_slug'       => $site_slug,
 			'plugin_file'     => $main_file,
+			'registration_callback' => $registration_callback,
 			'mu_plugin'       => $mu_plugin,
 			'block_names'     => $block_names,
 			// Handles of preserved island scripts the plugin carries + enqueues
@@ -639,6 +642,7 @@ class Static_Site_Importer_Companion_Plugin {
 	 * @param array<int,array<string,mixed>>  $block_specs     PHP-only block registration specs.
 	 * @param array<int,array<string,string>> $preserved       Preserved island descriptors.
 	 * @param string                          $plugin_file     Generated plugin basename.
+	 * @param string                          $inventory_hash  Deterministic generated inventory hash.
 	 * @return string
 	 */
 	private static function main_plugin_file(
@@ -647,10 +651,11 @@ class Static_Site_Importer_Companion_Plugin {
 		string $site_name,
 		array $block_specs,
 		array $preserved,
-		string $plugin_file
+		string $plugin_file,
+		string $inventory_hash
 	): string {
 		$header_name  = sprintf( 'SSI Companion: %s', $site_name );
-		$fn_prefix    = str_replace( '-', '_', $plugin_slug );
+		$fn_prefix    = str_replace( '-', '_', $plugin_slug ) . '_' . $inventory_hash;
 		$const_prefix = strtoupper( $fn_prefix );
 		$islands_php  = self::export_islands_php( $preserved );
 		$specs_php    = self::export_block_specs_php( $block_specs );

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -297,14 +297,14 @@ class Static_Site_Importer_Plugin_Materializer {
 		$slug        = isset( $descriptor['slug'] ) && is_string( $descriptor['slug'] ) ? $descriptor['slug'] : '';
 		$plugin_file = isset( $descriptor['plugin_file'] ) && is_string( $descriptor['plugin_file'] ) ? $descriptor['plugin_file'] : '';
 		$base_dir    = isset( $plan['base_dir'] ) && is_string( $plan['base_dir'] ) ? $plan['base_dir'] : '';
-		$callback    = str_replace( '-', '_', $slug ) . '_register_blocks';
+		$callback    = isset( $descriptor['registration_callback'] ) && is_string( $descriptor['registration_callback'] ) ? $descriptor['registration_callback'] : '';
 		$path        = '' === $base_dir || '' === $plugin_file ? '' : rtrim( $base_dir, '/\\' ) . '/' . $plugin_file;
 
-		if ( '' === $slug || '' === $path || ! is_readable( $path ) ) {
+		if ( '' === $slug || '' === $callback || '' === $path || ! is_readable( $path ) ) {
 			return new WP_Error( 'static_site_importer_companion_plugin_registration_unavailable', 'Generated companion block registration file is unavailable.' );
 		}
 		if ( ! function_exists( $callback ) ) {
-			require_once $path;
+			include $path;
 		}
 		if ( ! is_callable( $callback ) ) {
 			return new WP_Error( 'static_site_importer_companion_plugin_registration_unavailable', sprintf( 'Generated companion %s does not expose its block registration callback.', $slug ) );

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -305,6 +305,7 @@ $assert( is_array( $descriptor ), 'scaffold-returns-descriptor', is_array( $desc
 if ( is_array( $descriptor ) ) {
 	$assert( 'ssi-example-site' === $descriptor['slug'], 'scaffold-namespaces-slug', (string) $descriptor['slug'] );
 	$assert( 'ssi-example-site/ssi-example-site.php' === $descriptor['plugin_file'], 'scaffold-plugin-file-path', (string) $descriptor['plugin_file'] );
+	$assert( 1 === preg_match( '/^ssi_example_site_[a-f0-9]{16}_register_blocks$/', (string) ( $descriptor['registration_callback'] ?? '' ) ), 'scaffold-exposes-deterministic-inventory-callback' );
 	$assert( array( 'example/custom-hero' ) === $descriptor['block_names'], 'scaffold-preserves-declared-canonical-name' );
 	$assert( false === $descriptor['mu_plugin'], 'scaffold-regular-plugin-by-default' );
 
@@ -314,7 +315,7 @@ if ( is_array( $descriptor ) ) {
 	$assert( str_contains( $main, "add_filter( 'render_block'" ), 'main-file-scopes-island-enqueue' );
 	$assert( str_contains( $main, 'wp_enqueue_script' ), 'main-file-enqueues-island-js' );
 
-	$assert( str_contains( $main, "register_block_type( SSI_EXAMPLE_SITE_DIR . 'blocks/' . (string) \$spec['dir'] )" ), 'main-file-registers-metadata-block-directory' );
+	$assert( str_contains( $main, "register_block_type( SSI_EXAMPLE_SITE_" ) && str_contains( $main, "_DIR . 'blocks/' . (string) \$spec['dir'] )" ), 'main-file-registers-metadata-block-directory' );
 	$assert( str_contains( $main, "\$registered instanceof WP_Block_Type" ) && str_contains( $main, "static_site_importer_companion_block_owners" ) && str_contains( $main, "'plugin_file' => 'ssi-example-site/ssi-example-site.php'" ), 'main-file-records-owner-only-after-matching-registration' );
 	$assert( str_contains( $main, "register_block_type( (string) \$spec['name'], \$args )" ), 'main-file-retains-php-only-fallback-registration' );
 	$assert( str_contains( $main, "'api_version' => 3" ), 'main-file-declares-api-version' );
@@ -446,7 +447,7 @@ $assert( str_contains( $written_main, 'register_block_type' ), 'written-main-fil
 // marked as companion-owned, so a later materialization still fails closed.
 WP_Block_Type_Registry::$registered[] = 'example/custom-hero';
 $GLOBALS['static_site_importer_companion_block_owners'] = array();
-ssi_example_site_register_blocks();
+call_user_func( $descriptor['registration_callback'] );
 $assert( ! isset( $GLOBALS['static_site_importer_companion_block_owners']['example/custom-hero'] ), 'foreign-registration-before-generated-init-records-no-owner' );
 $foreign_init_collision = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $payload, static fn (): bool => true );
 $assert( 'failed' === ( $foreign_init_collision['status'] ?? '' ) && 'runtime_block_name_collision' === ( $foreign_init_collision['diagnostics'][0]['reason_code'] ?? '' ), 'foreign-registration-before-generated-init-blocks-refresh' );
@@ -467,6 +468,22 @@ $assert( 'refreshed' === ( $refresh_report['status'] ?? '' ), 'active-generated-
 $assert( in_array( 'refreshed', $refresh_report['actions'] ?? array(), true ), 'active-generated-plugin-records-refresh-action' );
 $assert( ! str_contains( $refreshed_main, "'type' => 'content'" ), 'active-generated-plugin-overwrites-stale-invalid-schema' );
 $assert( 'refreshed' === ( $refresh_report['status'] ?? '' ), 'active-companion-owned-registration-refreshes-successfully' );
+
+// Later batches may add blocks while the prior generated callback remains loaded.
+$expanded_payload = $payload;
+$expanded_payload['blocks'][] = array(
+	'name'       => 'custom-gallery',
+	'block_json' => array(
+		'name'     => 'example/custom-gallery',
+		'title'    => 'Custom Gallery',
+		'category' => 'design',
+	),
+	'render'     => '<div class="ssi-gallery">Gallery</div>',
+);
+$expanded_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $expanded_payload );
+$expanded_report     = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $expanded_payload, static fn (): bool => true );
+$assert( is_array( $expanded_descriptor ) && $descriptor['registration_callback'] !== $expanded_descriptor['registration_callback'], 'changed-inventory-uses-new-registration-callback' );
+$assert( 'refreshed' === ( $expanded_report['status'] ?? '' ) && in_array( 'example/custom-gallery', WP_Block_Type_Registry::$registered, true ), 'same-request-refresh-registers-new-block-inventory' );
 
 $GLOBALS['static_site_importer_companion_block_owners']['example/custom-hero'] = array(
 	'plugin_file' => 'foreign/foreign.php',


### PR DESCRIPTION
## Summary

- derive generated companion PHP symbols from the deterministic block/script inventory
- expose the exact generated registration callback through the companion descriptor
- load a changed generated inventory alongside the prior in-memory version without PHP symbol collisions
- add regression coverage for refreshing the same companion with a newly introduced block

Fixes #945. Related to the bounded URL-import acceptance work in #768.

## Why

Resumed URL batches may refresh the same generated companion plugin as later pages introduce additional generated blocks. The old implementation rewrote the plugin file but reused slug-stable PHP functions, so a long-lived runtime invoked the previous callback and failed to register the new block inventory.

Identical payloads still produce identical callback names. Changed inventories get deterministic new symbols and can be loaded safely in the current request.

## Verification

- `npm test` (59 selected manifest tests; all selected standalone PHP and Node tests passed)
- `php tests/smoke-companion-plugin.php` (104 assertions)
- `php tests/smoke-companion-plugin-js.php` (23 assertions)
- PHP syntax checks for all changed files
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol was used through OpenCode to reproduce the failure in a bounded Shopify acceptance workload, identify the generated callback lifecycle defect, implement the repair, and run verification. Chris Huber reviewed and is responsible for the submitted changes.