### PR TITLE
Keep generated multi-page artifacts intact

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -172,14 +172,15 @@ export async function runFixtureMatrix(options) {
     })
     : null;
   const fixtureRoot = path.resolve(intake?.fixture_root || options.fixtureRoot || path.join(packageRoot, 'tests', 'fixtures', 'fixture-matrix'));
+  const fixtureMaxDepth = intake ? 1 : options.maxDepth;
   const staticSiteImporterPath = options.staticSiteImporterPath || process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH || process.cwd();
   const dependencyOverrides = prepareDependencyOverrides(options);
-  const fixtureInspection = inspectFixtureDirectories(fixtureRoot, { maxDepth: options.maxDepth });
+  const fixtureInspection = inspectFixtureDirectories(fixtureRoot, { maxDepth: fixtureMaxDepth });
   const matrixInput = {
     id: options.id || `static-site-importer-fixture-matrix-${Date.now()}`,
     fixture_root: fixtureRoot,
     entrypoint: options.entrypoint || 'index.html',
-    maxDepth: options.maxDepth,
+    maxDepth: fixtureMaxDepth,
     // Lane selection comes from authored fixture manifests only. Absent options
     // leave the full matrix intact; missing metadata stays unknown rather than guessed.
     class: options.fixtureClass || options.class,

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -3587,6 +3587,36 @@ test('materializes generated artifact roots into matrix-compatible fixtures', ()
   assert.equal(betaArtifact.files.some((file) => file.path.includes('generated-artifact-metadata')), false);
 });
 
+test('keeps a generated multi-page website as one matrix fixture', async () => {
+  const sourceRoot = mkdtempSync(path.join(tmpdir(), 'ssi-generated-multi-page-artifact-'));
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-generated-multi-page-output-'));
+  mkdirSync(path.join(sourceRoot, 'site'), { recursive: true });
+  writeFileSync(path.join(sourceRoot, 'site', 'artifact.json'), JSON.stringify({
+    schema: 'blocks-engine/php-transformer/site-artifact/v1',
+    metadata: { site: 'Multi Page' },
+    files: [
+      { path: 'website/index.html', content: '<link rel="icon" href="/external/favicon.ico"><h1>Home</h1>' },
+      { path: 'website/anchor/index.html', content: '<link rel="icon" href="/external/favicon.ico"><h1>Anchor</h1>' },
+      { path: 'website/external/favicon.ico', content_base64: Buffer.from('icon').toString('base64') },
+    ],
+  }));
+
+  const { summary } = await runFixtureMatrix({
+    artifactRoot: sourceRoot,
+    outputDirectory,
+    staticSiteImporterPath: packageRoot,
+    run: false,
+  });
+  const matrix = JSON.parse(readFileSync(path.join(outputDirectory, 'matrix.json'), 'utf8'));
+  const artifact = JSON.parse(readFileSync(path.join(outputDirectory, 'multi-page', 'artifact.json'), 'utf8'));
+
+  assert.equal(summary.fixture_count, 1);
+  assert.deepEqual(matrix.fixtures.map((fixture) => fixture.id), ['multi-page']);
+  assert.equal(artifact.summary.file_count, 3);
+  assert.equal(artifact.files.some((file) => file.path === 'website/anchor/index.html'), true);
+  assert.equal(artifact.files.some((file) => file.path === 'website/external/favicon.ico'), true);
+});
+
 test('resolves Blocks Engine PHP transformer override paths', () => {
   const repoRoot = mkdtempSync(path.join(tmpdir(), 'blocks-engine-'));
   const transformerPackageRoot = path.join(repoRoot, 'php-transformer');


### PR DESCRIPTION
## Summary

- constrain generated-artifact fixture discovery to artifact-root directories
- preserve nested route directories and root-relative shared assets as one matrix fixture
- cover multi-page generated websites with a regression test

Closes the fixture-discovery gap encountered while validating #1201.

## Verification

- `npm run test:fixture-matrix` (280 passed)
- real four-route generated artifact completed one WP Codebox materialization with 4 documents and 205 files

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the fixture-boundary defect, implemented the minimal depth constraint and regression, ran the full fixture suite, and verified the repair against the real disposable WordPress workflow. Chris Huber directed and reviewed the work.