### PR TITLE
fix(ci): tighten the pixelmatch colour threshold in the promotion gate

### DIFF
--- a/.github/workflows/solved-site-promotion.yml
+++ b/.github/workflows/solved-site-promotion.yml
@@ -166,7 +166,7 @@ jobs:
             --wp-codebox-bin "$WP_CODEBOX_BIN" \
             --wordpress-version "$WORDPRESS_VERSION" \
             --pixel-threshold 0 \
-            --visual-parity-pixelmatch-threshold 0 \
+            --visual-parity-pixelmatch-threshold 0.01 \
             --visual-parity-max-vertical-shift 0 \
             --visual-parity-max-horizontal-shift 0 \
             --run-id "$RUN_ID" \


### PR DESCRIPTION
Fixes #1358.

```diff
-            --visual-parity-pixelmatch-threshold 0 \
+            --visual-parity-pixelmatch-threshold 0.01 \
```

## The flag is not what its use suggests

`--visual-parity-pixelmatch-threshold` is pixelmatch's **per-pixel colour distance** — `maxDelta = 35215 × threshold²` in YIQ space. It is not a fraction of allowed pixels. That is `--pixel-threshold`, which stays at `0`.

At `0`, a pixel counts as mismatched when any channel differs by `1/255`. Combined with `--pixel-threshold 0`, the gate required a **bit-exact render** across two independent headless browser runs — not "visually identical", byte-identical RGB. Rasterisation does not guarantee that: font hinting and subpixel positioning, image decode rounding, lazy-decode timing and compositor tile boundaries all produce ±1 channel drift on a handful of pixels.

## Why 0.01 and not pixelmatch's 0.1 default

Measured against the library — smallest delta that counts as a mismatch:

| threshold | grey shift (all channels) | red channel only |
|---|---|---|
| `0` | 1/255 | 1/255 |
| `0.005` | 2 | 3 |
| **`0.01`** | **3** | **5** |
| `0.02` | 6 | 10 |
| `0.05` | 14 | 24 |
| `0.1` | 27 | 47 |

`0.1` is pixelmatch's general-purpose screenshot default and tolerates a **27-level grey shift** — roughly 10% brightness, plainly visible. That is far too loose for a gate whose purpose is proving 1:1 parity.

`0.01` sits just above the noise floor:

```
at threshold 0.01:
  observed drift: 6px, red +1     -> 0 mismatched  tolerated
  1px grey +1  (noise)            -> 0 mismatched  tolerated
  1px grey +2  (noise)            -> 0 mismatched  tolerated
  1px grey +3  (real change)      -> 1 mismatched  CAUGHT
  1px grey +10 (real change)      -> 1 mismatched  CAUGHT
  1px red +5   (real change)      -> 1 mismatched  CAUGHT
```

## Evidence it was noise, not a regression

`blocks-engine` trunk at `f972274e`, after **eleven consecutive greens**:

```
Aligned visual parity mismatch: 6/9955320 pixels (0.00%)
exceed the 0.00% threshold
(raw full-page 0.00%, detected offset x=0px, y=0px)
```

`detected offset x=0px, y=0px` rules out layout shift, so the shift tolerances are not implicated.

Re-runs of the **same commit, no code change between attempts**:

| Commit | Result |
|---|---|
| `22b0807e` (prior green, control) | pass |
| `f972274e` | **fail** |
| `f972274e` re-run | **fail** |
| `f972274e` re-run | **pass** |

The change under suspicion was separately verified unreachable — an import inside a method with no callers — so it could not have moved a pixel.

## Where the 0 came from

All four zero-tolerances landed together in the gate's first commit, `6a4a8435` (2026-07-21, "Add solved site promotion gate"), and were never tuned. `tools/run-fixture-matrix.mjs:167` already defaults this knob to `0.1` when omitted; only the workflow overrode it.

## What is unchanged

`--pixel-threshold 0` and both shift tolerances stay at `0`. A single perceptibly different pixel still fails the gate, and any layout movement still fails it.

## Follow-up

`blocks-engine/.github/workflows/solved-fixture-regression.yml` pins this workflow by SHA (`@2edd49e6...`), so blocks-engine keeps the flaky behaviour until that pin is bumped to this commit.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed a red trunk gate, established the suspect change was dead code, ran control and repeat executions to separate flakiness from regression, bisected the flag's introduction, and measured the threshold's actual tolerance against pixelmatch to choose a value. Chris Huber directed the work, challenged the initial 0.1, and remains responsible for the change.