### PR TITLE
Make ZIP planning resumable

### DIFF
--- a/includes/class-static-site-importer-artifact-run.php
+++ b/includes/class-static-site-importer-artifact-run.php
@@ -122,7 +122,7 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 	}
 
 	public function publish_json( string $relative, array $data ) {
-		$json = wp_json_encode( $data, JSON_PRETTY_PRINT );
+		$json = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION );
 		return is_string( $json ) ? $this->publish_raw( $relative, $json ) : new WP_Error( 'static_site_importer_artifact_workspace_json_invalid', 'Workspace JSON could not be encoded.' );
 	}
 
@@ -369,7 +369,7 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 	/** Stream the exact JSON_PRETTY_PRINT token sequence without one complete JSON allocation. */
 	private static function write_json_value( $handle, $value, int $depth ): bool {
 		if ( ! is_array( $value ) ) {
-			$encoded = wp_json_encode( $value, JSON_PRETTY_PRINT );
+			$encoded = wp_json_encode( $value, JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION );
 			return is_string( $encoded ) && self::write_complete_handle( $handle, $encoded );
 		}
 		if ( empty( $value ) ) {
@@ -386,7 +386,7 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 				return false;
 			}
 			if ( ! $list ) {
-				$encoded_key = wp_json_encode( (string) $key, JSON_PRETTY_PRINT );
+				$encoded_key = wp_json_encode( (string) $key, JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION );
 				if ( ! is_string( $encoded_key ) || ! self::write_complete_handle( $handle, $encoded_key . ': ' ) ) {
 					return false;
 				}

--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -49,7 +49,7 @@ class Static_Site_Importer_Canonical_Import_Service {
 		if ( ! in_array( $type, array( 'html', 'files', 'zip', 'url' ), true ) ) {
 			return self::error( 'static_site_importer_invalid_import_source', 'source.type must be html, files, zip, or url.' );
 		}
-		if ( self::direct_artifact_continuation_available() && in_array( $type, array( 'html', 'files' ), true ) && '' !== (string) ( $source['import_id'] ?? '' ) ) {
+		if ( self::direct_artifact_continuation_available() && in_array( $type, array( 'html', 'files', 'zip' ), true ) && '' !== (string) ( $source['import_id'] ?? '' ) ) {
 			$args   = self::direct_artifact_args( $input );
 			$result = Static_Site_Importer_Direct_Artifact_Import::resume( (string) $source['import_id'], $args, $type, $operation, $source );
 			return is_wp_error( $result ) ? self::error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() ) : $result;
@@ -92,11 +92,9 @@ class Static_Site_Importer_Canonical_Import_Service {
 			if ( is_wp_error( $runtime_source['files'] ) ) {
 				return self::error( (string) $runtime_source['files']->get_error_code(), $runtime_source['files']->get_error_message(), $runtime_source['files']->get_error_data() );
 			}
-			if ( 'apply' === $operation ) {
-				$payload_reader = static_site_importer_staged_archive_payload_reader( $source['zip'] );
-				if ( is_wp_error( $payload_reader ) ) {
-					return self::error( (string) $payload_reader->get_error_code(), $payload_reader->get_error_message(), $payload_reader->get_error_data() );
-				}
+			$payload_reader = static_site_importer_staged_archive_payload_reader( $source['zip'] );
+			if ( is_wp_error( $payload_reader ) ) {
+				return self::error( (string) $payload_reader->get_error_code(), $payload_reader->get_error_message(), $payload_reader->get_error_data() );
 			}
 		} else {
 			$runtime_source['archive'] = isset( $source['zip'] ) && is_array( $source['zip'] ) ? $source['zip'] : array();
@@ -123,8 +121,8 @@ class Static_Site_Importer_Canonical_Import_Service {
 		if ( isset( $payload_reader ) ) {
 			$args['_static_site_importer_payload_reader'] = $payload_reader;
 		}
-		if ( self::direct_artifact_continuation_available() && in_array( $type, array( 'html', 'files' ), true ) && 'resume' !== $args['runtime_lifecycle_phase'] && self::artifact_html_page_count( $artifact ) > 1 ) {
-			$result = Static_Site_Importer_Direct_Artifact_Import::start( $artifact, $args, $type, $operation, $provenance );
+		if ( self::direct_artifact_continuation_available() && in_array( $type, array( 'html', 'files', 'zip' ), true ) && 'resume' !== $args['runtime_lifecycle_phase'] && self::artifact_html_page_count( $artifact ) > 1 ) {
+			$result = Static_Site_Importer_Direct_Artifact_Import::start( $artifact, $args, $type, $operation, $provenance, $payload_reader ?? null );
 			return is_wp_error( $result ) ? self::error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() ) : $result;
 		}
 		if ( 'plan' === $operation ) {

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -32,7 +32,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	private static array $checkpoint_read_cache = array();
 
 	/** Start a server-owned run after normal canonical source normalization. */
-	public static function start( array $artifact, array $args, string $source_type, string $operation, array $provenance ) {
+	public static function start( array $artifact, array $args, string $source_type, string $operation, array $provenance, ?object $payload_reader = null ) {
 		self::$checkpoint_read_cache = array();
 
 		$freeze_started  = microtime( true );
@@ -42,17 +42,23 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			return $source_policy;
 		}
 
-		$policy                                = Static_Site_Importer_Client_Script_Policy::apply( $artifact, $args );
-		$artifact                              = $policy['artifact'];
-		$args['client_script_policy_report']   = $policy['report'];
-		$args['source_metadata']['collection'] = is_array( $args['source_metadata']['collection'] ?? null ) ? $args['source_metadata']['collection'] : array();
-		$args['source_metadata']['collection']['script_policy'] = $policy['report'];
-		$identity  = self::hash( $artifact );
 		$import_id = bin2hex( random_bytes( 32 ) );
 		$workspace = self::workspace( $import_id, true );
 		if ( is_wp_error( $workspace ) ) {
 			return $workspace;
 		}
+		$retained = self::retain_payloads( $artifact, $payload_reader, $workspace );
+		if ( is_wp_error( $retained ) ) {
+			$workspace->purge();
+			return $retained;
+		}
+		unset( $args['_static_site_importer_payload_reader'] );
+		$policy                                = Static_Site_Importer_Client_Script_Policy::apply( $artifact, $args );
+		$artifact                              = $policy['artifact'];
+		$args['client_script_policy_report']   = $policy['report'];
+		$args['source_metadata']['collection'] = is_array( $args['source_metadata']['collection'] ?? null ) ? $args['source_metadata']['collection'] : array();
+		$args['source_metadata']['collection']['script_policy'] = $policy['report'];
+		$identity = self::hash( $artifact );
 
 		$run          = array(
 			'import_id'  => $import_id,
@@ -75,6 +81,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			'work'       => array(
 				'content_policy_applications'       => 1,
 				'client_script_policy_applications' => 1,
+				'payloads_retained'                 => $retained,
 				'shared_prepares'                   => 0,
 				'page_prepare_passes'               => 0,
 				'page_plans_prepared'               => 0,
@@ -216,6 +223,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			$prepare_pages  = array( $compiler, 'preparePages' );
 			$compile_pages  = array( $compiler, 'compilePreparedPages' );
 			$compose        = array( $compiler, 'compose' );
+			$payload_reader = self::payload_reader( $workspace );
 			if ( ! is_callable( $prepare_shared ) || ! is_callable( $prepare_pages ) || ! is_callable( $compile_pages ) || ! is_callable( $compose ) ) {
 				return self::fail( $workspace, $run, 'compiler', new WP_Error( 'static_site_importer_invalid_transformer', 'The direct artifact compiler does not implement the staged compilation contract.' ) );
 			}
@@ -255,7 +263,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 				$run = $entered;
 				self::before_phase( 'prepare_shared', $run );
-				$shared = call_user_func( $prepare_shared, $artifact_state['artifact'] );
+				$shared = call_user_func( $prepare_shared, $artifact_state['artifact'], $payload_reader );
 				if ( 'blocks-engine/php-transformer/staged-shared-plan/v1' !== ( $shared['schema'] ?? '' ) || empty( $shared['digest'] ) || ! is_array( $shared['analysis']['page_ids'] ?? null ) ) {
 					throw new RuntimeException( 'Blocks Engine returned an invalid shared plan.' );
 				}
@@ -319,7 +327,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 				self::before_phase( 'prepare_pages', $run, $prepare_ids );
 				$run['work']['page_prepare_passes'] = (int) $run['work']['page_prepare_passes'] + 1;
-				$page_plans                         = call_user_func( $prepare_pages, $artifact_state['artifact'], $shared );
+				$page_plans                         = call_user_func( $prepare_pages, $artifact_state['artifact'], $shared, $payload_reader );
 				foreach ( $prepare_ids as $page_id ) {
 					$page_plan = $page_plans[ $page_id ] ?? null;
 					$validated = self::validate_page_plan( $page_plan, $shared, $page_id );
@@ -395,7 +403,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 				$run = $entered;
 				self::before_phase( 'compile_pages', $run, $batch_ids );
-				$batch = call_user_func( $compile_pages, $shared, array_values( $plans ) );
+				$batch = call_user_func( $compile_pages, $shared, array_values( $plans ), $payload_reader );
 				if ( ! is_array( $batch ) || array_keys( $batch ) !== $batch_ids ) {
 					return self::fail( $workspace, $run, 'compile_pages', new WP_Error( 'static_site_importer_direct_artifact_receipt_set_mismatch', 'Blocks Engine did not return the exact requested compiled receipt batch.' ), $batch_ids );
 				}
@@ -470,7 +478,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				$composed = call_user_func( array( $result, 'toArray' ) );
 				$metrics  = is_array( $composed['metrics'] ?? null ) ? $composed['metrics'] : array();
 				if ( 0 !== (int) ( $metrics['html_document_transform_count'] ?? 0 ) || 0 !== (int) ( $metrics['normalization_count'] ?? 0 ) ) {
-					throw new RuntimeException( 'Terminal receipt composition performed HTML transforms or normalization.' );
+					throw new RuntimeException( sprintf( 'Terminal receipt composition performed %d HTML transforms and %d normalization passes.', (int) ( $metrics['html_document_transform_count'] ?? 0 ), (int) ( $metrics['normalization_count'] ?? 0 ) ) );
 				}
 				$ref = self::publish_checkpoint( $workspace, $run, 'composed', 'composed-result.json', array(
 					'result'        => $composed,
@@ -507,6 +515,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 
 			$args['compiled_artifact_result']                 = $composed_state['result'];
 			$args['_static_site_importer_precompiled_source'] = true;
+			$args['_static_site_importer_payload_reader']      = $payload_reader;
 
 			if ( 'plan' === $run['binding']['operation'] ) {
 				$entered = self::enter_phase( $workspace, $run, 'canonical_plan' );
@@ -792,6 +801,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			'work'                 => array(
 				'content_policy_applications'       => (int) ( $run['work']['content_policy_applications'] ?? 0 ),
 				'client_script_policy_applications' => (int) ( $run['work']['client_script_policy_applications'] ?? 0 ),
+				'payloads_retained'                  => (int) ( $run['work']['payloads_retained'] ?? 0 ),
 				'shared_prepares'                   => (int) ( $run['work']['shared_prepares'] ?? 0 ),
 				'page_prepare_passes'               => (int) ( $run['work']['page_prepare_passes'] ?? 0 ),
 				'page_plans_prepared'               => (int) ( $run['work']['page_plans_prepared'] ?? 0 ),
@@ -1094,6 +1104,75 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		return function_exists( 'apply_filters' ) ? apply_filters( 'static_site_importer_direct_artifact_compiler', $compiler ) : $compiler;
 	}
 
+	/** Retain every reference-backed artifact payload before the source archive can disappear. */
+	private static function retain_payloads( array $artifact, ?object $reader, Static_Site_Importer_Artifact_Run_Workspace $workspace ) {
+		$references = array();
+		foreach ( is_array( $artifact['files'] ?? null ) ? $artifact['files'] : array() as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+			$reference = $file['payload_reference'] ?? ( is_array( $file['payload']['reference'] ?? null ) ? $file['payload']['reference'] : null );
+			if ( null === $reference ) {
+				continue;
+			}
+			if ( ! is_array( $reference ) || 'blocks-engine/payload-reference/v1' !== ( $reference['schema'] ?? null ) || ! is_string( $reference['id'] ?? null ) || '' === $reference['id'] || ! is_string( $reference['sha256'] ?? null ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $reference['sha256'] ) || ! is_int( $reference['bytes'] ?? null ) || 0 > $reference['bytes'] ) {
+				return new WP_Error( 'static_site_importer_direct_artifact_payload_reference_invalid', 'A direct artifact payload reference is invalid.' );
+			}
+			$id       = $reference['id'];
+			$contract = array( 'sha256' => $reference['sha256'], 'bytes' => $reference['bytes'] );
+			if ( isset( $references[ $id ] ) && $references[ $id ] !== $contract ) {
+				return new WP_Error( 'static_site_importer_direct_artifact_payload_reference_conflict', 'A direct artifact reuses one payload reference for different bytes.' );
+			}
+			$references[ $id ] = $contract;
+		}
+		if ( empty( $references ) ) {
+			return 0;
+		}
+		if ( ! is_object( $reader ) || ! is_callable( array( $reader, 'read' ) ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_payload_reader_missing', 'Reference-backed direct artifacts require a payload reader.' );
+		}
+		foreach ( $references as $id => $contract ) {
+			$reference = array(
+				'schema' => 'blocks-engine/payload-reference/v1',
+				'id'     => $id,
+				'sha256' => $contract['sha256'],
+				'bytes'  => $contract['bytes'],
+			);
+			try {
+				$bytes = $reader->read( $reference );
+			} catch ( Throwable $error ) {
+				return new WP_Error( 'static_site_importer_direct_artifact_payload_unavailable', 'A referenced direct artifact payload is unavailable.' );
+			}
+			if ( ! is_string( $bytes ) || strlen( $bytes ) !== $contract['bytes'] || ! hash_equals( $contract['sha256'], hash( 'sha256', $bytes ) ) ) {
+				return new WP_Error( 'static_site_importer_direct_artifact_payload_mismatch', 'A referenced direct artifact payload does not match its declared digest and byte count.' );
+			}
+			$published = $workspace->publish_raw_once( self::payload_file( $id ), $bytes );
+			if ( is_wp_error( $published ) ) {
+				return $published;
+			}
+		}
+		return count( $references );
+	}
+
+	private static function payload_reader( Static_Site_Importer_Artifact_Run_Workspace $workspace ): object {
+		return new class( $workspace ) implements \Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\PayloadReader {
+			public function __construct( private Static_Site_Importer_Artifact_Run_Workspace $workspace ) {}
+
+			public function read( array $reference ): string {
+				$id    = is_string( $reference['id'] ?? null ) ? $reference['id'] : '';
+				$bytes = '' !== $id ? $this->workspace->read_raw( 'payloads/' . hash( 'sha256', $id ) . '.bin' ) : null;
+				if ( ! is_string( $bytes ) || ! is_int( $reference['bytes'] ?? null ) || strlen( $bytes ) !== $reference['bytes'] || ! is_string( $reference['sha256'] ?? null ) || ! hash_equals( $reference['sha256'], hash( 'sha256', $bytes ) ) ) {
+					throw new RuntimeException( 'A retained direct artifact payload is unavailable or corrupt.' );
+				}
+				return $bytes;
+			}
+		};
+	}
+
+	private static function payload_file( string $id ): string {
+		return 'payloads/' . hash( 'sha256', $id ) . '.bin';
+	}
+
 	private static function run_policy(): array {
 		$policy = array(
 			'compile_batch_pages'       => 2,
@@ -1150,7 +1229,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	}
 
 	private static function binding_args( array $args ): array {
-		unset( $args['runtime_lifecycle_invocation_id'], $args['client_script_policy_report'], $args['missing_author_stylesheet_diagnostics'], $args['compiled_artifact_result'], $args['_static_site_importer_precompiled_source'], $args['import_run_id'] );
+		unset( $args['runtime_lifecycle_invocation_id'], $args['client_script_policy_report'], $args['missing_author_stylesheet_diagnostics'], $args['compiled_artifact_result'], $args['_static_site_importer_precompiled_source'], $args['_static_site_importer_payload_reader'], $args['import_run_id'] );
 		if ( is_array( $args['source_metadata']['collection'] ?? null ) ) {
 			unset( $args['source_metadata']['collection']['script_policy'] );
 			if ( empty( $args['source_metadata']['collection'] ) ) {
@@ -1241,7 +1320,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	/** Stream JSON tokens so artifact identity never requires an artifact-sized string. */
 	private static function hash_json_value( $context, $value, bool $canonical ): void {
 		if ( ! is_array( $value ) ) {
-			$encoded = wp_json_encode( $value );
+			$encoded = wp_json_encode( $value, JSON_PRESERVE_ZERO_FRACTION );
 			hash_update( $context, is_string( $encoded ) ? $encoded : '' );
 			return;
 		}

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -515,7 +515,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 
 			$args['compiled_artifact_result']                 = $composed_state['result'];
 			$args['_static_site_importer_precompiled_source'] = true;
-			$args['_static_site_importer_payload_reader']      = $payload_reader;
+			$args['_static_site_importer_payload_reader']     = $payload_reader;
 
 			if ( 'plan' === $run['binding']['operation'] ) {
 				$entered = self::enter_phase( $workspace, $run, 'canonical_plan' );
@@ -801,7 +801,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			'work'                 => array(
 				'content_policy_applications'       => (int) ( $run['work']['content_policy_applications'] ?? 0 ),
 				'client_script_policy_applications' => (int) ( $run['work']['client_script_policy_applications'] ?? 0 ),
-				'payloads_retained'                  => (int) ( $run['work']['payloads_retained'] ?? 0 ),
+				'payloads_retained'                 => (int) ( $run['work']['payloads_retained'] ?? 0 ),
 				'shared_prepares'                   => (int) ( $run['work']['shared_prepares'] ?? 0 ),
 				'page_prepare_passes'               => (int) ( $run['work']['page_prepare_passes'] ?? 0 ),
 				'page_plans_prepared'               => (int) ( $run['work']['page_plans_prepared'] ?? 0 ),
@@ -1119,7 +1119,10 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				return new WP_Error( 'static_site_importer_direct_artifact_payload_reference_invalid', 'A direct artifact payload reference is invalid.' );
 			}
 			$id       = $reference['id'];
-			$contract = array( 'sha256' => $reference['sha256'], 'bytes' => $reference['bytes'] );
+			$contract = array(
+				'sha256' => $reference['sha256'],
+				'bytes'  => $reference['bytes'],
+			);
 			if ( isset( $references[ $id ] ) && $references[ $id ] !== $contract ) {
 				return new WP_Error( 'static_site_importer_direct_artifact_payload_reference_conflict', 'A direct artifact reuses one payload reference for different bytes.' );
 			}
@@ -1159,9 +1162,8 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			public function __construct( private Static_Site_Importer_Artifact_Run_Workspace $workspace ) {}
 
 			public function read( array $reference ): string {
-				$id    = is_string( $reference['id'] ?? null ) ? $reference['id'] : '';
-				$bytes = '' !== $id ? $this->workspace->read_raw( 'payloads/' . hash( 'sha256', $id ) . '.bin' ) : null;
-				if ( ! is_string( $bytes ) || ! is_int( $reference['bytes'] ?? null ) || strlen( $bytes ) !== $reference['bytes'] || ! is_string( $reference['sha256'] ?? null ) || ! hash_equals( $reference['sha256'], hash( 'sha256', $bytes ) ) ) {
+				$bytes = $this->workspace->read_raw( 'payloads/' . hash( 'sha256', $reference['id'] ) . '.bin' );
+				if ( null === $bytes || strlen( $bytes ) !== $reference['bytes'] || ! hash_equals( $reference['sha256'], hash( 'sha256', $bytes ) ) ) {
 					throw new RuntimeException( 'A retained direct artifact payload is unavailable or corrupt.' );
 				}
 				return $bytes;

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1323,8 +1323,12 @@ function static_site_importer_staged_archive_payload_reader( array $archive ) {
 	if ( is_wp_error( $path ) ) {
 		return $path;
 	}
+	$interface = 'Automattic\\BlocksEngine\\PhpTransformer\\ArtifactCompiler\\PayloadReader';
+	if ( ! interface_exists( $interface ) ) {
+		return new WP_Error( 'static_site_importer_missing_transformer_capability', 'Blocks Engine php-transformer does not expose the staged payload reader contract.' );
+	}
 
-	return new class( $path ) {
+	return new class( $path ) implements \Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\PayloadReader {
 		public function __construct( private string $archive_path ) {}
 
 		public function read( array $reference ): string {

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1332,7 +1332,7 @@ function static_site_importer_staged_archive_payload_reader( array $archive ) {
 		public function __construct( private string $archive_path ) {}
 
 		public function read( array $reference ): string {
-			$id = isset( $reference['id'] ) ? (string) $reference['id'] : '';
+			$id = $reference['id'];
 			if ( ! str_starts_with( $id, 'zip-entry:' ) ) {
 				throw new RuntimeException( 'The staged payload reference is invalid.' );
 			}
@@ -1356,7 +1356,7 @@ function static_site_importer_staged_archive_payload_reader( array $archive ) {
 			try {
 				$stat   = $zip->statName( $entry );
 				$limits = static_site_importer_staged_archive_limits();
-				if ( ! is_array( $stat ) || ! isset( $reference['bytes'] ) || ! is_int( $reference['bytes'] ) || (int) $stat['size'] !== $reference['bytes'] || (int) $stat['size'] > $limits['max_entry_uncompressed_bytes'] || ( 0 === (int) $stat['comp_size'] ? (int) $stat['size'] > 0 : (int) $stat['size'] / (int) $stat['comp_size'] > $limits['max_compression_ratio'] ) ) {
+				if ( ! is_array( $stat ) || (int) $stat['size'] !== $reference['bytes'] || (int) $stat['size'] > $limits['max_entry_uncompressed_bytes'] || ( 0 === (int) $stat['comp_size'] ? (int) $stat['size'] > 0 : (int) $stat['size'] / (int) $stat['comp_size'] > $limits['max_compression_ratio'] ) ) {
 					throw new RuntimeException( 'The staged payload byte count changed.' );
 				}
 				$bytes = $zip->getFromName( $entry );

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -11,6 +11,8 @@ $GLOBALS['ssi_direct_mutations'] = 0;
 $GLOBALS['ssi_direct_last_args'] = array();
 $GLOBALS['ssi_direct_compiled_results'] = array();
 $GLOBALS['ssi_direct_checkpoint_reads'] = array();
+$GLOBALS['ssi_direct_staged_files'] = array();
+$GLOBALS['ssi_direct_staged_payloads'] = array();
 
 class WP_Error {
 	public function __construct( private string $code, private string $message = '', private $data = null ) {}
@@ -44,15 +46,33 @@ function static_site_importer_source_runtime( array $source ): array {
 		$file['mime_type'] = str_ends_with( $path, '.html' ) ? 'text/html' : ( str_ends_with( $path, '.css' ) ? 'text/css' : 'application/octet-stream' );
 		$files[] = $file;
 	}
+	$entrypoint = (string) ( $source['entrypoint'] ?? '' );
+	if ( '' === $entrypoint ) {
+		$entrypoint = 'website/index.html';
+	}
 	return array(
 		'artifact' => array(
 			'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
-			'entrypoint' => (string) ( $source['entrypoint'] ?? 'website/index.html' ),
+			'entrypoint' => $entrypoint,
 			'files'      => $files,
 		),
 		'provider' => 'direct-artifact-smoke',
 		'source_metadata' => array( 'fixture' => 'direct-artifact-multi-page' ),
 	);
+}
+function static_site_importer_staged_archive_files( array $archive, bool $payload_references = false ): array {
+	return $GLOBALS['ssi_direct_staged_files'];
+}
+function static_site_importer_staged_archive_payload_reader( array $archive ): object {
+	return new class() implements \Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\PayloadReader {
+		public function read( array $reference ): string {
+			$id = (string) ( $reference['id'] ?? '' );
+			if ( ! isset( $GLOBALS['ssi_direct_staged_payloads'][ $id ] ) ) {
+				throw new RuntimeException( 'The staged fixture payload is unavailable.' );
+			}
+			return $GLOBALS['ssi_direct_staged_payloads'][ $id ];
+		}
+	};
 }
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
@@ -139,7 +159,7 @@ $assert( hash( 'sha256', (string) wp_json_encode( $ordered ) ) === $hash_json->i
 $assert( hash( 'sha256', (string) wp_json_encode( $canonical ) ) === $hash_json->invoke( null, $ordered, true ), 'streamed checkpoint identity must preserve the exact recursively canonical JSON hash' );
 $assert( wp_mkdir_p( $test_root ), 'the fixture workspace root must be created' );
 $primitive_workspace = new Static_Site_Importer_Artifact_Run_Workspace( $test_root, 'direct-checkpoint-primitives' );
-$assert( ! is_wp_error( $primitive_workspace->publish_json_once( 'ordered.json', $ordered ) ) && wp_json_encode( $ordered, JSON_PRETTY_PRINT ) === $primitive_workspace->read_raw( 'ordered.json' ), 'streamed immutable JSON must preserve exact pretty-printed checkpoint bytes' );
+$assert( ! is_wp_error( $primitive_workspace->publish_json_once( 'ordered.json', $ordered ) ) && wp_json_encode( $ordered, JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION ) === $primitive_workspace->read_raw( 'ordered.json' ), 'streamed immutable JSON must preserve exact pretty-printed checkpoint bytes' );
 $large_chunk = str_repeat( 'x', 1024 * 1024 );
 $large_artifact = array();
 for ( $index = 0; $index < 96; ++$index ) {
@@ -255,6 +275,79 @@ $canonical_compiled = static function ( array $result ) use ( &$canonical_compil
 	return $result;
 };
 $assert( $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][0] ) === $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][1] ), 'clean and resumed composition must produce identical canonical plans, companion payloads, pages, writes, diagnostics, and reconciliation identities' );
+
+$binary = str_repeat( "\x00\xffZIP", 1024 );
+$binary_ref = array(
+	'schema' => 'blocks-engine/payload-reference/v1',
+	'id'     => 'zip-entry:assets%2Fphoto.png',
+	'sha256' => hash( 'sha256', $binary ),
+	'bytes'  => strlen( $binary ),
+);
+$GLOBALS['ssi_direct_staged_payloads'][ $binary_ref['id'] ] = $binary;
+$GLOBALS['ssi_direct_staged_files'] = $files;
+$GLOBALS['ssi_direct_staged_files'][] = array(
+	'path'              => 'website/assets/photo.png',
+	'mime_type'         => 'image/png',
+	'payload_reference' => $binary_ref,
+);
+$GLOBALS['ssi_direct_filters']['static_site_importer_resolve_source_reference'][] = static function ( $resolved, string $reference, string $type ) {
+	return 'durable-zip' === $reference && 'zip' === $type ? array(
+		'source' => array( 'zip' => array( 'name' => 'website.zip', 'staged_path' => '/resolver-owned/website.zip' ) ),
+		'provenance' => array( 'owner' => 'server' ),
+	) : $resolved;
+};
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array( static fn ( array $policy ): array => array_merge( $policy, array( 'compile_batch_pages' => 1 ) ) );
+$zip_first = Static_Site_Importer_Canonical_Import_Service::import(
+	array(
+		'operation' => 'plan',
+		'source'    => array( 'type' => 'zip', 'ref' => 'durable-zip' ),
+	)
+);
+$zip_id = (string) ( $zip_first['import_id'] ?? '' );
+$assert( ! empty( $zip_first['continuation'] ) && 1 === ( $zip_first['artifact_run']['work']['payloads_retained'] ?? 0 ), 'resolver-owned multi-page ZIP planning must enter the durable phase machine and retain each referenced payload once' );
+$zip_workspace = new Static_Site_Importer_Artifact_Run_Workspace( $test_root . '/static-site-importer/direct-artifact-imports', 'direct-' . $zip_id );
+$assert( $binary === $zip_workspace->read_raw( 'payloads/' . hash( 'sha256', $binary_ref['id'] ) . '.bin' ), 'the direct run must own verified payload bytes without changing their canonical reference id' );
+$zip_artifact = static_site_importer_source_runtime( array( 'files' => $GLOBALS['ssi_direct_staged_files'] ) )['artifact'];
+$zip_reader = static_site_importer_staged_archive_payload_reader( array() );
+$zip_compiler = new Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler();
+$zip_shared = $zip_compiler->prepareShared( $zip_artifact, $zip_reader );
+$zip_pages = $zip_compiler->preparePages( $zip_artifact, $zip_shared, $zip_reader );
+$zip_receipts = $zip_compiler->compilePreparedPages( $zip_shared, array_values( $zip_pages ), $zip_reader );
+$zip_uninterrupted_plan = $zip_compiler->compose( $zip_shared, array_values( $zip_receipts ) )->toArray()['source_reports']['wordpress_site_plan'];
+$GLOBALS['ssi_direct_staged_payloads'] = array();
+$zip_terminal = $zip_first;
+for ( $attempt = 0; $attempt < 10 && ! empty( $zip_terminal['continuation'] ); ++$attempt ) {
+	$zip_terminal = Static_Site_Importer_Canonical_Import_Service::import(
+		array(
+			'operation' => 'plan',
+			'source'    => array( 'type' => 'zip', 'import_id' => $zip_id ),
+		)
+	);
+}
+$assert( ! empty( $zip_terminal['success'] ) && empty( $zip_terminal['continuation'] ) && 'blocks-engine/wordpress-site-plan/v2' === ( $zip_terminal['plan']['schema'] ?? '' ), 'ZIP continuation must finish from retained payloads without reacquiring the resolver-owned archive' );
+$assert( str_contains( (string) wp_json_encode( $zip_terminal['plan'] ), $binary_ref['id'] ) && ! str_contains( (string) wp_json_encode( $zip_terminal['plan'] ), base64_encode( $binary ) ), 'durable ZIP planning must preserve compact canonical payload references instead of inlining binary bytes' );
+$first_difference = static function ( $left, $right, string $path = '$' ) use ( &$first_difference ): string {
+	if ( gettype( $left ) !== gettype( $right ) ) {
+		return $path . ':type';
+	}
+	if ( ! is_array( $left ) ) {
+		return $left === $right ? '' : $path . ':' . (string) wp_json_encode( array( $left, $right ) );
+	}
+	if ( array_keys( $left ) !== array_keys( $right ) ) {
+		return $path . ':keys:' . (string) wp_json_encode( array( array_keys( $left ), array_keys( $right ) ) );
+	}
+	foreach ( $left as $key => $value ) {
+		$difference = $first_difference( $value, $right[ $key ], $path . '.' . $key );
+		if ( '' !== $difference ) {
+			return $difference;
+		}
+	}
+	return '';
+};
+$zip_uninterrupted_canonical = $canonical_compiled( $zip_uninterrupted_plan );
+$zip_resumed_canonical = $canonical_compiled( $zip_terminal['plan'] );
+$assert( $zip_uninterrupted_canonical === $zip_resumed_canonical, 'resumed ZIP planning must produce the byte-identical canonical plan from uninterrupted staged compilation outside process observations: ' . $first_difference( $zip_uninterrupted_canonical, $zip_resumed_canonical ) );
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array( static fn ( array $policy ): array => array_merge( $policy, array( 'compile_batch_pages' => 20 ) ) );
 
 $fail_materialization = true;
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_checkpoint_publish'][] = static function ( $allowed, string $kind ) use ( &$fail_materialization ) {


### PR DESCRIPTION
## Summary
- retain resolver-owned ZIP bytes in the durable artifact workspace before releasing the source resolution
- reconstruct a typed payload reader for resumable preparation, compilation, and materialization
- preserve compact source references and deterministic checkpoint hashes across continuation boundaries

## Verification
- `php tests/smoke-direct-artifact-import.php`
- `php tests/smoke-artifact-run-primitives.php`
- `php tests/smoke-canonical-import-ability.php`
- `php tests/smoke-importer-block.php` (332 assertions)
- `npm test` (68 selected suites passed)
- `git diff --check`

Fixes #1201.

## AI assistance
GPT-5.6 Sol via OpenCode was used to inspect the durable planning contracts, implement the retained-payload continuation path, add parity coverage, and run the verification commands. Chris Huber directed and reviewed the work.