### PR TITLE
Expose Playground import failures

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -280,7 +280,7 @@ function static_site_importer_rest_create_playground_open( array $artifact, arra
  * skips the GitHub release install step and imports against the bundled plugin.
  *
  * @param array<string,mixed> $input   Import ability input.
- * @param array<string,mixed> $options Optional. { install: bool (default true), package: array }.
+ * @param array<string,mixed> $options Optional. { install: bool (default true), package: array, user_id: positive int }.
  * @return array<int,array<string,mixed>>|WP_Error
  */
 function static_site_importer_playground_import_steps( array $input, array $options = array() ) {
@@ -289,23 +289,48 @@ function static_site_importer_playground_import_steps( array $input, array $opti
 	if ( is_wp_error( $package ) ) {
 		return $package;
 	}
+	$user_id = array_key_exists( 'user_id', $options ) ? (int) $options['user_id'] : 0;
+	if ( array_key_exists( 'user_id', $options ) && $user_id <= 0 ) {
+		return new WP_Error( 'static_site_importer_playground_user_invalid', __( 'The Playground import user ID must be a positive integer.', 'static-site-importer' ) );
+	}
 
 	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generates self-contained Playground import code.
 	$input_literal = var_export( $input, true );
+	$user_code     = $user_id > 0 ? '
+	if ( ! function_exists( "wp_set_current_user" ) ) {
+		throw new RuntimeException( "WordPress user selection is unavailable." );
+	}
+	wp_set_current_user( ' . $user_id . ' );
+' : '';
 	$import_code   = '<?php
-require_once "/wordpress/wp-load.php";
+try {
+	require_once "/wordpress/wp-load.php";' . $user_code . '
 
-if ( ! function_exists( "static_site_importer_ability_import" ) ) {
-	throw new RuntimeException( "Static Site Importer import function is unavailable." );
+	if ( ! function_exists( "static_site_importer_ability_import" ) ) {
+		throw new RuntimeException( "Static Site Importer import function is unavailable." );
+	}
+	$input = ' . $input_literal . ';
+	$result = static_site_importer_ability_import( $input );
+
+	if ( ! is_array( $result ) || empty( $result["success"] ) ) {
+		throw new RuntimeException( "Static Site Importer Playground import failed: " . wp_json_encode( $result ) );
+	}
+
+	update_option( "static_site_importer_playground_preview_result", $result, false );
+} catch ( Throwable $error ) {
+	$diagnostic = array(
+		"schema" => "static-site-importer/playground-import-failure/v1",
+		"error"  => array(
+			"type"    => get_class( $error ),
+			"message" => substr( $error->getMessage(), 0, 1000 ),
+			"file"    => basename( $error->getFile() ),
+			"line"    => $error->getLine(),
+		),
+	);
+	$encoded = function_exists( "wp_json_encode" ) ? wp_json_encode( $diagnostic ) : json_encode( $diagnostic );
+	echo "\nSTATIC_SITE_IMPORTER_PLAYGROUND_IMPORT_FAILURE " . $encoded . "\n";
+	exit( 1 );
 }
-$input = ' . $input_literal . ';
-$result = static_site_importer_ability_import( $input );
-
-if ( ! is_array( $result ) || empty( $result["success"] ) ) {
-	throw new RuntimeException( "Static Site Importer Playground import failed: " . wp_json_encode( $result ) );
-}
-
-update_option( "static_site_importer_playground_preview_result", $result, false );
 ?>';
 
 	$steps = array(
@@ -359,7 +384,7 @@ update_option( "static_site_importer_playground_preview_result", $result, false 
  * {@see static_site_importer_rest_playground_blueprint()} returns today.
  *
  * @param array<string,mixed> $input   Import ability input.
- * @param array<string,mixed> $options Optional. { install: bool (default true), package: array }.
+ * @param array<string,mixed> $options Optional. { install: bool (default true), package: array, user_id: positive int }.
  * @return array<string,mixed>|WP_Error
  */
 function static_site_importer_playground_import_blueprint( array $input, array $options = array() ) {

--- a/tests/smoke-playground-import-primitive.php
+++ b/tests/smoke-playground-import-primitive.php
@@ -9,6 +9,8 @@
  *  - passing [ 'install' => false ] omits the installPlugin step (for runtimes
  *    where SSI is already present) while keeping login + runPHP;
  *  - the runPHP code runs the proven import entrypoint;
+ *  - import failures emit a bounded structured diagnostic and retain a nonzero
+ *    process status before WordPress recovery mode can hide the exception;
  *  - static_site_importer_playground_import_blueprint() produces the same step
  *    set as the legacy static_site_importer_rest_playground_blueprint(), proving
  *    the legacy function delegates to the public primitive.
@@ -196,6 +198,63 @@ $assert(
 	'runphp-preview-result',
 	'runPHP code persists the preview result option'
 );
+$assert(
+	false !== strpos( $run_php_code, 'static-site-importer/playground-import-failure/v1' ),
+	'runphp-failure-schema',
+	'runPHP code emits the Playground import failure schema'
+);
+$assert(
+	false !== strpos( $run_php_code, 'substr( $error->getMessage(), 0, 1000 )' ),
+	'runphp-bounded-failure-message',
+	'runPHP code bounds failure messages'
+);
+$assert(
+	false !== strpos( $run_php_code, 'exit( 1 )' ),
+	'runphp-failure-status',
+	'runPHP code retains a nonzero failure status'
+);
+$user_steps = static_site_importer_playground_import_steps( $input, array( 'install' => false, 'user_id' => 7 ) );
+$user_code  = (string) ( $user_steps[1]['code'] ?? '' );
+$assert( false !== strpos( $user_code, 'wp_set_current_user( 7 )' ), 'runphp-explicit-user', 'runPHP code explicitly selects the requested import user' );
+$invalid_user = static_site_importer_playground_import_steps( $input, array( 'install' => false, 'user_id' => 0 ) );
+$assert( is_wp_error( $invalid_user ) && 'static_site_importer_playground_user_invalid' === $invalid_user->code, 'runphp-invalid-user', 'invalid explicit import users fail closed' );
+
+$bootstrap_path = tempnam( sys_get_temp_dir(), 'ssi-playground-bootstrap-' );
+$assert( false !== $bootstrap_path, 'runphp-failure-bootstrap', 'temporary failure bootstrap is available' );
+if ( false !== $bootstrap_path ) {
+	file_put_contents(
+		$bootstrap_path,
+		'<?php function static_site_importer_ability_import( array $input ) { throw new Error( "diagnostic marker" ); }'
+	);
+	$executable_code = str_replace( '/wordpress/wp-load.php', $bootstrap_path, $run_php_code );
+	$process         = proc_open(
+		array( PHP_BINARY ),
+		array(
+			0 => array( 'pipe', 'r' ),
+			1 => array( 'pipe', 'w' ),
+			2 => array( 'pipe', 'w' ),
+		),
+		$pipes
+	);
+	if ( is_resource( $process ) ) {
+		fwrite( $pipes[0], $executable_code );
+		fclose( $pipes[0] );
+		$failure_output = stream_get_contents( $pipes[1] );
+		fclose( $pipes[1] );
+		fclose( $pipes[2] );
+		$failure_status = proc_close( $process );
+		$marker_pos     = strpos( $failure_output, 'STATIC_SITE_IMPORTER_PLAYGROUND_IMPORT_FAILURE ' );
+		$failure_json   = false !== $marker_pos ? trim( substr( $failure_output, $marker_pos + strlen( 'STATIC_SITE_IMPORTER_PLAYGROUND_IMPORT_FAILURE ' ) ) ) : '';
+		$failure_data   = json_decode( $failure_json, true );
+		$assert( 1 === $failure_status, 'runphp-failure-exit', 'generated import code exits nonzero on Throwable' );
+		$assert( false !== $marker_pos, 'runphp-failure-marker', 'generated import code emits the stable failure marker' );
+		$assert( 'static-site-importer/playground-import-failure/v1' === ( $failure_data['schema'] ?? '' ), 'runphp-failure-output-schema', 'generated import code emits the structured failure schema' );
+		$assert( 'diagnostic marker' === ( $failure_data['error']['message'] ?? '' ), 'runphp-failure-output-message', 'generated import code preserves the exception message' );
+	} else {
+		$assert( false, 'runphp-failure-process', 'generated import code can be executed in a PHP subprocess' );
+	}
+	unlink( $bootstrap_path );
+}
 
 // --- Case 4: blueprint primitive matches the legacy REST blueprint (delegation parity). ---
 $primitive_blueprint = static_site_importer_playground_import_blueprint( $input, array( 'package' => $package ) );


### PR DESCRIPTION
## Summary
- emit a bounded structured diagnostic when Playground import code throws
- preserve a nonzero process status instead of allowing WordPress recovery mode to hide the failure
- support explicit positive `user_id` selection for capability-scoped headless imports
- execute the generated failure path in the smoke test

## Verification
- `npm test`
- `npm run test:runtime-package`
- `php tests/smoke-playground-import-primitive.php`
- live downstream Playground import reproduced the structured diagnostic and then completed successfully with explicit user selection

## AI assistance
GPT-5.6 Sol via OpenCode diagnosed the suppressed Playground failure, implemented the bounded diagnostic and explicit-user contract, and ran the test suites. Chris Huber directed and reviewed the work.