### PR TITLE
Exclude lifecycle transport from direct run identity

### DIFF
--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -1247,7 +1247,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	}
 
 	private static function binding_args( array $args ): array {
-		unset( $args['runtime_lifecycle_invocation_id'], $args['client_script_policy_report'], $args['missing_author_stylesheet_diagnostics'], $args['compiled_artifact_result'], $args['_static_site_importer_precompiled_source'], $args['_static_site_importer_payload_reader'], $args['import_run_id'] );
+		unset( $args['runtime_lifecycle_phase'], $args['runtime_lifecycle_request_id'], $args['runtime_lifecycle_invocation_id'], $args['runtime_lifecycle_checkpoint'], $args['_static_site_importer_lifecycle_checkpoint_root'], $args['client_script_policy_report'], $args['missing_author_stylesheet_diagnostics'], $args['compiled_artifact_result'], $args['_static_site_importer_precompiled_source'], $args['_static_site_importer_payload_reader'], $args['import_run_id'] );
 		if ( is_array( $args['source_metadata']['collection'] ?? null ) ) {
 			unset( $args['source_metadata']['collection']['script_policy'] );
 			if ( empty( $args['source_metadata']['collection'] ) ) {

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -92,6 +92,9 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				'materialization_claims'            => 0,
 				'materialization_attempts'          => 0,
 				'materializations'                  => 0,
+				'lifecycle_preparation_claims'       => 0,
+				'lifecycle_preparation_attempts'     => 0,
+				'lifecycle_preparations'             => 0,
 			),
 			'progress'   => array(
 				'phase'         => 'freezing',
@@ -127,7 +130,7 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			return self::continuation( $run, 'artifact_frozen' );
 		}
 
-		return self::execute( $workspace, $run );
+		return self::execute( $workspace, $run, $args );
 	}
 
 	/** Resume an opaque run without reacquiring source bytes. */
@@ -168,23 +171,23 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			return is_wp_error( $final ) ? $final : $final['response'];
 		}
 
-		return self::execute( $workspace, $run );
+		return self::execute( $workspace, $run, $args );
 	}
 
 	/** Continue the phase machine until its server-owned work boundary. */
