### PR TITLE
Materialize responsive layout companion blocks

### DIFF
--- a/.github/workflows/solved-site-promotion-pr.yml
+++ b/.github/workflows/solved-site-promotion-pr.yml
@@ -26,4 +26,4 @@ jobs:
     with:
       static-site-importer-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       static-site-importer-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      blocks-engine-sha: c47e806f9e758528b6d19cfda0bd3c20d46a6309
+      blocks-engine-sha: ae9716efb388ffa338ed0aa6d1b423f6eca3082c

--- a/docs/companion-block-strategy.md
+++ b/docs/companion-block-strategy.md
@@ -3,7 +3,8 @@
 Static Site Importer should use generated companion blocks only for generic
 runtime/editor gaps that WordPress core blocks cannot model with stable,
 editable Gutenberg markup. The Blocks Engine producer stays product-neutral: it
-emits typed facts, diagnostics, and `source_reports.companion_plugin_payload`.
+emits typed facts, diagnostics, and a `blocks-engine/wordpress-companion-plugin/v1`
+payload under `source_reports.companion_plugin_payload`.
 SSI owns WordPress runtime materialization: generated metadata blocks, provider
 dependency checks, activation, and import diagnostics.
 
@@ -14,10 +15,10 @@ functional after Static Site Importer and Blocks Engine are removed.
 
 The existing seam is enough for first implementations:
 
-- Blocks Engine emits `static-site-importer/companion-plugin/v1` payloads under `source_reports.companion_plugin_payload`.
+- Blocks Engine emits `blocks-engine/wordpress-companion-plugin/v1` payloads under `source_reports.companion_plugin_payload`.
 - SSI materializes that payload as a generated plugin dependency under `companion_plugins.dependencies`.
 - Typed payload blocks write `block.json`, render files, and declared assets; WordPress registers them from their block directories so `editorScript`, `style`, `editorStyle`, and `viewScript` file references resolve normally.
-- Typed payload blocks may select an explicitly audited SSI-owned renderer by versioned identifier; producer-authored PHP and unknown renderers remain invalid.
+- Typed payload blocks select producer-owned renderer capabilities by versioned identifier. SSI maps trusted capabilities to WordPress render templates through `static_site_importer_companion_renderers`; producer-authored PHP, unknown capabilities, and malformed registry entries remain invalid.
 - Provider-backed features should continue to use SSI entity materializer adapters before falling back to a companion block.
 
 ## Candidate Blocks

--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -28,6 +28,7 @@
     "tests/smoke-materialized-block-content-validation.php": { "environment": "standalone-php" },
     "tests/smoke-managed-classic-theme-materialization.php": { "environment": "standalone-php" },
     "tests/smoke-playground-import-primitive.php": { "environment": "standalone-php" },
+    "tests/smoke-post-meta-rollback.php": { "environment": "standalone-php" },
     "tests/smoke-plugin-materializer-lifecycle.php": { "environment": "standalone-php" },
     "tests/smoke-product-handoff-contract.php": { "environment": "standalone-php" },
     "tests/smoke-quality-budget-admission.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -1010,7 +1010,7 @@ $output = preg_replace_callback(
 ) ?? '';
 echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded semantic layout markup.
 PHP;
