### PR TITLE
Persist failed plan quality diagnostics

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -15,6 +15,7 @@
     "tests/smoke-diagnostic-loss-classes.php": { "environment": "standalone-php" },
     "tests/smoke-entity-materializer-registry.php": { "environment": "standalone-php" },
     "tests/smoke-external-report-destinations.php": { "environment": "standalone-php" },
+    "tests/smoke-failed-plan-validation.php": { "environment": "standalone-php" },
     "tests/smoke-export-theme-ability.php": { "environment": "standalone-php" },
     "tests/smoke-import-diagnostic-contract.php": { "environment": "standalone-php" },
     "tests/smoke-import-disposition.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-failed-plan-validation.php
+++ b/includes/class-static-site-importer-failed-plan-validation.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Builds durable, bounded evidence for plans rejected before materialization.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class Static_Site_Importer_Failed_Plan_Validation {
+
+	private const MAX_DIAGNOSTICS = 50;
+
+	/** @return array<string,mixed> */
+	public static function build( array $plan, array $args = array() ): array {
+		$diagnostics = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
+		$report = array(
+			'schema'      => 'static-site-importer/import-report/v1',
+			'version'     => 1,
+			'status'      => 'failed',
+			'theme_slug'  => (string) ( $args['slug'] ?? '' ),
+			'quality'     => isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array(),
+			'diagnostics' => array_slice( $diagnostics, 0, self::MAX_DIAGNOSTICS ),
+			'blocks_engine' => array(
+				'wordpress_site_plan' => array(
+					'schema'  => (string) ( $plan['schema'] ?? 'blocks-engine/wordpress-site-plan/v2' ),
+					'quality' => isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array(),
+				),
+			),
+			'failure_context' => array(
+				'stage' => 'pre_materialization_quality_admission',
+				'code'  => 'static_site_importer_quality_gate_failed',
+			),
+		);
+		if ( count( $diagnostics ) > self::MAX_DIAGNOSTICS ) {
+			$report['diagnostics_truncated'] = true;
+			$report['diagnostic_count']      = count( $diagnostics );
+		}
+
+		$quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $report, array_merge( $args, array( 'fail_on_quality' => true ) ) );
+		$quality['pass']            = false;
+		$quality['fail_import']     = true;
+		$quality['failure_reasons'] = self::failure_reasons( $plan, $quality );
+		$report['quality']          = $quality;
+		$report['compact_summary']  = Static_Site_Importer_Report_Diagnostics::import_report_summary( $report, $quality );
+		$report['finding_packets']  = Static_Site_Importer_Report_Diagnostics::finding_packets( $report );
+		$report['import_validation_result'] = Static_Site_Importer_Report_Diagnostics::import_validation_result( $report, $quality );
+
+		return array(
+			'import_report'            => $report,
+			'import_report_summary'    => $report['compact_summary'],
+			'import_validation_result' => $report['import_validation_result'],
+			'finding_packets'          => $report['finding_packets'],
+		);
+	}
+
+	/** @return array<string,string> */
+	public static function persist( array $artifacts, string $report_path ): array {
+		if ( '' === trim( $report_path ) ) {
+			return array();
+		}
+		$directory = dirname( $report_path );
+		$paths = array(
+			'import_report'            => $report_path,
+			'import_validation_result' => trailingslashit( $directory ) . 'import-validation-result.json',
+			'finding_packets'          => trailingslashit( $directory ) . 'finding-packets.json',
+		);
+		foreach ( $paths as $path ) {
+			if ( ! self::safe_destination( $path ) ) {
+				throw new RuntimeException( 'Failed-plan report destination is not ready.' );
+			}
+		}
+		self::write( $paths['import_report'], isset( $artifacts['import_report'] ) && is_array( $artifacts['import_report'] ) ? $artifacts['import_report'] : array() );
+		self::write( $paths['import_validation_result'], isset( $artifacts['import_validation_result'] ) && is_array( $artifacts['import_validation_result'] ) ? $artifacts['import_validation_result'] : array() );
+		self::write( $paths['finding_packets'], isset( $artifacts['finding_packets'] ) && is_array( $artifacts['finding_packets'] ) ? $artifacts['finding_packets'] : array() );
+		return $paths;
+	}
+
+	/** @return array<int,string> */
+	private static function failure_reasons( array $plan, array $quality ): array {
+		$reasons = isset( $plan['quality']['failure_reasons'] ) && is_array( $plan['quality']['failure_reasons'] ) ? $plan['quality']['failure_reasons'] : ( $quality['failure_reasons'] ?? array() );
+		$reasons = array_values( array_filter( $reasons, 'is_string' ) );
+		return empty( $reasons ) ? array( 'canonical_plan_quality_gate_failed' ) : array_slice( $reasons, 0, self::MAX_DIAGNOSTICS );
+	}
+
+	private static function safe_destination( string $path ): bool {
+		$normalized = str_replace( '\\', '/', $path );
+		if ( '' === $path || str_contains( $normalized, '/../' ) || str_starts_with( $normalized, '../' ) || str_ends_with( $normalized, '/..' ) ) {
+			return false;
+		}
+		$parent = dirname( $path );
+		if ( ! is_dir( $parent ) || is_link( $parent ) || is_link( $path ) || ( file_exists( $path ) && ! is_writable( $path ) ) || ! is_writable( $parent ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- Explicit CLI report artifacts are atomically replaced to preserve retryability.
+			return false;
+		}
+		return true;
+	}
+
+	private static function write( string $path, array $payload ): void {
+		$temp = tempnam( dirname( $path ), '.ssi-failed-plan-' );
+		$json = function_exists( 'wp_json_encode' ) ? wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) : json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		if ( false === $temp || false === $json || false === file_put_contents( $temp, $json . "\n" ) || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents,WordPress.WP.AlternativeFunctions.rename_rename -- Atomically writes bounded explicit report artifacts.
+			if ( is_string( $temp ) && file_exists( $temp ) ) {
+				unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes a failed atomic report temporary file.
+			}
+			throw new RuntimeException( 'Failed to write failed-plan report artifact.' );
+		}
+	}
+}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -26,6 +26,9 @@ if ( ! class_exists( 'Static_Site_Importer_Block_Document_Reporter' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Report_Diagnostics' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-report-diagnostics.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Failed_Plan_Validation' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-failed-plan-validation.php';
+}
 if ( ! class_exists( 'Static_Site_Importer_Client_Script_Policy' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-client-script-policy.php';
 }
@@ -91,12 +94,21 @@ class Static_Site_Importer_Theme_Generator {
 		$theme_materialization = $compiled_import['theme_materialization'];
 		$args['font_materialization'] = isset( $materialization_plan['theme']['font_materialization'] ) && is_array( $materialization_plan['theme']['font_materialization'] ) ? $materialization_plan['theme']['font_materialization'] : array();
 		if ( ! empty( $args['fail_on_quality'] ) && empty( $plan['quality']['pass'] ) ) {
+			$failed_plan = Static_Site_Importer_Failed_Plan_Validation::build( $plan, $args );
+			try {
+				$failed_plan['artifact_refs'] = Static_Site_Importer_Failed_Plan_Validation::persist( $failed_plan, (string) ( $args['report'] ?? '' ) );
+			} catch ( Throwable $error ) {
+				$failed_plan['artifact_persistence_error'] = $error->getMessage();
+			}
 			return new WP_Error(
 				'static_site_importer_quality_gate_failed',
 				'Website artifact did not pass the canonical plan quality gate.',
-				array(
-					'quality'     => $plan['quality'] ?? array(),
-					'diagnostics' => $plan['diagnostics'] ?? array(),
+				array_merge(
+					array(
+						'quality'     => $plan['quality'] ?? array(),
+						'diagnostics' => $plan['diagnostics'] ?? array(),
+					),
+					$failed_plan
 				)
 			);
 		}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -79,6 +79,7 @@ require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-di
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-validation-runtime.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-report-diagnostics.php';
+require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-failed-plan-validation.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-font-materializer.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-document-type-classifier.php';
 require_once STATIC_SITE_IMPORTER_PATH . 'includes/class-static-site-importer-current-site-capabilities.php';

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -21,6 +21,7 @@
     { "path": "tests/editor-validation-contract.test.mjs", "environment": "node" },
     { "path": "tests/smoke-entity-materializer-registry.php", "environment": "standalone-php" },
     { "path": "tests/smoke-external-report-destinations.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-failed-plan-validation.php", "environment": "standalone-php" },
     { "path": "tests/smoke-export-theme-ability.php", "environment": "standalone-php" },
     { "path": "tests/smoke-import-diagnostic-contract.php", "environment": "standalone-php" },
     { "path": "tests/smoke-import-disposition.php", "environment": "standalone-php" },

--- a/tests/smoke-failed-plan-validation.php
+++ b/tests/smoke-failed-plan-validation.php
@@ -1,0 +1,71 @@
+<?php
+/** Run: php tests/smoke-failed-plan-validation.php */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $path ): string {
+		return rtrim( $path, '/\\' ) . '/';
+	}
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return (string) preg_replace( '/[^a-z0-9_-]/', '', strtolower( $key ) );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-loss-classes.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-failed-plan-validation.php';
+
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+};
+
+$diagnostics = array();
+for ( $index = 0; $index < 75; ++$index ) {
+	$diagnostics[] = array(
+		'type'        => 'document_nesting',
+		'severity'    => 'error',
+		'reason_code' => 'document_nesting',
+		'message'     => 'Nested document ' . $index,
+	);
+}
+$plan = array(
+	'schema'      => 'blocks-engine/wordpress-site-plan/v2',
+	'quality'     => array( 'pass' => false, 'metrics' => array( 'fallback_count' => 0 ), 'failure_reasons' => array( 'document_nesting', 'empty_wrapper' ) ),
+	'diagnostics' => $diagnostics,
+);
+$original_plan = $plan;
+$artifacts = Static_Site_Importer_Failed_Plan_Validation::build( $plan, array( 'slug' => 'zero-fallback-failure', 'fail_on_quality' => true ) );
+
+$assert( false === ( $artifacts['import_report']['quality']['pass'] ?? true ), 'zero-fallback canonical quality failure remains failed' );
+$assert( true === ( $artifacts['import_report']['quality']['fail_import'] ?? false ), 'failed plan is marked terminal in the standard quality shape' );
+$assert( 0 === ( $artifacts['import_report']['quality']['fallback_count'] ?? -1 ), 'zero fallback evidence is retained' );
+$assert( 50 === count( $artifacts['import_report']['diagnostics'] ?? array() ), 'failed-plan report bounds diagnostics' );
+$assert( true === ( $artifacts['import_report']['diagnostics_truncated'] ?? false ), 'failed-plan report records truncation' );
+$assert( 75 === ( $artifacts['import_report']['diagnostic_count'] ?? 0 ), 'failed-plan report retains original diagnostic count' );
+$assert( 'blocks-engine/import-validation-result/v1' === ( $artifacts['import_validation_result']['schema'] ?? '' ), 'standard validation artifact schema is preserved' );
+$assert( 'blocks-engine/finding-packets/v1' === ( $artifacts['finding_packets']['schema'] ?? '' ), 'standard finding packet schema is preserved' );
+$assert( $plan === $original_plan, 'failed-plan evidence generation does not mutate the canonical plan' );
+
+$root = sys_get_temp_dir() . '/ssi-failed-plan-validation-' . uniqid( '', true );
+mkdir( $root );
+$paths = Static_Site_Importer_Failed_Plan_Validation::persist( $artifacts, $root . '/import-report.json' );
+$assert( 3 === count( $paths ), 'explicit report destination writes all standard artifacts' );
+$assert( is_file( $paths['import_report'] ) && is_file( $paths['import_validation_result'] ) && is_file( $paths['finding_packets'] ), 'explicit report artifacts exist' );
+$persisted = json_decode( (string) file_get_contents( $paths['import_report'] ), true );
+$assert( 'pre_materialization_quality_admission' === ( $persisted['failure_context']['stage'] ?? '' ), 'persisted report identifies its non-mutating admission stage' );
+
+$paths_again = Static_Site_Importer_Failed_Plan_Validation::persist( $artifacts, $root . '/import-report.json' );
+$assert( $paths === $paths_again, 'retrying a failed plan refreshes its owned report artifacts' );
+foreach ( $paths as $path ) {
+	unlink( $path );
+}
+rmdir( $root );
+
+echo "Failed-plan validation smoke passed.\n";


### PR DESCRIPTION
## Summary
- build bounded validation and finding artifacts for canonical plans rejected before materialization
- persist explicit CLI report destinations without changing the quality-gate error code or message
- cover zero-fallback failures, bounds, persistence, retryability, and immutability

Closes #1206

AI assistance: OpenAI gpt-5.6-sol via OpenCode implemented and tested the pre-materialization diagnostics path. Chris Huber reviewed and remains responsible for every line.