### PR TITLE
Add audited typed companion renderers

### DIFF
--- a/docs/companion-block-strategy.md
+++ b/docs/companion-block-strategy.md
@@ -12,7 +12,7 @@ The existing seam is enough for first implementations:
 
 - Blocks Engine emits `static-site-importer/companion-plugin/v1` payloads under `source_reports.companion_plugin_payload`.
 - SSI materializes that payload as a generated plugin dependency under `companion_plugins.dependencies`.
-- Typed payload blocks write `block.json`, render files, and declared assets; WordPress registers them from their block directories so `editorScript`, `style`, `editorStyle`, and `viewScript` file references resolve normally. PHP-only dynamic registration remains available for legacy scaffolds.
+- Typed payload blocks write `block.json`, render files, and declared assets; WordPress registers them from their block directories so `editorScript`, `style`, `editorStyle`, and `viewScript` file references resolve normally. A block may select an explicitly audited SSI-owned renderer by versioned identifier; producer-authored PHP and unknown renderers remain invalid. PHP-only dynamic registration remains available for legacy scaffolds.
 - Provider-backed features should continue to use SSI entity materializer adapters before falling back to a companion block.
 
 ## Candidate Blocks

--- a/docs/companion-block-strategy.md
+++ b/docs/companion-block-strategy.md
@@ -8,6 +8,11 @@ SSI owns WordPress runtime materialization: generated metadata blocks, legacy
 PHP-only dynamic registration, provider dependency checks, activation, and
 import diagnostics.
 
+The generated theme and companion plugins are the terminal runtime artifact.
+They contain their complete render, editor, style, and island implementations,
+use WordPress core or explicitly materialized provider plugins only, and remain
+functional after Static Site Importer and Blocks Engine are removed.
+
 The existing seam is enough for first implementations:
 
 - Blocks Engine emits `static-site-importer/companion-plugin/v1` payloads under `source_reports.companion_plugin_payload`.

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -42,6 +42,9 @@ class Static_Site_Importer_Companion_Plugin {
 	/** Maximum declared script files and dependency handles per block. */
 	private const MAX_SCRIPT_DEPENDENCIES = 32;
 
+	/** SSI-owned renderer available to typed responsive-media blocks. */
+	private const RESPONSIVE_MEDIA_RENDERER = 'static-site-importer/responsive-media/v1';
+
 	/**
 	 * Payload schema identifier consumed by the scaffolder.
 	 */
@@ -109,11 +112,24 @@ class Static_Site_Importer_Companion_Plugin {
 					return new WP_Error( 'static_site_importer_companion_plugin_asset_path_invalid', sprintf( 'Block %s has an unsafe asset path.', $name ) );
 				}
 			}
+			$renderer = $block['renderer'] ?? null;
+			if ( null !== $renderer ) {
+				if ( ! is_string( $renderer ) || self::RESPONSIVE_MEDIA_RENDERER !== $renderer ) {
+					return new WP_Error( 'static_site_importer_companion_plugin_renderer_invalid', sprintf( 'Block %s must declare a supported typed renderer.', $name ) );
+				}
+				if ( array_key_exists( 'render', $block ) ) {
+					return new WP_Error( 'static_site_importer_companion_plugin_renderer_conflict', sprintf( 'Block %s cannot declare both render markup and a typed renderer.', $name ) );
+				}
+				$content_schema = $block['block_json']['attributes']['content'] ?? null;
+				if ( ! is_array( $content_schema ) || 'string' !== ( $content_schema['type'] ?? null ) ) {
+					return new WP_Error( 'static_site_importer_companion_plugin_renderer_attributes_invalid', sprintf( 'Block %s responsive-media renderer requires a string content attribute.', $name ) );
+				}
+			}
 			if ( isset( $block['render'] ) && is_scalar( $block['render'] ) && Static_Site_Importer_Content_Policy::contains_server_code( (string) $block['render'] ) ) {
 				return new WP_Error( 'static_site_importer_companion_plugin_render_invalid', sprintf( 'Block %s render markup must be static HTML.', $name ) );
 			}
 			$metadata = $block['block_json'];
