### PR TITLE
Generate trusted companion script dependency manifests

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -207,7 +207,7 @@ class Static_Site_Importer_Companion_Plugin {
 		$inventory_hash        = substr( hash( 'sha256', (string) wp_json_encode( array( $block_specs, $preserved ) ) ), 0, 16 );
 		$registration_callback = str_replace( '-', '_', $plugin_slug ) . '_' . $inventory_hash . '_register_blocks';
 		$main_file             = $plugin_slug . '/' . $plugin_slug . '.php';
-		$files     = array_merge(
+		$files                 = array_merge(
 			array(
 				$main_file => self::main_plugin_file( $plugin_slug, $block_namespace, $site_name, $block_specs, $preserved, $main_file, $inventory_hash ),
 			),
@@ -215,23 +215,23 @@ class Static_Site_Importer_Companion_Plugin {
 		);
 
 		$descriptor = array(
-			'schema'          => self::PAYLOAD_SCHEMA,
-			'slug'            => $plugin_slug,
-			'namespace'       => $block_namespace,
-			'site_slug'       => $site_slug,
-			'plugin_file'     => $main_file,
+			'schema'                => self::PAYLOAD_SCHEMA,
+			'slug'                  => $plugin_slug,
+			'namespace'             => $block_namespace,
+			'site_slug'             => $site_slug,
+			'plugin_file'           => $main_file,
 			'registration_callback' => $registration_callback,
-			'mu_plugin'       => $mu_plugin,
-			'block_names'     => $block_names,
+			'mu_plugin'             => $mu_plugin,
+			'block_names'           => $block_names,
 			// Handles of preserved island scripts the plugin carries + enqueues
 			// scoped. Exposed so the gate/diagnostics can account for preserved
 			// island JS as companion-plugin-carried (theme-independent) rather
 			// than theme-coupled.
-			'island_handles'  => array_map(
+			'island_handles'        => array_map(
 				static fn ( array $island ): string => (string) $island['handle'],
 				$preserved
 			),
-			'runtime_scripts' => array_map(
+			'runtime_scripts'       => array_map(
 				static fn ( array $island ): array => array(
 					'handle'          => (string) $island['handle'],
 					'block'           => (string) $island['block'],
@@ -241,8 +241,8 @@ class Static_Site_Importer_Companion_Plugin {
 				),
 				$preserved
 			),
-			'loader_file'     => '',
-			'files'           => $files,
+			'loader_file'           => '',
+			'files'                 => $files,
 		);
 
 		if ( $mu_plugin ) {
@@ -1063,7 +1063,8 @@ class Static_Site_Importer_Companion_Plugin {
 
 	/** @return string */
 	private static function asset_manifest_path( string $script_path ): string {
-		return substr( $script_path, 0, strrpos( $script_path, '.' ) ) . '.asset.php';
+		$extension_offset = strrpos( $script_path, '.' );
+		return false === $extension_offset ? $script_path . '.asset.php' : substr( $script_path, 0, $extension_offset ) . '.asset.php';
 	}
 
 	/** @param array<int,string> $dependencies */

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -39,6 +39,9 @@ if ( ! class_exists( 'Static_Site_Importer_Content_Policy' ) ) {
  */
 class Static_Site_Importer_Companion_Plugin {
 
+	/** Maximum declared script files and dependency handles per block. */
+	private const MAX_SCRIPT_DEPENDENCIES = 32;
+
 	/**
 	 * Payload schema identifier consumed by the scaffolder.
 	 */
@@ -112,6 +115,10 @@ class Static_Site_Importer_Companion_Plugin {
 			$metadata = $block['block_json'];
 			if ( isset( $block['render'] ) && is_scalar( $block['render'] ) ) {
 				$metadata['render'] = 'file:./render.php';
+			}
+			$script_dependencies = self::validate_script_dependencies( $block, $assets, $metadata );
+			if ( is_wp_error( $script_dependencies ) ) {
+				return $script_dependencies;
 			}
 			$references = self::metadata_file_references( $metadata );
 			foreach ( $references as $path ) {
@@ -394,6 +401,9 @@ class Static_Site_Importer_Companion_Plugin {
 				continue;
 			}
 			$files[ $relative ] = (string) $content;
+		}
+		foreach ( self::script_dependencies( $block ) as $relative => $dependencies ) {
+			$files[ self::asset_manifest_path( $relative ) ] = self::asset_manifest( $dependencies, (string) $assets[ $relative ] );
 		}
 		$metadata = isset( $block['block_json'] ) && is_array( $block['block_json'] ) && ! array_is_list( $block['block_json'] );
 		if ( $metadata ) {
@@ -991,6 +1001,74 @@ class Static_Site_Importer_Companion_Plugin {
 		}
 
 		return implode( '/', $segments );
+	}
+
+	/**
+	 * Validate compiler-declared WordPress script dependencies before generating
+	 * trusted PHP asset manifests.
+	 *
+	 * @param array<string,mixed> $block    Block payload entry.
+	 * @param array<string,mixed> $assets   Declared static block assets.
+	 * @param array<string,mixed> $metadata Block metadata, including render normalization.
+	 * @return true|WP_Error
+	 */
+	private static function validate_script_dependencies( array $block, array $assets, array $metadata ) {
+		$dependencies = $block['script_dependencies'] ?? array();
+		if ( ! is_array( $dependencies ) || ( ! empty( $dependencies ) && array_is_list( $dependencies ) ) || count( $dependencies ) > self::MAX_SCRIPT_DEPENDENCIES ) {
+			return new WP_Error( 'static_site_importer_companion_plugin_script_dependencies_invalid', 'Block script_dependencies must be a bounded object map.' );
+		}
+
+		$script_references = self::metadata_script_file_references( $metadata );
+		foreach ( $dependencies as $path => $handles ) {
+			if ( ! is_string( $path ) || self::sanitize_relative_path( $path ) !== $path || ! preg_match( '/\.(?:js|mjs)$/', $path ) || ! array_key_exists( $path, $assets ) || ! isset( $script_references[ $path ] ) ) {
+				return new WP_Error( 'static_site_importer_companion_plugin_script_dependency_path_invalid', 'Block script_dependencies must reference a declared JavaScript asset used by block metadata.' );
+			}
+			if ( ! is_array( $handles ) || ! array_is_list( $handles ) || count( $handles ) > self::MAX_SCRIPT_DEPENDENCIES ) {
+				return new WP_Error( 'static_site_importer_companion_plugin_script_dependencies_invalid', 'Each script dependency declaration must be a bounded list.' );
+			}
+			$seen = array();
+			foreach ( $handles as $handle ) {
+				if ( ! is_string( $handle ) || ! preg_match( '/^[a-z0-9_-]+$/', $handle ) || isset( $seen[ $handle ] ) ) {
+					return new WP_Error( 'static_site_importer_companion_plugin_script_dependency_handle_invalid', 'Script dependency handles must be unique safe WordPress handles.' );
+				}
+				$seen[ $handle ] = true;
+			}
+		}
+
+		return true;
+	}
+
+	/** @return array<string,array<int,string>> */
+	private static function script_dependencies( array $block ): array {
+		return isset( $block['script_dependencies'] ) && is_array( $block['script_dependencies'] ) ? $block['script_dependencies'] : array();
+	}
+
+	/** @return array<string,bool> */
+	private static function metadata_script_file_references( array $block_json ): array {
+		$references = array();
+		foreach ( array( 'editorScript', 'script', 'viewScript', 'viewScriptModule' ) as $key ) {
+			$values = isset( $block_json[ $key ] ) && is_array( $block_json[ $key ] ) ? $block_json[ $key ] : array( $block_json[ $key ] ?? null );
+			foreach ( $values as $value ) {
+				if ( is_string( $value ) && str_starts_with( $value, 'file:./' ) ) {
+					$path = self::sanitize_relative_path( substr( $value, 7 ) );
+					if ( '' !== $path ) {
+						$references[ $path ] = true;
+					}
+				}
+			}
+		}
+
+		return $references;
+	}
+
+	/** @return string */
+	private static function asset_manifest_path( string $script_path ): string {
+		return substr( $script_path, 0, strrpos( $script_path, '.' ) ) . '.asset.php';
+	}
+
+	/** @param array<int,string> $dependencies */
+	private static function asset_manifest( array $dependencies, string $content ): string {
+		return "<?php\nreturn array(\n\t'dependencies' => " . self::export_php_value( $dependencies, 1 ) . ",\n\t'version' => '" . hash( 'sha256', $content ) . "',\n);\n";
 	}
 
 	/** @return array<int,string> */

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -231,7 +231,7 @@ $payload = array(
 				'supports'   => array(
 					'interactivity' => true,
 				),
-				'editorScript' => 'file:./editor.js',
+				'editorScript' => 'file:./index.js',
 				'script'       => array( 'file:./script.js', 'shared-script-handle' ),
 				'style'        => 'file:./style.css',
 				'editorStyle'  => 'file:./editor.css',
@@ -242,7 +242,7 @@ $payload = array(
 			),
 			'render'     => '<div class="ssi-hero">Example hero</div>',
 			'assets'     => array(
-				'editor.js'  => 'window.SSIEditor = true;',
+				'index.js'   => 'window.SSIEditor = true;',
 				'script.js'  => 'window.SSIScript = true;',
 				'style.css'  => '.ssi-hero { color: inherit; }',
 				'editor.css' => '.editor-styles-wrapper .ssi-hero { color: inherit; }',
@@ -250,6 +250,9 @@ $payload = array(
 				'view-module.js' => 'export const SSIView = true;',
 				'view.css' => '.ssi-hero { display: block; }',
 				'variations.json' => '[]',
+			),
+			'script_dependencies' => array(
+				'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ),
 			),
 		),
 	),
@@ -297,6 +300,18 @@ $assert( 'failed' === ( $php_asset_report['status'] ?? '' ) && empty( $GLOBALS['
 $php_render = $payload;
 $php_render['blocks'][0]['render'] = '<?php system( "id" );';
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $php_render ) ), 'php-render-template-rejected' );
+$malformed_dependencies = $payload;
+$malformed_dependencies['blocks'][0]['script_dependencies'] = array( array( 'wp-blocks' ) );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $malformed_dependencies ) ), 'script-dependency-map-must-be-an-object' );
+$unsafe_dependency_path = $payload;
+$unsafe_dependency_path['blocks'][0]['script_dependencies'] = array( '../index.js' => array( 'wp-blocks' ) );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $unsafe_dependency_path ) ), 'script-dependency-path-must-be-safe' );
+$missing_dependency_asset = $payload;
+unset( $missing_dependency_asset['blocks'][0]['assets']['index.js'] );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $missing_dependency_asset ) ), 'script-dependency-asset-must-exist-and-be-referenced' );
+$invalid_dependency_handle = $payload;
+$invalid_dependency_handle['blocks'][0]['script_dependencies']['index.js'] = array( 'wp-blocks', 'wp blocks' );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $invalid_dependency_handle ) ), 'script-dependency-handle-must-be-safe' );
 
 // 1. Scaffolder emits a valid plugin file set.
 $descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $payload );
