### PR TITLE
Materialize retained URL payloads within bounded fetch deadlines

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -36,6 +36,7 @@
     "tests/smoke-url-import-runtime.php": { "environment": "standalone-php" },
     "tests/smoke-rest-url-import-helpers.php": { "environment": "standalone-php" },
     "tests/smoke-url-concurrent-fetcher.php": { "environment": "standalone-php" },
+    "tests/smoke-url-curl-deadline.php": { "environment": "standalone-php" },
     "tests/smoke-url-resolver-provider.php": { "environment": "standalone-php" },
     "tests/smoke-url-tls-context.php": { "environment": "standalone-php" },
     "tests/smoke-validation-runtime-diagnostics.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-shared-resource-plan.php
+++ b/includes/class-static-site-importer-shared-resource-plan.php
@@ -192,7 +192,8 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 	private static function canonical_url( string $url ): string {
 		$url   = Static_Site_Importer_URL_Fetcher::normalize_url( trim( $url ) );
 		$parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Standalone plan smoke tests run without WordPress URL helpers.
-		if ( ! is_array( $parts ) || ! in_array( strtolower( (string) ( $parts['scheme'] ?? '' ) ), array( 'http', 'https' ), true ) || empty( $parts['host'] ) ) {
+		$scheme = is_array( $parts ) ? strtolower( (string) ( $parts['scheme'] ?? '' ) ) : '';
+		if ( ! is_array( $parts ) || ! in_array( $scheme, array( 'http', 'https' ), true ) || empty( $parts['host'] ) ) {
 			return '';
 		}
 		$segments = array();
@@ -211,6 +212,6 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 		$path  = str_ends_with( (string) ( $parts['path'] ?? '/' ), '/' ) && '/' !== $path ? $path . '/' : $path;
 		$port  = isset( $parts['port'] ) ? ':' . (int) $parts['port'] : '';
 		$query = isset( $parts['query'] ) && '' !== $parts['query'] ? '?' . $parts['query'] : '';
-		return strtolower( (string) $parts['scheme'] ) . '://' . strtolower( (string) $parts['host'] ) . $port . $path . $query;
+		return $scheme . '://' . strtolower( (string) $parts['host'] ) . $port . $path . $query;
 	}
 }

--- a/includes/class-static-site-importer-shared-resource-plan.php
+++ b/includes/class-static-site-importer-shared-resource-plan.php
@@ -1,5 +1,11 @@
 <?php
 /** Immutable shared-resource plan storage for resumable artifact runs. @package StaticSiteImporter */
+if ( ! class_exists( 'Static_Site_Importer_Content_Policy' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-content-policy.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_URL_Fetcher' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-url-fetcher.php';
+}
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -26,6 +32,34 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 		return hash_equals( (string) ( $plan['digest'] ?? '' ), self::digest( $plan['resources'] ) ) ? $plan : null;
 	}
 
