### PR TITLE
Make font readiness evidence deterministic

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -40,6 +40,7 @@
     "tests/smoke-visual-repair-css.php": { "environment": "standalone-php" },
     "tests/smoke-webfont-producer-consumer.php": { "environment": "standalone-php" },
     "tests/smoke-google-fonts-cap-fallback.php": { "environment": "standalone-php" },
+    "tests/smoke-google-fonts-retry-determinism.php": { "environment": "standalone-php" },
     "tests/smoke-website-artifact-import-input.php": { "environment": "standalone-php" },
     "tests/smoke-wordpress-site-plan-materializer.php": { "environment": "standalone-php" },
     "tests/smoke-woo-product-seeder-rollback.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-font-materializer.php
+++ b/includes/class-static-site-importer-font-materializer.php
@@ -592,14 +592,10 @@ final class Static_Site_Importer_Font_Materializer {
 		}
 		$bootstrap .= "\nadd_action( 'wp_enqueue_scripts', static function (): void {\n";
 		$bootstrap .= "    wp_enqueue_style( 'static-site-importer-embedded-fonts', get_theme_file_uri( 'assets/css/embedded-fonts.css' ), array(), null );\n";
-		if ( ! empty( $required_faces ) ) {
-			$bootstrap .= "    wp_enqueue_script( 'static-site-importer-font-readiness', get_theme_file_uri( 'assets/js/font-readiness.js' ), array(), null, false );\n";
-		}
+		$bootstrap .= "    wp_enqueue_script( 'static-site-importer-font-readiness', get_theme_file_uri( 'assets/js/font-readiness.js' ), array(), null, false );\n";
 		$bootstrap .= "} );\n";
 		$writes[]   = self::write( 'functions.php', $bootstrap, 'theme.font_materialization' );
