### PR TITLE
Materialize provider-bound forms directly

### DIFF
--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -718,9 +718,9 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 	public static function materialize_lifecycle_dependencies( array $lifecycle, array $args ) {
 		$reports = array();
 		foreach ( $lifecycle['dependencies'] ?? array() as $id => $prepared ) {
-			$adapter = $prepared['adapter'];
+			$adapter  = $prepared['adapter'];
 			$required = ! empty( $prepared['required'] ) || self::lifecycle_entity_has_bindings( $lifecycle['entities'][ $id ] ?? array() );
-			$waived  = ! empty( $args[ (string) ( $adapter['waiver_arg'] ?? '' ) ] );
+			$waived   = ! empty( $args[ (string) ( $adapter['waiver_arg'] ?? '' ) ] );
 			if ( $waived ) {
 				$reports[ $id ] = array(
 					'status'   => 'waived',

--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -719,6 +719,7 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 		$reports = array();
 		foreach ( $lifecycle['dependencies'] ?? array() as $id => $prepared ) {
 			$adapter = $prepared['adapter'];
+			$required = ! empty( $prepared['required'] ) || self::lifecycle_entity_has_bindings( $lifecycle['entities'][ $id ] ?? array() );
 			$waived  = ! empty( $args[ (string) ( $adapter['waiver_arg'] ?? '' ) ] );
 			if ( $waived ) {
 				$reports[ $id ] = array(
@@ -727,7 +728,7 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 				);
 				continue;
 			}
-			if ( empty( $args['materialize_dependencies'] ) && ! self::dependencies_available( $adapter ) && ! empty( $prepared['required'] ) ) {
+			if ( empty( $args['materialize_dependencies'] ) && ! self::dependencies_available( $adapter ) && $required ) {
 				return new WP_Error(
 					'static_site_importer_required_runtime_dependency_missing',
 					'A required runtime dependency is unavailable and dependency materialization is disabled.',
@@ -751,7 +752,7 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 					);
 				}
 			}
-			if ( 'prepare' !== ( $args['runtime_lifecycle_phase'] ?? '' ) && ! self::dependencies_available( $adapter ) && ! empty( $prepared['required'] ) ) {
+			if ( 'prepare' !== ( $args['runtime_lifecycle_phase'] ?? '' ) && ! self::dependencies_available( $adapter ) && $required ) {
 				return new WP_Error(
 					'static_site_importer_required_runtime_dependency_missing',
 					'SSI could not prepare a required runtime dependency.',
@@ -769,7 +770,7 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 	/** Materialize all prepared provider entities and retain their receipts. */
 	public static function materialize_lifecycle_entities( array $lifecycle, array $args ): array {
 		$reports  = array();
-		$required = array_filter( $lifecycle['entities'] ?? array(), static fn( array $prepared ): bool => ! empty( $prepared['required'] ) );
+		$required = array_filter( $lifecycle['entities'] ?? array(), static fn( array $prepared ): bool => ! empty( $prepared['required'] ) || self::lifecycle_entity_has_bindings( $prepared ) );
 		if ( empty( $args['seed_entities'] ) && empty( $required ) ) {
 			return array(
 				'reports' => $reports,
@@ -802,8 +803,9 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 			$reports[ $id ] = $report;
 			$counts         = is_array( $report['counts'] ?? null ) ? $report['counts'] : array();
 			$expected       = count( is_array( $prepared['manifest']['products'] ?? null ) ? $prepared['manifest']['products'] : ( $prepared['manifest']['forms'] ?? array() ) );
-			$completed      = array_sum( array_map( 'intval', array_intersect_key( $counts, array_flip( array( 'created', 'updated', 'mapped', 'skipped' ) ) ) ) );
-			if ( in_array( $report['status'] ?? '', array( 'failed', 'error' ), true ) || ! empty( $counts['failed'] ) || ! empty( $counts['error'] ) || ( ! empty( $prepared['required'] ) && $completed < $expected ) ) {
+			$completed_keys = self::lifecycle_entity_has_bindings( $prepared ) ? array( 'created', 'updated', 'mapped' ) : array( 'created', 'updated', 'mapped', 'skipped' );
+			$completed      = array_sum( array_map( 'intval', array_intersect_key( $counts, array_flip( $completed_keys ) ) ) );
+			if ( in_array( $report['status'] ?? '', array( 'failed', 'error' ), true ) || ! empty( $counts['failed'] ) || ! empty( $counts['error'] ) || ( ( ! empty( $prepared['required'] ) || self::lifecycle_entity_has_bindings( $prepared ) ) && $completed < $expected ) ) {
 				$code    = isset( $report['code'] ) && is_scalar( $report['code'] ) ? (string) $report['code'] : 'static_site_importer_entity_materialization_failed';
 				$message = isset( $report['error'] ) && is_scalar( $report['error'] ) ? (string) $report['error'] : ( isset( $report['reason'] ) && is_scalar( $report['reason'] ) && '' !== (string) $report['reason'] ? (string) $report['reason'] : 'Runtime entity materialization failed for declaration: ' . $id . '.' );
 				return array(
@@ -819,6 +821,18 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 			'reports' => $reports,
 			'error'   => null,
 		);
+	}
+
+	/** A canonical page binding makes its provider entity part of materialization. */
+	private static function lifecycle_entity_has_bindings( array $prepared ): bool {
+		$manifest = is_array( $prepared['manifest'] ?? null ) ? $prepared['manifest'] : array();
+		$entities = is_array( $manifest['products'] ?? null ) ? $manifest['products'] : ( is_array( $manifest['forms'] ?? null ) ? $manifest['forms'] : array() );
+		foreach ( $entities as $entity ) {
+			if ( is_array( $entity ) && ! empty( $entity['bindings'] ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/** Build exact provider-owned block replacements without consulting diagnostics. */

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -131,7 +131,11 @@ class Static_Site_Importer_Form_Seeder {
 		$report['provider']             = self::PROVIDER_ID;
 		$report['available']            = $available;
 		$report['availability_details'] = $availability;
-		$report['status']               = 'completed';
+		$report['status']               = $available ? 'completed' : 'failed';
+		if ( ! $available ) {
+			$report['code']   = 'static_site_importer_form_provider_unavailable';
+			$report['reason'] = 'provider_unavailable';
+		}
 
 		foreach ( $forms as $form ) {
 			$row               = $available ? self::seed_form( $form, true ) : self::unavailable_form_row( $form );
@@ -501,7 +505,7 @@ class Static_Site_Importer_Form_Seeder {
 		$unaccepted_losses           = array_values(
 			array_filter(
 				$layout['receipt']['losses'] ?? array(),
-				static fn( $loss ): bool => is_array( $loss ) && self::receipt_loss_requires_gate( $loss ) && true !== apply_filters( 'static_site_importer_form_receipt_loss_accepted', false, $loss, $form, $row )
+				static fn( $loss ): bool => is_array( $loss ) && self::receipt_loss_requires_gate( $loss ) && ! self::provider_represents_receipt_loss( $loss, $form, $field_blocks ) && true !== apply_filters( 'static_site_importer_form_receipt_loss_accepted', false, $loss, $form, $row )
 			)
 		);
 		$gate_overflow_count         = (int) ( $layout['receipt']['gate_required_loss_overflow_count'] ?? 0 );
@@ -516,11 +520,33 @@ class Static_Site_Importer_Form_Seeder {
 		if ( ! empty( $unaccepted_losses ) ) {
 			$row['provider_mapped']                = true;
 			$row['runtime_mapped']                 = false;
+			$row['status']                         = 'error';
 			$row['reason']                         = 'form_receipt_loss_unaccepted';
 			$row['form_receipt_unaccepted_losses'] = $unaccepted_losses;
 			$row['unaccepted_receipt_loss_count']  = count( $unaccepted_losses );
 		}
 		return $row;
+	}
+
+	/** A source label wrapper is carried by the mapped Jetpack field's label child. */
+	private static function provider_represents_receipt_loss( array $loss, array $form, array $field_blocks ): bool {
+		if ( 'unsupported_semantic_wrapper' !== ( $loss['reason_code'] ?? '' ) || ! is_string( $loss['node_hash'] ?? null ) ) {
+			return false;
+		}
+		$nodes = isset( $form['control_topology']['nodes'] ) && is_array( $form['control_topology']['nodes'] ) ? $form['control_topology']['nodes'] : array();
+		foreach ( $nodes as $node ) {
+			if ( ! is_array( $node ) || 'wrapper' !== ( $node['kind'] ?? '' ) || 'label' !== ( $node['tag'] ?? '' ) || hash( 'sha256', (string) ( $node['id'] ?? '' ) ) !== $loss['node_hash'] ) {
+				continue;
+			}
+			$controls = array_values(
+				array_filter(
+					$nodes,
+					static fn( $candidate ): bool => is_array( $candidate ) && 'control' === ( $candidate['kind'] ?? '' ) && ( $candidate['parent'] ?? '' ) === ( $node['id'] ?? '' ) && is_int( $candidate['control'] ?? null ) && isset( $field_blocks[ $candidate['control'] ] )
+				)
+			);
+			return 1 === count( $controls );
+		}
+		return false;
 	}
 
 	/**

--- a/includes/class-static-site-importer-quality-budget-admission.php
+++ b/includes/class-static-site-importer-quality-budget-admission.php
@@ -34,37 +34,37 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 		$families                = self::core_html_families( $diagnostics );
 		$unresolved_media        = self::metric( $metrics, array( 'unresolved_media_count', 'unresolved_asset_count' ) );
 		$unresolved_dependencies = self::metric( $metrics, array( 'unresolved_dependency_count', 'dependency_failure_count', 'runtime_dependency_parity_issue_count' ) );
-		$materialized_quality     = isset( $report['quality'] ) && is_array( $report['quality'] ) ? $report['quality'] : array();
-		$materialized_metrics     = isset( $materialized_quality['metrics'] ) && is_array( $materialized_quality['metrics'] ) ? $materialized_quality['metrics'] : $materialized_quality;
-		$fallbacks                = self::metric( $materialized_metrics, array( 'fallback_count', 'unresolved_fallback_count' ) );
+		$materialized_quality    = isset( $report['quality'] ) && is_array( $report['quality'] ) ? $report['quality'] : array();
+		$materialized_metrics    = isset( $materialized_quality['metrics'] ) && is_array( $materialized_quality['metrics'] ) ? $materialized_quality['metrics'] : $materialized_quality;
+		$fallbacks               = self::metric( $materialized_metrics, array( 'fallback_count', 'unresolved_fallback_count' ) );
 		if ( null === $fallbacks ) {
 			$fallbacks = self::metric( $metrics, array( 'fallback_count', 'unresolved_fallback_count' ) );
 		}
-		$bootstrap_bytes         = self::bootstrap_bytes( $writes );
-		$stylesheets             = self::stylesheet_count( $writes );
-		$evidence                = array(
+		$bootstrap_bytes = self::bootstrap_bytes( $writes );
+		$stylesheets     = self::stylesheet_count( $writes );
+		$evidence        = array(
 			'native_block_count'          => $native_blocks,
 			'core_html_block_count'       => $core_html,
 			'core_html_families'          => $families,
 			'unresolved_media_count'      => $unresolved_media,
 			'unresolved_dependency_count' => $unresolved_dependencies,
-			'fallback_count'               => $fallbacks,
+			'fallback_count'              => $fallbacks,
 			'bootstrap_bytes'             => $bootstrap_bytes,
 			'stylesheet_asset_count'      => $stylesheets,
 			'visual_gate'                 => self::gate_status( $args, $report, 'visual' ),
 			'editor_gate'                 => self::gate_status( $args, $report, 'editor' ),
 		);
-		$limits                  = array(
+		$limits          = array(
 			'max_native_block_count'          => $native_blocks,
 			'max_core_html_block_count'       => $core_html,
 			'max_core_html_family_count'      => count( $families ),
 			'max_unresolved_media_count'      => $unresolved_media,
 			'max_unresolved_dependency_count' => $unresolved_dependencies,
-			'max_fallback_count'               => $fallbacks,
+			'max_fallback_count'              => $fallbacks,
 			'max_bootstrap_bytes'             => $bootstrap_bytes,
 			'max_stylesheet_asset_count'      => $stylesheets,
 		);
-		$failures                = array();
+		$failures        = array();
 		foreach ( $limits as $limit => $actual ) {
 			if ( ! array_key_exists( $limit, $budget ) ) {
 				continue;

--- a/includes/class-static-site-importer-quality-budget-admission.php
+++ b/includes/class-static-site-importer-quality-budget-admission.php
@@ -34,6 +34,12 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 		$families                = self::core_html_families( $diagnostics );
 		$unresolved_media        = self::metric( $metrics, array( 'unresolved_media_count', 'unresolved_asset_count' ) );
 		$unresolved_dependencies = self::metric( $metrics, array( 'unresolved_dependency_count', 'dependency_failure_count', 'runtime_dependency_parity_issue_count' ) );
+		$materialized_quality     = isset( $report['quality'] ) && is_array( $report['quality'] ) ? $report['quality'] : array();
+		$materialized_metrics     = isset( $materialized_quality['metrics'] ) && is_array( $materialized_quality['metrics'] ) ? $materialized_quality['metrics'] : $materialized_quality;
+		$fallbacks                = self::metric( $materialized_metrics, array( 'fallback_count', 'unresolved_fallback_count' ) );
+		if ( null === $fallbacks ) {
+			$fallbacks = self::metric( $metrics, array( 'fallback_count', 'unresolved_fallback_count' ) );
+		}
 		$bootstrap_bytes         = self::bootstrap_bytes( $writes );
 		$stylesheets             = self::stylesheet_count( $writes );
 		$evidence                = array(
@@ -42,6 +48,7 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 			'core_html_families'          => $families,
 			'unresolved_media_count'      => $unresolved_media,
 			'unresolved_dependency_count' => $unresolved_dependencies,
+			'fallback_count'               => $fallbacks,
 			'bootstrap_bytes'             => $bootstrap_bytes,
 			'stylesheet_asset_count'      => $stylesheets,
 			'visual_gate'                 => self::gate_status( $args, $report, 'visual' ),
@@ -53,6 +60,7 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 			'max_core_html_family_count'      => count( $families ),
 			'max_unresolved_media_count'      => $unresolved_media,
 			'max_unresolved_dependency_count' => $unresolved_dependencies,
+			'max_fallback_count'               => $fallbacks,
 			'max_bootstrap_bytes'             => $bootstrap_bytes,
 			'max_stylesheet_asset_count'      => $stylesheets,
 		);

--- a/tests/fixtures/direct-artifact-multi-page/about.html
+++ b/tests/fixtures/direct-artifact-multi-page/about.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<html><head><title>About Direct Artifact</title><link rel="stylesheet" href="styles.css"><style>.repeated{color:#c2410c;font-weight:700}</style></head><body><main><article class="card"><h1>About</h1><p class="repeated">Shared presentation</p><a href="contact.html">Contact</a></article></main></body></html>
+<html><head><title>About Direct Artifact</title><link rel="stylesheet" href="styles.css"><style>.repeated{color:#c2410c;font-weight:700}</style></head><body><main><article class="card"><h1>About</h1><p class="repeated">Shared presentation</p><form class="contact-form desktop"><label>Email <input type="email" name="email" required></label><button type="submit">Contact me</button></form><a href="contact.html">Contact</a></article></main></body></html>

--- a/tests/fixtures/direct-artifact-multi-page/contact.html
+++ b/tests/fixtures/direct-artifact-multi-page/contact.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<html><head><title>Contact Direct Artifact</title><link rel="stylesheet" href="styles.css"><style>.repeated{color:#c2410c;font-weight:700}</style></head><body><main><article class="card"><h1>Contact</h1><p class="repeated">Shared presentation</p><a href="index.html">Home</a></article></main></body></html>
+<html><head><title>Contact Direct Artifact</title><link rel="stylesheet" href="styles.css"><style>.repeated{color:#c2410c;font-weight:700}</style></head><body><main><article class="card"><h1>Contact</h1><p class="repeated">Shared presentation</p><form class="contact-form mobile"><label>Email <input type="email" name="email" required></label><button type="submit">Contact me</button></form><a href="index.html">Home</a></article></main></body></html>

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -60,6 +60,19 @@ namespace {
 			return true;
 		}
 	}
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( private string $code, private string $message = '', private $data = null ) {}
+			public function get_error_code(): string { return $this->code; }
+			public function get_error_message(): string { return $this->message; }
+			public function get_error_data() { return $this->data; }
+		}
+	}
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $value ): bool {
+			return class_exists( 'WP_Error' ) && $value instanceof WP_Error;
+		}
+	}
 
 	$wp_root = getenv( 'STATIC_SITE_IMPORTER_WP_ROOT' ) ?: '/Users/chubes/Studio/intelligence-chubes4';
 	$parser  = rtrim( $wp_root, '/\\' ) . '/wp-includes/class-wp-block-parser.php';
@@ -287,6 +300,19 @@ namespace {
 	$assert( str_contains( $escaped_label_markup, '<!-- wp:jetpack/label ' . $expected_sensitive_attrs . ' /-->' ), 'field-attributes-byte-match-core-escaping', $escaped_label_markup );
 	$assert( str_contains( $expected_sensitive_attrs, '\\u005c' ) && str_contains( $expected_sensitive_attrs, '\\u0022' ) && str_contains( $expected_sensitive_attrs, '\\u002d\\u002d' ) && str_contains( $expected_sensitive_attrs, '\\u003c' ) && str_contains( $expected_sensitive_attrs, '\\u003e' ) && str_contains( $expected_sensitive_attrs, '\\u0026' ), 'field-attributes-core-escapes-every-comment-sensitive-character', $expected_sensitive_attrs );
 	$assert( $escaped_label_markup === serialize_blocks( parse_blocks( $escaped_label_markup ) ), 'field-attributes-round-trip-through-wordpress-block-parser', $escaped_label_markup );
+
+	// --- Composed route forms materialize directly without caller seeding ----
+	$route_form = '<main><form class="contact"><label>Email <input type="email" name="email" required></label><button type="submit">Contact me</button></form></main>';
+	$composed_result = ( new \Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler() )->compile(
+		array( 'entrypoint' => 'about.html', 'files' => array( 'about.html' => $route_form, 'contact.html' => $route_form ) )
+	)->toArray();
+	$composed_plan = $composed_result['source_reports']['wordpress_site_plan'] ?? array();
+	$composed_lifecycle = Static_Site_Importer_Entity_Materializer_Registry::plan_runtime_lifecycle( $composed_plan, array() );
+	$composed_entities = Static_Site_Importer_Entity_Materializer_Registry::materialize_lifecycle_entities( $composed_lifecycle, array( 'seed_entities' => false ) );
+	$composed_bindings = Static_Site_Importer_Entity_Materializer_Registry::block_bindings( $composed_lifecycle, $composed_entities['reports'] ?? array() );
+	$composed_form_receipt = reset( $composed_entities['reports'] );
+	$assert( 2 === ( $composed_plan['quality']['metrics']['fallback_count'] ?? -1 ) && 2 === ( $composed_form_receipt['counts']['mapped'] ?? 0 ), 'composed-route-forms-produce-one-provider-receipt' );
+	$assert( is_array( $composed_bindings ) && 2 === count( $composed_bindings ) && array() === array_filter( $composed_bindings, static fn( array $binding ): bool => 'jetpack' !== ( $binding['provider'] ?? '' ) || '' === ( $binding['fallback_reconciliation_identity'] ?? '' ) ), 'composed-route-forms-produce-identity-bound-provider-bindings', (string) wp_json_encode( array( 'receipt' => $composed_form_receipt, 'bindings' => $composed_bindings ) ) );
 
 	// --- Generic topology preserves nested rows and source presentation hooks --
 	$topology_form = array(
@@ -530,6 +556,7 @@ namespace {
 	$GLOBALS['ssi_jetpack_form_blocks_available'] = false;
 	$unavailable_seed                              = Static_Site_Importer_Form_Seeder::seed( $forms_manifest );
 	$unavailable_row                               = $unavailable_seed['forms'][0] ?? array();
+	$assert( 'failed' === ( $unavailable_seed['status'] ?? '' ) && 'static_site_importer_form_provider_unavailable' === ( $unavailable_seed['code'] ?? '' ), 'seed-unavailable-provider-fails-explicitly' );
 	$assert( 1 === ( $unavailable_seed['counts']['skipped'] ?? 0 ), 'seed-unavailable-provider-skips-form' );
 	$assert( 'provider_unavailable' === ( $unavailable_row['reason'] ?? '' ), 'seed-unavailable-provider-reason' );
 	$assert( false === ( $unavailable_row['runtime_mapped'] ?? true ), 'seed-unavailable-provider-not-runtime-mapped' );

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -222,6 +222,12 @@ $assert( 1 === ( $work['content_policy_applications'] ?? 0 ) && 1 === ( $work['c
 $assert( 1 === ( $work['materialization_claims'] ?? 0 ) && 1 === ( $work['materializations'] ?? 0 ) && true === ( $GLOBALS['ssi_direct_last_args']['_static_site_importer_precompiled_source'] ?? false ), 'apply must claim once and use the precompiled source handoff' );
 $assert( 0 === ( $terminal_work['html_document_transform_count'] ?? -1 ) && 0 === ( $terminal_work['normalization_count'] ?? -1 ), 'terminal composition must perform zero HTML transforms and normalization' );
 $assert( ! str_contains( (string) json_encode( $terminal['artifact_run'] ), $test_root ) && ! str_contains( (string) json_encode( $terminal['artifact_run'] ), 'website/index.html' ), 'public run evidence must remain bounded and path-free' );
+$composed_plan = $GLOBALS['ssi_direct_compiled_results'][0]['source_reports']['wordpress_site_plan'] ?? array();
+$form_declarations = array_values( array_filter( $composed_plan['runtime_declarations'] ?? array(), static fn( $declaration ): bool => is_array( $declaration ) && 'entity_collection' === ( $declaration['kind'] ?? '' ) && 'forms' === ( $declaration['type'] ?? '' ) ) );
+$form_dependencies = array_values( array_filter( $composed_plan['runtime_declarations'] ?? array(), static fn( $declaration ): bool => is_array( $declaration ) && 'dependency' === ( $declaration['kind'] ?? '' ) && 'form' === ( $declaration['capability'] ?? '' ) ) );
+$assert( 2 === ( $composed_plan['quality']['metrics']['fallback_count'] ?? -1 ) && 2 === count( $form_declarations[0]['payload']['entities'] ?? array() ), 'real terminal composition must retain both route-level provider-materializable form entities' );
+$assert( array() === array_filter( $form_declarations[0]['payload']['entities'] ?? array(), static fn( $entity ): bool => ! is_array( $entity ) || empty( $entity['bindings'] ) ), 'real terminal composition must retain an exact provider binding for each form entity' );
+$assert( in_array( 'entity_collection:forms', $form_dependencies[0]['required_for'] ?? array(), true ), 'compact page receipts must compose the form provider admission relationship' );
 
 $replay = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
 $assert( $terminal === $replay && 1 === $GLOBALS['ssi_direct_mutations'], 'terminal replay must return the durable response without compile or mutation' );

--- a/tests/smoke-entity-materializer-registry.php
+++ b/tests/smoke-entity-materializer-registry.php
@@ -29,9 +29,10 @@ namespace {
 
 	if ( ! class_exists( 'WP_Error' ) ) {
 		class WP_Error {
-			public function __construct( private string $code, private string $message ) {}
+			public function __construct( private string $code, private string $message, private $data = null ) {}
 			public function get_error_code(): string { return $this->code; }
 			public function get_error_message(): string { return $this->message; }
+			public function get_error_data() { return $this->data; }
 		}
 	}
 
@@ -99,6 +100,45 @@ namespace {
 	$assert( ! empty( $duplicate_products['errors'] ), 'duplicate-product-slugs-reject-provider-result-ambiguity' );
 	$duplicate_forms = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( array( 'source_path' => 'index.html', 'selector' => 'form', 'controls' => array( array( 'tag' => 'input', 'type' => 'email' ) ) ), array( 'source_path' => 'index.html', 'selector' => 'form', 'controls' => array( array( 'tag' => 'input', 'type' => 'email' ) ) ) ) ) );
 	$assert( ! empty( $duplicate_forms['errors'] ), 'duplicate-form-identities-reject-provider-result-ambiguity' );
+
+	$materializer_calls = 0;
+	$bound_adapter      = array(
+		'provider'     => 'test-provider',
+		'waiver_arg'   => 'allow_missing_test_provider',
+		'materializer' => static function ( array $manifest ) use ( &$materializer_calls ): array {
+			++$materializer_calls;
+			return array(
+				'status' => 'completed',
+				'counts' => array( 'mapped' => count( $manifest['forms'] ?? array() ) ),
+				'forms'  => $manifest['forms'] ?? array(),
+			);
+		},
+	);
+	$bound_forms = array(
+		'forms' => array(
+			array( 'source_path' => 'about.html', 'selector' => 'form.desktop', 'bindings' => array( array( 'role' => 'form' ) ) ),
+			array( 'source_path' => 'contact.html', 'selector' => 'form.mobile', 'bindings' => array( array( 'role' => 'form' ) ) ),
+		),
+	);
+	$bound_lifecycle = array(
+		'entities' => array(
+			'forms' => array( 'adapter' => $bound_adapter, 'manifest' => $bound_forms, 'required' => false ),
+		),
+	);
+	$bound_result = Static_Site_Importer_Entity_Materializer_Registry::materialize_lifecycle_entities( $bound_lifecycle, array( 'seed_entities' => false ) );
+	$assert( 1 === $materializer_calls && 2 === ( $bound_result['reports']['forms']['counts']['mapped'] ?? 0 ), 'bound-entities-materialize-without-opt-in-seeding' );
+
+	$form_adapter = Static_Site_Importer_Entity_Materializer_Registry::form_adapter();
+	$missing_provider_lifecycle = array(
+		'dependencies' => array(
+			'forms' => array( 'adapter' => $form_adapter, 'required' => false ),
+		),
+		'entities' => array(
+			'forms' => array( 'adapter' => $form_adapter, 'manifest' => $bound_forms, 'required' => false ),
+		),
+	);
+	$missing_provider = Static_Site_Importer_Entity_Materializer_Registry::materialize_lifecycle_dependencies( $missing_provider_lifecycle, array( 'materialize_dependencies' => false ) );
+	$assert( is_wp_error( $missing_provider ) && 'static_site_importer_required_runtime_dependency_missing' === $missing_provider->get_error_code(), 'bound-entity-missing-provider-rejects-admission' );
 
 	if ( $failures ) {
 		fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-quality-budget-admission.php
+++ b/tests/smoke-quality-budget-admission.php
@@ -26,4 +26,10 @@ $assert( 'preview' === $preview['status'] && 'failed' === $preview['production_s
 $unknown = Static_Site_Importer_Quality_Budget_Admission::evaluate( array(), array(), array() );
 $assert( 'not_proven' === $unknown['production_status'] && 'preview' === $unknown['status'], 'imports without budget evidence remain explicitly not proven' );
 
+$source_fallback_plan = array( 'quality' => array( 'metrics' => array( 'fallback_count' => 2 ) ) );
+$resolved_fallbacks = Static_Site_Importer_Quality_Budget_Admission::evaluate( $source_fallback_plan, array(), array( 'quality_budget' => array( 'mode' => 'production', 'max_fallback_count' => 0 ) ), array( 'quality' => array( 'fallback_count' => 0, 'source_fallback_count' => 2 ) ) );
+$assert( 'passed' === $resolved_fallbacks['production_status'] && 0 === $resolved_fallbacks['evidence']['fallback_count'], 'zero-fallback admission uses the provider-reconciled materialized result' );
+$unresolved_fallbacks = Static_Site_Importer_Quality_Budget_Admission::evaluate( $source_fallback_plan, array(), array( 'quality_budget' => array( 'mode' => 'production', 'max_fallback_count' => 0 ) ) );
+$assert( 'failed' === $unresolved_fallbacks['production_status'] && 2 === $unresolved_fallbacks['evidence']['fallback_count'], 'unresolved provider-materializable fallbacks fail zero-fallback admission' );
+
 print "quality budget admission smoke passed\n";


### PR DESCRIPTION
## Summary
- route provider-bound forms through the registered form materializer instead of fallback HTML
- preserve provider metadata through entity materialization
- cover admission, registry, and direct artifact import behavior

Closes #625

## Verification
- `php tests/form-materializer-smoke.php`
- `php tests/smoke-entity-materializer-registry.php`
- `php tests/smoke-quality-budget-admission.php`
- `php tests/smoke-direct-artifact-import.php`

## AI Assistance
OpenCode with OpenAI openai/gpt-5.6-sol, orchestrated by Chris Huber, implemented and verified the repair under direct human-directed workflow.