### PR TITLE
Fix reference-backed staged ZIP payloads

### DIFF
--- a/.github/workflows/solved-site-promotion-pr.yml
+++ b/.github/workflows/solved-site-promotion-pr.yml
@@ -26,4 +26,4 @@ jobs:
     with:
       static-site-importer-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       static-site-importer-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      blocks-engine-sha: 7858943a9913175993cc75870551c2e1926b4fb0
+      blocks-engine-sha: e32b74191771be44af5357c26aaff46ef98bc1ce

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -696,13 +696,13 @@ if ( ! function_exists( 'static_site_importer_ability_import_url_operation' ) ) 
 if ( ! function_exists( 'static_site_importer_ability_apply_approved_plan' ) ) {
 	/** @param array<string,mixed> $input @return array<string,mixed> */
 	function static_site_importer_ability_apply_approved_plan( array $input ): array {
-		$approved = $input['plan'];
-		$plan     = isset( $approved['plan'] ) && is_array( $approved['plan'] ) ? $approved['plan'] : $approved;
+		$approved       = $input['plan'];
+		$plan           = isset( $approved['plan'] ) && is_array( $approved['plan'] ) ? $approved['plan'] : $approved;
 		$payload_reader = static_site_importer_ability_approved_plan_payload_reader( $input, $approved );
 		if ( is_wp_error( $payload_reader ) ) {
 			return static_site_importer_ability_error( (string) $payload_reader->get_error_code(), $payload_reader->get_error_message(), $payload_reader->get_error_data() );
 		}
-		$classic  = isset( $approved['classic_materialization'] ) && is_array( $approved['classic_materialization'] ) ? $approved['classic_materialization'] : ( isset( $input['classic_materialization'] ) && is_array( $input['classic_materialization'] ) ? $input['classic_materialization'] : null );
+		$classic = isset( $approved['classic_materialization'] ) && is_array( $approved['classic_materialization'] ) ? $approved['classic_materialization'] : ( isset( $input['classic_materialization'] ) && is_array( $input['classic_materialization'] ) ? $input['classic_materialization'] : null );
 		if ( is_array( $classic ) ) {
 			$artifact   = $classic['artifact'] ?? null;
 			$projection = $classic['projection'] ?? null;
@@ -720,7 +720,7 @@ if ( ! function_exists( 'static_site_importer_ability_apply_approved_plan' ) ) {
 			if ( is_object( $payload_reader ) ) {
 				$args['_static_site_importer_payload_reader'] = $payload_reader;
 			}
-			$result                                   = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $args );
+			$result = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $args );
 			if ( is_wp_error( $result ) ) {
 				return static_site_importer_ability_error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
 			}

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -466,9 +466,15 @@ if ( ! function_exists( 'static_site_importer_ability_import' ) ) {
 		} elseif ( 'files' === $type ) {
 			$runtime_source['files'] = isset( $source['files'] ) && is_array( $source['files'] ) ? $source['files'] : array();
 		} elseif ( ! empty( $source['zip']['staged_path'] ) ) {
-			$runtime_source['files'] = static_site_importer_staged_archive_files( $source['zip'] );
+			$runtime_source['files'] = static_site_importer_staged_archive_files( $source['zip'], true );
 			if ( is_wp_error( $runtime_source['files'] ) ) {
 				return static_site_importer_ability_error( (string) $runtime_source['files']->get_error_code(), $runtime_source['files']->get_error_message(), $runtime_source['files']->get_error_data() );
+			}
+			if ( 'apply' === $operation ) {
+				$payload_reader = static_site_importer_staged_archive_payload_reader( $source['zip'] );
+				if ( is_wp_error( $payload_reader ) ) {
+					return static_site_importer_ability_error( (string) $payload_reader->get_error_code(), $payload_reader->get_error_message(), $payload_reader->get_error_data() );
+				}
 			}
 		} else {
 			$runtime_source['archive'] = isset( $source['zip'] ) && is_array( $source['zip'] ) ? $source['zip'] : array();
@@ -494,6 +500,9 @@ if ( ! function_exists( 'static_site_importer_ability_import' ) ) {
 		);
 
 		$args = Static_Site_Importer_Website_Artifact_Import_Input::normalize( $input );
+		if ( isset( $payload_reader ) ) {
+			$args['_static_site_importer_payload_reader'] = $payload_reader;
+		}
 		if ( '' !== $args['runtime_lifecycle_phase'] ) {
 			$args['runtime_lifecycle_invocation_id'] = wp_generate_uuid4();
 		}
@@ -689,6 +698,10 @@ if ( ! function_exists( 'static_site_importer_ability_apply_approved_plan' ) ) {
 	function static_site_importer_ability_apply_approved_plan( array $input ): array {
 		$approved = $input['plan'];
 		$plan     = isset( $approved['plan'] ) && is_array( $approved['plan'] ) ? $approved['plan'] : $approved;
+		$payload_reader = static_site_importer_ability_approved_plan_payload_reader( $input, $approved );
+		if ( is_wp_error( $payload_reader ) ) {
+			return static_site_importer_ability_error( (string) $payload_reader->get_error_code(), $payload_reader->get_error_message(), $payload_reader->get_error_data() );
+		}
 		$classic  = isset( $approved['classic_materialization'] ) && is_array( $approved['classic_materialization'] ) ? $approved['classic_materialization'] : ( isset( $input['classic_materialization'] ) && is_array( $input['classic_materialization'] ) ? $input['classic_materialization'] : null );
 		if ( is_array( $classic ) ) {
 			$artifact   = $classic['artifact'] ?? null;
@@ -704,6 +717,9 @@ if ( ! function_exists( 'static_site_importer_ability_apply_approved_plan' ) ) {
 			}
 			$args['approved_classic_plan_hash']       = (string) $classic['plan_hash'];
 			$args['approved_classic_projection_hash'] = (string) $projection_hash;
+			if ( is_object( $payload_reader ) ) {
+				$args['_static_site_importer_payload_reader'] = $payload_reader;
+			}
 			$result                                   = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $args );
 			if ( is_wp_error( $result ) ) {
 				return static_site_importer_ability_error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
@@ -718,6 +734,9 @@ if ( ! function_exists( 'static_site_importer_ability_apply_approved_plan' ) ) {
 				'error'             => null,
 			);
 		}
+		if ( is_object( $payload_reader ) ) {
+			$input['_static_site_importer_payload_reader'] = $payload_reader;
+		}
 		$receipt = static_site_importer_ability_materialize_wordpress_site_plan( $input );
 		$success = 'completed' === ( $receipt['status'] ?? '' );
 
@@ -731,6 +750,30 @@ if ( ! function_exists( 'static_site_importer_ability_apply_approved_plan' ) ) {
 				'message' => 'The approved plan could not be materialized.',
 			) ),
 		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_ability_approved_plan_payload_reader' ) ) {
+	/** Resolve the opaque staged ZIP again only for the transient apply reader. */
+	function static_site_importer_ability_approved_plan_payload_reader( array $input, array $approved ) {
+		$source = isset( $input['source'] ) && is_array( $input['source'] ) ? $input['source'] : ( isset( $approved['source'] ) && is_array( $approved['source'] ) ? $approved['source'] : array() );
+		if ( 'zip' !== (string) ( $source['type'] ?? '' ) ) {
+			return null;
+		}
+		$reference = (string) ( $source['ref'] ?? ( $source['provenance']['ref'] ?? '' ) );
+		if ( '' === $reference ) {
+			return null;
+		}
+		$resolved = apply_filters( 'static_site_importer_resolve_source_reference', null, $reference, 'zip', $input );
+		if ( ! is_array( $resolved ) ) {
+			return new WP_Error( 'static_site_importer_source_reference_unresolved', 'The opaque source reference was not resolved by a server-owned resolver.' );
+		}
+		$resolved_source = isset( $resolved['source'] ) && is_array( $resolved['source'] ) ? $resolved['source'] : $resolved;
+		$archive         = isset( $resolved_source['zip'] ) && is_array( $resolved_source['zip'] ) ? $resolved_source['zip'] : array();
+		if ( empty( $archive['staged_path'] ) ) {
+			return new WP_Error( 'static_site_importer_staged_archive_invalid', 'The approved plan requires a resolver-owned staged ZIP archive.' );
+		}
+		return static_site_importer_staged_archive_payload_reader( $archive );
 	}
 }
 

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1311,7 +1311,12 @@ function static_site_importer_staged_archive_payload_reader( array $archive ) {
 			if ( '' === $entry || static_site_importer_rest_artifact_path( $entry ) === '' ) {
 				throw new RuntimeException( 'The staged payload reference is invalid.' );
 			}
-			$path = static_site_importer_staged_archive_path( array( 'name' => 'payload.zip', 'staged_path' => $this->archive_path ) );
+			$path = static_site_importer_staged_archive_path(
+				array(
+					'name'        => 'payload.zip',
+					'staged_path' => $this->archive_path,
+				)
+			);
 			if ( is_wp_error( $path ) ) {
 				throw new RuntimeException( 'The staged archive is unavailable.' );
 			}
@@ -1320,7 +1325,7 @@ function static_site_importer_staged_archive_payload_reader( array $archive ) {
 				throw new RuntimeException( 'The staged archive is unavailable.' );
 			}
 			try {
-				$stat = $zip->statName( $entry );
+				$stat   = $zip->statName( $entry );
 				$limits = static_site_importer_staged_archive_limits();
 				if ( ! is_array( $stat ) || ! isset( $reference['bytes'] ) || ! is_int( $reference['bytes'] ) || (int) $stat['size'] !== $reference['bytes'] || (int) $stat['size'] > $limits['max_entry_uncompressed_bytes'] || ( 0 === (int) $stat['comp_size'] ? (int) $stat['size'] > 0 : (int) $stat['size'] / (int) $stat['comp_size'] > $limits['max_compression_ratio'] ) ) {
 					throw new RuntimeException( 'The staged payload byte count changed.' );

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1061,6 +1061,14 @@ function static_site_importer_source_runtime( array $source ) {
 				continue;
 			}
 
+			if ( isset( $file['payload_reference'] ) && is_array( $file['payload_reference'] ) ) {
+				$files[] = array(
+					'path'              => $path,
+					'payload_reference' => $file['payload_reference'],
+				);
+				continue;
+			}
+
 			if ( isset( $file['content_base64'] ) ) {
 				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes uploaded artifact payload content.
 				$content = base64_decode( (string) $file['content_base64'], true );
@@ -1253,7 +1261,17 @@ function static_site_importer_rest_archive_files( array $archive ) {
  * @param array<string,mixed> $archive Resolved archive payload.
  * @return array<int,array<string,mixed>>|WP_Error
  */
-function static_site_importer_staged_archive_files( array $archive ) {
+function static_site_importer_staged_archive_files( array $archive, bool $return_payload_references = false ) {
+	$path = static_site_importer_staged_archive_path( $archive );
+	if ( is_wp_error( $path ) ) {
+		return $path;
+	}
+
+	return static_site_importer_archive_files_from_path( $path, static_site_importer_staged_archive_limits(), false, $return_payload_references );
+}
+
+/** Resolve a server-owned staged archive without transferring ownership to SSI. */
+function static_site_importer_staged_archive_path( array $archive ) {
 	$name = isset( $archive['name'] ) ? (string) $archive['name'] : '';
 	$path = isset( $archive['staged_path'] ) ? (string) $archive['staged_path'] : '';
 	if ( ! preg_match( '/\.zip$/i', $name ) ) {
@@ -1266,13 +1284,57 @@ function static_site_importer_staged_archive_files( array $archive ) {
 		return new WP_Error( 'static_site_importer_staged_archive_invalid', __( 'The staged ZIP archive is unavailable.', 'static-site-importer' ), array( 'status' => 400 ) );
 	}
 
-	$limits = static_site_importer_staged_archive_limits();
-	$size   = filesize( $real_path );
-	if ( false === $size || $size > $limits['max_archive_bytes'] ) {
+	$size = filesize( $real_path );
+	if ( false === $size || $size > static_site_importer_staged_archive_limits()['max_archive_bytes'] ) {
 		return static_site_importer_rest_archive_limit_error( 'staged_bytes_exceeded' );
 	}
 
-	return static_site_importer_archive_files_from_path( $real_path, $limits, false );
+	return $real_path;
+}
+
+/** Return a transient reader for verified entries in a resolver-owned staged ZIP. */
+function static_site_importer_staged_archive_payload_reader( array $archive ) {
+	$path = static_site_importer_staged_archive_path( $archive );
+	if ( is_wp_error( $path ) ) {
+		return $path;
+	}
+
+	return new class( $path ) {
+		public function __construct( private string $archive_path ) {}
+
+		public function read( array $reference ): string {
+			$id = isset( $reference['id'] ) ? (string) $reference['id'] : '';
+			if ( ! str_starts_with( $id, 'zip-entry:' ) ) {
+				throw new RuntimeException( 'The staged payload reference is invalid.' );
+			}
+			$entry = rawurldecode( substr( $id, strlen( 'zip-entry:' ) ) );
+			if ( '' === $entry || static_site_importer_rest_artifact_path( $entry ) === '' ) {
+				throw new RuntimeException( 'The staged payload reference is invalid.' );
+			}
+			$path = static_site_importer_staged_archive_path( array( 'name' => 'payload.zip', 'staged_path' => $this->archive_path ) );
+			if ( is_wp_error( $path ) ) {
+				throw new RuntimeException( 'The staged archive is unavailable.' );
+			}
+			$zip = new ZipArchive();
+			if ( true !== $zip->open( $path ) ) {
+				throw new RuntimeException( 'The staged archive is unavailable.' );
+			}
+			try {
+				$stat = $zip->statName( $entry );
+				$limits = static_site_importer_staged_archive_limits();
+				if ( ! is_array( $stat ) || ! isset( $reference['bytes'] ) || ! is_int( $reference['bytes'] ) || (int) $stat['size'] !== $reference['bytes'] || (int) $stat['size'] > $limits['max_entry_uncompressed_bytes'] || ( 0 === (int) $stat['comp_size'] ? (int) $stat['size'] > 0 : (int) $stat['size'] / (int) $stat['comp_size'] > $limits['max_compression_ratio'] ) ) {
+					throw new RuntimeException( 'The staged payload byte count changed.' );
+				}
+				$bytes = $zip->getFromName( $entry );
+			} finally {
+				$zip->close();
+			}
+			if ( false === $bytes ) {
+				throw new RuntimeException( 'The staged payload is unavailable.' );
+			}
+			return $bytes;
+		}
+	};
 }
 
 /**
@@ -1283,7 +1345,7 @@ function static_site_importer_staged_archive_files( array $archive ) {
  * @param bool              $delete_path  Whether this importer owns the path.
  * @return array<int,array<string,mixed>>|WP_Error
  */
-function static_site_importer_archive_files_from_path( string $archive_path, array $limits, bool $delete_path ) {
+function static_site_importer_archive_files_from_path( string $archive_path, array $limits, bool $delete_path, bool $return_payload_references = false ) {
 	if ( ! class_exists( 'ZipArchive' ) ) {
 		return new WP_Error( 'static_site_importer_zip_unavailable', __( 'ZIP archive extraction is unavailable on this server.', 'static-site-importer' ), array( 'status' => 500 ) );
 	}
@@ -1367,6 +1429,19 @@ function static_site_importer_archive_files_from_path( string $archive_path, arr
 		if ( false === $file_content ) {
 			$cleanup( $zip );
 			return new WP_Error( 'static_site_importer_archive_entry_read_failed', __( 'A ZIP archive entry could not be read.', 'static-site-importer' ), array( 'status' => 400 ) );
+		}
+
+		if ( $return_payload_references && ! Static_Site_Importer_Content_Policy::is_textual_path( $path ) ) {
+			$files[] = array(
+				'path'              => $path,
+				'payload_reference' => array(
+					'schema' => 'blocks-engine/payload-reference/v1',
+					'id'     => 'zip-entry:' . rawurlencode( $entry ),
+					'bytes'  => strlen( $file_content ),
+					'sha256' => hash( 'sha256', $file_content ),
+				),
+			);
+			continue;
 		}
 
 		$files[] = array(

--- a/tests/smoke-canonical-import-ability.php
+++ b/tests/smoke-canonical-import-ability.php
@@ -79,6 +79,13 @@ function static_site_importer_staged_archive_files( $archive ) {
 		),
 	);
 }
+function static_site_importer_staged_archive_payload_reader( $archive ) {
+	$GLOBALS['ssi_staged_reader_archives'][] = $archive;
+	return new class() {
+		public function read( array $reference ): string {
+			return 'staged bytes'; }
+	};
+}
 class Static_Site_Importer_Theme_Generator {
 	public static $compiled = 0;
 	public static $applied  = 0;
@@ -243,6 +250,15 @@ $staged_zip = static_site_importer_ability_import(
 );
 if ( empty( $staged_zip['success'] ) || '/srv/private/website.zip' !== ( $GLOBALS['ssi_staged_archives'][0]['staged_path'] ?? '' ) || isset( $GLOBALS['ssi_runtime_sources'][3]['archive'] ) ) {
 	throw new RuntimeException( 'resolved staged archives must normalize through files without inline archive bytes' ); }
+$approved_staged_zip = static_site_importer_ability_import(
+	array(
+		'operation' => 'apply',
+		'plan'      => array( 'schema' => 'blocks-engine/wordpress-site-plan/v2' ),
+		'source'    => array( 'type' => 'zip', 'ref' => 'staged-zip-1' ),
+	)
+);
+if ( empty( $approved_staged_zip['success'] ) || '/srv/private/website.zip' !== ( $GLOBALS['ssi_staged_reader_archives'][0]['staged_path'] ?? '' ) || ! is_object( Static_Site_Importer_WordPress_Site_Plan_Materializer::$plans[0]['args']['_static_site_importer_payload_reader'] ?? null ) ) {
+	throw new RuntimeException( 'approved staged ZIP plans must reacquire a transient payload reader through the opaque resolver' ); }
 $url = static_site_importer_ability_import(
 	array(
 		'operation' => 'plan',
@@ -289,7 +305,7 @@ $approved_apply = static_site_importer_ability_import(
 		'slug'      => 'approved-plan',
 	)
 );
-if ( empty( $approved_apply['success'] ) || $approved !== ( Static_Site_Importer_WordPress_Site_Plan_Materializer::$plans[0]['plan'] ?? null ) || 2 !== Static_Site_Importer_Theme_Generator::$applied ) {
+if ( empty( $approved_apply['success'] ) || $approved !== ( Static_Site_Importer_WordPress_Site_Plan_Materializer::$plans[1]['plan'] ?? null ) || 2 !== Static_Site_Importer_Theme_Generator::$applied ) {
 	throw new RuntimeException( 'approved plan apply must delegate the exact plan without recompiling' ); }
 $classic_plan  = static_site_importer_ability_import(
 	array(

--- a/tests/smoke-importer-block.php
+++ b/tests/smoke-importer-block.php
@@ -1284,6 +1284,58 @@ if ( class_exists( 'ZipArchive' ) ) {
 	);
 	$assert( is_array( $staged ) && 'website/index.html' === ( $staged[0]['path'] ?? '' ), 'staged-zip-extracts-provider-owned-archive' );
 	$assert( file_exists( $staged_path ), 'staged-zip-preserves-provider-owned-archive' );
+	$staged_zip = new ZipArchive();
+	$staged_zip->open( $staged_path, ZipArchive::OVERWRITE );
+	$staged_zip->addFromString( 'index.html', '<main>Staged</main>' );
+	$staged_binary = str_repeat( "\x00\xffPNG", 65536 );
+	$staged_zip->addFromString( 'assets/photo.png', $staged_binary );
+	$staged_zip->setCompressionName( 'assets/photo.png', ZipArchive::CM_STORE );
+	$staged_zip->addFromString( 'assets/logo.svg', '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>' );
+	$staged_zip->close();
+	$referenced_staged = static_site_importer_staged_archive_files(
+		array(
+			'name'        => 'website.zip',
+			'staged_path' => $staged_path,
+		),
+		true
+	);
+	$referenced_by_path = is_array( $referenced_staged ) ? array_column( $referenced_staged, null, 'path' ) : array();
+	$assert( isset( $referenced_by_path['website/assets/photo.png']['payload_reference'] ) && ! isset( $referenced_by_path['website/assets/photo.png']['content_base64'] ) && isset( $referenced_by_path['website/assets/logo.svg']['content_base64'] ), 'staged-zip-references-only-non-svg-binary-entries' );
+	$inline_binary = base64_encode( $staged_binary );
+	$inline_plan   = wp_json_encode(
+		array(
+			'assets' => array( array( 'content_base64' => $inline_binary ) ),
+			'writes' => array( array( 'payload' => array( 'data' => $inline_binary ) ) ),
+		)
+	);
+	$reference_plan = wp_json_encode(
+		array(
+			'assets' => array( $referenced_by_path['website/assets/photo.png'] ),
+			'writes' => array( array( 'payload_reference' => $referenced_by_path['website/assets/photo.png']['payload_reference'] ) ),
+		)
+	);
+	$assert( is_string( $inline_plan ) && is_string( $reference_plan ) && strlen( $reference_plan ) < strlen( $inline_plan ) / 100, 'staged-zip-reference-plan-eliminates-duplicated-binary-payload-size', strlen( $reference_plan ) . '/' . strlen( $inline_plan ) );
+	$staged_reader = static_site_importer_staged_archive_payload_reader( array( 'name' => 'website.zip', 'staged_path' => $staged_path ) );
+	$staged_bytes  = is_object( $staged_reader ) ? $staged_reader->read( $referenced_by_path['website/assets/photo.png']['payload_reference'] ) : '';
+	$assert( hash( 'sha256', $staged_bytes ) === ( $referenced_by_path['website/assets/photo.png']['payload_reference']['sha256'] ?? '' ), 'staged-zip-reader-reopens-and-reads-the-declared-reference' );
+	$inline_staged   = static_site_importer_staged_archive_files( array( 'name' => 'website.zip', 'staged_path' => $staged_path ) );
+	$artifact_compiler = new Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler();
+	$inline_compiled   = $artifact_compiler->compile( array( 'entrypoint' => 'website/index.html', 'files' => $inline_staged ) )->toArray();
+	$reference_compiled = $artifact_compiler->compile( array( 'entrypoint' => 'website/index.html', 'files' => $referenced_staged ) )->toArray();
+	$inline_site_plan   = $inline_compiled['source_reports']['wordpress_site_plan'] ?? array();
+	$reference_site_plan = $reference_compiled['source_reports']['wordpress_site_plan'] ?? array();
+	$inline_plan_json   = wp_json_encode( $inline_site_plan );
+	$reference_plan_json = wp_json_encode( $reference_site_plan );
+	$assert( is_string( $inline_plan_json ) && is_string( $reference_plan_json ) && str_contains( $reference_plan_json, 'payload_reference' ) && ! str_contains( $reference_plan_json, $inline_binary ) && strlen( $reference_plan_json ) < strlen( $inline_plan_json ) / 50, 'staged-zip-compiler-plan-removes-duplicated-binary-assets-and-writes', strlen( $reference_plan_json ) . '/' . strlen( $inline_plan_json ) );
+	$staged_zip = new ZipArchive();
+	$staged_zip->open( $staged_path, ZipArchive::OVERWRITE );
+	$staged_zip->addFromString( 'index.html', '<main>Staged</main>' );
+	$staged_zip->addFromString( 'assets/photo.png', str_repeat( 'x', strlen( $staged_binary ) ) );
+	$staged_zip->setCompressionName( 'assets/photo.png', ZipArchive::CM_STORE );
+	$staged_zip->addFromString( 'assets/logo.svg', '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>' );
+	$staged_zip->close();
+	$tampered_bytes = $staged_reader->read( $referenced_by_path['website/assets/photo.png']['payload_reference'] );
+	$assert( ! hash_equals( $referenced_by_path['website/assets/photo.png']['payload_reference']['sha256'], hash( 'sha256', $tampered_bytes ) ), 'staged-zip-reader-does-not-cache-tampered-payloads-before-materializer-verification' );
 
 	$symlink_path = $staged_path . '.link';
 	if ( function_exists( 'symlink' ) && @symlink( $staged_path, $symlink_path ) ) {


### PR DESCRIPTION
## Summary

- emit `blocks-engine/payload-reference/v1` for eligible staged ZIP binary entries instead of duplicating base64 bytes in plan assets and writes
- reacquire the opaque source resolver during approved-plan apply and inject only a transient bounded payload reader
- preserve exact plan hashing and verify referenced byte counts and SHA-256 before mutation and immediately before write
- keep text, SVG, existing inline plans, and host-specific storage contracts unchanged

## Evidence

- measured test plan: 975,515 bytes inline to 14,672 bytes reference-backed, a 98.5% reduction
- `php tests/smoke-importer-block.php` (344 assertions)
- `php tests/smoke-canonical-import-ability.php`
- `php tests/smoke-wordpress-site-plan-materializer.php`
- `npm test` (63 passed, 0 failed)

Fixes #1010.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding and review subagents implemented and independently reviewed the payload-reference boundary, tests, and measured size evidence. Chris Huber remains responsible for every line.