### PR TITLE
Persist failed-plan reports for Abilities

### DIFF
--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -516,6 +516,13 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			$args['compiled_artifact_result']                 = $composed_state['result'];
 			$args['_static_site_importer_precompiled_source'] = true;
 			$args['_static_site_importer_payload_reader']     = $payload_reader;
+			if ( '' === trim( (string) ( $args['report'] ?? '' ) ) ) {
+				$failed_plan_report = self::failed_plan_report_destination( $workspace );
+				if ( is_wp_error( $failed_plan_report ) ) {
+					return self::fail( $workspace, $run, 'failed_plan_report_destination', $failed_plan_report );
+				}
+				$args['failed_plan_report_destination'] = $failed_plan_report;
+			}
 
 			if ( 'plan' === $run['binding']['operation'] ) {
 				$entered = self::enter_phase( $workspace, $run, 'canonical_plan' );
@@ -1063,6 +1070,14 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		} catch ( RuntimeException $error ) {
 			return new WP_Error( 'static_site_importer_direct_artifact_workspace_unavailable', $error->getMessage() );
 		}
+	}
+
+	/** Reserve the retained run's private location for a possible gate-failure report. */
+	private static function failed_plan_report_destination( Static_Site_Importer_Artifact_Run_Workspace $workspace ) {
+		if ( ! $workspace->claim_directory( 'failed-plan' ) && ! is_dir( $workspace->directory() . '/failed-plan' ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_failed_plan_workspace_unavailable', 'The failed-plan artifact workspace is unavailable.' );
+		}
+		return $workspace->path( 'failed-plan/import-report.json' );
 	}
 
 	/** Register expiry cleanup without exposing retained workspace paths. */

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -522,6 +522,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 					return self::fail( $workspace, $run, 'failed_plan_report_destination', $failed_plan_report );
 				}
 				$args['failed_plan_report_destination'] = $failed_plan_report;
