### PR TITLE
Preserve development package build failure evidence

### DIFF
--- a/tools/build-dev-package.mjs
+++ b/tools/build-dev-package.mjs
@@ -166,9 +166,22 @@ function runCommand(command, args, { cwd }) {
   try {
     return execFileSync(command, args, { cwd, encoding: "buffer", stdio: ["ignore", "pipe", "pipe"] })
   } catch (error) {
-    const detail = error.stderr?.toString().trim() || error.message
-    throw new Error(`${command} ${args.join(" ")} failed: ${detail}`)
+    throw new Error(commandFailureMessage(command, args, error))
   }
+}
+
+export function commandFailureMessage(command, args, error) {
+  const status = Number.isInteger(error.status) ? ` (exit ${error.status})` : ""
+  const output = [boundedOutput(error.stdout), boundedOutput(error.stderr)].filter(Boolean).join("\n")
+  return `${command} ${args.join(" ")}${status} failed: ${output || error.message}`
+}
+
+function boundedOutput(output, limit = 32768) {
+  const value = output?.toString().trim() ?? ""
+  if (value.length <= limit) return value
+  const marker = `\n...[truncated ${value.length - limit} characters]...\n`
+  const edge = Math.floor((limit - marker.length) / 2)
+  return `${value.slice(0, edge)}${marker}${value.slice(-edge)}`
 }
 
 function text(value) {

--- a/tools/build-dev-package.test.mjs
+++ b/tools/build-dev-package.test.mjs
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
 import test from "node:test"
-import { buildDevelopmentPackage, developmentComposerManifest, overlayWorkingTree, parseArguments, provenance, worktreeIdentity } from "./build-dev-package.mjs"
+import { buildDevelopmentPackage, commandFailureMessage, developmentComposerManifest, overlayWorkingTree, parseArguments, provenance, worktreeIdentity } from "./build-dev-package.mjs"
 
 test("parses explicit Blocks Engine inputs and sensible defaults", () => {
   const defaults = parseArguments([], "/workspace/static-site-importer")
@@ -102,4 +102,18 @@ test("worktree overlay rejects reconstructable directories", async () => {
   await mkdir(join(directory, "source", "vendor"), { recursive: true })
   await assert.rejects(() => overlayWorkingTree(join(directory, "source"), join(directory, "snapshot"), ["vendor/cache.php"]), /reconstructable path/)
   await rm(directory, { recursive: true, force: true })
+})
+
+test("nested command failures preserve bounded stdout and stderr evidence", () => {
+  const stdoutOnly = commandFailureMessage("homeboy", ["review", "build"], { status: 7, stdout: Buffer.from("structured stdout"), stderr: Buffer.from(""), message: "generic failure" })
+  assert.equal(stdoutOnly, "homeboy review build (exit 7) failed: structured stdout")
+
+  const combined = commandFailureMessage("homeboy", ["review", "build"], { status: 1, stdout: Buffer.from("stdout evidence"), stderr: Buffer.from("stderr evidence"), message: "generic failure" })
+  assert.match(combined, /stdout evidence\nstderr evidence$/)
+
+  const oversized = commandFailureMessage("homeboy", ["review", "build"], { status: 1, stdout: Buffer.from(`start-${"x".repeat(65536)}-end`), stderr: Buffer.from(""), message: "generic failure" })
+  assert.match(oversized, /start-/)
+  assert.match(oversized, /truncated \d+ characters/)
+  assert.match(oversized, /-end$/)
+  assert.ok(oversized.length < 33000)
 })


### PR DESCRIPTION
## Summary
- preserve bounded stdout and stderr from failed package build subprocesses
- include the failed command and exit status
- cover stdout-only, combined, and truncated failure evidence

## Verification
- `npm run test:dev-package`
- `node --check tools/build-dev-package.mjs`
- `node --check tools/build-dev-package.test.mjs`
- exact candidate package build completed through `homeboy review build`

Fixes #1347.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode diagnosed the dropped subprocess evidence, implemented the bounded formatter and regression coverage, and ran the package-build verification. Chris Huber directed the workflow and reviewed the resulting evidence.