### PR TITLE
Use released WP Codebox in solved-site promotion

### DIFF
--- a/.github/workflows/solved-site-promotion-pr.yml
+++ b/.github/workflows/solved-site-promotion-pr.yml
@@ -27,4 +27,3 @@ jobs:
       static-site-importer-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       static-site-importer-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       blocks-engine-sha: 7858943a9913175993cc75870551c2e1926b4fb0
-      wp-codebox-sha: 831d30576984077ab4f68b5da599d4580de48165

--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -21,16 +21,6 @@ on:
         required: false
         default: Automattic/blocks-engine
         type: string
-      wp-codebox-sha:
-        description: Full WP Codebox candidate commit SHA.
-        required: false
-        default: 831d30576984077ab4f68b5da599d4580de48165
-        type: string
-      wp-codebox-repository:
-        description: Repository containing the WP Codebox candidate SHA.
-        required: false
-        default: Automattic/wp-codebox
-        type: string
       wordpress-version:
         description: Exact WordPress version used by WP Codebox.
         required: false
@@ -51,9 +41,10 @@ jobs:
       HOMEBOY_VERSION: v0.298.1
       HOMEBOY_SHA256: 543a1eb7348a9dcde3bee671dbbeaabb9486781d350792bed8a77424fdad60d5
       HOMEBOY_EXTENSIONS_REF: 615fe3632d0cd30e9a70d5aea82be80460d733d5
-      WP_CODEBOX_VERSION: v0.20.0
-      WP_CODEBOX_WORKSPACE_ASSET: wp-codebox-workspace-0.20.0.tgz
-      WP_CODEBOX_SHA: ${{ inputs.wp-codebox-sha }}
+      WP_CODEBOX_VERSION: v0.21.0
+      WP_CODEBOX_WORKSPACE_ASSET: wp-codebox-workspace-0.21.0.tgz
+      WP_CODEBOX_SHA256: 8f5fdd58ff4c78186155e29de2dec07004ac2eacba93131bb39d32f466272990
+      WP_CODEBOX_SHA: b1ef4aa66a34924c3760d5176c58a497d7eaabcd
       WORDPRESS_VERSION: ${{ inputs.wordpress-version }}
 
     steps:
@@ -61,11 +52,9 @@ jobs:
         env:
           STATIC_SITE_IMPORTER_SHA: ${{ inputs.static-site-importer-sha }}
           BLOCKS_ENGINE_SHA: ${{ inputs.blocks-engine-sha }}
-          WP_CODEBOX_SHA: ${{ inputs.wp-codebox-sha }}
         run: |
           [[ "$STATIC_SITE_IMPORTER_SHA" =~ ^[a-f0-9]{40}$ ]]
           [[ "$BLOCKS_ENGINE_SHA" =~ ^[a-f0-9]{40}$ ]]
-          [[ "$WP_CODEBOX_SHA" =~ ^[a-f0-9]{40}$ ]]
 
       - name: Checkout Static Site Importer candidate
         uses: actions/checkout@v4
@@ -80,13 +69,6 @@ jobs:
           repository: ${{ inputs.blocks-engine-repository }}
           ref: ${{ inputs.blocks-engine-sha }}
           path: blocks-engine
-
-      - name: Checkout WP Codebox candidate
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.wp-codebox-repository }}
-          ref: ${{ inputs.wp-codebox-sha }}
-          path: wp-codebox
 
       - name: Setup pinned Node
         uses: actions/setup-node@v4
@@ -151,17 +133,14 @@ jobs:
           echo "HOMEBOY_BIN=$RUNNER_TEMP/homeboy/homeboy" >> "$GITHUB_ENV"
 
       - name: Install pinned WP Codebox
-        working-directory: wp-codebox
         run: |
