### PR TITLE
Use Core serialization for runtime graft anchors

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2040,7 +2040,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		$readable = isset( $finding['readable_blocks'] ) && is_array( $finding['readable_blocks'] ) ? $finding['readable_blocks'] : array();
-		$region   = self::serialize_readable_form_blocks( $readable );
+		$region   = self::serialize_readable_graft_anchor( $readable );
 		if ( '' === $region ) {
 			$core_html_graft = self::graft_form_block_into_core_html_fallback( $finding, $block_markup, $source_path, $page_contents );
 			return $core_html_graft['grafted'] ? $core_html_graft : $unanchorable( 'no_readable_fallback_blocks' );
@@ -2256,103 +2256,20 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
-	 * Serialize a transformer-style readable_blocks tree to comment-delimited
-	 * block markup.
+	 * Serialize a transformer-readable anchor with the WordPress runtime.
 	 *
-	 * Mirrors Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime block
-	 * serialization so the result matches the exact fallback region the
-	 * transformer emitted into serialized_blocks (and thus into post_content).
+	 * Graft anchors compare byte-for-byte with post_content, so Core owns all
+	 * Gutenberg delimiter and attribute escaping.
 	 *
 	 * @param array<int,array<string,mixed>> $readable_blocks Readable fallback block tree.
 	 * @return string
 	 */
-	private static function serialize_readable_form_blocks( array $readable_blocks ): string {
-		$serialized = '';
-		foreach ( array_values( $readable_blocks ) as $block ) {
-			$serialized .= self::serialize_readable_form_block( $block );
-		}
-		return $serialized;
-	}
-
-	/**
-	 * Serialize one transformer-style block node to comment-delimited markup.
-	 *
-	 * @param array<string,mixed> $block Block node (blockName/attrs/innerBlocks/innerHTML/innerContent).
-	 * @return string
-	 */
-	private static function serialize_readable_form_block( array $block ): string {
-		$content = self::serialize_readable_form_inner_content( $block );
-		$name    = isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '';
-		if ( '' === $name ) {
-			return $content;
-		}
-
-		$name  = str_starts_with( $name, 'core/' ) ? substr( $name, 5 ) : $name;
-		$attrs = self::serialize_readable_form_block_attributes( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array() );
-		if ( '' === $content ) {
-			return '<!-- wp:' . $name . $attrs . ' /-->';
-		}
-
-		return '<!-- wp:' . $name . $attrs . ' -->' . $content . '<!-- /wp:' . $name . ' -->';
-	}
-
-	/**
-	 * Serialize a transformer-style block's inner content.
-	 *
-	 * @param array<string,mixed> $block Block node.
-	 * @return string
-	 */
-	private static function serialize_readable_form_inner_content( array $block ): string {
-		$inner_blocks  = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? array_values( array_filter( $block['innerBlocks'], 'is_array' ) ) : array();
-		$inner_content = $block['innerContent'] ?? null;
-
-		if ( ! is_array( $inner_content ) ) {
-			$serialized = '';
-			foreach ( $inner_blocks as $inner_block ) {
-				$serialized .= self::serialize_readable_form_block( $inner_block );
-			}
-			return $serialized . ( isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ? $block['innerHTML'] : '' );
-		}
-
-		$serialized = '';
-		$index      = 0;
-		foreach ( $inner_content as $part ) {
-			if ( null === $part ) {
-				$inner_block = $inner_blocks[ $index ] ?? null;
-				$serialized .= is_array( $inner_block ) ? self::serialize_readable_form_block( $inner_block ) : '';
-				++$index;
-				continue;
-			}
-			$serialized .= (string) $part;
-		}
-
-		return $serialized;
-	}
-
-	/**
-	 * Serialize block attributes for a comment delimiter, matching WordPress core.
-	 *
-	 * @param array<string,mixed> $attrs Block attributes.
-	 * @return string
-	 */
-	private static function serialize_readable_form_block_attributes( array $attrs ): string {
-		if ( array() === $attrs ) {
+	private static function serialize_readable_graft_anchor( array $readable_blocks ): string {
+		if ( ! function_exists( 'serialize_blocks' ) ) {
 			return '';
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Fallback only for non-WordPress smoke tests; WordPress runtimes use wp_json_encode().
-		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $attrs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( $attrs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-		if ( ! is_string( $encoded ) ) {
-			return '';
-		}
-
-		$encoded = preg_replace( '/--/', '\\u002d\\u002d', $encoded ) ?? $encoded;
-		$encoded = preg_replace( '/</', '\\u003c', $encoded ) ?? $encoded;
-		$encoded = preg_replace( '/>/', '\\u003e', $encoded ) ?? $encoded;
-		$encoded = preg_replace( '/&/', '\\u0026', $encoded ) ?? $encoded;
-		$encoded = preg_replace( '/\\\\"/', '\\u0022', $encoded ) ?? $encoded;
-
-		return ' ' . $encoded;
+		return serialize_blocks( $readable_blocks );
 	}
 
 	/**
@@ -2522,7 +2439,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		$readable = isset( $finding['readable_blocks'] ) && is_array( $finding['readable_blocks'] ) ? $finding['readable_blocks'] : array();
-		$region   = self::serialize_readable_form_blocks( $readable );
+		$region   = self::serialize_readable_graft_anchor( $readable );
 		if ( '' === $region ) {
 			return $unanchorable( 'no_readable_fallback_blocks' );
 		}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2269,7 +2269,15 @@ class Static_Site_Importer_Report_Diagnostics {
 			return '';
 		}
 
-		return serialize_blocks( $readable_blocks );
+		/**
+		 * The transformer emits Core's parsed-block shape. This explicit boundary
+		 * preserves the broad diagnostic input type while Core serializes the tree.
+		 *
+		 * @var array<int|string,array{blockName:string|null,attrs:array,innerBlocks:array<array>,innerHTML:string,innerContent:array}> $core_blocks
+		 */
+		$core_blocks = $readable_blocks;
+
+		return serialize_blocks( $core_blocks );
 	}
 
 	/**

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -628,6 +628,27 @@ namespace {
 	$assert( str_contains( (string) $mapped_source_contents['posts/page-home.post_content'], 'wp:jetpack/contact-form' ), 'graft-source-document-key-contact-form' );
 	$assert( 'posts/page-home.post_content' === ( $mapped_source_report['diagnostics'][0]['graft_source_path'] ?? '' ), 'graft-source-path-recorded' );
 
+	// Graft anchors delegate every delimiter-sensitive byte to Core serialization.
+	$core_sensitive_blocks = array(
+		array(
+			'blockName'    => 'core/paragraph',
+			'attrs'        => array(
+				'backslash' => 'C:\\forms\\contact',
+				'delimiter' => 'before -- after',
+				'angle'     => '<form>',
+				'ampersand' => 'forms & support',
+				'quote'     => 'She said "submit"',
+			),
+			'innerBlocks'  => array(),
+			'innerHTML'    => '<p>Email Send</p>',
+			'innerContent' => array( '<p>Email Send</p>' ),
+		),
+	);
+	$core_sensitive_anchor = serialize_blocks( $core_sensitive_blocks );
+	$anchor_serializer     = new ReflectionMethod( 'Static_Site_Importer_Report_Diagnostics', 'serialize_readable_graft_anchor' );
+	$assert( $core_sensitive_anchor === $anchor_serializer->invoke( null, $core_sensitive_blocks ), 'graft-anchor-byte-matches-core-for-sensitive-attributes' );
+	$assert( str_contains( $core_sensitive_anchor, '\\u005c' ) && str_contains( $core_sensitive_anchor, '\\u002d\\u002d' ) && str_contains( $core_sensitive_anchor, '\\u003c' ) && str_contains( $core_sensitive_anchor, '\\u003e' ) && str_contains( $core_sensitive_anchor, '\\u0026' ) && str_contains( $core_sensitive_anchor, '\\u0022' ), 'graft-anchor-core-escapes-sensitive-attributes' );
+
 	// --- Generated core/html form diagnostics materialize per page ---------------
 	$core_html_form = '<form class="newsletter-form" action="#" method="post" novalidate><input type="email" name="email" placeholder="your@email.com" autocomplete="email" required aria-label="Email address"><button type="submit">Subscribe</button></form>';
 	$core_html_block = static function ( string $html ): string {

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -68,6 +68,10 @@ namespace {
 		require_once $parser;
 		require_once $blocks;
 	}
+	if ( ! function_exists( 'serialize_blocks' ) ) {
+		fwrite( STDERR, "SKIP: WordPress block serialization is unavailable. Set STATIC_SITE_IMPORTER_WP_ROOT.\n" );
+		exit( 0 );
+	}
 
 	$GLOBALS['ssi_jetpack_form_blocks_available'] = true;
 	$GLOBALS['ssi_jetpack_registered_form_blocks'] = array(
@@ -644,8 +648,8 @@ namespace {
 			'innerContent' => array( '<p>Email Send</p>' ),
 		),
 	);
-	$core_sensitive_anchor = serialize_blocks( $core_sensitive_blocks );
 	$anchor_serializer     = new ReflectionMethod( 'Static_Site_Importer_Report_Diagnostics', 'serialize_readable_graft_anchor' );
+	$core_sensitive_anchor = serialize_blocks( $core_sensitive_blocks );
 	$assert( $core_sensitive_anchor === $anchor_serializer->invoke( null, $core_sensitive_blocks ), 'graft-anchor-byte-matches-core-for-sensitive-attributes' );
 	$assert( str_contains( $core_sensitive_anchor, '\\u005c' ) && str_contains( $core_sensitive_anchor, '\\u002d\\u002d' ) && str_contains( $core_sensitive_anchor, '\\u003c' ) && str_contains( $core_sensitive_anchor, '\\u003e' ) && str_contains( $core_sensitive_anchor, '\\u0026' ) && str_contains( $core_sensitive_anchor, '\\u0022' ), 'graft-anchor-core-escapes-sensitive-attributes' );
 

--- a/tests/smoke-product-materializer.php
+++ b/tests/smoke-product-materializer.php
@@ -80,6 +80,15 @@ namespace {
 		}
 	}
 
+	// Product grafts depend on WordPress Core for canonical anchor serialization.
+	$wp_root = getenv( 'STATIC_SITE_IMPORTER_WP_ROOT' ) ?: '/Users/chubes/Studio/intelligence-chubes4';
+	$parser  = rtrim( $wp_root, '/\\' ) . '/wp-includes/class-wp-block-parser.php';
+	$blocks  = rtrim( $wp_root, '/\\' ) . '/wp-includes/blocks.php';
+	if ( is_readable( $parser ) && is_readable( $blocks ) ) {
+		require_once $parser;
+		require_once $blocks;
+	}
+
 	// --- WooCommerce runtime mock ------------------------------------------------
 	// Captures the seeded simple products so the smoke test can assert the prices
 	// the seeder wrote without a live WooCommerce install.
@@ -311,6 +320,14 @@ namespace {
 			),
 		),
 	);
+	$graft_report['diagnostics'][0]['readable_blocks'][0]['attrs'] = array(
+		'backslash' => 'C:\\products\\shop',
+		'delimiter' => 'before -- after',
+		'angle'     => '<cart>',
+		'ampersand' => 'cart & checkout',
+		'quote'     => 'Click "buy"',
+	);
+	$button_region                 = serialize_blocks( $graft_report['diagnostics'][0]['readable_blocks'] );
 	$page_contents                 = array( 'website/shop.html' => $button_region );
 	$graft_seeding                 = Static_Site_Importer_Report_Diagnostics::materialize_product_findings( $graft_report, array(), $page_contents );
 	$assert( 1 === ( $graft_seeding['shortcode_grafted_count'] ?? 0 ), 'shortcode-grafted-count' );
@@ -318,6 +335,7 @@ namespace {
 	$assert( str_contains( $page_contents['website/shop.html'], '<!-- wp:shortcode -->[add_to_cart id="' ), 'page-content-has-add-to-cart-shortcode' );
 	$assert( ! str_contains( $page_contents['website/shop.html'], '>Add to cart<' ), 'page-content-removes-static-add-to-cart' );
 	$assert( ! str_contains( $page_contents['website/shop.html'], '>Buy now<' ), 'page-content-removes-static-buy-now' );
+	$assert( str_contains( $button_region, '\\u005c' ) && str_contains( $button_region, '\\u002d\\u002d' ) && str_contains( $button_region, '\\u003c' ) && str_contains( $button_region, '\\u003e' ) && str_contains( $button_region, '\\u0026' ) && str_contains( $button_region, '\\u0022' ), 'product-graft-anchor-uses-core-sensitive-attribute-serialization' );
 
 	// A resolvable product finding cannot consume an identical region on another page.
 	$owned_graft_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/owned-shop.html' );


### PR DESCRIPTION
## Summary
- replace local readable-block anchor serialization with WordPress Core `serialize_blocks()`
- make form and product graft smoke tests explicitly load Core block serialization
- cover backslashes, `--`, angle brackets, ampersands, and escaped quotes through Core-backed anchors

## Testing
- `php tests/form-materializer-smoke.php`
- `php tests/smoke-product-materializer.php`
- `npm test` (one unrelated pre-existing failure: `tools/verify-solved-site-promotion.test.mjs` expects a stale Blocks Engine SHA)

Closes #1069

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented the Core serializer boundary and test coverage. Chris Huber directed the change and remains responsible for every line.