-			if ( isset( $block['render'] ) && is_scalar( $block['render'] ) ) {
+			if ( ( isset( $block['render'] ) && is_scalar( $block['render'] ) ) || null !== $renderer ) {
 				$metadata['render'] = 'file:./render.php';
 			}
 			$script_dependencies = self::validate_script_dependencies( $block, $assets, $metadata );
@@ -122,7 +138,7 @@ class Static_Site_Importer_Companion_Plugin {
 			}
 			$references = self::metadata_file_references( $metadata );
 			foreach ( $references as $path ) {
-				if ( ! array_key_exists( $path, $assets ) && ! ( 'render.php' === $path && isset( $block['render'] ) && is_scalar( $block['render'] ) ) ) {
+				if ( ! array_key_exists( $path, $assets ) && ! ( 'render.php' === $path && ( ( isset( $block['render'] ) && is_scalar( $block['render'] ) ) || null !== $renderer ) ) ) {
 					return new WP_Error( 'static_site_importer_companion_plugin_metadata_asset_missing', sprintf( 'Block %s metadata references undeclared asset %s.', $name, $path ) );
 				}
 			}
@@ -384,11 +400,12 @@ class Static_Site_Importer_Companion_Plugin {
 			return $args;
 		}
 
-		$has_render = isset( $block['render'] ) && is_scalar( $block['render'] );
-		$render     = $has_render ? (string) $block['render'] : '';
+		$renderer   = isset( $block['renderer'] ) && is_string( $block['renderer'] ) ? $block['renderer'] : '';
+		$has_render = ( isset( $block['render'] ) && is_scalar( $block['render'] ) ) || '' !== $renderer;
+		$render     = isset( $block['render'] ) && is_scalar( $block['render'] ) ? (string) $block['render'] : '';
 		$files      = array();
 		if ( $has_render ) {
-			$files['render.php'] = self::normalize_render( $render );
+			$files['render.php'] = '' !== $renderer ? self::typed_renderer( $renderer ) : self::normalize_render( $render );
 		}
 
 		// Carried static assets (e.g. block stylesheets or a hand-written
@@ -953,6 +970,134 @@ class Static_Site_Importer_Companion_Plugin {
 		// Static source markup is data, never executable template source. The only
 		// PHP in this file is SSI-generated code that emits an escaped literal.
 		return "<?php\n/** Generated companion block render. */\n\necho '" . self::php_single_quote( $render ) . "'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static source markup was validated before compilation.\n";
+	}
+
+	/**
+	 * Build an SSI-owned render template for an audited renderer identifier.
+	 *
+	 * @param string $renderer Validated renderer identifier.
+	 * @return string
+	 */
+	private static function typed_renderer( string $renderer ): string {
+		if ( self::RESPONSIVE_MEDIA_RENDERER !== $renderer ) {
+			return '';
+		}
+
+		return <<<'PHP'
+<?php
+/** Generated responsive-media companion block render. */
+
+$content    = is_string( $attributes['content'] ?? null ) ? $attributes['content'] : '';
+$normalized = strtolower( preg_replace( '/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]+/', '', html_entity_decode( $content, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ) ?? '' );
+if ( preg_match( '/<\s*(?:script|style|iframe|object|embed|svg)\b|\son[a-z]+\s*=/i', $normalized ) ) {
+	return;
+}
+
+$safe_url = static function ( string $url ): bool {
+	$normalized_url = strtolower( preg_replace( '/[\x00-\x20\x7f]+/', '', html_entity_decode( $url, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ) ?? '' );
+	$normalized_url = rawurldecode( rawurldecode( $normalized_url ) );
+	if ( '' === $normalized_url || ! preg_match( '/^([a-z][a-z0-9+.-]*):/i', $normalized_url, $scheme ) ) {
+		return '' !== $normalized_url;
+	}
+	if ( in_array( strtolower( $scheme[1] ), array( 'http', 'https' ), true ) ) {
+		return true;
+	}
+	return (bool) preg_match( '#^data:image/(?:avif|gif|jpeg|png|webp);base64,[a-z0-9+/=]+$#i', $normalized_url );
+};
+
+$sanitize_srcset = static function ( string $srcset ) use ( $safe_url ): string {
+	$candidates = array();
+	for ( $offset = 0, $length = strlen( $srcset ); $offset < $length; ) {
+		while ( $offset < $length && ( ctype_space( $srcset[ $offset ] ) || ',' === $srcset[ $offset ] ) ) {
+			++$offset;
+		}
+		$url_start = $offset;
+		while ( $offset < $length && ! ctype_space( $srcset[ $offset ] ) ) {
+			++$offset;
+		}
+		$url = substr( $srcset, $url_start, $offset - $url_start );
+		while ( $offset < $length && ctype_space( $srcset[ $offset ] ) ) {
+			++$offset;
+		}
+		$descriptor_start = $offset;
+		for ( $parentheses = 0; $offset < $length; ++$offset ) {
+			if ( '(' === $srcset[ $offset ] ) {
+				++$parentheses;
+			} elseif ( ')' === $srcset[ $offset ] && $parentheses > 0 ) {
+				--$parentheses;
+			} elseif ( ',' === $srcset[ $offset ] && 0 === $parentheses ) {
+				break;
+			}
+		}
+		$descriptor = trim( substr( $srcset, $descriptor_start, $offset - $descriptor_start ) );
+		if ( '' !== $url && $safe_url( $url ) ) {
+			$candidates[] = $url . ( '' === $descriptor ? '' : ' ' . $descriptor );
+		}
+	}
+	return implode( ', ', $candidates );
+};
+
+$content = preg_replace_callback(
+	'/\bsrcset\s*=\s*(?:(["\'])(.*?)\1|([^\s>]+))/is',
+	static function ( array $match ) use ( $sanitize_srcset ): string {
+		$srcset = $sanitize_srcset( '' !== ( $match[2] ?? '' ) ? $match[2] : ( $match[3] ?? '' ) );
+		return '' === $srcset ? '' : 'srcset="' . esc_attr( $srcset ) . '"';
+	},
+	$content
+) ?? '';
+
+// Preserve audited raster data URLs through KSES's protocol filter without
+// allowing the data scheme for links or other URL-bearing attributes.
+$data_images = array();
+$content     = preg_replace_callback(
+	'/\bsrc\s*=\s*(["\'])(data:image\/(?:avif|gif|jpeg|png|webp);base64,[a-z0-9+\/=]+)\1/i',
+	static function ( array $match ) use ( &$data_images ): string {
+		$placeholder                 = '/ssi-data-image-' . hash( 'sha256', $match[2] ) . '.invalid';
+		$data_images[ $placeholder ] = $match[2];
+		return 'src=' . $match[1] . $placeholder . $match[1];
+	},
+	$content
+) ?? '';
+
+$global = array(
+	'aria-controls'    => true,
+	'aria-current'     => true,
+	'aria-describedby' => true,
+	'aria-details'     => true,
+	'aria-expanded'    => true,
+	'aria-hidden'      => true,
+	'aria-label'       => true,
+	'aria-labelledby'  => true,
+	'aria-live'        => true,
+	'class'            => true,
+	'data-*'           => true,
+	'dir'              => true,
+	'hidden'           => true,
+	'id'               => true,
+	'lang'              => true,
+	'role'              => true,
+	'style'             => true,
+	'tabindex'          => true,
+	'title'             => true,
+	'xml:lang'          => true,
+);
+$output = wp_kses(
+	$content,
+	array(
+		'a'          => array_merge( $global, array( 'download' => true, 'href' => true, 'rel' => true, 'target' => true ) ),
+		'figure'     => $global,
+		'figcaption' => $global,
+		'picture'    => $global,
+		'source'     => array_merge( $global, array( 'media' => true, 'sizes' => true, 'srcset' => true, 'type' => true ) ),
+		'img'        => array_merge( $global, array( 'alt' => true, 'height' => true, 'loading' => true, 'longdesc' => true, 'sizes' => true, 'src' => true, 'srcset' => true, 'usemap' => true, 'width' => true ) ),
+	)
+);
+foreach ( $data_images as $placeholder => $data_image ) {
+	$output = str_replace( 'src="' . $placeholder . '"', 'src="' . esc_attr( $data_image ) . '"', $output );
+	$output = str_replace( "src='" . $placeholder . "'", "src='" . esc_attr( $data_image ) . "'", $output );
+}
+echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded media markup.
+PHP;
 	}
 
 	/**

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -793,9 +793,9 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return isset( $routes[ $route ] ) ? $matches[1] . $routes[ $route ] . $suffix . $matches[3] : $matches[0];
 		};
 		foreach ( array(
-			'/(\b(?:href|action)\s*=\s*["\'])([^"\']+)(["\'])/i',
-			'/(\b(?:href|action)\s*=\s*\\\\")([^"\\\\]*)(\\\\")/i',
-			'/(\b(?:href|action)\s*=\s*\\\\u0022)(.*?)(\\\\u0022)/i',
+			'/(\b(?:href|action|data-[a-z0-9_-]*url)\s*=\s*["\'])([^"\']+)(["\'])/i',
+			'/(\b(?:href|action|data-[a-z0-9_-]*url)\s*=\s*\\\\")([^"\\\\]*)(\\\\")/i',
+			'/(\b(?:href|action|data-[a-z0-9_-]*url)\s*=\s*\\\\u0022)(.*?)(\\\\u0022)/i',
 			'/(["\'](?:url|href|action)["\']\s*:\s*["\'])([^"\']+)(["\'])/i',
 		) as $pattern ) {
 			$content = preg_replace_callback( $pattern, $replace, $content ) ?? $content;

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -750,7 +750,13 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			}
 			$rewritten = self::rewrite_route_references( $content, $routes );
 			if ( $rewritten !== $content ) {
-				$updated = wp_update_post( array( 'ID' => $post_id, 'post_content' => wp_slash( $rewritten ) ), true );
+				$updated = wp_update_post(
+					array(
+						'ID'           => $post_id,
+						'post_content' => wp_slash( $rewritten ),
+					),
+					true
+				);
 				if ( is_wp_error( $updated ) ) {
 					return $updated;
 				}
@@ -773,10 +779,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	/** @param array<string,string> $routes */
 	private static function rewrite_route_references( string $content, array $routes ): string {
-		$replace = static function ( array $match ) use ( $routes ): string {
-			$value = (string) $match[2];
+		$replace = static function ( array $matches ) use ( $routes ): string {
+			$value = (string) $matches[2];
 			if ( '' === $value || preg_match( '~^(?:[a-z][a-z0-9+.-]*:|//|#|\?)~i', $value ) ) {
-				return $match[0];
+				return $matches[0];
 			}
 			$suffix = '';
 			if ( preg_match( '/^([^?#]*)(.*)$/', $value, $parts ) ) {
@@ -784,7 +790,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				$suffix = $parts[2];
 			}
 			$route = self::normalized_route_path( $value );
-			return isset( $routes[ $route ] ) ? $match[1] . $routes[ $route ] . $suffix . $match[3] : $match[0];
+			return isset( $routes[ $route ] ) ? $matches[1] . $routes[ $route ] . $suffix . $matches[3] : $matches[0];
 		};
 		foreach ( array(
 			'/(\b(?:href|action)\s*=\s*["\'])([^"\']+)(["\'])/i',

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -341,6 +341,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			}
 			unset( $binding_report );
 		}
+		$route_links = self::rewrite_materialized_route_links( $state );
+		if ( is_wp_error( $route_links ) ) {
+			return self::failed_receipt_from_error( $state, $route_links );
+		}
 
 		$short_write_attempt = 0;
 		foreach ( $state['resolved']['writes'] as $write ) {
@@ -716,6 +720,90 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		}
 		update_post_meta( (int) $id, self::RECONCILIATION_META_KEY, $page['reconciliation_identity'] );
 		return (int) $id;
+	}
+
+	/** Resolve destination-independent route references after WordPress has assigned every permalink. */
+	private static function rewrite_materialized_route_links( array &$state ) {
+		$routes = array();
+		foreach ( $state['ordered_pages'] as $page ) {
+			$source_path = (string) ( $page['source_path'] ?? '' );
+			$route       = self::normalized_route_path( (string) ( $page['route']['path'] ?? '' ) );
+			$post_id     = (int) ( $state['source_ids'][ $source_path ] ?? 0 );
+			$permalink   = $post_id > 0 && function_exists( 'get_permalink' ) ? get_permalink( $post_id ) : false;
+			if ( '' !== $route && is_string( $permalink ) && '' !== $permalink ) {
+				$routes[ $route ] = $permalink;
+			}
+		}
+		if ( array() === $routes ) {
+			return true;
+		}
+
+		foreach ( $state['ordered_pages'] as $page ) {
+			if ( ! empty( $page['skip_materialization'] ) ) {
+				continue;
+			}
+			$source_path = (string) ( $page['source_path'] ?? '' );
+			$post_id     = (int) ( $state['source_ids'][ $source_path ] ?? 0 );
+			$content     = $post_id > 0 && function_exists( 'get_post_field' ) ? get_post_field( 'post_content', $post_id ) : null;
+			if ( ! is_string( $content ) ) {
+				return new WP_Error( 'route_link_rewrite_failed', 'Materialized page content could not be read for route-link resolution.', array( 'source_path' => $source_path ) );
+			}
+			$rewritten = self::rewrite_route_references( $content, $routes );
+			if ( $rewritten !== $content ) {
+				$updated = wp_update_post( array( 'ID' => $post_id, 'post_content' => wp_slash( $rewritten ) ), true );
+				if ( is_wp_error( $updated ) ) {
+					return $updated;
+				}
+				$provenance = json_decode( (string) get_post_meta( $post_id, '_static_site_importer_provenance', true ), true );
+				if ( is_array( $provenance ) ) {
+					$provenance['content_hash'] = hash( 'sha256', $rewritten );
+					update_post_meta( $post_id, '_static_site_importer_provenance', wp_json_encode( $provenance ) );
+				}
+			}
+			foreach ( $state['applied']['runtime_declarations']['entity_bindings'] as &$binding_report ) {
+				if ( ( $binding_report['source_path'] ?? '' ) === $source_path && 'completed' === ( $binding_report['status'] ?? '' ) ) {
+					$binding_report['materialized_content_hash'] = hash( 'sha256', $rewritten );
+				}
+			}
+			unset( $binding_report );
+		}
+
+		return true;
+	}
+
+	/** @param array<string,string> $routes */
+	private static function rewrite_route_references( string $content, array $routes ): string {
+		$replace = static function ( array $match ) use ( $routes ): string {
+			$value = (string) $match[2];
+			if ( '' === $value || preg_match( '~^(?:[a-z][a-z0-9+.-]*:|//|#|\?)~i', $value ) ) {
+				return $match[0];
+			}
+			$suffix = '';
+			if ( preg_match( '/^([^?#]*)(.*)$/', $value, $parts ) ) {
+				$value  = $parts[1];
+				$suffix = $parts[2];
+			}
+			$route = self::normalized_route_path( $value );
+			return isset( $routes[ $route ] ) ? $match[1] . $routes[ $route ] . $suffix . $match[3] : $match[0];
+		};
+		foreach ( array(
+			'/(\b(?:href|action)\s*=\s*["\'])([^"\']+)(["\'])/i',
+			'/(\b(?:href|action)\s*=\s*\\\\")([^"\\\\]*)(\\\\")/i',
+			'/(\b(?:href|action)\s*=\s*\\\\u0022)(.*?)(\\\\u0022)/i',
+			'/(["\'](?:url|href|action)["\']\s*:\s*["\'])([^"\']+)(["\'])/i',
+		) as $pattern ) {
+			$content = preg_replace_callback( $pattern, $replace, $content ) ?? $content;
+		}
+
+		return $content;
+	}
+
+	private static function normalized_route_path( string $path ): string {
+		if ( '' === $path || ! str_starts_with( $path, '/' ) ) {
+			return '';
+		}
+		$normalized = '/' . trim( $path, '/' );
+		return '/' === $path ? '/' : $normalized;
 	}
 
 	/** Apply exact provider bindings to the resolved projection while retaining canonical plan markup. */

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -384,6 +384,7 @@ if ( is_array( $descriptor ) ) {
 
 	$assert( str_contains( $main, "register_block_type( SSI_EXAMPLE_SITE_" ) && str_contains( $main, "_DIR . 'blocks/' . (string) \$spec['dir'] )" ), 'main-file-registers-metadata-block-directory' );
 	$assert( str_contains( $main, "\$registered instanceof WP_Block_Type" ) && str_contains( $main, "static_site_importer_companion_block_owners" ) && str_contains( $main, "'plugin_file' => 'ssi-example-site/ssi-example-site.php'" ), 'main-file-records-owner-only-after-matching-registration' );
+	$assert( ! str_contains( $main, 'Requires Plugins:' ) && ! str_contains( $main, 'Static_Site_Importer_' ) && ! str_contains( $main, 'Automattic\\BlocksEngine' ), 'generated-plugin-declares-no-importer-or-compiler-runtime-dependency' );
 	$assert( str_contains( $main, "register_block_type( (string) \$spec['name'], \$args )" ), 'main-file-retains-php-only-fallback-registration' );
 	$assert( str_contains( $main, "'api_version' => 3" ), 'main-file-declares-api-version' );
 	$assert( str_contains( $main, "'name' => 'example/custom-hero'" ), 'main-file-carries-declared-block-name' );
@@ -475,6 +476,7 @@ $assert( is_array( $typed_descriptor ), 'typed-renderer-scaffold-returns-descrip
 if ( is_array( $typed_descriptor ) ) {
 	$typed_render = $typed_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
 	$assert( str_contains( $typed_render, 'Generated responsive-media companion block render' ) && ! str_contains( $typed_render, 'producer/arbitrary' ), 'typed-renderer-emits-ssi-owned-template' );
+	$assert( ! str_contains( $typed_render, 'Static_Site_Importer_' ) && ! str_contains( $typed_render, 'Automattic\\BlocksEngine' ), 'typed-renderer-is-self-contained-after-import' );
 	$attributes = array(
 		'content' => '<a data-track="profile" aria-label="Profile" href="/profile" target="_blank" rel="noopener"><picture><source media="(min-width:800px)" srcset="safe.webp 1x, javascript:alert(1) 2x, hero,wide.webp 3x"><img src="data:image/png;base64,aGVsbG8=" srcset="safe.png 1x, %6a%61vascript:alert(1) 2x, data:image/svg+xml;base64,PHN2Zz4= 3x" alt="Profile"></picture></a>',
 	);
@@ -534,6 +536,38 @@ $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' )
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/render.php' ), 'install-writes-render-php-to-disk' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/block.json' ), 'install-emits-block-json' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/index.js' ), 'install-emits-declared-editor-asset' );
+$standalone_bootstrap = <<<'PHP'
+define( 'ABSPATH', __DIR__ . '/' );
+class WP_Block_Type {
+	public function __construct( public string $name ) {}
+}
+function plugin_dir_path( string $file ): string { return dirname( $file ) . '/'; }
+function plugin_dir_url( string $file ): string { return 'https://example.test/plugins/' . basename( dirname( $file ) ) . '/'; }
+function add_action( string $hook, callable|string $callback ): void { if ( 'init' === $hook ) { call_user_func( $callback ); } }
+function add_filter( string $hook, callable|string $callback, int $priority = 10, int $accepted_args = 1 ): void {}
+function register_block_type( string $path, array $args = array() ): WP_Block_Type|false {
+	$metadata = is_file( $path . '/block.json' ) ? json_decode( (string) file_get_contents( $path . '/block.json' ), true ) : array();
+	$name = is_array( $metadata ) ? (string) ( $metadata['name'] ?? '' ) : '';
+	return '' !== $name ? new WP_Block_Type( $name ) : false;
+}
+function get_option( string $name, mixed $default = false ): mixed { return $default; }
+require $argv[1];
+exit( isset( $GLOBALS['static_site_importer_companion_block_owners']['example/custom-hero'] ) ? 0 : 1 );
+PHP;
+$standalone_process = proc_open(
+	array( PHP_BINARY, '-r', $standalone_bootstrap, WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ),
+	array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ),
+	$standalone_pipes
+);
+$standalone_output = '';
+$standalone_status = 1;
+if ( is_resource( $standalone_process ) ) {
+	$standalone_output = stream_get_contents( $standalone_pipes[1] ) . stream_get_contents( $standalone_pipes[2] );
+	fclose( $standalone_pipes[1] );
+	fclose( $standalone_pipes[2] );
+	$standalone_status = proc_close( $standalone_process );
+}
+$assert( 0 === $standalone_status, 'generated-plugin-loads-without-importer-or-compiler', $standalone_output );
 $written_asset_manifest = WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/index.asset.php';
 $asset_manifest_value  = file_exists( $written_asset_manifest ) ? include $written_asset_manifest : null;
 $assert( array( 'dependencies' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ), 'version' => hash( 'sha256', 'window.SSIEditor = true;' ) ) === $asset_manifest_value, 'installed-asset-manifest-executes-with-dependencies-and-content-version' );

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -82,6 +82,44 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( string $value ): string {
+		return htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'wp_kses' ) ) {
+	function wp_kses( string $content, array $allowed ): string {
+		$document = new DOMDocument();
+		$previous = libxml_use_internal_errors( true );
+		$document->loadHTML( '<div>' . $content . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NONET );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+		$root = $document->documentElement;
+		foreach ( iterator_to_array( $root->getElementsByTagName( '*' ) ) as $element ) {
+			$tag = strtolower( $element->tagName );
+			if ( ! isset( $allowed[ $tag ] ) ) {
+				$element->parentNode?->removeChild( $element );
+				continue;
+			}
+			foreach ( iterator_to_array( $element->attributes ) as $attribute ) {
+				$name      = strtolower( $attribute->name );
+				$permitted = isset( $allowed[ $tag ][ $name ] ) || ( str_starts_with( $name, 'aria-' ) && isset( $allowed[ $tag ]['aria-*'] ) ) || ( str_starts_with( $name, 'data-' ) && isset( $allowed[ $tag ]['data-*'] ) );
+				$value     = strtolower( rawurldecode( rawurldecode( preg_replace( '/\s+/', '', html_entity_decode( $attribute->value, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ) ?? '' ) ) );
+				$unsafe    = in_array( $name, array( 'href', 'src', 'longdesc' ), true ) && preg_match( '/^(?:javascript|vbscript|file|blob|data):/', $value );
+				if ( ! $permitted || $unsafe ) {
+					$element->removeAttribute( $attribute->name );
+				}
+			}
+		}
+		$output = '';
+		foreach ( iterator_to_array( $root->childNodes ) as $child ) {
+			$output .= $document->saveHTML( $child );
+		}
+		return $output;
+	}
+}
+
 if ( ! function_exists( 'sanitize_title' ) ) {
 	function sanitize_title( string $title ): string {
 		$title = strtolower( trim( $title ) );
@@ -300,6 +338,20 @@ $assert( 'failed' === ( $php_asset_report['status'] ?? '' ) && empty( $GLOBALS['
 $php_render = $payload;
 $php_render['blocks'][0]['render'] = '<?php system( "id" );';
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $php_render ) ), 'php-render-template-rejected' );
+$typed_renderer = $payload;
+unset( $typed_renderer['blocks'][0]['render'] );
+$typed_renderer['blocks'][0]['renderer'] = 'static-site-importer/responsive-media/v1';
+$typed_renderer['blocks'][0]['block_json']['attributes']['content']['type'] = 'string';
+$assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $typed_renderer ), 'known-typed-renderer-validates' );
+$unknown_renderer = $typed_renderer;
+$unknown_renderer['blocks'][0]['renderer'] = 'producer/arbitrary/v1';
+$assert( 'static_site_importer_companion_plugin_renderer_invalid' === Static_Site_Importer_Companion_Plugin::validate_payload( $unknown_renderer )->get_error_code(), 'unknown-typed-renderer-rejected' );
+$renderer_conflict = $typed_renderer;
+$renderer_conflict['blocks'][0]['render'] = '<div>conflict</div>';
+$assert( 'static_site_importer_companion_plugin_renderer_conflict' === Static_Site_Importer_Companion_Plugin::validate_payload( $renderer_conflict )->get_error_code(), 'typed-renderer-and-markup-conflict-rejected' );
+$invalid_renderer_attributes = $typed_renderer;
+$invalid_renderer_attributes['blocks'][0]['block_json']['attributes']['content']['type'] = 'object';
+$assert( 'static_site_importer_companion_plugin_renderer_attributes_invalid' === Static_Site_Importer_Companion_Plugin::validate_payload( $invalid_renderer_attributes )->get_error_code(), 'typed-renderer-requires-declared-string-content' );
 $malformed_dependencies = $payload;
 $malformed_dependencies['blocks'][0]['script_dependencies'] = array( array( 'wp-blocks' ) );
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $malformed_dependencies ) ), 'script-dependency-map-must-be-an-object' );
@@ -415,6 +467,33 @@ if ( is_array( $render_variants ) ) {
 	$variant_block_json = array_filter( array_keys( $variant_files ), static fn ( string $path ): bool => str_ends_with( $path, '/block.json' ) );
 	$assert( 2 === count( $variant_block_json ), 'render-variants-emit-block-json', implode( ',', $variant_block_json ) );
 	$assert( ! str_contains( $variant_main, 'file:./custom-render.php' ), 'php-args-drop-upstream-render-key' );
+}
+
+// Typed renderers emit only SSI-owned PHP and sanitize editable attributes at runtime.
+$typed_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $typed_renderer );
+$assert( is_array( $typed_descriptor ), 'typed-renderer-scaffold-returns-descriptor' );
+if ( is_array( $typed_descriptor ) ) {
+	$typed_render = $typed_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
+	$assert( str_contains( $typed_render, 'Generated responsive-media companion block render' ) && ! str_contains( $typed_render, 'producer/arbitrary' ), 'typed-renderer-emits-ssi-owned-template' );
+	$attributes = array(
+		'content' => '<a data-track="profile" aria-label="Profile" href="/profile" target="_blank" rel="noopener"><picture><source media="(min-width:800px)" srcset="safe.webp 1x, javascript:alert(1) 2x, hero,wide.webp 3x"><img src="data:image/png;base64,aGVsbG8=" srcset="safe.png 1x, %6a%61vascript:alert(1) 2x, data:image/svg+xml;base64,PHN2Zz4= 3x" alt="Profile"></picture></a>',
+	);
+	ob_start();
+	eval( '?>' . $typed_render );
+	$typed_output = (string) ob_get_clean();
+	foreach ( array( 'data-track="profile"', 'aria-label="Profile"', 'href="/profile"', 'safe.webp 1x', 'hero,wide.webp 3x', 'safe.png 1x', 'data:image/png;base64,aGVsbG8=' ) as $fragment ) {
+		$assert( str_contains( $typed_output, $fragment ), 'typed-renderer-preserves-' . $fragment );
+	}
+	foreach ( array( 'javascript:', '%6a%61vascript:', 'data:image/svg+xml' ) as $fragment ) {
+		$assert( ! str_contains( $typed_output, $fragment ), 'typed-renderer-removes-' . $fragment );
+	}
+	foreach ( array( '<script>alert(1)</script>', '<img src=x onerror=alert(1)>', '<a href="data:text/html;base64,PHNjcmlwdD4=">x</a>', '<img srcset=javascript:alert(1)>' ) as $unsafe_content ) {
+		$attributes = array( 'content' => $unsafe_content );
+		ob_start();
+		eval( '?>' . $typed_render );
+		$unsafe_output = strtolower( (string) ob_get_clean() );
+		$assert( ! str_contains( $unsafe_output, '<script' ) && ! str_contains( $unsafe_output, 'onerror' ) && ! str_contains( $unsafe_output, 'data:text' ) && ! str_contains( $unsafe_output, 'javascript:' ), 'typed-renderer-rejects-executable-content' );
+	}
 }
 
 // mu-plugin variant materializes a root loader stub.

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -162,6 +162,23 @@ function wp_insert_post( array $post, bool $wp_error ) {
 	$GLOBALS['ssi_plan_posts'][ $id ] = $post;
 	return $id;
 }
+function wp_update_post( array $post, bool $wp_error = false ) {
+	unset( $wp_error );
+	$id = (int) ( $post['ID'] ?? 0 );
+	if ( $id <= 0 || ! isset( $GLOBALS['ssi_plan_posts'][ $id ] ) ) {
+		return new WP_Error( 'missing_post' );
+	}
+	$GLOBALS['ssi_plan_posts'][ $id ] = array_merge( $GLOBALS['ssi_plan_posts'][ $id ], $post );
+	return $id;
+}
+function get_permalink( int|WP_Post $post ): string {
+	$id   = $post instanceof WP_Post ? $post->ID : $post;
+	$data = $GLOBALS['ssi_plan_posts'][ $id ] ?? array();
+	if ( 'post' === ( $data['post_type'] ?? '' ) ) {
+		return 'https://example.test/2024/03/' . (string) ( $data['post_name'] ?? '' ) . '/';
+	}
+	return 'https://example.test/' . (string) ( $data['post_name'] ?? '' ) . '/';
+}
 function get_post_field( string $field, int $id ): string {
 	return stripslashes( (string) ( $GLOBALS['ssi_plan_posts'][ $id ][ $field ] ?? '' ) ); }
 function sanitize_title( string $value ): string {
@@ -2256,6 +2273,22 @@ $descendant_only = $parent_order->invoke(
 	'batch-parent-run'
 );
 $assert( is_array( $descendant_only ) && 1 === count( $descendant_only ) && 'website/external/child/index.html' === ( $descendant_only[0]['source_path'] ?? '' ), 'external provenance parent satisfies ordering without being emitted as a page' );
+
+$GLOBALS['ssi_plan_posts'] = array();
+$GLOBALS['ssi_plan_meta']  = array();
+$route_artifact            = array(
+	'entrypoint' => 'website/index.html',
+	'files'      => array(
+		'website/index.html'         => '<main><a href="contact/index.html">Contact</a><a href="post/news/index.html">News</a></main>',
+		'website/contact/index.html' => '<main>Contact</main>',
+		array( 'path' => 'website/post/news/index.html', 'content' => '<article><time datetime="2024-03-01">March 1</time><h1>News</h1></article>', 'metadata' => array( 'post_type' => 'post' ) ),
+	),
+);
+$route_plan                = ( new ArtifactCompiler() )->compile( $route_artifact )->toArray()['source_reports']['wordpress_site_plan'];
+$route_receipt             = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $route_plan, array( 'slug' => 'route-link-plan' ) );
+$route_home                = current( array_filter( $GLOBALS['ssi_plan_posts'], static fn( array $post ): bool => 'index' === ( $post['post_name'] ?? '' ) ) );
+$route_content             = is_array( $route_home ) ? stripslashes( (string) ( $route_home['post_content'] ?? '' ) ) : '';
+$assert( 'completed' === ( $route_receipt['status'] ?? '' ) && str_contains( $route_content, 'href="https://example.test/contact/"' ) && str_contains( $route_content, 'href="https://example.test/2024/03/news/"' ), 'canonical routes resolve to actual WordPress page and dated-post permalinks after materialization' );
 
 $hash_plan = array(
 	'schema' => 'test/plan/v1',

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -2289,6 +2289,9 @@ $route_receipt             = Static_Site_Importer_WordPress_Site_Plan_Materializ
 $route_home                = current( array_filter( $GLOBALS['ssi_plan_posts'], static fn( array $post ): bool => 'index' === ( $post['post_name'] ?? '' ) ) );
 $route_content             = is_array( $route_home ) ? stripslashes( (string) ( $route_home['post_content'] ?? '' ) ) : '';
 $assert( 'completed' === ( $route_receipt['status'] ?? '' ) && str_contains( $route_content, 'href="https://example.test/contact/"' ) && str_contains( $route_content, 'href="https://example.test/2024/03/news/"' ), 'canonical routes resolve to actual WordPress page and dated-post permalinks after materialization' );
+$rewrite_route_references = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'rewrite_route_references' );
+$pin_route_content        = $rewrite_route_references->invoke( null, 'data-pin-url=\\u0022/post/news\\u0022', array( '/post/news' => 'https://example.test/2024/03/news/' ) );
+$assert( 'data-pin-url=\\u0022https://example.test/2024/03/news/\\u0022' === $pin_route_content, 'escaped route-bearing data URL attributes resolve to the materialized WordPress permalink' );
 
 $hash_plan = array(
 	'schema' => 'test/plan/v1',


### PR DESCRIPTION
## Summary

- add a versioned SSI-owned responsive-media renderer to the companion-plugin payload contract
- reject unknown renderers, raw-render conflicts, and incompatible attribute schemas before filesystem mutation
- preserve bounded media and accessibility markup while sanitizing runtime-edited URLs, `srcset`, executable markup, and unsafe data URLs
- document the typed-renderer ownership boundary

Fixes #1087.
Supports Automattic/blocks-engine#968.

## Verification

- `php tests/smoke-content-only-policy.php`
- `php tests/smoke-companion-plugin.php` (133 assertions)
- `php tests/smoke-companion-plugin-js.php` (23 assertions)
- `npm test`: 58 manifest targets passed; the sole failure is the existing solved-site promotion test expecting an older Blocks Engine SHA than current `main` config
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode analyzed the producer/consumer contract, implemented the SSI-owned renderer and tests, and performed security review. Chris Huber reviewed the approach and is responsible for every line.