### PR TITLE
Record the build that produced an import in the source-of-truth manifest

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -6,6 +6,7 @@
     "tests/smoke-ability-error-report-summary.php": { "environment": "standalone-php" },
     "tests/smoke-ability-import-success-diagnostics.php": { "environment": "standalone-php" },
     "tests/smoke-ability-registration-idempotent.php": { "environment": "standalone-php" },
+    "tests/smoke-build-provenance.php": { "environment": "standalone-php" },
     "tests/smoke-canonical-import-ability.php": { "environment": "standalone-php" },
     "tests/smoke-cli-import-continuation.php": { "environment": "standalone-php" },
     "tests/smoke-client-script-policy.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-build-provenance.php
+++ b/includes/class-static-site-importer-build-provenance.php
@@ -62,7 +62,7 @@ class Static_Site_Importer_Build_Provenance {
 				'figma_transformer' => function_exists( 'blocks_engine_figma_transformer_version' ) ? (string) blocks_engine_figma_transformer_version() : '',
 			),
 		);
-		$receipt = self::development_package_receipt();
+		$receipt    = self::development_package_receipt();
 		if ( array() !== $receipt ) {
 			$provenance['development_package'] = $receipt;
 		}

--- a/includes/class-static-site-importer-build-provenance.php
+++ b/includes/class-static-site-importer-build-provenance.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Build-provenance primitive.
+ *
+ * Single source of truth for the identity of the build that produced an import:
+ * the Static Site Importer version, the Blocks Engine transformer versions that
+ * performed the conversion, and — for development packages built from source —
+ * the packaged provenance receipt written by tools/build-dev-package.mjs.
+ *
+ * The importer plugin is frequently removed after an import completes, so the
+ * build identity has to be recorded into durable output (the source-of-truth
+ * manifest, and through it the import report) at import time. Without it a
+ * finished site cannot be attributed to a build, and two runs of one source
+ * cannot be compared.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Describes the build that produced an import.
+ */
+class Static_Site_Importer_Build_Provenance {
+
+	/**
+	 * Schema of the provenance record embedded in durable import output.
+	 */
+	public const SCHEMA = 'static-site-importer/build-provenance/v1';
+
+	/**
+	 * Plugin-root file carrying the development-package provenance receipt.
+	 */
+	public const DEVELOPMENT_PACKAGE_RECEIPT = 'build-provenance.json';
+
+	/**
+	 * Schema of the development-package receipt written by the package builder.
+	 */
+	public const DEVELOPMENT_PACKAGE_SCHEMA = 'static-site-importer/development-package-provenance/v1';
+
+	/**
+	 * Describe the running build.
+	 *
+	 * Released builds are identified by version alone. Development packages
+	 * additionally carry the source commits they were built from, which is the
+	 * only identity that distinguishes two dev builds sharing a release version.
+	 *
+	 * @param string $imported_at Optional ISO-8601 timestamp. Defaults to now (UTC).
+	 * @return array<string,mixed> Provenance record.
+	 */
+	public static function describe( string $imported_at = '' ): array {
+		$provenance = array(
+			'schema'               => self::SCHEMA,
+			'imported_at'          => '' !== $imported_at ? $imported_at : gmdate( 'Y-m-d\TH:i:s\Z' ),
+			'static_site_importer' => array(
+				'version' => defined( 'STATIC_SITE_IMPORTER_VERSION' ) ? (string) STATIC_SITE_IMPORTER_VERSION : '',
+			),
+			'blocks_engine'        => array(
+				'php_transformer'   => function_exists( 'blocks_engine_php_transformer_version' ) ? (string) blocks_engine_php_transformer_version() : '',
+				'figma_transformer' => function_exists( 'blocks_engine_figma_transformer_version' ) ? (string) blocks_engine_figma_transformer_version() : '',
+			),
+		);
+		$receipt = self::development_package_receipt();
+		if ( array() !== $receipt ) {
+			$provenance['development_package'] = $receipt;
+		}
+		return $provenance;
+	}
+
+	/**
+	 * Read the development-package receipt shipped inside the plugin, when present.
+	 *
+	 * Released packages do not carry a receipt; the absence of one is itself
+	 * meaningful and is reported by omission rather than by an empty structure.
+	 *
+	 * @param string $plugin_root Optional plugin root override for testing.
+	 * @return array<string,mixed> Receipt, or an empty array when this is not a development package.
+	 */
+	public static function development_package_receipt( string $plugin_root = '' ): array {
+		$root = '' !== $plugin_root ? $plugin_root : ( defined( 'STATIC_SITE_IMPORTER_PATH' ) ? (string) STATIC_SITE_IMPORTER_PATH : '' );
+		if ( '' === $root ) {
+			return array();
+		}
+		$path = rtrim( $root, '/' ) . '/' . self::DEVELOPMENT_PACKAGE_RECEIPT;
+		if ( ! is_readable( $path ) ) {
+			return array();
+		}
+		$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local plugin file read; WP_Filesystem is not initialized at import time.
+		if ( ! is_string( $contents ) || '' === trim( $contents ) ) {
+			return array();
+		}
+		$receipt = json_decode( $contents, true );
+		if ( ! is_array( $receipt ) || self::DEVELOPMENT_PACKAGE_SCHEMA !== ( $receipt['schema'] ?? '' ) ) {
+			return array();
+		}
+		return $receipt;
+	}
+}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -118,6 +118,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'source_of_truth'         => array(
 				'schema'           => 'static-site-importer/source-of-truth-manifest/v1',
 				'import_run_id'    => '',
+				'build'            => array(),
 				'artifact'         => array(),
 				'desired'          => array(
 					'pages'  => array(),

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -757,6 +757,7 @@ class Static_Site_Importer_Theme_Generator {
 			'schema'          => 'static-site-importer/source-of-truth-manifest/v1',
 			'version'         => 1,
 			'import_run_id'   => $report['import_run_id'],
+			'build'           => Static_Site_Importer_Build_Provenance::describe(),
 			'artifact'        => array_merge( $artifact, array( 'provenance' => $plan['source']['provenance'] ) ),
 			'manifest_path'   => 'static-site-importer-manifest.json',
 			'generated_theme' => array(

--- a/runtime-package-manifest.json
+++ b/runtime-package-manifest.json
@@ -21,6 +21,10 @@
           "path": "static-site-importer.php"
         },
         {
+          "type": "file",
+          "path": "build-provenance.json"
+        },
+        {
           "type": "prefix",
           "path": "blocks/"
         },

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -53,6 +53,7 @@ Static_Site_Importer_Lifecycle_Compile_Checkpoint::register_cleanup();
 register_deactivation_hook( __FILE__, array( Static_Site_Importer_Lifecycle_Compile_Checkpoint::class, 'unschedule_cleanup' ) );
 
 $static_site_importer_includes = array(
+	'class-static-site-importer-build-provenance.php',
 	'class-static-site-importer-site-identity.php',
 	'class-static-site-importer-website-artifact-import-input.php',
 	'class-static-site-importer-theme-materialization-strategy.php',

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -11,6 +11,7 @@
     { "path": "tests/smoke-ability-error-report-summary.php", "environment": "standalone-php" },
     { "path": "tests/smoke-ability-import-success-diagnostics.php", "environment": "standalone-php" },
     { "path": "tests/smoke-ability-registration-idempotent.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-build-provenance.php", "environment": "standalone-php" },
     { "path": "tests/smoke-canonical-import-ability.php", "environment": "standalone-php" },
     { "path": "tests/smoke-cli-import-continuation.php", "environment": "standalone-php" },
     { "path": "tests/smoke-client-script-policy.php", "environment": "standalone-php" },

--- a/tests/smoke-build-provenance.php
+++ b/tests/smoke-build-provenance.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Smoke test: build-provenance primitive records the build that produced an import.
+ *
+ * Run from the repository root:
+ * php tests/smoke-build-provenance.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+define( 'STATIC_SITE_IMPORTER_VERSION', '1.8.1' );
+
+if ( ! function_exists( 'blocks_engine_php_transformer_version' ) ) {
+	function blocks_engine_php_transformer_version(): string {
+		return '0.8.0';
+	}
+}
+
+if ( ! function_exists( 'blocks_engine_figma_transformer_version' ) ) {
+	function blocks_engine_figma_transformer_version(): string {
+		return '0.1.3';
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-build-provenance.php';
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$package_root = sys_get_temp_dir() . '/ssi-build-provenance-' . bin2hex( random_bytes( 6 ) );
+mkdir( $package_root, 0o777, true );
+$receipt_path = $package_root . '/' . Static_Site_Importer_Build_Provenance::DEVELOPMENT_PACKAGE_RECEIPT;
+
+$released = Static_Site_Importer_Build_Provenance::describe();
+
+$assert( Static_Site_Importer_Build_Provenance::SCHEMA === ( $released['schema'] ?? '' ), 'provenance-declares-schema' );
+$assert( '1.8.1' === ( $released['static_site_importer']['version'] ?? '' ), 'provenance-records-importer-version' );
+$assert( '0.8.0' === ( $released['blocks_engine']['php_transformer'] ?? '' ), 'provenance-records-php-transformer-version' );
+$assert( '0.1.3' === ( $released['blocks_engine']['figma_transformer'] ?? '' ), 'provenance-records-figma-transformer-version' );
+$assert(
+	1 === preg_match( '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/', (string) ( $released['imported_at'] ?? '' ) ),
+	'provenance-records-utc-import-timestamp',
+	(string) ( $released['imported_at'] ?? '' )
+);
+$assert( '2026-08-29T12:00:00Z' === ( Static_Site_Importer_Build_Provenance::describe( '2026-08-29T12:00:00Z' )['imported_at'] ?? '' ), 'provenance-accepts-explicit-timestamp' );
+$assert( ! array_key_exists( 'development_package', $released ), 'released-package-omits-development-receipt' );
+
+$assert( array() === Static_Site_Importer_Build_Provenance::development_package_receipt( $package_root ), 'absent-receipt-reads-empty' );
+
+file_put_contents( $receipt_path, 'not json' );
+$assert( array() === Static_Site_Importer_Build_Provenance::development_package_receipt( $package_root ), 'unreadable-receipt-reads-empty' );
+
+file_put_contents( $receipt_path, wp_json_encode_fixture( array( 'schema' => 'some/other/schema', 'static_site_importer' => array( 'head' => 'a' ) ) ) );
+$assert( array() === Static_Site_Importer_Build_Provenance::development_package_receipt( $package_root ), 'foreign-schema-receipt-is-rejected' );
+
+$packaged = array(
+	'schema'               => Static_Site_Importer_Build_Provenance::DEVELOPMENT_PACKAGE_SCHEMA,
+	'command'              => 'npm run build:dev-package',
+	'static_site_importer' => array(
+		'head'        => str_repeat( 'a', 40 ),
+		'dirty'       => true,
+		'diff_sha256' => str_repeat( 'b', 64 ),
+	),
+	'blocks_engine'        => array(
+		'ref' => 'origin/trunk',
+		'sha' => str_repeat( 'c', 40 ),
+	),
+	'composer_lock_sha256' => str_repeat( 'd', 64 ),
+);
+file_put_contents( $receipt_path, wp_json_encode_fixture( $packaged ) );
+
+$assert( $packaged === Static_Site_Importer_Build_Provenance::development_package_receipt( $package_root ), 'development-receipt-is-read-verbatim' );
+
+define( 'STATIC_SITE_IMPORTER_PATH', $package_root . '/' );
+$development = Static_Site_Importer_Build_Provenance::describe();
+$assert( $packaged === ( $development['development_package'] ?? array() ), 'development-package-identity-reaches-provenance' );
+$assert( '1.8.1' === ( $development['static_site_importer']['version'] ?? '' ), 'development-package-keeps-release-version' );
+
+unlink( $receipt_path );
+rmdir( $package_root );
+
+if ( $failures ) {
+	echo implode( "\n", $failures ) . "\n";
+	echo 'FAILED: build-provenance smoke (' . count( $failures ) . ' of ' . $assertions . " assertions)\n";
+	exit( 1 );
+}
+
+echo 'OK: build-provenance smoke passed (' . $assertions . " assertions)\n";
+
+/**
+ * Encode fixture receipts without depending on WordPress helpers.
+ *
+ * @param array<string,mixed> $value Receipt payload.
+ * @return string JSON payload.
+ */
+function wp_json_encode_fixture( array $value ): string {
+	return (string) json_encode( $value );
+}

--- a/tests/smoke-import-source-of-truth-manifest.php
+++ b/tests/smoke-import-source-of-truth-manifest.php
@@ -135,6 +135,11 @@ $assert( ! is_wp_error( $user_id ), 'user-page-created', is_wp_error( $user_id )
 		$assert( $stale_id > 0, 'first-import-created-stale-page' );
 		$assert( false !== file_put_contents( $unknown_file_path, '<!-- user file -->' ), 'unknown-file-created' );
 		$assert( $manifest === ( $report['source_of_truth'] ?? array() ), 'report-embeds-written-manifest' );
+		$build = $manifest['build'] ?? array();
+		$assert( Static_Site_Importer_Build_Provenance::SCHEMA === ( $build['schema'] ?? '' ), 'manifest-records-build-provenance' );
+		$assert( STATIC_SITE_IMPORTER_VERSION === ( $build['static_site_importer']['version'] ?? '' ), 'manifest-records-importer-version' );
+		$assert( '' !== (string) ( $build['blocks_engine']['php_transformer'] ?? '' ), 'manifest-records-blocks-engine-version' );
+		$assert( 1 === preg_match( '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/', (string) ( $build['imported_at'] ?? '' ) ), 'manifest-records-import-timestamp' );
 		$desired_kinds = array();
 		foreach ( $manifest['desired']['files'] ?? array() as $file ) {
 			if ( is_array( $file ) ) {

--- a/tools/build-dev-package.mjs
+++ b/tools/build-dev-package.mjs
@@ -8,6 +8,10 @@ import { fileURLToPath } from "node:url"
 const root = dirname(dirname(fileURLToPath(import.meta.url)))
 const schema = "static-site-importer/development-package-provenance/v1"
 
+// Shipped inside the package so an imported site can name the build that produced it.
+// Static_Site_Importer_Build_Provenance reads this file from the plugin root at import time.
+export const packagedIdentityFile = "build-provenance.json"
+
 export function parseArguments(argv, cwd = process.cwd()) {
   const options = {
     blocksEnginePath: resolve(cwd, "../blocks-engine"),
@@ -53,7 +57,7 @@ export function developmentComposerManifest(manifest, packageRoot) {
   }
 }
 
-export function provenance({ ssiSha, ssiDiff, blocksEngineSha, blocksEngineRef, composerLock, zip }) {
+export function buildIdentity({ ssiSha, ssiDiff, blocksEngineSha, blocksEngineRef, composerLock }) {
   return {
     schema,
     command: "npm run build:dev-package",
@@ -64,8 +68,11 @@ export function provenance({ ssiSha, ssiDiff, blocksEngineSha, blocksEngineRef, 
     },
     blocks_engine: { ref: blocksEngineRef, sha: blocksEngineSha },
     composer_lock_sha256: digest(composerLock),
-    zip: { file: basename(zip.path), sha256: digest(zip.bytes) },
   }
+}
+
+export function provenance({ zip, ...identity }) {
+  return { ...buildIdentity(identity), zip: { file: basename(zip.path), sha256: digest(zip.bytes) } }
 }
 
 export async function overlayWorkingTree(sourceRoot, snapshot, paths) {
@@ -135,6 +142,10 @@ export async function buildDevelopmentPackage(options, dependencies = {}) {
     await writeFile(composerPath, `${JSON.stringify(developmentComposerManifest(manifest, temporaryDirectory), null, 2)}\n`)
     await run("composer", ["update", "automattic/blocks-engine-php-transformer", "automattic/blocks-engine-figma-transformer", "--with-all-dependencies", "--no-dev", "--no-interaction", "--prefer-dist"], { cwd: snapshot })
 
+    const composerLock = await readFile(join(snapshot, "composer.lock"))
+    const identity = { ssiSha, ssiDiff, blocksEngineSha, blocksEngineRef: options.blocksEngineRef, composerLock }
+    await writeFile(join(snapshot, packagedIdentityFile), `${JSON.stringify(buildIdentity(identity), null, 2)}\n`)
+
     await run("homeboy", ["review", "--placement", "local", "build", "static-site-importer", "--path", snapshot], { cwd: snapshot })
     const generatedZip = join(snapshot, "build", "static-site-importer.zip")
     if (!await exists(generatedZip)) throw new Error(`Homeboy completed without the expected artifact: ${generatedZip}`)
@@ -146,14 +157,7 @@ export async function buildDevelopmentPackage(options, dependencies = {}) {
     const outputZip = join(options.outputDir, outputName)
     await mkdir(options.outputDir, { recursive: true })
     await cp(generatedZip, outputZip)
-    const receipt = provenance({
-      ssiSha,
-      ssiDiff,
-      blocksEngineSha,
-      blocksEngineRef: options.blocksEngineRef,
-      composerLock: await readFile(join(snapshot, "composer.lock")),
-      zip: { path: outputZip, bytes: await readFile(outputZip) },
-    })
+    const receipt = provenance({ ...identity, zip: { path: outputZip, bytes: await readFile(outputZip) } })
     const provenancePath = `${outputZip}.json`
     await writeFile(provenancePath, `${JSON.stringify(receipt, null, 2)}\n`)
     return { zip: outputZip, provenance: provenancePath, receipt }

--- a/tools/build-dev-package.test.mjs
+++ b/tools/build-dev-package.test.mjs
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
 import test from "node:test"
-import { buildDevelopmentPackage, commandFailureMessage, developmentComposerManifest, overlayWorkingTree, parseArguments, provenance, worktreeIdentity } from "./build-dev-package.mjs"
+import { buildDevelopmentPackage, buildIdentity, commandFailureMessage, developmentComposerManifest, overlayWorkingTree, packagedIdentityFile, parseArguments, provenance, worktreeIdentity } from "./build-dev-package.mjs"
 
 test("parses explicit Blocks Engine inputs and sensible defaults", () => {
   const defaults = parseArguments([], "/workspace/static-site-importer")
@@ -47,6 +47,18 @@ test("provenance binds immutable refs, the dirty identity, lock, and ZIP", async
   await rm(directory, { recursive: true, force: true })
 })
 
+test("packaged build identity carries the source identity the ZIP digest cannot", () => {
+  const inputs = { ssiSha: "a".repeat(40), ssiDiff: null, blocksEngineSha: "c".repeat(40), blocksEngineRef: "origin/trunk", composerLock: Buffer.from("lock fixture") }
+  const identity = buildIdentity(inputs)
+  assert.equal(identity.schema, "static-site-importer/development-package-provenance/v1")
+  assert.deepEqual(identity.static_site_importer, { head: "a".repeat(40), dirty: false, diff_sha256: null })
+  assert.deepEqual(identity.blocks_engine, { ref: "origin/trunk", sha: "c".repeat(40) })
+  assert.ok(!("zip" in identity), "the identity shipped inside the package cannot digest the package")
+  const { zip, ...receiptIdentity } = provenance({ ...inputs, zip: { path: "/tmp/package.zip", bytes: Buffer.from("zip fixture") } })
+  assert.deepEqual(receiptIdentity, identity)
+  assert.equal(zip.file, "package.zip")
+})
+
 test("orchestration packages modified and untracked source bytes without changing the caller", async () => {
   const fixture = await mkdtemp(join(tmpdir(), "ssi-dev-package-fixture-"))
   const source = join(fixture, "source")
@@ -63,6 +75,7 @@ test("orchestration packages modified and untracked source bytes without changin
   await writeFile(join(source, "vendor", "ignored.txt"), "ignored bytes")
   const commands = []
   let extracted = 0
+  let packagedIdentity = null
   const result = await buildDevelopmentPackage({ blocksEnginePath: engine, blocksEngineRef: "candidate", outputDir: output }, {
     sourceRoot: source,
     temporaryDirectory: temporary,
@@ -73,7 +86,10 @@ test("orchestration packages modified and untracked source bytes without changin
       if (command === "git" && args[0] === "status") return Buffer.from(" M tracked.txt\0?? untracked.txt\0")
       if (command === "git" && args[0] === "ls-files") return Buffer.from("composer.json\0composer.lock\0tracked.txt\0untracked.txt\0")
       if (command === "composer") return writeFile(join(context.cwd, "composer.lock"), "temporary lock")
-      if (command === "homeboy") return Promise.all([readFile(join(context.cwd, "tracked.txt"), "utf8"), readFile(join(context.cwd, "untracked.txt"), "utf8")]).then(([tracked, untracked]) => mkdir(join(context.cwd, "build"), { recursive: true }).then(() => writeFile(join(context.cwd, "build/static-site-importer.zip"), `${tracked}|${untracked}`)))
+      if (command === "homeboy" && args[0] === "review") return Promise.all([readFile(join(context.cwd, "tracked.txt"), "utf8"), readFile(join(context.cwd, "untracked.txt"), "utf8"), readFile(join(context.cwd, packagedIdentityFile), "utf8")]).then(([tracked, untracked, identity]) => {
+        packagedIdentity = JSON.parse(identity)
+        return mkdir(join(context.cwd, "build"), { recursive: true }).then(() => writeFile(join(context.cwd, "build/static-site-importer.zip"), `${tracked}|${untracked}`))
+      })
       return Buffer.from("")
     },
     async extractArchive(_archive, destination) {
@@ -94,6 +110,9 @@ test("orchestration packages modified and untracked source bytes without changin
   assert.equal(result.receipt.static_site_importer.diff_sha256, await worktreeIdentity(source, ["composer.json", "composer.lock", "tracked.txt", "untracked.txt"]))
   await assert.rejects(() => readFile(join(temporary, "static-site-importer", "vendor", "ignored.txt"), "utf8"), /ENOENT/)
   assert.equal((await readFile(result.provenance, "utf8")).includes("candidate"), true)
+  assert.equal(packagedIdentity.blocks_engine.sha, "b".repeat(40), "the build identity is packaged before Homeboy builds the ZIP")
+  assert.equal(packagedIdentity.static_site_importer.diff_sha256, result.receipt.static_site_importer.diff_sha256)
+  assert.equal(packagedIdentity.composer_lock_sha256, result.receipt.composer_lock_sha256)
   await rm(fixture, { recursive: true, force: true })
 })
 


### PR DESCRIPTION
Closes #1387.

## Problem

A finished site kept no trace of the build that produced it. The importer plugin removes itself after an import, and `static-site-importer-manifest.json` recorded only `artifact.provenance[].source_url` and `source_hash` — no importer version, no Blocks Engine version, no timestamp. When two runs of one source site differed, there was no way to tell whether the importer changed or the source did.

That gap is already costing triage. #1386 reports the same source site producing different button geometry on two builds, with the closing observation: *"Neither build records the importer version that produced it."*

## Change

The manifest now carries a `build` record, written once and embedded into the import report along with the rest of the manifest:

```json
"build": {
  "schema": "static-site-importer/build-provenance/v1",
  "imported_at": "2026-08-29T14:39:03Z",
  "static_site_importer": { "version": "1.8.1" },
  "blocks_engine": { "php_transformer": "0.8.0", "figma_transformer": "0.1.3" }
}
```

`Static_Site_Importer_Build_Provenance` is the single place that answers "which build is this?". It reads the running plugin version and the loaded transformer versions rather than inferring them from packaging.

A release version alone does not identify a development package: every dev build off `main` reports the same `1.8.1`. `tools/build-dev-package.mjs` already computes the identity that does — SSI HEAD, dirty-worktree digest, Blocks Engine ref and SHA, Composer lock digest — but wrote it only beside the ZIP, where an imported site can never see it. The builder now also writes that identity to `build-provenance.json` inside the package, and the runtime reports it as `development_package` when present. The ZIP digest stays exclusive to the external receipt, since a package cannot contain its own digest.

Released packages carry no receipt and omit the key, so absence is meaningful rather than an empty structure.

## Verification

Executed on this branch, not asserted from the diff.

**Fast lane** — `npm test`: 70 passed, 0 failed (57 standalone PHP + 13 node).

**Real WordPress runtime** — plugin installed into a disposable Studio site, `wp eval-file tests/smoke-import-source-of-truth-manifest.php`, then the theme manifest read off disk:

```json
"build": {
  "schema": "static-site-importer/build-provenance/v1",
  "imported_at": "2026-08-29T14:39:03Z",
  "static_site_importer": { "version": "1.8.1" },
  "blocks_engine": { "php_transformer": "0.8.0", "figma_transformer": "0.1.3" }
}
```

With a development receipt present in the plugin root, the same runtime reports `development_package` carrying the source commits verbatim.

**Packaging** — `npm run build:dev-package` produced `static-site-importer-dev-45c6c3a4ec33-blocks-engine-a1caccabc2c8.zip`, and `unzip -p … static-site-importer/build-provenance.json` returns the identity with `static_site_importer.head = 45c6c3a4ec33f6ff582abf43e35caa8125fa9778` and `blocks_engine.sha = a1caccabc2c8aa1b2735f9424aa7833e921c7e6e`. The file survives packaging, which is the claim the unit test alone cannot make.

**Coverage added**: `tests/smoke-build-provenance.php` (13 assertions: schema, versions, UTC timestamp shape, released-package omission, unreadable/foreign-schema receipt rejection, dev identity reaching provenance), a `buildIdentity` test asserting the packaged identity excludes the ZIP digest, an orchestration assertion that the identity is written before Homeboy packages, and four manifest assertions in the WordPress-runtime smoke.

**Unrelated pre-existing failures**: `tests/smoke-import-source-of-truth-manifest.php` fails `reimport-removes-and-records-stale-canonical-asset` and `reimport-reports-but-preserves-stale-page` on `main` (`1c56036`) on a virgin Studio site, identically to this branch. Not introduced here; filing separately.

## Notes for review

- The manifest gains a key without changing `static-site-importer/source-of-truth-manifest/v1`; every existing reader keys by name and is unaffected.
- `imported_at` makes the manifest intentionally non-deterministic across runs, which is the point of the issue.
- `build-provenance.json` is added to the `website-artifact-import` runtime-package profile so constrained-runtime packages keep the identity too.

## AI assistance

Claude Opus 4.5 via OpenCode investigated the manifest writer and package builder, implemented the change, wrote the tests, and ran the verification above, including the disposable-site runtime import and the development package build. Chris Huber directed the work, reviewed the result, and remains responsible for it.