### PR TITLE
Fix bounded lifecycle artifact receipt hashing

### DIFF
--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -18,8 +18,9 @@ if ( ! class_exists( 'Static_Site_Importer_Website_Artifact_Import_Input' ) ) {
  */
 class Static_Site_Importer_Validation_Runtime {
 
-	public const RESULT_SCHEMA                = 'static-site-importer/import-validation-result/v1';
-	public const FIXTURE_MATRIX_RESULT_SCHEMA = 'static-site-importer/fixture-matrix-validation-result/v1';
+	public const RESULT_SCHEMA                    = 'static-site-importer/import-validation-result/v1';
+	public const FIXTURE_MATRIX_RESULT_SCHEMA     = 'static-site-importer/fixture-matrix-validation-result/v1';
+	public const LIFECYCLE_ARTIFACT_DIGEST_SCHEMA = 'static-site-importer/lifecycle-artifact-digest/v1';
 
 	/**
 	 * Project the full validation result into the bounded fixture-matrix contract.
@@ -156,6 +157,57 @@ class Static_Site_Importer_Validation_Runtime {
 			'dependencies'      => $result['dependencies'] ?? array(),
 			'runtime_lifecycle' => $result['runtime_lifecycle'] ?? array(),
 		);
+	}
+
+	/**
+	 * Build a streaming digest for the exact JSON file handed between CLI lifecycle steps.
+	 *
+	 * This supplements, but does not replace, the canonical artifact_sha256 receipt field.
+	 *
+	 * @param string $artifact_path Artifact JSON file path.
+	 * @return array<string,string>|WP_Error
+	 */
+	public static function lifecycle_artifact_digest_from_file( string $artifact_path ) {
+		$digest = is_readable( $artifact_path ) ? hash_file( 'sha256', $artifact_path ) : false;
+		if ( ! is_string( $digest ) || ! preg_match( '/^[a-f0-9]{64}$/', $digest ) ) {
+			return new WP_Error( 'static_site_importer_lifecycle_artifact_digest_missing', 'The lifecycle artifact digest could not be calculated.' );
+		}
+
+		return array(
+			'schema'         => self::LIFECYCLE_ARTIFACT_DIGEST_SCHEMA,
+			'representation' => 'artifact-json-file-bytes',
+			'sha256'         => $digest,
+		);
+	}
+
+	/**
+	 * Verify that a lifecycle receipt binds to the supplied artifact.
+	 *
+	 * Versioned file digests are authoritative for newer CLI receipts and avoid
+	 * serializing the decoded artifact a second time. Receipts without one retain
+	 * the original canonical wp_json_encode() identity for compatibility.
+	 *
+	 * @param array<string,mixed> $receipt       Lifecycle receipt.
+	 * @param string              $artifact_path Artifact JSON file path.
+	 * @param array<string,mixed> $artifact      Decoded artifact for legacy receipts.
+	 */
+	public static function lifecycle_receipt_matches_artifact( array $receipt, string $artifact_path, array $artifact ): bool {
+		if ( isset( $receipt['artifact_digest'] ) ) {
+			$digest = $receipt['artifact_digest'];
+			if ( ! is_array( $digest ) || self::LIFECYCLE_ARTIFACT_DIGEST_SCHEMA !== ( $digest['schema'] ?? '' ) || 'artifact-json-file-bytes' !== ( $digest['representation'] ?? '' ) || ! is_string( $digest['sha256'] ) || ! preg_match( '/^[a-f0-9]{64}$/', $digest['sha256'] ) ) {
+				return false;
+			}
+
+			$current_digest = self::lifecycle_artifact_digest_from_file( $artifact_path );
+
+			return ! is_wp_error( $current_digest ) && hash_equals( $digest['sha256'], $current_digest['sha256'] );
+		}
+
+		// v1 receipts predate file-byte digests and retain their canonical identity.
+		$encoded_artifact = wp_json_encode( $artifact );
+		$artifact_hash    = false !== $encoded_artifact ? hash( 'sha256', $encoded_artifact ) : '';
+
+		return is_string( $receipt['artifact_sha256'] ?? null ) && hash_equals( $receipt['artifact_sha256'], $artifact_hash );
 	}
 
 	/** Resolve the server-owned identity for one validation invocation. */

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -371,12 +371,13 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			if ( is_wp_error( $result ) ) {
 				WP_CLI::error( $result->get_error_message() );
 			}
+			/** @var array<string,mixed> $result */
 			$artifact_digest = Static_Site_Importer_Validation_Runtime::lifecycle_artifact_digest_from_file( (string) ( $assoc_args['artifact'] ?? '' ) );
 			if ( is_wp_error( $artifact_digest ) ) {
 				WP_CLI::error( $artifact_digest->get_error_message() );
 			}
 			$result['artifact_digest'] = $artifact_digest;
-			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			$json                      = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 			if ( false === $json ) {
 				WP_CLI::error( 'Failed to encode dependency preparation receipt.' );
 			}
@@ -424,9 +425,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				$input['artifact'] = $artifact;
 			}
 			if ( isset( $assoc_args['lifecycle-receipt'] ) ) {
-				$receipt_json     = file_get_contents( (string) $assoc_args['lifecycle-receipt'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- CLI reads its explicit lifecycle handoff receipt.
-				$receipt          = json_decode( false === $receipt_json ? '' : $receipt_json, true );
-				$artifact_path    = isset( $assoc_args['artifact'] ) ? (string) $assoc_args['artifact'] : '';
+				$receipt_json  = file_get_contents( (string) $assoc_args['lifecycle-receipt'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- CLI reads its explicit lifecycle handoff receipt.
+				$receipt       = json_decode( false === $receipt_json ? '' : $receipt_json, true );
+				$artifact_path = isset( $assoc_args['artifact'] ) ? (string) $assoc_args['artifact'] : '';
 				if ( ! is_array( $receipt ) || 'static-site-importer/runtime-lifecycle-receipt/v1' !== ( $receipt['schema'] ?? '' ) || 'dependencies_prepared' !== ( $receipt['status'] ?? '' ) || ! isset( $input['artifact'] ) || ! Static_Site_Importer_Validation_Runtime::lifecycle_receipt_matches_artifact( $receipt, $artifact_path, $input['artifact'] ) ) {
 					WP_CLI::error( 'The --lifecycle-receipt must be a completed receipt for this exact artifact.' );
 				}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -371,6 +371,11 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			if ( is_wp_error( $result ) ) {
 				WP_CLI::error( $result->get_error_message() );
 			}
+			$artifact_digest = Static_Site_Importer_Validation_Runtime::lifecycle_artifact_digest_from_file( (string) ( $assoc_args['artifact'] ?? '' ) );
+			if ( is_wp_error( $artifact_digest ) ) {
+				WP_CLI::error( $artifact_digest->get_error_message() );
+			}
+			$result['artifact_digest'] = $artifact_digest;
 			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 			if ( false === $json ) {
 				WP_CLI::error( 'Failed to encode dependency preparation receipt.' );
@@ -421,9 +426,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 			if ( isset( $assoc_args['lifecycle-receipt'] ) ) {
 				$receipt_json     = file_get_contents( (string) $assoc_args['lifecycle-receipt'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- CLI reads its explicit lifecycle handoff receipt.
 				$receipt          = json_decode( false === $receipt_json ? '' : $receipt_json, true );
-				$encoded_artifact = isset( $input['artifact'] ) ? wp_json_encode( $input['artifact'] ) : false;
-				$artifact_hash    = false !== $encoded_artifact ? hash( 'sha256', $encoded_artifact ) : '';
-				if ( ! is_array( $receipt ) || 'static-site-importer/runtime-lifecycle-receipt/v1' !== ( $receipt['schema'] ?? '' ) || 'dependencies_prepared' !== ( $receipt['status'] ?? '' ) || ( $receipt['artifact_sha256'] ?? '' ) !== $artifact_hash ) {
+				$artifact_path    = isset( $assoc_args['artifact'] ) ? (string) $assoc_args['artifact'] : '';
+				if ( ! is_array( $receipt ) || 'static-site-importer/runtime-lifecycle-receipt/v1' !== ( $receipt['schema'] ?? '' ) || 'dependencies_prepared' !== ( $receipt['status'] ?? '' ) || ! isset( $input['artifact'] ) || ! Static_Site_Importer_Validation_Runtime::lifecycle_receipt_matches_artifact( $receipt, $artifact_path, $input['artifact'] ) ) {
 					WP_CLI::error( 'The --lifecycle-receipt must be a completed receipt for this exact artifact.' );
 				}
 				$input['runtime_lifecycle_phase']      = 'resume';

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -57,7 +57,10 @@ if ( ! function_exists( 'wp_generate_uuid4' ) ) {
 }
 
 if ( ! function_exists( 'wp_json_encode' ) ) {
+	$wp_json_encode_calls = 0;
 	function wp_json_encode( $value ) {
+		global $wp_json_encode_calls;
+		++$wp_json_encode_calls;
 		return json_encode( $value );
 	}
 }
@@ -276,7 +279,33 @@ $same_invocation_result       = Static_Site_Importer_Validation_Runtime::validat
 );
 $assert( is_wp_error( $same_invocation_result ) && 'static_site_importer_fresh_runtime_required' === $same_invocation_result->get_error_code(), 'same-invocation-resume-rejected' );
 
+$lifecycle_artifact_path = $artifact_dir . '/lifecycle-artifact.json';
+$lifecycle_artifact      = array( 'schema' => 'test/website-artifact/v1', 'files' => array( array( 'path' => 'website/index.html', 'content' => str_repeat( 'x', 8192 ) ) ) );
+file_put_contents( $lifecycle_artifact_path, json_encode( $lifecycle_artifact ) );
+$file_digest = Static_Site_Importer_Validation_Runtime::lifecycle_artifact_digest_from_file( $lifecycle_artifact_path );
+$receipt     = array(
+	'artifact_sha256' => hash( 'sha256', wp_json_encode( $lifecycle_artifact ) ),
+	'artifact_digest' => $file_digest,
+);
+$wp_json_encode_calls = 0;
+$assert( Static_Site_Importer_Validation_Runtime::lifecycle_receipt_matches_artifact( $receipt, $lifecycle_artifact_path, $lifecycle_artifact ) && 0 === $wp_json_encode_calls, 'versioned-cli-receipt-uses-streaming-file-digest-without-reencoding-artifact' );
+
+$mismatched_receipt                                = $receipt;
+$mismatched_receipt['artifact_digest']['sha256'] = str_repeat( '0', 64 );
+$wp_json_encode_calls                              = 0;
+$assert( ! Static_Site_Importer_Validation_Runtime::lifecycle_receipt_matches_artifact( $mismatched_receipt, $lifecycle_artifact_path, $lifecycle_artifact ) && 0 === $wp_json_encode_calls, 'mismatched-versioned-digest-is-rejected-without-legacy-fallback' );
+
+$legacy_receipt       = array( 'artifact_sha256' => hash( 'sha256', wp_json_encode( $lifecycle_artifact ) ) );
+$wp_json_encode_calls = 0;
+$assert( Static_Site_Importer_Validation_Runtime::lifecycle_receipt_matches_artifact( $legacy_receipt, $lifecycle_artifact_path, $lifecycle_artifact ) && 1 === $wp_json_encode_calls, 'legacy-receipt-retains-canonical-artifact-sha256-semantics' );
+
+$unknown_digest_receipt = $receipt;
+$unknown_digest_receipt['artifact_digest']['schema'] = 'static-site-importer/lifecycle-artifact-digest/v2';
+$wp_json_encode_calls = 0;
+$assert( ! Static_Site_Importer_Validation_Runtime::lifecycle_receipt_matches_artifact( $unknown_digest_receipt, $lifecycle_artifact_path, $lifecycle_artifact ) && 0 === $wp_json_encode_calls, 'unknown-versioned-digest-is-rejected-without-changing-its-meaning' );
+
 unlink( $report_path );
+unlink( $lifecycle_artifact_path );
 rmdir( $default_artifact_dir );
 rmdir( $override_artifact_dir );
 rmdir( $resume_artifact_dir );


### PR DESCRIPTION
## Summary

- add a versioned SHA-256 digest over the exact artifact JSON file bytes to CLI lifecycle receipts
- verify versioned receipts with streaming `hash_file()` instead of re-encoding the decoded artifact
- retain canonical `artifact_sha256` generation and legacy verification for mixed-version compatibility
- fail closed for malformed, unknown, or mismatched versioned digest contracts

Fixes #1008.

## Compatibility

New receipts retain the existing canonical `artifact_sha256`, so older validators continue to accept them. New validators use the versioned file-byte digest when present and fall back to the existing canonical `wp_json_encode()` identity only for legacy receipts.

## Verification

- `php tests/smoke-validation-runtime-diagnostics.php` (34 assertions)
- `php tests/form-materializer-smoke.php` (166 assertions)
- PHP syntax checks for all changed PHP files
- `git diff --check`
- WP Codebox 0.20.1 real-fixture replay with the 65.7 MB multi-page Figma artifact:
  - staged artifact remained intact
  - dependency discovery succeeded
  - `prepare-artifact-dependencies` succeeded and emitted `static-site-importer/lifecycle-artifact-digest/v1`
  - provider readiness succeeded
  - `validate-artifact` advanced beyond lifecycle receipt verification

The real fixture later exhausts PHP-WASM memory during import-time JSON serialization after receipt verification. That is a separate large-report/materialization memory boundary; this PR removes the lifecycle hashing blocker tracked by #1008 without broadening its compatibility-sensitive scope.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented the bounded digest contract, compatibility tests, and real-fixture verification. Chris Huber reviewed and remains responsible for every line.