### PR TITLE
Fix static front-page link canonicalization

### DIFF
--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -799,13 +799,14 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	/** Resolve destination-independent route references after WordPress has assigned every permalink. */
 	private static function rewrite_materialized_route_links( array &$state ) {
 		$routes = array();
+		$front_page_identity = self::front_page_reconciliation_identity( $state['resolved']['operations'] ?? array() );
 		foreach ( $state['ordered_pages'] as $page ) {
 			$source_path = (string) ( $page['source_path'] ?? '' );
 			$route       = self::normalized_route_path( (string) ( $page['route']['path'] ?? '' ) );
 			$post_id     = (int) ( $state['source_ids'][ $source_path ] ?? 0 );
 			$permalink   = $post_id > 0 && function_exists( 'get_permalink' ) ? get_permalink( $post_id ) : false;
 			if ( '' !== $route && is_string( $permalink ) && '' !== $permalink ) {
-				$routes[ $route ] = $permalink;
+				$routes[ $route ] = $front_page_identity === (string) ( $page['reconciliation_identity'] ?? '' ) ? home_url( '/' ) : $permalink;
 			}
 		}
 		if ( array() === $routes ) {
@@ -849,6 +850,17 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		}
 
 		return true;
+	}
+
+	/** @param array<int,array<string,mixed>> $operations */
+	private static function front_page_reconciliation_identity( array $operations ): string {
+		foreach ( $operations as $operation ) {
+			if ( 'site_reading' === ( $operation['kind'] ?? null ) && is_string( $operation['front_page_reconciliation_identity'] ?? null ) ) {
+				return $operation['front_page_reconciliation_identity'];
+			}
+		}
+
+		return '';
 	}
 
 	/** @param array<string,string> $routes */

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -798,7 +798,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	/** Resolve destination-independent route references after WordPress has assigned every permalink. */
 	private static function rewrite_materialized_route_links( array &$state ) {
-		$routes               = array();
+		$routes              = array();
 		$front_page_identity = self::front_page_reconciliation_identity( $state['resolved']['operations'] ?? array() );
 		foreach ( $state['ordered_pages'] as $page ) {
 			$source_path = (string) ( $page['source_path'] ?? '' );

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -798,7 +798,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	/** Resolve destination-independent route references after WordPress has assigned every permalink. */
 	private static function rewrite_materialized_route_links( array &$state ) {
-		$routes = array();
+		$routes               = array();
 		$front_page_identity = self::front_page_reconciliation_identity( $state['resolved']['operations'] ?? array() );
 		foreach ( $state['ordered_pages'] as $page ) {
 			$source_path = (string) ( $page['source_path'] ?? '' );
@@ -806,7 +806,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			$post_id     = (int) ( $state['source_ids'][ $source_path ] ?? 0 );
 			$permalink   = $post_id > 0 && function_exists( 'get_permalink' ) ? get_permalink( $post_id ) : false;
 			if ( '' !== $route && is_string( $permalink ) && '' !== $permalink ) {
-				$routes[ $route ] = $front_page_identity === (string) ( $page['reconciliation_identity'] ?? '' ) ? home_url( '/' ) : $permalink;
+				$routes[ $route ] = (string) ( $page['reconciliation_identity'] ?? '' ) === $front_page_identity ? home_url( '/' ) : $permalink;
 			}
 		}
 		if ( array() === $routes ) {

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -192,8 +192,13 @@ function get_permalink( int|WP_Post $post ): string {
 	if ( 'post' === ( $data['post_type'] ?? '' ) ) {
 		return 'https://example.test/2024/03/' . (string) ( $data['post_name'] ?? '' ) . '/';
 	}
+	if ( 'page' === ( $GLOBALS['ssi_plan_options']['show_on_front'] ?? '' ) && $id === (int) ( $GLOBALS['ssi_plan_options']['page_on_front'] ?? 0 ) ) {
+		return home_url( '/' );
+	}
 	return 'https://example.test/' . (string) ( $data['post_name'] ?? '' ) . '/';
 }
+function home_url( string $path = '/' ): string {
+	return 'https://example.test' . $path; }
 function get_post_field( string $field, int $id ): string {
 	return stripslashes( (string) ( $GLOBALS['ssi_plan_posts'][ $id ][ $field ] ?? '' ) ); }
 function sanitize_title( string $value ): string {
@@ -1247,6 +1252,41 @@ $nested_route_result = ( new ArtifactCompiler() )->compile(
 )->toArray();
 $nested_routes       = array_column( $nested_route_result['source_reports']['wordpress_site_plan']['routes'], 'target_path', 'source_path' );
 $assert( 3 === count( $nested_routes ) && '/' === ( $nested_routes['website/index.html'] ?? '' ) && '/api' === ( $nested_routes['website/api/index.html'] ?? '' ) && '/lifecycle' === ( $nested_routes['website/lifecycle/index.html'] ?? '' ), 'nested index documents retain distinct routes when the declared root entrypoint is ordered last' );
+
+$front_page_links_result = ( new ArtifactCompiler() )->compile(
+	array(
+		'entrypoint' => 'website/index.html',
+		'files'      => array(
+			'website/index.html'       => '<main><h1>Home</h1></main>',
+			'website/about.html'       => '<main><a href="/index.html?view=home#top">HOME</a><a href="/index/index.html?view=route#section">Index route</a></main>',
+			'website/index/index.html' => '<main><h1>Index route</h1></main>',
+		),
+	)
+)->toArray();
+$front_page_links_plan   = $front_page_links_result['source_reports']['wordpress_site_plan'];
+foreach ( $front_page_links_plan['pages'] as $page ) {
+	$register_document_blocks( parse_blocks( (string) ( $page['canonical_block_markup'] ?? '' ) ) );
+}
+$GLOBALS['ssi_plan_options'] = array(
+	'show_on_front' => 'posts',
+	'page_on_front' => 0,
+	'blogname'      => 'Before',
+	'use_smilies'   => true,
+);
+$front_page_links_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$front_page_links_plan,
+	array(
+		'slug'      => 'front-page-links',
+		'overwrite' => true,
+		'activate'  => true,
+	)
+);
+$front_page_links_pages   = $front_page_links_receipt['completed']['pages'] ?? array();
+$front_page_id            = (int) ( $front_page_links_pages['website/index.html'] ?? 0 );
+$about_page_id            = (int) ( $front_page_links_pages['website/about.html'] ?? 0 );
+$about_page_content       = get_post_field( 'post_content', $about_page_id );
+$assert( 'completed' === $front_page_links_receipt['status'] && $front_page_id === (int) $GLOBALS['ssi_plan_options']['page_on_front'] && 'page' === $GLOBALS['ssi_plan_options']['show_on_front'] && 'https://example.test/' === get_permalink( $front_page_id ), 'the declared website entrypoint becomes the static front page with the root permalink' );
+$assert( str_contains( $about_page_content, 'https://example.test/?view=home#top' ) && str_contains( $about_page_content, 'https://example.test/index/?view=route#section' ) && ! str_contains( $about_page_content, 'https://example.test/index.html' ), 'front-page aliases resolve to home while the distinct nested index route retains its native navigation URL and suffix' );
 
 $product_grid_artifact     = array(
 	'entrypoint' => 'index.html',


### PR DESCRIPTION
## Summary
- derive the selected static front page from the Blocks Engine `site_reading` operation’s reconciliation identity before stored page markup is rewritten
- project only that exact page route to `home_url( '/' )`; all other source identities continue to use their native permalinks
- cover `website/index.html`, HOME aliases with query/fragment suffixes, and the distinct `website/index/index.html` route

Closes #1269

## Tianna evidence
Tianna's captured artifact maps `website/index.html` to `/`, while SSI previously materialized its temporary `index` post permalink and wrote HOME links as `/index/` before applying `page_on_front`. This change uses the plan operation's exact reconciliation identity, so the selected source resolves directly to the WordPress home URL without filename inference. The fixture confirms the nested `website/index/index.html` source remains the legitimate `/index/` navigation target.

## Verification
- `php -l includes/class-static-site-importer-wordpress-site-plan-materializer.php`
- `php -l tests/smoke-wordpress-site-plan-materializer.php`
- `npm run test:inventory`
- `npm run test:all` (62 passed; 17 environment-gated checks skipped)
- `composer validate --strict`
- `npm run test:dev-package`
- `npm run test:runtime-package`
- `STATIC_SITE_IMPORTER_WP_ROOT=/Users/chubes/Studio/intelligence-chubes4 php tests/smoke-wordpress-site-plan-materializer.php` reaches an existing editability assertion failure before the new fixture; the same baseline assertion prevents standalone execution in this available Core/runtime setup.

## AI assistance
OpenCode with OpenAI GPT-5.6 Sol traced the Blocks Engine plan projection, implemented the reconciliation-identity mapping, and added integration coverage. Chris Huber reviewed and remains responsible.