### PR TITLE
Fix page-ready companion block registration

### DIFF
--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -171,10 +171,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'reason' => 'companion_plugin_payload_absent',
 			);
 		}
-		if ( $page_ready || ( array_key_exists( 'materialize_dependencies', $args ) && false === (bool) $args['materialize_dependencies'] ) ) {
+		if ( array_key_exists( 'materialize_dependencies', $args ) && false === (bool) $args['materialize_dependencies'] ) {
 			return array(
 				'status' => 'skipped',
-				'reason' => $page_ready ? 'page_ready_scope' : 'dependency_materialization_disabled',
+				'reason' => 'dependency_materialization_disabled',
 			);
 		}
 		$payload    = self::resolve_companion_asset_references( $payload, $prepared['plan'] ?? array(), $prepared['resolved'] ?? array() );

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -250,6 +250,7 @@ require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-companio
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-plugin-materializer.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-wordpress-site-plan-materializer.php';
 
 $failures   = array();
 $assertions = 0;
@@ -914,6 +915,23 @@ $replacement_report  = Static_Site_Importer_Plugin_Materializer::ensure_generate
 $assert( in_array( 'ssi-example-site/ssi-example-site.php', $GLOBALS['ssi_companion_deactivated'], true ), 'replacement-deactivates-previous-companion' );
 $assert( in_array( 'replaced:ssi-example-site/ssi-example-site.php', $replacement_report['actions'] ?? array(), true ), 'replacement-reports-previous-companion' );
 $assert( 'ssi-replacement-site/ssi-replacement-site.php' === get_option( Static_Site_Importer_Plugin_Materializer::ACTIVE_COMPANION_OPTION ), 'replacement-records-current-companion-plugin' );
+
+$page_ready_payload                                         = $payload;
+$page_ready_payload['site_slug']                            = 'page-ready-site';
+$page_ready_payload['site_name']                            = 'Page Ready Site';
+$page_ready_payload['blocks'][0]['block_json']['name'] = 'example/page-ready-control';
+$page_ready_materializer                                    = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'materialize_companion_dependency' );
+$page_ready_report                                          = $page_ready_materializer->invoke(
+	null,
+	$page_ready_payload,
+	array(
+		'args'     => array(),
+		'plan'     => array(),
+		'resolved' => array(),
+	),
+	true
+);
+$assert( 'skipped' !== ( $page_ready_report['status'] ?? '' ) && in_array( 'example/page-ready-control', WP_Block_Type_Registry::$registered, true ), 'page-ready-checkpoint-materializes-and-registers-declared-companion-blocks' );
 
 // Cleanup generated fixtures.
 $cleanup = static function ( string $dir ) use ( &$cleanup ): void {


### PR DESCRIPTION
## Summary

- materialize producer-declared companion plugins during page-ready checkpoints
- preserve explicit dependency-materialization opt-outs
- cover current-request block registration before editor admission

## Verification

- `php tests/smoke-companion-plugin.php`
- `npm test` (64 selected suites passed, 0 failed)

Closes #1329.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the page-ready lifecycle, implemented the minimal materialization fix, added the regression assertion, and ran the repository verification gates. Chris Huber directed and reviewed the work.