### PR TITLE
fix: render editable companion content through the audited safe-markup boundary

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -800,27 +800,47 @@ class Static_Site_Importer_Companion_Plugin {
 
 	/** Build the SSI-owned safe boundary for generic editable companion content. */
 	private static function editable_content_renderer(): string {
-		return <<<'PHP'
-<?php
-/** Generated editable-content companion block render. */
-
-$content = is_string( $attributes['content'] ?? null ) ? $attributes['content'] : '';
-echo wp_kses_post( $content ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Sanitized at this server-render boundary.
-PHP;
+		return self::safe_markup_renderer( 'editable-content' );
 	}
 
 	/**
-	 * Build an SSI-owned render template for an audited renderer identifier.
+	 * Compose a companion render template on the shared audited safe-markup
+	 * boundary, so editable-content and typed layout blocks sanitize through
+	 * one policy instead of duplicated divergent logic.
 	 *
-	 * @param string $renderer Validated renderer identifier.
+	 * The template reads the block's string content attribute into $content,
+	 * passes it through safe_markup_boundary(), and echoes the sanitized
+	 * $output.
+	 *
+	 * @param string $kind Renderer label for the generated doc comment.
 	 * @return string
 	 */
-	private static function typed_renderer( string $renderer ): string {
-		$layout = <<<'PHP'
-<?php
-/** Generated responsive-layout companion block render. */
+	private static function safe_markup_renderer( string $kind ): string {
+		$prologue = sprintf(
+			"<?php\n/** Generated %s companion block render. */\n\n\$content = is_string( \$attributes['content'] ?? null ) ? \$attributes['content'] : '';\n",
+			$kind
+		);
+		$epilogue = 'echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded markup through the shared audited safe-markup boundary.';
+		return $prologue . self::safe_markup_boundary() . "\n" . $epilogue;
+	}
 
-$content = is_string( $attributes['content'] ?? null ) ? $attributes['content'] : '';
+	/**
+	 * The audited safe-markup boundary shared by every content-rendering
+	 * companion template.
+	 *
+	 * Consumes the string $content variable and produces the sanitized $output
+	 * variable: executable and animation vectors (script, style, iframe,
+	 * object, embed, foreignObject, animate, animateMotion, animateTransform,
+	 * set), custom elements, and on* / data-wp-* attributes are removed in
+	 * paired, self-closing, and bare attribute forms, URL-bearing attributes
+	 * are protocol-checked, and the result is KSES-filtered against an
+	 * SVG-aware allowlist so inline SVG structure survives while nothing
+	 * executable reaches the frontend.
+	 *
+	 * @return string
+	 */
+	private static function safe_markup_boundary(): string {
+		return <<<'PHP'
 $content = preg_replace( '#<\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\b[^>]*>.*?</\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\s*>#is', '', $content ) ?? '';
 $content = preg_replace( '#<\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\b[^>]*/?\s*>#is', '', $content ) ?? '';
 $content = preg_replace( '#</?\s*[a-z][a-z0-9]*-[a-z0-9-]+\b[^>]*>#i', '', $content ) ?? '';
@@ -1008,8 +1028,17 @@ $output = preg_replace_callback(
 	},
 	$output
 ) ?? '';
-echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded semantic layout markup.
 PHP;
+	}
+
+	/**
+	 * Build an SSI-owned render template for an audited renderer identifier.
+	 *
+	 * @param string $renderer Validated renderer identifier.
+	 * @return string
+	 */
+	private static function typed_renderer( string $renderer ): string {
+		$layout = self::safe_markup_renderer( 'responsive-layout' );
 		$media  = <<<'PHP'
 <?php
 /** Generated responsive-media companion block render. */

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -128,28 +128,6 @@ if ( ! function_exists( 'wp_kses' ) ) {
 	}
 }
 
-if ( ! function_exists( 'wp_kses_post' ) ) {
-	function wp_kses_post( string $content ): string {
-		$global = array(
-			'aria-*' => true,
-			'class'  => true,
-			'data-*' => true,
-			'id'     => true,
-			'style'  => true,
-		);
-		return wp_kses(
-			$content,
-			array(
-				'a'    => array_merge( $global, array( 'href' => true, 'rel' => true, 'target' => true ) ),
-				'div'  => $global,
-				'img'  => array_merge( $global, array( 'alt' => true, 'height' => true, 'src' => true, 'width' => true ) ),
-				'p'    => $global,
-				'span' => $global,
-			)
-		);
-	}
-}
-
 if ( ! function_exists( 'sanitize_title' ) ) {
 	function sanitize_title( string $title ): string {
 		$title = strtolower( trim( $title ) );
@@ -502,7 +480,7 @@ if ( is_array( $descriptor ) ) {
 	$render = $files['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
 	$assert( '' !== $render, 'render-php-emitted' );
 	$assert( str_starts_with( ltrim( $render ), '<?php' ), 'render-php-opens-with-php-tag' );
-	$assert( str_contains( $render, 'Generated editable-content companion block render' ) && str_contains( $render, 'wp_kses_post' ) && ! str_contains( $render, 'Example hero' ), 'editable-render-uses-ssi-owned-safe-boundary' );
+	$assert( str_contains( $render, 'Generated editable-content companion block render' ) && ! str_contains( $render, 'wp_kses_post' ) && ! str_contains( $render, 'Example hero' ), 'editable-render-uses-ssi-owned-safe-boundary' );
 
 	$render_frontend = static function ( string $template, array $attributes ): string {
 		$content = '';
@@ -525,6 +503,23 @@ if ( is_array( $descriptor ) ) {
 	);
 	$assert( str_contains( $edited_output, $edited_url ) && str_contains( $edited_output, 'Edited hero' ) && ! str_contains( $edited_output, $canonical_url ), 'editable-render-reflects-saved-content-edit', $edited_output );
 	$assert( ! str_contains( $edited_output, '<script' ) && ! str_contains( $edited_output, 'onclick' ), 'editable-render-sanitizes-current-content-at-server-boundary', $edited_output );
+
+	// Inline SVG artwork in editable companion content renders instead of
+	// being deleted by a sanitization boundary without SVG elements (#1361).
+	$svg_markup = '<div class="ssi-map"><svg viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="Route map"><path d="M0 0 L100 100" stroke="black" fill="none"></path><circle cx="50" cy="50" r="5" fill="red"></circle></svg></div>';
+	$svg_output = $render_frontend( $render, array( 'content' => $svg_markup ) );
+	foreach ( array( '<svg viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="Route map">', '<path d="M0 0 L100 100" stroke="black" fill="none">', '<circle cx="50" cy="50" r="5" fill="red">' ) as $fragment ) {
+		$assert( str_contains( $svg_output, $fragment ), 'editable-render-preserves-inline-svg-' . $fragment, $svg_output );
+	}
+
+	// Every executable and animation vector stays stripped from editable
+	// rendering, across paired, self-closing, and bare/unquoted forms.
+	$hostile_markup = '<main onclick=alert(1) onmouseover=\'alert(2)\' data-wp-interactive data-wp-context=\'{"bad":true}\'><img src="safe.jpg" onerror=alert(4)><span>Kept copy</span><svg onload=alert(5)><path d="M0 0 L10 10" stroke="blue"></path><animate attributeName="x"></animate><animatemotion dur="1s"></animatemotion><set attributeName="z" to="1"></set><foreignObject><p>hidden</p></foreignObject></svg><script>alert(3)</script><style>*{color:red}</style><iframe src="https://evil.test/frame"></iframe><iframe src="https://evil.test/frame2"/><object data="https://evil.test/object"></object><object data="https://evil.test/object2"/><embed src="https://evil.test/embed"></embed><embed src="https://evil.test/embed2"/><animatetransform attributeName="transform"/><wow-image data-hook="hero">Custom element</wow-image></main>';
+	$hostile_output = strtolower( $render_frontend( $render, array( 'content' => $hostile_markup ) ) );
+	foreach ( array( '<script', '<style', '<iframe', '<object', '<embed', '<foreignobject', '<animate', '<animatemotion', '<animatetransform', '<set', '<wow-image', 'onclick', 'onmouseover', 'onerror', 'onload', 'data-wp-', 'evil.test' ) as $fragment ) {
+		$assert( ! str_contains( $hostile_output, $fragment ), 'editable-render-removes-' . $fragment, $hostile_output );
+	}
+	$assert( str_contains( $hostile_output, '<svg' ) && str_contains( $hostile_output, '<path d="m0 0 l10 10" stroke="blue"' ) && str_contains( $hostile_output, 'safe.jpg' ) && str_contains( $hostile_output, 'kept copy' ), 'editable-render-keeps-safe-svg-and-content-through-shared-boundary', $hostile_output );
 
 	// Preserved island JS (#496) is separate carried JS and still rides along.
 	$island_files = array_filter( array_keys( $files ), static fn ( string $path ): bool => str_contains( $path, '/islands/' ) && str_ends_with( $path, '.js' ) );
@@ -632,6 +627,12 @@ if ( is_array( $layout_descriptor ) ) {
 	eval( '?>' . $layout_render );
 	$nested_svg_output = strtolower( (string) ob_get_clean() );
 	$assert( str_contains( $nested_svg_output, '<main>beforeafter</main>' ) && ! str_contains( $nested_svg_output, '<svg' ) && ! str_contains( $nested_svg_output, 'evil.test' ), 'layout-renderer-rejects-nested-svg-before-url-bearing-attributes-are-admitted' );
+
+	// The editable-content and layout render templates resolve to one shared
+	// sanitization policy: identical input must render byte-identical output,
+	// so the two paths cannot diverge in safety or supported markup (#1361).
+	$shared_policy_input = array( 'content' => $svg_markup . $hostile_markup );
+	$assert( $render_frontend( $render, $shared_policy_input ) === $render_frontend( $layout_render, $shared_policy_input ), 'editable-and-layout-renderers-share-one-sanitization-policy' );
 }
 
 WP_Block_Type_Registry::$registered[] = 'example/custom-hero';


### PR DESCRIPTION
## Problem

Closes #1361.

Generated editable-content companion blocks rendered their `content` attribute through `wp_kses_post()`, whose allowlist has no SVG elements. The entire `<svg>` subtree was deleted at render time, so imported pages lost route maps, charts, and icon artwork even though the SVG survived capture, conversion, and storage in `post_content`. In the issue's reproduction (a Wix single-page source), 22 of 24 companion blocks (`collection-*`, `gallery-*`) rendered blank wherever inline SVG carried the artwork.

## Root cause

`editable_content_renderer()` in `includes/class-static-site-importer-companion-plugin.php` emitted:

```php
$content = is_string( $attributes['content'] ?? null ) ? $attributes['content'] : '';
echo wp_kses_post( $content );
```

## Fix

An audited SVG-safe boundary already existed in the same file for the `responsive-layout` typed renderer. This PR extracts it into a single shared boundary instead of duplicating policy:

1. **`safe_markup_boundary()`** — the audited sanitization pipeline, moved verbatim from the layout template: strips paired and self-closing `script`, `style`, `iframe`, `object`, `embed`, `foreignObject`, `animate`, `animateMotion`, `animateTransform`, `set`; strips custom elements; strips `on*` and `data-wp-*` attributes in quoted, unquoted, and bare forms; protocol-checks URL-bearing attributes (`srcset`, `style` `url()`, SVG `href`/`url()` references); rejects nested/unclosed SVG before admitting URL-bearing attributes; and KSES-filters against the SVG-aware allowlist, restoring `viewBox`/`preserveAspectRatio` casing.
2. **`safe_markup_renderer( $kind )`** — composes a render template (doc comment, content-attribute extraction, shared boundary, echo) so there is exactly one sanitization policy.
3. `editable_content_renderer()` and the layout typed renderer both delegate to it.

### Safety properties

- Nothing that was stripped before is stripped less now: the layout pipeline is moved byte-for-byte (verified identical against `origin/main` apart from the shared echo comment), and editable content moves from `wp_kses_post` to that same stricter pipeline — strips are added, not removed.
- The `responsive-media` typed renderer is intentionally untouched; it keeps rejecting SVG content outright.
- No source-specific or SVG-specific hacks; the boundary was already the audited generic policy.

## Tests

`tests/smoke-companion-plugin.php` (runs via `npm run test:companion-plugin`):

- An editable-content block whose `content` carries `<svg viewBox>` / `<path d stroke>` / `<circle cx cy r>` now **renders** that SVG (with `viewBox` casing restored).
- An adversarial editable-content payload proves every executable/animation vector is still stripped across paired, self-closing, and bare/unquoted attribute forms: `script`, `style`, `iframe`, `object`, `embed`, `foreignObject`, `animate`, `animateMotion`, `animateTransform`, `set`, custom elements, `on*` handlers, `data-wp-*` attributes, and foreign URLs — while safe SVG, images, and copy in the same payload survive.
- A policy-equivalence guard runs identical mixed input (inline SVG + full vector battery) through both the editable-content and layout render templates and requires byte-identical output, so the two paths cannot silently diverge.
- The obsolete `wp_kses_post` test stub is removed: an accidental reintroduction now fatals instead of silently passing.
- Existing editor-round-trip assertions (saved content edits reflect on the frontend, canonicalized URLs preserved) continue to pass unchanged.

End-to-end PHP proof (scaffold → execute generated `render.php` with inline SVG + `<script>` + `onclick`):

```
<div class="map"><svg viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="Route map"><path d="M0 0 L100 100" stroke="black" fill="none"></path><circle cx="50" cy="50" r="5" fill="red"></circle></svg><p>Route overview</p></div>

SVG preserved:      YES
script stripped:    YES
onclick stripped:   YES
```

## Verification

- `npm run test:companion-plugin` — 3 suites pass (361 assertions in the companion smoke)
- `npm test` (test manifest: standalone-php + node lanes) — 67 passed, 0 failed
- `npm run test:inventory` — manifest integrity OK
- `php -l` on both changed files — clean
- `homeboy review lint` could not run in the local sandbox (hangs awaiting a runner); CI runs it as a required check

## AI assistance

Investigated and implemented with AI assistance from Claude Sonnet 4.5 via an OpenCode subagent, orchestrated by Chris Huber. The model read issue #1361, extracted the audited layout sanitization into the shared boundary, rewired both renderers, added the smoke coverage (SVG rendering, vector battery, policy-equivalence guard), ran the test suites, and drafted this PR. Chris Huber reviewed the diff, verified the byte-identical pipeline move, and is responsible for this change.