### PR TITLE
fix: separate materialization errors from diagnostics

### DIFF
--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -106,6 +106,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			WordPressSitePlan::assertValid( $plan );
 		} catch ( InvalidArgumentException $error ) {
 			$state['diagnostics'][] = array( 'reason_code' => 'canonical_plan_rejected' );
+			$state['failure_reason'] = 'canonical_plan_rejected';
 			return array(
 				'status'  => 'rejected',
 				'receipt' => self::receipt( 'rejected', $state ),
@@ -114,6 +115,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$state['editability_report'] = self::editability_report_admission( $plan );
 		if ( 'rejected' === $state['editability_report']['status'] ) {
 			$state['diagnostics'][] = $state['editability_report']['diagnostic'];
+			$state['failure_reason'] = (string) ( $state['editability_report']['diagnostic']['reason_code'] ?? 'editability_report_rejected' );
 			return array(
 				'status'  => 'rejected',
 				'receipt' => self::receipt( 'rejected', $state ),
@@ -176,6 +178,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 					'reason_code'    => 'quality_budget_failed',
 					'quality_budget' => $state['quality_budget_admission'],
 				);
+				$state['failure_reason'] = 'quality_budget_failed';
 				return array(
 					'status'  => 'rejected',
 					'receipt' => self::receipt( 'rejected', $state ),
@@ -184,6 +187,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			self::preflight_state( $state, ! empty( $args['overwrite'] ), (string) ( $args['import_run_id'] ?? '' ) );
 		} catch ( InvalidArgumentException $error ) {
 			$state['diagnostics'][] = array( 'reason_code' => $error->getMessage() );
+			$state['failure_reason'] = $error->getMessage();
 			return array(
 				'status'  => 'rejected',
 				'receipt' => self::receipt( 'rejected', $state ),
@@ -220,6 +224,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 						'plan'             => isset( $prepared['plan'] ) && is_array( $prepared['plan'] ) ? $prepared['plan'] : array(),
 						'plan_identity'    => is_array( $prepared['plan_identity'] ?? null ) ? $prepared['plan_identity'] : array(),
 						'diagnostics'      => array( array( 'reason_code' => 'invalid_prepared_state' ) ),
+						'failure_reason'   => 'invalid_prepared_state',
 						'applied'          => array(
 							'posts'                => array(),
 							'files'                => array(),
@@ -241,6 +246,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$references = self::verify_payload_references( $prepared['resolved']['writes'], is_object( $prepared['payload_reader'] ?? null ) ? $prepared['payload_reader'] : null );
 		if ( is_wp_error( $references ) ) {
 			$prepared['diagnostics'][] = array( 'reason_code' => $references->get_error_code() );
+			$prepared['failure_reason'] = $references->get_error_code();
 			return array(
 				'status'  => 'rejected',
 				'receipt' => self::receipt( 'rejected', $prepared ),
@@ -256,6 +262,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			'plan'                  => $plan,
 			'plan_identity'         => self::plan_identity( $plan ),
 			'diagnostics'           => array( array( 'reason_code' => $error->get_error_code() ) ),
+			'failure_reason'        => $error->get_error_code(),
 			'applied'               => array(
 				'posts'                => array(),
 				'files'                => array(),
@@ -285,6 +292,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 					'plan'             => array(),
 					'plan_identity'    => array(),
 					'diagnostics'      => array( array( 'reason_code' => 'invalid_prepared_state' ) ),
+					'failure_reason'   => 'invalid_prepared_state',
 					'applied'          => array(
 						'posts'                => array(),
 						'files'                => array(),
@@ -314,6 +322,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		try {
 			self::validate_materialized_block_documents( $state['resolved'], $state['applied']['runtime_declarations']['entity_bindings'], $state['diagnostics'] );
 		} catch ( InvalidArgumentException $error ) {
+			$state['failure_reason'] = $error->getMessage();
 			return self::receipt( 'rejected', $state );
 		}
 		$args         = $state['args'];
@@ -521,6 +530,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 						'plan'             => is_array( $plan ) ? $plan : array(),
 						'plan_identity'    => array(),
 						'diagnostics'      => array( array( 'reason_code' => 'prepared_projection_changed' ) ),
+						'failure_reason'   => 'prepared_projection_changed',
 						'applied'          => array(
 							'posts'                => array(),
 							'files'                => array(),
@@ -604,6 +614,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 					'reason_code'    => 'quality_budget_failed',
 					'quality_budget' => $state['quality_budget_admission'],
 				);
+				$state['failure_reason'] = 'quality_budget_failed';
 				return array(
 					'status'  => 'rejected',
 					'receipt' => self::receipt( 'rejected', $state ),
@@ -613,6 +624,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			self::preflight_state( $state, ! empty( $args['overwrite'] ), (string) ( $args['import_run_id'] ?? '' ) );
 		} catch ( InvalidArgumentException $error ) {
 			$state['diagnostics'][] = array( 'reason_code' => $error->getMessage() );
+			$state['failure_reason'] = $error->getMessage();
 			return array(
 				'status'  => 'rejected',
 				'receipt' => self::receipt( 'rejected', $state ),
@@ -1812,6 +1824,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	/** @param array<string,mixed> $state */
 	private static function failed_receipt( array $state, int|string $reason ): array {
 		$state['diagnostics'][] = array( 'reason_code' => (string) $reason );
+		$state['failure_reason'] = (string) $reason;
 		self::rollback( $state );
 		return self::receipt( 'partial', $state );
 	}
@@ -1819,6 +1832,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	/** @param array<string,mixed> $state */
 	private static function failed_receipt_from_error( array $state, WP_Error $error ): array {
 		$state['diagnostics'][] = array( 'reason_code' => $error->get_error_code() );
+		$state['failure_reason'] = $error->get_error_code();
 		$data                   = $error->get_error_data();
 		if ( is_array( $data ) ) {
 			foreach ( $data as $diagnostic ) {
@@ -1950,6 +1964,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		}
 		$state                  = $receipt['transaction']->state;
 		$state['diagnostics'][] = array( 'reason_code' => $reason );
+		$state['failure_reason'] = $reason;
 		self::rollback( $state );
 		$result                        = self::receipt( 'partial', $state );
 		$receipt['transaction']->state = $state;
@@ -2037,13 +2052,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$resolved_plan['pages'] = $receipt_pages;
 		$errors                 = array();
 		$pages                  = isset( $state['source_ids'] ) && is_array( $state['source_ids'] ) ? $state['source_ids'] : array();
-		foreach ( $state['diagnostics'] as $diagnostic ) {
-			if ( isset( $diagnostic['reason_code'] ) && is_string( $diagnostic['reason_code'] ) ) {
-				$errors[] = array(
-					'code'    => $diagnostic['reason_code'],
-					'message' => $diagnostic['reason_code'],
-				);
-			}
+		if ( isset( $state['failure_reason'] ) && is_string( $state['failure_reason'] ) && '' !== $state['failure_reason'] ) {
+			$errors[] = array(
+				'code'    => $state['failure_reason'],
+				'message' => $state['failure_reason'],
+			);
 		}
 		$receipt = array(
 			'schema'                    => self::RECEIPT_SCHEMA,

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1691,7 +1691,17 @@ $hierarchy_binding['reconciliation_identity'] = hash( 'sha256', 'hierarchy-diagn
 $hierarchy_binding['replacement_block_markup'] = '<!-- wp:example/restricted-parent --><!-- wp:example/restricted-child --><div>Restricted child</div><!-- /wp:example/restricted-child --><!-- /wp:example/restricted-parent -->';
 $hierarchy_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $binding_plan, array( 'slug' => 'hierarchy-diagnostic-binding-plan', 'runtime_entity_bindings' => array( $hierarchy_binding ) ) );
 $hierarchy_reasons = array_column( $hierarchy_receipt['diagnostics'] ?? array(), 'reason_code' );
-$assert( 'completed' === $hierarchy_receipt['status'] && in_array( 'block_child_not_allowed', $hierarchy_reasons, true ) && in_array( 'block_parent_requirement_not_met', $hierarchy_reasons, true ), 'registered blocks retain parent and allowedBlocks editor-quality diagnostics' );
+$assert( 'completed' === $hierarchy_receipt['status'] && array() === ( $hierarchy_receipt['errors'] ?? null ) && in_array( 'block_child_not_allowed', $hierarchy_reasons, true ) && in_array( 'block_parent_requirement_not_met', $hierarchy_reasons, true ), 'registered blocks retain parent and allowedBlocks editor-quality diagnostics without reporting transaction errors' );
+$hierarchy_failure_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$binding_plan,
+	array(
+		'slug'                           => 'hierarchy-diagnostic-failure-plan',
+		'runtime_entity_bindings'        => array( $hierarchy_binding ),
+		'inject_materialization_failure' => 'theme_write_short',
+	)
+);
+$hierarchy_failure_reasons = array_column( $hierarchy_failure_receipt['diagnostics'] ?? array(), 'reason_code' );
+$assert( 'partial' === $hierarchy_failure_receipt['status'] && 'theme_write_failed' === ( $hierarchy_failure_receipt['errors'][0]['code'] ?? '' ) && in_array( 'block_child_not_allowed', $hierarchy_failure_reasons, true ) && in_array( 'block_parent_requirement_not_met', $hierarchy_failure_reasons, true ), 'failed receipts retain nonfatal editor diagnostics while exposing the transaction-breaking cause first' );
 $invalid_binding         = array(
 	'schema'                   => 'static-site-importer/runtime-entity-binding/v1',
 	'source_path'              => 'index.html',


### PR DESCRIPTION
## Summary
Verified intentional no-change review for existing candidate commit f0c30f89353eb345c21c3b77e0af974f0e8c3965. The commit correctly separates transaction-breaking receipt errors from nonfatal editor diagnostics for issue #1226.

## What changed
- The candidate records each rejected or partial materialization failure in a dedicated failure\_reason field and projects only that reason into receipt.errors.
- Nonfatal block hierarchy findings remain in receipt.diagnostics and completed receipts now retain those diagnostics with an empty errors array.
- Regression coverage verifies completed hierarchy diagnostics and verifies that a later injected theme-write failure is the exposed transaction error while earlier editor diagnostics remain available.
- No additional source or test changes were made; the existing immutable candidate and clean worktree were preserved.

## How to test
1. Run `php -l includes/class-static-site-importer-wordpress-site-plan-materializer.php && php -l tests/smoke-wordpress-site-plan-materializer.php`; expect passes as recorded by Cook's deterministic gate.
2. Run `npm run test:site-plan-materializer`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Low risk and contract-aligning. Receipt status, diagnostics, and materialization behavior are unchanged; only errors is narrowed to the actual transaction-breaking cause. Existing failure paths retain their established reason codes. The evidence boundary covers completed hierarchy diagnostics and a later theme-write failure; controller-owned gates provide authoritative syntax and runtime verification.

## Evidence
- Verified command `php -l includes/class-static-site-importer-wordpress-site-plan-materializer.php && php -l tests/smoke-wordpress-site-plan-materializer.php`: status=succeeded; candidate commit `19c94953cd4eb314043467d9afef97a69c72c007`, tree `d7b429a38525b7249ebb556b354be6ca830678d8`, fingerprint `789175b674eb8b56679765c629a6e989d999beaa55744c26b249b881e25b4da8`; durable gate `gate-1`
- Verified command `npm run test:site-plan-materializer`: status=succeeded; candidate commit `19c94953cd4eb314043467d9afef97a69c72c007`, tree `d7b429a38525b7249ebb556b354be6ca830678d8`, fingerprint `789175b674eb8b56679765c629a6e989d999beaa55744c26b249b881e25b4da8`; durable gate `gate-2`
- Base unchanged since verification: main remains at f1f597973bf2af4652f819063061501f4dbbd8d1.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 2 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/static-site-importer/issues/1226
- Task objective: Review the existing immutable candidate commit for issue #1226. Verify that receipt errors contain only the transaction-breaking failure while nonfatal editor diagnostics remain in diagnostics, and that the regression tests cover completed hierarchy diagnostics plus later failure ordering. If the candidate fully solves the issue, return a verified intentional no-change review bound to the existing commit; preserve the existing candidate rather than rewriting it.
- Verified candidate scope: 2 changed file(s): includes/class-static-site-importer-wordpress-site-plan-materializer.php, tests/smoke-wordpress-site-plan-materializer.php.
- Verified finalization base: main at f1f597973bf2af4652f819063061501f4dbbd8d1
- deterministic gate passed: sh -lc npm run test:site-plan-materializer (Passed)
- deterministic gate passed: sh -lc php -l includes/class-static-site-importer-wordpress-site-plan-materializer.php && php -l tests/smoke-wordpress-site-plan-materializer.php (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Reviewed the candidate against its parent, traced every rejected/partial receipt-producing implementation family, and inspected the adjacent receipt and hierarchy-test contracts. The first focused smoke could not load missing vendor/autoload.php; locked Composer dependencies installed successfully, after which the smoke exited successfully but skipped because STATIC\_SITE\_IMPORTER\_WP\_ROOT was unavailable. This establishes a verified intentional no-change review bound to f0c30f8, with full runtime execution deferred to Homeboy's controller-owned gate.