-		if ( ! empty( $required_faces ) ) {
-			$writes[] = self::write( 'assets/js/font-readiness.js', self::readiness_script( $required_faces ), 'theme.font_materialization' );
-		}
+		$writes[] = self::write( 'assets/js/font-readiness.js', self::readiness_script( $required_faces ), 'theme.font_materialization' );
 		return array(
 			'writes'         => $writes,
 			'diagnostics'    => $diagnostics,

--- a/includes/class-static-site-importer-font-materializer.php
+++ b/includes/class-static-site-importer-font-materializer.php
@@ -10,6 +10,8 @@ final class Static_Site_Importer_Font_Materializer {
 	private const CSS_LIMIT        = 262144;
 	private const FONT_LIMIT       = 2097152;
 	private const TOTAL_FONT_LIMIT = 4194304;
+	private const REQUEST_ATTEMPTS = 3;
+	private const RETRY_DELAY      = 100000;
 
 	/**
 	 * Resolve an explicit font plan into receipt-owned theme writes.
@@ -80,6 +82,9 @@ final class Static_Site_Importer_Font_Materializer {
 		}
 
 		$font_faces = self::resolve_google_font_faces( $plan, $families, $diagnostics );
+		if ( is_wp_error( $font_faces ) ) {
+			return $font_faces;
+		}
 		if ( 'preserved' === $font_faces['state'] ) {
 			$preserved_url = (string) $font_faces['url'];
 			$fallback_url  = self::is_google_stylesheet_url( $preserved_url ) ? $preserved_url : '';
@@ -116,6 +121,8 @@ final class Static_Site_Importer_Font_Materializer {
 				$outer_detail['aggregate_bytes'] = (int) ( $font_faces['aggregate_bytes'] ?? $font_faces['observed_bytes'] );
 			} elseif ( 'google_fonts_stylesheet_preserved_due_to_size' === $outer_detail['reason'] ) {
 				$outer_detail['limit_bytes'] = self::CSS_LIMIT;
+			} elseif ( 'font_payload_preserved_due_to_size' === $outer_detail['reason'] ) {
+				$outer_detail['limit_bytes'] = self::FONT_LIMIT;
 			}
 			$diagnostics[] = self::diagnostic_with_detail( 'font_materialization_partial_preserved', $outer_detail );
 			if ( '' === $css_body ) {
@@ -673,8 +680,9 @@ final class Static_Site_Importer_Font_Materializer {
 	/** @param array<int,string> $families @param array<int,array<string,string>> $diagnostics
 	 *  @return array{state:'embedded',css:string}
 	 *          | array{state:'preserved',reason:string,observed_bytes:int,url:string,aggregate_bytes?:int}
+	 *          | WP_Error
 	 */
-	private static function resolve_google_font_faces( array $plan, array $families, array &$diagnostics ): array {
+	private static function resolve_google_font_faces( array $plan, array $families, array &$diagnostics ): array|WP_Error {
 		$imports = array();
 		foreach ( $plan['stylesheets'] ?? array() as $stylesheet ) {
 			$content = is_array( $stylesheet ) && is_scalar( $stylesheet['content'] ?? null ) ? (string) $stylesheet['content'] : '';
@@ -719,12 +727,7 @@ final class Static_Site_Importer_Font_Materializer {
 						'limit_bytes'    => self::CSS_LIMIT,
 					)
 				);
-				return array(
-					'state'          => 'preserved',
-					'reason'         => 'stylesheet_fetch_failed',
-					'observed_bytes' => strlen( $css ),
-					'url'            => $import,
-				);
+				return new WP_Error( 'static_site_importer_font_materialization_failed', '', $diagnostics );
 			}
 			if ( strlen( $css ) > self::CSS_LIMIT ) {
 				$diagnostics[] = self::diagnostic_with_detail(
@@ -743,6 +746,9 @@ final class Static_Site_Importer_Font_Materializer {
 				);
 			}
 			$embedded = self::embed_font_sources( $css, $families, $font_payloads, $font_payload_bytes, $diagnostics );
+			if ( is_wp_error( $embedded ) ) {
+				return $embedded;
+			}
 			if ( 'preserved' === $embedded['state'] ) {
 				if ( '' === (string) $embedded['url'] ) {
 					$embedded['url'] = $import;
@@ -760,8 +766,9 @@ final class Static_Site_Importer_Font_Materializer {
 	/** @param array<int,string> $families @param array<string,string> $payloads @param array<int,array<string,string>> $diagnostics
 	 *  @return array{state:'embedded',css:string}
 	 *          | array{state:'preserved',reason:string,observed_bytes:int,url:string,aggregate_bytes?:int}
+	 *          | WP_Error
 	 */
-	private static function embed_font_sources( string $css, array $families, array &$payloads, int &$payload_bytes, array &$diagnostics ): array {
+	private static function embed_font_sources( string $css, array $families, array &$payloads, int &$payload_bytes, array &$diagnostics ): array|WP_Error {
 		if ( ! preg_match_all( '/@font-face\s*\{([^{}]*)\}/is', $css, $faces ) ) {
 			$diagnostics[] = self::diagnostic_with_detail(
 				'stylesheet_font_faces_missing',
@@ -811,7 +818,7 @@ final class Static_Site_Importer_Font_Materializer {
 					$response = self::request( $url, self::FONT_LIMIT );
 					$payload  = is_wp_error( $response ) ? '' : (string) wp_remote_retrieve_body( $response );
 					$observed = strlen( $payload );
-					if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $payload || $observed > self::FONT_LIMIT ) {
+					if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) || '' === $payload ) {
 						$diagnostics[] = self::diagnostic_with_detail(
 							'font_payload_fetch_failed',
 							array(
@@ -820,9 +827,20 @@ final class Static_Site_Importer_Font_Materializer {
 								'limit_bytes'    => self::FONT_LIMIT,
 							)
 						);
+						return new WP_Error( 'static_site_importer_font_materialization_failed', '', $diagnostics );
+					}
+					if ( $observed > self::FONT_LIMIT ) {
+						$diagnostics[] = self::diagnostic_with_detail(
+							'font_payload_preserved_due_to_size',
+							array(
+								'url'            => $url,
+								'observed_bytes' => $observed,
+								'limit_bytes'    => self::FONT_LIMIT,
+							)
+						);
 						return array(
 							'state'          => 'preserved',
-							'reason'         => 'font_payload_fetch_failed',
+							'reason'         => 'font_payload_preserved_due_to_size',
 							'observed_bytes' => $observed,
 							'url'            => $url,
 						);
@@ -870,14 +888,14 @@ final class Static_Site_Importer_Font_Materializer {
 			'headers'             => array( 'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' ),
 		);
 		$response = null;
-		for ( $attempt = 1; $attempt <= 3; ++$attempt ) {
+		for ( $attempt = 1; $attempt <= self::REQUEST_ATTEMPTS; ++$attempt ) {
 			$response = wp_safe_remote_get( $url, $args );
 			$status   = is_wp_error( $response ) ? 0 : (int) wp_remote_retrieve_response_code( $response );
 			if ( ! is_wp_error( $response ) && 0 !== $status && ! in_array( $status, array( 408, 429 ), true ) && $status < 500 ) {
 				break;
 			}
-			if ( $attempt < 3 ) {
-				usleep( 100000 * $attempt );
+			if ( $attempt < self::REQUEST_ATTEMPTS ) {
+				usleep( self::RETRY_DELAY * $attempt );
 			}
 		}
 		return $response;

--- a/lib/fixture-matrix/collectors/visual-parity.mjs
+++ b/lib/fixture-matrix/collectors/visual-parity.mjs
@@ -68,6 +68,19 @@ export function collectVisualParityDiagnostics(payload, options = {}) {
   const { threshold, gate, offsetTolerance } = normalizeVisualParityGateOptions(options);
   const diagnostics = [];
   for (const comparison of collectVisualParityComparisons(payload, options)) {
+    const incompleteReadiness = normalizeArray(comparison.candidate_readiness_records).filter((record) => record.status !== 'ready');
+    if (incompleteReadiness.length > 0) {
+      diagnostics.push({
+        kind: 'visual_parity_evidence_incomplete',
+        loss_class: 'evidence_gap',
+        ...(gate ? { gate: true, visual_parity_gate: true } : {}),
+        source_path: comparison.source_path || '',
+        readiness_records: incompleteReadiness,
+        artifact_refs: visualParityArtifactRefs(comparison),
+        message: `Visual parity evidence is incomplete: required candidate readiness record(s) ${incompleteReadiness.map((record) => `${record.selector}=${record.status}`).join(', ')}. Pixel output is retained for diagnosis but is not classified as a product visual regression.`,
+      });
+      continue;
+    }
     const gateRatio = comparison.aligned_mismatch_ratio ?? comparison.mismatch_ratio;
     // Dimension mismatch is only a hard gate when we cannot measure a fair ratio
     // (no overlap region — e.g. a zero-area/failed capture).
@@ -382,6 +395,7 @@ function normalizeVisualParityComparison(value, options = {}) {
     candidate_dom_snapshot: firstRef([artifacts.candidate_dom_snapshot, artifactSlots.candidate_dom_snapshot, files.candidateDomSnapshot, obj.candidate_dom_snapshot, obj.candidateDomSnapshot]),
     visual_explanation: visualExplanation,
     mismatch_regions: mismatchRegions,
+    candidate_readiness_records: normalizeArray(firstObject([obj.captureDiagnostics, summary.captureDiagnostics, visualCompare.captureDiagnostics]).candidate?.effectiveCapture?.readiness?.records),
   };
   const aligned = options.alignment ? computeAlignedVisualParity(normalized, options) : null;
   const withAlignment = aligned ? { ...normalized, ...aligned } : normalized;

--- a/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -69,6 +69,7 @@ export function visualParityCompareStep(input = {}) {
         waitFor: options.waitFor,
         durationMs: options.duration,
         blockExternalRequests: options.blockExternalRequests,
+        candidateRequiredReadinessRecord: '#static-site-importer-font-readiness',
         threshold: options.pixelThreshold,
         ...(options.animatedMedia ? { animatedMedia: options.animatedMedia } : {}),
         ...(options.maxExplanationElements ? { maxExplanationElements: options.maxExplanationElements } : {}),

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -46,6 +46,7 @@
     { "path": "tests/smoke-visual-repair-css.php", "environment": "standalone-php" },
     { "path": "tests/smoke-webfont-producer-consumer.php", "environment": "standalone-php" },
     { "path": "tests/smoke-google-fonts-cap-fallback.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-google-fonts-retry-determinism.php", "environment": "standalone-php" },
     { "path": "tests/smoke-website-artifact-import-input.php", "environment": "standalone-php" },
     { "path": "tests/smoke-wordpress-site-plan-materializer.php", "environment": "standalone-php" },
     { "path": "tests/smoke-woo-product-seeder-rollback.php", "environment": "standalone-php" },

--- a/tests/form-materializer-topology.test.mjs
+++ b/tests/form-materializer-topology.test.mjs
@@ -3,6 +3,8 @@ import test from 'node:test';
 import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { JSDOM, VirtualConsole } from 'jsdom';
 
 const require = createRequire( import.meta.url );
@@ -26,7 +28,7 @@ const { getBlockType, parse, serialize, validateBlock } = require( '@wordpress/b
 
 registerCoreBlocks();
 
-const wpRoot = process.env.STATIC_SITE_IMPORTER_WP_ROOT || '/Users/chubes/Studio/intelligence-chubes4';
+const wpRoot = process.env.STATIC_SITE_IMPORTER_WP_ROOT || join( homedir(), 'Studio', 'intelligence-chubes4' );
 const hasWordPressBlockSerialization = existsSync( `${wpRoot}/wp-includes/class-wp-block-parser.php` ) && existsSync( `${wpRoot}/wp-includes/blocks.php` );
 
 test( 'shared-row topology materializes through the PHP provider adapter', { skip: !hasWordPressBlockSerialization }, () => {

--- a/tests/form-materializer-topology.test.mjs
+++ b/tests/form-materializer-topology.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
 import { JSDOM, VirtualConsole } from 'jsdom';
 
 const require = createRequire( import.meta.url );
@@ -25,7 +26,10 @@ const { getBlockType, parse, serialize, validateBlock } = require( '@wordpress/b
 
 registerCoreBlocks();
 
-test( 'shared-row topology materializes through the PHP provider adapter', () => {
+const wpRoot = process.env.STATIC_SITE_IMPORTER_WP_ROOT || '/Users/chubes/Studio/intelligence-chubes4';
+const hasWordPressBlockSerialization = existsSync( `${wpRoot}/wp-includes/class-wp-block-parser.php` ) && existsSync( `${wpRoot}/wp-includes/blocks.php` );
+
+test( 'shared-row topology materializes through the PHP provider adapter', { skip: !hasWordPressBlockSerialization }, () => {
 	const output = execFileSync( 'php', [ 'tests/form-materializer-smoke.php' ], {
 		cwd: process.cwd(),
 		encoding: 'utf8',
@@ -67,7 +71,7 @@ namespace {
 	assert.equal( output, 'static_site_importer_jetpack_forms_loader_missing' );
 } );
 
-test( 'provider-constrained topology emits nested fields and an editor-valid core submit', () => {
+test( 'provider-constrained topology emits nested fields and an editor-valid core submit', { skip: !hasWordPressBlockSerialization }, () => {
 	const output = execFileSync( 'php', [ 'tests/form-materializer-smoke.php', '--emit-topology-markup' ], {
 		cwd: process.cwd(),
 		encoding: 'utf8',

--- a/tests/smoke-google-fonts-retry-determinism.php
+++ b/tests/smoke-google-fonts-retry-determinism.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Deterministic Google Fonts retry coverage for #661.
+ *
+ * Transient stylesheet and font-payload failures are retried through the
+ * bounded request policy and must resolve to self-contained fonts. Exhausted
+ * retries fail closed with the specific diagnostic instead of preserving a
+ * remote @import fallback that would let visual parity score fallback fonts.
+ *
+ * Run: php tests/smoke-google-fonts-retry-determinism.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['ssi_retry_attempts']  = array();
+$GLOBALS['ssi_retry_responder'] = null;
+
+class WP_Error {
+	private string $code;
+	private mixed $data;
+	public function __construct( string $code, string $message = '', mixed $data = null ) { $this->code = $code; $this->data = $data; }
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_data(): mixed { return $this->data; }
+}
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+function wp_parse_url( string $url ) { return parse_url( $url ); }
+function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
+function wp_remote_retrieve_response_code( $response ): int { return is_array( $response ) ? (int) ( $response['response']['code'] ?? 0 ) : 0; }
+function wp_remote_retrieve_body( $response ): string { return is_array( $response ) ? (string) ( $response['body'] ?? '' ) : ''; }
+function wp_safe_remote_get( string $url, array $args ) {
+	$attempt                             = ( $GLOBALS['ssi_retry_attempts'][ $url ] ?? 0 ) + 1;
+	$GLOBALS['ssi_retry_attempts'][ $url ] = $attempt;
+	$responder                           = $GLOBALS['ssi_retry_responder'];
+	return is_callable( $responder ) ? $responder( $url, $attempt, $args ) : new WP_Error( 'unexpected_request' );
+}
+
+require dirname( __DIR__ ) . '/vendor/autoload.php';
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-font-materializer.php';
+
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+};
+
+$google_url    = 'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap';
+$woff2_url     = 'https://fonts.gstatic.com/s/inter/v1/inter-latin.woff2';
+$css_body      = "@font-face { font-family: 'Inter'; font-style: normal; font-weight: 400; src: url({$woff2_url}) format('woff2'); }\n@font-face { font-family: 'Inter'; font-style: normal; font-weight: 700; src: url({$woff2_url}) format('woff2'); }";
+$functions_php = array( 'target_path' => 'functions.php', 'payload' => array( 'encoding' => 'utf8', 'data' => '<?php' ) );
+$plan          = array(
+	'schema'      => 'blocks-engine/php-transformer/font-materialization-plan/v1',
+	'provider'    => 'google_fonts',
+	'fonts'       => array( array( 'family' => 'Inter' ) ),
+	'stylesheets' => array(
+		array(
+			'path'    => 'assets/css/fonts.css',
+			'content' => "@import url('" . $google_url . "');\n",
+		),
+	),
+);
+
+// Case 1: transient stylesheet failure (two failed attempts) followed by success embeds self-contained fonts.
+$GLOBALS['ssi_retry_attempts']  = array();
+$GLOBALS['ssi_retry_responder'] = static function ( string $url, int $attempt ) use ( $google_url, $woff2_url, $css_body ) {
+	if ( $url === $google_url ) {
+		return $attempt < 3 ? new WP_Error( 'http_request_failed' ) : array( 'response' => array( 'code' => 200 ), 'body' => $css_body );
+	}
+	if ( $url === $woff2_url ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => 'inter-font-payload' );
+	}
+	return new WP_Error( 'unexpected_request' );
+};
+$overlay_stylesheet = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan, array( 'writes' => array( $functions_php ) ) );
+$assert( ! is_wp_error( $overlay_stylesheet ), 'case 1: transient stylesheet failure recovers into embedded fonts' );
+$assert( 3 === ( $GLOBALS['ssi_retry_attempts'][ $google_url ] ?? 0 ), 'case 1: stylesheet request retries through the bounded policy before succeeding' );
+$css_writes = array_values( array_filter( $overlay_stylesheet['writes'] ?? array(), static fn( array $write ): bool => 'assets/css/embedded-fonts.css' === $write['target_path'] ) );
+$assert( 1 === count( $css_writes ), 'case 1: exactly one embedded-fonts.css write' );
+$assert( str_contains( $css_writes[0]['content'], 'data:font/woff2;base64,' ) && ! str_contains( $css_writes[0]['content'], '@import' ), 'case 1: embedded stylesheet is self-contained' );
+
+// Case 2: transient font-payload failure (two failed attempts) followed by success embeds self-contained fonts.
+$GLOBALS['ssi_retry_attempts']  = array();
+$GLOBALS['ssi_retry_responder'] = static function ( string $url, int $attempt ) use ( $google_url, $woff2_url, $css_body ) {
+	if ( $url === $google_url ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => $css_body );
+	}
+	if ( $url === $woff2_url ) {
+		return $attempt < 3 ? new WP_Error( 'http_request_failed' ) : array( 'response' => array( 'code' => 200 ), 'body' => 'inter-font-payload' );
+	}
+	return new WP_Error( 'unexpected_request' );
+};
+$overlay_payload = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan, array( 'writes' => array( $functions_php ) ) );
+$assert( ! is_wp_error( $overlay_payload ), 'case 2: transient font-payload failure recovers into embedded fonts' );
+$assert( 3 === ( $GLOBALS['ssi_retry_attempts'][ $woff2_url ] ?? 0 ), 'case 2: font payload request retries through the bounded policy before succeeding' );
+$css_writes_payload = array_values( array_filter( $overlay_payload['writes'] ?? array(), static fn( array $write ): bool => 'assets/css/embedded-fonts.css' === $write['target_path'] ) );
+$assert( 1 === count( $css_writes_payload ) && str_contains( $css_writes_payload[0]['content'], 'data:font/woff2;base64,' ), 'case 2: embedded stylesheet is self-contained after payload recovery' );
+
+// Case 3: exhausted stylesheet retries fail closed with the specific diagnostic retained.
+$GLOBALS['ssi_retry_attempts']  = array();
+$GLOBALS['ssi_retry_responder'] = static function ( string $url ) use ( $google_url ) {
+	return $url === $google_url ? new WP_Error( 'http_request_failed' ) : new WP_Error( 'unexpected_request' );
+};
+$overlay_exhausted_stylesheet = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan, array( 'writes' => array( $functions_php ) ) );
+$assert( is_wp_error( $overlay_exhausted_stylesheet ) && 'static_site_importer_font_materialization_failed' === $overlay_exhausted_stylesheet->get_error_code(), 'case 3: exhausted stylesheet retries produce an evidence failure' );
+$assert( 3 === ( $GLOBALS['ssi_retry_attempts'][ $google_url ] ?? 0 ), 'case 3: stylesheet request exhausts the bounded retry budget' );
+$stylesheet_diagnostics = $overlay_exhausted_stylesheet->get_error_data();
+$assert( is_array( $stylesheet_diagnostics ) && count( array_filter( $stylesheet_diagnostics, static fn( array $row ): bool => 'stylesheet_fetch_failed' === ( $row['reason'] ?? '' ) ) ) >= 1, 'case 3: retains the stylesheet_fetch_failed diagnostic' );
+
+// Case 4: exhausted font-payload retries fail closed with the specific diagnostic retained.
+$GLOBALS['ssi_retry_attempts']  = array();
+$GLOBALS['ssi_retry_responder'] = static function ( string $url ) use ( $google_url, $woff2_url, $css_body ) {
+	if ( $url === $google_url ) {
+		return array( 'response' => array( 'code' => 200 ), 'body' => $css_body );
+	}
+	return $url === $woff2_url ? new WP_Error( 'http_request_failed' ) : new WP_Error( 'unexpected_request' );
+};
+$overlay_exhausted_payload = Static_Site_Importer_Font_Materializer::prepare_overlay( $plan, array( 'writes' => array( $functions_php ) ) );
+$assert( is_wp_error( $overlay_exhausted_payload ) && 'static_site_importer_font_materialization_failed' === $overlay_exhausted_payload->get_error_code(), 'case 4: exhausted font-payload retries produce an evidence failure' );
+$assert( 3 === ( $GLOBALS['ssi_retry_attempts'][ $woff2_url ] ?? 0 ), 'case 4: font-payload request exhausts the bounded retry budget' );
+$payload_diagnostics = $overlay_exhausted_payload->get_error_data();
+$assert( is_array( $payload_diagnostics ) && count( array_filter( $payload_diagnostics, static fn( array $row ): bool => 'font_payload_fetch_failed' === ( $row['reason'] ?? '' ) ) ) >= 1, 'case 4: retains the font_payload_fetch_failed diagnostic' );
+
+echo "Google Fonts retry determinism smoke passed.\n";

--- a/tests/smoke-product-materializer.php
+++ b/tests/smoke-product-materializer.php
@@ -88,6 +88,10 @@ namespace {
 		require_once $parser;
 		require_once $blocks;
 	}
+	if ( ! function_exists( 'serialize_blocks' ) ) {
+		fwrite( STDERR, "SKIP: WordPress block serialization is unavailable. Set STATIC_SITE_IMPORTER_WP_ROOT.\n" );
+		exit( 0 );
+	}
 
 	// --- WooCommerce runtime mock ------------------------------------------------
 	// Captures the seeded simple products so the smoke test can assert the prices

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -249,10 +249,17 @@ function wp_parse_args( $args, array $defaults = array() ): array {
 }
 
 $wp_root = getenv( 'STATIC_SITE_IMPORTER_WP_ROOT' ) ?: '/Users/chubes/Studio/intelligence-chubes4';
-require_once rtrim( $wp_root, '/\\' ) . '/wp-includes/class-wp-block-parser.php';
-require_once rtrim( $wp_root, '/\\' ) . '/wp-includes/class-wp-block-type.php';
-require_once rtrim( $wp_root, '/\\' ) . '/wp-includes/class-wp-block-type-registry.php';
-require_once rtrim( $wp_root, '/\\' ) . '/wp-includes/blocks.php';
+$wp_includes = rtrim( $wp_root, '/\\' ) . '/wp-includes/';
+$core_files  = array( 'class-wp-block-parser.php', 'class-wp-block-type.php', 'class-wp-block-type-registry.php', 'blocks.php' );
+foreach ( $core_files as $core_file ) {
+	if ( ! is_readable( $wp_includes . $core_file ) ) {
+		fwrite( STDERR, "SKIP: WordPress parser/serializer files are unavailable. Set STATIC_SITE_IMPORTER_WP_ROOT.\n" );
+		exit( 0 );
+	}
+}
+foreach ( $core_files as $core_file ) {
+	require_once $wp_includes . $core_file;
+}
 
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-font-materializer.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-document-type-classifier.php';

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -7059,9 +7059,9 @@ test('visual attribution options normalize positive limits and targeted selector
   });
 });
 
-test('visual attribution defaults leave visual-compare matrix JSON byte-compatible', () => {
+test('visual parity defaults require the candidate font readiness record', () => {
   const step = visualParityCompareStep({ fixture: { id: 'shop' } });
-  assert.equal(step.args[0], 'matrix-json={"comparisons":[{"name":"shop","sourceUrl":"/wp-content/uploads/static-site-importer-fixture-matrix/shop/source/index.html","candidateUrl":"/","sourceLabel":"shop-source","candidateLabel":"shop-candidate","viewport":"1280x1600","fullPage":true,"waitFor":"duration","durationMs":"4000ms","blockExternalRequests":true,"threshold":0}]}');
+  assert.equal(step.args[0], 'matrix-json={"comparisons":[{"name":"shop","sourceUrl":"/wp-content/uploads/static-site-importer-fixture-matrix/shop/source/index.html","candidateUrl":"/","sourceLabel":"shop-source","candidateLabel":"shop-candidate","viewport":"1280x1600","fullPage":true,"waitFor":"duration","durationMs":"4000ms","blockExternalRequests":true,"candidateRequiredReadinessRecord":"#static-site-importer-font-readiness","threshold":0}]}');
 });
 
 test('visual attribution options reach every fixture matrix comparison', () => {
@@ -8155,6 +8155,27 @@ test('visual-compare dimension mismatch gates even with zero pixel metrics when 
   const diagnostics = collectVisualParityDiagnostics(payload, { gate: true });
   assert.equal(diagnostics.length, 1);
   assert.equal(diagnostics[0].dimension_mismatch, true);
+});
+
+test('required candidate readiness failure is an evidence gap, not a pixel regression', () => {
+  const payload = {
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: { mismatchPixels: 200, totalPixels: 1000, dimensionMismatch: false },
+    captureDiagnostics: {
+      candidate: {
+        effectiveCapture: {
+          readiness: {
+            records: [{ selector: '#static-site-importer-font-readiness', expectedStatus: 'loaded', observedStatus: 'missing', status: 'invalid' }],
+          },
+        },
+      },
+    },
+  };
+  const diagnostics = collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true });
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].kind, 'visual_parity_evidence_incomplete');
+  assert.equal(diagnostics[0].loss_class, 'evidence_gap');
+  assert.equal(diagnostics[0].visual_parity_gate, true);
 });
 
 test('(fair) dimension-dominated raw ratio does NOT gate when the overlap is faithful', () => {

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -83,7 +83,7 @@ test('pins an immutable WP Codebox release package, commit, and checksum togethe
   assert.match(workflow, /sha256sum --check --status/);
   assert.doesNotMatch(workflow, /Checkout WP Codebox candidate|npm pack --pack-destination|wp-codebox-sha:/);
   assert.match(workflow, /wpCodeboxSha:process\.env\.WP_CODEBOX_SHA/);
-  assert.match(caller, /blocks-engine-sha: 7858943a9913175993cc75870551c2e1926b4fb0/);
+  assert.match(caller, /blocks-engine-sha: e32b74191771be44af5357c26aaff46ef98bc1ce/);
   assert.doesNotMatch(caller, /wp-codebox-sha:/);
 });
 


### PR DESCRIPTION
## Summary

- reuse the bounded, fail-closed Google Fonts retry repair from #942
- require the candidate's SSI-owned font readiness record during fixture visual capture
- retain screenshot artifacts while classifying missing or invalid font readiness as a gated `evidence_gap`, never a product pixel regression
- emit a readiness record for every materialized theme so no-font candidates prove their ready state too

Fixes #661.
Depends on Automattic/wp-codebox#2313. Supersedes #942.

## Verification

- `php tests/smoke-google-fonts-retry-determinism.php`
- `php tests/smoke-webfont-producer-consumer.php`
- `node --test tools/fixture-matrix.test.mjs` (278 passed)
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reused the existing retry candidate, implemented the readiness-evidence classification and integration, and ran the focused verification. Chris Huber remains responsible for every line.
