### PR TITLE
Refactor diagnostic projections around finalized reports

### DIFF
--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -439,64 +439,7 @@ if ( ! function_exists( 'static_site_importer_ability_apply_approved_plan' ) ) {
 	}
 }
 
-if ( ! function_exists( 'static_site_importer_success_diagnostics_contract' ) ) {
-	/**
-	 * Build the import-diagnostics contract from a successful import result.
-	 *
-	 * Maps the success result shape returned by
-	 * Static_Site_Importer_Theme_Generator::import_website_artifact() into the keys the
-	 * diagnostic contract reads. Fields the contract needs but the result does not carry
-	 * are mapped from what the import returns rather than fabricated.
-	 *
-	 * @param array<string,mixed> $result Import result.
-	 * @return array<string,mixed>
-	 */
-	function static_site_importer_success_diagnostics_contract( array $result ): array {
-		return Static_Site_Importer_Canonical_Import_Service::success_diagnostics_contract( $result );
-	}
-}
-
-if ( ! function_exists( 'static_site_importer_error_diagnostics' ) ) {
-	/**
-	 * Promote nested validation diagnostics to top-level ability fields.
-	 *
-	 * @param string              $code                  Error code.
-	 * @param string              $message               Error message.
-	 * @param mixed               $data                  Optional error data.
-	 * @param array<string,mixed> $import_report_summary Import report summary.
-	 * @return array<int,array<string,mixed>>
-	 */
-	function static_site_importer_error_diagnostics( string $code, string $message, $data, array $import_report_summary ): array {
-		return Static_Site_Importer_Canonical_Import_Service::error_diagnostics( $code, $message, $data, $import_report_summary );
-	}
-}
-
-if ( ! function_exists( 'static_site_importer_is_actionable_error_diagnostic' ) ) {
-	/**
-	 * Check whether an error diagnostic has machine-actionable identity or source context.
-	 *
-	 * @param mixed $diagnostic Candidate diagnostic.
-	 * @return bool
-	 */
-	function static_site_importer_is_actionable_error_diagnostic( $diagnostic ): bool {
-		return Static_Site_Importer_Canonical_Import_Service::is_actionable_error_diagnostic( $diagnostic );
-	}
-}
-
-if ( ! function_exists( 'static_site_importer_failure_report_summary' ) ) {
-	/**
-	 * Build a minimal report summary for failures that happen before a report file exists.
-	 *
-	 * @param string $code    Error code.
-	 * @param string $message Error message.
-	 * @return array<string, mixed>
-	 */
-	function static_site_importer_failure_report_summary( string $code, string $message ): array {
-		return Static_Site_Importer_Canonical_Import_Service::failure_report_summary( $code, $message );
-	}
-}
-
-// Public Ability helper names remain callable compatibility adapters.
+// Public Ability result helpers remain callable compatibility adapters.
 if ( ! function_exists( 'static_site_importer_ability_error' ) ) {
 	function static_site_importer_ability_error( string $code, string $message, $data = null ): array {
 		return Static_Site_Importer_Canonical_Import_Service::error( $code, $message, $data );
@@ -506,30 +449,6 @@ if ( ! function_exists( 'static_site_importer_ability_error' ) ) {
 if ( ! function_exists( 'static_site_importer_ability_import_success' ) ) {
 	function static_site_importer_ability_import_success( array $result, array $input ): array {
 		return Static_Site_Importer_Canonical_Import_Service::success( $result, $input );
-	}
-}
-
-if ( ! function_exists( 'static_site_importer_ability_handoff_hash' ) ) {
-	function static_site_importer_ability_handoff_hash( array $value ): string {
-		return Static_Site_Importer_Canonical_Import_Service::handoff_hash( $value );
-	}
-}
-
-if ( ! function_exists( 'static_site_importer_ability_plan_artifact' ) ) {
-	function static_site_importer_ability_plan_artifact( array $artifact, array $args, string $type, array $provenance ): array {
-		return Static_Site_Importer_Canonical_Import_Service::plan_artifact( $artifact, $args, $type, $provenance );
-	}
-}
-
-if ( ! function_exists( 'static_site_importer_ability_import_url_operation' ) ) {
-	function static_site_importer_ability_import_url_operation( array $input, array $source ): array {
-		return Static_Site_Importer_Canonical_Import_Service::import_url_operation( $input, $source );
-	}
-}
-
-if ( ! function_exists( 'static_site_importer_ability_approved_plan_payload_reader' ) ) {
-	function static_site_importer_ability_approved_plan_payload_reader( array $input, array $approved ) {
-		return Static_Site_Importer_Canonical_Import_Service::approved_plan_payload_reader( $input, $approved );
 	}
 }
 

--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -395,6 +395,9 @@ class Static_Site_Importer_Canonical_Import_Service {
 
 	/** @param array<string,mixed> $result @return array<string,mixed> */
 	public static function success_diagnostics_contract( array $result ): array {
+		if ( isset( $result['fixture_diagnostics'] ) && is_array( $result['fixture_diagnostics'] ) ) {
+			return $result['fixture_diagnostics'];
+		}
 		$validation  = isset( $result['import_validation_result'] ) && is_array( $result['import_validation_result'] ) ? $result['import_validation_result'] : array();
 		$quality     = isset( $result['quality'] ) && is_array( $result['quality'] ) ? $result['quality'] : array();
 		$diagnostics = isset( $validation['diagnostics'] ) && is_array( $validation['diagnostics'] ) ? $validation['diagnostics'] : array();

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -37,15 +37,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 
 		$quality_counts = self::quality_counts( $import_report, $summary, $result );
 
-		$diagnostics = array_merge(
-			self::diagnostic_rows_from_result( $result ),
-			self::diagnostic_rows_from_import_report( $import_report ),
-			self::blocks_engine_conversion_diagnostics( $import_report ),
-			self::runtime_dependency_target_gaps( $import_report ),
-			self::semantic_parity_diagnostics( $import_report ),
-			self::gutenberg_gap_diagnostics( $import_report ),
-			self::quality_count_consistency_diagnostics( $quality_counts )
-		);
+		$diagnostics = array_merge( self::diagnostic_rows( $result, $import_report ), self::quality_count_consistency_diagnostics( $quality_counts ) );
 		$diagnostics = self::dedupe_diagnostics( $diagnostics );
 
 		return array(
@@ -76,18 +68,6 @@ class Static_Site_Importer_Diagnostic_Contract {
 		);
 	}
 
-	/** Extract compiler Gutenberg gaps with their materialization outcome. */
-	private static function gutenberg_gap_diagnostics( array $import_report ): array {
-		$blocks_engine = isset( $import_report['blocks_engine'] ) && is_array( $import_report['blocks_engine'] ) ? $import_report['blocks_engine'] : array();
-		$gaps          = isset( $blocks_engine['gutenberg_gaps'] ) && is_array( $blocks_engine['gutenberg_gaps'] ) ? $blocks_engine['gutenberg_gaps'] : array();
-		foreach ( $gaps as $index => $gap ) {
-			if ( is_array( $gap ) && ! isset( $gap['type'] ) && ! isset( $gap['code'] ) ) {
-				$gaps[ $index ]['type'] = 'gutenberg_gap';
-			}
-		}
-		return self::normalize_diagnostic_rows( $gaps, 'gutenberg_gaps' );
-	}
-
 	/**
 	 * Extract an import report from common provider result slots.
 	 *
@@ -105,49 +85,46 @@ class Static_Site_Importer_Diagnostic_Contract {
 	}
 
 	/**
-	 * Read provider-level diagnostic rows.
+	 * Read one finalized diagnostic set, with a bounded fallback for early failures.
 	 *
-	 * @param array<string,mixed> $result Provider result.
+	 * @param array<string,mixed> $result        Provider result.
+	 * @param array<string,mixed> $import_report Import report.
 	 * @return array<int,array<string,mixed>>
 	 */
-	private static function diagnostic_rows_from_result( array $result ): array {
-		$rows = array();
-		foreach ( array( $result['diagnostics'] ?? array(), $result['artifact_diagnostics']['diagnostics'] ?? array(), $result['import_validation_result']['diagnostics'] ?? array(), $result['materialization_receipt']['diagnostics'] ?? array() ) as $candidate ) {
-			if ( is_array( $candidate ) ) {
-				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $candidate ) );
+	private static function diagnostic_rows( array $result, array $import_report ): array {
+		$finalized = $import_report['import_validation_result']['diagnostics'] ?? null;
+		if ( is_array( $finalized ) ) {
+			return self::normalize_diagnostic_rows( $finalized );
+		}
+
+		$sources = array(
+			array( $result['diagnostics'] ?? array(), '' ),
+			array( $result['artifact_diagnostics']['diagnostics'] ?? array(), '' ),
+			array( $result['import_validation_result']['diagnostics'] ?? array(), '' ),
+			array( $result['materialization_receipt']['diagnostics'] ?? array(), '' ),
+			array( $import_report['diagnostics'] ?? array(), '' ),
+			array( $import_report['artifact_diagnostics']['diagnostics'] ?? array(), '' ),
+		);
+		$conversion = isset( $import_report['blocks_engine']['conversion_report'] ) && is_array( $import_report['blocks_engine']['conversion_report'] ) ? $import_report['blocks_engine']['conversion_report'] : array();
+		foreach ( array( 'diagnostics', 'fallback_diagnostics', 'fallbacks', 'presentation_gaps', 'interaction_candidates' ) as $field ) {
+			$sources[] = array( $conversion[ $field ] ?? array(), 'blocks_engine_conversion_report' );
+		}
+		$blocks_engine = isset( $import_report['blocks_engine'] ) && is_array( $import_report['blocks_engine'] ) ? $import_report['blocks_engine'] : array();
+		$gaps          = isset( $blocks_engine['gutenberg_gaps'] ) && is_array( $blocks_engine['gutenberg_gaps'] ) ? $blocks_engine['gutenberg_gaps'] : array();
+		foreach ( $gaps as &$gap ) {
+			if ( is_array( $gap ) && ! isset( $gap['type'] ) && ! isset( $gap['code'] ) ) {
+				$gap['type'] = 'gutenberg_gap';
 			}
 		}
+		unset( $gap );
+		$sources[] = array( $gaps, 'gutenberg_gaps' );
+		$sources[] = array( $blocks_engine['semantic_parity']['findings'] ?? array(), 'semantic_parity' );
+		$sources[] = array( self::runtime_dependency_target_gaps( $import_report ), '' );
 
-		return $rows;
-	}
-
-	/**
-	 * Read import-report diagnostic rows.
-	 *
-	 * @param array<string,mixed> $import_report Import report.
-	 * @return array<int,array<string,mixed>>
-	 */
-	private static function diagnostic_rows_from_import_report( array $import_report ): array {
-		$rows = self::normalize_diagnostic_rows( isset( $import_report['diagnostics'] ) && is_array( $import_report['diagnostics'] ) ? $import_report['diagnostics'] : array() );
-		if ( isset( $import_report['artifact_diagnostics']['diagnostics'] ) && is_array( $import_report['artifact_diagnostics']['diagnostics'] ) ) {
-			$rows = array_merge( $rows, self::normalize_diagnostic_rows( $import_report['artifact_diagnostics']['diagnostics'] ) );
-		}
-
-		return $rows;
-	}
-
-	/**
-	 * Extract Blocks Engine conversion-report diagnostics and fallback rows.
-	 *
-	 * @param array<string,mixed> $import_report Import report.
-	 * @return array<int,array<string,mixed>>
-	 */
-	private static function blocks_engine_conversion_diagnostics( array $import_report ): array {
-		$conversion_report = isset( $import_report['blocks_engine']['conversion_report'] ) && is_array( $import_report['blocks_engine']['conversion_report'] ) ? $import_report['blocks_engine']['conversion_report'] : array();
-		$rows              = array();
-		foreach ( array( 'diagnostics', 'fallback_diagnostics', 'fallbacks', 'presentation_gaps', 'interaction_candidates' ) as $field ) {
-			if ( isset( $conversion_report[ $field ] ) && is_array( $conversion_report[ $field ] ) ) {
-				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $conversion_report[ $field ], 'blocks_engine_conversion_report' ) );
+		$rows = array();
+		foreach ( $sources as list( $source, $stage ) ) {
+			if ( is_array( $source ) ) {
+				$rows = array_merge( $rows, self::normalize_diagnostic_rows( $source, $stage ) );
 			}
 		}
 
@@ -170,19 +147,6 @@ class Static_Site_Importer_Diagnostic_Contract {
 		}
 
 		return $rows;
-	}
-
-	/**
-	 * Extract semantic parity findings.
-	 *
-	 * @param array<string,mixed> $import_report Import report.
-	 * @return array<int,array<string,mixed>>
-	 */
-	private static function semantic_parity_diagnostics( array $import_report ): array {
-		$semantic_parity = isset( $import_report['blocks_engine']['semantic_parity'] ) && is_array( $import_report['blocks_engine']['semantic_parity'] ) ? $import_report['blocks_engine']['semantic_parity'] : array();
-		$findings        = isset( $semantic_parity['findings'] ) && is_array( $semantic_parity['findings'] ) ? $semantic_parity['findings'] : array();
-
-		return self::normalize_diagnostic_rows( $findings, 'semantic_parity' );
 	}
 
 	/**

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -97,7 +97,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 			return self::normalize_diagnostic_rows( $finalized );
 		}
 
-		$sources = array(
+		$sources    = array(
 			array( $result['diagnostics'] ?? array(), '' ),
 			array( $result['artifact_diagnostics']['diagnostics'] ?? array(), '' ),
 			array( $result['import_validation_result']['diagnostics'] ?? array(), '' ),

--- a/includes/class-static-site-importer-failed-plan-validation.php
+++ b/includes/class-static-site-importer-failed-plan-validation.php
@@ -39,16 +39,14 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 		$quality['pass']            = false;
 		$quality['fail_import']     = true;
 		$quality['failure_reasons'] = self::failure_reasons( $plan, $quality );
-		$report['quality']          = $quality;
-		$report['compact_summary']  = Static_Site_Importer_Report_Diagnostics::import_report_summary( $report, $quality );
-		$report['finding_packets']  = Static_Site_Importer_Report_Diagnostics::finding_packets( $report );
-		$report['import_validation_result'] = Static_Site_Importer_Report_Diagnostics::import_validation_result( $report, $quality );
+		$fixture_diagnostics = Static_Site_Importer_Report_Diagnostics::refresh_projections( $report, $quality );
 
 		return array(
 			'import_report'            => $report,
 			'import_report_summary'    => $report['compact_summary'],
 			'import_validation_result' => $report['import_validation_result'],
 			'finding_packets'          => $report['finding_packets'],
+			'fixture_diagnostics'      => $fixture_diagnostics,
 		);
 	}
 

--- a/includes/class-static-site-importer-failed-plan-validation.php
+++ b/includes/class-static-site-importer-failed-plan-validation.php
@@ -16,16 +16,16 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 	/** @return array<string,mixed> */
 	public static function build( array $plan, array $args = array(), array $compiled = array() ): array {
 		$diagnostics = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
-		$report = array(
-			'schema'      => 'static-site-importer/import-report/v1',
-			'version'     => 1,
-			'status'      => 'failed',
-			'theme_slug'  => (string) ( $args['slug'] ?? '' ),
-			'quality'     => isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array(),
-			'diagnostics' => array_slice( $diagnostics, 0, self::MAX_DIAGNOSTICS ),
-			'blocks_engine' => self::compiler_evidence( $plan, $compiled ),
+		$report      = array(
+			'schema'           => 'static-site-importer/import-report/v1',
+			'version'          => 1,
+			'status'           => 'failed',
+			'theme_slug'       => (string) ( $args['slug'] ?? '' ),
+			'quality'          => isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array(),
+			'diagnostics'      => array_slice( $diagnostics, 0, self::MAX_DIAGNOSTICS ),
+			'blocks_engine'    => self::compiler_evidence( $plan, $compiled ),
 			'source_documents' => self::source_documents( $plan ),
-			'failure_context' => array(
+			'failure_context'  => array(
 				'stage' => 'pre_materialization_quality_admission',
 				'code'  => 'static_site_importer_quality_gate_failed',
 			),
@@ -35,11 +35,11 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 			$report['diagnostic_count']      = count( $diagnostics );
 		}
 
-		$quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $report, array_merge( $args, array( 'fail_on_quality' => true ) ) );
+		$quality                    = Static_Site_Importer_Report_Diagnostics::finalize_report( $report, array_merge( $args, array( 'fail_on_quality' => true ) ) );
 		$quality['pass']            = false;
 		$quality['fail_import']     = true;
 		$quality['failure_reasons'] = self::failure_reasons( $plan, $quality );
-		$fixture_diagnostics = Static_Site_Importer_Report_Diagnostics::refresh_projections( $report, $quality );
+		$fixture_diagnostics        = Static_Site_Importer_Report_Diagnostics::refresh_projections( $report, $quality );
 
 		return array(
 			'import_report'            => $report,
@@ -103,7 +103,7 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 			return array();
 		}
 		$directory = dirname( $report_path );
-		$paths = array(
+		$paths     = array(
 			'import_report'            => $report_path,
 			'import_validation_result' => trailingslashit( $directory ) . 'import-validation-result.json',
 			'finding_packets'          => trailingslashit( $directory ) . 'finding-packets.json',
@@ -140,7 +140,7 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 
 	private static function write( string $path, array $payload ): void {
 		$temp = tempnam( dirname( $path ), '.ssi-failed-plan-' );
-		$json = function_exists( 'wp_json_encode' ) ? wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) : json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		$json = function_exists( 'wp_json_encode' ) ? wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) : json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Standalone smoke tests do not load WordPress encoding helpers.
 		if ( false === $temp || false === $json || false === file_put_contents( $temp, $json . "\n" ) || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents,WordPress.WP.AlternativeFunctions.rename_rename -- Atomically writes bounded explicit report artifacts.
 			if ( is_string( $temp ) && file_exists( $temp ) ) {
 				unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes a failed atomic report temporary file.

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -292,13 +292,41 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return array<string, mixed>
 	 */
 	public static function finalize_report( array &$report, array $args ): array {
-		$quality                            = self::finalize_quality_report( $report, $args );
-		$report['visual_parity_artifacts']  = self::visual_parity_artifact_contract( isset( $args['validation_artifacts'] ) && is_array( $args['validation_artifacts'] ) ? $args['validation_artifacts'] : array() );
+		$quality                           = self::finalize_quality_report( $report, $args );
+		$report['visual_parity_artifacts'] = self::visual_parity_artifact_contract( isset( $args['validation_artifacts'] ) && is_array( $args['validation_artifacts'] ) ? $args['validation_artifacts'] : array() );
+		self::refresh_projections( $report, $quality, false );
+
+		return $quality;
+	}
+
+	/**
+	 * Refresh every public projection from one finalized report state.
+	 *
+	 * @param array<string,mixed> $report  Finalized import report.
+	 * @param array<string,mixed> $quality Finalized quality gate state.
+	 * @param bool                $build_fixture Whether to build the fixture projection.
+	 * @return array<string,mixed>
+	 */
+	public static function refresh_projections( array &$report, array $quality, bool $build_fixture = true ): array {
+		$report['quality']                  = $quality;
 		$report['compact_summary']          = self::import_report_summary( $report, $quality );
 		$report['finding_packets']          = self::finding_packets( $report );
 		$report['import_validation_result'] = self::import_validation_result( $report, $quality );
 
-		return $quality;
+		if ( $build_fixture && class_exists( 'Static_Site_Importer_Diagnostic_Contract' ) ) {
+			return Static_Site_Importer_Diagnostic_Contract::build(
+				array(
+					'success'                  => empty( $quality['fail_import'] ),
+					'status'                   => (string) ( $report['compact_summary']['status'] ?? '' ),
+					'slug'                     => (string) ( $report['theme_slug'] ?? '' ),
+					'import_validation_result' => $report['import_validation_result'],
+					'import_report'            => $report,
+					'materialization_receipt'  => isset( $report['materialization_receipt'] ) && is_array( $report['materialization_receipt'] ) ? $report['materialization_receipt'] : array(),
+				)
+			);
+		}
+
+		return array();
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -856,8 +856,8 @@ class Static_Site_Importer_Theme_Generator {
 		$receipt['quality_budget_admission']['mechanical_status'] = $receipt['status'] ?? 'completed';
 		$report['quality_budget_admission'] = $receipt['quality_budget_admission'];
 		$report['materialization_receipt'] = $receipt;
-		$validation = Static_Site_Importer_Report_Diagnostics::import_validation_result( $report, $quality );
-		$report['import_validation_result'] = $validation;
+		$fixture_diagnostics = Static_Site_Importer_Report_Diagnostics::refresh_projections( $report, $quality );
+		$validation = $report['import_validation_result'];
 		$findings   = $report['finding_packets'];
 		$theme_dir  = $theme['dir'];
 		$manifest_path = $theme_dir . '/static-site-importer-manifest.json';
@@ -913,6 +913,7 @@ class Static_Site_Importer_Theme_Generator {
 			),
 			'import_validation_result'        => $validation,
 			'finding_packets'                 => $findings,
+			'fixture_diagnostics'             => $fixture_diagnostics,
 			'quality'                         => $quality,
 			'source_of_truth'                 => $manifest,
 			'progress_events'                 => array(

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -350,7 +350,9 @@ class Static_Site_Importer_Validation_Runtime {
 				'finding_packets'         => self::local_file_artifact_ref( $finding_packets_path, 'static-site-importer/finding-packets' ),
 			),
 		);
-		$result['fixture_diagnostics'] = Static_Site_Importer_Diagnostic_Contract::build( $result );
+		$result['fixture_diagnostics'] = isset( $import_result['fixture_diagnostics'] ) && is_array( $import_result['fixture_diagnostics'] )
+			? $import_result['fixture_diagnostics']
+			: Static_Site_Importer_Diagnostic_Contract::build( $result );
 		$result['diagnostics']         = isset( $result['fixture_diagnostics']['diagnostics'] ) && is_array( $result['fixture_diagnostics']['diagnostics'] ) ? $result['fixture_diagnostics']['diagnostics'] : array();
 		$result['diagnostic_summary']  = isset( $result['fixture_diagnostics']['diagnostic_summary'] ) && is_array( $result['fixture_diagnostics']['diagnostic_summary'] ) ? $result['fixture_diagnostics']['diagnostic_summary'] : array();
 

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -375,7 +375,7 @@ class Static_Site_Importer_Validation_Runtime {
 			$directory  = trailingslashit( $base_dir ) . 'static-site-importer/validation-' . sanitize_title( $slug ) . '-' . sanitize_key( uniqid( '', true ) );
 		}
 
-		$created = function_exists( 'wp_mkdir_p' ) ? wp_mkdir_p( $directory ) : false;
+		$created  = function_exists( 'wp_mkdir_p' ) ? wp_mkdir_p( $directory ) : false;
 		$resolved = $created ? realpath( $directory ) : false;
 		if ( false === $resolved || ! is_dir( $resolved ) ) {
 			return new WP_Error( 'static_site_importer_validation_artifact_dir_failed', 'Could not create validation artifact directory.' );

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -884,7 +884,7 @@ function static_site_importer_rest_execute_import_ability( string $ability_name,
  * Route a URL-only REST import through the canonical unified import ability.
  *
  * The unified `static-site-importer/import` ability dispatches on `type`; setting
- * `type=url` routes to {@see static_site_importer_ability_import_url_operation()}.
+	 * `type=url` routes to {@see Static_Site_Importer_Canonical_Import_Service::import_url_operation()}.
  * This helper shapes the input the ability expects and unwraps the result
  * envelope into the REST response shape.
  *

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -485,6 +485,41 @@ $assert( 'client_script_execution' === ( $runtime_preservation_diagnostic['runti
 $assert( 'preserve' === ( $runtime_preservation_diagnostic['disposition'] ?? '' ), 'contract-preserves-runtime-disposition' );
 $assert( 'preserve_verbatim' === ( $runtime_preservation_diagnostic['js_handling'] ?? '' ), 'contract-preserves-runtime-js-handling' );
 
+$finalized_report = array(
+	'schema'      => 'static-site-importer/import-report/v1',
+	'version'     => 1,
+	'theme_slug'  => 'finalized-diagnostic-source',
+	'quality'     => array( 'fallback_count' => 0 ),
+	'diagnostics' => array(
+		array(
+			'type'        => 'invalid_block_content',
+			'source_path' => 'templates/front-page.html',
+		),
+	),
+	'blocks_engine' => array(
+		'conversion_report' => array(
+			'diagnostics' => array(
+				array(
+					'type'        => 'stale_nested_diagnostic',
+					'source_path' => 'legacy-report.html',
+				),
+			),
+		),
+	),
+);
+$finalized_quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $finalized_report, array() );
+$finalized_report['materialization_receipt'] = array(
+	'schema'    => 'static-site-importer/materialization-receipt/v2',
+	'status'    => 'completed',
+	'completed' => array( 'pages' => array( 1 ) ),
+);
+$cached_contract = Static_Site_Importer_Report_Diagnostics::refresh_projections( $finalized_report, $finalized_quality );
+$assert( 1 === ( $cached_contract['diagnostic_summary']['total'] ?? 0 ), 'finalized-report-is-sole-diagnostic-source' );
+$assert( 'invalid_block_content' === ( $cached_contract['diagnostics'][0]['type'] ?? '' ), 'finalized-report-builds-fixture-projection' );
+$assert( $cached_contract === Static_Site_Importer_Canonical_Import_Service::success_diagnostics_contract( array( 'fixture_diagnostics' => $cached_contract, 'import_report' => $finalized_report ) ), 'canonical-service-reuses-finalized-fixture-projection' );
+$assert( 'completed' === ( $cached_contract['materialization_receipt']['status'] ?? '' ), 'projection-refresh-includes-final-receipt' );
+$assert( ( $finalized_report['compact_summary']['status'] ?? '' ) === ( $cached_contract['status'] ?? '' ), 'projection-refresh-keeps-statuses-aligned' );
+
 $normalized_form_fallback = array(
 	'type'        => 'unsupported_html_fallback',
 	'code'        => 'html_form_fallback',

--- a/tests/smoke-rest-url-import-helpers.php
+++ b/tests/smoke-rest-url-import-helpers.php
@@ -4,7 +4,7 @@
  *
  * The unified `static-site-importer/import` ability dispatches on
  * `source.type`; URL sources are routed through
- * `static_site_importer_ability_import_url_operation()`. The REST router
+ * `Static_Site_Importer_Canonical_Import_Service::import_url_operation()`. The REST router
  * (`static_site_importer_rest_route_url_import`) shapes the input the
  * ability expects and unwraps the result envelope into the REST response.
  *


### PR DESCRIPTION
## Summary

- refresh compact summaries, validation results, finding packets, and fixture diagnostics from one finalized import-report state
- make finalized validation diagnostics authoritative while retaining a bounded fallback collector for early failures
- reuse the finalized fixture projection across Ability and validation-runtime responses
- remove unused Ability compatibility adapters

## Verification

- `npm test` (63 selected tests passed; 0 failed)
- fixture-matrix suite (279 passed; 0 failed)
- `php tests/smoke-import-diagnostic-contract.php` (95 assertions)
- `php tests/smoke-failed-plan-validation.php`
- `php tests/smoke-ability-import-success-diagnostics.php` (21 assertions)
- `php tests/smoke-rest-url-import-helpers.php` (30 assertions)
- WordPress site-plan materializer smoke

Closes #1297

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the diagnostic projection topology, implemented the finalized-report ownership boundary, consolidated fallback discovery, removed unused adapters, and ran the verification suite. Chris Huber directed the work and remains responsible for the change.