### PR TITLE
Consume compiler runtime declarations unchanged

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -232,7 +232,6 @@ class Static_Site_Importer_Theme_Generator {
 				return $companion_validation;
 			}
 		}
-		$plan = self::bridge_product_grid_findings_to_runtime_declarations( $plan );
 		if ( isset( $args['approved_classic_plan_hash'] ) && is_string( $args['approved_classic_plan_hash'] ) && ! hash_equals( $args['approved_classic_plan_hash'], hash( 'sha256', (string) wp_json_encode( $plan ) ) ) ) {
 			return new WP_Error( 'static_site_importer_approved_classic_plan_changed', 'Recompilation did not reproduce the approved canonical classic plan.' );
 		}
@@ -580,88 +579,6 @@ class Static_Site_Importer_Theme_Generator {
 		}
 
 		return $projected;
-	}
-
-	/**
-	 * Declare detected Blocks Engine product grids for the canonical v2 lifecycle.
-	 *
-	 * Product-grid findings carry product data but no canonical block replacement
-	 * anchors, so this bridge seeds only the explicit commerce entities. Provider
-	 * bindings remain limited to declarations that include their own exact anchors.
-	 *
-	 * @param array<string,mixed> $plan Compiled WordPress site plan.
-	 * @return array<string,mixed>
-	 */
-	private static function bridge_product_grid_findings_to_runtime_declarations( array $plan ): array {
-		$diagnostics = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
-		$products    = Static_Site_Importer_Report_Diagnostics::product_grid_manifest_products( $diagnostics );
-		if ( empty( $products ) ) {
-			return $plan;
-		}
-
-		$adapter    = Static_Site_Importer_Entity_Materializer_Registry::product_adapter();
-		$validation = Static_Site_Importer_Entity_Materializer_Registry::validate_manifest_generic(
-			$adapter,
-			array(
-				'schema_version' => 1,
-				'products'       => $products,
-			)
-		);
-		if ( ! empty( $validation['errors'] ) || empty( $validation['products'] ) ) {
-			return $plan;
-		}
-		$source_path = (string) ( $plan['source']['entry_path'] ?? '' );
-		$products = self::normalize_classic_product_grid_entities( $validation['products'], $source_path );
-		if ( is_wp_error( $products ) ) {
-			return $plan;
-		}
-
-		$declarations = isset( $plan['runtime_declarations'] ) && is_array( $plan['runtime_declarations'] ) ? $plan['runtime_declarations'] : array();
-		foreach ( $declarations as $declaration ) {
-			if ( is_array( $declaration ) && 'entity_collection' === ( $declaration['kind'] ?? null ) && 'products' === ( $declaration['type'] ?? null ) ) {
-				return $plan;
-			}
-		}
-
-		$identity    = hash( 'sha256', "static-site-importer/product-grid-bridge/v1\n" . wp_json_encode( $products ) );
-		$declarations[] = array(
-			'kind'                    => 'dependency',
-			'capability'              => 'shop',
-			'source_path'             => $source_path,
-			'required_for'            => array( 'entity_collection:products' ),
-			'reconciliation_identity' => hash( 'sha256', $identity . "\ndependency" ),
-		);
-		$declarations[] = array(
-			'kind'                    => 'entity_collection',
-			'type'                    => 'products',
-			'source_path'             => $source_path,
-			'payload'                 => array(
-				'schema'   => 'generic/products/v1',
-				'entities' => $products,
-			),
-			'reconciliation_identity' => hash( 'sha256', $identity . "\nentities" ),
-		);
-		$plan['runtime_declarations'] = $declarations;
-		return $plan;
-	}
-
-	/** Normalize bridge report source_selectors into one exact leaf source identity. */
-	private static function normalize_classic_product_grid_entities( array $products, string $default_source ) {
-		$normalized = array();
-		foreach ( $products as $product ) {
-			if ( ! is_array( $product ) ) {
-				return new WP_Error( 'static_site_importer_classic_product_shape_invalid', 'Product-grid bridge contains an invalid product.' ); }
-			$selectors = is_array( $product['source_selectors'] ?? null ) ? array_values( array_unique( array_filter( array_map( 'trim', $product['source_selectors'] ) ) ) ) : array();
-			$leaves = array_values( array_filter( $selectors, static fn( string $selector ): bool => str_contains( $selector, '#' ) || str_contains( $selector, ':nth-child(' ) || preg_match( '/(?:^|\s)(?:li|article|\.product-card)(?:\b|[.#:])/', $selector ) ) );
-			if ( 1 !== count( $leaves ) ) {
-				return new WP_Error( 'static_site_importer_classic_product_selector_ambiguous', 'Product-grid bridge requires exactly one product leaf selector per product.' ); }
-			$product['selector'] = $leaves[0];
-			$product['source_path'] = isset( $product['source_path'] ) && is_string( $product['source_path'] ) && '' !== $product['source_path'] ? $product['source_path'] : $default_source;
-			if ( '' === $product['source_path'] ) {
-				return new WP_Error( 'static_site_importer_classic_product_source_missing', 'Product-grid bridge requires a source path.' ); }
-			$normalized[] = $product;
-		}
-		return $normalized;
 	}
 
 	/**

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1058,19 +1058,32 @@ $product_grid_artifact     = array(
 	'files'      => array(
 		'index.html' => '<main><ul class="products"><li><article class="product-card"><h3>Tour Tee</h3><p>Heavy cotton shirt.</p><div class="price">$30</div><button class="add-to-cart">Add to cart</button></article></li><li><article class="product-card"><h3>Signed CD</h3><p>Hand-signed disc.</p><div class="price">$15</div><button class="add-to-cart">Add to cart</button></article></li></ul></main>',
 	),
+	'runtime_declarations' => array(
+		array( 'kind' => 'dependency', 'capability' => 'shop', 'source_path' => 'index.html', 'required_for' => array( 'entity_collection:products' ) ),
+		array(
+			'kind'        => 'entity_collection',
+			'type'        => 'products',
+			'source_path' => 'index.html',
+			'payload'     => array(
+				'schema'   => 'generic/products/v1',
+				'entities' => array(
+					array( 'name' => 'Tour Tee', 'slug' => 'tour-tee', 'regular_price' => '30', 'source_path' => 'index.html', 'selector' => 'ul.products li:nth-child(1)' ),
+					array( 'name' => 'Signed CD', 'slug' => 'signed-cd', 'regular_price' => '15', 'source_path' => 'index.html', 'selector' => 'ul.products li:nth-child(2)' ),
+				),
+			),
+		),
+	),
 );
 $product_grid_plan         = ( new ArtifactCompiler() )->compile( $product_grid_artifact )->toArray()['source_reports']['wordpress_site_plan'];
-$bridge_product_grid       = new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'bridge_product_grid_findings_to_runtime_declarations' );
-$bridged_product_grid_plan = $bridge_product_grid->invoke( null, $product_grid_plan );
-$bridged_declarations      = $bridged_product_grid_plan['runtime_declarations'] ?? array();
-$assert( 2 === count( $bridged_declarations ) && 'shop' === ( $bridged_declarations[0]['capability'] ?? '' ) && 'products' === ( $bridged_declarations[1]['type'] ?? '' ), 'active Blocks Engine product-grid findings bridge into explicit v2 commerce declarations' );
-$assert( true === in_array( 'entity_collection:products', $bridged_declarations[0]['required_for'] ?? array(), true ), 'bridged product entities retain the required commerce dependency relationship' );
-$assert( array( 'tour-tee', 'signed-cd' ) === array_column( $bridged_declarations[1]['payload']['entities'] ?? array(), 'slug' ), 'bridge preserves product-grid evidence as normalized Woo entity rows' );
-$bridged_products  = $bridged_declarations[1]['payload']['entities'] ?? array();
-$bridged_selectors = array_column( $bridged_products, 'selector' );
-$assert( 2 === count( array_unique( $bridged_selectors ) ) && 2 === count( array_filter( $bridged_selectors, static fn( $selector ): bool => is_string( $selector ) && '' !== $selector ) ) && 2 === count( array_filter( array_column( $bridged_products, 'source_path' ), static fn( $source ): bool => is_string( $source ) && '' !== $source ) ), 'actual product-grid bridge source_selectors normalize into deterministic exact classic leaf source identities' );
-$bridged_lifecycle = ( new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'prepare_wordpress_site_plan_lifecycle' ) )->invoke( null, $bridged_product_grid_plan, array() );
-$assert( 'runtime_declarations' === ( $bridged_lifecycle['status'] ?? '' ) && true === ( reset( $bridged_lifecycle['entities'] )['required'] ?? false ), 'bridged product entities enter the required canonical seeding lifecycle' );
+$declared_products = $product_grid_plan['runtime_declarations'] ?? array();
+$assert( 2 === count( $declared_products ) && 'shop' === ( $declared_products[0]['capability'] ?? '' ) && 'products' === ( $declared_products[1]['type'] ?? '' ), 'canonical plans carry explicit typed product declarations without diagnostic mutation' );
+$assert( true === in_array( 'entity_collection:products', $declared_products[0]['required_for'] ?? array(), true ), 'declared product entities retain the required capability relationship' );
+$assert( array( 'tour-tee', 'signed-cd' ) === array_column( $declared_products[1]['payload']['entities'] ?? array(), 'slug' ), 'canonical declarations retain product rows unchanged' );
+$declared_entities  = $declared_products[1]['payload']['entities'] ?? array();
+$declared_selectors = array_column( $declared_entities, 'selector' );
+$assert( 2 === count( array_unique( $declared_selectors ) ) && 2 === count( array_filter( $declared_selectors, static fn( $selector ): bool => is_string( $selector ) && '' !== $selector ) ) && 2 === count( array_filter( array_column( $declared_entities, 'source_path' ), static fn( $source ): bool => is_string( $source ) && '' !== $source ) ), 'canonical declarations retain compiler-owned exact classic source identities' );
+$declared_lifecycle = ( new ReflectionMethod( Static_Site_Importer_Theme_Generator::class, 'prepare_wordpress_site_plan_lifecycle' ) )->invoke( null, $product_grid_plan, array() );
+$assert( 'runtime_declarations' === ( $declared_lifecycle['status'] ?? '' ) && true === ( reset( $declared_lifecycle['entities'] )['required'] ?? false ), 'declared product entities enter the generic runtime lifecycle' );
 
 $entity_artifact                         = $artifact;
 $entity_search                           = '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button {"tagName":"button","text":"Add"} --><div class="wp-block-button"><button type="button" class="wp-block-button__link wp-element-button">Add</button></div><!-- /wp:button --></div><!-- /wp:buttons -->';


### PR DESCRIPTION
## Summary

Static Site Importer no longer rebuilds product runtime declarations from diagnostics or infers classic product leaf selectors. It validates and dispatches the canonical plan declarations through its existing generic capability/type adapters, preserving materialization receipts.

## Canonical plan

Blocks Engine emits blocks-engine/wordpress-site-plan/v1 with normalized, versioned runtime declarations. Each declaration has stable source identity, canonical payload/content hashes, and exact serialized-block replacement anchors where a runtime adapter replaces static output. Static Site Importer validates this plan unchanged, dispatches only through generic capability/type adapters, and records materialization outcomes in its receipt.

## Dependency

Depends on Automattic/blocks-engine#974, which emits the exact product source identities consumed here.

## Verification

- php tests/smoke-wordpress-site-plan-materializer.php
- php -l includes/class-static-site-importer-theme-generator.php
- php -l tests/smoke-wordpress-site-plan-materializer.php
- npm test (58 selected checks passed; one existing solved-site-promotion check expects obsolete Blocks Engine SHA 7858943a9913175993cc75870551c2e1926b4fb0 while main pins e32b74191771be44af5357c26aaff46ef98bc1ce)

Closes #1070.

## AI assistance

OpenAI gpt-5.6-terra via OpenCode traced the compiler/materializer contract, removed the downstream diagnostic bridge, and ran focused tests. Chris Huber remains responsible for every line.