### PR TITLE
fix: export resolved block theme output

### DIFF
--- a/includes/class-static-site-importer-theme-exporter.php
+++ b/includes/class-static-site-importer-theme-exporter.php
@@ -116,7 +116,12 @@ class Static_Site_Importer_Theme_Exporter {
 				$page_id   = isset( $page->ID ) ? (int) $page->ID : 0;
 				$template  = $is_front ? 'front-page' : 'page';
 				$page_html = self::export_resolved_template_html( $page, $theme_slug, $is_front );
-				$chrome    = '' === $page_html ? self::export_theme_chrome_html( $theme_dir, $template ) : array( 'before' => '', 'after' => '' );
+				$chrome    = '' === $page_html
+					? self::export_theme_chrome_html( $theme_dir, $template )
+					: array(
+						'before' => '',
+						'after'  => '',
+					);
 				if ( '' === $page_html ) {
 					$page_html = self::blocks_to_html( isset( $page->post_content ) ? (string) $page->post_content : '' );
 				}
@@ -394,12 +399,13 @@ class Static_Site_Importer_Theme_Exporter {
 			$hierarchy = self::export_template_hierarchy( $page, $is_front );
 			$template  = resolve_block_template( $hierarchy[0], $hierarchy, '' );
 		}
-		if ( ! is_object( $template ) || ! isset( $template->content ) || '' === (string) $template->content ) {
+		if ( null === $template || '' === $template->content ) {
 			return '';
 		}
 
 		global $post;
 		$previous_post = $post ?? null;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Dynamic block rendering reads the exported document from the global post context.
 		$post          = $page;
 		if ( function_exists( 'setup_postdata' ) ) {
 			setup_postdata( $page );
@@ -408,6 +414,7 @@ class Static_Site_Importer_Theme_Exporter {
 		if ( function_exists( 'wp_reset_postdata' ) ) {
 			wp_reset_postdata();
 		}
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the caller's global post after rendering the exported document.
 		$post = $previous_post;
 
 		return $html;
@@ -497,6 +504,7 @@ class Static_Site_Importer_Theme_Exporter {
 			$head .= '<link rel="stylesheet" href="style.css">';
 		}
 		if ( $include_global_styles ) {
+			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- This method emits standalone static HTML, not a WordPress-rendered page.
 			$head .= '<link rel="stylesheet" href="global-styles.css">';
 		}
 
@@ -620,7 +628,7 @@ class Static_Site_Importer_Theme_Exporter {
 		}
 
 		$stylesheet = wp_get_global_stylesheet();
-		if ( ! is_string( $stylesheet ) || '' === trim( $stylesheet ) ) {
+		if ( '' === trim( $stylesheet ) ) {
 			return null;
 		}
 

--- a/includes/class-static-site-importer-theme-exporter.php
+++ b/includes/class-static-site-importer-theme-exporter.php
@@ -46,6 +46,10 @@ class Static_Site_Importer_Theme_Exporter {
 		if ( null !== $stylesheet ) {
 			$files[] = $stylesheet;
 		}
+		$global_stylesheet = self::export_global_stylesheet_file( $root );
+		if ( null !== $global_stylesheet ) {
+			$files[] = $global_stylesheet;
+		}
 
 		$pages      = self::export_pages( $include_pages );
 		$post_count = 0;
@@ -57,7 +61,7 @@ class Static_Site_Importer_Theme_Exporter {
 			);
 			$files[]       = self::export_file_entry(
 				$entrypoint,
-				self::export_html_document( '', self::export_theme_chrome_html( $theme_dir, 'front-page' ), $theme_slug, null !== $stylesheet ),
+				self::export_html_document( '', self::export_theme_chrome_html( $theme_dir, 'front-page' ), $theme_slug, null !== $stylesheet, null !== $global_stylesheet ),
 				'document',
 				'entrypoint'
 			);
@@ -111,11 +115,15 @@ class Static_Site_Importer_Theme_Exporter {
 				$is_front  = $plan['is_front'];
 				$page_id   = isset( $page->ID ) ? (int) $page->ID : 0;
 				$template  = $is_front ? 'front-page' : 'page';
-				$page_html = self::blocks_to_html( isset( $page->post_content ) ? (string) $page->post_content : '' );
+				$page_html = self::export_resolved_template_html( $page, $theme_slug, $is_front );
+				$chrome    = '' === $page_html ? self::export_theme_chrome_html( $theme_dir, $template ) : array( 'before' => '', 'after' => '' );
+				if ( '' === $page_html ) {
+					$page_html = self::blocks_to_html( isset( $page->post_content ) ? (string) $page->post_content : '' );
+				}
 
 				$files[] = self::export_file_entry(
 					$path,
-					self::export_html_document( $page_html, self::export_theme_chrome_html( $theme_dir, $template ), self::export_page_title( $page, $theme_slug ), null !== $stylesheet ),
+					self::export_html_document( $page_html, $chrome, self::export_page_title( $page, $theme_slug ), null !== $stylesheet, null !== $global_stylesheet ),
 					'document',
 					$is_front ? 'entrypoint' : 'page',
 					array(
@@ -357,6 +365,85 @@ class Static_Site_Importer_Theme_Exporter {
 	}
 
 	/**
+	 * Render the template WordPress resolves for a document.
+	 *
+	 * get_block_template() and resolve_block_template() apply WordPress's normal
+	 * database-over-theme source precedence. do_blocks() then expands nested
+	 * template parts through core's template-part renderer.
+	 *
+	 * @param object $page       Document being exported.
+	 * @param string $theme_slug Active theme stylesheet.
+	 * @param bool   $is_front   Whether this is the front page.
+	 * @return string
+	 */
+	private static function export_resolved_template_html( object $page, string $theme_slug, bool $is_front ): string {
+		if ( ! function_exists( 'get_block_template' ) || ! function_exists( 'do_blocks' ) ) {
+			return '';
+		}
+
+		$template = null;
+		$slug     = '';
+		if ( function_exists( 'get_page_template_slug' ) && isset( $page->ID ) ) {
+			$slug = (string) get_page_template_slug( (int) $page->ID );
+		}
+		if ( '' !== $slug && 'default' !== $slug ) {
+			$template = get_block_template( $theme_slug . '//' . $slug );
+		}
+
+		if ( null === $template && function_exists( 'resolve_block_template' ) ) {
+			$hierarchy = self::export_template_hierarchy( $page, $is_front );
+			$template  = resolve_block_template( $hierarchy[0], $hierarchy, '' );
+		}
+		if ( ! is_object( $template ) || ! isset( $template->content ) || '' === (string) $template->content ) {
+			return '';
+		}
+
+		global $post;
+		$previous_post = $post ?? null;
+		$post          = $page;
+		if ( function_exists( 'setup_postdata' ) ) {
+			setup_postdata( $page );
+		}
+		$html = do_blocks( (string) $template->content );
+		if ( function_exists( 'wp_reset_postdata' ) ) {
+			wp_reset_postdata();
+		}
+		$post = $previous_post;
+
+		return $html;
+	}
+
+	/**
+	 * Build the standard block-template candidates for an exported singular post.
+	 *
+	 * @param object $page     Document being exported.
+	 * @param bool   $is_front Whether this is the front page.
+	 * @return array<int,string>
+	 */
+	private static function export_template_hierarchy( object $page, bool $is_front ): array {
+		$slug      = isset( $page->post_name ) ? sanitize_title( (string) $page->post_name ) : '';
+		$id        = isset( $page->ID ) ? (int) $page->ID : 0;
+		$post_type = isset( $page->post_type ) ? sanitize_key( (string) $page->post_type ) : 'page';
+		$hierarchy = $is_front ? array( 'front-page', 'home' ) : array();
+		if ( 'page' === $post_type ) {
+			if ( '' !== $slug ) {
+				$hierarchy[] = 'page-' . $slug;
+			}
+			if ( $id > 0 ) {
+				$hierarchy[] = 'page-' . $id;
+			}
+			$hierarchy[] = 'page';
+		} else {
+			$hierarchy[] = 'single-' . $post_type;
+			$hierarchy[] = 'single';
+		}
+		$hierarchy[] = 'singular';
+		$hierarchy[] = 'index';
+
+		return array_values( array_unique( $hierarchy ) );
+	}
+
+	/**
 	 * Convert a block markup file to HTML.
 	 *
 	 * @param string $path File path.
@@ -403,11 +490,14 @@ class Static_Site_Importer_Theme_Exporter {
 	 * @param bool                              $include_styles  Whether to link exported CSS.
 	 * @return string
 	 */
-	private static function export_html_document( string $page_html, array $chrome, string $title, bool $include_styles ): string {
+	private static function export_html_document( string $page_html, array $chrome, string $title, bool $include_styles, bool $include_global_styles = false ): string {
 		$head = '<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">';
 		if ( $include_styles ) {
 			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- This method emits standalone static HTML, not a WordPress-rendered page.
 			$head .= '<link rel="stylesheet" href="style.css">';
+		}
+		if ( $include_global_styles ) {
+			$head .= '<link rel="stylesheet" href="global-styles.css">';
 		}
 
 		return '<!doctype html>' . "\n"
@@ -516,6 +606,25 @@ class Static_Site_Importer_Theme_Exporter {
 		}
 
 		return self::export_file_entry( $root . '/style.css', $content, 'asset', 'stylesheet' );
+	}
+
+	/**
+	 * Export the merged theme.json, style variation, and user Global Styles CSS.
+	 *
+	 * @param string $root Artifact root.
+	 * @return array<string,mixed>|null
+	 */
+	private static function export_global_stylesheet_file( string $root ): ?array {
+		if ( ! function_exists( 'wp_get_global_stylesheet' ) ) {
+			return null;
+		}
+
+		$stylesheet = wp_get_global_stylesheet();
+		if ( ! is_string( $stylesheet ) || '' === trim( $stylesheet ) ) {
+			return null;
+		}
+
+		return self::export_file_entry( $root . '/global-styles.css', $stylesheet, 'asset', 'stylesheet' );
 	}
 
 	/**

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -68,6 +68,7 @@
     { "path": "tests/smoke-static-interactive-artifact.php", "environment": "wordpress-runtime" },
     { "path": "tests/smoke-url-batch-import-wordpress.php", "environment": "wordpress-runtime" },
     { "path": "tests/smoke-website-artifact-document-metadata.php", "environment": "wordpress-runtime" },
+    { "path": "tests/smoke-export-resolved-block-theme.php", "environment": "wordpress-runtime", "command": ["wp", "--skip-plugins=static-site-importer", "eval-file", "tests/smoke-export-resolved-block-theme.php"] },
     { "path": "tests/StaticSiteImporterFallbackDiagnosticsTest.php", "environment": "wordpress-runtime", "command": ["phpunit", "tests/StaticSiteImporterFallbackDiagnosticsTest.php"] },
     { "path": "tests/form-materializer-topology.test.mjs", "environment": "node" },
     { "path": "tools/build-dev-package.test.mjs", "environment": "node" },

--- a/tests/smoke-export-resolved-block-theme.php
+++ b/tests/smoke-export-resolved-block-theme.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Integration coverage for WordPress block template and Global Styles export.
+ *
+ * Run against WordPress with SSI skipped so this test loads the worktree class:
+ * studio wp --skip-plugins=static-site-importer eval-file tests/smoke-export-resolved-block-theme.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	fwrite( STDERR, "This test requires a WordPress runtime.\n" );
+	exit( 1 );
+}
+
+if ( ! function_exists( 'blocks_engine_php_transformer_convert_format' ) ) {
+	function blocks_engine_php_transformer_convert_format( string $content, string $from, string $to, array $options = array() ): array {
+		return array( 'documents' => array( array( 'content' => $content ) ) );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-exporter.php';
+
+$slug      = 'ssi-export-runtime-' . wp_generate_password( 8, false, false );
+$theme_dir = WP_CONTENT_DIR . '/themes/' . $slug;
+$old_theme = get_stylesheet();
+$options   = array( 'show_on_front' => get_option( 'show_on_front' ), 'page_on_front' => get_option( 'page_on_front' ) );
+$post_ids  = array();
+$failures  = array();
+$assert    = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( ! $condition ) {
+		$failures[] = $message;
+	}
+};
+
+try {
+	wp_mkdir_p( $theme_dir . '/templates' );
+	wp_mkdir_p( $theme_dir . '/parts' );
+	wp_mkdir_p( $theme_dir . '/styles' );
+	file_put_contents( $theme_dir . '/style.css', "/* Theme Name: SSI Export Runtime */\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	file_put_contents( $theme_dir . '/theme.json', wp_json_encode( array( 'version' => 3, 'styles' => array( 'color' => array( 'background' => '#010203' ) ) ) ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	file_put_contents( $theme_dir . '/styles/active.json', wp_json_encode( array( 'version' => 3, 'title' => 'Active', 'styles' => array( 'color' => array( 'text' => '#aabbcc' ) ) ) ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	file_put_contents( $theme_dir . '/templates/custom.html', '<!-- wp:template-part {"slug":"outer"} /--><!-- wp:post-content /-->' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	file_put_contents( $theme_dir . '/parts/outer.html', '<!-- wp:paragraph --><p>Theme outer</p><!-- /wp:paragraph -->' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+	switch_theme( $slug );
+	wp_clean_themes_cache();
+	WP_Theme_JSON_Resolver::clean_cached_data();
+
+	$page_id   = wp_insert_post( array( 'post_type' => 'page', 'post_status' => 'publish', 'post_title' => 'Runtime export', 'post_name' => 'runtime-export', 'post_content' => '<!-- wp:paragraph --><p>Page body</p><!-- /wp:paragraph -->' ) );
+	$post_ids[] = $page_id;
+	update_post_meta( $page_id, '_wp_page_template', 'custom' );
+	update_option( 'show_on_front', 'page' );
+	update_option( 'page_on_front', $page_id );
+
+	$template_id = wp_insert_post( array( 'post_type' => 'wp_template', 'post_status' => 'publish', 'post_title' => 'custom', 'post_name' => 'custom', 'post_content' => '<!-- wp:template-part {"slug":"outer"} /--><!-- wp:post-content /-->' ) );
+	$post_ids[]  = $template_id;
+	wp_set_post_terms( $template_id, array( $slug ), 'wp_theme' );
+	$outer_id   = wp_insert_post( array( 'post_type' => 'wp_template_part', 'post_status' => 'publish', 'post_title' => 'outer', 'post_name' => 'outer', 'post_content' => '<!-- wp:paragraph --><p>Database outer</p><!-- /wp:paragraph --><!-- wp:template-part {"slug":"inner"} /-->' ) );
+	$post_ids[] = $outer_id;
+	wp_set_post_terms( $outer_id, array( $slug ), 'wp_theme' );
+	$inner_id   = wp_insert_post( array( 'post_type' => 'wp_template_part', 'post_status' => 'publish', 'post_title' => 'inner', 'post_name' => 'inner', 'post_content' => '<!-- wp:paragraph --><p>Nested database part</p><!-- /wp:paragraph -->' ) );
+	$post_ids[] = $inner_id;
+	wp_set_post_terms( $inner_id, array( $slug ), 'wp_theme' );
+	$styles_id  = wp_insert_post( array( 'post_type' => 'wp_global_styles', 'post_status' => 'publish', 'post_title' => 'Active variation', 'post_name' => 'wp-global-styles-' . $slug, 'post_content' => wp_json_encode( array( 'version' => 3, 'isGlobalStylesUserThemeJSON' => true, 'styles' => array( 'color' => array( 'background' => '#f0e1d2' ) ) ) ) ) );
+	$post_ids[] = $styles_id;
+	wp_set_post_terms( $styles_id, array( $slug ), 'wp_theme' );
+	WP_Theme_JSON_Resolver::clean_cached_data();
+
+	$result   = Static_Site_Importer_Theme_Exporter::export_theme( array( 'theme_slug' => $slug, 'include_pages' => array( $page_id ) ) );
+	$artifact = $result['website_artifact'] ?? array();
+	$files    = array_column( $artifact['files'] ?? array(), 'content', 'path' );
+	$html     = $files['website/index.html'] ?? '';
+	$css      = $files['website/global-styles.css'] ?? '';
+	$assert( str_contains( $html, 'Database outer' ), 'Database template-part override did not win over the theme file.' );
+	$assert( str_contains( $html, 'Nested database part' ), 'Nested template part was not resolved by WordPress.' );
+	$assert( str_contains( $html, 'Page body' ), 'The custom database template did not render post content.' );
+	$assert( ! str_contains( $html, 'Theme outer' ), 'Theme template-part file won over its database override.' );
+	$assert( str_contains( $html, 'global-styles.css' ), 'Exported document does not link merged Global Styles.' );
+	$assert( str_contains( $css, '#f0e1d2' ), 'User Global Styles/style-variation presentation is absent from exported CSS.' );
+} finally {
+	foreach ( $post_ids as $post_id ) {
+		wp_delete_post( $post_id, true );
+	}
+	update_option( 'show_on_front', $options['show_on_front'] );
+	update_option( 'page_on_front', $options['page_on_front'] );
+	switch_theme( $old_theme );
+	WP_Theme_JSON_Resolver::clean_cached_data();
+	$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $theme_dir, FilesystemIterator::SKIP_DOTS ), RecursiveIteratorIterator::CHILD_FIRST );
+	foreach ( $iterator as $path ) {
+		$path->isDir() ? rmdir( $path->getPathname() ) : unlink( $path->getPathname() );
+	}
+	rmdir( $theme_dir );
+}
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo "OK: resolved block theme export integration passed\n";


### PR DESCRIPTION
## Summary
- resolve each exported document through WordPress block template APIs and render it with `do_blocks()`
- preserve database template and nested template-part precedence instead of hard-coding header/footer files
- package the merged Global Styles CSS emitted by WordPress, including active user style-variation presentation

## Tests
- `homeboy review lint static-site-importer --placement local --path . --changed-since e565e9d3ee4f75c5d2e132f6841dabb94b3a8b2b --extension wordpress --summary`
- `studio wp --skip-plugins=static-site-importer eval-file tests/smoke-export-resolved-block-theme.php`
- `php tests/smoke-export-theme-ability.php`
- `npm run test:inventory`
- `composer validate --no-check-publish`
- `npm test` (blocked before relevant tests because this fresh worktree has no `vendor/` or `node_modules/`; missing Blocks Engine classes, `pngjs`, and `jsdom`)

Closes #1074

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented the WordPress API integration and runtime coverage. Chris Huber directed the work and remains responsible for every line.