-          npm ci
-          mkdir -p "$RUNNER_TEMP/wp-codebox-package" "$RUNNER_TEMP/wp-codebox-install"
-          npm pack --pack-destination "$RUNNER_TEMP/wp-codebox-package"
-          WP_CODEBOX_SHA256=$(sha256sum "$RUNNER_TEMP/wp-codebox-package/${WP_CODEBOX_WORKSPACE_ASSET}" | cut -d' ' -f1)
-          echo "WP_CODEBOX_SHA256=$WP_CODEBOX_SHA256" >> "$GITHUB_ENV"
-          npm install --global --prefix "$RUNNER_TEMP/wp-codebox-install" "$RUNNER_TEMP/wp-codebox-package/${WP_CODEBOX_WORKSPACE_ASSET}"
-          node "$RUNNER_TEMP/wp-codebox-install/lib/node_modules/wp-codebox-workspace/node_modules/playwright/cli.js" install --with-deps chromium
-          "$RUNNER_TEMP/wp-codebox-install/bin/wp-codebox" commands --json
-          echo "WP_CODEBOX_BIN=$RUNNER_TEMP/wp-codebox-install/bin/wp-codebox" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/wp-codebox"
+          curl --fail --location --retry 3 --retry-all-errors --output "$RUNNER_TEMP/wp-codebox/workspace.tgz" "https://github.com/Automattic/wp-codebox/releases/download/${WP_CODEBOX_VERSION}/${WP_CODEBOX_WORKSPACE_ASSET}"
+          echo "${WP_CODEBOX_SHA256}  $RUNNER_TEMP/wp-codebox/workspace.tgz" | sha256sum --check --status
+          npm install --global --prefix "$RUNNER_TEMP/wp-codebox" "$RUNNER_TEMP/wp-codebox/workspace.tgz"
+          node "$RUNNER_TEMP/wp-codebox/lib/node_modules/wp-codebox-workspace/node_modules/playwright/cli.js" install --with-deps chromium
+          "$RUNNER_TEMP/wp-codebox/bin/wp-codebox" commands --json
+          echo "WP_CODEBOX_BIN=$RUNNER_TEMP/wp-codebox/bin/wp-codebox" >> "$GITHUB_ENV"
 
       - name: Record pinned runtime inputs
         env:

--- a/docs/contracts/solved-site-promotion-receipt-v1.md
+++ b/docs/contracts/solved-site-promotion-receipt-v1.md
@@ -11,7 +11,7 @@ The receipt is emitted only when:
 - every imported block is native and editor-valid through WP Codebox's loaded-post `wp.blocks.validateBlock` browser artifact, with registered block types and one complete recursive result per block;
 - source, imported, diff, and visual-diff artifacts exist with zero mismatch;
 - all evidence files are content-hashed under the uploaded artifact root;
-- the hashed runtime-input artifact binds the WP Codebox package checksum to its candidate commit;
+- the hashed runtime-input artifact binds the WP Codebox release version and package checksum to its release commit;
 - reviewer-facing references resolve to the GitHub Actions run and artifact list.
 
 SSI owns this decision and its schema. Homeboy may consume the receipt for generic finalization after validating the candidate and artifact identity chain; it does not reinterpret solved-site policy.

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -37,7 +37,7 @@ function fixture() {
     generated_from: { result_schema: matrix.schema, fixture_count: matrix.fixtures.length },
     fixture_decisions: [{ fixture_id: 'solved', fixture_corpus: 'solved', acceptance_status: 'solved_candidate' }],
   };
-  const runtime = { nodeVersion: '20.19.4', phpVersion: '8.1.29', wordpressVersion: '7.0.4', homeboyVersion: 'v0.298.1', homeboySha256: '3'.repeat(64), homeboyExtensionsRef: '4'.repeat(40), wpCodeboxVersion: 'v0.20.0', wpCodeboxSha256: '5'.repeat(64), wpCodeboxSha: WP_CODEBOX_SHA, staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA };
+  const runtime = { nodeVersion: '20.19.4', phpVersion: '8.1.29', wordpressVersion: '7.0.4', homeboyVersion: 'v0.298.1', homeboySha256: '3'.repeat(64), homeboyExtensionsRef: '4'.repeat(40), wpCodeboxVersion: 'v0.21.0', wpCodeboxSha256: '5'.repeat(64), wpCodeboxSha: WP_CODEBOX_SHA, staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA };
   const paths = { matrix: path.join(root, 'matrix.json'), registry: path.join(root, 'registry.json'), runtime: path.join(root, 'runtime.json') };
   write(paths.matrix, matrix); write(paths.registry, registry); write(paths.runtime, runtime);
   return { root, matrix, registry, runtime, paths, options: { matrixResult: paths.matrix, registry: paths.registry, runtimeInputs: paths.runtime, artifactRoot: root, staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA, wpCodeboxSha: WP_CODEBOX_SHA, fixtureTreeSha: '6'.repeat(40), solvedFixtureCount: 1, solvedFixtureIds: 'solved', runUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123', artifactUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123#artifacts', output: path.join(root, 'receipt.json'), manifestOutput: path.join(root, 'manifest.json') } };
