### PR TITLE
Fix resumable URL artifact finalization

### DIFF
--- a/includes/class-static-site-importer-url-batch-import.php
+++ b/includes/class-static-site-importer-url-batch-import.php
@@ -337,6 +337,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 							$body = isset( $retained['body_ref'] ) && is_string( $retained['body_ref'] ) ? $workspace->read_raw( $retained['body_ref'] ) : null;
 							return is_string( $body ) && hash_equals( (string) ( $retained['sha256'] ?? '' ), hash( 'sha256', $body ) ) ? $body : null;
 						},
+						'_static_site_importer_collection_should_yield'  => null !== $deadline ? static fn (): bool => self::deadline_reached( $deadline, $clock ) : null,
 						'_static_site_importer_collection_cursor_save'   => static function ( array $cursor ) use ( $workspace, $collection_cursor_name ) {
 							foreach ( $cursor['resources'] ?? array() as $url => $resource ) {
 								if ( ! isset( $resource['body'] ) || ! is_string( $resource['body'] ) ) {
@@ -356,6 +357,25 @@ final class Static_Site_Importer_URL_Batch_Import {
 								$resource['body_ref']        = $ref;
 								$resource['sha256']          = $hash;
 								$cursor['resources'][ $url ] = $resource;
+							}
+							foreach ( $cursor['finalization']['files'] ?? array() as $index => $file ) {
+								if ( ! isset( $file['body'] ) || ! is_string( $file['body'] ) ) {
+									continue;
+								}
+								$body = $file['body'];
+								$hash = hash( 'sha256', $body );
+								$ref  = 'collection-finalized/' . $hash . '.bin';
+								$path = $workspace->path( $ref );
+								if ( ! is_string( $path ) || ! is_file( $path ) ) {
+									$write = $workspace->publish_raw( $ref, $body );
+									if ( is_wp_error( $write ) ) {
+										return $write;
+									}
+								}
+								unset( $file['body'] );
+								$file['body_ref'] = $ref;
+								$file['sha256']   = $hash;
+								$cursor['finalization']['files'][ $index ] = $file;
 							}
 							return $workspace->publish_json( $collection_cursor_name, $cursor );
 						},

--- a/includes/class-static-site-importer-url-site-collector.php
+++ b/includes/class-static-site-importer-url-site-collector.php
@@ -86,8 +86,10 @@ class Static_Site_Importer_URL_Site_Collector {
 		$cursor_loader      = is_callable( $args['_static_site_importer_collection_cursor_load'] ?? null ) ? $args['_static_site_importer_collection_cursor_load'] : null;
 		$cursor_saver       = is_callable( $args['_static_site_importer_collection_cursor_save'] ?? null ) ? $args['_static_site_importer_collection_cursor_save'] : null;
 		$resource_loader    = is_callable( $args['_static_site_importer_collection_resource_load'] ?? null ) ? $args['_static_site_importer_collection_resource_load'] : null;
+		$should_yield       = is_callable( $args['_static_site_importer_collection_should_yield'] ?? null ) ? $args['_static_site_importer_collection_should_yield'] : null;
 		$cursor             = null !== $cursor_loader ? call_user_func( $cursor_loader ) : null;
-		if ( is_array( $cursor ) && 'static-site-importer/url-collection-cursor/v1' === ( $cursor['schema'] ?? '' ) && hash_equals( $cursor_contract, (string) ( $cursor['contract'] ?? '' ) ) ) {
+		$cursor_schemas     = array( 'static-site-importer/url-collection-cursor/v1', 'static-site-importer/url-collection-cursor/v2' );
+		if ( is_array( $cursor ) && in_array( $cursor['schema'] ?? '', $cursor_schemas, true ) && hash_equals( $cursor_contract, (string) ( $cursor['contract'] ?? '' ) ) ) {
 			$page_queue         = is_array( $cursor['page_queue'] ?? null ) ? $cursor['page_queue'] : array();
 			$asset_queue        = is_array( $cursor['asset_queue'] ?? null ) ? $cursor['asset_queue'] : array();
 			$queued_pages       = is_array( $cursor['queued_pages'] ?? null ) ? $cursor['queued_pages'] : array();
@@ -106,11 +108,13 @@ class Static_Site_Importer_URL_Site_Collector {
 			$entry_resource_url = (string) ( $cursor['entry_resource_url'] ?? $entry_url );
 			$site_url           = (string) ( $cursor['site_url'] ?? $entry_url );
 			$sitemap_urls       = is_array( $cursor['sitemap_urls'] ?? null ) ? $cursor['sitemap_urls'] : array();
+			$finalization       = is_array( $cursor['finalization'] ?? null ) ? $cursor['finalization'] : null;
 		} else {
 			$cursor = null;
 		}
 
 		if ( null === $cursor ) {
+			$finalization = null;
 			$sitemap_urls = isset( $args['_route_set'] ) && is_array( $args['_route_set'] ) ? array_values( $args['_route_set'] ) : self::sitemap_urls( $entry_url, $fetcher, $fetch_args );
 			if ( is_wp_error( $sitemap_urls ) ) {
 				return $sitemap_urls;
@@ -314,21 +318,9 @@ class Static_Site_Importer_URL_Site_Collector {
 				}
 			}
 		}
-		$checkpoint = self::checkpoint_collection_cursor( $cursor_saver, $cursor_contract, $page_queue, $asset_queue, $queued_pages, $queued_assets, $resources, $failures, $diagnostics, $source_exclusions, $script_exclusions, $aliases, $total_bytes, $truncated, $external_assets, $external_pages, $critical_assets, $entry_resource_url, $site_url, $sitemap_urls );
+		$checkpoint = self::checkpoint_collection_cursor( $cursor_saver, $cursor_contract, $page_queue, $asset_queue, $queued_pages, $queued_assets, $resources, $failures, $diagnostics, $source_exclusions, $script_exclusions, $aliases, $total_bytes, $truncated, $external_assets, $external_pages, $critical_assets, $entry_resource_url, $site_url, $sitemap_urls, $finalization );
 		if ( is_wp_error( $checkpoint ) ) {
 			return $checkpoint;
-		}
-		if ( null !== $resource_loader ) {
-			foreach ( $resources as $resource_url => $resource ) {
-				if ( isset( $resource['body'] ) ) {
-					continue;
-				}
-				$body = call_user_func( $resource_loader, $resource );
-				if ( ! is_string( $body ) ) {
-					return new WP_Error( 'static_site_importer_collection_cursor_resource_invalid', 'A retained URL collection resource could not be loaded.' );
-				}
-				$resources[ $resource_url ]['body'] = $body;
-			}
 		}
 
 		if ( ( ! empty( $truncated ) || ! empty( $failures ) ) && ! empty( $args['require_complete_collection'] ) ) {
@@ -374,13 +366,34 @@ class Static_Site_Importer_URL_Site_Collector {
 				$reference_paths[ $requested_url ] = $paths[ $final_url ];
 			}
 		}
-		$files          = array();
-		$snapshot_files = array();
-		foreach ( $resources as $resource_url => $resource ) {
+		$resource_urls = array_keys( $resources );
+		if ( ! is_array( $finalization ) || ( $finalization['resource_urls'] ?? null ) !== $resource_urls ) {
+			$finalization = array(
+				'resource_urls'  => $resource_urls,
+				'next_resource'  => 0,
+				'files'          => array(),
+				'snapshot_files' => array(),
+				'external_pages' => $external_pages,
+			);
+		}
+		$resource_count = count( $resource_urls );
+		while ( $finalization['next_resource'] < $resource_count ) {
+			if ( null !== $should_yield && call_user_func( $should_yield ) ) {
+				$checkpoint = self::checkpoint_collection_cursor( $cursor_saver, $cursor_contract, $page_queue, $asset_queue, $queued_pages, $queued_assets, $resources, $failures, $diagnostics, $source_exclusions, $script_exclusions, $aliases, $total_bytes, $truncated, $external_assets, $finalization['external_pages'], $critical_assets, $entry_resource_url, $site_url, $sitemap_urls, $finalization );
+				return is_wp_error( $checkpoint ) ? $checkpoint : new WP_Error( 'static_site_importer_invocation_deadline_exceeded', 'The URL batch invocation deadline was reached during artifact finalization.' );
+			}
+			$resource_url = $resource_urls[ $finalization['next_resource'] ];
+			$resource     = $resources[ $resource_url ];
+			$body         = $resource['body'] ?? null;
+			if ( ! is_string( $body ) && null !== $resource_loader ) {
+				$body = call_user_func( $resource_loader, $resource );
+			}
+			if ( ! is_string( $body ) ) {
+				return new WP_Error( 'static_site_importer_collection_cursor_resource_invalid', 'A retained URL collection resource could not be loaded.' );
+			}
 			$path = $paths[ $resource_url ];
-			$body = (string) $resource['body'];
 			if ( 'html' === $resource['kind'] ) {
-				$body = self::rewrite_html( $body, self::html_base_url( $body, $resource_url ), $path, $reference_paths, $aliases, $site_url, $external_assets, $external_pages, $known_pages );
+				$body = self::rewrite_html( $body, self::html_base_url( $body, $resource_url ), $path, $reference_paths, $aliases, $site_url, $external_assets, $finalization['external_pages'], $known_pages );
 			} elseif ( 'text/css' === $resource['content_type'] || str_ends_with( strtolower( $path ), '.css' ) ) {
 				$body = self::rewrite_css( $body, $resource_url, $path, $reference_paths, $external_assets );
 			}
@@ -388,24 +401,48 @@ class Static_Site_Importer_URL_Site_Collector {
 			$file = array(
 				'path'      => $path,
 				'mime_type' => $resource['content_type'],
+				'body'      => $body,
+				'is_text'   => self::is_text( $resource['content_type'], $path ),
 			);
 			if ( 'html' === $resource['kind'] ) {
 				$file['metadata'] = array( 'route_path' => $route_paths[ $resource_url ] );
 			}
-			if ( self::is_text( $resource['content_type'], $path ) ) {
-				$file['content'] = $body;
-			} else {
-				$file['content_base64'] = base64_encode( $body ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encodes binary artifact payload bytes.
-			}
-			$files[]          = $file;
-			$snapshot_files[] = array(
+			$finalization['files'][]          = $file;
+			$finalization['snapshot_files'][] = array(
 				'path'       => $path,
 				'source_url' => $resource_url,
 				'mime_type'  => $resource['content_type'],
 				'bytes'      => strlen( $body ),
 				'sha256'     => hash( 'sha256', $body ),
 			);
+			++$finalization['next_resource'];
+			$checkpoint = self::checkpoint_collection_cursor( $cursor_saver, $cursor_contract, $page_queue, $asset_queue, $queued_pages, $queued_assets, $resources, $failures, $diagnostics, $source_exclusions, $script_exclusions, $aliases, $total_bytes, $truncated, $external_assets, $finalization['external_pages'], $critical_assets, $entry_resource_url, $site_url, $sitemap_urls, $finalization );
+			if ( is_wp_error( $checkpoint ) ) {
+				return $checkpoint;
+			}
 		}
+		if ( null !== $should_yield && call_user_func( $should_yield ) ) {
+			return new WP_Error( 'static_site_importer_invocation_deadline_exceeded', 'The URL batch invocation deadline was reached before artifact assembly.' );
+		}
+		$files = array();
+		foreach ( $finalization['files'] as $retained_file ) {
+			$body = $retained_file['body'] ?? null;
+			if ( ! is_string( $body ) && null !== $resource_loader ) {
+				$body = call_user_func( $resource_loader, $retained_file );
+			}
+			if ( ! is_string( $body ) ) {
+				return new WP_Error( 'static_site_importer_collection_cursor_resource_invalid', 'A finalized URL collection resource could not be loaded.' );
+			}
+			$file = array_intersect_key( $retained_file, array_flip( array( 'path', 'mime_type', 'metadata' ) ) );
+			if ( ! empty( $retained_file['is_text'] ) ) {
+				$file['content'] = $body;
+			} else {
+				$file['content_base64'] = base64_encode( $body ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encodes binary artifact payload bytes.
+			}
+			$files[] = $file;
+		}
+		$snapshot_files = $finalization['snapshot_files'];
+		$external_pages = $finalization['external_pages'];
 		usort( $files, static fn ( array $left, array $right ): int => strcmp( (string) $left['path'], (string) $right['path'] ) );
 		usort( $snapshot_files, static fn ( array $left, array $right ): int => strcmp( (string) $left['path'], (string) $right['path'] ) );
 		$compiler_limits    = array(
@@ -479,8 +516,8 @@ class Static_Site_Importer_URL_Site_Collector {
 						'count'   => count( $external_pages ),
 						'samples' => array_slice(
 							array_map(
-								static fn ( string $url ): array => array(
-									'url'    => $url,
+								static fn ( int|string $url ): array => array(
+									'url'    => (string) $url,
 									'reason' => 'uncollected_page',
 								),
 								array_keys( $external_pages )
@@ -500,14 +537,14 @@ class Static_Site_Importer_URL_Site_Collector {
 		);
 	}
 
-	private static function checkpoint_collection_cursor( ?callable $saver, string $contract, array $page_queue, array $asset_queue, array $queued_pages, array $queued_assets, array $resources, array $failures, array $diagnostics, array $source_exclusions, array $script_exclusions, array $aliases, int $total_bytes, array $truncated, array $external_assets, array $external_pages, array $critical_assets, string $entry_resource_url, string $site_url, array $sitemap_urls ) {
+	private static function checkpoint_collection_cursor( ?callable $saver, string $contract, array $page_queue, array $asset_queue, array $queued_pages, array $queued_assets, array $resources, array $failures, array $diagnostics, array $source_exclusions, array $script_exclusions, array $aliases, int $total_bytes, array $truncated, array $external_assets, array $external_pages, array $critical_assets, string $entry_resource_url, string $site_url, array $sitemap_urls, ?array $finalization = null ) {
 		if ( null === $saver ) {
 			return true;
 		}
 		return call_user_func(
 			$saver,
 			array(
-				'schema'             => 'static-site-importer/url-collection-cursor/v1',
+				'schema'             => 'static-site-importer/url-collection-cursor/v2',
 				'contract'           => $contract,
 				'page_queue'         => array_values( $page_queue ),
 				'asset_queue'        => array_values( $asset_queue ),
@@ -527,6 +564,7 @@ class Static_Site_Importer_URL_Site_Collector {
 				'entry_resource_url' => $entry_resource_url,
 				'site_url'           => $site_url,
 				'sitemap_urls'       => $sitemap_urls,
+				'finalization'       => $finalization,
 				'updated_at'         => gmdate( 'c' ),
 			)
 		);

--- a/tests/smoke-url-site-collector.php
+++ b/tests/smoke-url-site-collector.php
@@ -187,6 +187,84 @@ $shuffled = Static_Site_Importer_URL_Site_Collector::collect(
 );
 $assert( ! is_wp_error( $shuffled ) && ( $snapshot['sha256'] ?? '' ) === ( $shuffled['source_metadata']['snapshot']['sha256'] ?? null ), 'snapshot-hash-independent-of-discovery-order' );
 
+$finalization_cursor = null;
+$retained_bodies     = array();
+$retained_loads      = array();
+$finalization_steps  = array();
+$finalization_fetcher = static function ( string $url, array $args ): array {
+	unset( $args );
+	$fixtures = array(
+		'https://finalize.test/'          => array( 'text/html', '<link rel="stylesheet" href="/style.css"><img src="/image.png">' ),
+		'https://finalize.test/style.css' => array( 'text/css', 'body{background:url(/image.png)}' ),
+		'https://finalize.test/image.png' => array( 'image/png', 'image-bytes' ),
+	);
+	return array( 'body' => $fixtures[ $url ][1], 'metadata' => array( 'content_type' => $fixtures[ $url ][0], 'final_url' => $url ) );
+};
+$finalization_args = array(
+	'max_pages'                                    => 1,
+	'max_assets'                                   => 2,
+	'_route_set'                                   => array( 'https://finalize.test/' ),
+	'_static_site_importer_collection_contract'    => 'finalization-test',
+	'_static_site_importer_collection_cursor_load' => static function () use ( &$finalization_cursor ) {
+		return $finalization_cursor;
+	},
+	'_static_site_importer_collection_resource_load' => static function ( array $retained ) use ( &$retained_bodies, &$retained_loads ) {
+		$ref                    = (string) ( $retained['body_ref'] ?? '' );
+		$retained_loads[ $ref ] = ( $retained_loads[ $ref ] ?? 0 ) + 1;
+		$body                   = $retained_bodies[ $ref ] ?? null;
+		return is_string( $body ) && hash_equals( (string) ( $retained['sha256'] ?? '' ), hash( 'sha256', $body ) ) ? $body : null;
+	},
+	'_static_site_importer_collection_cursor_save' => static function ( array $cursor ) use ( &$finalization_cursor, &$retained_bodies ) {
+		foreach ( $cursor['resources'] ?? array() as $url => $resource ) {
+			if ( isset( $resource['body'] ) && is_string( $resource['body'] ) ) {
+				$hash                     = hash( 'sha256', $resource['body'] );
+				$ref                      = 'source/' . $hash;
+				$retained_bodies[ $ref ]  = $resource['body'];
+				unset( $resource['body'] );
+				$resource['body_ref']      = $ref;
+				$resource['sha256']        = $hash;
+				$cursor['resources'][ $url ] = $resource;
+			}
+		}
+		foreach ( $cursor['finalization']['files'] ?? array() as $index => $file ) {
+			if ( isset( $file['body'] ) && is_string( $file['body'] ) ) {
+				$hash                                    = hash( 'sha256', $file['body'] );
+				$ref                                     = 'finalized/' . $hash;
+				$retained_bodies[ $ref ]                 = $file['body'];
+				unset( $file['body'] );
+				$file['body_ref']                         = $ref;
+				$file['sha256']                           = $hash;
+				$cursor['finalization']['files'][ $index ] = $file;
+			}
+		}
+		$finalization_cursor = $cursor;
+		return true;
+	},
+);
+$resumed_finalization = null;
+for ( $attempt = 0; $attempt < 5; ++$attempt ) {
+	$yield_checks = 0;
+	$attempt_args = $finalization_args;
+	$attempt_args['_static_site_importer_collection_should_yield'] = static function () use ( &$yield_checks ): bool {
+		return 1 < ++$yield_checks;
+	};
+	$resumed_finalization = Static_Site_Importer_URL_Site_Collector::collect( 'https://finalize.test/', $attempt_args, $finalization_fetcher );
+	$finalization_steps[] = (int) ( $finalization_cursor['finalization']['next_resource'] ?? 0 );
+	if ( ! is_wp_error( $resumed_finalization ) ) {
+		break;
+	}
+}
+$clean_finalization = Static_Site_Importer_URL_Site_Collector::collect( 'https://finalize.test/', array( 'max_pages' => 1, 'max_assets' => 2, '_route_set' => array( 'https://finalize.test/' ) ), $finalization_fetcher );
+$source_loads = array_filter( $retained_loads, static fn ( int $count, string $ref ): bool => str_starts_with( $ref, 'source/' ), ARRAY_FILTER_USE_BOTH );
+$finalized_refs_verify = array_filter(
+	$finalization_cursor['finalization']['files'] ?? array(),
+	static fn ( array $file ): bool => ! isset( $retained_bodies[ $file['body_ref'] ?? '' ] ) || ! hash_equals( (string) ( $file['sha256'] ?? '' ), hash( 'sha256', $retained_bodies[ $file['body_ref'] ] ) )
+);
+$assert( array( 1, 2, 3, 3 ) === $finalization_steps, 'finalization-cursor-advances-one-resource-per-invocation' );
+$assert( 'static-site-importer/url-collection-cursor/v2' === ( $finalization_cursor['schema'] ?? '' ) && array() === $finalized_refs_verify, 'finalization-cursor-retains-hash-verified-payloads' );
+$assert( 2 === count( $source_loads ) && array() === array_filter( $source_loads, static fn ( int $count ): bool => 1 !== $count ), 'resumed-finalization-does-not-reload-completed-source-resources' );
+$assert( ! is_wp_error( $resumed_finalization ) && ! is_wp_error( $clean_finalization ) && wp_json_encode( $clean_finalization['artifact'] ) === wp_json_encode( $resumed_finalization['artifact'] ), 'resumed-finalization-preserves-clean-artifact-bytes' );
+
 $schedule_calls = array();
 $schedule_delays = array();
 $scheduled = Static_Site_Importer_URL_Site_Collector::collect(


### PR DESCRIPTION
## Summary
- checkpoint URL artifact finalization one canonical resource at a time
- retain rewritten payloads in content-addressed workspace storage
- yield on invocation deadlines without replaying completed reads or rewrites
- preserve v1 cursor resume compatibility and byte-identical clean/resumed artifacts

## Verification
- `php tests/smoke-url-site-collector.php` (69 assertions)
- `php tests/smoke-url-batch-import.php`
- `npm test -- --files=tests/smoke-url-site-collector.php,tests/smoke-url-batch-import.php` (59 selected tests passed)
- `homeboy review lint --changed-only --summary --placement local` (PHPCS, ESLint, PHPStan clean)

Closes #768

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode was used to trace the post-hydration deadline boundary, implement the resumable finalization cursor, and run verification. Chris Huber reviewed and remains responsible for the change.