### PR TITLE
perf: reduce direct artifact checkpoint and preparation overhead

### DIFF
--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -20,17 +20,18 @@ if ( ! class_exists( 'Static_Site_Importer_Client_Script_Policy' ) ) {
 }
 
 final class Static_Site_Importer_Direct_Artifact_Import {
-	private const RUN_SCHEMA        = 'static-site-importer/direct-artifact-run/v1';
-	private const CHECKPOINT_SCHEMA = 'static-site-importer/direct-artifact-checkpoint/v1';
-	private const EVIDENCE_SCHEMA   = 'static-site-importer/direct-artifact-run-evidence/v1';
-	private const RECEIPT_SCHEMA    = 'blocks-engine/php-transformer/compiled-page-receipt/v2';
-	private const TTL               = 604800;
-	private const CLEANUP_HOOK      = 'static_site_importer_purge_direct_artifact_imports';
+	private const RUN_SCHEMA                    = 'static-site-importer/direct-artifact-run/v1';
+	private const CHECKPOINT_SCHEMA             = 'static-site-importer/direct-artifact-checkpoint/v1';
+	private const EVIDENCE_SCHEMA               = 'static-site-importer/direct-artifact-run-evidence/v1';
+	private const RECEIPT_SCHEMA                = 'blocks-engine/php-transformer/compiled-page-receipt/v2';
+	private const TTL                           = 604800;
+	private const CLEANUP_HOOK                  = 'static_site_importer_purge_direct_artifact_imports';
 	private static array $checkpoint_read_cache = array();
 
 	/** Start a server-owned run after normal canonical source normalization. */
 	public static function start( array $artifact, array $args, string $source_type, string $operation, array $provenance ) {
 		self::$checkpoint_read_cache = array();
+
 		$freeze_started  = microtime( true );
 		$source_identity = self::hash_json( $artifact, false );
 		$source_policy   = Static_Site_Importer_Content_Policy::validate_artifact( $artifact );
@@ -209,10 +210,10 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				return self::fail( $workspace, $run, 'compiler', $compiler );
 			}
 			$prepare_shared = array( $compiler, 'prepareShared' );
-			$prepare_page   = array( $compiler, 'preparePage' );
+			$prepare_pages  = array( $compiler, 'preparePages' );
 			$compile_pages  = array( $compiler, 'compilePreparedPages' );
 			$compose        = array( $compiler, 'compose' );
-			if ( ! is_callable( $prepare_shared ) || ! is_callable( $prepare_page ) || ! is_callable( $compile_pages ) || ! is_callable( $compose ) ) {
+			if ( ! is_callable( $prepare_shared ) || ! is_callable( $prepare_pages ) || ! is_callable( $compile_pages ) || ! is_callable( $compose ) ) {
 				return self::fail( $workspace, $run, 'compiler', new WP_Error( 'static_site_importer_invalid_transformer', 'The direct artifact compiler does not implement the staged compilation contract.' ) );
 			}
 			$artifact_state = null;
@@ -298,7 +299,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			$deadline = call_user_func( $clock ) + $policy['max_invocation_seconds'];
 
 			$pending_plans = array_values( array_diff( $run['page_ids'], array_keys( $run['refs']['pages'] ?? array() ) ) );
-			$prepare_ids   = self::deadline_reached( $deadline, $clock ) ? array() : array_slice( $pending_plans, 0, $policy['prepare_batch_pages'] );
+			$prepare_ids   = self::deadline_reached( $deadline, $clock ) ? array() : $pending_plans;
 			if ( ! empty( $prepare_ids ) ) {
 				if ( self::deadline_reached( $deadline, $clock ) ) {
 					return self::continuation( $run, 'deadline_exhausted' );
@@ -308,15 +309,16 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				if ( is_wp_error( $entered ) ) {
 					return $entered;
 				}
-				$run = $entered;
+				$run            = $entered;
 				$artifact_state = $load_artifact();
 				if ( is_wp_error( $artifact_state ) ) {
 					return $artifact_state;
 				}
 				self::before_phase( 'prepare_pages', $run, $prepare_ids );
 				$run['work']['page_prepare_passes'] = (int) $run['work']['page_prepare_passes'] + 1;
+				$page_plans                         = call_user_func( $prepare_pages, $artifact_state['artifact'], $shared );
 				foreach ( $prepare_ids as $page_id ) {
-					$page_plan = call_user_func( $prepare_page, $artifact_state['artifact'], $shared, $page_id );
+					$page_plan = $page_plans[ $page_id ] ?? null;
 					$validated = self::validate_page_plan( $page_plan, $shared, $page_id );
 					if ( is_wp_error( $validated ) ) {
 						return self::fail( $workspace, $run, 'prepare_pages', $validated, array( $page_id ) );
@@ -499,6 +501,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			}
 			$artifact = $artifact_state['artifact'];
 			$args     = $artifact_state['args'];
+
 			$args['compiled_artifact_result']                 = $composed_state['result'];
 			$args['_static_site_importer_precompiled_source'] = true;
 
@@ -1086,7 +1089,6 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 
 	private static function run_policy(): array {
 		$policy = array(
-			'prepare_batch_pages'       => 2,
 			'compile_batch_pages'       => 2,
 			'max_invocation_seconds'    => 20.0,
 			'freeze_continuation_bytes' => 8 * 1024 * 1024,
@@ -1098,7 +1100,6 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				$policy = array_merge( $policy, $filtered );
 			}
 		}
-		$policy['prepare_batch_pages']       = min( 20, max( 1, (int) $policy['prepare_batch_pages'] ) );
 		$policy['compile_batch_pages']       = min( 20, max( 1, (int) $policy['compile_batch_pages'] ) );
 		$policy['max_invocation_seconds']    = max( 0.001, (float) $policy['max_invocation_seconds'] );
 		$policy['freeze_continuation_bytes'] = max( 1, (int) $policy['freeze_continuation_bytes'] );

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -26,9 +26,11 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	private const RECEIPT_SCHEMA    = 'blocks-engine/php-transformer/compiled-page-receipt/v2';
 	private const TTL               = 604800;
 	private const CLEANUP_HOOK      = 'static_site_importer_purge_direct_artifact_imports';
+	private static array $checkpoint_read_cache = array();
 
 	/** Start a server-owned run after normal canonical source normalization. */
 	public static function start( array $artifact, array $args, string $source_type, string $operation, array $provenance ) {
+		self::$checkpoint_read_cache = array();
 		$freeze_started  = microtime( true );
 		$source_identity = self::hash_json( $artifact, false );
 		$source_policy   = Static_Site_Importer_Content_Policy::validate_artifact( $artifact );
@@ -119,6 +121,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 
 	/** Resume an opaque run without reacquiring source bytes. */
 	public static function resume( string $import_id, array $args, string $source_type, string $operation, array $source ) {
+		self::$checkpoint_read_cache = array();
 		if ( ! preg_match( '/^[a-f0-9]{64}$/', $import_id ) ) {
 			return new WP_Error( 'static_site_importer_invalid_direct_artifact_import_id', 'The direct artifact import_id is invalid.' );
 		}
@@ -148,10 +151,6 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		}
 		if ( self::implementation_binding() !== ( $run['binding']['implementation'] ?? null ) ) {
 			return new WP_Error( 'static_site_importer_direct_artifact_implementation_changed', 'The retained direct artifact run was created by a different compiler or policy implementation.' );
-		}
-		$validated = self::validate_retained_refs( $workspace, $run );
-		if ( is_wp_error( $validated ) ) {
-			return $validated;
 		}
 		if ( 'completed' === ( $run['state'] ?? '' ) ) {
 			$final = self::read_checkpoint( $workspace, $run, $run['refs']['final'] ?? array(), 'final' );
@@ -216,12 +215,13 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			if ( ! is_callable( $prepare_shared ) || ! is_callable( $prepare_page ) || ! is_callable( $compile_pages ) || ! is_callable( $compose ) ) {
 				return self::fail( $workspace, $run, 'compiler', new WP_Error( 'static_site_importer_invalid_transformer', 'The direct artifact compiler does not implement the staged compilation contract.' ) );
 			}
-			$artifact_state = self::read_checkpoint( $workspace, $run, $run['refs']['artifact'], 'artifact' );
-			if ( is_wp_error( $artifact_state ) ) {
+			$artifact_state = null;
+			$load_artifact  = static function () use ( &$artifact_state, $workspace, $run ) {
+				if ( null === $artifact_state ) {
+					$artifact_state = self::read_checkpoint( $workspace, $run, $run['refs']['artifact'], 'artifact' );
+				}
 				return $artifact_state;
-			}
-			$artifact = $artifact_state['artifact'];
-			$args     = $artifact_state['args'];
+			};
 
 			if ( empty( $run['refs']['shared'] ) ) {
 				$shared_ref = self::existing_checkpoint_ref( $workspace, $run, 'shared-plan.json', 'shared' );
@@ -240,6 +240,10 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 			}
 			if ( empty( $run['refs']['shared'] ) ) {
+				$artifact_state = $load_artifact();
+				if ( is_wp_error( $artifact_state ) ) {
+					return $artifact_state;
+				}
 				$started = microtime( true );
 				$entered = self::enter_phase( $workspace, $run, 'prepare_shared' );
 				if ( is_wp_error( $entered ) ) {
@@ -247,7 +251,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 				$run = $entered;
 				self::before_phase( 'prepare_shared', $run );
-				$shared = call_user_func( $prepare_shared, $artifact );
+				$shared = call_user_func( $prepare_shared, $artifact_state['artifact'] );
 				if ( 'blocks-engine/php-transformer/staged-shared-plan/v1' !== ( $shared['schema'] ?? '' ) || empty( $shared['digest'] ) || ! is_array( $shared['analysis']['page_ids'] ?? null ) ) {
 					throw new RuntimeException( 'Blocks Engine returned an invalid shared plan.' );
 				}
@@ -305,10 +309,14 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 					return $entered;
 				}
 				$run = $entered;
+				$artifact_state = $load_artifact();
+				if ( is_wp_error( $artifact_state ) ) {
+					return $artifact_state;
+				}
 				self::before_phase( 'prepare_pages', $run, $prepare_ids );
 				$run['work']['page_prepare_passes'] = (int) $run['work']['page_prepare_passes'] + 1;
 				foreach ( $prepare_ids as $page_id ) {
-					$page_plan = call_user_func( $prepare_page, $artifact, $shared, $page_id );
+					$page_plan = call_user_func( $prepare_page, $artifact_state['artifact'], $shared, $page_id );
 					$validated = self::validate_page_plan( $page_plan, $shared, $page_id );
 					if ( is_wp_error( $validated ) ) {
 						return self::fail( $workspace, $run, 'prepare_pages', $validated, array( $page_id ) );
@@ -485,6 +493,12 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			if ( self::deadline_reached( $deadline, $clock ) ) {
 				return self::continuation( $run, 'deadline_exhausted' );
 			}
+			$artifact_state = $load_artifact();
+			if ( is_wp_error( $artifact_state ) ) {
+				return $artifact_state;
+			}
+			$artifact = $artifact_state['artifact'];
+			$args     = $artifact_state['args'];
 			$args['compiled_artifact_result']                 = $composed_state['result'];
 			$args['_static_site_importer_precompiled_source'] = true;
 
@@ -709,34 +723,6 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		return true;
 	}
 
-	/** Validate every referenced retained value before a resumed phase reads it. */
-	private static function validate_retained_refs( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run ) {
-		$kinds = array(
-			'artifact'        => 'artifact',
-			'shared'          => 'shared',
-			'composed'        => 'composed',
-			'materialization' => 'materialization',
-			'final'           => 'final',
-		);
-		foreach ( $kinds as $key => $kind ) {
-			if ( isset( $run['refs'][ $key ] ) && is_wp_error( self::read_checkpoint( $workspace, $run, $run['refs'][ $key ], $kind ) ) ) {
-				return self::read_checkpoint( $workspace, $run, $run['refs'][ $key ], $kind );
-			}
-		}
-		foreach ( array(
-			'pages'    => 'page_plan',
-			'receipts' => 'receipt',
-		) as $key => $kind ) {
-			foreach ( is_array( $run['refs'][ $key ] ?? null ) ? $run['refs'][ $key ] : array() as $ref ) {
-				$value = self::read_checkpoint( $workspace, $run, $ref, $kind );
-				if ( is_wp_error( $value ) ) {
-					return $value;
-				}
-			}
-		}
-		return true;
-	}
-
 	/** Persist the boundary before entering an uninterruptible owning call. */
 	private static function enter_phase( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, string $phase, array $page_ids = array() ) {
 		$run['phase']                           = $phase;
@@ -908,6 +894,10 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	}
 
 	private static function read_checkpoint( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, array $ref, string $kind ) {
+		$cache_key = spl_object_id( $workspace ) . ':' . $kind . ':' . (string) ( $ref['sha256'] ?? '' );
+		if ( array_key_exists( $cache_key, self::$checkpoint_read_cache ) ) {
+			return self::$checkpoint_read_cache[ $cache_key ];
+		}
 		$relative = is_string( $ref['file'] ?? null ) ? $ref['file'] : '';
 		$raw      = '' !== $relative ? $workspace->read_raw( $relative ) : null;
 		$record   = is_string( $raw ) ? json_decode( $raw, true ) : null;
@@ -922,7 +912,11 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		if ( ! is_array( $record ) || ! hash_equals( (string) ( $ref['sha256'] ?? '' ), $raw_hash ) || self::CHECKPOINT_SCHEMA !== ( $record['schema'] ?? '' ) || ( $record['kind'] ?? '' ) !== $kind || ( $record['import_id'] ?? '' ) !== $run['import_id'] || ( $run['binding']['artifact_identity'] ?? '' ) !== ( $record['artifact_identity'] ?? '' ) || ! is_array( $record['payload'] ?? null ) || ! hash_equals( (string) ( $record['payload_sha256'] ?? '' ), self::hash( $record['payload'] ) ) || ! hash_equals( (string) ( $ref['payload'] ?? '' ), (string) $record['payload_sha256'] ) || ! self::checkpoint_contract_valid( $record['payload'], $kind, $run ) ) {
 			return new WP_Error( 'static_site_importer_direct_artifact_checkpoint_invalid', 'A retained direct artifact checkpoint failed its identity, hash, or contract validation.' );
 		}
-		return $record['payload'];
+		self::$checkpoint_read_cache[ $cache_key ] = $record['payload'];
+		if ( function_exists( 'do_action' ) ) {
+			do_action( 'static_site_importer_direct_artifact_checkpoint_read', $kind, self::evidence( $run ) );
+		}
+		return self::$checkpoint_read_cache[ $cache_key ];
 	}
 
 	private static function existing_checkpoint_ref( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, string $relative, string $kind ) {

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -160,7 +160,6 @@ $resume = static fn ( string $id, string $operation = 'apply' ): array => array(
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'][] = static fn ( array $policy ): array => array_merge(
 	$policy,
 	array(
-		'prepare_batch_pages' => 1,
 		'compile_batch_pages' => 1,
 	)
 );
@@ -172,10 +171,10 @@ $frozen = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' 
 $assert( ! empty( $frozen['success'] ) && ! empty( $frozen['continuation'] ) && 'artifact_frozen' === ( $frozen['continuation_reason'] ?? '' ) && 0 === ( $frozen['artifact_run']['progress']['prepared_count'] ?? -1 ), 'large direct artifacts must yield after durable freezing so source request memory can unwind before compilation' );
 array_pop( $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] );
 $frozen_resumed = Static_Site_Importer_Canonical_Import_Service::import( $resume( (string) $frozen['import_id'], 'plan' ) );
-$assert( ! empty( $frozen_resumed['success'] ) && ! empty( $frozen_resumed['continuation'] ) && 1 === ( $frozen_resumed['artifact_run']['progress']['prepared_count'] ?? 0 ), 'source-free resume must validate and hydrate immutable artifact file shards before bounded page work' );
+$assert( ! empty( $frozen_resumed['success'] ) && ! empty( $frozen_resumed['continuation'] ) && 3 === ( $frozen_resumed['artifact_run']['progress']['prepared_count'] ?? 0 ) && 1 === ( $frozen_resumed['artifact_run']['progress']['receipt_count'] ?? 0 ), 'source-free resume must hydrate the immutable artifact once, prepare every page in one pass, and compile only its bounded receipt batch' );
 
 $first = Static_Site_Importer_Canonical_Import_Service::import( $input() );
-$assert( ! empty( $first['success'] ) && ! empty( $first['continuation'] ) && 'pages_remaining' === ( $first['continuation_reason'] ?? '' ) && 1 === ( $first['artifact_run']['progress']['prepared_count'] ?? 0 ) && 0 === ( $first['artifact_run']['progress']['receipt_count'] ?? -1 ) && 'continuing' === ( $first['import_report_summary']['status'] ?? '' ), 'the first invocation must durably prepare only its bounded page batch and explicitly continue' );
+$assert( ! empty( $first['success'] ) && ! empty( $first['continuation'] ) && 'pages_remaining' === ( $first['continuation_reason'] ?? '' ) && 3 === ( $first['artifact_run']['progress']['prepared_count'] ?? 0 ) && 1 === ( $first['artifact_run']['progress']['receipt_count'] ?? -1 ) && 'continuing' === ( $first['import_report_summary']['status'] ?? '' ), 'the first invocation must durably prepare all page plans in one partition, compile one bounded receipt batch, and explicitly continue' );
 $import_id = (string) $first['import_id'];
 $mismatch = $resume( $import_id );
 $mismatch['slug'] = 'different-frozen-contract';
@@ -189,20 +188,15 @@ $assert( ! empty( $busy['continuation'] ) && 'run_in_progress' === ( $busy['cont
 $locked_workspace->release_lock( $execution_lock );
 $GLOBALS['ssi_direct_checkpoint_reads'] = array();
 $second = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
-$assert( ! empty( $second['continuation'] ) && 2 === ( $second['artifact_run']['progress']['prepared_count'] ?? 0 ) && 0 === ( $second['artifact_run']['progress']['receipt_count'] ?? -1 ), 'resume must skip the first durable page plan and prepare only the next page' );
-$assert( 1 === ( $GLOBALS['ssi_direct_checkpoint_reads']['artifact'] ?? 0 ) && 1 === ( $GLOBALS['ssi_direct_checkpoint_reads']['shared'] ?? 0 ), 'a preparation resume must hydrate each required large checkpoint once' );
-$third = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
-$assert( ! empty( $third['continuation'] ) && 3 === ( $third['artifact_run']['progress']['prepared_count'] ?? 0 ) && 1 === ( $third['artifact_run']['progress']['receipt_count'] ?? 0 ), 'the final preparation invocation may compile only its bounded first page batch' );
-$GLOBALS['ssi_direct_checkpoint_reads'] = array();
-$fourth = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
-$assert( ! empty( $fourth['continuation'] ) && 2 === ( $fourth['artifact_run']['progress']['receipt_count'] ?? 0 ), 'resume must skip the first durable receipt and compile only the next page' );
+$assert( ! empty( $second['continuation'] ) && 3 === ( $second['artifact_run']['progress']['prepared_count'] ?? 0 ) && 2 === ( $second['artifact_run']['progress']['receipt_count'] ?? -1 ), 'resume must reuse every durable page plan and compile only the next receipt batch' );
 $assert( 0 === ( $GLOBALS['ssi_direct_checkpoint_reads']['artifact'] ?? 0 ) && 1 === ( $GLOBALS['ssi_direct_checkpoint_reads']['shared'] ?? 0 ) && 1 === ( $GLOBALS['ssi_direct_checkpoint_reads']['page_plan'] ?? 0 ), 'a compile-only resume must skip the source artifact and decode each consumed checkpoint once' );
-$terminal = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
+$third = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
+$terminal = $third;
 $work = $terminal['artifact_run']['work'] ?? array();
 $terminal_work = $terminal['artifact_run']['terminal_result_work'] ?? array();
 $assert( ! empty( $terminal['success'] ) && empty( $terminal['continuation'] ) && 1 === $GLOBALS['ssi_direct_mutations'], 'resumed apply must perform exactly one importer mutation' );
 $assert( array( 1, 1, 1 ) === ( $work['page_compile_counts'] ?? null ) && 3 === count( $terminal['artifact_run']['receipt_identities'] ?? array() ) && 3 === ( $work['pages_compiled'] ?? 0 ), 'durable counters and receipt evidence must prove every page compiled exactly once' );
-$assert( 3 === ( $work['page_prepare_passes'] ?? 0 ) && 3 === ( $work['page_plans_prepared'] ?? 0 ), 'durable counters must prove every page was prepared in a bounded pass exactly once' );
+$assert( 1 === ( $work['page_prepare_passes'] ?? 0 ) && 3 === ( $work['page_plans_prepared'] ?? 0 ), 'durable counters must prove every page plan was prepared by one whole-artifact partition' );
 $assert( 1 === ( $work['content_policy_applications'] ?? 0 ) && 1 === ( $work['client_script_policy_applications'] ?? 0 ), 'content and client script policy must each run once before the artifact is frozen' );
 $assert( 1 === ( $work['materialization_claims'] ?? 0 ) && 1 === ( $work['materializations'] ?? 0 ) && true === ( $GLOBALS['ssi_direct_last_args']['_static_site_importer_precompiled_source'] ?? false ), 'apply must claim once and use the precompiled source handoff' );
 $assert( 0 === ( $terminal_work['html_document_transform_count'] ?? -1 ) && 0 === ( $terminal_work['normalization_count'] ?? -1 ), 'terminal composition must perform zero HTML transforms and normalization' );
@@ -211,7 +205,7 @@ $assert( ! str_contains( (string) json_encode( $terminal['artifact_run'] ), $tes
 $replay = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
 $assert( $terminal === $replay && 1 === $GLOBALS['ssi_direct_mutations'], 'terminal replay must return the durable response without compile or mutation' );
 
-$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array( static fn ( array $policy ): array => array_merge( $policy, array( 'prepare_batch_pages' => 20, 'compile_batch_pages' => 20 ) ) );
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array( static fn ( array $policy ): array => array_merge( $policy, array( 'compile_batch_pages' => 20 ) ) );
 $clean = Static_Site_Importer_Canonical_Import_Service::import( $input() );
 $canonical = static function ( array $response ): array {
 	unset( $response['import_id'], $response['artifact_run'] );

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -10,6 +10,7 @@ $GLOBALS['ssi_direct_actions'] = array();
 $GLOBALS['ssi_direct_mutations'] = 0;
 $GLOBALS['ssi_direct_last_args'] = array();
 $GLOBALS['ssi_direct_compiled_results'] = array();
+$GLOBALS['ssi_direct_checkpoint_reads'] = array();
 
 class WP_Error {
 	public function __construct( private string $code, private string $message = '', private $data = null ) {}
@@ -163,6 +164,9 @@ $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'
 		'compile_batch_pages' => 1,
 	)
 );
+$GLOBALS['ssi_direct_actions']['static_site_importer_direct_artifact_checkpoint_read'][] = static function ( string $kind ): void {
+	$GLOBALS['ssi_direct_checkpoint_reads'][ $kind ] = (int) ( $GLOBALS['ssi_direct_checkpoint_reads'][ $kind ] ?? 0 ) + 1;
+};
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'][] = static fn ( array $policy ): array => array_merge( $policy, array( 'freeze_continuation_bytes' => 1 ) );
 $frozen = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
 $assert( ! empty( $frozen['success'] ) && ! empty( $frozen['continuation'] ) && 'artifact_frozen' === ( $frozen['continuation_reason'] ?? '' ) && 0 === ( $frozen['artifact_run']['progress']['prepared_count'] ?? -1 ), 'large direct artifacts must yield after durable freezing so source request memory can unwind before compilation' );
@@ -183,12 +187,16 @@ $assert( is_resource( $execution_lock ), 'the fixture must own the serialized ex
 $busy = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
 $assert( ! empty( $busy['continuation'] ) && 'run_in_progress' === ( $busy['continuation_reason'] ?? '' ) && 0 === $GLOBALS['ssi_direct_mutations'], 'a concurrent resume must yield without mutating run state or WordPress' );
 $locked_workspace->release_lock( $execution_lock );
+$GLOBALS['ssi_direct_checkpoint_reads'] = array();
 $second = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
 $assert( ! empty( $second['continuation'] ) && 2 === ( $second['artifact_run']['progress']['prepared_count'] ?? 0 ) && 0 === ( $second['artifact_run']['progress']['receipt_count'] ?? -1 ), 'resume must skip the first durable page plan and prepare only the next page' );
+$assert( 1 === ( $GLOBALS['ssi_direct_checkpoint_reads']['artifact'] ?? 0 ) && 1 === ( $GLOBALS['ssi_direct_checkpoint_reads']['shared'] ?? 0 ), 'a preparation resume must hydrate each required large checkpoint once' );
 $third = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
 $assert( ! empty( $third['continuation'] ) && 3 === ( $third['artifact_run']['progress']['prepared_count'] ?? 0 ) && 1 === ( $third['artifact_run']['progress']['receipt_count'] ?? 0 ), 'the final preparation invocation may compile only its bounded first page batch' );
+$GLOBALS['ssi_direct_checkpoint_reads'] = array();
 $fourth = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
 $assert( ! empty( $fourth['continuation'] ) && 2 === ( $fourth['artifact_run']['progress']['receipt_count'] ?? 0 ), 'resume must skip the first durable receipt and compile only the next page' );
+$assert( 0 === ( $GLOBALS['ssi_direct_checkpoint_reads']['artifact'] ?? 0 ) && 1 === ( $GLOBALS['ssi_direct_checkpoint_reads']['shared'] ?? 0 ) && 1 === ( $GLOBALS['ssi_direct_checkpoint_reads']['page_plan'] ?? 0 ), 'a compile-only resume must skip the source artifact and decode each consumed checkpoint once' );
 $terminal = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
 $work = $terminal['artifact_run']['work'] ?? array();
 $terminal_work = $terminal['artifact_run']['terminal_result_work'] ?? array();


### PR DESCRIPTION
## Summary

- validate retained direct-artifact checkpoints on their first consuming read instead of eagerly scanning the whole run
- cache validated checkpoint payloads for one logical start/resume invocation
- hydrate the frozen source artifact only during shared/page preparation or terminal planning/materialization
- prepare every page plan through Blocks Engine `preparePages()` after one whole-artifact partition instead of repeatedly calling `preparePage()`
- preserve bounded, independently resumable receipt compilation and terminal composition
- add deterministic evidence proving one preparation pass and phase-local checkpoint reads

Fixes #1340.

## Corpus evidence

Measured against a retained 68.4 MB, 19-page artifact with the companion Blocks Engine shared-reduction change:

- page-plan preparation: 749.05 seconds across repeated preparations to 14.56 seconds in one pass
- retained shared checkpoint: approximately 121 MB to 138,684 bytes after existing file sharding
- all 19 page plans remain independently checkpointed and compilable

## Verification

- `npm test` (64 selected checks passed)
- `php tests/smoke-direct-artifact-import.php`
- `php tests/smoke-artifact-run-primitives.php`
- `homeboy review lint` PHPCS alignment findings resolved
- `git diff --check`

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode inspected the retained run, measured checkpoint sizes and phase timings, implemented phase-local validated hydration and one-pass page preparation, added deterministic resume evidence, resolved the prior lint gate, and ran verification. Chris Huber directed the repair and remains responsible for the change.