### PR TITLE
Validate runtime-bound block documents

### DIFF
--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -146,7 +146,8 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			}
 			$state['base_resolved_hash'] = self::hash( $resolved );
 			$state['resolved']           = $resolved;
-			self::apply_runtime_entity_bindings( $state['resolved'], isset( $args['runtime_entity_bindings'] ) && is_array( $args['runtime_entity_bindings'] ) ? $args['runtime_entity_bindings'] : array(), $state['applied']['runtime_declarations']['entity_bindings'] );
+			self::apply_runtime_entity_bindings( $state['resolved'], isset( $args['runtime_entity_bindings'] ) && is_array( $args['runtime_entity_bindings'] ) ? $args['runtime_entity_bindings'] : array(), $state['applied']['runtime_declarations']['entity_bindings'], $state['diagnostics'] );
+			self::validate_materialized_block_documents( $state['resolved'], $state['applied']['runtime_declarations']['entity_bindings'], $state['diagnostics'] );
 			$state['theme_dir'] = $theme_dir;
 			$state['theme']     = array(
 				'slug' => $slug,
@@ -546,7 +547,8 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			if ( ( $prepared['theme']['dir'] ?? null ) !== $theme_dir || ( $prepared['theme']['uri'] ?? null ) !== $theme_uri ) {
 				throw new InvalidArgumentException( 'prepared_destination_changed' );
 			}
-			self::apply_runtime_entity_bindings( $state['resolved'], isset( $args['runtime_entity_bindings'] ) && is_array( $args['runtime_entity_bindings'] ) ? $args['runtime_entity_bindings'] : array(), $state['applied']['runtime_declarations']['entity_bindings'] );
+			self::apply_runtime_entity_bindings( $state['resolved'], isset( $args['runtime_entity_bindings'] ) && is_array( $args['runtime_entity_bindings'] ) ? $args['runtime_entity_bindings'] : array(), $state['applied']['runtime_declarations']['entity_bindings'], $state['diagnostics'] );
+			self::validate_materialized_block_documents( $state['resolved'], $state['applied']['runtime_declarations']['entity_bindings'], $state['diagnostics'] );
 			self::preflight_state( $state, ! empty( $args['overwrite'] ), (string) ( $args['import_run_id'] ?? '' ) );
 		} catch ( InvalidArgumentException $error ) {
 			$state['diagnostics'][] = array( 'reason_code' => $error->getMessage() );
@@ -719,7 +721,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	}
 
 	/** Apply exact provider bindings to the resolved projection while retaining canonical plan markup. */
