### PR TITLE
Require PHP 8.2 and test through PHP 8.5

### DIFF
--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -120,11 +120,13 @@ $large_artifact = array();
 for ( $index = 0; $index < 96; ++$index ) {
 	$large_artifact[ 'file-' . $index ] = array( 'content' => $large_chunk );
 }
-memory_reset_peak_usage();
-$memory_before = memory_get_usage( true );
+if ( function_exists( 'memory_reset_peak_usage' ) ) {
+	memory_reset_peak_usage();
+}
+$memory_peak_before = memory_get_peak_usage( true );
 $large_identity = $hash_json->invoke( null, $large_artifact, false );
 $large_checkpoint = $primitive_workspace->publish_json_once( 'large.json', $large_artifact );
-$identity_peak_delta = memory_get_peak_usage( true ) - $memory_before;
+$identity_peak_delta = memory_get_peak_usage( true ) - $memory_peak_before;
 $assert( preg_match( '/^[a-f0-9]{64}$/', $large_identity ) && ! is_wp_error( $large_checkpoint ) && $identity_peak_delta < 16 * 1024 * 1024, 'streamed identity and checkpoint publication must not allocate the logical 96 MB artifact as one JSON string' );
 unset( $large_artifact, $large_chunk );
 $assert( ! is_wp_error( $primitive_workspace->publish_raw_once( 'immutable.json', '{"value":1}' ) ), 'immutable checkpoint publication must succeed once' );


### PR DESCRIPTION
## Summary

- raise Static Site Importer's declared PHP floor from 8.1 to 8.2 in Composer and WordPress plugin metadata
- move CI coverage from PHP 8.1-8.4 to PHP 8.2-8.5
- pin solved-site promotion to PHP 8.2.33
- update runtime and CI documentation

This intentionally drops PHP 8.1, which reached end of life. The matching Blocks Engine producer change is being published separately.

## Verification

- `composer validate --strict`
- `php tests/smoke-direct-artifact-import.php`
- PHPCS with the WordPress ruleset and `testVersion 8.2-`
- `npm test`: 63 selected PHP/Node tests and 279 fixture-matrix tests passed
- CI covers PHP 8.2, 8.3, 8.4, and 8.5

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode audited the declared runtime contract, updated Composer/plugin/workflow/documentation surfaces, regenerated lock metadata, and ran verification. Chris Huber selected the PHP 8.2 support floor and remains responsible.