### PR TITLE
Gate materialization on editability reports

### DIFF
--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -102,6 +102,14 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'receipt' => self::receipt( 'rejected', $state ),
 			);
 		}
+		$state['editability_report'] = self::editability_report_admission( $plan );
+		if ( 'rejected' === $state['editability_report']['status'] ) {
+			$state['diagnostics'][] = $state['editability_report']['diagnostic'];
+			return array(
+				'status'  => 'rejected',
+				'receipt' => self::receipt( 'rejected', $state ),
+			);
+		}
 
 		try {
 			$slug = sanitize_key( (string) ( $args['slug'] ?? '' ) );
@@ -1855,6 +1863,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			'skipped_targets'           => $state['skipped'],
 			'existing_matches'          => $state['existing_matches'],
 			'preparation'               => $state['preparation'] ?? array(),
+			'editability_report'        => $state['editability_report'] ?? array(
+				'schema' => 'static-site-importer/editability-report-admission/v1',
+				'status' => 'not_checked',
+			),
 			'diagnostics'               => $state['diagnostics'],
 			'errors'                    => $errors,
 			'theme_materialization'     => $state['theme_materialization'] ?? self::strategy_evidence( $state['args'] ?? array() ),
@@ -1863,6 +1875,86 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			$receipt['transaction'] = (object) array( 'state' => $state );
 		}
 		return $receipt;
+	}
+
+	/**
+	 * Admit producer-owned editability evidence without recreating its metrics or policy.
+	 *
+	 * Current Blocks Engine plans carry the required policy but not the report binding.
+	 * That compatibility path is explicit and can be retired by setting
+	 * quality.editability_report_required on plans from upgraded producers.
+	 *
+	 * @param array<string,mixed> $plan
+	 * @return array<string,mixed>
+	 */
+	private static function editability_report_admission( array $plan ): array {
+		$quality = isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array();
+		$policy  = isset( $quality['editability_policy'] ) && is_array( $quality['editability_policy'] ) ? $quality['editability_policy'] : array();
+		$base    = array(
+			'schema'        => 'static-site-importer/editability-report-admission/v1',
+			'owning_layer'  => 'blocks-engine',
+			'policy_schema' => (string) ( $policy['schema'] ?? '' ),
+		);
+		if ( 'blocks-engine/php-transformer/editability-policy/v1' !== ( $policy['schema'] ?? null ) || 'required' !== ( $policy['enforcement'] ?? null ) || ! in_array( $policy['status'] ?? null, array( 'passed', 'failed' ), true ) || ! isset( $policy['failures'] ) || ! is_array( $policy['failures'] ) ) {
+			return self::rejected_editability_report_admission( $base, 'editability_policy_invalid' );
+		}
+		if ( 'failed' === $policy['status'] ) {
+			return self::rejected_editability_report_admission( $base, 'editability_policy_failed', $policy['failures'] );
+		}
+
+		$report = $quality['editability_report'] ?? null;
+		if ( null === $report ) {
+			if ( ! empty( $quality['editability_report_required'] ) ) {
+				return self::rejected_editability_report_admission( $base, 'editability_report_required' );
+			}
+			return array_merge(
+				$base,
+				array(
+					'status' => 'compatibility_policy_only',
+					'diagnostic' => array(
+						'reason_code'  => 'editability_report_compatibility_policy_only',
+						'owning_layer' => 'blocks-engine',
+					),
+				)
+			);
+		}
+		if ( ! is_array( $report ) || 'blocks-engine/php-transformer/editability-report/v2' !== ( $report['schema'] ?? null ) || ! is_array( $report['metrics'] ?? null ) || ! is_array( $report['block_types'] ?? null ) || ! is_array( $report['signals'] ?? null ) || ! is_array( $report['signal_totals'] ?? null ) ) {
+			return self::rejected_editability_report_admission( $base, 'editability_report_schema_invalid' );
+		}
+		$bound_hash = $quality['editability_report_plan_hash'] ?? null;
+		if ( ! is_string( $bound_hash ) || ! preg_match( '/^[a-f0-9]{64}$/', $bound_hash ) ) {
+			return self::rejected_editability_report_admission( $base, 'editability_report_plan_hash_invalid' );
+		}
+		$unbound_plan = $plan;
+		unset( $unbound_plan['quality']['editability_report'], $unbound_plan['quality']['editability_report_plan_hash'], $unbound_plan['quality']['editability_report_required'] );
+		$expected_hash = self::hash( $unbound_plan );
+		if ( ! hash_equals( $expected_hash, $bound_hash ) ) {
+			return self::rejected_editability_report_admission( $base, 'editability_report_plan_hash_mismatch' );
+		}
+		return array_merge(
+			$base,
+			array(
+				'status'          => 'passed',
+				'report_schema'   => $report['schema'],
+				'plan_hash'       => $bound_hash,
+				'diagnostic'      => array(
+					'reason_code'  => 'editability_report_verified',
+					'owning_layer' => 'blocks-engine',
+				),
+			)
+		);
+	}
+
+	/** @param array<string,mixed> $base @param array<int,mixed> $failures @return array<string,mixed> */
+	private static function rejected_editability_report_admission( array $base, string $reason_code, array $failures = array() ): array {
+		$diagnostic = array(
+			'reason_code'  => $reason_code,
+			'owning_layer' => 'blocks-engine',
+		);
+		if ( array() !== $failures ) {
+			$diagnostic['threshold_failures'] = array_slice( array_values( array_filter( $failures, 'is_array' ) ), 0, 10 );
+		}
+		return array_merge( $base, array( 'status' => 'rejected', 'diagnostic' => $diagnostic ) );
 	}
 
 	/** @return array<string,mixed> */

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -504,6 +504,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$state      = array(
 			'plan'                         => $plan,
 			'plan_hash'                    => $prepared['plan_hash'],
+			'editability_report'           => $prepared['editability_report'] ?? array(),
 			'base_resolved'                => $base_resolved,
 			'base_resolved_hash'           => $prepared['base_resolved_hash'],
 			'resolved'                     => $base_resolved,
@@ -1895,10 +1896,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			'owning_layer'  => 'blocks-engine',
 			'policy_schema' => (string) ( $policy['schema'] ?? '' ),
 		);
