### PR TITLE
Fix shared bounded URL rewriting

### DIFF
--- a/includes/class-static-site-importer-classic-theme-projection.php
+++ b/includes/class-static-site-importer-classic-theme-projection.php
@@ -11,6 +11,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Document' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-document.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Srcset_Parser' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-srcset-parser.php';
+}
 
 final class Static_Site_Importer_Classic_Theme_Projection {
 	/** Build render-neutral source fragments before compiler block conversion. */
@@ -437,17 +440,16 @@ final class Static_Site_Importer_Classic_Theme_Projection {
 	private static function safe_url( string $url ): bool {
 		return ! preg_match( '/^(?:javascript|vbscript|data:text\/html)/i', self::canonical_url( $url ) ); }
 	private static function safe_srcset( string $srcset ): string {
-		return implode( ', ', array_filter( array_map( static fn( string $candidate ): string => self::safe_url( (string) ( preg_split( '/\s+/', trim( $candidate ), 2 )[0] ?? '' ) ) ? trim( $candidate ) : '', explode( ',', $srcset ) ) ) ); }
+		return implode( ', ', array_filter( array_map( static fn( array $candidate ): string => self::safe_url( $candidate['url'] ) ? trim( $candidate['url'] . ' ' . $candidate['descriptor'] ) : '', Static_Site_Importer_Srcset_Parser::parse( $srcset ) ) ) ); }
 	private static function rewrite_srcset( string $srcset, string $dir, array $assets, array $routes ): string {
 		return implode(
 			', ',
 			array_filter(
 				array_map(
-					static function ( string $candidate ) use ( $dir, $assets, $routes ): string {
-						$parts = preg_split( '/\s+/', trim( $candidate ), 2 );
-						return self::safe_url( $parts[0] ?? '' ) ? self::replacement( $parts[0] ?? '', $dir, $assets, $routes ) . ( isset( $parts[1] ) ? ' ' . $parts[1] : '' ) : '';
+					static function ( array $candidate ) use ( $dir, $assets, $routes ): string {
+						return self::safe_url( $candidate['url'] ) ? self::replacement( $candidate['url'], $dir, $assets, $routes ) . ( '' !== $candidate['descriptor'] ? ' ' . $candidate['descriptor'] : '' ) : '';
 					},
-					explode( ',', $srcset )
+					Static_Site_Importer_Srcset_Parser::parse( $srcset )
 				)
 			)
 		); }

--- a/includes/class-static-site-importer-srcset-parser.php
+++ b/includes/class-static-site-importer-srcset-parser.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Bounded srcset candidate parsing shared by importer collection and projection.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class Static_Site_Importer_Srcset_Parser {
+	/**
+	 * Parse srcset candidates without treating URL-internal commas as separators.
+	 *
+	 * @return array<int,array{url:string,descriptor:string}>
+	 */
+	public static function parse( string $srcset ): array {
+		$candidates = array();
+		$length     = strlen( $srcset );
+		$offset     = 0;
+		while ( $offset < $length ) {
+			while ( $offset < $length && ( ctype_space( $srcset[ $offset ] ) || ',' === $srcset[ $offset ] ) ) {
+				++$offset;
+			}
+			if ( $offset >= $length ) {
+				break;
+			}
+			$start = $offset;
+			while ( $offset < $length && ! ctype_space( $srcset[ $offset ] ) ) {
+				++$offset;
+			}
+			$url = substr( $srcset, $start, $offset - $start );
+			while ( $offset < $length && ctype_space( $srcset[ $offset ] ) ) {
+				++$offset;
+			}
+			$descriptor_start = $offset;
+			while ( $offset < $length && ',' !== $srcset[ $offset ] ) {
+				++$offset;
+			}
+			if ( '' !== $url ) {
+				$candidates[] = array(
+					'url'        => $url,
+					'descriptor' => trim( substr( $srcset, $descriptor_start, $offset - $descriptor_start ) ),
+				);
+			}
+		}
+		return $candidates;
+	}
+}

--- a/includes/class-static-site-importer-stylesheet-materializer.php
+++ b/includes/class-static-site-importer-stylesheet-materializer.php
@@ -10,6 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/class-static-site-importer-provider-layout-overlay.php';
+if ( ! class_exists( '\\Automattic\\BlocksEngine\\PhpTransformer\\AssetAnalysis\\CssUrlRewriter' ) ) {
+	require_once dirname( __DIR__ ) . '/vendor/automattic/blocks-engine-php-transformer/src/AssetAnalysis/CssUrlRewriter.php';
+}
 
 /**
  * Builds generated theme stylesheet write payloads.
@@ -100,22 +103,21 @@ class Static_Site_Importer_Stylesheet_Materializer {
 			return $css;
 		}
 
-		return (string) preg_replace_callback(
-			'#url\(\s*(["\']?)([^)"\']+)\1\s*\)#i',
-			static function ( array $matches ) use ( $replacements ): string {
-				$raw = trim( (string) $matches[2] );
+		return \Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\CssUrlRewriter::rewrite(
+			$css,
+			static function ( string $raw ) use ( $replacements ): string {
+				$raw = trim( $raw );
 				if ( '' === $raw || preg_match( '#^(?:data:|https?://|//)#i', $raw ) ) {
-					return $matches[0];
+					return $raw;
 				}
 
 				$key = self::normalize_css_asset_ref( $raw );
 				if ( '' === $key || ! isset( $replacements[ $key ] ) ) {
-					return $matches[0];
+					return $raw;
 				}
 
-				return 'url("' . esc_url_raw( $replacements[ $key ] ) . '")';
-			},
-			$css
+				return esc_url_raw( $replacements[ $key ] );
+			}
 		);
 	}
 
@@ -153,7 +155,7 @@ class Static_Site_Importer_Stylesheet_Materializer {
 		$ref = preg_replace( '#/+#', '/', (string) $ref );
 		$ref = trim( (string) $ref, '/' );
 
-		return preg_match( '#^[A-Za-z0-9_./-]+$#', $ref ) ? $ref : '';
+		return preg_match( '#^[A-Za-z0-9_./,-]+$#', $ref ) ? $ref : '';
 	}
 
 	/**

--- a/includes/class-static-site-importer-url-site-collector.php
+++ b/includes/class-static-site-importer-url-site-collector.php
@@ -9,6 +9,12 @@
 if ( ! class_exists( 'Static_Site_Importer_Source_Normalizer' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-source-normalizer.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Srcset_Parser' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-srcset-parser.php';
+}
+if ( ! class_exists( '\\Automattic\\BlocksEngine\\PhpTransformer\\AssetAnalysis\\CssUrlRewriter' ) ) {
+	require_once dirname( __DIR__ ) . '/vendor/automattic/blocks-engine-php-transformer/src/AssetAnalysis/CssUrlRewriter.php';
+}
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -862,8 +868,8 @@ class Static_Site_Importer_URL_Site_Collector {
 			}
 		}
 		foreach ( self::tag_attribute_values( $html, 'img|source', 'srcset' ) as $srcset ) {
-			foreach ( explode( ',', (string) $srcset ) as $candidate ) {
-				$reference = preg_split( '/\s+/', trim( $candidate ) )[0] ?? '';
+			foreach ( Static_Site_Importer_Srcset_Parser::parse( (string) $srcset ) as $candidate ) {
+				$reference = $candidate['url'];
 				$url       = self::resolve_url( $reference, $base_url );
 				if ( '' !== $url ) {
 					$urls[] = $url;
@@ -1079,11 +1085,10 @@ class Static_Site_Importer_URL_Site_Collector {
 			'#\bsrcset\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))#is',
 			static function ( array $matches ) use ( $base_url, $source_path, $paths, $external_assets ): string {
 				$candidates = array();
-				foreach ( explode( ',', self::matched_attribute_value( $matches, 1 ) ) as $candidate ) {
-					$parts        = preg_split( '/\s+/', trim( $candidate ), 2 );
-					$url          = self::resolve_url( $parts[0] ?? '', $base_url );
-					$ref          = isset( $paths[ $url ] ) ? self::relative_path( $source_path, $paths[ $url ] ) : ( isset( $external_assets[ $url ] ) ? self::external_asset_url( $url, (string) ( $parts[0] ?? '' ) ) : ( $parts[0] ?? '' ) );
-					$candidates[] = trim( $ref . ' ' . ( $parts[1] ?? '' ) );
+				foreach ( Static_Site_Importer_Srcset_Parser::parse( self::matched_attribute_value( $matches, 1 ) ) as $candidate ) {
+					$url          = self::resolve_url( $candidate['url'], $base_url );
+					$ref          = isset( $paths[ $url ] ) ? self::relative_path( $source_path, $paths[ $url ] ) : ( isset( $external_assets[ $url ] ) ? self::external_asset_url( $url, $candidate['url'] ) : $candidate['url'] );
+					$candidates[] = trim( $ref . ' ' . $candidate['descriptor'] );
 				}
 				return 'srcset="' . implode( ', ', $candidates ) . '"';
 			},
@@ -1094,13 +1099,12 @@ class Static_Site_Importer_URL_Site_Collector {
 
 	/** @param array<string,string> $paths */
 	private static function rewrite_css( string $css, string $base_url, string $source_path, array $paths, array $external_assets = array() ): string {
-		$css = (string) preg_replace_callback(
-			'#url\(\s*(["\']?)(.*?)\1\s*\)#is',
-			static function ( array $matches ) use ( $base_url, $source_path, $paths, $external_assets ): string {
-				$url = self::resolve_url( $matches[2], $base_url );
-				return isset( $paths[ $url ] ) ? 'url(' . $matches[1] . self::relative_path( $source_path, $paths[ $url ] ) . $matches[1] . ')' : ( isset( $external_assets[ $url ] ) ? 'url(' . $matches[1] . self::external_asset_url( $url, $matches[2] ) . $matches[1] . ')' : $matches[0] );
-			},
-			$css
+		$css = \Automattic\BlocksEngine\PhpTransformer\AssetAnalysis\CssUrlRewriter::rewrite(
+			$css,
+			static function ( string $reference ) use ( $base_url, $source_path, $paths, $external_assets ): string {
+				$url = self::resolve_url( $reference, $base_url );
+				return isset( $paths[ $url ] ) ? self::relative_path( $source_path, $paths[ $url ] ) : ( isset( $external_assets[ $url ] ) ? self::external_asset_url( $url, $reference ) : $reference );
+			}
 		);
 		return (string) preg_replace_callback(
 			'#@import\s+(["\'])(.*?)\1#is',

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -49,6 +49,7 @@ foreach ( $static_site_importer_figma_transformers as $static_site_importer_figm
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-site-identity.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-website-artifact-import-input.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-materialization-strategy.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-srcset-parser.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-classic-theme-projection.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-client-script-policy.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document.php';

--- a/tests/smoke-managed-classic-theme-materialization.php
+++ b/tests/smoke-managed-classic-theme-materialization.php
@@ -155,6 +155,18 @@ $unsafe_projection = Static_Site_Importer_Classic_Theme_Projection::build(
 );
 $unsafe_html       = $unsafe_projection['pages']['index.html']['html'] ?? '';
 $assert( ! is_wp_error( $unsafe_projection ) && ! str_contains( strtolower( $unsafe_html ), 'javascript:' ) && ! str_contains( strtolower( $unsafe_html ), '@import' ) && str_contains( $unsafe_html, '[artifact_shortcode]' ), 'hostile encoded URL and CSS schemes fail closed while artifact shortcode syntax remains inert text' );
+$srcset_projection = Static_Site_Importer_Classic_Theme_Projection::build(
+	array(
+		'entrypoint' => 'index.html',
+		'files'      => array( 'index.html' => '<main><img srcset="assets/hero,wide.png 1x, data:image/png;base64,AA== 2x"></main>' ),
+	),
+	array(
+		'source' => array( 'entry_path' => 'index.html' ),
+		'pages'  => array( array( 'source_path' => 'index.html' ) ),
+	)
+);
+$srcset_html = (string) ( $srcset_projection['pages']['index.html']['html'] ?? '' );
+$assert( ! is_wp_error( $srcset_projection ) && str_contains( $srcset_html, 'assets/hero,wide.png 1x' ) && str_contains( $srcset_html, 'data:image/png;base64,AA== 2x' ), 'classic projection preserves data URLs and URL-internal commas in srcset candidates' );
 $smil_projection = Static_Site_Importer_Classic_Theme_Projection::build(
 	array(
 		'entrypoint' => 'index.html',

--- a/tests/smoke-url-site-collector.php
+++ b/tests/smoke-url-site-collector.php
@@ -663,6 +663,27 @@ $assert( in_array( 'https://redirect.test/assets/background.png', $redirect_requ
 $assert( in_array( 'website/docs/index.html', $redirect_paths, true ) && in_array( 'website/assets/css/style.css', $redirect_paths, true ), 'redirected-resources-use-final-identities' );
 $assert( str_contains( (string) ( $redirect_files['website/index.html']['content'] ?? '' ), 'href="/docs/"' ), 'redirected-page-link-rewritten-to-final-route' );
 
+$srcset_requests = array();
+$srcset_result = Static_Site_Importer_URL_Site_Collector::collect(
+	'https://srcset.test/',
+	array( 'request_delay_ms' => 0 ),
+	static function ( string $url, array $args ) use ( &$srcset_requests ) {
+		unset( $args );
+		$srcset_requests[] = $url;
+		if ( 'https://srcset.test/' === $url ) {
+			return array( 'body' => '<main><img srcset="/images/hero,wide.png 1x, data:image/png;base64,AA== 2x"></main>', 'metadata' => array( 'content_type' => 'text/html', 'final_url' => $url ) );
+		}
+		if ( 'https://srcset.test/images/hero,wide.png' === $url ) {
+			return array( 'body' => "\x89PNGsrcset", 'metadata' => array( 'content_type' => 'image/png', 'final_url' => $url ) );
+		}
+		return new WP_Error( 'unexpected_srcset_request', $url );
+	}
+);
+$srcset_files = array_column( $srcset_result['artifact']['files'] ?? array(), null, 'path' );
+$srcset_html  = (string) ( $srcset_files['website/index.html']['content'] ?? '' );
+$assert( ! is_wp_error( $srcset_result ) && in_array( 'https://srcset.test/images/hero,wide.png', $srcset_requests, true ) && ! in_array( 'https://srcset.test/images/hero', $srcset_requests, true ), 'collector-keeps-url-internal-commas-in-srcset-candidates' );
+$assert( str_contains( $srcset_html, 'data:image/png;base64,AA== 2x' ) && str_contains( $srcset_html, 'hero-wide.png 1x' ), 'collector-preserves-data-url-srcset-candidates-during-rewrite' );
+
 if ( ! empty( $failures ) ) {
 	fwrite( STDERR, implode( PHP_EOL, $failures ) . PHP_EOL );
 	exit( 1 );

--- a/tests/smoke-visual-repair-css.php
+++ b/tests/smoke-visual-repair-css.php
@@ -16,7 +16,11 @@ if ( ! function_exists( 'trailingslashit' ) ) {
 if ( ! function_exists( 'wp_json_encode' ) ) {
 	function wp_json_encode( mixed $value, int $flags = 0 ): string|false { return json_encode( $value, $flags ); }
 }
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( string $url ): string { return $url; }
+}
 
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-provider-layout-overlay.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-stylesheet-materializer.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php';
@@ -45,5 +49,13 @@ $forged = $overlay;
 $forged['css'] = "/* Static Site Importer provider layout overlay: abcdef123456 */\nbody{background:url(https://example.test/x)}\n";
 $forged_writes = Static_Site_Importer_Stylesheet_Materializer::stylesheet_writes( '/tmp/visual-repair-smoke', 'Visual Repair Smoke', '.hero{}', array(), array(), array( $forged ) );
 $assert( ! str_contains( $forged_writes['/tmp/visual-repair-smoke/style.css'], 'example.test' ), 'Forged provider overlay CSS is rejected at stylesheet admission.' );
+$asset_writes = Static_Site_Importer_Stylesheet_Materializer::stylesheet_writes(
+	'/tmp/visual-repair-smoke',
+	'Visual Repair Smoke',
+	'.hero{background:url("images/hero,wide.png")} .data{background:url(data:image/png;base64,AA==)}',
+	array( 'images/hero,wide.png' => array( 'final_url' => 'https://example.test/hero.png' ) ),
+	array()
+);
+$assert( str_contains( $asset_writes['/tmp/visual-repair-smoke/style.css'], 'url("https://example.test/hero.png")' ) && str_contains( $asset_writes['/tmp/visual-repair-smoke/style.css'], 'url(data:image/png;base64,AA==)' ), 'stylesheet URL rewriter preserves data URLs and rewrites comma-bearing asset paths.' );
 
 echo 'PASS smoke-visual-repair-css.php (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary
- use one bounded srcset parser for URL collection and classic projection
- delegate collector and stylesheet CSS url() rewriting to Blocks Engine
- cover data URLs and URL-internal commas across collector, stylesheet, and classic paths

## Tests
- `composer install --no-interaction --prefer-dist`
- `npm ci`
- `php tests/smoke-shared-resource-plan.php`
- `php tests/smoke-url-site-collector.php`
- `php tests/smoke-managed-classic-theme-materialization.php`
- `php tests/smoke-visual-repair-css.php`
- `git diff --check`
- `npm test` completed 58 selected checks; one unrelated existing assertion failed in `tools/verify-solved-site-promotion.test.mjs` because the workflow pins a different Blocks Engine SHA than the test expects.
- `homeboy review lint --extension wordpress` was not run: Homeboy refused it under host resource policy (hot host and no ready Lab runner).

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode traced the importer rewrite paths, implemented the shared parser and shared CSS rewriter integration, and added regression coverage. Chris Huber directed the work and remains responsible for the change.