### PR TITLE
fix(lint): align equals signs to WordPress standard

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -200,7 +200,7 @@ class Static_Site_Importer_Companion_Plugin {
 		$inventory_hash        = substr( hash( 'sha256', (string) wp_json_encode( array( $block_specs, $preserved ) ) ), 0, 16 );
 		$registration_callback = str_replace( '-', '_', $plugin_slug ) . '_' . $inventory_hash . '_register_blocks';
 		$main_file             = $plugin_slug . '/' . $plugin_slug . '.php';
-		$files     = array_merge(
+		$files                 = array_merge(
 			array(
 				$main_file => self::main_plugin_file( $plugin_slug, $block_namespace, $site_name, $block_specs, $preserved, $main_file, $inventory_hash ),
 			),

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -279,11 +279,11 @@ class Static_Site_Importer_Diagnostic_Contract {
 	private static function quality_counts( array $import_report, array $summary, array $result ): array {
 		$keys                              = array( 'block_count', 'fallback_count', 'diagnostic_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
 		$compiler_quality                  = isset( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) && is_array( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) ? $import_report['blocks_engine']['wordpress_site_plan']['quality'] : array();
-		$report_quality   = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
-		$source_counts    = self::quality_metric_values( $compiler_quality, $keys );
-		$report_counts    = self::quality_metric_values( $report_quality, $keys );
+		$report_quality                    = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
+		$source_counts                     = self::quality_metric_values( $compiler_quality, $keys );
+		$report_counts                     = self::quality_metric_values( $report_quality, $keys );
 		$compiler_fallback_count_available = isset( $source_counts['fallback_count'] );
-		$provenance       = array();
+		$provenance                        = array();
 
 		foreach ( $keys as $key ) {
 			if ( ! isset( $source_counts[ $key ] ) && isset( $report_counts[ $key ] ) ) {
@@ -306,25 +306,25 @@ class Static_Site_Importer_Diagnostic_Contract {
 			);
 		}
 
-		$receipt                        = isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : ( isset( $import_report['materialization_receipt'] ) && is_array( $import_report['materialization_receipt'] ) ? $import_report['materialization_receipt'] : array() );
-		$reconciliation                 = isset( $import_report['quality_resolutions'] ) && is_array( $import_report['quality_resolutions'] )
+		$receipt                         = isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : ( isset( $import_report['materialization_receipt'] ) && is_array( $import_report['materialization_receipt'] ) ? $import_report['materialization_receipt'] : array() );
+		$reconciliation                  = isset( $import_report['quality_resolutions'] ) && is_array( $import_report['quality_resolutions'] )
 			? $import_report['quality_resolutions']
 			: ( isset( $import_report['fallback_reconciliation'] ) && is_array( $import_report['fallback_reconciliation'] ) ? $import_report['fallback_reconciliation'] : array() );
-		$resolved_counts                = array();
+		$resolved_counts                 = array();
 		$source_fallback_count_available = isset( $reconciliation['source_fallback_count'] ) && is_numeric( $reconciliation['source_fallback_count'] );
 		if ( ! $compiler_fallback_count_available && $source_fallback_count_available ) {
 			$source_counts['fallback_count'] = max( 0, (int) $reconciliation['source_fallback_count'] );
-			$provenance['source_detected'] = array(
+			$provenance['source_detected']   = array(
 				'owner'   => 'static-site-importer',
 				'path'    => 'quality_resolutions.source_fallback_count',
 				'schema'  => isset( $reconciliation['schema'] ) ? (string) $reconciliation['schema'] : '',
 				'metrics' => 'quality_resolutions',
 			);
 		}
-		$verified_resolutions            = self::verified_provider_resolution_count( $reconciliation );
+		$verified_resolutions = self::verified_provider_resolution_count( $reconciliation );
 		if ( ( $compiler_fallback_count_available || $source_fallback_count_available ) && null !== $verified_resolutions ) {
 			$resolved_counts['fallback_count'] = $verified_resolutions;
-			$provenance['materialized'] = array(
+			$provenance['materialized']        = array(
 				'owner'   => 'static-site-importer',
 				'path'    => 'quality_resolutions',
 				'schema'  => isset( $reconciliation['schema'] ) ? (string) $reconciliation['schema'] : '',

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -104,7 +104,7 @@ class Static_Site_Importer_Plugin_Materializer {
 				}
 				$report['active']    = true;
 				$report['actions'][] = 'reconciled_activated';
-				$preparation = self::prepare_plugin_runtime( $slug, $preparation_callback );
+				$preparation         = self::prepare_plugin_runtime( $slug, $preparation_callback );
 				if ( is_wp_error( $preparation ) ) {
 					return self::failed_report( $report, $preparation );
 				}

--- a/includes/class-static-site-importer-shared-resource-plan.php
+++ b/includes/class-static-site-importer-shared-resource-plan.php
@@ -53,7 +53,7 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 			if ( ! is_array( $resource ) || ! $this->materializable_resource( $resource ) ) {
 				continue;
 			}
-			$resource['source_url'] = self::canonical_url( $resource['source_url'] );
+			$resource['source_url']               = self::canonical_url( $resource['source_url'] );
 			$resources[ $resource['source_url'] ] = $resource;
 		}
 		ksort( $resources, SORT_STRING );
@@ -190,8 +190,8 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 	}
 
 	private static function canonical_url( string $url ): string {
-		$url   = Static_Site_Importer_URL_Fetcher::normalize_url( trim( $url ) );
-		$parts = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Standalone plan smoke tests run without WordPress URL helpers.
+		$url    = Static_Site_Importer_URL_Fetcher::normalize_url( trim( $url ) );
+		$parts  = function_exists( 'wp_parse_url' ) ? wp_parse_url( $url ) : parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Standalone plan smoke tests run without WordPress URL helpers.
 		$scheme = is_array( $parts ) ? strtolower( (string) ( $parts['scheme'] ?? '' ) ) : '';
 		if ( ! is_array( $parts ) || ! in_array( $scheme, array( 'http', 'https' ), true ) || empty( $parts['host'] ) ) {
 			return '';

--- a/includes/class-static-site-importer-url-fetcher-native-handle.php
+++ b/includes/class-static-site-importer-url-fetcher-native-handle.php
@@ -7,7 +7,7 @@
 
 class Static_Site_Importer_URL_Fetcher_Native_Handle {
 	public mixed $multi = null;
-	public mixed $curl = null;
+	public mixed $curl  = null;
 	public mixed $socket;
 	public array $target;
 	public array $options;
@@ -18,6 +18,6 @@ class Static_Site_Importer_URL_Fetcher_Native_Handle {
 	public string $error;
 	public int $ip_index;
 	public string $response_headers = '';
-	public string $body = '';
-	public string $limit_error = '';
+	public string $body             = '';
+	public string $limit_error      = '';
 }

--- a/includes/class-static-site-importer-url-fetcher.php
+++ b/includes/class-static-site-importer-url-fetcher.php
@@ -440,20 +440,20 @@ class Static_Site_Importer_URL_Fetcher {
 
 	/** Start a curl request pinned to one already validated IP without changing Host or SNI. */
 	private static function native_curl_start( array $target, array $options ): Static_Site_Importer_URL_Fetcher_Native_Handle {
-		$handle                  = new Static_Site_Importer_URL_Fetcher_Native_Handle();
-		$handle->target          = $target;
-		$handle->options         = $options;
-		$handle->started         = microtime( true );
-		$handle->ip_index        = 0;
-		$handle->multi           = curl_multi_init();
-		$handle->curl            = curl_init();
-		$ip                      = $target['ips'][0];
-		$host                    = $target['host'];
-		$host_header             = $host . ( ( 'https' === $target['scheme'] ? 443 : 80 ) === $target['port'] ? '' : ':' . $target['port'] );
-		$resolved_ip             = str_contains( $ip, ':' ) ? '[' . $ip . ']' : $ip;
-		$timeout_ms              = max( 1, (int) ceil( $options['timeout'] * 1000 ) );
-		$url_host                = str_contains( $host, ':' ) ? '[' . $host . ']' : $host;
-		$url                     = $target['scheme'] . '://' . $url_host . ( ( 'https' === $target['scheme'] ? 443 : 80 ) === $target['port'] ? '' : ':' . $target['port'] ) . $target['path'];
+		$handle           = new Static_Site_Importer_URL_Fetcher_Native_Handle();
+		$handle->target   = $target;
+		$handle->options  = $options;
+		$handle->started  = microtime( true );
+		$handle->ip_index = 0;
+		$handle->multi    = curl_multi_init();
+		$handle->curl     = curl_init();
+		$ip               = $target['ips'][0];
+		$host             = $target['host'];
+		$host_header      = $host . ( ( 'https' === $target['scheme'] ? 443 : 80 ) === $target['port'] ? '' : ':' . $target['port'] );
+		$resolved_ip      = str_contains( $ip, ':' ) ? '[' . $ip . ']' : $ip;
+		$timeout_ms       = max( 1, (int) ceil( $options['timeout'] * 1000 ) );
+		$url_host         = str_contains( $host, ':' ) ? '[' . $host . ']' : $host;
+		$url              = $target['scheme'] . '://' . $url_host . ( ( 'https' === $target['scheme'] ? 443 : 80 ) === $target['port'] ? '' : ':' . $target['port'] ) . $target['path'];
 
 		$curl_options = array(
 			CURLOPT_URL                    => $url,
@@ -488,7 +488,7 @@ class Static_Site_Importer_URL_Fetcher {
 		if ( false === filter_var( $host, FILTER_VALIDATE_IP ) ) {
 			$curl_options[ CURLOPT_RESOLVE ] = array( $host . ':' . $target['port'] . ':' . $resolved_ip );
 		}
-		$ca_bundle    = ABSPATH . WPINC . '/certificates/ca-bundle.crt';
+		$ca_bundle = ABSPATH . WPINC . '/certificates/ca-bundle.crt';
 		if ( is_readable( $ca_bundle ) ) {
 			$curl_options[ CURLOPT_CAINFO ] = $ca_bundle;
 		}
@@ -644,7 +644,7 @@ class Static_Site_Importer_URL_Fetcher {
 		if ( null !== $options['deadline'] && is_callable( $options['clock'] ) ) {
 			$options['timeout'] = max( 0.001, min( $options['timeout'], $options['deadline'] - call_user_func( $options['clock'] ) ) );
 		}
-		$next                  = self::native_start( $connect_target, $options );
+		$next = self::native_start( $connect_target, $options );
 		foreach ( get_object_vars( $next ) as $name => $value ) {
 			$handle->$name = $value;
 		}

--- a/includes/class-static-site-importer-url-site-collector.php
+++ b/includes/class-static-site-importer-url-site-collector.php
@@ -402,7 +402,7 @@ class Static_Site_Importer_URL_Site_Collector {
 		}
 		$finalization['assembly_next']  = (int) ( $finalization['assembly_next'] ?? 0 );
 		$finalization['artifact_files'] = is_array( $finalization['artifact_files'] ?? null ) ? $finalization['artifact_files'] : array();
-		$resource_count = count( $resource_urls );
+		$resource_count                 = count( $resource_urls );
 		while ( $finalization['next_resource'] < $resource_count ) {
 			if ( null !== $should_yield && call_user_func( $should_yield ) ) {
 				$checkpoint = self::checkpoint_collection_cursor( $cursor_saver, $cursor_contract, $page_queue, $asset_queue, $queued_pages, $queued_assets, $resources, $failures, $diagnostics, $source_exclusions, $script_exclusions, $aliases, $total_bytes, $truncated, $external_assets, $finalization['external_pages'], $critical_assets, $entry_resource_url, $site_url, $sitemap_urls, $finalization );
@@ -415,7 +415,7 @@ class Static_Site_Importer_URL_Site_Collector {
 				return $resource;
 			}
 			$resources[ $resource_url ] = $resource;
-			$body         = $resource['body'] ?? null;
+			$body                       = $resource['body'] ?? null;
 			if ( ! is_string( $body ) && null !== $resource_loader ) {
 				$body = call_user_func( $resource_loader, $resource );
 			}
@@ -470,7 +470,7 @@ class Static_Site_Importer_URL_Site_Collector {
 					return $retained_file;
 				}
 				$finalization['files'][ $index ] = $retained_file;
-				$path = (string) ( $retained_file['path'] ?? '' );
+				$path                            = (string) ( $retained_file['path'] ?? '' );
 				if ( ! Static_Site_Importer_Content_Policy::is_static_path( $path ) ) {
 					return new WP_Error( 'static_site_importer_executable_source_rejected', sprintf( 'Untrusted artifact file %s is not static content.', $path ), array( 'path' => $path ) );
 				}
@@ -674,9 +674,9 @@ class Static_Site_Importer_URL_Site_Collector {
 		}
 
 		unset( $record['body'] );
-		$record['body_ref'] = $reference['body_ref'];
-		$record['sha256']   = $reference['sha256'];
-		$record['bytes']    = $bytes;
+		$record['body_ref']         = $reference['body_ref'];
+		$record['sha256']           = $reference['sha256'];
+		$record['bytes']            = $bytes;
 		$record['retention_schema'] = 'static-site-importer/retained-payload/v1';
 		return $record;
 	}


### PR DESCRIPTION
## Summary
Realigns assignment equals signs in consecutive blocks so phpcs `Generic.Formatting.MultipleStatementAlignment` passes the Homeboy lint gate. Whitespace only, no behavior change.

Fixes #1023

## Changes
Seven files under `includes/`, 40 insertions / 40 deletions:

| File | Warnings fixed |
|------|----------------|
| class-static-site-importer-companion-plugin.php | 1 |
| class-static-site-importer-diagnostic-contract.php | 10 |
| class-static-site-importer-plugin-materializer.php | 1 |
| class-static-site-importer-shared-resource-plan.php | 3 |
| class-static-site-importer-url-fetcher-native-handle.php | 3 |
| class-static-site-importer-url-fetcher.php | 16 |
| class-static-site-importer-url-site-collector.php | 6 |

**Before:**
```php
$report_quality   = ...;
$source_counts    = self::quality_metric_values( $compiler_quality, $keys );
```
**After:**
```php
$report_quality                    = ...;
$source_counts                     = self::quality_metric_values( $compiler_quality, $keys );
```
**Why:** matches what the CI lint workflow (`homeboy-action --extension wordpress`) enforces; issue body lists all 40 findings for these files.

## Testing
**Test 1: phpcs check**
1. Run `phpcs --standard=WordPress --sniffs=Generic.Formatting.MultipleStatementAlignment includes/ *.php` on main: 40 warnings.
2. Same command on this branch.
Result: zero findings.

**Test 2: fast lane tests**
- `npm test`: 63 passed, 0 failed.
- Verified whitespace only: `git diff -w` is empty and PHP token streams of all seven files are byte-identical before and after.

Backward compatible: yes, no breaking changes.
