### PR TITLE
build: bump bundled php-transformer pin to v0.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   "require": {
     "php": "^8.2",
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "0.6.2"
+    "automattic/blocks-engine-php-transformer": "0.7.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06b853cb48a3aa2bc982cf99ac79ebbc",
+    "content-hash": "bfcf328c83f248026c0c8ba1e18f9cf6",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,22 +43,22 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "v0.6.2",
+            "version": "v0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "939299a474bc5dde8ecda3835ab5aee1823a54d9"
+                "reference": "9c1f8c18d974f1f63d91ec53e09423292b4b58c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/939299a474bc5dde8ecda3835ab5aee1823a54d9",
-                "reference": "939299a474bc5dde8ecda3835ab5aee1823a54d9",
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/9c1f8c18d974f1f63d91ec53e09423292b4b58c7",
+                "reference": "9c1f8c18d974f1f63d91ec53e09423292b4b58c7",
                 "shasum": ""
             },
             "require": {
                 "league/commonmark": "^2.5",
                 "league/html-to-markdown": "^5.1",
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.6",
@@ -91,7 +91,7 @@
                 "issues": "https://github.com/Automattic/blocks-engine/issues",
                 "source": "https://github.com/Automattic/blocks-engine-php-transformer"
             },
-            "time": "2026-08-24T23:35:41+00:00"
+            "time": "2026-08-27T20:17:01+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/tests/smoke-webfont-producer-consumer.php
+++ b/tests/smoke-webfont-producer-consumer.php
@@ -44,7 +44,7 @@ $assert = static function ( bool $condition, string $message ): void {
 	if ( ! $condition ) throw new RuntimeException( $message );
 };
 
-$assert( 'v0.6.2' === \Composer\InstalledVersions::getPrettyVersion( 'automattic/blocks-engine-php-transformer' ), 'producer-consumer integration runs against the locked Blocks Engine php-transformer v0.6.2 dependency' );
+$assert( 'v0.7.0' === \Composer\InstalledVersions::getPrettyVersion( 'automattic/blocks-engine-php-transformer' ), 'producer-consumer integration runs against the locked Blocks Engine php-transformer v0.7.0 dependency' );
 
 $fixture_html = '<!doctype html><html><head><link rel="stylesheet" href="css/style.css"></head><body><main>Inter fixture</main></body></html>';
 $fixture_css  = "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');\n:root{--font:'Inter',system-ui,sans-serif}body{font-family:var(--font)}";


### PR DESCRIPTION
Consumes Blocks Engine php-transformer **v0.7.0**, released from `trunk` as `php-transformer-v0.7.0` (release commit `034ba0ea`). That release carries the transformer work merged since `v0.6.2`, which is the version this plugin currently pins.

## Changes

- `composer.json` / `composer.lock`: `automattic/blocks-engine-php-transformer` `0.6.2` → `0.7.0`
- `tests/smoke-webfont-producer-consumer.php`: the integration guard asserts the locked dependency version, so it moves to `v0.7.0`

That guard is deliberate rather than incidental — it is what keeps the font materialization producer/consumer contract proven against the transformer version actually shipped, instead of whatever happens to be in `vendor/`. It failed on the bump exactly as intended, and updating it is the expected maintenance step.

## Verification

- Fast lane: 67 passed, 0 failed
- Fixture matrix rig: 279 passed, 0 failed
- The php-transformer `v0.7.0` release itself passed 16/16 Homeboy release gates, and `blocks-engine` trunk CI was green on the newest transformer-touching commit (`f972274e`) before the release was cut

## AI assistance disclosure

Prepared by Claude Sonnet 4.5 running in Claude Code: cut the upstream php-transformer release via `homeboy release`, verified the split-repo tag, applied the dependency bump, and ran the repo's own test gates locally. Reviewed by a human before submission.