-		if ( 'blocks-engine/php-transformer/editability-policy/v1' !== ( $policy['schema'] ?? null ) || 'required' !== ( $policy['enforcement'] ?? null ) || ! in_array( $policy['status'] ?? null, array( 'passed', 'failed' ), true ) || ! isset( $policy['failures'] ) || ! is_array( $policy['failures'] ) ) {
+		if ( array() !== $policy && ( 'blocks-engine/php-transformer/editability-policy/v1' !== ( $policy['schema'] ?? null ) || 'required' !== ( $policy['enforcement'] ?? null ) || ! in_array( $policy['status'] ?? null, array( 'passed', 'failed' ), true ) || ! isset( $policy['failures'] ) || ! is_array( $policy['failures'] ) ) ) {
 			return self::rejected_editability_report_admission( $base, 'editability_policy_invalid' );
 		}
-		if ( 'failed' === $policy['status'] ) {
+		if ( 'failed' === ( $policy['status'] ?? null ) ) {
 			return self::rejected_editability_report_admission( $base, 'editability_policy_failed', $policy['failures'] );
 		}
 
@@ -1918,7 +1919,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				)
 			);
 		}
-		if ( ! is_array( $report ) || 'blocks-engine/php-transformer/editability-report/v2' !== ( $report['schema'] ?? null ) || ! is_array( $report['metrics'] ?? null ) || ! is_array( $report['block_types'] ?? null ) || ! is_array( $report['signals'] ?? null ) || ! is_array( $report['signal_totals'] ?? null ) ) {
+		if ( ! is_array( $report ) || 'blocks-engine/php-transformer/editability-report/v1' !== ( $report['schema'] ?? null ) || ! is_array( $report['metrics'] ?? null ) || ! is_array( $report['block_types'] ?? null ) || ! is_array( $report['signals'] ?? null ) || ! is_array( $report['signal_totals'] ?? null ) ) {
 			return self::rejected_editability_report_admission( $base, 'editability_report_schema_invalid' );
 		}
 		$bound_hash = $quality['editability_report_plan_hash'] ?? null;

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -1910,7 +1910,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return array_merge(
 				$base,
 				array(
-					'status' => 'compatibility_policy_only',
+					'status'     => 'compatibility_policy_only',
 					'diagnostic' => array(
 						'reason_code'  => 'editability_report_compatibility_policy_only',
 						'owning_layer' => 'blocks-engine',
@@ -1934,10 +1934,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		return array_merge(
 			$base,
 			array(
-				'status'          => 'passed',
-				'report_schema'   => $report['schema'],
-				'plan_hash'       => $bound_hash,
-				'diagnostic'      => array(
+				'status'        => 'passed',
+				'report_schema' => $report['schema'],
+				'plan_hash'     => $bound_hash,
+				'diagnostic'    => array(
 					'reason_code'  => 'editability_report_verified',
 					'owning_layer' => 'blocks-engine',
 				),
@@ -1954,7 +1954,13 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		if ( array() !== $failures ) {
 			$diagnostic['threshold_failures'] = array_slice( array_values( array_filter( $failures, 'is_array' ) ), 0, 10 );
 		}
-		return array_merge( $base, array( 'status' => 'rejected', 'diagnostic' => $diagnostic ) );
+		return array_merge(
+			$base,
+			array(
+				'status'     => 'rejected',
+				'diagnostic' => $diagnostic,
+			)
+		);
 	}
 
 	/** @return array<string,mixed> */

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -300,10 +300,10 @@ $with_editability_report = static function ( array $candidate ) use ( $result, $
 };
 $strict_editability_plan = $with_editability_report( $plan );
 $strict_editability_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $strict_editability_plan, array( 'slug' => 'strict-editability-plan' ) );
-$assert( 'completed' === $strict_editability_receipt['status'] && 'passed' === ( $strict_editability_receipt['editability_report']['status'] ?? '' ) && 'blocks-engine/php-transformer/editability-report/v2' === ( $strict_editability_receipt['editability_report']['report_schema'] ?? '' ), 'valid hash-bound Blocks Engine editability reports are admitted before materialization' );
+$assert( 'completed' === $strict_editability_receipt['status'] && 'passed' === ( $strict_editability_receipt['editability_report']['status'] ?? '' ) && 'blocks-engine/php-transformer/editability-report/v1' === ( $strict_editability_receipt['editability_report']['report_schema'] ?? '' ), 'valid hash-bound Blocks Engine editability reports are admitted before materialization' );
 
 $compatibility_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'compatibility-editability-plan' ) );
-$assert( 'completed' === $compatibility_receipt['status'] && 'compatibility_policy_only' === ( $compatibility_receipt['editability_report']['status'] ?? '' ) && 'editability_report_compatibility_policy_only' === ( $compatibility_receipt['editability_report']['diagnostic']['reason_code'] ?? '' ), 'current policy-only producer plans retain explicit compatibility evidence' );
+$assert( 'completed' === $compatibility_receipt['status'] && 'compatibility_policy_only' === ( $compatibility_receipt['editability_report']['status'] ?? '' ) && 'editability_report_compatibility_policy_only' === ( $compatibility_receipt['editability_report']['diagnostic']['reason_code'] ?? '' ), 'current producer plans retain explicit compatibility evidence' );
 
 $missing_report_plan                                        = $plan;
 $missing_report_plan['quality']['editability_report_required'] = true;
@@ -312,7 +312,7 @@ $missing_report_receipt                                     = Static_Site_Import
 $assert( 'rejected' === $missing_report_receipt['status'] && 'editability_report_required' === ( $missing_report_receipt['errors'][0]['code'] ?? '' ) && $insert_calls_before_missing === $GLOBALS['ssi_plan_insert_calls'], 'required reports reject missing producer evidence before any write' );
 
 $malformed_report_plan                                      = $strict_editability_plan;
-$malformed_report_plan['quality']['editability_report']['schema'] = 'blocks-engine/php-transformer/editability-report/v1';
+$malformed_report_plan['quality']['editability_report']['schema'] = 'blocks-engine/php-transformer/editability-report/v0';
 $malformed_report_receipt                                   = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $malformed_report_plan, array( 'slug' => 'malformed-editability-report' ) );
 $assert( 'rejected' === $malformed_report_receipt['status'] && 'editability_report_schema_invalid' === ( $malformed_report_receipt['errors'][0]['code'] ?? '' ), 'malformed editability reports are rejected deterministically' );
 
@@ -324,6 +324,8 @@ $assert( 'rejected' === $hash_mismatch_receipt['status'] && 'editability_report_
 $failed_policy_plan                                              = $strict_editability_plan;
 $failed_policy_plan['quality']['status']                        = 'failed';
 $failed_policy_plan['quality']['pass']                          = false;
+$failed_policy_plan['quality']['editability_policy']['schema']  = 'blocks-engine/php-transformer/editability-policy/v1';
+$failed_policy_plan['quality']['editability_policy']['enforcement'] = 'required';
 $failed_policy_plan['quality']['editability_policy']['status']  = 'failed';
 $failed_policy_plan['quality']['editability_policy']['failures'] = array( array( 'metric' => 'max_nesting_depth', 'actual' => 21, 'maximum' => 20, 'source_path' => 'about.html' ) );
 $failed_policy_plan['quality']['editability_report_plan_hash']  = $plan_hash( $failed_policy_plan );

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -287,6 +287,49 @@ $plan     = $result['source_reports']['wordpress_site_plan'];
 $assert( 'blocks-engine/wordpress-site-plan/v2' === $plan['schema'], 'compiler emits the released v2 site plan' );
 $assert( isset( $result['source_reports']['wordpress_site_plan']['reporting'] ), 'compiler exposes the plan in source reports' );
 
+$plan_hash = static function ( array $candidate ): string {
+	unset( $candidate['quality']['editability_report'], $candidate['quality']['editability_report_plan_hash'], $candidate['quality']['editability_report_required'] );
+	$hash = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'hash' );
+	return $hash->invoke( null, $candidate );
+};
+$with_editability_report = static function ( array $candidate ) use ( $result, $plan_hash ): array {
+	$candidate['quality']['editability_report_required']  = true;
+	$candidate['quality']['editability_report']           = $result['source_reports']['editability_report'];
+	$candidate['quality']['editability_report_plan_hash'] = $plan_hash( $candidate );
+	return $candidate;
+};
+$strict_editability_plan = $with_editability_report( $plan );
+$strict_editability_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $strict_editability_plan, array( 'slug' => 'strict-editability-plan' ) );
+$assert( 'completed' === $strict_editability_receipt['status'] && 'passed' === ( $strict_editability_receipt['editability_report']['status'] ?? '' ) && 'blocks-engine/php-transformer/editability-report/v2' === ( $strict_editability_receipt['editability_report']['report_schema'] ?? '' ), 'valid hash-bound Blocks Engine editability reports are admitted before materialization' );
+
+$compatibility_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'compatibility-editability-plan' ) );
+$assert( 'completed' === $compatibility_receipt['status'] && 'compatibility_policy_only' === ( $compatibility_receipt['editability_report']['status'] ?? '' ) && 'editability_report_compatibility_policy_only' === ( $compatibility_receipt['editability_report']['diagnostic']['reason_code'] ?? '' ), 'current policy-only producer plans retain explicit compatibility evidence' );
+
+$missing_report_plan                                        = $plan;
+$missing_report_plan['quality']['editability_report_required'] = true;
+$insert_calls_before_missing                                = $GLOBALS['ssi_plan_insert_calls'];
+$missing_report_receipt                                     = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $missing_report_plan, array( 'slug' => 'missing-editability-report' ) );
+$assert( 'rejected' === $missing_report_receipt['status'] && 'editability_report_required' === ( $missing_report_receipt['errors'][0]['code'] ?? '' ) && $insert_calls_before_missing === $GLOBALS['ssi_plan_insert_calls'], 'required reports reject missing producer evidence before any write' );
+
+$malformed_report_plan                                      = $strict_editability_plan;
+$malformed_report_plan['quality']['editability_report']['schema'] = 'blocks-engine/php-transformer/editability-report/v1';
+$malformed_report_receipt                                   = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $malformed_report_plan, array( 'slug' => 'malformed-editability-report' ) );
+$assert( 'rejected' === $malformed_report_receipt['status'] && 'editability_report_schema_invalid' === ( $malformed_report_receipt['errors'][0]['code'] ?? '' ), 'malformed editability reports are rejected deterministically' );
+
+$hash_mismatch_plan                                      = $strict_editability_plan;
+$hash_mismatch_plan['quality']['editability_report_plan_hash'] = str_repeat( '0', 64 );
+$hash_mismatch_receipt                                   = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $hash_mismatch_plan, array( 'slug' => 'mismatched-editability-report' ) );
+$assert( 'rejected' === $hash_mismatch_receipt['status'] && 'editability_report_plan_hash_mismatch' === ( $hash_mismatch_receipt['errors'][0]['code'] ?? '' ), 'reports bound to a different canonical plan are rejected' );
+
+$failed_policy_plan                                              = $strict_editability_plan;
+$failed_policy_plan['quality']['status']                        = 'failed';
+$failed_policy_plan['quality']['pass']                          = false;
+$failed_policy_plan['quality']['editability_policy']['status']  = 'failed';
+$failed_policy_plan['quality']['editability_policy']['failures'] = array( array( 'metric' => 'max_nesting_depth', 'actual' => 21, 'maximum' => 20, 'source_path' => 'about.html' ) );
+$failed_policy_plan['quality']['editability_report_plan_hash']  = $plan_hash( $failed_policy_plan );
+$failed_policy_receipt                                          = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $failed_policy_plan, array( 'slug' => 'failed-editability-policy' ) );
+$assert( 'rejected' === $failed_policy_receipt['status'] && 'editability_policy_failed' === ( $failed_policy_receipt['errors'][0]['code'] ?? '' ) && 'about.html' === ( $failed_policy_receipt['editability_report']['diagnostic']['threshold_failures'][0]['source_path'] ?? '' ), 'failed producer thresholds hard-gate materialization with bounded source diagnostics' );
+
 // Gutenberg gaps are SSI receipt/report extensions and must never alter the
 // compiler-owned plan, whose schema and hash are producer contracts.
 $canonical_plan = $plan;


### PR DESCRIPTION
## Summary
- validate Blocks Engine editability-report/v2 shape and bind it to the canonical plan hash before materialization
- hard-reject invalid policies, failed producer thresholds, malformed reports, and hash mismatches with bounded deterministic diagnostics
- retain explicit policy-only compatibility for current producers until a plan marks the report required

## Testing
- `php -l includes/class-static-site-importer-wordpress-site-plan-materializer.php`
- `php -l tests/smoke-wordpress-site-plan-materializer.php`
- `git diff --check`
- `php tests/smoke-wordpress-site-plan-materializer.php` *(blocked: this bare DMC worktree intentionally has no `vendor/autoload.php`; dependencies were not installed due disk pressure)*

Related to #962. This is one independent admission/enforcement slice; it does not cover the runtime-binding validation in #1072 or importer fallback removal in #1073.

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode was used to inspect the Blocks Engine and SSI contracts, implement the report admission gate, and add focused coverage. Chris Huber remains responsible for the change.