@@ -72,17 +72,19 @@ test('accepts complete parent-document editor presentation evidence', () => {
   assert.equal(verifySolvedSitePromotion(input.options).status, 'accepted');
 });
 
-test('pins an immutable WP Codebox candidate package and checksum together', () => {
+test('pins an immutable WP Codebox release package, commit, and checksum together', () => {
   const workflow = fs.readFileSync(path.resolve('.github/workflows/solved-site-promotion.yml'), 'utf8');
   const caller = fs.readFileSync(path.resolve('.github/workflows/solved-site-promotion-pr.yml'), 'utf8');
-  assert.match(workflow, /default: 831d30576984077ab4f68b5da599d4580de48165/);
-  assert.match(workflow, /WP_CODEBOX_VERSION: v0\.20\.0/);
-  assert.match(workflow, /WP_CODEBOX_WORKSPACE_ASSET: wp-codebox-workspace-0\.20\.0\.tgz/);
-  assert.match(workflow, /npm pack --pack-destination/);
-  assert.match(workflow, /WP_CODEBOX_SHA256=\$\(sha256sum/);
+  assert.match(workflow, /WP_CODEBOX_VERSION: v0\.21\.0/);
+  assert.match(workflow, /WP_CODEBOX_WORKSPACE_ASSET: wp-codebox-workspace-0\.21\.0\.tgz/);
+  assert.match(workflow, /WP_CODEBOX_SHA256: 8f5fdd58ff4c78186155e29de2dec07004ac2eacba93131bb39d32f466272990/);
+  assert.match(workflow, /WP_CODEBOX_SHA: b1ef4aa66a34924c3760d5176c58a497d7eaabcd/);
+  assert.match(workflow, /releases\/download\/\$\{WP_CODEBOX_VERSION\}\/\$\{WP_CODEBOX_WORKSPACE_ASSET\}/);
+  assert.match(workflow, /sha256sum --check --status/);
+  assert.doesNotMatch(workflow, /Checkout WP Codebox candidate|npm pack --pack-destination|wp-codebox-sha:/);
   assert.match(workflow, /wpCodeboxSha:process\.env\.WP_CODEBOX_SHA/);
   assert.match(caller, /blocks-engine-sha: 7858943a9913175993cc75870551c2e1926b4fb0/);
-  assert.match(caller, /wp-codebox-sha: 831d30576984077ab4f68b5da599d4580de48165/);
+  assert.doesNotMatch(caller, /wp-codebox-sha:/);
 });
 
 test('resolves uniquely named durable copies of transient runtime evidence', () => {


### PR DESCRIPTION
## Summary
- install the published WP Codebox v0.21.0 workspace archive instead of checking out and packaging an unreleased candidate
- verify the published archive SHA-256 and retain the release commit in promotion runtime evidence
- remove the obsolete WP Codebox candidate inputs from the reusable workflow and caller

## Why
Blocks Engine PR #912 proved the receipt-safe promotion path against WP Codebox commit `b1ef4aa66a34924c3760d5176c58a497d7eaabcd`, which is already released as v0.21.0. The reusable gate should consume that immutable release artifact rather than rebuild source SHA `831d3057`.

Evidence: https://github.com/Automattic/blocks-engine/actions/runs/32497156116

## Verification
- `actionlint .github/workflows/solved-site-promotion.yml .github/workflows/solved-site-promotion-pr.yml`
- `npm run test:solved-site-promotion`
- `npm test` (63 selected tests, 0 failures)

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to trace the promotion evidence transport, verify the published release identity and digest, implement the workflow update, and run the checks. Chris Huber reviewed and is responsible for the change.