### PR TITLE
Canonicalize validation report paths

### DIFF
--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -374,11 +374,12 @@ class Static_Site_Importer_Validation_Runtime {
 		}
 
 		$created = function_exists( 'wp_mkdir_p' ) ? wp_mkdir_p( $directory ) : false;
-		if ( ! $created ) {
+		$resolved = $created ? realpath( $directory ) : false;
+		if ( false === $resolved || ! is_dir( $resolved ) ) {
 			return new WP_Error( 'static_site_importer_validation_artifact_dir_failed', 'Could not create validation artifact directory.' );
 		}
 
-		return $directory;
+		return $resolved;
 	}
 
 	/**

--- a/tests/smoke-validation-runtime-diagnostics.php
+++ b/tests/smoke-validation-runtime-diagnostics.php
@@ -126,6 +126,18 @@ $artifact_dir = sys_get_temp_dir() . '/ssi-validation-runtime-diagnostics-' . un
 mkdir( $artifact_dir, 0777, true );
 $report_path = $artifact_dir . '/import-report.json';
 
+$physical_artifact_root = $artifact_dir . '/physical';
+$aliased_artifact_root  = $artifact_dir . '/aliased';
+mkdir( $physical_artifact_root );
+if ( function_exists( 'symlink' ) && symlink( $physical_artifact_root, $aliased_artifact_root ) ) {
+	$artifact_dir_method = new ReflectionMethod( Static_Site_Importer_Validation_Runtime::class, 'artifact_dir' );
+	$resolved_artifact_dir = $artifact_dir_method->invoke( null, array( 'artifact_dir' => $aliased_artifact_root . '/validation' ), 'fixture' );
+	$assert( realpath( $physical_artifact_root . '/validation' ) === $resolved_artifact_dir, 'validation-artifact-directory-resolves-symlinked-ancestor' );
+	rmdir( $physical_artifact_root . '/validation' );
+	unlink( $aliased_artifact_root );
+}
+rmdir( $physical_artifact_root );
+
 file_put_contents(
 	$report_path,
 	json_encode(


### PR DESCRIPTION
## Summary

- resolve validation artifact directories to their physical filesystem path after creation
- keep the strict external report destination policy intact while supporting system path aliases such as macOS `/var` to `/private/var`
- cover validation directories reached through a symlinked ancestor

Follow-up to #1092. Unblocks end-to-end acceptance for Automattic/blocks-engine#1010.

## Root cause

Studio reports its uploads path beneath `/var`, which is a system symlink on macOS. Validation created the artifact directory successfully, then passed the aliased path to the external report preflight, which rejects every symlinked ancestor and returned `report_destination_not_ready`.

## Verification

- `php tests/smoke-validation-runtime-diagnostics.php` (38 assertions)
- `php tests/smoke-external-report-destinations.php`
- direct PHP syntax checks
- `npm test`: 58 manifest targets passed; the sole failure is the existing solved-site promotion test expecting Blocks Engine SHA `7858943a...` while workflow config pins `e32b7419...`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the Studio failure, traced the destination preflight, implemented the physical-path normalization and regression coverage, and ran the repository gates. Chris Huber is responsible for every line.