-		$media = <<<'PHP'
+		$media  = <<<'PHP'
 <?php
 /** Generated responsive-media companion block render. */
 

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -41,6 +41,9 @@ class Static_Site_Importer_Companion_Plugin {
 	/** SSI-owned renderer available to typed responsive-media blocks. */
 	private const RESPONSIVE_MEDIA_RENDERER = 'static-site-importer/responsive-media/v1';
 
+	/** SSI-owned renderer available to typed responsive-layout blocks. */
+	private const RESPONSIVE_LAYOUT_RENDERER = 'static-site-importer/responsive-layout/v1';
+
 	/**
 	 * Payload schema identifier consumed by the scaffolder.
 	 */
@@ -114,7 +117,7 @@ class Static_Site_Importer_Companion_Plugin {
 			}
 			$renderer = $block['renderer'] ?? null;
 			if ( null !== $renderer ) {
-				if ( ! is_string( $renderer ) || self::RESPONSIVE_MEDIA_RENDERER !== $renderer ) {
+				if ( ! is_string( $renderer ) || ! in_array( $renderer, array( self::RESPONSIVE_MEDIA_RENDERER, self::RESPONSIVE_LAYOUT_RENDERER ), true ) ) {
 					return new WP_Error( 'static_site_importer_companion_plugin_renderer_invalid', sprintf( 'Block %s must declare a supported typed renderer.', $name ) );
 				}
 				if ( array_key_exists( 'render', $block ) ) {
@@ -122,11 +125,7 @@ class Static_Site_Importer_Companion_Plugin {
 				}
 				$content_schema = $block['block_json']['attributes']['content'] ?? null;
 				if ( ! is_array( $content_schema ) || 'string' !== ( $content_schema['type'] ?? null ) ) {
-					return new WP_Error( 'static_site_importer_companion_plugin_renderer_attributes_invalid', sprintf( 'Block %s responsive-media renderer requires a string content attribute.', $name ) );
-				}
-				$kind_schema = $block['block_json']['attributes']['kind'] ?? null;
-				if ( ! is_array( $kind_schema ) || 'string' !== ( $kind_schema['type'] ?? null ) || 'media' !== ( $kind_schema['default'] ?? null ) ) {
-					return new WP_Error( 'static_site_importer_companion_plugin_renderer_attributes_invalid', sprintf( 'Block %s responsive-media renderer requires the released string kind attribute with a media default.', $name ) );
+					return new WP_Error( 'static_site_importer_companion_plugin_renderer_attributes_invalid', sprintf( 'Block %s typed renderer requires a string content attribute.', $name ) );
 				}
 			}
 			if ( isset( $block['render'] ) && is_scalar( $block['render'] ) && Static_Site_Importer_Content_Policy::contains_server_code( (string) $block['render'] ) ) {
@@ -817,15 +816,13 @@ PHP;
 	 * @return string
 	 */
 	private static function typed_renderer( string $renderer ): string {
-		if ( self::RESPONSIVE_MEDIA_RENDERER !== $renderer ) {
+		if ( ! in_array( $renderer, array( self::RESPONSIVE_MEDIA_RENDERER, self::RESPONSIVE_LAYOUT_RENDERER ), true ) ) {
 			return '';
 		}
 
 		$layout = <<<'PHP'
-/** Generated responsive-media layout mode companion block render. */
-
-$kind = is_string( $attributes['kind'] ?? null ) ? $attributes['kind'] : '';
-if ( 'layout' === $kind ) {
+<?php
+/** Generated responsive-layout companion block render. */
 
 $content = is_string( $attributes['content'] ?? null ) ? $attributes['content'] : '';
 $content = preg_replace( '#<\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\b[^>]*>.*?</\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\s*>#is', '', $content ) ?? '';
@@ -979,6 +976,12 @@ $output = wp_kses(
 		'a' => array_merge( $global, array( 'download' => true, 'href' => true, 'rel' => true, 'target' => true ) ),
 		'button' => array_merge( $global, array( 'disabled' => true, 'name' => true, 'type' => true, 'value' => true ) ),
 		'form' => array_merge( $flow, array( 'action' => true, 'method' => true ) ),
+		'fieldset' => array_merge( $flow, array( 'disabled' => true, 'name' => true ) ), 'legend' => $global,
+		'label' => array_merge( $global, array( 'for' => true ) ),
+		'input' => array_merge( $global, array( 'autocomplete' => true, 'checked' => true, 'disabled' => true, 'max' => true, 'maxlength' => true, 'min' => true, 'minlength' => true, 'multiple' => true, 'name' => true, 'pattern' => true, 'placeholder' => true, 'readonly' => true, 'required' => true, 'step' => true, 'type' => true, 'value' => true ) ),
+		'textarea' => array_merge( $global, array( 'cols' => true, 'disabled' => true, 'maxlength' => true, 'minlength' => true, 'name' => true, 'placeholder' => true, 'readonly' => true, 'required' => true, 'rows' => true ) ),
+		'select' => array_merge( $global, array( 'disabled' => true, 'multiple' => true, 'name' => true, 'required' => true, 'size' => true ) ),
+		'option' => array_merge( $global, array( 'disabled' => true, 'label' => true, 'selected' => true, 'value' => true ) ),
 		'figure' => $flow, 'figcaption' => $flow, 'picture' => $flow,
 		'source' => array_merge( $global, array( 'media' => true, 'sizes' => true, 'src' => true, 'srcset' => true, 'type' => true ) ),
 		'img' => array_merge( $global, array( 'alt' => true, 'decoding' => true, 'fetchpriority' => true, 'height' => true, 'loading' => true, 'longdesc' => true, 'sizes' => true, 'src' => true, 'srcset' => true, 'usemap' => true, 'width' => true ) ),
@@ -1010,9 +1013,10 @@ $output = preg_replace_callback(
 	$output
 ) ?? '';
 echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded semantic layout markup.
-return;
-}
 PHP;
+		if ( self::RESPONSIVE_LAYOUT_RENDERER === $renderer ) {
+			return $layout;
+		}
 
 		$media = <<<'PHP'
 <?php
@@ -1130,11 +1134,7 @@ foreach ( $data_images as $placeholder => $data_image ) {
 echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded media markup.
 PHP;
 
-		return preg_replace_callback(
-			'/^<\?php\n/',
-			static fn(): string => "<?php\n" . $layout . "\nif ( 'media' !== \$kind ) {\n\treturn;\n}\n\n",
-			$media
-		) ?? '';
+		return $media;
 	}
 
 	/**

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -39,15 +39,15 @@ class Static_Site_Importer_Companion_Plugin {
 	private const MAX_SCRIPT_DEPENDENCIES = 32;
 
 	/** SSI-owned renderer available to typed responsive-media blocks. */
-	private const RESPONSIVE_MEDIA_RENDERER = 'static-site-importer/responsive-media/v1';
+	private const RESPONSIVE_MEDIA_RENDERER = 'blocks-engine/responsive-media/v1';
 
 	/** SSI-owned renderer available to typed responsive-layout blocks. */
-	private const RESPONSIVE_LAYOUT_RENDERER = 'static-site-importer/responsive-layout/v1';
+	private const RESPONSIVE_LAYOUT_RENDERER = 'blocks-engine/responsive-layout/v1';
 
 	/**
 	 * Payload schema identifier consumed by the scaffolder.
 	 */
-	public const PAYLOAD_SCHEMA = 'static-site-importer/companion-plugin/v1';
+	public const PAYLOAD_SCHEMA = 'blocks-engine/wordpress-companion-plugin/v1';
 
 	/**
 	 * Validate a canonical compiled companion payload before any WordPress writes.
@@ -57,7 +57,7 @@ class Static_Site_Importer_Companion_Plugin {
 	 */
 	public static function validate_payload( array $payload ) {
 		if ( self::PAYLOAD_SCHEMA !== ( $payload['schema'] ?? null ) ) {
-			return new WP_Error( 'static_site_importer_companion_plugin_schema_invalid', 'Companion-plugin payload must use static-site-importer/companion-plugin/v1.' );
+			return new WP_Error( 'static_site_importer_companion_plugin_schema_invalid', 'Companion-plugin payload must use blocks-engine/wordpress-companion-plugin/v1.' );
 		}
 		if ( '' === self::site_slug( $payload ) ) {
 			return new WP_Error( 'static_site_importer_companion_plugin_site_slug_missing', 'Companion-plugin payload must declare a non-empty site_slug.' );
@@ -117,7 +117,7 @@ class Static_Site_Importer_Companion_Plugin {
 			}
 			$renderer = $block['renderer'] ?? null;
 			if ( null !== $renderer ) {
-				if ( ! is_string( $renderer ) || ! in_array( $renderer, array( self::RESPONSIVE_MEDIA_RENDERER, self::RESPONSIVE_LAYOUT_RENDERER ), true ) ) {
+				if ( ! is_string( $renderer ) || '' === self::typed_renderer( $renderer ) ) {
 					return new WP_Error( 'static_site_importer_companion_plugin_renderer_invalid', sprintf( 'Block %s must declare a supported typed renderer.', $name ) );
 				}
 				if ( array_key_exists( 'render', $block ) ) {
@@ -816,10 +816,6 @@ PHP;
 	 * @return string
 	 */
 	private static function typed_renderer( string $renderer ): string {
-		if ( ! in_array( $renderer, array( self::RESPONSIVE_MEDIA_RENDERER, self::RESPONSIVE_LAYOUT_RENDERER ), true ) ) {
-			return '';
-		}
-
 		$layout = <<<'PHP'
 <?php
 /** Generated responsive-layout companion block render. */
@@ -1014,10 +1010,6 @@ $output = preg_replace_callback(
 ) ?? '';
 echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded semantic layout markup.
 PHP;
-		if ( self::RESPONSIVE_LAYOUT_RENDERER === $renderer ) {
-			return $layout;
-		}
-
 		$media = <<<'PHP'
 <?php
 /** Generated responsive-media companion block render. */
@@ -1134,7 +1126,18 @@ foreach ( $data_images as $placeholder => $data_image ) {
 echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded media markup.
 PHP;
 
-		return $media;
+		$renderers = array(
+			self::RESPONSIVE_MEDIA_RENDERER  => $media,
+			self::RESPONSIVE_LAYOUT_RENDERER => $layout,
+		);
+		if ( function_exists( 'apply_filters' ) ) {
+			$renderers = apply_filters( 'static_site_importer_companion_renderers', $renderers );
+		}
+		if ( ! is_array( $renderers ) ) {
+			return '';
+		}
+		$source = $renderers[ $renderer ] ?? '';
+		return is_string( $source ) && str_starts_with( $source, '<?php' ) ? $source : '';
 	}
 
 	/**

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -1130,7 +1130,11 @@ foreach ( $data_images as $placeholder => $data_image ) {
 echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded media markup.
 PHP;
 
-		return preg_replace( '/^<\?php\n/', "<?php\n" . $layout . "\nif ( 'media' !== \$kind ) {\n\treturn;\n}\n\n", $media ) ?? '';
+		return preg_replace_callback(
+			'/^<\?php\n/',
+			static fn(): string => "<?php\n" . $layout . "\nif ( 'media' !== \$kind ) {\n\treturn;\n}\n\n",
+			$media
+		) ?? '';
 	}
 
 	/**

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -962,9 +962,15 @@ if ( preg_match_all( '/\s+(aria-[a-z][a-z0-9-]*)\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\
 		$svg_global[ strtolower( $aria_name ) ] = true;
 	}
 }
+$custom_elements = array();
+if ( preg_match_all( '/<\s*([a-z][a-z0-9]*-[a-z0-9-]+)\b/i', $content, $custom_names ) ) {
+	foreach ( $custom_names[1] as $custom_name ) {
+		$custom_elements[ strtolower( $custom_name ) ] = $flow;
+	}
+}
 $output = wp_kses(
 	$content,
-	array(
+	array_merge( array(
 		'main' => $flow, 'article' => $flow, 'aside' => $flow, 'section' => $flow, 'header' => $flow,
 		'footer' => $flow, 'nav' => $flow, 'div' => $flow, 'span' => $global, 'p' => $flow,
 		'h1' => $flow, 'h2' => $flow, 'h3' => $flow, 'h4' => $flow, 'h5' => $flow, 'h6' => $flow,
@@ -990,7 +996,7 @@ $output = wp_kses(
 		'rect' => array_merge( $svg_global, array( 'fill' => true, 'height' => true, 'opacity' => true, 'rx' => true, 'ry' => true, 'stroke' => true, 'stroke-width' => true, 'width' => true, 'x' => true, 'y' => true ) ),
 		'text' => array_merge( $svg_global, array( 'fill' => true, 'font-family' => true, 'font-size' => true, 'font-weight' => true, 'text-anchor' => true, 'x' => true, 'y' => true ) ),
 		'tspan' => array_merge( $svg_global, array( 'dx' => true, 'dy' => true, 'fill' => true, 'x' => true, 'y' => true ) ), 'title' => $svg_global, 'desc' => $svg_global,
-	)
+	), $custom_elements )
 );
 foreach ( $data_images as $placeholder => $data_image ) {
 	$output = str_replace( 'src="' . $placeholder . '"', 'src="' . esc_attr( $data_image ) . '"', $output );

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -981,7 +981,7 @@ $output = wp_kses(
 		'form' => array_merge( $flow, array( 'action' => true, 'method' => true ) ),
 		'figure' => $flow, 'figcaption' => $flow, 'picture' => $flow,
 		'source' => array_merge( $global, array( 'media' => true, 'sizes' => true, 'src' => true, 'srcset' => true, 'type' => true ) ),
-		'img' => array_merge( $global, array( 'alt' => true, 'decoding' => true, 'height' => true, 'loading' => true, 'longdesc' => true, 'sizes' => true, 'src' => true, 'srcset' => true, 'usemap' => true, 'width' => true ) ),
+		'img' => array_merge( $global, array( 'alt' => true, 'decoding' => true, 'fetchpriority' => true, 'height' => true, 'loading' => true, 'longdesc' => true, 'sizes' => true, 'src' => true, 'srcset' => true, 'usemap' => true, 'width' => true ) ),
 		'video' => array_merge( $global, array( 'autoplay' => true, 'controls' => true, 'height' => true, 'loop' => true, 'muted' => true, 'playsinline' => true, 'poster' => true, 'preload' => true, 'src' => true, 'width' => true ) ),
 		'audio' => array_merge( $global, array( 'autoplay' => true, 'controls' => true, 'loop' => true, 'muted' => true, 'preload' => true, 'src' => true ) ),
 		'svg' => array_merge( $svg_global, array( 'fill' => true, 'focusable' => true, 'height' => true, 'preserveaspectratio' => true, 'stroke' => true, 'viewbox' => true, 'width' => true, 'xmlns' => true, 'xmlns:xlink' => true ) ),

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -124,6 +124,10 @@ class Static_Site_Importer_Companion_Plugin {
 				if ( ! is_array( $content_schema ) || 'string' !== ( $content_schema['type'] ?? null ) ) {
 					return new WP_Error( 'static_site_importer_companion_plugin_renderer_attributes_invalid', sprintf( 'Block %s responsive-media renderer requires a string content attribute.', $name ) );
 				}
+				$kind_schema = $block['block_json']['attributes']['kind'] ?? null;
+				if ( ! is_array( $kind_schema ) || 'string' !== ( $kind_schema['type'] ?? null ) || 'media' !== ( $kind_schema['default'] ?? null ) ) {
+					return new WP_Error( 'static_site_importer_companion_plugin_renderer_attributes_invalid', sprintf( 'Block %s responsive-media renderer requires the released string kind attribute with a media default.', $name ) );
+				}
 			}
 			if ( isset( $block['render'] ) && is_scalar( $block['render'] ) && Static_Site_Importer_Content_Policy::contains_server_code( (string) $block['render'] ) ) {
 				return new WP_Error( 'static_site_importer_companion_plugin_render_invalid', sprintf( 'Block %s render markup must be static HTML.', $name ) );
@@ -817,7 +821,194 @@ PHP;
 			return '';
 		}
 
-		return <<<'PHP'
+		$layout = <<<'PHP'
+/** Generated responsive-media layout mode companion block render. */
+
+$kind = is_string( $attributes['kind'] ?? null ) ? $attributes['kind'] : '';
+if ( 'layout' === $kind ) {
+
+$content = is_string( $attributes['content'] ?? null ) ? $attributes['content'] : '';
+$content = preg_replace( '#<\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\b[^>]*>.*?</\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\s*>#is', '', $content ) ?? '';
+$content = preg_replace( '#<\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\b[^>]*/?\s*>#is', '', $content ) ?? '';
+$content = preg_replace( '/\s+(?:on[a-z0-9_-]+|data-wp-[a-z0-9_-]+)\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $content ) ?? '';
+
+$safe_url = static function ( string $url, bool $image = false ): bool {
+	$normalized = strtolower( preg_replace( '/[\x00-\x20\x7f]+/', '', html_entity_decode( $url, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ) ?? '' );
+	$normalized = rawurldecode( rawurldecode( $normalized ) );
+	if ( '' === $normalized || ! preg_match( '/^([a-z][a-z0-9+.-]*):/i', $normalized, $scheme ) ) {
+		return '' !== $normalized;
+	}
+	if ( in_array( strtolower( $scheme[1] ), array( 'http', 'https' ), true ) ) {
+		return true;
+	}
+	return $image && (bool) preg_match( '#^data:image/(?:avif|gif|jpeg|png|webp);base64,[a-z0-9+/=]+$#i', $normalized );
+};
+$sanitize_srcset = static function ( string $srcset ) use ( $safe_url ): string {
+	$candidates = array();
+	for ( $offset = 0, $length = strlen( $srcset ); $offset < $length; ) {
+		while ( $offset < $length && ( ctype_space( $srcset[ $offset ] ) || ',' === $srcset[ $offset ] ) ) {
+			++$offset;
+		}
+		$url_start = $offset;
+		while ( $offset < $length && ! ctype_space( $srcset[ $offset ] ) ) {
+			++$offset;
+		}
+		$url = substr( $srcset, $url_start, $offset - $url_start );
+		while ( $offset < $length && ctype_space( $srcset[ $offset ] ) ) {
+			++$offset;
+		}
+		$descriptor_start = $offset;
+		for ( $parentheses = 0; $offset < $length; ++$offset ) {
+			if ( '(' === $srcset[ $offset ] ) {
+				++$parentheses;
+			} elseif ( ')' === $srcset[ $offset ] && $parentheses > 0 ) {
+				--$parentheses;
+			} elseif ( ',' === $srcset[ $offset ] && 0 === $parentheses ) {
+				break;
+			}
+		}
+		$descriptor = trim( substr( $srcset, $descriptor_start, $offset - $descriptor_start ) );
+		if ( '' !== $url && $safe_url( $url, true ) ) {
+			$candidates[] = $url . ( '' === $descriptor ? '' : ' ' . $descriptor );
+		}
+	}
+	return implode( ', ', $candidates );
+};
+$content = preg_replace_callback(
+	'/\bsrcset\s*=\s*(?:("|\')(.*?)\1|([^\s>]+))/is',
+	static function ( array $match ) use ( $sanitize_srcset ): string {
+		$srcset = $sanitize_srcset( '' !== ( $match[2] ?? '' ) ? $match[2] : ( $match[3] ?? '' ) );
+		return '' === $srcset ? '' : 'srcset="' . esc_attr( $srcset ) . '"';
+	},
+	$content
+) ?? '';
+$content = preg_replace_callback(
+	'#<svg\b[^>]*>.*?</svg\s*>#is',
+	static function ( array $match ): string {
+		$svg = $match[0];
+		$ids = array();
+		if ( preg_match_all( '/\bid\s*=\s*(?:"([^"\s]+)"|\'([^\'\s]+)\'|([^\s>]+))/i', $svg, $id_matches ) ) {
+			foreach ( $id_matches[1] as $index => $double_quoted ) {
+				$id = '' !== $double_quoted ? $double_quoted : ( '' !== $id_matches[2][ $index ] ? $id_matches[2][ $index ] : $id_matches[3][ $index ] );
+				if ( preg_match( '/^[A-Za-z][A-Za-z0-9_.:-]*$/', $id ) ) {
+					$ids[ $id ] = true;
+				}
+			}
+		}
+		$svg = preg_replace_callback(
+			'/url\(\s*(["\']?)([^\s)"\']+)\1\s*\)/i',
+			static function ( array $url_match ) use ( $ids ): string {
+				$reference = $url_match[2];
+				return str_starts_with( $reference, '#' ) && isset( $ids[ substr( $reference, 1 ) ] ) ? $url_match[0] : '';
+			},
+			$svg
+		) ?? '';
+		$svg = preg_replace_callback(
+			'/\s+(?:href|xlink:href)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))/i',
+			static function ( array $href_match ) use ( $ids ): string {
+				$reference = '' !== ( $href_match[1] ?? '' ) ? $href_match[1] : ( '' !== ( $href_match[2] ?? '' ) ? $href_match[2] : ( $href_match[3] ?? '' ) );
+				return str_starts_with( $reference, '#' ) && isset( $ids[ substr( $reference, 1 ) ] ) ? ' href="' . esc_attr( $reference ) . '"' : '';
+			},
+			$svg
+		) ?? '';
+		return preg_replace( '#<use\b(?![^>]*(?:href|xlink:href)=)[^>]*(?:/>|>.*?</use\s*>)#is', '', $svg ) ?? '';
+	},
+	$content
+) ?? '';
+$content = preg_replace_callback(
+	'/\bstyle\s*=\s*(?:("|\')(.*?)\1|([^\s>]+))/is',
+	static function ( array $match ) use ( $safe_url ): string {
+		$value = '' !== ( $match[2] ?? '' ) ? $match[2] : ( $match[3] ?? '' );
+		if ( preg_match_all( '/url\(\s*["\']?([^\s)"\']+)/i', $value, $urls ) ) {
+			foreach ( $urls[1] as $url ) {
+				if ( ! $safe_url( $url, true ) ) {
+					return '';
+				}
+			}
+		}
+		return 'style="' . esc_attr( $value ) . '"';
+	},
+	$content
+) ?? '';
+
+// Preserve audited raster data URLs through KSES's protocol filter without
+// allowing the data scheme for links or other URL-bearing attributes.
+$data_images = array();
+$content     = preg_replace_callback(
+	'/\bsrc\s*=\s*(["\'])(data:image\/(?:avif|gif|jpeg|png|webp);base64,[a-z0-9+\/=]+)\1/i',
+	static function ( array $match ) use ( &$data_images ): string {
+		$placeholder                 = '/ssi-data-image-' . hash( 'sha256', $match[2] ) . '.invalid';
+		$data_images[ $placeholder ] = $match[2];
+		return 'src=' . $match[1] . $placeholder . $match[1];
+	},
+	$content
+) ?? '';
+
+$global = array(
+	'aria-controls' => true, 'aria-current' => true, 'aria-describedby' => true, 'aria-details' => true,
+	'aria-expanded' => true, 'aria-hidden' => true, 'aria-label' => true, 'aria-labelledby' => true,
+	'aria-live' => true, 'class' => true, 'data-*' => true, 'dir' => true, 'hidden' => true, 'id' => true,
+	'lang' => true, 'role' => true, 'style' => true, 'tabindex' => true, 'title' => true, 'xml:lang' => true,
+);
+$flow = array_merge( $global, array( 'align' => true ) );
+$svg_global = array(
+	'aria-hidden' => true, 'aria-label' => true, 'aria-labelledby' => true, 'class' => true, 'id' => true,
+	'role' => true, 'title' => true,
+);
+// KSES supports data-* but not aria-* wildcards. Admit syntactically valid
+// producer attributes explicitly so SVG accessibility metadata survives.
+if ( preg_match_all( '/\s+(aria-[a-z][a-z0-9-]*)\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s>]+)/i', $content, $aria_names ) ) {
+	foreach ( $aria_names[1] as $aria_name ) {
+		$svg_global[ strtolower( $aria_name ) ] = true;
+	}
+}
+$output = wp_kses(
+	$content,
+	array(
+		'main' => $flow, 'article' => $flow, 'aside' => $flow, 'section' => $flow, 'header' => $flow,
+		'footer' => $flow, 'nav' => $flow, 'div' => $flow, 'span' => $global, 'p' => $flow,
+		'h1' => $flow, 'h2' => $flow, 'h3' => $flow, 'h4' => $flow, 'h5' => $flow, 'h6' => $flow,
+		'ul' => $flow, 'ol' => $flow, 'li' => $flow, 'dl' => $flow, 'dt' => $flow, 'dd' => $flow,
+		'strong' => $global, 'b' => $global, 'em' => $global, 'i' => $global, 'small' => $global, 'br' => $global,
+		'a' => array_merge( $global, array( 'download' => true, 'href' => true, 'rel' => true, 'target' => true ) ),
+		'button' => array_merge( $global, array( 'disabled' => true, 'name' => true, 'type' => true, 'value' => true ) ),
+		'form' => array_merge( $flow, array( 'action' => true, 'method' => true ) ),
+		'figure' => $flow, 'figcaption' => $flow, 'picture' => $flow,
+		'source' => array_merge( $global, array( 'media' => true, 'sizes' => true, 'src' => true, 'srcset' => true, 'type' => true ) ),
+		'img' => array_merge( $global, array( 'alt' => true, 'decoding' => true, 'height' => true, 'loading' => true, 'longdesc' => true, 'sizes' => true, 'src' => true, 'srcset' => true, 'usemap' => true, 'width' => true ) ),
+		'video' => array_merge( $global, array( 'autoplay' => true, 'controls' => true, 'height' => true, 'loop' => true, 'muted' => true, 'playsinline' => true, 'poster' => true, 'preload' => true, 'src' => true, 'width' => true ) ),
+		'audio' => array_merge( $global, array( 'autoplay' => true, 'controls' => true, 'loop' => true, 'muted' => true, 'preload' => true, 'src' => true ) ),
+		'svg' => array_merge( $svg_global, array( 'fill' => true, 'focusable' => true, 'height' => true, 'preserveaspectratio' => true, 'stroke' => true, 'viewbox' => true, 'width' => true, 'xmlns' => true, 'xmlns:xlink' => true ) ),
+		'defs' => $svg_global, 'symbol' => array_merge( $svg_global, array( 'viewbox' => true ) ), 'lineargradient' => array_merge( $svg_global, array( 'gradientunits' => true, 'x1' => true, 'x2' => true, 'y1' => true, 'y2' => true ) ), 'radialgradient' => array_merge( $svg_global, array( 'cx' => true, 'cy' => true, 'r' => true ) ), 'stop' => array_merge( $svg_global, array( 'offset' => true, 'stop-color' => true, 'stop-opacity' => true ) ), 'clippath' => $svg_global, 'mask' => $svg_global, 'use' => array_merge( $svg_global, array( 'href' => true, 'xlink:href' => true ) ),
+		'g' => array_merge( $svg_global, array( 'clip-path' => true, 'fill' => true, 'fill-opacity' => true, 'opacity' => true, 'stroke' => true, 'stroke-width' => true, 'transform' => true ) ),
+		'path' => array_merge( $svg_global, array( 'd' => true, 'fill' => true, 'fill-rule' => true, 'opacity' => true, 'stroke' => true, 'stroke-linecap' => true, 'stroke-linejoin' => true, 'stroke-width' => true, 'transform' => true ) ),
+		'circle' => array_merge( $svg_global, array( 'cx' => true, 'cy' => true, 'fill' => true, 'opacity' => true, 'r' => true, 'stroke' => true, 'stroke-width' => true ) ),
+		'ellipse' => array_merge( $svg_global, array( 'cx' => true, 'cy' => true, 'fill' => true, 'opacity' => true, 'rx' => true, 'ry' => true, 'stroke' => true, 'stroke-width' => true ) ),
+		'line' => array_merge( $svg_global, array( 'fill' => true, 'stroke' => true, 'stroke-linecap' => true, 'stroke-width' => true, 'x1' => true, 'x2' => true, 'y1' => true, 'y2' => true ) ),
+		'polygon' => array_merge( $svg_global, array( 'fill' => true, 'points' => true, 'stroke' => true, 'stroke-linecap' => true, 'stroke-linejoin' => true, 'stroke-width' => true ) ),
+		'polyline' => array_merge( $svg_global, array( 'fill' => true, 'points' => true, 'stroke' => true, 'stroke-linecap' => true, 'stroke-linejoin' => true, 'stroke-width' => true ) ),
+		'rect' => array_merge( $svg_global, array( 'fill' => true, 'height' => true, 'opacity' => true, 'rx' => true, 'ry' => true, 'stroke' => true, 'stroke-width' => true, 'width' => true, 'x' => true, 'y' => true ) ),
+		'text' => array_merge( $svg_global, array( 'fill' => true, 'font-family' => true, 'font-size' => true, 'font-weight' => true, 'text-anchor' => true, 'x' => true, 'y' => true ) ),
+		'tspan' => array_merge( $svg_global, array( 'dx' => true, 'dy' => true, 'fill' => true, 'x' => true, 'y' => true ) ), 'title' => $svg_global, 'desc' => $svg_global,
+	)
+);
+foreach ( $data_images as $placeholder => $data_image ) {
+	$output = str_replace( 'src="' . $placeholder . '"', 'src="' . esc_attr( $data_image ) . '"', $output );
+	$output = str_replace( "src='" . $placeholder . "'", "src='" . esc_attr( $data_image ) . "'", $output );
+}
+$output = preg_replace_callback(
+	'#<svg\b[^>]*>#i',
+	static function ( array $match ): string {
+		return preg_replace( array( '/\bviewbox\b/i', '/\bpreserveaspectratio\b/i' ), array( 'viewBox', 'preserveAspectRatio' ), $match[0] ) ?? $match[0];
+	},
+	$output
+) ?? '';
+echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded semantic layout markup.
+return;
+}
+PHP;
+
+		$media = <<<'PHP'
 <?php
 /** Generated responsive-media companion block render. */
 
@@ -932,6 +1123,8 @@ foreach ( $data_images as $placeholder => $data_image ) {
 }
 echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded media markup.
 PHP;
+
+		return preg_replace( '/^<\?php\n/', "<?php\n" . $layout . "\nif ( 'media' !== \$kind ) {\n\treturn;\n}\n\n", $media ) ?? '';
 	}
 
 	/**

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -827,7 +827,10 @@ PHP;
 $content = is_string( $attributes['content'] ?? null ) ? $attributes['content'] : '';
 $content = preg_replace( '#<\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\b[^>]*>.*?</\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\s*>#is', '', $content ) ?? '';
 $content = preg_replace( '#<\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\b[^>]*/?\s*>#is', '', $content ) ?? '';
+$content = preg_replace( '#</?\s*[a-z][a-z0-9]*-[a-z0-9-]+\b[^>]*>#i', '', $content ) ?? '';
 $content = preg_replace( '/\s+(?:on[a-z0-9_-]+|data-wp-[a-z0-9_-]+)\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $content ) ?? '';
+$content = preg_replace( '/\s+(?:on[a-z0-9_-]+|data-wp-[a-z0-9_-]+)\s*=\s*(?=\/?>)/i', '', $content ) ?? '';
+$content = preg_replace( '/\s+(?:on[a-z0-9_-]+|data-wp-[a-z0-9_-]+)(?=\s|\/?>)/i', '', $content ) ?? '';
 
 $safe_url = static function ( string $url, bool $image = false ): bool {
 	$normalized = strtolower( preg_replace( '/[\x00-\x20\x7f]+/', '', html_entity_decode( $url, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ) ?? '' );
@@ -879,6 +882,9 @@ $content = preg_replace_callback(
 	},
 	$content
 ) ?? '';
+$content = preg_match( '#<svg\b[^>]*>(?:(?!</svg\s*>).)*<svg\b#is', $content ) ? ( preg_replace( '#<svg\b[^>]*>.*</svg\s*>#is', '', $content ) ?? '' ) : $content;
+$content = preg_replace( '#<svg\b[^>]*/\s*>#is', '', $content ) ?? '';
+$content = preg_replace( '#<svg\b[^>]*>(?:(?!</svg\s*>).)*$#is', '', $content ) ?? '';
 $content = preg_replace_callback(
 	'#<svg\b[^>]*>.*?</svg\s*>#is',
 	static function ( array $match ): string {
@@ -959,15 +965,9 @@ if ( preg_match_all( '/\s+(aria-[a-z][a-z0-9-]*)\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\
 		$svg_global[ strtolower( $aria_name ) ] = true;
 	}
 }
-$custom_elements = array();
-if ( preg_match_all( '/<\s*([a-z][a-z0-9]*-[a-z0-9-]+)\b/i', $content, $custom_names ) ) {
-	foreach ( $custom_names[1] as $custom_name ) {
-		$custom_elements[ strtolower( $custom_name ) ] = $flow;
-	}
-}
 $output = wp_kses(
 	$content,
-	array_merge( array(
+	array(
 		'main' => $flow, 'article' => $flow, 'aside' => $flow, 'section' => $flow, 'header' => $flow,
 		'footer' => $flow, 'nav' => $flow, 'div' => $flow, 'span' => $global, 'p' => $flow,
 		'h1' => $flow, 'h2' => $flow, 'h3' => $flow, 'h4' => $flow, 'h5' => $flow, 'h6' => $flow,
@@ -999,7 +999,7 @@ $output = wp_kses(
 		'rect' => array_merge( $svg_global, array( 'fill' => true, 'height' => true, 'opacity' => true, 'rx' => true, 'ry' => true, 'stroke' => true, 'stroke-width' => true, 'width' => true, 'x' => true, 'y' => true ) ),
 		'text' => array_merge( $svg_global, array( 'fill' => true, 'font-family' => true, 'font-size' => true, 'font-weight' => true, 'text-anchor' => true, 'x' => true, 'y' => true ) ),
 		'tspan' => array_merge( $svg_global, array( 'dx' => true, 'dy' => true, 'fill' => true, 'x' => true, 'y' => true ) ), 'title' => $svg_global, 'desc' => $svg_global,
-	), $custom_elements )
+	)
 );
 foreach ( $data_images as $placeholder => $data_image ) {
 	$output = str_replace( 'src="' . $placeholder . '"', 'src="' . esc_attr( $data_image ) . '"', $output );

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -2084,6 +2084,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'provenance'              => get_post_meta( $id, '_static_site_importer_provenance', true ),
 				'reconciliation_identity' => get_post_meta( $id, self::RECONCILIATION_META_KEY, true ),
 				'producer_reconciliation_identity' => get_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, true ),
+				'producer_reconciliation_identity_exists' => metadata_exists( 'post', $id, self::PRODUCER_RECONCILIATION_META_KEY ),
 			);
 			return;
 		}
@@ -2170,6 +2171,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'provenance'              => get_post_meta( $id, '_static_site_importer_provenance', true ),
 				'reconciliation_identity' => get_post_meta( $id, self::RECONCILIATION_META_KEY, true ),
 				'producer_reconciliation_identity' => get_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, true ),
+				'producer_reconciliation_identity_exists' => metadata_exists( 'post', $id, self::PRODUCER_RECONCILIATION_META_KEY ),
 			);
 		}
 	}
@@ -2223,7 +2225,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 					wp_update_post( $before['post'] );
 					update_post_meta( $id, '_static_site_importer_provenance', $before['provenance'] );
 					update_post_meta( $id, self::RECONCILIATION_META_KEY, $before['reconciliation_identity'] );
-					update_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, $before['producer_reconciliation_identity'] );
+					if ( ! empty( $before['producer_reconciliation_identity_exists'] ) ) {
+						update_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, $before['producer_reconciliation_identity'] );
+					} else {
+						delete_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY );
+					}
 				} elseif ( function_exists( 'wp_delete_post' ) && ! wp_delete_post( $id, true ) ) {
 					throw new RuntimeException( 'materialization_rollback_post_delete_failed' );
 				}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -1007,7 +1007,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	/** Persist and verify importer-owned post metadata. */
 	private static function write_post_meta( int $id, string $key, string $value ): bool {
 		update_post_meta( $id, $key, $value );
-		return metadata_exists( 'post', $id, $key ) && $value === (string) get_post_meta( $id, $key, true );
+		return metadata_exists( 'post', $id, $key ) && (string) get_post_meta( $id, $key, true ) === $value;
 	}
 
 	/** Resolve destination-independent route references after WordPress has assigned every permalink. */

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -554,8 +554,16 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			if ( empty( $page['planned_existing_id'] ) ) {
 				$state['rollback']['posts'][ $post ] = array( 'existing' => false );
 			}
+			$state['applied']['posts'][] = array(
+				'id'                      => $post,
+				'source_path'             => $page['source_path'],
+				'reconciliation_identity' => $page['reconciliation_identity'],
+			);
 			$state['page_ids'][ $page['reconciliation_identity'] ] = $post;
 			$state['source_ids'][ $page['source_path'] ]           = $post;
+			if ( ! self::write_post_meta( $post, self::RECONCILIATION_META_KEY, (string) $page['reconciliation_identity'] ) || ! self::write_post_meta( $post, self::PRODUCER_RECONCILIATION_META_KEY, (string) $page['reconciliation_identity'] ) ) {
+				return self::failed_receipt( $state, 'materialization_reconciliation_metadata_write_failed' );
+			}
 			$materialized_markup                                   = (string) ( $page['materialized_block_markup'] ?? $page['resolved_block_markup'] );
 			update_post_meta(
 				$post,
@@ -569,11 +577,6 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 						'content_hash'            => hash( 'sha256', $materialized_markup ),
 					)
 				)
-			);
-			$state['applied']['posts'][] = array(
-				'id'                      => $post,
-				'source_path'             => $page['source_path'],
-				'reconciliation_identity' => $page['reconciliation_identity'],
 			);
 			foreach ( $state['applied']['runtime_declarations']['entity_bindings'] as &$binding_report ) {
 				if ( ( $binding_report['source_path'] ?? '' ) === $page['source_path'] ) {
@@ -998,9 +1001,13 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		if ( is_wp_error( $id ) ) {
 			return $id;
 		}
-		update_post_meta( (int) $id, self::RECONCILIATION_META_KEY, $page['reconciliation_identity'] );
-		update_post_meta( (int) $id, self::PRODUCER_RECONCILIATION_META_KEY, $page['reconciliation_identity'] );
 		return (int) $id;
+	}
+
+	/** Persist and verify importer-owned post metadata. */
+	private static function write_post_meta( int $id, string $key, string $value ): bool {
+		update_post_meta( $id, $key, $value );
+		return metadata_exists( 'post', $id, $key ) && $value === (string) get_post_meta( $id, $key, true );
 	}
 
 	/** Resolve destination-independent route references after WordPress has assigned every permalink. */
@@ -2226,9 +2233,14 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 					update_post_meta( $id, '_static_site_importer_provenance', $before['provenance'] );
 					update_post_meta( $id, self::RECONCILIATION_META_KEY, $before['reconciliation_identity'] );
 					if ( ! empty( $before['producer_reconciliation_identity_exists'] ) ) {
-						update_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, $before['producer_reconciliation_identity'] );
+						if ( ! self::write_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, (string) $before['producer_reconciliation_identity'] ) ) {
+							throw new RuntimeException( 'materialization_rollback_post_meta_restore_failed' );
+						}
 					} else {
 						delete_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY );
+						if ( metadata_exists( 'post', $id, self::PRODUCER_RECONCILIATION_META_KEY ) ) {
+							throw new RuntimeException( 'materialization_rollback_post_meta_delete_failed' );
+						}
 					}
 				} elseif ( function_exists( 'wp_delete_post' ) && ! wp_delete_post( $id, true ) ) {
 					throw new RuntimeException( 'materialization_rollback_post_delete_failed' );

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -27,6 +27,7 @@ if ( ! class_exists( 'Static_Site_Importer_Quality_Budget_Admission' ) ) {
 final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	public const RECEIPT_SCHEMA           = 'static-site-importer/materialization-receipt/v2';
 	private const RECONCILIATION_META_KEY = '_static_site_importer_reconciliation_identity';
+	private const PRODUCER_RECONCILIATION_META_KEY = '_blocks_engine_reconciliation_identity';
 	private const BLOCK_PROVENANCE_LIMIT  = 50;
 
 	/**
@@ -998,6 +999,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return $id;
 		}
 		update_post_meta( (int) $id, self::RECONCILIATION_META_KEY, $page['reconciliation_identity'] );
+		update_post_meta( (int) $id, self::PRODUCER_RECONCILIATION_META_KEY, $page['reconciliation_identity'] );
 		return (int) $id;
 	}
 
@@ -2081,6 +2083,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'post'                    => $post,
 				'provenance'              => get_post_meta( $id, '_static_site_importer_provenance', true ),
 				'reconciliation_identity' => get_post_meta( $id, self::RECONCILIATION_META_KEY, true ),
+				'producer_reconciliation_identity' => get_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, true ),
 			);
 			return;
 		}
@@ -2166,6 +2169,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'post'                    => $post,
 				'provenance'              => get_post_meta( $id, '_static_site_importer_provenance', true ),
 				'reconciliation_identity' => get_post_meta( $id, self::RECONCILIATION_META_KEY, true ),
+				'producer_reconciliation_identity' => get_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, true ),
 			);
 		}
 	}
@@ -2219,6 +2223,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 					wp_update_post( $before['post'] );
 					update_post_meta( $id, '_static_site_importer_provenance', $before['provenance'] );
 					update_post_meta( $id, self::RECONCILIATION_META_KEY, $before['reconciliation_identity'] );
+					update_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, $before['producer_reconciliation_identity'] );
 				} elseif ( function_exists( 'wp_delete_post' ) && ! wp_delete_post( $id, true ) ) {
 					throw new RuntimeException( 'materialization_rollback_post_delete_failed' );
 				}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -25,10 +25,10 @@ if ( ! class_exists( 'Static_Site_Importer_Quality_Budget_Admission' ) ) {
 }
 
 final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
-	public const RECEIPT_SCHEMA           = 'static-site-importer/materialization-receipt/v2';
-	private const RECONCILIATION_META_KEY = '_static_site_importer_reconciliation_identity';
+	public const RECEIPT_SCHEMA                    = 'static-site-importer/materialization-receipt/v2';
+	private const RECONCILIATION_META_KEY          = '_static_site_importer_reconciliation_identity';
 	private const PRODUCER_RECONCILIATION_META_KEY = '_blocks_engine_reconciliation_identity';
-	private const BLOCK_PROVENANCE_LIMIT  = 50;
+	private const BLOCK_PROVENANCE_LIMIT           = 50;
 
 	/**
 	 * Materialize a fully canonical v2 plan. Compilation and plan validation belong to Blocks Engine.
@@ -195,10 +195,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return $payload;
 		}
 
-		$entries = array_values( array_filter( $plan['pages'] ?? array(), static fn( mixed $page ): bool => is_array( $page ) && ! empty( $page['entrypoint'] ) ) );
-		$entry   = $entries[0] ?? null;
-		$origin  = is_array( $entry ) && is_string( $entry['source_path'] ?? null ) ? $entry['source_path'] : '';
-		$root    = '' === $origin || '.' === dirname( $origin ) ? '' : trim( dirname( $origin ), '/' );
+		$entries       = array_values( array_filter( $plan['pages'] ?? array(), static fn( mixed $page ): bool => is_array( $page ) && ! empty( $page['entrypoint'] ) ) );
+		$entry         = $entries[0] ?? null;
+		$origin        = is_array( $entry ) && is_string( $entry['source_path'] ?? null ) ? $entry['source_path'] : '';
+		$root          = '' === $origin || '.' === dirname( $origin ) ? '' : trim( dirname( $origin ), '/' );
 		$canonicalizer = new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\AssetReferenceCanonicalizer( $tokens, $root );
 		$references    = WordPressSitePlanResolver::references( $tokens, $theme_uri );
 
@@ -206,7 +206,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			if ( ! is_array( $block ) || ! is_string( $block['render'] ?? null ) ) {
 				continue;
 			}
-			$canonical = $canonicalizer->content( $block['render'], $origin );
+			$canonical                             = $canonicalizer->content( $block['render'], $origin );
 			$payload['blocks'][ $index ]['render'] = WordPressSitePlanResolver::resolvePayload( $canonical, $references );
 		}
 
@@ -554,7 +554,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			if ( empty( $page['planned_existing_id'] ) ) {
 				$state['rollback']['posts'][ $post ] = array( 'existing' => false );
 			}
-			$state['applied']['posts'][] = array(
+			$state['applied']['posts'][]                           = array(
 				'id'                      => $post,
 				'source_path'             => $page['source_path'],
 				'reconciliation_identity' => $page['reconciliation_identity'],
@@ -564,7 +564,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			if ( ! self::write_post_meta( $post, self::RECONCILIATION_META_KEY, (string) $page['reconciliation_identity'] ) || ! self::write_post_meta( $post, self::PRODUCER_RECONCILIATION_META_KEY, (string) $page['reconciliation_identity'] ) ) {
 				return self::failed_receipt( $state, 'materialization_reconciliation_metadata_write_failed' );
 			}
-			$materialized_markup                                   = (string) ( $page['materialized_block_markup'] ?? $page['resolved_block_markup'] );
+			$materialized_markup = (string) ( $page['materialized_block_markup'] ?? $page['resolved_block_markup'] );
 			update_post_meta(
 				$post,
 				'_static_site_importer_provenance',
@@ -2086,11 +2086,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$post = 0 < $id && function_exists( 'get_post' ) ? get_post( $id, ARRAY_A ) : null;
 		if ( $post ) {
 			$state['rollback']['posts'][ $id ] = array(
-				'existing'                => true,
-				'post'                    => $post,
-				'provenance'              => get_post_meta( $id, '_static_site_importer_provenance', true ),
-				'reconciliation_identity' => get_post_meta( $id, self::RECONCILIATION_META_KEY, true ),
-				'producer_reconciliation_identity' => get_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, true ),
+				'existing'                                => true,
+				'post'                                    => $post,
+				'provenance'                              => get_post_meta( $id, '_static_site_importer_provenance', true ),
+				'reconciliation_identity'                 => get_post_meta( $id, self::RECONCILIATION_META_KEY, true ),
+				'producer_reconciliation_identity'        => get_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, true ),
 				'producer_reconciliation_identity_exists' => metadata_exists( 'post', $id, self::PRODUCER_RECONCILIATION_META_KEY ),
 			);
 			return;
@@ -2173,11 +2173,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$post = function_exists( 'get_post' ) ? get_post( $id, ARRAY_A ) : null;
 		if ( $post ) {
 			$receipt['transaction']->state['rollback']['posts'][ $id ] = array(
-				'existing'                => true,
-				'post'                    => $post,
-				'provenance'              => get_post_meta( $id, '_static_site_importer_provenance', true ),
-				'reconciliation_identity' => get_post_meta( $id, self::RECONCILIATION_META_KEY, true ),
-				'producer_reconciliation_identity' => get_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, true ),
+				'existing'                                => true,
+				'post'                                    => $post,
+				'provenance'                              => get_post_meta( $id, '_static_site_importer_provenance', true ),
+				'reconciliation_identity'                 => get_post_meta( $id, self::RECONCILIATION_META_KEY, true ),
+				'producer_reconciliation_identity'        => get_post_meta( $id, self::PRODUCER_RECONCILIATION_META_KEY, true ),
 				'producer_reconciliation_identity_exists' => metadata_exists( 'post', $id, self::PRODUCER_RECONCILIATION_META_KEY ),
 			);
 		}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -71,7 +71,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				)
 			);
 		}
-		$companion = self::materialize_companion_dependency( $companion_payload, $args, $page_ready );
+		$companion = self::materialize_companion_dependency( $companion_payload, $prepared, $page_ready );
 		if ( is_wp_error( $companion ) ) {
 			return $companion;
 		}
@@ -162,7 +162,8 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	}
 
 	/** Materialize the compiler-declared companion before provider dependencies. */
-	private static function materialize_companion_dependency( $payload, array $args, bool $page_ready ) {
+	private static function materialize_companion_dependency( $payload, array $prepared, bool $page_ready ) {
+		$args = is_array( $prepared['args'] ?? null ) ? $prepared['args'] : array();
 		if ( null === $payload ) {
 			return array(
 				'status' => 'skipped',
@@ -175,6 +176,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'reason' => $page_ready ? 'page_ready_scope' : 'dependency_materialization_disabled',
 			);
 		}
+		$payload    = self::resolve_companion_asset_references( $payload, $prepared['plan'] ?? array(), $prepared['resolved'] ?? array() );
 		$dependency = Static_Site_Importer_Entity_Materializer_Registry::companion_plugin_dependency( $payload );
 		$result     = Static_Site_Importer_Entity_Materializer_Registry::materialize_companion_dependency( $dependency, ! empty( $args['overwrite'] ) );
 		if ( 'failed' === ( $result['status'] ?? '' ) ) {
@@ -182,6 +184,32 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return new WP_Error( (string) ( $error['code'] ?? 'static_site_importer_companion_plugin_materialization_failed' ), (string) ( $error['message'] ?? 'Companion-plugin materialization failed.' ), $result );
 		}
 		return $result;
+	}
+
+	/** Resolve browser-visible asset references carried by generated block renders. */
+	private static function resolve_companion_asset_references( array $payload, array $plan, array $resolved ): array {
+		$tokens    = isset( $plan['reference_tokens'] ) && is_array( $plan['reference_tokens'] ) ? $plan['reference_tokens'] : array();
+		$theme_uri = isset( $resolved['resolution']['theme_uri'] ) && is_string( $resolved['resolution']['theme_uri'] ) ? $resolved['resolution']['theme_uri'] : '';
+		if ( empty( $tokens ) || '' === $theme_uri ) {
+			return $payload;
+		}
+
+		$entries = array_values( array_filter( $plan['pages'] ?? array(), static fn( mixed $page ): bool => is_array( $page ) && ! empty( $page['entrypoint'] ) ) );
+		$entry   = $entries[0] ?? null;
+		$origin  = is_array( $entry ) && is_string( $entry['source_path'] ?? null ) ? $entry['source_path'] : '';
+		$root    = '' === $origin || '.' === dirname( $origin ) ? '' : trim( dirname( $origin ), '/' );
+		$canonicalizer = new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\AssetReferenceCanonicalizer( $tokens, $root );
+		$references    = WordPressSitePlanResolver::references( $tokens, $theme_uri );
+
+		foreach ( $payload['blocks'] ?? array() as $index => $block ) {
+			if ( ! is_array( $block ) || ! is_string( $block['render'] ?? null ) ) {
+				continue;
+			}
+			$canonical = $canonicalizer->content( $block['render'], $origin );
+			$payload['blocks'][ $index ]['render'] = WordPressSitePlanResolver::resolvePayload( $canonical, $references );
+		}
+
+		return $payload;
 	}
 
 	/** Public because checkpoint preparation provisions the same typed dependencies. */

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -34,6 +34,7 @@
     { "path": "tests/smoke-materialized-block-content-validation.php", "environment": "standalone-php" },
     { "path": "tests/smoke-managed-classic-theme-materialization.php", "environment": "standalone-php" },
     { "path": "tests/smoke-playground-import-primitive.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-post-meta-rollback.php", "environment": "standalone-php" },
     { "path": "tests/smoke-plugin-materializer-lifecycle.php", "environment": "standalone-php" },
     { "path": "tests/smoke-product-handoff-contract.php", "environment": "standalone-php" },
     { "path": "tests/smoke-quality-budget-admission.php", "environment": "standalone-php" },

--- a/tests/fixtures/busy-bears-responsive-layout-contract.json
+++ b/tests/fixtures/busy-bears-responsive-layout-contract.json
@@ -1,0 +1,25 @@
+{
+  "schema": "static-site-importer/frozen-responsive-layout-contract/v1",
+  "source": "https://www.busybearscleaning.com/",
+  "captured_at": "2026-08-24",
+  "pages": [
+    {
+      "path": "website/contact/index.html",
+      "captured_layouts": [
+        { "bytes": 14069, "sha256": "d39d2adaa5550e80d3d997239c4de20c8aadc0f570185f11d24049baa9274ffb" },
+        { "bytes": 14091, "sha256": "317456fbc2718f8fc2230eba16cdb0f11bc603993109c0e0ebe1d90e775cc625" }
+      ],
+      "content": "<section style=\"min-height:559.156px\"><p>If you have any inquiries, please fill out this form and our team will get back to you within 5 business days.</p><form aria-label=\"Contact\"><fieldset><label for=\"first-name\">First name*</label><input id=\"first-name\" name=\"first_name\" required><label for=\"details\">Details*</label><textarea id=\"details\" name=\"details\" required></textarea><button type=\"submit\">Submit</button></fieldset></form><svg viewBox=\"0 0 16 16\" role=\"img\" aria-label=\"Submit\"><path d=\"M2 8h12\"></path></svg></section>",
+      "expected_text": ["If you have any inquiries", "First name", "Details", "Submit"]
+    },
+    {
+      "path": "website/get-a-quote/index.html",
+      "captured_layouts": [
+        { "bytes": 24873, "sha256": "141d79f79178bedf87ff50d28a416843cf7bbfea7bcfb37e5cfa35da6a311fba" },
+        { "bytes": 24895, "sha256": "3b1b2d2cd4c8af7b29b8b9848343dc41235dfb4b8cf6dad4d56661b8a0d5e69e" }
+      ],
+      "content": "<section style=\"min-height:1236.33px\"><h2>Request Your Custom Cleaning Quote</h2><p>Provide your home details below to receive a personalized estimate.</p><form><label for=\"address\">Address*</label><input id=\"address\" name=\"address\" required><label for=\"quote-details\">Details (please include the approximate square footage of the space you need cleaned) *</label><textarea id=\"quote-details\" name=\"details\" required></textarea><button type=\"submit\">Submit</button></form><h3>Why Choose Busy Bears</h3><svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><circle cx=\"8\" cy=\"8\" r=\"6\"></circle></svg></section>",
+      "expected_text": ["Request Your Custom Cleaning Quote", "Provide your home details", "Address", "approximate square footage", "Why Choose Busy Bears"]
+    }
+  ]
+}

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -511,11 +511,11 @@ $assert( is_array( $layout_descriptor ), 'layout-renderer-scaffold-returns-descr
 if ( is_array( $layout_descriptor ) ) {
 	$layout_render = $layout_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
 	$assert( str_contains( $layout_render, 'Generated responsive-media layout mode companion block render' ) && ! str_contains( $layout_render, 'responsive-layout/v1' ), 'layout-mode-uses-released-renderer-template' );
-	$attributes = array( 'kind' => 'layout', 'content' => '<main class="story"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
+	$attributes = array( 'kind' => 'layout', 'content' => '<main class="story"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
 	ob_start();
 	eval( '?>' . $layout_render );
 	$layout_output = (string) ob_get_clean();
-	foreach ( array( '<main class="story">', '<nav>', '<h1>Story</h1>', '<button type="button">Read more</button>', '<wow-image data-hook="hero">', '<img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async">', '<svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark">', '<path d="M0 0L10 10" stroke="#000"></path>' ) as $fragment ) {
+	foreach ( array( '<main class="story">', '<nav>', '<h1>Story</h1>', '<button type="button">Read more</button>', '<wow-image data-hook="hero">', '<img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high">', '<svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark">', '<path d="M0 0L10 10" stroke="#000"></path>' ) as $fragment ) {
 		$assert( str_contains( $layout_output, $fragment ), 'layout-renderer-preserves-' . $fragment );
 	}
 

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -414,6 +414,7 @@ $typed_renderer = $payload;
 unset( $typed_renderer['blocks'][0]['render'] );
 $typed_renderer['blocks'][0]['renderer'] = 'static-site-importer/responsive-media/v1';
 $typed_renderer['blocks'][0]['block_json']['attributes']['content']['type'] = 'string';
+$typed_renderer['blocks'][0]['block_json']['attributes']['kind'] = array( 'type' => 'string', 'default' => 'media' );
 $assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $typed_renderer ), 'known-typed-renderer-validates' );
 $unknown_renderer = $typed_renderer;
 $unknown_renderer['blocks'][0]['renderer'] = 'producer/arbitrary/v1';
@@ -424,6 +425,9 @@ $assert( 'static_site_importer_companion_plugin_renderer_conflict' === Static_Si
 $invalid_renderer_attributes = $typed_renderer;
 $invalid_renderer_attributes['blocks'][0]['block_json']['attributes']['content']['type'] = 'object';
 $assert( 'static_site_importer_companion_plugin_renderer_attributes_invalid' === Static_Site_Importer_Companion_Plugin::validate_payload( $invalid_renderer_attributes )->get_error_code(), 'typed-renderer-requires-declared-string-content' );
+$layout_renderer = $typed_renderer;
+$layout_renderer['blocks'][0]['block_json']['name'] = 'example/responsive-layout';
+$assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $layout_renderer ), 'known-layout-renderer-validates' );
 $malformed_dependencies = $payload;
 $malformed_dependencies['blocks'][0]['script_dependencies'] = array( array( 'wp-blocks' ) );
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $malformed_dependencies ) ), 'script-dependency-map-must-be-an-object' );
@@ -500,6 +504,82 @@ if ( is_array( $descriptor ) ) {
 	$assert( 1 === count( $island_files ), 'preserved-island-js-file-emitted' );
 }
 
+// The layout renderer preserves safe semantic content while its media sibling
+// remains restricted to media-only markup.
+$layout_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $layout_renderer );
+$assert( is_array( $layout_descriptor ), 'layout-renderer-scaffold-returns-descriptor' );
+if ( is_array( $layout_descriptor ) ) {
+	$layout_render = $layout_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
+	$assert( str_contains( $layout_render, 'Generated responsive-media layout mode companion block render' ) && ! str_contains( $layout_render, 'responsive-layout/v1' ), 'layout-mode-uses-released-renderer-template' );
+	$attributes = array( 'kind' => 'layout', 'content' => '<main class="story"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async"><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
+	ob_start();
+	eval( '?>' . $layout_render );
+	$layout_output = (string) ob_get_clean();
+	foreach ( array( '<main class="story">', '<nav>', '<h1>Story</h1>', '<button type="button">Read more</button>', '<img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async">', '<svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark">', '<path d="M0 0L10 10" stroke="#000"></path>' ) as $fragment ) {
+		$assert( str_contains( $layout_output, $fragment ), 'layout-renderer-preserves-' . $fragment );
+	}
+
+	// The producer admits these globals on every SVG element. Verify the rendered
+	// DOM, including local IDs and arbitrary aria-* names, rather than PHP text.
+	$svg_globals = array( 'class' => 'ssi-%s', 'id' => 'node-%s', 'role' => 'img', 'title' => 'title-%s', 'aria-label' => 'label-%s', 'aria-roledescription' => 'graphic-%s' );
+	$svg_shapes  = array(
+		'svg' => array( 'viewbox' => '0 0 10 10' ),
+		'g' => array( 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2', 'transform' => 'translate(1 2)' ),
+		'path' => array( 'd' => 'M0 0', 'fill' => 'url(#node-lineargradient)', 'stroke' => 'blue', 'stroke-width' => '2', 'stroke-linecap' => 'round', 'stroke-linejoin' => 'bevel' ),
+		'circle' => array( 'cx' => '1', 'cy' => '2', 'r' => '3', 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2' ),
+		'ellipse' => array( 'cx' => '1', 'cy' => '2', 'rx' => '3', 'ry' => '4', 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2' ),
+		'line' => array( 'x1' => '1', 'x2' => '2', 'y1' => '3', 'y2' => '4', 'stroke' => 'blue', 'stroke-width' => '2', 'stroke-linecap' => 'round' ),
+		'polyline' => array( 'points' => '0,0 1,1', 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2', 'stroke-linecap' => 'round', 'stroke-linejoin' => 'bevel' ),
+		'polygon' => array( 'points' => '0,0 1,1 2,0', 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2', 'stroke-linecap' => 'round', 'stroke-linejoin' => 'bevel' ),
+		'rect' => array( 'x' => '1', 'y' => '2', 'width' => '3', 'height' => '4', 'rx' => '1', 'ry' => '2', 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2' ),
+		'defs' => array(),
+		'lineargradient' => array( 'gradientunits' => 'userSpaceOnUse', 'x1' => '0', 'x2' => '1', 'y1' => '0', 'y2' => '1' ),
+		'radialgradient' => array( 'cx' => '1', 'cy' => '2', 'r' => '3' ),
+		'stop' => array( 'offset' => '0', 'stop-color' => '#fff', 'stop-opacity' => '0.5' ),
+	);
+	$svg_attributes = static function ( string $tag, array $attributes ) use ( $svg_globals ): string {
+		$rendered = array();
+		foreach ( array_merge( $svg_globals, $attributes ) as $name => $value ) {
+			$rendered[] = $name . '="' . sprintf( $value, $tag ) . '"';
+		}
+		return implode( ' ', $rendered );
+	};
+	$svg_content = '<svg ' . $svg_attributes( 'svg', $svg_shapes['svg'] ) . '>';
+	$svg_content .= '<defs ' . $svg_attributes( 'defs', $svg_shapes['defs'] ) . '><linearGradient ' . $svg_attributes( 'lineargradient', $svg_shapes['lineargradient'] ) . '><stop ' . $svg_attributes( 'stop', $svg_shapes['stop'] ) . '></stop></linearGradient><radialGradient ' . $svg_attributes( 'radialgradient', $svg_shapes['radialgradient'] ) . '></radialGradient></defs>';
+	foreach ( array( 'g', 'path', 'circle', 'ellipse', 'line', 'polyline', 'polygon', 'rect' ) as $tag ) {
+		$svg_content .= '<' . $tag . ' ' . $svg_attributes( $tag, $svg_shapes[ $tag ] ) . '></' . $tag . '>';
+	}
+	$svg_content .= '</svg>';
+	$attributes = array( 'kind' => 'layout', 'content' => $svg_content );
+	ob_start();
+	eval( '?>' . $layout_render );
+	$svg_output = (string) ob_get_clean();
+	$svg_document = new DOMDocument();
+	$previous_libxml_errors = libxml_use_internal_errors( true );
+	$svg_document->loadHTML( '<div>' . $svg_output . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NONET );
+	libxml_clear_errors();
+	libxml_use_internal_errors( $previous_libxml_errors );
+	foreach ( $svg_shapes as $tag => $shape_attributes ) {
+		$element = ( new DOMXPath( $svg_document ) )->query( '//*[@id="node-' . $tag . '"]' )->item( 0 );
+		$expected = array_merge( $svg_globals, $shape_attributes );
+		$assert( $element instanceof DOMElement && count( $element->attributes ) === count( $expected ), 'layout-renderer-retains-exact-svg-attributes-' . $tag );
+		if ( $element instanceof DOMElement ) {
+			foreach ( $expected as $name => $value ) {
+				$assert( sprintf( $value, $tag ) === $element->getAttribute( $name ), 'layout-renderer-retains-svg-' . $tag . '-' . $name );
+			}
+		}
+	}
+	$attributes = array( 'kind' => 'layout', 'content' => '<main onclick="alert(1)" data-wp-interactive="bad" style="background:url(javascript:alert(0))"><script>alert(2)</script><a href="%256a%2561vascript:alert(3)">bad</a><img src="javascript:alert(4)" srcset="safe.jpg 1x, javascript:alert(6) 2x"><audio><source src="song.mp3" type="audio/mpeg"></audio><svg onload="alert(5)"><foreignObject>bad</foreignObject><animate attributeName="x"></animate><defs><linearGradient id="paint"><stop offset="0" stop-color="#fff"></stop></linearGradient></defs><path fill="url(https://evil.test/x.svg#paint)" stroke="url(#paint)" d="M0 0"></path><use href="https://evil.test/icons.svg#icon"></use></svg></main>' );
+	ob_start();
+	eval( '?>' . $layout_render );
+	$unsafe_layout_output = strtolower( (string) ob_get_clean() );
+	foreach ( array( 'onclick', 'data-wp-', '<script', 'javascript:', '%256a', 'onload', 'foreignobject', '<animate', '<use', 'https://evil.test' ) as $fragment ) {
+		$assert( ! str_contains( $unsafe_layout_output, $fragment ), 'layout-renderer-removes-' . $fragment );
+	}
+	$assert( str_contains( $unsafe_layout_output, '<path' ) && str_contains( $unsafe_layout_output, 'd="m0 0"' ), 'layout-renderer-keeps-safe-svg-shapes' );
+	$assert( str_contains( $unsafe_layout_output, '<source src="song.mp3" type="audio/mpeg">' ) && str_contains( $unsafe_layout_output, 'stroke="url(#paint)"' ), 'layout-renderer-keeps-safe-local-media-and-svg-references' );
+}
+
 WP_Block_Type_Registry::$registered[] = 'example/custom-hero';
 $collision_report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $payload );
 $assert( 'failed' === ( $collision_report['status'] ?? '' ) && 'static_site_importer_companion_plugin_block_name_collision' === ( $collision_report['error']['code'] ?? '' ) && 'runtime_block_name_collision' === ( $collision_report['diagnostics'][0]['reason_code'] ?? '' ), 'registered-block-name-collision-fails-with-structured-receipt' );
@@ -563,6 +643,7 @@ if ( is_array( $typed_descriptor ) ) {
 	$assert( str_contains( $typed_render, 'Generated responsive-media companion block render' ) && ! str_contains( $typed_render, 'producer/arbitrary' ), 'typed-renderer-emits-ssi-owned-template' );
 	$assert( ! str_contains( $typed_render, 'Static_Site_Importer_' ) && ! str_contains( $typed_render, 'Automattic\\BlocksEngine' ), 'typed-renderer-is-self-contained-after-import' );
 	$attributes = array(
+		'kind'    => 'media',
 		'content' => '<a data-track="profile" aria-label="Profile" href="/profile" target="_blank" rel="noopener"><picture><source media="(min-width:800px)" srcset="safe.webp 1x, javascript:alert(1) 2x, hero,wide.webp 3x"><img src="data:image/png;base64,aGVsbG8=" srcset="safe.png 1x, %6a%61vascript:alert(1) 2x, data:image/svg+xml;base64,PHN2Zz4= 3x" alt="Profile"></picture></a>',
 	);
 	ob_start();
@@ -575,7 +656,7 @@ if ( is_array( $typed_descriptor ) ) {
 		$assert( ! str_contains( $typed_output, $fragment ), 'typed-renderer-removes-' . $fragment );
 	}
 	foreach ( array( '<script>alert(1)</script>', '<img src=x onerror=alert(1)>', '<a href="data:text/html;base64,PHNjcmlwdD4=">x</a>', '<img srcset=javascript:alert(1)>' ) as $unsafe_content ) {
-		$attributes = array( 'content' => $unsafe_content );
+		$attributes = array( 'kind' => 'media', 'content' => $unsafe_content );
 		ob_start();
 		eval( '?>' . $typed_render );
 		$unsafe_output = strtolower( (string) ob_get_clean() );

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -516,9 +516,10 @@ if ( is_array( $layout_descriptor ) ) {
 	ob_start();
 	eval( '?>' . $layout_render );
 	$layout_output = (string) ob_get_clean();
-	foreach ( array( '<main class="story"', '<nav>', '<h1>Story</h1>', '<button type="button">Read more</button>', '<wow-image data-hook="hero">', '<img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high">', '<svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark">', '<path d="M0 0L10 10" stroke="#000"></path>' ) as $fragment ) {
+	foreach ( array( '<main class="story"', '<nav>', '<h1>Story</h1>', '<button type="button">Read more</button>', '<img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high">', '<svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark">', '<path d="M0 0L10 10" stroke="#000"></path>' ) as $fragment ) {
 		$assert( str_contains( $layout_output, $fragment ), 'layout-renderer-preserves-' . $fragment );
 	}
+	$assert( ! str_contains( $layout_output, '<wow-image' ), 'layout-renderer-unwraps-potentially-active-custom-elements' );
 	$assert( str_contains( $layout_output, 'position:absolute' ) && str_contains( $layout_output, 'width:405px' ) && str_contains( $layout_output, 'height:516.812px' ) && str_contains( $layout_output, 'overflow:hidden' ), 'layout-renderer-preserves-quoted-inline-geometry', $layout_output );
 
 	$busy_bears_contract = json_decode( (string) file_get_contents( __DIR__ . '/fixtures/busy-bears-responsive-layout-contract.json' ), true );
@@ -586,7 +587,7 @@ if ( is_array( $layout_descriptor ) ) {
 			}
 		}
 	}
-	$attributes = array( 'content' => '<main onclick="alert(1)" data-wp-interactive="bad" style="background:url(javascript:alert(0))"><script>alert(2)</script><a href="%256a%2561vascript:alert(3)">bad</a><img src="javascript:alert(4)" srcset="safe.jpg 1x, javascript:alert(6) 2x"><audio><source src="song.mp3" type="audio/mpeg"></audio><svg onload="alert(5)"><foreignObject>bad</foreignObject><animate attributeName="x"></animate><defs><linearGradient id="paint"><stop offset="0" stop-color="#fff"></stop></linearGradient></defs><path fill="url(https://evil.test/x.svg#paint)" stroke="url(#paint)" d="M0 0"></path><use href="https://evil.test/icons.svg#icon"></use></svg></main>' );
+	$attributes = array( 'content' => '<main onclick="alert(1)" data-wp-interactive data-wp-bind=> data-wp-context="bad" style="background:url(javascript:alert(0))"><script>alert(2)</script><a href="%256a%2561vascript:alert(3)">bad</a><img src="javascript:alert(4)" srcset="safe.jpg 1x, javascript:alert(6) 2x"><audio><source src="song.mp3" type="audio/mpeg"></audio><svg onload="alert(5)"><foreignObject>bad</foreignObject><animate attributeName="x"></animate><defs><linearGradient id="paint"><stop offset="0" stop-color="#fff"></stop></linearGradient></defs><path fill="url(https://evil.test/x.svg#paint)" stroke="url(#paint)" d="M0 0"></path><use href="https://evil.test/icons.svg#icon"></use></svg></main>' );
 	ob_start();
 	eval( '?>' . $layout_render );
 	$unsafe_layout_output = strtolower( (string) ob_get_clean() );
@@ -595,6 +596,16 @@ if ( is_array( $layout_descriptor ) ) {
 	}
 	$assert( str_contains( $unsafe_layout_output, '<path' ) && str_contains( $unsafe_layout_output, 'd="m0 0"' ), 'layout-renderer-keeps-safe-svg-shapes' );
 	$assert( str_contains( $unsafe_layout_output, '<source src="song.mp3" type="audio/mpeg">' ) && str_contains( $unsafe_layout_output, 'stroke="url(#paint)"' ), 'layout-renderer-keeps-safe-local-media-and-svg-references' );
+	$attributes = array( 'content' => '<main>Before<svg><path fill="url(https://evil.test/unclosed.svg#paint)" d="M0 0"></path>' );
+	ob_start();
+	eval( '?>' . $layout_render );
+	$malformed_svg_output = strtolower( (string) ob_get_clean() );
+	$assert( str_contains( $malformed_svg_output, '<main>before' ) && ! str_contains( $malformed_svg_output, '<svg' ) && ! str_contains( $malformed_svg_output, 'evil.test' ), 'layout-renderer-rejects-unclosed-svg-before-url-bearing-attributes-are-admitted' );
+	$attributes = array( 'content' => '<main>Before<svg><svg></svg><path fill="url(https://evil.test/nested.svg#paint)" d="M0 0"></path></svg>After</main>' );
+	ob_start();
+	eval( '?>' . $layout_render );
+	$nested_svg_output = strtolower( (string) ob_get_clean() );
+	$assert( str_contains( $nested_svg_output, '<main>beforeafter</main>' ) && ! str_contains( $nested_svg_output, '<svg' ) && ! str_contains( $nested_svg_output, 'evil.test' ), 'layout-renderer-rejects-nested-svg-before-url-bearing-attributes-are-admitted' );
 }
 
 WP_Block_Type_Registry::$registered[] = 'example/custom-hero';

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -511,11 +511,11 @@ $assert( is_array( $layout_descriptor ), 'layout-renderer-scaffold-returns-descr
 if ( is_array( $layout_descriptor ) ) {
 	$layout_render = $layout_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
 	$assert( str_contains( $layout_render, 'Generated responsive-media layout mode companion block render' ) && ! str_contains( $layout_render, 'responsive-layout/v1' ), 'layout-mode-uses-released-renderer-template' );
-	$attributes = array( 'kind' => 'layout', 'content' => '<main class="story"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async"><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
+	$attributes = array( 'kind' => 'layout', 'content' => '<main class="story"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
 	ob_start();
 	eval( '?>' . $layout_render );
 	$layout_output = (string) ob_get_clean();
-	foreach ( array( '<main class="story">', '<nav>', '<h1>Story</h1>', '<button type="button">Read more</button>', '<img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async">', '<svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark">', '<path d="M0 0L10 10" stroke="#000"></path>' ) as $fragment ) {
+	foreach ( array( '<main class="story">', '<nav>', '<h1>Story</h1>', '<button type="button">Read more</button>', '<wow-image data-hook="hero">', '<img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async">', '<svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark">', '<path d="M0 0L10 10" stroke="#000"></path>' ) as $fragment ) {
 		$assert( str_contains( $layout_output, $fragment ), 'layout-renderer-preserves-' . $fragment );
 	}
 

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -426,6 +426,7 @@ $invalid_renderer_attributes = $typed_renderer;
 $invalid_renderer_attributes['blocks'][0]['block_json']['attributes']['content']['type'] = 'object';
 $assert( 'static_site_importer_companion_plugin_renderer_attributes_invalid' === Static_Site_Importer_Companion_Plugin::validate_payload( $invalid_renderer_attributes )->get_error_code(), 'typed-renderer-requires-declared-string-content' );
 $layout_renderer = $typed_renderer;
+$layout_renderer['blocks'][0]['renderer'] = 'static-site-importer/responsive-layout/v1';
 $layout_renderer['blocks'][0]['block_json']['name'] = 'example/responsive-layout';
 $assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $layout_renderer ), 'known-layout-renderer-validates' );
 $malformed_dependencies = $payload;
@@ -510,8 +511,8 @@ $layout_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $layout_re
 $assert( is_array( $layout_descriptor ), 'layout-renderer-scaffold-returns-descriptor' );
 if ( is_array( $layout_descriptor ) ) {
 	$layout_render = $layout_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
-	$assert( str_contains( $layout_render, 'Generated responsive-media layout mode companion block render' ) && ! str_contains( $layout_render, 'responsive-layout/v1' ), 'layout-mode-uses-released-renderer-template' );
-	$attributes = array( 'kind' => 'layout', 'content' => '<main class="story" style="position:absolute;inset:0 auto auto 0;width:405px;height:516.812px;overflow:hidden"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
+	$assert( str_contains( $layout_render, 'Generated responsive-layout companion block render' ) && ! str_contains( $layout_render, 'Generated responsive-media companion block render' ), 'dedicated-layout-renderer-uses-own-template' );
+	$attributes = array( 'content' => '<main class="story" style="position:absolute;inset:0 auto auto 0;width:405px;height:516.812px;overflow:hidden"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
 	ob_start();
 	eval( '?>' . $layout_render );
 	$layout_output = (string) ob_get_clean();
@@ -519,6 +520,21 @@ if ( is_array( $layout_descriptor ) ) {
 		$assert( str_contains( $layout_output, $fragment ), 'layout-renderer-preserves-' . $fragment );
 	}
 	$assert( str_contains( $layout_output, 'position:absolute' ) && str_contains( $layout_output, 'width:405px' ) && str_contains( $layout_output, 'height:516.812px' ) && str_contains( $layout_output, 'overflow:hidden' ), 'layout-renderer-preserves-quoted-inline-geometry', $layout_output );
+
+	$busy_bears_contract = json_decode( (string) file_get_contents( __DIR__ . '/fixtures/busy-bears-responsive-layout-contract.json' ), true );
+	$assert( 'static-site-importer/frozen-responsive-layout-contract/v1' === ( $busy_bears_contract['schema'] ?? '' ) && 2 === count( $busy_bears_contract['pages'] ?? array() ), 'busy-bears-frozen-layout-contract-loads' );
+	$assert( 14069 === ( $busy_bears_contract['pages'][0]['captured_layouts'][0]['bytes'] ?? 0 ) && 'd39d2adaa5550e80d3d997239c4de20c8aadc0f570185f11d24049baa9274ffb' === ( $busy_bears_contract['pages'][0]['captured_layouts'][0]['sha256'] ?? '' ) && 24895 === ( $busy_bears_contract['pages'][1]['captured_layouts'][1]['bytes'] ?? 0 ) && '3b1b2d2cd4c8af7b29b8b9848343dc41235dfb4b8cf6dad4d56661b8a0d5e69e' === ( $busy_bears_contract['pages'][1]['captured_layouts'][1]['sha256'] ?? '' ), 'busy-bears-contract-pins-captured-layout-identities' );
+	foreach ( $busy_bears_contract['pages'] ?? array() as $page ) {
+		$attributes = array( 'content' => (string) ( $page['content'] ?? '' ) );
+		ob_start();
+		eval( '?>' . $layout_render );
+		$page_output = (string) ob_get_clean();
+		foreach ( $page['expected_text'] ?? array() as $expected_text ) {
+			$assert( str_contains( $page_output, $expected_text ), 'busy-bears-layout-renders-' . (string) $page['path'] . '-' . $expected_text, $page_output );
+		}
+		$assert( str_contains( $page_output, '<form' ) && str_contains( $page_output, '<label' ) && str_contains( $page_output, '<input' ) && str_contains( $page_output, '<textarea' ) && str_contains( $page_output, '<svg' ), 'busy-bears-layout-renders-controls-and-svg-' . (string) $page['path'], $page_output );
+		$assert( preg_match( '/min-height:([1-9][0-9]*(?:\.[0-9]+)?)px/', $page_output ) === 1, 'busy-bears-layout-retains-nonzero-height-' . (string) $page['path'], $page_output );
+	}
 
 	// The producer admits these globals on every SVG element. Verify the rendered
 	// DOM, including local IDs and arbitrary aria-* names, rather than PHP text.
@@ -551,7 +567,7 @@ if ( is_array( $layout_descriptor ) ) {
 		$svg_content .= '<' . $tag . ' ' . $svg_attributes( $tag, $svg_shapes[ $tag ] ) . '></' . $tag . '>';
 	}
 	$svg_content .= '</svg>';
-	$attributes = array( 'kind' => 'layout', 'content' => $svg_content );
+	$attributes = array( 'content' => $svg_content );
 	ob_start();
 	eval( '?>' . $layout_render );
 	$svg_output = (string) ob_get_clean();
@@ -570,7 +586,7 @@ if ( is_array( $layout_descriptor ) ) {
 			}
 		}
 	}
-	$attributes = array( 'kind' => 'layout', 'content' => '<main onclick="alert(1)" data-wp-interactive="bad" style="background:url(javascript:alert(0))"><script>alert(2)</script><a href="%256a%2561vascript:alert(3)">bad</a><img src="javascript:alert(4)" srcset="safe.jpg 1x, javascript:alert(6) 2x"><audio><source src="song.mp3" type="audio/mpeg"></audio><svg onload="alert(5)"><foreignObject>bad</foreignObject><animate attributeName="x"></animate><defs><linearGradient id="paint"><stop offset="0" stop-color="#fff"></stop></linearGradient></defs><path fill="url(https://evil.test/x.svg#paint)" stroke="url(#paint)" d="M0 0"></path><use href="https://evil.test/icons.svg#icon"></use></svg></main>' );
+	$attributes = array( 'content' => '<main onclick="alert(1)" data-wp-interactive="bad" style="background:url(javascript:alert(0))"><script>alert(2)</script><a href="%256a%2561vascript:alert(3)">bad</a><img src="javascript:alert(4)" srcset="safe.jpg 1x, javascript:alert(6) 2x"><audio><source src="song.mp3" type="audio/mpeg"></audio><svg onload="alert(5)"><foreignObject>bad</foreignObject><animate attributeName="x"></animate><defs><linearGradient id="paint"><stop offset="0" stop-color="#fff"></stop></linearGradient></defs><path fill="url(https://evil.test/x.svg#paint)" stroke="url(#paint)" d="M0 0"></path><use href="https://evil.test/icons.svg#icon"></use></svg></main>' );
 	ob_start();
 	eval( '?>' . $layout_render );
 	$unsafe_layout_output = strtolower( (string) ob_get_clean() );

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -511,13 +511,14 @@ $assert( is_array( $layout_descriptor ), 'layout-renderer-scaffold-returns-descr
 if ( is_array( $layout_descriptor ) ) {
 	$layout_render = $layout_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
 	$assert( str_contains( $layout_render, 'Generated responsive-media layout mode companion block render' ) && ! str_contains( $layout_render, 'responsive-layout/v1' ), 'layout-mode-uses-released-renderer-template' );
-	$attributes = array( 'kind' => 'layout', 'content' => '<main class="story"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
+	$attributes = array( 'kind' => 'layout', 'content' => '<main class="story" style="position:absolute;inset:0 auto auto 0;width:405px;height:516.812px;overflow:hidden"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
 	ob_start();
 	eval( '?>' . $layout_render );
 	$layout_output = (string) ob_get_clean();
-	foreach ( array( '<main class="story">', '<nav>', '<h1>Story</h1>', '<button type="button">Read more</button>', '<wow-image data-hook="hero">', '<img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high">', '<svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark">', '<path d="M0 0L10 10" stroke="#000"></path>' ) as $fragment ) {
+	foreach ( array( '<main class="story"', '<nav>', '<h1>Story</h1>', '<button type="button">Read more</button>', '<wow-image data-hook="hero">', '<img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high">', '<svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark">', '<path d="M0 0L10 10" stroke="#000"></path>' ) as $fragment ) {
 		$assert( str_contains( $layout_output, $fragment ), 'layout-renderer-preserves-' . $fragment );
 	}
+	$assert( str_contains( $layout_output, 'position:absolute' ) && str_contains( $layout_output, 'width:405px' ) && str_contains( $layout_output, 'height:516.812px' ) && str_contains( $layout_output, 'overflow:hidden' ), 'layout-renderer-preserves-quoted-inline-geometry', $layout_output );
 
 	// The producer admits these globals on every SVG element. Verify the rendered
 	// DOM, including local IDs and arbitrary aria-* names, rather than PHP text.

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -30,6 +30,7 @@ $GLOBALS['ssi_companion_deactivated'] = array();
 $GLOBALS['ssi_companion_options']     = array();
 $GLOBALS['static_site_importer_companion_block_owners'] = array();
 $GLOBALS['ssi_companion_actions']     = array();
+$GLOBALS['ssi_companion_filters']     = array();
 
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
@@ -73,6 +74,13 @@ if ( ! class_exists( 'WP_Block_Type' ) ) {
 if ( ! function_exists( 'is_wp_error' ) ) {
 	function is_wp_error( mixed $thing ): bool {
 		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, mixed $value ): mixed {
+		$filter = $GLOBALS['ssi_companion_filters'][ $hook ] ?? null;
+		return is_callable( $filter ) ? $filter( $value ) : $value;
 	}
 }
 
@@ -412,13 +420,30 @@ $php_render['blocks'][0]['render'] = '<?php system( "id" );';
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $php_render ) ), 'php-render-template-rejected' );
 $typed_renderer = $payload;
 unset( $typed_renderer['blocks'][0]['render'] );
-$typed_renderer['blocks'][0]['renderer'] = 'static-site-importer/responsive-media/v1';
+$typed_renderer['blocks'][0]['renderer'] = 'blocks-engine/responsive-media/v1';
 $typed_renderer['blocks'][0]['block_json']['attributes']['content']['type'] = 'string';
 $typed_renderer['blocks'][0]['block_json']['attributes']['kind'] = array( 'type' => 'string', 'default' => 'media' );
 $assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $typed_renderer ), 'known-typed-renderer-validates' );
 $unknown_renderer = $typed_renderer;
 $unknown_renderer['blocks'][0]['renderer'] = 'producer/arbitrary/v1';
 $assert( 'static_site_importer_companion_plugin_renderer_invalid' === Static_Site_Importer_Companion_Plugin::validate_payload( $unknown_renderer )->get_error_code(), 'unknown-typed-renderer-rejected' );
+$GLOBALS['ssi_companion_filters']['static_site_importer_companion_renderers'] = static function ( array $renderers ): array {
+	$renderers['producer/custom/v1'] = '<?php echo esc_html( (string) ( $attributes["content"] ?? "" ) );';
+	return $renderers;
+};
+$custom_renderer = $typed_renderer;
+$custom_renderer['blocks'][0]['renderer'] = 'producer/custom/v1';
+$assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $custom_renderer ), 'registered-producer-renderer-validates' );
+$custom_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $custom_renderer );
+$assert( is_array( $custom_descriptor ) && str_contains( (string) ( $custom_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '' ), 'esc_html' ), 'registered-producer-renderer-materializes' );
+$GLOBALS['ssi_companion_filters']['static_site_importer_companion_renderers'] = static function ( array $renderers ): array {
+	$renderers['producer/malformed/v1'] = 'not a PHP render template';
+	return $renderers;
+};
+$malformed_renderer = $typed_renderer;
+$malformed_renderer['blocks'][0]['renderer'] = 'producer/malformed/v1';
+$assert( 'static_site_importer_companion_plugin_renderer_invalid' === Static_Site_Importer_Companion_Plugin::validate_payload( $malformed_renderer )->get_error_code(), 'malformed-registered-renderer-rejected' );
+unset( $GLOBALS['ssi_companion_filters']['static_site_importer_companion_renderers'] );
 $renderer_conflict = $typed_renderer;
 $renderer_conflict['blocks'][0]['render'] = '<div>conflict</div>';
 $assert( 'static_site_importer_companion_plugin_renderer_conflict' === Static_Site_Importer_Companion_Plugin::validate_payload( $renderer_conflict )->get_error_code(), 'typed-renderer-and-markup-conflict-rejected' );
@@ -426,7 +451,7 @@ $invalid_renderer_attributes = $typed_renderer;
 $invalid_renderer_attributes['blocks'][0]['block_json']['attributes']['content']['type'] = 'object';
 $assert( 'static_site_importer_companion_plugin_renderer_attributes_invalid' === Static_Site_Importer_Companion_Plugin::validate_payload( $invalid_renderer_attributes )->get_error_code(), 'typed-renderer-requires-declared-string-content' );
 $layout_renderer = $typed_renderer;
-$layout_renderer['blocks'][0]['renderer'] = 'static-site-importer/responsive-layout/v1';
+$layout_renderer['blocks'][0]['renderer'] = 'blocks-engine/responsive-layout/v1';
 $layout_renderer['blocks'][0]['block_json']['name'] = 'example/responsive-layout';
 $assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $layout_renderer ), 'known-layout-renderer-validates' );
 $malformed_dependencies = $payload;

--- a/tests/smoke-post-meta-rollback.php
+++ b/tests/smoke-post-meta-rollback.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Producer reconciliation metadata rollback coverage.
+ *
+ * @package StaticSiteImporter
+ */
+
+define( 'ARRAY_A', 'ARRAY_A' );
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+
+$GLOBALS['ssi_rollback_posts'] = array(
+	1 => array( 'ID' => 1, 'post_title' => 'Without producer identity' ),
+	2 => array( 'ID' => 2, 'post_title' => 'With producer identity' ),
+);
+$GLOBALS['ssi_rollback_meta'] = array(
+	1 => array(
+		'_static_site_importer_provenance'              => 'provenance-1',
+		'_static_site_importer_reconciliation_identity' => 'importer-1',
+	),
+	2 => array(
+		'_static_site_importer_provenance'              => 'provenance-2',
+		'_static_site_importer_reconciliation_identity' => 'importer-2',
+		'_blocks_engine_reconciliation_identity'        => 'producer-before',
+	),
+);
+
+function get_post( int $id, string $output ): ?array {
+	unset( $output );
+	return $GLOBALS['ssi_rollback_posts'][ $id ] ?? null;
+}
+function get_post_meta( int $id, string $key, bool $single ): string {
+	unset( $single );
+	return (string) ( $GLOBALS['ssi_rollback_meta'][ $id ][ $key ] ?? '' );
+}
+function metadata_exists( string $meta_type, int $id, string $key ): bool {
+	return 'post' === $meta_type && array_key_exists( $key, $GLOBALS['ssi_rollback_meta'][ $id ] ?? array() );
+}
+function wp_update_post( array $post ): int {
+	$GLOBALS['ssi_rollback_posts'][ $post['ID'] ] = $post;
+	return (int) $post['ID'];
+}
+function update_post_meta( int $id, string $key, string $value ): void {
+	$GLOBALS['ssi_rollback_meta'][ $id ][ $key ] = $value;
+}
+function delete_post_meta( int $id, string $key ): void {
+	unset( $GLOBALS['ssi_rollback_meta'][ $id ][ $key ] );
+}
+
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-wordpress-site-plan-materializer.php';
+
+$receipt = array( 'transaction' => (object) array( 'state' => array( 'rollback' => array( 'posts' => array() ) ) ) );
+Static_Site_Importer_WordPress_Site_Plan_Materializer::journal_receipt_post( $receipt, 1 );
+Static_Site_Importer_WordPress_Site_Plan_Materializer::journal_receipt_post( $receipt, 2 );
+
+$state = $receipt['transaction']->state;
+if ( true === $state['rollback']['posts'][1]['producer_reconciliation_identity_exists'] || true !== $state['rollback']['posts'][2]['producer_reconciliation_identity_exists'] ) {
+	throw new RuntimeException( 'producer metadata existence was not journaled' );
+}
+
+$GLOBALS['ssi_rollback_meta'][1]['_blocks_engine_reconciliation_identity'] = 'producer-new-1';
+$GLOBALS['ssi_rollback_meta'][2]['_blocks_engine_reconciliation_identity'] = 'producer-new-2';
+$state['applied']['posts'] = array( array( 'id' => 1 ), array( 'id' => 2 ) );
+$rollback = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'rollback' );
+$rollback->invokeArgs( null, array( &$state ) );
+
+if ( array_key_exists( '_blocks_engine_reconciliation_identity', $GLOBALS['ssi_rollback_meta'][1] ) ) {
+	throw new RuntimeException( 'rollback created producer metadata that did not previously exist' );
+}
+if ( 'producer-before' !== $GLOBALS['ssi_rollback_meta'][2]['_blocks_engine_reconciliation_identity'] ) {
+	throw new RuntimeException( 'rollback did not restore existing producer metadata' );
+}
+
+echo "Post metadata rollback smoke passed.\n";

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -318,6 +318,7 @@ $assert = static function ( bool $condition, string $message ): void {
 };
 
 $theme_generator_source = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php' );
+$materializer_source    = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-wordpress-site-plan-materializer.php' );
 $assert( false === strpos( (string) $theme_generator_source, 'function import_compiled_website_artifact' ), 'canonical import has no legacy compiled-artifact execution path' );
 
 $artifact = array(
@@ -592,6 +593,9 @@ $prepared_for_admission = Static_Site_Importer_WordPress_Site_Plan_Materializer:
 );
 $admitted_prepared      = Static_Site_Importer_WordPress_Site_Plan_Materializer::admit_prepared( $prepared_for_admission );
 $assert( 'prepared' === ( $prepared_for_admission['status'] ?? '' ) && ! empty( $prepared_for_admission['payload_references_admitted'] ) && $prepared_for_admission === $admitted_prepared && ! str_contains( (string) wp_json_encode( $prepared_for_admission['plan'] ), 'payload_references_admitted' ) && ! str_contains( (string) wp_json_encode( Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize_prepared( $prepared_for_admission ) ), 'payload_references_admitted' ), 'materializer lifecycle preparation admits referenced payloads once, before lifecycle work, without adding transient state to plans or receipts' );
+$materializer_companion_assets = strpos( (string) $materializer_source, 'resolve_companion_asset_references( $payload' );
+$materializer_companion        = strpos( (string) $materializer_source, '::materialize_companion_dependency( $dependency', $materializer_companion_assets + 1 );
+$assert( false !== $materializer_companion_assets && $materializer_companion_assets < $materializer_companion, 'materializer resolves generated companion assets before companion dependency materialization' );
 $rollback_order     = array();
 $block_lifecycle    = array(
 	'dependencies' => array(),
@@ -2889,6 +2893,7 @@ $root_media_page_id = (int) ( $root_media_receipt['completed']['pages']['website
 $root_media_content = stripslashes( (string) ( $GLOBALS['ssi_plan_posts'][ $root_media_page_id ]['post_content'] ?? '' ) );
 $root_media_url     = 'https://example.test/wp-content/themes/root-media-plan/assets/website/media/example.jpg';
 $assert( 'completed' === $root_media_receipt['status'] && 4 === substr_count( $root_media_content, $root_media_url ) && str_contains( $root_media_content, '"url":"' . $root_media_url . '"' ) && str_contains( $root_media_content, 'blocks-engine-background-image' ) && ! str_contains( $root_media_content, '/media/example.jpg?' ), 'root-relative captured media resolves through the canonical theme asset map for image and background-image blocks' );
+$assert( ( $root_media_plan['pages'][0]['reconciliation_identity'] ?? '' ) === ( $GLOBALS['ssi_plan_meta'][ $root_media_page_id ]['_blocks_engine_reconciliation_identity'] ?? '' ), 'materialized posts expose the producer reconciliation identity required by scoped theme bootstrap assets' );
 
 $resolved_root_media_plan = ( new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver() )->resolve(
 	$root_media_plan,

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -2899,14 +2899,17 @@ $root_media_url     = 'https://example.test/wp-content/themes/root-media-plan/as
 $assert( 'completed' === $root_media_receipt['status'] && 4 === substr_count( $root_media_content, $root_media_url ) && str_contains( $root_media_content, '"url":"' . $root_media_url . '"' ) && str_contains( $root_media_content, 'blocks-engine-background-image' ) && ! str_contains( $root_media_content, '/media/example.jpg?' ), 'root-relative captured media resolves through the canonical theme asset map for image and background-image blocks' );
 $assert( ( $root_media_plan['pages'][0]['reconciliation_identity'] ?? '' ) === ( $GLOBALS['ssi_plan_meta'][ $root_media_page_id ]['_blocks_engine_reconciliation_identity'] ?? '' ), 'materialized posts expose the producer reconciliation identity required by scoped theme bootstrap assets' );
 unset( $GLOBALS['ssi_plan_meta'][ $root_media_page_id ]['_blocks_engine_reconciliation_identity'] );
+$assert( wp_delete_file( (string) $root_media_receipt['theme']['dir'] . '/style.css' ), 'rollback fixture removes one generated target to force overwrite materialization' );
 $root_media_rollback = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
 	$root_media_plan,
 	array(
 		'slug'                           => 'root-media-plan',
+		'overwrite'                      => true,
 		'inject_materialization_failure' => 'theme_write_short',
 	)
 );
-$assert( 'partial' === $root_media_rollback['status'] && ! array_key_exists( '_blocks_engine_reconciliation_identity', $GLOBALS['ssi_plan_meta'][ $root_media_page_id ] ?? array() ), 'failed re-import restores the absence of producer reconciliation metadata on an existing post' );
+$assert( 'partial' === $root_media_rollback['status'], 'injected theme write failure produces a partial re-import receipt' );
+$assert( ! array_key_exists( '_blocks_engine_reconciliation_identity', $GLOBALS['ssi_plan_meta'][ $root_media_page_id ] ?? array() ), 'failed re-import restores the absence of producer reconciliation metadata on an existing post' );
 
 $resolved_root_media_plan = ( new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver() )->resolve(
 	$root_media_plan,

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -155,6 +155,10 @@ function update_post_meta( int $id, string $key, string $value ): void {
 	$GLOBALS['ssi_plan_meta'][ $id ][ $key ] = $value; }
 function get_post_meta( int $id, string $key, bool $single = true ): string {
 	return (string) ( $GLOBALS['ssi_plan_meta'][ $id ][ $key ] ?? '' ); }
+function metadata_exists( string $meta_type, int $id, string $key ): bool {
+	return 'post' === $meta_type && array_key_exists( $key, $GLOBALS['ssi_plan_meta'][ $id ] ?? array() ); }
+function delete_post_meta( int $id, string $key ): void {
+	unset( $GLOBALS['ssi_plan_meta'][ $id ][ $key ] ); }
 function get_posts( array $args ): array {
 	foreach ( $GLOBALS['ssi_plan_meta'] as $id => $meta ) {
 		if ( isset( $meta[ $args['meta_key'] ] ) && ( ! isset( $args['meta_value'] ) || $meta[ $args['meta_key'] ] === $args['meta_value'] ) ) {
@@ -2894,6 +2898,15 @@ $root_media_content = stripslashes( (string) ( $GLOBALS['ssi_plan_posts'][ $root
 $root_media_url     = 'https://example.test/wp-content/themes/root-media-plan/assets/website/media/example.jpg';
 $assert( 'completed' === $root_media_receipt['status'] && 4 === substr_count( $root_media_content, $root_media_url ) && str_contains( $root_media_content, '"url":"' . $root_media_url . '"' ) && str_contains( $root_media_content, 'blocks-engine-background-image' ) && ! str_contains( $root_media_content, '/media/example.jpg?' ), 'root-relative captured media resolves through the canonical theme asset map for image and background-image blocks' );
 $assert( ( $root_media_plan['pages'][0]['reconciliation_identity'] ?? '' ) === ( $GLOBALS['ssi_plan_meta'][ $root_media_page_id ]['_blocks_engine_reconciliation_identity'] ?? '' ), 'materialized posts expose the producer reconciliation identity required by scoped theme bootstrap assets' );
+unset( $GLOBALS['ssi_plan_meta'][ $root_media_page_id ]['_blocks_engine_reconciliation_identity'] );
+$root_media_rollback = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$root_media_plan,
+	array(
+		'slug'                           => 'root-media-plan',
+		'inject_materialization_failure' => 'theme_write_short',
+	)
+);
+$assert( 'partial' === $root_media_rollback['status'] && ! array_key_exists( '_blocks_engine_reconciliation_identity', $GLOBALS['ssi_plan_meta'][ $root_media_page_id ] ?? array() ), 'failed re-import restores the absence of producer reconciliation metadata on an existing post' );
 
 $resolved_root_media_plan = ( new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver() )->resolve(
 	$root_media_plan,

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -2890,4 +2890,18 @@ $root_media_content = stripslashes( (string) ( $GLOBALS['ssi_plan_posts'][ $root
 $root_media_url     = 'https://example.test/wp-content/themes/root-media-plan/assets/website/media/example.jpg';
 $assert( 'completed' === $root_media_receipt['status'] && 4 === substr_count( $root_media_content, $root_media_url ) && str_contains( $root_media_content, '"url":"' . $root_media_url . '"' ) && str_contains( $root_media_content, 'blocks-engine-background-image' ) && ! str_contains( $root_media_content, '/media/example.jpg?' ), 'root-relative captured media resolves through the canonical theme asset map for image and background-image blocks' );
 
+$resolved_root_media_plan = ( new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver() )->resolve(
+	$root_media_plan,
+	array( 'theme_uri' => 'https://example.test/wp-content/themes/root-media-plan', 'runtime_capabilities' => array( 'asset_materialization' ) )
+);
+$resolve_companion_assets = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'resolve_companion_asset_references' );
+$resolved_companion       = $resolve_companion_assets->invoke(
+	null,
+	array( 'blocks' => array( array( 'render' => '<img src="/media/example.jpg"><source srcset="/media/example.jpg 1x">' ) ) ),
+	$root_media_plan,
+	$resolved_root_media_plan
+);
+$resolved_companion_html = (string) ( $resolved_companion['blocks'][0]['render'] ?? '' );
+$assert( str_contains( $resolved_companion_html, 'src="' . $root_media_url . '"' ) && str_contains( $resolved_companion_html, 'srcset="' . $root_media_url . ' 1x"' ) && ! str_contains( $resolved_companion_html, '="/media/example.jpg' ), 'generated companion block renders resolve canonical root-relative assets through the materialized theme map' );
+
 echo "WordPress site plan materializer smoke passed.\n";

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -94,7 +94,7 @@ test('pins an immutable WP Codebox release package, commit, and checksum togethe
   assert.match(workflow, /sha256sum --check --status/);
   assert.doesNotMatch(workflow, /Checkout WP Codebox candidate|npm pack --pack-destination|wp-codebox-sha:/);
   assert.match(workflow, /wpCodeboxSha:process\.env\.WP_CODEBOX_SHA/);
-  assert.match(caller, /blocks-engine-sha: c47e806f9e758528b6d19cfda0bd3c20d46a6309/);
+  assert.match(caller, /blocks-engine-sha: ae9716efb388ffa338ed0aa6d1b423f6eca3082c/);
   assert.doesNotMatch(caller, /wp-codebox-sha:/);
 });
 


### PR DESCRIPTION
## Summary

- consume the producer-owned `blocks-engine/wordpress-companion-plugin/v1` contract
- map generic responsive media/layout capabilities through a fail-closed, filterable WordPress renderer registry
- preserve bounded semantic HTML, responsive media, safe SVG presentation, and required runtime assets
- restore producer metadata exactly during materialization rollback

Closes #1255

Producer: Automattic/blocks-engine#1191

## Verification

- `php tests/smoke-companion-plugin.php` (338 assertions)
- `php tests/smoke-post-meta-rollback.php`

## AI assistance

OpenCode with OpenAI `gpt-5.6-sol` traced Puffin materialization failures and the producer/consumer ownership leak, migrated SSI to producer-owned contracts, added registry validation, and reran companion-renderer and rollback coverage. Chris Huber directed the architecture and remains responsible for the change.