-	private static function apply_runtime_entity_bindings( array &$plan, array $bindings, array &$reports ): void {
+	private static function apply_runtime_entity_bindings( array &$plan, array $bindings, array &$reports, array &$diagnostics ): void {
 		$pages = array();
 		foreach ( $plan['pages'] as $index => $page ) {
 			$pages[ $page['source_path'] ] = $index;
@@ -749,6 +751,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				}
 			}
 			$seen[ $binding['reconciliation_identity'] ] = true;
+			self::validate_runtime_entity_binding_fragment( $binding, $diagnostics );
 			$index                                       = $pages[ $binding['source_path'] ];
 			$content                                     = (string) ( $plan['pages'][ $index ]['materialized_block_markup'] ?? $plan['pages'][ $index ]['resolved_block_markup'] ?? '' );
 			if ( substr_count( $content, $binding['search_block_markup'] ) < $binding['occurrence'] ) {
@@ -785,6 +788,122 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			$report['materialized_content_hash'] = hash( 'sha256', (string) ( $plan['pages'][ $index ]['materialized_block_markup'] ?? $plan['pages'][ $index ]['resolved_block_markup'] ) );
 		}
 		unset( $report );
+	}
+
+	/**
+	 * Reject a provider fragment unless Core can round-trip it as a complete block document.
+	 *
+	 * @param array<string,mixed> $binding     Runtime entity binding.
+	 * @param array<int,mixed>    $diagnostics Admission diagnostics.
+	 * @return void
+	 */
+	private static function validate_runtime_entity_binding_fragment( array $binding, array &$diagnostics ): void {
+		if ( ! self::is_complete_block_document( (string) $binding['replacement_block_markup'] ) ) {
+			$diagnostics[] = array(
+				'reason_code'               => 'runtime_entity_binding_replacement_invalid',
+				'source_path'               => $binding['source_path'],
+				'reconciliation_identity'   => $binding['reconciliation_identity'],
+				'declaration_id'            => $binding['declaration_id'] ?? '',
+				'provider'                  => $binding['provider'] ?? '',
+			);
+			throw new InvalidArgumentException( 'runtime_entity_binding_replacement_invalid' );
+		}
+	}
+
+	/**
+	 * Admit each post document after every runtime binding has been applied.
+	 *
+	 * @param array<string,mixed> $plan        Resolved plan with runtime replacements.
+	 * @param array<string,mixed> $bindings    Binding reports keyed by reconciliation identity.
+	 * @param array<int,mixed>    $diagnostics Admission diagnostics.
+	 * @return void
+	 */
+	private static function validate_materialized_block_documents( array $plan, array $bindings, array &$diagnostics ): void {
+		foreach ( $plan['pages'] ?? array() as $page ) {
+			if ( ! is_array( $page ) ) {
+				continue;
+			}
+			$markup       = (string) ( $page['materialized_block_markup'] ?? $page['resolved_block_markup'] ?? '' );
+			$source_path  = (string) ( $page['source_path'] ?? '' );
+			$page_bindings = array_values(
+				array_filter(
+					$bindings,
+					static fn ( $binding ): bool => is_array( $binding ) && $source_path === ( $binding['source_path'] ?? '' )
+				)
+			);
+			if ( self::is_complete_block_document( $markup ) ) {
+				continue;
+			}
+			$diagnostic = array(
+				'reason_code' => 'runtime_entity_bound_block_document_invalid',
+				'source_path' => $source_path,
+			);
+			if ( array() !== $page_bindings ) {
+				$diagnostic['binding_reconciliation_identities'] = array_values( array_filter( array_column( $page_bindings, 'reconciliation_identity' ), 'is_string' ) );
+			}
+			$diagnostics[] = $diagnostic;
+			throw new InvalidArgumentException( 'runtime_entity_bound_block_document_invalid' );
+		}
+	}
+
+	/**
+	 * Use WordPress's parser and serializer as the generic block-document boundary.
+	 *
+	 * The parser intentionally accepts block names it does not know, so registered
+	 * provider blocks and future blocks pass through without an importer allowlist.
+	 *
+	 * @param string $markup Block document markup.
+	 * @return bool
+	 */
+	private static function is_complete_block_document( string $markup ): bool {
+		if ( ! function_exists( 'parse_blocks' ) || ! function_exists( 'serialize_blocks' ) ) {
+			throw new InvalidArgumentException( 'block_document_validation_unavailable' );
+		}
+		$blocks = parse_blocks( $markup );
+		if ( ! is_array( $blocks ) || ! self::block_document_has_only_blocks( $blocks ) ) {
+			return false;
+		}
+		$serialized = serialize_blocks( $blocks );
+		if ( ! is_string( $serialized ) ) {
+			return false;
+		}
+		$round_tripped = parse_blocks( $serialized );
+		return is_array( $round_tripped ) && self::block_document_has_only_blocks( $round_tripped ) && self::block_document_topology( $blocks ) === self::block_document_topology( $round_tripped );
+	}
+
+	/** @param array<int,mixed> $blocks @return bool */
+	private static function block_document_has_only_blocks( array $blocks ): bool {
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				return false;
+			}
+			$name = $block['blockName'] ?? null;
+			if ( ! is_string( $name ) || '' === $name ) {
+				if ( '' !== trim( (string) ( $block['innerHTML'] ?? '' ) ) ) {
+					return false;
+				}
+				continue;
+			}
+			if ( ! isset( $block['innerBlocks'] ) || ! is_array( $block['innerBlocks'] ) || ! self::block_document_has_only_blocks( $block['innerBlocks'] ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/** @param array<int,mixed> $blocks @return array<int,mixed> */
+	private static function block_document_topology( array $blocks ): array {
+		$topology = array();
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) || ! is_string( $block['blockName'] ?? null ) || '' === $block['blockName'] ) {
+				continue;
+			}
+			$topology[] = array(
+				'name'  => $block['blockName'],
+				'inner' => self::block_document_topology( is_array( $block['innerBlocks'] ?? null ) ? $block['innerBlocks'] : array() ),
+			);
+		}
+		return $topology;
 	}
 
 	/** @param array<string,mixed> $state @param array<string,mixed> $page */

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -369,7 +369,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				$length = max( 1, intdiv( strlen( $data ), 2 ) );
 				return (int) fwrite( $stream, substr( $data, 0, $length ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- Deterministic test-only short-write injection.
 			} : null;
-			$result = self::write_file( $state['theme_dir'], $write, $state['payload_reader'], $chunk_writer );
+			$result       = self::write_file( $state['theme_dir'], $write, $state['payload_reader'], $chunk_writer );
 			if ( is_wp_error( $result ) ) {
 				return self::failed_receipt( $state, $result->get_error_code() );
 			}
@@ -752,8 +752,8 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			}
 			$seen[ $binding['reconciliation_identity'] ] = true;
 			self::validate_runtime_entity_binding_fragment( $binding, $diagnostics );