-	private static function execute( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run ) {
+	private static function execute( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, array $request_args ) {
 		$lock = $workspace->acquire_lock( 'execution.lock' );
 		if ( is_wp_error( $lock ) ) {
 			return self::continuation( $run, 'run_in_progress' );
 		}
 		try {
-			return self::execute_locked( $workspace, $run );
+			return self::execute_locked( $workspace, $run, $request_args );
 		} finally {
 			$workspace->release_lock( $lock );
 		}
 	}
 
-	private static function execute_locked( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run ) {
+	private static function execute_locked( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, array $request_args ) {
 		if ( $workspace->is_expired() ) {
 			$workspace->purge();
 			return new WP_Error( 'static_site_importer_direct_artifact_run_expired', 'The retained direct artifact run expired and must be restarted.' );
@@ -512,6 +515,28 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			}
 			$artifact = $artifact_state['artifact'];
 			$args     = $artifact_state['args'];
+			$lifecycle_preparation_ref = self::existing_checkpoint_ref( $workspace, $run, 'lifecycle-preparation-response.json', 'lifecycle_preparation' );
+			if ( is_wp_error( $lifecycle_preparation_ref ) ) {
+				return $lifecycle_preparation_ref;
+			}
+			if ( ! empty( $lifecycle_preparation_ref ) ) {
+				$run['refs']['lifecycle_preparation'] = $lifecycle_preparation_ref;
+				$prepared = self::read_checkpoint( $workspace, $run, $lifecycle_preparation_ref, 'lifecycle_preparation' );
+				if ( is_wp_error( $prepared ) ) {
+					return $prepared;
+				}
+				if ( '' === trim( (string) ( $request_args['runtime_lifecycle_checkpoint'] ?? '' ) ) ) {
+					return $prepared['response'];
+				}
+				$prepared_result = $prepared['response']['result'];
+				$prepared_request_id = (string) ( $prepared_result['fresh_runtime']['request_id'] ?? '' );
+				if ( 'resume' !== ( $request_args['runtime_lifecycle_phase'] ?? '' )
+					|| ! hash_equals( (string) $prepared_result['runtime_lifecycle_checkpoint'], (string) $request_args['runtime_lifecycle_checkpoint'] )
+					|| ( '' !== $prepared_request_id && ! hash_equals( $prepared_request_id, (string) ( $request_args['runtime_lifecycle_request_id'] ?? '' ) ) ) ) {
+					return new WP_Error( 'static_site_importer_direct_artifact_lifecycle_resume_mismatch', 'The runtime lifecycle resume transport does not match the durable dependency preparation response.' );
+				}
+				$args = self::with_lifecycle_transport( $args, $request_args );
+			}
 
 			$args['compiled_artifact_result']                 = $composed_state['result'];
 			$args['_static_site_importer_precompiled_source'] = true;
@@ -537,6 +562,44 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 				$response['source']['identity'] = (string) ( $run['binding']['source_identity'] ?? '' );
 			} else {
+				if ( empty( $lifecycle_preparation_ref ) && 'prepare' === ( $args['runtime_lifecycle_phase'] ?? '' ) ) {
+					if ( ! $workspace->claim_directory( 'lifecycle-preparation-claim' ) ) {
+						return self::fail( $workspace, $run, 'lifecycle_preparation_claim', new WP_Error( 'static_site_importer_direct_artifact_lifecycle_preparation_ambiguous', 'Runtime dependency preparation was already claimed without a durable result; the import will not repeat dependency mutation.' ) );
+					}
+					$run['work']['lifecycle_preparation_claims']   = 1;
+					$run['work']['lifecycle_preparation_attempts'] = (int) $run['work']['lifecycle_preparation_attempts'] + 1;
+					$args['import_run_id']                         = $run['import_id'];
+					$entered                                       = self::enter_phase( $workspace, $run, 'prepare_lifecycle' );
+					if ( is_wp_error( $entered ) ) {
+						return $entered;
+					}
+					$run = $entered;
+					self::before_phase( 'prepare_lifecycle', $run );
+					$prepared = Static_Site_Importer_Theme_Generator::import_website_artifact( $artifact, $args );
+					if ( is_wp_error( $prepared ) ) {
+						return self::fail( $workspace, $run, 'prepare_lifecycle', $prepared );
+					}
+					if ( 'dependencies_prepared' !== ( $prepared['status'] ?? '' ) || '' === trim( (string) ( $prepared['runtime_lifecycle_checkpoint'] ?? '' ) ) ) {
+						return self::fail( $workspace, $run, 'prepare_lifecycle', new WP_Error( 'static_site_importer_direct_artifact_lifecycle_preparation_invalid', 'Runtime dependency preparation did not return a resumable lifecycle checkpoint.' ) );
+					}
+					$response = Static_Site_Importer_Canonical_Import_Service::success(
+						$prepared,
+						array_merge( $args, array( 'operation' => 'apply', 'source' => array( 'type' => $run['binding']['source_type'], 'import_id' => $run['import_id'] ) ) )
+					);
+					$run['state']                              = 'running';
+					$run['phase']                              = 'dependencies_prepared';
+					$run['progress']['phase']                  = 'dependencies_prepared';
+					$run['progress']['updated_at']             = gmdate( 'c' );
+					$run['work']['lifecycle_preparations']     = 1;
+					$response                                  = array_merge( $response, array( 'import_id' => $run['import_id'], 'continuation' => true, 'continuation_reason' => 'dependencies_prepared', 'artifact_run' => self::evidence( $run ) ) );
+					$lifecycle_preparation_ref                 = self::publish_checkpoint( $workspace, $run, 'lifecycle_preparation', 'lifecycle-preparation-response.json', array( 'response' => $response ) );
+					if ( is_wp_error( $lifecycle_preparation_ref ) ) {
+						return self::fail( $workspace, $run, 'lifecycle_preparation', $lifecycle_preparation_ref );
+					}
+					$run['refs']['lifecycle_preparation'] = $lifecycle_preparation_ref;
+					$write = self::write_run( $workspace, $run );
+					return is_wp_error( $write ) ? self::fail( $workspace, $run, 'lifecycle_preparation_checkpoint', $write ) : $response;
+				}
 				if ( empty( $run['refs']['materialization'] ) ) {
 					$materialization_ref = self::existing_checkpoint_ref( $workspace, $run, 'materialization-result.json', 'materialization' );
 					if ( is_wp_error( $materialization_ref ) ) {
@@ -637,6 +700,13 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		$run['progress']['updated_at']         = gmdate( 'c' );
 		$write                                 = self::write_run( $workspace, $run );
 		return is_wp_error( $write ) ? $write : $run;
+	}
+
+	private static function with_lifecycle_transport( array $args, array $request_args ): array {
+		foreach ( array( 'runtime_lifecycle_phase', 'runtime_lifecycle_request_id', 'runtime_lifecycle_invocation_id', 'runtime_lifecycle_checkpoint' ) as $key ) {
+			$args[ $key ] = $request_args[ $key ] ?? '';
+		}
+		return $args;
 	}
 
 	/** @return array<string,mixed>|WP_Error */
@@ -820,6 +890,9 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				'materialization_claims'            => (int) ( $run['work']['materialization_claims'] ?? 0 ),
 				'materialization_attempts'          => (int) ( $run['work']['materialization_attempts'] ?? 0 ),
 				'materializations'                  => (int) ( $run['work']['materializations'] ?? 0 ),
+				'lifecycle_preparation_claims'       => (int) ( $run['work']['lifecycle_preparation_claims'] ?? 0 ),
+				'lifecycle_preparation_attempts'     => (int) ( $run['work']['lifecycle_preparation_attempts'] ?? 0 ),
+				'lifecycle_preparations'             => (int) ( $run['work']['lifecycle_preparations'] ?? 0 ),
 			),
 			'phase_timings'        => array_map(
 				'floatval',
@@ -1310,6 +1383,14 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		}
 		if ( 'materialization' === $kind ) {
 			return is_array( $payload['result'] ?? null );
+		}
+		if ( 'lifecycle_preparation' === $kind ) {
+			return is_array( $payload['response'] ?? null )
+				&& ! empty( $payload['response']['success'] )
+				&& ! empty( $payload['response']['continuation'] )
+				&& 'dependencies_prepared' === ( $payload['response']['continuation_reason'] ?? '' )
+				&& '' !== trim( (string) ( $payload['response']['result']['runtime_lifecycle_checkpoint'] ?? '' ) )
+				&& '' !== trim( (string) ( $payload['response']['result']['fresh_runtime']['request_id'] ?? '' ) );
 		}
 		if ( 'final' === $kind ) {
 			return is_array( $payload['response'] ?? null ) && ! empty( $payload['response']['success'] ) && empty( $payload['response']['continuation'] );

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -92,9 +92,9 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				'materialization_claims'            => 0,
 				'materialization_attempts'          => 0,
 				'materializations'                  => 0,
-				'lifecycle_preparation_claims'       => 0,
-				'lifecycle_preparation_attempts'     => 0,
-				'lifecycle_preparations'             => 0,
+				'lifecycle_preparation_claims'      => 0,
+				'lifecycle_preparation_attempts'    => 0,
+				'lifecycle_preparations'            => 0,
 			),
 			'progress'   => array(
 				'phase'         => 'freezing',
@@ -513,22 +513,22 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			if ( is_wp_error( $artifact_state ) ) {
 				return $artifact_state;
 			}
-			$artifact = $artifact_state['artifact'];
-			$args     = $artifact_state['args'];
+			$artifact                  = $artifact_state['artifact'];
+			$args                      = $artifact_state['args'];
 			$lifecycle_preparation_ref = self::existing_checkpoint_ref( $workspace, $run, 'lifecycle-preparation-response.json', 'lifecycle_preparation' );
 			if ( is_wp_error( $lifecycle_preparation_ref ) ) {
 				return $lifecycle_preparation_ref;
 			}
 			if ( ! empty( $lifecycle_preparation_ref ) ) {
 				$run['refs']['lifecycle_preparation'] = $lifecycle_preparation_ref;
-				$prepared = self::read_checkpoint( $workspace, $run, $lifecycle_preparation_ref, 'lifecycle_preparation' );
+				$prepared                             = self::read_checkpoint( $workspace, $run, $lifecycle_preparation_ref, 'lifecycle_preparation' );
 				if ( is_wp_error( $prepared ) ) {
 					return $prepared;
 				}
 				if ( '' === trim( (string) ( $request_args['runtime_lifecycle_checkpoint'] ?? '' ) ) ) {
 					return $prepared['response'];
 				}
-				$prepared_result = $prepared['response']['result'];
+				$prepared_result     = $prepared['response']['result'];
 				$prepared_request_id = (string) ( $prepared_result['fresh_runtime']['request_id'] ?? '' );
 				if ( 'resume' !== ( $request_args['runtime_lifecycle_phase'] ?? '' )
 					|| ! hash_equals( (string) $prepared_result['runtime_lifecycle_checkpoint'], (string) $request_args['runtime_lifecycle_checkpoint'] )
@@ -569,7 +569,8 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 					$run['work']['lifecycle_preparation_claims']   = 1;
 					$run['work']['lifecycle_preparation_attempts'] = (int) $run['work']['lifecycle_preparation_attempts'] + 1;
 					$args['import_run_id']                         = $run['import_id'];
-					$entered                                       = self::enter_phase( $workspace, $run, 'prepare_lifecycle' );
+
+					$entered = self::enter_phase( $workspace, $run, 'prepare_lifecycle' );
 					if ( is_wp_error( $entered ) ) {
 						return $entered;
 					}
@@ -582,22 +583,39 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 					if ( 'dependencies_prepared' !== ( $prepared['status'] ?? '' ) || '' === trim( (string) ( $prepared['runtime_lifecycle_checkpoint'] ?? '' ) ) ) {
 						return self::fail( $workspace, $run, 'prepare_lifecycle', new WP_Error( 'static_site_importer_direct_artifact_lifecycle_preparation_invalid', 'Runtime dependency preparation did not return a resumable lifecycle checkpoint.' ) );
 					}
-					$response = Static_Site_Importer_Canonical_Import_Service::success(
+					$response                              = Static_Site_Importer_Canonical_Import_Service::success(
 						$prepared,
-						array_merge( $args, array( 'operation' => 'apply', 'source' => array( 'type' => $run['binding']['source_type'], 'import_id' => $run['import_id'] ) ) )
+						array_merge(
+							$args,
+							array(
+								'operation' => 'apply',
+								'source'    => array(
+									'type'      => $run['binding']['source_type'],
+									'import_id' => $run['import_id'],
+								),
+							)
+						)
 					);
-					$run['state']                              = 'running';
-					$run['phase']                              = 'dependencies_prepared';
-					$run['progress']['phase']                  = 'dependencies_prepared';
-					$run['progress']['updated_at']             = gmdate( 'c' );
-					$run['work']['lifecycle_preparations']     = 1;
-					$response                                  = array_merge( $response, array( 'import_id' => $run['import_id'], 'continuation' => true, 'continuation_reason' => 'dependencies_prepared', 'artifact_run' => self::evidence( $run ) ) );
-					$lifecycle_preparation_ref                 = self::publish_checkpoint( $workspace, $run, 'lifecycle_preparation', 'lifecycle-preparation-response.json', array( 'response' => $response ) );
+					$run['state']                          = 'running';
+					$run['phase']                          = 'dependencies_prepared';
+					$run['progress']['phase']              = 'dependencies_prepared';
+					$run['progress']['updated_at']         = gmdate( 'c' );
+					$run['work']['lifecycle_preparations'] = 1;
+					$response                              = array_merge(
+						$response,
+						array(
+							'import_id'           => $run['import_id'],
+							'continuation'        => true,
+							'continuation_reason' => 'dependencies_prepared',
+							'artifact_run'        => self::evidence( $run ),
+						)
+					);
+					$lifecycle_preparation_ref             = self::publish_checkpoint( $workspace, $run, 'lifecycle_preparation', 'lifecycle-preparation-response.json', array( 'response' => $response ) );
 					if ( is_wp_error( $lifecycle_preparation_ref ) ) {
 						return self::fail( $workspace, $run, 'lifecycle_preparation', $lifecycle_preparation_ref );
 					}
 					$run['refs']['lifecycle_preparation'] = $lifecycle_preparation_ref;
-					$write = self::write_run( $workspace, $run );
+					$write                                = self::write_run( $workspace, $run );
 					return is_wp_error( $write ) ? self::fail( $workspace, $run, 'lifecycle_preparation_checkpoint', $write ) : $response;
 				}
 				if ( empty( $run['refs']['materialization'] ) ) {
@@ -890,9 +908,9 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				'materialization_claims'            => (int) ( $run['work']['materialization_claims'] ?? 0 ),
 				'materialization_attempts'          => (int) ( $run['work']['materialization_attempts'] ?? 0 ),
 				'materializations'                  => (int) ( $run['work']['materializations'] ?? 0 ),
-				'lifecycle_preparation_claims'       => (int) ( $run['work']['lifecycle_preparation_claims'] ?? 0 ),
-				'lifecycle_preparation_attempts'     => (int) ( $run['work']['lifecycle_preparation_attempts'] ?? 0 ),
-				'lifecycle_preparations'             => (int) ( $run['work']['lifecycle_preparations'] ?? 0 ),
+				'lifecycle_preparation_claims'      => (int) ( $run['work']['lifecycle_preparation_claims'] ?? 0 ),
+				'lifecycle_preparation_attempts'    => (int) ( $run['work']['lifecycle_preparation_attempts'] ?? 0 ),
+				'lifecycle_preparations'            => (int) ( $run['work']['lifecycle_preparations'] ?? 0 ),
 			),
 			'phase_timings'        => array_map(
 				'floatval',

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -107,6 +107,12 @@ class Static_Site_Importer_Theme_Generator {
 		if ( is_wp_error( $GLOBALS['ssi_direct_materialization_error'] ?? null ) ) {
 			return $GLOBALS['ssi_direct_materialization_error'];
 		}
+		if ( 'prepare' === ( $args['runtime_lifecycle_phase'] ?? '' ) ) {
+			return array(
+				'status'                       => 'dependencies_prepared',
+				'runtime_lifecycle_checkpoint' => 'prepare-checkpoint',
+			);
+		}
 		++$GLOBALS['ssi_direct_mutations'];
 		$GLOBALS['ssi_direct_last_args'] = $args;
 		$GLOBALS['ssi_direct_compiled_results'][] = $args['compiled_artifact_result'];
@@ -184,7 +190,8 @@ foreach ( array( 'index.html', 'about.html', 'contact.html', 'styles.css' ) as $
 		'content' => (string) file_get_contents( $fixture . '/' . $name ),
 	);
 }
-$input = static fn ( string $operation = 'apply' ): array => array(
+
+$input = static fn ( string $operation = 'apply', array $lifecycle = array() ): array => array_merge( array(
 	'operation' => $operation,
 	'slug'      => 'direct-artifact-fixture',
 	'source'    => array(
@@ -192,15 +199,15 @@ $input = static fn ( string $operation = 'apply' ): array => array(
 		'entrypoint' => 'website/index.html',
 		'files'      => $files,
 	),
-);
-$resume = static fn ( string $id, string $operation = 'apply' ): array => array(
+), $lifecycle );
+$resume = static fn ( string $id, string $operation = 'apply', array $lifecycle = array() ): array => array_merge( array(
 	'operation' => $operation,
 	'slug'      => 'direct-artifact-fixture',
 	'source'    => array(
 		'type'      => 'files',
 		'import_id' => $id,
 	),
-);
+), $lifecycle );
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'][] = static fn ( array $policy ): array => array_merge(
 	$policy,
 	array(
@@ -275,6 +282,33 @@ $canonical_compiled = static function ( array $result ) use ( &$canonical_compil
 	return $result;
 };
 $assert( $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][0] ) === $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][1] ), 'clean and resumed composition must produce identical canonical plans, companion payloads, pages, writes, diagnostics, and reconciliation identities' );
+
+$prepare_mutation_count = $GLOBALS['ssi_direct_mutations'];
+$prepare = Static_Site_Importer_Canonical_Import_Service::import(
+	$input(
+		'apply',
+		array(
+			'runtime_lifecycle_phase'      => 'prepare',
+			'runtime_lifecycle_request_id' => 'prepare-request',
+			'runtime_lifecycle_checkpoint' => 'prepare-checkpoint',
+		)
+	)
+);
+$prepare_work = $prepare['artifact_run']['work'] ?? array();
+$compiled_count = count( $GLOBALS['ssi_direct_compiled_results'] );
+$assert( ! empty( $prepare['success'] ) && 'dependencies_prepared' === ( $prepare['result']['status'] ?? '' ) && 3 === ( $prepare_work['pages_compiled'] ?? 0 ) && $prepare_mutation_count === $GLOBALS['ssi_direct_mutations'], 'a lifecycle prepare direct run must complete compilation, retain its dependency response, and avoid WordPress mutation' );
+$prepared_replay = Static_Site_Importer_Canonical_Import_Service::import(
+	$resume(
+		(string) $prepare['import_id'],
+		'apply',
+		array(
+			'runtime_lifecycle_phase'      => 'resume',
+			'runtime_lifecycle_request_id' => 'resume-request',
+			'runtime_lifecycle_checkpoint' => 'resume-checkpoint',
+		)
+	)
+);
+$assert( $prepare === $prepared_replay && $prepare_mutation_count === $GLOBALS['ssi_direct_mutations'] && $compiled_count === count( $GLOBALS['ssi_direct_compiled_results'] ), 'a fresh lifecycle resume must return the retained prepare response without additional compile or materialization work' );
 
 $binary = str_repeat( "\x00\xffZIP", 1024 );
 $binary_ref = array(

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -13,6 +13,7 @@ $GLOBALS['ssi_direct_compiled_results'] = array();
 $GLOBALS['ssi_direct_checkpoint_reads'] = array();
 $GLOBALS['ssi_direct_staged_files'] = array();
 $GLOBALS['ssi_direct_staged_payloads'] = array();
+$GLOBALS['ssi_direct_lifecycle_preparations'] = 0;
 
 class WP_Error {
 	public function __construct( private string $code, private string $message = '', private $data = null ) {}
@@ -108,9 +109,12 @@ class Static_Site_Importer_Theme_Generator {
 			return $GLOBALS['ssi_direct_materialization_error'];
 		}
 		if ( 'prepare' === ( $args['runtime_lifecycle_phase'] ?? '' ) ) {
+			++$GLOBALS['ssi_direct_lifecycle_preparations'];
+			$GLOBALS['ssi_direct_last_args'] = $args;
 			return array(
 				'status'                       => 'dependencies_prepared',
-				'runtime_lifecycle_checkpoint' => 'prepare-checkpoint',
+				'runtime_lifecycle_checkpoint' => '0123456789abcdef0123456789abcdef',
+				'fresh_runtime'                => array( 'request_id' => '00000000-0000-4000-8000-000000000827' ),
 			);
 		}
 		++$GLOBALS['ssi_direct_mutations'];
@@ -190,24 +194,23 @@ foreach ( array( 'index.html', 'about.html', 'contact.html', 'styles.css' ) as $
 		'content' => (string) file_get_contents( $fixture . '/' . $name ),
 	);
 }
-
-$input = static fn ( string $operation = 'apply', array $lifecycle = array() ): array => array_merge( array(
-	'operation' => $operation,
-	'slug'      => 'direct-artifact-fixture',
-	'source'    => array(
+$input = static fn ( string $operation = 'apply' ): array => array(
+	'operation'               => $operation,
+	'slug'                    => 'direct-artifact-fixture',
+	'source'                  => array(
 		'type'       => 'files',
 		'entrypoint' => 'website/index.html',
 		'files'      => $files,
 	),
-), $lifecycle );
-$resume = static fn ( string $id, string $operation = 'apply', array $lifecycle = array() ): array => array_merge( array(
-	'operation' => $operation,
-	'slug'      => 'direct-artifact-fixture',
-	'source'    => array(
+);
+$resume = static fn ( string $id, string $operation = 'apply' ): array => array(
+	'operation'                    => $operation,
+	'slug'                         => 'direct-artifact-fixture',
+	'source'                       => array(
 		'type'      => 'files',
 		'import_id' => $id,
 	),
-), $lifecycle );
+);
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'][] = static fn ( array $policy ): array => array_merge(
 	$policy,
 	array(
@@ -283,32 +286,29 @@ $canonical_compiled = static function ( array $result ) use ( &$canonical_compil
 };
 $assert( $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][0] ) === $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][1] ), 'clean and resumed composition must produce identical canonical plans, companion payloads, pages, writes, diagnostics, and reconciliation identities' );
 
-$prepare_mutation_count = $GLOBALS['ssi_direct_mutations'];
-$prepare = Static_Site_Importer_Canonical_Import_Service::import(
-	$input(
-		'apply',
-		array(
-			'runtime_lifecycle_phase'      => 'prepare',
-			'runtime_lifecycle_request_id' => 'prepare-request',
-			'runtime_lifecycle_checkpoint' => 'prepare-checkpoint',
-		)
-	)
-);
-$prepare_work = $prepare['artifact_run']['work'] ?? array();
-$compiled_count = count( $GLOBALS['ssi_direct_compiled_results'] );
-$assert( ! empty( $prepare['success'] ) && 'dependencies_prepared' === ( $prepare['result']['status'] ?? '' ) && 3 === ( $prepare_work['pages_compiled'] ?? 0 ) && $prepare_mutation_count === $GLOBALS['ssi_direct_mutations'], 'a lifecycle prepare direct run must complete compilation, retain its dependency response, and avoid WordPress mutation' );
-$prepared_replay = Static_Site_Importer_Canonical_Import_Service::import(
-	$resume(
-		(string) $prepare['import_id'],
-		'apply',
-		array(
-			'runtime_lifecycle_phase'      => 'resume',
-			'runtime_lifecycle_request_id' => 'resume-request',
-			'runtime_lifecycle_checkpoint' => 'resume-checkpoint',
-		)
-	)
-);
-$assert( $prepare === $prepared_replay && $prepare_mutation_count === $GLOBALS['ssi_direct_mutations'] && $compiled_count === count( $GLOBALS['ssi_direct_compiled_results'] ), 'a fresh lifecycle resume must return the retained prepare response without additional compile or materialization work' );
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array( static fn ( array $policy ): array => array_merge( $policy, array( 'compile_batch_pages' => 1 ) ) );
+$lifecycle_input = $input();
+$lifecycle_input['runtime_lifecycle_phase'] = 'prepare';
+$lifecycle_prepared = Static_Site_Importer_Canonical_Import_Service::import( $lifecycle_input );
+$lifecycle_id = (string) ( $lifecycle_prepared['import_id'] ?? '' );
+$assert( 'pages_remaining' === ( $lifecycle_prepared['continuation_reason'] ?? '' ) && 0 === $GLOBALS['ssi_direct_lifecycle_preparations'], 'bounded compilation must continue before runtime dependency preparation' );
+$lifecycle_retry = $resume( $lifecycle_id );
+$lifecycle_retry['runtime_lifecycle_phase'] = 'resume';
+for ( $attempt = 0; $attempt < 10 && 'dependencies_prepared' !== ( $lifecycle_prepared['continuation_reason'] ?? '' ); ++$attempt ) {
+	$lifecycle_prepared = Static_Site_Importer_Canonical_Import_Service::import( $lifecycle_retry );
+}
+$assert( ! empty( $lifecycle_prepared['success'] ) && ! empty( $lifecycle_prepared['continuation'] ) && 'dependencies_prepared' === ( $lifecycle_prepared['continuation_reason'] ?? '' ) && '0123456789abcdef0123456789abcdef' === ( $lifecycle_prepared['result']['runtime_lifecycle_checkpoint'] ?? '' ) && 1 === $GLOBALS['ssi_direct_lifecycle_preparations'], 'direct apply must expose dependency preparation as a durable intermediate lifecycle response' );
+$assert( $lifecycle_prepared === Static_Site_Importer_Canonical_Import_Service::import( $lifecycle_retry ) && 1 === $GLOBALS['ssi_direct_lifecycle_preparations'], 'a resume without the lifecycle checkpoint must replay the durable dependency preparation response without mutation' );
+$lifecycle_resume = $lifecycle_retry;
+$lifecycle_resume['runtime_lifecycle_request_id'] = '00000000-0000-4000-8000-000000000827';
+$lifecycle_resume['runtime_lifecycle_checkpoint'] = 'ffffffffffffffffffffffffffffffff';
+$lifecycle_mismatch = Static_Site_Importer_Canonical_Import_Service::import( $lifecycle_resume );
+$assert( 'static_site_importer_direct_artifact_lifecycle_resume_mismatch' === ( $lifecycle_mismatch['error']['code'] ?? '' ) && 2 === $GLOBALS['ssi_direct_mutations'], 'invalid lifecycle transport must fail before consuming the final materialization claim' );
+$lifecycle_resume['runtime_lifecycle_checkpoint'] = '0123456789abcdef0123456789abcdef';
+$lifecycle_terminal = Static_Site_Importer_Canonical_Import_Service::import( $lifecycle_resume );
+$assert( ! empty( $lifecycle_terminal['success'] ) && empty( $lifecycle_terminal['continuation'] ) && 'resume' === ( $GLOBALS['ssi_direct_last_args']['runtime_lifecycle_phase'] ?? '' ) && '0123456789abcdef0123456789abcdef' === ( $GLOBALS['ssi_direct_last_args']['runtime_lifecycle_checkpoint'] ?? '' ), 'the lifecycle checkpoint must resume the compiled direct artifact through exactly one terminal materialization' );
+$lifecycle_work = $lifecycle_terminal['artifact_run']['work'] ?? array();
+$assert( 1 === ( $lifecycle_work['lifecycle_preparation_claims'] ?? 0 ) && 1 === ( $lifecycle_work['lifecycle_preparations'] ?? 0 ) && 1 === ( $lifecycle_work['materialization_claims'] ?? 0 ) && 1 === ( $lifecycle_work['materializations'] ?? 0 ), 'direct lifecycle evidence must distinguish one dependency preparation from one final materialization' );
 
 $binary = str_repeat( "\x00\xffZIP", 1024 );
 $binary_ref = array(
@@ -386,6 +386,7 @@ $owned_report_destination = (string) ( $GLOBALS['ssi_direct_last_args']['failed_
 $assert( str_contains( $owned_report_destination, '/static-site-importer/direct-artifact-imports/.ssi-artifact-run-direct-' ) && str_ends_with( $owned_report_destination, '/failed-plan/import-report.json' ) && is_dir( dirname( $owned_report_destination ) ), 'direct Ability runs reserve an importer-owned failed-plan report destination inside the retained workspace' );
 
 $fail_materialization = true;
+$mutations_before_interruption = $GLOBALS['ssi_direct_mutations'];
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_checkpoint_publish'][] = static function ( $allowed, string $kind ) use ( &$fail_materialization ) {
 	if ( $fail_materialization && 'materialization' === $kind ) {
 		$fail_materialization = false;
@@ -395,10 +396,10 @@ $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_checkpoint_
 };
 $interrupted = Static_Site_Importer_Canonical_Import_Service::import( $input() );
 $interrupted_data = $interrupted['error']['data'] ?? array();
-$assert( 'injected_materialization_publication_failure' === ( $interrupted['error']['code'] ?? '' ) && 3 === $GLOBALS['ssi_direct_mutations'], 'post-mutation checkpoint failure must return structured interruption evidence' );
+$assert( 'injected_materialization_publication_failure' === ( $interrupted['error']['code'] ?? '' ) && $mutations_before_interruption + 1 === $GLOBALS['ssi_direct_mutations'], 'post-mutation checkpoint failure must return structured interruption evidence' );
 $interrupted_id = (string) ( $interrupted_data['import_id'] ?? '' );
 $ambiguous = Static_Site_Importer_Canonical_Import_Service::import( $resume( $interrupted_id ) );
-$assert( 'static_site_importer_direct_artifact_materialization_ambiguous' === ( $ambiguous['error']['code'] ?? '' ) && 3 === $GLOBALS['ssi_direct_mutations'], 'resume across the mutation receipt boundary must fail closed instead of repeating WordPress mutation' );
+$assert( 'static_site_importer_direct_artifact_materialization_ambiguous' === ( $ambiguous['error']['code'] ?? '' ) && $mutations_before_interruption + 1 === $GLOBALS['ssi_direct_mutations'], 'resume across the mutation receipt boundary must fail closed instead of repeating WordPress mutation' );
 
 $fail_run_after_receipt = true;
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_checkpoint_publish'][] = static function ( $allowed, string $kind, string $relative, array $evidence ) use ( &$fail_run_after_receipt ) {


### PR DESCRIPTION
Closes #1396.

## Summary

- Excludes lifecycle transport from durable direct artifact request identity while keeping import policy, source metadata, operation, owner, and implementation binding strict.
- Persists dependency preparation as a distinct durable intermediate checkpoint instead of a terminal materialization result.
- Validates the lifecycle checkpoint/request pair before final materialization.
- Reuses compiled page receipts and performs dependency preparation and final WordPress materialization exactly once each.
- Preserves durable argument mismatch and ambiguous post-mutation replay rejection.

## Root cause

A multi-page direct artifact run can complete its bounded compile/materialization work under lifecycle `prepare` and retain a final `dependencies_prepared` response. The next fresh runtime resumes the same opaque direct `import_id` under lifecycle `resume` with new request and checkpoint transport values.

The direct run binding treated those orchestration values as durable import options, so `resume()` rejected the run. Merely ignoring them would replay `dependencies_prepared` forever because the prepare response had been persisted as the terminal materialization result.

This change gives dependency preparation its own claimed checkpoint. A resume without a lifecycle checkpoint safely replays that intermediate response. A resume with the matching lifecycle checkpoint injects the fresh transport into the retained compiled artifact and performs one final materialization.

## Verification

- `php tests/smoke-direct-artifact-import.php`
- `npm test`: 69 selected checks, 0 failures
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode implemented the fix and initial regression coverage. OpenAI GPT-5.6 Sol via OpenCode diagnosed and orchestrated the work, reviewed the diff, strengthened the no-mutation assertion, and reran the complete test suite. Chris Huber remains responsible for the submitted changes.
