### PR TITLE
Normalize partial quality reports before finalization

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -45,25 +45,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				),
 				$source_metadata
 			),
-			'quality'                 => array(
-				'pass'                                  => true,
-				'fallback_count'                        => 0,
-				'content_loss_count'                    => 0,
-				'empty_conversion_count'                => 0,
-				'core_html_block_count'                 => 0,
-				'freeform_block_count'                  => 0,
-				'invalid_block_count'                   => 0,
-				'invalid_block_document_count'          => 0,
-				'unsafe_svg_count'                      => 0,
-				'svg_materialization_failure_count'     => 0,
-				'svg_sprite_reference_failure_count'    => 0,
-				'commerce_dependency_failures'          => 0,
-				'companion_plugin_dependency_failures'  => 0,
-				'interaction_candidate_count'           => 0,
-				'runtime_dependency_parity_issue_count' => 0,
-				'semantic_parity_failure_count'         => 0,
-				'failure_reasons'                       => array(),
-			),
+			'quality'                 => self::quality_defaults(),
 			'source_documents'        => array(
 				'total_count'                => 0,
 				'counts_by_format'           => array(
@@ -415,6 +397,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return array<string, mixed>
 	 */
 	public static function finalize_quality_report( array &$report, array $args ): array {
+		self::normalize_quality_report( $report );
 		self::reconcile_provider_materialized_fallbacks( $report );
 		self::mark_active_companion_script_fallbacks_materialized( $report );
 		self::normalize_import_diagnostics( $report );
@@ -483,6 +466,60 @@ class Static_Site_Importer_Report_Diagnostics {
 		$report['artifact_diagnostics'] = Static_Site_Importer_Artifact_Diagnostics_Adapter::build_for_import_report( $report );
 
 		return $quality;
+	}
+
+	/**
+	 * Return the canonical quality shape consumed by report finalization.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function quality_defaults(): array {
+		return array(
+			'pass'                                  => true,
+			'fallback_count'                        => 0,
+			'content_loss_count'                    => 0,
+			'empty_conversion_count'                => 0,
+			'core_html_block_count'                 => 0,
+			'freeform_block_count'                  => 0,
+			'invalid_block_count'                   => 0,
+			'invalid_block_document_count'          => 0,
+			'unsafe_svg_count'                      => 0,
+			'svg_materialization_failure_count'     => 0,
+			'svg_sprite_reference_failure_count'    => 0,
+			'commerce_dependency_failures'          => 0,
+			'companion_plugin_dependency_failures'  => 0,
+			'interaction_candidate_count'           => 0,
+			'runtime_dependency_parity_issue_count' => 0,
+			'semantic_parity_failure_count'         => 0,
+			'failure_reasons'                       => array(),
+		);
+	}
+
+	/**
+	 * Normalize partial report quality and retain unresolved compiler fallbacks.
+	 *
+	 * Website-artifact composition supplies the compiler's nested metrics rather
+	 * than the complete conversion-report quality shape. Preserve every supplied
+	 * report value while making the quality gate consume its authoritative fallback
+	 * count until a materialization receipt explicitly resolves it.
+	 *
+	 * @param array<string,mixed> $report Import report.
+	 * @return void
+	 */
+	private static function normalize_quality_report( array &$report ): void {
+		$supplied = isset( $report['quality'] ) && is_array( $report['quality'] ) ? $report['quality'] : array();
+		$metrics  = isset( $supplied['metrics'] ) && is_array( $supplied['metrics'] ) ? $supplied['metrics'] : array();
+		$quality  = array_merge( self::quality_defaults(), $metrics, $supplied );
+
+		$plan_quality = isset( $report['blocks_engine']['wordpress_site_plan']['quality'] ) && is_array( $report['blocks_engine']['wordpress_site_plan']['quality'] )
+			? $report['blocks_engine']['wordpress_site_plan']['quality']
+			: array();
+		$plan_metrics = isset( $plan_quality['metrics'] ) && is_array( $plan_quality['metrics'] ) ? $plan_quality['metrics'] : $plan_quality;
+		if ( isset( $plan_metrics['fallback_count'] ) && is_numeric( $plan_metrics['fallback_count'] ) ) {
+			$quality['fallback_count'] = max( (int) $quality['fallback_count'], (int) $plan_metrics['fallback_count'] );
+		}
+
+		$report['quality'] = $quality;
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -445,7 +445,7 @@ class Static_Site_Importer_Theme_Generator {
 				),
 				'block_documents'     => array_map(
 					static function ( array $page ) use ( $receipt ): array {
-						$materialized = $receipt['completed']['materialized_pages'][ $page['source_path'] ]['block_markup'] ?? $page['resolved_block_markup'];
+						$materialized = $receipt['completed']['materialized_pages'][ $page['source_path'] ]['block_markup'] ?? $page['resolved_block_markup'] ?? '';
 						$document = array(
 							'path'    => 'posts/page-' . ( ! empty( $page['entrypoint'] ) ? 'home' : $page['slug'] ) . '.post_content',
 							'content' => $materialized,

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -39,6 +39,8 @@ if ( ! function_exists( 'add_action' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
 require_once dirname( __DIR__ ) . '/includes/abilities.php';
 
 $failures   = array();
@@ -215,6 +217,43 @@ $clean_quality_contract = Static_Site_Importer_Diagnostic_Contract::build(
 $assert( 0 === ( $clean_quality_contract['quality_counts']['fallback_count'] ?? null ), 'quality-reconciliation-keeps-clean-fallbacks-zero' );
 $assert( true === ( $clean_quality_contract['quality_counts']['consistent'] ?? false ), 'quality-reconciliation-keeps-clean-layers-consistent' );
 $assert( 0 === ( $clean_quality_contract['diagnostic_summary']['total'] ?? null ), 'quality-reconciliation-does-not-diagnose-clean-layers' );
+
+$partial_quality_report = array(
+	'blocks_engine' => array( 'wordpress_site_plan' => array( 'quality' => array( 'metrics' => array( 'fallback_count' => 2 ) ) ) ),
+	'quality'       => array( 'metrics' => array( 'block_count' => 1 ) ),
+	'diagnostics'   => array( array( 'type' => 'unsupported_html_fallback', 'severity' => 'warning' ) ),
+);
+$partial_quality_warning_handler = set_error_handler(
+	static function ( int $severity, string $message, string $file, int $line ): never {
+		throw new RuntimeException( sprintf( 'PHP warning/notice [%d] %s at %s:%d', $severity, $message, $file, $line ) );
+	}
+);
+try {
+	$partial_quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $partial_quality_report, array( 'fail_on_quality' => true ) );
+} finally {
+	restore_error_handler();
+}
+$partial_quality_counters = array(
+	'fallback_count'                        => 2,
+	'content_loss_count'                    => 0,
+	'empty_conversion_count'                => 0,
+	'core_html_block_count'                 => 0,
+	'freeform_block_count'                  => 0,
+	'invalid_block_count'                   => 0,
+	'invalid_block_document_count'          => 0,
+	'unsafe_svg_count'                      => 0,
+	'svg_materialization_failure_count'     => 0,
+	'svg_sprite_reference_failure_count'    => 0,
+	'commerce_dependency_failures'          => 0,
+	'companion_plugin_dependency_failures'  => 0,
+	'interaction_candidate_count'           => 0,
+	'runtime_dependency_parity_issue_count' => 0,
+	'semantic_parity_failure_count'         => 0,
+	'source_fallback_count'                 => 2,
+);
+$assert( 2 === ( $partial_quality['fallback_count'] ?? 0 ), 'quality-finalization-normalizes-partial-compiler-reports' );
+$assert( $partial_quality_counters === array_intersect_key( $partial_quality, $partial_quality_counters ) && 1 === ( $partial_quality['block_count'] ?? 0 ), 'quality-finalization-provides-the-complete-normalized-counter-schema' );
+$assert( false === ( $partial_quality['pass'] ?? true ) && true === ( $partial_quality['fail_import'] ?? false ) && in_array( 'unsupported_html_fallback', $partial_quality['failure_reasons'] ?? array(), true ), 'quality-finalization-turns-compiler-fallback-warning-into-strict-failure' );
 
 $importer_only_contract = Static_Site_Importer_Diagnostic_Contract::build(
 	array(

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -496,6 +496,45 @@ $other_failure_report['quality']['core_html_block_count'] = 1;
 $other_failure_quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $other_failure_report, array( 'fail_on_quality' => true ) );
 $other_failure_validation = Static_Site_Importer_Report_Diagnostics::import_validation_result( $other_failure_report, $other_failure_quality );
 $assert( 0 === ( $other_failure_quality['fallback_count'] ?? -1 ) && false === ( $other_failure_quality['pass'] ?? true ) && true === ( $other_failure_quality['fail_import'] ?? false ) && array( 'core_html_block' ) === ( $other_failure_quality['failure_reasons'] ?? null ) && 'failed' === ( $other_failure_validation['status'] ?? '' ), 'receipt reconciliation preserves unrelated quality failures and validation status' );
+// Exercise the production result composition path with the partial compiler
+// quality envelope that website-artifact imports supply.
+$partial_quality_plan                     = $plan;
+$partial_quality_plan['quality']          = array( 'metrics' => array( 'block_count' => 1, 'fallback_count' => 1 ) );
+$partial_quality_plan['diagnostics']      = array( array( 'type' => 'unsupported_html_fallback', 'severity' => 'warning' ) );
+$partial_quality_receipt                  = $receipt;
+$partial_quality_receipt['plan']          = $partial_quality_plan;
+$compose_partial_quality_result           = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'public_result_from_wordpress_site_plan_receipt' );
+$partial_quality_warning_handler          = set_error_handler(
+	static function ( int $severity, string $message, string $file, int $line ): never {
+		throw new RuntimeException( sprintf( 'PHP warning/notice [%d] %s at %s:%d', $severity, $message, $file, $line ) );
+	}
+);
+try {
+	$partial_quality_result = $compose_partial_quality_result->invoke( null, $partial_quality_receipt, array( 'fail_on_quality' => true ) );
+} finally {
+	restore_error_handler();
+}
+$partial_quality          = $partial_quality_result['quality'] ?? array();
+$partial_quality_counters = array(
+	'fallback_count'                        => 1,
+	'content_loss_count'                    => 0,
+	'empty_conversion_count'                => 0,
+	'core_html_block_count'                 => 0,
+	'freeform_block_count'                  => 0,
+	'invalid_block_count'                   => 0,
+	'invalid_block_document_count'          => 0,
+	'unsafe_svg_count'                      => 0,
+	'svg_materialization_failure_count'     => 0,
+	'svg_sprite_reference_failure_count'    => 0,
+	'commerce_dependency_failures'          => 0,
+	'companion_plugin_dependency_failures'  => 0,
+	'interaction_candidate_count'           => 0,
+	'runtime_dependency_parity_issue_count' => 0,
+	'semantic_parity_failure_count'         => 0,
+	'source_fallback_count'                 => 1,
+);
+$assert( $partial_quality_counters === array_intersect_key( $partial_quality, $partial_quality_counters ) && 1 === ( $partial_quality['block_count'] ?? 0 ) && array( 'block_count' => 1, 'fallback_count' => 1 ) === ( $partial_quality['metrics'] ?? null ), 'partial website-artifact result composition preserves supplied metrics and normalizes the complete quality counter schema' );
+$assert( false === ( $partial_quality['pass'] ?? true ) && true === ( $partial_quality['fail_import'] ?? false ) && in_array( 'unsupported_html_fallback', $partial_quality['failure_reasons'] ?? array(), true ), 'partial website-artifact reports retain unresolved compiler fallbacks as strict quality failures' );
 $tampered_fragment_receipt = $form_binding_receipt;
 $tampered_fragment_receipt['completed']['runtime_declarations']['entity_bindings'][ hash( 'sha256', 'form-fallback-binding' ) ]['persisted_fragment_hash'] = hash( 'sha256', 'tampered fragment' );
 $tampered_fragment_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );


### PR DESCRIPTION
## Summary
- Normalize partial import quality reports against one canonical counter schema.
- Reconcile authoritative WordPress site-plan fallbacks before final quality gating.
- Fail tests on PHP warnings and verify the complete normalized schema.

Closes #947.

## Verification
- `php tests/smoke-wordpress-site-plan-materializer.php`
- `php tests/smoke-import-diagnostic-contract.php` (80 assertions)

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and reviewed the change and regression coverage. Chris Huber reviewed and remains responsible for every line.
