### PR TITLE
Fix Transformer 0.5 form serialization compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   ],
   "require": {
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "0.4.20",
+    "automattic/blocks-engine-php-transformer": "0.5.0",
     "php": "^8.1"
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b00bdb8fae76ee70161cdc42a0ec620",
+    "content-hash": "1c6151b209d5ad369073f74965df707f",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "v0.4.20",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "1a70f3e01e8cbec525a2d4f5e6f4b18ff8dd32db"
+                "reference": "796a45e5c5180f0477b5e657c4b8e1883c5f462c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/1a70f3e01e8cbec525a2d4f5e6f4b18ff8dd32db",
-                "reference": "1a70f3e01e8cbec525a2d4f5e6f4b18ff8dd32db",
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/796a45e5c5180f0477b5e657c4b8e1883c5f462c",
+                "reference": "796a45e5c5180f0477b5e657c4b8e1883c5f462c",
                 "shasum": ""
             },
             "require": {
@@ -91,7 +91,7 @@
                 "issues": "https://github.com/Automattic/blocks-engine/issues",
                 "source": "https://github.com/Automattic/blocks-engine-php-transformer"
             },
-            "time": "2026-08-15T12:52:58+00:00"
+            "time": "2026-08-22T20:50:42+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2156,7 +2156,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$blocks  = array();
 		$matches = array();
 		preg_match_all( '/<!--\s+wp:html\s+(\{.*?\})\s+\/-->/s', $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE );
-		preg_match_all( '/<!--\s+wp:html\s+(\{.*?\})\s+-->(.*?)<!--\s+\/wp:html\s+-->/s', $content, $wrapped_matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE );
+		preg_match_all( '/<!--\s+wp:html(?:\s+(\{.*?\}))?\s+-->(.*?)<!--\s+\/wp:html\s+-->/s', $content, $wrapped_matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE );
 		$matches = array_merge( $matches, $wrapped_matches );
 
 		foreach ( $matches as $match ) {


### PR DESCRIPTION
## Summary
- pin Blocks Engine PHP Transformer 0.5.0 by immutable mirror commit
- accept canonical wrapped `core/html` serialization without redundant JSON attributes
- preserve bounded form fingerprinting and source-owned provider grafting

## Verification
- `npm test` (59 selected, 0 failed)
- `npm run test:runtime-package`
- `npm run test:dev-package`
- `composer validate --strict`
- `composer install --dry-run --no-interaction`
- `composer audit`
- `php -l includes/class-static-site-importer-report-diagnostics.php`
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to diagnose the cross-package serialization regression, make the minimal compatibility change, and run verification. Chris Huber reviewed and remains responsible for the change.