### PR TITLE
Require PHP 8.2 and test through PHP 8.5

### DIFF
--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 90
     env:
       NODE_VERSION: '20.19.4'
-      PHP_VERSION: '8.1.34'
+      PHP_VERSION: '8.2.33'
       HOMEBOY_VERSION: v0.298.1
       HOMEBOY_SHA256: 543a1eb7348a9dcde3bee671dbbeaabb9486781d350792bed8a77424fdad60d5
       HOMEBOY_EXTENSIONS_REF: 615fe3632d0cd30e9a70d5aea82be80460d733d5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ When a generated artifact contains full-document HTML, Static Site Importer rout
 ## Requirements
 
 - WordPress 6.6 or later.
-- PHP 8.1 or later.
+- PHP 8.2 or later.
 - Composer dependencies installed with `composer install`.
 - Node dependencies installed only when running the JavaScript block-validation smoke tests.
 
@@ -462,7 +462,7 @@ The `wordpress-is-dead` smoke verifies the multi-page fixture, generated block-t
 homeboy test static-site-importer --path /path/to/static-site-importer
 ```
 
-The GitHub workflow runs `Extra-Chill/homeboy-action@v2` with the `test` command across PHP 8.1, 8.2, 8.3, and 8.4.
+The GitHub workflow runs `Extra-Chill/homeboy-action@v2` with the `test` command across PHP 8.2, 8.3, 8.4, and 8.5.
 
 ### JavaScript Block Validation
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     }
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
     "automattic/blocks-engine-php-transformer": "0.6.2"
   },
@@ -50,7 +50,7 @@
   "prefer-stable": true,
   "config": {
     "platform": {
-      "php": "8.1.0"
+      "php": "8.2.0"
     },
     "sort-packages": true
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a599f78dda38c3d8d8052e9bced14908",
+    "content-hash": "06b853cb48a3aa2bc982cf99ac79ebbc",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -815,11 +815,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1.0"
+        "php": "8.2.0"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -5,7 +5,7 @@
  * Version: 1.7.0
  * Author: Chris Huber
  * Requires at least: 6.9
- * Requires PHP: 8.1
+ * Requires PHP: 8.2
  * Text Domain: static-site-importer
  *
  * @package StaticSiteImporter

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -120,13 +120,11 @@ $large_artifact = array();
 for ( $index = 0; $index < 96; ++$index ) {
 	$large_artifact[ 'file-' . $index ] = array( 'content' => $large_chunk );
 }
-if ( function_exists( 'memory_reset_peak_usage' ) ) {
-	memory_reset_peak_usage();
-}
-$memory_peak_before = memory_get_peak_usage( true );
+memory_reset_peak_usage();
+$memory_before = memory_get_usage( true );
 $large_identity = $hash_json->invoke( null, $large_artifact, false );
 $large_checkpoint = $primitive_workspace->publish_json_once( 'large.json', $large_artifact );
-$identity_peak_delta = memory_get_peak_usage( true ) - $memory_peak_before;
+$identity_peak_delta = memory_get_peak_usage( true ) - $memory_before;
 $assert( preg_match( '/^[a-f0-9]{64}$/', $large_identity ) && ! is_wp_error( $large_checkpoint ) && $identity_peak_delta < 16 * 1024 * 1024, 'streamed identity and checkpoint publication must not allocate the logical 96 MB artifact as one JSON string' );
 unset( $large_artifact, $large_chunk );
 $assert( ! is_wp_error( $primitive_workspace->publish_raw_once( 'immutable.json', '{"value":1}' ) ), 'immutable checkpoint publication must succeed once' );


### PR DESCRIPTION
## Summary

- raise Static Site Importer's declared PHP floor from 8.1 to 8.2 in Composer and WordPress plugin metadata
- move CI coverage from PHP 8.1-8.4 to PHP 8.2-8.5
- pin solved-site promotion to PHP 8.2.33
- update runtime and CI documentation
- remove the PHP 8.1-only compatibility path merged in #1313 because PHP 8.1 is no longer supported

This intentionally drops PHP 8.1, which reached end of life. The matching Blocks Engine producer change is being published separately.

## Verification

- `composer validate --strict`
- `php tests/smoke-direct-artifact-import.php`
- PHPCS with the WordPress ruleset and `testVersion 8.2-`
- `npm test`: 63 selected PHP/Node tests and 279 fixture-matrix tests passed
- CI covers PHP 8.2, 8.3, 8.4, and 8.5

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode audited the declared runtime contract, updated Composer/plugin/workflow/documentation surfaces, regenerated lock metadata, and ran verification. Chris Huber selected the PHP 8.2 support floor and remains responsible.