### PR TITLE
Fix truncated Figma form layout graphs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "0.4.16",
+    "automattic/blocks-engine-php-transformer": "0.4.20",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dcc272fbb6a743ddd32048ef43431b24",
+    "content-hash": "6b00bdb8fae76ee70161cdc42a0ec620",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "v0.4.16",
+            "version": "v0.4.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "8871be064be55bb22b6c8bea10d19809d51a8c5d"
+                "reference": "1a70f3e01e8cbec525a2d4f5e6f4b18ff8dd32db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/8871be064be55bb22b6c8bea10d19809d51a8c5d",
-                "reference": "8871be064be55bb22b6c8bea10d19809d51a8c5d",
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/1a70f3e01e8cbec525a2d4f5e6f4b18ff8dd32db",
+                "reference": "1a70f3e01e8cbec525a2d4f5e6f4b18ff8dd32db",
                 "shasum": ""
             },
             "require": {
@@ -91,7 +91,7 @@
                 "issues": "https://github.com/Automattic/blocks-engine/issues",
                 "source": "https://github.com/Automattic/blocks-engine-php-transformer"
             },
-            "time": "2026-08-12T11:31:58+00:00"
+            "time": "2026-08-15T12:52:58+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -214,6 +214,18 @@ namespace {
 	$assert( array() === $submit_only['forms'], 'submit-only-form-rejected' );
 	$assert( ! empty( $submit_only['errors'] ), 'submit-only-form-error-recorded' );
 
+	// Truncated graphs remain producer fallback evidence, never runtime input.
+	$truncated_css   = str_repeat( '@media (min-width:1px){', 9 ) . '.form{display:grid}' . str_repeat( '}', 9 );
+	$truncated_forms = str_repeat( '<form class="form"><input name="email"><button type="submit">Send</button></form>', 8 );
+	$truncated_result = ( new \Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler() )->compile(
+		array( 'entrypoint' => 'index.html', 'files' => array( 'index.html' => '<style>' . $truncated_css . '</style>' . $truncated_forms ) )
+	)->toArray();
+	$truncated_fallbacks = array_values( array_filter( $truncated_result['fallbacks'] ?? array(), static fn( mixed $fallback ): bool => true === ( $fallback['layout_graph']['truncated'] ?? false ) ) );
+	$truncated_forms_declaration = array_values( array_filter( $truncated_result['source_reports']['wordpress_site_plan']['runtime_declarations'] ?? array(), static fn( mixed $declaration ): bool => 'forms' === ( $declaration['type'] ?? null ) ) )[0] ?? array();
+	$truncated_runtime_forms = $truncated_forms_declaration['payload']['entities'] ?? array();
+	$truncated_validation    = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => $truncated_runtime_forms ) );
+	$assert( 8 === count( $truncated_fallbacks ) && 8 === count( $truncated_runtime_forms ) && array() === array_filter( $truncated_runtime_forms, static fn( mixed $form ): bool => array_key_exists( 'layout_graph', $form ) ) && empty( $truncated_validation['errors'] ), 'truncated-layout-graphs-are-omitted-before-strict-runtime-validation' );
+
 	// --- Jetpack form seeder maps controls to contact-form blocks -----------
 	$forms_manifest = array(
 		'forms' => array(


### PR DESCRIPTION
## Summary
- update `automattic/blocks-engine-php-transformer` from `0.4.16` to `0.4.20`
- keep truncated form layout graphs as producer fallback evidence instead of runtime declarations
- verify strict SSI form validation accepts the resulting runtime entities

Closes #1002.

## Verification
- `php tests/form-materializer-smoke.php` (166 assertions)
- `node --test tools/run-fig-fixture-e2e.test.mjs` (11 tests)
- `composer validate --no-check-publish`
- the real multi-page Figma fixture transforms successfully, stages intact with WP Codebox `0.20.1`, discovers Jetpack dependencies, and completes dependency preparation

## Remaining fixture gate limit
The 65.7 MB embedded artifact reaches `validate-artifact`, where PHP-WASM exhausts memory while re-encoding the decoded artifact for lifecycle-receipt hashing (`static-site-importer.php:424`): approximately 1.25 GB allocated plus a failed 125 MB allocation. This is separate from the truncated layout-graph failure and is intentionally not worked around in this focused change.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode diagnosed the stale WP Codebox install, verified the `0.20.1` runtime path, investigated the fixture evidence, and prepared the focused dependency and regression-test change. Chris Huber remains responsible for every line.