### PR TITLE
Build development packages from source heads

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Import a static site or generated website artifact into WordPress pages and a co
 
 Static Site Importer is a WordPress plugin. It requires the [Blocks Engine PHP transformer](https://github.com/Automattic/blocks-engine/tree/trunk/php-transformer) Composer package and calls that package's canonical helper functions for generic artifact compilation and format conversion.
 
+## Development packages
+
+Build a production-shaped development ZIP using immutable Blocks Engine source without changing this checkout's Composer files:
+
+```bash
+npm run build:dev-package -- --blocks-engine-path ../blocks-engine --blocks-engine-ref origin/trunk
+```
+
+The command resolves the requested ref once, archives `php-transformer/` and `figma-transformer/` from that commit into an isolated temporary snapshot, installs production dependencies there, and delegates ZIP assembly to `homeboy review build`. The ZIP and adjacent provenance JSON are written to `build/`. Use `--output-dir <path>` to select another destination. The receipt records SSI `HEAD`, a dirty worktree identity when present, the Blocks Engine ref and SHA, Composer lock digest, ZIP digest, and schema version.
+
 ## Runtime package profiles
 
 `runtime-package-manifest.json` is the canonical package-composition contract for constrained or embedded WordPress runtimes. Consumers locate the manifest inside the normal plugin release, select a named profile, copy only matching relative paths, and fail if any declared `required_files` entry is absent. The contract is deployment-neutral: storage, archive transport, scheduling, and runtime infrastructure remain consumer concerns.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test:php-wasm-zstd": "node --test tools/php-wasm-zstd.test.mjs",
     "test:playground-launch": "node tools/verify-playground-launch.mjs",
     "build:php-wasm-zstd": "bash tools/build-php-wasm-zstd.sh",
+    "build:dev-package": "node tools/build-dev-package.mjs",
+    "test:dev-package": "node --test tools/build-dev-package.test.mjs",
     "test:js-block-validation": "node tests/smoke-generated-theme-block-validation.cjs",
     "test:validation": "node tests/run-validation-harness.cjs",
     "test:form-materializer-topology": "node --test tests/form-materializer-topology.test.mjs"

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -69,6 +69,7 @@
     { "path": "tests/smoke-website-artifact-document-metadata.php", "environment": "wordpress-runtime" },
     { "path": "tests/StaticSiteImporterFallbackDiagnosticsTest.php", "environment": "wordpress-runtime", "command": ["phpunit", "tests/StaticSiteImporterFallbackDiagnosticsTest.php"] },
     { "path": "tests/form-materializer-topology.test.mjs", "environment": "node" },
+    { "path": "tools/build-dev-package.test.mjs", "environment": "node" },
     { "path": "tools/fig-intent-parity-report.test.mjs", "environment": "node" },
     { "path": "tools/fixture-matrix.test.mjs", "environment": "node" },
     { "path": "tools/php-wasm-zstd.test.mjs", "environment": "node" },

--- a/tools/build-dev-package.mjs
+++ b/tools/build-dev-package.mjs
@@ -1,0 +1,206 @@
+import { createHash } from "node:crypto"
+import { execFileSync } from "node:child_process"
+import { cp, lstat, mkdtemp, mkdir, readFile, readlink, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { basename, dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)))
+const schema = "static-site-importer/development-package-provenance/v1"
+
+export function parseArguments(argv, cwd = process.cwd()) {
+  const options = {
+    blocksEnginePath: resolve(cwd, "../blocks-engine"),
+    blocksEngineRef: "origin/trunk",
+    outputDir: resolve(cwd, "build"),
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (value === "--blocks-engine-path") options.blocksEnginePath = resolve(cwd, requiredValue(argv, ++index, value))
+    else if (value === "--blocks-engine-ref") options.blocksEngineRef = requiredValue(argv, ++index, value)
+    else if (value === "--output-dir") options.outputDir = resolve(cwd, requiredValue(argv, ++index, value))
+    else if (value === "--help") options.help = true
+    else throw new Error(`Unknown argument: ${value}`)
+  }
+  return options
+}
+
+function requiredValue(argv, index, flag) {
+  if (!argv[index] || argv[index].startsWith("--")) throw new Error(`${flag} requires a value`)
+  return argv[index]
+}
+
+export function developmentComposerManifest(manifest, packageRoot) {
+  const packages = [
+    ["php-transformer", "automattic/blocks-engine-php-transformer"],
+    ["figma-transformer", "automattic/blocks-engine-figma-transformer"],
+  ]
+  return {
+    ...manifest,
+    repositories: [
+      ...packages.map(([directory, name]) => ({
+        type: "path",
+        url: join(packageRoot, "blocks-engine", directory),
+        options: { symlink: false, versions: { [name]: "dev-main" } },
+      })),
+      ...(manifest.repositories ?? []),
+    ],
+    require: {
+      ...manifest.require,
+      "automattic/blocks-engine-php-transformer": "*@dev",
+      "automattic/blocks-engine-figma-transformer": "*@dev",
+    },
+  }
+}
+
+export function provenance({ ssiSha, ssiDiff, blocksEngineSha, blocksEngineRef, composerLock, zip }) {
+  return {
+    schema,
+    command: "npm run build:dev-package",
+    static_site_importer: {
+      head: ssiSha,
+      dirty: ssiDiff !== null,
+      diff_sha256: ssiDiff,
+    },
+    blocks_engine: { ref: blocksEngineRef, sha: blocksEngineSha },
+    composer_lock_sha256: digest(composerLock),
+    zip: { file: basename(zip.path), sha256: digest(zip.bytes) },
+  }
+}
+
+export async function overlayWorkingTree(sourceRoot, snapshot, paths) {
+  const included = [...new Set(paths.map((path) => validateSourcePath(path)))].sort()
+  for (const path of included) {
+    const source = join(sourceRoot, path)
+    const destination = join(snapshot, path)
+    try {
+      const metadata = await lstat(source)
+      if (metadata.isDirectory()) throw new Error(`tracked directory cannot be packaged as a source file: ${path}`)
+      await mkdir(dirname(destination), { recursive: true })
+      await cp(source, destination, { force: true, dereference: false, preserveTimestamps: true })
+    } catch (error) {
+      if (error.code === "ENOENT") await rm(destination, { force: true })
+      else throw error
+    }
+  }
+  return included
+}
+
+export async function worktreeIdentity(sourceRoot, paths) {
+  const entries = []
+  for (const path of [...new Set(paths.map((path) => validateSourcePath(path)))].sort()) {
+    try {
+      const metadata = await lstat(join(sourceRoot, path))
+      if (metadata.isDirectory()) throw new Error(`tracked directory cannot be identified as a source file: ${path}`)
+      const bytes = metadata.isSymbolicLink() ? Buffer.from(await readlink(join(sourceRoot, path))) : await readFile(join(sourceRoot, path))
+      entries.push(`${path}\0${metadata.mode & 0o777}\0${digest(bytes)}\n`)
+    } catch (error) {
+      if (error.code === "ENOENT") entries.push(`${path}\0missing\n`)
+      else throw error
+    }
+  }
+  return digest(entries.join(""))
+}
+
+export async function buildDevelopmentPackage(options, dependencies = {}) {
+  const sourceRoot = dependencies.sourceRoot ?? root
+  const run = dependencies.run ?? runCommand
+  const temporaryDirectory = dependencies.temporaryDirectory ?? await mkdtemp(join(tmpdir(), "static-site-importer-dev-package-"))
+  const cleanup = dependencies.cleanup ?? (async () => rm(temporaryDirectory, { recursive: true, force: true }))
+  const extractArchive = dependencies.extractArchive ?? ((archive, destination) => run("tar", ["-xf", archive, "-C", destination], { cwd: temporaryDirectory }))
+  const snapshot = join(temporaryDirectory, "static-site-importer")
+  const blocksEngine = join(temporaryDirectory, "blocks-engine")
+
+  try {
+    for (const tool of ["git", "tar", "composer", "homeboy"]) await run(tool, ["--version"], { cwd: sourceRoot })
+    const ssiSha = text(await run("git", ["rev-parse", "HEAD"], { cwd: sourceRoot }))
+    const blocksEngineSha = text(await run("git", ["rev-parse", `${options.blocksEngineRef}^{commit}`], { cwd: options.blocksEnginePath }))
+    const status = await run("git", ["status", "--porcelain=v1", "-z"], { cwd: sourceRoot, allowEmpty: true })
+    const sourcePaths = text(await run("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard"], { cwd: sourceRoot })).split("\0").filter(Boolean)
+    const ssiDiff = status.length ? await worktreeIdentity(sourceRoot, sourcePaths) : null
+
+    await mkdir(snapshot, { recursive: true })
+    const ssiArchive = join(temporaryDirectory, "ssi.tar")
+    await run("git", ["archive", "--format=tar", `--output=${ssiArchive}`, ssiSha], { cwd: sourceRoot })
+    await extractArchive(ssiArchive, snapshot)
+    await overlayWorkingTree(sourceRoot, snapshot, sourcePaths)
+
+    await mkdir(blocksEngine, { recursive: true })
+    const blocksArchive = join(temporaryDirectory, "blocks-engine.tar")
+    await run("git", ["archive", "--format=tar", `--output=${blocksArchive}`, blocksEngineSha, "php-transformer", "figma-transformer"], { cwd: options.blocksEnginePath })
+    await extractArchive(blocksArchive, blocksEngine)
+
+    const composerPath = join(snapshot, "composer.json")
+    const manifest = JSON.parse(await readFile(composerPath, "utf8"))
+    await writeFile(composerPath, `${JSON.stringify(developmentComposerManifest(manifest, temporaryDirectory), null, 2)}\n`)
+    await run("composer", ["update", "automattic/blocks-engine-php-transformer", "automattic/blocks-engine-figma-transformer", "--with-all-dependencies", "--no-dev", "--no-interaction", "--prefer-dist"], { cwd: snapshot })
+
+    await run("homeboy", ["review", "--placement", "local", "build", "static-site-importer", "--path", snapshot], { cwd: snapshot })
+    const generatedZip = join(snapshot, "build", "static-site-importer.zip")
+    if (!await exists(generatedZip)) throw new Error(`Homeboy completed without the expected artifact: ${generatedZip}`)
+
+    const sourceIdentity = ssiDiff
+      ? `${ssiSha.slice(0, 12)}-dirty-${ssiDiff.slice(0, 12)}`
+      : ssiSha.slice(0, 12)
+    const outputName = `static-site-importer-dev-${sourceIdentity}-blocks-engine-${blocksEngineSha.slice(0, 12)}.zip`
+    const outputZip = join(options.outputDir, outputName)
+    await mkdir(options.outputDir, { recursive: true })
+    await cp(generatedZip, outputZip)
+    const receipt = provenance({
+      ssiSha,
+      ssiDiff,
+      blocksEngineSha,
+      blocksEngineRef: options.blocksEngineRef,
+      composerLock: await readFile(join(snapshot, "composer.lock")),
+      zip: { path: outputZip, bytes: await readFile(outputZip) },
+    })
+    const provenancePath = `${outputZip}.json`
+    await writeFile(provenancePath, `${JSON.stringify(receipt, null, 2)}\n`)
+    return { zip: outputZip, provenance: provenancePath, receipt }
+  } finally {
+    await cleanup()
+  }
+}
+
+function runCommand(command, args, { cwd }) {
+  try {
+    return execFileSync(command, args, { cwd, encoding: "buffer", stdio: ["ignore", "pipe", "pipe"] })
+  } catch (error) {
+    const detail = error.stderr?.toString().trim() || error.message
+    throw new Error(`${command} ${args.join(" ")} failed: ${detail}`)
+  }
+}
+
+function text(value) {
+  return value.toString().trim()
+}
+
+function digest(value) {
+  return createHash("sha256").update(value).digest("hex")
+}
+
+function validateSourcePath(path) {
+  if (!path || path.startsWith("/") || path.split("/").some((part) => !part || part === "." || part === "..")) throw new Error(`invalid Git source path: ${path}`)
+  if (path.split("/").some((part) => [".git", "vendor", "node_modules", "build", ".homeboy-build"].includes(part))) throw new Error(`reconstructable path cannot be packaged from the worktree: ${path}`)
+  return path
+}
+
+async function exists(path) {
+  try {
+    return (await stat(path)).isFile()
+  } catch {
+    return false
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const options = parseArguments(process.argv.slice(2), root)
+  if (options.help) {
+    console.log("Usage: npm run build:dev-package -- [--blocks-engine-path <path>] [--blocks-engine-ref <ref>] [--output-dir <path>]")
+  } else {
+    buildDevelopmentPackage(options).then(({ zip, provenance: receipt }) => console.log(`Built ${zip}\nProvenance ${receipt}`)).catch((error) => {
+      console.error(`Development package build failed: ${error.message}`)
+      process.exitCode = 1
+    })
+  }
+}

--- a/tools/build-dev-package.test.mjs
+++ b/tools/build-dev-package.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict"
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { basename, join } from "node:path"
+import test from "node:test"
+import { buildDevelopmentPackage, developmentComposerManifest, overlayWorkingTree, parseArguments, provenance, worktreeIdentity } from "./build-dev-package.mjs"
+
+test("parses explicit Blocks Engine inputs and sensible defaults", () => {
+  const defaults = parseArguments([], "/workspace/static-site-importer")
+  assert.equal(defaults.blocksEnginePath, "/workspace/blocks-engine")
+  assert.equal(defaults.blocksEngineRef, "origin/trunk")
+  assert.equal(defaults.outputDir, "/workspace/static-site-importer/build")
+  assert.deepEqual(parseArguments(["--blocks-engine-path", "../engine", "--blocks-engine-ref", "feature/head", "--output-dir", "artifacts"], "/workspace/static-site-importer"), {
+    blocksEnginePath: "/workspace/engine",
+    blocksEngineRef: "feature/head",
+    outputDir: "/workspace/static-site-importer/artifacts",
+  })
+})
+
+test("development Composer metadata uses isolated, non-symlinked transformer snapshots", () => {
+  const original = { require: { php: "^8.1" }, repositories: [{ type: "composer", url: "https://repo.packagist.org" }] }
+  const overridden = developmentComposerManifest(original, "/tmp/package")
+  assert.deepEqual(original, { require: { php: "^8.1" }, repositories: [{ type: "composer", url: "https://repo.packagist.org" }] })
+  assert.deepEqual(overridden.repositories.slice(0, 2), [
+    { type: "path", url: "/tmp/package/blocks-engine/php-transformer", options: { symlink: false, versions: { "automattic/blocks-engine-php-transformer": "dev-main" } } },
+    { type: "path", url: "/tmp/package/blocks-engine/figma-transformer", options: { symlink: false, versions: { "automattic/blocks-engine-figma-transformer": "dev-main" } } },
+  ])
+  assert.equal(overridden.require["automattic/blocks-engine-php-transformer"], "*@dev")
+  assert.equal(overridden.require["automattic/blocks-engine-figma-transformer"], "*@dev")
+})
+
+test("provenance binds immutable refs, the dirty identity, lock, and ZIP", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "ssi-dev-package-test-"))
+  const zip = join(directory, "package.zip")
+  await mkdir(directory, { recursive: true })
+  await writeFile(zip, "zip fixture")
+  const receipt = provenance({
+    ssiSha: "a".repeat(40), ssiDiff: "b".repeat(64), blocksEngineSha: "c".repeat(40), blocksEngineRef: "origin/trunk",
+    composerLock: Buffer.from("lock fixture"), zip: { path: zip, bytes: await readFile(zip) },
+  })
+  assert.equal(receipt.schema, "static-site-importer/development-package-provenance/v1")
+  assert.equal(receipt.static_site_importer.head, "a".repeat(40))
+  assert.equal(receipt.static_site_importer.diff_sha256, "b".repeat(64))
+  assert.equal(receipt.blocks_engine.sha, "c".repeat(40))
+  assert.match(receipt.composer_lock_sha256, /^[a-f0-9]{64}$/)
+  assert.match(receipt.zip.sha256, /^[a-f0-9]{64}$/)
+  await rm(directory, { recursive: true, force: true })
+})
+
+test("orchestration packages modified and untracked source bytes without changing the caller", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "ssi-dev-package-fixture-"))
+  const source = join(fixture, "source")
+  const engine = join(fixture, "blocks-engine")
+  const output = join(fixture, "output")
+  const temporary = join(fixture, "temporary")
+  await mkdir(source, { recursive: true })
+  await mkdir(engine, { recursive: true })
+  await writeFile(join(source, "composer.json"), JSON.stringify({ require: { php: "^8.1" } }))
+  await writeFile(join(source, "composer.lock"), "caller lock")
+  await writeFile(join(source, "tracked.txt"), "modified tracked bytes")
+  await writeFile(join(source, "untracked.txt"), "untracked bytes")
+  await mkdir(join(source, "vendor"), { recursive: true })
+  await writeFile(join(source, "vendor", "ignored.txt"), "ignored bytes")
+  const commands = []
+  let extracted = 0
+  const result = await buildDevelopmentPackage({ blocksEnginePath: engine, blocksEngineRef: "candidate", outputDir: output }, {
+    sourceRoot: source,
+    temporaryDirectory: temporary,
+    cleanup: async () => {},
+    run(command, args, context) {
+      commands.push({ command, args, context })
+      if (command === "git" && args[0] === "rev-parse") return Buffer.from(context.cwd === source ? `${"a".repeat(40)}\n` : `${"b".repeat(40)}\n`)
+      if (command === "git" && args[0] === "status") return Buffer.from(" M tracked.txt\0?? untracked.txt\0")
+      if (command === "git" && args[0] === "ls-files") return Buffer.from("composer.json\0composer.lock\0tracked.txt\0untracked.txt\0")
+      if (command === "composer") return writeFile(join(context.cwd, "composer.lock"), "temporary lock")
+      if (command === "homeboy") return Promise.all([readFile(join(context.cwd, "tracked.txt"), "utf8"), readFile(join(context.cwd, "untracked.txt"), "utf8")]).then(([tracked, untracked]) => mkdir(join(context.cwd, "build"), { recursive: true }).then(() => writeFile(join(context.cwd, "build/static-site-importer.zip"), `${tracked}|${untracked}`)))
+      return Buffer.from("")
+    },
+    async extractArchive(_archive, destination) {
+      extracted += 1
+      if (extracted === 1) await writeFile(join(destination, "composer.json"), JSON.stringify({ require: { php: "^8.1" } }))
+      else await mkdir(join(destination, "php-transformer"), { recursive: true })
+    },
+  })
+  assert.equal(await readFile(join(source, "composer.json"), "utf8"), JSON.stringify({ require: { php: "^8.1" } }))
+  assert.equal(await readFile(join(source, "tracked.txt"), "utf8"), "modified tracked bytes")
+  assert.equal(await readFile(join(source, "untracked.txt"), "utf8"), "untracked bytes")
+  assert.equal(extracted, 2)
+  assert.ok(commands.some(({ command, args }) => command === "git" && args.join(" ") === "rev-parse candidate^{commit}"))
+  assert.ok(commands.some(({ command, args }) => command === "git" && args.join(" ") === `archive --format=tar --output=${join(temporary, "blocks-engine.tar")} ${"b".repeat(40)} php-transformer figma-transformer`))
+  assert.ok(commands.some(({ command, args }) => command === "homeboy" && args.join(" ") === `review --placement local build static-site-importer --path ${join(temporary, "static-site-importer")}`))
+  assert.equal(basename(result.zip), `static-site-importer-dev-${"a".repeat(12)}-dirty-${result.receipt.static_site_importer.diff_sha256.slice(0, 12)}-blocks-engine-${"b".repeat(12)}.zip`)
+  assert.equal(await readFile(result.zip, "utf8"), "modified tracked bytes|untracked bytes")
+  assert.equal(result.receipt.static_site_importer.diff_sha256, await worktreeIdentity(source, ["composer.json", "composer.lock", "tracked.txt", "untracked.txt"]))
+  await assert.rejects(() => readFile(join(temporary, "static-site-importer", "vendor", "ignored.txt"), "utf8"), /ENOENT/)
+  assert.equal((await readFile(result.provenance, "utf8")).includes("candidate"), true)
+  await rm(fixture, { recursive: true, force: true })
+})
+
+test("worktree overlay rejects reconstructable directories", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "ssi-dev-package-overlay-"))
+  await mkdir(join(directory, "source", "vendor"), { recursive: true })
+  await assert.rejects(() => overlayWorkingTree(join(directory, "source"), join(directory, "snapshot"), ["vendor/cache.php"]), /reconstructable path/)
+  await rm(directory, { recursive: true, force: true })
+})


### PR DESCRIPTION
## Summary

- build vendor-complete SSI development ZIPs from the current SSI worktree
- resolve one explicit Blocks Engine ref to an immutable SHA and package both PHP and Figma transformers from that commit
- delegate final WordPress ZIP assembly to `homeboy review build`
- emit adjacent provenance binding source state, Composer lock, and ZIP digests

Closes #1015.

## Verification

- `npm run test:dev-package` (5 tests)
- `npm run test:runtime-package`
- real package build against Blocks Engine `f9de01f5e8d4ed2f31dc5ddb8fc915a849ff506b`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode analyzed the packaging boundaries, implemented the development builder and deterministic tests, and ran verification. Chris Huber remains responsible for every line.