### PR TITLE
Run fixture scripts in isolated previews

### DIFF
--- a/lib/fixture-matrix/run-config.mjs
+++ b/lib/fixture-matrix/run-config.mjs
@@ -21,6 +21,8 @@ export const FIXTURE_MATRIX_RUN_FIELDS = Object.freeze({
   maxExtraSurfaces: { env: 'SSI_FIXTURE_MATRIX_MAX_EXTRA_SURFACES', integer: { min: 0 }, projections: { recipe: 'maxExtraSurfaces' } },
   editorValidation: { env: 'SSI_FIXTURE_MATRIX_EDITOR_VALIDATION', boolean: true, default: true, always: true, projections: { recipe: 'editorValidation' } },
   visualParity: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY', boolean: true, default: true, always: true, projections: { recipe: 'visualParity' } },
+  visualParityViewportWidth: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_VIEWPORT_WIDTH', integer: { min: 1 }, projections: { recipe: 'visualParityViewport.width' } },
+  visualParityViewportHeight: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_VIEWPORT_HEIGHT', integer: { min: 1 }, projections: { recipe: 'visualParityViewport.height' } },
   visualParityGate: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE', boolean: true, default: true, always: true, projections: { gate: 'visualParity.gate' } },
   pixelThreshold: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD', number: true, projections: { recipe: 'pixelThreshold', gate: 'visualParity.threshold' } },
   visualParityAlignment: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_ALIGNMENT', boolean: true, projections: { gate: 'visualParity.alignment' } },

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -377,7 +377,7 @@ function fixtureWorkflowSteps(options) {
         runtimePresentationEvidenceMergeStep({ fixture, artifactRoot: commandArtifactsDirectory, outputArtifacts: evidenceSurfaces.map(({ outputArtifact }) => outputArtifact) }),
       ];
     })() : []),
-    prepareFixtureDependenciesStep(fixture, commandArtifactsDirectory, attemptId, runtimePresentationEvidence ? RUNTIME_PRESENTATION_EVIDENCE_ARTIFACT_FILENAME : 'artifact.json'),
+    prepareFixtureDependenciesStep(fixture, commandArtifactsDirectory, runId, attemptId, runtimePresentationEvidence ? RUNTIME_PRESENTATION_EVIDENCE_ARTIFACT_FILENAME : 'artifact.json'),
     ...providerReadinessSteps(fixture, dependencyPlan),
     importFixtureStep(fixture, commandArtifactsDirectory, runId, attemptId, runtimePresentationEvidence ? RUNTIME_PRESENTATION_EVIDENCE_ARTIFACT_FILENAME : 'artifact.json'),
     materializationSidecarReadbackStep(fixture, commandArtifactsDirectory, attemptId),
