### PR TITLE
Render editable companion blocks from saved content

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -372,8 +372,12 @@ class Static_Site_Importer_Companion_Plugin {
 		$has_render    = ( isset( $block['render'] ) && is_scalar( $block['render'] ) ) || '' !== $renderer;
 		$render        = isset( $block['render'] ) && is_scalar( $block['render'] ) ? (string) $block['render'] : '';
 		$files         = array();
-		if ( $has_render ) {
-			$files['render.php'] = '' !== $renderer ? self::typed_renderer( $renderer ) : self::normalize_render( $render );
+		if ( '' !== $renderer ) {
+			$files['render.php'] = self::typed_renderer( $renderer );
+		} elseif ( self::has_editable_content_render( $block ) ) {
+			$files['render.php'] = self::editable_content_renderer();
+		} elseif ( $has_render ) {
+			$files['render.php'] = self::normalize_render( $render );
 		}
 
 		// Carried static assets (e.g. block stylesheets or a hand-written
@@ -783,6 +787,23 @@ class Static_Site_Importer_Companion_Plugin {
 		// Static source markup is data, never executable template source. The only
 		// PHP in this file is SSI-generated code that emits an escaped literal.
 		return "<?php\n/** Generated companion block render. */\n\necho '" . self::php_single_quote( $render ) . "'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static source markup was validated before compilation.\n";
+	}
+
+	/** Whether static payload markup represents an editable per-instance content attribute. */
+	private static function has_editable_content_render( array $block ): bool {
+		$content_schema = $block['block_json']['attributes']['content'] ?? null;
+		return isset( $block['render'] ) && is_scalar( $block['render'] ) && is_array( $content_schema ) && 'string' === ( $content_schema['type'] ?? null );
+	}
+
+	/** Build the SSI-owned safe boundary for generic editable companion content. */
+	private static function editable_content_renderer(): string {
+		return <<<'PHP'
+<?php
+/** Generated editable-content companion block render. */
+
+$content = is_string( $attributes['content'] ?? null ) ? $attributes['content'] : '';
+echo wp_kses_post( $content ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Sanitized at this server-render boundary.
+PHP;
 	}
 
 	/**

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -120,6 +120,28 @@ if ( ! function_exists( 'wp_kses' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( string $content ): string {
+		$global = array(
+			'aria-*' => true,
+			'class'  => true,
+			'data-*' => true,
+			'id'     => true,
+			'style'  => true,
+		);
+		return wp_kses(
+			$content,
+			array(
+				'a'    => array_merge( $global, array( 'href' => true, 'rel' => true, 'target' => true ) ),
+				'div'  => $global,
+				'img'  => array_merge( $global, array( 'alt' => true, 'height' => true, 'src' => true, 'width' => true ) ),
+				'p'    => $global,
+				'span' => $global,
+			)
+		);
+	}
+}
+
 if ( ! function_exists( 'sanitize_title' ) ) {
 	function sanitize_title( string $title ): string {
 		$title = strtolower( trim( $title ) );
@@ -449,7 +471,29 @@ if ( is_array( $descriptor ) ) {
 	$render = $files['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
 	$assert( '' !== $render, 'render-php-emitted' );
 	$assert( str_starts_with( ltrim( $render ), '<?php' ), 'render-php-opens-with-php-tag' );
-	$assert( str_contains( $render, "echo '<div class=\"ssi-hero\">Example hero</div>';" ) && ! str_contains( $render, 'system(' ), 'render-php-emits-static-source-markup-only' );
+	$assert( str_contains( $render, 'Generated editable-content companion block render' ) && str_contains( $render, 'wp_kses_post' ) && ! str_contains( $render, 'Example hero' ), 'editable-render-uses-ssi-owned-safe-boundary' );
+
+	$render_frontend = static function ( string $template, array $attributes ): string {
+		$content = '';
+		$block   = null;
+		ob_start();
+		eval( '?>' . $template );
+		return (string) ob_get_clean();
+	};
+	$canonical_url  = 'https://example.test/wp-content/themes/generated-example/assets/media/hero.jpg';
+	$imported_output = $render_frontend(
+		$render,
+		array( 'content' => '<div class="ssi-hero"><img src="' . $canonical_url . '" alt=""><p>Imported hero</p></div>' )
+	);
+	$assert( str_contains( $imported_output, $canonical_url ) && ! str_contains( $imported_output, 'Example hero' ), 'editable-render-outputs-imported-canonicalized-url', $imported_output );
+
+	$edited_url    = 'https://example.test/wp-content/themes/generated-example/assets/media/edited-hero.jpg';
+	$edited_output = $render_frontend(
+		$render,
+		array( 'content' => '<div class="ssi-hero" onclick="alert(1)"><img src="' . $edited_url . '" alt=""><p>Edited hero</p><script>alert(1)</script></div>' )
+	);
+	$assert( str_contains( $edited_output, $edited_url ) && str_contains( $edited_output, 'Edited hero' ) && ! str_contains( $edited_output, $canonical_url ), 'editable-render-reflects-saved-content-edit', $edited_output );
+	$assert( ! str_contains( $edited_output, '<script' ) && ! str_contains( $edited_output, 'onclick' ), 'editable-render-sanitizes-current-content-at-server-boundary', $edited_output );
 
 	// Preserved island JS (#496) is separate carried JS and still rides along.
 	$island_files = array_filter( array_keys( $files ), static fn ( string $path ): bool => str_contains( $path, '/islands/' ) && str_ends_with( $path, '.js' ) );


### PR DESCRIPTION
## Summary

- render generated scalar-render/string-content companion blocks from each block instance's current `content` attribute
- sanitize generic editable HTML through SSI-owned `wp_kses_post()` server-rendering code
- preserve literal rendering for non-editable blocks and the existing dedicated responsive-media renderer
- execute generated render PHP in contract coverage to prove canonicalized imported URLs and later saved-content edits reach frontend output

Fixes #1278.

## Verification

- `npm run test:companion-plugin` (`140` companion assertions and `23` JS seam assertions)
- `php -l includes/class-static-site-importer-companion-plugin.php`
- `php -l tests/smoke-companion-plugin.php`
- `git diff --check`
- `npm test` before the final one-commit `origin/main` reconciliation: `62` passed, `0` failed
- `npm run test:all` before reconciliation: `62` passed, `0` failed, `17` environment/operator lanes intentionally skipped

The focused companion suite and syntax/diff checks were rerun after rebasing onto current `origin/main`. The retained source artifact was not modified or recaptured. Reimport verification against that retained artifact remains an operator follow-up after this branch is installed.

## AI Assistance

OpenCode using `openai/gpt-5.6-sol` was used to inspect producer and rendering contracts, implement the scoped SSI renderer change, add and run contract coverage, reconcile the branch, self-review the diff, and draft this pull request. Chris Huber directed the repair and publication workflow.