### PR TITLE
Add configurable materialization quality admission

### DIFF
--- a/docs/contracts/quality-admission-v1.md
+++ b/docs/contracts/quality-admission-v1.md
@@ -1,0 +1,20 @@
+# Quality Admission v1
+
+`static-site-importer/quality-admission/v1` is an additive materialization receipt and import-report field. It separates `mechanical_status` (WordPress writes completed) from `production_ready` (`passed`, `hard_budget_failed`, `evidence_failed`, or `unknown`).
+
+Callers configure it with `quality_admission`:
+
+```php
+array(
+    'mode' => 'production_ready', // evidence (default), preview, or production_ready.
+    'budgets' => array(
+        'max_raw_html_fallback_count' => 0,
+        'max_unresolved_media_count' => 0,
+        'max_unresolved_dependency_count' => 0,
+        'max_theme_bootstrap_bytes' => 250000,
+        'max_stylesheet_asset_count' => 20,
+    ),
+)
+```
+
+Budgets are opt-in hard limits. `preview` preserves materialized output and reports the production decision for inspection. Existing callers without canonical quality evidence receive `unknown`; SSI never infers visual or editor parity from successful writes. Metrics use the canonical resolved plan and finalized report only: native blocks, raw HTML fallback counts/families, unresolved media/dependencies, bootstrap bytes, stylesheet assets, and supplied visual/editor evidence. Compiler repairs remain owned upstream by Blocks Engine.