@@ -565,10 +565,11 @@ function importFixtureStep(fixture, commandArtifactsDirectory, runId, attemptId,
   const fixtureDirectory = path.join(commandArtifactsDirectory, fixture.id);
   const sidecarName = `materialization-receipt--${sidecarToken(attemptId)}.json`;
   const dynamicClientAssetsFlag = fixture.allow_unproven_dynamic_client_assets ? ' --allow-unproven-dynamic-client-assets' : '';
+  const clientScriptFlags = isolatedPreviewClientScriptFlags(runId, fixture.id);
   return {
     command: 'wordpress.wp-cli',
     args: [
-      `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(fixtureDirectory, artifactFilename))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --lifecycle-receipt=${shellToken(path.join(fixtureDirectory, `dependency-receipt--${sidecarToken(attemptId)}.json`))} --format=fixture-matrix --receipt-sidecar=${shellToken(path.join(fixtureDirectory, sidecarName))} --receipt-run-id=${shellToken(runId)} --receipt-step-id=import --receipt-attempt-id=${shellToken(attemptId)} --allow-failure${dynamicClientAssetsFlag}`,
+      `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(fixtureDirectory, artifactFilename))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --lifecycle-receipt=${shellToken(path.join(fixtureDirectory, `dependency-receipt--${sidecarToken(attemptId)}.json`))} --format=fixture-matrix --receipt-sidecar=${shellToken(path.join(fixtureDirectory, sidecarName))} --receipt-run-id=${shellToken(runId)} --receipt-step-id=import --receipt-attempt-id=${shellToken(attemptId)} --allow-failure${dynamicClientAssetsFlag}${clientScriptFlags}`,
     ],
     metadata: fixtureStepMetadata(fixture, 'import', {
       artifact: path.join(commandArtifactsDirectory, fixture.id, artifactFilename),
@@ -594,13 +595,18 @@ WP_CLI::line(wp_json_encode($payload, JSON_UNESCAPED_SLASHES));`;
   };
 }
 
-function prepareFixtureDependenciesStep(fixture, commandArtifactsDirectory, attemptId, artifactFilename = 'artifact.json') {
+function prepareFixtureDependenciesStep(fixture, commandArtifactsDirectory, runId, attemptId, artifactFilename = 'artifact.json') {
   const fixtureDirectory = path.join(commandArtifactsDirectory, fixture.id);
   return {
     command: 'wordpress.wp-cli',
-    args: [`command=static-site-importer prepare-artifact-dependencies --artifact=${shellToken(path.join(fixtureDirectory, artifactFilename))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --receipt=${shellToken(path.join(fixtureDirectory, `dependency-receipt--${sidecarToken(attemptId)}.json`))}`],
+    args: [`command=static-site-importer prepare-artifact-dependencies --artifact=${shellToken(path.join(fixtureDirectory, artifactFilename))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --receipt=${shellToken(path.join(fixtureDirectory, `dependency-receipt--${sidecarToken(attemptId)}.json`))}${isolatedPreviewClientScriptFlags(runId, fixture.id)}`],
     metadata: fixtureStepMetadata(fixture, 'dependency-prepare', { artifact: path.join(commandArtifactsDirectory, fixture.id, artifactFilename) }),
   };
+}
+
+function isolatedPreviewClientScriptFlags(runId, fixtureId) {
+  const provenance = `fixture-matrix:${runId}:${fixtureId}`;
+  return ` --client-script-policy=isolated_preview --client-script-provenance=${shellToken(provenance)} --client-script-isolated`;
 }
 
 function providerReadinessSteps(fixture, plan) {

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -407,6 +407,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 				'allow_missing_woocommerce'            => isset( $assoc_args['allow-missing-woocommerce'] ),
 				'require_proven_dynamic_client_assets' => ! isset( $assoc_args['allow-unproven-dynamic-client-assets'] ),
 			);
+			$input = static_site_importer_cli_apply_client_script_args( $input, $assoc_args );
 			if ( isset( $assoc_args['host-staged-dependencies'] ) ) {
 				$input['materialize_dependencies'] = false;
 			}
@@ -538,13 +539,28 @@ function static_site_importer_cli_artifact_input( array $assoc_args ) {
 	if ( ! is_array( $artifact ) ) {
 		return new WP_Error( 'static_site_importer_cli_artifact_invalid', 'The --artifact file must contain a JSON object.' );
 	}
-	return array(
+	return static_site_importer_cli_apply_client_script_args( array(
 		'artifact'  => $artifact,
 		'slug'      => isset( $assoc_args['slug'] ) ? (string) $assoc_args['slug'] : '',
 		'name'      => isset( $assoc_args['name'] ) ? (string) $assoc_args['name'] : '',
 		'activate'  => ! isset( $assoc_args['no-activate'] ),
 		'overwrite' => ! isset( $assoc_args['no-overwrite'] ),
-	);
+	), $assoc_args );
+}
+
+/** Apply the explicit isolated-preview script policy shared by artifact lifecycle commands. */
+function static_site_importer_cli_apply_client_script_args( array $input, array $assoc_args ): array {
+	if ( isset( $assoc_args['client-script-policy'] ) ) {
+		$input['client_script_policy'] = (string) $assoc_args['client-script-policy'];
+	}
+	if ( isset( $assoc_args['client-script-provenance'] ) ) {
+		$input['client_script_provenance'] = array( 'ref' => (string) $assoc_args['client-script-provenance'] );
+	}
+	if ( isset( $assoc_args['client-script-isolated'] ) ) {
+		$input['client_script_isolated'] = true;
+	}
+
+	return $input;
 }
 
 /**

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -739,6 +739,11 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer prepare-artifact-dependencies/);
   assert.match(recipe.workflow.steps[2].args[0], /static-site-importer validate-artifact/);
+  for (const step of [recipe.workflow.steps[1], recipe.workflow.steps[2]]) {
+    assert.match(step.args[0], /--client-script-policy=isolated_preview/);
+    assert.match(step.args[0], /--client-script-provenance=fixture-matrix:[^ ]+:simple-site/);
+    assert.match(step.args[0], /--client-script-isolated/);
+  }
   assert.match(recipe.workflow.steps[2].args[0], /--lifecycle-receipt=/);
   assert.match(recipe.workflow.steps[2].args[0], /--format=fixture-matrix/);
   assert.match(recipe.workflow.steps[2].args[0], /--receipt-sidecar=\/wordpress\/wp-content\/uploads\/static-site-importer-fixture-matrix\/simple-site\/materialization-receipt--[A-Za-z0-9-]+\.json/);

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -760,6 +760,19 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   assert.deepEqual(recipe.inputs.mounts, []);
 });
 
+test('fixture matrix run config projects an explicit visual viewport into browser recipes', () => {
+  const config = normalizeFixtureMatrixRunConfig({
+    fixtureRoot: '/tmp/fixtures',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    visualParityViewportWidth: 390,
+    visualParityViewportHeight: 844,
+  });
+  const input = fixtureMatrixRecipeInput(config);
+  assert.deepEqual(input.visualParityViewport, { width: 390, height: 844 });
+  assert.equal(fixtureMatrixHomeboySettings(config).SSI_FIXTURE_MATRIX_VISUAL_PARITY_VIEWPORT_WIDTH, '390');
+  assert.equal(fixtureMatrixHomeboySettings(config).SSI_FIXTURE_MATRIX_VISUAL_PARITY_VIEWPORT_HEIGHT, '844');
+});
+
 test('runtime presentation evidence persists, merges, and reaches the Blocks Engine compilation input in order', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'runtime-presentation-evidence' });
   const defaultRecipe = buildFixtureMatrixRecipe({ matrix, artifactsDirectory: '/tmp/artifacts', staticSiteImporterPath: '/tmp/static-site-importer' });

--- a/tools/run-fixture-matrix.mjs
+++ b/tools/run-fixture-matrix.mjs
@@ -1071,7 +1071,7 @@ function printDependencyOverlayReferenceHelp() {
 // Visual attribution controls are separate so the main usage text remains
 // readable alongside the long routing contract above.
 function printVisualAttributionHelp() {
-  process.stdout.write('  --max-explanation-elements <n>      Maximum source elements for visual attribution.\n  --max-explanation-candidates <n>    Maximum candidate elements for visual attribution.\n  --explain-selectors <list>          Comma-separated selectors targeted for visual attribution.\n');
+  process.stdout.write('  --visual-parity-viewport-width <n>  Browser viewport width for visual capture.\n  --visual-parity-viewport-height <n> Browser viewport height for visual capture.\n  --max-explanation-elements <n>      Maximum source elements for visual attribution.\n  --max-explanation-candidates <n>    Maximum candidate elements for visual attribution.\n  --explain-selectors <list>          Comma-separated selectors targeted for visual attribution.\n');
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## Summary
- add explicit client-script policy flags to artifact lifecycle CLI commands
- run fixture-matrix imports with provenance-bound `isolated_preview` script execution
- preserve the default inert policy for normal imports

## Why
The disposable WP Codebox fixture matrix was using SSI's safe `inert` default, so executable source behavior was removed before Blocks Engine compilation. Visual acceptance could therefore pass while preserved runtime behavior was never exercised.

## Testing
- `node --test tools/fixture-matrix.test.mjs`
- `php -l static-site-importer.php`
- `php tests/smoke-client-script-policy.php`
- `php tests/smoke-website-artifact-import-input.php`
- `php tests/smoke-companion-plugin-js.php`

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode helped trace the policy mismatch, implement the CLI and fixture-matrix wiring, and run the listed verification. Chris Huber reviewed and remains responsible for the changes.