### PR TITLE
Bound retained URL finalization work

### DIFF
--- a/includes/class-static-site-importer-url-batch-import.php
+++ b/includes/class-static-site-importer-url-batch-import.php
@@ -344,57 +344,9 @@ final class Static_Site_Importer_URL_Batch_Import {
 							$body = isset( $retained['body_ref'] ) && is_string( $retained['body_ref'] ) ? $workspace->read_raw( $retained['body_ref'] ) : null;
 							return is_string( $body ) && hash_equals( (string) ( $retained['sha256'] ?? '' ), hash( 'sha256', $body ) ) ? $body : null;
 						},
-						'_static_site_importer_collection_resource_store' => static function ( string $body ) use ( $workspace ) {
-							$hash  = hash( 'sha256', $body );
-							$ref   = 'collection-finalized/' . $hash . '.bin';
-							$write = $workspace->publish_raw( $ref, $body );
-							return is_wp_error( $write ) ? null : array(
-								'body_ref' => $ref,
-								'sha256'   => $hash,
-								'bytes'    => strlen( $body ),
-							);
-						},
+						'_static_site_importer_collection_resource_store' => static fn ( string $body ) => self::store_collection_payload( $workspace, $body ),
 						'_static_site_importer_collection_should_yield'  => null !== $deadline ? static fn (): bool => self::deadline_reached( $deadline, $clock ) : null,
 						'_static_site_importer_collection_cursor_save'   => static function ( array $cursor ) use ( $workspace, $collection_cursor_name ) {
-							foreach ( $cursor['resources'] ?? array() as $url => $resource ) {
-								if ( ! isset( $resource['body'] ) || ! is_string( $resource['body'] ) ) {
-									continue;
-								}
-								$body = $resource['body'];
-								$hash = hash( 'sha256', $body );
-								$ref  = 'collection-resources/' . $hash . '.bin';
-								$path = $workspace->path( $ref );
-								if ( ! is_string( $path ) || ! is_file( $path ) ) {
-									$write = $workspace->publish_raw( $ref, $body );
-									if ( is_wp_error( $write ) ) {
-										return $write;
-									}
-								}
-								unset( $resource['body'] );
-								$resource['body_ref']        = $ref;
-								$resource['sha256']          = $hash;
-								$cursor['resources'][ $url ] = $resource;
-							}
-							foreach ( $cursor['finalization']['files'] ?? array() as $index => $file ) {
-								if ( ! isset( $file['body'] ) || ! is_string( $file['body'] ) ) {
-									continue;
-								}
-								$body = $file['body'];
-								$hash = hash( 'sha256', $body );
-								$ref  = 'collection-finalized/' . $hash . '.bin';
-								$path = $workspace->path( $ref );
-								if ( ! is_string( $path ) || ! is_file( $path ) ) {
-									$write = $workspace->publish_raw( $ref, $body );
-									if ( is_wp_error( $write ) ) {
-										return $write;
-									}
-								}
-								unset( $file['body'] );
-								$file['body_ref'] = $ref;
-								$file['sha256']   = $hash;
-								$file['bytes']    = strlen( $body );
-								$cursor['finalization']['files'][ $index ] = $file;
-							}
 							return $workspace->publish_json( $collection_cursor_name, $cursor );
 						},
 					)
@@ -706,6 +658,30 @@ final class Static_Site_Importer_URL_Batch_Import {
 				return $bytes;
 			}
 		};
