### PR TITLE
Accept server-owned staged ZIP archives

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -428,6 +428,9 @@ if ( ! function_exists( 'static_site_importer_ability_import' ) ) {
 
 		$provenance = array( 'type' => $type );
 		$reference  = (string) ( $source['ref'] ?? '' );
+		if ( 'zip' === $type && ! empty( $source['zip']['staged_path'] ) ) {
+			return static_site_importer_ability_error( 'static_site_importer_staged_archive_forbidden', 'Staged archive paths must come from a server-owned opaque reference resolver.' );
+		}
 		if ( '' !== $reference ) {
 			$resolved = apply_filters( 'static_site_importer_resolve_source_reference', null, $reference, $type, $input );
 			if ( ! is_array( $resolved ) ) {
@@ -462,6 +465,11 @@ if ( ! function_exists( 'static_site_importer_ability_import' ) ) {
 			$runtime_source['html'] = (string) ( $source['html'] ?? '' );
 		} elseif ( 'files' === $type ) {
 			$runtime_source['files'] = isset( $source['files'] ) && is_array( $source['files'] ) ? $source['files'] : array();
+		} elseif ( ! empty( $source['zip']['staged_path'] ) ) {
+			$runtime_source['files'] = static_site_importer_staged_archive_files( $source['zip'] );
+			if ( is_wp_error( $runtime_source['files'] ) ) {
+				return static_site_importer_ability_error( (string) $runtime_source['files']->get_error_code(), $runtime_source['files']->get_error_message(), $runtime_source['files']->get_error_data() );
+			}
 		} else {
 			$runtime_source['archive'] = isset( $source['zip'] ) && is_array( $source['zip'] ) ? $source['zip'] : array();
 		}

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1241,17 +1241,70 @@ function static_site_importer_rest_archive_files( array $archive ) {
 		return new WP_Error( 'static_site_importer_archive_tempfile_failed', __( 'Uploaded ZIP archive could not be staged for extraction.', 'static-site-importer' ), array( 'status' => 500 ) );
 	}
 
-	$zip = new ZipArchive();
-	if ( true !== $zip->open( $tmp ) ) {
-		if ( file_exists( $tmp ) ) {
-			wp_delete_file( $tmp );
+	return static_site_importer_archive_files_from_path( $tmp, $limits, true );
+}
+
+/**
+ * Extract a server-owned staged ZIP without taking lifecycle ownership.
+ *
+ * The canonical ability calls this only after an opaque reference resolver has
+ * supplied the path. Direct ability and REST inputs never route staged paths here.
+ *
+ * @param array<string,mixed> $archive Resolved archive payload.
+ * @return array<int,array<string,mixed>>|WP_Error
+ */
+function static_site_importer_staged_archive_files( array $archive ) {
+	$name = isset( $archive['name'] ) ? (string) $archive['name'] : '';
+	$path = isset( $archive['staged_path'] ) ? (string) $archive['staged_path'] : '';
+	if ( ! preg_match( '/\.zip$/i', $name ) ) {
+		return new WP_Error( 'static_site_importer_invalid_archive_type', __( 'ZIP uploads must use a .zip file.', 'static-site-importer' ), array( 'status' => 400 ) );
+	}
+
+	$is_absolute = str_starts_with( $path, '/' ) || 1 === preg_match( '#^[A-Za-z]:[\\\\/]#', $path );
+	$real_path   = $is_absolute && ! is_link( $path ) ? realpath( $path ) : false;
+	if ( false === $real_path || ! is_file( $real_path ) || ! is_readable( $real_path ) ) {
+		return new WP_Error( 'static_site_importer_staged_archive_invalid', __( 'The staged ZIP archive is unavailable.', 'static-site-importer' ), array( 'status' => 400 ) );
+	}
+
+	$limits = static_site_importer_staged_archive_limits();
+	$size   = filesize( $real_path );
+	if ( false === $size || $size > $limits['max_archive_bytes'] ) {
+		return static_site_importer_rest_archive_limit_error( 'staged_bytes_exceeded' );
+	}
+
+	return static_site_importer_archive_files_from_path( $real_path, $limits, false );
+}
+
+/**
+ * Validate and extract a ZIP from a local path.
+ *
+ * @param string            $archive_path Local ZIP path.
+ * @param array<string,int> $limits       Bounded archive policy.
+ * @param bool              $delete_path  Whether this importer owns the path.
+ * @return array<int,array<string,mixed>>|WP_Error
+ */
+function static_site_importer_archive_files_from_path( string $archive_path, array $limits, bool $delete_path ) {
+	if ( ! class_exists( 'ZipArchive' ) ) {
+		return new WP_Error( 'static_site_importer_zip_unavailable', __( 'ZIP archive extraction is unavailable on this server.', 'static-site-importer' ), array( 'status' => 500 ) );
+	}
+
+	$cleanup = static function ( $zip = null ) use ( $archive_path, $delete_path ): void {
+		if ( $zip instanceof ZipArchive ) {
+			$zip->close();
 		}
+		if ( $delete_path && file_exists( $archive_path ) ) {
+			wp_delete_file( $archive_path );
+		}
+	};
+
+	$zip = new ZipArchive();
+	if ( true !== $zip->open( $archive_path ) ) {
+		$cleanup();
 		return new WP_Error( 'static_site_importer_archive_open_failed', __( 'Uploaded ZIP archive could not be opened.', 'static-site-importer' ), array( 'status' => 400 ) );
 	}
 
 	if ( $zip->numFiles > $limits['max_entries'] ) {
-		$zip->close();
-		wp_delete_file( $tmp );
+		$cleanup( $zip );
 		return static_site_importer_rest_archive_limit_error( 'entry_count_exceeded' );
 	}
 
@@ -1259,29 +1312,25 @@ function static_site_importer_rest_archive_files( array $archive ) {
 	for ( $i = 0; $i < $zip->numFiles; $i++ ) {
 		$stat = $zip->statIndex( $i );
 		if ( ! is_array( $stat ) || $stat['size'] < 0 || $stat['comp_size'] < 0 ) {
-			$zip->close();
-			wp_delete_file( $tmp );
+			$cleanup( $zip );
 			return new WP_Error( 'static_site_importer_archive_metadata_invalid', __( 'A ZIP archive entry has invalid metadata.', 'static-site-importer' ), array( 'status' => 400 ) );
 		}
 
 		$entry_uncompressed_bytes = (int) $stat['size'];
 		$entry_compressed_bytes   = (int) $stat['comp_size'];
 		if ( $entry_uncompressed_bytes > $limits['max_entry_uncompressed_bytes'] ) {
-			$zip->close();
-			wp_delete_file( $tmp );
+			$cleanup( $zip );
 			return static_site_importer_rest_archive_limit_error( 'entry_uncompressed_bytes_exceeded' );
 		}
 
 		$total_uncompressed_bytes += $entry_uncompressed_bytes;
 		if ( $total_uncompressed_bytes > $limits['max_total_uncompressed_bytes'] ) {
-			$zip->close();
-			wp_delete_file( $tmp );
+			$cleanup( $zip );
 			return static_site_importer_rest_archive_limit_error( 'total_uncompressed_bytes_exceeded' );
 		}
 
 		if ( 0 === $entry_compressed_bytes ? $entry_uncompressed_bytes > 0 : $entry_uncompressed_bytes / $entry_compressed_bytes > $limits['max_compression_ratio'] ) {
-			$zip->close();
-			wp_delete_file( $tmp );
+			$cleanup( $zip );
 			return static_site_importer_rest_archive_limit_error( 'compression_ratio_exceeded' );
 		}
 	}
@@ -1303,10 +1352,7 @@ function static_site_importer_rest_archive_files( array $archive ) {
 		}
 
 		if ( ! Static_Site_Importer_Content_Policy::is_static_path( $path ) ) {
-			$zip->close();
-			if ( file_exists( $tmp ) ) {
-				wp_delete_file( $tmp );
-			}
+			$cleanup( $zip );
 			return new WP_Error(
 				'static_site_importer_executable_source_rejected',
 				__( 'ZIP archives may contain static content only.', 'static-site-importer' ),
@@ -1319,10 +1365,7 @@ function static_site_importer_rest_archive_files( array $archive ) {
 
 		$file_content = $zip->getFromIndex( $i );
 		if ( false === $file_content ) {
-			$zip->close();
-			if ( file_exists( $tmp ) ) {
-				wp_delete_file( $tmp );
-			}
+			$cleanup( $zip );
 			return new WP_Error( 'static_site_importer_archive_entry_read_failed', __( 'A ZIP archive entry could not be read.', 'static-site-importer' ), array( 'status' => 400 ) );
 		}
 
@@ -1333,10 +1376,7 @@ function static_site_importer_rest_archive_files( array $archive ) {
 		);
 	}
 
-	$zip->close();
-	if ( file_exists( $tmp ) ) {
-		wp_delete_file( $tmp );
-	}
+	$cleanup( $zip );
 
 	return $files;
 }
@@ -1364,6 +1404,37 @@ function static_site_importer_rest_archive_limits(): array {
 		'max_compression_ratio'        => 100,
 	);
 	$limits      = apply_filters( 'static_site_importer_archive_limits', $defaults );
+	$limits      = is_array( $limits ) ? $limits : $defaults;
+
+	foreach ( $hard_limits as $key => $maximum ) {
+		$candidate      = isset( $limits[ $key ] ) ? (int) $limits[ $key ] : $defaults[ $key ];
+		$limits[ $key ] = min( $maximum, max( 1, $candidate ) );
+	}
+
+	return $limits;
+}
+
+/**
+ * Return hard-bounded limits for server-owned staged ZIP archives.
+ *
+ * @return array<string,int>
+ */
+function static_site_importer_staged_archive_limits(): array {
+	$hard_limits = array(
+		'max_archive_bytes'            => 262144000,
+		'max_entries'                  => 10000,
+		'max_entry_uncompressed_bytes' => 67108864,
+		'max_total_uncompressed_bytes' => 268435456,
+		'max_compression_ratio'        => 200,
+	);
+	$defaults    = array(
+		'max_archive_bytes'            => 209715200,
+		'max_entries'                  => 5000,
+		'max_entry_uncompressed_bytes' => 52428800,
+		'max_total_uncompressed_bytes' => 262144000,
+		'max_compression_ratio'        => 100,
+	);
+	$limits      = apply_filters( 'static_site_importer_staged_archive_limits', $defaults );
 	$limits      = is_array( $limits ) ? $limits : $defaults;
 
 	foreach ( $hard_limits as $key => $maximum ) {

--- a/tests/smoke-canonical-import-ability.php
+++ b/tests/smoke-canonical-import-ability.php
@@ -70,6 +70,15 @@ function static_site_importer_source_runtime( $source ) {
 		'source_metadata' => array(),
 	);
 }
+function static_site_importer_staged_archive_files( $archive ) {
+	$GLOBALS['ssi_staged_archives'][] = $archive;
+	return array(
+		array(
+			'path'    => 'website/index.html',
+			'content' => '<h1>Staged ZIP</h1>',
+		),
+	);
+}
 class Static_Site_Importer_Theme_Generator {
 	public static $compiled = 0;
 	public static $applied  = 0;
@@ -179,6 +188,17 @@ $rejected = static_site_importer_ability_import(
 );
 if ( 'static_site_importer_source_reference_unresolved' !== ( $rejected['error']['code'] ?? '' ) ) {
 	throw new RuntimeException( 'caller paths must not be accepted without an opaque reference resolver' ); }
+$rejected_staged_path = static_site_importer_ability_import(
+	array(
+		'operation' => 'plan',
+		'source'    => array(
+			'type' => 'zip',
+			'zip'  => array( 'name' => 'website.zip', 'staged_path' => '/tmp/caller-path.zip' ),
+		),
+	)
+);
+if ( 'static_site_importer_staged_archive_forbidden' !== ( $rejected_staged_path['error']['code'] ?? '' ) ) {
+	throw new RuntimeException( 'direct staged archive paths must be rejected before source normalization' ); }
 $GLOBALS['ssi_filters']['static_site_importer_resolve_source_reference'] = static function ( $value, $reference, $type ) {
 	return 'opaque-zip-1' === $reference && 'zip' === $type ? array(
 		'source'     => array(
@@ -201,6 +221,28 @@ $zip = static_site_importer_ability_import(
 );
 if ( empty( $zip['success'] ) || 'server' !== ( $zip['source']['provenance']['owner'] ?? '' ) ) {
 	throw new RuntimeException( 'opaque references must resolve the declared source type' ); }
+$GLOBALS['ssi_filters']['static_site_importer_resolve_source_reference'] = static function ( $value, $reference, $type ) {
+	return 'staged-zip-1' === $reference && 'zip' === $type ? array(
+		'source'     => array(
+			'zip' => array(
+				'name'        => 'website.zip',
+				'staged_path' => '/srv/private/website.zip',
+			),
+		),
+		'provenance' => array( 'owner' => 'server' ),
+	) : $value;
+};
+$staged_zip = static_site_importer_ability_import(
+	array(
+		'operation' => 'plan',
+		'source'    => array(
+			'type' => 'zip',
+			'ref'  => 'staged-zip-1',
+		),
+	)
+);
+if ( empty( $staged_zip['success'] ) || '/srv/private/website.zip' !== ( $GLOBALS['ssi_staged_archives'][0]['staged_path'] ?? '' ) || isset( $GLOBALS['ssi_runtime_sources'][3]['archive'] ) ) {
+	throw new RuntimeException( 'resolved staged archives must normalize through files without inline archive bytes' ); }
 $url = static_site_importer_ability_import(
 	array(
 		'operation' => 'plan',

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -1270,6 +1270,59 @@ if ( class_exists( 'ZipArchive' ) ) {
 	$hard_limited = static_site_importer_rest_archive_limits();
 	unset( $GLOBALS['ssi_filters']['static_site_importer_archive_limits'] );
 	$assert( 52428800 >= $hard_limited['max_encoded_bytes'], 'rest-zip-filter-cannot-exceed-encoded-hard-ceiling' );
+
+	$staged_path = tempnam( sys_get_temp_dir(), 'ssi-staged-' );
+	$staged_zip  = new ZipArchive();
+	$staged_zip->open( $staged_path, ZipArchive::OVERWRITE );
+	$staged_zip->addFromString( 'index.html', '<main>Staged</main>' );
+	$staged_zip->close();
+	$staged = static_site_importer_staged_archive_files(
+		array(
+			'name'        => 'website.zip',
+			'staged_path' => $staged_path,
+		)
+	);
+	$assert( is_array( $staged ) && 'website/index.html' === ( $staged[0]['path'] ?? '' ), 'staged-zip-extracts-provider-owned-archive' );
+	$assert( file_exists( $staged_path ), 'staged-zip-preserves-provider-owned-archive' );
+
+	$symlink_path = $staged_path . '.link';
+	if ( function_exists( 'symlink' ) && @symlink( $staged_path, $symlink_path ) ) {
+		$symlinked = static_site_importer_staged_archive_files(
+			array(
+				'name'        => 'website.zip',
+				'staged_path' => $symlink_path,
+			)
+		);
+		$assert( is_wp_error( $symlinked ) && 'static_site_importer_staged_archive_invalid' === $symlinked->get_error_code(), 'staged-zip-rejects-symlink' );
+		@unlink( $symlink_path );
+	}
+
+	$GLOBALS['ssi_filters']['static_site_importer_staged_archive_limits'] = array(
+		static function ( array $limits ): array {
+			$limits['max_archive_bytes'] = 1;
+			return $limits;
+		},
+	);
+	$oversized_staged = static_site_importer_staged_archive_files(
+		array(
+			'name'        => 'website.zip',
+			'staged_path' => $staged_path,
+		)
+	);
+	unset( $GLOBALS['ssi_filters']['static_site_importer_staged_archive_limits'] );
+	$assert( is_wp_error( $oversized_staged ) && 'static_site_importer_archive_staged_bytes_exceeded' === $oversized_staged->get_error_code(), 'staged-zip-enforces-archive-byte-limit' );
+	$assert( file_exists( $staged_path ), 'staged-zip-preserves-provider-archive-on-policy-failure' );
+	@unlink( $staged_path );
+
+	$GLOBALS['ssi_filters']['static_site_importer_staged_archive_limits'] = array(
+		static function ( array $limits ): array {
+			$limits['max_archive_bytes'] = PHP_INT_MAX;
+			return $limits;
+		},
+	);
+	$hard_staged_limits = static_site_importer_staged_archive_limits();
+	unset( $GLOBALS['ssi_filters']['static_site_importer_staged_archive_limits'] );
+	$assert( 262144000 === $hard_staged_limits['max_archive_bytes'], 'staged-zip-filter-cannot-exceed-hard-ceiling' );
 }
 
 $artifact = static_site_importer_rest_source_artifact(


### PR DESCRIPTION
## Summary

- allow opaque source resolvers to provide a server-owned staged ZIP path
- reject staged paths supplied directly through the canonical ability
- reuse ZIP bomb, static-content, and traversal policy without copying the complete archive
- preserve provider lifecycle ownership on success and failure
- apply separate hard-bounded staged archive limits while retaining existing REST limits

Fixes #1027.

## Testing

- `npm test` (63 manifest tests passed; 276 Node tests passed in the largest suite)
- `php tests/smoke-importer-block.php` (339 assertions)
- `php tests/smoke-canonical-import-ability.php`
- PHP syntax checks and `git diff --check`

AI assistance: OpenAI `gpt-5.6-sol` via OpenCode implemented and tested the staged archive contract under Chris Huber direction.