### PR TITLE
Allow runtimes to provide artifact workspace locks

### DIFF
--- a/includes/class-static-site-importer-artifact-run.php
+++ b/includes/class-static-site-importer-artifact-run.php
@@ -170,6 +170,14 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 		if ( ! is_string( $path ) || is_link( $path ) ) {
 			return new WP_Error( 'static_site_importer_artifact_workspace_path_invalid', 'The workspace lock path is invalid.' );
 		}
+		$provided = function_exists( 'apply_filters' ) ? apply_filters( 'static_site_importer_artifact_workspace_lock', null, 'acquire', $path, null ) : null;
+		if ( null !== $provided ) {
+			return is_wp_error( $provided ) ? $provided : array(
+				'schema' => 'static-site-importer/artifact-workspace-lock/v1',
+				'path'   => $path,
+				'token'  => $provided,
+			);
+		}
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- Opens an importer-owned advisory lock file.
 		$handle = fopen( $path, 'c' );
 		if ( false === $handle || ! flock( $handle, LOCK_EX | LOCK_NB ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock -- Serializes one importer-owned run executor.
@@ -182,6 +190,12 @@ final class Static_Site_Importer_Artifact_Run_Workspace {
 	}
 
 	public function release_lock( $handle ): void {
+		if ( is_array( $handle ) && 'static-site-importer/artifact-workspace-lock/v1' === ( $handle['schema'] ?? '' ) && is_string( $handle['path'] ?? null ) ) {
+			if ( function_exists( 'apply_filters' ) ) {
+				apply_filters( 'static_site_importer_artifact_workspace_lock', null, 'release', $handle['path'], $handle['token'] ?? null );
+			}
+			return;
+		}
 		if ( is_resource( $handle ) ) {
 			flock( $handle, LOCK_UN ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock -- Releases the importer-owned run lock.
 			fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the native stream only after releasing its advisory lock.

--- a/tests/smoke-artifact-run-primitives.php
+++ b/tests/smoke-artifact-run-primitives.php
@@ -5,9 +5,11 @@ class WP_Error { public function __construct( private string $code, private stri
 function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
 function wp_mkdir_p( string $path ): bool { return is_dir( $path ) || mkdir( $path, 0777, true ); }
 function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
+function apply_filters( string $hook, $value, ...$args ) { return isset( $GLOBALS['ssi_artifact_filters'][ $hook ] ) ? $GLOBALS['ssi_artifact_filters'][ $hook ]( $value, ...$args ) : $value; }
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-run.php';
 $root = sys_get_temp_dir() . '/ssi-artifact-primitives-' . bin2hex( random_bytes( 4 ) ); wp_mkdir_p( $root ); file_put_contents( $root . '/unrelated.txt', 'keep' );
 $workspace = new Static_Site_Importer_Artifact_Run_Workspace( $root, 'test', array( 'on_success' => 'purge_on_success' ) );
+$released = null; $GLOBALS['ssi_artifact_filters']['static_site_importer_artifact_workspace_lock'] = static function ( $value, string $operation, string $path, $token ) use ( &$released ) { if ( 'acquire' === $operation ) { return 'provider-token'; } $released = array( $path, $token ); return true; }; $provided_lock = $workspace->acquire_lock( 'provided.lock' ); $workspace->release_lock( $provided_lock ); unset( $GLOBALS['ssi_artifact_filters']['static_site_importer_artifact_workspace_lock'] ); if ( ! is_array( $provided_lock ) || 'provider-token' !== ( $provided_lock['token'] ?? '' ) || array( $workspace->directory() . '/provided.lock', 'provider-token' ) !== $released ) { throw new RuntimeException( 'workspace locks must support an opaque runtime-owned acquire and release contract' ); }
 if ( ! is_wp_error( $workspace->path( '../escape' ) ) || ! is_wp_error( $workspace->publish_raw( '/escape', 'x' ) ) ) { throw new RuntimeException( 'workspace must reject path traversal and absolute paths' ); }
 if ( is_wp_error( $workspace->publish_raw( 'nested/evidence.bin', 'evidence' ) ) ) { throw new RuntimeException( 'workspace must atomically publish owned bytes' ); }
 $cache = new Static_Site_Importer_Artifact_Byte_Cache( $workspace, 'payload', 1, 1024 ); $cache->put( 'one', 'body', array( 'kind' => 'test' ) ); $hit = $cache->get( 'one' ); $cache->hit();


### PR DESCRIPTION
## Summary

- let an embedding runtime provide artifact workspace lock acquisition and release
- preserve the native non-blocking `flock()` implementation as the default
- pass the provider's opaque acquisition token back during release

## Problem

Artifact workspace execution currently requires filesystem `flock()`. Shared filesystems that support the workspace files but do not provide advisory locks return `No locks available`, preventing every continuation from entering the otherwise valid workspace.

## Contract

The `static_site_importer_artifact_workspace_lock` filter receives the operation, validated lock path, and release token. Returning `null` during acquisition preserves SSI's native lock. A provider returns an opaque token on successful acquisition or `WP_Error` on contention/failure; SSI returns that exact token to the provider on release.

## Verification

- `npm test`
- `npm run test:all` (`70` passed, `0` failed; runtime/operator suites skipped by manifest)
- `php tests/smoke-artifact-run-primitives.php`
- `php tests/smoke-direct-artifact-import.php`
- PHP syntax checks and `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the workspace lock failure, implemented the runtime-provider seam and opaque-token coverage, and ran the verification commands. Chris Huber directed the work and is responsible for the change.