### PR TITLE
Skip hidden form inputs as provider fidelity losses

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -528,6 +528,20 @@ class Static_Site_Importer_Form_Seeder {
 		return $row;
 	}
 
+	/**
+	 * Report whether a source control carries content the provider is expected to represent.
+	 *
+	 * Hidden inputs carry the source platform's form-handler plumbing, such as endpoint
+	 * identifiers and captcha tokens, rather than content an author wrote or a visitor sees.
+	 * A provider form supersedes that plumbing, so leaving hidden inputs behind is the intended
+	 * conversion rather than a fidelity loss.
+	 *
+	 * @param string $type Normalized source control type.
+	 */
+	private static function control_carries_authored_content( string $type ): bool {
+		return 'hidden' !== $type;
+	}
+
 	/** A source label wrapper is carried by the mapped Jetpack field's label child. */
 	private static function provider_represents_receipt_loss( array $loss, array $form, array $field_blocks ): bool {
 		if ( 'unsupported_semantic_wrapper' !== ( $loss['reason_code'] ?? '' ) || ! is_string( $loss['node_hash'] ?? null ) ) {
@@ -713,7 +727,10 @@ class Static_Site_Importer_Form_Seeder {
 					if ( isset( $field_blocks[ $control_index ] ) ) {
 						$blocks[] = $field_blocks[ $control_index ];
 					} elseif ( isset( $controls[ $control_index ] ) ) {
-						$type     = strtolower( trim( (string) ( $controls[ $control_index ]['type'] ?? $controls[ $control_index ]['tag'] ?? '' ) ) );
+						$type = strtolower( trim( (string) ( $controls[ $control_index ]['type'] ?? $controls[ $control_index ]['tag'] ?? '' ) ) );
+						if ( ! self::control_carries_authored_content( $type ) ) {
+							continue;
+						}
 						$losses[] = array(
 							'dimension'         => 'topology',
 							'reason_code'       => 'unsupported_control_unrepresentable',

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -536,6 +536,17 @@ namespace {
 	$assert( empty( $unsupported_control_validation['errors'] ) && array( 'file' ) === ( $unsupported_control_row['skipped_types'] ?? array() ), 'unsupported-file-control-keeps-provider-skipped-type-diagnostic' );
 	$assert( 'topology' === ( $unsupported_control_loss['dimension'] ?? '' ) && 'unsupported_control_unrepresentable' === ( $unsupported_control_loss['reason_code'] ?? '' ) && 1 === ( $unsupported_control_loss['control_index'] ?? null ) && hash( 'sha256', 'file' ) === ( $unsupported_control_loss['control_type_hash'] ?? '' ) && 64 === strlen( (string) ( $unsupported_control_loss['node_hash'] ?? '' ) ), 'unsupported-file-control-records-node-addressable-topology-loss' );
 	$assert( str_contains( $unsupported_control_markup, 'First name' ) && ! str_contains( $unsupported_control_markup, 'Attachment' ) && str_contains( $unsupported_control_markup, 'Message' ), 'unsupported-file-control-preserves-supported-topology-order-around-loss' );
+	$hidden_control = $topology_form;
+	$hidden_control['forms'][0]['controls'][] = array( 'tag' => 'input', 'type' => 'hidden', 'name' => 'ucfid', 'value' => '980337499904279388' );
+	$hidden_control['forms'][0]['control_topology']['nodes'][] = array( 'id' => 'control-4', 'kind' => 'control', 'parent' => null, 'order' => 3, 'depth' => 0, 'control' => 4 );
+	$hidden_control_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $hidden_control );
+	$hidden_control_seed = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $hidden_control_validation['forms'] ) );
+	$hidden_control_row = $hidden_control_seed['forms'][0] ?? array();
+	$hidden_control_markup = (string) ( $hidden_control_row['block_markup'] ?? '' );
+	$hidden_control_losses = array_values( array_filter( $hidden_control_row['computed_layout_receipt']['losses'] ?? array(), static fn ( $loss ): bool => 'unsupported_control_unrepresentable' === ( $loss['reason_code'] ?? '' ) ) );
+	$assert( empty( $hidden_control_validation['errors'] ) && array() === $hidden_control_losses, 'hidden-control-plumbing-records-no-topology-loss' );
+	$assert( 'mapped' === ( $hidden_control_row['status'] ?? '' ) && empty( $hidden_control_row['form_receipt_unaccepted_losses'] ), 'hidden-control-plumbing-keeps-the-form-materializable' );
+	$assert( str_contains( $hidden_control_markup, 'First name' ) && str_contains( $hidden_control_markup, 'Message' ) && ! str_contains( $hidden_control_markup, 'ucfid' ), 'hidden-control-plumbing-is-dropped-without-disturbing-authored-fields' );
 	$deep_topology = $topology_form;
 	$deep_nodes = array();
 	for ( $depth = 0; $depth < 8; ++$depth ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/static-site-importer/issues/1367

## Reproduction
Weebly reservation forms on https://www.tasteandtravelitaly.com/ ship hidden plumbing fields (`ucfid`, `form_version`, `wsite_approved`, `recaptcha_token`, `wsite_subject`). The form seeder counted each as `unsupported_control_unrepresentable`, gated the forms, and rolled back the whole import (`static_site_importer_entity_materialization_failed`, 4 form errors).

Hidden inputs are not authored content. This drops them before topology losses are recorded. Visible unrepresentable controls such as `type=file` still gate.

## Test evidence
- `php tests/form-materializer-smoke.php` — 105 assertions, including three new hidden-control cases that fail if the skip is reverted (`FAIL [hidden-control-plumbing-records-no-topology-loss]`, `FAIL [hidden-control-plumbing-keeps-the-form-materializable]`).
- `node tools/run-test-manifest.mjs` — passed: 67; failed: 0.

## AI assistance
Grok 4.6 through OpenCode implemented this from a live Studio import of tasteandtravelitaly.com.