### PR TITLE
Reject production-ready imports when quality budgets fail

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -28,6 +28,7 @@
     "tests/smoke-playground-import-primitive.php": { "environment": "standalone-php" },
     "tests/smoke-plugin-materializer-lifecycle.php": { "environment": "standalone-php" },
     "tests/smoke-product-handoff-contract.php": { "environment": "standalone-php" },
+    "tests/smoke-quality-budget-admission.php": { "environment": "standalone-php" },
     "tests/smoke-provider-presentation.php": { "environment": "standalone-php" },
     "tests/smoke-site-identity.php": { "environment": "standalone-php" },
     "tests/smoke-url-import-runtime.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-quality-budget-admission.php
+++ b/includes/class-static-site-importer-quality-budget-admission.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Evaluates caller-owned quality budgets without changing compiler output.
+ *
+ * @package StaticSiteImporter
+ */
+
+final class Static_Site_Importer_Quality_Budget_Admission {
+
+	public const SCHEMA = 'static-site-importer/quality-budget-admission/v1';
+
+	/**
+	 * Evaluate plan evidence and resolved write facts.
+	 *
+	 * `quality_budget` is an optional caller contract. Its mode is `preview`
+	 * (the compatibility default) or `production`. Limits are optional, so a
+	 * caller can tighten only the dimensions it has a policy for.
+	 *
+	 * @param array<string,mixed> $plan
+	 * @param array<string,mixed> $resolved
+	 * @param array<string,mixed> $args
+	 * @param array<string,mixed> $report
+	 * @return array<string,mixed>
+	 */
+	public static function evaluate( array $plan, array $resolved, array $args = array(), array $report = array() ): array {
+		$budget = isset( $args['quality_budget'] ) && is_array( $args['quality_budget'] ) ? $args['quality_budget'] : ( isset( $args['quality_budgets'] ) && is_array( $args['quality_budgets'] ) ? $args['quality_budgets'] : array() );
+		$mode   = in_array( $budget['mode'] ?? 'preview', array( 'production', 'production_ready' ), true ) ? 'production' : 'preview';
+		$quality = isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array();
+		$metrics = isset( $quality['metrics'] ) && is_array( $quality['metrics'] ) ? $quality['metrics'] : $quality;
+		$diagnostics = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
+		$writes = isset( $resolved['writes'] ) && is_array( $resolved['writes'] ) ? $resolved['writes'] : ( isset( $plan['writes'] ) && is_array( $plan['writes'] ) ? $plan['writes'] : array() );
+		$native_blocks = self::metric( $metrics, array( 'native_block_count', 'block_count' ) );
+		$core_html = self::metric( $metrics, array( 'core_html_block_count' ) );
+		$families = self::core_html_families( $diagnostics );
+		$unresolved_media = self::metric( $metrics, array( 'unresolved_media_count', 'unresolved_asset_count' ) );
+		$unresolved_dependencies = self::metric( $metrics, array( 'unresolved_dependency_count', 'dependency_failure_count', 'runtime_dependency_parity_issue_count' ) );
+		$bootstrap_bytes = self::bootstrap_bytes( $writes );
+		$stylesheets = self::stylesheet_count( $writes );
+		$evidence = array(
+			'native_block_count'            => $native_blocks,
+			'core_html_block_count'         => $core_html,
+			'core_html_families'            => $families,
+			'unresolved_media_count'        => $unresolved_media,
+			'unresolved_dependency_count'   => $unresolved_dependencies,
+			'bootstrap_bytes'               => $bootstrap_bytes,
+			'stylesheet_asset_count'        => $stylesheets,
+			'visual_gate'                   => self::gate_status( $args, $report, 'visual' ),
+			'editor_gate'                   => self::gate_status( $args, $report, 'editor' ),
+		);
+		$limits = array(
+			'max_native_block_count'          => $native_blocks,
+			'max_core_html_block_count'       => $core_html,
+			'max_core_html_family_count'      => count( $families ),
+			'max_unresolved_media_count'      => $unresolved_media,
+			'max_unresolved_dependency_count' => $unresolved_dependencies,
+			'max_bootstrap_bytes'             => $bootstrap_bytes,
+			'max_stylesheet_asset_count'      => $stylesheets,
+		);
+		$failures = array();
+		foreach ( $limits as $limit => $actual ) {
+			if ( ! array_key_exists( $limit, $budget ) ) {
+				continue;
+			}
+			if ( null === $actual ) {
+				$failures[] = self::failure( $limit, 'not_proven', $actual, $budget[ $limit ] );
+			} elseif ( is_numeric( $budget[ $limit ] ) && $actual > (int) $budget[ $limit ] ) {
+				$failures[] = self::failure( $limit, 'exceeded', $actual, (int) $budget[ $limit ] );
+			}
+		}
+		foreach ( array( 'visual', 'editor' ) as $gate ) {
+			if ( empty( $budget[ 'require_' . $gate . '_gate' ] ) ) {
+				continue;
+			}
+			if ( 'passed' !== $evidence[ $gate . '_gate' ] ) {
+				$failures[] = self::failure( $gate . '_gate', $evidence[ $gate . '_gate' ], $evidence[ $gate . '_gate' ], 'passed' );
+			}
+		}
+		$production_status = empty( $budget ) ? 'not_proven' : ( empty( $failures ) ? 'passed' : 'failed' );
+		return array(
+			'schema'            => self::SCHEMA,
+			'mode'              => $mode,
+			'mechanical_status' => 'not_materialized',
+			'production_status' => $production_status,
+			'status'            => 'production' === $mode ? $production_status : 'preview',
+			'evidence'          => $evidence,
+			'budget'            => $budget,
+			'failures'          => $failures,
+		);
+	}
+
+	/** @param array<string,mixed> $admission */
+	public static function rejects_materialization( array $admission ): bool {
+		return 'production' === ( $admission['mode'] ?? '' ) && 'failed' === ( $admission['production_status'] ?? '' );
+	}
+
+	/** @param array<string,mixed> $metrics @param array<int,string> $keys */
+	private static function metric( array $metrics, array $keys ): ?int {
+		foreach ( $keys as $key ) {
+			if ( isset( $metrics[ $key ] ) && is_numeric( $metrics[ $key ] ) ) {
+				return max( 0, (int) $metrics[ $key ] );
+			}
+		}
+		return null;
+	}
+
+	/** @param array<int,mixed> $diagnostics @return array<string,int> */
+	private static function core_html_families( array $diagnostics ): array {
+		$families = array();
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) || ! str_contains( (string) ( $diagnostic['type'] ?? $diagnostic['reason_code'] ?? '' ), 'core_html' ) ) {
+				continue;
+			}
+			$family = (string) ( $diagnostic['tag_name'] ?? $diagnostic['block_name'] ?? 'unknown' );
+			$families[ $family ] = ( $families[ $family ] ?? 0 ) + 1;
+		}
+		ksort( $families, SORT_STRING );
+		return $families;
+	}
+
+	/** @param array<int,mixed> $writes */
+	private static function bootstrap_bytes( array $writes ): int {
+		$bytes = 0;
+		foreach ( $writes as $write ) {
+			if ( is_array( $write ) && 'theme_bootstrap' === ( $write['kind'] ?? '' ) ) {
+				$bytes += strlen( (string) ( $write['payload']['data'] ?? '' ) );
+			}
+		}
+		return $bytes;
+	}
+
+	/** @param array<int,mixed> $writes */
+	private static function stylesheet_count( array $writes ): int {
+		$count = 0;
+		foreach ( $writes as $write ) {
+			$path = is_array( $write ) ? (string) ( $write['target_path'] ?? '' ) : '';
+			if ( str_ends_with( strtolower( $path ), '.css' ) ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
+	/** @param array<string,mixed> $args @param array<string,mixed> $report */
+	private static function gate_status( array $args, array $report, string $gate ): string {
+		$artifacts = isset( $args['validation_artifacts'] ) && is_array( $args['validation_artifacts'] ) ? $args['validation_artifacts'] : array();
+		if ( isset( $artifacts[ $gate . '_gate']['status'] ) ) {
+			return (string) $artifacts[ $gate . '_gate']['status'];
+		}
+		if ( 'visual' === $gate && 'passed' === ( $report['visual_fidelity']['status'] ?? null ) ) {
+			return 'passed';
+		}
+		if ( 'editor' === $gate && 'passed' === ( $report['import_validation_result']['quality_gates']['editor']['status'] ?? null ) ) {
+			return 'passed';
+		}
+		return 'not_proven';
+	}
+
+	private static function failure( string $metric, string $status, $actual, $limit ): array {
+		return array( 'metric' => $metric, 'status' => $status, 'actual' => $actual, 'limit' => $limit, 'repair_class' => in_array( $metric, array( 'bootstrap_bytes', 'stylesheet_asset_count' ), true ) ? 'static-site-importer' : ( str_ends_with( $metric, '_gate' ) ? 'runtime-validation' : 'blocks-engine' ) );
+	}
+}

--- a/includes/class-static-site-importer-quality-budget-admission.php
+++ b/includes/class-static-site-importer-quality-budget-admission.php
@@ -23,31 +23,31 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 	 * @return array<string,mixed>
 	 */
 	public static function evaluate( array $plan, array $resolved, array $args = array(), array $report = array() ): array {
-		$budget = isset( $args['quality_budget'] ) && is_array( $args['quality_budget'] ) ? $args['quality_budget'] : ( isset( $args['quality_budgets'] ) && is_array( $args['quality_budgets'] ) ? $args['quality_budgets'] : array() );
-		$mode   = in_array( $budget['mode'] ?? 'preview', array( 'production', 'production_ready' ), true ) ? 'production' : 'preview';
-		$quality = isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array();
-		$metrics = isset( $quality['metrics'] ) && is_array( $quality['metrics'] ) ? $quality['metrics'] : $quality;
-		$diagnostics = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
-		$writes = isset( $resolved['writes'] ) && is_array( $resolved['writes'] ) ? $resolved['writes'] : ( isset( $plan['writes'] ) && is_array( $plan['writes'] ) ? $plan['writes'] : array() );
-		$native_blocks = self::metric( $metrics, array( 'native_block_count', 'block_count' ) );
-		$core_html = self::metric( $metrics, array( 'core_html_block_count' ) );
-		$families = self::core_html_families( $diagnostics );
-		$unresolved_media = self::metric( $metrics, array( 'unresolved_media_count', 'unresolved_asset_count' ) );
+		$budget                  = isset( $args['quality_budget'] ) && is_array( $args['quality_budget'] ) ? $args['quality_budget'] : ( isset( $args['quality_budgets'] ) && is_array( $args['quality_budgets'] ) ? $args['quality_budgets'] : array() );
+		$mode                    = in_array( $budget['mode'] ?? 'preview', array( 'production', 'production_ready' ), true ) ? 'production' : 'preview';
+		$quality                 = isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array();
+		$metrics                 = isset( $quality['metrics'] ) && is_array( $quality['metrics'] ) ? $quality['metrics'] : $quality;
+		$diagnostics             = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
+		$writes                  = isset( $resolved['writes'] ) && is_array( $resolved['writes'] ) ? $resolved['writes'] : ( isset( $plan['writes'] ) && is_array( $plan['writes'] ) ? $plan['writes'] : array() );
+		$native_blocks           = self::metric( $metrics, array( 'native_block_count', 'block_count' ) );
+		$core_html               = self::metric( $metrics, array( 'core_html_block_count' ) );
+		$families                = self::core_html_families( $diagnostics );
+		$unresolved_media        = self::metric( $metrics, array( 'unresolved_media_count', 'unresolved_asset_count' ) );
 		$unresolved_dependencies = self::metric( $metrics, array( 'unresolved_dependency_count', 'dependency_failure_count', 'runtime_dependency_parity_issue_count' ) );
-		$bootstrap_bytes = self::bootstrap_bytes( $writes );
-		$stylesheets = self::stylesheet_count( $writes );
-		$evidence = array(
-			'native_block_count'            => $native_blocks,
-			'core_html_block_count'         => $core_html,
-			'core_html_families'            => $families,
-			'unresolved_media_count'        => $unresolved_media,
-			'unresolved_dependency_count'   => $unresolved_dependencies,
-			'bootstrap_bytes'               => $bootstrap_bytes,
-			'stylesheet_asset_count'        => $stylesheets,
-			'visual_gate'                   => self::gate_status( $args, $report, 'visual' ),
-			'editor_gate'                   => self::gate_status( $args, $report, 'editor' ),
+		$bootstrap_bytes         = self::bootstrap_bytes( $writes );
+		$stylesheets             = self::stylesheet_count( $writes );
+		$evidence                = array(
+			'native_block_count'          => $native_blocks,
+			'core_html_block_count'       => $core_html,
+			'core_html_families'          => $families,
+			'unresolved_media_count'      => $unresolved_media,
+			'unresolved_dependency_count' => $unresolved_dependencies,
+			'bootstrap_bytes'             => $bootstrap_bytes,
+			'stylesheet_asset_count'      => $stylesheets,
+			'visual_gate'                 => self::gate_status( $args, $report, 'visual' ),
+			'editor_gate'                 => self::gate_status( $args, $report, 'editor' ),
 		);
-		$limits = array(
+		$limits                  = array(
 			'max_native_block_count'          => $native_blocks,
 			'max_core_html_block_count'       => $core_html,
 			'max_core_html_family_count'      => count( $families ),
@@ -56,7 +56,7 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 			'max_bootstrap_bytes'             => $bootstrap_bytes,
 			'max_stylesheet_asset_count'      => $stylesheets,
 		);
-		$failures = array();
+		$failures                = array();
 		foreach ( $limits as $limit => $actual ) {
 			if ( ! array_key_exists( $limit, $budget ) ) {
 				continue;
@@ -110,7 +110,7 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 			if ( ! is_array( $diagnostic ) || ! str_contains( (string) ( $diagnostic['type'] ?? $diagnostic['reason_code'] ?? '' ), 'core_html' ) ) {
 				continue;
 			}
-			$family = (string) ( $diagnostic['tag_name'] ?? $diagnostic['block_name'] ?? 'unknown' );
+			$family              = (string) ( $diagnostic['tag_name'] ?? $diagnostic['block_name'] ?? 'unknown' );
 			$families[ $family ] = ( $families[ $family ] ?? 0 ) + 1;
 		}
 		ksort( $families, SORT_STRING );
@@ -143,8 +143,8 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 	/** @param array<string,mixed> $args @param array<string,mixed> $report */
 	private static function gate_status( array $args, array $report, string $gate ): string {
 		$artifacts = isset( $args['validation_artifacts'] ) && is_array( $args['validation_artifacts'] ) ? $args['validation_artifacts'] : array();
-		if ( isset( $artifacts[ $gate . '_gate']['status'] ) ) {
-			return (string) $artifacts[ $gate . '_gate']['status'];
+		if ( isset( $artifacts[ $gate . '_gate' ]['status'] ) ) {
+			return (string) $artifacts[ $gate . '_gate' ]['status'];
 		}
 		if ( 'visual' === $gate && 'passed' === ( $report['visual_fidelity']['status'] ?? null ) ) {
 			return 'passed';
@@ -156,6 +156,12 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 	}
 
 	private static function failure( string $metric, string $status, $actual, $limit ): array {
-		return array( 'metric' => $metric, 'status' => $status, 'actual' => $actual, 'limit' => $limit, 'repair_class' => in_array( $metric, array( 'bootstrap_bytes', 'stylesheet_asset_count' ), true ) ? 'static-site-importer' : ( str_ends_with( $metric, '_gate' ) ? 'runtime-validation' : 'blocks-engine' ) );
+		return array(
+			'metric'       => $metric,
+			'status'       => $status,
+			'actual'       => $actual,
+			'limit'        => $limit,
+			'repair_class' => in_array( $metric, array( 'bootstrap_bytes', 'stylesheet_asset_count' ), true ) ? 'static-site-importer' : ( str_ends_with( $metric, '_gate' ) ? 'runtime-validation' : 'blocks-engine' ),
+		);
 	}
 }

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -357,6 +357,7 @@ class Static_Site_Importer_Report_Diagnostics {
 					'owner'  => (string) ( $report['semantic_fidelity']['gate_owner'] ?? 'benchmark_harness' ),
 				),
 			),
+			'quality_budget_admission' => isset( $report['quality_budget_admission'] ) && is_array( $report['quality_budget_admission'] ) ? $report['quality_budget_admission'] : array(),
 			'diagnostic_summary'      => $summary['diagnostic_summary'] ?? array(),
 			'diagnostics'             => self::compact_import_report_diagnostics( $diagnostics ),
 			'diagnostic_refs'         => isset( $quality['diagnostic_refs'] ) && is_array( $quality['diagnostic_refs'] ) ? $quality['diagnostic_refs'] : array(),

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -812,7 +812,12 @@ class Static_Site_Importer_Theme_Generator {
 		$manifest['cleanup'] = $cleanup;
 		$report['source_of_truth'] = $manifest;
 		$quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $report, $args );
-		$validation = $report['import_validation_result'];
+		$receipt['quality_budget_admission'] = Static_Site_Importer_Quality_Budget_Admission::evaluate( $plan, $receipt['plan'] ?? array(), $args, $report );
+		$receipt['quality_budget_admission']['mechanical_status'] = $receipt['status'] ?? 'completed';
+		$report['quality_budget_admission'] = $receipt['quality_budget_admission'];
+		$report['materialization_receipt'] = $receipt;
+		$validation = Static_Site_Importer_Report_Diagnostics::import_validation_result( $report, $quality );
+		$report['import_validation_result'] = $validation;
 		$findings   = $report['finding_packets'];
 		$theme_dir  = $theme['dir'];
 		$manifest_path = $theme_dir . '/static-site-importer-manifest.json';

--- a/includes/class-static-site-importer-website-artifact-import-input.php
+++ b/includes/class-static-site-importer-website-artifact-import-input.php
@@ -50,6 +50,7 @@ class Static_Site_Importer_Website_Artifact_Import_Input {
 		'compiler_options'                     => array( 'type' => 'object' ),
 		'source_metadata'                      => array( 'type' => 'object' ),
 		'validation_artifacts'                 => array( 'type' => 'object' ),
+		'quality_budget'                       => array( 'type' => 'object' ),
 		'client_script_policy'                 => array(
 			'type' => 'string',
 			'enum' => array( 'inert', 'isolated_preview' ),
@@ -97,6 +98,7 @@ class Static_Site_Importer_Website_Artifact_Import_Input {
 				'compiler_options'                     => array(),
 				'source_metadata'                      => array(),
 				'validation_artifacts'                 => array(),
+				'quality_budget'                       => array(),
 				'client_script_policy'                 => 'inert',
 				'client_script_provenance'             => array(),
 				'client_script_isolated'               => false,
@@ -117,7 +119,7 @@ class Static_Site_Importer_Website_Artifact_Import_Input {
 		foreach ( array( 'activate', 'overwrite', 'disable_smilies', 'remove_default_content', 'fail_on_quality', 'allow_missing_woocommerce', 'allow_missing_jetpack', 'materialize_dependencies', 'require_proven_dynamic_client_assets', 'seed_entities', 'write_theme_report_artifacts', 'client_script_isolated' ) as $field ) {
 			$values[ $field ] = (bool) $values[ $field ];
 		}
-		foreach ( array( 'products_manifest', 'commerce_context', 'asset_map', 'compiler_options', 'source_metadata', 'validation_artifacts', 'client_script_provenance' ) as $field ) {
+		foreach ( array( 'products_manifest', 'commerce_context', 'asset_map', 'compiler_options', 'source_metadata', 'validation_artifacts', 'quality_budget', 'client_script_provenance' ) as $field ) {
 			$values[ $field ] = is_array( $values[ $field ] ) ? $values[ $field ] : array();
 		}
 

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -20,6 +20,9 @@ if ( ! class_exists( 'Static_Site_Importer_Classic_Theme_Projection' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Current_Site_Capabilities' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-current-site-capabilities.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Quality_Budget_Admission' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-quality-budget-admission.php';
+}
 
 final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	public const RECEIPT_SCHEMA           = 'static-site-importer/materialization-receipt/v2';
@@ -167,6 +170,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'dir'  => $theme_dir,
 				'uri'  => $theme_uri,
 			);
+			$state['quality_budget_admission'] = Static_Site_Importer_Quality_Budget_Admission::evaluate( $plan, $resolved, $args );
+			if ( Static_Site_Importer_Quality_Budget_Admission::rejects_materialization( $state['quality_budget_admission'] ) ) {
+				$state['diagnostics'][] = array( 'reason_code' => 'quality_budget_failed', 'quality_budget' => $state['quality_budget_admission'] );
+				return array( 'status' => 'rejected', 'receipt' => self::receipt( 'rejected', $state ) );
+			}
 			self::preflight_state( $state, ! empty( $args['overwrite'] ), (string) ( $args['import_run_id'] ?? '' ) );
 		} catch ( InvalidArgumentException $error ) {
 			$state['diagnostics'][] = array( 'reason_code' => $error->getMessage() );
@@ -584,6 +592,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				throw new InvalidArgumentException( 'prepared_destination_changed' );
 			}
 			self::apply_runtime_entity_bindings( $state['resolved'], isset( $args['runtime_entity_bindings'] ) && is_array( $args['runtime_entity_bindings'] ) ? $args['runtime_entity_bindings'] : array(), $state['applied']['runtime_declarations']['entity_bindings'], $state['diagnostics'] );
+			$state['quality_budget_admission'] = Static_Site_Importer_Quality_Budget_Admission::evaluate( $plan, $state['resolved'], $args );
+			if ( Static_Site_Importer_Quality_Budget_Admission::rejects_materialization( $state['quality_budget_admission'] ) ) {
+				$state['diagnostics'][] = array( 'reason_code' => 'quality_budget_failed', 'quality_budget' => $state['quality_budget_admission'] );
+				return array( 'status' => 'rejected', 'receipt' => self::receipt( 'rejected', $state ) );
+			}
 			self::validate_materialized_block_documents( $state['resolved'], $state['applied']['runtime_declarations']['entity_bindings'], $state['diagnostics'] );
 			self::preflight_state( $state, ! empty( $args['overwrite'] ), (string) ( $args['import_run_id'] ?? '' ) );
 		} catch ( InvalidArgumentException $error ) {
@@ -2067,10 +2080,12 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'schema' => 'static-site-importer/editability-report-admission/v1',
 				'status' => 'not_checked',
 			),
+			'quality_budget_admission'  => $state['quality_budget_admission'] ?? Static_Site_Importer_Quality_Budget_Admission::evaluate( $plan, $resolved_plan, $state['args'] ?? array() ),
 			'diagnostics'               => $state['diagnostics'],
 			'errors'                    => $errors,
 			'theme_materialization'     => $state['theme_materialization'] ?? self::strategy_evidence( $state['args'] ?? array() ),
 		);
+		$receipt['quality_budget_admission']['mechanical_status'] = 'completed' === $status ? 'completed' : $status;
 		if ( ! empty( $state['args']['defer_materialization_commit'] ) && 'completed' === $status ) {
 			$receipt['transaction'] = (object) array( 'state' => $state );
 		}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -172,8 +172,14 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			);
 			$state['quality_budget_admission'] = Static_Site_Importer_Quality_Budget_Admission::evaluate( $plan, $resolved, $args );
 			if ( Static_Site_Importer_Quality_Budget_Admission::rejects_materialization( $state['quality_budget_admission'] ) ) {
-				$state['diagnostics'][] = array( 'reason_code' => 'quality_budget_failed', 'quality_budget' => $state['quality_budget_admission'] );
-				return array( 'status' => 'rejected', 'receipt' => self::receipt( 'rejected', $state ) );
+				$state['diagnostics'][] = array(
+					'reason_code'    => 'quality_budget_failed',
+					'quality_budget' => $state['quality_budget_admission'],
+				);
+				return array(
+					'status'  => 'rejected',
+					'receipt' => self::receipt( 'rejected', $state ),
+				);
 			}
 			self::preflight_state( $state, ! empty( $args['overwrite'] ), (string) ( $args['import_run_id'] ?? '' ) );
 		} catch ( InvalidArgumentException $error ) {
@@ -594,8 +600,14 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			self::apply_runtime_entity_bindings( $state['resolved'], isset( $args['runtime_entity_bindings'] ) && is_array( $args['runtime_entity_bindings'] ) ? $args['runtime_entity_bindings'] : array(), $state['applied']['runtime_declarations']['entity_bindings'], $state['diagnostics'] );
 			$state['quality_budget_admission'] = Static_Site_Importer_Quality_Budget_Admission::evaluate( $plan, $state['resolved'], $args );
 			if ( Static_Site_Importer_Quality_Budget_Admission::rejects_materialization( $state['quality_budget_admission'] ) ) {
-				$state['diagnostics'][] = array( 'reason_code' => 'quality_budget_failed', 'quality_budget' => $state['quality_budget_admission'] );
-				return array( 'status' => 'rejected', 'receipt' => self::receipt( 'rejected', $state ) );
+				$state['diagnostics'][] = array(
+					'reason_code'    => 'quality_budget_failed',
+					'quality_budget' => $state['quality_budget_admission'],
+				);
+				return array(
+					'status'  => 'rejected',
+					'receipt' => self::receipt( 'rejected', $state ),
+				);
 			}
 			self::validate_materialized_block_documents( $state['resolved'], $state['applied']['runtime_declarations']['entity_bindings'], $state['diagnostics'] );
 			self::preflight_state( $state, ! empty( $args['overwrite'] ), (string) ( $args['import_run_id'] ?? '' ) );

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -83,6 +83,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-re
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-font-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document-type-classifier.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-current-site-capabilities.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-quality-budget-admission.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-wordpress-site-plan-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-figma-import.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-theme-exporter.php';

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -34,6 +34,7 @@
     { "path": "tests/smoke-playground-import-primitive.php", "environment": "standalone-php" },
     { "path": "tests/smoke-plugin-materializer-lifecycle.php", "environment": "standalone-php" },
     { "path": "tests/smoke-product-handoff-contract.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-quality-budget-admission.php", "environment": "standalone-php" },
     { "path": "tests/smoke-product-materializer.php", "environment": "wordpress-runtime" },
     { "path": "tests/smoke-provider-presentation.php", "environment": "standalone-php" },
     { "path": "tests/smoke-site-identity.php", "environment": "standalone-php" },

--- a/tests/smoke-quality-budget-admission.php
+++ b/tests/smoke-quality-budget-admission.php
@@ -1,0 +1,29 @@
+<?php
+/** Run: php tests/smoke-quality-budget-admission.php */
+
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-quality-budget-admission.php';
+
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+};
+
+$plan = array(
+	'quality' => array( 'metrics' => array( 'block_count' => 12, 'core_html_block_count' => 2, 'unresolved_media_count' => 0, 'unresolved_dependency_count' => 0 ) ),
+	'diagnostics' => array( array( 'type' => 'core_html_block', 'tag_name' => 'table' ), array( 'type' => 'core_html_block', 'tag_name' => 'form' ) ),
+);
+$resolved = array( 'writes' => array( array( 'kind' => 'theme_bootstrap', 'payload' => array( 'data' => 'bootstrap' ) ), array( 'target_path' => 'assets/site.css' ) ) );
+$pass = Static_Site_Importer_Quality_Budget_Admission::evaluate( $plan, $resolved, array( 'quality_budget' => array( 'mode' => 'production', 'max_native_block_count' => 12, 'max_core_html_block_count' => 2, 'max_core_html_family_count' => 2, 'max_bootstrap_bytes' => 9, 'max_stylesheet_asset_count' => 1 ) ) );
+$assert( 'passed' === $pass['production_status'] && ! Static_Site_Importer_Quality_Budget_Admission::rejects_materialization( $pass ), 'within explicit production budgets passes admission' );
+
+$failed = Static_Site_Importer_Quality_Budget_Admission::evaluate( $plan, $resolved, array( 'quality_budget' => array( 'mode' => 'production', 'max_core_html_block_count' => 1, 'max_unresolved_media_count' => 0 ) ) );
+$assert( 'failed' === $failed['production_status'] && Static_Site_Importer_Quality_Budget_Admission::rejects_materialization( $failed ) && 'blocks-engine' === ( $failed['failures'][0]['repair_class'] ?? '' ), 'exceeded production evidence rejects with its owning repair class' );
+
+$preview = Static_Site_Importer_Quality_Budget_Admission::evaluate( $plan, $resolved, array( 'quality_budget' => array( 'max_core_html_block_count' => 1 ) ) );
+$assert( 'preview' === $preview['status'] && 'failed' === $preview['production_status'] && ! Static_Site_Importer_Quality_Budget_Admission::rejects_materialization( $preview ), 'preview retains failing evidence without blocking materialization' );
+
+$unknown = Static_Site_Importer_Quality_Budget_Admission::evaluate( array(), array(), array() );
+$assert( 'not_proven' === $unknown['production_status'] && 'preview' === $unknown['status'], 'imports without budget evidence remain explicitly not proven' );
+
+print "quality budget admission smoke passed\n";

--- a/tests/smoke-website-artifact-import-input.php
+++ b/tests/smoke-website-artifact-import-input.php
@@ -151,6 +151,7 @@ $input  = array(
 	'compiler_options'                     => array( 'include_conversion_report' => false ),
 	'source_metadata'                      => array( 'request_id' => 'contract-1' ),
 	'validation_artifacts'                 => array( 'visual_diff' => array( 'path' => '/tmp/diff.png' ) ),
+	'quality_budget'                       => array( 'mode' => 'production', 'max_core_html_block_count' => 0 ),
 	'client_script_policy'                 => 'isolated_preview',
 	'client_script_provenance'             => array( 'ref' => 'contract:preview' ),
 	'client_script_isolated'               => true,


### PR DESCRIPTION
Closes #1181

## Summary
- add a generic `quality_budget` admission contract with configurable native/core HTML, fallback-family, unresolved dependency/media, bootstrap, stylesheet, visual, and editor limits
- reject explicit production mode before materialization when a budget fails; preserve preview evidence and explicit not-proven status for existing callers
- include final quality-budget evidence in materialization receipts, import reports, and validation results

## Tests
- `npm test`
- `php tests/smoke-quality-budget-admission.php`
- `php tests/smoke-website-artifact-import-input.php`
- PHP syntax checks

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode was used to trace the canonical-plan/materialization/receipt lifecycle, implement the generic quality-budget admission contract, and add focused coverage. Chris Huber remains responsible for every line.