-			$index                                       = $pages[ $binding['source_path'] ];
-			$content                                     = (string) ( $plan['pages'][ $index ]['materialized_block_markup'] ?? $plan['pages'][ $index ]['resolved_block_markup'] ?? '' );
+			$index   = $pages[ $binding['source_path'] ];
+			$content = (string) ( $plan['pages'][ $index ]['materialized_block_markup'] ?? $plan['pages'][ $index ]['resolved_block_markup'] ?? '' );
 			if ( substr_count( $content, $binding['search_block_markup'] ) < $binding['occurrence'] ) {
 				throw new InvalidArgumentException( 'runtime_entity_binding_cardinality_mismatch' );
 			}
@@ -800,11 +800,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	private static function validate_runtime_entity_binding_fragment( array $binding, array &$diagnostics ): void {
 		if ( ! self::is_complete_block_document( (string) $binding['replacement_block_markup'] ) ) {
 			$diagnostics[] = array(
-				'reason_code'               => 'runtime_entity_binding_replacement_invalid',
-				'source_path'               => $binding['source_path'],
-				'reconciliation_identity'   => $binding['reconciliation_identity'],
-				'declaration_id'            => $binding['declaration_id'] ?? '',
-				'provider'                  => $binding['provider'] ?? '',
+				'reason_code'             => 'runtime_entity_binding_replacement_invalid',
+				'source_path'             => $binding['source_path'],
+				'reconciliation_identity' => $binding['reconciliation_identity'],
+				'declaration_id'          => $binding['declaration_id'] ?? '',
+				'provider'                => $binding['provider'] ?? '',
 			);
 			throw new InvalidArgumentException( 'runtime_entity_binding_replacement_invalid' );
 		}
@@ -823,12 +823,12 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			if ( ! is_array( $page ) ) {
 				continue;
 			}
-			$markup       = (string) ( $page['materialized_block_markup'] ?? $page['resolved_block_markup'] ?? '' );
-			$source_path  = (string) ( $page['source_path'] ?? '' );
+			$markup        = (string) ( $page['materialized_block_markup'] ?? $page['resolved_block_markup'] ?? '' );
+			$source_path   = (string) ( $page['source_path'] ?? '' );
 			$page_bindings = array_values(
 				array_filter(
 					$bindings,
-					static fn ( $binding ): bool => is_array( $binding ) && $source_path === ( $binding['source_path'] ?? '' )
+					static fn ( $binding ): bool => is_array( $binding ) && ( $binding['source_path'] ?? '' ) === $source_path
 				)
 			);
 			if ( self::is_complete_block_document( $markup ) ) {
@@ -860,18 +860,15 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			throw new InvalidArgumentException( 'block_document_validation_unavailable' );
 		}
 		$blocks = parse_blocks( $markup );
-		if ( ! is_array( $blocks ) || ! self::block_document_has_only_blocks( $blocks ) ) {
+		if ( ! self::block_document_has_only_blocks( $blocks ) ) {
 			return false;
 		}
-		$serialized = serialize_blocks( $blocks );
-		if ( ! is_string( $serialized ) ) {
-			return false;
-		}
+		$serialized    = serialize_blocks( $blocks );
 		$round_tripped = parse_blocks( $serialized );
-		return is_array( $round_tripped ) && self::block_document_has_only_blocks( $round_tripped ) && self::block_document_topology( $blocks ) === self::block_document_topology( $round_tripped );
+		return self::block_document_has_only_blocks( $round_tripped ) && self::block_document_topology( $blocks ) === self::block_document_topology( $round_tripped );
 	}
 
-	/** @param array<int,mixed> $blocks @return bool */
+	/** @param array<array-key,mixed> $blocks @return bool */
 	private static function block_document_has_only_blocks( array $blocks ): bool {
 		foreach ( $blocks as $block ) {
 			if ( ! is_array( $block ) ) {
@@ -891,16 +888,20 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		return true;
 	}
 
-	/** @param array<int,mixed> $blocks @return array<int,mixed> */
+	/** @param array<array-key,mixed> $blocks @return array<int,mixed> */
 	private static function block_document_topology( array $blocks ): array {
 		$topology = array();
 		foreach ( $blocks as $block ) {
 			if ( ! is_array( $block ) || ! is_string( $block['blockName'] ?? null ) || '' === $block['blockName'] ) {
 				continue;
 			}
+			$inner_blocks = $block['innerBlocks'] ?? array();
+			if ( ! is_array( $inner_blocks ) ) {
+				$inner_blocks = array();
+			}
 			$topology[] = array(
 				'name'  => $block['blockName'],
-				'inner' => self::block_document_topology( is_array( $block['innerBlocks'] ?? null ) ? $block['innerBlocks'] : array() ),
+				'inner' => self::block_document_topology( $inner_blocks ),
 			);
 		}
 		return $topology;
@@ -950,10 +951,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		if ( ! is_dir( dirname( $path ) ) && ! wp_mkdir_p( dirname( $path ) ) ) {
 			return new WP_Error( 'theme_directory_create_failed' );
 		}
-		$temp   = tempnam( dirname( $path ), '.ssi-plan-' );
-		$stream = false !== $temp ? fopen( $temp, 'wb' ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Streams the canonical theme write into an atomic temporary file.
+		$temp    = tempnam( dirname( $path ), '.ssi-plan-' );
+		$stream  = false !== $temp ? fopen( $temp, 'wb' ) : false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Streams the canonical theme write into an atomic temporary file.
 		$written = is_resource( $stream ) && self::write_all( $stream, $data, $chunk_writer ) && fflush( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fflush -- Flushes complete canonical write bytes before publication.
-		$closed = ! is_resource( $stream ) || fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes canonical write before atomic publication.
+		$closed  = ! is_resource( $stream ) || fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes canonical write before atomic publication.
 		if ( false === $data || false === $temp || ! $written || ! $closed || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Atomically materializes only complete canonical declared theme writes.
 			if ( is_string( $temp ) && file_exists( $temp ) ) {
 				unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes a failed temporary materialization file.

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -244,6 +244,15 @@ class WP_Post_Type {
 function get_post_type_object( string $post_type ): ?object {
 	return in_array( $post_type, array( 'page', 'post' ), true ) ? new WP_Post_Type( $post_type ) : null;
 }
+function wp_parse_args( $args, array $defaults = array() ): array {
+	return array_merge( $defaults, is_array( $args ) ? $args : array() );
+}
+
+$wp_root = getenv( 'STATIC_SITE_IMPORTER_WP_ROOT' ) ?: '/Users/chubes/Studio/intelligence-chubes4';
+require_once rtrim( $wp_root, '/\\' ) . '/wp-includes/class-wp-block-parser.php';
+require_once rtrim( $wp_root, '/\\' ) . '/wp-includes/class-wp-block-type.php';
+require_once rtrim( $wp_root, '/\\' ) . '/wp-includes/class-wp-block-type-registry.php';
+require_once rtrim( $wp_root, '/\\' ) . '/wp-includes/blocks.php';
 
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-font-materializer.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-document-type-classifier.php';
@@ -1463,6 +1472,74 @@ $duplicate_binding_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializ
 );
 $duplicate_markup          = $duplicate_binding_receipt['completed']['materialized_pages']['index.html']['block_markup'] ?? '';
 $assert( str_contains( $duplicate_markup, '[add_to_cart id="42"]' ) && str_contains( $duplicate_markup, '[add_to_cart id="43"]' ), 'duplicate markup anchors resolve by descending deterministic occurrence' );
+$duplicate_blocks = parse_blocks( $duplicate_markup );
+$assert( 'core/group' === ( $duplicate_blocks[0]['blockName'] ?? '' ) && array( 'core/shortcode', 'core/shortcode' ) === array_column( $duplicate_blocks[0]['innerBlocks'] ?? array(), 'blockName' ), 'multiple nested replacements preserve the surrounding parsed block topology' );
+$malformed_fragment_binding                            = $invalid_coverage_binding;
+$malformed_fragment_binding['reconciliation_identity'] = hash( 'sha256', 'malformed-fragment-binding' );
+$malformed_fragment_binding['replacement_block_markup'] = '<div>Provider control without a block wrapper</div>';
+$malformed_fragment_binding['superseded_runtime_selectors'] = array( '.add-to-cart' );
+$inserts_before_malformed_fragment                     = $GLOBALS['ssi_plan_insert_calls'];
+$malformed_fragment_receipt                            = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$binding_plan,
+	array(
+		'slug'                    => 'malformed-fragment-binding-plan',
+		'runtime_entity_bindings' => array( $malformed_fragment_binding ),
+	)
+);
+$malformed_fragment_diagnostic = $malformed_fragment_receipt['diagnostics'][0] ?? array();
+$assert( 'rejected' === $malformed_fragment_receipt['status'] && 'runtime_entity_binding_replacement_invalid' === ( $malformed_fragment_receipt['errors'][0]['code'] ?? '' ) && $inserts_before_malformed_fragment === $GLOBALS['ssi_plan_insert_calls'] && 'index.html' === ( $malformed_fragment_diagnostic['source_path'] ?? '' ) && $malformed_fragment_binding['reconciliation_identity'] === ( $malformed_fragment_diagnostic['reconciliation_identity'] ?? '' ), 'malformed replacement fragments are rejected with binding attribution before page mutation' );
+$topology_breaking_binding                            = $invalid_coverage_binding;
+$topology_breaking_binding['reconciliation_identity'] = hash( 'sha256', 'topology-breaking-binding' );
+$topology_breaking_binding['search_block_markup']     = '<!-- wp:paragraph {"content":"Replace me"} -->';
+$topology_breaking_binding['replacement_block_markup'] = '<!-- wp:shortcode /-->';
+$topology_breaking_binding['superseded_runtime_selectors'] = array( '.add-to-cart' );
+$inserts_before_topology_break                         = $GLOBALS['ssi_plan_insert_calls'];
+$topology_breaking_receipt                             = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$binding_plan,
+	array(
+		'slug'                    => 'topology-breaking-binding-plan',
+		'runtime_entity_bindings' => array( $topology_breaking_binding ),
+	)
+);
+$topology_breaking_diagnostic = $topology_breaking_receipt['diagnostics'][0] ?? array();
+$assert( 'rejected' === $topology_breaking_receipt['status'] && 'runtime_entity_bound_block_document_invalid' === ( $topology_breaking_receipt['errors'][0]['code'] ?? '' ) && $inserts_before_topology_break === $GLOBALS['ssi_plan_insert_calls'] && 'index.html' === ( $topology_breaking_diagnostic['source_path'] ?? '' ) && array( $topology_breaking_binding['reconciliation_identity'] ) === ( $topology_breaking_diagnostic['binding_reconciliation_identities'] ?? array() ), 'final complete documents are rejected when a valid fragment breaks surrounding topology' );
+$provider_block_name = 'static-site-importer/runtime-provider-test';
+WP_Block_Type_Registry::get_instance()->register( $provider_block_name, array() );
+$provider_binding                            = $invalid_coverage_binding;
+$provider_binding['reconciliation_identity'] = hash( 'sha256', 'registered-provider-binding' );
+$provider_binding['replacement_block_markup'] = '<!-- wp:static-site-importer/runtime-provider-test --><div>Provider control</div><!-- /wp:static-site-importer/runtime-provider-test -->';
+$provider_binding['superseded_runtime_selectors'] = array( '.add-to-cart' );
+$provider_binding_receipt                    = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$binding_plan,
+	array(
+		'slug'                    => 'registered-provider-binding-plan',
+		'runtime_entity_bindings' => array( $provider_binding ),
+	)
+);
+$provider_markup = $provider_binding_receipt['completed']['materialized_pages']['index.html']['block_markup'] ?? '';
+$contains_block = static function ( array $blocks, string $block_name ) use ( &$contains_block ): bool {
+	foreach ( $blocks as $block ) {
+		if ( $block_name === ( $block['blockName'] ?? '' ) || ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) && $contains_block( $block['innerBlocks'], $block_name ) ) ) {
+			return true;
+		}
+	}
+	return false;
+};
+$assert( null !== WP_Block_Type_Registry::get_instance()->get_registered( $provider_block_name ), 'registered provider block is available to the materialization runtime' );
+$assert( 'completed' === $provider_binding_receipt['status'], 'registered provider blocks pass the generic Core admission boundary without an importer allowlist' );
+$assert( $contains_block( parse_blocks( $provider_markup ), $provider_block_name ), 'registered provider block survives the persisted document round-trip' );
+$unknown_block_binding                            = $provider_binding;
+$unknown_block_binding['reconciliation_identity'] = hash( 'sha256', 'unknown-provider-binding' );
+$unknown_block_binding['replacement_block_markup'] = '<!-- wp:future-provider/control --><div>Future provider control</div><!-- /wp:future-provider/control -->';
+$unknown_block_receipt                            = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$binding_plan,
+	array(
+		'slug'                    => 'unknown-provider-binding-plan',
+		'runtime_entity_bindings' => array( $unknown_block_binding ),
+	)
+);
+$unknown_markup = $unknown_block_receipt['completed']['materialized_pages']['index.html']['block_markup'] ?? '';
+$assert( 'completed' === $unknown_block_receipt['status'] && $contains_block( parse_blocks( $unknown_markup ), 'future-provider/control' ), 'unknown block names pass through the generic Core admission boundary unchanged' );
 $invalid_binding         = array(
 	'schema'                   => 'static-site-importer/runtime-entity-binding/v1',
 	'source_path'              => 'index.html',


### PR DESCRIPTION
## Summary
- admit each runtime replacement fragment through WordPress parse/serialize APIs before it can mutate a page
- admit every final page document after all runtime bindings, with page and binding attribution on rejection
- preserve registered and unknown block names without an importer allowlist

## Tests
- php tests/smoke-wordpress-site-plan-materializer.php
- php tests/smoke-materialized-block-content-validation.php
- npm test (one existing failure: tools/verify-solved-site-promotion.test.mjs expects an older Blocks Engine SHA than the tracked workflow pin)

Closes #1072

## AI assistance
OpenAI gpt-5.6-terra via OpenCode implemented the Core parser/serializer admission boundary, added focused coverage, and ran verification. Chris Huber remains responsible for the change.