### PR TITLE
Type the import report and drop by-reference envelope mutation (#1372)

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -18,6 +18,7 @@
     "tests/smoke-failed-plan-validation.php": { "environment": "standalone-php" },
     "tests/smoke-export-theme-ability.php": { "environment": "standalone-php" },
     "tests/smoke-import-diagnostic-contract.php": { "environment": "standalone-php" },
+    "tests/smoke-import-report.php": { "environment": "standalone-php" },
     "tests/smoke-missing-author-stylesheet-diagnostics.php": { "environment": "standalone-php" },
     "tests/smoke-import-disposition.php": { "environment": "standalone-php" },
     "tests/smoke-import-permission-filter.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-artifact-diagnostics-adapter.php
+++ b/includes/class-static-site-importer-artifact-diagnostics-adapter.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Import_Report' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-import-report.php';
+}
+
 /**
  * Builds artifact diagnostics without owning the WP Codebox diagnostics schema.
  */
@@ -20,7 +24,7 @@ class Static_Site_Importer_Artifact_Diagnostics_Adapter {
 	 * @param array<string,mixed> $report Import report.
 	 * @return array<string,mixed>
 	 */
-	public static function build_for_import_report( array $report ): array {
+	public static function build_for_import_report( array|Static_Site_Importer_Import_Report $report ): array {
 		$input   = array( 'diagnostics' => $report['diagnostics'] ?? array() );
 		$options = array(
 			'source'          => 'static-site-importer',
@@ -73,7 +77,7 @@ class Static_Site_Importer_Artifact_Diagnostics_Adapter {
 	 * @param array<string,mixed> $report Import report.
 	 * @return array<string,mixed>
 	 */
-	private static function build_static_site_importer_diagnostics( array $report ): array {
+	private static function build_static_site_importer_diagnostics( array|Static_Site_Importer_Import_Report $report ): array {
 		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? array_values( $report['diagnostics'] ) : array();
 		$summary     = array(
 			'total'   => count( $diagnostics ),

--- a/includes/class-static-site-importer-asset-reporter.php
+++ b/includes/class-static-site-importer-asset-reporter.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Import_Report' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-import-report.php';
+}
+
 /**
  * Initializes asset-map and local asset policy report fields.
  */
@@ -16,11 +20,11 @@ class Static_Site_Importer_Asset_Reporter {
 	/**
 	 * Initialize report fields for the caller-supplied local asset policy.
 	 *
-	 * @param array<string,mixed> $report Conversion report envelope, passed by reference.
+	 * @param Static_Site_Importer_Import_Report $report Conversion report envelope.
 	 * @param array<string,mixed> $args   Import args.
 	 * @return string|WP_Error Normalized local asset materialization policy, or error.
 	 */
-	public static function initialize_report( array &$report, array $args ) {
+	public static function initialize_report( Static_Site_Importer_Import_Report $report, array $args ) {
 		$asset_policy = self::normalize_asset_materialization_policy( $args['asset_materialization_policy'] ?? '' );
 		if ( is_wp_error( $asset_policy ) ) {
 			return $asset_policy;

--- a/includes/class-static-site-importer-asset-reporter.php
+++ b/includes/class-static-site-importer-asset-reporter.php
@@ -32,10 +32,20 @@ class Static_Site_Importer_Asset_Reporter {
 
 		$asset_map = self::normalize_asset_map( isset( $args['asset_map'] ) && is_array( $args['asset_map'] ) ? $args['asset_map'] : array() );
 
-		$report['assets']['policy']         = 'theme';
-		$report['assets']['local_policy']   = $asset_policy;
-		$report['asset_map']['supplied']    = ! empty( $asset_map );
-		$report['asset_map']['entry_count'] = count( $asset_map );
+		$report->merge_section(
+			'assets',
+			array(
+				'policy'       => 'theme',
+				'local_policy' => $asset_policy,
+			)
+		);
+		$report->merge_section(
+			'asset_map',
+			array(
+				'supplied'    => ! empty( $asset_map ),
+				'entry_count' => count( $asset_map ),
+			)
+		);
 
 		return $asset_policy;
 	}

--- a/includes/class-static-site-importer-block-document-reporter.php
+++ b/includes/class-static-site-importer-block-document-reporter.php
@@ -6,13 +6,17 @@
  * server-visible block-quality issues and records actionable diagnostics into the
  * import conversion report. Extracted from Static_Site_Importer_Theme_Generator as a
  * behavior-preserving decomposition slice; the generator delegates to this class and
- * passes its conversion report by reference.
+ * passes its conversion report object.
  *
  * @package StaticSiteImporter
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
+}
+
+if ( ! class_exists( 'Static_Site_Importer_Import_Report' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-import-report.php';
 }
 
 /**
@@ -28,7 +32,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @param array<string,mixed>  $report    Conversion report (mutated by reference).
 	 * @return void
 	 */
-	public static function analyze_generated_theme_block_documents( array $writes, string $theme_dir, array &$report ): void {
+	public static function analyze_generated_theme_block_documents( array $writes, string $theme_dir, Static_Site_Importer_Import_Report $report ): void {
 		foreach ( $writes as $path => $content ) {
 			$relative_path = ltrim( str_replace( trailingslashit( $theme_dir ), '', $path ), '/' );
 			if ( ! self::is_generated_block_document_path( $relative_path ) ) {
@@ -47,7 +51,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @param array<string,mixed> $report Conversion report (mutated by reference).
 	 * @return void
 	 */
-	public static function reset_generated_block_document_analysis( array &$report ): void {
+	public static function reset_generated_block_document_analysis( Static_Site_Importer_Import_Report $report ): void {
 		foreach ( array( 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count' ) as $metric ) {
 			$report['quality'][ $metric ] = 0;
 		}
@@ -101,7 +105,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @param array<string,mixed> $report        Conversion report (mutated by reference).
 	 * @return array<string,mixed>
 	 */
-	public static function analyze_generated_block_document( string $relative_path, string $block_markup, array &$report ): array {
+	public static function analyze_generated_block_document( string $relative_path, string $block_markup, Static_Site_Importer_Import_Report $report ): array {
 		$validation_method = function_exists( 'parse_blocks' ) && function_exists( 'serialize_blocks' ) ? 'wordpress_parse_blocks_serialize_blocks' : 'unavailable';
 		if ( 'unavailable' === $validation_method ) {
 			return array(
@@ -195,7 +199,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @param array<int,int>                 $path            Parsed block path.
 	 * @return void
 	 */
-	private static function analyze_generated_block_list( array $blocks, int &$block_count, int &$core_html_count, int &$freeform_count, int &$invalid_count, array &$invalid_blocks, array &$report, string $source = '', array $path = array() ): void {
+	private static function analyze_generated_block_list( array $blocks, int &$block_count, int &$core_html_count, int &$freeform_count, int &$invalid_count, array &$invalid_blocks, Static_Site_Importer_Import_Report $report, string $source = '', array $path = array() ): void {
 		foreach ( $blocks as $index => $block ) {
 			$block_path = array_merge( $path, array( $index ) );
 			$name       = isset( $block['blockName'] ) ? $block['blockName'] : null;
@@ -267,7 +271,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @param array<string,mixed> $report Conversion report (mutated by reference).
 	 * @return void
 	 */
-	private static function record_generated_core_html_block( string $source, array $path, array $block, array &$report ): void {
+	private static function record_generated_core_html_block( string $source, array $path, array $block, Static_Site_Importer_Import_Report $report ): void {
 		$html = '';
 		if ( isset( $block['attrs']['content'] ) && is_string( $block['attrs']['content'] ) ) {
 			$html = $block['attrs']['content'];
@@ -304,7 +308,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @param array<string,mixed> $report     Conversion report (mutated by reference).
 	 * @return void
 	 */
-	private static function record_generated_freeform_block( string $source, array $path, array $block, bool $malformed, array &$report ): void {
+	private static function record_generated_freeform_block( string $source, array $path, array $block, bool $malformed, Static_Site_Importer_Import_Report $report ): void {
 		$html = '';
 		if ( isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ) {
 			$html = $block['innerHTML'];

--- a/includes/class-static-site-importer-block-document-reporter.php
+++ b/includes/class-static-site-importer-block-document-reporter.php
@@ -29,7 +29,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 *
 	 * @param array<string,string> $writes    Generated theme writes keyed by absolute path.
 	 * @param string               $theme_dir Generated theme directory.
-	 * @param array<string,mixed>  $report    Conversion report (mutated by reference).
+	 * @param Static_Site_Importer_Import_Report  $report    Conversion report (mutated by reference).
 	 * @return void
 	 */
 	public static function analyze_generated_theme_block_documents( array $writes, string $theme_dir, Static_Site_Importer_Import_Report $report ): void {
@@ -39,8 +39,8 @@ class Static_Site_Importer_Block_Document_Reporter {
 				continue;
 			}
 
-			$block_markup                                   = self::generated_block_document_markup( $relative_path, $content );
-			$analysis                                       = self::analyze_generated_block_document( $relative_path, $block_markup, $report );
+			$block_markup = self::generated_block_document_markup( $relative_path, $content );
+			$analysis     = self::analyze_generated_block_document( $relative_path, $block_markup, $report );
 			$report->append_to_section( 'generated_theme', 'block_documents', $analysis );
 		}
 	}
@@ -48,7 +48,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	/**
 	 * Clear generated-document analysis before analyzing mutated final documents.
 	 *
-	 * @param array<string,mixed> $report Conversion report (mutated by reference).
+	 * @param Static_Site_Importer_Import_Report $report Conversion report (mutated by reference).
 	 * @return void
 	 */
 	public static function reset_generated_block_document_analysis( Static_Site_Importer_Import_Report $report ): void {
@@ -102,7 +102,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 *
 	 * @param string              $relative_path Theme-relative path.
 	 * @param string              $block_markup  Block markup.
-	 * @param array<string,mixed> $report        Conversion report (mutated by reference).
+	 * @param Static_Site_Importer_Import_Report $report        Conversion report (mutated by reference).
 	 * @return array<string,mixed>
 	 */
 	public static function analyze_generated_block_document( string $relative_path, string $block_markup, Static_Site_Importer_Import_Report $report ): array {
@@ -194,7 +194,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @param int                            $freeform_count  Freeform block count.
 	 * @param int                            $invalid_count   Invalid block count.
 	 * @param array<int,mixed>               $invalid_blocks  Collected invalid block summaries.
-	 * @param array<string,mixed>            $report          Conversion report (mutated by reference).
+	 * @param Static_Site_Importer_Import_Report            $report          Conversion report (mutated by reference).
 	 * @param string                         $source          Theme-relative source document path.
 	 * @param array<int,int>                 $path            Parsed block path.
 	 * @return void
@@ -268,7 +268,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @param string              $source Theme-relative source document path.
 	 * @param array<int,int>      $path   Parsed block path.
 	 * @param array<string,mixed> $block  Parsed block.
-	 * @param array<string,mixed> $report Conversion report (mutated by reference).
+	 * @param Static_Site_Importer_Import_Report $report Conversion report (mutated by reference).
 	 * @return void
 	 */
 	private static function record_generated_core_html_block( string $source, array $path, array $block, Static_Site_Importer_Import_Report $report ): void {
@@ -305,7 +305,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @param array<int,int>      $path       Parsed block path.
 	 * @param array<string,mixed> $block      Parsed block.
 	 * @param bool                $malformed  Whether the block parser exposed raw HTML without a block name.
-	 * @param array<string,mixed> $report     Conversion report (mutated by reference).
+	 * @param Static_Site_Importer_Import_Report $report     Conversion report (mutated by reference).
 	 * @return void
 	 */
 	private static function record_generated_freeform_block( string $source, array $path, array $block, bool $malformed, Static_Site_Importer_Import_Report $report ): void {

--- a/includes/class-static-site-importer-block-document-reporter.php
+++ b/includes/class-static-site-importer-block-document-reporter.php
@@ -41,7 +41,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 
 			$block_markup                                   = self::generated_block_document_markup( $relative_path, $content );
 			$analysis                                       = self::analyze_generated_block_document( $relative_path, $block_markup, $report );
-			$report['generated_theme']['block_documents'][] = $analysis;
+			$report->append_to_section( 'generated_theme', 'block_documents', $analysis );
 		}
 	}
 
@@ -52,21 +52,21 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @return void
 	 */
 	public static function reset_generated_block_document_analysis( Static_Site_Importer_Import_Report $report ): void {
-		foreach ( array( 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count' ) as $metric ) {
-			$report['quality'][ $metric ] = 0;
-		}
-
-		$diagnostics                                       = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
-		$report['diagnostics']                             = array_values(
-			array_filter(
-				$diagnostics,
-				static function ( $diagnostic ): bool {
-					return ! is_array( $diagnostic ) || 'generated_theme_block_analysis' !== (string) ( $diagnostic['stage'] ?? '' );
-				}
+		$report->merge_quality(
+			array(
+				'core_html_block_count'        => 0,
+				'freeform_block_count'         => 0,
+				'invalid_block_count'          => 0,
+				'invalid_block_document_count' => 0,
 			)
 		);
-		$report['materialized_content']['block_documents'] = array();
-		$report['generated_theme']['block_documents']      = array();
+		$report->filter_diagnostics(
+			static function ( $diagnostic ): bool {
+				return ! is_array( $diagnostic ) || 'generated_theme_block_analysis' !== (string) ( $diagnostic['stage'] ?? '' );
+			}
+		);
+		$report->set_in_section( 'materialized_content', 'block_documents', array() );
+		$report->set_in_section( 'generated_theme', 'block_documents', array() );
 	}
 
 	/**
@@ -139,11 +139,11 @@ class Static_Site_Importer_Block_Document_Reporter {
 			$first_differing_token = self::first_differing_block_document_token( $block_markup, $serialized );
 		}
 
-		$report['quality']['core_html_block_count'] += $core_html_count;
-		$report['quality']['freeform_block_count']  += $freeform_count;
-		$report['quality']['invalid_block_count']   += $invalid_count;
+		$report->increment_quality( 'core_html_block_count', $core_html_count );
+		$report->increment_quality( 'freeform_block_count', $freeform_count );
+		$report->increment_quality( 'invalid_block_count', $invalid_count );
 		if ( $invalid_count > 0 ) {
-			++$report['quality']['invalid_block_document_count'];
+			$report->increment_quality( 'invalid_block_document_count' );
 			$first_invalid_block = $invalid_blocks[0] ?? self::first_parsed_block_summary( $analyzed_blocks );
 			$validation_message  = $serialization_mismatch ? 'Serialized block document differs from generated block markup.' : 'Generated block document contains parser-exposed invalid block markup.';
 			$diagnostic          = array(
@@ -170,7 +170,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 				$diagnostic['first_differing_token'] = $first_differing_token;
 			}
 
-			$report['diagnostics'][] = $diagnostic;
+			$report->append_diagnostic( $diagnostic );
 		}
 
 		return array(
@@ -295,7 +295,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 			$diagnostic['form']     = $manifest['form'];
 			$diagnostic['controls'] = $manifest['controls'];
 		}
-		$report['diagnostics'][] = $diagnostic;
+		$report->append_diagnostic( $diagnostic );
 	}
 
 	/**
@@ -337,8 +337,8 @@ class Static_Site_Importer_Block_Document_Reporter {
 		$entry['emitted_block_preview'] = Static_Site_Importer_Report_Diagnostics::diagnostic_excerpt( $emitted );
 		$entry['malformed']             = $malformed;
 
-		$report['diagnostics'][]                        = $entry;
-		$report['generated_theme']['freeform_blocks'][] = $entry;
+		$report->append_diagnostic( $entry );
+		$report->append_to_section( 'generated_theme', 'freeform_blocks', $entry );
 	}
 
 	/**

--- a/includes/class-static-site-importer-client-script-policy-report.php
+++ b/includes/class-static-site-importer-client-script-policy-report.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Client-script policy report.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Records client-script dispositions under a closed key set.
+ *
+ * Replaces the previous `$report[ $disposition ][] = $row` dynamic write, which
+ * allowed any string to become a top-level report key.
+ */
+final class Static_Site_Importer_Client_Script_Policy_Report {
+
+	public const SCHEMA       = 'static-site-importer/client-script-policy-report/v1';
+	public const DISPOSITIONS = array( 'dropped', 'quarantined', 'preserved' );
+
+	/**
+	 * @param string                         $policy      Applied policy name.
+	 * @param string                         $trust       Trust classification.
+	 * @param string                         $provenance  Provenance reference.
+	 * @param array<int,array<string,mixed>> $dropped     Dropped rows.
+	 * @param array<int,array<string,mixed>> $quarantined Quarantined rows.
+	 * @param array<int,array<string,mixed>> $preserved   Preserved rows.
+	 */
+	public function __construct(
+		private string $policy,
+		private string $trust,
+		private string $provenance,
+		private array $dropped = array(),
+		private array $quarantined = array(),
+		private array $preserved = array()
+	) {}
+
+	/**
+	 * Record one script row under a declared disposition.
+	 *
+	 * @param string              $disposition One of DISPOSITIONS.
+	 * @param array<string,mixed> $row         Script row.
+	 */
+	public function record( string $disposition, array $row ): void {
+		if ( ! in_array( $disposition, self::DISPOSITIONS, true ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal contract violation message; this class runs before any WordPress escaping API is guaranteed.
+			throw new InvalidArgumentException( sprintf( 'Unknown client-script disposition "%s".', $disposition ) );
+		}
+
+		$this->{$disposition}[] = $row;
+	}
+
+	/**
+	 * Persistable array form.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function to_array(): array {
+		return array(
+			'schema'      => self::SCHEMA,
+			'policy'      => $this->policy,
+			'trust'       => $this->trust,
+			'provenance'  => $this->provenance,
+			'dropped'     => $this->dropped,
+			'quarantined' => $this->quarantined,
+			'preserved'   => $this->preserved,
+		);
+	}
+}

--- a/includes/class-static-site-importer-client-script-policy.php
+++ b/includes/class-static-site-importer-client-script-policy.php
@@ -9,6 +9,54 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Client-script policy report. Disposition keys are closed: dropped, quarantined, preserved.
+ */
+final class Static_Site_Importer_Client_Script_Policy_Report {
+
+	public const SCHEMA       = 'static-site-importer/client-script-policy-report/v1';
+	public const DISPOSITIONS = array( 'dropped', 'quarantined', 'preserved' );
+
+	/**
+	 * @param array<int,array<string,mixed>> $dropped
+	 * @param array<int,array<string,mixed>> $quarantined
+	 * @param array<int,array<string,mixed>> $preserved
+	 */
+	public function __construct(
+		private string $policy,
+		private string $trust,
+		private string $provenance,
+		private array $dropped = array(),
+		private array $quarantined = array(),
+		private array $preserved = array()
+	) {}
+
+	/**
+	 * @param array<string,mixed> $row
+	 */
+	public function record( string $disposition, array $row ): void {
+		if ( ! in_array( $disposition, self::DISPOSITIONS, true ) ) {
+			throw new InvalidArgumentException( sprintf( 'Unknown client-script disposition "%s".', $disposition ) );
+		}
+		$this->{$disposition}[] = $row;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	public function to_array(): array {
+		return array(
+			'schema'      => self::SCHEMA,
+			'policy'      => $this->policy,
+			'trust'       => $this->trust,
+			'provenance'  => $this->provenance,
+			'dropped'     => $this->dropped,
+			'quarantined' => $this->quarantined,
+			'preserved'   => $this->preserved,
+		);
+	}
+}
+
 /** Applies an explicit, provenance-bound client-script policy before compilation. */
 class Static_Site_Importer_Client_Script_Policy {
 	/**
@@ -20,14 +68,10 @@ class Static_Site_Importer_Client_Script_Policy {
 		$policy     = self::policy_name( $args );
 		$provenance = self::provenance( $args );
 		$preserve   = 'isolated_preview' === $policy && ! empty( $args['client_script_isolated'] ) && '' !== $provenance;
-		$report     = array(
-			'schema'      => 'static-site-importer/client-script-policy-report/v1',
-			'policy'      => $preserve ? 'isolated_preview' : 'inert',
-			'trust'       => 'untrusted_imported_code',
-			'provenance'  => $preserve ? $provenance : '',
-			'dropped'     => array(),
-			'quarantined' => array(),
-			'preserved'   => array(),
+		$report     = new Static_Site_Importer_Client_Script_Policy_Report(
+			$preserve ? 'isolated_preview' : 'inert',
+			'untrusted_imported_code',
+			$preserve ? $provenance : ''
 		);
 		$files      = isset( $artifact['files'] ) && is_array( $artifact['files'] ) ? $artifact['files'] : array();
 		$filtered   = array();
@@ -55,7 +99,7 @@ class Static_Site_Importer_Client_Script_Policy {
 		$artifact['files'] = $filtered;
 		return array(
 			'artifact' => $artifact,
-			'report'   => $report,
+			'report'   => $report->to_array(),
 		);
 	}
 
@@ -86,10 +130,10 @@ class Static_Site_Importer_Client_Script_Policy {
 		return (bool) preg_match( '/\.(?:js|mjs|cjs)$/', $path ) || str_contains( $mime, 'javascript' ) || str_contains( $mime, 'ecmascript' );
 	}
 
-	private static function filter_html( string $html, string $path, bool $preserve, array &$report ): string {
+	private static function filter_html( string $html, string $path, bool $preserve, Static_Site_Importer_Client_Script_Policy_Report $report ): string {
 		$html = (string) preg_replace_callback(
 			'#<script\b([^>]*)>(.*?)</script\s*>#is',
-			static function ( array $matches ) use ( $path, $preserve, &$report ): string {
+			static function ( array $matches ) use ( $path, $preserve, $report ): string {
 				$attributes = $matches[1];
 				$source     = self::attribute( $attributes, 'src' );
 				$type       = strtolower( trim( (string) self::attribute( $attributes, 'type' ) ) );
@@ -113,7 +157,7 @@ class Static_Site_Importer_Client_Script_Policy {
 		);
 		return (string) preg_replace_callback(
 			'#<link\b([^>]*)/?>#is',
-			static function ( array $matches ) use ( $path, $preserve, &$report ): string {
+			static function ( array $matches ) use ( $path, $preserve, $report ): string {
 				$attributes = $matches[1];
 				$relation   = strtolower( trim( (string) self::attribute( $attributes, 'rel' ) ) );
 				$as         = strtolower( trim( (string) self::attribute( $attributes, 'as' ) ) );
@@ -198,7 +242,7 @@ class Static_Site_Importer_Client_Script_Policy {
 		return $file;
 	}
 
-	private static function record( array &$report, string $disposition, array $row ): void {
-		$report[ $disposition ][] = $row;
+	private static function record( Static_Site_Importer_Client_Script_Policy_Report $report, string $disposition, array $row ): void {
+		$report->record( $disposition, $row );
 	}
 }

--- a/includes/class-static-site-importer-client-script-policy.php
+++ b/includes/class-static-site-importer-client-script-policy.php
@@ -9,52 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Client-script policy report. Disposition keys are closed: dropped, quarantined, preserved.
- */
-final class Static_Site_Importer_Client_Script_Policy_Report {
-
-	public const SCHEMA       = 'static-site-importer/client-script-policy-report/v1';
-	public const DISPOSITIONS = array( 'dropped', 'quarantined', 'preserved' );
-
-	/**
-	 * @param array<int,array<string,mixed>> $dropped
-	 * @param array<int,array<string,mixed>> $quarantined
-	 * @param array<int,array<string,mixed>> $preserved
-	 */
-	public function __construct(
-		private string $policy,
-		private string $trust,
-		private string $provenance,
-		private array $dropped = array(),
-		private array $quarantined = array(),
-		private array $preserved = array()
-	) {}
-
-	/**
-	 * @param array<string,mixed> $row
-	 */
-	public function record( string $disposition, array $row ): void {
-		if ( ! in_array( $disposition, self::DISPOSITIONS, true ) ) {
-			throw new InvalidArgumentException( sprintf( 'Unknown client-script disposition "%s".', $disposition ) );
-		}
-		$this->{$disposition}[] = $row;
-	}
-
-	/**
-	 * @return array<string,mixed>
-	 */
-	public function to_array(): array {
-		return array(
-			'schema'      => self::SCHEMA,
-			'policy'      => $this->policy,
-			'trust'       => $this->trust,
-			'provenance'  => $this->provenance,
-			'dropped'     => $this->dropped,
-			'quarantined' => $this->quarantined,
-			'preserved'   => $this->preserved,
-		);
-	}
+if ( ! class_exists( 'Static_Site_Importer_Client_Script_Policy_Report' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-client-script-policy-report.php';
 }
 
 /** Applies an explicit, provenance-bound client-script policy before compilation. */

--- a/includes/class-static-site-importer-document-metadata-reporter.php
+++ b/includes/class-static-site-importer-document-metadata-reporter.php
@@ -41,18 +41,20 @@ class Static_Site_Importer_Document_Metadata_Reporter {
 			'scripts'     => self::normalize_document_scripts( $metadata['scripts'] ?? array() ),
 		);
 
-		$report['generated_theme']['document_metadata'] = $normalized;
-		$report['diagnostics'][]                        = array(
-			'type'         => 'document_metadata_routed',
-			'source'       => $normalized['source_path'],
-			'severity'     => 'info',
-			'stage'        => 'website_artifact_materialization',
-			'constraints'  => 'report_only',
-			'message'      => 'Full-document metadata/assets were routed through the generated_theme.document_metadata contract instead of generated page block content.',
-			'meta_count'   => count( $normalized['meta'] ),
-			'link_count'   => count( $normalized['links'] ),
-			'style_count'  => count( $normalized['styles'] ),
-			'script_count' => count( $normalized['scripts'] ),
+		$report->set_in_section( 'generated_theme', 'document_metadata', $normalized );
+		$report->append_diagnostic(
+			array(
+				'type'         => 'document_metadata_routed',
+				'source'       => $normalized['source_path'],
+				'severity'     => 'info',
+				'stage'        => 'website_artifact_materialization',
+				'constraints'  => 'report_only',
+				'message'      => 'Full-document metadata/assets were routed through the generated_theme.document_metadata contract instead of generated page block content.',
+				'meta_count'   => count( $normalized['meta'] ),
+				'link_count'   => count( $normalized['links'] ),
+				'style_count'  => count( $normalized['styles'] ),
+				'script_count' => count( $normalized['scripts'] ),
+			)
 		);
 	}
 

--- a/includes/class-static-site-importer-document-metadata-reporter.php
+++ b/includes/class-static-site-importer-document-metadata-reporter.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Import_Report' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-import-report.php';
+}
+
 /**
  * Records compiler-routed full-document metadata into the import report.
  */
@@ -16,11 +20,11 @@ class Static_Site_Importer_Document_Metadata_Reporter {
 	/**
 	 * Record compiler-routed full-document metadata and asset references.
 	 *
-	 * @param array<string,mixed> $report    Conversion report envelope, passed by reference.
+	 * @param Static_Site_Importer_Import_Report $report Conversion report envelope.
 	 * @param array<string,mixed> $artifacts WordPress artifacts from Blocks Engine.
 	 * @return void
 	 */
-	public static function record( array &$report, array $artifacts ): void {
+	public static function record( Static_Site_Importer_Import_Report $report, array $artifacts ): void {
 		$metadata = isset( $artifacts['document_metadata'] ) && is_array( $artifacts['document_metadata'] ) ? $artifacts['document_metadata'] : array();
 		if ( 'blocks-engine/php-transformer/document-metadata/v1' !== (string) ( $metadata['schema'] ?? '' ) ) {
 			return;

--- a/includes/class-static-site-importer-failed-plan-validation.php
+++ b/includes/class-static-site-importer-failed-plan-validation.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Import_Report' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-import-report.php';
+}
+
 final class Static_Site_Importer_Failed_Plan_Validation {
 
 	private const MAX_DIAGNOSTICS = 50;
@@ -16,8 +20,9 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 	/** @return array<string,mixed> */
 	public static function build( array $plan, array $args = array(), array $compiled = array() ): array {
 		$diagnostics = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
-		$report      = array(
-			'schema'           => 'static-site-importer/import-report/v1',
+		$report      = Static_Site_Importer_Import_Report::from_array(
+			array(
+			'schema'           => Static_Site_Importer_Import_Report::SCHEMA,
 			'version'          => 1,
 			'status'           => 'failed',
 			'theme_slug'       => (string) ( $args['slug'] ?? '' ),
@@ -29,6 +34,7 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 				'stage' => 'pre_materialization_quality_admission',
 				'code'  => 'static_site_importer_quality_gate_failed',
 			),
+			)
 		);
 		if ( count( $diagnostics ) > self::MAX_DIAGNOSTICS ) {
 			$report['diagnostics_truncated'] = true;
@@ -42,7 +48,7 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 		$fixture_diagnostics        = Static_Site_Importer_Report_Diagnostics::refresh_projections( $report, $quality );
 
 		return array(
-			'import_report'            => $report,
+			'import_report'            => $report->to_array(),
 			'import_report_summary'    => $report['compact_summary'],
 			'import_validation_result' => $report['import_validation_result'],
 			'finding_packets'          => $report['finding_packets'],

--- a/includes/class-static-site-importer-failed-plan-validation.php
+++ b/includes/class-static-site-importer-failed-plan-validation.php
@@ -20,8 +20,7 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 	/** @return array<string,mixed> */
 	public static function build( array $plan, array $args = array(), array $compiled = array() ): array {
 		$diagnostics = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
-		$report      = Static_Site_Importer_Import_Report::from_array(
-			array(
+		$envelope    = array(
 			'schema'           => Static_Site_Importer_Import_Report::SCHEMA,
 			'version'          => 1,
 			'status'           => 'failed',
@@ -34,8 +33,8 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 				'stage' => 'pre_materialization_quality_admission',
 				'code'  => 'static_site_importer_quality_gate_failed',
 			),
-			)
 		);
+		$report      = Static_Site_Importer_Import_Report::from_array( $envelope );
 		if ( count( $diagnostics ) > self::MAX_DIAGNOSTICS ) {
 			$report['diagnostics_truncated'] = true;
 			$report['diagnostic_count']      = count( $diagnostics );

--- a/includes/class-static-site-importer-import-report.php
+++ b/includes/class-static-site-importer-import-report.php
@@ -12,11 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Declares the import-report top-level schema and owns mutation of that envelope.
  *
- * Three factories historically built `static-site-importer/import-report/v1`
- * arrays (conversion, site-plan receipt, failed-plan) and then 8 classes
- * mutated the result by reference. This object is the single declared shape:
- * unknown top-level keys throw, known keys are writable, and `to_array()` is
- * the persistence/REST seam so serialized output stays an array.
+ * Reads may use ArrayAccess. Writes go through named mutators so nested
+ * `$report['quality']['x'] = 0` cannot bypass the schema. `to_array()` is the
+ * persistence/REST seam.
  */
 final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSerializable {
 
@@ -24,11 +22,6 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 
 	/**
 	 * Every top-level key the import report may carry.
-	 *
-	 * Union of the conversion factory, the site-plan receipt factory, the
-	 * failed-plan factory, and keys written during finalization. Nested
-	 * structure inside these keys is owned by the writer; this list is the
-	 * top-level contract.
 	 *
 	 * @var array<int,string>
 	 */
@@ -86,13 +79,6 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 	private array $data = array();
 
 	/**
-	 * Placeholder returned by reference when a known key is missing.
-	 *
-	 * @var mixed
-	 */
-	private $missing = null;
-
-	/**
 	 * @param array<string,mixed> $data Initial envelope.
 	 */
 	private function __construct( array $data ) {
@@ -106,9 +92,6 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 
 	/**
 	 * Wrap an existing array envelope.
-	 *
-	 * Unknown keys already present are preserved so older reports still load;
-	 * subsequent writes of a *new* unknown key throw.
 	 *
 	 * @param array<string,mixed> $data Existing envelope.
 	 */
@@ -126,7 +109,7 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 	}
 
 	/**
-	 * Persistable array form. Byte-identical to the historical envelope.
+	 * Persistable array form.
 	 *
 	 * @return array<string,mixed>
 	 */
@@ -141,48 +124,170 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 		return $this->data;
 	}
 
-	/**
-	 * Whether a top-level key is part of the declared schema.
-	 */
 	public static function is_known_key( string $key ): bool {
 		return in_array( $key, self::TOP_LEVEL_KEYS, true );
 	}
 
+	public function has( string $key ): bool {
+		return array_key_exists( $key, $this->data );
+	}
+
 	/**
-	 * Append a diagnostic row.
+	 * Read a top-level value.
+	 */
+	public function get( string $key, mixed $default = null ): mixed {
+		return array_key_exists( $key, $this->data ) ? $this->data[ $key ] : $default;
+	}
+
+	/**
+	 * Replace a top-level value. Unknown keys throw.
+	 */
+	public function set( string $key, mixed $value ): void {
+		if ( ! self::is_known_key( $key ) && ! array_key_exists( $key, $this->data ) ) {
+			throw new InvalidArgumentException( sprintf( 'Unknown import-report top-level key "%s".', $key ) );
+		}
+		$this->data[ $key ] = $value;
+	}
+
+	/**
+	 * Read a top-level array section.
 	 *
+	 * @return array<string,mixed>
+	 */
+	public function section( string $key ): array {
+		$value = $this->get( $key, array() );
+		return is_array( $value ) ? $value : array();
+	}
+
+	/**
+	 * Replace a top-level array section.
+	 *
+	 * @param array<string,mixed> $section Section payload.
+	 */
+	public function set_section( string $key, array $section ): void {
+		$this->set( $key, $section );
+	}
+
+	/**
+	 * Overlay keys onto a top-level array section.
+	 *
+	 * @param array<string,mixed> $values Values to merge.
+	 */
+	public function merge_section( string $key, array $values ): void {
+		$this->set_section( $key, array_replace( $this->section( $key ), $values ) );
+	}
+
+	/**
+	 * Set one child of a top-level array section.
+	 */
+	public function set_in_section( string $key, string $child, mixed $value ): void {
+		$section           = $this->section( $key );
+		$section[ $child ] = $value;
+		$this->set_section( $key, $section );
+	}
+
+	/**
+	 * Append a row onto a list nested under a top-level section.
+	 *
+	 * @param array<string,mixed> $row Row to append.
+	 */
+	public function append_to_section( string $key, string $list_key, array $row ): void {
+		$section = $this->section( $key );
+		$list    = isset( $section[ $list_key ] ) && is_array( $section[ $list_key ] ) ? $section[ $list_key ] : array();
+		$list[]  = $row;
+		$section[ $list_key ] = $list;
+		$this->set_section( $key, $section );
+	}
+
+	/**
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function diagnostics(): array {
+		$diagnostics = $this->get( 'diagnostics', array() );
+		return is_array( $diagnostics ) ? array_values( $diagnostics ) : array();
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $diagnostics Diagnostic rows.
+	 */
+	public function set_diagnostics( array $diagnostics ): void {
+		$this->set( 'diagnostics', array_values( $diagnostics ) );
+	}
+
+	/**
 	 * @param array<string,mixed> $diagnostic Diagnostic row.
 	 */
 	public function append_diagnostic( array $diagnostic ): void {
-		if ( ! isset( $this->data['diagnostics'] ) || ! is_array( $this->data['diagnostics'] ) ) {
-			$this->data['diagnostics'] = array();
+		$diagnostics   = $this->diagnostics();
+		$diagnostics[] = $diagnostic;
+		$this->set_diagnostics( $diagnostics );
+	}
+
+	/**
+	 * @param callable(array<string,mixed>):bool $keep Predicate.
+	 */
+	public function filter_diagnostics( callable $keep ): void {
+		$this->set_diagnostics( array_values( array_filter( $this->diagnostics(), $keep ) ) );
+	}
+
+	/**
+	 * @param array<string,mixed> $diagnostic Replacement row.
+	 */
+	public function replace_diagnostic( int $index, array $diagnostic ): void {
+		$diagnostics = $this->diagnostics();
+		if ( ! array_key_exists( $index, $diagnostics ) ) {
+			throw new InvalidArgumentException( sprintf( 'Import report has no diagnostic at index %d.', $index ) );
 		}
-		$this->data['diagnostics'][] = $diagnostic;
+		$diagnostics[ $index ] = $diagnostic;
+		$this->set_diagnostics( $diagnostics );
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	public function quality(): array {
+		return $this->section( 'quality' );
+	}
+
+	/**
+	 * @param array<string,mixed> $quality Quality payload.
+	 */
+	public function set_quality( array $quality ): void {
+		$this->set_section( 'quality', $quality );
+	}
+
+	/**
+	 * @param array<string,mixed> $quality Quality overlay.
+	 */
+	public function merge_quality( array $quality ): void {
+		$this->merge_section( 'quality', $quality );
+	}
+
+	public function increment_quality( string $metric, int $amount = 1 ): void {
+		$quality            = $this->quality();
+		$quality[ $metric ] = (int) ( $quality[ $metric ] ?? 0 ) + $amount;
+		$this->set_quality( $quality );
 	}
 
 	public function offsetExists( mixed $offset ): bool {
 		return is_string( $offset ) && array_key_exists( $offset, $this->data );
 	}
 
-	public function &offsetGet( mixed $offset ): mixed {
+	/**
+	 * Read-only. Nested `$report['quality']['x'] = 0` does not persist; use mutators.
+	 */
+	public function offsetGet( mixed $offset ): mixed {
 		if ( ! is_string( $offset ) ) {
 			throw new InvalidArgumentException( 'Import report keys must be strings.' );
 		}
-		if ( array_key_exists( $offset, $this->data ) ) {
-			return $this->data[ $offset ];
-		}
-		$this->missing = null;
-		return $this->missing;
+		return $this->get( $offset );
 	}
 
 	public function offsetSet( mixed $offset, mixed $value ): void {
 		if ( ! is_string( $offset ) ) {
 			throw new InvalidArgumentException( 'Import report keys must be strings.' );
 		}
-		if ( ! self::is_known_key( $offset ) && ! array_key_exists( $offset, $this->data ) ) {
-			throw new InvalidArgumentException( sprintf( 'Unknown import-report top-level key "%s".', $offset ) );
-		}
-		$this->data[ $offset ] = $value;
+		$this->set( $offset, $value );
 	}
 
 	public function offsetUnset( mixed $offset ): void {

--- a/includes/class-static-site-importer-import-report.php
+++ b/includes/class-static-site-importer-import-report.php
@@ -79,7 +79,7 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 	private array $data = array();
 
 	/**
-	 * @param array<string,mixed> $data Initial envelope.
+	 * @param array<mixed> $data Initial envelope.
 	 */
 	private function __construct( array $data ) {
 		foreach ( $data as $key => $value ) {
@@ -93,7 +93,7 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 	/**
 	 * Wrap an existing array envelope.
 	 *
-	 * @param array<string,mixed> $data Existing envelope.
+	 * @param array<mixed> $data Existing envelope.
 	 */
 	public static function from_array( array $data ): self {
 		return new self( $data );
@@ -135,15 +135,20 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 	/**
 	 * Read a top-level value.
 	 */
-	public function get( string $key, mixed $default = null ): mixed {
-		return array_key_exists( $key, $this->data ) ? $this->data[ $key ] : $default;
+	public function get( string $key, mixed $fallback = null ): mixed {
+		return array_key_exists( $key, $this->data ) ? $this->data[ $key ] : $fallback;
 	}
 
 	/**
-	 * Replace a top-level value. Unknown keys throw.
+	 * Replace a top-level value. Only declared keys are writable.
+	 *
+	 * Undeclared keys carried in by {@see from_array()} stay readable and
+	 * round-trip through {@see to_array()}, but cannot be written, so loading a
+	 * stale envelope never launders a key into the schema.
 	 */
 	public function set( string $key, mixed $value ): void {
-		if ( ! self::is_known_key( $key ) && ! array_key_exists( $key, $this->data ) ) {
+		if ( ! self::is_known_key( $key ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal schema violation message; this class runs before any WordPress escaping API is guaranteed.
 			throw new InvalidArgumentException( sprintf( 'Unknown import-report top-level key "%s".', $key ) );
 		}
 		$this->data[ $key ] = $value;
@@ -192,15 +197,18 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 	 * @param array<string,mixed> $row Row to append.
 	 */
 	public function append_to_section( string $key, string $list_key, array $row ): void {
-		$section = $this->section( $key );
-		$list    = isset( $section[ $list_key ] ) && is_array( $section[ $list_key ] ) ? $section[ $list_key ] : array();
-		$list[]  = $row;
+		$section              = $this->section( $key );
+		$list                 = isset( $section[ $list_key ] ) && is_array( $section[ $list_key ] ) ? $section[ $list_key ] : array();
+		$list[]               = $row;
 		$section[ $list_key ] = $list;
 		$this->set_section( $key, $section );
 	}
 
 	/**
-	 * @return array<int,array<string,mixed>>
+	 * Diagnostic rows. Entries are not type-narrowed: callers walk heterogeneous
+	 * envelopes loaded from persisted JSON.
+	 *
+	 * @return array<int,mixed>
 	 */
 	public function diagnostics(): array {
 		$diagnostics = $this->get( 'diagnostics', array() );
@@ -208,7 +216,7 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 	}
 
 	/**
-	 * @param array<int,array<string,mixed>> $diagnostics Diagnostic rows.
+	 * @param array<int,mixed> $diagnostics Diagnostic rows.
 	 */
 	public function set_diagnostics( array $diagnostics ): void {
 		$this->set( 'diagnostics', array_values( $diagnostics ) );
@@ -224,18 +232,19 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 	}
 
 	/**
-	 * @param callable(array<string,mixed>):bool $keep Predicate.
+	 * @param callable(mixed):bool $keep Predicate.
 	 */
 	public function filter_diagnostics( callable $keep ): void {
 		$this->set_diagnostics( array_values( array_filter( $this->diagnostics(), $keep ) ) );
 	}
 
 	/**
-	 * @param array<string,mixed> $diagnostic Replacement row.
+	 * @param array<mixed> $diagnostic Replacement row.
 	 */
 	public function replace_diagnostic( int $index, array $diagnostic ): void {
 		$diagnostics = $this->diagnostics();
 		if ( ! array_key_exists( $index, $diagnostics ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal schema violation message; this class runs before any WordPress escaping API is guaranteed.
 			throw new InvalidArgumentException( sprintf( 'Import report has no diagnostic at index %d.', $index ) );
 		}
 		$diagnostics[ $index ] = $diagnostic;

--- a/includes/class-static-site-importer-import-report.php
+++ b/includes/class-static-site-importer-import-report.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Typed import-report envelope.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Declares the import-report top-level schema and owns mutation of that envelope.
+ *
+ * Three factories historically built `static-site-importer/import-report/v1`
+ * arrays (conversion, site-plan receipt, failed-plan) and then 8 classes
+ * mutated the result by reference. This object is the single declared shape:
+ * unknown top-level keys throw, known keys are writable, and `to_array()` is
+ * the persistence/REST seam so serialized output stays an array.
+ */
+final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSerializable {
+
+	public const SCHEMA = 'static-site-importer/import-report/v1';
+
+	/**
+	 * Every top-level key the import report may carry.
+	 *
+	 * Union of the conversion factory, the site-plan receipt factory, the
+	 * failed-plan factory, and keys written during finalization. Nested
+	 * structure inside these keys is owned by the writer; this list is the
+	 * top-level contract.
+	 *
+	 * @var array<int,string>
+	 */
+	public const TOP_LEVEL_KEYS = array(
+		'artifact_diagnostics',
+		'asset_map',
+		'assets',
+		'blocks_engine',
+		'client_script_policy',
+		'commerce',
+		'commerce_context',
+		'compact_summary',
+		'companion_plugin_materialization',
+		'companion_plugins',
+		'conversion_fragments',
+		'diagnostic_count',
+		'diagnostics',
+		'diagnostics_truncated',
+		'entity_lifecycle',
+		'entry_file',
+		'failure_context',
+		'fallback_reconciliation',
+		'finding_packets',
+		'generated_theme',
+		'import_run_id',
+		'import_validation_result',
+		'materialization_receipt',
+		'materialized_content',
+		'notes',
+		'plan_identity',
+		'plugin_materialization',
+		'product_finding_seeding',
+		'product_seeding',
+		'quality',
+		'quality_budget_admission',
+		'quality_resolutions',
+		'schema',
+		'semantic_fidelity',
+		'source',
+		'source_artifact',
+		'source_documents',
+		'source_of_truth',
+		'source_region_selection',
+		'status',
+		'theme_materialization',
+		'theme_slug',
+		'version',
+		'visual_fidelity',
+		'visual_parity_artifacts',
+	);
+
+	/**
+	 * @var array<string,mixed>
+	 */
+	private array $data = array();
+
+	/**
+	 * Placeholder returned by reference when a known key is missing.
+	 *
+	 * @var mixed
+	 */
+	private $missing = null;
+
+	/**
+	 * @param array<string,mixed> $data Initial envelope.
+	 */
+	private function __construct( array $data ) {
+		foreach ( $data as $key => $value ) {
+			if ( ! is_string( $key ) ) {
+				throw new InvalidArgumentException( 'Import report keys must be strings.' );
+			}
+			$this->data[ $key ] = $value;
+		}
+	}
+
+	/**
+	 * Wrap an existing array envelope.
+	 *
+	 * Unknown keys already present are preserved so older reports still load;
+	 * subsequent writes of a *new* unknown key throw.
+	 *
+	 * @param array<string,mixed> $data Existing envelope.
+	 */
+	public static function from_array( array $data ): self {
+		return new self( $data );
+	}
+
+	/**
+	 * Coerce an array or report object to a report object.
+	 *
+	 * @param array<string,mixed>|self $report Envelope.
+	 */
+	public static function from( array|self $report ): self {
+		return $report instanceof self ? $report : self::from_array( $report );
+	}
+
+	/**
+	 * Persistable array form. Byte-identical to the historical envelope.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function to_array(): array {
+		return $this->data;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	public function jsonSerialize(): array {
+		return $this->data;
+	}
+
+	/**
+	 * Whether a top-level key is part of the declared schema.
+	 */
+	public static function is_known_key( string $key ): bool {
+		return in_array( $key, self::TOP_LEVEL_KEYS, true );
+	}
+
+	/**
+	 * Append a diagnostic row.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic row.
+	 */
+	public function append_diagnostic( array $diagnostic ): void {
+		if ( ! isset( $this->data['diagnostics'] ) || ! is_array( $this->data['diagnostics'] ) ) {
+			$this->data['diagnostics'] = array();
+		}
+		$this->data['diagnostics'][] = $diagnostic;
+	}
+
+	public function offsetExists( mixed $offset ): bool {
+		return is_string( $offset ) && array_key_exists( $offset, $this->data );
+	}
+
+	public function &offsetGet( mixed $offset ): mixed {
+		if ( ! is_string( $offset ) ) {
+			throw new InvalidArgumentException( 'Import report keys must be strings.' );
+		}
+		if ( array_key_exists( $offset, $this->data ) ) {
+			return $this->data[ $offset ];
+		}
+		$this->missing = null;
+		return $this->missing;
+	}
+
+	public function offsetSet( mixed $offset, mixed $value ): void {
+		if ( ! is_string( $offset ) ) {
+			throw new InvalidArgumentException( 'Import report keys must be strings.' );
+		}
+		if ( ! self::is_known_key( $offset ) && ! array_key_exists( $offset, $this->data ) ) {
+			throw new InvalidArgumentException( sprintf( 'Unknown import-report top-level key "%s".', $offset ) );
+		}
+		$this->data[ $offset ] = $value;
+	}
+
+	public function offsetUnset( mixed $offset ): void {
+		if ( is_string( $offset ) ) {
+			unset( $this->data[ $offset ] );
+		}
+	}
+}

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -53,7 +53,7 @@ class Static_Site_Importer_Plugin_Materializer {
 			$report['installed'] = true;
 		} else {
 			$report['attempted_actions'][] = 'install';
-			$capabilities = Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( true );
+			$capabilities                  = Static_Site_Importer_Current_Site_Capabilities::check_plugin_install( true );
 			if ( is_wp_error( $capabilities ) ) {
 				return self::failed_report( $report, $capabilities );
 			}
@@ -81,9 +81,9 @@ class Static_Site_Importer_Plugin_Materializer {
 		}
 
 		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( $plugin_file ) ) {
-			$report['active'] = true;
+			$report['active']              = true;
 			$report['attempted_actions'][] = 'prepare_runtime';
-			$preparation      = self::prepare_plugin_runtime( $slug, $preparation_callback );
+			$preparation                   = self::prepare_plugin_runtime( $slug, $preparation_callback );
 			if ( is_wp_error( $preparation ) ) {
 				return self::failed_report( $report, $preparation );
 			}
@@ -93,7 +93,7 @@ class Static_Site_Importer_Plugin_Materializer {
 				return self::failed_report( $report, $capabilities );
 			}
 			$report['attempted_actions'][] = 'activate';
-			$lifecycle = self::prepare_activation_lifecycle_replay();
+			$lifecycle                     = self::prepare_activation_lifecycle_replay();
 			try {
 				$activate = activate_plugin( $plugin_file );
 			} catch ( Throwable $error ) {
@@ -107,16 +107,16 @@ class Static_Site_Importer_Plugin_Materializer {
 				if ( ! is_plugin_active( $plugin_file ) ) {
 					return self::failed_report( $report, $activate );
 				}
-				$report['active']    = true;
-				$report['actions'][] = 'reconciled_activated';
+				$report['active']              = true;
+				$report['actions'][]           = 'reconciled_activated';
 				$report['attempted_actions'][] = 'prepare_runtime';
-				$preparation         = self::prepare_plugin_runtime( $slug, $preparation_callback );
+				$preparation                   = self::prepare_plugin_runtime( $slug, $preparation_callback );
 				if ( is_wp_error( $preparation ) ) {
 					return self::failed_report( $report, $preparation );
 				}
 			} else {
 				$report['attempted_actions'][] = 'prepare_runtime';
-				$preparation = self::prepare_plugin_runtime( $slug, $preparation_callback );
+				$preparation                   = self::prepare_plugin_runtime( $slug, $preparation_callback );
 				if ( is_wp_error( $preparation ) ) {
 					self::restore_activation_lifecycle_actions( $lifecycle );
 					if ( ! is_plugin_active( $plugin_file ) ) {
@@ -243,7 +243,7 @@ class Static_Site_Importer_Plugin_Materializer {
 				return self::failed_report( $report, $registered );
 			}
 			$report['registration'] = $registered;
-			$report = self::replace_active_generated_companion( $plugin_file, $report );
+			$report                 = self::replace_active_generated_companion( $plugin_file, $report );
 			if ( function_exists( 'update_option' ) ) {
 				update_option( self::ACTIVE_COMPANION_OPTION, $plugin_file, false );
 			}
@@ -410,6 +410,7 @@ class Static_Site_Importer_Plugin_Materializer {
 
 		// A byte-identical entrypoint proves this is the prior SSI scaffold for the
 		// same destination and payload, rather than a coincidental block namespace.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads a local scaffold file from the plugin directory, not a remote URL.
 		return hash_equals( $expected_main, (string) file_get_contents( $path ) );
 	}
 
@@ -565,13 +566,13 @@ class Static_Site_Importer_Plugin_Materializer {
 	 */
 	private static function new_report( string $slug, string $plugin_file ): array {
 		return array(
-			'slug'        => $slug,
-			'plugin_file' => $plugin_file,
-			'source'      => 'wordpress.org',
-			'status'      => 'not_run',
-			'attempted'   => false,
-			'installed'   => false,
-			'active'      => false,
+			'slug'              => $slug,
+			'plugin_file'       => $plugin_file,
+			'source'            => 'wordpress.org',
+			'status'            => 'not_run',
+			'attempted'         => false,
+			'installed'         => false,
+			'active'            => false,
 			'actions'           => array(),
 			'attempted_actions' => array(),
 			'error'             => '',

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -42,8 +42,7 @@ class Static_Site_Importer_Plugin_Materializer {
 			$report['status']    = 'already_available';
 			$report['installed'] = true;
 			$report['active']    = true;
-			self::record_installed_provenance( $report );
-			return $report;
+			return self::record_installed_provenance( $report );
 		}
 
 		$report['attempted'] = true;
@@ -126,8 +125,7 @@ class Static_Site_Importer_Plugin_Materializer {
 					$report['active']    = true;
 					$report['actions'][] = 'activated';
 					$report['status']    = 'activated_pending_fresh_runtime';
-					self::record_installed_provenance( $report );
-					return $report;
+					return self::record_installed_provenance( $report );
 				}
 				try {
 					$report['lifecycle_replay'] = self::complete_activation_lifecycle_replay( $lifecycle );
@@ -154,8 +152,7 @@ class Static_Site_Importer_Plugin_Materializer {
 		if ( ! self::available( $availability_check ) ) {
 			$report['status'] = 'activated_pending_fresh_runtime';
 		}
-		self::record_installed_provenance( $report );
-		return $report;
+		return self::record_installed_provenance( $report );
 	}
 
 	/** @return true|WP_Error */
@@ -246,7 +243,7 @@ class Static_Site_Importer_Plugin_Materializer {
 				return self::failed_report( $report, $registered );
 			}
 			$report['registration'] = $registered;
-			self::replace_active_generated_companion( $plugin_file, $report );
+			$report = self::replace_active_generated_companion( $plugin_file, $report );
 			if ( function_exists( 'update_option' ) ) {
 				update_option( self::ACTIVE_COMPANION_OPTION, $plugin_file, false );
 			}
@@ -288,7 +285,7 @@ class Static_Site_Importer_Plugin_Materializer {
 			return self::failed_report( $report, $registered );
 		}
 		$report['registration'] = $registered;
-		self::replace_active_generated_companion( $plugin_file, $report );
+		$report                 = self::replace_active_generated_companion( $plugin_file, $report );
 		if ( function_exists( 'update_option' ) ) {
 			update_option( self::ACTIVE_COMPANION_OPTION, $plugin_file, false );
 		}
@@ -428,20 +425,26 @@ class Static_Site_Importer_Plugin_Materializer {
 	 * @param string               $plugin_file New generated companion basename.
 	 * @param array<string, mixed> $report      Materialization report.
 	 */
-	private static function replace_active_generated_companion( string $plugin_file, array &$report ): void {
+	/**
+	 * @param array<string,mixed> $report Materialization report.
+	 * @return array<string,mixed>
+	 */
+	private static function replace_active_generated_companion( string $plugin_file, array $report ): array {
 		if ( ! function_exists( 'get_option' ) ) {
-			return;
+			return $report;
 		}
 
 		$previous = (string) get_option( self::ACTIVE_COMPANION_OPTION, '' );
 		if ( '' === $previous || $plugin_file === $previous || ! function_exists( 'deactivate_plugins' ) ) {
-			return;
+			return $report;
 		}
 
 		if ( ! function_exists( 'is_plugin_active' ) || is_plugin_active( $previous ) ) {
 			deactivate_plugins( $previous );
 			$report['actions'][] = 'replaced:' . $previous;
 		}
+
+		return $report;
 	}
 
 	/**
@@ -580,11 +583,16 @@ class Static_Site_Importer_Plugin_Materializer {
 		);
 	}
 
-	/** Record the exact activated plugin entrypoint instead of inferring a package version. */
-	private static function record_installed_provenance( array &$report ): void {
+	/**
+	 * Record the exact activated plugin entrypoint instead of inferring a package version.
+	 *
+	 * @param array<string,mixed> $report Materialization report.
+	 * @return array<string,mixed>
+	 */
+	private static function record_installed_provenance( array $report ): array {
 		$file = trailingslashit( WP_PLUGIN_DIR ) . (string) $report['plugin_file'];
 		if ( ! is_readable( $file ) ) {
-			return;
+			return $report;
 		}
 		$headers              = function_exists( 'get_plugin_data' ) ? get_plugin_data( $file, false, false ) : array();
 		$sha256               = hash_file( 'sha256', $file );
@@ -593,6 +601,7 @@ class Static_Site_Importer_Plugin_Materializer {
 			'version' => (string) ( $headers['Version'] ?? '' ),
 			'sha256'  => false !== $sha256 ? $sha256 : '',
 		);
+		return $report;
 	}
 
 	/** Re-read an upgrader-mutated entrypoint instead of reusing pre-install state. */

--- a/includes/class-static-site-importer-quality-budget-admission.php
+++ b/includes/class-static-site-importer-quality-budget-admission.php
@@ -22,7 +22,7 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 	 * @param array<string,mixed> $report
 	 * @return array<string,mixed>
 	 */
-	public static function evaluate( array $plan, array $resolved, array $args = array(), array $report = array() ): array {
+	public static function evaluate( array $plan, array $resolved, array $args = array(), array|Static_Site_Importer_Import_Report $report = array() ): array {
 		$budget                  = isset( $args['quality_budget'] ) && is_array( $args['quality_budget'] ) ? $args['quality_budget'] : ( isset( $args['quality_budgets'] ) && is_array( $args['quality_budgets'] ) ? $args['quality_budgets'] : array() );
 		$mode                    = in_array( $budget['mode'] ?? 'preview', array( 'production', 'production_ready' ), true ) ? 'production' : 'preview';
 		$quality                 = isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array();

--- a/includes/class-static-site-importer-quality-budget-admission.php
+++ b/includes/class-static-site-importer-quality-budget-admission.php
@@ -19,7 +19,7 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 	 * @param array<string,mixed> $plan
 	 * @param array<string,mixed> $resolved
 	 * @param array<string,mixed> $args
-	 * @param array<string,mixed> $report
+	 * @param array<string,mixed>|Static_Site_Importer_Import_Report $report
 	 * @return array<string,mixed>
 	 */
 	public static function evaluate( array $plan, array $resolved, array $args = array(), array|Static_Site_Importer_Import_Report $report = array() ): array {
@@ -148,8 +148,8 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 		return $count;
 	}
 
-	/** @param array<string,mixed> $args @param array<string,mixed> $report */
-	private static function gate_status( array $args, array $report, string $gate ): string {
+	/** @param array<string,mixed> $args @param array<string,mixed>|Static_Site_Importer_Import_Report $report */
+	private static function gate_status( array $args, array|Static_Site_Importer_Import_Report $report, string $gate ): string {
 		$artifacts = isset( $args['validation_artifacts'] ) && is_array( $args['validation_artifacts'] ) ? $args['validation_artifacts'] : array();
 		if ( isset( $artifacts[ $gate . '_gate' ]['status'] ) ) {
 			return (string) $artifacts[ $gate . '_gate' ]['status'];

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -12,6 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Product_Handoff_Contract' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-product-handoff-contract.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Import_Report' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-import-report.php';
+}
 if ( ! class_exists( 'Static_Site_Importer_Diagnostic_Loss_Classes' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-diagnostic-loss-classes.php';
 }
@@ -50,11 +53,12 @@ class Static_Site_Importer_Report_Diagnostics {
 	 *
 	 * @param string              $html_path       Imported entry file.
 	 * @param array<string,mixed> $source_metadata Source metadata.
-	 * @return array<string, mixed>
+	 * @return Static_Site_Importer_Import_Report
 	 */
-	public static function new_conversion_report( string $html_path, array $source_metadata = array() ): array {
-		return array(
-			'schema'                  => Static_Site_Importer_Product_Handoff_Contract::SSI_IMPORT_REPORT_SCHEMA,
+	public static function new_conversion_report( string $html_path, array $source_metadata = array() ): Static_Site_Importer_Import_Report {
+		return Static_Site_Importer_Import_Report::from_array(
+			array(
+			'schema'                  => Static_Site_Importer_Import_Report::SCHEMA,
 			'version'                 => 1,
 			'entry_file'              => $html_path,
 			'source'                  => array_merge(
@@ -174,6 +178,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'Visual fidelity requires browser rendering; use visual_parity_artifacts for durable Codebox/runtime evidence and explicit pending/not-captured slots.',
 				'Semantic fidelity requires browser DOM extraction; use semantic_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
 			),
+			)
 		);
 	}
 
@@ -184,7 +189,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $compiled Compiler result envelope.
 	 * @return void
 	 */
-	public static function record_direct_website_artifact_source_summary( array &$report, array $compiled ): void {
+	public static function record_direct_website_artifact_source_summary( Static_Site_Importer_Import_Report $report, array $compiled ): void {
 		$artifacts = isset( $compiled['artifacts'] ) && is_array( $compiled['artifacts'] ) ? $compiled['artifacts'] : array();
 		$files     = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
 		$source    = (string) ( $compiled['provenance']['source'] ?? ( $compiled['input']['entry_path'] ?? 'website_artifact' ) );
@@ -309,7 +314,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $args   Import args.
 	 * @return array<string, mixed>
 	 */
-	public static function finalize_report( array &$report, array $args ): array {
+	public static function finalize_report( Static_Site_Importer_Import_Report $report, array $args ): array {
 		$quality                           = self::finalize_quality_report( $report, $args );
 		$report['visual_parity_artifacts'] = self::visual_parity_artifact_contract( isset( $args['validation_artifacts'] ) && is_array( $args['validation_artifacts'] ) ? $args['validation_artifacts'] : array() );
 		self::refresh_projections( $report, $quality, false );
@@ -325,7 +330,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param bool                $build_fixture Whether to build the fixture projection.
 	 * @return array<string,mixed>
 	 */
-	public static function refresh_projections( array &$report, array $quality, bool $build_fixture = true ): array {
+	public static function refresh_projections( Static_Site_Importer_Import_Report $report, array $quality, bool $build_fixture = true ): array {
 		$report['quality']                  = $quality;
 		$report['compact_summary']          = self::import_report_summary( $report, $quality );
 		$report['finding_packets']          = self::finding_packets( $report );
@@ -338,7 +343,7 @@ class Static_Site_Importer_Report_Diagnostics {
 					'status'                   => (string) ( $report['compact_summary']['status'] ?? '' ),
 					'slug'                     => (string) ( $report['theme_slug'] ?? '' ),
 					'import_validation_result' => $report['import_validation_result'],
-					'import_report'            => $report,
+					'import_report'            => $report->to_array(),
 					'materialization_receipt'  => isset( $report['materialization_receipt'] ) && is_array( $report['materialization_receipt'] ) ? $report['materialization_receipt'] : array(),
 				)
 			);
@@ -354,7 +359,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $quality Finalized quality gate state.
 	 * @return array<string,mixed>
 	 */
-	public static function import_validation_result( array $report, array $quality ): array {
+	public static function import_validation_result( array|Static_Site_Importer_Import_Report $report, array $quality ): array {
 		$summary          = self::import_report_summary( $report, $quality );
 		$diagnostics      = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
 		$source_documents = isset( $report['source_documents'] ) && is_array( $report['source_documents'] ) ? $report['source_documents'] : array();
@@ -423,7 +428,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report Full import report.
 	 * @return array<string,mixed>
 	 */
-	public static function finding_packets( array $report ): array {
+	public static function finding_packets( array|Static_Site_Importer_Import_Report $report ): array {
 		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
 		$packets     = array();
 
@@ -752,7 +757,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $args   Import args.
 	 * @return array<string, mixed>
 	 */
-	public static function finalize_quality_report( array &$report, array $args ): array {
+	public static function finalize_quality_report( Static_Site_Importer_Import_Report $report, array $args ): array {
 		self::normalize_quality_report( $report );
 		self::reconcile_provider_materialized_fallbacks( $report );
 		self::mark_active_companion_script_fallbacks_materialized( $report );
@@ -867,7 +872,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report Import report.
 	 * @return void
 	 */
-	private static function normalize_quality_report( array &$report ): void {
+	private static function normalize_quality_report( Static_Site_Importer_Import_Report $report ): void {
 		$supplied = isset( $report['quality'] ) && is_array( $report['quality'] ) ? $report['quality'] : array();
 		$metrics  = isset( $supplied['metrics'] ) && is_array( $supplied['metrics'] ) ? $supplied['metrics'] : array();
 		$quality  = array_merge( self::quality_defaults(), $metrics, $supplied );
@@ -952,7 +957,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param bool                 $waived     Whether enforcement is waived.
 	 * @return void
 	 */
-	public static function record_companion_plugin_dependency( array &$report, array $dependency, bool $waived ): void {
+	public static function record_companion_plugin_dependency( Static_Site_Importer_Import_Report $report, array $dependency, bool $waived ): void {
 		$row  = Static_Site_Importer_Entity_Materializer_Registry::companion_dependency_row( $dependency, $waived );
 		$slug = (string) ( $row['slug'] ?? '' );
 		if ( '' === $slug ) {
@@ -1031,7 +1036,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string, mixed> $quality Finalized quality summary.
 	 * @return array<string, mixed>
 	 */
-	public static function import_report_summary( array $report, array $quality ): array {
+	public static function import_report_summary( array|Static_Site_Importer_Import_Report $report, array $quality ): array {
 		$diagnostics            = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
 		$source_documents       = isset( $report['source_documents'] ) && is_array( $report['source_documents'] ) ? $report['source_documents'] : array();
 		$commerce               = isset( $report['commerce'] ) && is_array( $report['commerce'] ) ? $report['commerce'] : array();
@@ -1359,7 +1364,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report Full import report.
 	 * @return array<string,mixed>
 	 */
-	private static function validation_provenance( array $report ): array {
+	private static function validation_provenance( array|Static_Site_Importer_Import_Report $report ): array {
 		$source   = isset( $report['source'] ) && is_array( $report['source'] ) ? $report['source'] : array();
 		$compiler = isset( $report['blocks_engine']['website_artifact'] ) && is_array( $report['blocks_engine']['website_artifact'] ) ? $report['blocks_engine']['website_artifact'] : array();
 
@@ -1379,7 +1384,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report Full import report.
 	 * @return array<string,mixed>
 	 */
-	private static function validation_reproduction_context( array $report ): array {
+	private static function validation_reproduction_context( array|Static_Site_Importer_Import_Report $report ): array {
 		return array(
 			'entry_file'       => isset( $report['entry_file'] ) ? (string) $report['entry_file'] : '',
 			'theme_slug'       => isset( $report['theme_slug'] ) ? (string) $report['theme_slug'] : '',
@@ -1432,7 +1437,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report     Full import report.
 	 * @return array<string,mixed>
 	 */
-	private static function finding_packet_from_diagnostic( array $diagnostic, array $report ): array {
+	private static function finding_packet_from_diagnostic( array $diagnostic, array|Static_Site_Importer_Import_Report $report ): array {
 		$id       = isset( $diagnostic['id'] ) && is_scalar( $diagnostic['id'] ) ? (string) $diagnostic['id'] : 'finding';
 		$type     = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : 'import_diagnostic';
 		$severity = isset( $diagnostic['severity'] ) && is_scalar( $diagnostic['severity'] ) ? (string) $diagnostic['severity'] : self::diagnostic_severity( $type );
@@ -1991,7 +1996,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,string> $page_contents Materialized page post_content keyed by source filename, mutated in place.
 	 * @return array<string,mixed> The recorded product_finding_seeding report.
 	 */
-	public static function materialize_product_findings( array &$report, array $args = array(), array &$page_contents = array() ): array {
+	public static function materialize_product_findings( Static_Site_Importer_Import_Report $report, array $args = array(), array &$page_contents = array() ): array {
 		$adapter = Static_Site_Importer_Entity_Materializer_Registry::product_adapter();
 
 		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
@@ -2542,7 +2547,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report Full import report.
 	 * @return array<string,mixed>
 	 */
-	private static function compact_semantic_parity_summary( array $report ): array {
+	private static function compact_semantic_parity_summary( array|Static_Site_Importer_Import_Report $report ): array {
 		$semantic_parity = isset( $report['blocks_engine']['semantic_parity'] ) && is_array( $report['blocks_engine']['semantic_parity'] ) ? $report['blocks_engine']['semantic_parity'] : array();
 		if ( empty( $semantic_parity ) ) {
 			return array(
@@ -2567,7 +2572,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param string                         $slug             Companion plugin slug.
 	 * @return void
 	 */
-	private static function mark_companion_script_fallbacks_materialized( array &$report, array $runtime_scripts, string $slug ): void {
+	private static function mark_companion_script_fallbacks_materialized( Static_Site_Importer_Import_Report $report, array $runtime_scripts, string $slug ): void {
 		$selectors = array();
 		foreach ( $runtime_scripts as $script ) {
 			$selector = self::first_scalar( $script, array( 'selector' ) );
@@ -2625,7 +2630,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report Import report.
 	 * @return void
 	 */
-	private static function mark_active_companion_script_fallbacks_materialized( array &$report ): void {
+	private static function mark_active_companion_script_fallbacks_materialized( Static_Site_Importer_Import_Report $report ): void {
 		$dependencies = $report['companion_plugins']['dependencies'] ?? array();
 		if ( ! is_array( $dependencies ) ) {
 			return;
@@ -2650,7 +2655,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report Import report.
 	 * @return void
 	 */
-	public static function reconcile_provider_materialized_fallbacks( array &$report, array $receipts = array() ): void {
+	public static function reconcile_provider_materialized_fallbacks( Static_Site_Importer_Import_Report $report, array $receipts = array() ): void {
 		if ( ! isset( $report['quality'] ) || ! is_array( $report['quality'] ) ) {
 			$report['quality'] = array();
 		}
@@ -2761,7 +2766,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report Import report.
 	 * @return void
 	 */
-	private static function normalize_import_diagnostics( array &$report ): void {
+	private static function normalize_import_diagnostics( Static_Site_Importer_Import_Report $report ): void {
 		if ( empty( $report['diagnostics'] ) || ! is_array( $report['diagnostics'] ) ) {
 			return;
 		}
@@ -2972,7 +2977,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report Import report.
 	 * @return void
 	 */
-	private static function normalize_source_document_diagnostic_refs( array &$report ): void {
+	private static function normalize_source_document_diagnostic_refs( Static_Site_Importer_Import_Report $report ): void {
 		$diagnostics = isset( $report['diagnostics'] ) && is_array( $report['diagnostics'] ) ? $report['diagnostics'] : array();
 		$refs        = array(
 			'unresolved_link_count'      => array(),
@@ -3204,7 +3209,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @param array<string,mixed> $report Full conversion report.
 	 * @return array<string,mixed>
 	 */
-	private static function compact_import_report_compiler_summary( array $report ): array {
+	private static function compact_import_report_compiler_summary( array|Static_Site_Importer_Import_Report $report ): array {
 		$compiler = isset( $report['blocks_engine'] ) && is_array( $report['blocks_engine'] ) ? $report['blocks_engine'] : array();
 		$summary  = array(
 			'available'      => ! empty( $compiler['available'] ),

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -56,8 +56,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return Static_Site_Importer_Import_Report
 	 */
 	public static function new_conversion_report( string $html_path, array $source_metadata = array() ): Static_Site_Importer_Import_Report {
-		return Static_Site_Importer_Import_Report::from_array(
-			array(
+		$envelope = array(
 			'schema'                  => Static_Site_Importer_Import_Report::SCHEMA,
 			'version'                 => 1,
 			'entry_file'              => $html_path,
@@ -178,14 +177,15 @@ class Static_Site_Importer_Report_Diagnostics {
 				'Visual fidelity requires browser rendering; use visual_parity_artifacts for durable Codebox/runtime evidence and explicit pending/not-captured slots.',
 				'Semantic fidelity requires browser DOM extraction; use semantic_fidelity.comparison_targets to compare source static HTML against the generated WordPress URL.',
 			),
-			)
 		);
+
+		return Static_Site_Importer_Import_Report::from_array( $envelope );
 	}
 
 	/**
 	 * Record source and contract notes for direct website-artifact materialization.
 	 *
-	 * @param array<string,mixed> $report   Import report.
+	 * @param Static_Site_Importer_Import_Report $report   Import report.
 	 * @param array<string,mixed> $compiled Compiler result envelope.
 	 * @return void
 	 */
@@ -194,7 +194,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$files     = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
 		$source    = (string) ( $compiled['provenance']['source'] ?? ( $compiled['input']['entry_path'] ?? 'website_artifact' ) );
 
-		$source_documents                              = array_merge(
+		$source_documents                            = array_merge(
 			$report->section( 'source_documents' ),
 			array(
 				'total_count'      => 1,
@@ -310,7 +310,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Finalize quality summary, compact summary, and artifact diagnostics.
 	 *
-	 * @param array<string,mixed> $report Import report.
+	 * @param Static_Site_Importer_Import_Report $report Import report.
 	 * @param array<string,mixed> $args   Import args.
 	 * @return array<string, mixed>
 	 */
@@ -325,7 +325,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Refresh every public projection from one finalized report state.
 	 *
-	 * @param array<string,mixed> $report  Finalized import report.
+	 * @param Static_Site_Importer_Import_Report $report  Finalized import report.
 	 * @param array<string,mixed> $quality Finalized quality gate state.
 	 * @param bool                $build_fixture Whether to build the fixture projection.
 	 * @return array<string,mixed>
@@ -355,7 +355,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Build the first-class import validation artifact for automation consumers.
 	 *
-	 * @param array<string,mixed> $report  Full import report.
+	 * @param array<string,mixed>|Static_Site_Importer_Import_Report $report  Full import report.
 	 * @param array<string,mixed> $quality Finalized quality gate state.
 	 * @return array<string,mixed>
 	 */
@@ -425,7 +425,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Build the finding packet artifact set for repair-loop routing.
 	 *
-	 * @param array<string,mixed> $report Full import report.
+	 * @param array<string,mixed>|Static_Site_Importer_Import_Report $report Full import report.
 	 * @return array<string,mixed>
 	 */
 	public static function finding_packets( array|Static_Site_Importer_Import_Report $report ): array {
@@ -753,7 +753,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Finalize quality summary and gate status.
 	 *
-	 * @param array<string,mixed> $report Import report.
+	 * @param Static_Site_Importer_Import_Report $report Import report.
 	 * @param array<string,mixed> $args   Import args.
 	 * @return array<string, mixed>
 	 */
@@ -869,7 +869,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * report value while making the quality gate consume its authoritative fallback
 	 * count until a materialization receipt explicitly resolves it.
 	 *
-	 * @param array<string,mixed> $report Import report.
+	 * @param Static_Site_Importer_Import_Report $report Import report.
 	 * @return void
 	 */
 	private static function normalize_quality_report( Static_Site_Importer_Import_Report $report ): void {
@@ -952,7 +952,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * declared dependency row is stored under `companion_plugins.dependencies` keyed
 	 * by the namespaced companion slug, distinct from `commerce.dependencies`.
 	 *
-	 * @param array<string, mixed> $report     Conversion report (mutated in place).
+	 * @param Static_Site_Importer_Import_Report $report     Conversion report (mutated in place).
 	 * @param array<string, mixed> $dependency Companion dependency definition.
 	 * @param bool                 $waived     Whether enforcement is waived.
 	 * @return void
@@ -1027,7 +1027,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Build the compact report summary consumed by validation harnesses.
 	 *
-	 * @param array<string, mixed> $report  Full conversion report.
+	 * @param array<string,mixed>|Static_Site_Importer_Import_Report $report  Full conversion report.
 	 * @param array<string, mixed> $quality Finalized quality summary.
 	 * @return array<string, mixed>
 	 */
@@ -1356,7 +1356,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Build provenance for machine artifacts.
 	 *
-	 * @param array<string,mixed> $report Full import report.
+	 * @param array<string,mixed>|Static_Site_Importer_Import_Report $report Full import report.
 	 * @return array<string,mixed>
 	 */
 	private static function validation_provenance( array|Static_Site_Importer_Import_Report $report ): array {
@@ -1376,7 +1376,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Build import-level reproduction context for machine artifacts.
 	 *
-	 * @param array<string,mixed> $report Full import report.
+	 * @param array<string,mixed>|Static_Site_Importer_Import_Report $report Full import report.
 	 * @return array<string,mixed>
 	 */
 	private static function validation_reproduction_context( array|Static_Site_Importer_Import_Report $report ): array {
@@ -1429,7 +1429,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * Convert one normalized diagnostic into a FindingPacket.
 	 *
 	 * @param array<string,mixed> $diagnostic Normalized diagnostic.
-	 * @param array<string,mixed> $report     Full import report.
+	 * @param array<string,mixed>|Static_Site_Importer_Import_Report $report     Full import report.
 	 * @return array<string,mixed>
 	 */
 	private static function finding_packet_from_diagnostic( array $diagnostic, array|Static_Site_Importer_Import_Report $report ): array {
@@ -1986,7 +1986,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * keep no signal and stay an unacceptable parity loss, which lets the existing
 	 * commerce dependency gate report the missing runtime.
 	 *
-	 * @param array<string,mixed>  $report        Import report (mutated in place).
+	 * @param Static_Site_Importer_Import_Report  $report        Import report (mutated in place).
 	 * @param array<string,mixed>  $args          Import args.
 	 * @param array<string,string> $page_contents Materialized page post_content keyed by source filename, mutated in place.
 	 * @return array<string,mixed> The recorded product_finding_seeding report.
@@ -2539,7 +2539,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Compact semantic parity metrics for import-report summaries.
 	 *
-	 * @param array<string,mixed> $report Full import report.
+	 * @param array<string,mixed>|Static_Site_Importer_Import_Report $report Full import report.
 	 * @return array<string,mixed>
 	 */
 	private static function compact_semantic_parity_summary( array|Static_Site_Importer_Import_Report $report ): array {
@@ -2562,7 +2562,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Resolve script fallback diagnostics after the generated companion plugin is active.
 	 *
-	 * @param array<string,mixed>            $report          Import report.
+	 * @param Static_Site_Importer_Import_Report            $report          Import report.
 	 * @param array<int,array<string,mixed>> $runtime_scripts Materialized companion scripts.
 	 * @param string                         $slug             Companion plugin slug.
 	 * @return void
@@ -2626,7 +2626,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Reconcile late-added fallback rows against active companion dependencies.
 	 *
-	 * @param array<string,mixed> $report Import report.
+	 * @param Static_Site_Importer_Import_Report $report Import report.
 	 * @return void
 	 */
 	private static function mark_active_companion_script_fallbacks_materialized( Static_Site_Importer_Import_Report $report ): void {
@@ -2651,12 +2651,12 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * quality count excludes a form after a completed receipt proves that exact
 	 * source fallback was replaced by the provider's persisted block markup.
 	 *
-	 * @param array<string,mixed> $report Import report.
+	 * @param Static_Site_Importer_Import_Report $report Import report.
 	 * @return void
 	 */
 	public static function reconcile_provider_materialized_fallbacks( Static_Site_Importer_Import_Report $report, array $receipts = array() ): void {
-		$quality      = $report->quality();
-		$source_total = max(
+		$quality                          = $report->quality();
+		$source_total                     = max(
 			(int) ( $quality['source_fallback_count'] ?? 0 ),
 			(int) ( $quality['fallback_count'] ?? 0 )
 		);
@@ -2731,14 +2731,14 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		$report->merge_quality( array( 'fallback_count' => max( 0, $source_total - $resolved ) ) );
-		$report['quality_resolutions']       = array(
+		$report['quality_resolutions']     = array(
 			'schema'                    => 'static-site-importer/quality-resolutions/v1',
 			'source_fallback_count'     => $source_total,
 			'resolved_by_provider'      => $resolved,
 			'unresolved_fallback_count' => max( 0, $source_total - $resolved ),
 			'resolutions'               => $resolutions,
 		);
-		$report['fallback_reconciliation']   = $report['quality_resolutions'];
+		$report['fallback_reconciliation'] = $report['quality_resolutions'];
 	}
 
 	/**
@@ -2761,7 +2761,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Normalize import diagnostics into a stable, machine-actionable shape.
 	 *
-	 * @param array<string,mixed> $report Import report.
+	 * @param Static_Site_Importer_Import_Report $report Import report.
 	 * @return void
 	 */
 	private static function normalize_import_diagnostics( Static_Site_Importer_Import_Report $report ): void {
@@ -2972,7 +2972,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Link source-document counts back to concrete diagnostics.
 	 *
-	 * @param array<string,mixed> $report Import report.
+	 * @param Static_Site_Importer_Import_Report $report Import report.
 	 * @return void
 	 */
 	private static function normalize_source_document_diagnostic_refs( Static_Site_Importer_Import_Report $report ): void {
@@ -3204,7 +3204,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	/**
 	 * Summarize compiler evidence for compact import metrics.
 	 *
-	 * @param array<string,mixed> $report Full conversion report.
+	 * @param array<string,mixed>|Static_Site_Importer_Import_Report $report Full conversion report.
 	 * @return array<string,mixed>
 	 */
 	private static function compact_import_report_compiler_summary( array|Static_Site_Importer_Import_Report $report ): array {

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -194,8 +194,8 @@ class Static_Site_Importer_Report_Diagnostics {
 		$files     = isset( $artifacts['files'] ) && is_array( $artifacts['files'] ) ? $artifacts['files'] : array();
 		$source    = (string) ( $compiled['provenance']['source'] ?? ( $compiled['input']['entry_path'] ?? 'website_artifact' ) );
 
-		$source_documents = array_merge(
-			$report['source_documents'],
+		$source_documents                              = array_merge(
+			$report->section( 'source_documents' ),
 			array(
 				'total_count'      => 1,
 				'counts_by_format' => array(
@@ -205,19 +205,19 @@ class Static_Site_Importer_Report_Diagnostics {
 				),
 			)
 		);
-
-		$report['source_documents']                            = $source_documents;
-		$report['source_documents']['direct_website_artifact'] = array(
+		$source_documents['direct_website_artifact'] = array(
 			'source'     => '' !== $source ? $source : 'website_artifact',
 			'file_count' => count( $files ),
 		);
-
-		$report['diagnostics'][] = array(
-			'type'        => 'website_artifact_materialization_contract_note',
-			'source'      => '' !== $source ? $source : 'website_artifact',
-			'message'     => 'Direct materialization consumed block_markup, documents, files, and materialization-plan artifacts. Static Site Importer owns WordPress writes and product seeding while Blocks Engine owns materializer-neutral site/theme compilation.',
-			'contract'    => isset( $compiled['schema'] ) && is_scalar( $compiled['schema'] ) ? (string) $compiled['schema'] : 'blocks-engine/php-transformer/result/v1',
-			'constraints' => 'report_only',
+		$report->set_section( 'source_documents', $source_documents );
+		$report->append_diagnostic(
+			array(
+				'type'        => 'website_artifact_materialization_contract_note',
+				'source'      => '' !== $source ? $source : 'website_artifact',
+				'message'     => 'Direct materialization consumed block_markup, documents, files, and materialization-plan artifacts. Static Site Importer owns WordPress writes and product seeding while Blocks Engine owns materializer-neutral site/theme compilation.',
+				'contract'    => isset( $compiled['schema'] ) && is_scalar( $compiled['schema'] ) ? (string) $compiled['schema'] : 'blocks-engine/php-transformer/result/v1',
+				'constraints' => 'report_only',
+			)
 		);
 	}
 
@@ -964,17 +964,12 @@ class Static_Site_Importer_Report_Diagnostics {
 			return;
 		}
 
-		if ( ! isset( $report['companion_plugins'] ) || ! is_array( $report['companion_plugins'] ) ) {
-			$report['companion_plugins'] = array( 'dependencies' => array() );
+		$companion = $report->section( 'companion_plugins' );
+		if ( ! isset( $companion['dependencies'] ) || ! is_array( $companion['dependencies'] ) ) {
+			$companion['dependencies'] = array();
 		}
-		if ( ! isset( $report['companion_plugins']['dependencies'] ) || ! is_array( $report['companion_plugins']['dependencies'] ) ) {
-			$report['companion_plugins']['dependencies'] = array();
-		}
-		$report['companion_plugins']['dependencies'][ $slug ] = $row;
-
-		if ( ! isset( $report['diagnostics'] ) || ! is_array( $report['diagnostics'] ) ) {
-			$report['diagnostics'] = array();
-		}
+		$companion['dependencies'][ $slug ] = $row;
+		$report->set_section( 'companion_plugins', $companion );
 
 		$source = 'companion_plugins.dependencies.' . $slug;
 
@@ -998,34 +993,34 @@ class Static_Site_Importer_Report_Diagnostics {
 				$present['runtime_carried'] = true;
 				$present['message']         = sprintf( 'Companion plugin %s is active; generated blocks and preserved island JS are carried theme-independently.', $slug );
 			}
-			$report['diagnostics'][] = $present;
+			$report->append_diagnostic( $present );
 			return;
 		}
 
 		if ( $waived ) {
-			$report['diagnostics'][] = array(
-				'code'        => 'companion_plugin_waived',
-				'severity'    => 'warning',
-				'source'      => $source,
-				'message'     => sprintf( 'Companion plugin %s requirement was waived; generated blocks were not installed.', $slug ),
-				'slug'        => $slug,
-				'block_names' => $row['block_names'] ?? array(),
+			$report->append_diagnostic(
+				array(
+					'code'        => 'companion_plugin_waived',
+					'severity'    => 'warning',
+					'source'      => $source,
+					'message'     => sprintf( 'Companion plugin %s requirement was waived; generated blocks were not installed.', $slug ),
+					'slug'        => $slug,
+					'block_names' => $row['block_names'] ?? array(),
+				)
 			);
 			return;
 		}
 
-		if ( ! isset( $report['quality'] ) || ! is_array( $report['quality'] ) ) {
-			$report['quality'] = array();
-		}
-		$report['quality']['companion_plugin_dependency_failures'] = (int) ( $report['quality']['companion_plugin_dependency_failures'] ?? 0 ) + 1;
-
-		$report['diagnostics'][] = array(
-			'code'        => 'companion_plugin_missing',
-			'severity'    => 'error',
-			'source'      => $source,
-			'message'     => sprintf( 'Companion plugin %s is required to house generated blocks but is not installed/active.', $slug ),
-			'slug'        => $slug,
-			'block_names' => $row['block_names'] ?? array(),
+		$report->increment_quality( 'companion_plugin_dependency_failures' );
+		$report->append_diagnostic(
+			array(
+				'code'        => 'companion_plugin_missing',
+				'severity'    => 'error',
+				'source'      => $source,
+				'message'     => sprintf( 'Companion plugin %s is required to house generated blocks but is not installed/active.', $slug ),
+				'slug'        => $slug,
+				'block_names' => $row['block_names'] ?? array(),
+			)
 		);
 	}
 
@@ -2085,19 +2080,19 @@ class Static_Site_Importer_Report_Diagnostics {
 			foreach ( $slugs as $slug ) {
 				if ( isset( $seeded_products_by_slug[ $slug ] ) ) {
 					++$seeding['mapped_count'];
-					$report['diagnostics'][ $index ] = self::mark_product_finding_mapped( $report['diagnostics'][ $index ], $seeding['provider'] );
+					$report->replace_diagnostic( $index, self::mark_product_finding_mapped( $report->diagnostics()[ $index ], $seeding['provider'] ) );
 					break;
 				}
 			}
 
 			if ( ! empty( $page_contents ) ) {
-				$graft                           = self::graft_product_add_to_cart_shortcodes_into_page_contents( $report['diagnostics'][ $index ], $seeded_products_by_slug, $page_contents );
-				$report['diagnostics'][ $index ] = $graft['finding'];
+				$graft = self::graft_product_add_to_cart_shortcodes_into_page_contents( $report->diagnostics()[ $index ], $seeded_products_by_slug, $page_contents );
+				$report->replace_diagnostic( $index, $graft['finding'] );
 				if ( $graft['grafted'] ) {
 					++$seeding['shortcode_grafted_count'];
 				}
 				if ( is_array( $graft['diagnostic'] ) ) {
-					$report['diagnostics'][] = $graft['diagnostic'];
+					$report->append_diagnostic( $graft['diagnostic'] );
 				}
 			}
 		}
@@ -2584,8 +2579,9 @@ class Static_Site_Importer_Report_Diagnostics {
 			return;
 		}
 
-		$resolved = array();
-		foreach ( $report['diagnostics'] as &$diagnostic ) {
+		$resolved    = array();
+		$diagnostics = $report->diagnostics();
+		foreach ( $diagnostics as &$diagnostic ) {
 			if ( ! is_array( $diagnostic ) || ! self::is_script_runtime_fallback_diagnostic( $diagnostic ) ) {
 				continue;
 			}
@@ -2610,9 +2606,12 @@ class Static_Site_Importer_Report_Diagnostics {
 			$resolved[ $selector ]                       = true;
 		}
 		unset( $diagnostic );
+		$report->set_diagnostics( $diagnostics );
 
 		if ( ! empty( $resolved ) ) {
-			$report['quality']['fallback_count'] = max( 0, (int) ( $report['quality']['fallback_count'] ?? 0 ) - count( $resolved ) );
+			$quality                   = $report->quality();
+			$quality['fallback_count'] = max( 0, (int) ( $quality['fallback_count'] ?? 0 ) - count( $resolved ) );
+			$report->set_quality( $quality );
 		}
 	}
 
@@ -2656,14 +2655,13 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return void
 	 */
 	public static function reconcile_provider_materialized_fallbacks( Static_Site_Importer_Import_Report $report, array $receipts = array() ): void {
-		if ( ! isset( $report['quality'] ) || ! is_array( $report['quality'] ) ) {
-			$report['quality'] = array();
-		}
-		$source_total                               = max(
-			(int) ( $report['quality']['source_fallback_count'] ?? 0 ),
-			(int) ( $report['quality']['fallback_count'] ?? 0 )
+		$quality      = $report->quality();
+		$source_total = max(
+			(int) ( $quality['source_fallback_count'] ?? 0 ),
+			(int) ( $quality['fallback_count'] ?? 0 )
 		);
-		$report['quality']['source_fallback_count'] = $source_total;
+		$quality['source_fallback_count'] = $source_total;
+		$report->set_quality( $quality );
 
 		if ( empty( $receipts ) ) {
 			$bindings = $report['materialization_receipt']['completed']['runtime_declarations']['entity_bindings'] ?? array();
@@ -2720,7 +2718,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'state'        => $resolved_by_provider ? 'resolved_by_provider' : 'unresolved',
 				'receipt'      => $receipt,
 			);
-			$report['diagnostics'][ $index ]                = $diagnostic;
+			$report->replace_diagnostic( $index, $diagnostic );
 			if ( $resolved_by_provider ) {
 				++$resolved;
 			}
@@ -2732,7 +2730,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			);
 		}
 
-		$report['quality']['fallback_count'] = max( 0, $source_total - $resolved );
+		$report->merge_quality( array( 'fallback_count' => max( 0, $source_total - $resolved ) ) );
 		$report['quality_resolutions']       = array(
 			'schema'                    => 'static-site-importer/quality-resolutions/v1',
 			'source_fallback_count'     => $source_total,
@@ -3000,7 +2998,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			}
 		}
 
-		$report['source_documents']['diagnostic_refs'] = $refs;
+		$report->set_in_section( 'source_documents', 'diagnostic_refs', $refs );
 	}
 
 	/**

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -631,8 +631,7 @@ class Static_Site_Importer_Theme_Generator {
 		if ( isset( $args['missing_author_stylesheet_diagnostics'] ) && is_array( $args['missing_author_stylesheet_diagnostics'] ) ) {
 			$diagnostics = array_merge( $diagnostics, array_values( array_filter( $args['missing_author_stylesheet_diagnostics'], 'is_array' ) ) );
 		}
-		$report       = Static_Site_Importer_Import_Report::from_array(
-			array(
+		$envelope     = array(
 			'schema'                           => Static_Site_Importer_Import_Report::SCHEMA,
 			'import_run_id'                    => self::import_run_id( $args ),
 			'plan_identity'                    => $receipt['plan_identity'] ?? array(),
@@ -693,8 +692,8 @@ class Static_Site_Importer_Theme_Generator {
 					'mdx'      => 0,
 				),
 			),
-			)
 		);
+		$report       = Static_Site_Importer_Import_Report::from_array( $envelope );
 		$report['source_artifact'] = array( 'hash' => (string) ( $args['artifact_hash'] ?? $plan['source']['source_hash'] ) );
 		$report['materialization_receipt'] = $receipt;
 		$artifact = array_merge(

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -631,8 +631,9 @@ class Static_Site_Importer_Theme_Generator {
 		if ( isset( $args['missing_author_stylesheet_diagnostics'] ) && is_array( $args['missing_author_stylesheet_diagnostics'] ) ) {
 			$diagnostics = array_merge( $diagnostics, array_values( array_filter( $args['missing_author_stylesheet_diagnostics'], 'is_array' ) ) );
 		}
-		$report       = array(
-			'schema'                           => 'static-site-importer/import-report/v1',
+		$report       = Static_Site_Importer_Import_Report::from_array(
+			array(
+			'schema'                           => Static_Site_Importer_Import_Report::SCHEMA,
 			'import_run_id'                    => self::import_run_id( $args ),
 			'plan_identity'                    => $receipt['plan_identity'] ?? array(),
 			'blocks_engine'                    => array(
@@ -692,6 +693,7 @@ class Static_Site_Importer_Theme_Generator {
 					'mdx'      => 0,
 				),
 			),
+			)
 		);
 		$report['source_artifact'] = array( 'hash' => (string) ( $args['artifact_hash'] ?? $plan['source']['source_hash'] ) );
 		$report['materialization_receipt'] = $receipt;
@@ -863,7 +865,7 @@ class Static_Site_Importer_Theme_Generator {
 			$report_path = $theme_dir . '/import-report.json';
 			$validation_path = $theme_dir . '/import-validation-result.json';
 			$findings_path = $theme_dir . '/finding-packets.json';
-			self::write_plan_projection( $report_path, $report, $receipt );
+			self::write_plan_projection( $report_path, $report->to_array(), $receipt );
 			self::write_plan_projection( $validation_path, $validation, $receipt );
 			self::write_plan_projection( $findings_path, $findings, $receipt );
 		}
@@ -880,7 +882,7 @@ class Static_Site_Importer_Theme_Generator {
 					throw new RuntimeException( 'External report destination changed after preflight.' );
 				}
 			}
-			self::write_plan_projection( $external_report_path, $report, $receipt );
+			self::write_plan_projection( $external_report_path, $report->to_array(), $receipt );
 			self::write_plan_projection( $external_validation_result_path, $validation, $receipt );
 			self::write_plan_projection( $external_finding_packets_path, $findings, $receipt );
 		}
@@ -900,7 +902,7 @@ class Static_Site_Importer_Theme_Generator {
 			'external_finding_packets_path'   => $external_finding_packets_path,
 			'manifest_path'                   => $manifest_path,
 			'pages'                           => $receipt['completed']['pages'],
-			'import_report'                   => $report,
+			'import_report'                   => $report->to_array(),
 			'import_report_summary'           => array(
 				'status'           => $receipt['status'],
 				'diagnostic_count' => count( $diagnostics ),

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -79,6 +79,7 @@ $static_site_importer_includes = array(
 	'class-static-site-importer-form-seeder.php',
 	'class-static-site-importer-product-handoff-contract.php',
 	'class-static-site-importer-diagnostic-loss-classes.php',
+	'class-static-site-importer-import-report.php',
 	'class-static-site-importer-diagnostic-contract.php',
 	'class-static-site-importer-artifact-diagnostics-adapter.php',
 	'class-static-site-importer-validation-runtime.php',

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -57,6 +57,7 @@ $static_site_importer_includes = array(
 	'class-static-site-importer-website-artifact-import-input.php',
 	'class-static-site-importer-theme-materialization-strategy.php',
 	'class-static-site-importer-classic-theme-projection.php',
+	'class-static-site-importer-client-script-policy-report.php',
 	'class-static-site-importer-client-script-policy.php',
 	'class-static-site-importer-document.php',
 	'class-static-site-importer-source-page.php',

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -24,6 +24,7 @@
     { "path": "tests/smoke-failed-plan-validation.php", "environment": "standalone-php" },
     { "path": "tests/smoke-export-theme-ability.php", "environment": "standalone-php" },
     { "path": "tests/smoke-import-diagnostic-contract.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-import-report.php", "environment": "standalone-php" },
     { "path": "tests/smoke-missing-author-stylesheet-diagnostics.php", "environment": "standalone-php" },
     { "path": "tests/smoke-import-disposition.php", "environment": "standalone-php" },
     { "path": "tests/smoke-import-permission-filter.php", "environment": "standalone-php" },

--- a/tests/StaticSiteImporterFallbackDiagnosticsTest.php
+++ b/tests/StaticSiteImporterFallbackDiagnosticsTest.php
@@ -123,7 +123,8 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 	 * Import validation and finding packet artifacts expose repair-loop contracts.
 	 */
 	public function test_import_validation_result_and_finding_packets_are_machine_readable(): void {
-		$report = array(
+		$report = Static_Site_Importer_Import_Report::from_array(
+			array(
 			'schema'                  => 'static-site-importer/import-report/v1',
 			'entry_file'              => '/tmp/source/index.html',
 			'version'                 => 1,
@@ -181,6 +182,7 @@ class StaticSiteImporterFallbackDiagnosticsTest extends WP_UnitTestCase {
 					'block_path'             => '0',
 				),
 			),
+			)
 		);
 
 		$quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $report, array() );

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -176,16 +176,18 @@ $assert( array( 'hero-island', 'runtime-unit-effect-carousel' ) === ( $row['isla
 
 // Active companion: present diagnostic flags JS as runtime-carried theme-independently.
 $GLOBALS['ssi_companion_js_active'] = true;
-$report                            = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
-$report['quality']['fallback_count'] = 1;
-$report['diagnostics'][] = array(
-	'code'       => 'html_script_fallback',
-	'kind'       => 'unsupported_html_fallback',
-	'type'       => 'unsupported_html_fallback',
-	'tag'        => 'script',
-	'selector'   => 'script:nth-of-type(1)',
-	'source_path' => 'index.html',
-);
+	$report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+	$report->merge_quality( array( 'fallback_count' => 1 ) );
+	$report->append_diagnostic(
+		array(
+			'code'        => 'html_script_fallback',
+			'kind'        => 'unsupported_html_fallback',
+			'type'        => 'unsupported_html_fallback',
+			'tag'         => 'script',
+			'selector'    => 'script:nth-of-type(1)',
+			'source_path' => 'index.html',
+		)
+	);
 Static_Site_Importer_Report_Diagnostics::record_companion_plugin_dependency( $report, $dependency, false );
 $present = array_values( array_filter( $report['diagnostics'] ?? array(), static fn ( array $d ): bool => 'companion_plugin_present' === ( $d['code'] ?? '' ) ) );
 $assert( 1 === count( $present ), 'present-diagnostic-emitted-when-active' );
@@ -195,14 +197,16 @@ $materialized = array_values( array_filter( $report['diagnostics'] ?? array(), s
 $assert( 1 === count( $materialized ), 'companion-materialization-resolves-script-fallback' );
 $assert( 'native_conversion' === ( $materialized[0]['loss_class'] ?? '' ), 'materialized-script-is-native-conversion-outcome' );
 $assert( 0 === ( $report['quality']['fallback_count'] ?? -1 ), 'materialized-script-no-longer-counts-as-fallback' );
-$report['diagnostics'][] = array(
-	'code'        => 'html_script_fallback',
-	'kind'        => 'html',
-	'tag'         => 'script',
-	'selector'    => 'script:nth-of-type(1)',
-	'source_path' => 'index.html',
-	'reason'      => 'script_requires_runtime',
-);
+	$report->append_diagnostic(
+		array(
+			'code'        => 'html_script_fallback',
+			'kind'        => 'html',
+			'tag'         => 'script',
+			'selector'    => 'script:nth-of-type(1)',
+			'source_path' => 'index.html',
+			'reason'      => 'script_requires_runtime',
+		)
+	);
 Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $report, array() );
 $unresolved = array_filter( $report['diagnostics'], static fn ( array $d ): bool => 'html_script_fallback' === ( $d['code'] ?? '' ) );
 $assert( empty( $unresolved ), 'finalization-reconciles-late-script-fallback-rows' );

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -224,10 +224,12 @@ $assert( 0 === ( $clean_quality_contract['quality_counts']['fallback_count'] ?? 
 $assert( true === ( $clean_quality_contract['quality_counts']['consistent'] ?? false ), 'quality-reconciliation-keeps-clean-layers-consistent' );
 $assert( 0 === ( $clean_quality_contract['diagnostic_summary']['total'] ?? null ), 'quality-reconciliation-does-not-diagnose-clean-layers' );
 
-$partial_quality_report = array(
+$partial_quality_report = Static_Site_Importer_Import_Report::from_array(
+	array(
 	'blocks_engine' => array( 'wordpress_site_plan' => array( 'quality' => array( 'metrics' => array( 'fallback_count' => 2 ) ) ) ),
 	'quality'       => array( 'metrics' => array( 'block_count' => 1 ) ),
 	'diagnostics'   => array( array( 'type' => 'unsupported_html_fallback', 'severity' => 'warning' ) ),
+	)
 );
 $partial_quality_warning_handler = set_error_handler(
 	static function ( int $severity, string $message, string $file, int $line ): never {
@@ -485,7 +487,8 @@ $assert( 'client_script_execution' === ( $runtime_preservation_diagnostic['runti
 $assert( 'preserve' === ( $runtime_preservation_diagnostic['disposition'] ?? '' ), 'contract-preserves-runtime-disposition' );
 $assert( 'preserve_verbatim' === ( $runtime_preservation_diagnostic['js_handling'] ?? '' ), 'contract-preserves-runtime-js-handling' );
 
-$finalized_report = array(
+$finalized_report = Static_Site_Importer_Import_Report::from_array(
+	array(
 	'schema'      => 'static-site-importer/import-report/v1',
 	'version'     => 1,
 	'theme_slug'  => 'finalized-diagnostic-source',
@@ -506,6 +509,7 @@ $finalized_report = array(
 			),
 		),
 	),
+	)
 );
 $finalized_quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $finalized_report, array() );
 $finalized_report['materialization_receipt'] = array(
@@ -516,7 +520,7 @@ $finalized_report['materialization_receipt'] = array(
 $cached_contract = Static_Site_Importer_Report_Diagnostics::refresh_projections( $finalized_report, $finalized_quality );
 $assert( 1 === ( $cached_contract['diagnostic_summary']['total'] ?? 0 ), 'finalized-report-is-sole-diagnostic-source' );
 $assert( 'invalid_block_content' === ( $cached_contract['diagnostics'][0]['type'] ?? '' ), 'finalized-report-builds-fixture-projection' );
-$assert( $cached_contract === Static_Site_Importer_Canonical_Import_Service::success_diagnostics_contract( array( 'fixture_diagnostics' => $cached_contract, 'import_report' => $finalized_report ) ), 'canonical-service-reuses-finalized-fixture-projection' );
+$assert( $cached_contract === Static_Site_Importer_Canonical_Import_Service::success_diagnostics_contract( array( 'fixture_diagnostics' => $cached_contract, 'import_report' => $finalized_report->to_array() ) ), 'canonical-service-reuses-finalized-fixture-projection' );
 $assert( 'completed' === ( $cached_contract['materialization_receipt']['status'] ?? '' ), 'projection-refresh-includes-final-receipt' );
 $assert( ( $finalized_report['compact_summary']['status'] ?? '' ) === ( $cached_contract['status'] ?? '' ), 'projection-refresh-keeps-statuses-aligned' );
 
@@ -558,7 +562,8 @@ $provider_receipt = array(
 	'materialized_content_hash'        => $page_hash,
 	'provider'                         => 'jetpack',
 );
-$normalized_form_report = array(
+$normalized_form_report = Static_Site_Importer_Import_Report::from_array(
+	array(
 	'quality'                 => array( 'fallback_count' => 2 ),
 	'diagnostics'             => array( $normalized_form_fallback, $hidden_response_iframe ),
 	'materialization_receipt' => array(
@@ -568,6 +573,7 @@ $normalized_form_report = array(
 			),
 		),
 	),
+	)
 );
 Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $normalized_form_report, array( $provider_receipt ) );
 $assert( 1 === ( $normalized_form_report['quality']['fallback_count'] ?? 0 ) && 2 === ( $normalized_form_report['quality']['source_fallback_count'] ?? 0 ) && 1 === ( $normalized_form_report['quality_resolutions']['resolved_by_provider'] ?? 0 ), 'normalized-form-diagnostic-reconciles-exact-provider-receipt' );
@@ -575,13 +581,14 @@ $assert( 'resolved_by_provider' === ( $normalized_form_report['quality_resolutio
 
 $mismatched_receipt                  = $provider_receipt;
 $mismatched_receipt['fallback_hash'] = hash( 'sha256', 'mismatched fallback' );
-$mismatched_form_report              = $normalized_form_report;
-$mismatched_form_report['quality']   = array( 'fallback_count' => 1 );
+$mismatched_form_report                = Static_Site_Importer_Import_Report::from_array( $normalized_form_report->to_array() );
+$mismatched_form_report['quality']     = array( 'fallback_count' => 1 );
 $mismatched_form_report['diagnostics'] = array( $normalized_form_fallback );
 Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $mismatched_form_report, array( $mismatched_receipt ) );
 $assert( 1 === ( $mismatched_form_report['quality']['fallback_count'] ?? 0 ) && 'unresolved' === ( $mismatched_form_report['quality_resolutions']['resolutions'][0]['state'] ?? '' ), 'normalized-form-diagnostic-rejects-mismatched-provider-receipt' );
 
-$safe_runtime_report = array(
+$safe_runtime_report = Static_Site_Importer_Import_Report::from_array(
+	array(
 	'quality' => array( 'fallback_count' => 1 ),
 	'diagnostics' => array(
 		array(
@@ -597,6 +604,7 @@ $safe_runtime_report = array(
 			'materialization_path'  => 'runtime_island_registry',
 		),
 	),
+	)
 );
 $safe_runtime_quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $safe_runtime_report, array( 'fail_on_quality' => true ) );
 $assert( true === ( $safe_runtime_quality['pass'] ?? false ) && false === ( $safe_runtime_quality['fail_import'] ?? true ), 'bounded-safe-runtime-iframe-passes-quality-admission' );
@@ -604,13 +612,13 @@ $assert( 1 === ( $safe_runtime_quality['accepted_preserved_runtime_island_count'
 $assert( 1 === ( $safe_runtime_report['import_validation_result']['counts']['accepted_preserved_runtime_islands'] ?? 0 ) && 'passed' === ( $safe_runtime_report['import_validation_result']['quality_gates']['fallback_blocks']['status'] ?? '' ), 'validation-result-reports-accepted-runtime-island-without-fallback-failure' );
 $assert( 'sanitized_embed_markup' === ( $safe_runtime_report['finding_packets']['packets'][0]['preservation']['strategy'] ?? '' ) && 'runtime_island_registry' === ( $safe_runtime_report['finding_packets']['packets'][0]['preservation']['materialization_path'] ?? '' ), 'finding-packet-preserves-runtime-island-contract-evidence' );
 
-$unsafe_runtime_report = $safe_runtime_report;
+$unsafe_runtime_report = Static_Site_Importer_Import_Report::from_array( $safe_runtime_report->to_array() );
 $unsafe_runtime_report['diagnostics'][0]['source_html_preview'] = '<iframe srcdoc="<script>alert(1)</script>"></iframe>';
 $unsafe_runtime_quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $unsafe_runtime_report, array( 'fail_on_quality' => true ) );
 $assert( false === ( $unsafe_runtime_quality['pass'] ?? true ) && true === ( $unsafe_runtime_quality['fail_import'] ?? false ), 'unsafe-runtime-iframe-remains-fail-closed' );
 $assert( 0 === ( $unsafe_runtime_quality['accepted_preserved_runtime_island_count'] ?? -1 ) && 1 === ( $unsafe_runtime_quality['unsupported_fallback_count'] ?? 0 ), 'unsafe-runtime-iframe-is-counted-as-unsupported-fallback' );
 
-$incomplete_runtime_report = $safe_runtime_report;
+$incomplete_runtime_report = Static_Site_Importer_Import_Report::from_array( $safe_runtime_report->to_array() );
 unset( $incomplete_runtime_report['diagnostics'][0]['materialization_path'] );
 $incomplete_runtime_quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $incomplete_runtime_report, array( 'fail_on_quality' => true ) );
 $assert( false === ( $incomplete_runtime_quality['pass'] ?? true ) && true === ( $incomplete_runtime_quality['fail_import'] ?? false ), 'missing-runtime-materialization-contract-remains-fail-closed' );

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -613,13 +613,17 @@ $assert( 1 === ( $safe_runtime_report['import_validation_result']['counts']['acc
 $assert( 'sanitized_embed_markup' === ( $safe_runtime_report['finding_packets']['packets'][0]['preservation']['strategy'] ?? '' ) && 'runtime_island_registry' === ( $safe_runtime_report['finding_packets']['packets'][0]['preservation']['materialization_path'] ?? '' ), 'finding-packet-preserves-runtime-island-contract-evidence' );
 
 $unsafe_runtime_report = Static_Site_Importer_Import_Report::from_array( $safe_runtime_report->to_array() );
-$unsafe_runtime_report['diagnostics'][0]['source_html_preview'] = '<iframe srcdoc="<script>alert(1)</script>"></iframe>';
+$unsafe_diagnostics    = $unsafe_runtime_report->diagnostics();
+$unsafe_diagnostics[0]['source_html_preview'] = '<iframe srcdoc="<script>alert(1)</script>"></iframe>';
+$unsafe_runtime_report->set_diagnostics( $unsafe_diagnostics );
 $unsafe_runtime_quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $unsafe_runtime_report, array( 'fail_on_quality' => true ) );
 $assert( false === ( $unsafe_runtime_quality['pass'] ?? true ) && true === ( $unsafe_runtime_quality['fail_import'] ?? false ), 'unsafe-runtime-iframe-remains-fail-closed' );
 $assert( 0 === ( $unsafe_runtime_quality['accepted_preserved_runtime_island_count'] ?? -1 ) && 1 === ( $unsafe_runtime_quality['unsupported_fallback_count'] ?? 0 ), 'unsafe-runtime-iframe-is-counted-as-unsupported-fallback' );
 
 $incomplete_runtime_report = Static_Site_Importer_Import_Report::from_array( $safe_runtime_report->to_array() );
-unset( $incomplete_runtime_report['diagnostics'][0]['materialization_path'] );
+$incomplete_diagnostics    = $incomplete_runtime_report->diagnostics();
+unset( $incomplete_diagnostics[0]['materialization_path'] );
+$incomplete_runtime_report->set_diagnostics( $incomplete_diagnostics );
 $incomplete_runtime_quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $incomplete_runtime_report, array( 'fail_on_quality' => true ) );
 $assert( false === ( $incomplete_runtime_quality['pass'] ?? true ) && true === ( $incomplete_runtime_quality['fail_import'] ?? false ), 'missing-runtime-materialization-contract-remains-fail-closed' );
 

--- a/tests/smoke-import-report.php
+++ b/tests/smoke-import-report.php
@@ -12,10 +12,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 }
 
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.keyFound
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $str ) {
+		return trim( (string) $str );
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( public $code = '', public $message = '' ) {}
+	}
+}
+
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-import-report.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-loss-classes.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-asset-reporter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document-metadata-reporter.php';
 
 $failures   = array();
 $assertions = 0;
@@ -32,10 +55,28 @@ $assert( Static_Site_Importer_Import_Report::SCHEMA === $report['schema'], 'sche
 $assert( 'index.html' === $report['entry_file'], 'arrayaccess-read' );
 
 $report['theme_slug'] = 'typed-report';
-$assert( 'typed-report' === $report['theme_slug'], 'arrayaccess-write-known-key' );
+$assert( 'typed-report' === $report->get( 'theme_slug' ), 'top-level-set' );
 
-$report['diagnostics'][] = array( 'type' => 'document_metadata_routed' );
-$assert( 1 === count( $report['diagnostics'] ), 'nested-append' );
+$report->append_diagnostic( array( 'type' => 'document_metadata_routed' ) );
+$assert( 1 === count( $report->diagnostics() ), 'append-diagnostic' );
+
+$nested_write_notice = false;
+set_error_handler(
+	static function ( int $severity, string $message ) use ( &$nested_write_notice ): bool {
+		if ( str_contains( $message, 'Indirect modification of overloaded element' ) ) {
+			$nested_write_notice = true;
+			return true;
+		}
+		return false;
+	}
+);
+$report['quality']['fallback_count'] = 99;
+restore_error_handler();
+$assert( $nested_write_notice, 'nested-arrayaccess-write-warns' );
+$assert( 99 !== ( $report->quality()['fallback_count'] ?? null ), 'nested-arrayaccess-write-does-not-persist' );
+
+$report->merge_quality( array( 'fallback_count' => 2 ) );
+$assert( 2 === $report->quality()['fallback_count'], 'merge-quality' );
 
 $roundtrip = $report->to_array();
 $assert( is_array( $roundtrip ), 'to-array-is-array' );
@@ -44,11 +85,38 @@ $assert( $roundtrip === Static_Site_Importer_Import_Report::from_array( $roundtr
 
 $unknown_threw = false;
 try {
-	$report['not_a_real_top_level_key'] = 1;
+	$report->set( 'not_a_real_top_level_key', 1 );
 } catch ( InvalidArgumentException $e ) {
 	$unknown_threw = str_contains( $e->getMessage(), 'not_a_real_top_level_key' );
 }
 $assert( $unknown_threw, 'unknown-key-throws' );
+
+$isolated = Static_Site_Importer_Import_Report::from_array( array() );
+$policy   = Static_Site_Importer_Asset_Reporter::initialize_report( $isolated, array() );
+$assert( 'copy_to_theme' === $policy, 'asset-reporter-default-policy' );
+$assert( 'theme' === $isolated->section( 'assets' )['policy'], 'asset-reporter-sets-policy' );
+$assert( 'copy_to_theme' === $isolated->section( 'assets' )['local_policy'], 'asset-reporter-sets-local-policy' );
+$assert( false === $isolated->section( 'asset_map' )['supplied'], 'asset-reporter-empty-map' );
+
+$isolated = Static_Site_Importer_Import_Report::from_array( array() );
+Static_Site_Importer_Document_Metadata_Reporter::record( $isolated, array() );
+$assert( array() === $isolated->diagnostics(), 'metadata-reporter-ignores-missing-contract' );
+Static_Site_Importer_Document_Metadata_Reporter::record(
+	$isolated,
+	array(
+		'document_metadata' => array(
+			'schema'      => 'blocks-engine/php-transformer/document-metadata/v1',
+			'source_path' => 'website/index.html',
+			'title'       => 'Home',
+			'meta'        => array(),
+			'links'       => array(),
+			'styles'      => array(),
+			'scripts'     => array(),
+		),
+	)
+);
+$assert( 'document_metadata_routed' === ( $isolated->diagnostics()[0]['type'] ?? '' ), 'metadata-reporter-appends-diagnostic' );
+$assert( 'website/index.html' === ( $isolated->section( 'generated_theme' )['document_metadata']['source_path'] ?? '' ), 'metadata-reporter-stores-document-metadata' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-import-report.php
+++ b/tests/smoke-import-report.php
@@ -91,6 +91,23 @@ try {
 }
 $assert( $unknown_threw, 'unknown-key-throws' );
 
+// A stale envelope round-trips its unknown keys but never launders them into the schema.
+$stale = Static_Site_Importer_Import_Report::from_array(
+	array(
+		'schema'        => Static_Site_Importer_Import_Report::SCHEMA,
+		'retired_field' => 'carried',
+	)
+);
+$assert( 'carried' === $stale->get( 'retired_field' ), 'stale-key-readable' );
+$assert( 'carried' === ( $stale->to_array()['retired_field'] ?? null ), 'stale-key-round-trips' );
+$stale_threw = false;
+try {
+	$stale->set( 'retired_field', 'rewritten' );
+} catch ( InvalidArgumentException $e ) {
+	$stale_threw = true;
+}
+$assert( $stale_threw, 'stale-key-is-not-writable' );
+
 $isolated = Static_Site_Importer_Import_Report::from_array( array() );
 $policy   = Static_Site_Importer_Asset_Reporter::initialize_report( $isolated, array() );
 $assert( 'copy_to_theme' === $policy, 'asset-reporter-default-policy' );

--- a/tests/smoke-import-report.php
+++ b/tests/smoke-import-report.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Typed import-report envelope coverage.
+ *
+ * Run from the repository root:
+ * php tests/smoke-import-report.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-import-report.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-loss-classes.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
+$assert( $report instanceof Static_Site_Importer_Import_Report, 'factory-returns-typed-report' );
+$assert( Static_Site_Importer_Import_Report::SCHEMA === $report['schema'], 'schema-constant' );
+$assert( 'index.html' === $report['entry_file'], 'arrayaccess-read' );
+
+$report['theme_slug'] = 'typed-report';
+$assert( 'typed-report' === $report['theme_slug'], 'arrayaccess-write-known-key' );
+
+$report['diagnostics'][] = array( 'type' => 'document_metadata_routed' );
+$assert( 1 === count( $report['diagnostics'] ), 'nested-append' );
+
+$roundtrip = $report->to_array();
+$assert( is_array( $roundtrip ), 'to-array-is-array' );
+$assert( 'typed-report' === $roundtrip['theme_slug'], 'to-array-preserves-writes' );
+$assert( $roundtrip === Static_Site_Importer_Import_Report::from_array( $roundtrip )->to_array(), 'from-array-roundtrip' );
+
+$unknown_threw = false;
+try {
+	$report['not_a_real_top_level_key'] = 1;
+} catch ( InvalidArgumentException $e ) {
+	$unknown_threw = str_contains( $e->getMessage(), 'not_a_real_top_level_key' );
+}
+$assert( $unknown_threw, 'unknown-key-throws' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: import report smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-product-materializer.php
+++ b/tests/smoke-product-materializer.php
@@ -219,8 +219,9 @@ namespace {
 	}
 
 	// --- materialize_product_findings: manifest + seeding + gate-closure -----
-	$report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/shop.html' );
-	$report['diagnostics'][] = array(
+	$report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/shop.html' );
+	$report->append_diagnostic(
+		array(
 		'type'               => 'unsupported_html_fallback',
 		'diagnostic_code'    => 'html_product_grid_fallback',
 		'loss_class'         => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
@@ -250,6 +251,7 @@ namespace {
 				'source_selector'  => 'ul.products li:nth-child(2)',
 			),
 		),
+		)
 	);
 
 	$seeding = Static_Site_Importer_Report_Diagnostics::materialize_product_findings( $report, array() );
@@ -295,8 +297,9 @@ namespace {
 		. '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Add to cart</a></div><!-- /wp:button --></div><!-- /wp:buttons -->'
 		. '<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Buy now</a></div><!-- /wp:button --></div><!-- /wp:buttons -->'
 		. '</div><!-- /wp:group -->';
-	$graft_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/shop.html' );
-	$graft_report['diagnostics'][] = array(
+	$graft_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/shop.html' );
+	$graft_report->append_diagnostic(
+		array(
 		'type'               => 'unsupported_html_fallback',
 		'diagnostic_code'    => 'html_product_grid_fallback',
 		'loss_class'         => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
@@ -323,15 +326,18 @@ namespace {
 				'has_cart_control' => true,
 			),
 		),
+		)
 	);
-	$graft_report['diagnostics'][0]['readable_blocks'][0]['attrs'] = array(
+	$graft_diagnostics = $graft_report->diagnostics();
+	$graft_diagnostics[0]['readable_blocks'][0]['attrs'] = array(
 		'backslash' => 'C:\\products\\shop',
 		'delimiter' => 'before -- after',
 		'angle'     => '<cart>',
 		'ampersand' => 'cart & checkout',
 		'quote'     => 'Click "buy"',
 	);
-	$button_region                 = serialize_blocks( $graft_report['diagnostics'][0]['readable_blocks'] );
+	$graft_report->set_diagnostics( $graft_diagnostics );
+	$button_region                 = serialize_blocks( $graft_report->diagnostics()[0]['readable_blocks'] );
 	$page_contents                 = array( 'website/shop.html' => $button_region );
 	$graft_seeding                 = Static_Site_Importer_Report_Diagnostics::materialize_product_findings( $graft_report, array(), $page_contents );
 	$assert( 1 === ( $graft_seeding['shortcode_grafted_count'] ?? 0 ), 'shortcode-grafted-count' );
@@ -342,9 +348,10 @@ namespace {
 	$assert( str_contains( $button_region, '\\u005c' ) && str_contains( $button_region, '\\u002d\\u002d' ) && str_contains( $button_region, '\\u003c' ) && str_contains( $button_region, '\\u003e' ) && str_contains( $button_region, '\\u0026' ) && str_contains( $button_region, '\\u0022' ), 'product-graft-anchor-uses-core-sensitive-attribute-serialization' );
 
 	// A resolvable product finding cannot consume an identical region on another page.
-	$owned_graft_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/owned-shop.html' );
-	$owned_graft_report['diagnostics'][] = $graft_report['diagnostics'][0];
-	$owned_graft_report['diagnostics'][0]['source_path'] = 'website/owned-shop.html';
+	$owned_graft_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/owned-shop.html' );
+	$owned_finding      = $graft_report->diagnostics()[0];
+	$owned_finding['source_path'] = 'website/owned-shop.html';
+	$owned_graft_report->append_diagnostic( $owned_finding );
 	$owned_graft_contents = array(
 		'website/owned-shop.html' => '<!-- wp:paragraph --><p>owner anchor is absent</p><!-- /wp:paragraph -->',
 		'website/other-shop.html' => $button_region,
@@ -378,9 +385,10 @@ namespace {
 	$assert( ! str_contains( $no_id_contents['website/shop.html'], '[add_to_cart id=' ), 'no-product-id-no-shortcode' );
 
 	// Quantity/options/custom state stay as honest preserved runtime HTML.
-	$unsafe_report                  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/shop.html' );
-	$unsafe_report['diagnostics'][] = $graft_report['diagnostics'][0];
-	$unsafe_report['diagnostics'][0]['products'][0]['has_quantity_control'] = true;
+	$unsafe_report  = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'website/shop.html' );
+	$unsafe_finding = $graft_report->diagnostics()[0];
+	$unsafe_finding['products'][0]['has_quantity_control'] = true;
+	$unsafe_report->append_diagnostic( $unsafe_finding );
 	$unsafe_contents = array( 'website/shop.html' => str_replace( '<!-- wp:buttons -->', '<button class="qty-btn">+</button><span class="qty-display">1</span><!-- wp:buttons -->', $button_region ) );
 	$unsafe_seeding  = Static_Site_Importer_Report_Diagnostics::materialize_product_findings( $unsafe_report, array(), $unsafe_contents );
 	$assert( 0 === ( $unsafe_seeding['shortcode_grafted_count'] ?? -1 ), 'unsafe-shortcode-not-grafted' );

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1861,7 +1861,7 @@ $form_binding_receipt                             = Static_Site_Importer_WordPre
 );
 $form_binding_report                              = reset( $form_binding_receipt['completed']['runtime_declarations']['entity_bindings'] );
 $form_quality_report                              = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
-$form_quality_report['quality']['fallback_count'] = 1;
+$form_quality_report->merge_quality( array( 'fallback_count' => 1 ) );
 $form_quality_report['diagnostics']               = array( $form_fallback );
 $form_quality_report['materialization_receipt']   = $form_binding_receipt;
 Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $form_quality_report );
@@ -1892,7 +1892,7 @@ $unrelated_failure_plan = $form_admission_plan;
 $unrelated_failure_plan['quality']['failure_reasons'][] = 'core_html_block';
 $assert( false === $form_admission->invoke( null, $unrelated_failure_plan, $form_admission_lifecycle ), 'unrelated quality failures remain rejected before materialization' );
 $other_failure_report                                     = Static_Site_Importer_Import_Report::from_array( $form_quality_report->to_array() );
-$other_failure_report['quality']['core_html_block_count'] = 1;
+$other_failure_report->merge_quality( array( 'core_html_block_count' => 1 ) );
 $other_failure_quality                                    = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $other_failure_report, array( 'fail_on_quality' => true ) );
 $other_failure_validation                                 = Static_Site_Importer_Report_Diagnostics::import_validation_result( $other_failure_report, $other_failure_quality );
 $assert( 0 === ( $other_failure_quality['fallback_count'] ?? -1 ) && false === ( $other_failure_quality['pass'] ?? true ) && true === ( $other_failure_quality['fail_import'] ?? false ) && array( 'core_html_block' ) === ( $other_failure_quality['failure_reasons'] ?? null ) && 'failed' === ( $other_failure_validation['status'] ?? '' ), 'receipt reconciliation preserves unrelated quality failures and validation status' );
@@ -1954,7 +1954,7 @@ $assert( false === ( $partial_quality['pass'] ?? true ) && true === ( $partial_q
 $tampered_fragment_receipt = $form_binding_receipt;
 $tampered_fragment_receipt['completed']['runtime_declarations']['entity_bindings'][ hash( 'sha256', 'form-fallback-binding' ) ]['persisted_fragment_hash'] = hash( 'sha256', 'tampered fragment' );
 $tampered_fragment_report                              = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
-$tampered_fragment_report['quality']['fallback_count'] = 1;
+$tampered_fragment_report->merge_quality( array( 'fallback_count' => 1 ) );
 $tampered_fragment_report['diagnostics']               = array( $form_fallback );
 $tampered_fragment_report['materialization_receipt']   = $tampered_fragment_receipt;
 Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $tampered_fragment_report );
@@ -1962,7 +1962,7 @@ $assert( 1 === ( $tampered_fragment_report['quality']['fallback_count'] ?? 0 ) &
 $tampered_content_receipt = $form_binding_receipt;
 $tampered_content_receipt['completed']['runtime_declarations']['entity_bindings'][ hash( 'sha256', 'form-fallback-binding' ) ]['materialized_content_hash'] = hash( 'sha256', 'tampered page' );
 $tampered_content_report                              = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
-$tampered_content_report['quality']['fallback_count'] = 1;
+$tampered_content_report->merge_quality( array( 'fallback_count' => 1 ) );
 $tampered_content_report['diagnostics']               = array( $form_fallback );
 $tampered_content_report['materialization_receipt']   = $tampered_content_receipt;
 Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $tampered_content_report );
@@ -2188,7 +2188,7 @@ $resumed_form_binding_receipt                             = Static_Site_Importer
 	)
 );
 $resumed_form_quality_report                              = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
-$resumed_form_quality_report['quality']['fallback_count'] = 1;
+$resumed_form_quality_report->merge_quality( array( 'fallback_count' => 1 ) );
 $resumed_form_quality_report['diagnostics']               = array( $form_fallback );
 $resumed_form_quality_report['materialization_receipt']   = $resumed_form_binding_receipt;
 Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $resumed_form_quality_report );

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1891,7 +1891,7 @@ $assert( false === $form_admission->invoke( null, $form_admission_plan, $missing
 $unrelated_failure_plan = $form_admission_plan;
 $unrelated_failure_plan['quality']['failure_reasons'][] = 'core_html_block';
 $assert( false === $form_admission->invoke( null, $unrelated_failure_plan, $form_admission_lifecycle ), 'unrelated quality failures remain rejected before materialization' );
-$other_failure_report                                     = $form_quality_report;
+$other_failure_report                                     = Static_Site_Importer_Import_Report::from_array( $form_quality_report->to_array() );
 $other_failure_report['quality']['core_html_block_count'] = 1;
 $other_failure_quality                                    = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $other_failure_report, array( 'fail_on_quality' => true ) );
 $other_failure_validation                                 = Static_Site_Importer_Report_Diagnostics::import_validation_result( $other_failure_report, $other_failure_quality );


### PR DESCRIPTION
Fixes #1372.

The original audit counted 25 `array &$report` sites as one envelope. They were three shapes sharing a variable name. This PR types each one instead of stuffing them into a single class.

## What changed

**Import report** (`static-site-importer/import-report/v1`) is now `Static_Site_Importer_Import_Report`:

- Top-level schema is declared once (`TOP_LEVEL_KEYS`, 45 keys — the union of the conversion factory, the site-plan receipt factory, the failed-plan factory, and finalization writes).
- **Writes go through named mutators**: `append_diagnostic()`, `replace_diagnostic()`, `filter_diagnostics()`, `merge_quality()`, `increment_quality()`, `merge_section()`, `set_in_section()`, `append_to_section()`.
- **`ArrayAccess` is read-only for nested paths.** `$report['quality']['x'] = 0` emits a PHP notice and does not persist, so the schema cannot be bypassed by reaching through a section. Top-level `$report['quality'] = $x` still routes through `set()`.
- Only declared keys are writable. An envelope loaded via `from_array()` keeps unknown keys readable and round-trips them through `to_array()`, but cannot write them — loading a stale report never launders a key into the schema.
- `to_array()` is the persistence/REST seam. JSON artifacts and public result envelopes stay arrays; `is_array( $result['import_report'] )` consumers are unchanged.
- `new_conversion_report()` returns the object. The other two factories wrap with `from_array()`.

**Client-script policy report** is `Static_Site_Importer_Client_Script_Policy_Report` in its own file. Dispositions are a closed set (`dropped`, `quarantined`, `preserved`); an unknown disposition throws. The `$report[ $disposition ]` dynamic write is gone, and closures capture the object handle so `&$report` is gone too.

**Plugin materialization report** stays an array — a different, smaller shape — but the two by-ref helpers now return the report instead of mutating through `&`.

## Acceptance

- `grep -n 'array &$report' includes/` matches only `array &$reports` (plural) in the site-plan materializer, which is a map of entity receipts, not the import report.
- No dynamically-computed top-level keys remain on any of the three report shapes.
- Reporters are testable in isolation: `Asset_Reporter` and `Document_Metadata_Reporter` are exercised against an empty `Import_Report` with no accumulated pipeline state.
- 55/55 standalone-php tests pass.
- `homeboy review lint` passes: phpstan 0, eslint 0, phpcs 24 warnings with **0 in the files this PR touches**.

`tests/smoke-import-report.php` asserts factory typing, nested-write rejection (notice raised, value discarded), unknown-key rejection, stale-key round-trip without write access, and isolated reporter behavior.

## Related

- #1371 / #1373 — contract adoption for producer findings (independent; different files)
- Automattic/blocks-engine#242 — the audit this came from

---

*AI assistance disclosure: researched, implemented, and this PR drafted by Claude Sonnet 4.6 running in Claude Code, operated by @chubes4. The AI identified that the original 25-site count mixed three report shapes, introduced the typed import-report envelope and its mutator API, closed the client-script disposition set, converted plugin-materializer helpers to return-based mutation, and resolved the phpstan/phpcs findings the change introduced. Tests and lint were run locally. Reviewed by a human before merge.*
