### PR TITLE
Activate installed runtime provider plugins before installation

### DIFF
--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -81,7 +81,7 @@ class Static_Site_Importer_Plugin_Materializer {
 			return self::failed_report( $report, $activation_deps );
 		}
 
-		if ( is_plugin_active( $plugin_file ) ) {
+		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( $plugin_file ) ) {
 			$report['active'] = true;
 			$report['attempted_actions'][] = 'prepare_runtime';
 			$preparation      = self::prepare_plugin_runtime( $slug, $preparation_callback );

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -48,19 +48,19 @@ class Static_Site_Importer_Plugin_Materializer {
 
 		$report['attempted'] = true;
 
-		$deps = self::load_admin_dependencies();
-		if ( is_wp_error( $deps ) ) {
-			return self::failed_report( $report, $deps );
-		}
-
 		$plugin_path   = trailingslashit( WP_PLUGIN_DIR ) . $plugin_file;
 		$needs_install = ! self::plugin_entrypoint_exists( $plugin_path );
 		if ( ! $needs_install ) {
 			$report['installed'] = true;
 		} else {
+			$report['attempted_actions'][] = 'install';
 			$capabilities = Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( true );
 			if ( is_wp_error( $capabilities ) ) {
 				return self::failed_report( $report, $capabilities );
+			}
+			$deps = self::load_admin_dependencies();
+			if ( is_wp_error( $deps ) ) {
+				return self::failed_report( $report, $deps );
 			}
 			$install = self::install_wp_org_plugin( $slug );
 			if ( is_wp_error( $install ) ) {
@@ -76,9 +76,14 @@ class Static_Site_Importer_Plugin_Materializer {
 				$report['actions'][] = 'installed';
 			}
 		}
+		$activation_deps = self::load_activation_dependencies();
+		if ( is_wp_error( $activation_deps ) ) {
+			return self::failed_report( $report, $activation_deps );
+		}
 
-		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( $plugin_file ) ) {
+		if ( is_plugin_active( $plugin_file ) ) {
 			$report['active'] = true;
+			$report['attempted_actions'][] = 'prepare_runtime';
 			$preparation      = self::prepare_plugin_runtime( $slug, $preparation_callback );
 			if ( is_wp_error( $preparation ) ) {
 				return self::failed_report( $report, $preparation );
@@ -88,6 +93,7 @@ class Static_Site_Importer_Plugin_Materializer {
 			if ( is_wp_error( $capabilities ) ) {
 				return self::failed_report( $report, $capabilities );
 			}
+			$report['attempted_actions'][] = 'activate';
 			$lifecycle = self::prepare_activation_lifecycle_replay();
 			try {
 				$activate = activate_plugin( $plugin_file );
@@ -104,11 +110,13 @@ class Static_Site_Importer_Plugin_Materializer {
 				}
 				$report['active']    = true;
 				$report['actions'][] = 'reconciled_activated';
+				$report['attempted_actions'][] = 'prepare_runtime';
 				$preparation         = self::prepare_plugin_runtime( $slug, $preparation_callback );
 				if ( is_wp_error( $preparation ) ) {
 					return self::failed_report( $report, $preparation );
 				}
 			} else {
+				$report['attempted_actions'][] = 'prepare_runtime';
 				$preparation = self::prepare_plugin_runtime( $slug, $preparation_callback );
 				if ( is_wp_error( $preparation ) ) {
 					self::restore_activation_lifecycle_actions( $lifecycle );
@@ -561,9 +569,10 @@ class Static_Site_Importer_Plugin_Materializer {
 			'attempted'   => false,
 			'installed'   => false,
 			'active'      => false,
-			'actions'     => array(),
-			'error'       => '',
-			'provenance'  => array(
+			'actions'           => array(),
+			'attempted_actions' => array(),
+			'error'             => '',
+			'provenance'        => array(
 				'source'  => 'wordpress.org',
 				'version' => '',
 				'sha256'  => '',
@@ -792,6 +801,27 @@ class Static_Site_Importer_Plugin_Materializer {
 			return new WP_Error(
 				'static_site_importer_plugin_upgrader_unavailable',
 				'WordPress plugin upgrader classes are unavailable.'
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Load only the WordPress dependency required to activate an installed plugin.
+	 *
+	 * @return true|WP_Error
+	 */
+	private static function load_activation_dependencies() {
+		$file = ABSPATH . 'wp-admin/includes/plugin.php';
+		if ( is_readable( $file ) ) {
+			require_once $file;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) || ! function_exists( 'activate_plugin' ) ) {
+			return new WP_Error(
+				'static_site_importer_plugin_activation_unavailable',
+				'WordPress plugin activation functions are unavailable.'
 			);
 		}
 

--- a/tests/smoke-plugin-materializer-lifecycle.php
+++ b/tests/smoke-plugin-materializer-lifecycle.php
@@ -17,7 +17,18 @@ class WP_Error {
 	public function get_error_message(): string { return $this->message; }
 	public function get_error_data(): mixed { return $this->data; }
 }
-class Plugin_Upgrader {}
+class Plugin_Upgrader {
+	public function __construct( mixed $skin = null ) {}
+	public function install( string $download_link ): bool|WP_Error {
+		++$GLOBALS['ssi_install_attempts'];
+		if ( 'install_failure' === $GLOBALS['ssi_install_outcome'] ) {
+			return new WP_Error( 'install_failed', 'Plugin installation failed.' );
+		}
+		mkdir( WP_PLUGIN_DIR . '/absent-plugin', 0777, true );
+		file_put_contents( WP_PLUGIN_DIR . '/absent-plugin/absent-plugin.php', "<?php\n" );
+		return true;
+	}
+}
 class Automatic_Upgrader_Skin {}
 class SSI_Test_Hook {
 	public array $callbacks = array();
@@ -32,6 +43,9 @@ $GLOBALS['ssi_replay_order']  = array();
 $GLOBALS['ssi_existing_runs'] = 0;
 $GLOBALS['ssi_prepared']      = false;
 $GLOBALS['ssi_activation_outcome'] = 'success';
+$GLOBALS['ssi_activation_attempts'] = 0;
+$GLOBALS['ssi_install_attempts'] = 0;
+$GLOBALS['ssi_install_outcome'] = 'success';
 
 function ssi_test_callback_id( callable $callback ): string {
 	if ( is_string( $callback ) ) return $callback;
@@ -53,8 +67,13 @@ function did_action( string $hook ): int { return (int) ( $GLOBALS['wp_actions']
 function is_wp_error( mixed $value ): bool { return $value instanceof WP_Error; }
 function trailingslashit( string $value ): string { return rtrim( $value, '/\\' ) . '/'; }
 function is_plugin_active( string $plugin_file ): bool { return $GLOBALS['ssi_plugin_active']; }
+function plugins_api( string $action, array $args ): object {
+	unset( $action, $args );
+	return (object) array( 'download_link' => 'https://example.test/absent-plugin.zip' );
+}
 function activate_plugin( string $plugin_file ) {
 	unset( $plugin_file );
+	++$GLOBALS['ssi_activation_attempts'];
 	if ( 'throw_without_state_change' !== $GLOBALS['ssi_activation_outcome'] ) {
 		$GLOBALS['ssi_plugin_active'] = true;
 	}
@@ -107,6 +126,16 @@ $assert( 0 === $GLOBALS['ssi_existing_runs'], 'existing-callbacks-not-replayed' 
 $assert( 1 === did_action( 'plugins_loaded' ) && 1 === did_action( 'init' ) && 1 === did_action( 'wp_loaded' ), 'action-counts-restored' );
 $assert( 1 === ( $report['lifecycle_replay']['plugins_loaded'] ?? 0 ), 'plugins-loaded-replay-reported' );
 $assert( 1 === ( $report['lifecycle_replay']['init'] ?? 0 ), 'init-replay-reported' );
+$assert( 0 === $GLOBALS['ssi_install_attempts'], 'installed-inactive-does-not-install' );
+
+$GLOBALS['ssi_activation_attempts'] = 0;
+$GLOBALS['ssi_plugin_active'] = true;
+$active_report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
+	'late-plugin',
+	'late-plugin/late-plugin.php',
+	static fn (): bool => true
+);
+$assert( 'already_available' === ( $active_report['status'] ?? '' ) && 0 === $GLOBALS['ssi_activation_attempts'], 'active-provider-is-not-reactivated' );
 
 $GLOBALS['ssi_plugin_active'] = false;
 $GLOBALS['ssi_activation_outcome'] = 'error_after_state_change';
@@ -148,9 +177,30 @@ $activation_throw_failure = Static_Site_Importer_Plugin_Materializer::ensure_wp_
 	static fn (): bool => true
 );
 $assert( 'failed' === ( $activation_throw_failure['status'] ?? '' ) && 'static_site_importer_plugin_activation_failed' === ( $activation_throw_failure['error']['code'] ?? '' ), 'genuine-thrown-activation-failure-rejected' );
+$assert( 'late-plugin' === ( $activation_throw_failure['slug'] ?? '' ) && in_array( 'activate', $activation_throw_failure['attempted_actions'] ?? array(), true ) && false !== strpos( (string) ( $activation_throw_failure['error']['message'] ?? '' ), 'Activation callback threw.' ), 'activation-failure-evidence' );
 
 unlink( WP_PLUGIN_DIR . '/late-plugin/late-plugin.php' );
 rmdir( WP_PLUGIN_DIR . '/late-plugin' );
+$GLOBALS['ssi_plugin_active'] = false;
+$GLOBALS['ssi_activation_outcome'] = 'success';
+$absent_report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
+	'absent-plugin',
+	'absent-plugin/absent-plugin.php',
+	static fn (): bool => $GLOBALS['ssi_plugin_active'],
+	static fn (): bool => true
+);
+$assert( 'installed_activated' === ( $absent_report['status'] ?? '' ) && 1 === $GLOBALS['ssi_install_attempts'] && in_array( 'install', $absent_report['attempted_actions'] ?? array(), true ) && in_array( 'activate', $absent_report['attempted_actions'] ?? array(), true ), 'absent-provider-installs-then-activates' );
+
+unlink( WP_PLUGIN_DIR . '/absent-plugin/absent-plugin.php' );
+rmdir( WP_PLUGIN_DIR . '/absent-plugin' );
+$GLOBALS['ssi_install_outcome'] = 'install_failure';
+$install_failure_report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
+	'absent-plugin',
+	'absent-plugin/absent-plugin.php',
+	static fn (): bool => false
+);
+$assert( 'failed' === ( $install_failure_report['status'] ?? '' ) && 'absent-plugin' === ( $install_failure_report['slug'] ?? '' ) && in_array( 'install', $install_failure_report['attempted_actions'] ?? array(), true ) && 'install_failed' === ( $install_failure_report['error']['code'] ?? '' ) && 'Plugin installation failed.' === ( $install_failure_report['error']['message'] ?? '' ), 'installation-failure-evidence' );
+
 rmdir( WP_PLUGIN_DIR );
 rmdir( $tmp );
 


### PR DESCRIPTION
## Summary

- inspect the provider entrypoint before loading WordPress installer dependencies
- load only activation support for installed-inactive providers, avoiding an unnecessary install or reinstall path
- retain absent-provider installation, active-provider no-op behavior, lifecycle replay, and structured action/error evidence

## Testing

- `php tests/smoke-plugin-materializer-lifecycle.php`
- `npm test` (62 selected checks passed)
- `git diff --check`

Fixes #1212.

## AI assistance

OpenAI gpt-5.6-sol was used through OpenCode to inspect the plugin lifecycle, implement the dependency split and regression coverage, and run verification. Chris Huber reviewed and is responsible for the changes.