### PR TITLE
fix: preserve failed-plan compiler evidence

### DIFF
--- a/includes/class-static-site-importer-failed-plan-validation.php
+++ b/includes/class-static-site-importer-failed-plan-validation.php
@@ -14,7 +14,7 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 	private const MAX_DIAGNOSTICS = 50;
 
 	/** @return array<string,mixed> */
-	public static function build( array $plan, array $args = array() ): array {
+	public static function build( array $plan, array $args = array(), array $compiled = array() ): array {
 		$diagnostics = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
 		$report = array(
 			'schema'      => 'static-site-importer/import-report/v1',
@@ -23,12 +23,8 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 			'theme_slug'  => (string) ( $args['slug'] ?? '' ),
 			'quality'     => isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array(),
 			'diagnostics' => array_slice( $diagnostics, 0, self::MAX_DIAGNOSTICS ),
-			'blocks_engine' => array(
-				'wordpress_site_plan' => array(
-					'schema'  => (string) ( $plan['schema'] ?? 'blocks-engine/wordpress-site-plan/v2' ),
-					'quality' => isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array(),
-				),
-			),
+			'blocks_engine' => self::compiler_evidence( $plan, $compiled ),
+			'source_documents' => self::source_documents( $plan ),
 			'failure_context' => array(
 				'stage' => 'pre_materialization_quality_admission',
 				'code'  => 'static_site_importer_quality_gate_failed',
@@ -53,6 +49,53 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 			'import_report_summary'    => $report['compact_summary'],
 			'import_validation_result' => $report['import_validation_result'],
 			'finding_packets'          => $report['finding_packets'],
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function compiler_evidence( array $plan, array $compiled ): array {
+		$source     = isset( $plan['source'] ) && is_array( $plan['source'] ) ? $plan['source'] : array();
+		$reporting  = isset( $plan['reporting'] ) && is_array( $plan['reporting'] ) ? $plan['reporting'] : array();
+		$metrics    = isset( $reporting['metrics'] ) && is_array( $reporting['metrics'] ) ? $reporting['metrics'] : array();
+		$provenance = isset( $compiled['provenance'] ) && is_array( $compiled['provenance'] ) ? $compiled['provenance'] : ( isset( $source['provenance'] ) && is_array( $source['provenance'] ) ? $source['provenance'] : array() );
+		$summary    = array_filter(
+			array(
+				'schema'           => (string) ( $compiled['result_schema'] ?? $compiled['schema'] ?? '' ),
+				'status'           => (string) ( $compiled['status'] ?? '' ),
+				'source'           => (string) ( $source['schema'] ?? '' ),
+				'page_count'       => (int) ( $metrics['source_document_count'] ?? count( $plan['pages'] ?? array() ) ),
+				'block_count'      => (int) ( $plan['quality']['metrics']['block_count'] ?? 0 ),
+				'diagnostic_count' => count( $plan['diagnostics'] ?? array() ),
+			),
+			static fn( $value ): bool => '' !== $value
+		);
+
+		return array(
+			'available'           => ! empty( $compiled ),
+			'website_artifact'    => array(
+				'summary'    => $summary,
+				'provenance' => array_slice( $provenance, 0, self::MAX_DIAGNOSTICS ),
+			),
+			'wordpress_site_plan' => array(
+				'schema'  => (string) ( $plan['schema'] ?? 'blocks-engine/wordpress-site-plan/v2' ),
+				'source'  => $source,
+				'quality' => isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array(),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function source_documents( array $plan ): array {
+		$pages = isset( $plan['pages'] ) && is_array( $plan['pages'] ) ? $plan['pages'] : array();
+		return array(
+			'source'                       => 'blocks_engine',
+			'total_count'                  => count( $pages ),
+			'blocks_engine_document_count' => count( $pages ),
+			'counts_by_format'             => array(
+				'html'     => count( $pages ),
+				'markdown' => 0,
+				'mdx'      => 0,
+			),
 		);
 	}
 

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -3611,8 +3611,10 @@ class Static_Site_Importer_Report_Diagnostics {
 			}
 		}
 
-		if ( isset( $compiler_summary['diagnostic_count'] ) ) {
-			$summary['diagnostic_count'] = (int) $compiler_summary['diagnostic_count'];
+		foreach ( array( 'page_count', 'block_count', 'diagnostic_count' ) as $field ) {
+			if ( isset( $compiler_summary[ $field ] ) ) {
+				$summary[ $field ] = (int) $compiler_summary[ $field ];
+			}
 		}
 
 		return $summary;

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -94,7 +94,7 @@ class Static_Site_Importer_Theme_Generator {
 		$theme_materialization = $compiled_import['theme_materialization'];
 		$args['font_materialization'] = isset( $materialization_plan['theme']['font_materialization'] ) && is_array( $materialization_plan['theme']['font_materialization'] ) ? $materialization_plan['theme']['font_materialization'] : array();
 		if ( ! empty( $args['fail_on_quality'] ) && empty( $plan['quality']['pass'] ) ) {
-			$failed_plan = Static_Site_Importer_Failed_Plan_Validation::build( $plan, $args );
+			$failed_plan = Static_Site_Importer_Failed_Plan_Validation::build( $plan, $args, $compiled_import['compiled'] ?? array() );
 			try {
 				$failed_plan['artifact_refs'] = Static_Site_Importer_Failed_Plan_Validation::persist( $failed_plan, (string) ( $args['report'] ?? '' ) );
 			} catch ( Throwable $error ) {

--- a/tests/smoke-failed-plan-validation.php
+++ b/tests/smoke-failed-plan-validation.php
@@ -37,11 +37,21 @@ for ( $index = 0; $index < 75; ++$index ) {
 }
 $plan = array(
 	'schema'      => 'blocks-engine/wordpress-site-plan/v2',
-	'quality'     => array( 'pass' => false, 'metrics' => array( 'fallback_count' => 0 ), 'failure_reasons' => array( 'document_nesting', 'empty_wrapper' ) ),
+	'source'      => array( 'schema' => 'blocks-engine/php-transformer/site-artifact/v1', 'provenance' => array( array( 'source_format' => 'artifact', 'source_hash' => str_repeat( 'a', 64 ) ) ) ),
+	'pages'       => array_map( static fn( int $index ): array => array( 'source_path' => 'website/page-' . $index . '.html' ), range( 1, 8 ) ),
+	'reporting'   => array( 'metrics' => array( 'source_document_count' => 8, 'block_document_count' => 8, 'native_block_count' => 102 ) ),
+	'quality'     => array( 'pass' => false, 'metrics' => array( 'fallback_count' => 0, 'block_count' => 102 ), 'failure_reasons' => array( 'document_nesting', 'empty_wrapper' ) ),
 	'diagnostics' => $diagnostics,
 );
 $original_plan = $plan;
-$artifacts = Static_Site_Importer_Failed_Plan_Validation::build( $plan, array( 'slug' => 'zero-fallback-failure', 'fail_on_quality' => true ) );
+$compiled = array(
+	'schema'        => 'blocks-engine/php-transformer/materialization-view/v1',
+	'result_schema' => 'blocks-engine/php-transformer/result/v1',
+	'status'        => 'failed',
+	'documents'     => array_map( static fn( int $index ): array => array( 'source_path' => 'website/page-' . $index . '.html' ), range( 1, 8 ) ),
+	'provenance'    => array( array( 'source_format' => 'artifact', 'source_hash' => str_repeat( 'b', 64 ) ) ),
+);
+$artifacts = Static_Site_Importer_Failed_Plan_Validation::build( $plan, array( 'slug' => 'zero-fallback-failure', 'fail_on_quality' => true ), $compiled );
 
 $assert( false === ( $artifacts['import_report']['quality']['pass'] ?? true ), 'zero-fallback canonical quality failure remains failed' );
 $assert( true === ( $artifacts['import_report']['quality']['fail_import'] ?? false ), 'failed plan is marked terminal in the standard quality shape' );
@@ -49,6 +59,13 @@ $assert( 0 === ( $artifacts['import_report']['quality']['fallback_count'] ?? -1 
 $assert( 50 === count( $artifacts['import_report']['diagnostics'] ?? array() ), 'failed-plan report bounds diagnostics' );
 $assert( true === ( $artifacts['import_report']['diagnostics_truncated'] ?? false ), 'failed-plan report records truncation' );
 $assert( 75 === ( $artifacts['import_report']['diagnostic_count'] ?? 0 ), 'failed-plan report retains original diagnostic count' );
+$assert( true === ( $artifacts['import_report']['compact_summary']['compiler']['available'] ?? false ), 'failed-plan report preserves compiler availability' );
+$assert( 'blocks-engine/php-transformer/result/v1' === ( $artifacts['import_report']['compact_summary']['compiler']['schema'] ?? '' ), 'failed-plan report preserves compiler result schema' );
+$assert( 'failed' === ( $artifacts['import_report']['compact_summary']['compiler']['status'] ?? '' ), 'failed-plan report preserves compiler status' );
+$assert( 102 === ( $artifacts['import_report']['compact_summary']['compiler']['block_count'] ?? 0 ), 'failed-plan report preserves compiler block summary' );
+$assert( $compiled['provenance'] === ( $artifacts['import_report']['blocks_engine']['website_artifact']['provenance'] ?? null ), 'failed-plan report preserves compiler provenance' );
+$assert( 8 === ( $artifacts['import_report']['compact_summary']['source_document_count'] ?? 0 ), 'failed-plan report derives source-document count from canonical plan pages' );
+$assert( 8 === ( $artifacts['import_validation_result']['counts']['source_documents'] ?? 0 ), 'failed-plan validation receipt preserves source-document count' );
 $assert( 'blocks-engine/import-validation-result/v1' === ( $artifacts['import_validation_result']['schema'] ?? '' ), 'standard validation artifact schema is preserved' );
 $assert( 'blocks-engine/finding-packets/v1' === ( $artifacts['finding_packets']['schema'] ?? '' ), 'standard finding packet schema is preserved' );
 $assert( $plan === $original_plan, 'failed-plan evidence generation does not mutate the canonical plan' );


### PR DESCRIPTION
## Summary
Preserves bounded compiler evidence and source document counts when the pre-materialization quality gate rejects a plan.

Fixes #1229

## Tests
- `php tests/smoke-failed-plan-validation.php`
- `npm test`

AI assistance: OpenAI gpt-5.6-terra via OpenCode was used to inspect the failed-plan reporting flow, implement the scoped fix, and run verification. Chris Huber remains responsible for this change.