### PR TITLE
Accept compact Blocks Engine artifact receipts

### DIFF
--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -23,7 +23,10 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	private const RUN_SCHEMA                    = 'static-site-importer/direct-artifact-run/v1';
 	private const CHECKPOINT_SCHEMA             = 'static-site-importer/direct-artifact-checkpoint/v1';
 	private const EVIDENCE_SCHEMA               = 'static-site-importer/direct-artifact-run-evidence/v1';
-	private const RECEIPT_SCHEMA                = 'blocks-engine/php-transformer/compiled-page-receipt/v2';
+	private const RECEIPT_SCHEMAS               = array(
+		'blocks-engine/php-transformer/compiled-page-receipt/v2',
+		'blocks-engine/php-transformer/compiled-page-receipt/v3',
+	);
 	private const TTL                           = 604800;
 	private const CLEANUP_HOOK                  = 'static_site_importer_purge_direct_artifact_imports';
 	private static array $checkpoint_read_cache = array();
@@ -717,11 +720,15 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	}
 
 	private static function validate_receipt( $receipt, array $page_plan, array $shared ) {
+		$receipt_schema     = $receipt['receipt_schema'] ?? '';
 		$reduction          = is_array( $receipt['terminal_reduction'] ?? null ) ? $receipt['terminal_reduction'] : array();
-		$required_reduction = array( 'files', 'normalization', 'source_documents', 'owned_transformable_paths', 'stylesheet_occurrence_files', 'component_facts', 'block_types' );
+		$required_reduction = array( 'normalization', 'source_documents', 'owned_transformable_paths', 'stylesheet_occurrence_files', 'component_facts', 'block_types' );
+		if ( 'blocks-engine/php-transformer/compiled-page-receipt/v2' === $receipt_schema ) {
+			$required_reduction[] = 'files';
+		}
 		$reduction_complete = empty( array_diff( $required_reduction, array_keys( $reduction ) ) );
-		if ( ! is_array( $receipt ) || self::RECEIPT_SCHEMA !== ( $receipt['receipt_schema'] ?? '' ) || ( $page_plan['page_id'] ?? '' ) !== ( $receipt['page_id'] ?? '' ) || ( $shared['digest'] ?? '' ) !== ( $receipt['shared_digest'] ?? '' ) || ( $shared['shared_reduction_digest'] ?? '' ) !== ( $receipt['shared_reduction_digest'] ?? '' ) || ( $page_plan['compiler_options'] ?? null ) !== ( $receipt['compiler_options'] ?? null ) || ( $page_plan['output_schema'] ?? null ) !== ( $receipt['output_schema'] ?? null ) || ( $page_plan['digest'] ?? '' ) === ( $receipt['digest'] ?? '' ) || empty( $receipt['digest'] ) || ! is_array( $receipt['compiled_documents'] ?? null ) || ! is_array( $receipt['owned_document_paths'] ?? null ) || ! $reduction_complete ) {
-			return new WP_Error( 'static_site_importer_direct_artifact_receipt_invalid', 'A compiled page receipt does not satisfy the frozen v2 receipt contract.' );
+		if ( ! is_array( $receipt ) || ! in_array( $receipt_schema, self::RECEIPT_SCHEMAS, true ) || ( $page_plan['page_id'] ?? '' ) !== ( $receipt['page_id'] ?? '' ) || ( $shared['digest'] ?? '' ) !== ( $receipt['shared_digest'] ?? '' ) || ( $shared['shared_reduction_digest'] ?? '' ) !== ( $receipt['shared_reduction_digest'] ?? '' ) || ( $page_plan['compiler_options'] ?? null ) !== ( $receipt['compiler_options'] ?? null ) || ( $page_plan['output_schema'] ?? null ) !== ( $receipt['output_schema'] ?? null ) || ( $page_plan['digest'] ?? '' ) === ( $receipt['digest'] ?? '' ) || empty( $receipt['digest'] ) || ! is_array( $receipt['compiled_documents'] ?? null ) || ! is_array( $receipt['owned_document_paths'] ?? null ) || ! $reduction_complete ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_receipt_invalid', 'A compiled page receipt does not satisfy a published terminal receipt contract.' );
 		}
 		return true;
 	}
@@ -1194,7 +1201,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		}
 		if ( 'receipt' === $kind ) {
 			return is_string( $payload['page_id'] ?? null )
-				&& self::RECEIPT_SCHEMA === ( $payload['receipt']['receipt_schema'] ?? '' )
+				&& in_array( $payload['receipt']['receipt_schema'] ?? '', self::RECEIPT_SCHEMAS, true )
 				&& ( $payload['receipt']['page_id'] ?? null ) === $payload['page_id']
 				&& is_array( $payload['receipt']['terminal_reduction'] ?? null );
 		}

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -108,6 +108,27 @@ $assert = static function ( bool $condition, string $message ): void {
 		throw new RuntimeException( $message );
 	}
 };