+				$args['failed_plan_artifact_prefix']    = 'direct-' . $run['import_id'] . '/failed-plan';
 			}
 
 			if ( 'plan' === $run['binding']['operation'] ) {

--- a/includes/class-static-site-importer-failed-plan-validation.php
+++ b/includes/class-static-site-importer-failed-plan-validation.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'Static_Site_Importer_Import_Report' ) ) {
 
 final class Static_Site_Importer_Failed_Plan_Validation {
 
-	private const MAX_DIAGNOSTICS = 50;
+	private const MAX_DIAGNOSTICS    = 50;
 	private const MAX_ARTIFACT_BYTES = 10485760;
 
 	/** @return array<string,mixed> */
@@ -123,6 +123,28 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 		self::write( $paths['import_validation_result'], isset( $artifacts['import_validation_result'] ) && is_array( $artifacts['import_validation_result'] ) ? $artifacts['import_validation_result'] : array() );
 		self::write( $paths['finding_packets'], isset( $artifacts['finding_packets'] ) && is_array( $artifacts['finding_packets'] ) ? $artifacts['finding_packets'] : array() );
 		return $paths;
+	}
+
+	/** @return array<string,array<string,string>> */
+	public static function artifact_refs( string $prefix ): array {
+		$prefix = trim( $prefix, '/' );
+		if ( '' === $prefix ) {
+			return array();
+		}
+		return array(
+			'import_report'            => array(
+				'artifact_id' => $prefix . '/import-report.json',
+				'kind'        => 'blocks-engine/import-report',
+			),
+			'import_validation_result' => array(
+				'artifact_id' => $prefix . '/import-validation-result.json',
+				'kind'        => 'blocks-engine/import-validation-result',
+			),
+			'finding_packets'          => array(
+				'artifact_id' => $prefix . '/finding-packets.json',
+				'kind'        => 'blocks-engine/finding-packets',
+			),
+		);
 	}
 
 	/** @return array<int,string> */

--- a/includes/class-static-site-importer-failed-plan-validation.php
+++ b/includes/class-static-site-importer-failed-plan-validation.php
@@ -16,6 +16,7 @@ if ( ! class_exists( 'Static_Site_Importer_Import_Report' ) ) {
 final class Static_Site_Importer_Failed_Plan_Validation {
 
 	private const MAX_DIAGNOSTICS = 50;
+	private const MAX_ARTIFACT_BYTES = 10485760;
 
 	/** @return array<string,mixed> */
 	public static function build( array $plan, array $args = array(), array $compiled = array() ): array {
@@ -144,8 +145,11 @@ final class Static_Site_Importer_Failed_Plan_Validation {
 	}
 
 	private static function write( string $path, array $payload ): void {
-		$temp = tempnam( dirname( $path ), '.ssi-failed-plan-' );
 		$json = function_exists( 'wp_json_encode' ) ? wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) : json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Standalone smoke tests do not load WordPress encoding helpers.
+		if ( is_string( $json ) && strlen( $json ) + 1 > self::MAX_ARTIFACT_BYTES ) {
+			throw new RuntimeException( 'Failed-plan report artifact exceeds its 10 MiB bound.' );
+		}
+		$temp = tempnam( dirname( $path ), '.ssi-failed-plan-' );
 		if ( false === $temp || false === $json || false === file_put_contents( $temp, $json . "\n" ) || ! rename( $temp, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents,WordPress.WP.AlternativeFunctions.rename_rename -- Atomically writes bounded explicit report artifacts.
 			if ( is_string( $temp ) && file_exists( $temp ) ) {
 				unlink( $temp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes a failed atomic report temporary file.

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -106,7 +106,9 @@ class Static_Site_Importer_Theme_Generator {
 			$compiled_evidence = isset( $compiled_import['compiled'] ) && is_array( $compiled_import['compiled'] ) ? $compiled_import['compiled'] : array();
 			$failed_plan       = Static_Site_Importer_Failed_Plan_Validation::build( $plan, $args, $compiled_evidence );
 			try {
-				$failed_plan['artifact_refs'] = Static_Site_Importer_Failed_Plan_Validation::persist( $failed_plan, (string) ( $args['failed_plan_report_destination'] ?? $args['report'] ?? '' ) );
+				$paths           = Static_Site_Importer_Failed_Plan_Validation::persist( $failed_plan, (string) ( $args['failed_plan_report_destination'] ?? $args['report'] ?? '' ) );
+				$artifact_prefix = (string) ( $args['failed_plan_artifact_prefix'] ?? '' );
+				$failed_plan['artifact_refs'] = '' !== $artifact_prefix ? Static_Site_Importer_Failed_Plan_Validation::artifact_refs( $artifact_prefix ) : $paths;
 			} catch ( Throwable $error ) {
 				$failed_plan['artifact_persistence_error'] = $error->getMessage();
 			}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -106,7 +106,7 @@ class Static_Site_Importer_Theme_Generator {
 			$compiled_evidence = isset( $compiled_import['compiled'] ) && is_array( $compiled_import['compiled'] ) ? $compiled_import['compiled'] : array();
 			$failed_plan       = Static_Site_Importer_Failed_Plan_Validation::build( $plan, $args, $compiled_evidence );
 			try {
-				$failed_plan['artifact_refs'] = Static_Site_Importer_Failed_Plan_Validation::persist( $failed_plan, (string) ( $args['report'] ?? '' ) );
+				$failed_plan['artifact_refs'] = Static_Site_Importer_Failed_Plan_Validation::persist( $failed_plan, (string) ( $args['failed_plan_report_destination'] ?? $args['report'] ?? '' ) );
 			} catch ( Throwable $error ) {
 				$failed_plan['artifact_persistence_error'] = $error->getMessage();
 			}

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -276,6 +276,7 @@ $canonical_compiled = static function ( array $result ) use ( &$canonical_compil
 };
 $assert( $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][0] ) === $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][1] ), 'clean and resumed composition must produce identical canonical plans, companion payloads, pages, writes, diagnostics, and reconciliation identities' );
 
+<<<<<<< HEAD
 $binary = str_repeat( "\x00\xffZIP", 1024 );
 $binary_ref = array(
 	'schema' => 'blocks-engine/payload-reference/v1',
@@ -348,6 +349,8 @@ $zip_uninterrupted_canonical = $canonical_compiled( $zip_uninterrupted_plan );
 $zip_resumed_canonical = $canonical_compiled( $zip_terminal['plan'] );
 $assert( $zip_uninterrupted_canonical === $zip_resumed_canonical, 'resumed ZIP planning must produce the byte-identical canonical plan from uninterrupted staged compilation outside process observations: ' . $first_difference( $zip_uninterrupted_canonical, $zip_resumed_canonical ) );
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array( static fn ( array $policy ): array => array_merge( $policy, array( 'compile_batch_pages' => 20 ) ) );
+$owned_report_destination = (string) ( $GLOBALS['ssi_direct_last_args']['failed_plan_report_destination'] ?? '' );
+$assert( str_contains( $owned_report_destination, '/static-site-importer/direct-artifact-imports/.ssi-artifact-run-direct-' ) && str_ends_with( $owned_report_destination, '/failed-plan/import-report.json' ) && is_dir( dirname( $owned_report_destination ) ), 'direct Ability runs reserve an importer-owned failed-plan report destination inside the retained workspace' );
 
 $fail_materialization = true;
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_checkpoint_publish'][] = static function ( $allowed, string $kind ) use ( &$fail_materialization ) {
@@ -431,6 +434,9 @@ $quality_failure_response = $quality_failure_data['failure']['error']['data'] ??
 $assert( 'inline_svg_fallback' === ( $quality_failure_response['quality']['fallbacks'][0]['reason'] ?? '' ) && 'runtime_dependent_content' === ( $quality_failure_response['quality']['editability_policy']['failures'][0] ?? '' ) && $quality_failure_response === $quality_failure_evidence, 'quality-gate failures must return actionable fallback and editability reasons in both caller and run evidence' );
 $scrubbed_quality = $quality_failure_response['quality'] ?? array();
 $assert( ! isset( $scrubbed_quality['path'], $scrubbed_quality['workspace'], $scrubbed_quality['manifest'] ) && 1000 === strlen( $scrubbed_quality['long_value'] ?? '' ) && true === ( $scrubbed_quality['many']['_truncated'] ?? false ) && '[truncated]' === ( $scrubbed_quality['over_deep']['one']['two']['three']['four'] ?? '' ), 'quality-gate evidence must retain path stripping, string and item caps, and the original depth bound' );
+$cli_report = $test_root . '/cli-import-report.json';
+Static_Site_Importer_Canonical_Import_Service::import_with_cli_report( $input(), $cli_report );
+$assert( $cli_report === ( $GLOBALS['ssi_direct_last_args']['report'] ?? '' ) && ! isset( $GLOBALS['ssi_direct_last_args']['failed_plan_report_destination'] ), 'the explicit CLI report destination remains authoritative over the owned failed-plan destination' );
 
 Static_Site_Importer_Artifact_Run_Workspace::purge_expired_in( $test_root );
 $primitive_workspace->purge();

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -276,7 +276,6 @@ $canonical_compiled = static function ( array $result ) use ( &$canonical_compil
 };
 $assert( $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][0] ) === $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][1] ), 'clean and resumed composition must produce identical canonical plans, companion payloads, pages, writes, diagnostics, and reconciliation identities' );
 
-<<<<<<< HEAD
 $binary = str_repeat( "\x00\xffZIP", 1024 );
 $binary_ref = array(
 	'schema' => 'blocks-engine/payload-reference/v1',
@@ -434,6 +433,7 @@ $quality_failure_response = $quality_failure_data['failure']['error']['data'] ??
 $assert( 'inline_svg_fallback' === ( $quality_failure_response['quality']['fallbacks'][0]['reason'] ?? '' ) && 'runtime_dependent_content' === ( $quality_failure_response['quality']['editability_policy']['failures'][0] ?? '' ) && $quality_failure_response === $quality_failure_evidence, 'quality-gate failures must return actionable fallback and editability reasons in both caller and run evidence' );
 $scrubbed_quality = $quality_failure_response['quality'] ?? array();
 $assert( ! isset( $scrubbed_quality['path'], $scrubbed_quality['workspace'], $scrubbed_quality['manifest'] ) && 1000 === strlen( $scrubbed_quality['long_value'] ?? '' ) && true === ( $scrubbed_quality['many']['_truncated'] ?? false ) && '[truncated]' === ( $scrubbed_quality['over_deep']['one']['two']['three']['four'] ?? '' ), 'quality-gate evidence must retain path stripping, string and item caps, and the original depth bound' );
+$GLOBALS['ssi_direct_materialization_error'] = null;
 $cli_report = $test_root . '/cli-import-report.json';
 Static_Site_Importer_Canonical_Import_Service::import_with_cli_report( $input(), $cli_report );
 $assert( $cli_report === ( $GLOBALS['ssi_direct_last_args']['report'] ?? '' ) && ! isset( $GLOBALS['ssi_direct_last_args']['failed_plan_report_destination'] ), 'the explicit CLI report destination remains authoritative over the owned failed-plan destination' );

--- a/tests/smoke-failed-plan-validation.php
+++ b/tests/smoke-failed-plan-validation.php
@@ -80,6 +80,11 @@ $assert( 'pre_materialization_quality_admission' === ( $persisted['failure_conte
 
 $paths_again = Static_Site_Importer_Failed_Plan_Validation::persist( $artifacts, $root . '/import-report.json' );
 $assert( $paths === $paths_again, 'retrying a failed plan refreshes its owned report artifacts' );
+$artifact_refs = Static_Site_Importer_Failed_Plan_Validation::artifact_refs( 'direct-import-123/failed-plan' );
+$assert( 'direct-import-123/failed-plan/import-report.json' === ( $artifact_refs['import_report']['artifact_id'] ?? '' ), 'direct failure payloads expose stable artifact identifiers' );
+$assert( ! isset( $artifact_refs['import_report']['path'], $artifact_refs['import_report']['full_path'], $artifact_refs['import_report']['local_path'] ), 'direct failure payload refs do not expose local paths' );
+$resolved_paths = array_combine( array_keys( $artifact_refs ), array_values( $paths ) );
+$assert( is_file( $resolved_paths['import_report'] ?? '' ) && is_file( $resolved_paths['import_validation_result'] ?? '' ) && is_file( $resolved_paths['finding_packets'] ?? '' ), 'opaque direct failure refs resolve to persisted owned artifacts' );
 $oversized = $artifacts;
 $oversized['import_report'] = array( 'payload' => str_repeat( 'x', 10485761 ) );
 try {

--- a/tests/smoke-failed-plan-validation.php
+++ b/tests/smoke-failed-plan-validation.php
@@ -80,6 +80,15 @@ $assert( 'pre_materialization_quality_admission' === ( $persisted['failure_conte
 
 $paths_again = Static_Site_Importer_Failed_Plan_Validation::persist( $artifacts, $root . '/import-report.json' );
 $assert( $paths === $paths_again, 'retrying a failed plan refreshes its owned report artifacts' );
+$oversized = $artifacts;
+$oversized['import_report'] = array( 'payload' => str_repeat( 'x', 10485761 ) );
+try {
+	Static_Site_Importer_Failed_Plan_Validation::persist( $oversized, $root . '/oversized-import-report.json' );
+	$oversized_rejected = false;
+} catch ( RuntimeException $error ) {
+	$oversized_rejected = str_contains( $error->getMessage(), '10 MiB bound' );
+}
+$assert( $oversized_rejected, 'failed-plan artifacts enforce the existing 10 MiB per-file bound' );
 foreach ( $paths as $path ) {
 	unlink( $path );
 }


### PR DESCRIPTION
## Summary
- reserve a retained direct-artifact workspace destination for failed-plan evidence when an Ability caller has no CLI report destination
- persist quality-gate reports through the existing safe destination checks and return their artifact refs
- cap each failed-plan artifact at the existing 10 MiB per-file boundary

## Verification
- `npm test`
- `php tests/smoke-direct-artifact-import.php`
- `php tests/smoke-failed-plan-validation.php`
- `php tests/smoke-website-artifact-import-input.php`

Closes #1380

## AI assistance
OpenAI GPT-5.6 Terra, using OpenCode, was used to trace the report-destination flow, implement the scoped change, add coverage, and run the test suite. The author reviewed the resulting diff and tests.