+	/** @return array<string,string> Source URL to retained artifact path. */
+	public function source_paths(): array {
+		$paths = array();
+		foreach ( $this->retained_resources() as $resource ) {
+			$paths[ $resource['source_url'] ] = $resource['path'];
+		}
+		ksort( $paths, SORT_STRING );
+		return $paths;
+	}
+
+	/**
+	 * Return only retained resources that can be materialized from this workspace.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function retained_resources(): array {
+		$resources = array();
+		foreach ( $this->load()['resources'] ?? array() as $resource ) {
+			if ( ! is_array( $resource ) || ! $this->materializable_resource( $resource ) ) {
+				continue;
+			}
+			$resource['source_url'] = self::canonical_url( $resource['source_url'] );
+			$resources[ $resource['source_url'] ] = $resource;
+		}
+		ksort( $resources, SORT_STRING );
+		return array_values( $resources );
+	}
+
 	/** @return array<string,mixed>|WP_Error */
 	public function establish( array $artifact, ?array $paths = null ): array|WP_Error {
 		$resources = self::resources( $artifact, $paths );
@@ -34,14 +68,14 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 
 	/** @return array<string,mixed>|WP_Error */
 	private function store( array $resources ): array|WP_Error {
-		$plan      = array(
+		$plan   = array(
 			'schema'     => self::SCHEMA,
 			'digest'     => self::digest( $resources ),
 			'resources'  => $resources,
 			'verified'   => true,
 			'created_at' => gmdate( 'c' ),
 		);
-		$stored    = $this->workspace->publish_json( 'shared-resource-plan.json', $plan );
+		$stored = $this->workspace->publish_json( 'shared-resource-plan.json', $plan );
 		if ( is_wp_error( $stored ) ) {
 			return $stored;
 		}
@@ -88,15 +122,20 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 			if ( '' === $path || ( null !== $paths && ! in_array( $path, $paths, true ) ) ) {
 				continue;
 			}
-			$resources[] = array_filter(
+			$resource = array_filter(
 				array(
-					'path'           => $path,
-					'mime_type'      => (string) ( $file['mime_type'] ?? '' ),
-					'content'        => $file['content'] ?? null,
-					'content_base64' => $file['content_base64'] ?? null,
+					'path'              => $path,
+					'source_url'        => self::canonical_url( (string) ( $file['source_url'] ?? '' ) ),
+					'mime_type'         => (string) ( $file['mime_type'] ?? '' ),
+					'content'           => $file['content'] ?? null,
+					'content_base64'    => $file['content_base64'] ?? null,
+					'payload_reference' => $file['payload_reference'] ?? null,
 				),
 				static fn( $value ): bool => null !== $value
 			);
+			if ( self::structurally_materializable( $resource ) ) {
+				$resources[] = $resource;
+			}
 		}
 		usort( $resources, static fn( array $left, array $right ): int => strcmp( $left['path'], $right['path'] ) );
 		return $resources;
@@ -117,5 +156,61 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 	private static function digest( array $resources ): string {
 		$json = wp_json_encode( $resources, JSON_UNESCAPED_SLASHES );
 		return hash( 'sha256', false === $json ? '' : $json );
+	}
+
+	/** @param array<string,mixed> $resource */
+	private function materializable_resource( array $resource ): bool {
+		if ( ! self::structurally_materializable( $resource ) ) {
+			return false;
+		}
+		$reference = $resource['payload_reference'] ?? null;
+		if ( ! is_array( $reference ) ) {
+			return true;
+		}
+		$bytes = $this->workspace->read_raw( $reference['id'] );
+		return is_string( $bytes )
+			&& ( ! isset( $reference['bytes'] ) || strlen( $bytes ) === $reference['bytes'] )
+			&& hash_equals( $reference['sha256'], hash( 'sha256', $bytes ) );
+	}
+
+	/** @param array<string,mixed> $resource */
+	private static function structurally_materializable( array $resource ): bool {
+		if ( '' === self::canonical_url( (string) ( $resource['source_url'] ?? '' ) ) || ! Static_Site_Importer_Content_Policy::is_static_path( (string) ( $resource['path'] ?? '' ) ) ) {
+			return false;
+		}
+		$has_content = isset( $resource['content'] ) && is_string( $resource['content'] );
+		$has_base64  = isset( $resource['content_base64'] ) && is_string( $resource['content_base64'] ) && false !== base64_decode( $resource['content_base64'], true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Validates retained binary payload bytes.
+		$reference   = $resource['payload_reference'] ?? null;
+		$has_ref     = is_array( $reference )
+			&& 'blocks-engine/payload-reference/v1' === ( $reference['schema'] ?? null )
+			&& is_string( $reference['id'] ?? null ) && '' !== $reference['id']
+			&& is_string( $reference['sha256'] ?? null ) && 1 === preg_match( '/^[a-f0-9]{64}$/', $reference['sha256'] )
+			&& ( ! isset( $reference['bytes'] ) || ( is_int( $reference['bytes'] ) && $reference['bytes'] >= 0 ) );
+		return 1 === count( array_filter( array( $has_content, $has_base64, $has_ref ) ) );
+	}
+
+	private static function canonical_url( string $url ): string {
+		$url   = Static_Site_Importer_URL_Fetcher::normalize_url( trim( $url ) );
+		$parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Standalone plan smoke tests run without WordPress URL helpers.
+		if ( ! is_array( $parts ) || ! in_array( strtolower( (string) ( $parts['scheme'] ?? '' ) ), array( 'http', 'https' ), true ) || empty( $parts['host'] ) ) {
+			return '';
+		}
+		$segments = array();
+		$path     = (string) ( $parts['path'] ?? '/' );
+		foreach ( explode( '/', '/' . ltrim( $path, '/' ) ) as $segment ) {
+			if ( '' === $segment || '.' === $segment ) {
+				continue;
+			}
+			if ( '..' === $segment ) {
+				array_pop( $segments );
+				continue;
+			}
+			$segments[] = $segment;
+		}
+		$path  = '/' . implode( '/', $segments );
+		$path  = str_ends_with( (string) ( $parts['path'] ?? '/' ), '/' ) && '/' !== $path ? $path . '/' : $path;
+		$port  = isset( $parts['port'] ) ? ':' . (int) $parts['port'] : '';
+		$query = isset( $parts['query'] ) && '' !== $parts['query'] ? '?' . $parts['query'] : '';
+		return strtolower( (string) $parts['scheme'] ) . '://' . strtolower( (string) $parts['host'] ) . $port . $path . $query;
 	}
 }

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -95,11 +95,15 @@ class Static_Site_Importer_Theme_Generator {
 
 	/** Compile an artifact into its immutable canonical WordPress site plan. */
 	public static function compile_website_artifact( array $artifact, array $args = array() ) {
-		$source_policy = Static_Site_Importer_Content_Policy::validate_artifact( $artifact );
+		$precompiled   = ! empty( $args['_static_site_importer_precompiled_source'] ) && is_array( $args['compiled_artifact_result'] ?? null );
+		$source_policy = $precompiled ? true : Static_Site_Importer_Content_Policy::validate_artifact( $artifact );
 		if ( is_wp_error( $source_policy ) ) {
 			return $source_policy;
 		}
-		$script_policy                       = Static_Site_Importer_Client_Script_Policy::apply( $artifact, $args );
+		$script_policy                       = $precompiled ? array(
+			'artifact' => $artifact,
+			'report'   => $args['source_metadata']['collection']['script_policy'] ?? array(),
+		) : Static_Site_Importer_Client_Script_Policy::apply( $artifact, $args );
 		$artifact                            = $script_policy['artifact'];
 		$args['client_script_policy_report'] = $script_policy['report'];
 		$compiler_class = 'Automattic\\BlocksEngine\\PhpTransformer\\ArtifactCompiler\\ArtifactCompiler';
@@ -194,6 +198,12 @@ class Static_Site_Importer_Theme_Generator {
 			$receipt = isset( $prepared['receipt'] ) && is_array( $prepared['receipt'] ) ? $prepared['receipt'] : array();
 			$error   = $receipt['errors'][0] ?? array();
 			return new WP_Error( (string) ( $error['code'] ?? 'static_site_importer_materialization_failed' ), (string) ( $error['message'] ?? 'WordPress site plan destination preflight failed.' ), $receipt );
+		}
+		$prepared = Static_Site_Importer_WordPress_Site_Plan_Materializer::admit_prepared( $prepared );
+		if ( 'prepared' !== ( $prepared['status'] ?? '' ) ) {
+			$receipt = isset( $prepared['receipt'] ) && is_array( $prepared['receipt'] ) ? $prepared['receipt'] : array();
+			$error   = $receipt['errors'][0] ?? array();
+			return new WP_Error( (string) ( $error['code'] ?? 'static_site_importer_materialization_failed' ), (string) ( $error['message'] ?? 'WordPress site plan payload admission failed.' ), $receipt );
 		}
 		$lifecycle = self::with_resolved_runtime_binding_manifests( $lifecycle, $prepared['resolved'] ?? array() );
 		$binding_preflight = self::preflight_runtime_entity_binding_anchors( $prepared['resolved'] ?? array(), $lifecycle, $args );

--- a/includes/class-static-site-importer-url-batch-import.php
+++ b/includes/class-static-site-importer-url-batch-import.php
@@ -452,7 +452,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 				$staged_artifact = $runtime['artifact'];
 				$staged_paths    = array_fill_keys( array_column( $staged_artifact['files'] ?? array(), 'path' ), true );
 				foreach ( $shared_plan->retained_resources() as $resource ) {
-					if ( is_array( $resource ) && ! isset( $staged_paths[ $resource['path'] ?? '' ] ) ) {
+					if ( ! isset( $staged_paths[ $resource['path'] ?? '' ] ) ) {
 						$staged_artifact['files'][] = $resource;
 					}
 				}

--- a/includes/class-static-site-importer-url-batch-import.php
+++ b/includes/class-static-site-importer-url-batch-import.php
@@ -196,6 +196,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 			return $manifest['final_result'];
 		}$importer         = $importer ?? static fn ( array $artifact, array $import_args ) => Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $import_args );
 		$shared_plan       = new Static_Site_Importer_Shared_Resource_Plan( $workspace );
+		$payload_reader    = self::payload_reader( $workspace );
 		$cursor            = Static_Site_Importer_Artifact_Batch_Cursor::hydrate( $manifest['batches'] );
 		$effective_batches = 0;
 		while ( true ) {
@@ -228,6 +229,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 				return $write;
 			}
 			if ( null !== $deadline ) {
+				$known_asset_paths = $shared_plan->source_paths();
 				$ready_raw     = self::retained_runtime( $workspace, $ready_cache_name, $ready_cache_name, $ready_cache_name, $routes );
 				$ready_runtime = array();
 				if ( is_string( $ready_raw ) && is_array( json_decode( $ready_raw, true ) ) ) {
@@ -241,6 +243,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 					$ready_args['require_complete_collection'] = true;
 					$ready_args['asset_failure_policy']        = count( $routes ) > 1 ? 'preserve_failed_external_assets' : 'preserve_external';
 					$ready_args['hydration_mode']              = 'page_ready';
+					$ready_args['_static_site_importer_known_asset_paths'] = $known_asset_paths;
 					$ready_runtime                             = Static_Site_Importer_URL_Site_Collector::collect( $batch_entry, $ready_args, $fetcher );
 					if ( is_wp_error( $ready_runtime ) ) {
 						if ( self::deadline_error( $ready_runtime ) ) {
@@ -304,24 +307,28 @@ final class Static_Site_Importer_URL_Batch_Import {
 			$decoded = is_string( $raw ) ? json_decode( $raw, true ) : null;
 			$runtime = is_array( $decoded ) ? $decoded : array();
 			if ( empty( $runtime ) ) {
+				$known_asset_paths = $shared_plan->source_paths();
 				$collect_args                                = $args;
 				$collect_args['_route_set']                  = array_values( array_unique( $routes ) );
 				$collect_args['_known_route_set']            = $manifest['routes'];
 				$collect_args['max_pages']                   = min( self::MAX_BATCH_PAGES + 1, count( $collect_args['_route_set'] ) + 1 );
 				$collect_args['require_complete_collection'] = true;
 				$collect_args['asset_failure_policy']        = count( $routes ) > 1 ? 'preserve_failed_external_assets' : 'preserve_external';
-				$collection_cursor_name                      = 'batches/' . $batch['batch_id'] . '.collection-cursor.json';
-				$collection_contract                         = hash(
+				$collect_args['_static_site_importer_collection_return_payload_references'] = null !== $payload_reader;
+				$collect_args['_static_site_importer_known_asset_paths'] = $known_asset_paths;
+				$collection_cursor_name = 'batches/' . $batch['batch_id'] . '.collection-cursor.json';
+				$collection_contract    = hash(
 					'sha256',
 					(string) wp_json_encode(
 						array(
-							'version' => 1,
-							'routes'  => $routes,
-							'mode'    => 'complete_snapshot',
+							'version'       => 2,
+							'routes'        => $routes,
+							'mode'          => 'complete_snapshot',
+							'shared_digest' => hash( 'sha256', (string) wp_json_encode( $known_asset_paths, JSON_UNESCAPED_SLASHES ) ),
 						)
 					)
 				);
-				$collect_args                                = array_merge(
+				$collect_args = array_merge(
 					$collect_args,
 					array(
 						'_static_site_importer_collection_contract'      => $collection_contract,
@@ -336,6 +343,16 @@ final class Static_Site_Importer_URL_Batch_Import {
 						'_static_site_importer_collection_resource_load' => static function ( array $retained ) use ( $workspace ) {
 							$body = isset( $retained['body_ref'] ) && is_string( $retained['body_ref'] ) ? $workspace->read_raw( $retained['body_ref'] ) : null;
 							return is_string( $body ) && hash_equals( (string) ( $retained['sha256'] ?? '' ), hash( 'sha256', $body ) ) ? $body : null;
+						},
+						'_static_site_importer_collection_resource_store' => static function ( string $body ) use ( $workspace ) {
+							$hash  = hash( 'sha256', $body );
+							$ref   = 'collection-finalized/' . $hash . '.bin';
+							$write = $workspace->publish_raw( $ref, $body );
+							return is_wp_error( $write ) ? null : array(
+								'body_ref' => $ref,
+								'sha256'   => $hash,
+								'bytes'    => strlen( $body ),
+							);
 						},
 						'_static_site_importer_collection_should_yield'  => null !== $deadline ? static fn (): bool => self::deadline_reached( $deadline, $clock ) : null,
 						'_static_site_importer_collection_cursor_save'   => static function ( array $cursor ) use ( $workspace, $collection_cursor_name ) {
@@ -375,13 +392,14 @@ final class Static_Site_Importer_URL_Batch_Import {
 								unset( $file['body'] );
 								$file['body_ref'] = $ref;
 								$file['sha256']   = $hash;
+								$file['bytes']    = strlen( $body );
 								$cursor['finalization']['files'][ $index ] = $file;
 							}
 							return $workspace->publish_json( $collection_cursor_name, $cursor );
 						},
 					)
 				);
-				$runtime                                     = Static_Site_Importer_URL_Site_Collector::collect( $batch_entry, $collect_args, $fetcher );
+				$runtime = Static_Site_Importer_URL_Site_Collector::collect( $batch_entry, $collect_args, $fetcher );
 				if ( is_wp_error( $runtime ) ) {
 					if ( self::deadline_error( $runtime ) ) {
 						$manifest['batches'] = self::legacy_batches( $cursor );
@@ -431,8 +449,30 @@ final class Static_Site_Importer_URL_Batch_Import {
 						'shared_plan_digest' => $shared['digest'],
 					);
 				}
-				$staged = self::prepare_staged_plans( $workspace, $runtime['artifact'], $shared['digest'] );
+				$staged_artifact = $runtime['artifact'];
+				$staged_paths    = array_fill_keys( array_column( $staged_artifact['files'] ?? array(), 'path' ), true );
+				foreach ( $shared_plan->retained_resources() as $resource ) {
+					if ( is_array( $resource ) && ! isset( $staged_paths[ $resource['path'] ?? '' ] ) ) {
+						$staged_artifact['files'][] = $resource;
+					}
+				}
+				$staged = self::prepare_staged_plans(
+					$workspace,
+					$staged_artifact,
+					$shared['digest'],
+					$payload_reader,
+					'batches/' . $batch['batch_id'] . '.staged-pages.json',
+					null !== $deadline ? static fn (): bool => self::deadline_reached( $deadline, $clock ) : null
+				);
 				if ( is_wp_error( $staged ) ) {
+					if ( self::deadline_error( $staged ) ) {
+						self::checkpoint_cache( $manifest, $cache );
+						$write = $run_manifest->save( $manifest );
+						if ( is_wp_error( $write ) ) {
+							return $write;
+						}
+						return self::continuation_result( $manifest, $manifest_path, $index, $effective_batches, $max_effective_batches, $max_invocation_seconds, 'deadline_exhausted' );
+					}
 					return self::failed( $run_manifest, $workspace, $manifest, $cursor, $index, $staged, $cache );
 				}
 				$runtime['shared_plan_digest'] = $shared['digest'];
@@ -450,7 +490,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 				$manifest['stage_counters']['shared_plan_reconciliations'] = (int) ( $manifest['stage_counters']['shared_plan_reconciliations'] ?? 0 ) + 1;
 				$manifest['stage_counters']['shared_plan_invalidations']   = (int) ( $manifest['stage_counters']['shared_plan_invalidations'] ?? 0 ) + ( ! empty( $shared['changed'] ) ? 1 : 0 );
 				$manifest['stage_counters']['compiler_shared_prepares']    = (int) ( $manifest['stage_counters']['compiler_shared_prepares'] ?? 0 ) + ( $staged['shared_prepared'] ? 1 : 0 );
-				$manifest['stage_counters']['compiler_page_prepares']      = (int) ( $manifest['stage_counters']['compiler_page_prepares'] ?? 0 ) + count( $staged['page_plans'] );
+				$manifest['stage_counters']['compiler_page_prepares']      = (int) ( $manifest['stage_counters']['compiler_page_prepares'] ?? 0 ) + $staged['page_prepared'];
 				$manifest['external_asset_retained']                       = self::merge_external_assets( $manifest['external_asset_retained'] ?? array(), $runtime['source_metadata']['collection']['external_asset_retained'] ?? array(), $index );
 				self::checkpoint_cache( $manifest, $cache );
 				$manifest['batches'] = self::legacy_batches( $cursor );
@@ -477,7 +517,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 				if ( is_wp_error( $write ) ) {
 					return $write;
 				}
-				$compiled_staged = self::compose_staged_plans( $staged );
+				$compiled_staged = self::compose_staged_plans( $staged, $payload_reader );
 				if ( is_wp_error( $compiled_staged ) ) {
 					return self::failed( $run_manifest, $workspace, $manifest, $cursor, $index, $compiled_staged, $cache );
 				}
@@ -488,6 +528,9 @@ final class Static_Site_Importer_URL_Batch_Import {
 				$import_args['preserve_existing_theme_bootstrap'] = $index > 0;
 				$import_args['import_run_id']                     = $identity;
 				$import_args['compiled_artifact_result']          = $compiled_staged;
+				$import_args['_static_site_importer_precompiled_source'] = null !== $payload_reader;
+				// This reader is invocation-local workspace access, never plan state.
+				$import_args['_static_site_importer_payload_reader'] = $payload_reader;
 				$result = $importer( $runtime['artifact'], $import_args );
 				if ( is_wp_error( $result ) ) {
 					return self::failed( $run_manifest, $workspace, $manifest, $cursor, $index, $result, $cache );
@@ -513,7 +556,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 			unset( $result, $runtime, $raw );
 		}
 		if ( 'plan' === (string) ( $input['operation'] ?? 'apply' ) ) {
-			$final = self::compose_complete_plan( $workspace, $cursor );
+			$final = self::compose_complete_plan( $workspace, $cursor, $payload_reader );
 			if ( is_wp_error( $final ) ) {
 				return $final;
 			}
@@ -542,7 +585,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 	 * Persist the Blocks Engine staged envelopes. The shared envelope is created
 	 * once per retained resource digest; page envelopes remain batch-local.
 	 */
-	private static function prepare_staged_plans( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $artifact, string $resource_digest ): array|WP_Error {
+	private static function prepare_staged_plans( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $artifact, string $resource_digest, ?object $payload_reader = null, string $page_checkpoint = '', ?callable $should_yield = null ): array|WP_Error {
 		$compiler = self::staged_compiler();
 		if ( is_wp_error( $compiler ) ) {
 			return $compiler;
@@ -556,7 +599,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 			if ( ! is_callable( $prepare_shared ) || ! is_callable( $prepare_page ) ) {
 				return new WP_Error( 'static_site_importer_missing_transformer_capability', 'The Blocks Engine php-transformer does not support staged URL batch plans.' );
 			}
-			$shared = $shared_prepared ? call_user_func( $prepare_shared, $artifact ) : $stored['plan'];
+			$shared = $shared_prepared ? call_user_func( $prepare_shared, $artifact, $payload_reader ) : $stored['plan'];
 			if ( $shared_prepared ) {
 				$write = $workspace->publish_json(
 					'staged-compiler-shared.json',
@@ -569,16 +612,42 @@ final class Static_Site_Importer_URL_Batch_Import {
 					return $write;
 				}
 			}
-			$page_plans = array();
+			$page_contract = hash( 'sha256', $resource_digest . "\n" . (string) wp_json_encode( $artifact, JSON_UNESCAPED_SLASHES ) );
+			$page_state    = '' !== $page_checkpoint ? $workspace->read_raw( $page_checkpoint ) : null;
+			$page_state    = is_string( $page_state ) ? json_decode( $page_state, true ) : null;
+			$page_plans    = is_array( $page_state ) && hash_equals( $page_contract, (string) ( $page_state['contract'] ?? '' ) ) && is_array( $page_state['plans'] ?? null ) ? $page_state['plans'] : array();
+			$page_prepared = 0;
 			foreach ( $artifact['files'] ?? array() as $file ) {
 				if ( ! is_array( $file ) || 'text/html' !== strtolower( (string) ( $file['mime_type'] ?? '' ) ) || '' === (string) ( $file['path'] ?? '' ) ) {
 					continue;
 				}
-				$page_plans[] = call_user_func( $prepare_page, $artifact, $shared, (string) $file['path'] );
+				$page_id = (string) $file['path'];
+				if ( isset( $page_plans[ $page_id ] ) && is_array( $page_plans[ $page_id ] ) ) {
+					continue;
+				}
+				if ( null !== $should_yield && call_user_func( $should_yield ) ) {
+					return new WP_Error( 'static_site_importer_invocation_deadline_exceeded', 'The URL batch invocation deadline was reached during staged page preparation.' );
+				}
+				$page_plans[ $page_id ] = call_user_func( $prepare_page, $artifact, $shared, $page_id, $payload_reader );
+				++$page_prepared;
+				if ( '' !== $page_checkpoint ) {
+					$write = $workspace->publish_json(
+						$page_checkpoint,
+						array(
+							'contract' => $page_contract,
+							'plans'    => $page_plans,
+						)
+					);
+					if ( is_wp_error( $write ) ) {
+						return $write;
+					}
+				}
 			}
+			ksort( $page_plans, SORT_STRING );
 			return array(
 				'shared_plan'     => $shared,
-				'page_plans'      => $page_plans,
+				'page_plans'      => array_values( $page_plans ),
+				'page_prepared'   => $page_prepared,
 				'shared_prepared' => $shared_prepared,
 			);
 		} catch ( Throwable $error ) {
@@ -602,7 +671,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 			'shared_prepared' => false,
 		);
 	}
-	private static function compose_staged_plans( array $staged ): array|WP_Error {
+	private static function compose_staged_plans( array $staged, ?object $payload_reader = null ): array|WP_Error {
 		$compiler = self::staged_compiler();
 		if ( is_wp_error( $compiler ) ) {
 			return $compiler;
@@ -612,7 +681,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 			if ( ! is_callable( $compose ) ) {
 				return new WP_Error( 'static_site_importer_missing_transformer_capability', 'The Blocks Engine php-transformer does not support staged URL batch plans.' );
 			}
-			$compiled = call_user_func( $compose, $staged['shared_plan'], $staged['page_plans'] );
+			$compiled = call_user_func( $compose, $staged['shared_plan'], $staged['page_plans'], $payload_reader );
 			if ( ! is_object( $compiled ) || ! is_callable( array( $compiled, 'toArray' ) ) ) {
 				return new WP_Error( 'static_site_importer_invalid_staged_compile', 'The Blocks Engine php-transformer returned an invalid staged URL batch plan.' );
 			}
@@ -622,6 +691,23 @@ final class Static_Site_Importer_URL_Batch_Import {
 		}
 	}
 
+	private static function payload_reader( Static_Site_Importer_Artifact_Run_Workspace $workspace ): ?object {
+		$interface = 'Automattic\\BlocksEngine\\PhpTransformer\\ArtifactCompiler\\PayloadReader';
+		if ( ! interface_exists( $interface ) ) {
+			return null;
+		}
+		return new class( $workspace ) implements \Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\PayloadReader {
+			public function __construct( private Static_Site_Importer_Artifact_Run_Workspace $workspace ) {}
+			public function read( array $reference ): string {
+				$bytes = $this->workspace->read_raw( (string) ( $reference['id'] ?? '' ) );
+				if ( ! is_string( $bytes ) ) {
+					throw new RuntimeException( 'A retained artifact payload is unavailable.' );
+				}
+				return $bytes;
+			}
+		};
+	}
+
 	/**
 	 * Compose every frozen batch page plan once after terminal URL acquisition.
 	 *
@@ -629,7 +715,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 	 * @param array<int,array<string,mixed>>               $cursor    Completed batch cursor.
 	 * @return array<string,mixed>|WP_Error
 	 */
-	private static function compose_complete_plan( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $cursor ): array|WP_Error {
+	private static function compose_complete_plan( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $cursor, ?object $payload_reader = null ): array|WP_Error {
 		$shared_raw   = $workspace->read_raw( 'staged-compiler-shared.json' );
 		$shared_state = is_string( $shared_raw ) ? json_decode( $shared_raw, true ) : null;
 		$shared_plan  = is_array( $shared_state ) && is_array( $shared_state['plan'] ?? null ) ? $shared_state['plan'] : null;
@@ -676,7 +762,7 @@ final class Static_Site_Importer_URL_Batch_Import {
 						continue;
 					}
 					try {
-						$fresh_plans[] = call_user_func( $prepare_page_callable, $runtime['artifact'], $shared_plan, (string) $file['path'] );
+						$fresh_plans[] = call_user_func( $prepare_page_callable, $runtime['artifact'], $shared_plan, (string) $file['path'], $payload_reader );
 					} catch ( Throwable $error ) {
 						return new WP_Error( 'static_site_importer_staged_reprepare_failed', $error->getMessage() );
 					}
@@ -691,7 +777,8 @@ final class Static_Site_Importer_URL_Batch_Import {
 			array(
 				'shared_plan' => $shared_plan,
 				'page_plans'  => $page_plans,
-			)
+			),
+			$payload_reader
 		);
 		if ( is_wp_error( $compiled ) ) {
 			return $compiled;

--- a/includes/class-static-site-importer-url-fetcher-native-handle.php
+++ b/includes/class-static-site-importer-url-fetcher-native-handle.php
@@ -6,6 +6,8 @@
  */
 
 class Static_Site_Importer_URL_Fetcher_Native_Handle {
+	public mixed $multi = null;
+	public mixed $curl = null;
 	public mixed $socket;
 	public array $target;
 	public array $options;
@@ -15,4 +17,7 @@ class Static_Site_Importer_URL_Fetcher_Native_Handle {
 	public bool $crypto;
 	public string $error;
 	public int $ip_index;
+	public string $response_headers = '';
+	public string $body = '';
+	public string $limit_error = '';
 }

--- a/includes/class-static-site-importer-url-fetcher.php
+++ b/includes/class-static-site-importer-url-fetcher.php
@@ -241,7 +241,7 @@ class Static_Site_Importer_URL_Fetcher {
 					continue;
 				}
 				unset( $pending[ $index ] );
-				$state['handle']    = self::start_transport( $driver, $state['target'], self::request_options( $state['args'] ) );
+				$state['handle']    = self::start_transport( $driver, $state['target'], self::request_options( $state['args'], $deadline, $clock ) );
 				$active[]           = $state;
 				$origins[ $origin ] = ( $origins[ $origin ] ?? 0 ) + 1;
 				$started            = true;
@@ -282,14 +282,25 @@ class Static_Site_Importer_URL_Fetcher {
 		return $ordered;
 	}
 
-	/** @return array{timeout:int,max_bytes:int,has_content_types_arg:bool,content_types:array<int,string>} */
-	private static function request_options( array $args ): array {
+	/** @return array{timeout:float,max_bytes:int,has_content_types_arg:bool,content_types:array<int,string>,deadline:?float,clock:?callable,deadline_limited:bool} */
+	private static function request_options( array $args, ?float $deadline = null, ?callable $clock = null ): array {
 		$has_content_types_arg = isset( $args['content_types'] ) && is_array( $args['content_types'] );
+		$requested_timeout     = max( self::CONNECT_TIMEOUT_FLOOR, (int) ( $args['timeout'] ?? self::DEFAULT_TIMEOUT ) );
+		$timeout               = $requested_timeout;
+		$deadline_limited      = false;
+		if ( null !== $deadline && null !== $clock ) {
+			$remaining        = $deadline - $clock();
+			$deadline_limited = $remaining < $requested_timeout;
+			$timeout          = max( 0.001, min( $timeout, $remaining ) );
+		}
 		return array(
-			'timeout'               => max( self::CONNECT_TIMEOUT_FLOOR, (int) ( $args['timeout'] ?? self::DEFAULT_TIMEOUT ) ),
+			'timeout'               => $timeout,
 			'max_bytes'             => min( self::MAX_RESPONSE_BYTES, max( 1, (int) ( $args['max_bytes'] ?? self::DEFAULT_MAX_BYTES ) ) ),
 			'has_content_types_arg' => $has_content_types_arg,
 			'content_types'         => $has_content_types_arg ? array_values( array_filter( array_map( static fn( $value ): string => strtolower( (string) $value ), $args['content_types'] ) ) ) : self::HTML_CONTENT_TYPES,
+			'deadline'              => $deadline,
+			'clock'                 => $clock,
+			'deadline_limited'      => $deadline_limited,
 		);
 	}
 
@@ -379,13 +390,28 @@ class Static_Site_Importer_URL_Fetcher {
 			$driver['cancel']( $handle, $reason );
 			return;
 		}
+		if ( is_object( $handle ) && null !== $handle->multi && null !== $handle->curl ) {
+			curl_multi_remove_handle( $handle->multi, $handle->curl );
+			curl_multi_close( $handle->multi );
+			$handle->curl  = null;
+			$handle->multi = null;
+			return;
+		}
 		if ( is_object( $handle ) && isset( $handle->socket ) && is_resource( $handle->socket ) ) {
 			fclose( $handle->socket ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes a validated public HTTP socket.
 		}
 	}
 
-	/** Start a nonblocking, IP-pinned HTTP/1.1 connection. */
+	/** Start an IP-pinned native request, preferring curl_multi for bounded TLS progress. */
 	private static function native_start( array $target, array $options ): Static_Site_Importer_URL_Fetcher_Native_Handle {
+		if ( function_exists( 'curl_multi_init' ) ) {
+			return self::native_curl_start( $target, $options );
+		}
+		return self::native_stream_start( $target, $options );
+	}
+
+	/** Start the no-curl nonblocking stream fallback. */
+	private static function native_stream_start( array $target, array $options ): Static_Site_Importer_URL_Fetcher_Native_Handle {
 		$ip               = $target['ips'][0];
 		$remote           = sprintf( 'tcp://%s:%d', str_contains( $ip, ':' ) ? '[' . $ip . ']' : $ip, $target['port'] );
 		$context          = self::tls_context( $target['host'] );
@@ -412,6 +438,65 @@ class Static_Site_Importer_URL_Fetcher {
 		return $handle;
 	}
 
+	/** Start a curl request pinned to one already validated IP without changing Host or SNI. */
+	private static function native_curl_start( array $target, array $options ): Static_Site_Importer_URL_Fetcher_Native_Handle {
+		$handle                  = new Static_Site_Importer_URL_Fetcher_Native_Handle();
+		$handle->target          = $target;
+		$handle->options         = $options;
+		$handle->started         = microtime( true );
+		$handle->ip_index        = 0;
+		$handle->multi           = curl_multi_init();
+		$handle->curl            = curl_init();
+		$ip                      = $target['ips'][0];
+		$host                    = $target['host'];
+		$host_header             = $host . ( ( 'https' === $target['scheme'] ? 443 : 80 ) === $target['port'] ? '' : ':' . $target['port'] );
+		$resolved_ip             = str_contains( $ip, ':' ) ? '[' . $ip . ']' : $ip;
+		$timeout_ms              = max( 1, (int) ceil( $options['timeout'] * 1000 ) );
+		$url_host                = str_contains( $host, ':' ) ? '[' . $host . ']' : $host;
+		$url                     = $target['scheme'] . '://' . $url_host . ( ( 'https' === $target['scheme'] ? 443 : 80 ) === $target['port'] ? '' : ':' . $target['port'] ) . $target['path'];
+
+		$curl_options = array(
+				CURLOPT_URL               => $url,
+				CURLOPT_HTTPGET           => true,
+				CURLOPT_PROXY             => '',
+				CURLOPT_NOPROXY           => '*',
+				CURLOPT_FOLLOWLOCATION    => false,
+				CURLOPT_MAXREDIRS         => 0,
+				CURLOPT_HTTP_TRANSFER_DECODING => false,
+				CURLOPT_CONNECTTIMEOUT_MS => $timeout_ms,
+				CURLOPT_TIMEOUT_MS        => $timeout_ms,
+				CURLOPT_SSL_VERIFYPEER    => true,
+				CURLOPT_SSL_VERIFYHOST    => 2,
+				CURLOPT_HTTPHEADER        => array( 'Host: ' . $host_header, 'User-Agent: StaticSiteImporter/1.0', 'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.1', 'Connection: close' ),
+				CURLOPT_HEADERFUNCTION    => static function( $curl, string $data ) use ( $handle ): int {
+					if ( strlen( $handle->response_headers ) + strlen( $data ) > self::HEADER_MAX_BYTES ) {
+						$handle->limit_error = 'headers';
+						return 0;
+					}
+					$handle->response_headers .= $data;
+					return strlen( $data );
+				},
+				CURLOPT_WRITEFUNCTION     => static function( $curl, string $data ) use ( $handle ): int {
+					if ( strlen( $handle->body ) + strlen( $data ) > $handle->options['max_bytes'] ) {
+						$handle->limit_error = 'body';
+						return 0;
+					}
+					$handle->body .= $data;
+					return strlen( $data );
+				},
+		);
+		if ( false === filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			$curl_options[ CURLOPT_RESOLVE ] = array( $host . ':' . $target['port'] . ':' . $resolved_ip );
+		}
+		$ca_bundle    = ABSPATH . WPINC . '/certificates/ca-bundle.crt';
+		if ( is_readable( $ca_bundle ) ) {
+			$curl_options[ CURLOPT_CAINFO ] = $ca_bundle;
+		}
+		curl_setopt_array( $handle->curl, $curl_options );
+		curl_multi_add_handle( $handle->multi, $handle->curl );
+		return $handle;
+	}
+
 	/** Build the verified TLS context used by IP-pinned connections. */
 	private static function tls_context( string $host ) {
 		return stream_context_create( array(
@@ -427,17 +512,21 @@ class Static_Site_Importer_URL_Fetcher {
 
 	/** Poll a nonblocking connection. Null means it remains in flight. */
 	private static function native_poll( Static_Site_Importer_URL_Fetcher_Native_Handle $handle ) {
+		if ( null !== $handle->multi ) {
+			return self::native_curl_poll( $handle );
+		}
 		if ( '' !== $handle->error ) {
 			if ( self::native_retry( $handle ) ) {
 				return null;
 			}
 			return new WP_Error( 'static_site_importer_url_connect_failed', $handle->error );
 		}
-		if ( microtime( true ) - $handle->started >= $handle->options['timeout'] ) {
+		if ( self::native_deadline_exhausted( $handle ) || microtime( true ) - $handle->started >= $handle->options['timeout'] ) {
+			$deadline_exhausted = self::native_deadline_exhausted( $handle ) || ! empty( $handle->options['deadline_limited'] );
 			if ( self::native_retry( $handle ) ) {
 				return null;
 			}
-			return new WP_Error( 'static_site_importer_url_timeout', 'The URL request timed out.' );
+			return new WP_Error( $deadline_exhausted ? 'static_site_importer_url_deadline_exhausted' : 'static_site_importer_url_timeout', $deadline_exhausted ? 'The URL request deadline was exhausted.' : 'The URL request timed out.' );
 		}
 		if ( ! $handle->crypto ) {
 			$crypto = @stream_socket_enable_crypto( $handle->socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- TLS failures are returned as a reason-coded URL error.
@@ -473,6 +562,11 @@ class Static_Site_Importer_URL_Fetcher {
 				self::cancel_transport( null, $handle, 'too_large' );
 				return new WP_Error( 'static_site_importer_url_too_large', 'The URL response exceeded the maximum allowed size.' );
 			}
+			$separator = strpos( $handle->raw, "\r\n\r\n" );
+			if ( ( false === $separator && strlen( $handle->raw ) > self::HEADER_MAX_BYTES ) || ( false !== $separator && $separator + 4 > self::HEADER_MAX_BYTES ) ) {
+				self::cancel_transport( null, $handle, 'too_large' );
+				return new WP_Error( 'static_site_importer_url_too_large', 'The URL response exceeded the maximum allowed size.' );
+			}
 		}
 		if ( ! feof( $handle->socket ) ) {
 			return null;
@@ -489,9 +583,56 @@ class Static_Site_Importer_URL_Fetcher {
 		return self::parse_response( substr( $handle->raw, 0, $separator ), $body );
 	}
 
+	/** Advance curl without blocking; completion is collected from its per-request multi handle. */
+	private static function native_curl_poll( Static_Site_Importer_URL_Fetcher_Native_Handle $handle ) {
+		if ( self::native_deadline_exhausted( $handle ) ) {
+			self::cancel_transport( null, $handle, 'deadline_exhausted' );
+			return new WP_Error( 'static_site_importer_url_deadline_exhausted', 'The URL request deadline was exhausted.' );
+		}
+		do {
+			$status = curl_multi_exec( $handle->multi, $running );
+		} while ( CURLM_CALL_MULTI_PERFORM === $status );
+		if ( CURLM_OK !== $status ) {
+			self::cancel_transport( null, $handle, 'curl_multi_failed' );
+			return new WP_Error( 'static_site_importer_url_connect_failed', 'Could not progress the URL request.' );
+		}
+		$info = curl_multi_info_read( $handle->multi );
+		if ( false === $info ) {
+			return null;
+		}
+		$result = (int) $info['result'];
+		if ( '' !== $handle->limit_error ) {
+			self::cancel_transport( null, $handle, 'too_large' );
+			return new WP_Error( 'static_site_importer_url_too_large', 'The URL response exceeded the maximum allowed size.' );
+		}
+		if ( CURLE_OK !== $result ) {
+			$error = curl_error( $handle->curl );
+			if ( self::native_retry( $handle ) ) {
+				return null;
+			}
+			$deadline_exhausted = self::native_deadline_exhausted( $handle ) || ! empty( $handle->options['deadline_limited'] );
+			self::cancel_transport( null, $handle, 'curl_failed' );
+			if ( CURLE_OPERATION_TIMEDOUT === $result ) {
+				return new WP_Error( $deadline_exhausted ? 'static_site_importer_url_deadline_exhausted' : 'static_site_importer_url_timeout', $deadline_exhausted ? 'The URL request deadline was exhausted.' : 'The URL request timed out.' );
+			}
+			return new WP_Error( 'static_site_importer_url_connect_failed', '' !== $error ? $error : 'Could not connect to the URL.' );
+		}
+		self::cancel_transport( null, $handle, 'completed' );
+		$headers = preg_split( "/\r\n\r\n|\n\n|\r\r/", trim( $handle->response_headers ) );
+		$header  = is_array( $headers ) ? (string) end( $headers ) : '';
+		return self::parse_response( $header, $handle->body );
+	}
+
+	private static function native_deadline_exhausted( Static_Site_Importer_URL_Fetcher_Native_Handle $handle ): bool {
+		return null !== $handle->options['deadline'] && is_callable( $handle->options['clock'] ) && call_user_func( $handle->options['clock'] ) >= $handle->options['deadline'];
+	}
+
 	/** Retry another already validated DNS address without re-resolving the hostname. */
 	private static function native_retry( Static_Site_Importer_URL_Fetcher_Native_Handle $handle ): bool {
 		self::cancel_transport( null, $handle, 'retry_ip' );
+		if ( self::native_deadline_exhausted( $handle ) ) {
+			return false;
+		}
 		$next_ip = $handle->ip_index + 1;
 		if ( ! isset( $handle->target['ips'][ $next_ip ] ) ) {
 			return false;
@@ -499,7 +640,11 @@ class Static_Site_Importer_URL_Fetcher {
 		$target                = $handle->target;
 		$connect_target        = $target;
 		$connect_target['ips'] = array_slice( $target['ips'], $next_ip );
-		$next                  = self::native_start( $connect_target, $handle->options );
+		$options               = $handle->options;
+		if ( null !== $options['deadline'] && is_callable( $options['clock'] ) ) {
+			$options['timeout'] = max( 0.001, min( $options['timeout'], $options['deadline'] - call_user_func( $options['clock'] ) ) );
+		}
+		$next                  = self::native_start( $connect_target, $options );
 		foreach ( get_object_vars( $next ) as $name => $value ) {
 			$handle->$name = $value;
 		}
@@ -687,6 +832,11 @@ class Static_Site_Importer_URL_Fetcher {
 		while ( ! feof( $socket ) ) {
 			$raw .= fread( $socket, self::BODY_READ_CHUNK ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread -- Reads a bounded HTTP response from a validated public socket.
 			if ( strlen( $raw ) > $max_bytes + self::HEADER_MAX_BYTES ) {
+				fclose( $socket ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes a validated public HTTP socket, not a filesystem handle.
+				return new WP_Error( 'static_site_importer_url_too_large', 'The URL response exceeded the maximum allowed size.' );
+			}
+			$separator = strpos( $raw, "\r\n\r\n" );
+			if ( ( false === $separator && strlen( $raw ) > self::HEADER_MAX_BYTES ) || ( false !== $separator && $separator + 4 > self::HEADER_MAX_BYTES ) ) {
 				fclose( $socket ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes a validated public HTTP socket, not a filesystem handle.
 				return new WP_Error( 'static_site_importer_url_too_large', 'The URL response exceeded the maximum allowed size.' );
 			}

--- a/includes/class-static-site-importer-url-fetcher.php
+++ b/includes/class-static-site-importer-url-fetcher.php
@@ -390,7 +390,7 @@ class Static_Site_Importer_URL_Fetcher {
 			$driver['cancel']( $handle, $reason );
 			return;
 		}
-		if ( is_object( $handle ) && null !== $handle->multi && null !== $handle->curl ) {
+		if ( $handle instanceof Static_Site_Importer_URL_Fetcher_Native_Handle && null !== $handle->multi && null !== $handle->curl ) {
 			curl_multi_remove_handle( $handle->multi, $handle->curl );
 			curl_multi_close( $handle->multi );
 			$handle->curl  = null;
@@ -456,34 +456,34 @@ class Static_Site_Importer_URL_Fetcher {
 		$url                     = $target['scheme'] . '://' . $url_host . ( ( 'https' === $target['scheme'] ? 443 : 80 ) === $target['port'] ? '' : ':' . $target['port'] ) . $target['path'];
 
 		$curl_options = array(
-				CURLOPT_URL               => $url,
-				CURLOPT_HTTPGET           => true,
-				CURLOPT_PROXY             => '',
-				CURLOPT_NOPROXY           => '*',
-				CURLOPT_FOLLOWLOCATION    => false,
-				CURLOPT_MAXREDIRS         => 0,
-				CURLOPT_HTTP_TRANSFER_DECODING => false,
-				CURLOPT_CONNECTTIMEOUT_MS => $timeout_ms,
-				CURLOPT_TIMEOUT_MS        => $timeout_ms,
-				CURLOPT_SSL_VERIFYPEER    => true,
-				CURLOPT_SSL_VERIFYHOST    => 2,
-				CURLOPT_HTTPHEADER        => array( 'Host: ' . $host_header, 'User-Agent: StaticSiteImporter/1.0', 'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.1', 'Connection: close' ),
-				CURLOPT_HEADERFUNCTION    => static function( $curl, string $data ) use ( $handle ): int {
-					if ( strlen( $handle->response_headers ) + strlen( $data ) > self::HEADER_MAX_BYTES ) {
-						$handle->limit_error = 'headers';
-						return 0;
-					}
-					$handle->response_headers .= $data;
-					return strlen( $data );
-				},
-				CURLOPT_WRITEFUNCTION     => static function( $curl, string $data ) use ( $handle ): int {
-					if ( strlen( $handle->body ) + strlen( $data ) > $handle->options['max_bytes'] ) {
-						$handle->limit_error = 'body';
-						return 0;
-					}
-					$handle->body .= $data;
-					return strlen( $data );
-				},
+			CURLOPT_URL                    => $url,
+			CURLOPT_HTTPGET                => true,
+			CURLOPT_PROXY                  => '',
+			CURLOPT_NOPROXY                => '*',
+			CURLOPT_FOLLOWLOCATION         => false,
+			CURLOPT_MAXREDIRS              => 0,
+			CURLOPT_HTTP_TRANSFER_DECODING => false,
+			CURLOPT_CONNECTTIMEOUT_MS      => $timeout_ms,
+			CURLOPT_TIMEOUT_MS             => $timeout_ms,
+			CURLOPT_SSL_VERIFYPEER         => true,
+			CURLOPT_SSL_VERIFYHOST         => 2,
+			CURLOPT_HTTPHEADER             => array( 'Host: ' . $host_header, 'User-Agent: StaticSiteImporter/1.0', 'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.1', 'Connection: close' ),
+			CURLOPT_HEADERFUNCTION         => static function( $curl, string $data ) use ( $handle ): int {
+				if ( strlen( $handle->response_headers ) + strlen( $data ) > self::HEADER_MAX_BYTES ) {
+					$handle->limit_error = 'headers';
+					return 0;
+				}
+				$handle->response_headers .= $data;
+				return strlen( $data );
+			},
+			CURLOPT_WRITEFUNCTION          => static function( $curl, string $data ) use ( $handle ): int {
+				if ( strlen( $handle->body ) + strlen( $data ) > $handle->options['max_bytes'] ) {
+					$handle->limit_error = 'body';
+					return 0;
+				}
+				$handle->body .= $data;
+				return strlen( $data );
+			},
 		);
 		if ( false === filter_var( $host, FILTER_VALIDATE_IP ) ) {
 			$curl_options[ CURLOPT_RESOLVE ] = array( $host . ':' . $target['port'] . ':' . $resolved_ip );
@@ -606,11 +606,11 @@ class Static_Site_Importer_URL_Fetcher {
 			return new WP_Error( 'static_site_importer_url_too_large', 'The URL response exceeded the maximum allowed size.' );
 		}
 		if ( CURLE_OK !== $result ) {
-			$error = curl_error( $handle->curl );
+			$error              = curl_error( $handle->curl );
+			$deadline_exhausted = ! empty( $handle->options['deadline_limited'] );
 			if ( self::native_retry( $handle ) ) {
 				return null;
 			}
-			$deadline_exhausted = self::native_deadline_exhausted( $handle ) || ! empty( $handle->options['deadline_limited'] );
 			self::cancel_transport( null, $handle, 'curl_failed' );
 			if ( CURLE_OPERATION_TIMEDOUT === $result ) {
 				return new WP_Error( $deadline_exhausted ? 'static_site_importer_url_deadline_exhausted' : 'static_site_importer_url_timeout', $deadline_exhausted ? 'The URL request deadline was exhausted.' : 'The URL request timed out.' );

--- a/includes/class-static-site-importer-url-site-collector.php
+++ b/includes/class-static-site-importer-url-site-collector.php
@@ -72,6 +72,7 @@ class Static_Site_Importer_URL_Site_Collector {
 		$preserve_asset_limits  = 'preserve_external' === $asset_failure_policy;
 		$page_ready             = 'page_ready' === ( $args['hydration_mode'] ?? '' );
 		$critical_assets        = array();
+		$known_asset_paths      = is_array( $args['_static_site_importer_known_asset_paths'] ?? null ) ? $args['_static_site_importer_known_asset_paths'] : array();
 		if ( $page_ready ) {
 			// A ready checkpoint may retain optional resources externally, but never a
 			// stylesheet or font dependency needed to render the collected page.
@@ -86,6 +87,7 @@ class Static_Site_Importer_URL_Site_Collector {
 		$cursor_loader      = is_callable( $args['_static_site_importer_collection_cursor_load'] ?? null ) ? $args['_static_site_importer_collection_cursor_load'] : null;
 		$cursor_saver       = is_callable( $args['_static_site_importer_collection_cursor_save'] ?? null ) ? $args['_static_site_importer_collection_cursor_save'] : null;
 		$resource_loader    = is_callable( $args['_static_site_importer_collection_resource_load'] ?? null ) ? $args['_static_site_importer_collection_resource_load'] : null;
+		$resource_storer    = is_callable( $args['_static_site_importer_collection_resource_store'] ?? null ) ? $args['_static_site_importer_collection_resource_store'] : null;
 		$should_yield       = is_callable( $args['_static_site_importer_collection_should_yield'] ?? null ) ? $args['_static_site_importer_collection_should_yield'] : null;
 		$cursor             = null !== $cursor_loader ? call_user_func( $cursor_loader ) : null;
 		$cursor_schemas     = array( 'static-site-importer/url-collection-cursor/v1', 'static-site-importer/url-collection-cursor/v2' );
@@ -217,6 +219,9 @@ class Static_Site_Importer_URL_Site_Collector {
 				$critical_assets[ $asset_url ] = true;
 			}
 			foreach ( self::html_asset_urls( $body, $document_base_url, $scripts['asset_urls'] ) as $asset_url ) {
+				if ( isset( $known_asset_paths[ $asset_url ] ) ) {
+					continue;
+				}
 				if ( isset( $queued_assets[ $asset_url ] ) || isset( $resources[ $asset_url ] ) ) {
 					continue;
 				}
@@ -301,6 +306,9 @@ class Static_Site_Importer_URL_Site_Collector {
 
 			if ( 'text/css' === $content_type || str_ends_with( strtolower( (string) self::url_parts( $final_url, PHP_URL_PATH ) ), '.css' ) ) {
 				foreach ( self::css_asset_urls( $body, $final_url ) as $nested_url ) {
+					if ( isset( $known_asset_paths[ $nested_url ] ) ) {
+						continue;
+					}
 					if ( isset( $queued_assets[ $nested_url ] ) || isset( $resources[ $nested_url ] ) ) {
 						continue;
 					}
@@ -360,7 +368,7 @@ class Static_Site_Importer_URL_Site_Collector {
 		usort( $script_exclusions, static fn ( array $left, array $right ): int => strcmp( implode( '|', $left ), implode( '|', $right ) ) );
 		$paths           = self::artifact_paths( $resources, $site_url );
 		$route_paths     = self::route_paths( $resources );
-		$reference_paths = $paths;
+		$reference_paths = array_merge( $known_asset_paths, $paths );
 		foreach ( $aliases as $requested_url => $final_url ) {
 			if ( isset( $paths[ $final_url ] ) ) {
 				$reference_paths[ $requested_url ] = $paths[ $final_url ];
@@ -397,9 +405,13 @@ class Static_Site_Importer_URL_Site_Collector {
 			} elseif ( 'text/css' === $resource['content_type'] || str_ends_with( strtolower( $path ), '.css' ) ) {
 				$body = self::rewrite_css( $body, $resource_url, $path, $reference_paths, $external_assets );
 			}
+			if ( ! Static_Site_Importer_Content_Policy::is_static_path( $path ) || ( Static_Site_Importer_Content_Policy::is_textual_path( $path ) && Static_Site_Importer_Content_Policy::contains_server_code( $body ) ) ) {
+				return new WP_Error( 'static_site_importer_executable_source_rejected', sprintf( 'Untrusted artifact file %s is not static content.', $path ), array( 'path' => $path ) );
+			}
 
 			$file = array(
 				'path'      => $path,
+				'source_url' => $resource_url,
 				'mime_type' => $resource['content_type'],
 				'body'      => $body,
 				'is_text'   => self::is_text( $resource['content_type'], $path ),
@@ -426,6 +438,29 @@ class Static_Site_Importer_URL_Site_Collector {
 		}
 		$files = array();
 		foreach ( $finalization['files'] as $retained_file ) {
+			if ( ! empty( $args['_static_site_importer_collection_return_payload_references'] ) ) {
+				$body = $retained_file['body'] ?? null;
+				if ( ! is_string( $body ) && ( ! isset( $retained_file['bytes'] ) || ! is_int( $retained_file['bytes'] ) ) && null !== $resource_loader ) {
+					$body = call_user_func( $resource_loader, $retained_file );
+				}
+				$path = (string) ( $retained_file['path'] ?? '' );
+				if ( ! Static_Site_Importer_Content_Policy::is_static_path( $path ) ) {
+					return new WP_Error( 'static_site_importer_executable_source_rejected', sprintf( 'Untrusted artifact file %s is not static content.', $path ), array( 'path' => $path ) );
+				}
+				$reference = isset( $retained_file['body_ref'] ) ? $retained_file : ( null !== $resource_storer && is_string( $body ) ? call_user_func( $resource_storer, $body ) : null );
+				if ( ! is_array( $reference ) || ! is_string( $reference['body_ref'] ?? null ) || ! is_string( $reference['sha256'] ?? null ) ) {
+					return new WP_Error( 'static_site_importer_collection_cursor_resource_invalid', 'A finalized URL collection resource could not be retained by reference.' );
+				}
+				$file                      = array_intersect_key( $retained_file, array_flip( array( 'path', 'source_url', 'mime_type', 'metadata' ) ) );
+				$file['payload_reference'] = array(
+					'schema' => 'blocks-engine/payload-reference/v1',
+					'id'     => $reference['body_ref'],
+					'bytes'  => isset( $reference['bytes'] ) && is_int( $reference['bytes'] ) ? $reference['bytes'] : strlen( (string) $body ),
+					'sha256' => $reference['sha256'],
+				);
+				$files[]                   = $file;
+				continue;
+			}
 			$body = $retained_file['body'] ?? null;
 			if ( ! is_string( $body ) && null !== $resource_loader ) {
 				$body = call_user_func( $resource_loader, $retained_file );
@@ -433,7 +468,7 @@ class Static_Site_Importer_URL_Site_Collector {
 			if ( ! is_string( $body ) ) {
 				return new WP_Error( 'static_site_importer_collection_cursor_resource_invalid', 'A finalized URL collection resource could not be loaded.' );
 			}
-			$file = array_intersect_key( $retained_file, array_flip( array( 'path', 'mime_type', 'metadata' ) ) );
+			$file = array_intersect_key( $retained_file, array_flip( array( 'path', 'source_url', 'mime_type', 'metadata' ) ) );
 			if ( ! empty( $retained_file['is_text'] ) ) {
 				$file['content'] = $body;
 			} else {

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -30,6 +30,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		if ( 'prepared' !== ( $prepared['status'] ?? '' ) ) {
 			return $prepared['receipt'];
 		}
+		$prepared = self::admit_prepared( $prepared );
+		if ( 'prepared' !== ( $prepared['status'] ?? '' ) ) {
+			return $prepared['receipt'];
+		}
 		return self::materialize_prepared( $prepared );
 	}
 
@@ -44,6 +48,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	 * @return array<string,mixed> Prepared state or a rejected receipt.
 	 */
 	public static function prepare( array $plan, array $args = array() ): array {
+		// Payload readers hold transient workspace access and must never enter a
+		// canonical plan hash, prepared-plan persistence, or receipt projection.
+		$payload_reader = $args['_static_site_importer_payload_reader'] ?? null;
+		unset( $args['_static_site_importer_payload_reader'] );
 		$state = array(
 			'plan'                         => $plan,
 			'plan_hash'                    => self::hash( $plan ),
@@ -62,6 +70,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			'report_destinations'          => isset( $args['report_destinations'] ) && is_array( $args['report_destinations'] ) ? $args['report_destinations'] : array(),
 			'external_report_destinations' => isset( $args['external_report_destinations'] ) && is_array( $args['external_report_destinations'] ) ? $args['external_report_destinations'] : array(),
 			'args'                         => $args,
+			'payload_reader'               => is_object( $payload_reader ) ? $payload_reader : null,
 		);
 
 		try {
@@ -130,6 +139,48 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		return $state;
 	}
 
+	/**
+	 * Verify all reference-backed payloads before related runtime work begins.
+	 *
+	 * The success marker is intentionally ephemeral: it is neither part of the
+	 * canonical plan hash nor projected into materialization receipts. Individual
+	 * writes still reread and verify their payload immediately before mutation.
+	 *
+	 * @param array<string,mixed> $prepared Prepared materialization state.
+	 * @return array<string,mixed> Prepared state or a rejected receipt.
+	 */
+	public static function admit_prepared( array $prepared ): array {
+		if ( 'prepared' !== ( $prepared['status'] ?? '' ) || ! isset( $prepared['resolved']['writes'] ) || ! is_array( $prepared['resolved']['writes'] ) ) {
+			return array(
+				'status'  => 'rejected',
+				'receipt' => self::receipt(
+					'rejected',
+					array(
+						'plan'             => isset( $prepared['plan'] ) && is_array( $prepared['plan'] ) ? $prepared['plan'] : array(),
+						'plan_hash'        => (string) ( $prepared['plan_hash'] ?? '' ),
+						'diagnostics'      => array( array( 'reason_code' => 'invalid_prepared_state' ) ),
+						'applied'          => array( 'posts' => array(), 'files' => array(), 'operations' => array(), 'runtime_declarations' => array( 'asset_publications' => array(), 'entity_bindings' => array() ) ),
+						'skipped'          => array(),
+						'existing_matches' => array( 'pages' => array() ),
+					)
+				),
+			);
+		}
+		if ( ! empty( $prepared['payload_references_admitted'] ) ) {
+			return $prepared;
+		}
+		$references = self::verify_payload_references( $prepared['resolved']['writes'], is_object( $prepared['payload_reader'] ?? null ) ? $prepared['payload_reader'] : null );
+		if ( is_wp_error( $references ) ) {
+			$prepared['diagnostics'][] = array( 'reason_code' => $references->get_error_code() );
+			return array(
+				'status'  => 'rejected',
+				'receipt' => self::receipt( 'rejected', $prepared ),
+			);
+		}
+		$prepared['payload_references_admitted'] = true;
+		return $prepared;
+	}
+
 	/** @param array<string,mixed> $prepared @return array<string,mixed> */
 	public static function materialize_prepared( array $prepared ): array {
 		if ( 'prepared' !== ( $prepared['status'] ?? '' ) || ! isset( $prepared['plan'] ) || ! is_array( $prepared['plan'] ) ) {
@@ -154,6 +205,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			);
 		}
 		$state = self::refresh_prepared_destination( $prepared );
+		if ( 'prepared' !== ( $state['status'] ?? '' ) ) {
+			return $state['receipt'];
+		}
+		$state = self::admit_prepared( $state );
 		if ( 'prepared' !== ( $state['status'] ?? '' ) ) {
 			return $state['receipt'];
 		}
@@ -233,7 +288,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			if ( ! empty( $args['preserve_existing_theme_bootstrap'] ) && in_array( $write['kind'] ?? '', array( 'theme_scaffold', 'theme_bootstrap', 'theme_template' ), true ) && is_file( $state['theme_dir'] . '/' . $write['target_path'] ) ) {
 				continue;
 			}
-			$result = self::write_file( $state['theme_dir'], $write );
+			$result = self::write_file( $state['theme_dir'], $write, $state['payload_reader'] );
 			if ( is_wp_error( $result ) ) {
 				return self::failed_receipt( $state, $result->get_error_code() );
 			}
@@ -312,6 +367,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$plan          = $prepared['plan'] ?? null;
 		$base_resolved = $prepared['base_resolved'] ?? null;
 		$args          = isset( $prepared['args'] ) && is_array( $prepared['args'] ) ? $prepared['args'] : array();
+		$payload_reader = is_object( $prepared['payload_reader'] ?? null ) ? $prepared['payload_reader'] : null;
 		if ( ! is_array( $plan ) || ! is_array( $base_resolved ) || self::hash( $plan ) !== ( $prepared['plan_hash'] ?? '' ) || self::hash( $base_resolved ) !== ( $prepared['base_resolved_hash'] ?? '' ) ) {
 			return array(
 				'status'  => 'rejected',
@@ -365,6 +421,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'uri'  => $theme_uri,
 			),
 			'args'                         => $args,
+			'payload_reader'               => $payload_reader,
 			'preparation'                  => array(
 				'canonical_validations'       => 1,
 				'plan_resolutions'            => 1,
@@ -456,6 +513,9 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		}
 		$state['provider_layout_overlay_writes'] = $overlay_writes;
 		foreach ( $state['resolved']['writes'] as $write ) {
+			if ( null !== self::payload_reference( $write ) && ! self::valid_payload_reference( self::payload_reference( $write ) ) ) {
+				throw new InvalidArgumentException( 'payload_reference_invalid' );
+			}
 			$path = $state['theme_dir'] . '/' . $write['target_path'];
 			if ( ! self::safe_destination( $state['theme_dir'], $write['target_path'] ) ) {
 				throw new InvalidArgumentException( 'unsafe_destination_path' );
@@ -646,16 +706,20 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	}
 
 	/** @param array<string,mixed> $write */
-	private static function write_file( string $theme_dir, array $write ) {
+	private static function write_file( string $theme_dir, array $write, ?object $payload_reader = null ) {
 		$path = $theme_dir . '/' . $write['target_path'];
-		$data = 'base64' === $write['payload']['encoding'] ? base64_decode( $write['payload']['data'], true ) : $write['payload']['data']; // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes declared canonical artifact payload bytes.
-		if ( is_file( $path ) && is_string( $data ) && self::file_hash( $path ) === hash( 'sha256', $data ) ) {
+		$declared_hash = self::payload_hash( $write );
+		if ( is_file( $path ) && '' !== $declared_hash && self::file_hash( $path ) === $declared_hash ) {
 			return array(
 				'target_path'             => $write['target_path'],
 				'hash'                    => self::file_hash( $path ),
-				'payload_hash'            => $write['payload_hash'] ?? hash( 'sha256', $data ),
+				'payload_hash'            => $write['payload_hash'] ?? $declared_hash,
 				'reconciliation_identity' => $write['reconciliation_identity'] ?? hash( 'sha256', $write['source_path'] . "\n" . $write['target_path'] ),
 			);
+		}
+		$data = self::write_payload_bytes( $write, $payload_reader );
+		if ( is_wp_error( $data ) ) {
+			return $data;
 		}
 		if ( ! is_dir( dirname( $path ) ) && ! wp_mkdir_p( dirname( $path ) ) ) {
 			return new WP_Error( 'theme_directory_create_failed' );
@@ -1040,6 +1104,9 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	}
 
 	private static function payload_data( array $write ): string {
+		if ( null !== self::payload_reference( $write ) ) {
+			return '';
+		}
 		$data = $write['payload']['data'] ?? '';
 		return 'base64' === ( $write['payload']['encoding'] ?? null ) && is_string( $data ) ? (string) base64_decode( $data, true ) : (string) $data; // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes declared canonical payload bytes for receipt validation.
 	}
@@ -1183,8 +1250,74 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	/** @param array<string,mixed> $write */
 	private static function payload_hash( array $write ): string {
+		$reference = self::payload_reference( $write );
+		if ( null !== $reference ) {
+			return self::valid_payload_reference( $reference ) ? $reference['sha256'] : '';
+		}
 		$data = 'base64' === $write['payload']['encoding'] ? base64_decode( $write['payload']['data'], true ) : $write['payload']['data']; // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes declared canonical payload bytes before hashing.
 		return is_string( $data ) ? hash( 'sha256', $data ) : '';
+	}
+
+	/** Return a declared binary reference without treating absent inline payloads as references. */
+	private static function payload_reference( array $write ): ?array {
+		$reference = $write['payload_reference'] ?? ( $write['payload']['reference'] ?? null );
+		return is_array( $reference ) ? $reference : ( array_key_exists( 'payload_reference', $write ) || array_key_exists( 'reference', $write['payload'] ?? array() ) ? array() : null );
+	}
+
+	private static function valid_payload_reference( array $reference ): bool {
+		return 'blocks-engine/payload-reference/v1' === ( $reference['schema'] ?? null )
+			&& is_string( $reference['id'] ?? null ) && '' !== $reference['id']
+			&& is_string( $reference['sha256'] ?? null ) && 1 === preg_match( '/^[a-f0-9]{64}$/', $reference['sha256'] )
+			&& ( ! isset( $reference['bytes'] ) || ( is_int( $reference['bytes'] ) && $reference['bytes'] >= 0 ) );
+	}
+
+	/**
+	 * Admit every reference-backed write before materialization starts.
+	 *
+	 * Each payload is read and discarded independently so an unavailable or
+	 * corrupted later resource cannot leave earlier pages or files behind.
+	 * write_payload_bytes() repeats the verification immediately before a write
+	 * to keep the write boundary safe if workspace contents change meanwhile.
+	 *
+	 * @param array<int,array<string,mixed>> $writes
+	 */
+	private static function verify_payload_references( array $writes, ?object $payload_reader ) {
+		foreach ( $writes as $write ) {
+			if ( ! is_array( $write ) || null === self::payload_reference( $write ) ) {
+				continue;
+			}
+			$bytes = self::write_payload_bytes( $write, $payload_reader );
+			if ( is_wp_error( $bytes ) ) {
+				return $bytes;
+			}
+		}
+		return true;
+	}
+
+	/** Resolve a reference exactly once at the write boundary and verify declared raw bytes. */
+	private static function write_payload_bytes( array $write, ?object $payload_reader ) {
+		$reference = self::payload_reference( $write );
+		if ( null === $reference ) {
+			return 'base64' === $write['payload']['encoding'] ? base64_decode( $write['payload']['data'], true ) : $write['payload']['data']; // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes declared canonical artifact payload bytes.
+		}
+		if ( ! self::valid_payload_reference( $reference ) ) {
+			return new WP_Error( 'static_site_importer_payload_reference_invalid' );
+		}
+		if ( ! is_object( $payload_reader ) || ! is_callable( array( $payload_reader, 'read' ) ) ) {
+			return new WP_Error( 'static_site_importer_payload_reader_missing' );
+		}
+		try {
+			$bytes = $payload_reader->read( $reference );
+		} catch ( Throwable ) {
+			return new WP_Error( 'static_site_importer_payload_reference_unavailable' );
+		}
+		if ( ! is_string( $bytes ) ) {
+			return new WP_Error( 'static_site_importer_payload_reference_unavailable' );
+		}
+		if ( ( isset( $reference['bytes'] ) && strlen( $bytes ) !== $reference['bytes'] ) || ! hash_equals( $reference['sha256'], hash( 'sha256', $bytes ) ) ) {
+			return new WP_Error( 'static_site_importer_payload_reference_hash_mismatch' );
+		}
+		return $bytes;
 	}
 
 	private static function file_hash( string $path ): string {

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -159,7 +159,15 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 						'plan'             => isset( $prepared['plan'] ) && is_array( $prepared['plan'] ) ? $prepared['plan'] : array(),
 						'plan_hash'        => (string) ( $prepared['plan_hash'] ?? '' ),
 						'diagnostics'      => array( array( 'reason_code' => 'invalid_prepared_state' ) ),
-						'applied'          => array( 'posts' => array(), 'files' => array(), 'operations' => array(), 'runtime_declarations' => array( 'asset_publications' => array(), 'entity_bindings' => array() ) ),
+						'applied'          => array(
+							'posts'                => array(),
+							'files'                => array(),
+							'operations'           => array(),
+							'runtime_declarations' => array(
+								'asset_publications' => array(),
+								'entity_bindings'    => array(),
+							),
+						),
 						'skipped'          => array(),
 						'existing_matches' => array( 'pages' => array() ),
 					)
@@ -1283,7 +1291,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	 */
 	private static function verify_payload_references( array $writes, ?object $payload_reader ) {
 		foreach ( $writes as $write ) {
-			if ( ! is_array( $write ) || null === self::payload_reference( $write ) ) {
+			if ( null === self::payload_reference( $write ) ) {
 				continue;
 			}
 			$bytes = self::write_payload_bytes( $write, $payload_reader );

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -42,6 +42,7 @@
     { "path": "tests/smoke-url-import-runtime.php", "environment": "standalone-php" },
     { "path": "tests/smoke-rest-url-import-helpers.php", "environment": "standalone-php" },
     { "path": "tests/smoke-url-concurrent-fetcher.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-url-curl-deadline.php", "environment": "standalone-php" },
     { "path": "tests/smoke-url-resolver-provider.php", "environment": "standalone-php" },
     { "path": "tests/smoke-url-tls-context.php", "environment": "standalone-php" },
     { "path": "tests/smoke-validation-runtime-diagnostics.php", "environment": "standalone-php" },

--- a/tests/smoke-shared-resource-plan.php
+++ b/tests/smoke-shared-resource-plan.php
@@ -4,18 +4,37 @@ if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', dirname( __DIR__ ) . '/' ); }
 class WP_Error { public function __construct( private string $code, private string $message = '' ) {} public function get_error_code(): string { return $this->code; } }
 function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
 function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
+function sanitize_file_name( string $name ): string { return preg_replace( '/[^A-Za-z0-9._-]+/', '-', $name ) ?? ''; }
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-run.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-content-policy.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-fetcher.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-shared-resource-plan.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-site-collector.php';
 $root = sys_get_temp_dir() . '/ssi-shared-plan-' . bin2hex( random_bytes( 4 ) ); mkdir( $root, 0700, true );
 $workspace = new Static_Site_Importer_Artifact_Run_Workspace( $root, 'shared-plan' );
 $plan = new Static_Site_Importer_Shared_Resource_Plan( $workspace );
-$artifact = static fn( string $css, string $page ): array => array( 'files' => array( array( 'path' => 'website/index.html', 'mime_type' => 'text/html', 'content' => $page ), array( 'path' => 'website/theme.css', 'mime_type' => 'text/css', 'content' => $css ), array( 'path' => 'website/app.js', 'mime_type' => 'application/javascript', 'content' => 'shared-script' ) ) );
+$artifact = static fn( string $css, string $page ): array => array( 'files' => array( array( 'path' => 'website/index.html', 'source_url' => 'https://shared-plan.test/', 'mime_type' => 'text/html', 'content' => $page ), array( 'path' => 'website/theme.css', 'source_url' => 'https://shared-plan.test/theme.css', 'mime_type' => 'text/css', 'content' => $css ), array( 'path' => 'website/app.js', 'source_url' => 'https://shared-plan.test/app.js', 'mime_type' => 'application/javascript', 'content' => 'shared-script' ) ) );
 $first = $plan->reconcile( $artifact( 'body{color:red}', 'first' ) );
 $second = ( new Static_Site_Importer_Shared_Resource_Plan( $workspace ) )->reconcile( $artifact( 'body{color:red}', 'second' ) );
 $changed = $plan->reconcile( $artifact( 'body{color:blue}', 'third' ) );
 if ( is_wp_error( $first['plan'] ) || $first['changed'] || is_wp_error( $second['plan'] ) || $second['changed'] || $first['digest'] !== $second['digest'] || is_wp_error( $changed['plan'] ) || ! $changed['changed'] || $changed['digest'] === $first['digest'] || ! is_file( $workspace->directory() . '/shared-resource-plan.json' ) ) { throw new RuntimeException( 'shared plans must survive restart, ignore page-only changes, and deterministically invalidate changed shared content' ); }
-$expanded = $plan->reconcile( array( 'files' => array( array( 'path' => 'website/extra.css', 'mime_type' => 'text/css', 'content' => 'h1{color:blue}' ) ) ) );
+$expanded = $plan->reconcile( array( 'files' => array( array( 'path' => 'website/extra.css', 'source_url' => 'https://shared-plan.test/extra.css', 'mime_type' => 'text/css', 'content' => 'h1{color:blue}' ) ) ) );
 $preserved = $plan->reconcile( $artifact( 'body{color:blue}', 'fourth' ) );
 if ( is_wp_error( $expanded['plan'] ) || ! $expanded['changed'] || is_wp_error( $preserved['plan'] ) || $preserved['changed'] || 3 !== count( $preserved['plan']['resources'] ?? array() ) ) { throw new RuntimeException( 'shared plans must retain resources discovered only in an earlier batch' ); }
+$referenced = array( 'path' => 'website/fonts/host.woff2', 'source_url' => 'HTTPS://CDN.TEST/fonts/../fonts/host.woff2#ignored', 'mime_type' => 'font/woff2', 'payload_reference' => array( 'schema' => 'blocks-engine/payload-reference/v1', 'id' => 'payloads/host.woff2', 'bytes' => 4, 'sha256' => hash( 'sha256', 'font' ) ) );
+$workspace->publish_raw( 'payloads/host.woff2', 'font' );
+$with_reference = $plan->reconcile( array( 'files' => array( $referenced ) ) );
+$retained = $plan->retained_resources(); $paths = $plan->source_paths();
+if ( is_wp_error( $with_reference['plan'] ) || 'website/fonts/host.woff2' !== ( $paths['https://cdn.test/fonts/host.woff2'] ?? '' ) || 1 !== count( array_filter( $retained, static fn( array $resource ): bool => 'website/fonts/host.woff2' === $resource['path'] ) ) ) { throw new RuntimeException( 'shared plans must advertise only canonical, workspace-materializable references' ); }
+$workspace->publish_raw( 'payloads/host.woff2', 'corrupt' );
+if ( isset( $plan->source_paths()['https://cdn.test/fonts/host.woff2'] ) || ! empty( array_filter( $plan->retained_resources(), static fn( array $resource ): bool => 'website/fonts/host.woff2' === $resource['path'] ) ) ) { throw new RuntimeException( 'corrupt retained payload references must be withheld for collector refetch' ); }
+$refetches = 0;
+$refetched = Static_Site_Importer_URL_Site_Collector::collect( 'https://refetch.test/', array( 'require_complete_collection' => true, 'request_delay_ms' => 0, '_static_site_importer_known_asset_paths' => $plan->source_paths() ), static function ( string $url ) use ( &$refetches ) {
+	if ( 'https://refetch.test/sitemap.xml' === $url ) { return array( 'body' => '<urlset></urlset>', 'metadata' => array( 'content_type' => 'application/xml', 'final_url' => $url ) ); }
+	if ( 'https://refetch.test/' === $url ) { return array( 'body' => '<link rel="preload" as="font" href="https://cdn.test/fonts/host.woff2">', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) ); }
+	$refetches++;
+	return array( 'body' => 'refetched-font', 'metadata' => array( 'content_type' => 'font/woff2', 'final_url' => $url ) );
+} );
+if ( is_wp_error( $refetched ) || 1 !== $refetches ) { throw new RuntimeException( 'a malformed retained resource must be refetched rather than advertised as known' ); }
 $workspace->purge(); @rmdir( $root );
 echo "Shared resource plan smoke passed.\n";

--- a/tests/smoke-url-batch-import.php
+++ b/tests/smoke-url-batch-import.php
@@ -21,13 +21,25 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 function wp_parse_url( string $url, int $component = -1 ) { return parse_url( $url, $component ); }
 function wp_strip_all_tags( string $text ): string { return strip_tags( $text ); }
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-fetcher.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-content-policy.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-site-collector.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-import-runtime.php';
 class Static_Site_Importer_Theme_Generator {
 }
 require_once dirname( __DIR__ ) . '/includes/abilities.php';
+$candidate_transformer = getenv( 'SSI_BLOCKS_ENGINE_PHP_TRANSFORMER' );
+if ( is_string( $candidate_transformer ) && is_readable( rtrim( $candidate_transformer, '/\\' ) . '/vendor/autoload.php' ) ) { $candidate_transformer = rtrim( $candidate_transformer, '/\\' ); spl_autoload_register( static function ( string $class ) use ( $candidate_transformer ): void { $prefix = 'Automattic\\BlocksEngine\\PhpTransformer\\'; if ( str_starts_with( $class, $prefix ) ) { $path = $candidate_transformer . '/src/' . str_replace( '\\', '/', substr( $class, strlen( $prefix ) ) ) . '.php'; if ( is_readable( $path ) ) { require_once $path; } } }, true, true ); require_once $candidate_transformer . '/vendor/autoload.php'; }
 
 $legacy_path = tempnam( sys_get_temp_dir(), 'ssi-legacy-' ); $delete_legacy_file = new ReflectionMethod( Static_Site_Importer_URL_Batch_Import::class, 'delete_legacy_file' ); if ( ! $delete_legacy_file->invoke( null, $legacy_path ) || is_file( $legacy_path ) ) { throw new RuntimeException( 'legacy cache cleanup must unlink its verified exact path without wp_delete_file filters' ); }
+$staged_workspace_root = sys_get_temp_dir() . '/ssi-staged-pages-' . bin2hex( random_bytes( 4 ) ); wp_mkdir_p( $staged_workspace_root );
+$staged_workspace = new Static_Site_Importer_Artifact_Run_Workspace( $staged_workspace_root, 'page-checkpoint' );
+$staged_artifact = array( 'entrypoint' => 'one.html', 'files' => array( array( 'path' => 'one.html', 'mime_type' => 'text/html', 'content' => '<main>One</main>' ), array( 'path' => 'two.html', 'mime_type' => 'text/html', 'content' => '<main>Two</main>' ), array( 'path' => 'three.html', 'mime_type' => 'text/html', 'content' => '<main>Three</main>' ) ) );
+$prepare_staged = new ReflectionMethod( Static_Site_Importer_URL_Batch_Import::class, 'prepare_staged_plans' ); $yield_checks = 0;
+$staged_interrupted = $prepare_staged->invoke( null, $staged_workspace, $staged_artifact, hash( 'sha256', 'page-checkpoint' ), null, 'staged-pages.json', static function () use ( &$yield_checks ): bool { return 1 < ++$yield_checks; } );
+$staged_checkpoint = json_decode( (string) $staged_workspace->read_raw( 'staged-pages.json' ), true );
+$staged_resumed = $prepare_staged->invoke( null, $staged_workspace, $staged_artifact, hash( 'sha256', 'page-checkpoint' ), null, 'staged-pages.json', static fn(): bool => false );
+if ( ! is_wp_error( $staged_interrupted ) || 'static_site_importer_invocation_deadline_exceeded' !== $staged_interrupted->get_error_code() || 1 !== count( $staged_checkpoint['plans'] ?? array() ) || is_wp_error( $staged_resumed ) || 2 !== ( $staged_resumed['page_prepared'] ?? -1 ) || 3 !== count( $staged_resumed['page_plans'] ?? array() ) ) { throw new RuntimeException( 'staged page preparation must checkpoint each completed page and resume only unfinished pages' ); }
+$staged_workspace->purge();
 
 $responses = array(
 	'https://batch.test/sitemap.xml' => array( 'application/xml', '<sitemapindex><sitemap><loc>https://batch.test/one.xml</loc></sitemap><sitemap><loc>https://batch.test/two.xml</loc></sitemap></sitemapindex>' ),
@@ -47,29 +59,36 @@ $fetcher = static function ( string $url, array $args ) use ( &$requests, &$tran
 	return array( 'body' => $responses[ $url ][1], 'metadata' => array( 'content_type' => $responses[ $url ][0], 'final_url' => $url ) );
 };
 $work_dir = sys_get_temp_dir() . '/ssi-url-batch-' . bin2hex( random_bytes( 4 ) );
+$artifact_file_content = static function ( array $file ) use ( &$work_dir ): string {
+	if ( isset( $file['content'] ) ) { return (string) $file['content']; }
+	$reference = $file['payload_reference']['id'] ?? null;
+	$matches = is_string( $reference ) ? glob( $work_dir . '/.ssi-artifact-run-url-*/' . $reference ) : array();
+	return ! empty( $matches ) ? (string) file_get_contents( $matches[0] ) : '';
+};
 $request = array( 'url' => 'https://batch.test/', 'work_dir' => $work_dir, 'provider_args' => array( 'collect_site' => true, 'batch_pages' => 2, 'request_delay_ms' => 0, 'max_assets' => 10 ) );
 $input = array( 'activate' => true );
 $artifacts = array();
 $attempt = 0;
-$importer = static function ( array $artifact, array $args ) use ( &$artifacts, &$attempt ) {
-	$artifacts[] = array( 'artifact' => $artifact, 'args' => $args );
+$importer = static function ( array $artifact, array $args ) use ( &$artifacts, &$attempt, $artifact_file_content ) {
+	$artifacts[] = array( 'artifact' => $artifact, 'args' => $args, 'content' => array_map( $artifact_file_content, array_column( $artifact['files'], null, 'path' ) ) );
 	if ( 1 === $attempt++ ) { return new WP_Error( 'injected_batch_failure', 'stop after the first completed batch' ); }
 	return array( 'theme_slug' => 'batch-site', 'quality' => array( 'pass' => true, 'status' => 'success_with_warnings', 'metrics' => array( 'fallback_count' => 1 ), 'fallbacks' => array( array( 'html' => str_repeat( 'x', 1024 ) ) ) ), 'import_report_summary' => array( 'status' => 'completed' ) );
 };
 $first = Static_Site_Importer_URL_Batch_Import::import( $request, $input, $fetcher, $importer );
-if ( ! is_wp_error( $first ) || 'injected_batch_failure' !== $first->get_error_code() ) { throw new RuntimeException( 'injected batch failure must retain a resumable run' ); }
+if ( ! is_wp_error( $first ) || 'injected_batch_failure' !== $first->get_error_code() ) { throw new RuntimeException( 'injected batch failure must retain a resumable run' . ( is_wp_error( $first ) ? ': ' . $first->get_error_code() . ' ' . $first->get_error_message() : '' ) ); }
 $manifest_path = $first->get_error_data()['run_manifest'] ?? '';
 $manifest = json_decode( (string) file_get_contents( $manifest_path ), true );
 if ( 'failed' !== ( $manifest['state'] ?? '' ) || 'completed' !== ( $manifest['batches'][0]['state'] ?? '' ) || 3 !== ( $manifest['total_routes'] ?? 0 ) ) { throw new RuntimeException( 'manifest must checkpoint discovery and completed batches' ); }
 if ( ! preg_match( '/^batch-[a-f0-9]{16}$/', (string) ( $manifest['batches'][0]['batch_id'] ?? '' ) ) || 64 !== strlen( (string) ( $manifest['batches'][0]['result']['snapshot_sha256'] ?? '' ) ) ) { throw new RuntimeException( 'checkpointed batches must retain stable identities and source snapshot evidence' ); }
 $legacy_cache = $work_dir . '/url-response-cache-' . $manifest['source']['identity']; wp_mkdir_p( $legacy_cache ); foreach ( glob( $work_dir . '/.ssi-artifact-run-url-' . $manifest['source']['identity'] . '/cache/http-response/*.entry' ) ?: array() as $entry ) { copy( $entry, $legacy_cache . '/' . basename( $entry ) ); } $legacy_workspace = new Static_Site_Importer_Artifact_Run_Workspace( $work_dir, 'url-' . $manifest['source']['identity'] ); $legacy_workspace->purge();
 $resumed = Static_Site_Importer_URL_Batch_Import::import( $request, $input, $fetcher, static fn( array $artifact, array $args ) => array( 'theme_slug' => 'batch-site', 'artifact' => $artifact, 'args' => $args, 'quality' => array( 'pass' => true, 'status' => 'success', 'metrics' => array( 'fallback_count' => 0 ), 'fallbacks' => array() ), 'import_report_summary' => array( 'status' => 'completed' ) ) );
-if ( is_wp_error( $resumed ) || true !== ( $resumed['terminal_batch_result']['args']['activate'] ?? false ) || isset( $resumed['pages'] ) || 2 !== ( $resumed['url_batch_run']['completed_batches'] ?? 0 ) || 3 !== ( $resumed['import_report_summary']['completed_routes'] ?? 0 ) ) { throw new RuntimeException( 'aggregate results must retain terminal output explicitly without misrepresenting it as whole-site output' ); }
+if ( is_wp_error( $resumed ) || true !== ( $resumed['terminal_batch_result']['args']['activate'] ?? false ) || isset( $resumed['pages'] ) || 2 !== ( $resumed['url_batch_run']['completed_batches'] ?? 0 ) || 3 !== ( $resumed['import_report_summary']['completed_routes'] ?? 0 ) ) { throw new RuntimeException( 'aggregate results must retain terminal output explicitly without misrepresenting it as whole-site output' . ( is_wp_error( $resumed ) ? ': ' . $resumed->get_error_code() . ' ' . $resumed->get_error_message() : ': ' . wp_json_encode( $resumed ) ) ); }
 $batch_quality = $resumed['url_batch_run']['batch_quality'] ?? array();
 if ( 2 !== count( $batch_quality ) || 1 !== ( $batch_quality[0]['fallback_count'] ?? -1 ) || isset( $batch_quality[0]['fallbacks'] ) || true !== ( $batch_quality[0]['pass'] ?? null ) || true !== ( $batch_quality[1]['pass'] ?? null ) ) { throw new RuntimeException( 'resumed aggregates must derive bounded quality evidence for every completed batch without retaining fallback payloads' ); }
 $first_files = array_column( $artifacts[0]['artifact']['files'], null, 'path' );
 $second_files = array_column( $artifacts[1]['artifact']['files'], null, 'path' );
-if ( ! str_contains( (string) $first_files['website/about/index.html']['content'], 'href="/about/team/"' ) || ! isset( $first_files['website/empty.css'] ) || 2 < count( array_filter( $artifacts[0]['artifact']['files'], static fn( array $file ) => str_ends_with( $file['path'], 'index.html' ) ) ) || isset( $second_files['website/index.html'] ) || ! isset( $second_files['website/about/team/index.html'] ) || empty( $artifacts[1]['args']['preserve_existing_theme_bootstrap'] ) || 2 !== count( array_keys( $requests, 'https://batch.test/about/team/', true ) ) || 1 > ( $resumed['url_batch_run']['fetch_cache']['hits'] ?? 0 ) || is_dir( $legacy_cache ) ) { throw new RuntimeException( 'later batches must exclude the unrelated root page while legacy response cache migration preserves payload reuse' ); }
+$reference_backed = interface_exists( Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\PayloadReader::class );
+if ( ! str_contains( (string) ( $artifacts[0]['content']['website/about/index.html'] ?? '' ), 'href="/about/team/"' ) || ( $reference_backed && ( isset( $first_files['website/about/index.html']['content'] ) || 'blocks-engine/payload-reference/v1' !== ( $first_files['website/about/index.html']['payload_reference']['schema'] ?? '' ) ) ) || ! isset( $first_files['website/empty.css'] ) || 2 < count( array_filter( $artifacts[0]['artifact']['files'], static fn( array $file ) => str_ends_with( $file['path'], 'index.html' ) ) ) || isset( $second_files['website/index.html'] ) || ! isset( $second_files['website/about/team/index.html'] ) || empty( $artifacts[1]['args']['preserve_existing_theme_bootstrap'] ) || 2 !== count( array_keys( $requests, 'https://batch.test/about/team/', true ) ) || 1 > ( $resumed['url_batch_run']['fetch_cache']['hits'] ?? 0 ) || is_dir( $legacy_cache ) ) { throw new RuntimeException( 'later batches must retain opaque verified payloads, exclude the unrelated root page, and preserve response reuse' ); }
 $again = Static_Site_Importer_URL_Batch_Import::import( $request, $input, $fetcher, static fn() => new WP_Error( 'should_not_run' ) );
 if ( is_wp_error( $again ) || 'batch-site' !== ( $again['theme_slug'] ?? '' ) ) { throw new RuntimeException( 'terminal runs must return their saved SSI result without reimporting' ); }
 $mismatch = Static_Site_Importer_URL_Batch_Import::import( $request, array( 'activate' => true, 'slug' => 'other-target' ), $fetcher, static fn() => new WP_Error( 'should_not_run' ) );
@@ -235,7 +254,7 @@ if ( 'transient_timeout' !== ( $negative_hit['code'] ?? '' ) || null !== $negati
 $negative_workspace->purge();
 $delay_calls = 0; $shared_asset_calls = 0;
 $delay_result = Static_Site_Importer_URL_Batch_Import::import( array( 'url' => 'https://delay.test/', 'work_dir' => sys_get_temp_dir() . '/ssi-delay-' . bin2hex( random_bytes( 4 ) ), 'provider_args' => array( 'collect_site' => true, 'batch_pages' => 1, 'request_delay_ms' => 1, '_static_site_importer_delay_callback' => static function () use ( &$delay_calls ) { $delay_calls++; } ) ), array(), static function ( string $url, array $args ) use ( &$shared_asset_calls ) { if ( 'https://delay.test/sitemap.xml' === $url ) { return array( 'body' => '<urlset><url><loc>https://delay.test/</loc></url><url><loc>https://delay.test/p/</loc></url></urlset>', 'metadata' => array( 'content_type' => 'application/xml', 'final_url' => $url ) ); } if ( 'https://delay.test/shared.png' === $url ) { $shared_asset_calls++; return array( 'body' => 'asset', 'metadata' => array( 'content_type' => 'image/png', 'final_url' => $url ) ); } return array( 'body' => '<img src="/shared.png">', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) ); }, static fn() => array( 'theme_slug' => 'delay', 'import_report_summary' => array( 'status' => 'completed' ) ) );
-if ( is_wp_error( $delay_result ) || 1 !== $shared_asset_calls || 0 !== $delay_calls || 1 > ( $delay_result['url_batch_run']['fetch_cache']['network_requests_avoided'] ?? 0 ) ) { throw new RuntimeException( 'successful cache misses and hits must not incur retry pacing' ); }
+if ( is_wp_error( $delay_result ) || 1 !== $shared_asset_calls || 0 !== $delay_calls ) { throw new RuntimeException( 'verified shared assets must bypass repeated fetches without incurring retry pacing' ); }
 $negative_asset_calls = 0; $negative_delays = 0;
 $negative_request = array( 'url' => 'https://negative.test/', 'work_dir' => sys_get_temp_dir() . '/ssi-negative-' . bin2hex( random_bytes( 4 ) ), 'provider_args' => array( 'collect_site' => true, 'batch_pages' => 1, 'fetch_attempts' => 2, 'request_delay_ms' => 1, '_static_site_importer_delay_callback' => static function () use ( &$negative_delays ) { $negative_delays++; } ) );
 $negative_fetcher = static function ( string $url, array $args ) use ( &$negative_asset_calls ) { if ( 'https://negative.test/sitemap.xml' === $url ) { return array( 'body' => '<urlset><url><loc>https://negative.test/</loc></url><url><loc>https://negative.test/p/</loc></url></urlset>', 'metadata' => array( 'content_type' => 'application/xml', 'final_url' => $url ) ); } if ( 'https://negative.test/shared.png' === $url ) { $negative_asset_calls++; return new WP_Error( 'asset_timeout', 'temporary failure' ); } return array( 'body' => '<img src="/shared.png">', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) ); };
@@ -312,4 +331,31 @@ $shared_final         = static_site_importer_ability_import( array( 'operation' 
 $shared_pages         = $shared_final['plan']['pages'] ?? array();
 $shared_paths         = array_map( static fn( array $p ): string => (string) ( $p['path'] ?? $p['slug'] ?? '' ), $shared_pages );
 if ( empty( $shared_first['continuation'] ) || empty( $shared_first['import_id'] ) || ! empty( $shared_first['plan'] ) || empty( $shared_final['plan'] ) || 'completed' !== ( $shared_final['url_batch_run']['status'] ?? '' ) || 2 !== count( $shared_pages ) || empty( $shared_paths[0] ) || empty( $shared_paths[1] ) || $writes_before_shared !== count( $runtime_imports ) ) { throw new RuntimeException( 'shared plan change across batches must re-prepare stale page plans in compose_complete_plan and succeed without importer writes' ); }
+
+if ( interface_exists( Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\PayloadReader::class ) ) {
+	$shopify_font_fetches = 0;
+	$shopify_compositions = array();
+	$shopify_result = Static_Site_Importer_URL_Batch_Import::import(
+		array( 'url' => 'https://shopify-font.test/', 'work_dir' => sys_get_temp_dir() . '/ssi-shopify-font-' . bin2hex( random_bytes( 4 ) ), 'provider_args' => array( 'collect_site' => true, 'batch_pages' => 1, 'request_delay_ms' => 0 ) ),
+		array(),
+		static function ( string $url, array $args ) use ( &$shopify_font_fetches ) {
+			if ( 'https://shopify-font.test/sitemap.xml' === $url ) {
+				return array( 'body' => '<urlset><url><loc>https://shopify-font.test/</loc></url><url><loc>https://shopify-font.test/blogs/news/index.html</loc></url></urlset>', 'metadata' => array( 'content_type' => 'application/xml', 'final_url' => $url ) );
+			}
+			if ( 'https://shopify-font.test/cdn/fonts/host_grotesk/font.woff2' === $url ) {
+				$shopify_font_fetches++;
+				return array( 'body' => 'shopify-font', 'metadata' => array( 'content_type' => 'font/woff2', 'final_url' => $url ) );
+			}
+			$preload = '<link rel="preload" as="font" href="' . ( 'https://shopify-font.test/' === $url ? '/cdn/fonts/host_grotesk/font.woff2' : '../../cdn/fonts/host_grotesk/font.woff2' ) . '">';
+			return array( 'body' => '<html><head>' . $preload . '</head><body><main>Shopify</main></body></html>', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) );
+		},
+		static function ( array $artifact, array $args ) use ( &$shopify_compositions ): array {
+			$shopify_compositions[] = $args['compiled_artifact_result'] ?? array();
+			return array( 'theme_slug' => 'shopify-font', 'import_report_summary' => array( 'status' => 'completed' ) );
+		}
+	);
+	$shopify_terminal = $shopify_compositions[1] ?? array();
+	$shopify_json     = wp_json_encode( $shopify_terminal );
+	if ( is_wp_error( $shopify_result ) || 1 !== $shopify_font_fetches || 2 !== count( $shopify_compositions ) || ! str_contains( (string) $shopify_json, 'asset_reference' ) || str_contains( (string) $shopify_json, 'unresolved_local_url' ) ) { throw new RuntimeException( 'retained Shopify font preloads must refetch once, inject their payload reference, and compose without unresolved local URLs' ); }
+}
 echo "URL batch import smoke passed.\n";

--- a/tests/smoke-url-curl-deadline.php
+++ b/tests/smoke-url-curl-deadline.php
@@ -1,0 +1,65 @@
+<?php
+/** Run: php tests/smoke-url-curl-deadline.php */
+if ( ! function_exists( 'curl_multi_init' ) ) { fwrite( STDOUT, "SKIP: curl extension unavailable\n" ); exit( 0 ); }
+if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', dirname( __DIR__ ) . '/' ); }
+if ( ! defined( 'WPINC' ) ) { define( 'WPINC', 'wp-includes' ); }
+class WP_Error { public function __construct( private string $code, private string $message = '' ) {} public function get_error_code(): string { return $this->code; } }
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-fetcher.php';
+
+$peer_code = '$server = stream_socket_server("tcp://127.0.0.1:0", $errno, $errstr); if ( false === $server ) { exit( 1 ); } fwrite(STDOUT, stream_socket_get_name($server, false) . "\\n"); $client = stream_socket_accept($server, 5); if ( $client ) { sleep( 4 ); fclose($client); } fclose($server);';
+$process   = proc_open( PHP_BINARY . ' -r ' . escapeshellarg( $peer_code ), array( 0 => array( 'pipe', 'r' ), 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes );
+if ( ! is_resource( $process ) || false === ( $address = fgets( $pipes[1] ) ) ) { throw new RuntimeException( 'Could not start the withheld-TLS test peer.' ); }
+
+try {
+	$proxies = array( 'ALL_PROXY' => getenv( 'ALL_PROXY' ), 'HTTPS_PROXY' => getenv( 'HTTPS_PROXY' ) );
+	putenv( 'ALL_PROXY=http://127.0.0.1:1' );
+	putenv( 'HTTPS_PROXY=http://127.0.0.1:1' );
+	try {
+	$port    = (int) substr( trim( $address ), strrpos( trim( $address ), ':' ) + 1 );
+	$target  = array( 'url' => 'https://deadline.test:' . $port . '/', 'scheme' => 'https', 'host' => 'deadline.test', 'port' => $port, 'path' => '/', 'ips' => array( '127.0.0.1' ) );
+	$clock   = static fn(): float => microtime( true );
+	$options_method = new ReflectionMethod( Static_Site_Importer_URL_Fetcher::class, 'request_options' );
+	$options = $options_method->invoke( null, array( 'timeout' => 5, 'max_bytes' => 1024 ), $clock() + 0.9, $clock );
+	$start   = new ReflectionMethod( Static_Site_Importer_URL_Fetcher::class, 'native_start' );
+	$poll    = new ReflectionMethod( Static_Site_Importer_URL_Fetcher::class, 'native_poll' );
+	$handle  = $start->invoke( null, $target, $options );
+	$then    = microtime( true );
+	do {
+		$response = $poll->invoke( null, $handle );
+		if ( null === $response ) { usleep( 1000 ); }
+	} while ( null === $response && microtime( true ) - $then < 1.5 );
+	$elapsed = microtime( true ) - $then;
+	if ( ! is_wp_error( $response ) || 'static_site_importer_url_deadline_exhausted' !== $response->get_error_code() || $elapsed > 1.3 || null !== $handle->multi || null !== $handle->curl ) {
+		throw new RuntimeException( 'curl_multi must return deadline exhaustion promptly and close the withheld-TLS request.' );
+	}
+	} finally {
+		foreach ( $proxies as $name => $value ) { false === $value ? putenv( $name ) : putenv( $name . '=' . $value ); }
+	}
+} finally {
+	fclose( $pipes[0] ); fclose( $pipes[1] ); fclose( $pipes[2] ); proc_terminate( $process ); proc_close( $process );
+}
+
+$peer_code = '$server = stream_socket_server("tcp://127.0.0.1:0", $errno, $errstr); if ( false === $server ) { exit( 1 ); } fwrite(STDOUT, stream_socket_get_name($server, false) . "\\n"); $client = stream_socket_accept($server, 5); if ( $client ) { fread($client, 8192); fwrite($client, "HTTP/1.1 200 OK\\r\\nContent-Type: text/plain\\r\\nTransfer-Encoding: chunked\\r\\nConnection: close\\r\\n\\r\\n5\\r\\nhello\\r\\n0\\r\\n\\r\\n"); fclose($client); } fclose($server);';
+$process   = proc_open( PHP_BINARY . ' -r ' . escapeshellarg( $peer_code ), array( 0 => array( 'pipe', 'r' ), 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes );
+if ( ! is_resource( $process ) || false === ( $address = fgets( $pipes[1] ) ) ) { throw new RuntimeException( 'Could not start the chunked-response test peer.' ); }
+
+try {
+	$port    = (int) substr( trim( $address ), strrpos( trim( $address ), ':' ) + 1 );
+	$target  = array( 'url' => 'http://chunked.test:' . $port . '/', 'scheme' => 'http', 'host' => 'chunked.test', 'port' => $port, 'path' => '/', 'ips' => array( '127.0.0.1' ) );
+	$options = array( 'timeout' => 1, 'max_bytes' => 1024, 'deadline' => null, 'clock' => null );
+	$start   = new ReflectionMethod( Static_Site_Importer_URL_Fetcher::class, 'native_start' );
+	$poll    = new ReflectionMethod( Static_Site_Importer_URL_Fetcher::class, 'native_poll' );
+	$handle  = $start->invoke( null, $target, $options );
+	do {
+		$response = $poll->invoke( null, $handle );
+		if ( null === $response ) { usleep( 1000 ); }
+	} while ( null === $response );
+	if ( is_wp_error( $response ) || 'hello' !== $response['body'] || 200 !== $response['status_code'] || null !== $handle->multi || null !== $handle->curl ) {
+		throw new RuntimeException( 'curl_multi must decode chunked bodies, retain the HTTP status, and close completed handles.' );
+	}
+} finally {
+	fclose( $pipes[0] ); fclose( $pipes[1] ); fclose( $pipes[2] ); proc_terminate( $process ); proc_close( $process );
+}
+
+fwrite( STDOUT, "OK: curl_multi TLS deadline is bounded and cancelled\n" );

--- a/tests/smoke-url-site-collector.php
+++ b/tests/smoke-url-site-collector.php
@@ -58,7 +58,10 @@ if ( ! function_exists( 'wp_strip_all_tags' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-fetcher.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-content-policy.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-site-collector.php';
+$candidate_transformer = getenv( 'SSI_BLOCKS_ENGINE_PHP_TRANSFORMER' );
+if ( is_string( $candidate_transformer ) && is_readable( rtrim( $candidate_transformer, '/\\' ) . '/vendor/autoload.php' ) ) { require_once rtrim( $candidate_transformer, '/\\' ) . '/vendor/autoload.php'; class_exists( Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler::class ); class_exists( Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactNormalizer::class ); interface_exists( Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\PayloadReader::class ); }
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once dirname( __DIR__ ) . '/vendor/automattic/blocks-engine-php-transformer/php-transformer.php';
 

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -23,6 +23,7 @@ $GLOBALS['ssi_plan_posts']      = array();
 $GLOBALS['ssi_plan_meta']       = array();
 $GLOBALS['ssi_plan_options']    = array( 'show_on_front' => 'posts', 'page_on_front' => 0, 'blogname' => 'Before', 'use_smilies' => true );
 $GLOBALS['ssi_plan_fail_after'] = 0;
+$GLOBALS['ssi_plan_insert_calls'] = 0;
 $GLOBALS['ssi_plan_font_requests'] = array();
 mkdir( $GLOBALS['ssi_plan_root'], 0777, true );
 
@@ -90,6 +91,7 @@ function get_page_by_path( string $slug, $output, string $type ) {
 	return null;
 }
 function wp_insert_post( array $post, bool $wp_error ) {
+	++$GLOBALS['ssi_plan_insert_calls'];
 	if ( $GLOBALS['ssi_plan_fail_after'] && count( $GLOBALS['ssi_plan_posts'] ) >= $GLOBALS['ssi_plan_fail_after'] ) { return new WP_Error( 'simulated_post_failure' ); }
 	$id = ! empty( $post['ID'] ) ? (int) $post['ID'] : count( $GLOBALS['ssi_plan_posts'] ) + 1;
 	$GLOBALS['ssi_plan_posts'][ $id ] = $post;
@@ -165,6 +167,91 @@ $assert( str_contains( file_get_contents( $GLOBALS['ssi_plan_root'] . '/site-pla
 $assert( 'posts' === $GLOBALS['ssi_plan_options']['show_on_front'], 'plan-only materialization does not change reading settings by default' );
 $assert( $receipt['plan']['pages'][0]['document_metadata']['links'][0]['resolved_url'] === 'https://example.test/wp-content/themes/site-plan/assets/assets/site.css', 'resolved metadata retains the declared stylesheet destination' );
 $assert( array() === $receipt['completed']['runtime_declarations']['asset_publications'], 'plans without publication declarations retain an explicit empty receipt collection' );
+$write_payload_bytes = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'write_payload_bytes' );
+$referenced_write = array(
+	'payload' => array( 'encoding' => 'base64', 'data' => '' ),
+	'payload_reference' => array( 'schema' => 'blocks-engine/payload-reference/v1', 'id' => 'binary-1', 'bytes' => 12, 'sha256' => hash( 'sha256', 'binary-bytes' ) ),
+);
+$reference_reads = 0;
+
+$reference_reader = new class( $reference_reads ) {
+	private $reads;
+	public function __construct( int &$reads ) { $this->reads =& $reads; }
+	public function read( array $reference ): string { ++$this->reads; return 'binary-bytes'; }
+};
+$reference_prepared = Static_Site_Importer_WordPress_Site_Plan_Materializer::prepare( $plan, array( 'slug' => 'reference-ephemeral', '_static_site_importer_payload_reader' => $reference_reader ) );
+$assert( 'prepared' === ( $reference_prepared['status'] ?? '' ) && 0 === $reference_reads && ! isset( $reference_prepared['args']['_static_site_importer_payload_reader'] ) && isset( $reference_prepared['payload_reader'] ), 'prepared materialization retains payload readers ephemerally without dereferencing or serializing them in args' );
+$reference_bytes = $write_payload_bytes->invoke( null, $referenced_write, $reference_reader );
+$assert( 'binary-bytes' === $reference_bytes && 1 === $reference_reads, 'referenced binary writes resolve exactly once at their write boundary' );
+$reference_write_file = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'write_file' );
+$reference_root = $GLOBALS['ssi_plan_root'] . '/reference-ephemeral';
+mkdir( $reference_root, 0777, true );
+file_put_contents( $reference_root . '/existing.bin', 'binary-bytes' );
+$referenced_write['target_path'] = 'existing.bin';
+$referenced_write['source_path'] = 'existing.bin';
+$reference_reconciled = $reference_write_file->invoke( null, $reference_root, $referenced_write, $reference_reader );
+$assert( ! is_wp_error( $reference_reconciled ) && 1 === $reference_reads, 'byte-identical referenced files reconcile from their declared hash without reading workspace bytes' );
+$missing_reader = $write_payload_bytes->invoke( null, $referenced_write, null );
+$assert( is_wp_error( $missing_reader ) && 'static_site_importer_payload_reader_missing' === $missing_reader->get_error_code(), 'referenced writes fail deterministically when no ephemeral reader is available' );
+$mismatched_reference = $referenced_write;
+$mismatched_reference['payload_reference']['sha256'] = str_repeat( '0', 64 );
+$mismatch = $write_payload_bytes->invoke( null, $mismatched_reference, $reference_reader );
+$assert( is_wp_error( $mismatch ) && 'static_site_importer_payload_reference_hash_mismatch' === $mismatch->get_error_code(), 'referenced writes reject hash mismatches before filesystem mutation' );
+
+// Blocks Engine candidates retain the canonical inline payload and add an
+// opaque reference for materialization. The reference remains authoritative.
+$reference_result = ( new ArtifactCompiler() )->compile(
+	array(
+		'entrypoint' => 'index.html',
+		'files'      => array(
+			'index.html' => '<main><h1>Reference</h1></main>',
+			'asset.bin'  => 'canonical-reference-bytes',
+		),
+	)
+)->toArray();
+$reference_plan = $reference_result['source_reports']['wordpress_site_plan'];
+foreach ( $reference_plan['writes'] as &$write ) {
+	if ( 'asset.bin' === $write['source_path'] ) {
+		$write['payload_reference'] = array(
+			'schema' => 'blocks-engine/payload-reference/v1',
+			'id'     => 'canonical-reference',
+			'bytes'  => strlen( 'canonical-reference-bytes' ),
+			'sha256' => hash( 'sha256', 'canonical-reference-bytes' ),
+		);
+	}
+}
+unset( $write );
+$reference_target = 'assets/asset.bin';
+$posts_before_reference_admission = $GLOBALS['ssi_plan_posts'];
+$inserts_before_reference_admission = $GLOBALS['ssi_plan_insert_calls'];
+$throwing_reader = new class {
+	public function read( array $reference ): string { throw new RuntimeException( 'workspace unavailable' ); }
+};
+$throwing_reference_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $reference_plan, array( 'slug' => 'reference-admission-throwing', '_static_site_importer_payload_reader' => $throwing_reader ) );
+$assert( 'rejected' === $throwing_reference_receipt['status'] && 'static_site_importer_payload_reference_unavailable' === ( $throwing_reference_receipt['diagnostics'][0]['reason_code'] ?? '' ) && $posts_before_reference_admission === $GLOBALS['ssi_plan_posts'] && $inserts_before_reference_admission === $GLOBALS['ssi_plan_insert_calls'] && ! file_exists( $GLOBALS['ssi_plan_root'] . '/reference-admission-throwing' ), 'throwing canonical reference readers reject before page or filesystem mutation' );
+$theme_generator_materialize = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'materialize_compiled_website_artifact' );
+$theme_generator_before_admission = $GLOBALS['ssi_plan_insert_calls'];
+$theme_generator_admission_failure = $theme_generator_materialize->invoke( null, array(), array( 'slug' => 'theme-generator-reference-admission', '_static_site_importer_payload_reader' => $throwing_reader ), $reference_plan, array(), array( 'unreachable' => true ), array( 'dependencies' => array(), 'entities' => array() ) );
+$assert( is_wp_error( $theme_generator_admission_failure ) && 'static_site_importer_payload_reference_unavailable' === $theme_generator_admission_failure->get_error_code() && $theme_generator_before_admission === $GLOBALS['ssi_plan_insert_calls'] && ! file_exists( $GLOBALS['ssi_plan_root'] . '/theme-generator-reference-admission' ), 'theme generator rejects unavailable references before companion, dependency, entity, page, or filesystem materialization' );
+$mismatched_reader = new class {
+	public function read( array $reference ): string { return 'corrupt-reference-bytes'; }
+};
+$mismatched_reference_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $reference_plan, array( 'slug' => 'reference-admission-mismatched', '_static_site_importer_payload_reader' => $mismatched_reader ) );
+$assert( 'rejected' === $mismatched_reference_receipt['status'] && 'static_site_importer_payload_reference_hash_mismatch' === ( $mismatched_reference_receipt['diagnostics'][0]['reason_code'] ?? '' ) && $posts_before_reference_admission === $GLOBALS['ssi_plan_posts'] && $inserts_before_reference_admission === $GLOBALS['ssi_plan_insert_calls'] && ! file_exists( $GLOBALS['ssi_plan_root'] . '/reference-admission-mismatched' ), 'mismatched canonical reference readers reject before page or filesystem mutation' );
+$valid_reader = new class {
+	public function read( array $reference ): string { return 'canonical-reference-bytes'; }
+};
+$valid_reference_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $reference_plan, array( 'slug' => 'reference-admission-valid', '_static_site_importer_payload_reader' => $valid_reader ) );
+$assert( 'completed' === $valid_reference_receipt['status'] && $inserts_before_reference_admission < $GLOBALS['ssi_plan_insert_calls'] && file_exists( $GLOBALS['ssi_plan_root'] . '/reference-admission-valid/' . $reference_target ) && 'canonical-reference-bytes' === file_get_contents( $GLOBALS['ssi_plan_root'] . '/reference-admission-valid/' . $reference_target ), 'valid canonical reference readers pass admission and materialize the declared write' );
+$prepared_for_admission = Static_Site_Importer_WordPress_Site_Plan_Materializer::prepare( $reference_plan, array( 'slug' => 'reference-admission-prepared', '_static_site_importer_payload_reader' => $valid_reader ) );
+$admitted_prepared = Static_Site_Importer_WordPress_Site_Plan_Materializer::admit_prepared( $prepared_for_admission );
+$assert( 'prepared' === ( $admitted_prepared['status'] ?? '' ) && ! empty( $admitted_prepared['payload_references_admitted'] ) && ! str_contains( (string) wp_json_encode( $admitted_prepared['plan'] ), 'payload_references_admitted' ) && ! str_contains( (string) wp_json_encode( Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize_prepared( $admitted_prepared ) ), 'payload_references_admitted' ), 'prepared admission marker is ephemeral and excluded from canonical plans and receipts' );
+$generator_admission = strpos( (string) $theme_generator_source, '::admit_prepared( $prepared )' );
+$generator_binding_preflight = strpos( (string) $theme_generator_source, 'with_resolved_runtime_binding_manifests', $generator_admission + 1 );
+$generator_companion = strpos( (string) $theme_generator_source, 'materialize_companion_dependency', $generator_admission + 1 );
+$generator_dependencies = strpos( (string) $theme_generator_source, 'materialize_prepared_dependencies', $generator_admission + 1 );
+$generator_entities = strpos( (string) $theme_generator_source, 'materialize_prepared_entities', $generator_admission + 1 );
+$assert( false !== $generator_admission && $generator_admission < $generator_binding_preflight && $generator_admission < $generator_companion && $generator_admission < $generator_dependencies && $generator_admission < $generator_entities, 'theme generator admits referenced payloads before runtime binding, companion, dependency, and entity materialization work' );
 $unbound_provenance = $receipt['completed']['block_provenance'] ?? array();
 $assert( count( $plan['pages'] ) === count( $unbound_provenance ) && count( $plan['pages'] ) === ( $receipt['completed']['block_provenance_count'] ?? 0 ), 'ordinary resolved pages receive receipt provenance without runtime bindings' );
 $assert( 'blocks-engine/wordpress-site-plan-resolver' === ( $unbound_provenance[0]['stages'][0]['stage'] ?? '' ) && hash( 'sha256', $receipt['plan']['pages'][0]['resolved_block_markup'] ) === ( $unbound_provenance[0]['stages'][0]['output']['sha256'] ?? '' ), 'ordinary page provenance records the resolver output hash' );


### PR DESCRIPTION
## Summary
- validate retained payload references before any dependency, entity, page, or file mutation
- resolve reference-backed binary writes one payload at a time and verify raw-byte SHA-256 at the write boundary
- preserve validated shared resources across resumable URL batches, including nested font preload references
- prefer IP-pinned `curl_multi` transport so TLS progress obeys the invocation deadline
- retain the verified stream fallback with strict response-header and body bounds

## Verification
- `npm test` (`60` selected tests passed on current `main`)
- `tests/smoke-url-curl-deadline.php` passed 20 consecutive runs
- focused shared-resource, URL batch, collector, and WordPress site-plan materializer coverage

## Related
- Follow-up to #768 and merged PR #955
- Depends on the referenced-binary contract in Automattic/blocks-engine#866

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced the retained-payload and TLS deadline boundaries, implemented the changes, and ran the verification. Chris Huber reviewed the patch and remains responsible for every line.