--- a/includes/class-static-site-importer-quality-admission.php
+++ b/includes/class-static-site-importer-quality-admission.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Evaluates materialized-site quality without changing compiler output.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class Static_Site_Importer_Quality_Admission {
+	public const SCHEMA = 'static-site-importer/quality-admission/v1';
+
+	/**
+	 * Return a generic admission decision from canonical plan, receipt, and report evidence.
+	 *
+	 * `quality_admission.mode` is deliberately additive: existing callers retain their
+	 * mechanical materialization result while production-ready callers opt into its
+	 * explicit decision. No missing evidence is interpreted as visual or editor parity.
+	 *
+	 * @param array<string,mixed> $plan    Resolved canonical plan.
+	 * @param array<string,mixed> $args    Materialization arguments.
+	 * @param array<string,mixed> $report  Optional finalized import report.
+	 * @return array<string,mixed>
+	 */
+	public static function evaluate( array $plan, array $args = array(), array $report = array() ): array {
+		$config  = isset( $args['quality_admission'] ) && is_array( $args['quality_admission'] ) ? $args['quality_admission'] : array();
+		$mode    = isset( $config['mode'] ) && is_string( $config['mode'] ) ? $config['mode'] : 'evidence';
+		$mode    = in_array( $mode, array( 'evidence', 'preview', 'production_ready' ), true ) ? $mode : 'evidence';
+		$budgets = self::budgets( $config['budgets'] ?? array() );
+		$metrics = self::metrics( $plan, $report );
+		$visual  = self::evidence_status( $report, 'visual' );
+		$editor  = self::evidence_status( $report, 'editor' );
+		$failures = array();
+		foreach ( $budgets as $budget => $maximum ) {
+			$metric = substr( $budget, 4 );
+			if ( $metrics[ $metric ] > $maximum ) {
+				$failures[] = array( 'budget' => $budget, 'metric' => $metric, 'actual' => $metrics[ $metric ], 'maximum' => $maximum );
+			}
+		}
+		$canonical_evidence = isset( $plan['quality'] ) && is_array( $plan['quality'] ) && ( isset( $plan['quality']['metrics'] ) || isset( $plan['quality']['fallback_count'] ) || isset( $plan['quality']['block_count'] ) );
+		$production_status  = ! empty( $failures ) ? 'hard_budget_failed' : ( 'failed' === $visual || 'failed' === $editor ? 'evidence_failed' : ( $canonical_evidence ? 'passed' : 'unknown' ) );
+
+		return array(
+			'schema'           => self::SCHEMA,
+			'mode'             => $mode,
+			'status'           => 'preview' === $mode ? 'preview' : $production_status,
+			'production_ready' => $production_status,
+			'mechanical_status' => 'completed',
+			'budgets'          => $budgets,
+			'metrics'          => $metrics,
+			'evidence'         => array(
+				'canonical_plan' => $canonical_evidence ? 'provided' : 'unknown',
+				'visual'         => $visual,
+				'editor'         => $editor,
+			),
+			'failures'         => $failures,
+			'repair_owner'     => ! empty( $failures ) || 'failed' === $visual || 'failed' === $editor ? 'blocks-engine' : 'none',
+		);
+	}
+
+	/** @return array<string,int> */
+	private static function budgets( $raw ): array {
+		$allowed = array( 'max_raw_html_fallback_count', 'max_unresolved_media_count', 'max_unresolved_dependency_count', 'max_theme_bootstrap_bytes', 'max_stylesheet_asset_count' );
+		$budgets = array();
+		if ( ! is_array( $raw ) ) {
+			return $budgets;
+		}
+		foreach ( $allowed as $name ) {
+			if ( isset( $raw[ $name ] ) && is_numeric( $raw[ $name ] ) && 0 <= $raw[ $name ] ) {
+				$budgets[ $name ] = (int) $raw[ $name ];
+			}
+		}
+		return $budgets;
+	}
+
+	/** @return array<string,mixed> */
+	private static function metrics( array $plan, array $report ): array {
+		$blocks = array( 'native_block_count' => 0, 'raw_html_fallback_count' => 0, 'raw_html_fallback_families' => array() );
+		foreach ( array_merge( self::documents( $plan['pages'] ?? array() ), self::documents( $plan['template_parts'] ?? array() ) ) as $markup ) {
+			if ( preg_match_all( '/<!--\s+wp:([^\s>{]+).*?(?:\/-->|-->)/i', $markup, $matches ) ) {
+				foreach ( $matches[1] as $name ) {
+					$name = strtolower( (string) $name );
+					if ( in_array( $name, array( 'html', 'core/html', 'freeform', 'core/freeform' ), true ) ) {
+						++$blocks['raw_html_fallback_count'];
+						$family = str_contains( $name, 'freeform' ) ? 'freeform' : 'core_html';
+						$blocks['raw_html_fallback_families'][ $family ] = (int) ( $blocks['raw_html_fallback_families'][ $family ] ?? 0 ) + 1;
+					} else {
+						++$blocks['native_block_count'];
+					}
+				}
+			}
+		}
+		$diagnostics = array_merge( is_array( $plan['diagnostics'] ?? null ) ? $plan['diagnostics'] : array(), is_array( $report['diagnostics'] ?? null ) ? $report['diagnostics'] : array() );
+		$media = 0;
+		$dependencies = 0;
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+			$fields = array_filter( array_intersect_key( $diagnostic, array_flip( array( 'type', 'code', 'reason_code', 'reason' ) ) ), 'is_scalar' );
+			$signal = strtolower( implode( ' ', array_map( 'strval', $fields ) ) );
+			if ( ! str_contains( $signal, 'unresolved' ) && ! str_contains( $signal, 'missing' ) && ! str_contains( $signal, 'not_materialized' ) ) {
+				continue;
+			}
+			if ( preg_match( '/asset|image|media|svg|font/', $signal ) ) {
+				++$media;
+			} elseif ( preg_match( '/depend|plugin|runtime|script|provider/', $signal ) ) {
+				++$dependencies;
+			}
+		}
+		$asset_map = is_array( $report['asset_map'] ?? null ) ? $report['asset_map'] : array();
+		$media = max( $media, (int) ( $asset_map['unresolved_count'] ?? 0 ) );
+		return array_merge( $blocks, array(
+			'unresolved_media_count'      => $media,
+			'unresolved_dependency_count' => $dependencies,
+			'theme_bootstrap_bytes'       => self::bootstrap_bytes( $plan['writes'] ?? array() ),
+			'stylesheet_asset_count'      => self::stylesheet_assets( $plan['assets'] ?? array() ),
+		) );
+	}
+
+	/** @return array<int,string> */
+	private static function documents( $rows ): array {
+		$documents = array();
+		foreach ( is_array( $rows ) ? $rows : array() as $row ) {
+			if ( is_array( $row ) && is_string( $row['resolved_block_markup'] ?? null ) ) {
+				$documents[] = $row['resolved_block_markup'];
+			}
+		}
+		return $documents;
+	}
+
+	private static function bootstrap_bytes( $writes ): int {
+		$bytes = 0;
+		foreach ( is_array( $writes ) ? $writes : array() as $write ) {
+			if ( ! is_array( $write ) || 'theme_bootstrap' !== ( $write['kind'] ?? null ) ) {
+				continue;
+			}
+			$payload = is_array( $write['payload'] ?? null ) ? $write['payload'] : array();
+			if ( isset( $payload['data'] ) && is_string( $payload['data'] ) ) {
+				$decoded = 'base64' === ( $payload['encoding'] ?? null ) ? base64_decode( $payload['data'], true ) : $payload['data'];
+				$bytes += is_string( $decoded ) ? strlen( $decoded ) : 0;
+			} elseif ( isset( $write['bytes'] ) && is_numeric( $write['bytes'] ) ) {
+				$bytes += max( 0, (int) $write['bytes'] );
+			}
+		}
+		return $bytes;
+	}
+
+	private static function stylesheet_assets( $assets ): int {
+		$paths = array();
+		foreach ( is_array( $assets ) ? $assets : array() as $asset ) {
+			if ( ! is_array( $asset ) ) {
+				continue;
+			}
+			$path = (string) ( $asset['target_path'] ?? $asset['source_path'] ?? '' );
+			if ( str_ends_with( strtolower( strtok( $path, '?' ) ), '.css' ) ) {
+				$paths[ $path ] = true;
+			}
+		}
+		return count( $paths );
+	}
+
+	private static function evidence_status( array $report, string $kind ): string {
+		$key = 'visual' === $kind ? 'visual_fidelity' : 'editor_fidelity';
+		$status = strtolower( (string) ( $report[ $key ]['status'] ?? $report['quality_evidence'][ $kind ]['status'] ?? '' ) );
+		return in_array( $status, array( 'passed', 'failed' ), true ) ? $status : 'unknown';
+	}
+}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -26,6 +26,9 @@ if ( ! class_exists( 'Static_Site_Importer_Block_Document_Reporter' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Report_Diagnostics' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-report-diagnostics.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Quality_Admission' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-quality-admission.php';
+}
 if ( ! class_exists( 'Static_Site_Importer_Client_Script_Policy' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-client-script-policy.php';
 }
@@ -812,7 +815,16 @@ class Static_Site_Importer_Theme_Generator {
 		$manifest['cleanup'] = $cleanup;
 		$report['source_of_truth'] = $manifest;
 		$quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $report, $args );
+		$admission = Static_Site_Importer_Quality_Admission::evaluate( $receipt['plan'], $args, $report );
+		$receipt['quality_admission']        = $admission;
+		$report['quality_admission']         = $admission;
+		$report['materialization_receipt']   = $receipt;
 		$validation = $report['import_validation_result'];
+		$validation['quality_admission'] = $admission;
+		if ( in_array( $admission['production_ready'], array( 'hard_budget_failed', 'evidence_failed' ), true ) ) {
+			$validation['status'] = 'failed';
+		}
+		$report['import_validation_result'] = $validation;
 		$findings   = $report['finding_packets'];
 		$theme_dir  = $theme['dir'];
 		$manifest_path = $theme_dir . '/static-site-importer-manifest.json';

--- a/includes/class-static-site-importer-website-artifact-import-input.php
+++ b/includes/class-static-site-importer-website-artifact-import-input.php
@@ -50,6 +50,7 @@ class Static_Site_Importer_Website_Artifact_Import_Input {
 		'compiler_options'                     => array( 'type' => 'object' ),
 		'source_metadata'                      => array( 'type' => 'object' ),
 		'validation_artifacts'                 => array( 'type' => 'object' ),
+		'quality_admission'                    => array( 'type' => 'object' ),
 		'client_script_policy'                 => array(
 			'type' => 'string',
 			'enum' => array( 'inert', 'isolated_preview' ),
@@ -97,6 +98,7 @@ class Static_Site_Importer_Website_Artifact_Import_Input {
 				'compiler_options'                     => array(),
 				'source_metadata'                      => array(),
 				'validation_artifacts'                 => array(),
+				'quality_admission'                    => array(),
 				'client_script_policy'                 => 'inert',
 				'client_script_provenance'             => array(),
 				'client_script_isolated'               => false,
@@ -117,7 +119,7 @@ class Static_Site_Importer_Website_Artifact_Import_Input {
 		foreach ( array( 'activate', 'overwrite', 'disable_smilies', 'remove_default_content', 'fail_on_quality', 'allow_missing_woocommerce', 'allow_missing_jetpack', 'materialize_dependencies', 'require_proven_dynamic_client_assets', 'seed_entities', 'write_theme_report_artifacts', 'client_script_isolated' ) as $field ) {
 			$values[ $field ] = (bool) $values[ $field ];
 		}
-		foreach ( array( 'products_manifest', 'commerce_context', 'asset_map', 'compiler_options', 'source_metadata', 'validation_artifacts', 'client_script_provenance' ) as $field ) {
+		foreach ( array( 'products_manifest', 'commerce_context', 'asset_map', 'compiler_options', 'source_metadata', 'validation_artifacts', 'quality_admission', 'client_script_provenance' ) as $field ) {
 			$values[ $field ] = is_array( $values[ $field ] ) ? $values[ $field ] : array();
 		}
 

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -20,6 +20,9 @@ if ( ! class_exists( 'Static_Site_Importer_Classic_Theme_Projection' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Current_Site_Capabilities' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-current-site-capabilities.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Quality_Admission' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-quality-admission.php';
+}
 
 final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	public const RECEIPT_SCHEMA           = 'static-site-importer/materialization-receipt/v2';
@@ -2071,6 +2074,8 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			'errors'                    => $errors,
 			'theme_materialization'     => $state['theme_materialization'] ?? self::strategy_evidence( $state['args'] ?? array() ),
 		);
+		$receipt['quality_admission']                      = Static_Site_Importer_Quality_Admission::evaluate( $resolved_plan, $state['args'] ?? array() );
+		$receipt['quality_admission']['mechanical_status'] = $status;
 		if ( ! empty( $state['args']['defer_materialization_commit'] ) && 'completed' === $status ) {
 			$receipt['transaction'] = (object) array( 'state' => $state );
 		}
@@ -2118,7 +2123,8 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				)
 			);
 		}
-		if ( ! is_array( $report ) || 'blocks-engine/php-transformer/editability-report/v1' !== ( $report['schema'] ?? null ) || ! is_array( $report['metrics'] ?? null ) || ! is_array( $report['block_types'] ?? null ) || ! is_array( $report['signals'] ?? null ) || ! is_array( $report['signal_totals'] ?? null ) ) {
+		// v2 adds scoped document evidence without changing the aggregate fields SSI admits.
+		if ( ! is_array( $report ) || ! in_array( $report['schema'] ?? null, array( 'blocks-engine/php-transformer/editability-report/v1', 'blocks-engine/php-transformer/editability-report/v2' ), true ) || ! is_array( $report['metrics'] ?? null ) || ! is_array( $report['block_types'] ?? null ) || ! is_array( $report['signals'] ?? null ) || ! is_array( $report['signal_totals'] ?? null ) ) {
 			return self::rejected_editability_report_admission( $base, 'editability_report_schema_invalid' );
 		}
 		$bound_hash = $quality['editability_report_plan_hash'] ?? null;

--- a/tests/smoke-quality-admission.php
+++ b/tests/smoke-quality-admission.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Quality-admission contract coverage.
+ *
+ * Run: php tests/smoke-quality-admission.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-quality-admission.php';
+
+$assertions = 0;
+$failures   = array();
+$assert     = static function ( bool $condition, string $label ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']';
+	}
+};
+
+$plan = array(
+	'schema'      => 'blocks-engine/wordpress-site-plan/v2',
+	'quality'     => array( 'metrics' => array( 'block_count' => 3, 'fallback_count' => 1 ) ),
+	'pages'       => array(
+		array( 'resolved_block_markup' => '<!-- wp:paragraph --><p>Native</p><!-- /wp:paragraph --><!-- wp:html --><iframe></iframe><!-- /wp:html -->' ),
+	),
+	'template_parts' => array(),
+	'writes'       => array(
+		array( 'kind' => 'theme_bootstrap', 'payload' => array( 'encoding' => 'plain', 'data' => 'bootstrap' ) ),
+	),
+	'assets'       => array( array( 'target_path' => 'assets/site.css' ), array( 'target_path' => 'assets/logo.svg' ) ),
+);
+$report = array(
+	'asset_map'         => array( 'unresolved_count' => 0 ),
+	'visual_fidelity'   => array( 'status' => 'passed' ),
+	'editor_fidelity'   => array( 'status' => 'passed' ),
+	'diagnostics'       => array(),
+);
+
+$pass = Static_Site_Importer_Quality_Admission::evaluate(
+	$plan,
+	array( 'quality_admission' => array( 'mode' => 'production_ready', 'budgets' => array( 'max_raw_html_fallback_count' => 1, 'max_theme_bootstrap_bytes' => 9, 'max_stylesheet_asset_count' => 1 ) ) ),
+	$report
+);
+$assert( 'passed' === $pass['status'] && 'completed' === $pass['mechanical_status'], 'production-ready-pass' );
+$assert( 1 === $pass['metrics']['native_block_count'] && 1 === $pass['metrics']['raw_html_fallback_count'] && array( 'core_html' => 1 ) === $pass['metrics']['raw_html_fallback_families'], 'native-and-raw-html-metrics' );
+$assert( 9 === $pass['metrics']['theme_bootstrap_bytes'] && 1 === $pass['metrics']['stylesheet_asset_count'], 'asset-budget-metrics' );
+
+$fail = Static_Site_Importer_Quality_Admission::evaluate( $plan, array( 'quality_admission' => array( 'mode' => 'production_ready', 'budgets' => array( 'max_raw_html_fallback_count' => 0 ) ) ), $report );
+$assert( 'hard_budget_failed' === $fail['status'] && 'max_raw_html_fallback_count' === ( $fail['failures'][0]['budget'] ?? '' ), 'hard-budget-fail' );
+
+$preview = Static_Site_Importer_Quality_Admission::evaluate( $plan, array( 'quality_admission' => array( 'mode' => 'preview', 'budgets' => array( 'max_raw_html_fallback_count' => 0 ) ) ), $report );
+$assert( 'preview' === $preview['status'] && 'hard_budget_failed' === $preview['production_ready'], 'preview-preserves-failure-evidence' );
+
+$unknown = Static_Site_Importer_Quality_Admission::evaluate( array( 'pages' => $plan['pages'], 'writes' => array(), 'assets' => array() ) );
+$assert( 'unknown' === $unknown['status'] && 'unknown' === $unknown['evidence']['canonical_plan'] && 'unknown' === $unknown['evidence']['visual'], 'missing-evidence-is-unknown' );
+
+$receipt = array( 'schema' => 'static-site-importer/materialization-receipt/v2', 'status' => 'completed', 'quality_admission' => $pass );
+$encoded = json_encode( $receipt );
+$persisted = json_decode( false === $encoded ? '' : $encoded, true );
+$assert( Static_Site_Importer_Quality_Admission::SCHEMA === ( $persisted['quality_admission']['schema'] ?? '' ) && 'passed' === ( $persisted['quality_admission']['status'] ?? '' ), 'receipt-persistence' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: quality admission smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-rest-import-normalization.php
+++ b/tests/smoke-rest-import-normalization.php
@@ -46,6 +46,7 @@ $options = array(
 	'compiler_options'             => array( 'include_conversion_report' => false ),
 	'source_metadata'              => array( 'request_id' => 'rest-normalization-smoke', 'source' => 'caller' ),
 	'validation_artifacts'         => array( 'visual_diff' => array( 'ref' => 'rest-diff' ) ),
+	'quality_admission'            => array( 'mode' => 'preview', 'budgets' => array( 'max_raw_html_fallback_count' => 0 ) ),
 );
 $artifact = array(
 	'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',

--- a/tests/smoke-website-artifact-import-input.php
+++ b/tests/smoke-website-artifact-import-input.php
@@ -151,6 +151,7 @@ $input  = array(
 	'compiler_options'                     => array( 'include_conversion_report' => false ),
 	'source_metadata'                      => array( 'request_id' => 'contract-1' ),
 	'validation_artifacts'                 => array( 'visual_diff' => array( 'path' => '/tmp/diff.png' ) ),
+	'quality_admission'                    => array( 'mode' => 'preview', 'budgets' => array( 'max_raw_html_fallback_count' => 0 ) ),
 	'client_script_policy'                 => 'isolated_preview',
 	'client_script_provenance'             => array( 'ref' => 'contract:preview' ),
 	'client_script_isolated'               => true,

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -347,7 +347,7 @@ $with_editability_report = static function ( array $candidate ) use ( $result, $
 };
 $strict_editability_plan = $with_editability_report( $plan );
 $strict_editability_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $strict_editability_plan, array( 'slug' => 'strict-editability-plan' ) );
-$assert( 'completed' === $strict_editability_receipt['status'] && 'passed' === ( $strict_editability_receipt['editability_report']['status'] ?? '' ) && 'blocks-engine/php-transformer/editability-report/v1' === ( $strict_editability_receipt['editability_report']['report_schema'] ?? '' ), 'valid hash-bound Blocks Engine editability reports are admitted before materialization' );
+$assert( 'completed' === $strict_editability_receipt['status'] && 'passed' === ( $strict_editability_receipt['editability_report']['status'] ?? '' ) && 'blocks-engine/php-transformer/editability-report/v2' === ( $strict_editability_receipt['editability_report']['report_schema'] ?? '' ), 'valid hash-bound Blocks Engine editability reports are admitted before materialization' );
 
 $compatibility_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'compatibility-editability-plan' ) );
 $assert( 'completed' === $compatibility_receipt['status'] && 'compatibility_policy_only' === ( $compatibility_receipt['editability_report']['status'] ?? '' ) && 'editability_report_compatibility_policy_only' === ( $compatibility_receipt['editability_report']['diagnostic']['reason_code'] ?? '' ), 'current producer plans retain explicit compatibility evidence' );
@@ -414,6 +414,7 @@ $assert( 'installed_activated' === ( $gap_diagnostics[0]['materialization_status
 $receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $plan, array( 'slug' => 'site-plan' ) );
 $assert( 'completed' === $receipt['status'], 'valid plan completes' );
 $assert( 'static-site-importer/materialization-receipt/v2' === $receipt['schema'] && $plan['plan_identity'] === ( $receipt['plan_identity'] ?? null ), 'receipt binds the producer plan identity.' );
+$assert( 'static-site-importer/quality-admission/v1' === ( $receipt['quality_admission']['schema'] ?? '' ) && 'unknown' === ( $receipt['quality_admission']['status'] ?? '' ), 'materialization receipt persists explicit unknown quality evidence when canonical evidence is absent' );
 $assert( count( $plan['writes'] ) === count( $receipt['generated_files'] ), 'all canonical writes are materialized' );
 $assert( file_exists( $GLOBALS['ssi_plan_root'] . '/site-plan/templates/front-page.html' ), 'templates are materialized' );
 $assert( str_contains( file_get_contents( $GLOBALS['ssi_plan_root'] . '/site-plan/assets/assets/site.css' ), 'https://example.test/wp-content/themes/site-plan/assets/assets/logo.svg' ), 'root-relative stylesheet references resolve to declared theme assets' );


### PR DESCRIPTION
Closes #1181

## Summary
- add the versioned, configurable quality admission decision to receipts and import reports
- distinguish mechanical completion from production-ready pass, hard-budget failure, preview, and unknown evidence
- report canonical block/fallback, dependency/media, bootstrap, stylesheet, and supplied visual/editor evidence without changing compiler output
- expose the contract through the shared import input schema and cover pass, fail, preview, unknown, budgets, and receipt persistence

## Testing
- `zsh -c 'for test in tests/smoke-*.php; do php "$test"; done'`\n- `php tests/smoke-quality-admission.php`\n- PHP syntax checks and `git diff --check`\n\nThe runtime-backed `smoke-wordpress-site-plan-materializer.php` remains skipped in the normal suite without `STATIC_SITE_IMPORTER_WP_ROOT`. When run against the local runtime it exposes an existing fixture mismatch: the pinned transformer emits editability-report v2 and validates real plan identities while the origin/main smoke supplies synthetic identities. This PR explicitly admits v2 aggregate evidence alongside v1.\n\n## AI assistance\nOpenAI GPT-5.6-sol via OpenCode general coding subagent implemented the admission contract, tests, and documentation. Chris Huber remains responsible for every line.