+$validate_receipt = new ReflectionMethod( Static_Site_Importer_Direct_Artifact_Import::class, 'validate_receipt' );
+$shared_receipt_contract = array( 'digest' => 'shared-digest', 'shared_reduction_digest' => 'shared-reduction-digest' );
+$page_receipt_contract = array( 'page_id' => 'website/index.html', 'digest' => 'page-digest', 'compiler_options' => array(), 'output_schema' => 'blocks-engine/php-transformer/result/v1' );
+$compact_receipt = array(
+	'receipt_schema'          => 'blocks-engine/php-transformer/compiled-page-receipt/v3',
+	'page_id'                 => 'website/index.html',
+	'shared_digest'           => 'shared-digest',
+	'shared_reduction_digest' => 'shared-reduction-digest',
+	'compiler_options'        => array(),
+	'output_schema'           => 'blocks-engine/php-transformer/result/v1',
+	'digest'                  => 'compact-receipt-digest',
+	'compiled_documents'      => array(),
+	'owned_document_paths'    => array(),
+	'terminal_reduction'      => array_fill_keys( array( 'normalization', 'source_documents', 'owned_transformable_paths', 'stylesheet_occurrence_files', 'component_facts', 'block_types' ), array() ),
+);
+$assert( true === $validate_receipt->invoke( null, $compact_receipt, $page_receipt_contract, $shared_receipt_contract ), 'compact v3 receipts must validate without duplicated shared files' );
+$legacy_receipt = $compact_receipt;
+$legacy_receipt['receipt_schema'] = 'blocks-engine/php-transformer/compiled-page-receipt/v2';
+$assert( is_wp_error( $validate_receipt->invoke( null, $legacy_receipt, $page_receipt_contract, $shared_receipt_contract ) ), 'v2 receipts must retain their files reduction contract' );
+$legacy_receipt['terminal_reduction']['files'] = array();
+$assert( true === $validate_receipt->invoke( null, $legacy_receipt, $page_receipt_contract, $shared_receipt_contract ), 'complete v2 receipts must remain compatible' );
 $hash_json = new ReflectionMethod( Static_Site_Importer_Direct_Artifact_Import::class, 'hash_json' );
 $ordered = array( 'z' => array( 'b' => 2, 'a' => 1 ), 'a' => 'https://example.com/a/b' );
 $canonical = array( 'a' => 'https://example.com/a/b', 'z' => array( 'a' => 1, 'b' => 2 ) );


### PR DESCRIPTION
## Summary
- accept published Blocks Engine compiled-page receipt v2 and compact v3 contracts
- require the files terminal reduction only for v2 receipts
- retain fail-closed validation for receipt bindings and immutable checkpoints
- cover compact v3 and legacy v2 validation behavior

## Runtime evidence
A fresh 19-page June Digan import using merged Blocks Engine `f2b42751` reached its first compile batch, where SSI rejected the emitted v3 receipt because the validator was pinned to v2. The run made zero WordPress mutations.

## Verification
- `php tests/smoke-direct-artifact-import.php`
- `node --test tools/build-dev-package.test.mjs`
- PHP syntax checks and `git diff --check`
- `npm test`: 63 passed, 1 unrelated timing-sensitive fixture-matrix test failed under concurrent Homeboy process load and also failed in isolation

Closes #1340

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode diagnosed the persisted cross-repository receipt mismatch, implemented the scoped validator and regression coverage, built the exact merged dependency package, and ran the verification. Chris Huber directed the workflow and reviewed the evidence.