### PR TITLE
fix: scope fallback grafts to source page

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2116,8 +2116,10 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
-	 * Return candidate page content keys for a resolved source path, preferring the
-	 * matching page and falling back to the supplied order.
+	 * Return candidate page content keys for a resolved source path.
+	 *
+	 * A resolvable source owns its fallback. Only source-less or unresolvable legacy
+	 * findings may scan the supplied page order for a matching core/html fallback.
 	 *
 	 * @param string               $source_path   Resolved post_content path.
 	 * @param array<string,string> $page_contents Materialized page post_content keyed by source filename.
@@ -2133,10 +2135,12 @@ class Static_Site_Importer_Report_Diagnostics {
 			}
 		}
 
+		if ( ! empty( $keys ) ) {
+			return $keys;
+		}
+
 		foreach ( array_keys( $page_contents ) as $key ) {
-			if ( ! in_array( (string) $key, $keys, true ) ) {
-				$keys[] = (string) $key;
-			}
+			$keys[] = (string) $key;
 		}
 
 		return $keys;
@@ -2175,8 +2179,8 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Resolve the page content key that owns a form finding's fallback region.
 	 *
-	 * Prefers the finding's own source page; only falls back to scanning other
-	 * provided pages when the finding carries no resolvable source path.
+	 * A resolvable source page exclusively owns the fallback region. Only source-less
+	 * or unresolvable legacy findings scan page contents in their supplied order.
 	 *
 	 * @param string               $source_path   Finding source path.
 	 * @param string               $region        Serialized readable fallback region.
