### PR TITLE
fix: bound import success responses

### DIFF
--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -382,6 +382,7 @@ class Static_Site_Importer_Canonical_Import_Service {
 	/** @param array<string,mixed> $result @param array<string,mixed> $input @return array<string,mixed> */
 	public static function success( array $result, array $input ): array {
 		$contract = self::success_diagnostics_contract( $result );
+		$result   = self::bound_success_result( $result );
 		if ( function_exists( 'do_action' ) ) {
 			do_action( 'static_site_importer_import_completed', $contract, $result, $input );
 		}
@@ -391,6 +392,108 @@ class Static_Site_Importer_Canonical_Import_Service {
 			'diagnostics'         => isset( $contract['diagnostics'] ) && is_array( $contract['diagnostics'] ) ? $contract['diagnostics'] : array(),
 			'fixture_diagnostics' => $contract,
 		);
+	}
+
+	/** Persist unbounded success payloads and replace them with durable references. */
+	public static function bound_success_result( array $result ): array {
+		$payloads = array_filter(
+			array(
+				'import_report'           => isset( $result['import_report'] ) && is_array( $result['import_report'] ) ? $result['import_report'] : null,
+				'materialization_receipt' => isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : null,
+			),
+			'is_array'
+		);
+		if ( empty( $payloads ) ) {
+			return $result;
+		}
+
+		$receipt = $payloads['materialization_receipt'] ?? array();
+		$receipt_summary = array_filter(
+			array(
+				'schema'              => $receipt['schema'] ?? null,
+				'status'              => $receipt['status'] ?? null,
+				'receipt_instance_id' => $receipt['receipt_instance_id'] ?? null,
+				'plan_identity'       => $receipt['plan_identity'] ?? null,
+			),
+			static fn ( $value ): bool => null !== $value
+		);
+		$result['materialization_receipt_summary'] = $receipt_summary;
+		if ( isset( $payloads['materialization_receipt'] ) ) {
+			unset( $payloads['materialization_receipt']['plan'] );
+		}
+		if ( isset( $payloads['import_report']['materialization_receipt'] ) ) {
+			$payloads['import_report']['materialization_receipt'] = $receipt_summary;
+		}
+		unset( $result['import_report'], $result['materialization_receipt'] );
+
+		$artifacts = array(
+			'schema'    => 'static-site-importer/import-response-artifacts/v1',
+			'status'    => 'failed',
+			'artifacts' => array(),
+			'errors'    => array(),
+		);
+		$uploads   = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
+		$basedir   = is_array( $uploads ) && is_string( $uploads['basedir'] ?? null ) ? rtrim( $uploads['basedir'], '/\\' ) : '';
+		// Share the retained-run root so the existing daily expiry sweep owns these artifacts.
+		$root      = $basedir . '/static-site-importer/direct-artifact-imports';
+		if ( '' === $basedir || ! function_exists( 'wp_mkdir_p' ) || ( ! is_dir( $root ) && ! wp_mkdir_p( $root ) ) ) {
+			$artifacts['errors'][] = array(
+				'code'    => 'static_site_importer_import_response_workspace_unavailable',
+				'message' => 'The importer-owned response artifact workspace is unavailable.',
+			);
+			$result['response_artifacts'] = $artifacts;
+			return $result;
+		}
+
+		$report   = $payloads['import_report'] ?? array();
+		$identity = (string) ( $report['import_run_id'] ?? $receipt['receipt_instance_id'] ?? '' );
+		if ( '' === $identity ) {
+			$identity = hash( 'sha256', (string) ( $result['theme_slug'] ?? '' ) . "\n" . (string) ( $receipt['plan_identity']['hash'] ?? '' ) );
+		}
+		$identity = trim( (string) preg_replace( '/[^A-Za-z0-9_-]/', '-', $identity ), '-' );
+		try {
+			$workspace = new Static_Site_Importer_Artifact_Run_Workspace(
+				$root,
+				'import-response-' . ( '' !== $identity ? $identity : hash( 'sha256', microtime( true ) . wp_rand() ) ),
+				array(
+					'on_success' => 'retain',
+					'expires_at' => gmdate( 'c', time() + WEEK_IN_SECONDS ),
+				)
+			);
+			foreach ( $payloads as $name => $payload ) {
+				$path = $workspace->publish_json_once( str_replace( '_', '-', $name ) . '.json', $payload );
+				if ( is_wp_error( $path ) ) {
+					$artifacts['errors'][] = array(
+						'code'    => $path->get_error_code(),
+						'message' => $path->get_error_message(),
+					);
+					continue;
+				}
+				$digest = hash_file( 'sha256', $path );
+				$bytes  = filesize( $path );
+				if ( ! is_string( $digest ) || false === $bytes ) {
+					$artifacts['errors'][] = array(
+						'code'    => 'static_site_importer_import_response_artifact_unverifiable',
+						'message' => 'A persisted response artifact could not be verified.',
+					);
+					continue;
+				}
+				$artifacts['artifacts'][ $name ] = array(
+					'path'   => $path,
+					'sha256' => $digest,
+					'bytes'  => $bytes,
+					'schema' => is_string( $payload['schema'] ?? null ) ? $payload['schema'] : '',
+				);
+			}
+		} catch ( Throwable $error ) {
+			$artifacts['errors'][] = array(
+				'code'    => 'static_site_importer_import_response_artifact_persistence_failed',
+				'message' => $error->getMessage(),
+			);
+		}
+		$artifacts['status']         = empty( $artifacts['errors'] ) ? 'completed' : 'failed';
+		$result['response_artifacts'] = $artifacts;
+		return $result;
 	}
 
 	/** @param array<string,mixed> $result @return array<string,mixed> */

--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -381,21 +381,33 @@ class Static_Site_Importer_Canonical_Import_Service {
 
 	/** @param array<string,mixed> $result @param array<string,mixed> $input @return array<string,mixed> */
 	public static function success( array $result, array $input ): array {
-		$contract = self::success_diagnostics_contract( $result );
-		$result   = self::bound_success_result( $result );
+		$contract             = self::success_diagnostics_contract( $result );
+		$result               = self::bound_success_result( $result );
+		$contract_diagnostics = isset( $contract['diagnostics'] ) && is_array( $contract['diagnostics'] ) ? $contract['diagnostics'] : array();
+		unset( $contract['diagnostics'] );
+		if ( 25 < count( $contract_diagnostics ) ) {
+			$contract_diagnostics = array_merge( array_slice( $contract_diagnostics, 0, 24 ), array_slice( $contract_diagnostics, -1 ) );
+		}
+		$remaining_items  = 400;
+		$bounded_contract = self::bounded_inline_value( $contract, $remaining_items );
+		$bounded_contract = is_array( $bounded_contract ) ? $bounded_contract : array();
+		$remaining_items  = 1000;
+		$diagnostics      = self::bounded_inline_value( $contract_diagnostics, $remaining_items );
+		$bounded_contract['diagnostics'] = is_array( $diagnostics ) ? $diagnostics : array();
 		if ( function_exists( 'do_action' ) ) {
-			do_action( 'static_site_importer_import_completed', $contract, $result, $input );
+			do_action( 'static_site_importer_import_completed', $bounded_contract, $result, $input );
 		}
 		return array(
 			'success'             => true,
 			'result'              => $result,
-			'diagnostics'         => isset( $contract['diagnostics'] ) && is_array( $contract['diagnostics'] ) ? $contract['diagnostics'] : array(),
-			'fixture_diagnostics' => $contract,
+			'diagnostics'         => isset( $bounded_contract['diagnostics'] ) && is_array( $bounded_contract['diagnostics'] ) ? $bounded_contract['diagnostics'] : array(),
+			'fixture_diagnostics' => $bounded_contract,
 		);
 	}
 
 	/** Persist unbounded success payloads and replace them with durable references. */
 	public static function bound_success_result( array $result ): array {
+		$details  = $result;
 		$payloads = array_filter(
 			array(
 				'import_report'           => isset( $result['import_report'] ) && is_array( $result['import_report'] ) ? $result['import_report'] : null,
@@ -424,7 +436,45 @@ class Static_Site_Importer_Canonical_Import_Service {
 		if ( isset( $payloads['import_report']['materialization_receipt'] ) ) {
 			$payloads['import_report']['materialization_receipt'] = $receipt_summary;
 		}
-		unset( $result['import_report'], $result['materialization_receipt'] );
+		unset( $details['import_report'], $details['materialization_receipt'] );
+		$payloads['result_details'] = $details;
+
+		$inline_keys = array(
+			'theme_slug',
+			'theme_name',
+			'theme_dir',
+			'report_path',
+			'validation_result_path',
+			'finding_packets_path',
+			'external_report_path',
+			'external_validation_result_path',
+			'external_finding_packets_path',
+			'manifest_path',
+			'import_id',
+			'import_run_id',
+			'status',
+			'import_report_summary',
+			'import_validation_result',
+			'fixture_diagnostics',
+			'quality',
+			'progress_events',
+		);
+		$remaining = 200;
+		$bounded   = array(
+			'materialization_receipt_summary' => self::bounded_inline_value( $receipt_summary, $remaining ),
+		);
+		if ( isset( $result['pages'] ) && is_array( $result['pages'] ) ) {
+			$page_items               = 100;
+			$bounded['page_count']    = count( $result['pages'] );
+			$bounded['pages']         = self::bounded_inline_value( $result['pages'], $page_items );
+			$bounded['pages_truncated'] = count( $result['pages'] ) > count( $bounded['pages'] );
+		}
+		foreach ( $inline_keys as $key ) {
+			if ( array_key_exists( $key, $result ) ) {
+				$bounded[ $key ] = self::bounded_inline_value( $result[ $key ], $remaining );
+			}
+		}
+		$result = $bounded;
 
 		$artifacts = array(
 			'schema'    => 'static-site-importer/import-response-artifacts/v1',
@@ -432,10 +482,10 @@ class Static_Site_Importer_Canonical_Import_Service {
 			'artifacts' => array(),
 			'errors'    => array(),
 		);
-		$uploads   = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
-		$basedir   = is_array( $uploads ) && is_string( $uploads['basedir'] ?? null ) ? rtrim( $uploads['basedir'], '/\\' ) : '';
+		$uploads = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
+		$basedir = is_string( $uploads['basedir'] ?? null ) ? rtrim( $uploads['basedir'], '/\\' ) : '';
 		// Share the retained-run root so the existing daily expiry sweep owns these artifacts.
-		$root      = $basedir . '/static-site-importer/direct-artifact-imports';
+		$root = $basedir . '/static-site-importer/direct-artifact-imports';
 		if ( '' === $basedir || ! function_exists( 'wp_mkdir_p' ) || ( ! is_dir( $root ) && ! wp_mkdir_p( $root ) ) ) {
 			$artifacts['errors'][] = array(
 				'code'    => 'static_site_importer_import_response_workspace_unavailable',
@@ -445,10 +495,11 @@ class Static_Site_Importer_Canonical_Import_Service {
 			return $result;
 		}
 
-		$report   = $payloads['import_report'] ?? array();
-		$identity = (string) ( $report['import_run_id'] ?? $receipt['receipt_instance_id'] ?? '' );
+		$report        = $payloads['import_report'] ?? array();
+		$identity      = (string) ( $report['import_run_id'] ?? $receipt['receipt_instance_id'] ?? '' );
+		$plan_identity = is_array( $receipt['plan_identity'] ?? null ) ? $receipt['plan_identity'] : array();
 		if ( '' === $identity ) {
-			$identity = hash( 'sha256', (string) ( $result['theme_slug'] ?? '' ) . "\n" . (string) ( $receipt['plan_identity']['hash'] ?? '' ) );
+			$identity = hash( 'sha256', (string) ( $result['theme_slug'] ?? '' ) . "\n" . (string) ( $plan_identity['hash'] ?? '' ) );
 		}
 		$identity = trim( (string) preg_replace( '/[^A-Za-z0-9_-]/', '-', $identity ), '-' );
 		try {
@@ -494,6 +545,29 @@ class Static_Site_Importer_Canonical_Import_Service {
 		$artifacts['status']         = empty( $artifacts['errors'] ) ? 'completed' : 'failed';
 		$result['response_artifacts'] = $artifacts;
 		return $result;
+	}
+
+	/** Return a globally bounded transport projection while preserving array shape. */
+	private static function bounded_inline_value( $value, int &$remaining_items, int $depth = 0 ) {
+		if ( 0 >= $remaining_items || 8 <= $depth ) {
+			return null;
+		}
+		--$remaining_items;
+		if ( is_string( $value ) ) {
+			return strlen( $value ) > 256 ? substr( $value, 0, 256 ) : $value;
+		}
+		if ( ! is_array( $value ) ) {
+			return is_scalar( $value ) || null === $value ? $value : null;
+		}
+
+		$bounded = array();
+		foreach ( $value as $key => $item ) {
+			if ( 0 >= $remaining_items ) {
+				break;
+			}
+			$bounded[ $key ] = self::bounded_inline_value( $item, $remaining_items, $depth + 1 );
+		}
+		return $bounded;
 	}
 
 	/** @param array<string,mixed> $result @return array<string,mixed> */

--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -419,8 +419,8 @@ class Static_Site_Importer_Canonical_Import_Service {
 			return $result;
 		}
 
-		$receipt = $payloads['materialization_receipt'] ?? array();
-		$receipt_summary = array_filter(
+		$receipt                                   = $payloads['materialization_receipt'] ?? array();
+		$receipt_summary                           = array_filter(
 			array(
 				'schema'              => $receipt['schema'] ?? null,
 				'status'              => $receipt['status'] ?? null,
@@ -459,8 +459,8 @@ class Static_Site_Importer_Canonical_Import_Service {
 			'quality',
 			'progress_events',
 		);
-		$remaining = 200;
-		$bounded   = array(
+		$remaining   = 200;
+		$bounded     = array(
 			'materialization_receipt_summary' => self::bounded_inline_value( $receipt_summary, $remaining ),
 		);
 		if ( isset( $result['pages'] ) && is_array( $result['pages'] ) ) {
@@ -482,12 +482,12 @@ class Static_Site_Importer_Canonical_Import_Service {
 			'artifacts' => array(),
 			'errors'    => array(),
 		);
-		$uploads = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
-		$basedir = is_string( $uploads['basedir'] ?? null ) ? rtrim( $uploads['basedir'], '/\\' ) : '';
+		$uploads   = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
+		$basedir   = is_string( $uploads['basedir'] ?? null ) ? rtrim( $uploads['basedir'], '/\\' ) : '';
 		// Share the retained-run root so the existing daily expiry sweep owns these artifacts.
 		$root = $basedir . '/static-site-importer/direct-artifact-imports';
 		if ( '' === $basedir || ! function_exists( 'wp_mkdir_p' ) || ( ! is_dir( $root ) && ! wp_mkdir_p( $root ) ) ) {
-			$artifacts['errors'][] = array(
+			$artifacts['errors'][]        = array(
 				'code'    => 'static_site_importer_import_response_workspace_unavailable',
 				'message' => 'The importer-owned response artifact workspace is unavailable.',
 			);

--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -388,11 +388,11 @@ class Static_Site_Importer_Canonical_Import_Service {
 		if ( 25 < count( $contract_diagnostics ) ) {
 			$contract_diagnostics = array_merge( array_slice( $contract_diagnostics, 0, 24 ), array_slice( $contract_diagnostics, -1 ) );
 		}
-		$remaining_items  = 400;
-		$bounded_contract = self::bounded_inline_value( $contract, $remaining_items );
-		$bounded_contract = is_array( $bounded_contract ) ? $bounded_contract : array();
-		$remaining_items  = 1000;
-		$diagnostics      = self::bounded_inline_value( $contract_diagnostics, $remaining_items );
+		$remaining_items                 = 400;
+		$bounded_contract                = self::bounded_inline_value( $contract, $remaining_items );
+		$bounded_contract                = is_array( $bounded_contract ) ? $bounded_contract : array();
+		$remaining_items                 = 1000;
+		$diagnostics                     = self::bounded_inline_value( $contract_diagnostics, $remaining_items );
 		$bounded_contract['diagnostics'] = is_array( $diagnostics ) ? $diagnostics : array();
 		if ( function_exists( 'do_action' ) ) {
 			do_action( 'static_site_importer_import_completed', $bounded_contract, $result, $input );
@@ -400,7 +400,7 @@ class Static_Site_Importer_Canonical_Import_Service {
 		return array(
 			'success'             => true,
 			'result'              => $result,
-			'diagnostics'         => isset( $bounded_contract['diagnostics'] ) && is_array( $bounded_contract['diagnostics'] ) ? $bounded_contract['diagnostics'] : array(),
+			'diagnostics'         => $bounded_contract['diagnostics'],
 			'fixture_diagnostics' => $bounded_contract,
 		);
 	}
@@ -464,9 +464,9 @@ class Static_Site_Importer_Canonical_Import_Service {
 			'materialization_receipt_summary' => self::bounded_inline_value( $receipt_summary, $remaining ),
 		);
 		if ( isset( $result['pages'] ) && is_array( $result['pages'] ) ) {
-			$page_items               = 100;
-			$bounded['page_count']    = count( $result['pages'] );
-			$bounded['pages']         = self::bounded_inline_value( $result['pages'], $page_items );
+			$page_items                 = 100;
+			$bounded['page_count']      = count( $result['pages'] );
+			$bounded['pages']           = self::bounded_inline_value( $result['pages'], $page_items );
 			$bounded['pages_truncated'] = count( $result['pages'] ) > count( $bounded['pages'] );
 		}
 		foreach ( $inline_keys as $key ) {
@@ -542,7 +542,7 @@ class Static_Site_Importer_Canonical_Import_Service {
 				'message' => $error->getMessage(),
 			);
 		}
-		$artifacts['status']         = empty( $artifacts['errors'] ) ? 'completed' : 'failed';
+		$artifacts['status']          = empty( $artifacts['errors'] ) ? 'completed' : 'failed';
 		$result['response_artifacts'] = $artifacts;
 		return $result;
 	}

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -530,7 +530,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 						return self::fail( $workspace, $run, 'materialize', $materialized );
 					}
 					$materialized = Static_Site_Importer_Canonical_Import_Service::bound_success_result( $materialized );
-					$ref = self::publish_checkpoint( $workspace, $run, 'materialization', 'materialization-result.json', array( 'result' => $materialized ) );
+					$ref          = self::publish_checkpoint( $workspace, $run, 'materialization', 'materialization-result.json', array( 'result' => $materialized ) );
 					if ( is_wp_error( $ref ) ) {
 						return self::fail( $workspace, $run, 'materialize', $ref );
 					}

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -529,6 +529,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 					if ( is_wp_error( $materialized ) ) {
 						return self::fail( $workspace, $run, 'materialize', $materialized );
 					}
+					$materialized = Static_Site_Importer_Canonical_Import_Service::bound_success_result( $materialized );
 					$ref = self::publish_checkpoint( $workspace, $run, 'materialization', 'materialization-result.json', array( 'result' => $materialized ) );
 					if ( is_wp_error( $ref ) ) {
 						return self::fail( $workspace, $run, 'materialize', $ref );

--- a/tests/smoke-ability-import-success-diagnostics.php
+++ b/tests/smoke-ability-import-success-diagnostics.php
@@ -179,10 +179,21 @@ for ( $index = 1; $index <= 8; ++$index ) {
 		),
 	);
 }
+$large_diagnostics = array();
+for ( $index = 0; $index < 500; ++$index ) {
+	$large_diagnostics[] = array(
+		'type'        => 'bounded-response-diagnostic',
+		'source_path' => 'website/page-' . $index . '.html',
+		'message'     => str_repeat( 'd', 10000 ),
+	);
+}
 $reconciled_result = array(
-	'theme_slug'   => 'compiler-quality-site',
-	'theme_name'   => 'Compiler Quality Site',
-	'quality'      => array( 'block_count' => 0, 'fallback_count' => 0, 'diagnostic_count' => 0 ),
+	'theme_slug'      => 'compiler-quality-site',
+	'theme_name'      => 'Compiler Quality Site',
+	'pages'           => range( 1, 5000 ),
+	'finding_packets' => array_fill( 0, 500, str_repeat( 'f', 10000 ) ),
+	'source_of_truth' => array( 'large_manifest_projection' => str_repeat( 's', 2 * 1024 * 1024 ) ),
+	'quality'         => array( 'block_count' => 0, 'fallback_count' => 0, 'diagnostic_count' => 0 ),
 	'import_report' => array(
 		'schema'                  => 'static-site-importer/import-report/v1',
 		'import_run_id'           => 'bounded-response-smoke',
@@ -201,6 +212,11 @@ $reconciled_result = array(
 			'unresolved_fallback_count' => 450,
 			'resolutions'               => $provider_resolutions,
 		),
+		'import_validation_result' => array(
+			'schema'      => 'blocks-engine/import-validation-result/v1',
+			'status'      => 'reported',
+			'diagnostics' => $large_diagnostics,
+		),
 	),
 	'materialization_receipt' => array(
 		'schema'              => 'static-site-importer/materialization-receipt/v2',
@@ -218,22 +234,29 @@ $assert( 8 === ( $reconciled_contract['quality_counts']['materialized']['fallbac
 $assert( 'blocks_engine.wordpress_site_plan.quality' === ( $reconciled_contract['quality_counts']['provenance']['source_detected']['path'] ?? '' ), 'success-envelope-identifies-compiler-provenance' );
 $assert( 'static-site-importer/materialization-receipt/v2' === ( $reconciled_contract['quality_counts']['provenance']['materialized']['receipt'] ?? '' ), 'success-envelope-identifies-materialization-receipt' );
 $assert( false === ( $reconciled_contract['quality_counts']['consistent'] ?? true ), 'success-envelope-flags-contradictory-quality-layers' );
-$assert( 'quality_count_consistency_failure' === ( $reconciled_contract['diagnostics'][0]['type'] ?? '' ), 'success-envelope-emits-consistency-diagnostic' );
+$consistency_diagnostics = array_values( array_filter( $reconciled_contract['diagnostics'] ?? array(), static fn ( array $diagnostic ): bool => 'quality_count_consistency_failure' === ( $diagnostic['type'] ?? '' ) ) );
+$assert( 1 === count( $consistency_diagnostics ), 'success-envelope-emits-consistency-diagnostic' );
 $bounded_result = $reconciled_envelope['result'] ?? array();
 $artifacts      = $bounded_result['response_artifacts']['artifacts'] ?? array();
 $assert( ! isset( $bounded_result['import_report'], $bounded_result['materialization_receipt'] ), 'success-envelope-omits-unbounded-payloads' );
+$assert( ! isset( $bounded_result['finding_packets'], $bounded_result['source_of_truth'] ), 'success-envelope-externalizes-site-sized-details' );
+$assert( 0 < count( $bounded_result['pages'] ?? array() ) && 100 > count( $bounded_result['pages'] ?? array() ), 'success-envelope-bounds-inline-page-identities' );
+$assert( 5000 === ( $bounded_result['page_count'] ?? 0 ) && true === ( $bounded_result['pages_truncated'] ?? false ), 'success-envelope-reports-page-identity-truncation' );
 $assert( 'completed' === ( $bounded_result['response_artifacts']['status'] ?? '' ), 'response-artifacts-persisted' );
 $assert( 'completed' === ( $bounded_result['materialization_receipt_summary']['status'] ?? '' ), 'receipt-identity-remains-inline' );
 $assert( 200000 > strlen( (string) wp_json_encode( $reconciled_envelope ) ), 'success-envelope-remains-bounded' );
-foreach ( array( 'import_report', 'materialization_receipt' ) as $artifact_name ) {
+foreach ( array( 'import_report', 'materialization_receipt', 'result_details' ) as $artifact_name ) {
 	$artifact = $artifacts[ $artifact_name ] ?? array();
 	$assert( is_file( $artifact['path'] ?? '' ), $artifact_name . '-artifact-exists' );
 	$assert( hash_file( 'sha256', $artifact['path'] ) === ( $artifact['sha256'] ?? '' ), $artifact_name . '-artifact-digest' );
 }
 $persisted_report  = json_decode( (string) file_get_contents( $artifacts['import_report']['path'] ?? '' ), true );
 $persisted_receipt = json_decode( (string) file_get_contents( $artifacts['materialization_receipt']['path'] ?? '' ), true );
+$persisted_details = json_decode( (string) file_get_contents( $artifacts['result_details']['path'] ?? '' ), true );
 $assert( ! isset( $persisted_receipt['plan'] ), 'persisted-receipt-references-plan-identity' );
 $assert( ! isset( $persisted_report['materialization_receipt']['plan'] ), 'persisted-report-does-not-duplicate-receipt-plan' );
+$assert( 500 === count( $persisted_details['finding_packets'] ?? array() ), 'persisted-details-retain-full-finding-packets' );
+$assert( 5000 === count( $persisted_details['pages'] ?? array() ), 'persisted-details-retain-all-page-identities' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-ability-import-success-diagnostics.php
+++ b/tests/smoke-ability-import-success-diagnostics.php
@@ -45,6 +45,36 @@ if ( ! function_exists( 'add_action' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code, private string $message ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, int $flags = 0 ) { return json_encode( $value, $flags ); }
+}
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( string $path ): bool { return is_dir( $path ) || mkdir( $path, 0700, true ); }
+}
+if ( ! function_exists( 'wp_upload_dir' ) ) {
+	function wp_upload_dir(): array {
+		$root = sys_get_temp_dir() . '/ssi-bounded-response-smoke-' . getmypid();
+		wp_mkdir_p( $root );
+		return array( 'basedir' => $root );
+	}
+}
+if ( ! function_exists( 'wp_rand' ) ) {
+	function wp_rand(): int { return random_int( 1, PHP_INT_MAX ); }
+}
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+	define( 'WEEK_IN_SECONDS', 604800 );
+}
+
 $GLOBALS['ssi_smoke_fired_hooks'] = array();
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( string $hook_name, ...$args ): void {
@@ -155,6 +185,8 @@ $reconciled_result = array(
 	'quality'      => array( 'block_count' => 0, 'fallback_count' => 0, 'diagnostic_count' => 0 ),
 	'import_report' => array(
 		'schema'                  => 'static-site-importer/import-report/v1',
+		'import_run_id'           => 'bounded-response-smoke',
+		'large_report_projection' => str_repeat( 'r', 2 * 1024 * 1024 ),
 		'quality'                 => array( 'block_count' => 0, 'fallback_count' => 0, 'diagnostic_count' => 0 ),
 		'blocks_engine'           => array(
 			'wordpress_site_plan' => array(
@@ -171,8 +203,11 @@ $reconciled_result = array(
 		),
 	),
 	'materialization_receipt' => array(
-		'schema' => 'static-site-importer/materialization-receipt/v2',
-		'status' => 'completed',
+		'schema'              => 'static-site-importer/materialization-receipt/v2',
+		'status'              => 'completed',
+		'receipt_instance_id' => 'receipt-bounded-response-smoke',
+		'plan_identity'       => array( 'schema' => 'blocks-engine/wordpress-site-plan-identity/v1', 'hash' => hash( 'sha256', 'plan' ) ),
+		'plan'                => array( 'large_resolved_plan' => str_repeat( 'p', 2 * 1024 * 1024 ) ),
 	),
 );
 $reconciled_envelope = static_site_importer_ability_import_success( $reconciled_result, array( 'slug' => 'compiler-quality-site' ) );
@@ -184,6 +219,21 @@ $assert( 'blocks_engine.wordpress_site_plan.quality' === ( $reconciled_contract[
 $assert( 'static-site-importer/materialization-receipt/v2' === ( $reconciled_contract['quality_counts']['provenance']['materialized']['receipt'] ?? '' ), 'success-envelope-identifies-materialization-receipt' );
 $assert( false === ( $reconciled_contract['quality_counts']['consistent'] ?? true ), 'success-envelope-flags-contradictory-quality-layers' );
 $assert( 'quality_count_consistency_failure' === ( $reconciled_contract['diagnostics'][0]['type'] ?? '' ), 'success-envelope-emits-consistency-diagnostic' );
+$bounded_result = $reconciled_envelope['result'] ?? array();
+$artifacts      = $bounded_result['response_artifacts']['artifacts'] ?? array();
+$assert( ! isset( $bounded_result['import_report'], $bounded_result['materialization_receipt'] ), 'success-envelope-omits-unbounded-payloads' );
+$assert( 'completed' === ( $bounded_result['response_artifacts']['status'] ?? '' ), 'response-artifacts-persisted' );
+$assert( 'completed' === ( $bounded_result['materialization_receipt_summary']['status'] ?? '' ), 'receipt-identity-remains-inline' );
+$assert( 200000 > strlen( (string) wp_json_encode( $reconciled_envelope ) ), 'success-envelope-remains-bounded' );
+foreach ( array( 'import_report', 'materialization_receipt' ) as $artifact_name ) {
+	$artifact = $artifacts[ $artifact_name ] ?? array();
+	$assert( is_file( $artifact['path'] ?? '' ), $artifact_name . '-artifact-exists' );
+	$assert( hash_file( 'sha256', $artifact['path'] ) === ( $artifact['sha256'] ?? '' ), $artifact_name . '-artifact-digest' );
+}
+$persisted_report  = json_decode( (string) file_get_contents( $artifacts['import_report']['path'] ?? '' ), true );
+$persisted_receipt = json_decode( (string) file_get_contents( $artifacts['materialization_receipt']['path'] ?? '' ), true );
+$assert( ! isset( $persisted_receipt['plan'] ), 'persisted-receipt-references-plan-identity' );
+$assert( ! isset( $persisted_report['materialization_receipt']['plan'] ), 'persisted-report-does-not-duplicate-receipt-plan' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- stream full import reports, materialization receipts, and result details into importer-owned, seven-day run artifacts
- return a globally bounded inline contract with artifact metadata, compact summaries, bounded diagnostics and findings, and up to 100 page identities with explicit count/truncation metadata
- remove the resolved plan from the durable receipt and avoid duplicating the receipt plan inside the report artifact
- compact the materialization result before resumable-run checkpointing

Closes #1317.

## Verification
- `php tests/smoke-ability-import-success-diagnostics.php` (38 assertions; 5,000 pages, 500 large diagnostics, 500 large finding packets, three 2 MB payloads, and an inline response below 200 KB)
- `php tests/smoke-direct-artifact-import.php`
- `npm test` (64 passed, 0 failed)
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced response and checkpoint duplication, implemented and strengthened the bounded artifact-backed contract, and ran verification under Chris Huber's direction.