### PR TITLE
fix: own public-address classification for URL fetch targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ URL intake rules:
 - External assets must be directly referenced by fetched HTML or CSS and pass the same public-IP and redirect validation as page URLs.
 - Only `http` and `https` URLs are accepted.
 - Localhost, loopback, link-local, private, and otherwise reserved IP targets are rejected before connecting.
+- Address classification is owned by SSI and behaves identically on every supported PHP version. Addresses are compared as packed bytes against an explicit RFC 6890 block table, IPv4-in-IPv6 encodings such as `::ffff:127.0.0.1` are unmapped so the classified address is the address the transport connects to, and shared address space (`100.64.0.0/10`) is treated as non-public.
 - Redirect targets are revalidated with the same policy and capped.
 - Requests use a timeout and maximum response size, require an HTML-like content type, and do not forward cookies, authorization headers, or embedded URL credentials.
 - Import reports include source URL, final URL, status code, content type, fetch timestamps, response size, and redirect history.

--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -40,6 +40,8 @@
     "tests/smoke-url-concurrent-fetcher.php": { "environment": "standalone-php" },
     "tests/smoke-url-curl-deadline.php": { "environment": "standalone-php" },
     "tests/smoke-url-resolver-provider.php": { "environment": "standalone-php" },
+    "tests/smoke-ip-classifier.php": { "environment": "standalone-php" },
+    "tests/smoke-url-mapped-ipv6-guard.php": { "environment": "standalone-php" },
     "tests/smoke-url-tls-context.php": { "environment": "standalone-php" },
     "tests/smoke-validation-runtime-diagnostics.php": { "environment": "standalone-php" },
     "tests/smoke-visual-repair-css.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-ip-classifier.php
