### PR TITLE
refactor: drop the vestigial page-ready companion parameter

### DIFF
--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -72,7 +72,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				)
 			);
 		}
-		$companion = self::materialize_companion_dependency( $companion_payload, $prepared, $page_ready );
+		$companion = self::materialize_companion_dependency( $companion_payload, $prepared );
 		if ( is_wp_error( $companion ) ) {
 			return $companion;
 		}
@@ -162,8 +162,8 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		);
 	}
 
-	/** Materialize the compiler-declared companion before provider dependencies. */
-	private static function materialize_companion_dependency( $payload, array $prepared, bool $page_ready ) {
+	/** Materialize the compiler-declared companion before provider dependencies, in every materialization scope. */
+	private static function materialize_companion_dependency( $payload, array $prepared ) {
 		$args = is_array( $prepared['args'] ?? null ) ? $prepared['args'] : array();
 		if ( null === $payload ) {
 			return array(


### PR DESCRIPTION
`Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize_companion_dependency()` still takes a `bool $page_ready` argument that nothing reads.

## Why it is dead rather than a dropped condition

`8b931133` ("Fix page-ready companion registration") intentionally removed the short-circuit that used it:

```php
- if ( $page_ready || ( array_key_exists( 'materialize_dependencies', $args ) && false === (bool) $args['materialize_dependencies'] ) ) {
-         'reason' => $page_ready ? 'page_ready_scope' : 'dependency_materialization_disabled',
```

The point of that fix was that the companion **must** register in page-ready scope too. So the parameter is genuinely vestigial, and leaving it in the signature implies a scope-dependent path that no longer exists. `$page_ready` remains in use elsewhere in the caller (runtime dependencies, bindings, provider overlays, activation), so only this argument goes.

The method is `private static` with a single call site, so the change is contained.

## Why now

This is the only baseline-new lint finding on `main` (`Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed`), and it fails the Homeboy release preflight lint gate, blocking a release.

## Verification

- `tests/smoke-companion-plugin.php`: 361 assertions pass — that smoke was extended by `8b931133` specifically to cover page-ready companion registration, so it is the direct guard for this behaviour
- Fast lane: 67 passed, 0 failed
- Lint on changed files: 0 findings

## AI assistance disclosure

Investigated and prepared by Claude Sonnet 4.5 running in Claude Code: traced the parameter to the commit that removed its use, confirmed the single call site, made the change, and ran the repo's test and lint gates locally. Reviewed by a human before submission.