@@ -329,10 +344,12 @@ if ( is_array( $descriptor ) ) {
 	$assert( array() === $invalid_schema_types, 'main-file-emits-only-builtin-rest-schema-types', implode( ',', $invalid_schema_types ) );
 	$block_json = $files['ssi-example-site/blocks/custom-hero/block.json'] ?? '';
 	$assert( '' !== $block_json, 'metadata-block-json-emitted' );
-	$assert( str_contains( $block_json, '"editorScript": "file:./editor.js"' ), 'metadata-block-json-declares-editor-script' );
+	$assert( str_contains( $block_json, '"editorScript": "file:./index.js"' ), 'metadata-block-json-declares-editor-script' );
 	$assert( str_contains( $block_json, '"viewScript"' ) && str_contains( $block_json, '"file:./view.js"' ), 'metadata-block-json-declares-view-script' );
 	$assert( str_contains( $block_json, '"viewScriptModule"' ) && str_contains( $block_json, '"viewStyle"' ) && str_contains( $block_json, '"script"' ), 'metadata-block-json-retains-all-core-metadata-fields' );
-	$assert( isset( $files['ssi-example-site/blocks/custom-hero/editor.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/script.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/style.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/editor.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view-module.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/variations.json'] ), 'metadata-block-assets-emitted' );
+	$assert( isset( $files['ssi-example-site/blocks/custom-hero/index.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/script.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/style.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/editor.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view-module.js'] ) && isset( $files['ssi-example-site/blocks/custom-hero/view.css'] ) && isset( $files['ssi-example-site/blocks/custom-hero/variations.json'] ), 'metadata-block-assets-emitted' );
+	$asset_manifest = $files['ssi-example-site/blocks/custom-hero/index.asset.php'] ?? '';
+	$assert( str_contains( $asset_manifest, "'dependencies' => array(\n\t\t'wp-blocks',\n\t\t'wp-block-editor',\n\t\t'wp-element'," ) && str_contains( $asset_manifest, "'version' => '" . hash( 'sha256', 'window.SSIEditor = true;' ) . "'" ), 'script-dependency-asset-manifest-is-deterministic' );
 
 	// The render.php is the server-rendered template the render_callback runs.
 	$render = $files['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
@@ -437,7 +454,10 @@ $assert( 'ssi-example-site/ssi-example-site.php' === get_option( Static_Site_Imp
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ), 'install-writes-main-file-to-disk' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/render.php' ), 'install-writes-render-php-to-disk' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/block.json' ), 'install-emits-block-json' );
-$assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/editor.js' ), 'install-emits-declared-editor-asset' );
+$assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/index.js' ), 'install-emits-declared-editor-asset' );
+$written_asset_manifest = WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/index.asset.php';
+$asset_manifest_value  = file_exists( $written_asset_manifest ) ? include $written_asset_manifest : null;
+$assert( array( 'dependencies' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ), 'version' => hash( 'sha256', 'window.SSIEditor = true;' ) ) === $asset_manifest_value, 'installed-asset-manifest-executes-with-dependencies-and-content-version' );
 $assert( in_array( 'example/custom-hero', WP_Block_Type_Registry::$registered, true ), 'install-registers-declared-block-before-editor-use' );
 $assert( isset( $GLOBALS['static_site_importer_companion_block_owners']['example/custom-hero'] ), 'install-records-declared-block-owner-before-editor-use' );
 $written_main = file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) ? (string) file_get_contents( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) : '';


### PR DESCRIPTION
## Summary

- accept bounded declarative script dependency maps for generated companion blocks
- validate script paths, metadata references, assets, and WordPress handles
- generate trusted `.asset.php` manifests inside SSI without allowing producer-supplied PHP

## Why

Generated metadata blocks were registered server-side but could execute their editor script before `wp.blocks` loaded. Blocks Engine cannot safely supply executable PHP manifests because SSI correctly treats compiler payloads as untrusted static content. This adds the trusted materialization half of that contract.

## Verification

- `npm test`
- `npm run test:companion-plugin`
- Live disposable WordPress editor acceptance with the paired Blocks Engine branch: `blocks-engine/authored-input` loaded as a valid client block with zero editor warnings.

## Merge order

Merge this before the paired Blocks Engine dependency declaration change so the new payload field has an active trusted materializer.

Closes #1038.
Related: Automattic/blocks-engine#829.

## AI assistance

GPT-5.6 Sol via OpenCode was used to reproduce the editor failure, trace WordPress asset metadata loading, implement and test the trusted manifest boundary, and run live editor acceptance. Chris Huber reviewed the approach and is responsible for every line.