### PR TITLE
Fix production report finalization

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -665,6 +665,7 @@ class Static_Site_Importer_Theme_Generator {
 			),
 			'source_documents'                 => array(
 				'source'                       => 'blocks_engine',
+				'total_count'                  => count( $plan['pages'] ),
 				'blocks_engine_document_count' => count( $plan['pages'] ),
 				'blocks_engine_documents'      => array_map(
 					static fn( array $page ): array => array(
@@ -683,7 +684,6 @@ class Static_Site_Importer_Theme_Generator {
 		);
 		$report['source_artifact'] = array( 'hash' => (string) ( $args['artifact_hash'] ?? $plan['source']['source_hash'] ) );
 		$report['materialization_receipt'] = $receipt;
-		$quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $report, $args );
 		$artifact = array_merge(
 			isset( $args['source_artifact_reference'] ) && is_array( $args['source_artifact_reference'] ) ? $args['source_artifact_reference'] : array(),
 			array_filter(
@@ -810,33 +810,9 @@ class Static_Site_Importer_Theme_Generator {
 		}
 		$manifest['cleanup'] = $cleanup;
 		$report['source_of_truth'] = $manifest;
-		$visual_parity = array(
-			'schema'    => 'static-site-importer/visual-parity-artifacts/v1',
-			'status'    => 'pending',
-			'owner'     => 'codebox_runtime',
-			'artifacts' => array(
-				'import_report'     => array(
-					'status' => 'captured',
-					'ref'    => array( 'artifact_name' => 'import-report.json' ),
-				),
-				'source_screenshot' => array( 'status' => 'pending' ),
-				'visual_diff'       => array( 'capture_state' => 'not_captured' ),
-			),
-		);
-		$report['visual_parity_artifacts'] = $visual_parity;
-		$validation = array(
-			'schema'                  => 'blocks-engine/import-validation-result/v1',
-			'artifact_type'           => 'ImportValidationResult',
-			'status'                  => ! empty( $quality['pass'] ) ? 'passed' : 'failed',
-			'diagnostics'             => $diagnostics,
-			'quality'                 => $quality,
-			'visual_parity_artifacts' => $visual_parity,
-		);
-		$findings   = array(
-			'schema'        => 'blocks-engine/finding-packets/v1',
-			'artifact_type' => 'FindingPacketSet',
-			'findings'      => $diagnostics,
-		);
+		$quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $report, $args );
+		$validation = $report['import_validation_result'];
+		$findings   = $report['finding_packets'];
 		$theme_dir  = $theme['dir'];
 		$manifest_path = $theme_dir . '/static-site-importer-manifest.json';
 		self::write_plan_projection( $manifest_path, $manifest, $receipt );

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -147,6 +147,11 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( 'blocks-engine/import-validation-result/v1' === ( $validation_result['schema'] ?? '' ), 'validation-result-schema' );
 	$assert( 'ImportValidationResult' === ( $validation_result['artifact_type'] ?? '' ), 'validation-result-artifact-type' );
 	$assert( 'passed' === ( $validation_result['status'] ?? '' ), 'validation-result-status-passed' );
+	$assert( 1 === ( $validation_result['counts']['source_documents'] ?? 0 ), 'default-validation-result-counts-source-document' );
+	$assert( isset( $validation_result['quality_gates']['fallback_blocks']['diagnostic_refs'] ), 'default-validation-result-includes-quality-gates' );
+	$assert( isset( $validation_result['diagnostic_summary'] ), 'default-validation-result-includes-diagnostic-summary' );
+	$assert( 'import-validation-result.json' === ( $validation_result['artifacts']['import_validation_result']['path'] ?? '' ), 'default-validation-result-includes-artifact-refs' );
+	$assert( ! static_site_importer_smoke_contains_local_path( $validation_result ), 'default-validation-result-contains-no-local-paths' );
 	$visual_parity = $report['visual_parity_artifacts'] ?? array();
 	$visual_parity_validation = $validation_result['visual_parity_artifacts'] ?? array();
 	$assert( 'static-site-importer/visual-parity-artifacts/v1' === ( $visual_parity['schema'] ?? '' ), 'visual-parity-artifact-schema' );
@@ -160,6 +165,7 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( ! static_site_importer_smoke_contains_local_path( $visual_parity ), 'visual-parity-artifacts-contain-no-local-paths' );
 	$assert( 'blocks-engine/finding-packets/v1' === ( $finding_packets['schema'] ?? '' ), 'finding-packets-schema' );
 	$assert( 'FindingPacketSet' === ( $finding_packets['artifact_type'] ?? '' ), 'finding-packets-artifact-type' );
+	$assert( isset( $finding_packets['count'], $finding_packets['packets'] ), 'default-finding-packets-are-complete' );
 	$assert( 'static-site-importer/document-metadata/v1' === ( $metadata['schema'] ?? '' ), 'metadata-contract-is-recorded' );
 	$assert( 'Ember & Rye' === ( $metadata['title'] ?? '' ), 'title-is-preserved-in-metadata' );
 	$assert( 'utf-8' === ( $metadata['meta'][0]['charset'] ?? '' ), 'charset-meta-is-preserved-in-metadata' );
@@ -234,6 +240,8 @@ $assert( ! is_wp_error( $multi_page_result ), 'multi-page-import-succeeds', is_w
 
 if ( ! is_wp_error( $multi_page_result ) ) {
 	$multi_report    = json_decode( $read( $multi_page_result['report_path'] ), true );
+	$multi_validation = json_decode( $read( $multi_page_result['validation_result_path'] ), true );
+	$multi_findings   = json_decode( $read( $multi_page_result['finding_packets_path'] ), true );
 	$source_docs     = $multi_report['source_documents'] ?? array();
 	$blocks_engine_documents = $source_docs['blocks_engine_documents'] ?? array();
 	$wordpress_site_plan = $multi_report['blocks_engine']['wordpress_site_plan'] ?? array();
@@ -268,6 +276,10 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 	$assert( 'menu' === ( $documents_by_source['website/menu.html']['slug'] ?? '' ), 'menu-page-materializes' );
 	$assert( 'contact' === ( $documents_by_source['website/contact.html']['slug'] ?? '' ), 'contact-page-materializes' );
 	$assert( 'blocks-engine/wordpress-site-plan/v2' === ( $wordpress_site_plan['schema'] ?? '' ), 'wordpress-site-plan-contract-is-recorded' );
+	$assert( 'blocks-engine/import-validation-result/v1' === ( $multi_report['import_validation_result']['schema'] ?? '' ), 'theme-report-persists-finalized-validation-result' );
+	$assert( $multi_report['import_validation_result'] === $multi_validation, 'theme-validation-sidecar-matches-finalized-report-contract' );
+	$assert( $multi_report['finding_packets'] === $multi_findings, 'theme-findings-sidecar-matches-finalized-report-contract' );
+	$assert( isset( $multi_validation['quality_gates'], $multi_validation['diagnostic_summary'] ), 'theme-validation-sidecar-is-complete' );
 	$assert( 3 === count( $wordpress_site_plan['pages'] ?? array() ), 'wordpress-site-plan-page-count-is-recorded' );
 	$assert( isset( $template_parts_by_path['parts/header.html'] ), 'multi-page-synthesizes-header-template-part' );
 	$assert( isset( $template_parts_by_path['parts/footer.html'] ), 'multi-page-synthesizes-footer-template-part' );
@@ -275,6 +287,45 @@ if ( ! is_wp_error( $multi_page_result ) ) {
 	$assert( str_contains( $read( $multi_page_result['theme_dir'] . '/templates/front-page.html' ), '"slug":"footer"' ), 'multi-page-template-references-synthesized-footer-part' );
 	$assert( array() === $pattern_documents, 'blocks-engine-document-import-does-not-generate-page-pattern-copies' );
 }
+
+$external_report_dir = sys_get_temp_dir() . '/ssi-external-report-' . uniqid( '', true );
+mkdir( $external_report_dir, 0700, true );
+$external_report_dir = (string) realpath( $external_report_dir );
+$external_report_path = $external_report_dir . '/import-report.json';
+$external_result = Static_Site_Importer_Theme_Generator::import_website_artifact(
+	array(
+		'schema' => 'blocks-engine/php-transformer/site-artifact/v1',
+		'files'  => array(
+			array(
+				'path'    => 'index.html',
+				'content' => '<main><h1>External report contract</h1></main>',
+			),
+		),
+	),
+	array(
+		'name'     => 'External Report Contract',
+		'slug'     => 'external-report-contract-smoke',
+		'overwrite' => true,
+		'activate' => false,
+		'report'   => $external_report_path,
+	)
+);
+$assert( ! is_wp_error( $external_result ), 'external-report-import-succeeds', is_wp_error( $external_result ) ? $external_result->get_error_message() : '' );
+if ( ! is_wp_error( $external_result ) ) {
+	$external_report = json_decode( $read( $external_result['external_report_path'] ), true );
+	$external_validation = json_decode( $read( $external_result['external_validation_result_path'] ), true );
+	$external_findings = json_decode( $read( $external_result['external_finding_packets_path'] ), true );
+	$assert( 'blocks-engine/import-validation-result/v1' === ( $external_report['import_validation_result']['schema'] ?? '' ), 'external-report-persists-finalized-validation-result' );
+	$assert( $external_report['import_validation_result'] === $external_validation, 'external-validation-sidecar-matches-finalized-report-contract' );
+	$assert( $external_report['finding_packets'] === $external_findings, 'external-findings-sidecar-matches-finalized-report-contract' );
+	$assert( ! static_site_importer_smoke_contains_local_path( $external_validation ), 'external-validation-result-contains-no-local-paths' );
+}
+foreach ( array( $external_report_path, $external_report_dir . '/import-validation-result.json', $external_report_dir . '/finding-packets.json' ) as $path ) {
+	if ( is_file( $path ) ) {
+		unlink( $path );
+	}
+}
+rmdir( $external_report_dir );
 
 function static_site_importer_smoke_contains_local_path( $value ): bool {
 	if ( is_array( $value ) ) {
@@ -291,7 +342,7 @@ function static_site_importer_smoke_contains_local_path( $value ): bool {
 		return false;
 	}
 
-	return (bool) preg_match( '#^(?:/|[A-Za-z]:\\\\|file://|~[/\\\\]|(?:\.\.?[/\\\\]))#', $value );
+	return (bool) preg_match( '#^(?:/(?:private|var|tmp|Users|home)/|[A-Za-z]:\\\\|file://|~[/\\\\]|(?:\.\.?[/\\\\]))#', $value );
 }
 
 if ( ! empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- finalize production reports through `Static_Site_Importer_Report_Diagnostics::finalize_report()` after receipt and manifest attachment
- remove duplicate validation-result and finding-packet construction
- cover complete default, theme-artifact, and external-report contracts, including durable filesystem-path hygiene

Closes #1122

## Verification
- `composer validate --strict`
- `composer check-platform-reqs`
- `php -l includes/class-static-site-importer-theme-generator.php`
- `php -l tests/smoke-website-artifact-document-metadata.php`
- `npm test` (one unrelated failure: stale Blocks Engine SHA expectation in `tools/verify-solved-site-promotion.test.mjs`)
- Studio PHP 8.3 runtime smoke reached the new report assertions; it retains three unrelated document-metadata script assertions that fail in the current Studio runtime.

## AI assistance
OpenAI GPT-5.6-terra via OpenCode audited the production report paths, implemented the canonical finalization route, and added regression coverage. Chris Huber directs the change and remains responsible for every line.