### PR TITLE
Bump PHP transformer to 0.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   "require": {
     "php": "^8.2",
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "0.7.0"
+    "automattic/blocks-engine-php-transformer": "0.8.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfcf328c83f248026c0c8ba1e18f9cf6",
+    "content-hash": "7ccb8d7a38b583b9f01f30784e7089c8",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "v0.7.0",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "9c1f8c18d974f1f63d91ec53e09423292b4b58c7"
+                "reference": "154c9557e879645ea71d8de2094ce14efd60032e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/9c1f8c18d974f1f63d91ec53e09423292b4b58c7",
-                "reference": "9c1f8c18d974f1f63d91ec53e09423292b4b58c7",
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/154c9557e879645ea71d8de2094ce14efd60032e",
+                "reference": "154c9557e879645ea71d8de2094ce14efd60032e",
                 "shasum": ""
             },
             "require": {
@@ -91,7 +91,7 @@
                 "issues": "https://github.com/Automattic/blocks-engine/issues",
                 "source": "https://github.com/Automattic/blocks-engine-php-transformer"
             },
-            "time": "2026-08-27T20:17:01+00:00"
+            "time": "2026-08-29T12:52:30+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/tests/smoke-webfont-producer-consumer.php
+++ b/tests/smoke-webfont-producer-consumer.php
@@ -44,7 +44,7 @@ $assert = static function ( bool $condition, string $message ): void {
 	if ( ! $condition ) throw new RuntimeException( $message );
 };
 
-$assert( 'v0.7.0' === \Composer\InstalledVersions::getPrettyVersion( 'automattic/blocks-engine-php-transformer' ), 'producer-consumer integration runs against the locked Blocks Engine php-transformer v0.7.0 dependency' );
+$assert( 'v0.8.0' === \Composer\InstalledVersions::getPrettyVersion( 'automattic/blocks-engine-php-transformer' ), 'producer-consumer integration runs against the locked Blocks Engine php-transformer v0.8.0 dependency' );
 
 $fixture_html = '<!doctype html><html><head><link rel="stylesheet" href="css/style.css"></head><body><main>Inter fixture</main></body></html>';
 $fixture_css  = "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');\n:root{--font:'Inter',system-ui,sans-serif}body{font-family:var(--font)}";


### PR DESCRIPTION
## Summary

- pin `automattic/blocks-engine-php-transformer` to the released `0.8.0` package
- refresh only that package in the Composer lockfile
- update the producer-consumer contract assertion to the new locked version

This brings the stylesheet simplification and performance work tracked in #1201 into SSI.

Blocks Engine release: https://github.com/Automattic/blocks-engine/releases/tag/php-transformer-v0.8.0

## Verification

- `composer validate --strict`
- `composer install --dry-run`
- `npm test`
- `npm run test:all`: 68 passed, 0 failed; 18 environment/operator-gated tests skipped with explicit requirements
- `php tests/smoke-webfont-producer-consumer.php`

## AI Assistance

GPT-5.6 Sol was used through OpenCode to update the dependency and lockfile, diagnose the version-bound smoke assertion, run the complete test manifests, and prepare this PR.