### PR TITLE
Materialize companion dialog view scripts and forms

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -100,7 +100,10 @@ class Static_Site_Importer_Companion_Plugin {
 				return new WP_Error( 'static_site_importer_companion_plugin_block_json_name_invalid', sprintf( 'Block %s resolves to a duplicate WordPress block name.', $name ) );
 			}
 			$block_names[ $effective_name ] = true;
-			$assets                         = $block['assets'] ?? array();
+			$assets                         = self::block_assets( $block );
+			if ( is_wp_error( $assets ) ) {
+				return $assets;
+			}
 			if ( ! is_array( $assets ) || ( ! empty( $assets ) && array_is_list( $assets ) ) ) {
 				return new WP_Error( 'static_site_importer_companion_plugin_assets_invalid', sprintf( 'Block %s assets must be an object.', $name ) );
 			}
@@ -394,7 +397,10 @@ class Static_Site_Importer_Companion_Plugin {
 		// Carried static assets (e.g. block stylesheets or a hand-written
 		// Interactivity API view module) ride alongside render.php. These are
 		// pass-through files, not generated JS build output.
-		$assets = isset( $block['assets'] ) && is_array( $block['assets'] ) ? $block['assets'] : array();
+		$assets = self::block_assets( $block );
+		if ( is_wp_error( $assets ) ) {
+			return $assets;
+		}
 		foreach ( $assets as $relative => $content ) {
 			$relative = self::sanitize_relative_path( (string) $relative );
 			if ( '' === $relative || ! is_scalar( $content ) ) {
@@ -430,6 +436,32 @@ class Static_Site_Importer_Companion_Plugin {
 			),
 			'files'      => $files,
 		);
+	}
+
+	/**
+	 * Normalize producer-owned dedicated assets into the metadata file map.
+	 *
+	 * Blocks Engine carries a generated block's audited frontend script in the
+	 * established `view_js` slot. WordPress block metadata addresses that payload
+	 * as `file:./view.js`, so validation and scaffolding must see one canonical
+	 * asset regardless of which producer representation supplied it.
+	 *
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function block_assets( array $block ) {
+		$assets = isset( $block['assets'] ) && is_array( $block['assets'] ) ? $block['assets'] : array();
+		if ( ! array_key_exists( 'view_js', $block ) ) {
+			return $assets;
+		}
+		if ( ! is_scalar( $block['view_js'] ) || Static_Site_Importer_Content_Policy::contains_server_code( (string) $block['view_js'] ) ) {
+			return new WP_Error( 'static_site_importer_companion_plugin_view_script_invalid', 'Companion block view_js must contain safe JavaScript.' );
+		}
+		$view_js = (string) $block['view_js'];
+		if ( isset( $assets['view.js'] ) && (string) $assets['view.js'] !== $view_js ) {
+			return new WP_Error( 'static_site_importer_companion_plugin_view_script_conflict', 'Companion block view_js conflicts with its declared view.js asset.' );
+		}
+		$assets['view.js'] = $view_js;
+		return $assets;
 	}
 
 	/**

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -100,15 +100,16 @@ class Static_Site_Importer_Companion_Plugin {
 				return new WP_Error( 'static_site_importer_companion_plugin_block_json_name_invalid', sprintf( 'Block %s resolves to a duplicate WordPress block name.', $name ) );
 			}
 			$block_names[ $effective_name ] = true;
-			$assets                         = self::block_assets( $block );
+			$declared_assets                = $block['assets'] ?? array();
+			if ( ! is_array( $declared_assets ) || ( ! empty( $declared_assets ) && array_is_list( $declared_assets ) ) ) {
+				return new WP_Error( 'static_site_importer_companion_plugin_assets_invalid', sprintf( 'Block %s assets must be an object.', $name ) );
+			}
+			$assets = self::block_assets( $block );
 			if ( is_wp_error( $assets ) ) {
 				return $assets;
 			}
-			if ( ! is_array( $assets ) || ( ! empty( $assets ) && array_is_list( $assets ) ) ) {
-				return new WP_Error( 'static_site_importer_companion_plugin_assets_invalid', sprintf( 'Block %s assets must be an object.', $name ) );
-			}
 			foreach ( $assets as $path => $content ) {
-				if ( ! is_string( $path ) || self::sanitize_relative_path( $path ) !== $path || ! Static_Site_Importer_Content_Policy::is_companion_asset_path( $path ) || ! is_scalar( $content ) || Static_Site_Importer_Content_Policy::contains_server_code( (string) $content ) ) {
+				if ( self::sanitize_relative_path( $path ) !== $path || ! Static_Site_Importer_Content_Policy::is_companion_asset_path( $path ) || ! is_scalar( $content ) || Static_Site_Importer_Content_Policy::contains_server_code( (string) $content ) ) {
 					return new WP_Error( 'static_site_importer_companion_plugin_asset_path_invalid', sprintf( 'Block %s has an unsafe asset path.', $name ) );
 				}
 			}
@@ -446,7 +447,7 @@ class Static_Site_Importer_Companion_Plugin {
 	 * as `file:./view.js`, so validation and scaffolding must see one canonical
 	 * asset regardless of which producer representation supplied it.
 	 *
-	 * @return array<string,mixed>|WP_Error
+	 * @return array<array-key,mixed>|WP_Error
 	 */
 	private static function block_assets( array $block ) {
 		$assets = isset( $block['assets'] ) && is_array( $block['assets'] ) ? $block['assets'] : array();

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -913,6 +913,20 @@ namespace {
 		$assert( str_contains( $single_grafted, 'Contact' ), 'graft-content-preserves-surrounding-content' );
 		$assert( ! str_contains( $single_grafted, '<!-- wp:html' ), 'graft-content-has-no-core-html-island' );
 
+		// The same form binding remains graftable when Blocks Engine places the
+		// editable fallback inside a generated companion dialog block.
+		$dialog_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/contact-dialog.html' );
+		$dialog_report['diagnostics'][] = $build_form_diagnostic( $single_fallback, 'website/contact-dialog.html' );
+		$dialog_contents                = array(
+			'website/contact-dialog.html' => '<!-- wp:ssi-example/captured-dialog {"dialogId":"contact-dialog","triggerId":"contact-trigger"} --><dialog id="contact-dialog" data-blocks-engine-trigger="contact-trigger">' . $single_serialized . '</dialog><!-- /wp:ssi-example/captured-dialog -->',
+		);
+		$dialog_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $dialog_report, array(), $dialog_contents );
+		$dialog_grafted = (string) ( $dialog_contents['website/contact-dialog.html'] ?? '' );
+		$assert( 1 === ( $dialog_seeding['grafted_count'] ?? 0 ), 'dialog-form-grafted-once' );
+		$assert( str_contains( $dialog_grafted, '<!-- wp:ssi-example/captured-dialog' ) && str_contains( $dialog_grafted, '<dialog id="contact-dialog"' ), 'dialog-form-graft-preserves-companion-wrapper' );
+		$assert( str_contains( $dialog_grafted, 'wp:jetpack/contact-form' ) && str_contains( $dialog_grafted, 'wp:jetpack/field-email' ), 'dialog-form-graft-materializes-wordpress-owned-form-blocks' );
+		$assert( ! str_contains( $dialog_grafted, 'mailto:hello@example.com' ), 'dialog-form-graft-removes-source-provider-endpoint' );
+
 		// Multi-form page: two forms on one page graft independently.
 		$multi_html       = '<section><h2>Contact A</h2><form class="contact-a" action="mailto:a@example.com" method="post"><input id="a-email" type="email" name="email" required aria-label="Email"><textarea name="msg" aria-label="Message"></textarea><button type="submit">Send A</button></form></section><section><h2>Contact B</h2><form class="contact-b" action="mailto:b@example.com" method="post"><input id="b-name" type="text" name="name" required aria-label="Name"><button type="submit">Send B</button></form></section>';
 		$multi_transform  = blocks_engine_php_transformer_transform_html( $multi_html );

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -918,7 +918,7 @@ namespace {
 		$dialog_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/contact-dialog.html' );
 		$dialog_report['diagnostics'][] = $build_form_diagnostic( $single_fallback, 'website/contact-dialog.html' );
 		$dialog_contents                = array(
-			'website/contact-dialog.html' => '<!-- wp:ssi-example/captured-dialog {"dialogId":"contact-dialog","triggerId":"contact-trigger"} --><dialog id="contact-dialog" data-blocks-engine-trigger="contact-trigger">' . $single_serialized . '</dialog><!-- /wp:ssi-example/captured-dialog -->',
+			'website/contact-dialog.html' => '<!-- wp:ssi-example/captured-dialog {"dialogId":"contact-dialog","triggerIds":["contact-trigger"]} --><dialog id="contact-dialog" data-blocks-engine-triggers="contact-trigger">' . $single_serialized . '</dialog><!-- /wp:ssi-example/captured-dialog -->',
 		);
 		$dialog_seeding = Static_Site_Importer_Report_Diagnostics::materialize_form_findings( $dialog_report, array(), $dialog_contents );
 		$dialog_grafted = (string) ( $dialog_contents['website/contact-dialog.html'] ?? '' );

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -266,6 +266,57 @@ $payload = array(
 );
 
 $assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $payload ), 'canonical-payload-validates-all-core-metadata-fields' );
+$dialog_payload = array(
+	'schema'    => Static_Site_Importer_Companion_Plugin::PAYLOAD_SCHEMA,
+	'site_slug' => 'captured-dialog-site',
+	'site_name' => 'Captured Dialog Site',
+	'blocks'    => array(
+		array(
+			'name'       => 'captured-dialog',
+			'block_json' => array(
+				'apiVersion'   => 3,
+				'name'         => 'ssi-captured-dialog-site/captured-dialog',
+				'title'        => 'Dialog',
+				'category'     => 'widgets',
+				'editorScript' => 'file:./index.js',
+				'viewScript'   => 'file:./view.js',
+				'attributes'   => array(
+					'dialogId'       => array( 'type' => 'string', 'default' => '' ),
+					'triggerId'      => array( 'type' => 'string', 'default' => '' ),
+					'addCloseButton' => array( 'type' => 'boolean', 'default' => false ),
+				),
+				'supports'     => array( 'html' => false, 'customClassName' => false ),
+			),
+			'view_js'   => '(function(){document.querySelectorAll("dialog[data-blocks-engine-trigger]").forEach(function(dialog){var trigger=document.getElementById(dialog.getAttribute("data-blocks-engine-trigger"));if(trigger)trigger.addEventListener("click",function(){dialog.showModal();});});})();',
+			'assets'    => array(
+				'index.js' => '(function(blocks,blockEditor,element){blocks.registerBlockType("ssi-captured-dialog-site/captured-dialog",{edit:function(){return element.createElement(blockEditor.InnerBlocks);},save:function(){return element.createElement("dialog",null,element.createElement(blockEditor.InnerBlocks.Content));}});})(window.wp.blocks,window.wp.blockEditor,window.wp.element);',
+			),
+			'script_dependencies' => array(
+				'index.js' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ),
+			),
+		),
+	),
+	'preserved_js' => array(),
+);
+$dialog_validation = Static_Site_Importer_Companion_Plugin::validate_payload( $dialog_payload );
+$assert( true === $dialog_validation, 'captured-dialog-payload-validates', is_wp_error( $dialog_validation ) ? $dialog_validation->get_error_message() : '' );
+$dialog_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $dialog_payload );
+$assert( is_array( $dialog_descriptor ), 'captured-dialog-payload-scaffolds' );
+if ( is_array( $dialog_descriptor ) ) {
+	$dialog_files = $dialog_descriptor['files'] ?? array();
+	$dialog_block_json = (string) ( $dialog_files['ssi-captured-dialog-site/blocks/captured-dialog/block.json'] ?? '' );
+	$assert( str_contains( $dialog_block_json, '"viewScript": "file:./view.js"' ), 'captured-dialog-metadata-retains-scoped-view-script' );
+	$assert( str_contains( (string) ( $dialog_files['ssi-captured-dialog-site/blocks/captured-dialog/view.js'] ?? '' ), 'showModal' ), 'captured-dialog-scaffold-writes-native-dialog-behavior' );
+	$assert( str_contains( (string) ( $dialog_files['ssi-captured-dialog-site/blocks/captured-dialog/index.js'] ?? '' ), 'InnerBlocks' ), 'captured-dialog-scaffold-writes-editable-inner-block-editor' );
+}
+$conflicting_dialog_payload = $dialog_payload;
+$conflicting_dialog_payload['blocks'][0]['assets']['view.js'] = 'window.conflict = true;';
+$conflicting_dialog_validation = Static_Site_Importer_Companion_Plugin::validate_payload( $conflicting_dialog_payload );
+$assert( is_wp_error( $conflicting_dialog_validation ) && 'static_site_importer_companion_plugin_view_script_conflict' === $conflicting_dialog_validation->get_error_code(), 'captured-dialog-conflicting-view-script-rejected' );
+$unsafe_dialog_payload = $dialog_payload;
+$unsafe_dialog_payload['blocks'][0]['view_js'] = '<?php system( "id" );';
+$unsafe_dialog_validation = Static_Site_Importer_Companion_Plugin::validate_payload( $unsafe_dialog_payload );
+$assert( is_wp_error( $unsafe_dialog_validation ) && 'static_site_importer_companion_plugin_view_script_invalid' === $unsafe_dialog_validation->get_error_code(), 'captured-dialog-server-code-view-script-rejected' );
 $missing_metadata_asset = $payload;
 unset( $missing_metadata_asset['blocks'][0]['assets']['view-module.js'] );
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $missing_metadata_asset ) ), 'array-metadata-file-reference-requires-declared-asset' );

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -282,12 +282,12 @@ $dialog_payload = array(
 				'viewScript'   => 'file:./view.js',
 				'attributes'   => array(
 					'dialogId'       => array( 'type' => 'string', 'default' => '' ),
-					'triggerId'      => array( 'type' => 'string', 'default' => '' ),
+					'triggerIds'     => array( 'type' => 'array', 'default' => array(), 'items' => array( 'type' => 'string' ) ),
 					'addCloseButton' => array( 'type' => 'boolean', 'default' => false ),
 				),
 				'supports'     => array( 'html' => false, 'customClassName' => false ),
 			),
