### PR TITLE
Fix companion ownership across filesystem aliases

### DIFF
--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -390,7 +390,7 @@ class Static_Site_Importer_Plugin_Materializer {
 
 		if ( is_array( $owner ) ) {
 			return (string) ( $owner['plugin_file'] ?? '' ) === $plugin_file
-				&& str_replace( '\\', '/', (string) ( $owner['plugin_path'] ?? '' ) ) === $path;
+				&& self::canonical_plugin_path( (string) ( $owner['plugin_path'] ?? '' ) ) === self::canonical_plugin_path( $path );
 		}
 
 		if ( ! $overwrite || '' === $path || ! is_readable( $path ) ) {
@@ -406,6 +406,12 @@ class Static_Site_Importer_Plugin_Materializer {
 		// A byte-identical entrypoint proves this is the prior SSI scaffold for the
 		// same destination and payload, rather than a coincidental block namespace.
 		return hash_equals( $expected_main, (string) file_get_contents( $path ) );
+	}
+
+	/** Resolve filesystem aliases before comparing an active generated plugin owner. */
+	private static function canonical_plugin_path( string $path ): string {
+		$resolved = '' !== $path ? realpath( $path ) : false;
+		return str_replace( '\\', '/', false !== $resolved ? $resolved : $path );
 	}
 
 	/**

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -463,8 +463,17 @@ $assert( isset( $GLOBALS['static_site_importer_companion_block_owners']['example
 $written_main = file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) ? (string) file_get_contents( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) : '';
 $assert( str_contains( $written_main, 'register_block_type' ), 'written-main-file-registers-blocks' );
 
-// A second overwrite import starts in a fresh request with the first import's
-// generated block still registered but without its request-local owner record.
+// Runtime paths may use filesystem aliases (for example /var and /private/var
+// on macOS) while still identifying the same generated companion entrypoint.
+$GLOBALS['static_site_importer_companion_block_owners']['example/custom-hero'] = array(
+	'plugin_file' => 'ssi-example-site/ssi-example-site.php',
+	'plugin_path' => dirname( WP_PLUGIN_DIR ) . '/plugins/../plugins/ssi-example-site/ssi-example-site.php',
+);
+$aliased_owner_report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $payload, static fn (): bool => true );
+$assert( 'refreshed' === ( $aliased_owner_report['status'] ?? '' ), 'same-companion-filesystem-alias-reuses-registered-block' );
+
+// A second overwrite import can also start without its request-local owner
+// record when the active entrypoint is byte-identical to the pending scaffold.
 $GLOBALS['static_site_importer_companion_block_owners'] = array();
 $overwrite_report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $payload, static fn (): bool => true, true );
 $assert( 'refreshed' === ( $overwrite_report['status'] ?? '' ), 'same-companion-overwrite-reuses-prior-registered-block' );


### PR DESCRIPTION
## Summary

- canonicalize existing generated-companion paths before ownership comparison
- recognize `/var` and `/private/var` aliases as the same active SSI companion
- retain byte-identical overwrite fallback and fail-closed foreign-owner behavior

Fixes #1056.

## Verification

- `npm run test:companion-plugin`
- `npm run test:site-plan-materializer`
- Companion coverage: 113 PHP assertions and 23 JS seam assertions
- Real Studio acceptance: a failed Nicole Louise import resumed with the already-active generated companion, completed without a block-name collision, and cleared lifecycle state
- Clean first-pass Studio acceptance completed after the separate bounded-result fix on Automattic/studio#3952

## AI assistance

OpenAI GPT-5.6-sol via OpenCode was used to reproduce the collision, compare the recorded owner path with `WP_PLUGIN_DIR`, implement the canonical path comparison, run tests, and draft this PR. Chris Huber remains responsible for every line.