### PR TITLE
fix(lint): align url collector array and rename resource param

### DIFF
--- a/includes/class-static-site-importer-shared-resource-plan.php
+++ b/includes/class-static-site-importer-shared-resource-plan.php
@@ -158,12 +158,12 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 		return hash( 'sha256', false === $json ? '' : $json );
 	}
 
-	/** @param array<string,mixed> $resource */
-	private function materializable_resource( array $resource ): bool {
-		if ( ! self::structurally_materializable( $resource ) ) {
+	/** @param array<string,mixed> $entry */
+	private function materializable_resource( array $entry ): bool {
+		if ( ! self::structurally_materializable( $entry ) ) {
 			return false;
 		}
-		$reference = $resource['payload_reference'] ?? null;
+		$reference = $entry['payload_reference'] ?? null;
 		if ( ! is_array( $reference ) ) {
 			return true;
 		}
@@ -173,14 +173,14 @@ final class Static_Site_Importer_Shared_Resource_Plan {
 			&& hash_equals( $reference['sha256'], hash( 'sha256', $bytes ) );
 	}
 
-	/** @param array<string,mixed> $resource */
-	private static function structurally_materializable( array $resource ): bool {
-		if ( '' === self::canonical_url( (string) ( $resource['source_url'] ?? '' ) ) || ! Static_Site_Importer_Content_Policy::is_static_path( (string) ( $resource['path'] ?? '' ) ) ) {
+	/** @param array<string,mixed> $entry */
+	private static function structurally_materializable( array $entry ): bool {
+		if ( '' === self::canonical_url( (string) ( $entry['source_url'] ?? '' ) ) || ! Static_Site_Importer_Content_Policy::is_static_path( (string) ( $entry['path'] ?? '' ) ) ) {
 			return false;
 		}
-		$has_content = isset( $resource['content'] ) && is_string( $resource['content'] );
-		$has_base64  = isset( $resource['content_base64'] ) && is_string( $resource['content_base64'] ) && false !== base64_decode( $resource['content_base64'], true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Validates retained binary payload bytes.
-		$reference   = $resource['payload_reference'] ?? null;
+		$has_content = isset( $entry['content'] ) && is_string( $entry['content'] );
+		$has_base64  = isset( $entry['content_base64'] ) && is_string( $entry['content_base64'] ) && false !== base64_decode( $entry['content_base64'], true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Validates retained binary payload bytes.
+		$reference   = $entry['payload_reference'] ?? null;
 		$has_ref     = is_array( $reference )
 			&& 'blocks-engine/payload-reference/v1' === ( $reference['schema'] ?? null )
 			&& is_string( $reference['id'] ?? null ) && '' !== $reference['id']

--- a/includes/class-static-site-importer-url-site-collector.php
+++ b/includes/class-static-site-importer-url-site-collector.php
@@ -433,11 +433,11 @@ class Static_Site_Importer_URL_Site_Collector {
 			}
 
 			$file = array(
-				'path'      => $path,
+				'path'       => $path,
 				'source_url' => $resource_url,
-				'mime_type' => $resource['content_type'],
-				'body'      => $body,
-				'is_text'   => self::is_text( $resource['content_type'], $path ),
+				'mime_type'  => $resource['content_type'],
+				'body'       => $body,
+				'is_text'    => self::is_text( $resource['content_type'], $path ),
 			);
 			if ( 'html' === $resource['kind'] ) {
 				$file['metadata'] = array( 'route_path' => $route_paths[ $resource_url ] );


### PR DESCRIPTION
## Summary
Cleans up the remaining live PHPCS lint findings from the automated lint report. Two files touched, cosmetic only, no behavior change.

Fixes #986

## Changes

### includes/class-static-site-importer-url-site-collector.php
**Before:**
```php
$file = array(
    'path'      => $path,
    'source_url' => $resource_url,
    'mime_type' => $resource['content_type'],
    'body'      => $body,
    'is_text'   => self::is_text( $resource['content_type'], $path ),
);
```
**After:**
```php
$file = array(
    'path'       => $path,
    'source_url' => $resource_url,
    'mime_type'  => $resource['content_type'],
    'body'       => $body,
    'is_text'    => self::is_text( $resource['content_type'], $path ),
);
```
**Why:** Fixes `WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned` on lines 436, 438, 439, 440.

### includes/class-static-site-importer-shared-resource-plan.php
**Before:**
```php
private function materializable_resource( array $resource ): bool { ... }
private static function structurally_materializable( array $resource ): bool { ... }
```
**After:**
```php
private function materializable_resource( array $entry ): bool { ... }
private static function structurally_materializable( array $entry ): bool { ... }
```
**Why:** `resource` is a reserved PHP keyword; renamed the parameter to `$entry` in both methods to satisfy `Universal.NamingConventions.NoReservedKeywordParameterNames`. Loop-local `$resource` variables elsewhere in the file are untouched.

## Testing
**Test 1: Lint**
```bash
phpcs --standard=WordPress \
  --sniffs=WordPress.Arrays.MultipleStatementAlignment,Universal.NamingConventions.NoReservedKeywordParameterNames \
  includes/class-static-site-importer-url-site-collector.php \
  includes/class-static-site-importer-shared-resource-plan.php
```
Result: 0 findings.

**Test 2: Standalone smoke tests**
```bash
php tests/smoke-shared-resource-plan.php   # Shared resource plan smoke passed.
php tests/smoke-url-site-collector.php     # URL site collector smoke passed (78 assertions).
```
Result: both exit 0.

**Test 3: Fast lane**
```bash
npm test   # 63 passed, 0 failed
```
Result: all pass.

Note: the original issue listed 21 findings, but 15 were already fixed on main before this branch. This PR covers the 6 that remain live on current code.