### PR TITLE
Resume direct artifact imports from staged receipts

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -22,6 +22,7 @@
     "tests/smoke-import-permission-filter.php": { "environment": "standalone-php" },
     "tests/smoke-current-site-capabilities.php": { "environment": "standalone-php" },
     "tests/smoke-default-content.php": { "environment": "standalone-php" },
+    "tests/smoke-direct-artifact-import.php": { "environment": "standalone-php" },
     "tests/smoke-importer-block.php": { "environment": "standalone-php" },
     "tests/smoke-lifecycle-compile-checkpoint.php": { "environment": "standalone-php" },
     "tests/smoke-materialized-block-content-validation.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-artifact-run.php
+++ b/includes/class-static-site-importer-artifact-run.php
@@ -31,9 +31,9 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 			throw new RuntimeException( 'Artifact workspace could not be created.' );
 		}
 
-		$existing     = $this->read_raw( 'workspace.json' );
-		$record       = is_string( $existing ) ? json_decode( $existing, true ) : null;
-		if ( ( is_file( $this->directory . '/workspace.json' ) || is_string( $existing ) ) && ( ! is_array( $record ) || 'static-site-importer/artifact-workspace/v1' !== ( $record['schema'] ?? '' ) || $token !== ( $record['purpose'] ?? '' ) ) ) {
+		$existing = $this->read_raw( 'workspace.json' );
+		$record   = is_string( $existing ) ? json_decode( $existing, true ) : null;
+		if ( ( is_file( $this->directory . '/workspace.json' ) || is_string( $existing ) ) && ( ! is_array( $record ) || 'static-site-importer/artifact-workspace/v1' !== ( $record['schema'] ?? '' ) || ( $record['purpose'] ?? '' ) !== $token ) ) {
 			throw new RuntimeException( 'Artifact workspace ownership record is invalid.' );
 		}
 		$this->record = is_array( $record ) ? $record : array(
@@ -148,7 +148,7 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 		$handle = fopen( $path, 'c' );
 		if ( false === $handle || ! flock( $handle, LOCK_EX | LOCK_NB ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock -- Serializes one importer-owned run executor.
 			if ( is_resource( $handle ) ) {
-				fclose( $handle );
+				fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the native stream required by flock after a failed lock attempt.
 			}
 			return new WP_Error( 'static_site_importer_artifact_workspace_locked', 'The artifact run is already executing.' );
 		}
@@ -158,7 +158,7 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 	public function release_lock( $handle ): void {
 		if ( is_resource( $handle ) ) {
 			flock( $handle, LOCK_UN ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock -- Releases the importer-owned run lock.
-			fclose( $handle );
+			fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the native stream only after releasing its advisory lock.
 		}
 	}
 
@@ -277,8 +277,8 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 			$record  = is_string( $raw ) ? json_decode( $raw, true ) : null;
 			$expires = is_array( $record ) ? ( $record['retention']['expires_at'] ?? '' ) : '';
 			if ( is_string( $expires ) && '' !== $expires && strtotime( $expires ) <= time() ) {
-				$workspace  = new self( $resolved_parent, substr( basename( $path ), strlen( '.ssi-artifact-run-' ) ) );
-				$lock       = $workspace->acquire_lock( 'execution.lock' );
+				$workspace = new self( $resolved_parent, substr( basename( $path ), strlen( '.ssi-artifact-run-' ) ) );
+				$lock      = $workspace->acquire_lock( 'execution.lock' );
 				if ( is_wp_error( $lock ) ) {
 					continue;
 				}
@@ -316,14 +316,14 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- Writes a private temporary checkpoint file.
 			$written = fwrite( $handle, substr( $bytes, $offset ) );
 			if ( false === $written || 0 === $written ) {
-				fclose( $handle );
+				fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the native stream used by the complete-write loop on failure.
 				return false;
 			}
 			$offset += $written;
 		}
 		$flushed = fflush( $handle );
 		$synced  = ! function_exists( 'fsync' ) || fsync( $handle );
-		$closed  = fclose( $handle );
+		$closed  = fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Preserves flush, sync, then close durability ordering on the native stream.
 		return $flushed && $synced && $closed;
 	}
 

--- a/includes/class-static-site-importer-artifact-run.php
+++ b/includes/class-static-site-importer-artifact-run.php
@@ -33,6 +33,9 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 
 		$existing     = $this->read_raw( 'workspace.json' );
 		$record       = is_string( $existing ) ? json_decode( $existing, true ) : null;
+		if ( ( is_file( $this->directory . '/workspace.json' ) || is_string( $existing ) ) && ( ! is_array( $record ) || 'static-site-importer/artifact-workspace/v1' !== ( $record['schema'] ?? '' ) || $token !== ( $record['purpose'] ?? '' ) ) ) {
+			throw new RuntimeException( 'Artifact workspace ownership record is invalid.' );
+		}
 		$this->record = is_array( $record ) ? $record : array(
 			'schema'     => 'static-site-importer/artifact-workspace/v1',
 			'purpose'    => $token,
@@ -76,8 +79,8 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 		}
 
 		$temp    = tempnam( $parent, '.ssi-artifact-' );
-		$written = false === $temp ? false : file_put_contents( $temp, $bytes ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writes an importer-owned temporary file before atomic publication.
-		if ( false === $temp || strlen( $bytes ) !== $written || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Atomically publishes importer-owned workspace data on the same filesystem.
+		$written = is_string( $temp ) && self::write_complete_file( $temp, $bytes );
+		if ( ! is_string( $temp ) || ! $written || ! self::filesystem_operation( static fn () => rename( $temp, $path ) ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Atomically publishes importer-owned workspace data on the same filesystem.
 			if ( is_string( $temp ) && is_file( $temp ) ) {
 				unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes a failed importer-owned temporary file.
 			}
@@ -87,9 +90,76 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 		return $path;
 	}
 
+	/** Atomically publish immutable bytes, accepting only an identical existing value. */
+	public function publish_raw_once( string $relative, string $bytes ) {
+		$path = $this->path( $relative );
+		if ( is_wp_error( $path ) ) {
+			return $path;
+		}
+
+		$parent = dirname( $path );
+		if ( ! is_dir( $parent ) && ! mkdir( $parent, 0700, true ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- Creates importer-owned nested directories without initializing a global filesystem transport.
+			return new WP_Error( 'static_site_importer_artifact_workspace_unavailable', 'Workspace directory is unavailable.' );
+		}
+		if ( is_link( $parent ) || ! str_starts_with( (string) realpath( $parent ) . '/', $this->directory . '/' ) ) {
+			return new WP_Error( 'static_site_importer_artifact_workspace_symlink', 'Workspace writes must remain in owned directories.' );
+		}
+
+		$temp    = tempnam( $parent, '.ssi-artifact-' );
+		$written = is_string( $temp ) && self::write_complete_file( $temp, $bytes );
+		$linked  = $written && self::filesystem_operation( static fn () => link( $temp, $path ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_link -- Hard-link publication atomically creates an immutable checkpoint on the same filesystem.
+		if ( is_string( $temp ) && is_file( $temp ) ) {
+			unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes the private publication temporary file.
+		}
+		if ( $linked ) {
+			return $path;
+		}
+		if ( is_file( $path ) && hash_equals( hash( 'sha256', $bytes ), hash( 'sha256', (string) $this->read_raw( $relative ) ) ) ) {
+			return $path;
+		}
+
+		return new WP_Error( 'static_site_importer_artifact_workspace_conflict', 'An immutable workspace checkpoint already exists with different content.' );
+	}
+
 	public function publish_json( string $relative, array $data ) {
 		$json = wp_json_encode( $data, JSON_PRETTY_PRINT );
 		return is_string( $json ) ? $this->publish_raw( $relative, $json ) : new WP_Error( 'static_site_importer_artifact_workspace_json_invalid', 'Workspace JSON could not be encoded.' );
+	}
+
+	public function publish_json_once( string $relative, array $data ) {
+		$json = wp_json_encode( $data, JSON_PRETTY_PRINT );
+		return is_string( $json ) ? $this->publish_raw_once( $relative, $json ) : new WP_Error( 'static_site_importer_artifact_workspace_json_invalid', 'Workspace JSON could not be encoded.' );
+	}
+
+	/** Atomically claim a private workspace directory exactly once. */
+	public function claim_directory( string $relative ): bool {
+		$path = $this->path( $relative . '/claim' );
+		$path = is_string( $path ) ? dirname( $path ) : '';
+		return '' !== $path && ! is_link( $path ) && self::filesystem_operation( static fn () => mkdir( $path, 0700 ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- mkdir is the atomic workspace claim primitive.
+	}
+
+	/** Acquire a non-blocking workspace execution lock. */
+	public function acquire_lock( string $relative ) {
+		$path = $this->path( $relative );
+		if ( ! is_string( $path ) || is_link( $path ) ) {
+			return new WP_Error( 'static_site_importer_artifact_workspace_path_invalid', 'The workspace lock path is invalid.' );
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Opens an importer-owned advisory lock file.
+		$handle = fopen( $path, 'c' );
+		if ( false === $handle || ! flock( $handle, LOCK_EX | LOCK_NB ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock -- Serializes one importer-owned run executor.
+			if ( is_resource( $handle ) ) {
+				fclose( $handle );
+			}
+			return new WP_Error( 'static_site_importer_artifact_workspace_locked', 'The artifact run is already executing.' );
+		}
+		return $handle;
+	}
+
+	public function release_lock( $handle ): void {
+		if ( is_resource( $handle ) ) {
+			flock( $handle, LOCK_UN ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock -- Releases the importer-owned run lock.
+			fclose( $handle );
+		}
 	}
 
 	public function read_raw( string $relative ): ?string {
@@ -208,7 +278,15 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 			$expires = is_array( $record ) ? ( $record['retention']['expires_at'] ?? '' ) : '';
 			if ( is_string( $expires ) && '' !== $expires && strtotime( $expires ) <= time() ) {
 				$workspace  = new self( $resolved_parent, substr( basename( $path ), strlen( '.ssi-artifact-run-' ) ) );
-				$receipts[] = $workspace->purge();
+				$lock       = $workspace->acquire_lock( 'execution.lock' );
+				if ( is_wp_error( $lock ) ) {
+					continue;
+				}
+				try {
+					$receipts[] = $workspace->purge();
+				} finally {
+					$workspace->release_lock( $lock );
+				}
 			}
 		}
 
@@ -224,6 +302,29 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads importer-owned workspace metadata while treating concurrent removal as absent.
 		$bytes = self::filesystem_operation( static fn () => file_get_contents( $path ) );
 		return is_string( $bytes ) ? $bytes : null;
+	}
+
+	private static function write_complete_file( string $path, string $bytes ): bool {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Writes and flushes a private temporary file before atomic publication.
+		$handle = fopen( $path, 'wb' );
+		if ( false === $handle ) {
+			return false;
+		}
+		$offset = 0;
+		$length = strlen( $bytes );
+		while ( $offset < $length ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- Writes a private temporary checkpoint file.
+			$written = fwrite( $handle, substr( $bytes, $offset ) );
+			if ( false === $written || 0 === $written ) {
+				fclose( $handle );
+				return false;
+			}
+			$offset += $written;
+		}
+		$flushed = fflush( $handle );
+		$synced  = ! function_exists( 'fsync' ) || fsync( $handle );
+		$closed  = fclose( $handle );
+		return $flushed && $synced && $closed;
 	}
 
 	private static function filesystem_operation( callable $operation ): mixed {

--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -50,7 +50,7 @@ class Static_Site_Importer_Canonical_Import_Service {
 			return self::error( 'static_site_importer_invalid_import_source', 'source.type must be html, files, zip, or url.' );
 		}
 		if ( self::direct_artifact_continuation_available() && in_array( $type, array( 'html', 'files' ), true ) && '' !== (string) ( $source['import_id'] ?? '' ) ) {
-			$args = self::direct_artifact_args( $input );
+			$args   = self::direct_artifact_args( $input );
 			$result = Static_Site_Importer_Direct_Artifact_Import::resume( (string) $source['import_id'], $args, $type, $operation, $source );
 			return is_wp_error( $result ) ? self::error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() ) : $result;
 		}

--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Direct_Artifact_Import' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-direct-artifact-import.php';
+}
+
 class Static_Site_Importer_Canonical_Import_Service {
 	private static string $cli_report_destination = '';
 
@@ -44,6 +48,11 @@ class Static_Site_Importer_Canonical_Import_Service {
 		}
 		if ( ! in_array( $type, array( 'html', 'files', 'zip', 'url' ), true ) ) {
 			return self::error( 'static_site_importer_invalid_import_source', 'source.type must be html, files, zip, or url.' );
+		}
+		if ( self::direct_artifact_continuation_available() && in_array( $type, array( 'html', 'files' ), true ) && '' !== (string) ( $source['import_id'] ?? '' ) ) {
+			$args = self::direct_artifact_args( $input );
+			$result = Static_Site_Importer_Direct_Artifact_Import::resume( (string) $source['import_id'], $args, $type, $operation, $source );
+			return is_wp_error( $result ) ? self::error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() ) : $result;
 		}
 
 		$provenance = array( 'type' => $type );
@@ -110,15 +119,13 @@ class Static_Site_Importer_Canonical_Import_Service {
 				'source_metadata' => $runtime['source_metadata'],
 			)
 		);
-		$args       = Static_Site_Importer_Website_Artifact_Import_Input::normalize( $input );
+		$args       = self::direct_artifact_args( $input );
 		if ( isset( $payload_reader ) ) {
 			$args['_static_site_importer_payload_reader'] = $payload_reader;
 		}
-		if ( '' !== $args['runtime_lifecycle_phase'] ) {
-			$args['runtime_lifecycle_invocation_id'] = wp_generate_uuid4();
-		}
-		if ( '' !== self::$cli_report_destination ) {
-			$args['report'] = self::$cli_report_destination;
+		if ( self::direct_artifact_continuation_available() && in_array( $type, array( 'html', 'files' ), true ) && 'resume' !== $args['runtime_lifecycle_phase'] && self::artifact_html_page_count( $artifact ) > 1 ) {
+			$result = Static_Site_Importer_Direct_Artifact_Import::start( $artifact, $args, $type, $operation, $provenance );
+			return is_wp_error( $result ) ? self::error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() ) : $result;
 		}
 		if ( 'plan' === $operation ) {
 			return self::plan_artifact( $artifact, $args, $type, $provenance );
@@ -128,6 +135,38 @@ class Static_Site_Importer_Canonical_Import_Service {
 			return self::error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
 		}
 		return self::success( $result, $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	private static function direct_artifact_args( array $input ): array {
+		$args = Static_Site_Importer_Website_Artifact_Import_Input::normalize( $input );
+		if ( '' !== $args['runtime_lifecycle_phase'] ) {
+			$args['runtime_lifecycle_invocation_id'] = wp_generate_uuid4();
+		}
+		if ( '' !== self::$cli_report_destination ) {
+			$args['report'] = self::$cli_report_destination;
+		}
+		return $args;
+	}
+
+	/** @param array<string,mixed> $artifact */
+	private static function artifact_html_page_count( array $artifact ): int {
+		$count = 0;
+		foreach ( is_array( $artifact['files'] ?? null ) ? $artifact['files'] : array() as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+			$path = strtolower( (string) ( $file['path'] ?? '' ) );
+			$mime = strtolower( (string) ( $file['mime_type'] ?? '' ) );
+			if ( str_ends_with( $path, '.html' ) || str_ends_with( $path, '.htm' ) || str_contains( $mime, 'html' ) ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
+	private static function direct_artifact_continuation_available(): bool {
+		return function_exists( 'wp_json_encode' ) && function_exists( 'wp_mkdir_p' ) && function_exists( 'wp_upload_dir' );
 	}
 
 	/** @param array<string,mixed> $input @return array<string,mixed> */

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -29,44 +29,44 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 
 	/** Start a server-owned run after normal canonical source normalization. */
 	public static function start( array $artifact, array $args, string $source_type, string $operation, array $provenance ) {
-		$freeze_started = microtime( true );
+		$freeze_started  = microtime( true );
 		$source_identity = hash( 'sha256', (string) wp_json_encode( $artifact ) );
-		$source_policy = Static_Site_Importer_Content_Policy::validate_artifact( $artifact );
+		$source_policy   = Static_Site_Importer_Content_Policy::validate_artifact( $artifact );
 		if ( is_wp_error( $source_policy ) ) {
 			return $source_policy;
 		}
 
-		$policy   = Static_Site_Importer_Client_Script_Policy::apply( $artifact, $args );
-		$artifact = $policy['artifact'];
-		$args['client_script_policy_report'] = $policy['report'];
+		$policy                                = Static_Site_Importer_Client_Script_Policy::apply( $artifact, $args );
+		$artifact                              = $policy['artifact'];
+		$args['client_script_policy_report']   = $policy['report'];
 		$args['source_metadata']['collection'] = is_array( $args['source_metadata']['collection'] ?? null ) ? $args['source_metadata']['collection'] : array();
 		$args['source_metadata']['collection']['script_policy'] = $policy['report'];
-		$identity = self::hash( $artifact );
+		$identity  = self::hash( $artifact );
 		$import_id = bin2hex( random_bytes( 32 ) );
 		$workspace = self::workspace( $import_id, true );
 		if ( is_wp_error( $workspace ) ) {
 			return $workspace;
 		}
 
-		$run = array(
-			'import_id'   => $import_id,
-			'binding'     => array(
-				'source_type'      => $source_type,
-				'operation'        => $operation,
-				'args'             => self::binding_args( $args ),
-				'owner'            => self::owner(),
-				'source_identity'  => $source_identity,
+		$run          = array(
+			'import_id'  => $import_id,
+			'binding'    => array(
+				'source_type'       => $source_type,
+				'operation'         => $operation,
+				'args'              => self::binding_args( $args ),
+				'owner'             => self::owner(),
+				'source_identity'   => $source_identity,
 				'artifact_identity' => $identity,
 				'implementation'    => self::implementation_binding(),
 			),
-			'provenance'  => $provenance,
-			'state'       => 'running',
-			'phase'       => 'freezing',
-			'refs'        => array(),
-			'page_ids'    => array(),
-			'failures'    => array(),
-			'timings'     => array( 'freeze_seconds' => microtime( true ) - $freeze_started ),
-			'work'        => array(
+			'provenance' => $provenance,
+			'state'      => 'running',
+			'phase'      => 'freezing',
+			'refs'       => array(),
+			'page_ids'   => array(),
+			'failures'   => array(),
+			'timings'    => array( 'freeze_seconds' => microtime( true ) - $freeze_started ),
+			'work'       => array(
 				'content_policy_applications'       => 1,
 				'client_script_policy_applications' => 1,
 				'shared_prepares'                   => 0,
@@ -80,7 +80,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				'materialization_attempts'          => 0,
 				'materializations'                  => 0,
 			),
-			'progress'    => array(
+			'progress'   => array(
 				'phase'         => 'freezing',
 				'page_count'    => 0,
 				'receipt_count' => 0,
@@ -93,16 +93,16 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			'artifact',
 			'artifact.json',
 			array(
-				'artifact'     => $artifact,
-				'args'         => $args,
-				'policy_report'=> $policy['report'],
+				'artifact'      => $artifact,
+				'args'          => $args,
+				'policy_report' => $policy['report'],
 			)
 		);
 		if ( is_wp_error( $artifact_ref ) ) {
 			$workspace->purge();
 			return $artifact_ref;
 		}
-		$run['refs']['artifact'] = $artifact_ref;
+		$run['refs']['artifact']  = $artifact_ref;
 		$run['phase']             = 'preparing_shared';
 		$run['progress']['phase'] = 'preparing_shared';
 		$write                    = self::write_run( $workspace, $run );
@@ -175,9 +175,9 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			$workspace->purge();
 			return new WP_Error( 'static_site_importer_direct_artifact_run_expired', 'The retained direct artifact run expired and must be restarted.' );
 		}
-		$policy   = self::run_policy();
-		$clock    = $policy['clock'];
-		$deadline = call_user_func( $clock ) + $policy['max_invocation_seconds'];
+		$policy       = self::run_policy();
+		$clock        = $policy['clock'];
+		$deadline     = call_user_func( $clock ) + $policy['max_invocation_seconds'];
 		$run['state'] = 'running';
 		$write        = self::write_run( $workspace, $run );
 		if ( is_wp_error( $write ) ) {
@@ -192,12 +192,12 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			if ( is_wp_error( $final ) ) {
 				return $final;
 			}
-			$run['refs']['final']         = $final_ref;
-			$run['state']                 = 'completed';
-			$run['phase']                 = 'completed';
-			$run['progress']['phase']     = 'completed';
+			$run['refs']['final']          = $final_ref;
+			$run['state']                  = 'completed';
+			$run['phase']                  = 'completed';
+			$run['progress']['phase']      = 'completed';
 			$run['progress']['updated_at'] = gmdate( 'c' );
-			$write = self::write_run( $workspace, $run );
+			$write                         = self::write_run( $workspace, $run );
 			return is_wp_error( $write ) ? self::fail( $workspace, $run, 'terminal_checkpoint', $write ) : $final['response'];
 		}
 
@@ -205,6 +205,13 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			$compiler = self::compiler();
 			if ( is_wp_error( $compiler ) ) {
 				return self::fail( $workspace, $run, 'compiler', $compiler );
+			}
+			$prepare_shared = array( $compiler, 'prepareShared' );
+			$prepare_page   = array( $compiler, 'preparePage' );
+			$compile_pages  = array( $compiler, 'compilePreparedPages' );
+			$compose        = array( $compiler, 'compose' );
+			if ( ! is_callable( $prepare_shared ) || ! is_callable( $prepare_page ) || ! is_callable( $compile_pages ) || ! is_callable( $compose ) ) {
+				return self::fail( $workspace, $run, 'compiler', new WP_Error( 'static_site_importer_invalid_transformer', 'The direct artifact compiler does not implement the staged compilation contract.' ) );
 			}
 			$artifact_state = self::read_checkpoint( $workspace, $run, $run['refs']['artifact'], 'artifact' );
 			if ( is_wp_error( $artifact_state ) ) {
@@ -223,8 +230,8 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 					if ( is_wp_error( $shared_state ) ) {
 						return $shared_state;
 					}
-					$run['refs']['shared']          = $shared_ref;
-					$run['page_ids']               = array_values( $shared_state['plan']['analysis']['page_ids'] );
+					$run['refs']['shared'] = $shared_ref;
+					$run['page_ids']       = array_values( $shared_state['plan']['analysis']['page_ids'] );
 					sort( $run['page_ids'], SORT_STRING );
 					$run['work']['shared_prepares'] = 1;
 				}
@@ -237,7 +244,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 				$run = $entered;
 				self::before_phase( 'prepare_shared', $run );
-				$shared = call_user_func( array( $compiler, 'prepareShared' ), $artifact );
+				$shared = call_user_func( $prepare_shared, $artifact );
 				if ( 'blocks-engine/php-transformer/staged-shared-plan/v1' !== ( $shared['schema'] ?? '' ) || empty( $shared['digest'] ) || ! is_array( $shared['analysis']['page_ids'] ?? null ) ) {
 					throw new RuntimeException( 'Blocks Engine returned an invalid shared plan.' );
 				}
@@ -245,16 +252,16 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				if ( is_wp_error( $ref ) ) {
 					return self::fail( $workspace, $run, 'prepare_shared', $ref );
 				}
-				$run['refs']['shared']                  = $ref;
-				$run['page_ids']                       = array_values( $shared['analysis']['page_ids'] );
+				$run['refs']['shared'] = $ref;
+				$run['page_ids']       = array_values( $shared['analysis']['page_ids'] );
 				sort( $run['page_ids'], SORT_STRING );
-				$run['work']['shared_prepares']         = 1;
+				$run['work']['shared_prepares']           = 1;
 				$run['timings']['prepare_shared_seconds'] = microtime( true ) - $started;
-				$run['phase']                           = 'preparing_pages';
-				$run['progress']['phase']               = 'preparing_pages';
-				$run['progress']['page_count']          = count( $run['page_ids'] );
-				$run['progress']['updated_at']          = gmdate( 'c' );
-				$write = self::write_run( $workspace, $run );
+				$run['phase']                             = 'preparing_pages';
+				$run['progress']['phase']                 = 'preparing_pages';
+				$run['progress']['page_count']            = count( $run['page_ids'] );
+				$run['progress']['updated_at']            = gmdate( 'c' );
+				$write                                    = self::write_run( $workspace, $run );
 				if ( is_wp_error( $write ) ) {
 					return self::fail( $workspace, $run, 'prepare_shared_checkpoint', $write );
 				}
@@ -264,17 +271,17 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			if ( is_wp_error( $shared_state ) ) {
 				return $shared_state;
 			}
-			$shared = $shared_state['plan'];
+			$shared  = $shared_state['plan'];
 			$adopted = self::adopt_page_plans( $workspace, $run, $shared );
 			if ( is_wp_error( $adopted ) ) {
 				return $adopted;
 			}
-			if ( $adopted !== ( $run['refs']['pages'] ?? array() ) ) {
-				$run['refs']['pages']                       = $adopted;
-				$run['work']['page_plans_prepared']         = count( $adopted );
-				$run['progress']['prepared_page_count']     = count( $adopted );
-				$run['progress']['updated_at']              = gmdate( 'c' );
-				$write = self::write_run( $workspace, $run );
+			if ( ( $run['refs']['pages'] ?? array() ) !== $adopted ) {
+				$run['refs']['pages']                   = $adopted;
+				$run['work']['page_plans_prepared']     = count( $adopted );
+				$run['progress']['prepared_page_count'] = count( $adopted );
+				$run['progress']['updated_at']          = gmdate( 'c' );
+				$write                                  = self::write_run( $workspace, $run );
 				if ( is_wp_error( $write ) ) {
 					return self::fail( $workspace, $run, 'prepare_pages_checkpoint', $write );
 				}
@@ -295,30 +302,33 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				self::before_phase( 'prepare_pages', $run, $prepare_ids );
 				$run['work']['page_prepare_passes'] = (int) $run['work']['page_prepare_passes'] + 1;
 				foreach ( $prepare_ids as $page_id ) {
-					$page_plan = call_user_func( array( $compiler, 'preparePage' ), $artifact, $shared, $page_id );
+					$page_plan = call_user_func( $prepare_page, $artifact, $shared, $page_id );
 					$validated = self::validate_page_plan( $page_plan, $shared, $page_id );
 					if ( is_wp_error( $validated ) ) {
 						return self::fail( $workspace, $run, 'prepare_pages', $validated, array( $page_id ) );
 					}
 					$relative = self::page_file( 'page-plans', $page_id );
-					$ref      = self::publish_checkpoint( $workspace, $run, 'page_plan', $relative, array( 'page_id' => $page_id, 'plan' => $page_plan ) );
+					$ref      = self::publish_checkpoint( $workspace, $run, 'page_plan', $relative, array(
+						'page_id' => $page_id,
+						'plan'    => $page_plan,
+					) );
 					if ( is_wp_error( $ref ) ) {
 						return self::fail( $workspace, $run, 'prepare_pages', $ref, array( $page_id ) );
 					}
-					$run['refs']['pages'][ $page_id ] = $ref;
-					$run['work']['page_plans_prepared'] = count( $run['refs']['pages'] );
+					$run['refs']['pages'][ $page_id ]       = $ref;
+					$run['work']['page_plans_prepared']     = count( $run['refs']['pages'] );
 					$run['progress']['prepared_page_count'] = count( $run['refs']['pages'] );
-					$run['progress']['updated_at'] = gmdate( 'c' );
-					$write = self::write_run( $workspace, $run );
+					$run['progress']['updated_at']          = gmdate( 'c' );
+					$write                                  = self::write_run( $workspace, $run );
 					if ( is_wp_error( $write ) ) {
 						return self::fail( $workspace, $run, 'prepare_pages_checkpoint', $write, array( $page_id ) );
 					}
 				}
-				$run['timings']['prepare_pages_seconds']     = (float) ( $run['timings']['prepare_pages_seconds'] ?? 0 ) + microtime( true ) - $started;
-				$run['phase']                                = 'compiling_pages';
-				$run['progress']['phase']                    = 'compiling_pages';
-				$run['progress']['updated_at']               = gmdate( 'c' );
-				$write = self::write_run( $workspace, $run );
+				$run['timings']['prepare_pages_seconds'] = (float) ( $run['timings']['prepare_pages_seconds'] ?? 0 ) + microtime( true ) - $started;
+				$run['phase']                            = 'compiling_pages';
+				$run['progress']['phase']                = 'compiling_pages';
+				$run['progress']['updated_at']           = gmdate( 'c' );
+				$write                                   = self::write_run( $workspace, $run );
 				if ( is_wp_error( $write ) ) {
 					return self::fail( $workspace, $run, 'prepare_pages_checkpoint', $write, $prepare_ids );
 				}
@@ -333,7 +343,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			if ( is_wp_error( $adopted ) ) {
 				return $adopted;
 			}
-			if ( $adopted !== ( $run['refs']['receipts'] ?? array() ) ) {
+			if ( ( $run['refs']['receipts'] ?? array() ) !== $adopted ) {
 				$run['refs']['receipts'] = $adopted;
 				foreach ( array_keys( $adopted ) as $page_id ) {
 					$run['work']['page_compile_counts'][ $page_id ] = 1;
@@ -342,7 +352,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				$run['work']['compile_batches']   = max( (int) ( $run['work']['compile_batches'] ?? 0 ), empty( $adopted ) ? 0 : 1 );
 				$run['progress']['receipt_count'] = count( $adopted );
 				$run['progress']['updated_at']    = gmdate( 'c' );
-				$write = self::write_run( $workspace, $run );
+				$write                            = self::write_run( $workspace, $run );
 				if ( is_wp_error( $write ) ) {
 					return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, array_keys( $adopted ) );
 				}
@@ -366,7 +376,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 				$run = $entered;
 				self::before_phase( 'compile_pages', $run, $batch_ids );
-				$batch = call_user_func( array( $compiler, 'compilePreparedPages' ), $shared, array_values( $plans ) );
+				$batch = call_user_func( $compile_pages, $shared, array_values( $plans ) );
 				if ( ! is_array( $batch ) || array_keys( $batch ) !== $batch_ids ) {
 					return self::fail( $workspace, $run, 'compile_pages', new WP_Error( 'static_site_importer_direct_artifact_receipt_set_mismatch', 'Blocks Engine did not return the exact requested compiled receipt batch.' ), $batch_ids );
 				}
@@ -379,22 +389,25 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				$run['work']['compile_batches'] = (int) $run['work']['compile_batches'] + 1;
 				foreach ( $batch_ids as $page_id ) {
 					$receipt = $batch[ $page_id ];
-					$ref = self::publish_checkpoint( $workspace, $run, 'receipt', self::page_file( 'receipts', $page_id ), array( 'page_id' => $page_id, 'receipt' => $receipt ) );
+					$ref     = self::publish_checkpoint( $workspace, $run, 'receipt', self::page_file( 'receipts', $page_id ), array(
+						'page_id' => $page_id,
+						'receipt' => $receipt,
+					) );
 					if ( is_wp_error( $ref ) ) {
 						return self::fail( $workspace, $run, 'compile_pages', $ref, $batch_ids );
 					}
-					$run['refs']['receipts'][ $page_id ] = $ref;
-					$run['work']['pages_compiled'] = (int) $run['work']['pages_compiled'] + 1;
+					$run['refs']['receipts'][ $page_id ]            = $ref;
+					$run['work']['pages_compiled']                  = (int) $run['work']['pages_compiled'] + 1;
 					$run['work']['page_compile_counts'][ $page_id ] = (int) ( $run['work']['page_compile_counts'][ $page_id ] ?? 0 ) + 1;
-					$run['progress']['receipt_count'] = count( $run['refs']['receipts'] );
-					$run['progress']['updated_at'] = gmdate( 'c' );
+					$run['progress']['receipt_count']               = count( $run['refs']['receipts'] );
+					$run['progress']['updated_at']                  = gmdate( 'c' );
 					$write = self::write_run( $workspace, $run );
 					if ( is_wp_error( $write ) ) {
 						return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, array( $page_id ) );
 					}
 				}
 				$run['timings']['compile_pages_seconds'] = (float) ( $run['timings']['compile_pages_seconds'] ?? 0 ) + microtime( true ) - $started;
-				$write = self::write_run( $workspace, $run );
+				$write                                   = self::write_run( $workspace, $run );
 				if ( is_wp_error( $write ) ) {
 					return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, $batch_ids );
 				}
@@ -431,7 +444,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 				$run = $entered;
 				self::before_phase( 'compose', $run, $run['page_ids'] );
-				$result = call_user_func( array( $compiler, 'compose' ), $shared, array_values( $receipts ) );
+				$result = call_user_func( $compose, $shared, array_values( $receipts ) );
 				if ( ! is_object( $result ) || ! is_callable( array( $result, 'toArray' ) ) ) {
 					throw new RuntimeException( 'Blocks Engine returned an invalid composed result.' );
 				}
@@ -440,17 +453,20 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				if ( 0 !== (int) ( $metrics['html_document_transform_count'] ?? 0 ) || 0 !== (int) ( $metrics['normalization_count'] ?? 0 ) ) {
 					throw new RuntimeException( 'Terminal receipt composition performed HTML transforms or normalization.' );
 				}
-				$ref = self::publish_checkpoint( $workspace, $run, 'composed', 'composed-result.json', array( 'result' => $composed, 'terminal_work' => $metrics ) );
+				$ref = self::publish_checkpoint( $workspace, $run, 'composed', 'composed-result.json', array(
+					'result'        => $composed,
+					'terminal_work' => $metrics,
+				) );
 				if ( is_wp_error( $ref ) ) {
 					return self::fail( $workspace, $run, 'compose', $ref, $run['page_ids'] );
 				}
-				$run['refs']['composed']             = $ref;
-				$run['work']['compositions']          = 1;
-				$run['timings']['compose_seconds']    = microtime( true ) - $started;
-				$run['phase']                         = 'composed';
-				$run['progress']['phase']             = 'composed';
-				$run['progress']['updated_at']        = gmdate( 'c' );
-				$write = self::write_run( $workspace, $run );
+				$run['refs']['composed']           = $ref;
+				$run['work']['compositions']       = 1;
+				$run['timings']['compose_seconds'] = microtime( true ) - $started;
+				$run['phase']                      = 'composed';
+				$run['progress']['phase']          = 'composed';
+				$run['progress']['updated_at']     = gmdate( 'c' );
+				$write                             = self::write_run( $workspace, $run );
 				if ( is_wp_error( $write ) ) {
 					return self::fail( $workspace, $run, 'compose_checkpoint', $write, $run['page_ids'] );
 				}
@@ -463,7 +479,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			if ( self::deadline_reached( $deadline, $clock ) ) {
 				return self::continuation( $run, 'deadline_exhausted' );
 			}
-			$args['compiled_artifact_result']               = $composed_state['result'];
+			$args['compiled_artifact_result']                 = $composed_state['result'];
 			$args['_static_site_importer_precompiled_source'] = true;
 
 			if ( 'plan' === $run['binding']['operation'] ) {
@@ -471,7 +487,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				if ( is_wp_error( $entered ) ) {
 					return $entered;
 				}
-				$run = $entered;
+				$run      = $entered;
 				$response = Static_Site_Importer_Canonical_Import_Service::plan_artifact( $artifact, $args, $run['binding']['source_type'], $run['provenance'] );
 				if ( empty( $response['success'] ) ) {
 					return self::fail( $workspace, $run, 'canonical_plan', self::response_error( $response ) );
@@ -484,7 +500,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 						return $materialization_ref;
 					}
 					if ( ! empty( $materialization_ref ) ) {
-						$run['refs']['materialization']   = $materialization_ref;
+						$run['refs']['materialization']  = $materialization_ref;
 						$run['work']['materializations'] = 1;
 					}
 				}
@@ -493,14 +509,14 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 					if ( is_wp_error( $claim ) ) {
 						return self::fail( $workspace, $run, 'materialization_claim', $claim );
 					}
-					$run = $claim;
-					$args['import_run_id'] = $run['import_id'];
+					$run                                     = $claim;
+					$args['import_run_id']                   = $run['import_id'];
 					$run['work']['materialization_attempts'] = (int) $run['work']['materialization_attempts'] + 1;
-					$entered = self::enter_phase( $workspace, $run, 'materialize' );
+					$entered                                 = self::enter_phase( $workspace, $run, 'materialize' );
 					if ( is_wp_error( $entered ) ) {
 						return $entered;
 					}
-					$run = $entered;
+					$run     = $entered;
 					$started = microtime( true );
 					self::before_phase( 'materialize', $run );
 					$materialized = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $args );
@@ -511,10 +527,10 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 					if ( is_wp_error( $ref ) ) {
 						return self::fail( $workspace, $run, 'materialize', $ref );
 					}
-					$run['refs']['materialization']          = $ref;
-					$run['work']['materializations']         = 1;
-					$run['timings']['materialize_seconds']   = microtime( true ) - $started;
-					$write = self::write_run( $workspace, $run );
+					$run['refs']['materialization']        = $ref;
+					$run['work']['materializations']       = 1;
+					$run['timings']['materialize_seconds'] = microtime( true ) - $started;
+					$write                                 = self::write_run( $workspace, $run );
 					if ( is_wp_error( $write ) ) {
 						return self::fail( $workspace, $run, 'materialization_checkpoint', $write );
 					}
@@ -542,7 +558,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			$run['phase']                  = 'completed';
 			$run['progress']['phase']      = 'completed';
 			$run['progress']['updated_at'] = gmdate( 'c' );
-			$response = array_merge(
+			$response                      = array_merge(
 				$response,
 				array(
 					'import_id'           => $run['import_id'],
@@ -551,12 +567,12 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 					'artifact_run'        => self::evidence( $run, $composed_state['terminal_work'] ?? array() ),
 				)
 			);
-			$final_ref = self::publish_checkpoint( $workspace, $run, 'final', 'final-response.json', array( 'response' => $response ) );
+			$final_ref                     = self::publish_checkpoint( $workspace, $run, 'final', 'final-response.json', array( 'response' => $response ) );
 			if ( is_wp_error( $final_ref ) ) {
 				return self::fail( $workspace, $run, 'terminal_checkpoint', $final_ref );
 			}
 			$run['refs']['final'] = $final_ref;
-			$write = self::write_run( $workspace, $run );
+			$write                = self::write_run( $workspace, $run );
 			if ( is_wp_error( $write ) ) {
 				return self::fail( $workspace, $run, 'terminal_checkpoint', $write );
 			}
@@ -572,10 +588,10 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			return new WP_Error( 'static_site_importer_direct_artifact_materialization_ambiguous', 'Materialization was already claimed without a durable result; the import will not repeat WordPress mutation.' );
 		}
 		$run['work']['materialization_claims'] = 1;
-		$run['phase']                  = 'materialization_claimed';
-		$run['progress']['phase']      = 'materialization_claimed';
-		$run['progress']['updated_at'] = gmdate( 'c' );
-		$write = self::write_run( $workspace, $run );
+		$run['phase']                          = 'materialization_claimed';
+		$run['progress']['phase']              = 'materialization_claimed';
+		$run['progress']['updated_at']         = gmdate( 'c' );
+		$write                                 = self::write_run( $workspace, $run );
 		return is_wp_error( $write ) ? $write : $run;
 	}
 
@@ -622,7 +638,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				continue;
 			}
 			$row = self::read_checkpoint( $workspace, $run, $ref, 'page_plan' );
-			if ( is_wp_error( $row ) || ( $row['plan']['shared_digest'] ?? '' ) !== ( $shared['digest'] ?? '' ) || $page_id !== ( $row['plan']['page_id'] ?? '' ) ) {
+			if ( is_wp_error( $row ) || ( $row['plan']['shared_digest'] ?? '' ) !== ( $shared['digest'] ?? '' ) || ( $row['plan']['page_id'] ?? '' ) !== $page_id ) {
 				return is_wp_error( $row ) ? $row : new WP_Error( 'static_site_importer_direct_artifact_page_plan_mismatch', 'A retained page plan does not match the frozen shared plan.' );
 			}
 			$refs[ $page_id ] = $ref;
@@ -670,14 +686,14 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	}
 
 	private static function validate_page_plan( $plan, array $shared, string $page_id ) {
-		if ( ! is_array( $plan ) || 'blocks-engine/php-transformer/staged-page-plan/v1' !== ( $plan['schema'] ?? '' ) || $page_id !== ( $plan['page_id'] ?? '' ) || ( $shared['digest'] ?? '' ) !== ( $plan['shared_digest'] ?? '' ) || empty( $plan['digest'] ) ) {
+		if ( ! is_array( $plan ) || 'blocks-engine/php-transformer/staged-page-plan/v1' !== ( $plan['schema'] ?? '' ) || ( $plan['page_id'] ?? '' ) !== $page_id || ( $shared['digest'] ?? '' ) !== ( $plan['shared_digest'] ?? '' ) || empty( $plan['digest'] ) ) {
 			return new WP_Error( 'static_site_importer_direct_artifact_page_plan_invalid', 'A prepared page plan is not bound to the frozen shared plan.' );
 		}
 		return true;
 	}
 
 	private static function validate_receipt( $receipt, array $page_plan, array $shared ) {
-		$reduction = is_array( $receipt['terminal_reduction'] ?? null ) ? $receipt['terminal_reduction'] : array();
+		$reduction          = is_array( $receipt['terminal_reduction'] ?? null ) ? $receipt['terminal_reduction'] : array();
 		$required_reduction = array( 'files', 'normalization', 'source_documents', 'owned_transformable_paths', 'stylesheet_occurrence_files', 'component_facts', 'block_types' );
 		$reduction_complete = empty( array_diff( $required_reduction, array_keys( $reduction ) ) );
 		if ( ! is_array( $receipt ) || self::RECEIPT_SCHEMA !== ( $receipt['receipt_schema'] ?? '' ) || ( $page_plan['page_id'] ?? '' ) !== ( $receipt['page_id'] ?? '' ) || ( $shared['digest'] ?? '' ) !== ( $receipt['shared_digest'] ?? '' ) || ( $shared['shared_reduction_digest'] ?? '' ) !== ( $receipt['shared_reduction_digest'] ?? '' ) || ( $page_plan['compiler_options'] ?? null ) !== ( $receipt['compiler_options'] ?? null ) || ( $page_plan['output_schema'] ?? null ) !== ( $receipt['output_schema'] ?? null ) || ( $page_plan['digest'] ?? '' ) === ( $receipt['digest'] ?? '' ) || empty( $receipt['digest'] ) || ! is_array( $receipt['compiled_documents'] ?? null ) || ! is_array( $receipt['owned_document_paths'] ?? null ) || ! $reduction_complete ) {
@@ -700,7 +716,10 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				return self::read_checkpoint( $workspace, $run, $run['refs'][ $key ], $kind );
 			}
 		}
-		foreach ( array( 'pages' => 'page_plan', 'receipts' => 'receipt' ) as $key => $kind ) {
+		foreach ( array(
+			'pages'    => 'page_plan',
+			'receipts' => 'receipt',
+		) as $key => $kind ) {
 			foreach ( is_array( $run['refs'][ $key ] ?? null ) ? $run['refs'][ $key ] : array() as $ref ) {
 				$value = self::read_checkpoint( $workspace, $run, $ref, $kind );
 				if ( is_wp_error( $value ) ) {
@@ -713,13 +732,13 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 
 	/** Persist the boundary before entering an uninterruptible owning call. */
 	private static function enter_phase( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, string $phase, array $page_ids = array() ) {
-		$run['phase']                         = $phase;
-		$run['progress']['phase']             = $phase;
-		$run['progress']['attempted_page_ids'] = array_values( $page_ids );
-		$run['progress']['phase_started_at']  = gmdate( 'c' );
+		$run['phase']                           = $phase;
+		$run['progress']['phase']               = $phase;
+		$run['progress']['attempted_page_ids']  = array_values( $page_ids );
+		$run['progress']['phase_started_at']    = gmdate( 'c' );
 		$run['progress']['phase_started_epoch'] = microtime( true );
-		$run['progress']['updated_at']        = $run['progress']['phase_started_at'];
-		$write = self::write_run( $workspace, $run );
+		$run['progress']['updated_at']          = $run['progress']['phase_started_at'];
+		$write                                  = self::write_run( $workspace, $run );
 		return is_wp_error( $write ) ? $write : $run;
 	}
 
@@ -738,7 +757,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	private static function evidence( array $run, array $terminal_work = array() ): array {
 		$counts = array_values( is_array( $run['work']['page_compile_counts'] ?? null ) ? $run['work']['page_compile_counts'] : array() );
 		sort( $counts, SORT_NUMERIC );
-		$counts = array_slice( $counts, 0, 50 );
+		$counts             = array_slice( $counts, 0, 50 );
 		$receipt_identities = array();
 		foreach ( is_array( $run['refs']['receipts'] ?? null ) ? $run['refs']['receipts'] : array() as $page_id => $ref ) {
 			$receipt_identities[] = hash( 'sha256', $page_id . "\n" . (string) ( $ref['sha256'] ?? '' ) );
@@ -752,7 +771,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				'attempted_page_ids' => array_map( static fn ( string $id ): string => hash( 'sha256', $id ), array_slice( is_array( $failure['attempted_page_ids'] ?? null ) ? $failure['attempted_page_ids'] : array(), 0, 20 ) ),
 				'phase_started_at'   => (string) ( $failure['phase_started_at'] ?? '' ),
 				'elapsed_seconds'    => (float) ( $failure['elapsed_seconds'] ?? 0 ),
-				'error'               => self::scrub_error( $failure['error'] ?? array() ),
+				'error'              => self::scrub_error( $failure['error'] ?? array() ),
 			),
 			array_slice( is_array( $run['failures'] ?? null ) ? $run['failures'] : array(), -5 )
 		);
@@ -762,24 +781,24 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			'phase'                => (string) ( $run['phase'] ?? '' ),
 			'artifact_identity'    => (string) ( $run['binding']['artifact_identity'] ?? '' ),
 			'progress'             => array(
-				'page_count'    => count( $run['page_ids'] ?? array() ),
-				'prepared_count'=> count( $run['refs']['pages'] ?? array() ),
-				'receipt_count' => count( $run['refs']['receipts'] ?? array() ),
-				'remaining'     => max( 0, count( $run['page_ids'] ?? array() ) - count( $run['refs']['receipts'] ?? array() ) ),
+				'page_count'     => count( $run['page_ids'] ?? array() ),
+				'prepared_count' => count( $run['refs']['pages'] ?? array() ),
+				'receipt_count'  => count( $run['refs']['receipts'] ?? array() ),
+				'remaining'      => max( 0, count( $run['page_ids'] ?? array() ) - count( $run['refs']['receipts'] ?? array() ) ),
 			),
 			'work'                 => array(
 				'content_policy_applications'       => (int) ( $run['work']['content_policy_applications'] ?? 0 ),
 				'client_script_policy_applications' => (int) ( $run['work']['client_script_policy_applications'] ?? 0 ),
-				'shared_prepares'                    => (int) ( $run['work']['shared_prepares'] ?? 0 ),
-				'page_prepare_passes'                => (int) ( $run['work']['page_prepare_passes'] ?? 0 ),
-				'page_plans_prepared'                => (int) ( $run['work']['page_plans_prepared'] ?? 0 ),
-				'compile_batches'                    => (int) ( $run['work']['compile_batches'] ?? 0 ),
-				'pages_compiled'                     => (int) ( $run['work']['pages_compiled'] ?? 0 ),
-				'page_compile_counts'                => $counts,
-				'compositions'                       => (int) ( $run['work']['compositions'] ?? 0 ),
-				'materialization_claims'             => (int) ( $run['work']['materialization_claims'] ?? 0 ),
-				'materialization_attempts'           => (int) ( $run['work']['materialization_attempts'] ?? 0 ),
-				'materializations'                   => (int) ( $run['work']['materializations'] ?? 0 ),
+				'shared_prepares'                   => (int) ( $run['work']['shared_prepares'] ?? 0 ),
+				'page_prepare_passes'               => (int) ( $run['work']['page_prepare_passes'] ?? 0 ),
+				'page_plans_prepared'               => (int) ( $run['work']['page_plans_prepared'] ?? 0 ),
+				'compile_batches'                   => (int) ( $run['work']['compile_batches'] ?? 0 ),
+				'pages_compiled'                    => (int) ( $run['work']['pages_compiled'] ?? 0 ),
+				'page_compile_counts'               => $counts,
+				'compositions'                      => (int) ( $run['work']['compositions'] ?? 0 ),
+				'materialization_claims'            => (int) ( $run['work']['materialization_claims'] ?? 0 ),
+				'materialization_attempts'          => (int) ( $run['work']['materialization_attempts'] ?? 0 ),
+				'materializations'                  => (int) ( $run['work']['materializations'] ?? 0 ),
 			),
 			'phase_timings'        => array_map(
 				'floatval',
@@ -804,27 +823,27 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			$message = $error->getMessage();
 			$data    = null;
 		}
-		$failure = array(
+		$failure                       = array(
 			'phase'              => $phase,
 			'exception_class'    => get_class( $error ),
 			'artifact_identity'  => (string) ( $run['binding']['artifact_identity'] ?? '' ),
 			'attempted_page_ids' => ! empty( $page_ids ) ? array_values( $page_ids ) : array_values( is_array( $run['progress']['attempted_page_ids'] ?? null ) ? $run['progress']['attempted_page_ids'] : array() ),
 			'phase_started_at'   => (string) ( $run['progress']['phase_started_at'] ?? '' ),
 			'elapsed_seconds'    => max( 0.0, microtime( true ) - (float) ( $run['progress']['phase_started_epoch'] ?? microtime( true ) ) ),
-			'error'               => array(
+			'error'              => array(
 				'code'    => $code,
 				'message' => $message,
 				'data'    => self::scrub_error( $data ),
 			),
-			'at'                  => gmdate( 'c' ),
+			'at'                 => gmdate( 'c' ),
 		);
 		$run['failures'][]             = $failure;
 		$run['failures']               = array_slice( $run['failures'], -20 );
 		$run['state']                  = 'failed';
 		$run['progress']['phase']      = $phase;
 		$run['progress']['updated_at'] = gmdate( 'c' );
-		$write = self::write_run( $workspace, $run );
-		$error_data = array(
+		$write                         = self::write_run( $workspace, $run );
+		$error_data                    = array(
 			'import_id'    => (string) ( $run['import_id'] ?? '' ),
 			'artifact_run' => self::evidence( $run ),
 			'failure'      => self::scrub_error( $failure ),
@@ -848,7 +867,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			return new WP_Error( 'static_site_importer_direct_artifact_checkpoint_rejected', 'The direct artifact checkpoint publication was rejected.' );
 		}
 		$payload_hash = self::hash( $payload );
-		$record = array(
+		$record       = array(
 			'schema'            => self::CHECKPOINT_SCHEMA,
 			'kind'              => $kind,
 			'import_id'         => $run['import_id'],
@@ -856,7 +875,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			'payload_sha256'    => $payload_hash,
 			'payload'           => $payload,
 		);
-		$write = $workspace->publish_json_once( $relative, $record );
+		$write        = $workspace->publish_json_once( $relative, $record );
 		if ( is_wp_error( $write ) ) {
 			return $write;
 		}
@@ -875,7 +894,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		$relative = is_string( $ref['file'] ?? null ) ? $ref['file'] : '';
 		$raw      = '' !== $relative ? $workspace->read_raw( $relative ) : null;
 		$record   = is_string( $raw ) ? json_decode( $raw, true ) : null;
-		if ( ! is_string( $raw ) || ! is_array( $record ) || ! hash_equals( (string) ( $ref['sha256'] ?? '' ), hash( 'sha256', $raw ) ) || self::CHECKPOINT_SCHEMA !== ( $record['schema'] ?? '' ) || $kind !== ( $record['kind'] ?? '' ) || $run['import_id'] !== ( $record['import_id'] ?? '' ) || ( $run['binding']['artifact_identity'] ?? '' ) !== ( $record['artifact_identity'] ?? '' ) || ! is_array( $record['payload'] ?? null ) || ! hash_equals( (string) ( $record['payload_sha256'] ?? '' ), self::hash( $record['payload'] ) ) || ! hash_equals( (string) ( $ref['payload'] ?? '' ), (string) $record['payload_sha256'] ) || ! self::checkpoint_contract_valid( $record['payload'], $kind, $run ) ) {
+		if ( ! is_string( $raw ) || ! is_array( $record ) || ! hash_equals( (string) ( $ref['sha256'] ?? '' ), hash( 'sha256', $raw ) ) || self::CHECKPOINT_SCHEMA !== ( $record['schema'] ?? '' ) || ( $record['kind'] ?? '' ) !== $kind || ( $record['import_id'] ?? '' ) !== $run['import_id'] || ( $run['binding']['artifact_identity'] ?? '' ) !== ( $record['artifact_identity'] ?? '' ) || ! is_array( $record['payload'] ?? null ) || ! hash_equals( (string) ( $record['payload_sha256'] ?? '' ), self::hash( $record['payload'] ) ) || ! hash_equals( (string) ( $ref['payload'] ?? '' ), (string) $record['payload_sha256'] ) || ! self::checkpoint_contract_valid( $record['payload'], $kind, $run ) ) {
 			return new WP_Error( 'static_site_importer_direct_artifact_checkpoint_invalid', 'A retained direct artifact checkpoint failed its identity, hash, or contract validation.' );
 		}
 		return $record['payload'];
@@ -887,7 +906,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		if ( ! is_string( $raw ) ) {
 			return array();
 		}
-		if ( ! is_array( $record ) || self::CHECKPOINT_SCHEMA !== ( $record['schema'] ?? '' ) || $kind !== ( $record['kind'] ?? '' ) || $run['import_id'] !== ( $record['import_id'] ?? '' ) || ( $run['binding']['artifact_identity'] ?? '' ) !== ( $record['artifact_identity'] ?? '' ) || ! is_array( $record['payload'] ?? null ) || ! hash_equals( (string) ( $record['payload_sha256'] ?? '' ), self::hash( $record['payload'] ) ) || ! self::checkpoint_contract_valid( $record['payload'], $kind, $run ) ) {
+		if ( ! is_array( $record ) || self::CHECKPOINT_SCHEMA !== ( $record['schema'] ?? '' ) || ( $record['kind'] ?? '' ) !== $kind || ( $record['import_id'] ?? '' ) !== $run['import_id'] || ( $run['binding']['artifact_identity'] ?? '' ) !== ( $record['artifact_identity'] ?? '' ) || ! is_array( $record['payload'] ?? null ) || ! hash_equals( (string) ( $record['payload_sha256'] ?? '' ), self::hash( $record['payload'] ) ) || ! self::checkpoint_contract_valid( $record['payload'], $kind, $run ) ) {
 			return new WP_Error( 'static_site_importer_direct_artifact_checkpoint_invalid', 'An unpublished retained checkpoint failed validation.' );
 		}
 		return array(
@@ -916,7 +935,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	private static function read_run( Static_Site_Importer_Artifact_Run_Workspace $workspace, string $import_id ) {
 		$raw    = $workspace->read_raw( 'run.json' );
 		$record = is_string( $raw ) ? json_decode( $raw, true ) : null;
-		if ( ! is_array( $record ) || self::RUN_SCHEMA !== ( $record['schema'] ?? '' ) || ! is_array( $record['payload'] ?? null ) || ! hash_equals( (string) ( $record['payload_sha256'] ?? '' ), self::hash( $record['payload'] ) ) || $import_id !== ( $record['payload']['import_id'] ?? '' ) || ! is_array( $record['payload']['binding'] ?? null ) ) {
+		if ( ! is_array( $record ) || self::RUN_SCHEMA !== ( $record['schema'] ?? '' ) || ! is_array( $record['payload'] ?? null ) || ! hash_equals( (string) ( $record['payload_sha256'] ?? '' ), self::hash( $record['payload'] ) ) || ( $record['payload']['import_id'] ?? '' ) !== $import_id || ! is_array( $record['payload']['binding'] ?? null ) ) {
 			return new WP_Error( 'static_site_importer_direct_artifact_run_not_found', 'The direct artifact run was not found or failed validation.' );
 		}
 		return $record['payload'];
@@ -987,8 +1006,8 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 
 	private static function run_policy(): array {
 		$policy = array(
-			'prepare_batch_pages'   => 2,
-			'compile_batch_pages'   => 2,
+			'prepare_batch_pages'    => 2,
+			'compile_batch_pages'    => 2,
 			'max_invocation_seconds' => 20.0,
 			'clock'                  => static fn (): float => microtime( true ),
 		);
@@ -1018,7 +1037,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		);
 		$binding = array();
 		foreach ( $classes as $class ) {
-			$file = class_exists( $class ) ? ( new ReflectionClass( $class ) )->getFileName() : false;
+			$file              = class_exists( $class ) ? ( new ReflectionClass( $class ) )->getFileName() : false;
 			$binding[ $class ] = is_string( $file ) && is_readable( $file ) ? hash_file( 'sha256', $file ) : '';
 		}
 		return $binding;
@@ -1071,13 +1090,13 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		if ( 'page_plan' === $kind ) {
 			return is_string( $payload['page_id'] ?? null )
 				&& 'blocks-engine/php-transformer/staged-page-plan/v1' === ( $payload['plan']['schema'] ?? '' )
-				&& ( $payload['page_id'] ?? '' ) === ( $payload['plan']['page_id'] ?? null )
+				&& ( $payload['plan']['page_id'] ?? null ) === $payload['page_id']
 				&& is_string( $payload['plan']['digest'] ?? null );
 		}
 		if ( 'receipt' === $kind ) {
 			return is_string( $payload['page_id'] ?? null )
 				&& self::RECEIPT_SCHEMA === ( $payload['receipt']['receipt_schema'] ?? '' )
-				&& ( $payload['page_id'] ?? '' ) === ( $payload['receipt']['page_id'] ?? null )
+				&& ( $payload['receipt']['page_id'] ?? null ) === $payload['page_id']
 				&& is_array( $payload['receipt']['terminal_reduction'] ?? null );
 		}
 		if ( 'composed' === $kind ) {

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -1,0 +1,1148 @@
+<?php
+/**
+ * Durable, bounded compilation for direct multi-page artifacts.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'Static_Site_Importer_Artifact_Run_Workspace' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-artifact-run.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Content_Policy' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-content-policy.php';
+}
+if ( ! class_exists( 'Static_Site_Importer_Client_Script_Policy' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-client-script-policy.php';
+}
+
+final class Static_Site_Importer_Direct_Artifact_Import {
+	private const RUN_SCHEMA        = 'static-site-importer/direct-artifact-run/v1';
+	private const CHECKPOINT_SCHEMA = 'static-site-importer/direct-artifact-checkpoint/v1';
+	private const EVIDENCE_SCHEMA   = 'static-site-importer/direct-artifact-run-evidence/v1';
+	private const RECEIPT_SCHEMA    = 'blocks-engine/php-transformer/compiled-page-receipt/v2';
+	private const TTL               = 604800;
+	private const CLEANUP_HOOK      = 'static_site_importer_purge_direct_artifact_imports';
+
+	/** Start a server-owned run after normal canonical source normalization. */
+	public static function start( array $artifact, array $args, string $source_type, string $operation, array $provenance ) {
+		$freeze_started = microtime( true );
+		$source_identity = hash( 'sha256', (string) wp_json_encode( $artifact ) );
+		$source_policy = Static_Site_Importer_Content_Policy::validate_artifact( $artifact );
+		if ( is_wp_error( $source_policy ) ) {
+			return $source_policy;
+		}
+
+		$policy   = Static_Site_Importer_Client_Script_Policy::apply( $artifact, $args );
+		$artifact = $policy['artifact'];
+		$args['client_script_policy_report'] = $policy['report'];
+		$args['source_metadata']['collection'] = is_array( $args['source_metadata']['collection'] ?? null ) ? $args['source_metadata']['collection'] : array();
+		$args['source_metadata']['collection']['script_policy'] = $policy['report'];
+		$identity = self::hash( $artifact );
+		$import_id = bin2hex( random_bytes( 32 ) );
+		$workspace = self::workspace( $import_id, true );
+		if ( is_wp_error( $workspace ) ) {
+			return $workspace;
+		}
+
+		$run = array(
+			'import_id'   => $import_id,
+			'binding'     => array(
+				'source_type'      => $source_type,
+				'operation'        => $operation,
+				'args'             => self::binding_args( $args ),
+				'owner'            => self::owner(),
+				'source_identity'  => $source_identity,
+				'artifact_identity' => $identity,
+				'implementation'    => self::implementation_binding(),
+			),
+			'provenance'  => $provenance,
+			'state'       => 'running',
+			'phase'       => 'freezing',
+			'refs'        => array(),
+			'page_ids'    => array(),
+			'failures'    => array(),
+			'timings'     => array( 'freeze_seconds' => microtime( true ) - $freeze_started ),
+			'work'        => array(
+				'content_policy_applications'       => 1,
+				'client_script_policy_applications' => 1,
+				'shared_prepares'                   => 0,
+				'page_prepare_passes'               => 0,
+				'page_plans_prepared'               => 0,
+				'compile_batches'                   => 0,
+				'pages_compiled'                    => 0,
+				'page_compile_counts'               => array(),
+				'compositions'                      => 0,
+				'materialization_claims'            => 0,
+				'materialization_attempts'          => 0,
+				'materializations'                  => 0,
+			),
+			'progress'    => array(
+				'phase'         => 'freezing',
+				'page_count'    => 0,
+				'receipt_count' => 0,
+				'updated_at'    => gmdate( 'c' ),
+			),
+		);
+		$artifact_ref = self::publish_checkpoint(
+			$workspace,
+			$run,
+			'artifact',
+			'artifact.json',
+			array(
+				'artifact'     => $artifact,
+				'args'         => $args,
+				'policy_report'=> $policy['report'],
+			)
+		);
+		if ( is_wp_error( $artifact_ref ) ) {
+			$workspace->purge();
+			return $artifact_ref;
+		}
+		$run['refs']['artifact'] = $artifact_ref;
+		$run['phase']             = 'preparing_shared';
+		$run['progress']['phase'] = 'preparing_shared';
+		$write                    = self::write_run( $workspace, $run );
+		if ( is_wp_error( $write ) ) {
+			return $write;
+		}
+
+		return self::execute( $workspace, $run );
+	}
+
+	/** Resume an opaque run without reacquiring source bytes. */
+	public static function resume( string $import_id, array $args, string $source_type, string $operation, array $source ) {
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $import_id ) ) {
+			return new WP_Error( 'static_site_importer_invalid_direct_artifact_import_id', 'The direct artifact import_id is invalid.' );
+		}
+		foreach ( array( 'html', 'files', 'entrypoint', 'ref', 'zip', 'metadata' ) as $field ) {
+			if ( array_key_exists( $field, $source ) ) {
+				return new WP_Error( 'static_site_importer_direct_artifact_source_mismatch', 'A retained direct artifact run must be resumed without replacement source data.' );
+			}
+		}
+		$workspace = self::workspace( $import_id, false );
+		if ( is_wp_error( $workspace ) ) {
+			return $workspace;
+		}
+		$run = self::read_run( $workspace, $import_id );
+		if ( is_wp_error( $run ) ) {
+			return $run;
+		}
+		$requested = array(
+			'source_type' => $source_type,
+			'operation'   => $operation,
+			'args'        => self::binding_args( $args ),
+			'owner'       => self::owner(),
+		);
+		foreach ( $requested as $key => $value ) {
+			if ( self::canonical( $value ) !== self::canonical( $run['binding'][ $key ] ?? null ) ) {
+				return new WP_Error( 'static_site_importer_direct_artifact_run_mismatch', 'The direct artifact import_id does not match this source type, operation, import options, or owner.' );
+			}
+		}
+		if ( self::implementation_binding() !== ( $run['binding']['implementation'] ?? null ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_implementation_changed', 'The retained direct artifact run was created by a different compiler or policy implementation.' );
+		}
+		$validated = self::validate_retained_refs( $workspace, $run );
+		if ( is_wp_error( $validated ) ) {
+			return $validated;
+		}
+		if ( 'completed' === ( $run['state'] ?? '' ) ) {
+			$final = self::read_checkpoint( $workspace, $run, $run['refs']['final'] ?? array(), 'final' );
+			return is_wp_error( $final ) ? $final : $final['response'];
+		}
+
+		return self::execute( $workspace, $run );
+	}
+
+	/** Continue the phase machine until its server-owned work boundary. */
+	private static function execute( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run ) {
+		$lock = $workspace->acquire_lock( 'execution.lock' );
+		if ( is_wp_error( $lock ) ) {
+			return self::continuation( $run, 'run_in_progress' );
+		}
+		try {
+			return self::execute_locked( $workspace, $run );
+		} finally {
+			$workspace->release_lock( $lock );
+		}
+	}
+
+	private static function execute_locked( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run ) {
+		if ( $workspace->is_expired() ) {
+			$workspace->purge();
+			return new WP_Error( 'static_site_importer_direct_artifact_run_expired', 'The retained direct artifact run expired and must be restarted.' );
+		}
+		$policy   = self::run_policy();
+		$clock    = $policy['clock'];
+		$deadline = call_user_func( $clock ) + $policy['max_invocation_seconds'];
+		$run['state'] = 'running';
+		$write        = self::write_run( $workspace, $run );
+		if ( is_wp_error( $write ) ) {
+			return self::fail( $workspace, $run, 'run_checkpoint', $write );
+		}
+		$final_ref = self::existing_checkpoint_ref( $workspace, $run, 'final-response.json', 'final' );
+		if ( is_wp_error( $final_ref ) ) {
+			return $final_ref;
+		}
+		if ( ! empty( $final_ref ) ) {
+			$final = self::read_checkpoint( $workspace, $run, $final_ref, 'final' );
+			if ( is_wp_error( $final ) ) {
+				return $final;
+			}
+			$run['refs']['final']         = $final_ref;
+			$run['state']                 = 'completed';
+			$run['phase']                 = 'completed';
+			$run['progress']['phase']     = 'completed';
+			$run['progress']['updated_at'] = gmdate( 'c' );
+			$write = self::write_run( $workspace, $run );
+			return is_wp_error( $write ) ? self::fail( $workspace, $run, 'terminal_checkpoint', $write ) : $final['response'];
+		}
+
+		try {
+			$compiler = self::compiler();
+			if ( is_wp_error( $compiler ) ) {
+				return self::fail( $workspace, $run, 'compiler', $compiler );
+			}
+			$artifact_state = self::read_checkpoint( $workspace, $run, $run['refs']['artifact'], 'artifact' );
+			if ( is_wp_error( $artifact_state ) ) {
+				return $artifact_state;
+			}
+			$artifact = $artifact_state['artifact'];
+			$args     = $artifact_state['args'];
+
+			if ( empty( $run['refs']['shared'] ) ) {
+				$shared_ref = self::existing_checkpoint_ref( $workspace, $run, 'shared-plan.json', 'shared' );
+				if ( is_wp_error( $shared_ref ) ) {
+					return $shared_ref;
+				}
+				if ( ! empty( $shared_ref ) ) {
+					$shared_state = self::read_checkpoint( $workspace, $run, $shared_ref, 'shared' );
+					if ( is_wp_error( $shared_state ) ) {
+						return $shared_state;
+					}
+					$run['refs']['shared']          = $shared_ref;
+					$run['page_ids']               = array_values( $shared_state['plan']['analysis']['page_ids'] );
+					sort( $run['page_ids'], SORT_STRING );
+					$run['work']['shared_prepares'] = 1;
+				}
+			}
+			if ( empty( $run['refs']['shared'] ) ) {
+				$started = microtime( true );
+				$entered = self::enter_phase( $workspace, $run, 'prepare_shared' );
+				if ( is_wp_error( $entered ) ) {
+					return $entered;
+				}
+				$run = $entered;
+				self::before_phase( 'prepare_shared', $run );
+				$shared = call_user_func( array( $compiler, 'prepareShared' ), $artifact );
+				if ( 'blocks-engine/php-transformer/staged-shared-plan/v1' !== ( $shared['schema'] ?? '' ) || empty( $shared['digest'] ) || ! is_array( $shared['analysis']['page_ids'] ?? null ) ) {
+					throw new RuntimeException( 'Blocks Engine returned an invalid shared plan.' );
+				}
+				$ref = self::publish_checkpoint( $workspace, $run, 'shared', 'shared-plan.json', array( 'plan' => $shared ) );
+				if ( is_wp_error( $ref ) ) {
+					return self::fail( $workspace, $run, 'prepare_shared', $ref );
+				}
+				$run['refs']['shared']                  = $ref;
+				$run['page_ids']                       = array_values( $shared['analysis']['page_ids'] );
+				sort( $run['page_ids'], SORT_STRING );
+				$run['work']['shared_prepares']         = 1;
+				$run['timings']['prepare_shared_seconds'] = microtime( true ) - $started;
+				$run['phase']                           = 'preparing_pages';
+				$run['progress']['phase']               = 'preparing_pages';
+				$run['progress']['page_count']          = count( $run['page_ids'] );
+				$run['progress']['updated_at']          = gmdate( 'c' );
+				$write = self::write_run( $workspace, $run );
+				if ( is_wp_error( $write ) ) {
+					return self::fail( $workspace, $run, 'prepare_shared_checkpoint', $write );
+				}
+			}
+
+			$shared_state = self::read_checkpoint( $workspace, $run, $run['refs']['shared'], 'shared' );
+			if ( is_wp_error( $shared_state ) ) {
+				return $shared_state;
+			}
+			$shared = $shared_state['plan'];
+			$adopted = self::adopt_page_plans( $workspace, $run, $shared );
+			if ( is_wp_error( $adopted ) ) {
+				return $adopted;
+			}
+			if ( $adopted !== ( $run['refs']['pages'] ?? array() ) ) {
+				$run['refs']['pages']                       = $adopted;
+				$run['work']['page_plans_prepared']         = count( $adopted );
+				$run['progress']['prepared_page_count']     = count( $adopted );
+				$run['progress']['updated_at']              = gmdate( 'c' );
+				$write = self::write_run( $workspace, $run );
+				if ( is_wp_error( $write ) ) {
+					return self::fail( $workspace, $run, 'prepare_pages_checkpoint', $write );
+				}
+			}
+
+			$pending_plans = array_values( array_diff( $run['page_ids'], array_keys( $run['refs']['pages'] ?? array() ) ) );
+			$prepare_ids   = self::deadline_reached( $deadline, $clock ) ? array() : array_slice( $pending_plans, 0, $policy['prepare_batch_pages'] );
+			if ( ! empty( $prepare_ids ) ) {
+				if ( self::deadline_reached( $deadline, $clock ) ) {
+					return self::continuation( $run, 'deadline_exhausted' );
+				}
+				$started = microtime( true );
+				$entered = self::enter_phase( $workspace, $run, 'prepare_pages', $prepare_ids );
+				if ( is_wp_error( $entered ) ) {
+					return $entered;
+				}
+				$run = $entered;
+				self::before_phase( 'prepare_pages', $run, $prepare_ids );
+				$run['work']['page_prepare_passes'] = (int) $run['work']['page_prepare_passes'] + 1;
+				foreach ( $prepare_ids as $page_id ) {
+					$page_plan = call_user_func( array( $compiler, 'preparePage' ), $artifact, $shared, $page_id );
+					$validated = self::validate_page_plan( $page_plan, $shared, $page_id );
+					if ( is_wp_error( $validated ) ) {
+						return self::fail( $workspace, $run, 'prepare_pages', $validated, array( $page_id ) );
+					}
+					$relative = self::page_file( 'page-plans', $page_id );
+					$ref      = self::publish_checkpoint( $workspace, $run, 'page_plan', $relative, array( 'page_id' => $page_id, 'plan' => $page_plan ) );
+					if ( is_wp_error( $ref ) ) {
+						return self::fail( $workspace, $run, 'prepare_pages', $ref, array( $page_id ) );
+					}
+					$run['refs']['pages'][ $page_id ] = $ref;
+					$run['work']['page_plans_prepared'] = count( $run['refs']['pages'] );
+					$run['progress']['prepared_page_count'] = count( $run['refs']['pages'] );
+					$run['progress']['updated_at'] = gmdate( 'c' );
+					$write = self::write_run( $workspace, $run );
+					if ( is_wp_error( $write ) ) {
+						return self::fail( $workspace, $run, 'prepare_pages_checkpoint', $write, array( $page_id ) );
+					}
+				}
+				$run['timings']['prepare_pages_seconds']     = (float) ( $run['timings']['prepare_pages_seconds'] ?? 0 ) + microtime( true ) - $started;
+				$run['phase']                                = 'compiling_pages';
+				$run['progress']['phase']                    = 'compiling_pages';
+				$run['progress']['updated_at']               = gmdate( 'c' );
+				$write = self::write_run( $workspace, $run );
+				if ( is_wp_error( $write ) ) {
+					return self::fail( $workspace, $run, 'prepare_pages_checkpoint', $write, $prepare_ids );
+				}
+			}
+			$remaining_plans = count( $run['page_ids'] ) - count( $run['refs']['pages'] ?? array() );
+			if ( 0 < $remaining_plans ) {
+				$reason = self::deadline_reached( $deadline, $clock ) ? 'deadline_exhausted' : 'pages_remaining';
+				return self::continuation( $run, $reason );
+			}
+
+			$adopted = self::adopt_receipts( $workspace, $run, $shared );
+			if ( is_wp_error( $adopted ) ) {
+				return $adopted;
+			}
+			if ( $adopted !== ( $run['refs']['receipts'] ?? array() ) ) {
+				$run['refs']['receipts'] = $adopted;
+				foreach ( array_keys( $adopted ) as $page_id ) {
+					$run['work']['page_compile_counts'][ $page_id ] = 1;
+				}
+				$run['work']['pages_compiled']    = count( $adopted );
+				$run['work']['compile_batches']   = max( (int) ( $run['work']['compile_batches'] ?? 0 ), empty( $adopted ) ? 0 : 1 );
+				$run['progress']['receipt_count'] = count( $adopted );
+				$run['progress']['updated_at']    = gmdate( 'c' );
+				$write = self::write_run( $workspace, $run );
+				if ( is_wp_error( $write ) ) {
+					return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, array_keys( $adopted ) );
+				}
+			}
+
+			$pending   = array_values( array_diff( $run['page_ids'], array_keys( $run['refs']['receipts'] ?? array() ) ) );
+			$batch_ids = self::deadline_reached( $deadline, $clock ) ? array() : array_slice( $pending, 0, $policy['compile_batch_pages'] );
+			if ( ! empty( $batch_ids ) ) {
+				$plans = array();
+				foreach ( $batch_ids as $page_id ) {
+					$page_state = self::read_checkpoint( $workspace, $run, $run['refs']['pages'][ $page_id ] ?? array(), 'page_plan' );
+					if ( is_wp_error( $page_state ) ) {
+						return $page_state;
+					}
+					$plans[ $page_id ] = $page_state['plan'];
+				}
+				$started = microtime( true );
+				$entered = self::enter_phase( $workspace, $run, 'compile_pages', $batch_ids );
+				if ( is_wp_error( $entered ) ) {
+					return $entered;
+				}
+				$run = $entered;
+				self::before_phase( 'compile_pages', $run, $batch_ids );
+				$batch = call_user_func( array( $compiler, 'compilePreparedPages' ), $shared, array_values( $plans ) );
+				if ( ! is_array( $batch ) || array_keys( $batch ) !== $batch_ids ) {
+					return self::fail( $workspace, $run, 'compile_pages', new WP_Error( 'static_site_importer_direct_artifact_receipt_set_mismatch', 'Blocks Engine did not return the exact requested compiled receipt batch.' ), $batch_ids );
+				}
+				foreach ( $batch_ids as $page_id ) {
+					$valid = self::validate_receipt( $batch[ $page_id ], $plans[ $page_id ], $shared );
+					if ( is_wp_error( $valid ) ) {
+						return self::fail( $workspace, $run, 'compile_pages', $valid, $batch_ids );
+					}
+				}
+				$run['work']['compile_batches'] = (int) $run['work']['compile_batches'] + 1;
+				foreach ( $batch_ids as $page_id ) {
+					$receipt = $batch[ $page_id ];
+					$ref = self::publish_checkpoint( $workspace, $run, 'receipt', self::page_file( 'receipts', $page_id ), array( 'page_id' => $page_id, 'receipt' => $receipt ) );
+					if ( is_wp_error( $ref ) ) {
+						return self::fail( $workspace, $run, 'compile_pages', $ref, $batch_ids );
+					}
+					$run['refs']['receipts'][ $page_id ] = $ref;
+					$run['work']['pages_compiled'] = (int) $run['work']['pages_compiled'] + 1;
+					$run['work']['page_compile_counts'][ $page_id ] = (int) ( $run['work']['page_compile_counts'][ $page_id ] ?? 0 ) + 1;
+					$run['progress']['receipt_count'] = count( $run['refs']['receipts'] );
+					$run['progress']['updated_at'] = gmdate( 'c' );
+					$write = self::write_run( $workspace, $run );
+					if ( is_wp_error( $write ) ) {
+						return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, array( $page_id ) );
+					}
+				}
+				$run['timings']['compile_pages_seconds'] = (float) ( $run['timings']['compile_pages_seconds'] ?? 0 ) + microtime( true ) - $started;
+				$write = self::write_run( $workspace, $run );
+				if ( is_wp_error( $write ) ) {
+					return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, $batch_ids );
+				}
+			}
+
+			$remaining = count( $run['page_ids'] ) - count( $run['refs']['receipts'] ?? array() );
+			if ( 0 < $remaining ) {
+				$reason = self::deadline_reached( $deadline, $clock ) ? 'deadline_exhausted' : 'pages_remaining';
+				return self::continuation( $run, $reason );
+			}
+			if ( self::deadline_reached( $deadline, $clock ) && empty( $run['refs']['composed'] ) ) {
+				return self::continuation( $run, 'deadline_exhausted' );
+			}
+
+			if ( empty( $run['refs']['composed'] ) ) {
+				$composed_ref = self::existing_checkpoint_ref( $workspace, $run, 'composed-result.json', 'composed' );
+				if ( is_wp_error( $composed_ref ) ) {
+					return $composed_ref;
+				}
+				if ( ! empty( $composed_ref ) ) {
+					$run['refs']['composed']     = $composed_ref;
+					$run['work']['compositions'] = 1;
+				}
+			}
+			if ( empty( $run['refs']['composed'] ) ) {
+				$receipts = self::complete_receipts( $workspace, $run, $shared );
+				if ( is_wp_error( $receipts ) ) {
+					return self::fail( $workspace, $run, 'compose', $receipts );
+				}
+				$started = microtime( true );
+				$entered = self::enter_phase( $workspace, $run, 'compose', $run['page_ids'] );
+				if ( is_wp_error( $entered ) ) {
+					return $entered;
+				}
+				$run = $entered;
+				self::before_phase( 'compose', $run, $run['page_ids'] );
+				$result = call_user_func( array( $compiler, 'compose' ), $shared, array_values( $receipts ) );
+				if ( ! is_object( $result ) || ! is_callable( array( $result, 'toArray' ) ) ) {
+					throw new RuntimeException( 'Blocks Engine returned an invalid composed result.' );
+				}
+				$composed = call_user_func( array( $result, 'toArray' ) );
+				$metrics  = is_array( $composed['metrics'] ?? null ) ? $composed['metrics'] : array();
+				if ( 0 !== (int) ( $metrics['html_document_transform_count'] ?? 0 ) || 0 !== (int) ( $metrics['normalization_count'] ?? 0 ) ) {
+					throw new RuntimeException( 'Terminal receipt composition performed HTML transforms or normalization.' );
+				}
+				$ref = self::publish_checkpoint( $workspace, $run, 'composed', 'composed-result.json', array( 'result' => $composed, 'terminal_work' => $metrics ) );
+				if ( is_wp_error( $ref ) ) {
+					return self::fail( $workspace, $run, 'compose', $ref, $run['page_ids'] );
+				}
+				$run['refs']['composed']             = $ref;
+				$run['work']['compositions']          = 1;
+				$run['timings']['compose_seconds']    = microtime( true ) - $started;
+				$run['phase']                         = 'composed';
+				$run['progress']['phase']             = 'composed';
+				$run['progress']['updated_at']        = gmdate( 'c' );
+				$write = self::write_run( $workspace, $run );
+				if ( is_wp_error( $write ) ) {
+					return self::fail( $workspace, $run, 'compose_checkpoint', $write, $run['page_ids'] );
+				}
+			}
+
+			$composed_state = self::read_checkpoint( $workspace, $run, $run['refs']['composed'], 'composed' );
+			if ( is_wp_error( $composed_state ) ) {
+				return $composed_state;
+			}
+			if ( self::deadline_reached( $deadline, $clock ) ) {
+				return self::continuation( $run, 'deadline_exhausted' );
+			}
+			$args['compiled_artifact_result']               = $composed_state['result'];
+			$args['_static_site_importer_precompiled_source'] = true;
+
+			if ( 'plan' === $run['binding']['operation'] ) {
+				$entered = self::enter_phase( $workspace, $run, 'canonical_plan' );
+				if ( is_wp_error( $entered ) ) {
+					return $entered;
+				}
+				$run = $entered;
+				$response = Static_Site_Importer_Canonical_Import_Service::plan_artifact( $artifact, $args, $run['binding']['source_type'], $run['provenance'] );
+				if ( empty( $response['success'] ) ) {
+					return self::fail( $workspace, $run, 'canonical_plan', self::response_error( $response ) );
+				}
+				$response['source']['identity'] = (string) ( $run['binding']['source_identity'] ?? '' );
+			} else {
+				if ( empty( $run['refs']['materialization'] ) ) {
+					$materialization_ref = self::existing_checkpoint_ref( $workspace, $run, 'materialization-result.json', 'materialization' );
+					if ( is_wp_error( $materialization_ref ) ) {
+						return $materialization_ref;
+					}
+					if ( ! empty( $materialization_ref ) ) {
+						$run['refs']['materialization']   = $materialization_ref;
+						$run['work']['materializations'] = 1;
+					}
+				}
+				if ( empty( $run['refs']['materialization'] ) ) {
+					$claim = self::claim_materialization( $workspace, $run );
+					if ( is_wp_error( $claim ) ) {
+						return self::fail( $workspace, $run, 'materialization_claim', $claim );
+					}
+					$run = $claim;
+					$args['import_run_id'] = $run['import_id'];
+					$run['work']['materialization_attempts'] = (int) $run['work']['materialization_attempts'] + 1;
+					$entered = self::enter_phase( $workspace, $run, 'materialize' );
+					if ( is_wp_error( $entered ) ) {
+						return $entered;
+					}
+					$run = $entered;
+					$started = microtime( true );
+					self::before_phase( 'materialize', $run );
+					$materialized = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $args );
+					if ( is_wp_error( $materialized ) ) {
+						return self::fail( $workspace, $run, 'materialize', $materialized );
+					}
+					$ref = self::publish_checkpoint( $workspace, $run, 'materialization', 'materialization-result.json', array( 'result' => $materialized ) );
+					if ( is_wp_error( $ref ) ) {
+						return self::fail( $workspace, $run, 'materialize', $ref );
+					}
+					$run['refs']['materialization']          = $ref;
+					$run['work']['materializations']         = 1;
+					$run['timings']['materialize_seconds']   = microtime( true ) - $started;
+					$write = self::write_run( $workspace, $run );
+					if ( is_wp_error( $write ) ) {
+						return self::fail( $workspace, $run, 'materialization_checkpoint', $write );
+					}
+				}
+				$materialization = self::read_checkpoint( $workspace, $run, $run['refs']['materialization'], 'materialization' );
+				if ( is_wp_error( $materialization ) ) {
+					return $materialization;
+				}
+				$response = Static_Site_Importer_Canonical_Import_Service::success(
+					$materialization['result'],
+					array_merge(
+						$args,
+						array(
+							'operation' => 'apply',
+							'source'    => array(
+								'type'      => $run['binding']['source_type'],
+								'import_id' => $run['import_id'],
+							),
+						)
+					)
+				);
+			}
+
+			$run['state']                  = 'completed';
+			$run['phase']                  = 'completed';
+			$run['progress']['phase']      = 'completed';
+			$run['progress']['updated_at'] = gmdate( 'c' );
+			$response = array_merge(
+				$response,
+				array(
+					'import_id'           => $run['import_id'],
+					'continuation'        => false,
+					'continuation_reason' => '',
+					'artifact_run'        => self::evidence( $run, $composed_state['terminal_work'] ?? array() ),
+				)
+			);
+			$final_ref = self::publish_checkpoint( $workspace, $run, 'final', 'final-response.json', array( 'response' => $response ) );
+			if ( is_wp_error( $final_ref ) ) {
+				return self::fail( $workspace, $run, 'terminal_checkpoint', $final_ref );
+			}
+			$run['refs']['final'] = $final_ref;
+			$write = self::write_run( $workspace, $run );
+			if ( is_wp_error( $write ) ) {
+				return self::fail( $workspace, $run, 'terminal_checkpoint', $write );
+			}
+			return $response;
+		} catch ( Throwable $error ) {
+			return self::fail( $workspace, $run, (string) ( $run['progress']['phase'] ?? $run['phase'] ?? 'runtime' ), $error );
+		}
+	}
+
+	/** Atomically reserve the only materialization attempt before mutation. */
+	private static function claim_materialization( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run ) {
+		if ( ! $workspace->claim_directory( 'materialization-claim' ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_materialization_ambiguous', 'Materialization was already claimed without a durable result; the import will not repeat WordPress mutation.' );
+		}
+		$run['work']['materialization_claims'] = 1;
+		$run['phase']                  = 'materialization_claimed';
+		$run['progress']['phase']      = 'materialization_claimed';
+		$run['progress']['updated_at'] = gmdate( 'c' );
+		$write = self::write_run( $workspace, $run );
+		return is_wp_error( $write ) ? $write : $run;
+	}
+
+	/** @return array<string,mixed>|WP_Error */
+	private static function complete_receipts( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, array $shared ) {
+		$refs = $run['refs']['receipts'] ?? array();
+		if ( array_keys( $refs ) !== $run['page_ids'] ) {
+			$ordered = array();
+			foreach ( $run['page_ids'] as $page_id ) {
+				if ( ! isset( $refs[ $page_id ] ) ) {
+					return new WP_Error( 'static_site_importer_direct_artifact_receipts_incomplete', 'Composition requires one receipt for every frozen page.' );
+				}
+				$ordered[ $page_id ] = $refs[ $page_id ];
+			}
+			$refs = $ordered;
+		}
+		$receipts = array();
+		foreach ( $run['page_ids'] as $page_id ) {
+			$page = self::read_checkpoint( $workspace, $run, $run['refs']['pages'][ $page_id ] ?? array(), 'page_plan' );
+			$row  = self::read_checkpoint( $workspace, $run, $refs[ $page_id ], 'receipt' );
+			if ( is_wp_error( $page ) || is_wp_error( $row ) ) {
+				return is_wp_error( $page ) ? $page : $row;
+			}
+			$valid = self::validate_receipt( $row['receipt'], $page['plan'], $shared );
+			if ( is_wp_error( $valid ) ) {
+				return $valid;
+			}
+			$receipts[ $page_id ] = $row['receipt'];
+		}
+		return $receipts;
+	}
+
+	private static function adopt_page_plans( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, array $shared ) {
+		$refs = is_array( $run['refs']['pages'] ?? null ) ? $run['refs']['pages'] : array();
+		foreach ( $run['page_ids'] as $page_id ) {
+			if ( isset( $refs[ $page_id ] ) ) {
+				continue;
+			}
+			$ref = self::existing_checkpoint_ref( $workspace, $run, self::page_file( 'page-plans', $page_id ), 'page_plan' );
+			if ( is_wp_error( $ref ) ) {
+				return $ref;
+			}
+			if ( empty( $ref ) ) {
+				continue;
+			}
+			$row = self::read_checkpoint( $workspace, $run, $ref, 'page_plan' );
+			if ( is_wp_error( $row ) || ( $row['plan']['shared_digest'] ?? '' ) !== ( $shared['digest'] ?? '' ) || $page_id !== ( $row['plan']['page_id'] ?? '' ) ) {
+				return is_wp_error( $row ) ? $row : new WP_Error( 'static_site_importer_direct_artifact_page_plan_mismatch', 'A retained page plan does not match the frozen shared plan.' );
+			}
+			$refs[ $page_id ] = $ref;
+		}
+		$ordered = array();
+		foreach ( $run['page_ids'] as $page_id ) {
+			if ( isset( $refs[ $page_id ] ) ) {
+				$ordered[ $page_id ] = $refs[ $page_id ];
+			}
+		}
+		return $ordered;
+	}
+
+	private static function adopt_receipts( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, array $shared ) {
+		$refs = is_array( $run['refs']['receipts'] ?? null ) ? $run['refs']['receipts'] : array();
+		foreach ( $run['page_ids'] as $page_id ) {
+			if ( isset( $refs[ $page_id ] ) ) {
+				continue;
+			}
+			$ref = self::existing_checkpoint_ref( $workspace, $run, self::page_file( 'receipts', $page_id ), 'receipt' );
+			if ( is_wp_error( $ref ) ) {
+				return $ref;
+			}
+			if ( empty( $ref ) ) {
+				continue;
+			}
+			$page = self::read_checkpoint( $workspace, $run, $run['refs']['pages'][ $page_id ] ?? array(), 'page_plan' );
+			$row  = self::read_checkpoint( $workspace, $run, $ref, 'receipt' );
+			if ( is_wp_error( $page ) || is_wp_error( $row ) ) {
+				return is_wp_error( $page ) ? $page : $row;
+			}
+			$valid = self::validate_receipt( $row['receipt'], $page['plan'], $shared );
+			if ( is_wp_error( $valid ) ) {
+				return $valid;
+			}
+			$refs[ $page_id ] = $ref;
+		}
+		$ordered = array();
+		foreach ( $run['page_ids'] as $page_id ) {
+			if ( isset( $refs[ $page_id ] ) ) {
+				$ordered[ $page_id ] = $refs[ $page_id ];
+			}
+		}
+		return $ordered;
+	}
+
+	private static function validate_page_plan( $plan, array $shared, string $page_id ) {
+		if ( ! is_array( $plan ) || 'blocks-engine/php-transformer/staged-page-plan/v1' !== ( $plan['schema'] ?? '' ) || $page_id !== ( $plan['page_id'] ?? '' ) || ( $shared['digest'] ?? '' ) !== ( $plan['shared_digest'] ?? '' ) || empty( $plan['digest'] ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_page_plan_invalid', 'A prepared page plan is not bound to the frozen shared plan.' );
+		}
+		return true;
+	}
+
+	private static function validate_receipt( $receipt, array $page_plan, array $shared ) {
+		$reduction = is_array( $receipt['terminal_reduction'] ?? null ) ? $receipt['terminal_reduction'] : array();
+		$required_reduction = array( 'files', 'normalization', 'source_documents', 'owned_transformable_paths', 'stylesheet_occurrence_files', 'component_facts', 'block_types' );
+		$reduction_complete = empty( array_diff( $required_reduction, array_keys( $reduction ) ) );
+		if ( ! is_array( $receipt ) || self::RECEIPT_SCHEMA !== ( $receipt['receipt_schema'] ?? '' ) || ( $page_plan['page_id'] ?? '' ) !== ( $receipt['page_id'] ?? '' ) || ( $shared['digest'] ?? '' ) !== ( $receipt['shared_digest'] ?? '' ) || ( $shared['shared_reduction_digest'] ?? '' ) !== ( $receipt['shared_reduction_digest'] ?? '' ) || ( $page_plan['compiler_options'] ?? null ) !== ( $receipt['compiler_options'] ?? null ) || ( $page_plan['output_schema'] ?? null ) !== ( $receipt['output_schema'] ?? null ) || ( $page_plan['digest'] ?? '' ) === ( $receipt['digest'] ?? '' ) || empty( $receipt['digest'] ) || ! is_array( $receipt['compiled_documents'] ?? null ) || ! is_array( $receipt['owned_document_paths'] ?? null ) || ! $reduction_complete ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_receipt_invalid', 'A compiled page receipt does not satisfy the frozen v2 receipt contract.' );
+		}
+		return true;
+	}
+
+	/** Validate every referenced retained value before a resumed phase reads it. */
+	private static function validate_retained_refs( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run ) {
+		$kinds = array(
+			'artifact'        => 'artifact',
+			'shared'          => 'shared',
+			'composed'        => 'composed',
+			'materialization' => 'materialization',
+			'final'           => 'final',
+		);
+		foreach ( $kinds as $key => $kind ) {
+			if ( isset( $run['refs'][ $key ] ) && is_wp_error( self::read_checkpoint( $workspace, $run, $run['refs'][ $key ], $kind ) ) ) {
+				return self::read_checkpoint( $workspace, $run, $run['refs'][ $key ], $kind );
+			}
+		}
+		foreach ( array( 'pages' => 'page_plan', 'receipts' => 'receipt' ) as $key => $kind ) {
+			foreach ( is_array( $run['refs'][ $key ] ?? null ) ? $run['refs'][ $key ] : array() as $ref ) {
+				$value = self::read_checkpoint( $workspace, $run, $ref, $kind );
+				if ( is_wp_error( $value ) ) {
+					return $value;
+				}
+			}
+		}
+		return true;
+	}
+
+	/** Persist the boundary before entering an uninterruptible owning call. */
+	private static function enter_phase( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, string $phase, array $page_ids = array() ) {
+		$run['phase']                         = $phase;
+		$run['progress']['phase']             = $phase;
+		$run['progress']['attempted_page_ids'] = array_values( $page_ids );
+		$run['progress']['phase_started_at']  = gmdate( 'c' );
+		$run['progress']['phase_started_epoch'] = microtime( true );
+		$run['progress']['updated_at']        = $run['progress']['phase_started_at'];
+		$write = self::write_run( $workspace, $run );
+		return is_wp_error( $write ) ? $write : $run;
+	}
+
+	private static function continuation( array $run, string $reason ): array {
+		return array(
+			'success'               => true,
+			'operation'             => $run['binding']['operation'],
+			'import_id'             => $run['import_id'],
+			'continuation'          => true,
+			'continuation_reason'   => $reason,
+			'import_report_summary' => array( 'status' => 'continuing' ),
+			'artifact_run'          => self::evidence( $run ),
+		);
+	}
+
+	private static function evidence( array $run, array $terminal_work = array() ): array {
+		$counts = array_values( is_array( $run['work']['page_compile_counts'] ?? null ) ? $run['work']['page_compile_counts'] : array() );
+		sort( $counts, SORT_NUMERIC );
+		$counts = array_slice( $counts, 0, 50 );
+		$receipt_identities = array();
+		foreach ( is_array( $run['refs']['receipts'] ?? null ) ? $run['refs']['receipts'] : array() as $page_id => $ref ) {
+			$receipt_identities[] = hash( 'sha256', $page_id . "\n" . (string) ( $ref['sha256'] ?? '' ) );
+		}
+		sort( $receipt_identities, SORT_STRING );
+		$failures = array_map(
+			static fn ( array $failure ): array => array(
+				'phase'              => (string) ( $failure['phase'] ?? '' ),
+				'exception_class'    => (string) ( $failure['exception_class'] ?? '' ),
+				'artifact_identity'  => (string) ( $failure['artifact_identity'] ?? '' ),
+				'attempted_page_ids' => array_map( static fn ( string $id ): string => hash( 'sha256', $id ), array_slice( is_array( $failure['attempted_page_ids'] ?? null ) ? $failure['attempted_page_ids'] : array(), 0, 20 ) ),
+				'phase_started_at'   => (string) ( $failure['phase_started_at'] ?? '' ),
+				'elapsed_seconds'    => (float) ( $failure['elapsed_seconds'] ?? 0 ),
+				'error'               => self::scrub_error( $failure['error'] ?? array() ),
+			),
+			array_slice( is_array( $run['failures'] ?? null ) ? $run['failures'] : array(), -5 )
+		);
+		return array(
+			'schema'               => self::EVIDENCE_SCHEMA,
+			'state'                => (string) ( $run['state'] ?? '' ),
+			'phase'                => (string) ( $run['phase'] ?? '' ),
+			'artifact_identity'    => (string) ( $run['binding']['artifact_identity'] ?? '' ),
+			'progress'             => array(
+				'page_count'    => count( $run['page_ids'] ?? array() ),
+				'prepared_count'=> count( $run['refs']['pages'] ?? array() ),
+				'receipt_count' => count( $run['refs']['receipts'] ?? array() ),
+				'remaining'     => max( 0, count( $run['page_ids'] ?? array() ) - count( $run['refs']['receipts'] ?? array() ) ),
+			),
+			'work'                 => array(
+				'content_policy_applications'       => (int) ( $run['work']['content_policy_applications'] ?? 0 ),
+				'client_script_policy_applications' => (int) ( $run['work']['client_script_policy_applications'] ?? 0 ),
+				'shared_prepares'                    => (int) ( $run['work']['shared_prepares'] ?? 0 ),
+				'page_prepare_passes'                => (int) ( $run['work']['page_prepare_passes'] ?? 0 ),
+				'page_plans_prepared'                => (int) ( $run['work']['page_plans_prepared'] ?? 0 ),
+				'compile_batches'                    => (int) ( $run['work']['compile_batches'] ?? 0 ),
+				'pages_compiled'                     => (int) ( $run['work']['pages_compiled'] ?? 0 ),
+				'page_compile_counts'                => $counts,
+				'compositions'                       => (int) ( $run['work']['compositions'] ?? 0 ),
+				'materialization_claims'             => (int) ( $run['work']['materialization_claims'] ?? 0 ),
+				'materialization_attempts'           => (int) ( $run['work']['materialization_attempts'] ?? 0 ),
+				'materializations'                   => (int) ( $run['work']['materializations'] ?? 0 ),
+			),
+			'phase_timings'        => array_map(
+				'floatval',
+				array_intersect_key(
+					is_array( $run['timings'] ?? null ) ? $run['timings'] : array(),
+					array_flip( array( 'freeze_seconds', 'prepare_shared_seconds', 'prepare_pages_seconds', 'compile_pages_seconds', 'compose_seconds', 'materialize_seconds' ) )
+				)
+			),
+			'receipt_identities'   => array_slice( $receipt_identities, 0, 50 ),
+			'terminal_result_work' => array_intersect_key( $terminal_work, array_flip( array( 'html_document_transform_count', 'normalization_count', 'analysis_count', 'terminal_reduction_count' ) ) ),
+			'failures'             => $failures,
+		);
+	}
+
+	private static function fail( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, string $phase, Throwable|WP_Error $error, array $page_ids = array() ) {
+		if ( is_wp_error( $error ) ) {
+			$code    = (string) $error->get_error_code();
+			$message = $error->get_error_message();
+			$data    = $error->get_error_data();
+		} else {
+			$code    = 'static_site_importer_direct_artifact_phase_failed';
+			$message = $error->getMessage();
+			$data    = null;
+		}
+		$failure = array(
+			'phase'              => $phase,
+			'exception_class'    => get_class( $error ),
+			'artifact_identity'  => (string) ( $run['binding']['artifact_identity'] ?? '' ),
+			'attempted_page_ids' => ! empty( $page_ids ) ? array_values( $page_ids ) : array_values( is_array( $run['progress']['attempted_page_ids'] ?? null ) ? $run['progress']['attempted_page_ids'] : array() ),
+			'phase_started_at'   => (string) ( $run['progress']['phase_started_at'] ?? '' ),
+			'elapsed_seconds'    => max( 0.0, microtime( true ) - (float) ( $run['progress']['phase_started_epoch'] ?? microtime( true ) ) ),
+			'error'               => array(
+				'code'    => $code,
+				'message' => $message,
+				'data'    => self::scrub_error( $data ),
+			),
+			'at'                  => gmdate( 'c' ),
+		);
+		$run['failures'][]             = $failure;
+		$run['failures']               = array_slice( $run['failures'], -20 );
+		$run['state']                  = 'failed';
+		$run['progress']['phase']      = $phase;
+		$run['progress']['updated_at'] = gmdate( 'c' );
+		$write = self::write_run( $workspace, $run );
+		$error_data = array(
+			'import_id'    => (string) ( $run['import_id'] ?? '' ),
+			'artifact_run' => self::evidence( $run ),
+			'failure'      => self::scrub_error( $failure ),
+			'resumable'    => ! in_array( $phase, array( 'materialize', 'materialization_claim' ), true ),
+		);
+		if ( is_wp_error( $write ) ) {
+			$error_data['checkpoint_error'] = array(
+				'code'    => $write->get_error_code(),
+				'message' => $write->get_error_message(),
+			);
+		}
+		return new WP_Error( $code, $message, $error_data );
+	}
+
+	private static function publish_checkpoint( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, string $kind, string $relative, array $payload ) {
+		$allowed = function_exists( 'apply_filters' ) ? apply_filters( 'static_site_importer_direct_artifact_checkpoint_publish', true, $kind, $relative, self::evidence( $run ) ) : true;
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		if ( true !== $allowed ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_checkpoint_rejected', 'The direct artifact checkpoint publication was rejected.' );
+		}
+		$payload_hash = self::hash( $payload );
+		$record = array(
+			'schema'            => self::CHECKPOINT_SCHEMA,
+			'kind'              => $kind,
+			'import_id'         => $run['import_id'],
+			'artifact_identity' => $run['binding']['artifact_identity'],
+			'payload_sha256'    => $payload_hash,
+			'payload'           => $payload,
+		);
+		$write = $workspace->publish_json_once( $relative, $record );
+		if ( is_wp_error( $write ) ) {
+			return $write;
+		}
+		$raw = $workspace->read_raw( $relative );
+		if ( ! is_string( $raw ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_checkpoint_missing', 'The published direct artifact checkpoint could not be verified.' );
+		}
+		return array(
+			'file'    => $relative,
+			'sha256'  => hash( 'sha256', $raw ),
+			'payload' => $payload_hash,
+		);
+	}
+
+	private static function read_checkpoint( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, array $ref, string $kind ) {
+		$relative = is_string( $ref['file'] ?? null ) ? $ref['file'] : '';
+		$raw      = '' !== $relative ? $workspace->read_raw( $relative ) : null;
+		$record   = is_string( $raw ) ? json_decode( $raw, true ) : null;
+		if ( ! is_string( $raw ) || ! is_array( $record ) || ! hash_equals( (string) ( $ref['sha256'] ?? '' ), hash( 'sha256', $raw ) ) || self::CHECKPOINT_SCHEMA !== ( $record['schema'] ?? '' ) || $kind !== ( $record['kind'] ?? '' ) || $run['import_id'] !== ( $record['import_id'] ?? '' ) || ( $run['binding']['artifact_identity'] ?? '' ) !== ( $record['artifact_identity'] ?? '' ) || ! is_array( $record['payload'] ?? null ) || ! hash_equals( (string) ( $record['payload_sha256'] ?? '' ), self::hash( $record['payload'] ) ) || ! hash_equals( (string) ( $ref['payload'] ?? '' ), (string) $record['payload_sha256'] ) || ! self::checkpoint_contract_valid( $record['payload'], $kind, $run ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_checkpoint_invalid', 'A retained direct artifact checkpoint failed its identity, hash, or contract validation.' );
+		}
+		return $record['payload'];
+	}
+
+	private static function existing_checkpoint_ref( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, string $relative, string $kind ) {
+		$raw    = $workspace->read_raw( $relative );
+		$record = is_string( $raw ) ? json_decode( $raw, true ) : null;
+		if ( ! is_string( $raw ) ) {
+			return array();
+		}
+		if ( ! is_array( $record ) || self::CHECKPOINT_SCHEMA !== ( $record['schema'] ?? '' ) || $kind !== ( $record['kind'] ?? '' ) || $run['import_id'] !== ( $record['import_id'] ?? '' ) || ( $run['binding']['artifact_identity'] ?? '' ) !== ( $record['artifact_identity'] ?? '' ) || ! is_array( $record['payload'] ?? null ) || ! hash_equals( (string) ( $record['payload_sha256'] ?? '' ), self::hash( $record['payload'] ) ) || ! self::checkpoint_contract_valid( $record['payload'], $kind, $run ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_checkpoint_invalid', 'An unpublished retained checkpoint failed validation.' );
+		}
+		return array(
+			'file'    => $relative,
+			'sha256'  => hash( 'sha256', $raw ),
+			'payload' => $record['payload_sha256'],
+		);
+	}
+
+	private static function write_run( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run ) {
+		$allowed = function_exists( 'apply_filters' ) ? apply_filters( 'static_site_importer_direct_artifact_checkpoint_publish', true, 'run', 'run.json', self::evidence( $run ) ) : true;
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		if ( true !== $allowed ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_checkpoint_rejected', 'The direct artifact run checkpoint publication was rejected.' );
+		}
+		$record = array(
+			'schema'         => self::RUN_SCHEMA,
+			'payload_sha256' => self::hash( $run ),
+			'payload'        => $run,
+		);
+		return $workspace->publish_json( 'run.json', $record );
+	}
+
+	private static function read_run( Static_Site_Importer_Artifact_Run_Workspace $workspace, string $import_id ) {
+		$raw    = $workspace->read_raw( 'run.json' );
+		$record = is_string( $raw ) ? json_decode( $raw, true ) : null;
+		if ( ! is_array( $record ) || self::RUN_SCHEMA !== ( $record['schema'] ?? '' ) || ! is_array( $record['payload'] ?? null ) || ! hash_equals( (string) ( $record['payload_sha256'] ?? '' ), self::hash( $record['payload'] ) ) || $import_id !== ( $record['payload']['import_id'] ?? '' ) || ! is_array( $record['payload']['binding'] ?? null ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_run_not_found', 'The direct artifact run was not found or failed validation.' );
+		}
+		return $record['payload'];
+	}
+
+	private static function workspace( string $import_id, bool $create ) {
+		$root = self::root();
+		if ( ! wp_mkdir_p( $root ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_workspace_unavailable', 'The direct artifact run workspace is unavailable.' );
+		}
+		$directory = trailingslashit( $root ) . '.ssi-artifact-run-direct-' . $import_id;
+		if ( ! $create && ! is_dir( $directory ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_run_not_found', 'The direct artifact run was not found.' );
+		}
+		try {
+			return new Static_Site_Importer_Artifact_Run_Workspace(
+				$root,
+				'direct-' . $import_id,
+				array(
+					'on_success' => 'retain',
+					'on_failure' => 'retain',
+					'expires_at' => gmdate( 'c', time() + self::TTL ),
+				)
+			);
+		} catch ( RuntimeException $error ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_workspace_unavailable', $error->getMessage() );
+		}
+	}
+
+	/** Register expiry cleanup without exposing retained workspace paths. */
+	public static function register_cleanup(): void {
+		if ( function_exists( 'add_action' ) ) {
+			add_action( self::CLEANUP_HOOK, array( self::class, 'purge_expired' ) );
+		}
+		if ( function_exists( 'wp_next_scheduled' ) && function_exists( 'wp_schedule_event' ) && ! wp_next_scheduled( self::CLEANUP_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CLEANUP_HOOK );
+		}
+	}
+
+	public static function unschedule_cleanup(): void {
+		if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
+			wp_clear_scheduled_hook( self::CLEANUP_HOOK );
+		}
+	}
+
+	public static function purge_expired(): void {
+		$root = self::root();
+		if ( wp_mkdir_p( $root ) ) {
+			Static_Site_Importer_Artifact_Run_Workspace::purge_expired_in( $root );
+		}
+	}
+
+	private static function root(): string {
+		$uploads = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
+		$base    = isset( $uploads['basedir'] ) ? (string) $uploads['basedir'] : sys_get_temp_dir();
+		$root    = trailingslashit( $base ) . 'static-site-importer/direct-artifact-imports';
+		return function_exists( 'apply_filters' ) ? (string) apply_filters( 'static_site_importer_direct_artifact_root', $root ) : $root;
+	}
+
+	private static function compiler() {
+		$class = 'Automattic\\BlocksEngine\\PhpTransformer\\ArtifactCompiler\\ArtifactCompiler';
+		if ( ! class_exists( $class ) ) {
+			return new WP_Error( 'static_site_importer_missing_transformer', 'Blocks Engine php-transformer is required for direct multi-page imports.' );
+		}
+		$compiler = new $class();
+		return function_exists( 'apply_filters' ) ? apply_filters( 'static_site_importer_direct_artifact_compiler', $compiler ) : $compiler;
+	}
+
+	private static function run_policy(): array {
+		$policy = array(
+			'prepare_batch_pages'   => 2,
+			'compile_batch_pages'   => 2,
+			'max_invocation_seconds' => 20.0,
+			'clock'                  => static fn (): float => microtime( true ),
+		);
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( 'static_site_importer_direct_artifact_run_policy', $policy );
+			if ( is_array( $filtered ) ) {
+				$policy = array_merge( $policy, $filtered );
+			}
+		}
+		$policy['prepare_batch_pages']    = min( 20, max( 1, (int) $policy['prepare_batch_pages'] ) );
+		$policy['compile_batch_pages']    = min( 20, max( 1, (int) $policy['compile_batch_pages'] ) );
+		$policy['max_invocation_seconds'] = max( 0.001, (float) $policy['max_invocation_seconds'] );
+		$policy['clock']                  = is_callable( $policy['clock'] ) ? $policy['clock'] : static fn (): float => microtime( true );
+		return $policy;
+	}
+
+	private static function implementation_binding(): array {
+		$classes = array(
+			'Static_Site_Importer_Content_Policy',
+			'Static_Site_Importer_Client_Script_Policy',
+			'Static_Site_Importer_Canonical_Import_Service',
+			'Static_Site_Importer_Theme_Generator',
+			'Static_Site_Importer_Theme_Materialization_Strategy',
+			'Static_Site_Importer_WordPress_Site_Plan_Materializer',
+			self::class,
+			'Automattic\\BlocksEngine\\PhpTransformer\\ArtifactCompiler\\ArtifactCompiler',
+		);
+		$binding = array();
+		foreach ( $classes as $class ) {
+			$file = class_exists( $class ) ? ( new ReflectionClass( $class ) )->getFileName() : false;
+			$binding[ $class ] = is_string( $file ) && is_readable( $file ) ? hash_file( 'sha256', $file ) : '';
+		}
+		return $binding;
+	}
+
+	private static function binding_args( array $args ): array {
+		unset( $args['runtime_lifecycle_invocation_id'], $args['client_script_policy_report'], $args['compiled_artifact_result'], $args['_static_site_importer_precompiled_source'], $args['import_run_id'] );
+		if ( is_array( $args['source_metadata']['collection'] ?? null ) ) {
+			unset( $args['source_metadata']['collection']['script_policy'] );
+			if ( empty( $args['source_metadata']['collection'] ) ) {
+				unset( $args['source_metadata']['collection'] );
+			}
+		}
+		return self::canonical( $args );
+	}
+
+	private static function owner(): string {
+		if ( class_exists( 'Static_Site_Importer_Lifecycle_Compile_Checkpoint' ) ) {
+			return Static_Site_Importer_Lifecycle_Compile_Checkpoint::current_owner();
+		}
+		$site = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+		$user = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+		return 'site:' . $site . ';user:' . $user;
+	}
+
+	private static function before_phase( string $phase, array $run, array $page_ids = array() ): void {
+		if ( function_exists( 'do_action' ) ) {
+			do_action( 'static_site_importer_direct_artifact_before_phase', $phase, self::evidence( $run ), array_map( 'strval', $page_ids ) );
+		}
+	}
+
+	private static function response_error( array $response ): WP_Error {
+		$error = is_array( $response['error'] ?? null ) ? $response['error'] : array();
+		return new WP_Error( (string) ( $error['code'] ?? 'static_site_importer_direct_artifact_canonical_plan_failed' ), (string) ( $error['message'] ?? 'The composed artifact did not produce a canonical plan.' ), $error['data'] ?? null );
+	}
+
+	private static function checkpoint_contract_valid( array $payload, string $kind, array $run ): bool {
+		if ( 'artifact' === $kind ) {
+			return is_array( $payload['artifact'] ?? null )
+				&& is_array( $payload['args'] ?? null )
+				&& is_array( $payload['policy_report'] ?? null )
+				&& hash_equals( (string) $run['binding']['artifact_identity'], self::hash( $payload['artifact'] ) )
+				&& self::binding_args( $payload['args'] ) === ( $run['binding']['args'] ?? null );
+		}
+		if ( 'shared' === $kind ) {
+			return 'blocks-engine/php-transformer/staged-shared-plan/v1' === ( $payload['plan']['schema'] ?? '' )
+				&& is_string( $payload['plan']['digest'] ?? null )
+				&& is_array( $payload['plan']['analysis']['page_ids'] ?? null );
+		}
+		if ( 'page_plan' === $kind ) {
+			return is_string( $payload['page_id'] ?? null )
+				&& 'blocks-engine/php-transformer/staged-page-plan/v1' === ( $payload['plan']['schema'] ?? '' )
+				&& ( $payload['page_id'] ?? '' ) === ( $payload['plan']['page_id'] ?? null )
+				&& is_string( $payload['plan']['digest'] ?? null );
+		}
+		if ( 'receipt' === $kind ) {
+			return is_string( $payload['page_id'] ?? null )
+				&& self::RECEIPT_SCHEMA === ( $payload['receipt']['receipt_schema'] ?? '' )
+				&& ( $payload['page_id'] ?? '' ) === ( $payload['receipt']['page_id'] ?? null )
+				&& is_array( $payload['receipt']['terminal_reduction'] ?? null );
+		}
+		if ( 'composed' === $kind ) {
+			$work = is_array( $payload['terminal_work'] ?? null ) ? $payload['terminal_work'] : array();
+			return 'blocks-engine/php-transformer/result/v1' === ( $payload['result']['schema'] ?? '' )
+				&& 0 === (int) ( $work['html_document_transform_count'] ?? -1 )
+				&& 0 === (int) ( $work['normalization_count'] ?? -1 );
+		}
+		if ( 'materialization' === $kind ) {
+			return is_array( $payload['result'] ?? null );
+		}
+		if ( 'final' === $kind ) {
+			return is_array( $payload['response'] ?? null ) && ! empty( $payload['response']['success'] ) && empty( $payload['response']['continuation'] );
+		}
+		return false;
+	}
+
+	private static function page_file( string $directory, string $page_id ): string {
+		return $directory . '/' . hash( 'sha256', $page_id ) . '.json';
+	}
+
+	private static function deadline_reached( float $deadline, callable $clock ): bool {
+		return (float) call_user_func( $clock ) >= $deadline;
+	}
+
+	private static function hash( array $value ): string {
+		$json = wp_json_encode( self::canonical( $value ) );
+		return hash( 'sha256', is_string( $json ) ? $json : '' );
+	}
+
+	private static function canonical( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+		foreach ( $value as &$item ) {
+			$item = self::canonical( $item );
+		}
+		unset( $item );
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value, SORT_STRING );
+		}
+		return $value;
+	}
+
+	private static function scrub_error( $value, int $depth = 0 ) {
+		if ( $depth >= 6 ) {
+			return '[truncated]';
+		}
+		if ( ! is_array( $value ) ) {
+			if ( is_string( $value ) ) {
+				return substr( $value, 0, 1000 );
+			}
+			return is_scalar( $value ) || null === $value ? $value : get_debug_type( $value );
+		}
+		$clean = array();
+		foreach ( $value as $key => $item ) {
+			if ( count( $clean ) >= 20 ) {
+				$clean['_truncated'] = true;
+				break;
+			}
+			if ( is_string( $key ) && ( str_contains( strtolower( $key ), 'path' ) || str_contains( strtolower( $key ), 'workspace' ) || str_contains( strtolower( $key ), 'manifest' ) ) ) {
+				continue;
+			}
+			$clean[ $key ] = self::scrub_error( $item, $depth + 1 );
+		}
+		return $clean;
+	}
+}

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -94,11 +94,15 @@ $static_site_importer_includes = array(
 	'class-static-site-importer-theme-generator.php',
 	'class-static-site-importer-provider-presentation.php',
 	'class-static-site-importer-commerce-presentation.php',
+	'class-static-site-importer-direct-artifact-import.php',
 	'class-static-site-importer-canonical-import-service.php',
 );
 foreach ( $static_site_importer_includes as $static_site_importer_include ) {
 	require_once STATIC_SITE_IMPORTER_PATH . 'includes/' . $static_site_importer_include;
 }
+
+Static_Site_Importer_Direct_Artifact_Import::register_cleanup();
+register_deactivation_hook( __FILE__, array( Static_Site_Importer_Direct_Artifact_Import::class, 'unschedule_cleanup' ) );
 
 Static_Site_Importer_Figma_Import::register_default_zstd_decoder();
 Static_Site_Importer_Entity_Materializer_Registry::register_presentations();

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -28,6 +28,7 @@
     { "path": "tests/smoke-import-permission-filter.php", "environment": "standalone-php" },
     { "path": "tests/smoke-current-site-capabilities.php", "environment": "standalone-php" },
     { "path": "tests/smoke-default-content.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-direct-artifact-import.php", "environment": "standalone-php" },
     { "path": "tests/smoke-importer-block.php", "environment": "standalone-php" },
     { "path": "tests/smoke-lifecycle-compile-checkpoint.php", "environment": "standalone-php" },
     { "path": "tests/smoke-materialized-block-content-validation.php", "environment": "standalone-php" },

--- a/tests/fixtures/direct-artifact-multi-page/about.html
+++ b/tests/fixtures/direct-artifact-multi-page/about.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html><head><title>About Direct Artifact</title><link rel="stylesheet" href="styles.css"><style>.repeated{color:#c2410c;font-weight:700}</style></head><body><main><article class="card"><h1>About</h1><p class="repeated">Shared presentation</p><a href="contact.html">Contact</a></article></main></body></html>

--- a/tests/fixtures/direct-artifact-multi-page/contact.html
+++ b/tests/fixtures/direct-artifact-multi-page/contact.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html><head><title>Contact Direct Artifact</title><link rel="stylesheet" href="styles.css"><style>.repeated{color:#c2410c;font-weight:700}</style></head><body><main><article class="card"><h1>Contact</h1><p class="repeated">Shared presentation</p><a href="index.html">Home</a></article></main></body></html>

--- a/tests/fixtures/direct-artifact-multi-page/index.html
+++ b/tests/fixtures/direct-artifact-multi-page/index.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html><head><title>Direct Artifact Home</title><link rel="stylesheet" href="styles.css"><style>.repeated{color:#c2410c;font-weight:700}</style></head><body><main><article class="card"><h1>Home</h1><p class="repeated">Shared presentation</p><a href="about.html">About</a></article></main></body></html>

--- a/tests/fixtures/direct-artifact-multi-page/styles.css
+++ b/tests/fixtures/direct-artifact-multi-page/styles.css
@@ -1,0 +1,3 @@
+:root { --accent: #c2410c; }
+body { margin: 0; font-family: sans-serif; }
+.card { border: 2px solid var(--accent); padding: 1rem; }

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -1,0 +1,266 @@
+<?php
+/** Run: php tests/smoke-direct-artifact-import.php */
+
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+define( 'STATIC_SITE_IMPORTER_PATH', dirname( __DIR__ ) . '/' );
+
+$test_root = sys_get_temp_dir() . '/ssi-direct-artifact-' . bin2hex( random_bytes( 4 ) );
+$GLOBALS['ssi_direct_filters'] = array();
+$GLOBALS['ssi_direct_actions'] = array();
+$GLOBALS['ssi_direct_mutations'] = 0;
+$GLOBALS['ssi_direct_last_args'] = array();
+$GLOBALS['ssi_direct_compiled_results'] = array();
+
+class WP_Error {
+	public function __construct( private string $code, private string $message = '', private $data = null ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data() { return $this->data; }
+}
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
+function wp_mkdir_p( string $path ): bool { return is_dir( $path ) || mkdir( $path, 0777, true ); }
+function trailingslashit( string $path ): string { return rtrim( $path, '/\\' ) . '/'; }
+function wp_upload_dir(): array { return array( 'basedir' => $GLOBALS['test_root'] ); }
+function get_current_blog_id(): int { return 17; }
+function get_current_user_id(): int { return 827; }
+function wp_generate_uuid4(): string { return '00000000-0000-4000-8000-000000000827'; }
+function apply_filters( string $hook, $value, ...$args ) {
+	foreach ( $GLOBALS['ssi_direct_filters'][ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value, ...$args );
+	}
+	return $value;
+}
+function do_action( string $hook, ...$args ): void {
+	foreach ( $GLOBALS['ssi_direct_actions'][ $hook ] ?? array() as $callback ) {
+		$callback( ...$args );
+	}
+}
+function static_site_importer_source_runtime( array $source ): array {
+	$files = array();
+	foreach ( $source['files'] ?? array() as $file ) {
+		$path = (string) ( $file['path'] ?? '' );
+		$file['mime_type'] = str_ends_with( $path, '.html' ) ? 'text/html' : ( str_ends_with( $path, '.css' ) ? 'text/css' : 'application/octet-stream' );
+		$files[] = $file;
+	}
+	return array(
+		'artifact' => array(
+			'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+			'entrypoint' => (string) ( $source['entrypoint'] ?? 'website/index.html' ),
+			'files'      => $files,
+		),
+		'provider' => 'direct-artifact-smoke',
+		'source_metadata' => array( 'fixture' => 'direct-artifact-multi-page' ),
+	);
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-run.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-content-policy.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-client-script-policy.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-website-artifact-import-input.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-direct-artifact-import.php';
+
+class Static_Site_Importer_Theme_Generator {
+	public static function compile_website_artifact( array $artifact, array $args = array() ) {
+		$compiled = $args['compiled_artifact_result'] ?? array();
+		$plan = is_array( $compiled['source_reports']['wordpress_site_plan'] ?? null ) ? $compiled['source_reports']['wordpress_site_plan'] : array();
+		if ( empty( $plan ) ) {
+			return new WP_Error( 'missing_precompiled_plan', 'The smoke materializer requires the real staged compiler result.' );
+		}
+		return array(
+			'artifact'              => $artifact,
+			'args'                  => $args,
+			'compiled'              => $compiled,
+			'plan'                  => $plan,
+			'gutenberg_gaps'        => $compiled['source_reports']['gutenberg_gaps'] ?? array(),
+			'companion_payload'     => null,
+			'materialization_plan'  => $compiled['source_reports']['materialization_plan'] ?? array(),
+			'theme_materialization' => array( 'strategy' => 'block' ),
+		);
+	}
+	public static function import_website_artifact( array $artifact, array $args = array() ): array {
+		if ( true !== ( $args['_static_site_importer_precompiled_source'] ?? null ) || ! is_array( $args['compiled_artifact_result'] ?? null ) || ! preg_match( '/^[a-f0-9]{64}$/', (string) ( $args['import_run_id'] ?? '' ) ) ) {
+			throw new RuntimeException( 'Materialization must receive the frozen precompiled result and stable run id.' );
+		}
+		++$GLOBALS['ssi_direct_mutations'];
+		$GLOBALS['ssi_direct_last_args'] = $args;
+		$GLOBALS['ssi_direct_compiled_results'][] = $args['compiled_artifact_result'];
+		$plan = $args['compiled_artifact_result']['source_reports']['wordpress_site_plan'] ?? array();
+		return array(
+			'theme_slug'            => 'direct-artifact-fixture',
+			'theme_name'            => 'Direct Artifact Fixture',
+			'quality'               => $plan['quality'] ?? array(),
+			'import_report_summary' => array( 'status' => 'completed' ),
+			'materialization_receipt' => array(
+				'status'     => 'completed',
+				'page_count' => count( $plan['pages'] ?? array() ),
+			),
+		);
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-canonical-import-service.php';
+
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+};
+$assert( wp_mkdir_p( $test_root ), 'the fixture workspace root must be created' );
+$primitive_workspace = new Static_Site_Importer_Artifact_Run_Workspace( $test_root, 'direct-checkpoint-primitives' );
+$assert( ! is_wp_error( $primitive_workspace->publish_raw_once( 'immutable.json', '{"value":1}' ) ), 'immutable checkpoint publication must succeed once' );
+$assert( ! is_wp_error( $primitive_workspace->publish_raw_once( 'immutable.json', '{"value":1}' ) ), 'identical immutable checkpoint replay must be accepted' );
+$immutable_conflict = $primitive_workspace->publish_raw_once( 'immutable.json', '{"value":2}' );
+$assert( is_wp_error( $immutable_conflict ) && 'static_site_importer_artifact_workspace_conflict' === $immutable_conflict->get_error_code(), 'different immutable checkpoint bytes must fail closed' );
+$fixture = dirname( __DIR__ ) . '/tests/fixtures/direct-artifact-multi-page';
+$files = array();
+foreach ( array( 'index.html', 'about.html', 'contact.html', 'styles.css' ) as $name ) {
+	$files[] = array(
+		'path'    => 'website/' . $name,
+		'content' => (string) file_get_contents( $fixture . '/' . $name ),
+	);
+}
+$input = static fn ( string $operation = 'apply' ): array => array(
+	'operation' => $operation,
+	'slug'      => 'direct-artifact-fixture',
+	'source'    => array(
+		'type'       => 'files',
+		'entrypoint' => 'website/index.html',
+		'files'      => $files,
+	),
+);
+$resume = static fn ( string $id, string $operation = 'apply' ): array => array(
+	'operation' => $operation,
+	'slug'      => 'direct-artifact-fixture',
+	'source'    => array(
+		'type'      => 'files',
+		'import_id' => $id,
+	),
+);
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'][] = static fn ( array $policy ): array => array_merge(
+	$policy,
+	array(
+		'prepare_batch_pages' => 1,
+		'compile_batch_pages' => 1,
+	)
+);
+
+$first = Static_Site_Importer_Canonical_Import_Service::import( $input() );
+$assert( ! empty( $first['success'] ) && ! empty( $first['continuation'] ) && 'pages_remaining' === ( $first['continuation_reason'] ?? '' ) && 1 === ( $first['artifact_run']['progress']['prepared_count'] ?? 0 ) && 0 === ( $first['artifact_run']['progress']['receipt_count'] ?? -1 ) && 'continuing' === ( $first['import_report_summary']['status'] ?? '' ), 'the first invocation must durably prepare only its bounded page batch and explicitly continue' );
+$import_id = (string) $first['import_id'];
+$mismatch = $resume( $import_id );
+$mismatch['slug'] = 'different-frozen-contract';
+$mismatch = Static_Site_Importer_Canonical_Import_Service::import( $mismatch );
+$assert( 'static_site_importer_direct_artifact_run_mismatch' === ( $mismatch['error']['code'] ?? '' ) && 0 === $GLOBALS['ssi_direct_mutations'], 'resume must reject normalized argument mismatches before compile or mutation' );
+$locked_workspace = new Static_Site_Importer_Artifact_Run_Workspace( $test_root . '/static-site-importer/direct-artifact-imports', 'direct-' . $import_id );
+$execution_lock = $locked_workspace->acquire_lock( 'execution.lock' );
+$assert( is_resource( $execution_lock ), 'the fixture must own the serialized execution lock' );
+$busy = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
+$assert( ! empty( $busy['continuation'] ) && 'run_in_progress' === ( $busy['continuation_reason'] ?? '' ) && 0 === $GLOBALS['ssi_direct_mutations'], 'a concurrent resume must yield without mutating run state or WordPress' );
+$locked_workspace->release_lock( $execution_lock );
+$second = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
+$assert( ! empty( $second['continuation'] ) && 2 === ( $second['artifact_run']['progress']['prepared_count'] ?? 0 ) && 0 === ( $second['artifact_run']['progress']['receipt_count'] ?? -1 ), 'resume must skip the first durable page plan and prepare only the next page' );
+$third = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
+$assert( ! empty( $third['continuation'] ) && 3 === ( $third['artifact_run']['progress']['prepared_count'] ?? 0 ) && 1 === ( $third['artifact_run']['progress']['receipt_count'] ?? 0 ), 'the final preparation invocation may compile only its bounded first page batch' );
+$fourth = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
+$assert( ! empty( $fourth['continuation'] ) && 2 === ( $fourth['artifact_run']['progress']['receipt_count'] ?? 0 ), 'resume must skip the first durable receipt and compile only the next page' );
+$terminal = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
+$work = $terminal['artifact_run']['work'] ?? array();
+$terminal_work = $terminal['artifact_run']['terminal_result_work'] ?? array();
+$assert( ! empty( $terminal['success'] ) && empty( $terminal['continuation'] ) && 1 === $GLOBALS['ssi_direct_mutations'], 'resumed apply must perform exactly one importer mutation' );
+$assert( array( 1, 1, 1 ) === ( $work['page_compile_counts'] ?? null ) && 3 === count( $terminal['artifact_run']['receipt_identities'] ?? array() ) && 3 === ( $work['pages_compiled'] ?? 0 ), 'durable counters and receipt evidence must prove every page compiled exactly once' );
+$assert( 3 === ( $work['page_prepare_passes'] ?? 0 ) && 3 === ( $work['page_plans_prepared'] ?? 0 ), 'durable counters must prove every page was prepared in a bounded pass exactly once' );
+$assert( 1 === ( $work['content_policy_applications'] ?? 0 ) && 1 === ( $work['client_script_policy_applications'] ?? 0 ), 'content and client script policy must each run once before the artifact is frozen' );
+$assert( 1 === ( $work['materialization_claims'] ?? 0 ) && 1 === ( $work['materializations'] ?? 0 ) && true === ( $GLOBALS['ssi_direct_last_args']['_static_site_importer_precompiled_source'] ?? false ), 'apply must claim once and use the precompiled source handoff' );
+$assert( 0 === ( $terminal_work['html_document_transform_count'] ?? -1 ) && 0 === ( $terminal_work['normalization_count'] ?? -1 ), 'terminal composition must perform zero HTML transforms and normalization' );
+$assert( ! str_contains( (string) json_encode( $terminal['artifact_run'] ), $test_root ) && ! str_contains( (string) json_encode( $terminal['artifact_run'] ), 'website/index.html' ), 'public run evidence must remain bounded and path-free' );
+
+$replay = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
+$assert( $terminal === $replay && 1 === $GLOBALS['ssi_direct_mutations'], 'terminal replay must return the durable response without compile or mutation' );
+
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array( static fn ( array $policy ): array => array_merge( $policy, array( 'prepare_batch_pages' => 20, 'compile_batch_pages' => 20 ) ) );
+$clean = Static_Site_Importer_Canonical_Import_Service::import( $input() );
+$canonical = static function ( array $response ): array {
+	unset( $response['import_id'], $response['artifact_run'] );
+	return $response;
+};
+$assert( empty( $clean['continuation'] ) && 2 === $GLOBALS['ssi_direct_mutations'] && $canonical( $terminal ) === $canonical( $clean ), 'clean and resumed canonical apply outputs must match outside run observations' );
+$canonical_compiled = static function ( array $result ) use ( &$canonical_compiled ): array {
+	unset( $result['metrics'], $result['work'] );
+	foreach ( $result as $key => &$value ) {
+		if ( is_array( $value ) ) {
+			$value = $canonical_compiled( $value );
+		} elseif ( is_string( $key ) && str_ends_with( $key, '_duration_ms' ) ) {
+			unset( $result[ $key ] );
+		}
+	}
+	unset( $value );
+	return $result;
+};
+$assert( $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][0] ) === $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][1] ), 'clean and resumed composition must produce identical canonical plans, companion payloads, pages, writes, diagnostics, and reconciliation identities' );
+
+$fail_materialization = true;
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_checkpoint_publish'][] = static function ( $allowed, string $kind ) use ( &$fail_materialization ) {
+	if ( $fail_materialization && 'materialization' === $kind ) {
+		$fail_materialization = false;
+		return new WP_Error( 'injected_materialization_publication_failure', 'Injected post-mutation checkpoint failure.' );
+	}
+	return $allowed;
+};
+$interrupted = Static_Site_Importer_Canonical_Import_Service::import( $input() );
+$interrupted_data = $interrupted['error']['data'] ?? array();
+$assert( 'injected_materialization_publication_failure' === ( $interrupted['error']['code'] ?? '' ) && 3 === $GLOBALS['ssi_direct_mutations'], 'post-mutation checkpoint failure must return structured interruption evidence' );
+$interrupted_id = (string) ( $interrupted_data['import_id'] ?? '' );
+$ambiguous = Static_Site_Importer_Canonical_Import_Service::import( $resume( $interrupted_id ) );
+$assert( 'static_site_importer_direct_artifact_materialization_ambiguous' === ( $ambiguous['error']['code'] ?? '' ) && 3 === $GLOBALS['ssi_direct_mutations'], 'resume across the mutation receipt boundary must fail closed instead of repeating WordPress mutation' );
+
+$fail_run_after_receipt = true;
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_checkpoint_publish'][] = static function ( $allowed, string $kind, string $relative, array $evidence ) use ( &$fail_run_after_receipt ) {
+	if ( $fail_run_after_receipt && 'run' === $kind && 1 === ( $evidence['progress']['receipt_count'] ?? 0 ) ) {
+		$fail_run_after_receipt = false;
+		return new WP_Error( 'injected_run_publication_failure', 'Injected run checkpoint failure after immutable receipt publication.' );
+	}
+	return $allowed;
+};
+$run_failed = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
+$run_failure_data = $run_failed['error']['data'] ?? array();
+$assert( 'injected_run_publication_failure' === ( $run_failed['error']['code'] ?? '' ) && preg_match( '/^[a-f0-9]{64}$/', (string) ( $run_failure_data['import_id'] ?? '' ) ), 'run checkpoint failures after immutable work publication must retain a structured resumable import id' );
+$run_recovered = Static_Site_Importer_Canonical_Import_Service::import( $resume( (string) $run_failure_data['import_id'], 'plan' ) );
+$assert( ! empty( $run_recovered['success'] ) && array( 1, 1, 1 ) === ( $run_recovered['artifact_run']['work']['page_compile_counts'] ?? null ), 'resume must adopt the immutable receipt and never recompile completed page work' );
+$source_artifact = static_site_importer_source_runtime( $input( 'plan' )['source'] )['artifact'];
+$assert( hash( 'sha256', (string) wp_json_encode( $source_artifact ) ) === ( $run_recovered['source']['identity'] ?? '' ), 'staged planning must preserve the canonical normalized source identity from before script policy transforms' );
+
+$fail_receipt = true;
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_checkpoint_publish'][] = static function ( $allowed, string $kind ) use ( &$fail_receipt ) {
+	if ( $fail_receipt && 'receipt' === $kind ) {
+		$fail_receipt = false;
+		return new WP_Error( 'injected_receipt_publication_failure', 'Injected receipt checkpoint failure.' );
+	}
+	return $allowed;
+};
+$failed = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
+$failure_data = $failed['error']['data'] ?? array();
+$assert( 'injected_receipt_publication_failure' === ( $failed['error']['code'] ?? '' ) && 0 === ( $failure_data['artifact_run']['progress']['receipt_count'] ?? -1 ) && 0 === ( $failure_data['artifact_run']['work']['compositions'] ?? -1 ), 'receipt publication failure must fail closed before receipt progress or composition' );
+$failed_id = (string) ( $failure_data['import_id'] ?? '' );
+$recovered = Static_Site_Importer_Canonical_Import_Service::import( $resume( $failed_id, 'plan' ) );
+$assert( ! empty( $recovered['success'] ) && empty( $recovered['continuation'] ), 'a structured checkpoint publication failure must remain resumable' );
+
+$throw_compose = true;
+$GLOBALS['ssi_direct_actions']['static_site_importer_direct_artifact_before_phase'][] = static function ( string $phase ) use ( &$throw_compose ): void {
+	if ( $throw_compose && 'compose' === $phase ) {
+		$throw_compose = false;
+		throw new RuntimeException( 'Injected compose exception.' );
+	}
+};
+$thrown = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
+$thrown_data = $thrown['error']['data'] ?? array();
+$last_failure = $thrown_data['artifact_run']['failures'][0] ?? array();
+$assert( 'static_site_importer_direct_artifact_phase_failed' === ( $thrown['error']['code'] ?? '' ) && 'compose' === ( $last_failure['phase'] ?? '' ) && 'RuntimeException' === ( $last_failure['exception_class'] ?? '' ) && ! empty( $last_failure['artifact_identity'] ), 'thrown exceptions must persist structured phase, class, and artifact evidence' );
+$thrown_id = (string) ( $thrown_data['import_id'] ?? '' );
+$recovered_throw = Static_Site_Importer_Canonical_Import_Service::import( $resume( $thrown_id, 'plan' ) );
+$assert( ! empty( $recovered_throw['success'] ) && empty( $recovered_throw['continuation'] ), 'a thrown phase failure must resume from durable receipts without recompiling pages' );
+
+Static_Site_Importer_Artifact_Run_Workspace::purge_expired_in( $test_root );
+$primitive_workspace->purge();
+echo "Direct artifact import smoke passed.\n";


### PR DESCRIPTION
## Summary

- route multi-page direct `html` / `files` artifacts through durable Blocks Engine shared, page-plan, compiled-page-receipt, and composition checkpoints
- bound page preparation and compilation per invocation while preserving explicit continuation, phase timing, structured failure evidence, and immutable checkpoint adoption
- serialize run execution and WordPress materialization, replay completed receipts, and fail closed rather than repeat mutation across an ambiguous post-mutation interruption
- preserve clean-versus-resumed canonical plans, companion payloads, pages, writes, diagnostics, reconciliation identities, and source identity on a repeated-CSS fixture

Fixes #827.

## Verification

- `php tests/smoke-direct-artifact-import.php`
- `php tests/smoke-artifact-run-primitives.php`
- `php tests/smoke-lifecycle-compile-checkpoint.php`
- `php tests/smoke-canonical-import-ability.php`
- `npm run test:companion-plugin`
- PHP syntax checks for every changed PHP file
- `npm run test:inventory`
- `npm run test:runtime-package`
- `npm run test:dev-package`
- `composer validate --strict`
- `git diff --check`

`tests/smoke-wordpress-site-plan-materializer.php` skips without `STATIC_SITE_IMPORTER_WP_ROOT`, as expected in this worktree. The full `npm test` lane passed 62 checks and repeatedly hit one unrelated timing-sensitive assertion in `tools/fixture-matrix.test.mjs`; that test passes in isolation, and this PR does not modify the fixture-matrix subsystem.

## Interruption Boundaries

- immutable shared/page/receipt/composed/materialization/final values are atomically create-once and hash-bound
- mutable run checkpoint failures return a structured resumable import id and adopt already-published immutable work
- concurrent resumes yield `run_in_progress` without changing run state
- expiry cleanup skips a locked run
- a materialization claim without a durable result is non-resumable and cannot repeat WordPress mutation
- individual Blocks Engine calls remain uninterruptible; the continuation boundary limits page batches and does not claim a hard deadline inside one owning call

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the preserved candidate and current Blocks Engine staged contracts, reconciled current `origin/main`, implemented and reviewed checkpoint and interruption handling, ran verification, and drafted this pull request. Chris Huber reviewed and remains responsible for the change.