@@ -2184,12 +2188,23 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return string|null
 	 */
 	private static function form_fallback_page_content_key( string $source_path, string $region, array $page_contents ): ?string {
+		$source_keys = array();
 		if ( '' !== $source_path ) {
-			foreach ( $page_contents as $key => $content ) {
-				if ( self::form_source_paths_match( $source_path, (string) $key ) && str_contains( (string) $content, $region ) ) {
-					return (string) $key;
+			foreach ( array_keys( $page_contents ) as $key ) {
+				if ( self::form_source_paths_match( $source_path, (string) $key ) ) {
+					$source_keys[] = (string) $key;
 				}
 			}
+		}
+
+		if ( ! empty( $source_keys ) ) {
+			foreach ( $source_keys as $key ) {
+				if ( str_contains( (string) $page_contents[ $key ], $region ) ) {
+					return $key;
+				}
+			}
+
+			return null;
 		}
 
 		foreach ( $page_contents as $key => $content ) {

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -945,6 +945,60 @@ namespace {
 	$assert( 'no_readable_fallback_blocks' === ( $unanchorable_diag['reason'] ?? '' ), 'graft-unanchorable-reason' );
 	$assert( '<!-- wp:paragraph --><p>keep this fallback page</p><!-- /wp:paragraph -->' === $unanchorable_grafted, 'graft-unanchorable-fallback-left-in-place' );
 
+	// Identical forms on two pages only replace the finding's resolved owner page.
+	$two_page_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/owner.html' );
+	$two_page_report['diagnostics'][] = array(
+		'type'            => 'unsupported_html_fallback',
+		'diagnostic_code' => 'html_form_fallback',
+		'loss_class'      => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path'     => 'website/owner.html',
+		'selector'        => 'form.identical',
+		'tag'             => 'form',
+		'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $identical_form, 'form.identical', 1 ),
+		'form'            => array( 'class' => 'identical' ),
+		'controls'        => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
+	);
+	$two_page_contents = array(
+		'website/owner.html' => $core_html_block( $identical_form ),
+		'website/other.html' => $core_html_block( $identical_form ),
+	);
+	$two_page_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $two_page_report, array(), $two_page_contents );
+	$assert( 1 === ( $two_page_seeding['grafted_count'] ?? 0 ) && str_contains( $two_page_contents['website/owner.html'], 'wp:jetpack/contact-form' ) && str_contains( $two_page_contents['website/other.html'], '<!-- wp:html' ) && ! str_contains( $two_page_contents['website/other.html'], 'wp:jetpack/contact-form' ), 'graft-two-identical-page-forms-only-mutates-declared-owner' );
+
+	// A resolvable page owns its finding even when an identical anchor exists elsewhere.
+	$owned_page_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/owned.html' );
+	$owned_page_report['diagnostics'][] = array(
+		'type'            => 'unsupported_html_fallback',
+		'diagnostic_code' => 'html_form_fallback',
+		'loss_class'      => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+		'source_path'     => 'website/owned.html',
+		'selector'        => 'form.identical',
+		'tag'             => 'form',
+		'form_presentation' => Static_Site_Importer_Report_Diagnostics::form_presentation_from_html( $identical_form, 'form.identical', 1 ),
+		'form'            => array( 'class' => 'identical' ),
+		'controls'        => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
+	);
+	$owned_page_contents = array(
+		'website/owned.html' => '<!-- wp:paragraph --><p>owner anchor is absent</p><!-- /wp:paragraph -->',
+		'website/other.html' => $core_html_block( $identical_form ),
+	);
+	$owned_page_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $owned_page_report, array(), $owned_page_contents );
+	$owned_page_diag    = array_values( array_filter( $owned_page_report['diagnostics'], static fn ( array $diagnostic ): bool => 'form_block_graft_unanchorable' === ( $diagnostic['type'] ?? '' ) ) );
+	$assert( 0 === ( $owned_page_seeding['grafted_count'] ?? -1 ) && false === ( $owned_page_report['diagnostics'][0]['content_grafted'] ?? true ), 'graft-resolved-source-missing-anchor-is-not-grafted' );
+	$assert( 1 === count( $owned_page_diag ) && 'no_readable_fallback_blocks' === ( $owned_page_diag[0]['reason'] ?? '' ) && 'website/owned.html' === ( $owned_page_diag[0]['source_path'] ?? '' ), 'graft-resolved-source-emits-bounded-owner-diagnostic' );
+	$assert( str_contains( $owned_page_contents['website/other.html'], '<!-- wp:html' ) && ! str_contains( $owned_page_contents['website/other.html'], 'wp:jetpack/contact-form' ), 'graft-resolved-source-never-mutates-identical-other-page-form' );
+
+	// Source-less legacy findings retain deterministic page-order fallback lookup.
+	$legacy_source_less_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/legacy.html' );
+	$legacy_source_less_report['diagnostics'][] = $owned_page_report['diagnostics'][0];
+	unset( $legacy_source_less_report['diagnostics'][0]['source_path'] );
+	$legacy_source_less_contents = array(
+		'website/first.html'  => $core_html_block( $identical_form ),
+		'website/second.html' => $core_html_block( $identical_form ),
+	);
+	$legacy_source_less_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $legacy_source_less_report, array(), $legacy_source_less_contents );
+	$assert( 1 === ( $legacy_source_less_seeding['grafted_count'] ?? 0 ) && str_contains( $legacy_source_less_contents['website/first.html'], 'wp:jetpack/contact-form' ) && str_contains( $legacy_source_less_contents['website/second.html'], '<!-- wp:html' ), 'graft-source-less-fallback-scans-page-order-deterministically' );
+
 	// --- Provider override routes to a different registered adapter ----------
 	add_filter(
 		'static_site_importer_entity_materializers',

--- a/tests/smoke-product-materializer.php
+++ b/tests/smoke-product-materializer.php
@@ -319,6 +319,20 @@ namespace {
 	$assert( ! str_contains( $page_contents['website/shop.html'], '>Add to cart<' ), 'page-content-removes-static-add-to-cart' );
 	$assert( ! str_contains( $page_contents['website/shop.html'], '>Buy now<' ), 'page-content-removes-static-buy-now' );
 
+	// A resolvable product finding cannot consume an identical region on another page.
+	$owned_graft_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/owned-shop.html' );
+	$owned_graft_report['diagnostics'][] = $graft_report['diagnostics'][0];
+	$owned_graft_report['diagnostics'][0]['source_path'] = 'website/owned-shop.html';
+	$owned_graft_contents = array(
+		'website/owned-shop.html' => '<!-- wp:paragraph --><p>owner anchor is absent</p><!-- /wp:paragraph -->',
+		'website/other-shop.html' => $button_region,
+	);
+	$owned_graft_seeding = Static_Site_Importer_Report_Diagnostics::materialize_product_findings( $owned_graft_report, array(), $owned_graft_contents );
+	$owned_graft_diag    = array_values( array_filter( $owned_graft_report['diagnostics'], static fn ( array $diagnostic ): bool => 'product_add_to_cart_graft_unanchorable' === ( $diagnostic['type'] ?? '' ) ) );
+	$assert( 0 === ( $owned_graft_seeding['shortcode_grafted_count'] ?? -1 ) && false === ( $owned_graft_report['diagnostics'][0]['product_shortcode_grafted'] ?? true ), 'product-graft-resolved-source-missing-anchor-is-not-grafted' );
+	$assert( 1 === count( $owned_graft_diag ) && 'fallback_region_not_found_in_post_content' === ( $owned_graft_diag[0]['reason'] ?? '' ) && 'website/owned-shop.html' === ( $owned_graft_diag[0]['source_path'] ?? '' ), 'product-graft-resolved-source-emits-bounded-owner-diagnostic' );
+	$assert( str_contains( $owned_graft_contents['website/other-shop.html'], '>Add to cart<' ) && ! str_contains( $owned_graft_contents['website/other-shop.html'], '[add_to_cart id=' ), 'product-graft-resolved-source-never-mutates-identical-other-page-region' );
+
 	// Grafting requires a seeded Woo product ID; source-only product metadata is not enough.
 	$graft_method   = new ReflectionMethod( 'Static_Site_Importer_Report_Diagnostics', 'graft_product_add_to_cart_shortcodes_into_page_contents' );
 	$no_id_contents = array( 'website/shop.html' => $button_region );


### PR DESCRIPTION
## Summary
- restrict form and product fallback grafts to page keys resolved from the finding source
- keep deterministic cross-page lookup only for source-less or unresolvable legacy findings
- record the existing bounded unanchorable diagnostic when a resolved owner lacks its anchor, without mutating another page

Closes #1075

## Scope
This change only governs source-to-page resolution. It intentionally leaves canonical block serialization to #1069.

## Tests
- `php tests/form-materializer-smoke.php`
- `php tests/smoke-product-materializer.php`
- `npm run test:all`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent was used to investigate the source-resolution defect, implement the scoped lookup, and add regression coverage. Chris Huber reviewed the change and remains responsible for every line.