-			'view_js'   => '(function(){document.querySelectorAll("dialog[data-blocks-engine-trigger]").forEach(function(dialog){var trigger=document.getElementById(dialog.getAttribute("data-blocks-engine-trigger"));if(trigger)trigger.addEventListener("click",function(){dialog.showModal();});});})();',
+			'view_js'   => '(function(){document.querySelectorAll("dialog[data-blocks-engine-triggers]").forEach(function(dialog){dialog.showModal();});})();',
 			'assets'    => array(
 				'index.js' => '(function(blocks,blockEditor,element){blocks.registerBlockType("ssi-captured-dialog-site/captured-dialog",{edit:function(){return element.createElement(blockEditor.InnerBlocks);},save:function(){return element.createElement("dialog",null,element.createElement(blockEditor.InnerBlocks.Content));}});})(window.wp.blocks,window.wp.blockEditor,window.wp.element);',
 			),


### PR DESCRIPTION
Fixes #1106.

Depends on Automattic/blocks-engine#985.

## What

- Normalizes Blocks Engine's established `view_js` companion-block payload slot to the `view.js` file referenced by WordPress block metadata.
- Rejects conflicting duplicate view scripts and source containing server code before scaffolding or filesystem mutation.
- Adds producer/consumer coverage for the generated captured-dialog payload shape.
- Proves that a form nested inside a companion dialog is grafted to Jetpack Form blocks while preserving the dialog wrapper and removing the source provider endpoint.

## Verification

- `npm run test:companion-plugin`: 120 assertions passed.
- `php tests/form-materializer-smoke.php`: 177 assertions passed.
- `npm test`: 58 selected suites ran; 57 passed. The sole failure is an unrelated existing solved-site promotion fixture expecting an older pinned Blocks Engine SHA than the workflow currently contains.

## AI assistance

- **Model:** OpenAI gpt-5.6-sol
- **Tool:** OpenCode
- **Used for:** Producer/consumer contract tracing, implementation, integration tests, and verification. Chris Huber selected the WordPress companion-block direction and remains responsible for every line.
