### PR TITLE
Consume Blocks Engine fallback output unchanged

### DIFF
--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -319,6 +319,11 @@ $assert( str_contains( file_get_contents( $GLOBALS['ssi_plan_root'] . '/site-pla
 $assert( 'posts' === $GLOBALS['ssi_plan_options']['show_on_front'], 'plan-only materialization does not change reading settings by default' );
 $assert( $receipt['plan']['pages'][0]['document_metadata']['links'][0]['resolved_url'] === 'https://example.test/wp-content/themes/site-plan/assets/assets/site.css', 'resolved metadata retains the declared stylesheet destination' );
 $assert( array() === $receipt['completed']['runtime_declarations']['asset_publications'], 'plans without publication declarations retain an explicit empty receipt collection' );
+$producer_page_markup = (string) ( $receipt['plan']['pages'][0]['resolved_block_markup'] ?? '' );
+$page_source          = (string) ( $receipt['plan']['pages'][0]['source_path'] ?? '' );
+$page_id              = (int) ( $receipt['completed']['pages'][ $page_source ] ?? 0 );
+$persisted_page       = stripslashes( (string) ( $GLOBALS['ssi_plan_posts'][ $page_id ]['post_content'] ?? '' ) );
+$assert( $producer_page_markup === $persisted_page, 'materializer-persists-producer-block-markup-without-html-recompilation' );
 $short_write_target  = (string) ( $plan['writes'][0]['target_path'] ?? '' );
 $short_write_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
 	$plan,


### PR DESCRIPTION
## Summary

Adds materialization coverage proving SSI persists the final serialized block markup resolved by Blocks Engine unchanged. SSI no longer contains the legacy `Page_Materializer` HTML-to-core-block compiler; safe fallback recognition and Gutenberg save-shape ownership now live in the upstream producer.

Depends on Automattic/blocks-engine#973. Merge that producer contract first.

Closes #1073

## Validation

- `php tests/smoke-wordpress-site-plan-materializer.php`
- `npm run test:all` (58 selected passed; 14 intentionally skipped; one unrelated solved-site-promotion pin assertion fails because it expects `7858943a…` while the checked-in workflow pins `e32b7419…`)

## AI assistance

OpenAI GPT-5.6-terra via OpenCode was used to trace the retired importer compiler, add the producer-output persistence contract, and run the test suites. Chris Huber reviewed the approach and remains responsible for every line.