+	}
+
+	/** @return array{body_ref:string,sha256:string,bytes:int}|WP_Error */
+	private static function store_collection_payload( Static_Site_Importer_Artifact_Run_Workspace $workspace, string $body ) {
+		$hash = hash( 'sha256', $body );
+		$ref  = 'collection-payloads/' . $hash . '.bin';
+		$path = $workspace->path( $ref );
+		if ( is_string( $path ) && is_file( $path ) ) {
+			$existing = $workspace->read_raw( $ref );
+			if ( ! is_string( $existing ) || ! hash_equals( $hash, hash( 'sha256', $existing ) ) ) {
+				return new WP_Error( 'static_site_importer_collection_payload_corrupt', 'A retained URL collection payload does not match its content-addressed path.', array( 'ref' => $ref ) );
+			}
+		} else {
+			$write = $workspace->publish_raw( $ref, $body );
+			if ( is_wp_error( $write ) ) {
+				return $write;
+			}
+		}
+
+		return array(
+			'body_ref' => $ref,
+			'sha256'   => $hash,
+			'bytes'    => strlen( $body ),
+		);
 	}
 
 	/**

--- a/includes/class-static-site-importer-url-site-collector.php
+++ b/includes/class-static-site-importer-url-site-collector.php
@@ -114,7 +114,6 @@ class Static_Site_Importer_URL_Site_Collector {
 		} else {
 			$cursor = null;
 		}
-
 		if ( null === $cursor ) {
 			$finalization = null;
 			$sitemap_urls = isset( $args['_route_set'] ) && is_array( $args['_route_set'] ) ? array_values( $args['_route_set'] ) : self::sitemap_urls( $entry_url, $fetcher, $fetch_args );
@@ -240,6 +239,11 @@ class Static_Site_Importer_URL_Site_Collector {
 				$queued_assets[ $asset_url ] = true;
 				$asset_queue[]               = $asset_url;
 			}
+			$retained = self::retain_collection_payload( $resources[ $final_url ], $resource_storer );
+			if ( is_wp_error( $retained ) ) {
+				return $retained;
+			}
+			$resources[ $final_url ] = $retained;
 		}
 
 		$asset_fetcher = self::prefetched_fetcher( array_slice( $asset_queue, 0, $max_assets ), array_merge( $fetch_args, array( 'content_types' => array() ) ), $fetcher, $use_many_fetcher, $args );
@@ -325,10 +329,17 @@ class Static_Site_Importer_URL_Site_Collector {
 					$asset_queue[]                = $nested_url;
 				}
 			}
+			$retained = self::retain_collection_payload( $resources[ $final_url ], $resource_storer );
+			if ( is_wp_error( $retained ) ) {
+				return $retained;
+			}
+			$resources[ $final_url ] = $retained;
 		}
-		$checkpoint = self::checkpoint_collection_cursor( $cursor_saver, $cursor_contract, $page_queue, $asset_queue, $queued_pages, $queued_assets, $resources, $failures, $diagnostics, $source_exclusions, $script_exclusions, $aliases, $total_bytes, $truncated, $external_assets, $external_pages, $critical_assets, $entry_resource_url, $site_url, $sitemap_urls, $finalization );
-		if ( is_wp_error( $checkpoint ) ) {
-			return $checkpoint;
+		if ( null === $finalization ) {
+			$checkpoint = self::checkpoint_collection_cursor( $cursor_saver, $cursor_contract, $page_queue, $asset_queue, $queued_pages, $queued_assets, $resources, $failures, $diagnostics, $source_exclusions, $script_exclusions, $aliases, $total_bytes, $truncated, $external_assets, $external_pages, $critical_assets, $entry_resource_url, $site_url, $sitemap_urls );
+			if ( is_wp_error( $checkpoint ) ) {
+				return $checkpoint;
+			}
 		}
 
 		if ( ( ! empty( $truncated ) || ! empty( $failures ) ) && ! empty( $args['require_complete_collection'] ) ) {
@@ -382,8 +393,12 @@ class Static_Site_Importer_URL_Site_Collector {
 				'files'          => array(),
 				'snapshot_files' => array(),
 				'external_pages' => $external_pages,
+				'assembly_next'  => 0,
+				'artifact_files' => array(),
 			);
 		}
+		$finalization['assembly_next']  = (int) ( $finalization['assembly_next'] ?? 0 );
+		$finalization['artifact_files'] = is_array( $finalization['artifact_files'] ?? null ) ? $finalization['artifact_files'] : array();
 		$resource_count = count( $resource_urls );
 		while ( $finalization['next_resource'] < $resource_count ) {
 			if ( null !== $should_yield && call_user_func( $should_yield ) ) {
@@ -392,6 +407,11 @@ class Static_Site_Importer_URL_Site_Collector {
 			}
 			$resource_url = $resource_urls[ $finalization['next_resource'] ];
 			$resource     = $resources[ $resource_url ];
+			$resource     = self::retain_collection_payload( $resource, $resource_storer, $resource_loader );
+			if ( is_wp_error( $resource ) ) {
+				return $resource;
+			}
+			$resources[ $resource_url ] = $resource;
 			$body         = $resource['body'] ?? null;
 			if ( ! is_string( $body ) && null !== $resource_loader ) {
 				$body = call_user_func( $resource_loader, $resource );
@@ -419,6 +439,10 @@ class Static_Site_Importer_URL_Site_Collector {
 			if ( 'html' === $resource['kind'] ) {
 				$file['metadata'] = array( 'route_path' => $route_paths[ $resource_url ] );
 			}
+			$file = self::retain_collection_payload( $file, $resource_storer );
+			if ( is_wp_error( $file ) ) {
+				return $file;
+			}
 			$finalization['files'][]          = $file;
 			$finalization['snapshot_files'][] = array(
 				'path'       => $path,
@@ -428,53 +452,72 @@ class Static_Site_Importer_URL_Site_Collector {
 				'sha256'     => hash( 'sha256', $body ),
 			);
 			++$finalization['next_resource'];
-			$checkpoint = self::checkpoint_collection_cursor( $cursor_saver, $cursor_contract, $page_queue, $asset_queue, $queued_pages, $queued_assets, $resources, $failures, $diagnostics, $source_exclusions, $script_exclusions, $aliases, $total_bytes, $truncated, $external_assets, $finalization['external_pages'], $critical_assets, $entry_resource_url, $site_url, $sitemap_urls, $finalization );
-			if ( is_wp_error( $checkpoint ) ) {
-				return $checkpoint;
+		}
+		$file_count = count( $finalization['files'] );
+		while ( $finalization['assembly_next'] < $file_count ) {
+			if ( null !== $should_yield && call_user_func( $should_yield ) ) {
+				$checkpoint = self::checkpoint_collection_cursor( $cursor_saver, $cursor_contract, $page_queue, $asset_queue, $queued_pages, $queued_assets, $resources, $failures, $diagnostics, $source_exclusions, $script_exclusions, $aliases, $total_bytes, $truncated, $external_assets, $finalization['external_pages'], $critical_assets, $entry_resource_url, $site_url, $sitemap_urls, $finalization );
+				return is_wp_error( $checkpoint ) ? $checkpoint : new WP_Error( 'static_site_importer_invocation_deadline_exceeded', 'The URL batch invocation deadline was reached during artifact assembly.' );
 			}
-		}
-		if ( null !== $should_yield && call_user_func( $should_yield ) ) {
-			return new WP_Error( 'static_site_importer_invocation_deadline_exceeded', 'The URL batch invocation deadline was reached before artifact assembly.' );
-		}
-		$files = array();
-		foreach ( $finalization['files'] as $retained_file ) {
+			$index         = $finalization['assembly_next'];
+			$retained_file = $finalization['files'][ $index ];
 			if ( ! empty( $args['_static_site_importer_collection_return_payload_references'] ) ) {
-				$body = $retained_file['body'] ?? null;
-				if ( ! is_string( $body ) && ( ! isset( $retained_file['bytes'] ) || ! is_int( $retained_file['bytes'] ) ) && null !== $resource_loader ) {
-					$body = call_user_func( $resource_loader, $retained_file );
+				$retained_file = self::retain_collection_payload( $retained_file, $resource_storer, $resource_loader );
+				if ( is_wp_error( $retained_file ) ) {
+					return $retained_file;
 				}
+				$finalization['files'][ $index ] = $retained_file;
 				$path = (string) ( $retained_file['path'] ?? '' );
 				if ( ! Static_Site_Importer_Content_Policy::is_static_path( $path ) ) {
 					return new WP_Error( 'static_site_importer_executable_source_rejected', sprintf( 'Untrusted artifact file %s is not static content.', $path ), array( 'path' => $path ) );
 				}
-				$reference = isset( $retained_file['body_ref'] ) ? $retained_file : ( null !== $resource_storer && is_string( $body ) ? call_user_func( $resource_storer, $body ) : null );
-				if ( ! is_array( $reference ) || ! is_string( $reference['body_ref'] ?? null ) || ! is_string( $reference['sha256'] ?? null ) ) {
+				if ( ! is_string( $retained_file['body_ref'] ?? null ) || ! is_string( $retained_file['sha256'] ?? null ) || ! isset( $retained_file['bytes'] ) ) {
 					return new WP_Error( 'static_site_importer_collection_cursor_resource_invalid', 'A finalized URL collection resource could not be retained by reference.' );
 				}
 				$file                      = array_intersect_key( $retained_file, array_flip( array( 'path', 'source_url', 'mime_type', 'metadata' ) ) );
 				$file['payload_reference'] = array(
 					'schema' => 'blocks-engine/payload-reference/v1',
-					'id'     => $reference['body_ref'],
-					'bytes'  => isset( $reference['bytes'] ) && is_int( $reference['bytes'] ) ? $reference['bytes'] : strlen( (string) $body ),
-					'sha256' => $reference['sha256'],
+					'id'     => $retained_file['body_ref'],
+					'bytes'  => (int) $retained_file['bytes'],
+					'sha256' => $retained_file['sha256'],
 				);
-				$files[]                   = $file;
-				continue;
-			}
-			$body = $retained_file['body'] ?? null;
-			if ( ! is_string( $body ) && null !== $resource_loader ) {
-				$body = call_user_func( $resource_loader, $retained_file );
-			}
-			if ( ! is_string( $body ) ) {
-				return new WP_Error( 'static_site_importer_collection_cursor_resource_invalid', 'A finalized URL collection resource could not be loaded.' );
-			}
-			$file = array_intersect_key( $retained_file, array_flip( array( 'path', 'source_url', 'mime_type', 'metadata' ) ) );
-			if ( ! empty( $retained_file['is_text'] ) ) {
-				$file['content'] = $body;
 			} else {
-				$file['content_base64'] = base64_encode( $body ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encodes binary artifact payload bytes.
+				$retained_file = self::retain_collection_payload( $retained_file, $resource_storer, $resource_loader );
+				if ( is_wp_error( $retained_file ) ) {
+					return $retained_file;
+				}
+				$finalization['files'][ $index ] = $retained_file;
+				$file                            = $retained_file;
 			}
-			$files[] = $file;
+			$finalization['artifact_files'][] = $file;
+			++$finalization['assembly_next'];
+		}
+		$checkpoint = self::checkpoint_collection_cursor( $cursor_saver, $cursor_contract, $page_queue, $asset_queue, $queued_pages, $queued_assets, $resources, $failures, $diagnostics, $source_exclusions, $script_exclusions, $aliases, $total_bytes, $truncated, $external_assets, $finalization['external_pages'], $critical_assets, $entry_resource_url, $site_url, $sitemap_urls, $finalization );
+		if ( is_wp_error( $checkpoint ) ) {
+			return $checkpoint;
+		}
+		if ( null !== $should_yield && call_user_func( $should_yield ) ) {
+			return new WP_Error( 'static_site_importer_invocation_deadline_exceeded', 'The URL batch invocation deadline was reached before artifact digest assembly.' );
+		}
+		$files = $finalization['artifact_files'];
+		if ( empty( $args['_static_site_importer_collection_return_payload_references'] ) ) {
+			$files = array();
+			foreach ( $finalization['artifact_files'] as $retained_file ) {
+				$body = $retained_file['body'] ?? null;
+				if ( ! is_string( $body ) && null !== $resource_loader ) {
+					$body = call_user_func( $resource_loader, $retained_file );
+				}
+				if ( ! is_string( $body ) ) {
+					return new WP_Error( 'static_site_importer_collection_cursor_resource_invalid', 'A finalized URL collection resource could not be loaded.' );
+				}
+				$file = array_intersect_key( $retained_file, array_flip( array( 'path', 'source_url', 'mime_type', 'metadata' ) ) );
+				if ( ! empty( $retained_file['is_text'] ) ) {
+					$file['content'] = $body;
+				} else {
+					$file['content_base64'] = base64_encode( $body ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encodes binary artifact payload bytes.
+				}
+				$files[] = $file;
+			}
 		}
 		$snapshot_files = $finalization['snapshot_files'];
 		$external_pages = $finalization['external_pages'];
@@ -603,6 +646,36 @@ class Static_Site_Importer_URL_Site_Collector {
 				'updated_at'         => gmdate( 'c' ),
 			)
 		);
+	}
+
+	/** @return array<string,mixed>|WP_Error */
+	private static function retain_collection_payload( array $record, ?callable $storer, ?callable $loader = null ) {
+		$body = $record['body'] ?? null;
+		if ( ! is_string( $body ) && null !== $storer && null !== $loader && isset( $record['body_ref'] ) && 'static-site-importer/retained-payload/v1' !== ( $record['retention_schema'] ?? '' ) ) {
+			$body = call_user_func( $loader, $record );
+		}
+		if ( ! is_string( $body ) || null === $storer ) {
+			return $record;
+		}
+
+		$reference = call_user_func( $storer, $body );
+		if ( is_wp_error( $reference ) ) {
+			return $reference;
+		}
+		if ( ! is_array( $reference ) || ! is_string( $reference['body_ref'] ?? null ) || ! is_string( $reference['sha256'] ?? null ) || ! hash_equals( hash( 'sha256', $body ), $reference['sha256'] ) ) {
+			return new WP_Error( 'static_site_importer_collection_cursor_resource_invalid', 'A URL collection payload could not be retained with a verified content reference.' );
+		}
+		$bytes = isset( $reference['bytes'] ) ? (int) $reference['bytes'] : strlen( $body );
+		if ( strlen( $body ) !== $bytes ) {
+			return new WP_Error( 'static_site_importer_collection_cursor_resource_invalid', 'A retained URL collection payload byte count does not match its content.' );
+		}
+
+		unset( $record['body'] );
+		$record['body_ref'] = $reference['body_ref'];
+		$record['sha256']   = $reference['sha256'];
+		$record['bytes']    = $bytes;
+		$record['retention_schema'] = 'static-site-importer/retained-payload/v1';
+		return $record;
 	}
 
 	private static function source_broken_asset_status( WP_Error $error ): int {

--- a/tests/smoke-url-batch-import.php
+++ b/tests/smoke-url-batch-import.php
@@ -41,6 +41,16 @@ $staged_resumed = $prepare_staged->invoke( null, $staged_workspace, $staged_arti
 if ( ! is_wp_error( $staged_interrupted ) || 'static_site_importer_invocation_deadline_exceeded' !== $staged_interrupted->get_error_code() || 1 !== count( $staged_checkpoint['plans'] ?? array() ) || is_wp_error( $staged_resumed ) || 2 !== ( $staged_resumed['page_prepared'] ?? -1 ) || 3 !== count( $staged_resumed['page_plans'] ?? array() ) ) { throw new RuntimeException( 'staged page preparation must checkpoint each completed page and resume only unfinished pages' ); }
 $staged_workspace->purge();
 
+$payload_workspace_root = sys_get_temp_dir() . '/ssi-collection-payload-' . bin2hex( random_bytes( 4 ) );
+wp_mkdir_p( $payload_workspace_root );
+$payload_workspace = new Static_Site_Importer_Artifact_Run_Workspace( $payload_workspace_root, 'corruption' );
+$store_payload      = new ReflectionMethod( Static_Site_Importer_URL_Batch_Import::class, 'store_collection_payload' );
+$stored_payload     = $store_payload->invoke( null, $payload_workspace, 'verified-payload' );
+if ( is_wp_error( $stored_payload ) || false === file_put_contents( $payload_workspace->path( $stored_payload['body_ref'] ), 'corrupt-payload' ) ) { throw new RuntimeException( 'collection payload corruption fixture setup failed' ); }
+$corrupt_payload = $store_payload->invoke( null, $payload_workspace, 'verified-payload' );
+if ( ! is_wp_error( $corrupt_payload ) || 'static_site_importer_collection_payload_corrupt' !== $corrupt_payload->get_error_code() ) { throw new RuntimeException( 'content-addressed collection payload reuse must verify existing bytes' ); }
+$payload_workspace->purge();
+
 $responses = array(
 	'https://batch.test/sitemap.xml' => array( 'application/xml', '<sitemapindex><sitemap><loc>https://batch.test/one.xml</loc></sitemap><sitemap><loc>https://batch.test/two.xml</loc></sitemap></sitemapindex>' ),
 	'https://batch.test/one.xml' => array( 'application/xml', '<urlset><url><loc>https://batch.test/</loc></url><url><loc>https://batch.test/about/</loc></url></urlset>' ),

--- a/tests/smoke-url-site-collector.php
+++ b/tests/smoke-url-site-collector.php
@@ -194,6 +194,7 @@ $finalization_cursor = null;
 $retained_bodies     = array();
 $retained_loads      = array();
 $finalization_steps  = array();
+$finalization_saves  = 0;
 $finalization_fetcher = static function ( string $url, array $args ): array {
 	unset( $args );
 	$fixtures = array(
@@ -217,7 +218,10 @@ $finalization_args = array(
 		$body                   = $retained_bodies[ $ref ] ?? null;
 		return is_string( $body ) && hash_equals( (string) ( $retained['sha256'] ?? '' ), hash( 'sha256', $body ) ) ? $body : null;
 	},
-	'_static_site_importer_collection_cursor_save' => static function ( array $cursor ) use ( &$finalization_cursor, &$retained_bodies ) {
+	'_static_site_importer_collection_cursor_save' => static function ( array $cursor ) use ( &$finalization_cursor, &$retained_bodies, &$finalization_saves ) {
+		if ( is_array( $cursor['finalization'] ?? null ) ) {
+			++$finalization_saves;
+		}
 		foreach ( $cursor['resources'] ?? array() as $url => $resource ) {
 			if ( isset( $resource['body'] ) && is_string( $resource['body'] ) ) {
 				$hash                     = hash( 'sha256', $resource['body'] );
@@ -245,7 +249,7 @@ $finalization_args = array(
 	},
 );
 $resumed_finalization = null;
-for ( $attempt = 0; $attempt < 5; ++$attempt ) {
+for ( $attempt = 0; $attempt < 10; ++$attempt ) {
 	$yield_checks = 0;
 	$attempt_args = $finalization_args;
 	$attempt_args['_static_site_importer_collection_should_yield'] = static function () use ( &$yield_checks ): bool {
@@ -253,6 +257,9 @@ for ( $attempt = 0; $attempt < 5; ++$attempt ) {
 	};
 	$resumed_finalization = Static_Site_Importer_URL_Site_Collector::collect( 'https://finalize.test/', $attempt_args, $finalization_fetcher );
 	$finalization_steps[] = (int) ( $finalization_cursor['finalization']['next_resource'] ?? 0 );
+	if ( 0 === $attempt && is_wp_error( $resumed_finalization ) ) {
+		$finalization_cursor['schema'] = 'static-site-importer/url-collection-cursor/v1';
+	}
 	if ( ! is_wp_error( $resumed_finalization ) ) {
 		break;
 	}
@@ -263,10 +270,112 @@ $finalized_refs_verify = array_filter(
 	$finalization_cursor['finalization']['files'] ?? array(),
 	static fn ( array $file ): bool => ! isset( $retained_bodies[ $file['body_ref'] ?? '' ] ) || ! hash_equals( (string) ( $file['sha256'] ?? '' ), hash( 'sha256', $retained_bodies[ $file['body_ref'] ] ) )
 );
-$assert( array( 1, 2, 3, 3 ) === $finalization_steps, 'finalization-cursor-advances-one-resource-per-invocation' );
+$assert( array( 1, 2, 3, 3, 3, 3, 3 ) === $finalization_steps, 'finalization-cursor-advances-one-resource-per-invocation' );
+$assert( 7 === $finalization_saves, 'finalization-and-assembly-persist-once-per-yielded-slice' );
 $assert( 'static-site-importer/url-collection-cursor/v2' === ( $finalization_cursor['schema'] ?? '' ) && array() === $finalized_refs_verify, 'finalization-cursor-retains-hash-verified-payloads' );
 $assert( 2 === count( $source_loads ) && array() === array_filter( $source_loads, static fn ( int $count ): bool => 1 !== $count ), 'resumed-finalization-does-not-reload-completed-source-resources' );
 $assert( ! is_wp_error( $resumed_finalization ) && ! is_wp_error( $clean_finalization ) && wp_json_encode( $clean_finalization['artifact'] ) === wp_json_encode( $resumed_finalization['artifact'] ), 'resumed-finalization-preserves-clean-artifact-bytes' );
+
+$store_failure = Static_Site_Importer_URL_Site_Collector::collect(
+	'https://store-failure.test/',
+	array(
+		'max_pages'                                      => 1,
+		'max_assets'                                     => 0,
+		'_route_set'                                     => array( 'https://store-failure.test/' ),
+		'_static_site_importer_collection_contract'      => 'store-failure-test',
+		'_static_site_importer_collection_resource_store' => static fn ( string $body ) => new WP_Error( 'fixture_payload_store_failed', (string) strlen( $body ) ),
+		'_static_site_importer_collection_cursor_save'   => static fn ( array $cursor ): bool => ! empty( $cursor ),
+	),
+	static fn ( string $url ): array => array( 'body' => '<main>Store failure</main>', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) )
+);
+$assert( is_wp_error( $store_failure ) && 'fixture_payload_store_failed' === $store_failure->get_error_code(), 'payload-storage-errors-preserve-owning-failure-semantics' );
+
+$linear_asset_count = 512;
+$linear_cursor      = null;
+$linear_payloads    = array();
+$linear_store_calls = 0;
+$linear_raw_cursors = 0;
+$linear_finalization_saves = 0;
+$linear_attempts    = 0;
+$linear_fetcher     = static function ( string $url ) use ( $linear_asset_count ) {
+	if ( 'https://linear-finalize.test/' === $url ) {
+		$html = '<main>';
+		for ( $index = 0; $index < $linear_asset_count; ++$index ) {
+			$html .= '<img src="/asset-' . $index . '.png">';
+		}
+		return array( 'body' => $html . '</main>', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) );
+	}
+	return array( 'body' => 'payload-' . basename( $url ), 'metadata' => array( 'content_type' => 'image/png', 'final_url' => $url ) );
+};
+$linear_args        = array(
+	'max_pages'                                      => 1,
+	'max_assets'                                     => $linear_asset_count,
+	'_route_set'                                     => array( 'https://linear-finalize.test/' ),
+	'_static_site_importer_collection_return_payload_references' => true,
+	'_static_site_importer_collection_contract'      => 'linear-finalization-test',
+	'_static_site_importer_collection_cursor_load'   => static function () use ( &$linear_cursor ) {
+		return $linear_cursor;
+	},
+	'_static_site_importer_collection_resource_load' => static function ( array $retained ) use ( &$linear_payloads ) {
+		$body = $linear_payloads[ $retained['body_ref'] ?? '' ] ?? null;
+		return is_string( $body ) && hash_equals( (string) ( $retained['sha256'] ?? '' ), hash( 'sha256', $body ) ) ? $body : null;
+	},
+	'_static_site_importer_collection_resource_store' => static function ( string $body ) use ( &$linear_payloads, &$linear_store_calls ) {
+		++$linear_store_calls;
+		$hash                       = hash( 'sha256', $body );
+		$ref                        = 'linear/' . $hash;
+		$linear_payloads[ $ref ] = $body;
+		return array( 'body_ref' => $ref, 'sha256' => $hash, 'bytes' => strlen( $body ) );
+	},
+	'_static_site_importer_collection_cursor_save'   => static function ( array $cursor ) use ( &$linear_cursor, &$linear_raw_cursors, &$linear_finalization_saves ) {
+		if ( is_array( $cursor['finalization'] ?? null ) ) {
+			++$linear_finalization_saves;
+		}
+		$records = array_merge( $cursor['resources'] ?? array(), $cursor['finalization']['files'] ?? array(), $cursor['finalization']['artifact_files'] ?? array() );
+		if ( array_filter( $records, static fn ( array $record ): bool => isset( $record['body'] ) ) ) {
+			++$linear_raw_cursors;
+		}
+		$linear_cursor = $cursor;
+		return true;
+	},
+);
+$linear_result      = null;
+for ( $attempt = 0; $attempt < 20; ++$attempt ) {
+	++$linear_attempts;
+	$yield_checks = 0;
+	$attempt_args = $linear_args;
+	$attempt_args['_static_site_importer_collection_should_yield'] = static function () use ( &$yield_checks ): bool {
+		return 64 < ++$yield_checks;
+	};
+	$linear_result = Static_Site_Importer_URL_Site_Collector::collect( 'https://linear-finalize.test/', $attempt_args, $linear_fetcher );
+	if ( 0 === $attempt && is_wp_error( $linear_result ) ) {
+		foreach ( array( 'resources', 'finalization' ) as $section ) {
+			$records = 'resources' === $section ? $linear_cursor['resources'] : $linear_cursor['finalization']['files'];
+			$key     = 'resources' === $section ? $linear_cursor['finalization']['resource_urls'][100] : array_key_first( $records );
+			$record  = $records[ $key ];
+			$old_ref = ( 'resources' === $section ? 'collection-resources/' : 'collection-finalized/' ) . $record['sha256'] . '.bin';
+			$linear_payloads[ $old_ref ] = $linear_payloads[ $record['body_ref'] ];
+			$record['body_ref']           = $old_ref;
+			unset( $record['retention_schema'] );
+			if ( 'resources' === $section ) {
+				$linear_cursor['resources'][ $key ] = $record;
+			} else {
+				$linear_cursor['finalization']['files'][ $key ] = $record;
+			}
+		}
+		$linear_cursor['schema'] = 'static-site-importer/url-collection-cursor/v1';
+	}
+	if ( ! is_wp_error( $linear_result ) ) {
+		break;
+	}
+}
+$linear_resource_count = $linear_asset_count + 1;
+$assert( 0 === $linear_raw_cursors, 'retained-cursors-never-rewrite-raw-payloads' );
+$assert( 2 * $linear_resource_count + 2 === $linear_store_calls, 'retained-payload-storage-is-linear-in-produced-resources' );
+$assert( $linear_attempts === $linear_finalization_saves, 'large-finalization-persists-once-per-bounded-slice' );
+$assert( 17 === $linear_attempts && $linear_resource_count === (int) ( $linear_cursor['finalization']['next_resource'] ?? 0 ) && $linear_resource_count === (int) ( $linear_cursor['finalization']['assembly_next'] ?? 0 ), 'large-finalization-and-assembly-resume-in-bounded-linear-chunks' );
+$assert( ! is_wp_error( $linear_result ) && $linear_resource_count === count( $linear_result['artifact']['files'] ?? array() ), 'large-resumed-finalization-produces-the-complete-artifact' );
+$assert( ! is_wp_error( $linear_result ) && array() === array_filter( $linear_result['artifact']['files'], static fn ( array $file ): bool => ! str_starts_with( (string) ( $file['payload_reference']['id'] ?? '' ), 'linear/' ) ), 'legacy-retained-references-migrate-to-canonical-artifact-identities' );
 
 $schedule_calls = array();
 $schedule_delays = array();


### PR DESCRIPTION
## Summary

- retain collected and finalized payloads once at production time instead of re-hashing raw bodies in every cursor save
- checkpoint finalization and artifact assembly once per bounded yielded slice
- migrate legacy retained references deterministically as each resource is consumed
- verify existing content-addressed payload bytes and preserve workspace storage errors
- keep inline compatibility output out of intermediate cursor payloads

## Verification

- `npm test` (`60` selected tests passed)
- `php tests/smoke-url-site-collector.php` (`77` assertions)
- `php tests/smoke-url-batch-import.php`
- `php tests/smoke-shared-resource-plan.php`
- `php tests/smoke-wordpress-site-plan-materializer.php`
- 513-resource interrupted/resumed finalization and assembly coverage

## Acceptance

Shopify acceptance exposed an independent PHP.wasm no-cURL TLS cancellation defect tracked in #979. The candidate reduced cursor amplification, but full browser/editor/visual acceptance remains blocked because `stream_socket_enable_crypto()` can hold an invocation beyond its five-second deadline. No acceptance success is claimed here.

Closes #974. Related to #979.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode traced the cursor amplification, implemented bounded retained-payload finalization and assembly, added deterministic compatibility coverage, ran the test suite, and analyzed the blocked Shopify acceptance evidence. Chris Huber reviewed and remains responsible for every line.