### PR TITLE
Preserve bounded fetch transports across URL collection resumes

### DIFF
--- a/includes/class-static-site-importer-url-site-collector.php
+++ b/includes/class-static-site-importer-url-site-collector.php
@@ -53,6 +53,9 @@ class Static_Site_Importer_URL_Site_Collector {
 		$fetcher                 = self::scheduled_fetcher( $fetcher, $args );
 		$fetch_args              = array_intersect_key( $args, array_flip( array( 'timeout' ) ) );
 		$fetch_args['max_bytes'] = min( self::MAX_RESPONSE_BYTES, $max_total_bytes, max( 1, (int) ( $args['max_bytes'] ?? 5242880 ) ) );
+		if ( isset( $args['_static_site_importer_fetch_many_transport'] ) && is_array( $args['_static_site_importer_fetch_many_transport'] ) ) {
+			$fetch_args['transport'] = $args['_static_site_importer_fetch_many_transport'];
+		}
 
 		$page_queue             = array( $entry_url );
 		$asset_queue            = array();

--- a/tests/smoke-url-site-collector.php
+++ b/tests/smoke-url-site-collector.php
@@ -190,6 +190,29 @@ $shuffled = Static_Site_Importer_URL_Site_Collector::collect(
 );
 $assert( ! is_wp_error( $shuffled ) && ( $snapshot['sha256'] ?? '' ) === ( $shuffled['source_metadata']['snapshot']['sha256'] ?? null ), 'snapshot-hash-independent-of-discovery-order' );
 
+$bounded_transport_starts = 0;
+$bounded_transport        = array(
+	'start'  => static function ( array $target, array $options ) use ( &$bounded_transport_starts ): object {
+		++$bounded_transport_starts;
+		return (object) array( 'target' => $target, 'options' => $options );
+	},
+	'poll'   => static fn ( object $handle ): array => array( 'status_code' => 200, 'headers' => array( 'content-type' => array( 'text/html' ) ), 'body' => '<main>Bounded host transport</main>' ),
+	'cancel' => static function (): void {},
+);
+$bounded_transport_result = Static_Site_Importer_URL_Site_Collector::collect(
+	'http://1.1.1.1/',
+	array(
+		'max_pages'                                      => 1,
+		'max_assets'                                     => 0,
+		'_route_set'                                     => array( 'http://1.1.1.1/' ),
+		'_static_site_importer_fetch_many_transport'     => $bounded_transport,
+		'_static_site_importer_collection_contract'      => 'bounded-transport-test',
+		'_static_site_importer_collection_cursor_save'   => static fn (): bool => true,
+	),
+	static fn ( string $url, array $fetch_args ) => Static_Site_Importer_URL_Fetcher::fetch( $url, $fetch_args + array( 'deadline' => microtime( true ) + 1 ) )
+);
+$assert( 1 === $bounded_transport_starts && ! is_wp_error( $bounded_transport_result ), 'resumable-single-fetch-path-uses-custom-bounded-transport' );
+
 $finalization_cursor = null;
 $retained_bodies     = array();
 $retained_loads      = array();


### PR DESCRIPTION
## Summary
- propagate the configured multi-fetch transport into resumable single-fetch URL collection
- cover the resumed collection path with the bounded transport smoke harness

Addresses #979 and pairs with Automattic/wp-codebox#2258.

## Verification
- `php tests/smoke-url-site-collector.php` (78 assertions)
- `php tests/smoke-url-batch-import.php`
- `git diff --check`
- downstream Shopify acceptance used the custom host transport successfully and advanced through structured continuations

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode was used to trace the resumed fetch path, implement the propagation and regression coverage, and analyze acceptance evidence. Chris Huber reviewed and remains responsible for the change.