### PR TITLE
fix: satisfy wp alternatives lint

### DIFF
--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -405,7 +405,7 @@ class Static_Site_Importer_Plugin_Materializer {
 
 		// A byte-identical entrypoint proves this is the prior SSI scaffold for the
 		// same destination and payload, rather than a coincidental block namespace.
-		return hash_equals( $expected_main, (string) file_get_contents( $path ) );
+		return hash_equals( $expected_main, (string) file_get_contents( $path ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Byte-compares the importer-owned companion entrypoint on disk.
 	}
 
 	/** Resolve filesystem aliases before comparing an active generated plugin owner. */

--- a/includes/class-static-site-importer-url-fetcher.php
+++ b/includes/class-static-site-importer-url-fetcher.php
@@ -391,8 +391,8 @@ class Static_Site_Importer_URL_Fetcher {
 			return;
 		}
 		if ( $handle instanceof Static_Site_Importer_URL_Fetcher_Native_Handle && null !== $handle->multi && null !== $handle->curl ) {
-			curl_multi_remove_handle( $handle->multi, $handle->curl );
-			curl_multi_close( $handle->multi );
+			curl_multi_remove_handle( $handle->multi, $handle->curl ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_remove_handle -- Tears down the curl multi handle behind an IP-pinned request.
+			curl_multi_close( $handle->multi ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_close -- Releases the curl multi transport after an IP-pinned request.
 			$handle->curl  = null;
 			$handle->multi = null;
 			return;
@@ -445,8 +445,8 @@ class Static_Site_Importer_URL_Fetcher {
 		$handle->options  = $options;
 		$handle->started  = microtime( true );
 		$handle->ip_index = 0;
-		$handle->multi    = curl_multi_init();
-		$handle->curl     = curl_init();
+		$handle->multi    = curl_multi_init(); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_init -- Initializes the curl multi transport for an IP-pinned request.
+		$handle->curl     = curl_init(); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_init -- Initializes the curl handle for an IP-pinned request.
 		$ip               = $target['ips'][0];
 		$host             = $target['host'];
 		$host_header      = $host . ( ( 'https' === $target['scheme'] ? 443 : 80 ) === $target['port'] ? '' : ':' . $target['port'] );
@@ -492,8 +492,8 @@ class Static_Site_Importer_URL_Fetcher {
 		if ( is_readable( $ca_bundle ) ) {
 			$curl_options[ CURLOPT_CAINFO ] = $ca_bundle;
 		}
-		curl_setopt_array( $handle->curl, $curl_options );
-		curl_multi_add_handle( $handle->multi, $handle->curl );
+		curl_setopt_array( $handle->curl, $curl_options ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt_array -- Configures the IP-pinned request without changing Host or SNI.
+		curl_multi_add_handle( $handle->multi, $handle->curl ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_add_handle -- Registers the IP-pinned request with the curl multi transport.
 		return $handle;
 	}
 
@@ -590,13 +590,13 @@ class Static_Site_Importer_URL_Fetcher {
 			return new WP_Error( 'static_site_importer_url_deadline_exhausted', 'The URL request deadline was exhausted.' );
 		}
 		do {
-			$status = curl_multi_exec( $handle->multi, $running );
+			$status = curl_multi_exec( $handle->multi, $running ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_exec -- Advances the nonblocking IP-pinned request without blocking.
 		} while ( CURLM_CALL_MULTI_PERFORM === $status );
 		if ( CURLM_OK !== $status ) {
 			self::cancel_transport( null, $handle, 'curl_multi_failed' );
 			return new WP_Error( 'static_site_importer_url_connect_failed', 'Could not progress the URL request.' );
 		}
-		$info = curl_multi_info_read( $handle->multi );
+		$info = curl_multi_info_read( $handle->multi ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_info_read -- Collects the completed IP-pinned request from the curl multi transport.
 		if ( false === $info ) {
 			return null;
 		}
@@ -606,7 +606,7 @@ class Static_Site_Importer_URL_Fetcher {
 			return new WP_Error( 'static_site_importer_url_too_large', 'The URL response exceeded the maximum allowed size.' );
 		}
 		if ( CURLE_OK !== $result ) {
-			$error              = curl_error( $handle->curl );
+			$error              = curl_error( $handle->curl ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_error -- Reads the transport error for a reason-coded URL failure.
 			$deadline_exhausted = ! empty( $handle->options['deadline_limited'] );
 			if ( self::native_retry( $handle ) ) {
 				return null;


### PR DESCRIPTION
## Summary

Resolves the 10 `WordPress.WP.AlternativeFunctions` findings from the Homeboy lint gate with justified inline `phpcs:ignore` annotations. Comments only, no behavior change.

Fixes #1037
Fixes #1014
Fixes #1020
Fixes #1026
Fixes #1032
Fixes #1046
Fixes #1050
Fixes #1055
Fixes #1060
Fixes #1065

## Why these are intentional (not replaceable with `wp_remote_get()`)

### includes/class-static-site-importer-url-fetcher.php
9 `curl_*` calls form the IP-pinned `curl_multi` transport. It pins each request to a DNS IP that was already resolved and validated (SSRF defense against DNS rebinding), bounds TLS handshake progress, and enforces the invocation deadline with per-handle cancellation. `wp_remote_get()` cannot pin a pre-validated IP, multiplex nonblocking requests, or cancel mid-handshake. The no-curl stream fallback stays as the alternate path.

### includes/class-static-site-importer-plugin-materializer.php
`file_get_contents( $path )` at line 408 reads a local, importer-owned companion plugin entrypoint (guarded by `is_readable()`) for a `hash_equals()` byte comparison before reusing a prior scaffold. It is a local read, not a remote fetch, matching the existing annotation pattern used across `includes/`.

## Testing

**Test 1: fast lane**
1. `composer install`
2. `npm test`
Result: passed, failed 0 (64 passed across standalone-php + node)

**Test 2: URL fetcher smokes**
1. `php tests/smoke-url-concurrent-fetcher.php`
2. `php tests/smoke-url-curl-deadline.php` (curl-path deadline cancellation and chunked decoding)
3. `php tests/smoke-url-tls-context.php`

**Test 3: lint**
1. Push and watch the `homeboy-lint` CI job
Result: expected clean; the bot should stop refiling this category

Backward compatible: yes, no behavior change, comments only.