### PR TITLE
Preserve declared artifact report paths

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1029,7 +1029,9 @@ function static_site_importer_source_runtime( array $source ) {
 		);
 	}
 
-	$files = array();
+	$files        = array();
+	$metadata     = isset( $source['metadata'] ) && is_array( $source['metadata'] ) ? $source['metadata'] : array();
+	$report_paths = isset( $metadata['reports'] ) && is_array( $metadata['reports'] ) ? $metadata['reports'] : array();
 
 	if ( isset( $source['html'] ) && '' !== trim( (string) $source['html'] ) ) {
 		$files[] = array(
@@ -1044,7 +1046,7 @@ function static_site_importer_source_runtime( array $source ) {
 				continue;
 			}
 
-			$path = isset( $file['path'] ) ? static_site_importer_rest_artifact_path( (string) $file['path'] ) : '';
+			$path = isset( $file['path'] ) ? static_site_importer_rest_source_file_path( (string) $file['path'], $report_paths ) : '';
 			if ( '' === $path ) {
 				continue;
 			}
@@ -1107,8 +1109,6 @@ function static_site_importer_source_runtime( array $source ) {
 	if ( '' === $entrypoint || ! in_array( $entrypoint, array_column( $files, 'path' ), true ) ) {
 		$entrypoint = static_site_importer_rest_entrypoint( $files );
 	}
-
-	$metadata = isset( $source['metadata'] ) && is_array( $source['metadata'] ) ? $source['metadata'] : array();
 
 	$artifact      = array_merge(
 		$metadata,
@@ -1551,16 +1551,50 @@ function static_site_importer_rest_archive_limit_error( string $reason ): WP_Err
  * @return string
  */
 function static_site_importer_rest_artifact_path( string $path ): string {
-	$path = str_replace( '\\', '/', $path );
-	$path = preg_replace( '#(^|/)\.\.(?=/|$)#', '', $path );
-	$path = ltrim( (string) $path, '/' );
-	$path = preg_replace( '#/+#', '/', $path );
+	$path = static_site_importer_rest_normalize_artifact_path( $path );
 
 	if ( '' === $path ) {
 		return '';
 	}
 
 	return str_starts_with( $path, 'website/' ) ? $path : 'website/' . $path;
+}
+
+/**
+ * Normalize a source file path while preserving paths declared by an artifact report manifest.
+ *
+ * @param string       $path         File path.
+ * @param array<mixed> $report_paths Artifact report paths.
+ * @return string
+ */
+function static_site_importer_rest_source_file_path( string $path, array $report_paths ): string {
+	$path = static_site_importer_rest_normalize_artifact_path( $path );
+	if ( '' === $path ) {
+		return '';
+	}
+
+	foreach ( $report_paths as $report_path ) {
+		if ( is_string( $report_path ) && $path === static_site_importer_rest_normalize_artifact_path( $report_path ) ) {
+			return $path;
+		}
+	}
+
+	return static_site_importer_rest_artifact_path( $path );
+}
+
+/**
+ * Normalize a relative artifact path without assigning it to the website root.
+ *
+ * @param string $path File path.
+ * @return string
+ */
+function static_site_importer_rest_normalize_artifact_path( string $path ): string {
+	$path = str_replace( '\\', '/', $path );
+	$path = preg_replace( '#(^|/)\.\.(?=/|$)#', '', $path );
+	$path = ltrim( (string) $path, '/' );
+	$path = preg_replace( '#/+#', '/', $path );
+
+	return (string) $path;
 }
 
 /**

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1574,7 +1574,7 @@ function static_site_importer_rest_source_file_path( string $path, array $report
 	}
 
 	foreach ( $report_paths as $report_path ) {
-		if ( is_string( $report_path ) && $path === static_site_importer_rest_normalize_artifact_path( $report_path ) ) {
+		if ( is_string( $report_path ) && static_site_importer_rest_normalize_artifact_path( $report_path ) === $path ) {
 			return $path;
 		}
 	}

--- a/tests/smoke-rest-url-import-helpers.php
+++ b/tests/smoke-rest-url-import-helpers.php
@@ -60,6 +60,15 @@ if ( ! function_exists( 'home_url' ) ) {
 	function home_url( $path = '/' ) { return 'https://current-site.test' . $path; }
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Content_Policy' ) ) {
+	class Static_Site_Importer_Content_Policy {
+		public static function validate_artifact( array $artifact ): true {
+			unset( $artifact );
+			return true;
+		}
+	}
+}
+
 $GLOBALS['ssi_ability_results']  = array();
 $GLOBALS['ssi_ability_last_input'] = null;
 
@@ -78,6 +87,25 @@ if ( ! function_exists( 'wp_get_ability' ) ) {
 }
 
 require_once dirname( __DIR__ ) . '/includes/rest.php';
+
+$report_paths = array( 'interaction-states.json', 'reports/capture.json' );
+$assert( 'interaction-states.json' === static_site_importer_rest_source_file_path( 'interaction-states.json', $report_paths ), 'declared-root-report-path-is-preserved' );
+$assert( 'reports/capture.json' === static_site_importer_rest_source_file_path( 'reports/capture.json', $report_paths ), 'declared-nested-report-path-is-preserved' );
+$assert( 'website/index.html' === static_site_importer_rest_source_file_path( 'index.html', $report_paths ), 'ordinary-source-file-remains-website-rooted' );
+$assert( 'website/interaction-states.json' === static_site_importer_rest_source_file_path( 'interaction-states.json', array() ), 'undeclared-report-like-file-remains-website-rooted' );
+$artifact_runtime = static_site_importer_source_runtime(
+	array(
+		'entrypoint' => 'website/index.html',
+		'metadata'   => array( 'reports' => $report_paths ),
+		'files'      => array(
+			array( 'path' => 'website/index.html', 'content' => '<main>Example</main>' ),
+			array( 'path' => 'interaction-states.json', 'content' => '{}' ),
+			array( 'path' => 'diagnostics.json', 'content' => '{}' ),
+		),
+	)
+);
+$artifact_paths = is_array( $artifact_runtime ) ? array_column( $artifact_runtime['artifact']['files'] ?? array(), 'path' ) : array();
+$assert( array( 'website/index.html', 'interaction-states.json', 'website/diagnostics.json' ) === $artifact_paths, 'source-runtime-preserves-only-declared-report-paths' );
 
 $continuation_envelope = array(
 	'success'               => true,


### PR DESCRIPTION
## Summary
- Preserve file paths explicitly declared by a canonical artifact `metadata.reports` manifest.
- Keep existing `website/` normalization for ordinary source files.
- Cover root reports, nested reports, undeclared report-like files, and the complete source-runtime projection.

Closes #1175.

## Why

Studio URL capture emits canonical interaction reports such as `interaction-states.json`. File-source normalization moved those reports under `website/`, so Blocks Engine could not discover captured dialogs and SSI omitted the generated companion plugin.

This change keeps the artifact contract intact while preserving existing behavior for all files not explicitly declared as reports.

## Verification
- `php tests/smoke-rest-url-import-helpers.php` (30 assertions)
- `npm test` (59 selected commands, zero failures)
- Real `studio site create --from artifact.json` import: 17 pages, 15 captured dialogs, 15 Jetpack forms, zero `core/html`, zero unknown blocks, and zero serialization mismatches.

## AI assistance
- **Model/tool:** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Root-cause tracing across Studio, SSI, and Blocks Engine; implementation; regression coverage; package construction; and live WordPress verification.
- Chris Huber reviewed and remains responsible for the change.