### PR TITLE
Classify producer findings through ConversionFindingContract (#1371)

### DIFF
--- a/includes/class-static-site-importer-diagnostic-loss-classes.php
+++ b/includes/class-static-site-importer-diagnostic-loss-classes.php
@@ -5,12 +5,30 @@
  * @package StaticSiteImporter
  */
 
+use Automattic\BlocksEngine\PhpTransformer\Contract\ConversionFindingContract;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
  * Classifies existing diagnostics into stable product readiness buckets.
+ *
+ * Two kinds of row arrive here:
+ *
+ *  1. Producer findings emitted by blocks-engine's php-transformer. These conform
+ *     to {@see ConversionFindingContract} (schema
+ *     `blocks-engine/php-transformer/conversion-finding/v1`) and already carry an
+ *     authoritative `reason_code` / `pattern_family` / `repair_bucket` triplet.
+ *     They are classified by mapping the contract's `repair_bucket` remediation
+ *     lane onto a product bucket — never by inspecting strings.
+ *  2. Importer-side rows raised by this plugin (materialization failures, gating,
+ *     document routing). These are not producer findings, carry no contract
+ *     identifier, and are classified by the legacy heuristic below.
+ *
+ * Keeping those two paths distinct is the point: previously every row went
+ * through the heuristic, so an upstream vocabulary change silently rerouted
+ * findings into the wrong product bucket instead of failing.
  */
 class Static_Site_Importer_Diagnostic_Loss_Classes {
 
@@ -21,17 +39,174 @@ class Static_Site_Importer_Diagnostic_Loss_Classes {
 	public const IMPORTER_MATERIALIZATION_BUG = 'importer_materialization_bug';
 
 	/**
+	 * Classification provenance markers, returned by {@see classify_with_provenance()}.
+	 */
+	public const SOURCE_EXPLICIT  = 'explicit';
+	public const SOURCE_CONTRACT  = 'contract';
+	public const SOURCE_HEURISTIC = 'heuristic';
+
+	/**
+	 * Upstream contract `repair_bucket` remediation lane => product-facing bucket.
+	 *
+	 * This is the entire cross-repo coupling, stated once and explicitly. Every
+	 * lane {@see ConversionFindingContract::classify()} can emit appears here; an
+	 * upstream rename or addition surfaces as an unmapped lane rather than as a
+	 * silent reclassification.
+	 *
+	 * @var array<string,string>
+	 */
+	private const REPAIR_BUCKET_CLASSES = array(
+		// Nothing to repair — the conversion landed natively, or the finding is
+		// informational rather than a loss.
+		'no_repair_needed'                            => self::NATIVE_CONVERSION,
+		'drop_empty_html_block'                       => self::NATIVE_CONVERSION,
+		'informational_var_density'                   => self::NATIVE_CONVERSION,
+		'runtime_behavior_superseded_by_native_block' => self::NATIVE_CONVERSION,
+
+		// Source behavior deliberately preserved as a bounded runtime island.
+		'preserve_runtime_island'                     => self::PRESERVED_RUNTIME_ISLAND,
+		'runtime_canvas_target_preservation'          => self::PRESERVED_RUNTIME_ISLAND,
+		'preserve_static_metadata'                    => self::PRESERVED_RUNTIME_ISLAND,
+
+		// The importer failed to materialize something it is responsible for.
+		'block_serialization_validity_repair'         => self::IMPORTER_MATERIALIZATION_BUG,
+		'runtime_dom_target_preservation'             => self::IMPORTER_MATERIALIZATION_BUG,
+		'runtime_script_materialization'              => self::IMPORTER_MATERIALIZATION_BUG,
+		'materialize_static_asset'                    => self::IMPORTER_MATERIALIZATION_BUG,
+		'materialize_commerce_products'               => self::IMPORTER_MATERIALIZATION_BUG,
+		'materialize_commerce_runtime'                => self::IMPORTER_MATERIALIZATION_BUG,
+		'materialize_form_provider'                   => self::IMPORTER_MATERIALIZATION_BUG,
+		'richtext_invalid_content_risk'               => self::IMPORTER_MATERIALIZATION_BUG,
+
+		// No native mapping exists yet, or source content did not survive.
+		'add_generic_pattern_recognizer'              => self::UNSUPPORTED_LOSS,
+		'svg_content_lost'                            => self::UNSUPPORTED_LOSS,
+
+		// Converted, editable, but not a faithful native equivalent.
+		'semantic_structure_parity_restoration'       => self::EDITABLE_APPROXIMATION,
+		'typography_parity_restoration'               => self::EDITABLE_APPROXIMATION,
+		'runtime_interactive_behavior_restoration'    => self::EDITABLE_APPROXIMATION,
+		'restore_interactive_behavior'                => self::EDITABLE_APPROXIMATION,
+		'review_generic_mapping'                      => self::EDITABLE_APPROXIMATION,
+		'native_block_recognition'                    => self::EDITABLE_APPROXIMATION,
+		'preserve_responsive_image_markup'            => self::EDITABLE_APPROXIMATION,
+		'layout_direction_misrecognition'             => self::EDITABLE_APPROXIMATION,
+		'cover_gate_rejection'                        => self::EDITABLE_APPROXIMATION,
+	);
+
+	/**
+	 * Contract repair buckets seen at runtime with no entry in the map above.
+	 *
+	 * Upstream is free to add remediation lanes. When it does, the finding still
+	 * classifies (via the heuristic) but the lane is recorded here so drift is
+	 * observable instead of silent. `tests/smoke-diagnostic-loss-classes.php`
+	 * fails when the fixture corpus produces any unmapped lane.
+	 *
+	 * @var array<string,int>
+	 */
+	private static $unmapped_repair_buckets = array();
+
+	/**
+	 * Contract repair buckets encountered that this plugin does not map.
+	 *
+	 * @return array<string,int> Bucket name => occurrence count.
+	 */
+	public static function unmapped_repair_buckets(): array {
+		return self::$unmapped_repair_buckets;
+	}
+
+	/**
+	 * Reset recorded drift. Intended for test isolation.
+	 */
+	public static function reset_unmapped_repair_buckets(): void {
+		self::$unmapped_repair_buckets = array();
+	}
+
+	/**
 	 * Return the stable product-facing loss class for an existing diagnostic row.
 	 *
 	 * @param array<string,mixed> $diagnostic Diagnostic row.
 	 * @return string
 	 */
 	public static function classify( array $diagnostic ): string {
+		return self::classify_with_provenance( $diagnostic )['class'];
+	}
+
+	/**
+	 * Classify a diagnostic and report which path produced the answer.
+	 *
+	 * Provenance is what makes the remaining heuristic auditable: a producer
+	 * finding that reports `heuristic` is a finding the contract failed to cover.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic row.
+	 * @return array{class:string,source:string,repair_bucket:string}
+	 */
+	public static function classify_with_provenance( array $diagnostic ): array {
 		$explicit = self::scalar( $diagnostic, array( 'loss_class', 'diagnostic_class' ) );
 		if ( in_array( $explicit, self::classes(), true ) ) {
-			return $explicit;
+			return array(
+				'class'         => $explicit,
+				'source'        => self::SOURCE_EXPLICIT,
+				'repair_bucket' => '',
+			);
 		}
 
+		$contract_bucket = self::contract_repair_bucket( $diagnostic );
+		if ( '' !== $contract_bucket && isset( self::REPAIR_BUCKET_CLASSES[ $contract_bucket ] ) ) {
+			return array(
+				'class'         => self::REPAIR_BUCKET_CLASSES[ $contract_bucket ],
+				'source'        => self::SOURCE_CONTRACT,
+				'repair_bucket' => $contract_bucket,
+			);
+		}
+
+		if ( '' !== $contract_bucket ) {
+			self::$unmapped_repair_buckets[ $contract_bucket ] = ( self::$unmapped_repair_buckets[ $contract_bucket ] ?? 0 ) + 1;
+		}
+
+		return array(
+			'class'         => self::classify_by_heuristic( $diagnostic ),
+			'source'        => self::SOURCE_HEURISTIC,
+			'repair_bucket' => $contract_bucket,
+		);
+	}
+
+	/**
+	 * Resolve the upstream contract's remediation lane for a diagnostic row.
+	 *
+	 * Returns '' when the transformer contract is unavailable (the vendored
+	 * package is an optional autoload in this plugin) or when the row is not a
+	 * producer finding — i.e. it carries no `code` / `diagnostic_code` identifier.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic row.
+	 * @return string
+	 */
+	private static function contract_repair_bucket( array $diagnostic ): string {
+		if ( ! class_exists( ConversionFindingContract::class ) ) {
+			return '';
+		}
+
+		if ( ! ConversionFindingContract::isFinding( $diagnostic ) ) {
+			return '';
+		}
+
+		$classification = ConversionFindingContract::classify( $diagnostic );
+
+		return $classification['repair_bucket'] ?? '';
+	}
+
+	/**
+	 * Legacy string-matching classification.
+	 *
+	 * Retained for importer-side diagnostics, which are raised by this plugin and
+	 * never pass through the transformer's finding contract. Producer findings
+	 * should not reach this method; when they do it means the contract map above
+	 * is missing a lane.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic row.
+	 * @return string
+	 */
+	private static function classify_by_heuristic( array $diagnostic ): string {
 		$type       = sanitize_key( self::scalar( $diagnostic, array( 'type', 'kind', 'code' ) ) );
 		$category   = sanitize_key( self::scalar( $diagnostic, array( 'category' ) ) );
 		$repair     = sanitize_key( self::scalar( $diagnostic, array( 'suggested_repair_class', 'repair_bucket', 'group_key' ) ) );

--- a/tests/smoke-diagnostic-loss-classes.php
+++ b/tests/smoke-diagnostic-loss-classes.php
@@ -20,6 +20,11 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+$static_site_importer_autoload = dirname( __DIR__ ) . '/vendor/autoload.php';
+if ( is_readable( $static_site_importer_autoload ) ) {
+	require_once $static_site_importer_autoload;
+}
+
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-loss-classes.php';
 
 $failures   = array();
@@ -95,6 +100,108 @@ $assert( 2 === ( $counts['editable_approximation'] ?? 0 ), 'counts-editable' );
 $assert( 2 === ( $counts['preserved_runtime_island'] ?? 0 ), 'counts-runtime' );
 $assert( 1 === ( $counts['unsupported_loss'] ?? 0 ), 'counts-unsupported' );
 $assert( 1 === ( $counts['importer_materialization_bug'] ?? 0 ), 'counts-importer' );
+
+/*
+ * Every fixture above is an importer-side row: raised by this plugin, carrying no
+ * `code` / `diagnostic_code`, so it is not a transformer finding and is expected
+ * to take the heuristic path. Assert that explicitly — it is the boundary that
+ * keeps the heuristic scoped to importer diagnostics.
+ */
+foreach ( $fixtures as $label => $fixture ) {
+	$provenance = Static_Site_Importer_Diagnostic_Loss_Classes::classify_with_provenance( $fixture['diagnostic'] );
+	$assert(
+		Static_Site_Importer_Diagnostic_Loss_Classes::SOURCE_HEURISTIC === $provenance['source'],
+		'importer-row-uses-heuristic-' . $label,
+		'got source: ' . $provenance['source']
+	);
+}
+
+/*
+ * Contract path, driven by real transformer output.
+ *
+ * Rather than asserting against hand-built finding stubs, run the vendored
+ * php-transformer over this repo's own HTML fixtures and classify every finding
+ * it actually emits. This is what proves the cross-repo coupling holds: if
+ * upstream renames a remediation lane, real findings start landing in
+ * `unmapped_repair_buckets()` and this test fails.
+ */
+$contract_class = 'Automattic\\BlocksEngine\\PhpTransformer\\Contract\\ConversionFindingContract';
+$transformer_class = 'Automattic\\BlocksEngine\\PhpTransformer\\HtmlToBlocks\\HtmlTransformer';
+
+if ( class_exists( $contract_class ) && class_exists( $transformer_class ) ) {
+	Static_Site_Importer_Diagnostic_Loss_Classes::reset_unmapped_repair_buckets();
+
+	$html_fixtures = glob( __DIR__ . '/fixtures/*/*.html' ) ?: array();
+	sort( $html_fixtures );
+
+	$findings_seen   = 0;
+	$heuristic_leaks = array();
+	$observed_classes = array();
+
+	foreach ( $html_fixtures as $html_fixture ) {
+		$html = file_get_contents( $html_fixture );
+		if ( ! is_string( $html ) || '' === trim( $html ) ) {
+			continue;
+		}
+
+		try {
+			$result = ( new $transformer_class() )->transform( $html );
+		} catch ( Throwable $e ) {
+			continue;
+		}
+
+		foreach ( array_merge( $result->fallbacks, $result->diagnostics ) as $finding ) {
+			if ( ! is_array( $finding ) || ! $contract_class::isFinding( $finding ) ) {
+				continue;
+			}
+
+			++$findings_seen;
+			$provenance = Static_Site_Importer_Diagnostic_Loss_Classes::classify_with_provenance( $finding );
+			$observed_classes[ $provenance['class'] ] = true;
+
+			if ( Static_Site_Importer_Diagnostic_Loss_Classes::SOURCE_HEURISTIC === $provenance['source'] ) {
+				$heuristic_leaks[ $contract_class::findingCode( $finding ) ] = $provenance['repair_bucket'];
+			}
+		}
+	}
+
+	$assert( $findings_seen > 0, 'contract-fixtures-produced-findings', 'no transformer findings emitted from tests/fixtures' );
+
+	// A transformer finding must never be classified by string matching.
+	$assert(
+		array() === $heuristic_leaks,
+		'no-producer-finding-falls-to-heuristic',
+		'codes leaking to heuristic: ' . wp_json_encode_fallback( $heuristic_leaks )
+	);
+
+	// Upstream drift guard: an unrecognized remediation lane fails here.
+	$unmapped = Static_Site_Importer_Diagnostic_Loss_Classes::unmapped_repair_buckets();
+	$assert(
+		array() === $unmapped,
+		'no-unmapped-contract-repair-buckets',
+		'unmapped lanes: ' . wp_json_encode_fallback( $unmapped )
+	);
+
+	// The corpus must exercise more than a single product bucket, otherwise the
+	// mapping is not actually being discriminated by this test.
+	$assert(
+		count( $observed_classes ) > 1,
+		'contract-corpus-spans-multiple-classes',
+		'observed: ' . wp_json_encode_fallback( array_keys( $observed_classes ) )
+	);
+}
+
+/**
+ * Minimal JSON encoder so failure detail works without WordPress loaded.
+ *
+ * @param mixed $value Value to encode.
+ * @return string
+ */
+function wp_json_encode_fallback( $value ): string {
+	$encoded = json_encode( $value );
+
+	return is_string( $encoded ) ? $encoded : '';
+}
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
Fixes #1371.

Producer findings from `blocks-engine/php-transformer` now classify through `ConversionFindingContract` v1. The heuristic is retained only for importer-side rows that are not transformer findings.

## What changed

`Static_Site_Importer_Diagnostic_Loss_Classes::classify()` now has three explicit paths:

1. **explicit** — the row already carries a product `loss_class` / `diagnostic_class`
2. **contract** — the row is a transformer finding (`ConversionFindingContract::isFinding()`); map the contract's `repair_bucket` onto a product bucket
3. **heuristic** — importer-side diagnostics only (no `code` / `diagnostic_code`)

The entire cross-repo coupling is the `REPAIR_BUCKET_CLASSES` map. An upstream rename or addition no longer silently lands in `native_conversion` (the heuristic default). It is recorded in `unmapped_repair_buckets()` and fails `tests/smoke-diagnostic-loss-classes.php`.

Verified by removing `materialize_form_provider` from the map: the test fails with

```
FAIL [no-producer-finding-falls-to-heuristic]: codes leaking to heuristic: {"html_form_fallback":"materialize_form_provider"}
FAIL [no-unmapped-contract-repair-buckets]: unmapped lanes: {"materialize_form_provider":4}
```

## Measured delta (not gate-neutral)

The old heuristic's default was `native_conversion`. Any producer finding the substring matcher did not recognize was counted as a successful native conversion. That is the bug this PR fixes, so classification **does change**.

Against 1,265 real transformer findings from 120 `blocks-engine/fixtures/websites` HTML files:

| Provenance | Count |
|---|---:|
| contract | 1,235 |
| explicit | 30 |
| heuristic (producer leak) | **0** |

583 unchanged, 682 reclassified. The ones that change **acceptability** (native/editable → unsupported/importer-bug, i.e. `unacceptable_imported_output_defect`):

| Code | Count | Old | New |
|---|---:|---|---|
| `html_form_fallback` | 126 | native_conversion | importer_materialization_bug (`materialize_form_provider`) |
| `html_unsupported_element` | 104 | native_conversion | unsupported_loss (`add_generic_pattern_recognizer`) |
| `html_commerce_controls_fallback` | 34 | native_conversion | importer_materialization_bug (`materialize_commerce_runtime`) |
| `wp_block_validity_*` | 27 | native_conversion | importer_materialization_bug (`block_serialization_validity_repair`) |

The rest move native → editable_approximation and stay `acceptable_conversion` (`author_layout_topology_changed`, `html_head_metadata_not_carried`, etc.).

Fixture-matrix quality-gate counts may move. That is the correct signal: those findings were losses the heuristic was hiding. If a specific corpus needs a waiver, that should be an explicit accepted-loss, not a silent re-bucket.

## Tests

- Existing importer-side fixtures still pass (heuristic path, provenance asserted)
- New coverage runs the vendored transformer over `tests/fixtures/*/*.html` and asserts: every producer finding takes the contract path, no unmapped `repair_bucket`, corpus spans more than one product bucket
- All 54 standalone-php tests in `test-manifest.json` pass
- phpcs: 0 findings on the changed files
- phpstan: the one new finding (`is_string()` on an already-narrowed type) was fixed before commit

## Related

- Automattic/blocks-engine#242 workstream 2 (the contract was built upstream; this is the missing consumer)
- #1372 types the import report (the other structural finding from the same audit)

---

*AI assistance disclosure: researched, implemented, and this PR drafted by Claude Sonnet 4.6 running in Claude Code, operated by @chubes4. The AI read both repositories, measured the 1,265-finding delta against the blocks-engine fixture corpus, implemented the contract map and drift guard, and wrote the tests. Findings and the gate-impact call were reviewed by a human before opening.*
