### PR TITLE
Expose importer theme materialization strategy

### DIFF
--- a/blocks/importer/block.json
+++ b/blocks/importer/block.json
@@ -29,6 +29,11 @@
     "openInPlayground": {
       "type": "boolean",
       "default": true
+    },
+    "themeMaterialization": {
+      "type": "string",
+      "enum": ["block", "classic"],
+      "default": "block"
     }
   },
   "editorScript": "file:./editor.js",

--- a/blocks/importer/editor.js
+++ b/blocks/importer/editor.js
@@ -29,6 +29,19 @@
 							setAttributes( { applyToCurrentSite: Boolean( value ) } );
 						},
 					} )
+					: null,
+				components && components.SelectControl
+					? el( components.SelectControl, {
+						label: 'Theme materialization',
+						value: attributes.themeMaterialization || 'block',
+						options: [
+							{ label: 'Editable block theme', value: 'block' },
+							{ label: 'Managed classic theme', value: 'classic' },
+						],
+						onChange( value ) {
+							setAttributes( { themeMaterialization: value === 'classic' ? 'classic' : 'block' } );
+						},
+					} )
 					: null
 			);
 		},

--- a/blocks/importer/view.js
+++ b/blocks/importer/view.js
@@ -271,11 +271,13 @@
 		const restUrl = root.getAttribute( 'data-static-site-importer-figma-rest-url' );
 		const nonce = root.getAttribute( 'data-static-site-importer-nonce' );
 		const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
+		const themeMaterialization = root.getAttribute( 'data-static-site-importer-theme-materialization' ) === 'classic' ? 'classic' : 'block';
 		const formData = new FormData();
 		formData.append( 'figma_file', file );
 		formData.append( 'apply_to_current_site', isCurrentSiteImport ? '1' : '0' );
 		formData.append( 'activate', isCurrentSiteImport ? '1' : '0' );
 		formData.append( 'overwrite', isCurrentSiteImport ? '1' : '0' );
+		formData.append( 'theme_materialization', themeMaterialization );
 
 		showStatus( root, isCurrentSiteImport ? 'Importing Figma file to this site...' : 'Preparing Figma file for WordPress preview...' );
 
@@ -333,6 +335,7 @@
 			const uploadInputs = root.querySelectorAll( '[data-static-site-importer-source-files], [data-static-site-importer-source-directory]' );
 			const provider = root.getAttribute( 'data-static-site-importer-provider' ) || '';
 			const isCurrentSiteImport = root.getAttribute( 'data-static-site-importer-apply-to-current-site' ) === '1';
