### PR TITLE
Preserve authored form context during provider grafting

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -358,22 +358,27 @@ class Static_Site_Importer_Form_Seeder {
 		$selector    = isset( $form['selector'] ) && is_scalar( $form['selector'] ) ? (string) $form['selector'] : '';
 		$source_path = isset( $form['source_path'] ) && is_scalar( $form['source_path'] ) ? (string) $form['source_path'] : '';
 
-		$scope                    = self::layout_scope( $form );
-		$field_blocks             = array();
-		$mapped_types             = array();
-		$submit_text              = 'Submit';
-		$skipped                  = array();
-		$control_attribute_losses = array();
-		$has_topology             = isset( $form['control_topology'] );
-		$has_source_submit        = false;
+		$scope                         = self::layout_scope( $form );
+		$field_blocks                  = array();
+		$mapped_types                  = array();
+		$submit_text                   = 'Submit';
+		$skipped                       = array();
+		$control_attribute_losses      = array();
+		$has_topology                  = isset( $form['control_topology'] );
+		$has_source_submit             = false;
 		$textarea_height_omitted_count = (int) ( $form['form']['textarea_height_omitted_count'] ?? 0 );
 		if ( ! empty( $form['form']['interleaved_context'] ) ) {
 			return array(
-				'selector' => $selector, 'source_path' => $source_path, 'provider' => self::PROVIDER_ID,
-				'block_name' => 'jetpack/contact-form', 'status' => 'skipped', 'reason' => 'interleaved_context_unrepresentable', 'runtime_mapped' => false,
+				'selector'       => $selector,
+				'source_path'    => $source_path,
+				'provider'       => self::PROVIDER_ID,
+				'block_name'     => 'jetpack/contact-form',
+				'status'         => 'skipped',
+				'reason'         => 'interleaved_context_unrepresentable',
+				'runtime_mapped' => false,
 			);
 		}
-		$submit_presentation      = isset( $form['form']['submit_presentation'] ) && is_array( $form['form']['submit_presentation'] ) ? $form['form']['submit_presentation'] : array();
+		$submit_presentation = isset( $form['form']['submit_presentation'] ) && is_array( $form['form']['submit_presentation'] ) ? $form['form']['submit_presentation'] : array();
 		if ( is_string( $submit_presentation['text'] ?? null ) && '' !== trim( $submit_presentation['text'] ) ) {
 			$submit_text = trim( $submit_presentation['text'] );
 		}
@@ -454,7 +459,11 @@ class Static_Site_Importer_Form_Seeder {
 		$layout_form['layout_graph'] = $provider_graph;
 		$layout                      = Static_Site_Importer_Computed_Layout_Strategy::apply( $layout_form, $inner_blocks );
 		if ( $textarea_height_omitted_count > 0 ) {
-			$control_attribute_losses[] = array( 'dimension' => 'control', 'reason_code' => 'textarea_height_omitted', 'omitted_count' => $textarea_height_omitted_count );
+			$control_attribute_losses[] = array(
+				'dimension'     => 'control',
+				'reason_code'   => 'textarea_height_omitted',
+				'omitted_count' => $textarea_height_omitted_count,
+			);
 		}
 		self::append_receipt_entries( $layout['receipt'], 'operations', $topology['operations'] );
 		self::append_receipt_entries( $layout['receipt'], 'losses', $control_attribute_losses );
@@ -759,7 +768,7 @@ class Static_Site_Importer_Form_Seeder {
 			}
 			if ( 'textarea' === $lookup ) {
 				$input_attrs['type'] = 'textarea';
-				$height = isset( $control['height'] ) && is_scalar( $control['height'] ) ? trim( (string) $control['height'] ) : '';
+				$height              = isset( $control['height'] ) && is_scalar( $control['height'] ) ? trim( (string) $control['height'] ) : '';
 				if ( '' !== $height && preg_match( '/^[0-9]{1,4}(?:\.[0-9]+)?(?:px|em|rem|vh|vw|%)$/D', $height ) ) {
 					$input_attrs['style']['dimensions']['minHeight'] = $height;
 				}

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -856,7 +856,7 @@ class Static_Site_Importer_Form_Seeder {
 
 	/** Serialize source context as editable core blocks beside the provider form. */
 	private static function context_block_markup( array $form ): string {
-		$context = isset( $form['form']['context_blocks'] ) && is_array( $form['form']['context_blocks'] ) ? $form['form']['context_blocks'] : array();
+		$context = isset( $form['form']['context_before'] ) && is_array( $form['form']['context_before'] ) ? $form['form']['context_before'] : array();
 		$markup  = '';
 		foreach ( $context as $block ) {
 			if ( ! is_array( $block ) || ! is_string( $block['text'] ?? null ) || '' === trim( $block['text'] ) ) {

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -835,6 +835,7 @@ class Static_Site_Importer_Form_Seeder {
 	private static function receipt_loss_requires_gate( array $loss ): bool {
 		return 'unsupported_control_unrepresentable' === ( $loss['reason_code'] ?? '' )
 			|| 'unsupported_control_attribute' === ( $loss['reason_code'] ?? '' )
+			|| 'textarea_height_omitted' === ( $loss['reason_code'] ?? '' )
 			|| in_array( $loss['dimension'] ?? '', array( 'semantic', 'topology' ), true )
 			|| in_array( $loss['reason_code'] ?? '', array( 'provider_structure_mismatch', 'direct_child_relationship_unrepresentable' ), true );
 	}

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -366,6 +366,10 @@ class Static_Site_Importer_Form_Seeder {
 		$control_attribute_losses = array();
 		$has_topology             = isset( $form['control_topology'] );
 		$has_source_submit        = false;
+		$submit_presentation      = isset( $form['form']['submit_presentation'] ) && is_array( $form['form']['submit_presentation'] ) ? $form['form']['submit_presentation'] : array();
+		if ( is_string( $submit_presentation['text'] ?? null ) && '' !== trim( $submit_presentation['text'] ) ) {
+			$submit_text = trim( $submit_presentation['text'] );
+		}
 
 		foreach ( $controls as $control_index => $control ) {
 			if ( ! is_array( $control ) ) {
@@ -380,7 +384,7 @@ class Static_Site_Importer_Form_Seeder {
 				$submit_text       = '' !== $text ? $text : $submit_text;
 				$has_source_submit = true;
 				if ( $has_topology ) {
-					$field_blocks[ $control_index ] = self::submit_button_block( $submit_text, self::layout_node_class( $scope, 'control-' . $control_index ) );
+					$field_blocks[ $control_index ] = self::submit_button_block( $submit_text, self::layout_node_class( $scope, 'control-' . $control_index ), $submit_presentation );
 				}
 				continue;
 			}
@@ -427,7 +431,7 @@ class Static_Site_Importer_Form_Seeder {
 		}
 		$inner_blocks = $topology['blocks'];
 		if ( ! $has_topology || ! $has_source_submit ) {
-			$inner_blocks[] = self::submit_button_block( $submit_text, self::layout_node_class( $scope, 'control-submit' ) );
+			$inner_blocks[] = self::submit_button_block( $submit_text, self::layout_node_class( $scope, 'control-submit' ), $submit_presentation );
 		}
 		$form['topology_losses'] = $topology['losses'];
 		$provider_graph          = is_array( $form['layout_graph'] ?? null ) ? $form['layout_graph'] : array(
@@ -457,7 +461,7 @@ class Static_Site_Importer_Form_Seeder {
 		self::append_receipt_entries( $layout['receipt'], 'operations', $overlay['operations'] );
 		self::append_receipt_entries( $layout['receipt'], 'losses', $overlay['losses'] );
 		$layout['receipt']['status'] = $layout['receipt']['operations_total'] > 0 ? 'applied' : ( $layout['receipt']['losses_total'] > 0 ? 'deferred' : 'skipped' );
-		$markup                      = self::serialize_block( 'jetpack/contact-form', $form_attrs, $inner_blocks );
+		$markup                      = self::context_block_markup( $form ) . self::serialize_block( 'jetpack/contact-form', $form_attrs, $inner_blocks );
 
 		return array(
 			'selector'                    => $selector,
@@ -687,7 +691,7 @@ class Static_Site_Importer_Form_Seeder {
 
 		$attrs = array();
 		$label = self::control_text( $control );
-		if ( ! empty( $control['required'] ) ) {
+		if ( ! empty( $control['required'] ) || 'true' === strtolower( trim( (string) ( $control['aria-required'] ?? $control['aria_required'] ?? '' ) ) ) ) {
 			$attrs['required'] = true;
 		}
 		$id = isset( $control['id'] ) && is_scalar( $control['id'] ) ? trim( (string) $control['id'] ) : '';
@@ -827,8 +831,9 @@ class Static_Site_Importer_Form_Seeder {
 	 * @param string $text Submit button label.
 	 * @return array<string, mixed>
 	 */
-	private static function submit_button_block( string $text, string $class_name = '' ): array {
-		$class_name = trim( 'form-button-submit is-submit ' . $class_name );
+	private static function submit_button_block( string $text, string $class_name = '', array $presentation = array() ): array {
+		$source_classes = isset( $presentation['classes'] ) && is_array( $presentation['classes'] ) ? implode( ' ', array_filter( $presentation['classes'], 'is_string' ) ) : '';
+		$class_name     = trim( 'form-button-submit is-submit ' . $source_classes . ' ' . $class_name );
 		return array(
 			'name'    => 'core/button',
 			'attrs'   => array(
@@ -843,6 +848,24 @@ class Static_Site_Importer_Form_Seeder {
 			'content' => '' !== trim( $text ) ? trim( $text ) : 'Submit',
 			'wrapper' => 'submit',
 		);
+	}
+
+	/** Serialize source context as editable core blocks beside the provider form. */
+	private static function context_block_markup( array $form ): string {
+		$context = isset( $form['form']['context_blocks'] ) && is_array( $form['form']['context_blocks'] ) ? $form['form']['context_blocks'] : array();
+		$markup  = '';
+		foreach ( $context as $block ) {
+			if ( ! is_array( $block ) || ! is_string( $block['text'] ?? null ) || '' === trim( $block['text'] ) ) {
+				continue;
+			}
+			if ( 'heading' === ( $block['type'] ?? null ) ) {
+				$level   = min( 6, max( 1, (int) ( $block['level'] ?? 2 ) ) );
+				$markup .= self::serialize_block( 'core/heading', 2 === $level ? array() : array( 'level' => $level ), array(), 'heading', $block['text'] );
+			} elseif ( 'paragraph' === ( $block['type'] ?? null ) ) {
+				$markup .= self::serialize_block( 'core/paragraph', array(), array(), 'paragraph', $block['text'] );
+			}
+		}
+		return $markup;
 	}
 
 	/**
@@ -971,7 +994,7 @@ class Static_Site_Importer_Form_Seeder {
 			}
 		}
 
-		if ( empty( $inner_blocks ) && 'submit' !== $wrapper ) {
+		if ( empty( $inner_blocks ) && ! in_array( $wrapper, array( 'submit', 'heading', 'paragraph' ), true ) ) {
 			return '<!-- wp:' . $comment_name . $attr_json . ' /-->';
 		}
 
@@ -999,6 +1022,11 @@ class Static_Site_Importer_Form_Seeder {
 		} elseif ( 'submit' === $wrapper ) {
 			$classes      = trim( 'wp-block-button ' . (string) ( $attrs['className'] ?? '' ) );
 			$inner_markup = '<div class="' . self::escape_attribute( $classes ) . '"><button type="submit" class="wp-block-button__link wp-element-button">' . htmlspecialchars( $content, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ) . '</button></div>';
+		} elseif ( 'heading' === $wrapper ) {
+			$level        = min( 6, max( 1, (int) ( $attrs['level'] ?? 2 ) ) );
+			$inner_markup = '<h' . $level . ' class="wp-block-heading">' . htmlspecialchars( $content, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ) . '</h' . $level . '>';
+		} elseif ( 'paragraph' === $wrapper ) {
+			$inner_markup = '<p>' . htmlspecialchars( $content, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ) . '</p>';
 		} elseif ( 'group' === $wrapper ) {
 			$classes = 'wp-block-group' . ( ! empty( $attrs['className'] ) ? ' ' . $attrs['className'] : '' );
 			if ( 'flex' === ( $attrs['layout']['type'] ?? '' ) ) {

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -749,6 +749,10 @@ class Static_Site_Importer_Form_Seeder {
 			}
 			if ( 'textarea' === $lookup ) {
 				$input_attrs['type'] = 'textarea';
+				$height = isset( $control['height'] ) && is_scalar( $control['height'] ) ? trim( (string) $control['height'] ) : '';
+				if ( '' !== $height && preg_match( '/^[0-9]{1,4}(?:\.[0-9]+)?(?:px|em|rem|vh|vw|%)$/D', $height ) ) {
+					$input_attrs['style']['dimensions']['minHeight'] = $height;
+				}
 			} elseif ( 'select' === $lookup ) {
 				$input_attrs['type'] = 'dropdown';
 			}

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -366,6 +366,7 @@ class Static_Site_Importer_Form_Seeder {
 		$control_attribute_losses = array();
 		$has_topology             = isset( $form['control_topology'] );
 		$has_source_submit        = false;
+		$textarea_height_omitted_count = (int) ( $form['form']['textarea_height_omitted_count'] ?? 0 );
 		if ( ! empty( $form['form']['interleaved_context'] ) ) {
 			return array(
 				'selector' => $selector, 'source_path' => $source_path, 'provider' => self::PROVIDER_ID,
@@ -452,6 +453,9 @@ class Static_Site_Importer_Form_Seeder {
 		$layout_form                 = $form;
 		$layout_form['layout_graph'] = $provider_graph;
 		$layout                      = Static_Site_Importer_Computed_Layout_Strategy::apply( $layout_form, $inner_blocks );
+		if ( $textarea_height_omitted_count > 0 ) {
+			$control_attribute_losses[] = array( 'dimension' => 'control', 'reason_code' => 'textarea_height_omitted', 'omitted_count' => $textarea_height_omitted_count );
+		}
 		self::append_receipt_entries( $layout['receipt'], 'operations', $topology['operations'] );
 		self::append_receipt_entries( $layout['receipt'], 'losses', $control_attribute_losses );
 		$inner_blocks                 = $layout['blocks'];

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -366,6 +366,12 @@ class Static_Site_Importer_Form_Seeder {
 		$control_attribute_losses = array();
 		$has_topology             = isset( $form['control_topology'] );
 		$has_source_submit        = false;
+		if ( ! empty( $form['form']['interleaved_context'] ) ) {
+			return array(
+				'selector' => $selector, 'source_path' => $source_path, 'provider' => self::PROVIDER_ID,
+				'block_name' => 'jetpack/contact-form', 'status' => 'skipped', 'reason' => 'interleaved_context_unrepresentable', 'runtime_mapped' => false,
+			);
+		}
 		$submit_presentation      = isset( $form['form']['submit_presentation'] ) && is_array( $form['form']['submit_presentation'] ) ? $form['form']['submit_presentation'] : array();
 		if ( is_string( $submit_presentation['text'] ?? null ) && '' !== trim( $submit_presentation['text'] ) ) {
 			$submit_text = trim( $submit_presentation['text'] );
@@ -461,7 +467,7 @@ class Static_Site_Importer_Form_Seeder {
 		self::append_receipt_entries( $layout['receipt'], 'operations', $overlay['operations'] );
 		self::append_receipt_entries( $layout['receipt'], 'losses', $overlay['losses'] );
 		$layout['receipt']['status'] = $layout['receipt']['operations_total'] > 0 ? 'applied' : ( $layout['receipt']['losses_total'] > 0 ? 'deferred' : 'skipped' );
-		$markup                      = self::context_block_markup( $form ) . self::serialize_block( 'jetpack/contact-form', $form_attrs, $inner_blocks );
+		$markup                      = self::context_block_markup( $form, 'context_before' ) . self::serialize_block( 'jetpack/contact-form', $form_attrs, $inner_blocks ) . self::context_block_markup( $form, 'context_after' );
 
 		return array(
 			'selector'                    => $selector,
@@ -855,8 +861,8 @@ class Static_Site_Importer_Form_Seeder {
 	}
 
 	/** Serialize source context as editable core blocks beside the provider form. */
-	private static function context_block_markup( array $form ): string {
-		$context = isset( $form['form']['context_before'] ) && is_array( $form['form']['context_before'] ) ? $form['form']['context_before'] : array();
+	private static function context_block_markup( array $form, string $position ): string {
+		$context = isset( $form['form'][ $position ] ) && is_array( $form['form'][ $position ] ) ? $form['form'][ $position ] : array();
 		$markup  = '';
 		foreach ( $context as $block ) {
 			if ( ! is_array( $block ) || ! is_string( $block['text'] ?? null ) || '' === trim( $block['text'] ) ) {

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -250,7 +250,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			$manifest                   = self::form_manifest_from_html( $element_html );
 			$entry['form']              = $manifest['form'];
 			$entry['controls']          = $manifest['controls'];
-			$entry['form_presentation'] = self::form_presentation_from_html( $element_html, $selector );
+			$entry['form_presentation'] = self::form_presentation_from_html( $element_html, $selector, (int) ( $context['occurrence'] ?? 0 ) );
 		}
 
 		return $entry;
@@ -1364,7 +1364,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 *
 	 * @return array<string,mixed>
 	 */
-	public static function form_presentation_from_html( string $html, string $selector = '' ): array {
+	public static function form_presentation_from_html( string $html, string $selector = '', int $occurrence = 0 ): array {
 		$manifest = self::form_manifest_from_html( $html );
 		$form     = self::preserved_form_presentation( $html, $manifest['form'], $manifest['controls'] );
 		$doc      = new DOMDocument();
@@ -1405,16 +1405,29 @@ class Static_Site_Importer_Report_Diagnostics {
 				$heights[ $index ] = $control['height'];
 			}
 		}
+		$fingerprint = array(
+			'class' => $manifest['form']['class'] ?? '', 'action' => $manifest['form']['action'] ?? '', 'method' => $manifest['form']['method'] ?? '',
+			'controls' => array_map( static fn ( array $control ): array => array_intersect_key( $control, array_flip( array( 'tag', 'type', 'name', 'id', 'label' ) ) ), $manifest['controls'] ),
+			'submit_text' => $form['submit_presentation']['text'] ?? '',
+			'context_before_hash' => hash( 'sha256', wp_json_encode( $before ) ), 'context_after_hash' => hash( 'sha256', wp_json_encode( $after ) ),
+		);
+		$stored_heights = array_slice( $heights, 0, 16, true );
 		return array_filter( array(
 			'schema' => 'generic/form-presentation/v1',
 			'selector' => $selector,
-			'fingerprint' => hash( 'sha256', wp_json_encode( array( 'action' => $manifest['form']['action'] ?? '', 'controls' => array_map( static fn ( array $control ): array => array_intersect_key( $control, array_flip( array( 'tag', 'type', 'name', 'id' ) ) ), $manifest['controls'] ) ) ) ),
+			'occurrence' => $occurrence > 0 ? $occurrence : self::form_selector_occurrence( $selector ),
+			'fingerprint' => hash( 'sha256', wp_json_encode( $fingerprint ) ),
 			'context_before' => array_slice( $before, 0, 8 ),
 			'context_after' => array_slice( $after, 0, 8 ),
 			'interleaved_context' => $interleaved,
 			'submit_presentation' => $form['submit_presentation'] ?? null,
-			'textarea_heights' => $heights,
+			'textarea_heights' => $stored_heights,
+			'textarea_height_omitted_count' => max( 0, count( $heights ) - count( $stored_heights ) ),
 		) );
+	}
+
+	private static function form_selector_occurrence( string $selector ): int {
+		return preg_match( '/:nth-of-type\((\d+)\)/', $selector, $match ) ? max( 1, (int) $match[1] ) : 0;
 	}
 
 	/** Apply structured presentation facts without retaining source HTML. */
@@ -1429,6 +1442,9 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 		if ( ! empty( $presentation['interleaved_context'] ) ) {
 			$form['interleaved_context'] = true;
+		}
+		if ( ! empty( $presentation['textarea_height_omitted_count'] ) ) {
+			$form['textarea_height_omitted_count'] = (int) $presentation['textarea_height_omitted_count'];
 		}
 		foreach ( $presentation['textarea_heights'] ?? array() as $index => $height ) {
 			if ( isset( $controls[ $index ] ) && is_string( $height ) ) {
@@ -1942,10 +1958,15 @@ class Static_Site_Importer_Report_Diagnostics {
 	private static function graft_form_block_into_core_html_fallback( array $finding, string $block_markup, string $source_path, array &$page_contents ): array {
 		foreach ( self::form_fallback_page_content_keys_for_source( $source_path, $page_contents ) as $key ) {
 			$content = (string) ( $page_contents[ $key ] ?? '' );
-			foreach ( self::serialized_core_html_blocks( $content ) as $block ) {
-				if ( ! self::core_html_form_matches_finding( $block['html'], $finding ) ) {
-					continue;
-				}
+			$matches = array_values( array_filter( self::serialized_core_html_blocks( $content ), static fn ( array $block ): bool => self::core_html_form_matches_finding( $block['html'], $finding ) ) );
+			if ( empty( $matches ) ) {
+				continue;
+			}
+			$occurrence = (int) ( $finding['form_presentation']['occurrence'] ?? 0 );
+			if ( count( $matches ) > 1 && ( $occurrence < 1 || $occurrence > count( $matches ) ) ) {
+				continue;
+			}
+			foreach ( array( count( $matches ) > 1 ? $matches[ $occurrence - 1 ] : $matches[0] ) as $block ) {
 
 				$position = strpos( $content, $block['serialized'] );
 				if ( false === $position ) {

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1415,7 +1415,9 @@ class Static_Site_Importer_Report_Diagnostics {
 		return array_filter( array(
 			'schema' => 'generic/form-presentation/v1',
 			'selector' => $selector,
-			'occurrence' => $occurrence > 0 ? $occurrence : self::form_selector_occurrence( $selector ),
+			// The transformer supplies the form's document-wide position. A selector's
+			// nth-of-type position is scoped to siblings and cannot safely identify it.
+			'document_ordinal' => $occurrence > 0 ? $occurrence : null,
 			'fingerprint' => hash( 'sha256', wp_json_encode( $fingerprint ) ),
 			'context_before' => array_slice( $before, 0, 8 ),
 			'context_after' => array_slice( $after, 0, 8 ),
@@ -1424,10 +1426,6 @@ class Static_Site_Importer_Report_Diagnostics {
 			'textarea_heights' => $stored_heights,
 			'textarea_height_omitted_count' => max( 0, count( $heights ) - count( $stored_heights ) ),
 		) );
-	}
-
-	private static function form_selector_occurrence( string $selector ): int {
-		return preg_match( '/:nth-of-type\((\d+)\)/', $selector, $match ) ? max( 1, (int) $match[1] ) : 0;
 	}
 
 	/** Apply structured presentation facts without retaining source HTML. */
@@ -1459,21 +1457,59 @@ class Static_Site_Importer_Report_Diagnostics {
 		$presentation = is_array( $diagnostic['form_presentation'] ?? null ) ? $diagnostic['form_presentation'] : array();
 		$source_path  = self::first_scalar( $diagnostic, array( 'graft_source_path', 'source_path', 'source' ) );
 		foreach ( self::form_fallback_page_content_keys_for_source( $source_path, $page_contents ) as $key ) {
-			foreach ( self::serialized_core_html_blocks( (string) ( $page_contents[ $key ] ?? '' ) ) as $block ) {
-				if ( self::form_presentation_matches_html( $presentation, $block['html'] ) ) {
-					return self::form_manifest_from_html( $block['html'] );
-				}
+			$block = self::matching_core_html_form_block( $presentation, (string) ( $page_contents[ $key ] ?? '' ) );
+			if ( null !== $block ) {
+				return self::form_manifest_from_html( $block['html'] );
 			}
 		}
 		return array( 'form' => array(), 'controls' => array() );
 	}
 
-	private static function form_presentation_matches_html( array $presentation, string $html ): bool {
+	/**
+	 * Select a generated core/html form using a fingerprint and document-wide ordinal.
+	 *
+	 * @return array{serialized:string,html:string,document_ordinal:int}|null
+	 */
+	private static function matching_core_html_form_block( array $presentation, string $content ): ?array {
 		if ( ! is_string( $presentation['fingerprint'] ?? null ) ) {
-			return false;
+			return null;
 		}
-		$candidate = self::form_presentation_from_html( $html, (string) ( $presentation['selector'] ?? '' ) );
-		return hash_equals( $presentation['fingerprint'], (string) ( $candidate['fingerprint'] ?? '' ) );
+
+		$matches          = array();
+		$document_ordinal = 0;
+		foreach ( self::serialized_core_html_blocks( $content ) as $block ) {
+			$form_count = self::form_count_from_html( $block['html'] );
+			if ( 1 !== $form_count ) {
+				$document_ordinal += $form_count;
+				continue;
+			}
+			++$document_ordinal;
+			$candidate = self::form_presentation_from_html( $block['html'] );
+			if ( hash_equals( $presentation['fingerprint'], (string) ( $candidate['fingerprint'] ?? '' ) ) ) {
+				$block['document_ordinal'] = $document_ordinal;
+				$matches[]                  = $block;
+			}
+		}
+
+		if ( 1 === count( $matches ) ) {
+			return $matches[0];
+		}
+
+		$source_ordinal = (int) ( $presentation['document_ordinal'] ?? 0 );
+		if ( $source_ordinal < 1 ) {
+			return null;
+		}
+		$ordinal_matches = array_values( array_filter( $matches, static fn ( array $block ): bool => $source_ordinal === $block['document_ordinal'] ) );
+		return 1 === count( $ordinal_matches ) ? $ordinal_matches[0] : null;
+	}
+
+	private static function form_count_from_html( string $html ): int {
+		$doc      = new DOMDocument();
+		$previous = libxml_use_internal_errors( true );
+		$doc->loadHTML( '<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+		return $doc->getElementsByTagName( 'form' )->length;
 	}
 
 	private static function is_submit_control_node( DOMElement $node ): bool {
@@ -1829,6 +1865,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	private static function form_receipt_loss_requires_gate( array $loss ): bool {
 		return 'unsupported_control_unrepresentable' === ( $loss['reason_code'] ?? '' )
 			|| 'unsupported_control_attribute' === ( $loss['reason_code'] ?? '' )
+			|| 'textarea_height_omitted' === ( $loss['reason_code'] ?? '' )
 			|| in_array( $loss['dimension'] ?? '', array( 'semantic', 'topology' ), true )
 			|| in_array( $loss['reason_code'] ?? '', array( 'provider_structure_mismatch', 'direct_child_relationship_unrepresentable' ), true );
 	}
@@ -1958,32 +1995,26 @@ class Static_Site_Importer_Report_Diagnostics {
 	private static function graft_form_block_into_core_html_fallback( array $finding, string $block_markup, string $source_path, array &$page_contents ): array {
 		foreach ( self::form_fallback_page_content_keys_for_source( $source_path, $page_contents ) as $key ) {
 			$content = (string) ( $page_contents[ $key ] ?? '' );
-			$matches = array_values( array_filter( self::serialized_core_html_blocks( $content ), static fn ( array $block ): bool => self::core_html_form_matches_finding( $block['html'], $finding ) ) );
-			if ( empty( $matches ) ) {
+			$block   = self::matching_core_html_form_block( is_array( $finding['form_presentation'] ?? null ) ? $finding['form_presentation'] : array(), $content );
+			if ( null === $block ) {
 				continue;
 			}
-			$occurrence = (int) ( $finding['form_presentation']['occurrence'] ?? 0 );
-			if ( count( $matches ) > 1 && ( $occurrence < 1 || $occurrence > count( $matches ) ) ) {
+
+			$position = strpos( $content, $block['serialized'] );
+			if ( false === $position ) {
 				continue;
 			}
-			foreach ( array( count( $matches ) > 1 ? $matches[ $occurrence - 1 ] : $matches[0] ) as $block ) {
 
-				$position = strpos( $content, $block['serialized'] );
-				if ( false === $position ) {
-					continue;
-				}
+			$page_contents[ $key ]               = substr( $content, 0, $position ) . $block_markup . substr( $content, $position + strlen( $block['serialized'] ) );
+			$finding['content_grafted']          = true;
+			$finding['grafted_post_content_key'] = $key;
+			$finding['graft_anchor']             = 'core_html_form_block';
 
-				$page_contents[ $key ]               = substr( $content, 0, $position ) . $block_markup . substr( $content, $position + strlen( $block['serialized'] ) );
-				$finding['content_grafted']          = true;
-				$finding['grafted_post_content_key'] = $key;
-				$finding['graft_anchor']             = 'core_html_form_block';
-
-				return array(
-					'grafted'    => true,
-					'finding'    => $finding,
-					'diagnostic' => null,
-				);
-			}
+			return array(
+				'grafted'    => true,
+				'finding'    => $finding,
+				'diagnostic' => null,
+			);
 		}
 
 		$finding['content_grafted'] = false;
@@ -2048,44 +2079,6 @@ class Static_Site_Importer_Report_Diagnostics {
 		return $blocks;
 	}
 
-	/**
-	 * Determine whether a decoded core/html form payload matches a form finding.
-	 *
-	 * @param string              $html    Decoded core/html payload.
-	 * @param array<string,mixed> $finding Form finding.
-	 * @return bool
-	 */
-	private static function core_html_form_matches_finding( string $html, array $finding ): bool {
-		if ( ! str_contains( strtolower( $html ), '<form' ) ) {
-			return false;
-		}
-		if ( is_array( $finding['form_presentation'] ?? null ) ) {
-			return self::form_presentation_matches_html( $finding['form_presentation'], $html );
-		}
-
-		$form = isset( $finding['form'] ) && is_array( $finding['form'] ) ? $finding['form'] : array();
-		foreach ( array( 'class', 'action', 'method' ) as $field ) {
-			$value = isset( $form[ $field ] ) && is_scalar( $form[ $field ] ) ? trim( (string) $form[ $field ] ) : '';
-			if ( '' !== $value && ! str_contains( $html, $value ) ) {
-				return false;
-			}
-		}
-
-		$controls = isset( $finding['controls'] ) && is_array( $finding['controls'] ) ? $finding['controls'] : array();
-		foreach ( $controls as $control ) {
-			if ( ! is_array( $control ) ) {
-				continue;
-			}
-			foreach ( array( 'id', 'name' ) as $field ) {
-				$value = isset( $control[ $field ] ) && is_scalar( $control[ $field ] ) ? trim( (string) $control[ $field ] ) : '';
-				if ( '' !== $value && ! str_contains( $html, $value ) ) {
-					return false;
-				}
-			}
-		}
-
-		return true;
-	}
 
 	/**
 	 * Resolve the page content key that owns a form finding's fallback region.

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1469,6 +1469,60 @@ class Static_Site_Importer_Report_Diagnostics {
 		);
 	}
 
+	/** Apply bounded presentation from canonical form bindings before provider validation. */
+	public static function apply_form_binding_presentation( array $entity ): array {
+		$presentations  = array();
+		$control_shape = self::ordered_form_control_identity( isset( $entity['controls'] ) && is_array( $entity['controls'] ) ? $entity['controls'] : array() );
+		$bindings      = isset( $entity['bindings'] ) && is_array( $entity['bindings'] ) ? $entity['bindings'] : array();
+		foreach ( $bindings as $binding ) {
+			if ( ! is_array( $binding ) || 'generic/block-binding/v1' !== ( $binding['schema'] ?? null ) || 'form' !== ( $binding['role'] ?? null ) || ! is_int( $binding['occurrence'] ?? null ) || $binding['occurrence'] < 1 || ! is_string( $binding['source_path'] ?? null ) || ! is_string( $binding['search_block_markup'] ?? null ) || '' === trim( $binding['search_block_markup'] ) || strlen( $binding['search_block_markup'] ) > 262144 ) {
+				continue;
+			}
+			$manifest = self::form_manifest_from_html( $binding['search_block_markup'] );
+			if ( $control_shape !== self::ordered_form_control_identity( $manifest['controls'] ) ) {
+				return $entity;
+			}
+			$presentation = self::form_presentation_from_html(
+				$binding['search_block_markup'],
+				is_string( $entity['selector'] ?? null ) ? $entity['selector'] : '',
+				$binding['occurrence']
+			);
+			if ( 'generic/form-presentation/v1' === ( $presentation['schema'] ?? null ) ) {
+				$presentations[] = $presentation;
+			}
+		}
+		$presentation_keys = array_map(
+			static fn( array $presentation ): string => hash( 'sha256', (string) wp_json_encode( array_intersect_key( $presentation, array_flip( array( 'context_before', 'context_after', 'interleaved_context', 'submit_presentation', 'textarea_heights', 'textarea_height_omitted_count' ) ) ) ) ),
+			$presentations
+		);
+		if ( empty( $presentations ) || 1 !== count( array_unique( $presentation_keys ) ) ) {
+			return $entity;
+		}
+
+		$controls           = isset( $entity['controls'] ) && is_array( $entity['controls'] ) ? $entity['controls'] : array();
+		$form               = isset( $entity['form'] ) && is_array( $entity['form'] ) ? $entity['form'] : array();
+		$entity['form']     = self::apply_form_presentation( $presentations[0], $form, $controls );
+		$entity['controls'] = $controls;
+		return $entity;
+	}
+
+	/** @param array<int,mixed> $controls @return array<int,string> */
+	private static function ordered_form_control_identity( array $controls ): array {
+		return array_map(
+			static function ( $control ): string {
+				if ( ! is_array( $control ) ) {
+					return '';
+				}
+				$identity = array_map( static fn( string $key ): string => isset( $control[ $key ] ) && is_scalar( $control[ $key ] ) ? strtolower( trim( (string) $control[ $key ] ) ) : '', array( 'tag', 'type', 'name', 'id' ) );
+				if ( '' === $identity[1] && in_array( $identity[0], array( 'select', 'textarea' ), true ) ) {
+					$identity[1] = $identity[0];
+				}
+				return hash( 'sha256', implode( ':', $identity ) );
+			},
+			array_values( $controls )
+		);
+	}
+
 	/** Apply structured presentation facts without retaining source HTML. */
 	private static function apply_form_presentation( array $presentation, array $form, array &$controls ): array {
 		if ( 'generic/form-presentation/v1' !== ( $presentation['schema'] ?? null ) ) {

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1161,7 +1161,6 @@ class Static_Site_Importer_Report_Diagnostics {
 			$diagnostic = $report['diagnostics'][ $index ];
 			$controls   = isset( $diagnostic['controls'] ) && is_array( $diagnostic['controls'] ) ? $diagnostic['controls'] : array();
 			$form       = isset( $diagnostic['form'] ) && is_array( $diagnostic['form'] ) ? $diagnostic['form'] : array();
-			$form       = self::preserved_form_presentation( $diagnostic, $form );
 			if ( empty( $controls ) && self::is_generated_core_html_form_diagnostic( $diagnostic ) ) {
 				$extracted                                   = self::extract_form_manifest_from_diagnostic( $diagnostic );
 				$controls                                    = $extracted['controls'];
@@ -1169,6 +1168,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				$report['diagnostics'][ $index ]['controls'] = $controls;
 				$report['diagnostics'][ $index ]['form']     = $form;
 			}
+			$form = self::preserved_form_presentation( $diagnostic, $form, $controls );
 			$manifest_forms[] = array(
 				'selector'    => isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '',
 				'source_path' => isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : ( isset( $diagnostic['source'] ) && is_scalar( $diagnostic['source'] ) ? (string) $diagnostic['source'] : '' ),
@@ -1270,9 +1270,10 @@ class Static_Site_Importer_Report_Diagnostics {
 	 *
 	 * @param array<string,mixed> $diagnostic Form fallback finding.
 	 * @param array<string,mixed> $form       Extracted form metadata.
+	 * @param array<int,array<string,mixed>> $controls Extracted controls, enriched in place.
 	 * @return array<string,mixed>
 	 */
-	private static function preserved_form_presentation( array $diagnostic, array $form ): array {
+	private static function preserved_form_presentation( array $diagnostic, array $form, array &$controls ): array {
 		$html = isset( $diagnostic['html'] ) && is_string( $diagnostic['html'] ) ? $diagnostic['html'] : ( isset( $diagnostic['source_html_preview'] ) && is_string( $diagnostic['source_html_preview'] ) ? $diagnostic['source_html_preview'] : '' );
 		if ( '' === $html ) {
 			return $form;
@@ -1300,6 +1301,15 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 		if ( ! empty( $context ) ) {
 			$form['context_blocks'] = $context;
+		}
+		if ( preg_match_all( '/<textarea\b([^>]*)>/is', $html, $textareas, PREG_SET_ORDER ) ) {
+			$textarea_indexes = array_keys( array_filter( $controls, static fn ( array $control ): bool => 'textarea' === strtolower( (string) ( $control['tag'] ?? '' ) ) ) );
+			foreach ( $textareas as $index => $textarea ) {
+				if ( ! isset( $textarea_indexes[ $index ] ) || ! preg_match( '/\bstyle\s*=\s*(["\'])(.*?)\1/is', $textarea[1], $style ) || ! preg_match( '/(?:^|;)\s*height\s*:\s*([0-9]{1,4}(?:\.[0-9]+)?(?:px|em|rem|vh|vw|%))\s*(?:;|$)/i', $style[2], $height ) ) {
+					continue;
+				}
+				$controls[ $textarea_indexes[ $index ] ]['height'] = $height[1];
+			}
 		}
 
 		if ( preg_match_all( '/<(?:a|button)\b([^>]*)>(.*?)<\/(?:a|button)>/is', $html, $buttons, PREG_SET_ORDER ) ) {

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1174,7 +1174,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				$report['diagnostics'][ $index ]['controls'] = $controls;
 				$report['diagnostics'][ $index ]['form']     = $form;
 			}
-			$form = self::apply_form_presentation( is_array( $diagnostic['form_presentation'] ?? null ) ? $diagnostic['form_presentation'] : array(), $form, $controls );
+			$form             = self::apply_form_presentation( is_array( $diagnostic['form_presentation'] ?? null ) ? $diagnostic['form_presentation'] : array(), $form, $controls );
 			$manifest_forms[] = array(
 				'selector'    => isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '',
 				'source_path' => isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : ( isset( $diagnostic['source'] ) && is_scalar( $diagnostic['source'] ) ? (string) $diagnostic['source'] : '' ),
@@ -1215,8 +1215,8 @@ class Static_Site_Importer_Report_Diagnostics {
 			$seeding['validation_errors'] = $validation['errors'];
 		}
 
-		$pending = $indexes;
-		$rows    = isset( $seeding['forms'] ) && is_array( $seeding['forms'] ) ? $seeding['forms'] : array();
+		$pending        = $indexes;
+		$rows           = isset( $seeding['forms'] ) && is_array( $seeding['forms'] ) ? $seeding['forms'] : array();
 		$graft_requests = array();
 		foreach ( $rows as $row ) {
 			if ( ! is_array( $row ) ) {
@@ -1232,9 +1232,13 @@ class Static_Site_Importer_Report_Diagnostics {
 			if ( empty( $row['runtime_mapped'] ) ) {
 				if ( 'interleaved_context_unrepresentable' === ( $row['reason'] ?? '' ) ) {
 					$report['diagnostics'][] = array(
-						'type' => 'form_context_unrepresentable', 'diagnostic_code' => 'form_context_interleaved', 'reason' => 'interleaved_context_unrepresentable',
-						'source_path' => $source_path, 'selector' => $selector, 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
-						'message' => 'Form context occurs between controls and was left in the original fallback to avoid semantic reordering.',
+						'type'            => 'form_context_unrepresentable',
+						'diagnostic_code' => 'form_context_interleaved',
+						'reason'          => 'interleaved_context_unrepresentable',
+						'source_path'     => $source_path,
+						'selector'        => $selector,
+						'loss_class'      => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+						'message'         => 'Form context occurs between controls and was left in the original fallback to avoid semantic reordering.',
 					);
 				}
 				$pending = array_values( array_diff( $pending, array( $index ) ) );
@@ -1303,8 +1307,8 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * replaced, so retain headings, standalone notes, and a visible submit treatment
 	 * before the provider block is serialized.
 	 *
-	 * @param string              $html       Complete internal fallback HTML.
-	 * @param array<string,mixed> $form       Extracted form metadata.
+	 * @param string                         $html       Complete internal fallback HTML.
+	 * @param array<string,mixed>            $form       Extracted form metadata.
 	 * @param array<int,array<string,mixed>> $controls Extracted controls, enriched in place.
 	 * @return array<string,mixed>
 	 */
@@ -1332,9 +1336,16 @@ class Static_Site_Importer_Report_Diagnostics {
 			}
 			$text = self::form_presentation_text( $node->textContent );
 			if ( preg_match( '/^h[1-6]$/', $tag ) && '' !== $text ) {
-				$context[] = array( 'type' => 'heading', 'level' => (int) substr( $tag, 1 ), 'text' => $text );
+				$context[] = array(
+					'type'  => 'heading',
+					'level' => (int) substr( $tag, 1 ),
+					'text'  => $text,
+				);
 			} elseif ( 'label' === $tag && preg_match( '/(?:required|note|instruction|help)/i', $node->getAttribute( 'class' ) ) && '' !== $text ) {
-				$context[] = array( 'type' => 'paragraph', 'text' => $text );
+				$context[] = array(
+					'type' => 'paragraph',
+					'text' => $text,
+				);
 			}
 		}
 		if ( ! empty( $context ) ) {
@@ -1363,11 +1374,11 @@ class Static_Site_Importer_Report_Diagnostics {
 			$visible_node = self::next_element_sibling( $node );
 			if ( self::submit_control_is_visually_hidden( $node ) && $visible_node instanceof DOMElement && in_array( strtolower( $visible_node->nodeName ), array( 'a', 'button' ), true ) ) {
 				$visible = self::submit_presentation_from_node( $visible_node );
-				if ( '' !== (string) ( $visible['text'] ?? '' ) && (string) ( $visible['text'] ?? '' ) === (string) ( $presentation['text'] ?? '' ) ) {
+				if ( '' !== $visible['text'] && $visible['text'] === $presentation['text'] ) {
 					$presentation = $visible;
 				}
 			}
-			if ( '' !== (string) ( $presentation['text'] ?? '' ) ) {
+			if ( '' !== $presentation['text'] ) {
 				$form['submit_presentation'] = $presentation;
 			}
 			break;
@@ -1390,11 +1401,11 @@ class Static_Site_Importer_Report_Diagnostics {
 		$doc->loadHTML( '<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 		libxml_clear_errors();
 		libxml_use_internal_errors( $previous );
-		$form_node = $doc->getElementsByTagName( 'form' )->item( 0 );
-		$before    = array();
-		$after     = array();
-		$interleaved = false;
-		$seen_controls = 0;
+		$form_node      = $doc->getElementsByTagName( 'form' )->item( 0 );
+		$before         = array();
+		$after          = array();
+		$interleaved    = false;
+		$seen_controls  = 0;
 		$total_controls = count( $manifest['controls'] );
 		if ( $form_node instanceof DOMElement ) {
 			foreach ( $form_node->getElementsByTagName( '*' ) as $node ) {
@@ -1404,7 +1415,14 @@ class Static_Site_Importer_Report_Diagnostics {
 					continue;
 				}
 				$text = self::form_presentation_text( $node->textContent );
-				$item = preg_match( '/^h[1-6]$/', $tag ) && '' !== $text ? array( 'type' => 'heading', 'level' => (int) substr( $tag, 1 ), 'text' => $text ) : ( in_array( $tag, array( 'label', 'p' ), true ) && preg_match( '/(?:required|note|instruction|help)/i', $node->getAttribute( 'class' ) ) && '' !== $text ? array( 'type' => 'paragraph', 'text' => $text ) : null );
+				$item = preg_match( '/^h[1-6]$/', $tag ) && '' !== $text ? array(
+					'type'  => 'heading',
+					'level' => (int) substr( $tag, 1 ),
+					'text'  => $text,
+				) : ( in_array( $tag, array( 'label', 'p' ), true ) && preg_match( '/(?:required|note|instruction|help)/i', $node->getAttribute( 'class' ) ) && '' !== $text ? array(
+					'type' => 'paragraph',
+					'text' => $text,
+				) : null );
 				if ( ! is_array( $item ) ) {
 					continue;
 				}
@@ -1423,27 +1441,32 @@ class Static_Site_Importer_Report_Diagnostics {
 				$heights[ $index ] = $control['height'];
 			}
 		}
-		$fingerprint = array(
-			'class' => $manifest['form']['class'] ?? '', 'action' => $manifest['form']['action'] ?? '', 'method' => $manifest['form']['method'] ?? '',
-			'controls' => array_map( static fn ( array $control ): array => array_intersect_key( $control, array_flip( array( 'tag', 'type', 'name', 'id', 'label' ) ) ), $manifest['controls'] ),
-			'submit_text' => $form['submit_presentation']['text'] ?? '',
-			'context_before_hash' => hash( 'sha256', wp_json_encode( $before ) ), 'context_after_hash' => hash( 'sha256', wp_json_encode( $after ) ),
+		$fingerprint    = array(
+			'class'               => $manifest['form']['class'] ?? '',
+			'action'              => $manifest['form']['action'] ?? '',
+			'method'              => $manifest['form']['method'] ?? '',
+			'controls'            => array_map( static fn ( array $control ): array => array_intersect_key( $control, array_flip( array( 'tag', 'type', 'name', 'id', 'label' ) ) ), $manifest['controls'] ),
+			'submit_text'         => $form['submit_presentation']['text'] ?? '',
+			'context_before_hash' => hash( 'sha256', (string) wp_json_encode( $before ) ),
+			'context_after_hash'  => hash( 'sha256', (string) wp_json_encode( $after ) ),
 		);
 		$stored_heights = array_slice( $heights, 0, 16, true );
-		return array_filter( array(
-			'schema' => 'generic/form-presentation/v1',
-			'selector' => $selector,
-			// The transformer supplies the form's document-wide position. A selector's
-			// nth-of-type position is scoped to siblings and cannot safely identify it.
-			'document_ordinal' => $occurrence > 0 ? $occurrence : null,
-			'fingerprint' => hash( 'sha256', wp_json_encode( $fingerprint ) ),
-			'context_before' => array_slice( $before, 0, 8 ),
-			'context_after' => array_slice( $after, 0, 8 ),
-			'interleaved_context' => $interleaved,
-			'submit_presentation' => $form['submit_presentation'] ?? null,
-			'textarea_heights' => $stored_heights,
-			'textarea_height_omitted_count' => max( 0, count( $heights ) - count( $stored_heights ) ),
-		) );
+		return array_filter(
+			array(
+				'schema'                        => 'generic/form-presentation/v1',
+				'selector'                      => $selector,
+				// The transformer supplies the form's document-wide position. A selector's
+				// nth-of-type position is scoped to siblings and cannot safely identify it.
+				'document_ordinal'              => $occurrence > 0 ? $occurrence : null,
+				'fingerprint'                   => hash( 'sha256', (string) wp_json_encode( $fingerprint ) ),
+				'context_before'                => array_slice( $before, 0, 8 ),
+				'context_after'                 => array_slice( $after, 0, 8 ),
+				'interleaved_context'           => $interleaved,
+				'submit_presentation'           => $form['submit_presentation'] ?? null,
+				'textarea_heights'              => $stored_heights,
+				'textarea_height_omitted_count' => max( 0, count( $heights ) - count( $stored_heights ) ),
+			)
+		);
 	}
 
 	/** Apply structured presentation facts without retaining source HTML. */
@@ -1480,7 +1503,10 @@ class Static_Site_Importer_Report_Diagnostics {
 				return self::form_manifest_from_html( $block['html'] );
 			}
 		}
-		return array( 'form' => array(), 'controls' => array() );
+		return array(
+			'form'     => array(),
+			'controls' => array(),
+		);
 	}
 
 	/**
@@ -1505,7 +1531,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			$candidate = self::form_presentation_from_html( $block['html'] );
 			if ( hash_equals( $presentation['fingerprint'], (string) ( $candidate['fingerprint'] ?? '' ) ) ) {
 				$block['document_ordinal'] = $document_ordinal;
-				$matches[]                  = $block;
+				$matches[]                 = $block;
 			}
 		}
 
@@ -1539,7 +1565,10 @@ class Static_Site_Importer_Report_Diagnostics {
 	/** @return array{text:string,classes:array<int,string>} */
 	private static function submit_presentation_from_node( DOMElement $node ): array {
 		$text = 'input' === strtolower( $node->nodeName ) ? trim( $node->getAttribute( 'value' ) ) : self::form_presentation_text( $node->textContent );
-		return array( 'text' => $text, 'classes' => self::form_presentation_classes( 'class="' . $node->getAttribute( 'class' ) . '"' ) );
+		return array(
+			'text'    => $text,
+			'classes' => self::form_presentation_classes( 'class="' . $node->getAttribute( 'class' ) . '"' ),
+		);
 	}
 
 	private static function submit_control_is_visually_hidden( DOMElement $node ): bool {
@@ -1561,13 +1590,13 @@ class Static_Site_Importer_Report_Diagnostics {
 			return array();
 		}
 		$classes = preg_split( '/\s+/', trim( $match[2] ) );
-		return array_values( array_slice( array_filter( $classes ?: array(), static fn ( string $class ): bool => (bool) preg_match( '/^[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $class ) ), 0, 8 ) );
+		return array_slice( array_filter( is_array( $classes ) ? $classes : array(), static fn ( string $class_name ): bool => (bool) preg_match( '/^[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $class_name ) ), 0, 8 );
 	}
 
 	private static function form_presentation_text( string $html ): string {
 		$plain = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $html ) : strip_tags( $html ); // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- Fallback only for runtime-free smoke tests.
-		$text  = trim( preg_replace( '/\s+/', ' ', $plain ) ?: '' );
-		return substr( $text, 0, 200 );
+		$normalized = preg_replace( '/\s+/', ' ', $plain );
+		return substr( trim( is_string( $normalized ) ? $normalized : '' ), 0, 200 );
 	}
 
 	/**
@@ -1678,17 +1707,6 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 		sort( $identity );
 		return $identity;
-	}
-
-	/**
-	 * Extract the provider manifest shape from a generated core/html form diagnostic.
-	 *
-	 * @param array<string,mixed> $diagnostic Diagnostic row.
-	 * @return array{form:array<string,string>,controls:array<int,array<string,mixed>>}
-	 */
-	private static function extract_form_manifest_from_diagnostic( array $diagnostic ): array {
-		$html = self::first_scalar( $diagnostic, array( 'source_html_preview', 'html_excerpt', 'excerpt' ) );
-		return self::form_manifest_from_html( $html );
 	}
 
 	/**
@@ -2018,8 +2036,8 @@ class Static_Site_Importer_Report_Diagnostics {
 				continue;
 			}
 
-			$position = $block['offset'] ?? -1;
-			if ( ! is_int( $position ) || $position < 0 || $block['serialized'] !== substr( $content, $position, strlen( $block['serialized'] ) ) ) {
+			$position = $block['offset'];
+			if ( 0 > $position || substr( $content, $position, strlen( $block['serialized'] ) ) !== $block['serialized'] ) {
 				continue;
 			}
 

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1161,6 +1161,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			$diagnostic = $report['diagnostics'][ $index ];
 			$controls   = isset( $diagnostic['controls'] ) && is_array( $diagnostic['controls'] ) ? $diagnostic['controls'] : array();
 			$form       = isset( $diagnostic['form'] ) && is_array( $diagnostic['form'] ) ? $diagnostic['form'] : array();
+			$form       = self::preserved_form_presentation( $diagnostic, $form );
 			if ( empty( $controls ) && self::is_generated_core_html_form_diagnostic( $diagnostic ) ) {
 				$extracted                                   = self::extract_form_manifest_from_diagnostic( $diagnostic );
 				$controls                                    = $extracted['controls'];
@@ -1258,6 +1259,76 @@ class Static_Site_Importer_Report_Diagnostics {
 
 		$report['form_seeding'] = $seeding;
 		return $seeding;
+	}
+
+	/**
+	 * Carry bounded authored form context into the provider adapter.
+	 *
+	 * The fallback HTML is the only complete representation when a form island is
+	 * replaced, so retain headings, standalone notes, and a visible submit treatment
+	 * before the provider block is serialized.
+	 *
+	 * @param array<string,mixed> $diagnostic Form fallback finding.
+	 * @param array<string,mixed> $form       Extracted form metadata.
+	 * @return array<string,mixed>
+	 */
+	private static function preserved_form_presentation( array $diagnostic, array $form ): array {
+		$html = isset( $diagnostic['html'] ) && is_string( $diagnostic['html'] ) ? $diagnostic['html'] : ( isset( $diagnostic['source_html_preview'] ) && is_string( $diagnostic['source_html_preview'] ) ? $diagnostic['source_html_preview'] : '' );
+		if ( '' === $html ) {
+			return $form;
+		}
+
+		$context = array();
+		if ( preg_match_all( '/<h([1-6])\b[^>]*>(.*?)<\/h\1>/is', $html, $headings, PREG_SET_ORDER ) ) {
+			foreach ( array_slice( $headings, 0, 8 ) as $heading ) {
+				$text = self::form_presentation_text( $heading[2] );
+				if ( '' !== $text ) {
+					$context[] = array( 'type' => 'heading', 'level' => (int) $heading[1], 'text' => $text );
+				}
+			}
+		}
+		if ( preg_match_all( '/<label\b([^>]*)>(.*?)<\/label>/is', $html, $labels, PREG_SET_ORDER ) ) {
+			foreach ( array_slice( $labels, 0, 16 ) as $label ) {
+				if ( ! preg_match( '/(?:required|note|instruction|help)/i', $label[1] ) || preg_match( '/<(?:input|select|textarea|button)\b/i', $label[2] ) ) {
+					continue;
+				}
+				$text = self::form_presentation_text( $label[2] );
+				if ( '' !== $text && ! in_array( $text, array_column( $context, 'text' ), true ) ) {
+					$context[] = array( 'type' => 'paragraph', 'text' => $text );
+				}
+			}
+		}
+		if ( ! empty( $context ) ) {
+			$form['context_blocks'] = $context;
+		}
+
+		if ( preg_match_all( '/<(?:a|button)\b([^>]*)>(.*?)<\/(?:a|button)>/is', $html, $buttons, PREG_SET_ORDER ) ) {
+			foreach ( $buttons as $button ) {
+				$text    = self::form_presentation_text( $button[2] );
+				$classes = self::form_presentation_classes( $button[1] );
+				if ( '' !== $text && ! empty( $classes ) && preg_grep( '/(?:button|submit)/i', $classes ) ) {
+					$form['submit_presentation'] = array( 'text' => $text, 'classes' => $classes );
+					break;
+				}
+			}
+		}
+
+		return $form;
+	}
+
+	/** @return array<int,string> */
+	private static function form_presentation_classes( string $attributes ): array {
+		if ( ! preg_match( '/\bclass\s*=\s*(["\'])(.*?)\1/is', $attributes, $match ) ) {
+			return array();
+		}
+		$classes = preg_split( '/\s+/', trim( $match[2] ) );
+		return array_values( array_slice( array_filter( $classes ?: array(), static fn ( string $class ): bool => (bool) preg_match( '/^[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $class ) ), 0, 8 ) );
+	}
+
+	private static function form_presentation_text( string $html ): string {
+		$plain = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $html ) : strip_tags( $html ); // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- Fallback only for runtime-free smoke tests.
+		$text  = trim( preg_replace( '/\s+/', ' ', $plain ) ?: '' );
+		return substr( $text, 0, 200 );
 	}
 
 	/**

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -227,7 +227,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'type'                  => $type,
 			'source'                => $source,
 			'selector'              => '' !== $selector ? $selector : null,
-			'excerpt'               => self::diagnostic_excerpt( wp_strip_all_tags( $element_html ) ),
+			'excerpt'               => self::diagnostic_excerpt( function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $element_html ) : strip_tags( $element_html ) ), // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- Fallback only for runtime-free smoke tests.
 			'source_html_preview'   => self::diagnostic_excerpt( $element_html ),
 			'emitted_block_preview' => self::diagnostic_excerpt( $emitted ),
 			'reason'                => isset( $context['reason'] ) ? (string) $context['reason'] : 'unknown',
@@ -247,8 +247,10 @@ class Static_Site_Importer_Report_Diagnostics {
 			$entry['block_path'] = (string) $context['path'];
 		}
 		if ( 'form' === strtolower( (string) $entry['tag_name'] ) ) {
-			// Transient materialization input: removed before public report output.
-			$entry['form_source_html'] = $element_html;
+			$manifest                   = self::form_manifest_from_html( $element_html );
+			$entry['form']              = $manifest['form'];
+			$entry['controls']          = $manifest['controls'];
+			$entry['form_presentation'] = self::form_presentation_from_html( $element_html, $selector );
 		}
 
 		return $entry;
@@ -1163,18 +1165,16 @@ class Static_Site_Importer_Report_Diagnostics {
 		$manifest_forms = array();
 		foreach ( $indexes as $index ) {
 			$diagnostic = $report['diagnostics'][ $index ];
-			$source_html = self::take_form_source_html( $diagnostic, $page_contents );
-			unset( $report['diagnostics'][ $index ]['form_source_html'] );
 			$controls   = isset( $diagnostic['controls'] ) && is_array( $diagnostic['controls'] ) ? $diagnostic['controls'] : array();
 			$form       = isset( $diagnostic['form'] ) && is_array( $diagnostic['form'] ) ? $diagnostic['form'] : array();
 			if ( empty( $controls ) && self::is_generated_core_html_form_diagnostic( $diagnostic ) ) {
-				$extracted                                   = self::form_manifest_from_html( $source_html );
+				$extracted                                   = self::form_manifest_from_core_html( $diagnostic, $page_contents );
 				$controls                                    = $extracted['controls'];
 				$form                                        = $extracted['form'];
 				$report['diagnostics'][ $index ]['controls'] = $controls;
 				$report['diagnostics'][ $index ]['form']     = $form;
 			}
-			$form = self::preserved_form_presentation( $source_html, $form, $controls );
+			$form = self::apply_form_presentation( is_array( $diagnostic['form_presentation'] ?? null ) ? $diagnostic['form_presentation'] : array(), $form, $controls );
 			$manifest_forms[] = array(
 				'selector'    => isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '',
 				'source_path' => isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : ( isset( $diagnostic['source'] ) && is_scalar( $diagnostic['source'] ) ? (string) $diagnostic['source'] : '' ),
@@ -1218,7 +1218,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$pending = $indexes;
 		$rows    = isset( $seeding['forms'] ) && is_array( $seeding['forms'] ) ? $seeding['forms'] : array();
 		foreach ( $rows as $row ) {
-			if ( ! is_array( $row ) || empty( $row['runtime_mapped'] ) ) {
+			if ( ! is_array( $row ) ) {
 				continue;
 			}
 
@@ -1226,6 +1226,17 @@ class Static_Site_Importer_Report_Diagnostics {
 			$source_path = isset( $row['source_path'] ) && is_scalar( $row['source_path'] ) ? (string) $row['source_path'] : '';
 			$index       = self::form_finding_index_for_selector( $report['diagnostics'], $pending, $selector, $source_path );
 			if ( null === $index ) {
+				continue;
+			}
+			if ( empty( $row['runtime_mapped'] ) ) {
+				if ( 'interleaved_context_unrepresentable' === ( $row['reason'] ?? '' ) ) {
+					$report['diagnostics'][] = array(
+						'type' => 'form_context_unrepresentable', 'diagnostic_code' => 'form_context_interleaved', 'reason' => 'interleaved_context_unrepresentable',
+						'source_path' => $source_path, 'selector' => $selector, 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+						'message' => 'Form context occurs between controls and was left in the original fallback to avoid semantic reordering.',
+					);
+				}
+				$pending = array_values( array_diff( $pending, array( $index ) ) );
 				continue;
 			}
 
@@ -1347,23 +1358,106 @@ class Static_Site_Importer_Report_Diagnostics {
 		return $form;
 	}
 
-	/** Read and remove the non-public full fallback payload for form materialization. */
-	private static function take_form_source_html( array $diagnostic, array $page_contents ): string {
-		if ( is_string( $diagnostic['form_source_html'] ?? null ) ) {
-			return $diagnostic['form_source_html'];
-		}
-		if ( is_string( $diagnostic['html'] ?? null ) ) {
-			return $diagnostic['html'];
-		}
-		$source_path = self::first_scalar( $diagnostic, array( 'graft_source_path', 'source_path', 'source' ) );
-		foreach ( self::form_fallback_page_content_keys_for_source( $source_path, $page_contents ) as $key ) {
-			foreach ( self::serialized_core_html_blocks( (string) ( $page_contents[ $key ] ?? '' ) ) as $block ) {
-				if ( self::core_html_form_matches_finding( $block['html'], $diagnostic ) ) {
-					return $block['html'];
+	/**
+	 * Extract bounded presentation facts while the exact fallback form is in scope.
+	 * Raw fallback HTML never enters a diagnostic or materialization manifest.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function form_presentation_from_html( string $html, string $selector = '' ): array {
+		$manifest = self::form_manifest_from_html( $html );
+		$form     = self::preserved_form_presentation( $html, $manifest['form'], $manifest['controls'] );
+		$doc      = new DOMDocument();
+		$previous = libxml_use_internal_errors( true );
+		$doc->loadHTML( '<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+		$form_node = $doc->getElementsByTagName( 'form' )->item( 0 );
+		$before    = array();
+		$after     = array();
+		$interleaved = false;
+		$seen_controls = 0;
+		$total_controls = count( $manifest['controls'] );
+		if ( $form_node instanceof DOMElement ) {
+			foreach ( $form_node->getElementsByTagName( '*' ) as $node ) {
+				$tag = strtolower( $node->nodeName );
+				if ( in_array( $tag, array( 'input', 'select', 'textarea', 'button' ), true ) ) {
+					++$seen_controls;
+					continue;
+				}
+				$text = self::form_presentation_text( $node->textContent );
+				$item = preg_match( '/^h[1-6]$/', $tag ) && '' !== $text ? array( 'type' => 'heading', 'level' => (int) substr( $tag, 1 ), 'text' => $text ) : ( in_array( $tag, array( 'label', 'p' ), true ) && preg_match( '/(?:required|note|instruction|help)/i', $node->getAttribute( 'class' ) ) && '' !== $text ? array( 'type' => 'paragraph', 'text' => $text ) : null );
+				if ( ! is_array( $item ) ) {
+					continue;
+				}
+				if ( 0 === $seen_controls ) {
+					$before[] = $item;
+				} elseif ( $seen_controls >= $total_controls ) {
+					$after[] = $item;
+				} else {
+					$interleaved = true;
 				}
 			}
 		}
-		return '';
+		$heights = array();
+		foreach ( $manifest['controls'] as $index => $control ) {
+			if ( isset( $control['height'] ) ) {
+				$heights[ $index ] = $control['height'];
+			}
+		}
+		return array_filter( array(
+			'schema' => 'generic/form-presentation/v1',
+			'selector' => $selector,
+			'fingerprint' => hash( 'sha256', wp_json_encode( array( 'action' => $manifest['form']['action'] ?? '', 'controls' => array_map( static fn ( array $control ): array => array_intersect_key( $control, array_flip( array( 'tag', 'type', 'name', 'id' ) ) ), $manifest['controls'] ) ) ) ),
+			'context_before' => array_slice( $before, 0, 8 ),
+			'context_after' => array_slice( $after, 0, 8 ),
+			'interleaved_context' => $interleaved,
+			'submit_presentation' => $form['submit_presentation'] ?? null,
+			'textarea_heights' => $heights,
+		) );
+	}
+
+	/** Apply structured presentation facts without retaining source HTML. */
+	private static function apply_form_presentation( array $presentation, array $form, array &$controls ): array {
+		if ( 'generic/form-presentation/v1' !== ( $presentation['schema'] ?? null ) ) {
+			return $form;
+		}
+		foreach ( array( 'context_before', 'context_after', 'submit_presentation' ) as $key ) {
+			if ( isset( $presentation[ $key ] ) ) {
+				$form[ $key ] = $presentation[ $key ];
+			}
+		}
+		if ( ! empty( $presentation['interleaved_context'] ) ) {
+			$form['interleaved_context'] = true;
+		}
+		foreach ( $presentation['textarea_heights'] ?? array() as $index => $height ) {
+			if ( isset( $controls[ $index ] ) && is_string( $height ) ) {
+				$controls[ $index ]['height'] = $height;
+			}
+		}
+		return $form;
+	}
+
+	/** Extract a generated core/html form only when its structured fingerprint matches. */
+	private static function form_manifest_from_core_html( array $diagnostic, array $page_contents ): array {
+		$presentation = is_array( $diagnostic['form_presentation'] ?? null ) ? $diagnostic['form_presentation'] : array();
+		$source_path  = self::first_scalar( $diagnostic, array( 'graft_source_path', 'source_path', 'source' ) );
+		foreach ( self::form_fallback_page_content_keys_for_source( $source_path, $page_contents ) as $key ) {
+			foreach ( self::serialized_core_html_blocks( (string) ( $page_contents[ $key ] ?? '' ) ) as $block ) {
+				if ( self::form_presentation_matches_html( $presentation, $block['html'] ) ) {
+					return self::form_manifest_from_html( $block['html'] );
+				}
+			}
+		}
+		return array( 'form' => array(), 'controls' => array() );
+	}
+
+	private static function form_presentation_matches_html( array $presentation, string $html ): bool {
+		if ( ! is_string( $presentation['fingerprint'] ?? null ) ) {
+			return false;
+		}
+		$candidate = self::form_presentation_from_html( $html, (string) ( $presentation['selector'] ?? '' ) );
+		return hash_equals( $presentation['fingerprint'], (string) ( $candidate['fingerprint'] ?? '' ) );
 	}
 
 	private static function is_submit_control_node( DOMElement $node ): bool {
@@ -1943,6 +2037,9 @@ class Static_Site_Importer_Report_Diagnostics {
 	private static function core_html_form_matches_finding( string $html, array $finding ): bool {
 		if ( ! str_contains( strtolower( $html ), '<form' ) ) {
 			return false;
+		}
+		if ( is_array( $finding['form_presentation'] ?? null ) ) {
+			return self::form_presentation_matches_html( $finding['form_presentation'], $html );
 		}
 
 		$form = isset( $finding['form'] ) && is_array( $finding['form'] ) ? $finding['form'] : array();

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1471,7 +1471,7 @@ class Static_Site_Importer_Report_Diagnostics {
 
 	/** Apply bounded presentation from canonical form bindings before provider validation. */
 	public static function apply_form_binding_presentation( array $entity ): array {
-		$presentations  = array();
+		$presentations = array();
 		$control_shape = self::ordered_form_control_identity( isset( $entity['controls'] ) && is_array( $entity['controls'] ) ? $entity['controls'] : array() );
 		$bindings      = isset( $entity['bindings'] ) && is_array( $entity['bindings'] ) ? $entity['bindings'] : array();
 		foreach ( $bindings as $binding ) {
@@ -1479,7 +1479,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				continue;
 			}
 			$manifest = self::form_manifest_from_html( $binding['search_block_markup'] );
-			if ( $control_shape !== self::ordered_form_control_identity( $manifest['controls'] ) ) {
+			if ( self::ordered_form_control_identity( $manifest['controls'] ) !== $control_shape ) {
 				return $entity;
 			}
 			$presentation = self::form_presentation_from_html(
@@ -1648,7 +1648,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	private static function form_presentation_text( string $html ): string {
-		$plain = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $html ) : strip_tags( $html ); // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- Fallback only for runtime-free smoke tests.
+		$plain      = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $html ) : strip_tags( $html ); // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- Fallback only for runtime-free smoke tests.
 		$normalized = preg_replace( '/\s+/', ' ', $plain );
 		return substr( trim( is_string( $normalized ) ? $normalized : '' ), 0, 200 );
 	}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -246,6 +246,10 @@ class Static_Site_Importer_Report_Diagnostics {
 		if ( isset( $context['path'] ) && is_scalar( $context['path'] ) ) {
 			$entry['block_path'] = (string) $context['path'];
 		}
+		if ( 'form' === strtolower( (string) $entry['tag_name'] ) ) {
+			// Transient materialization input: removed before public report output.
+			$entry['form_source_html'] = $element_html;
+		}
 
 		return $entry;
 	}
@@ -1159,16 +1163,18 @@ class Static_Site_Importer_Report_Diagnostics {
 		$manifest_forms = array();
 		foreach ( $indexes as $index ) {
 			$diagnostic = $report['diagnostics'][ $index ];
+			$source_html = self::take_form_source_html( $diagnostic, $page_contents );
+			unset( $report['diagnostics'][ $index ]['form_source_html'] );
 			$controls   = isset( $diagnostic['controls'] ) && is_array( $diagnostic['controls'] ) ? $diagnostic['controls'] : array();
 			$form       = isset( $diagnostic['form'] ) && is_array( $diagnostic['form'] ) ? $diagnostic['form'] : array();
 			if ( empty( $controls ) && self::is_generated_core_html_form_diagnostic( $diagnostic ) ) {
-				$extracted                                   = self::extract_form_manifest_from_diagnostic( $diagnostic );
+				$extracted                                   = self::form_manifest_from_html( $source_html );
 				$controls                                    = $extracted['controls'];
 				$form                                        = $extracted['form'];
 				$report['diagnostics'][ $index ]['controls'] = $controls;
 				$report['diagnostics'][ $index ]['form']     = $form;
 			}
-			$form = self::preserved_form_presentation( $diagnostic, $form, $controls );
+			$form = self::preserved_form_presentation( $source_html, $form, $controls );
 			$manifest_forms[] = array(
 				'selector'    => isset( $diagnostic['selector'] ) && is_scalar( $diagnostic['selector'] ) ? (string) $diagnostic['selector'] : '',
 				'source_path' => isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : ( isset( $diagnostic['source'] ) && is_scalar( $diagnostic['source'] ) ? (string) $diagnostic['source'] : '' ),
@@ -1268,62 +1274,121 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * replaced, so retain headings, standalone notes, and a visible submit treatment
 	 * before the provider block is serialized.
 	 *
-	 * @param array<string,mixed> $diagnostic Form fallback finding.
+	 * @param string              $html       Complete internal fallback HTML.
 	 * @param array<string,mixed> $form       Extracted form metadata.
 	 * @param array<int,array<string,mixed>> $controls Extracted controls, enriched in place.
 	 * @return array<string,mixed>
 	 */
-	private static function preserved_form_presentation( array $diagnostic, array $form, array &$controls ): array {
-		$html = isset( $diagnostic['html'] ) && is_string( $diagnostic['html'] ) ? $diagnostic['html'] : ( isset( $diagnostic['source_html_preview'] ) && is_string( $diagnostic['source_html_preview'] ) ? $diagnostic['source_html_preview'] : '' );
+	private static function preserved_form_presentation( string $html, array $form, array &$controls ): array {
 		if ( '' === $html ) {
 			return $form;
 		}
 
-		$context = array();
-		if ( preg_match_all( '/<h([1-6])\b[^>]*>(.*?)<\/h\1>/is', $html, $headings, PREG_SET_ORDER ) ) {
-			foreach ( array_slice( $headings, 0, 8 ) as $heading ) {
-				$text = self::form_presentation_text( $heading[2] );
-				if ( '' !== $text ) {
-					$context[] = array( 'type' => 'heading', 'level' => (int) $heading[1], 'text' => $text );
-				}
-			}
+		$doc      = new DOMDocument();
+		$previous = libxml_use_internal_errors( true );
+		$doc->loadHTML( '<?xml encoding="utf-8" ?><body>' . $html . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+		$form_node = $doc->getElementsByTagName( 'form' )->item( 0 );
+		if ( null === $form_node ) {
+			return $form;
 		}
-		if ( preg_match_all( '/<label\b([^>]*)>(.*?)<\/label>/is', $html, $labels, PREG_SET_ORDER ) ) {
-			foreach ( array_slice( $labels, 0, 16 ) as $label ) {
-				if ( ! preg_match( '/(?:required|note|instruction|help)/i', $label[1] ) || preg_match( '/<(?:input|select|textarea|button)\b/i', $label[2] ) ) {
-					continue;
-				}
-				$text = self::form_presentation_text( $label[2] );
-				if ( '' !== $text && ! in_array( $text, array_column( $context, 'text' ), true ) ) {
-					$context[] = array( 'type' => 'paragraph', 'text' => $text );
-				}
+
+		$context = array();
+		$nodes   = $form_node->getElementsByTagName( '*' );
+		foreach ( $nodes as $node ) {
+			$tag = strtolower( $node->nodeName );
+			if ( in_array( $tag, array( 'input', 'select', 'textarea', 'button' ), true ) ) {
+				break;
+			}
+			$text = self::form_presentation_text( $node->textContent );
+			if ( preg_match( '/^h[1-6]$/', $tag ) && '' !== $text ) {
+				$context[] = array( 'type' => 'heading', 'level' => (int) substr( $tag, 1 ), 'text' => $text );
+			} elseif ( 'label' === $tag && preg_match( '/(?:required|note|instruction|help)/i', $node->getAttribute( 'class' ) ) && '' !== $text ) {
+				$context[] = array( 'type' => 'paragraph', 'text' => $text );
 			}
 		}
 		if ( ! empty( $context ) ) {
-			$form['context_blocks'] = $context;
-		}
-		if ( preg_match_all( '/<textarea\b([^>]*)>/is', $html, $textareas, PREG_SET_ORDER ) ) {
-			$textarea_indexes = array_keys( array_filter( $controls, static fn ( array $control ): bool => 'textarea' === strtolower( (string) ( $control['tag'] ?? '' ) ) ) );
-			foreach ( $textareas as $index => $textarea ) {
-				if ( ! isset( $textarea_indexes[ $index ] ) || ! preg_match( '/\bstyle\s*=\s*(["\'])(.*?)\1/is', $textarea[1], $style ) || ! preg_match( '/(?:^|;)\s*height\s*:\s*([0-9]{1,4}(?:\.[0-9]+)?(?:px|em|rem|vh|vw|%))\s*(?:;|$)/i', $style[2], $height ) ) {
-					continue;
-				}
-				$controls[ $textarea_indexes[ $index ] ]['height'] = $height[1];
-			}
+			$form['context_before'] = $context;
 		}
 
-		if ( preg_match_all( '/<(?:a|button)\b([^>]*)>(.*?)<\/(?:a|button)>/is', $html, $buttons, PREG_SET_ORDER ) ) {
-			foreach ( $buttons as $button ) {
-				$text    = self::form_presentation_text( $button[2] );
-				$classes = self::form_presentation_classes( $button[1] );
-				if ( '' !== $text && ! empty( $classes ) && preg_grep( '/(?:button|submit)/i', $classes ) ) {
-					$form['submit_presentation'] = array( 'text' => $text, 'classes' => $classes );
-					break;
+		$textarea_index = 0;
+		foreach ( $nodes as $node ) {
+			if ( 'textarea' !== strtolower( $node->nodeName ) ) {
+				continue;
+			}
+			while ( isset( $controls[ $textarea_index ] ) && 'textarea' !== strtolower( (string) ( $controls[ $textarea_index ]['tag'] ?? '' ) ) ) {
+				++$textarea_index;
+			}
+			if ( isset( $controls[ $textarea_index ] ) && preg_match( '/(?:^|;)\s*height\s*:\s*([0-9]{1,4}(?:\.[0-9]+)?(?:px|em|rem|vh|vw|%))\s*(?:;|$)/i', $node->getAttribute( 'style' ), $height ) ) {
+				$controls[ $textarea_index ]['height'] = $height[1];
+			}
+			++$textarea_index;
+		}
+
+		foreach ( $nodes as $node ) {
+			if ( ! self::is_submit_control_node( $node ) ) {
+				continue;
+			}
+			$presentation = self::submit_presentation_from_node( $node );
+			$visible_node = self::next_element_sibling( $node );
+			if ( self::submit_control_is_visually_hidden( $node ) && $visible_node instanceof DOMElement && in_array( strtolower( $visible_node->nodeName ), array( 'a', 'button' ), true ) ) {
+				$visible = self::submit_presentation_from_node( $visible_node );
+				if ( '' !== (string) ( $visible['text'] ?? '' ) && (string) ( $visible['text'] ?? '' ) === (string) ( $presentation['text'] ?? '' ) ) {
+					$presentation = $visible;
 				}
 			}
+			if ( '' !== (string) ( $presentation['text'] ?? '' ) ) {
+				$form['submit_presentation'] = $presentation;
+			}
+			break;
 		}
 
 		return $form;
+	}
+
+	/** Read and remove the non-public full fallback payload for form materialization. */
+	private static function take_form_source_html( array $diagnostic, array $page_contents ): string {
+		if ( is_string( $diagnostic['form_source_html'] ?? null ) ) {
+			return $diagnostic['form_source_html'];
+		}
+		if ( is_string( $diagnostic['html'] ?? null ) ) {
+			return $diagnostic['html'];
+		}
+		$source_path = self::first_scalar( $diagnostic, array( 'graft_source_path', 'source_path', 'source' ) );
+		foreach ( self::form_fallback_page_content_keys_for_source( $source_path, $page_contents ) as $key ) {
+			foreach ( self::serialized_core_html_blocks( (string) ( $page_contents[ $key ] ?? '' ) ) as $block ) {
+				if ( self::core_html_form_matches_finding( $block['html'], $diagnostic ) ) {
+					return $block['html'];
+				}
+			}
+		}
+		return '';
+	}
+
+	private static function is_submit_control_node( DOMElement $node ): bool {
+		$tag  = strtolower( $node->nodeName );
+		$type = strtolower( trim( $node->getAttribute( 'type' ) ) );
+		return ( 'input' === $tag && in_array( $type, array( 'submit', 'image' ), true ) ) || ( 'button' === $tag && ( '' === $type || 'submit' === $type ) );
+	}
+
+	/** @return array{text:string,classes:array<int,string>} */
+	private static function submit_presentation_from_node( DOMElement $node ): array {
+		$text = 'input' === strtolower( $node->nodeName ) ? trim( $node->getAttribute( 'value' ) ) : self::form_presentation_text( $node->textContent );
+		return array( 'text' => $text, 'classes' => self::form_presentation_classes( 'class="' . $node->getAttribute( 'class' ) . '"' ) );
+	}
+
+	private static function submit_control_is_visually_hidden( DOMElement $node ): bool {
+		return (bool) preg_match( '/(?:display\s*:\s*none|visibility\s*:\s*hidden|left\s*:\s*-\s*[0-9]+px)/i', $node->getAttribute( 'style' ) );
+	}
+
+	private static function next_element_sibling( DOMElement $node ): ?DOMElement {
+		for ( $sibling = $node->nextSibling; null !== $sibling; $sibling = $sibling->nextSibling ) {
+			if ( $sibling instanceof DOMElement ) {
+				return $sibling;
+			}
+		}
+		return null;
 	}
 
 	/** @return array<int,string> */
@@ -1499,8 +1564,10 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		$controls = array();
-		foreach ( array( 'input', 'textarea', 'select', 'button' ) as $tag_name ) {
-			foreach ( $form_node->getElementsByTagName( $tag_name ) as $control_node ) {
+		foreach ( $form_node->getElementsByTagName( '*' ) as $control_node ) {
+			if ( ! in_array( strtolower( $control_node->tagName ), array( 'input', 'textarea', 'select', 'button' ), true ) ) {
+				continue;
+			}
 				$control = array(
 					'tag'  => strtolower( $control_node->tagName ),
 					'type' => strtolower( trim( $control_node->getAttribute( 'type' ) ) ),
@@ -1530,9 +1597,11 @@ class Static_Site_Importer_Report_Diagnostics {
 				if ( $control_node->hasAttribute( 'required' ) ) {
 					$control['required'] = true;
 				}
+				if ( $control_node->hasAttribute( 'aria-required' ) ) {
+					$control['aria-required'] = $control_node->getAttribute( 'aria-required' );
+				}
 
 				$controls[] = $control;
-			}
 		}
 
 		return array(

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1217,6 +1217,7 @@ class Static_Site_Importer_Report_Diagnostics {
 
 		$pending = $indexes;
 		$rows    = isset( $seeding['forms'] ) && is_array( $seeding['forms'] ) ? $seeding['forms'] : array();
+		$graft_requests = array();
 		foreach ( $rows as $row ) {
 			if ( ! is_array( $row ) ) {
 				continue;
@@ -1261,17 +1262,34 @@ class Static_Site_Importer_Report_Diagnostics {
 			if ( $generated_document_owns_graft ) {
 				$report['diagnostics'][ $index ]['graft_delegated_to_generated_document'] = true;
 			} elseif ( ! empty( $page_contents ) ) {
-				$markup = isset( $row['block_markup'] ) && is_scalar( $row['block_markup'] ) ? (string) $row['block_markup'] : '';
-				$graft  = self::graft_form_block_into_page_contents( $report['diagnostics'][ $index ], $markup, $page_contents );
-				if ( $graft['grafted'] ) {
-					++$seeding['grafted_count'];
-				}
-				$report['diagnostics'][ $index ] = $graft['finding'];
-				if ( ! empty( $graft['diagnostic'] ) ) {
-					$report['diagnostics'][] = $graft['diagnostic'];
-				}
+				$graft_requests[] = array(
+					'index'  => $index,
+					'markup' => isset( $row['block_markup'] ) && is_scalar( $row['block_markup'] ) ? (string) $row['block_markup'] : '',
+				);
 			}
 			$pending = array_values( array_diff( $pending, array( $index ) ) );
+		}
+
+		// Resolve duplicate forms from right to left, so removing a later form never
+		// changes the document-wide ordinal used by an earlier source finding.
+		usort(
+			$graft_requests,
+			static function ( array $left, array $right ) use ( $report ): int {
+				$left_ordinal  = (int) ( $report['diagnostics'][ $left['index'] ]['form_presentation']['document_ordinal'] ?? 0 );
+				$right_ordinal = (int) ( $report['diagnostics'][ $right['index'] ]['form_presentation']['document_ordinal'] ?? 0 );
+				return $right_ordinal <=> $left_ordinal;
+			}
+		);
+		foreach ( $graft_requests as $request ) {
+			$index = $request['index'];
+			$graft = self::graft_form_block_into_page_contents( $report['diagnostics'][ $index ], $request['markup'], $page_contents );
+			if ( $graft['grafted'] ) {
+				++$seeding['grafted_count'];
+			}
+			$report['diagnostics'][ $index ] = $graft['finding'];
+			if ( ! empty( $graft['diagnostic'] ) ) {
+				$report['diagnostics'][] = $graft['diagnostic'];
+			}
 		}
 
 		$report['form_seeding'] = $seeding;
@@ -1468,7 +1486,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Select a generated core/html form using a fingerprint and document-wide ordinal.
 	 *
-	 * @return array{serialized:string,html:string,document_ordinal:int}|null
+	 * @return array{serialized:string,html:string,offset:int,document_ordinal:int}|null
 	 */
 	private static function matching_core_html_form_block( array $presentation, string $content ): ?array {
 		if ( ! is_string( $presentation['fingerprint'] ?? null ) ) {
@@ -2000,8 +2018,8 @@ class Static_Site_Importer_Report_Diagnostics {
 				continue;
 			}
 
-			$position = strpos( $content, $block['serialized'] );
-			if ( false === $position ) {
+			$position = $block['offset'] ?? -1;
+			if ( ! is_int( $position ) || $position < 0 || $block['serialized'] !== substr( $content, $position, strlen( $block['serialized'] ) ) ) {
 				continue;
 			}
 
@@ -2056,26 +2074,28 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * Extract serialized core/html blocks and their decoded HTML payloads.
 	 *
 	 * @param string $content Serialized block document.
-	 * @return array<int,array{serialized:string,html:string}>
+	 * @return array<int,array{serialized:string,html:string,offset:int}>
 	 */
 	private static function serialized_core_html_blocks( string $content ): array {
 		$blocks  = array();
 		$matches = array();
-		preg_match_all( '/<!--\s+wp:html\s+(\{.*?\})\s+\/-->/s', $content, $matches, PREG_SET_ORDER );
-		preg_match_all( '/<!--\s+wp:html\s+(\{.*?\})\s+-->(.*?)<!--\s+\/wp:html\s+-->/s', $content, $wrapped_matches, PREG_SET_ORDER );
+		preg_match_all( '/<!--\s+wp:html\s+(\{.*?\})\s+\/-->/s', $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE );
+		preg_match_all( '/<!--\s+wp:html\s+(\{.*?\})\s+-->(.*?)<!--\s+\/wp:html\s+-->/s', $content, $wrapped_matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE );
 		$matches = array_merge( $matches, $wrapped_matches );
 
 		foreach ( $matches as $match ) {
-			$attrs = json_decode( (string) $match[1], true );
-			$html  = is_array( $attrs ) && isset( $attrs['content'] ) && is_scalar( $attrs['content'] ) ? (string) $attrs['content'] : ( isset( $match[2] ) ? (string) $match[2] : '' );
+			$attrs = json_decode( (string) $match[1][0], true );
+			$html  = is_array( $attrs ) && isset( $attrs['content'] ) && is_scalar( $attrs['content'] ) ? (string) $attrs['content'] : ( isset( $match[2] ) ? (string) $match[2][0] : '' );
 			if ( '' !== $html ) {
 				$blocks[] = array(
-					'serialized' => (string) $match[0],
+					'serialized' => (string) $match[0][0],
 					'html'       => $html,
+					'offset'     => (int) $match[0][1],
 				);
 			}
 		}
 
+		usort( $blocks, static fn ( array $left, array $right ): int => $left['offset'] <=> $right['offset'] );
 		return $blocks;
 	}
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1052,6 +1052,9 @@ class Static_Site_Importer_Theme_Generator {
 			}
 			if ( 'entity_collection' === $kind ) {
 				$entities = isset( $declaration['payload']['entities'] ) && is_array( $declaration['payload']['entities'] ) ? $declaration['payload']['entities'] : array();
+				if ( 'form' === $capability ) {
+					$entities = array_map( static fn( $entity ) => is_array( $entity ) ? Static_Site_Importer_Report_Diagnostics::apply_form_binding_presentation( $entity ) : $entity, $entities );
+				}
 				$manifest = 'shop' === $capability ? array(
 					'schema_version' => 1,
 					'products'       => $entities,

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -630,6 +630,38 @@ namespace {
 	$assert( ! str_contains( (string) $duplicate_generated_contents['posts/page-home.post_content'], '<!-- wp:html' ), 'graft-generated-home-core-html-removed' );
 	$assert( ! str_contains( (string) $duplicate_generated_contents['posts/page-contact.post_content'], '<!-- wp:html' ), 'graft-generated-contact-core-html-removed' );
 
+	// Complete fallback grafts retain authored context and presentation, rather than
+	// rebuilding a form from only its flat control list.
+	$cara_form_html = '<form class="contact-form"><h2>Contact Me</h2><label class="required-note"><span>*</span> Indicates required field</label><div class="name-row"><div class="first"><input aria-required="true" placeholder="First" type="text" name="first"><label>First</label></div><div class="last"><input aria-required="true" placeholder="Last" type="text" name="last"><label>Last</label></div></div><textarea aria-required="true" name="message" style="height:200px"></textarea><input type="submit" value="Submit"><a class="wsite-button"><span class="wsite-button-inner">Submit</span></a></form>';
+	$cara_report    = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/contact.html' );
+	$cara_report['diagnostics'][] = array(
+		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path' => 'website/contact.html', 'selector' => 'form.contact-form', 'tag' => 'form', 'html' => $cara_form_html,
+		'form' => array( 'class' => 'contact-form' ),
+		'controls' => array(
+			array( 'tag' => 'input', 'type' => 'text', 'name' => 'first', 'label' => 'First', 'aria-required' => 'true' ),
+			array( 'tag' => 'input', 'type' => 'text', 'name' => 'last', 'label' => 'Last', 'aria_required' => 'true' ),
+			array( 'tag' => 'textarea', 'type' => 'textarea', 'name' => 'message', 'label' => 'Message', 'aria-required' => 'true' ),
+			array( 'tag' => 'input', 'type' => 'submit', 'value' => 'Submit' ),
+		),
+		'control_topology' => array( 'schema' => 'generic/form-control-topology/v1', 'max_depth' => 8, 'max_nodes' => 128, 'truncated' => false, 'nodes' => array(
+			array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 0, 'depth' => 0, 'tag' => 'div', 'class' => 'name-row' ),
+			array( 'id' => 'wrapper-1', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'tag' => 'div', 'class' => 'first' ),
+			array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-1', 'order' => 0, 'depth' => 2, 'control' => 0 ),
+			array( 'id' => 'wrapper-2', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 1, 'depth' => 1, 'tag' => 'div', 'class' => 'last' ),
+			array( 'id' => 'control-1', 'kind' => 'control', 'parent' => 'wrapper-2', 'order' => 0, 'depth' => 2, 'control' => 1 ),
+			array( 'id' => 'control-2', 'kind' => 'control', 'parent' => null, 'order' => 1, 'depth' => 0, 'control' => 2 ),
+			array( 'id' => 'control-3', 'kind' => 'control', 'parent' => null, 'order' => 2, 'depth' => 0, 'control' => 3 ),
+		) ),
+		'layout_graph' => $layout_graph( array( $layout_node( 'wrapper-0', array( 'display' => 'grid', 'columns' => 'repeat(2, 1fr)' ) ) ) ),
+	);
+	$cara_contents = array( 'website/contact.html' => $core_html_block( $cara_form_html ) );
+	$cara_seeding  = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $cara_report, array(), $cara_contents );
+	$cara_grafted  = (string) $cara_contents['website/contact.html'];
+	$assert( 1 === ( $cara_seeding['grafted_count'] ?? 0 ) && str_contains( $cara_grafted, '>Contact Me</h2>' ) && str_contains( $cara_grafted, '<p>* Indicates required field</p>' ), 'graft-preserves-authored-heading-and-required-note', $cara_grafted );
+	$assert( 2 === substr_count( $cara_grafted, '"width":50' ) && str_contains( $cara_grafted, '"required":true' ), 'graft-preserves-compound-name-widths-and-aria-required-semantics' );
+	$assert( str_contains( $cara_grafted, 'wsite-button') && str_contains( $cara_grafted, '>Submit</button>' ), 'graft-preserves-visible-submit-presentation' );
+
 	// A source fallback delegates to its generated-document finding instead of
 	// reporting a duplicate unanchorable graft after URL/class normalization.
 	$delegated_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
@@ -784,7 +816,7 @@ namespace {
 	$assert( 'woocommerce' === Static_Site_Importer_Entity_Materializer_Registry::provider_for( 'shop' ), 'shop-provider-unaffected-by-form-override' );
 
 	if ( empty( $failures ) && in_array( '--emit-topology-markup', $argv ?? array(), true ) ) {
-		echo wp_json_encode( array( 'markup' => $topology_markup, 'depth_markup' => $deep_topology_markup ) ) . "\n";
+		echo wp_json_encode( array( 'markup' => $topology_markup, 'depth_markup' => $deep_topology_markup, 'cara_markup' => $cara_grafted ) ) . "\n";
 		exit( 0 );
 	}
 

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -660,6 +660,7 @@ namespace {
 	$cara_grafted  = (string) $cara_contents['website/contact.html'];
 	$assert( 1 === ( $cara_seeding['grafted_count'] ?? 0 ) && str_contains( $cara_grafted, '>Contact Me</h2>' ) && str_contains( $cara_grafted, '<p>* Indicates required field</p>' ), 'graft-preserves-authored-heading-and-required-note', $cara_grafted );
 	$assert( 2 === substr_count( $cara_grafted, '"width":50' ) && str_contains( $cara_grafted, '"required":true' ), 'graft-preserves-compound-name-widths-and-aria-required-semantics' );
+	$assert( str_contains( $cara_grafted, '"minHeight":"200px"' ), 'graft-preserves-textarea-height' );
 	$assert( str_contains( $cara_grafted, 'wsite-button') && str_contains( $cara_grafted, '>Submit</button>' ), 'graft-preserves-visible-submit-presentation' );
 
 	// A source fallback delegates to its generated-document finding instead of

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -616,6 +616,7 @@ namespace {
 			'tag_name'            => 'FORM',
 			'block_name'          => 'core/html',
 			'source_html_preview' => $core_html_form,
+			'form_presentation'   => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $core_html_form, 'form.newsletter-form' ),
 		);
 	}
 	$duplicate_generated_contents = array(
@@ -636,7 +637,7 @@ namespace {
 	$cara_report    = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/contact.html' );
 	$cara_report['diagnostics'][] = array(
 		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
-		'source_path' => 'website/contact.html', 'selector' => 'form.contact-form', 'tag' => 'form', 'html' => $cara_form_html,
+		'source_path' => 'website/contact.html', 'selector' => 'form.contact-form', 'tag' => 'form', 'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $cara_form_html, 'form.contact-form' ),
 		'form' => array( 'class' => 'contact-form' ),
 		'controls' => array(
 			array( 'tag' => 'input', 'type' => 'text', 'name' => 'first', 'label' => 'First', 'aria-required' => 'true' ),
@@ -665,25 +666,28 @@ namespace {
 
 	// Internal full-source payloads are consumed before the public diagnostic preview
 	// and removed before the report is returned. Context order follows source order.
-	$long_form_html = '<form class="long-form">' . str_repeat( '<span>padding</span>', 25 ) . '<h2>First context</h2><label class="required-note">Required note</label><h3>Second context</h3><input name="email" type="email"><button class="native-submit" type="submit">Send</button></form>';
+	$long_form_html = '<form class="long-form">' . str_repeat( '<span>padding</span>', 25 ) . '<h2>First context</h2><label class="required-note">Required note</label><h3>Second context</h3><input name="email" type="email"><button class="native-submit" type="submit">Send</button><p class="help-note">After context</p></form>';
 	$long_report    = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/long.html' );
+	$long_entry     = Static_Site_Importer_Report_Diagnostics::fallback_diagnostic_entry( 'unsupported_html_fallback', 'website/long.html', $long_form_html, array( 'tag_name' => 'form', 'selector' => 'form.long-form' ), array() );
+	$assert( ! str_contains( wp_json_encode( $long_entry ), $long_form_html ) && 'generic/form-presentation/v1' === ( $long_entry['form_presentation']['schema'] ?? '' ), 'form-diagnostic-never-stores-raw-full-html-before-materialization' );
 	$long_report['diagnostics'][] = array(
 		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
-		'source_path' => 'website/long.html', 'selector' => 'form.long-form', 'tag' => 'form', 'form_source_html' => $long_form_html, 'source_html_preview' => substr( $long_form_html, 0, 300 ),
+		'source_path' => 'website/long.html', 'selector' => 'form.long-form', 'tag' => 'form', 'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $long_form_html, 'form.long-form' ), 'source_html_preview' => substr( $long_form_html, 0, 300 ),
 		'form' => array( 'class' => 'long-form' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
 	);
 	$long_contents = array( 'website/long.html' => $core_html_block( $long_form_html ) );
 	Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $long_report, array(), $long_contents );
 	$long_grafted = (string) $long_contents['website/long.html'];
 	$assert( strlen( $long_form_html ) > 300 && false === (bool) str_contains( substr( $long_form_html, 0, 300 ), 'First context' ) && str_contains( $long_grafted, 'First context' ), 'graft-uses-full-internal-source-not-public-preview' );
-	$assert( false === isset( $long_report['diagnostics'][0]['form_source_html'] ), 'graft-removes-internal-source-payload-from-public-diagnostic' );
+	$assert( ! str_contains( wp_json_encode( $long_report ), $long_form_html ) && 'generic/form-presentation/v1' === ( $long_report['diagnostics'][0]['form_presentation']['schema'] ?? '' ), 'graft-report-retains-only-structured-presentation-metadata' );
 	$assert( strpos( $long_grafted, 'First context' ) < strpos( $long_grafted, 'Required note' ) && strpos( $long_grafted, 'Required note' ) < strpos( $long_grafted, 'Second context' ), 'graft-preserves-ordered-context-before-provider-form' );
+	$assert( strpos( $long_grafted, 'After context' ) > strpos( $long_grafted, '<!-- /wp:jetpack/contact-form -->' ), 'graft-preserves-representable-suffix-context-after-provider-form' );
 
 	$adversarial_html = '<form class="adversarial"><a class="wsite-button cancel" href="/">Cancel</a><input name="email" type="email"><button class="native-submit" type="submit">Send</button><a class="wsite-button navigation" href="/next">Continue</a></form>';
 	$adversarial_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/adversarial.html' );
 	$adversarial_report['diagnostics'][] = array(
 		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
-		'source_path' => 'website/adversarial.html', 'selector' => 'form.adversarial', 'tag' => 'form', 'form_source_html' => $adversarial_html,
+		'source_path' => 'website/adversarial.html', 'selector' => 'form.adversarial', 'tag' => 'form', 'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $adversarial_html, 'form.adversarial' ),
 		'form' => array( 'class' => 'adversarial' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
 	);
 	$adversarial_contents = array( 'website/adversarial.html' => $core_html_block( $adversarial_html ) );
@@ -695,13 +699,40 @@ namespace {
 	$conflict_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/conflict.html' );
 	$conflict_report['diagnostics'][] = array(
 		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
-		'source_path' => 'website/conflict.html', 'selector' => 'form.conflict', 'tag' => 'form', 'form_source_html' => $conflict_html,
+		'source_path' => 'website/conflict.html', 'selector' => 'form.conflict', 'tag' => 'form', 'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $conflict_html, 'form.conflict' ),
 		'form' => array( 'class' => 'conflict' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ), array( 'tag' => 'input', 'type' => 'submit', 'value' => 'Send' ) ),
 	);
 	$conflict_contents = array( 'website/conflict.html' => $core_html_block( $conflict_html ) );
 	Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $conflict_report, array(), $conflict_contents );
 	$conflict_grafted = (string) $conflict_contents['website/conflict.html'];
 	$assert( str_contains( $conflict_grafted, '>Send</button>' ) && ! str_contains( $conflict_grafted, 'wsite-button' ) && ! str_contains( $conflict_grafted, '>Cancel</button>' ), 'graft-rejects-conflicting-visible-submit-presentation' );
+
+	$interleaved_html = '<form class="interleaved"><input name="email" type="email"><p class="required-note">This note is between fields.</p><textarea name="message"></textarea><button type="submit">Send</button></form>';
+	$interleaved_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/interleaved.html' );
+	$interleaved_report['diagnostics'][] = array(
+		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path' => 'website/interleaved.html', 'selector' => 'form.interleaved', 'tag' => 'form', 'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $interleaved_html, 'form.interleaved' ),
+		'form' => array( 'class' => 'interleaved' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ), array( 'tag' => 'textarea', 'type' => 'textarea', 'name' => 'message' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
+	);
+	$interleaved_contents = array( 'website/interleaved.html' => $core_html_block( $interleaved_html ) );
+	$interleaved_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $interleaved_report, array(), $interleaved_contents );
+	$assert( 0 === ( $interleaved_seeding['grafted_count'] ?? -1 ) && str_contains( $interleaved_contents['website/interleaved.html'], 'This note is between fields.') && 'form_context_interleaved' === ( $interleaved_report['diagnostics'][1]['diagnostic_code'] ?? '' ), 'graft-fails-closed-for-interleaved-context-with-truthful-diagnostic' );
+
+	$paired_forms = array(
+		'<form class="same" action="/a"><input name="email" type="email"><button type="submit">Send A</button></form>',
+		'<form class="same" action="/b"><input name="email" type="email"><button type="submit">Send B</button></form>',
+	);
+	$paired_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/paired.html' );
+	foreach ( $paired_forms as $paired_index => $paired_form ) {
+		$paired_report['diagnostics'][] = array(
+			'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+			'source_path' => 'website/paired.html', 'selector' => 'form.same:nth-of-type(' . ( $paired_index + 1 ) . ')', 'tag' => 'form', 'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $paired_form, 'form.same:nth-of-type(' . ( $paired_index + 1 ) . ')' ),
+			'form' => array( 'class' => 'same', 'action' => '/' . ( 0 === $paired_index ? 'a' : 'b' ) ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' . ( 0 === $paired_index ? ' A' : ' B' ) ) ),
+		);
+	}
+	$paired_contents = array( 'website/paired.html' => $core_html_block( $paired_forms[1] ) . $core_html_block( $paired_forms[0] ) );
+	$paired_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $paired_report, array(), $paired_contents );
+	$assert( 2 === ( $paired_seeding['grafted_count'] ?? 0 ) && str_contains( $paired_contents['website/paired.html'], '>Send A</button>' ) && str_contains( $paired_contents['website/paired.html'], '>Send B</button>' ), 'graft-pairs-same-named-forms-by-action-and-control-fingerprint' );
 
 	// A source fallback delegates to its generated-document finding instead of
 	// reporting a duplicate unanchorable graft after URL/class normalization.
@@ -746,7 +777,7 @@ namespace {
 			'tag'             => 'form',
 			'form'            => $transformer_fallback['form'] ?? array(),
 			'controls'        => $transformer_fallback['controls'] ?? array(),
-			'form_source_html' => $transformer_fallback['html'] ?? '',
+			'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( (string) ( $transformer_fallback['html'] ?? '' ), (string) ( $transformer_fallback['selector'] ?? '' ) ),
 			'readable_blocks' => $transformer_fallback['readable_blocks'] ?? array(),
 		);
 	};
@@ -801,7 +832,7 @@ namespace {
 		$assert( str_contains( $multi_grafted, 'wp:jetpack/field-text' ), 'graft-multi-form-b-field-text' );
 		$assert( ! str_contains( $multi_grafted, 'Send A</a>' ), 'graft-multi-drops-form-a-fallback' );
 		$assert( str_contains( $multi_grafted, 'Contact A' ) && str_contains( $multi_grafted, 'Contact B' ), 'graft-multi-preserves-both-sections' );
-		$assert( 2 === count( $multi_report['diagnostics'] ) && ! isset( $multi_report['diagnostics'][0]['form_source_html'] ) && ! isset( $multi_report['diagnostics'][1]['form_source_html'] ), 'graft-multi-consumes-dedicated-source-payloads-without-public-duplication' );
+		$assert( 2 === count( $multi_report['diagnostics'] ) && 'generic/form-presentation/v1' === ( $multi_report['diagnostics'][0]['form_presentation']['schema'] ?? '' ) && 'generic/form-presentation/v1' === ( $multi_report['diagnostics'][1]['form_presentation']['schema'] ?? '' ), 'graft-multi-retains-deduplicated-structured-presentation-metadata' );
 	}
 
 	// --- Graft leaves an unanchorable finding's fallback in place --------------

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -360,6 +360,23 @@ namespace {
 	$number_control_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $number_control_report, array() );
 	$number_control_finding = $number_control_report['diagnostics'][0] ?? array();
 	$assert( false === ( $number_control_finding['runtime_mapped'] ?? true ) && array( 'min', 'max' ) === array_column( $number_control_finding['form_receipt_unaccepted_losses'] ?? array(), 'attribute' ) && 2 === ( $number_control_seeding['unaccepted_receipt_loss_count'] ?? 0 ), 'number-unsupported-attributes-gate-form-runtime-acceptance' );
+	$height_controls = array();
+	$height_html     = '<form class="many-heights">';
+	for ( $height_index = 1; $height_index <= 17; ++$height_index ) {
+		$height_html       .= '<textarea name="message-' . $height_index . '" style="height:' . $height_index . 'px"></textarea>';
+		$height_controls[] = array( 'tag' => 'textarea', 'type' => 'textarea', 'name' => 'message-' . $height_index );
+	}
+	$height_html       .= '<button type="submit">Send</button></form>';
+	$height_controls[] = array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' );
+	$height_report      = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/many-heights.html' );
+	$height_report['diagnostics'][] = array(
+		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path' => 'website/many-heights.html', 'selector' => 'form.many-heights', 'tag' => 'form', 'controls' => $height_controls,
+		'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $height_html, 'form.many-heights', 1 ),
+	);
+	$height_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $height_report, array() );
+	$height_finding = $height_report['diagnostics'][0] ?? array();
+	$assert( false === ( $height_finding['runtime_mapped'] ?? true ) && 'textarea_height_omitted' === ( $height_finding['form_receipt_unaccepted_losses'][0]['reason_code'] ?? '' ) && 1 === ( $height_seeding['unaccepted_receipt_loss_count'] ?? 0 ), 'omitted-textarea-heights-gate-form-runtime-acceptance' );
 	$newsletter = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => array( array( 'selector' => 'form.newsletter', 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ), array( 'tag' => 'button', 'type' => 'submit', 'text' => 'Subscribe to newsletter' ) ) ) ) ) );
 	$assert( 'Subscribe to newsletter' === ( $newsletter['forms'][0]['submit_text'] ?? '' ), 'canonical-control-text-preserves-newsletter-submit-label' );
 	if ( function_exists( 'parse_blocks' ) ) {
@@ -734,6 +751,36 @@ namespace {
 	$paired_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $paired_report, array(), $paired_contents );
 	$assert( 2 === ( $paired_seeding['grafted_count'] ?? 0 ) && str_contains( $paired_contents['website/paired.html'], '>Send Alpha</button>' ) && str_contains( $paired_contents['website/paired.html'], '>Send Beta</button>' ) && str_contains( $paired_contents['website/paired.html'], 'Alpha heading' ) && str_contains( $paired_contents['website/paired.html'], 'Beta heading' ), 'graft-pairs-same-action-same-control-forms-by-presentation-fingerprint' );
 
+	$identical_form = '<form class="identical"><input name="email" type="email"><button type="submit">Send</button></form>';
+	$ordinal_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/ordinals.html' );
+	foreach ( array( array( 3, 'Third' ), array( 2, 'Second' ) ) as $ordinal_source ) {
+		$ordinal = $ordinal_source[0];
+		$label   = $ordinal_source[1];
+		$ordinal_report['diagnostics'][] = array(
+			'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+			'source_path' => 'website/ordinals.html', 'selector' => 'form.identical-' . strtolower( $label ), 'tag' => 'form',
+			'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $identical_form, 'form.identical-' . strtolower( $label ), $ordinal ),
+			'form' => array( 'class' => 'identical' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => $label ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
+		);
+	}
+	$ordinal_contents = array( 'website/ordinals.html' => $core_html_block( '<form class="unrelated"><input name="other" type="email"><button type="submit">Other</button></form>' ) . $core_html_block( $identical_form ) . $core_html_block( $identical_form ) );
+	$resolve_core_html_form = new ReflectionMethod( 'Static_Site_Importer_Report_Diagnostics', 'matching_core_html_form_block' );
+	$second_candidate       = $resolve_core_html_form->invoke( null, $ordinal_report['diagnostics'][1]['form_presentation'], $ordinal_contents['website/ordinals.html'] );
+	$third_candidate        = $resolve_core_html_form->invoke( null, $ordinal_report['diagnostics'][0]['form_presentation'], $ordinal_contents['website/ordinals.html'] );
+	$ordinal_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $ordinal_report, array(), $ordinal_contents );
+	$assert( 2 === ( $ordinal_seeding['grafted_count'] ?? 0 ) && 2 === ( $second_candidate['document_ordinal'] ?? 0 ) && 3 === ( $third_candidate['document_ordinal'] ?? 0 ) && str_contains( $ordinal_contents['website/ordinals.html'], 'unrelated' ), 'graft-matches-identical-forms-by-document-ordinal-despite-preceding-form-and-reversed-diagnostics' );
+
+	$ambiguous_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/ambiguous.html' );
+	$ambiguous_report['diagnostics'][] = array(
+		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path' => 'website/ambiguous.html', 'selector' => 'form.identical', 'tag' => 'form',
+		'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $identical_form, 'form.identical' ),
+		'form' => array( 'class' => 'identical' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
+	);
+	$ambiguous_contents = array( 'website/ambiguous.html' => $core_html_block( $identical_form ) . $core_html_block( $identical_form ) );
+	$ambiguous_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $ambiguous_report, array(), $ambiguous_contents );
+	$assert( 0 === ( $ambiguous_seeding['grafted_count'] ?? -1 ) && 2 === substr_count( $ambiguous_contents['website/ambiguous.html'], '<!-- wp:html' ), 'graft-fails-closed-for-ambiguous-fingerprint-without-document-ordinal' );
+
 	// A source fallback delegates to its generated-document finding instead of
 	// reporting a duplicate unanchorable graft after URL/class normalization.
 	$delegated_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/index.html' );
@@ -757,6 +804,7 @@ namespace {
 		'source_html_preview' => $core_html_form,
 		'form'                => array( 'class' => 'newsletter-form', 'action' => '#', 'method' => 'post' ),
 		'controls'            => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ) ),
+		'form_presentation'   => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $core_html_form, 'form.generated-form', 1 ),
 	);
 	$delegated_contents = array( 'parts/footer.html' => $core_html_block( $core_html_form ) );
 	$delegated_seeding  = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $delegated_report, array(), $delegated_contents );

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -719,20 +719,20 @@ namespace {
 	$assert( 0 === ( $interleaved_seeding['grafted_count'] ?? -1 ) && str_contains( $interleaved_contents['website/interleaved.html'], 'This note is between fields.') && 'form_context_interleaved' === ( $interleaved_report['diagnostics'][1]['diagnostic_code'] ?? '' ), 'graft-fails-closed-for-interleaved-context-with-truthful-diagnostic' );
 
 	$paired_forms = array(
-		'<form class="same" action="/a"><input name="email" type="email"><button type="submit">Send A</button></form>',
-		'<form class="same" action="/b"><input name="email" type="email"><button type="submit">Send B</button></form>',
+		'<form class="same" action="/submit"><h2>Alpha heading</h2><input name="email" type="email" aria-label="Alpha email"><button class="alpha-submit" type="submit">Send Alpha</button></form>',
+		'<form class="same" action="/submit"><h2>Beta heading</h2><input name="email" type="email" aria-label="Beta email"><button class="beta-submit" type="submit">Send Beta</button></form>',
 	);
 	$paired_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/paired.html' );
 	foreach ( $paired_forms as $paired_index => $paired_form ) {
 		$paired_report['diagnostics'][] = array(
 			'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
 			'source_path' => 'website/paired.html', 'selector' => 'form.same:nth-of-type(' . ( $paired_index + 1 ) . ')', 'tag' => 'form', 'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $paired_form, 'form.same:nth-of-type(' . ( $paired_index + 1 ) . ')' ),
-			'form' => array( 'class' => 'same', 'action' => '/' . ( 0 === $paired_index ? 'a' : 'b' ) ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' . ( 0 === $paired_index ? ' A' : ' B' ) ) ),
+			'form' => array( 'class' => 'same', 'action' => '/submit' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send ' . ( 0 === $paired_index ? 'Alpha' : 'Beta' ) ) ),
 		);
 	}
 	$paired_contents = array( 'website/paired.html' => $core_html_block( $paired_forms[1] ) . $core_html_block( $paired_forms[0] ) );
 	$paired_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $paired_report, array(), $paired_contents );
-	$assert( 2 === ( $paired_seeding['grafted_count'] ?? 0 ) && str_contains( $paired_contents['website/paired.html'], '>Send A</button>' ) && str_contains( $paired_contents['website/paired.html'], '>Send B</button>' ), 'graft-pairs-same-named-forms-by-action-and-control-fingerprint' );
+	$assert( 2 === ( $paired_seeding['grafted_count'] ?? 0 ) && str_contains( $paired_contents['website/paired.html'], '>Send Alpha</button>' ) && str_contains( $paired_contents['website/paired.html'], '>Send Beta</button>' ) && str_contains( $paired_contents['website/paired.html'], 'Alpha heading' ) && str_contains( $paired_contents['website/paired.html'], 'Beta heading' ), 'graft-pairs-same-action-same-control-forms-by-presentation-fingerprint' );
 
 	// A source fallback delegates to its generated-document finding instead of
 	// reporting a duplicate unanchorable graft after URL/class normalization.

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -770,6 +770,23 @@ namespace {
 	$ordinal_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $ordinal_report, array(), $ordinal_contents );
 	$assert( 2 === ( $ordinal_seeding['grafted_count'] ?? 0 ) && 2 === ( $second_candidate['document_ordinal'] ?? 0 ) && 3 === ( $third_candidate['document_ordinal'] ?? 0 ) && str_contains( $ordinal_contents['website/ordinals.html'], 'unrelated' ), 'graft-matches-identical-forms-by-document-ordinal-despite-preceding-form-and-reversed-diagnostics' );
 
+	$ascending_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/ascending-ordinals.html' );
+	foreach ( array( array( 2, 'Second' ), array( 3, 'Third' ) ) as $ordinal_source ) {
+		$ordinal = $ordinal_source[0];
+		$label   = $ordinal_source[1];
+		$ascending_report['diagnostics'][] = array(
+			'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+			'source_path' => 'website/ascending-ordinals.html', 'selector' => 'form.ascending-' . strtolower( $label ), 'tag' => 'form',
+			'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $identical_form, 'form.ascending-' . strtolower( $label ), $ordinal ),
+			'form' => array( 'class' => 'identical' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => $label ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
+		);
+	}
+	$ascending_contents = array( 'website/ascending-ordinals.html' => $core_html_block( '<form class="unrelated"><input name="other" type="email"><button type="submit">Other</button></form>' ) . $core_html_block( $identical_form ) . $core_html_block( $identical_form ) );
+	$ascending_seeding  = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $ascending_report, array(), $ascending_contents );
+	$second_position    = strpos( $ascending_contents['website/ascending-ordinals.html'], '"label":"Second"' );
+	$third_position     = strpos( $ascending_contents['website/ascending-ordinals.html'], '"label":"Third"' );
+	$assert( 2 === ( $ascending_seeding['grafted_count'] ?? 0 ) && false !== $second_position && false !== $third_position && $second_position < $third_position && str_contains( $ascending_contents['website/ascending-ordinals.html'], 'unrelated' ), 'graft-uses-original-document-ordinals-for-ascending-diagnostics' );
+
 	$ambiguous_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/ambiguous.html' );
 	$ambiguous_report['diagnostics'][] = array(
 		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -632,7 +632,7 @@ namespace {
 
 	// Complete fallback grafts retain authored context and presentation, rather than
 	// rebuilding a form from only its flat control list.
-	$cara_form_html = '<form class="contact-form"><h2>Contact Me</h2><label class="required-note"><span>*</span> Indicates required field</label><div class="name-row"><div class="first"><input aria-required="true" placeholder="First" type="text" name="first"><label>First</label></div><div class="last"><input aria-required="true" placeholder="Last" type="text" name="last"><label>Last</label></div></div><textarea aria-required="true" name="message" style="height:200px"></textarea><input type="submit" value="Submit"><a class="wsite-button"><span class="wsite-button-inner">Submit</span></a></form>';
+	$cara_form_html = '<form class="contact-form"><h2>Contact Me</h2><label class="required-note"><span>*</span> Indicates required field</label><div class="name-row"><div class="first"><input aria-required="true" placeholder="First" type="text" name="first"><label>First</label></div><div class="last"><input aria-required="true" placeholder="Last" type="text" name="last"><label>Last</label></div></div><textarea aria-required="true" name="message" style="height:200px"></textarea><input type="submit" value="Submit" style="position:absolute;left:-9999px"><a class="wsite-button"><span class="wsite-button-inner">Submit</span></a></form>';
 	$cara_report    = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/contact.html' );
 	$cara_report['diagnostics'][] = array(
 		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
@@ -662,6 +662,46 @@ namespace {
 	$assert( 2 === substr_count( $cara_grafted, '"width":50' ) && str_contains( $cara_grafted, '"required":true' ), 'graft-preserves-compound-name-widths-and-aria-required-semantics' );
 	$assert( str_contains( $cara_grafted, '"minHeight":"200px"' ), 'graft-preserves-textarea-height' );
 	$assert( str_contains( $cara_grafted, 'wsite-button') && str_contains( $cara_grafted, '>Submit</button>' ), 'graft-preserves-visible-submit-presentation' );
+
+	// Internal full-source payloads are consumed before the public diagnostic preview
+	// and removed before the report is returned. Context order follows source order.
+	$long_form_html = '<form class="long-form">' . str_repeat( '<span>padding</span>', 25 ) . '<h2>First context</h2><label class="required-note">Required note</label><h3>Second context</h3><input name="email" type="email"><button class="native-submit" type="submit">Send</button></form>';
+	$long_report    = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/long.html' );
+	$long_report['diagnostics'][] = array(
+		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path' => 'website/long.html', 'selector' => 'form.long-form', 'tag' => 'form', 'form_source_html' => $long_form_html, 'source_html_preview' => substr( $long_form_html, 0, 300 ),
+		'form' => array( 'class' => 'long-form' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
+	);
+	$long_contents = array( 'website/long.html' => $core_html_block( $long_form_html ) );
+	Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $long_report, array(), $long_contents );
+	$long_grafted = (string) $long_contents['website/long.html'];
+	$assert( strlen( $long_form_html ) > 300 && false === (bool) str_contains( substr( $long_form_html, 0, 300 ), 'First context' ) && str_contains( $long_grafted, 'First context' ), 'graft-uses-full-internal-source-not-public-preview' );
+	$assert( false === isset( $long_report['diagnostics'][0]['form_source_html'] ), 'graft-removes-internal-source-payload-from-public-diagnostic' );
+	$assert( strpos( $long_grafted, 'First context' ) < strpos( $long_grafted, 'Required note' ) && strpos( $long_grafted, 'Required note' ) < strpos( $long_grafted, 'Second context' ), 'graft-preserves-ordered-context-before-provider-form' );
+
+	$adversarial_html = '<form class="adversarial"><a class="wsite-button cancel" href="/">Cancel</a><input name="email" type="email"><button class="native-submit" type="submit">Send</button><a class="wsite-button navigation" href="/next">Continue</a></form>';
+	$adversarial_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/adversarial.html' );
+	$adversarial_report['diagnostics'][] = array(
+		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path' => 'website/adversarial.html', 'selector' => 'form.adversarial', 'tag' => 'form', 'form_source_html' => $adversarial_html,
+		'form' => array( 'class' => 'adversarial' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
+	);
+	$adversarial_contents = array( 'website/adversarial.html' => $core_html_block( $adversarial_html ) );
+	Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $adversarial_report, array(), $adversarial_contents );
+	$adversarial_grafted = (string) $adversarial_contents['website/adversarial.html'];
+	$assert( str_contains( $adversarial_grafted, 'native-submit' ) && ! str_contains( $adversarial_grafted, 'wsite-button' ) && str_contains( $adversarial_grafted, '>Send</button>' ), 'graft-ignores-non-submit-cancel-and-navigation-presentation' );
+
+	$conflict_html = '<form class="conflict"><input name="email" type="email"><input type="submit" value="Send" style="position:absolute;left:-9999px"><a class="wsite-button">Cancel</a></form>';
+	$conflict_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/conflict.html' );
+	$conflict_report['diagnostics'][] = array(
+		'type' => 'unsupported_html_fallback', 'diagnostic_code' => 'html_form_fallback', 'loss_class' => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path' => 'website/conflict.html', 'selector' => 'form.conflict', 'tag' => 'form', 'form_source_html' => $conflict_html,
+		'form' => array( 'class' => 'conflict' ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email' ), array( 'tag' => 'input', 'type' => 'submit', 'value' => 'Send' ) ),
+	);
+	$conflict_contents = array( 'website/conflict.html' => $core_html_block( $conflict_html ) );
+	Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $conflict_report, array(), $conflict_contents );
+	$conflict_grafted = (string) $conflict_contents['website/conflict.html'];
+	$assert( str_contains( $conflict_grafted, '>Send</button>' ) && ! str_contains( $conflict_grafted, 'wsite-button' ) && ! str_contains( $conflict_grafted, '>Cancel</button>' ), 'graft-rejects-conflicting-visible-submit-presentation' );
 
 	// A source fallback delegates to its generated-document finding instead of
 	// reporting a duplicate unanchorable graft after URL/class normalization.
@@ -706,6 +746,7 @@ namespace {
 			'tag'             => 'form',
 			'form'            => $transformer_fallback['form'] ?? array(),
 			'controls'        => $transformer_fallback['controls'] ?? array(),
+			'form_source_html' => $transformer_fallback['html'] ?? '',
 			'readable_blocks' => $transformer_fallback['readable_blocks'] ?? array(),
 		);
 	};
@@ -760,6 +801,7 @@ namespace {
 		$assert( str_contains( $multi_grafted, 'wp:jetpack/field-text' ), 'graft-multi-form-b-field-text' );
 		$assert( ! str_contains( $multi_grafted, 'Send A</a>' ), 'graft-multi-drops-form-a-fallback' );
 		$assert( str_contains( $multi_grafted, 'Contact A' ) && str_contains( $multi_grafted, 'Contact B' ), 'graft-multi-preserves-both-sections' );
+		$assert( 2 === count( $multi_report['diagnostics'] ) && ! isset( $multi_report['diagnostics'][0]['form_source_html'] ) && ! isset( $multi_report['diagnostics'][1]['form_source_html'] ), 'graft-multi-consumes-dedicated-source-payloads-without-public-duplication' );
 	}
 
 	// --- Graft leaves an unanchorable finding's fallback in place --------------

--- a/tests/form-materializer-topology.test.mjs
+++ b/tests/form-materializer-topology.test.mjs
@@ -72,7 +72,7 @@ test( 'provider-constrained topology emits nested fields and an editor-valid cor
 		cwd: process.cwd(),
 		encoding: 'utf8',
 	} );
-	const { markup, depth_markup: depthMarkup } = JSON.parse( output );
+	const { markup, depth_markup: depthMarkup, cara_markup: caraMarkup } = JSON.parse( output );
 	const warnings = [];
 	const originalWarn = console.warn;
 	const originalError = console.error;
@@ -107,6 +107,12 @@ test( 'provider-constrained topology emits nested fields and an editor-valid cor
 	assert.equal( coreButtons.length, 1 );
 	assert.equal( validateBlock( coreButtons[ 0 ] )[ 0 ], true );
 	assert.match( serialize( coreButtons ), /form-button-submit is-submit/ );
+	const caraBlocks = parse( caraMarkup );
+	assert.equal( caraBlocks[ 0 ].name, 'core/heading' );
+	assert.equal( caraBlocks[ 1 ].name, 'core/paragraph' );
+	assert.match( caraMarkup, /"required":true/ );
+	assert.match( caraMarkup, /wsite-button/ );
+	assert.equal( serialize( parse( serialize( caraBlocks ) ) ), serialize( caraBlocks ), 'complete fallback graft is Gutenberg byte-stable after canonical serialization' );
 } );
 
 test( 'Jetpack provider definitions are explicitly unavailable to this core-only validation', () => {

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1087,6 +1087,12 @@ $topology_form                             = array(
 			'label' => 'Name',
 		),
 		array(
+			'tag'   => 'textarea',
+			'type'  => 'textarea',
+			'name'  => 'message',
+			'label' => 'Message',
+		),
+		array(
 			'tag'   => 'button',
 			'type'  => 'submit',
 			'label' => 'Send',
@@ -1124,6 +1130,23 @@ $topology_form                             = array(
 				'depth'   => 0,
 				'control' => 1,
 			),
+			array(
+				'id'      => 'control-2',
+				'kind'    => 'control',
+				'parent'  => null,
+				'order'   => 2,
+				'depth'   => 0,
+				'control' => 2,
+			),
+		),
+	),
+	'bindings'         => array(
+		array(
+			'schema'                       => 'generic/block-binding/v1',
+			'source_path'                  => 'index.html',
+			'search_block_markup'          => '<!-- wp:html --><form class="contact"><h2>Contact Me</h2><label class="required-note">* Indicates required field</label><input name="name"><textarea name="message" style="height:200px"></textarea><button type="submit" class="wsite-button">Send</button></form><!-- /wp:html -->',
+			'occurrence'                   => 1,
+			'role'                         => 'form',
 		),
 	),
 );
@@ -1148,8 +1171,55 @@ $runtime_form_plan['runtime_declarations'] = array(
 	),
 );
 $runtime_form_lifecycle                    = $prepare_lifecycle->invoke( null, $runtime_form_plan, array() );
-$runtime_form_manifest                     = $runtime_form_lifecycle['entities'][ $form_declaration_id ]['manifest']['forms'][0] ?? array();
+$assert( ! is_wp_error( $runtime_form_lifecycle ), 'canonical form binding presentation passes runtime declaration validation' . ( is_wp_error( $runtime_form_lifecycle ) ? ': ' . $runtime_form_lifecycle->get_error_code() . ' ' . wp_json_encode( $runtime_form_lifecycle->get_error_data() ) : '' ) );
+$runtime_form_manifest                     = is_wp_error( $runtime_form_lifecycle ) ? array() : ( $runtime_form_lifecycle['entities'][ $form_declaration_id ]['manifest']['forms'][0] ?? array() );
 $assert( 'section' === ( $runtime_form_manifest['control_topology']['nodes'][0]['tag'] ?? '' ), 'runtime declarations retain validated form topology' );
+$assert( 'Contact Me' === ( $runtime_form_manifest['form']['context_before'][0]['text'] ?? '' ) && '* Indicates required field' === ( $runtime_form_manifest['form']['context_before'][1]['text'] ?? '' ), 'canonical form bindings preserve ordered heading and required-note context before provider validation' );
+$assert( '200px' === ( $runtime_form_manifest['controls'][1]['height'] ?? '' ) && 'Send' === ( $runtime_form_manifest['form']['submit_presentation']['text'] ?? '' ) && in_array( 'wsite-button', $runtime_form_manifest['form']['submit_presentation']['classes'] ?? array(), true ), 'canonical form bindings preserve textarea sizing and visible submit presentation before provider validation' );
+$presentation_conflicts = array(
+	str_replace( 'Contact Me', 'Write Me', $topology_form['bindings'][0]['search_block_markup'] ),
+	str_replace( '</form>', '<p class="help-note">After</p></form>', $topology_form['bindings'][0]['search_block_markup'] ),
+	str_replace( '<textarea', '<p class="help-note">Between</p><textarea', $topology_form['bindings'][0]['search_block_markup'] ),
+	str_replace( 'class="wsite-button"', 'class="alternate-button"', $topology_form['bindings'][0]['search_block_markup'] ),
+	str_replace( 'height:200px', 'height:300px', $topology_form['bindings'][0]['search_block_markup'] ),
+);
+foreach ( $presentation_conflicts as $conflicting_markup ) {
+	$conflicting_presentation_form = $topology_form;
+	$conflicting_presentation_form['bindings'][] = array_replace( $topology_form['bindings'][0], array( 'search_block_markup' => $conflicting_markup ) );
+	$assert( ! isset( Static_Site_Importer_Report_Diagnostics::apply_form_binding_presentation( $conflicting_presentation_form )['form']['context_before'] ), 'conflicting bounded presentation across canonical form bindings fails closed' );
+}
+$many_textarea_controls = array();
+$many_textareas_full    = '<form>';
+$many_textareas_partial = '<form>';
+for ( $index = 0; $index < 17; ++$index ) {
+	$many_textarea_controls[] = array( 'tag' => 'textarea', 'type' => 'textarea', 'name' => 'message-' . $index );
+	$many_textareas_full     .= '<textarea name="message-' . $index . '" style="height:200px"></textarea>';
+	$many_textareas_partial  .= '<textarea name="message-' . $index . '"' . ( 16 === $index ? '' : ' style="height:200px"' ) . '></textarea>';
+}
+$many_textarea_controls[] = array( 'tag' => 'button', 'type' => 'submit' );
+$many_textareas_full     .= '<button type="submit">Send</button></form>';
+$many_textareas_partial  .= '<button type="submit">Send</button></form>';
+$many_textarea_form       = array(
+	'controls' => $many_textarea_controls,
+	'bindings' => array(
+		array( 'schema' => 'generic/block-binding/v1', 'source_path' => 'index.html', 'search_block_markup' => $many_textareas_full, 'occurrence' => 1, 'role' => 'form' ),
+		array( 'schema' => 'generic/block-binding/v1', 'source_path' => 'index.html', 'search_block_markup' => $many_textareas_partial, 'occurrence' => 1, 'role' => 'form' ),
+	),
+);
+$assert( ! isset( Static_Site_Importer_Report_Diagnostics::apply_form_binding_presentation( $many_textarea_form )['controls'][0]['height'] ), 'conflicting bounded textarea-height omission counts fail closed' );
+$reordered_presentation_form             = $topology_form;
+$reordered_presentation_form['controls'] = array_reverse( $reordered_presentation_form['controls'] );
+$assert( ! isset( Static_Site_Importer_Report_Diagnostics::apply_form_binding_presentation( $reordered_presentation_form )['form']['context_before'] ), 'binding presentation fails closed when declaration control order does not match the exact anchor' );
+$invalid_presentation_form                            = $topology_form;
+$invalid_presentation_form['bindings'][0]['schema']   = 'generic/block-binding/invalid';
+$assert( ! isset( Static_Site_Importer_Report_Diagnostics::apply_form_binding_presentation( $invalid_presentation_form )['form']['context_before'] ), 'non-canonical form bindings are ignored before presentation extraction' );
+$scalar_bindings_form             = $topology_form;
+$scalar_bindings_form['bindings'] = 'invalid';
+$assert( $scalar_bindings_form === Static_Site_Importer_Report_Diagnostics::apply_form_binding_presentation( $scalar_bindings_form ), 'malformed binding collections remain unchanged for structured provider validation' );
+$malformed_entity_plan = $runtime_form_plan;
+$malformed_entity_plan['runtime_declarations'][1]['payload']['entities'] = array( 'invalid' );
+$malformed_entity_lifecycle = $prepare_lifecycle->invoke( null, $malformed_entity_plan, array() );
+$assert( is_wp_error( $malformed_entity_lifecycle ) && 'static_site_importer_runtime_entity_invalid' === $malformed_entity_lifecycle->get_error_code(), 'malformed form entities retain structured pre-provider rejection' );
 
 $unknown_topology_form                                  = $topology_form;
 $unknown_topology_form['control_topology']['untrusted'] = 'reject-me';


### PR DESCRIPTION
## Summary

- preserve ordered heading/note context, required semantics, compound fields, textarea sizing, and submit presentation
- extract bounded structured presentation metadata without leaking raw form HTML
- pair same-page forms through collision-resistant fingerprints and stable source coordinates
- fail closed when interleaved context or ambiguous identity cannot be preserved

Fixes #975.

## Verification

- `npm run test:all` (62 passed, 14 environment-gated skips)
- `php tests/form-materializer-smoke.php` (165 assertions)
- `php tests/smoke-contact-layout-transformer.php` (13 assertions)

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode implemented the generic form-grafting repair, generated adversarial pairing and preservation tests, and ran iterative independent code-review agents. Chris Huber reviewed every finding, verified the final branch, and owns the change.