### PR TITLE
Fix bounded large import report persistence

### DIFF
--- a/includes/class-static-site-importer-font-materializer.php
+++ b/includes/class-static-site-importer-font-materializer.php
@@ -406,7 +406,8 @@ final class Static_Site_Importer_Font_Materializer {
 					}
 					$rewritten     = str_replace( $source_url, '../fonts/' . basename( $asset['target_path'] ), $rewritten );
 					$svg_rewritten = str_replace( $source_url, 'data:font/' . $asset['format'] . ';base64,' . base64_encode( $asset['payload'] ), $svg_rewritten ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encodes a fetched font asset for a data URL.
-					$assets[]      = $asset + array( 'source_url' => $source_url );
+					// Writes retain the exact bytes; receipts retain only durable evidence.
+					$assets[] = self::asset_receipt( $asset, $source_url );
 				}
 				$css[ hash( 'sha256', $rewritten ) ]                          = $rewritten;
 				$svg_faces[ $face['id'] ][ hash( 'sha256', $svg_rewritten ) ] = $svg_rewritten;
@@ -562,6 +563,17 @@ final class Static_Site_Importer_Font_Materializer {
 			'format'          => $format,
 			'expected_sha256' => $expected_sha256,
 			'observed_sha256' => $hash,
+		);
+	}
+
+	/** Return public receipt evidence without carrying the downloaded binary payload. */
+	private static function asset_receipt( array $asset, string $source_url ): array {
+		return array(
+			'target_path'     => $asset['target_path'],
+			'format'          => $asset['format'],
+			'source_url'      => $source_url,
+			'expected_sha256' => $asset['expected_sha256'],
+			'observed_sha256' => $asset['observed_sha256'],
 		);
 	}
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -1687,16 +1687,91 @@ class Static_Site_Importer_Theme_Generator {
 	/** @param array<string,mixed> $payload */
 	private static function write_plan_projection( string $path, array $payload, array &$receipt = array() ): void {
 		Static_Site_Importer_WordPress_Site_Plan_Materializer::journal_receipt_file( $receipt, $path );
-		$json = wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
-		$data = false === $json ? false : $json . "\n";
-		$temp = is_string( $data ) ? tempnam( dirname( $path ), '.ssi-projection-' ) : false;
-		$written = is_string( $data ) && false !== $temp ? file_put_contents( $temp, $data ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Atomically writes preflighted public import artifacts.
-		if ( false === $data || false === $temp || strlen( $data ) !== $written || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Same-directory rename atomically publishes the preflighted artifact.
+		$temp = tempnam( dirname( $path ), '.ssi-projection-' );
+		$stream = false !== $temp ? fopen( $temp, 'wb' ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Streams a public projection into an atomic temporary file.
+		$written = is_resource( $stream ) && self::write_json_projection( $stream, $payload, 0 ) && self::write_all( $stream, "\n" ) && fflush( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fflush -- Flushes the complete temporary projection before publication.
+		$closed = ! is_resource( $stream ) || fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the complete temporary projection before publication.
+		if ( ! $written || ! $closed || false === $temp || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Same-directory rename atomically publishes the complete preflighted artifact.
 			if ( is_string( $temp ) && file_exists( $temp ) ) {
 				unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes a failed atomic projection temporary file.
 			}
 			throw new RuntimeException( 'Failed to write a preflighted import artifact.' );
 		}
+	}
+
+	/** Stream JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES without a full payload string. */
+	private static function write_json_projection( $stream, mixed $value, int $depth ): bool {
+		if ( 512 < $depth ) {
+			return false;
+		}
+		if ( is_object( $value ) ) {
+			$value = $value instanceof JsonSerializable ? $value->jsonSerialize() : get_object_vars( $value );
+			return self::write_json_object( $stream, $value, $depth );
+		}
+		if ( ! is_array( $value ) ) {
+			$json = wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
+			return false !== $json && self::write_all( $stream, $json );
+		}
+		$list = self::json_list( $value );
+		return self::write_json_container( $stream, $value, $depth, $list );
+	}
+
+	/** @param array<mixed> $value */
+	private static function write_json_object( $stream, array $value, int $depth ): bool {
+		return self::write_json_container( $stream, $value, $depth, false );
+	}
+
+	/** @param array<mixed> $value */
+	private static function write_json_container( $stream, array $value, int $depth, bool $list ): bool {
+		if ( empty( $value ) ) {
+			return self::write_all( $stream, $list ? '[]' : '{}' );
+		}
+		if ( ! self::write_all( $stream, $list ? '[' : '{' ) ) {
+			return false;
+		}
+		$first = true;
+		foreach ( $value as $key => $item ) {
+			if ( ! self::write_all( $stream, $first ? "\n" : ",\n" ) || ! self::write_all( $stream, str_repeat( '    ', $depth + 1 ) ) ) {
+				return false;
+			}
+			$first = false;
+			if ( ! $list ) {
+				$key_json = wp_json_encode( (string) $key, JSON_UNESCAPED_SLASHES );
+				if ( false === $key_json || ! self::write_all( $stream, $key_json . ': ' ) ) {
+					return false;
+				}
+			}
+			if ( ! self::write_json_projection( $stream, $item, $depth + 1 ) ) {
+				return false;
+			}
+		}
+		return self::write_all( $stream, "\n" . str_repeat( '    ', $depth ) . ( $list ? ']' : '}' ) );
+	}
+
+	/** Write every byte or fail before the temporary projection can be published. */
+	private static function write_all( $stream, string $data ): bool {
+		$offset = 0;
+		$length = strlen( $data );
+		while ( $offset < $length ) {
+			$written = fwrite( $stream, substr( $data, $offset ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- Handles short writes while streaming a public projection.
+			if ( ! is_int( $written ) || 0 >= $written ) {
+				return false;
+			}
+			$offset += $written;
+		}
+		return true;
+	}
+
+	/** Match PHP's array-to-JSON list detection without encoding an array. */
+	private static function json_list( array $value ): bool {
+		$index = 0;
+		foreach ( $value as $key => $_ ) {
+			if ( $key !== $index ) {
+				return false;
+			}
+			++$index;
+		}
+		return true;
 	}
 
 	/**

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -341,6 +341,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			unset( $binding_report );
 		}
 
+		$short_write_attempt = 0;
 		foreach ( $state['resolved']['writes'] as $write ) {
 			$path = $state['theme_dir'] . '/' . $write['target_path'];
 			self::journal_file( $state, $path );
@@ -359,7 +360,14 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			if ( ! empty( $args['preserve_existing_theme_bootstrap'] ) && in_array( $write['kind'] ?? '', array( 'theme_scaffold', 'theme_bootstrap', 'theme_template' ), true ) && is_file( $state['theme_dir'] . '/' . $write['target_path'] ) ) {
 				continue;
 			}
-			$result = self::write_file( $state['theme_dir'], $write, $state['payload_reader'] );
+			$chunk_writer = self::injected_failure( $args, 'theme_write_short' ) ? static function ( $stream, string $data ) use ( &$short_write_attempt ): int {
+				if ( 0 < $short_write_attempt++ ) {
+					return 0;
+				}
+				$length = max( 1, intdiv( strlen( $data ), 2 ) );
+				return (int) fwrite( $stream, substr( $data, 0, $length ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- Deterministic test-only short-write injection.
+			} : null;
+			$result = self::write_file( $state['theme_dir'], $write, $state['payload_reader'], $chunk_writer );
 			if ( is_wp_error( $result ) ) {
 				return self::failed_receipt( $state, $result->get_error_code() );
 			}
@@ -804,7 +812,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	}
 
 	/** @param array<string,mixed> $write */
-	private static function write_file( string $theme_dir, array $write, ?object $payload_reader = null ) {
+	private static function write_file( string $theme_dir, array $write, ?object $payload_reader = null, ?Closure $chunk_writer = null ) {
 		$path          = $theme_dir . '/' . $write['target_path'];
 		$declared_hash = self::payload_hash( $write );
 		if ( is_file( $path ) && '' !== $declared_hash && self::file_hash( $path ) === $declared_hash ) {
@@ -822,8 +830,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		if ( ! is_dir( dirname( $path ) ) && ! wp_mkdir_p( dirname( $path ) ) ) {
 			return new WP_Error( 'theme_directory_create_failed' );
 		}
-		$temp = tempnam( dirname( $path ), '.ssi-plan-' );
-		if ( false === $data || false === $temp || false === file_put_contents( $temp, $data ) || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents,WordPress.WP.AlternativeFunctions.rename_rename -- Atomically materializes the canonical declared theme write.
+		$temp   = tempnam( dirname( $path ), '.ssi-plan-' );
+		$stream = false !== $temp ? fopen( $temp, 'wb' ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Streams the canonical theme write into an atomic temporary file.
+		$written = is_resource( $stream ) && self::write_all( $stream, $data, $chunk_writer ) && fflush( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fflush -- Flushes complete canonical write bytes before publication.
+		$closed = ! is_resource( $stream ) || fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes canonical write before atomic publication.
+		if ( false === $data || false === $temp || ! $written || ! $closed || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Atomically materializes only complete canonical declared theme writes.
 			if ( is_string( $temp ) && file_exists( $temp ) ) {
 				unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes a failed temporary materialization file.
 			}
@@ -835,6 +846,21 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			'payload_hash'            => $write['payload_hash'] ?? hash( 'sha256', $data ),
 			'reconciliation_identity' => $write['reconciliation_identity'] ?? hash( 'sha256', $write['source_path'] . "\n" . $write['target_path'] ),
 		);
+	}
+
+	/** Write every canonical byte or fail before the temporary file can be published. */
+	private static function write_all( $stream, string $data, ?Closure $chunk_writer = null ): bool {
+		$offset = 0;
+		$length = strlen( $data );
+		while ( $offset < $length ) {
+			$remaining = substr( $data, $offset );
+			$written   = null === $chunk_writer ? fwrite( $stream, $remaining ) : $chunk_writer( $stream, $remaining ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- Handles short writes while materializing canonical theme bytes.
+			if ( ! is_int( $written ) || 0 >= $written || strlen( $remaining ) < $written ) {
+				return false;
+			}
+			$offset += $written;
+		}
+		return true;
 	}
 
 	/** Report final bytes while retaining the canonical write's reconciliation identity. */
@@ -1781,6 +1807,51 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	/** @param array<string,mixed> $plan */
 	private static function hash( array $plan ): string {
-		return hash( 'sha256', (string) wp_json_encode( $plan, JSON_UNESCAPED_SLASHES ) );
+		$context = hash_init( 'sha256' );
+		self::hash_json_value( $context, $plan );
+		return hash_final( $context );
+	}
+
+	/** Stream the exact JSON token sequence previously passed to hash(). */
+	private static function hash_json_value( $context, mixed $value ): void {
+		if ( ! is_array( $value ) ) {
+			hash_update( $context, (string) wp_json_encode( $value, JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+		if ( self::json_list( $value ) ) {
+			hash_update( $context, '[' );
+			foreach ( $value as $index => $item ) {
+				if ( 0 !== $index ) {
+					hash_update( $context, ',' );
+				}
+				self::hash_json_value( $context, $item );
+			}
+			hash_update( $context, ']' );
+			return;
+		}
+		hash_update( $context, '{' );
+		$first = true;
+		foreach ( $value as $key => $item ) {
+			if ( ! $first ) {
+				hash_update( $context, ',' );
+			}
+			$first = false;
+			hash_update( $context, (string) wp_json_encode( (string) $key, JSON_UNESCAPED_SLASHES ) );
+			hash_update( $context, ':' );
+			self::hash_json_value( $context, $item );
+		}
+		hash_update( $context, '}' );
+	}
+
+	/** Match PHP's array-to-JSON list detection without materializing JSON. */
+	private static function json_list( array $value ): bool {
+		$index = 0;
+		foreach ( $value as $key => $_ ) {
+			if ( $key !== $index ) {
+				return false;
+			}
+			++$index;
+		}
+		return true;
 	}
 }

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -60,6 +60,9 @@ function get_theme_root_uri(): string {
 function trailingslashit( string $path ): string {
 	return rtrim( $path, '/' ) . '/'; }
 function wp_json_encode( $value, int $options = 0 ) {
+	if ( ! empty( $GLOBALS['ssi_plan_count_aggregate_encodes'] ) && ( is_array( $value ) || is_object( $value ) ) ) {
+		$GLOBALS['ssi_plan_json_array_calls'] = (int) ( $GLOBALS['ssi_plan_json_array_calls'] ?? 0 ) + 1;
+	}
 	return json_encode( $value, $options ); }
 function wp_slash( string $value ): string {
 	return addslashes( $value ); }
@@ -90,7 +93,7 @@ function wp_safe_remote_get( string $url, array $args ) {
 	if ( 'https://fonts.example.test/inter.woff2' === $url ) {
 		return array(
 			'response' => array( 'code' => 200 ),
-			'body'     => 'inter-variable-glyph-payload',
+			'body'     => $GLOBALS['ssi_plan_binary_font'],
 		);
 	}
 	if ( str_starts_with( $url, 'https://fonts.googleapis.com/' ) ) {
@@ -309,6 +312,16 @@ $assert( str_contains( file_get_contents( $GLOBALS['ssi_plan_root'] . '/site-pla
 $assert( 'posts' === $GLOBALS['ssi_plan_options']['show_on_front'], 'plan-only materialization does not change reading settings by default' );
 $assert( $receipt['plan']['pages'][0]['document_metadata']['links'][0]['resolved_url'] === 'https://example.test/wp-content/themes/site-plan/assets/assets/site.css', 'resolved metadata retains the declared stylesheet destination' );
 $assert( array() === $receipt['completed']['runtime_declarations']['asset_publications'], 'plans without publication declarations retain an explicit empty receipt collection' );
+$short_write_target  = (string) ( $plan['writes'][0]['target_path'] ?? '' );
+$short_write_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$plan,
+	array(
+		'slug'                           => 'short-write-plan',
+		'inject_materialization_failure' => 'theme_write_short',
+	)
+);
+$short_write_path = $GLOBALS['ssi_plan_root'] . '/short-write-plan/' . $short_write_target;
+$assert( 'partial' === $short_write_receipt['status'] && 'theme_write_failed' === ( $short_write_receipt['errors'][0]['code'] ?? '' ) && array() === ( $short_write_receipt['completed']['files'] ?? null ) && array() === ( $short_write_receipt['wordpress'] ?? null ) && ! is_file( $short_write_path ) && empty( glob( dirname( $short_write_path ) . '/.ssi-plan-*' ) ), 'short canonical writes cannot publish a truncated destination and return a rolled-back error receipt' );
 $write_payload_bytes = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'write_payload_bytes' );
 $referenced_write    = array(
 	'payload'           => array(
@@ -782,7 +795,8 @@ $assert( Static_Site_Importer_Font_Materializer::svg_uses_font_family( '<svg><te
 $assert( Static_Site_Importer_Font_Materializer::svg_uses_font_family( '<svg><text font-family="serif, Example Font">Label</text></svg>', array( 'example font' ) ), 'SVG presentation attributes normalize case and fallback-list position' );
 $assert( ! Static_Site_Importer_Font_Materializer::svg_uses_font_family( '<svg><text font-family="Example Font Pro, sans-serif">Label</text></svg>', array( 'Example Font' ) ), 'SVG font matching compares complete family tokens instead of prefixes' );
 
-$inter_payload                                        = 'inter-variable-glyph-payload';
+$inter_payload                                        = "\xff" . str_repeat( "\x80", 1048575 );
+$GLOBALS['ssi_plan_binary_font']                      = $inter_payload;
 $typed_font_plan                                      = array(
 	'schema'           => 'blocks-engine/php-transformer/font-materialization-plan/v1',
 	'webfont_contract' => array(
@@ -931,6 +945,55 @@ $assert(
 	'nested producer contract retains static and range weights, all axes, unicode ranges, and receipt provenance'
 );
 $assert( $inter_payload === file_get_contents( $typed_font_root . '/' . $typed_faces[0]['assets'][0]['target_path'] ) && $inter_payload === file_get_contents( $typed_font_root . '/' . $typed_faces[1]['assets'][0]['target_path'] ), 'typed font assets are locally materialized as verified binary payloads without network-dependent test fixtures' );
+$typed_asset = $typed_faces[0]['assets'][0] ?? array();
+$assert( array( 'target_path', 'format', 'source_url', 'expected_sha256', 'observed_sha256' ) === array_keys( $typed_asset ) && ! isset( $typed_asset['payload'] ) && hash( 'sha256', $inter_payload ) === ( $typed_asset['observed_sha256'] ?? '' ) && is_string( wp_json_encode( $typed_font_receipt, JSON_UNESCAPED_SLASHES ) ), 'completed font receipts exclude invalid binary payloads while retaining path, format, source, and digest evidence' );
+$typed_plan_writes = $typed_font_receipt['plan']['writes'] ?? array();
+$assert( ! empty( $typed_plan_writes ) && array() === array_filter( $typed_plan_writes, static fn( array $write ): bool => ! isset( $write['payload']['encoding'], $write['payload']['data'] ) ), 'public receipt plan preserves the canonical v2 write payload shape and encoding' );
+$projection_path = $GLOBALS['ssi_plan_root'] . '/large-invalid-binary-report.json';
+$projection_payload = array( 'schema' => 'static-site-importer/import-report/v1', 'materialization_receipt' => $typed_font_receipt );
+$projection_receipt = $typed_font_receipt;
+$write_projection = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'write_plan_projection' );
+$write_projection->invokeArgs( null, array( $projection_path, $projection_payload, &$projection_receipt ) );
+$projection_json = (string) file_get_contents( $projection_path );
+$projection = json_decode( $projection_json, true );
+$assert( is_array( $projection ) && false === str_contains( $projection_json, $inter_payload ) && hash( 'sha256', $inter_payload ) === ( $projection['materialization_receipt']['completed']['font_materialization']['required_faces'][0]['assets'][0]['observed_sha256'] ?? '' ), 'streamed report persistence retains canonical receipt structure without invalid font bytes while retaining digest evidence' );
+$json_compatibility_payload = array(
+	'unicode' => json_decode( '"\\u00e9 \\u6f22 \\ud83d\\ude80"' ),
+	'escaped' => "quote:\" slash:/ backslash:\\ control:\n\t\x01",
+);
+$json_compatibility_path = $GLOBALS['ssi_plan_root'] . '/json-compatibility.json';
+$json_compatibility_receipt = array();
+$write_projection->invokeArgs( null, array( $json_compatibility_path, $json_compatibility_payload, &$json_compatibility_receipt ) );
+$assert( (string) wp_json_encode( $json_compatibility_payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" === file_get_contents( $json_compatibility_path ), 'streamed public JSON matches historical WordPress encoding for Unicode, quotes, slashes, and control characters' );
+$deferred_font_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$font_plan,
+	array(
+		'slug'                        => 'deferred-font-report-plan',
+		'font_materialization'        => $typed_font_plan,
+		'defer_materialization_commit' => true,
+	)
+);
+$large_asset_base64 = base64_encode( $inter_payload );
+$deferred_font_receipt['plan']['assets'][] = array(
+	'source_path'    => 'assets/fonts/large-invalid.woff2',
+	'target_path'    => 'assets/fonts/large-invalid.woff2',
+	'content_base64' => $large_asset_base64,
+);
+$GLOBALS['ssi_plan_json_array_calls'] = 0;
+$GLOBALS['ssi_plan_count_aggregate_encodes'] = true;
+$production_result = $write_projection->getDeclaringClass()->getMethod( 'public_result_from_wordpress_site_plan_receipt' )->invoke(
+	null,
+	$deferred_font_receipt,
+	array(
+		'slug'                         => 'deferred-font-report-plan',
+		'artifact_hash'                => hash( 'sha256', 'deferred-font-report-plan' ),
+		'write_theme_report_artifacts' => true,
+	)
+);
+$GLOBALS['ssi_plan_count_aggregate_encodes'] = false;
+$production_report_json = (string) file_get_contents( $production_result['report_path'] ?? '' );
+$production_report = json_decode( $production_report_json, true );
+$assert( 0 === $GLOBALS['ssi_plan_json_array_calls'] && is_array( $production_report ) && $large_asset_base64 === ( $production_report['blocks_engine']['wordpress_site_plan']['assets'][ count( $production_report['blocks_engine']['wordpress_site_plan']['assets'] ) - 1 ]['content_base64'] ?? '' ) && isset( $production_report['materialization_receipt']['transaction']['state'] ) && hash( 'sha256', $inter_payload ) === ( $production_report['materialization_receipt']['completed']['font_materialization']['required_faces'][0]['assets'][0]['observed_sha256'] ?? '' ), 'production report assembly streams deferred transaction state and large base64 assets without aggregate JSON encoding while preserving canonical report fields and invalid-font digest evidence' );
 $typed_css = (string) file_get_contents( $typed_font_root . '/assets/css/embedded-fonts.css' );
 $assert( str_contains( $typed_css, 'font-weight:100 900' ) && str_contains( $typed_css, 'font-stretch:75% 125%' ) && str_contains( $typed_css, 'unicode-range:U+0000-00FF' ) && ! str_contains( $typed_css, 'fonts.example.test' ), 'producer font faces preserve all declared axes and unicode ranges while rewriting only local sources' );
 $typed_readiness = (string) file_get_contents( $typed_font_root . '/assets/js/font-readiness.js' );
@@ -968,7 +1031,7 @@ $font_without_svg_root    = $GLOBALS['ssi_plan_root'] . '/font-site-plan-without
 $assert( 'completed' === $font_without_svg_receipt['status'], 'canonical font materialization completes without SVG consumers' );
 $assert( str_contains( (string) file_get_contents( $font_without_svg_root . '/assets/css/embedded-fonts.css' ), 'data:font/woff2;base64,' ), 'page fonts are self-contained without SVG consumers' );
 $assert( str_contains( (string) file_get_contents( $font_without_svg_root . '/functions.php' ), "wp_enqueue_style( 'static-site-importer-embedded-fonts'" ), 'page fonts load without SVG consumers' );
-$assert( 7 === count( $GLOBALS['ssi_plan_font_requests'] ), 'each successful and rejected font materialization resolves only its declared stylesheet or typed payload URLs' );
+$assert( 9 === count( $GLOBALS['ssi_plan_font_requests'] ), 'each successful and rejected font materialization resolves only its declared stylesheet or typed payload URLs' );
 
 $nested_route_result = ( new ArtifactCompiler() )->compile(
 	array(
@@ -2186,5 +2249,19 @@ $descendant_only = $parent_order->invoke(
 	'batch-parent-run'
 );
 $assert( is_array( $descendant_only ) && 1 === count( $descendant_only ) && 'website/external/child/index.html' === ( $descendant_only[0]['source_path'] ?? '' ), 'external provenance parent satisfies ordering without being emitted as a page' );
+
+$hash_plan = array(
+	'schema' => 'test/plan/v1',
+	'escaped' => "quote:\" slash:/ backslash:\\ control:\n\t\x01",
+	'unicode' => json_decode( '"\\u00e9 \\u6f22 \\ud83d\\ude80"' ),
+	'large' => array_fill( 0, 256, str_repeat( 'plan-token/', 1024 ) ),
+);
+$GLOBALS['ssi_plan_count_aggregate_encodes'] = true;
+$legacy_hash = hash( 'sha256', (string) wp_json_encode( $hash_plan, JSON_UNESCAPED_SLASHES ) );
+$GLOBALS['ssi_plan_json_array_calls'] = 0;
+$plan_hash_method = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'hash' );
+$streamed_hash = $plan_hash_method->invoke( null, $hash_plan );
+$GLOBALS['ssi_plan_count_aggregate_encodes'] = false;
+$assert( $legacy_hash === $streamed_hash && 0 === $GLOBALS['ssi_plan_json_array_calls'], 'streamed plan hashing preserves canonical JSON SHA-256 identity without materializing the full plan JSON' );
 
 echo "WordPress site plan materializer smoke passed.\n";


### PR DESCRIPTION
## Summary

- stream canonical plan hashing without materializing a complete JSON string
- stream nested report persistence atomically while preserving the existing report and plan schemas
- keep binary font bytes in canonical writes and retain path/source/digest evidence in public font receipts
- reject short theme/report writes before atomic publication

## Verification

- `npm test` (64 selected groups passed)
- deterministic 1 MiB invalid-binary font and large base64 report coverage
- canonical streamed JSON/hash compatibility coverage
- short-write rollback and atomic-publication coverage

The exact WP Codebox LEGO workload was not rerun after the final change; the deterministic test exercises the identified report amplification and persistence boundaries directly.

Fixes #1010

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the report amplification, implemented the bounded persistence changes, generated tests, and performed iterative code review. Chris Huber directed the work and remains responsible for every line.