+			const themeMaterialization = root.getAttribute( 'data-static-site-importer-theme-materialization' ) === 'classic' ? 'classic' : 'block';
 			const source = {
 				url: sourceUrl ? sourceUrl.value : '',
 				html: html ? html.value : '',
@@ -359,6 +362,7 @@
 						apply_to_current_site: isCurrentSiteImport,
 						activate: isCurrentSiteImport,
 						overwrite: isCurrentSiteImport,
+						theme_materialization: themeMaterialization,
 					};
 					if ( importId ) {
 						body.source = Object.assign( {}, importSource, { import_id: importId } );

--- a/includes/block.php
+++ b/includes/block.php
@@ -30,17 +30,18 @@ function static_site_importer_register_block(): void {
  * @return string
  */
 function static_site_importer_render_block( array $attributes = array() ): string {
-	$figma_available = Static_Site_Importer_Figma_Import::zstd_decoder_available();
-	$title           = isset( $attributes['title'] ) && '' !== trim( (string) $attributes['title'] ) ? (string) $attributes['title'] : __( 'Bring a site into WordPress.', 'static-site-importer' );
-	$default_intro   = $figma_available
+	$figma_available       = Static_Site_Importer_Figma_Import::zstd_decoder_available();
+	$title                 = isset( $attributes['title'] ) && '' !== trim( (string) $attributes['title'] ) ? (string) $attributes['title'] : __( 'Bring a site into WordPress.', 'static-site-importer' );
+	$default_intro         = $figma_available
 		? __( 'Capture a public site, upload a static site, ZIP, folder, or Figma file, or paste HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' )
 		: __( 'Capture a public site, upload a static site, ZIP, or folder, or paste HTML. Static Site Importer will compile it into a block theme.', 'static-site-importer' );
-	$intro           = isset( $attributes['intro'] ) && '' !== trim( (string) $attributes['intro'] ) ? (string) $attributes['intro'] : $default_intro;
-	$provider        = isset( $attributes['provider'] ) ? sanitize_key( (string) $attributes['provider'] ) : '';
-	$default_url     = isset( $attributes['defaultUrl'] ) ? esc_url_raw( (string) $attributes['defaultUrl'] ) : '';
-	$apply           = ! empty( $attributes['applyToCurrentSite'] );
-	$playground      = ! empty( $attributes['openInPlayground'] );
-	$button_text     = $apply ? __( 'Import to this site', 'static-site-importer' ) : __( 'Generate WordPress Website', 'static-site-importer' );
+	$intro                 = isset( $attributes['intro'] ) && '' !== trim( (string) $attributes['intro'] ) ? (string) $attributes['intro'] : $default_intro;
+	$provider              = isset( $attributes['provider'] ) ? sanitize_key( (string) $attributes['provider'] ) : '';
+	$default_url           = isset( $attributes['defaultUrl'] ) ? esc_url_raw( (string) $attributes['defaultUrl'] ) : '';
+	$apply                 = ! empty( $attributes['applyToCurrentSite'] );
+	$playground            = ! empty( $attributes['openInPlayground'] );
+	$theme_materialization = 'classic' === ( $attributes['themeMaterialization'] ?? '' ) ? 'classic' : 'block';
+	$button_text           = $apply ? __( 'Import to this site', 'static-site-importer' ) : __( 'Generate WordPress Website', 'static-site-importer' );
 
 	/**
 	 * Filters the importer block wrapper CSS classes.
@@ -88,7 +89,7 @@ function static_site_importer_render_block( array $attributes = array() ): strin
 
 	ob_start();
 	?>
-	<div class="<?php echo esc_attr( $wrapper_classes ); ?>"<?php echo $extra_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Name sanitized, value escaped with esc_attr() above. ?> data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-figma-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/import-figma-file' ) ); ?>" data-static-site-importer-figma-available="<?php echo $figma_available ? '1' : '0'; ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>" data-static-site-importer-apply-to-current-site="<?php echo $apply ? '1' : '0'; ?>" data-static-site-importer-open-in-playground="<?php echo $playground ? '1' : '0'; ?>">
+	<div class="<?php echo esc_attr( $wrapper_classes ); ?>"<?php echo $extra_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Name sanitized, value escaped with esc_attr() above. ?> data-static-site-importer data-static-site-importer-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/imports' ) ); ?>" data-static-site-importer-figma-rest-url="<?php echo esc_url( rest_url( 'static-site-importer/v1/import-figma-file' ) ); ?>" data-static-site-importer-figma-available="<?php echo $figma_available ? '1' : '0'; ?>" data-static-site-importer-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>" data-static-site-importer-provider="<?php echo esc_attr( $provider ); ?>" data-static-site-importer-theme-materialization="<?php echo esc_attr( $theme_materialization ); ?>" data-static-site-importer-apply-to-current-site="<?php echo $apply ? '1' : '0'; ?>" data-static-site-importer-open-in-playground="<?php echo $playground ? '1' : '0'; ?>">
 		<section class="ssi-importer__panel" aria-labelledby="ssi-importer-title">
 			<p class="ssi-importer__eyebrow"><?php esc_html_e( 'Static Site Importer', 'static-site-importer' ); ?></p>
 			<h1 id="ssi-importer-title" class="ssi-importer__title"><?php echo esc_html( $title ); ?></h1>

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -425,6 +425,7 @@ $assert( ! str_contains( $rest_source, 'generate_in_current_runtime' ), 'rest-do
 
 $metadata = json_decode( file_get_contents( dirname( __DIR__ ) . '/blocks/importer/block.json' ), true );
 $assert( is_array( $metadata ), 'block-json-decodes' );
+$assert( 'block' === ( $metadata['attributes']['themeMaterialization']['default'] ?? '' ), 'block-json-defaults-to-block-materialization' );
 $assert( 'static-site-importer/importer' === ( $metadata['name'] ?? '' ), 'block-name-is-product-importer' );
 $assert( 'Static Site Importer' === ( $metadata['title'] ?? '' ), 'block-title-is-product-name' );
 $assert( isset( $metadata['viewScript'] ), 'block-has-frontend-script' );
@@ -495,6 +496,9 @@ $assert( ! str_contains( $html, 'Import status' ), 'render-omits-import-status-s
 $assert( str_contains( $html, 'Import your site' ), 'render-uses-custom-title' );
 $assert( str_contains( $html, 'https://example.com/source' ), 'render-uses-default-url' );
 $assert( str_contains( static_site_importer_render_block(), 'Generate WordPress Website' ), 'render-preview-mode-button-generates-wordpress-website' );
+$assert( str_contains( static_site_importer_render_block(), 'data-static-site-importer-theme-materialization="block"' ), 'render-defaults-to-block-materialization' );
+$assert( str_contains( static_site_importer_render_block( array( 'themeMaterialization' => 'classic' ) ), 'data-static-site-importer-theme-materialization="classic"' ), 'render-projects-classic-materialization' );
+$assert( str_contains( static_site_importer_render_block( array( 'themeMaterialization' => 'invalid' ) ), 'data-static-site-importer-theme-materialization="block"' ), 'render-fails-safe-to-block-materialization' );
 $playground_html = static_site_importer_render_block( array( 'openInPlayground' => true ) );
 $assert( str_contains( $playground_html, 'data-static-site-importer-apply-to-current-site="0"' ), 'render-playground-does-not-enable-current-site-apply' );
 $assert( str_contains( $playground_html, 'data-static-site-importer-open-in-playground="1"' ), 'render-can-target-playground-with-generate-label' );
@@ -611,6 +615,7 @@ $assert( str_contains( $view_js, 'input.click()' ), 'view-opens-selected-hidden-
 $assert( str_contains( $view_js, 'webkitGetAsEntry' ), 'view-supports-dropped-directory-entries' );
 $assert( str_contains( $view_js, 'archive: await buildArchive( uploadInputs, root )' ), 'view-sends-zip-from-combined-upload-as-archive-payload' );
 $assert( str_contains( $view_js, "formData.append( 'figma_file', file )" ), 'view-sends-figma-file-as-multipart-upload' );
+$assert( str_contains( $view_js, "formData.append( 'theme_materialization', themeMaterialization )" ), 'view-sends-figma-materialization-strategy' );
 $assert( str_contains( $view_js, "data-static-site-importer-figma-available' ) !== '1'" ), 'view-guards-figma-submit-by-runtime-capability' );
 $assert( ! str_contains( $view_js, 'buildFigmaFile' ), 'view-does-not-build-figma-file-payload' );
 $assert( str_contains( $view_js, '/\\.zip$/i' ), 'view-excludes-zip-files-from-generic-static-upload' );
@@ -622,6 +627,7 @@ $assert( str_contains( $view_js, 'isCurrentSiteImport' ), 'view-names-current-si
 $assert( str_contains( $view_js, 'apply_to_current_site: isCurrentSiteImport' ), 'view-sends-current-site-apply-flag-only-from-apply-mode' );
 $assert( str_contains( $view_js, 'activate: isCurrentSiteImport' ), 'view-activates-only-current-site-imports' );
 $assert( str_contains( $view_js, 'overwrite: isCurrentSiteImport' ), 'view-overwrites-only-current-site-imports' );
+$assert( str_contains( $view_js, 'theme_materialization: themeMaterialization' ), 'view-sends-materialization-strategy-for-json-imports-and-continuations' );
 $assert( ! str_contains( $view_js, 'about:blank' ), 'view-does-not-open-window-before-preview-url-is-ready' );
 $assert( ! str_contains( $view_js, 'openPendingPreviewWindow' ), 'view-has-no-pending-preview-window-helper' );
 $assert( str_contains( $view_js, 'openPreview( report )' ), 'view-opens-preview-only-after-report-is-ready' );


### PR DESCRIPTION
## Summary
- add a versioned importer block attribute for selecting block or classic theme materialization
- project the normalized strategy into multipart Figma and JSON import requests, including URL continuations
- preserve block materialization as the compatibility default and fail safe for invalid block attributes

Closes #992.

## Testing
- `npm test` (62 selected tests passed)
- `php tests/smoke-importer-block.php` (333 assertions)
- `node --check blocks/importer/view.js`
- `node --check blocks/importer/editor.js`

## AI assistance
Implemented with OpenAI GPT-5.6 Sol using OpenCode. AI was used to inspect the importer request paths, implement the block strategy plumbing, and run the repository test suite. Chris Huber reviewed and remains responsible for the change.