### PR TITLE
Flatten list grouping wrappers instead of failing form materialization

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -549,8 +549,15 @@ class Static_Site_Importer_Form_Seeder {
 		}
 		$nodes = isset( $form['control_topology']['nodes'] ) && is_array( $form['control_topology']['nodes'] ) ? $form['control_topology']['nodes'] : array();
 		foreach ( $nodes as $node ) {
-			if ( ! is_array( $node ) || 'wrapper' !== ( $node['kind'] ?? '' ) || 'label' !== ( $node['tag'] ?? '' ) || hash( 'sha256', (string) ( $node['id'] ?? '' ) ) !== $loss['node_hash'] ) {
+			if ( ! is_array( $node ) || 'wrapper' !== ( $node['kind'] ?? '' ) || hash( 'sha256', (string) ( $node['id'] ?? '' ) ) !== $loss['node_hash'] ) {
 				continue;
+			}
+			$tag = (string) ( $node['tag'] ?? 'div' );
+			if ( in_array( $tag, array( 'ul', 'ol', 'li' ), true ) ) {
+				return true;
+			}
+			if ( 'label' !== $tag ) {
+				return false;
 			}
 			$controls = array_values(
 				array_filter(

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -547,6 +547,15 @@ namespace {
 	$assert( empty( $hidden_control_validation['errors'] ) && array() === $hidden_control_losses, 'hidden-control-plumbing-records-no-topology-loss' );
 	$assert( 'mapped' === ( $hidden_control_row['status'] ?? '' ) && empty( $hidden_control_row['form_receipt_unaccepted_losses'] ), 'hidden-control-plumbing-keeps-the-form-materializable' );
 	$assert( str_contains( $hidden_control_markup, 'First name' ) && str_contains( $hidden_control_markup, 'Message' ) && ! str_contains( $hidden_control_markup, 'ucfid' ), 'hidden-control-plumbing-is-dropped-without-disturbing-authored-fields' );
+	$list_wrapper = $topology_form;
+	$list_wrapper['forms'][0]['control_topology']['nodes'][0]['tag'] = 'ul';
+	$list_wrapper['forms'][0]['layout_graph']['nodes'] = array();
+	$list_wrapper_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $list_wrapper );
+	$list_wrapper_seed = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $list_wrapper_validation['forms'] ) );
+	$list_wrapper_row = $list_wrapper_seed['forms'][0] ?? array();
+	$list_wrapper_markup = (string) ( $list_wrapper_row['block_markup'] ?? '' );
+	$assert( 'mapped' === ( $list_wrapper_row['status'] ?? '' ) && empty( $list_wrapper_row['form_receipt_unaccepted_losses'] ), 'list-grouping-wrapper-keeps-the-form-materializable' );
+	$assert( str_contains( $list_wrapper_markup, 'First name' ) && str_contains( $list_wrapper_markup, 'Email' ) && ! str_contains( $list_wrapper_markup, '<ul' ), 'list-grouping-wrapper-flattens-into-provider-fields' );
 	$deep_topology = $topology_form;
 	$deep_nodes = array();
 	for ( $depth = 0; $depth < 8; ++$depth ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/static-site-importer/issues/1366

Stacked on https://github.com/Automattic/static-site-importer/issues/1367. After hidden plumbing is dropped, Weebly still wraps fields in a `<ul>`. That wrapper emitted `unsupported_semantic_wrapper` and kept aborting Jetpack form materialization.

List grouping tags (`ul`, `ol`, `li`) now flatten into the provider field list, matching how Jetpack contact forms actually render. `<fieldset>` and other real semantics still gate. Label wrappers around a single mapped field are unchanged.

## Test
- `php tests/form-materializer-smoke.php` — 107 assertions. The two new list-wrapper cases fail if the flatten is reverted.

## AI assistance
Grok 4.6 through OpenCode reproduced this on a live Studio `--from` import of tasteandtravelitaly.com and implemented the fix.