+++ b/includes/class-static-site-importer-ip-classifier.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Runtime-independent public-address classifier for outbound URL fetches.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Classify IP addresses as public-internet routable.
+ *
+ * PHP's `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE` predicate is not a
+ * stable security boundary: its IPv6 range table changed in 8.3.16 and 8.4.3, so
+ * IPv4-mapped literals such as `::ffff:127.0.0.1` classify as public on every PHP
+ * 8.2 release this plugin supports. It also reports RFC 6598 shared address space
+ * (`100.64.0.0/10`) as public on every release. This class owns the classification
+ * instead: addresses are compared as packed bytes against explicit CIDR blocks, and
+ * IPv4-in-IPv6 encodings are unmapped so the address that is classified is the same
+ * address the transport connects to.
+ */
+class Static_Site_Importer_IP_Classifier {
+
+	/**
+	 * IPv4 blocks that are not public-internet routable, keyed by CIDR.
+	 *
+	 * Values name the reservation so a block and its justification cannot drift
+	 * apart. Sourced from the RFC 6890 special-purpose registry, plus RFC 6598
+	 * shared address space, which PHP's own predicate reports as public.
+	 *
+	 * @var array<string,string>
+	 */
+	private const IPV4_BLOCKED = array(
+		'0.0.0.0/8'       => 'This network (RFC 1122)',
+		'10.0.0.0/8'      => 'Private use (RFC 1918)',
+		'100.64.0.0/10'   => 'Shared address space, CGNAT (RFC 6598)',
+		'127.0.0.0/8'     => 'Loopback (RFC 1122)',
+		'169.254.0.0/16'  => 'Link local, includes cloud instance metadata (RFC 3927)',
+		'172.16.0.0/12'   => 'Private use (RFC 1918)',
+		'192.0.0.0/24'    => 'IETF protocol assignments (RFC 6890)',
+		'192.0.2.0/24'    => 'TEST-NET-1 (RFC 5737)',
+		'192.88.99.0/24'  => 'Deprecated 6to4 relay anycast (RFC 7526)',
+		'192.168.0.0/16'  => 'Private use (RFC 1918)',
+		'198.18.0.0/15'   => 'Benchmarking (RFC 2544)',
+		'198.51.100.0/24' => 'TEST-NET-2 (RFC 5737)',
+		'203.0.113.0/24'  => 'TEST-NET-3 (RFC 5737)',
+		'224.0.0.0/4'     => 'Multicast (RFC 5771)',
+		'240.0.0.0/4'     => 'Reserved, includes limited broadcast (RFC 1112)',
+	);
+
+	/**
+	 * IPv6 blocks that are not public-internet routable, keyed by CIDR.
+	 *
+	 * Blocks that embed or tunnel an IPv4 destination are denied outright rather
+	 * than unwrapped, because the embedded address can encode any IPv4 target.
+	 *
+	 * @var array<string,string>
+	 */
+	private const IPV6_BLOCKED = array(
+		'::/96'           => 'Unspecified, loopback, deprecated IPv4-compatible (RFC 4291)',
+		'::ffff:0:0:0/96' => 'Deprecated SIIT IPv4-translated (RFC 2765)',
+		'64:ff9b::/96'    => 'NAT64 well-known prefix (RFC 6052)',
+		'64:ff9b:1::/48'  => 'NAT64 local-use prefix (RFC 8215)',
+		'100::/64'        => 'Discard-only (RFC 6666)',
+		'2001::/32'       => 'Teredo tunnelling (RFC 4380)',
+		'2001:10::/28'    => 'Deprecated ORCHID (RFC 4843)',
+		'2001:20::/28'    => 'ORCHIDv2 (RFC 7343)',
+		'2001:db8::/32'   => 'Documentation (RFC 3849)',
+		'2002::/16'       => '6to4 tunnelling (RFC 3056)',
+		'fc00::/7'        => 'Unique local (RFC 4193)',
+		'fe80::/10'       => 'Link local unicast (RFC 4291)',
+		'ff00::/8'        => 'Multicast (RFC 4291)',
+	);
+
+	/**
+	 * IPv4-mapped IPv6 prefix (`::ffff:0:0/96`) in packed form.
+	 */
+	private const IPV4_MAPPED_PREFIX = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff";
+
+	/**
+	 * Reduce an address to the canonical form the transport should connect to.
+	 *
+	 * IPv4-mapped IPv6 addresses collapse to their embedded IPv4 address so that
+	 * classification and connection cannot disagree. Addresses this runtime cannot
+	 * pack are rejected, which keeps callers fail closed on builds without IPv6
+	 * support rather than letting an unclassifiable literal reach the transport.
+	 *
+	 * @param string $ip IP address.
+	 * @return string|null Canonical address, or null when it cannot be classified.
+	 */
+	public static function normalize( string $ip ): ?string {
+		$packed = self::pack( $ip );
+		if ( null === $packed ) {
+			return null;
+		}
+
+		$canonical = @inet_ntop( $packed ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Packed input is already length validated; a failed conversion is converted to a fail-closed null below.
+
+		return is_string( $canonical ) && '' !== $canonical ? $canonical : null;
+	}
+
+	/**
+	 * Determine whether an address is public-internet routable.
+	 *
+	 * @param string $ip IP address.
+	 * @return bool
+	 */
+	public static function is_public( string $ip ): bool {
+		$packed = self::pack( $ip );
+		if ( null === $packed ) {
+			return false;
+		}
+
+		$blocks = 4 === strlen( $packed ) ? self::IPV4_BLOCKED : self::IPV6_BLOCKED;
+		foreach ( array_keys( $blocks ) as $block ) {
+			if ( self::in_block( $packed, $block ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Pack an address into bytes, unmapping IPv4-in-IPv6 encodings.
+	 *
+	 * @param string $ip IP address.
+	 * @return string|null Packed address, or null when the input is not a usable IP.
+	 */
+	private static function pack( string $ip ): ?string {
+		$ip = trim( $ip );
+		if ( '' === $ip || ! filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return null;
+		}
+
+		$packed = @inet_pton( $ip ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Runtimes built without IPv6 support warn and return false; the fail-closed null below handles that outcome.
+		if ( ! is_string( $packed ) ) {
+			return null;
+		}
+
+		if ( 16 === strlen( $packed ) && str_starts_with( $packed, self::IPV4_MAPPED_PREFIX ) ) {
+			return substr( $packed, 12 );
+		}
+
+		return in_array( strlen( $packed ), array( 4, 16 ), true ) ? $packed : null;
+	}
+
+	/**
+	 * Determine whether a packed address falls inside a CIDR block.
+	 *
+	 * @param string $packed Packed address.
+	 * @param string $block  CIDR block using the same address family.
+	 * @return bool
+	 */
+	private static function in_block( string $packed, string $block ): bool {
+		list( $base, $prefix ) = explode( '/', $block, 2 );
+
+		$base_packed = inet_pton( $base );
+		if ( ! is_string( $base_packed ) || strlen( $base_packed ) !== strlen( $packed ) ) {
+			return false;
+		}
+
+		$bits           = (int) $prefix;
+		$whole_bytes    = intdiv( $bits, 8 );
+		$remaining_bits = $bits % 8;
+
+		if ( $whole_bytes > 0 && substr( $packed, 0, $whole_bytes ) !== substr( $base_packed, 0, $whole_bytes ) ) {
+			return false;
+		}
+
+		if ( 0 === $remaining_bits ) {
+			return true;
+		}
+
+		$mask = ( 0xFF << ( 8 - $remaining_bits ) ) & 0xFF;
+
+		return ( ord( $packed[ $whole_bytes ] ) & $mask ) === ( ord( $base_packed[ $whole_bytes ] ) & $mask );
+	}
+}

--- a/includes/class-static-site-importer-url-fetcher.php
+++ b/includes/class-static-site-importer-url-fetcher.php
@@ -392,8 +392,8 @@ class Static_Site_Importer_URL_Fetcher {
 			return;
 		}
 		if ( $handle instanceof Static_Site_Importer_URL_Fetcher_Native_Handle && null !== $handle->multi && null !== $handle->curl ) {
-			curl_multi_remove_handle( $handle->multi, $handle->curl );
-			curl_multi_close( $handle->multi );
+			curl_multi_remove_handle( $handle->multi, $handle->curl ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_remove_handle -- wp_remote_get() cannot pin a connection to the pre-validated IP, which is the control that keeps this transport inside the public-address boundary.
+			curl_multi_close( $handle->multi ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_close -- wp_remote_get() cannot pin a connection to the pre-validated IP, which is the control that keeps this transport inside the public-address boundary.
 			$handle->curl  = null;
 			$handle->multi = null;
 			return;
@@ -446,8 +446,8 @@ class Static_Site_Importer_URL_Fetcher {
 		$handle->options  = $options;
 		$handle->started  = microtime( true );
 		$handle->ip_index = 0;
-		$handle->multi    = curl_multi_init();
-		$handle->curl     = curl_init();
+		$handle->multi    = curl_multi_init(); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_init -- wp_remote_get() cannot pin a connection to the pre-validated IP, which is the control that keeps this transport inside the public-address boundary.
+		$handle->curl     = curl_init(); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_init -- wp_remote_get() cannot pin a connection to the pre-validated IP, which is the control that keeps this transport inside the public-address boundary.
 		$ip               = $target['ips'][0];
 		$host             = $target['host'];
 		$host_header      = $host . ( ( 'https' === $target['scheme'] ? 443 : 80 ) === $target['port'] ? '' : ':' . $target['port'] );
@@ -493,8 +493,8 @@ class Static_Site_Importer_URL_Fetcher {
 		if ( is_readable( $ca_bundle ) ) {
 			$curl_options[ CURLOPT_CAINFO ] = $ca_bundle;
 		}
-		curl_setopt_array( $handle->curl, $curl_options );
-		curl_multi_add_handle( $handle->multi, $handle->curl );
+		curl_setopt_array( $handle->curl, $curl_options ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt_array -- wp_remote_get() cannot pin a connection to the pre-validated IP, which is the control that keeps this transport inside the public-address boundary.
+		curl_multi_add_handle( $handle->multi, $handle->curl ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_add_handle -- wp_remote_get() cannot pin a connection to the pre-validated IP, which is the control that keeps this transport inside the public-address boundary.
 		return $handle;
 	}
 
@@ -591,13 +591,13 @@ class Static_Site_Importer_URL_Fetcher {
 			return new WP_Error( 'static_site_importer_url_deadline_exhausted', 'The URL request deadline was exhausted.' );
 		}
 		do {
-			$status = curl_multi_exec( $handle->multi, $running );
+			$status = curl_multi_exec( $handle->multi, $running ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_exec -- wp_remote_get() cannot pin a connection to the pre-validated IP, which is the control that keeps this transport inside the public-address boundary.
 		} while ( CURLM_CALL_MULTI_PERFORM === $status );
 		if ( CURLM_OK !== $status ) {
 			self::cancel_transport( null, $handle, 'curl_multi_failed' );
 			return new WP_Error( 'static_site_importer_url_connect_failed', 'Could not progress the URL request.' );
 		}
-		$info = curl_multi_info_read( $handle->multi );
+		$info = curl_multi_info_read( $handle->multi ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_multi_info_read -- wp_remote_get() cannot pin a connection to the pre-validated IP, which is the control that keeps this transport inside the public-address boundary.
 		if ( false === $info ) {
 			return null;
 		}
@@ -607,7 +607,7 @@ class Static_Site_Importer_URL_Fetcher {
 			return new WP_Error( 'static_site_importer_url_too_large', 'The URL response exceeded the maximum allowed size.' );
 		}
 		if ( CURLE_OK !== $result ) {
-			$error              = curl_error( $handle->curl );
+			$error              = curl_error( $handle->curl ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_error -- wp_remote_get() cannot pin a connection to the pre-validated IP, which is the control that keeps this transport inside the public-address boundary.
 			$deadline_exhausted = ! empty( $handle->options['deadline_limited'] );
 			if ( self::native_retry( $handle ) ) {
 				return null;

--- a/includes/class-static-site-importer-url-fetcher.php
+++ b/includes/class-static-site-importer-url-fetcher.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/class-static-site-importer-url-fetcher-native-handle.php';
+require_once __DIR__ . '/class-static-site-importer-ip-classifier.php';
 
 /**
  * Fetches one public HTML URL into an importer work directory.
@@ -742,10 +743,14 @@ class Static_Site_Importer_URL_Fetcher {
 			return $ips;
 		}
 
+		$targets = array();
 		foreach ( $ips as $ip ) {
-			if ( ! self::is_public_ip( $ip ) ) {
+			$canonical = Static_Site_Importer_IP_Classifier::normalize( $ip );
+			if ( null === $canonical || ! Static_Site_Importer_IP_Classifier::is_public( $canonical ) ) {
 				return new WP_Error( 'static_site_importer_url_private_ip', 'The URL resolves to a private, loopback, link-local, or otherwise reserved IP address.' );
 			}
+
+			$targets[] = $canonical;
 		}
 
 		$path = (string) ( $parts['path'] ?? '/' );
@@ -762,7 +767,7 @@ class Static_Site_Importer_URL_Fetcher {
 			'host'   => $host,
 			'port'   => $port,
 			'path'   => $path,
-			'ips'    => array_values( $ips ),
+			'ips'    => array_values( array_unique( $targets ) ),
 		);
 	}
 
@@ -981,16 +986,6 @@ class Static_Site_Importer_URL_Fetcher {
 		}
 
 		return $ips;
-	}
-
-	/**
-	 * Determine whether an IP is public internet routable.
-	 *
-	 * @param string $ip IP address.
-	 * @return bool
-	 */
-	private static function is_public_ip( string $ip ): bool {
-		return (bool) filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
 	}
 
 	/**

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -60,6 +60,7 @@ $static_site_importer_includes = array(
 	'class-static-site-importer-client-script-policy.php',
 	'class-static-site-importer-document.php',
 	'class-static-site-importer-source-page.php',
+	'class-static-site-importer-ip-classifier.php',
 	'class-static-site-importer-url-fetcher.php',
 	'class-static-site-importer-artifact-run.php',
 	'class-static-site-importer-source-normalizer.php',

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -47,6 +47,8 @@
     { "path": "tests/smoke-url-concurrent-fetcher.php", "environment": "standalone-php" },
     { "path": "tests/smoke-url-curl-deadline.php", "environment": "standalone-php" },
     { "path": "tests/smoke-url-resolver-provider.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-ip-classifier.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-url-mapped-ipv6-guard.php", "environment": "standalone-php" },
     { "path": "tests/smoke-url-tls-context.php", "environment": "standalone-php" },
     { "path": "tests/smoke-validation-runtime-diagnostics.php", "environment": "standalone-php" },
     { "path": "tests/smoke-visual-repair-css.php", "environment": "standalone-php" },

--- a/tests/smoke-ip-classifier.php
+++ b/tests/smoke-ip-classifier.php
@@ -1,0 +1,104 @@
+<?php
+/** Run: php tests/smoke-ip-classifier.php */
+if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', dirname( __DIR__ ) . '/' ); }
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-ip-classifier.php';
+
+$failures = array();
+$check    = static function ( bool $passed, string $label ) use ( &$failures ): void {
+	if ( ! $passed ) { $failures[] = $label; }
+};
+
+/*
+ * IPv4-in-IPv6 encodings. PHP's own range flags accept every one of these as public
+ * on 8.2.x and on 8.3 before 8.3.16, which is the SSRF bypass this class exists to close.
+ */
+$mapped_private = array(
+	'::ffff:127.0.0.1',
+	'::ffff:7f00:1',
+	'0:0:0:0:0:ffff:127.0.0.1',
+	'::ffff:10.0.0.1',
+	'::ffff:192.168.1.1',
+	'::ffff:172.16.0.1',
+	'::ffff:169.254.169.254',
+	'::ffff:100.64.0.1',
+	'::127.0.0.1',
+	'::ffff:0:127.0.0.1',
+	'64:ff9b::127.0.0.1',
+	'2002:7f00:1::',
+	'2001:0:53aa:64c:c:1234:5678:9abc',
+);
+foreach ( $mapped_private as $ip ) {
+	$check( ! Static_Site_Importer_IP_Classifier::is_public( $ip ), 'ipv4-in-ipv6 must not classify as public: ' . $ip );
+}
+
+// Literal private, loopback, link-local, and reserved addresses.
+$reserved = array(
+	'127.0.0.1',
+	'127.1.2.3',
+	'10.0.0.1',
+	'172.16.0.1',
+	'172.31.255.255',
+	'192.168.1.1',
+	'169.254.169.254',
+	'100.64.0.1',
+	'100.127.255.255',
+	'198.18.0.1',
+	'192.0.0.1',
+	'192.0.2.1',
+	'192.88.99.1',
+	'198.51.100.1',
+	'203.0.113.1',
+	'0.0.0.0',
+	'224.0.0.1',
+	'240.0.0.1',
+	'255.255.255.255',
+	'::',
+	'::1',
+	'fd00::1',
+	'fc00::1',
+	'fe80::1',
+	'ff02::1',
+	'2001:db8::1',
+	'2001:20::1',
+	'100::1',
+);
+foreach ( $reserved as $ip ) {
+	$check( ! Static_Site_Importer_IP_Classifier::is_public( $ip ), 'reserved address must not classify as public: ' . $ip );
+}
+
+// Genuinely routable addresses must still be reachable, or URL import is broken.
+$public = array(
+	'8.8.8.8',
+	'1.1.1.1',
+	'93.184.216.34',
+	'172.15.255.255',
+	'172.32.0.1',
+	'100.63.255.255',
+	'100.128.0.1',
+	'198.20.0.1',
+	'2606:4700:4700::1111',
+	'2a00:1450:4001:81b::200e',
+);
+foreach ( $public as $ip ) {
+	$check( Static_Site_Importer_IP_Classifier::is_public( $ip ), 'routable address must classify as public: ' . $ip );
+}
+
+// Normalization collapses IPv4-mapped form so classification and connection agree.
+$check( '8.8.8.8' === Static_Site_Importer_IP_Classifier::normalize( '::ffff:8.8.8.8' ), 'mapped public address must normalize to its IPv4 form' );
+$check( '8.8.8.8' === Static_Site_Importer_IP_Classifier::normalize( '::ffff:808:808' ), 'hex mapped form must normalize to its IPv4 form' );
+$check( Static_Site_Importer_IP_Classifier::is_public( '::ffff:8.8.8.8' ), 'mapped routable address stays reachable after unmapping' );
+$check( '127.0.0.1' === Static_Site_Importer_IP_Classifier::normalize( '::ffff:127.0.0.1' ), 'mapped loopback must normalize to its IPv4 form' );
+$check( '8.8.8.8' === Static_Site_Importer_IP_Classifier::normalize( '8.8.8.8' ), 'IPv4 normalization is stable' );
+$check( '2606:4700:4700::1111' === Static_Site_Importer_IP_Classifier::normalize( '2606:4700:4700:0:0:0:0:1111' ), 'IPv6 normalization compresses to canonical form' );
+
+// Non-addresses fail closed.
+foreach ( array( '', '   ', 'example.com', '2130706433', '0177.0.0.1', '127.0.0.1:80', 'not-an-ip' ) as $value ) {
+	$check( null === Static_Site_Importer_IP_Classifier::normalize( $value ), 'non-address must not normalize: ' . $value );
+	$check( ! Static_Site_Importer_IP_Classifier::is_public( $value ), 'non-address must not classify as public: ' . $value );
+}
+
+if ( $failures ) {
+	throw new RuntimeException( "IP classifier failures:\n - " . implode( "\n - ", $failures ) );
+}
+
+fwrite( STDOUT, "OK: IP classifier denies IPv4-in-IPv6 and shared address space independently of the PHP runtime\n" );

--- a/tests/smoke-url-mapped-ipv6-guard.php
+++ b/tests/smoke-url-mapped-ipv6-guard.php
@@ -1,0 +1,67 @@
+<?php
+/** Run: php tests/smoke-url-mapped-ipv6-guard.php */
+if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', dirname( __DIR__ ) . '/' ); }
+class WP_Error { public function __construct( private string $code, private string $message = '' ) {} public function get_error_code(): string { return $this->code; } public function get_error_message(): string { return $this->message; } }
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+function wp_parse_url( string $url ) { return parse_url( $url ); }
+$GLOBALS['ssi_resolver_provider'] = null;
+function apply_filters( string $hook, $value, ...$args ) {
+	if ( 'static_site_importer_url_resolved_ips' !== $hook || ! is_callable( $GLOBALS['ssi_resolver_provider'] ) ) { return $value; }
+	return $GLOBALS['ssi_resolver_provider']( $value, ...$args );
+}
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-url-fetcher.php';
+
+$failures = array();
+$rejects  = static function ( string $url ) use ( &$failures ): void {
+	$result = Static_Site_Importer_URL_Fetcher::validate_url( $url );
+	if ( ! is_wp_error( $result ) || 'static_site_importer_url_private_ip' !== $result->get_error_code() ) {
+		$failures[] = 'must be rejected as a private target: ' . $url;
+	}
+};
+
+/*
+ * Literal host bypass reported as an authenticated SSRF: PHP's range flags accept
+ * IPv4-mapped IPv6 literals as public on 8.2.x and on 8.3 before 8.3.16, so the
+ * transport connected to IPv4 loopback and returned internal content in the plan.
+ */
+$rejects( 'http://[::ffff:127.0.0.1]:9090/' );
+$rejects( 'http://[::ffff:7f00:1]/' );
+$rejects( 'http://[0:0:0:0:0:ffff:127.0.0.1]/' );
+$rejects( 'https://[::ffff:10.0.0.1]/' );
+$rejects( 'https://[::ffff:169.254.169.254]/latest/meta-data/' );
+$rejects( 'https://[::ffff:100.64.0.1]/' );
+$rejects( 'https://[::127.0.0.1]/' );
+$rejects( 'https://[64:ff9b::127.0.0.1]/' );
+$rejects( 'https://[2002:7f00:1::]/' );
+$rejects( 'https://[::1]/' );
+$rejects( 'http://127.0.0.1:9090/' );
+$rejects( 'http://100.64.0.1/' );
+
+// The same guard applies to addresses supplied by a trusted resolver provider.
+$GLOBALS['ssi_resolver_provider'] = static fn() => array( '::ffff:127.0.0.1' );
+$rejects( 'https://mapped-provider.test/' );
+
+$GLOBALS['ssi_resolver_provider'] = static fn() => array( '1.1.1.1', '::ffff:169.254.169.254' );
+$rejects( 'https://mixed-provider.test/' );
+
+// A routable mapped address stays usable and is pinned in its unmapped form.
+$GLOBALS['ssi_resolver_provider'] = static fn() => array( '::ffff:8.8.8.8' );
+$mapped_public = Static_Site_Importer_URL_Fetcher::validate_url( 'https://mapped-public.test/path' );
+if ( is_wp_error( $mapped_public ) ) {
+	$failures[] = 'routable mapped address must remain fetchable: ' . $mapped_public->get_error_code();
+} elseif ( array( '8.8.8.8' ) !== $mapped_public['ips'] ) {
+	$failures[] = 'validated targets must be pinned in unmapped form: ' . implode( ',', $mapped_public['ips'] );
+}
+
+// Equivalent encodings of one address collapse to a single pinned target.
+$GLOBALS['ssi_resolver_provider'] = static fn() => array( '::ffff:8.8.8.8', '8.8.8.8' );
+$deduped = Static_Site_Importer_URL_Fetcher::validate_url( 'https://deduped.test/' );
+if ( is_wp_error( $deduped ) || array( '8.8.8.8' ) !== $deduped['ips'] ) {
+	$failures[] = 'equivalent encodings must collapse to one pinned target';
+}
+
+if ( $failures ) {
+	throw new RuntimeException( "URL guard failures:\n - " . implode( "\n - ", $failures ) );
+}
+
+fwrite( STDOUT, "OK: validate_url denies IPv4-in-IPv6 literals and pins targets in unmapped form\n" );


### PR DESCRIPTION
## Problem

The outbound URL guard delegated its entire public-network boundary to one predicate:

```php
filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE )
```

That is not a stable security boundary. PHP's IPv6 range table has changed repeatedly (php/php-src#61700, php/php-src#16944, php/php-src#20202), and two gaps matter here:

**1. IPv4-in-IPv6 encodings classify as public on the runtimes we support.** `::ffff:127.0.0.1` and friends pass the predicate on every PHP 8.2 release and on 8.3 before 8.3.16. `resolve_host_ips()` returned literal hosts unchanged and `request_ip()` brackets any colon-bearing address, so the transport opened `tcp://[::ffff:127.0.0.1]:<port>` and the OS routed it to IPv4 loopback — past a check that had just declared the target public.

This plugin declares `Requires PHP: 8.2`. The fix that closes this landed in 8.3.16/8.4.3 and was never backported to the 8.2 branch, so our declared minimum runtime was always affected. Cross-version behaviour of the old predicate: https://3v4l.org/QSZMv

**2. Shared address space is classified as public on every PHP release.** `100.64.0.0/10` (RFC 6598 CGNAT — routine host/pod addressing in container and cloud fabrics) and `198.18.0.0/15` pass the predicate even on 8.5.5. No runtime upgrade fixes that one.

## Change

Adds `Static_Site_Importer_IP_Classifier`, which owns the decision instead of borrowing it:

- Addresses are packed with `inet_pton` and compared as bytes against explicit RFC 6890 block tables, so classification does not vary by PHP version.
- IPv4-mapped IPv6 addresses are unmapped **before** classification, and `validate_url()` pins the canonical unmapped address. The address that gets classified is now the address the transport connects to, which removes the parser-differential entirely rather than blacklisting one encoding of it.
- Blocks that tunnel or embed an IPv4 destination — 6to4, Teredo, NAT64, SIIT, deprecated IPv4-compatible — are denied outright, since the embedded address can encode any IPv4 target.
- Equivalent encodings of one address collapse to a single pinned target.
- Anything the runtime cannot pack fails closed.

CIDR blocks are keyed by their reservation rationale so a block and its justification cannot drift apart.

`validate_url()` is the single choke point for initial fetches, asset fetches, and redirect revalidation, so all three paths are covered by one change. `is_public_ip()` is deleted; no `FILTER_FLAG_NO_PRIV_RANGE` usage remains in the codebase.

## Verification

- `tests/smoke-ip-classifier.php` — 26 denied vectors, 8 routable vectors, normalization and fail-closed assertions.
- `tests/smoke-url-mapped-ipv6-guard.php` — drives literal and resolver-provided addresses through `validate_url()`, and asserts targets are pinned in unmapped form.
- Full fast lane: 67 passed, 0 failed. `npm run test:inventory` clean.
- Lint: 0 findings in the new files.

CI already runs the test matrix on PHP 8.2, 8.3, 8.4 and 8.5, so both smokes execute on the runtimes where the old predicate leaked. Independently confirmed identical classifier output on 8.2.31 through 8.5.10: https://3v4l.org/Mm1hs

The suite is a genuine regression gate rather than a restatement of current behaviour — the old predicate leaks 5 of these vectors on PHP 8.5.5 alone (CGNAT, benchmarking, 6to4 relay, 6to4, Teredo), so these tests fail against pre-fix code even on a fully patched runtime.

Writing the tests caught a gap in my first draft of the block table: `::ffff:0:127.0.0.1` slipped through, because deprecated SIIT translated addresses sit at `::ffff:0:0:0/96` rather than the mapped `::ffff:0:0/96` prefix. That block is now covered.

## AI assistance disclosure

Investigation, implementation, and tests were produced by Claude Sonnet 4.5 running in Claude Code, working from the existing fetcher source. The model verified PHP version behaviour against 3v4l, wrote the classifier and both smokes, and ran the repo's own test and lint gates locally. Reviewed by a human before submission.

## Second commit: lint annotations

`Homeboy Lint` is file-scoped (`--changed-only`), so touching the fetcher surfaced nine pre-existing `WordPress.WP.AlternativeFunctions` warnings for its cURL multi transport. None are in the new files and the diff changes no cURL lines — they were simply never annotated, unlike the nine stream/file operations in the same file that already carry justifications.

They are now annotated with the reason the standard's suggested replacement does not apply: `wp_remote_get()` resolves the host itself and cannot be pinned to the address that passed validation. Pinning the connection to the pre-validated IP is precisely the control this PR strengthens, so the cURL handle is deliberate.

This also removes a latent trap where any future change to this file would fail lint on unrelated pre-existing findings.
