### PR TITLE
Forward the pixelmatch colour threshold to the visual comparator

### DIFF
--- a/lib/fixture-matrix/run-config.mjs
+++ b/lib/fixture-matrix/run-config.mjs
@@ -29,7 +29,11 @@ export const FIXTURE_MATRIX_RUN_FIELDS = Object.freeze({
   visualParityMaxVerticalShift: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_VERTICAL_SHIFT', number: true, projections: { gate: 'visualParity.maxVerticalShift' } },
   visualParityMaxHorizontalShift: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_MAX_HORIZONTAL_SHIFT', number: true, projections: { gate: 'visualParity.maxHorizontalShift' } },
   visualParityOffsetTolerance: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_OFFSET_TOLERANCE', number: true, projections: { gate: 'visualParity.offsetTolerance' } },
-  visualParityPixelmatchThreshold: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD', number: true, projections: { gate: 'visualParity.pixelmatchThreshold' } },
+  // Projects into BOTH surfaces: the recipe forwards it to the comparator as
+  // pixelmatch's colour distance, and the gate reuses it for host-side alignment
+  // scoring. A gate-only projection left the comparator on its own default and
+  // made the configured value inert (Refs #1404).
+  visualParityPixelmatchThreshold: { env: 'SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXELMATCH_THRESHOLD', number: true, projections: { recipe: 'visualParityPixelmatchThreshold', gate: 'visualParity.pixelmatchThreshold' } },
   maxExplanationElements: { env: 'SSI_FIXTURE_MATRIX_MAX_EXPLANATION_ELEMENTS', integer: { min: 1 }, projections: { recipe: 'maxExplanationElements' } },
   maxExplanationCandidates: { env: 'SSI_FIXTURE_MATRIX_MAX_EXPLANATION_CANDIDATES', integer: { min: 1 }, projections: { recipe: 'maxExplanationCandidates' } },
   explainSelectors: { env: 'SSI_FIXTURE_MATRIX_EXPLAIN_SELECTORS', list: true, projections: { recipe: 'explainSelectors' } },

--- a/lib/fixture-matrix/shared/constants.mjs
+++ b/lib/fixture-matrix/shared/constants.mjs
@@ -76,7 +76,22 @@ export const NON_NATIVE_FALLBACK_BLOCK_NAMES = new Set([CORE_HTML_BLOCK_NAME, 'c
 // positive `--min-native-rate`/`minNativeRate` threshold.
 export const LOW_NATIVE_CONVERSION_KIND = 'native_conversion_rate_below_min';
 
+// Two distinct quantities, deliberately named apart because conflating them
+// produced a gate that demanded a bit-exact render (Refs #1404, #1358):
+//
+// - PIXEL threshold: the allowed FRACTION of mismatched pixels. Gated host-side
+//   by the visual-parity collector. Zero means a single mismatched pixel fails.
+// - PIXELMATCH threshold: pixelmatch's PER-PIXEL colour distance, forwarded to
+//   `wordpress.visual-compare` as its `threshold` option. It decides whether a
+//   pixel counts as mismatched at all.
+//
+// The colour threshold defaults to 0.01 rather than pixelmatch's own 0.1: 0.1
+// tolerates a 27-level shift, which is visible and far too loose for a gate that
+// exists to prove 1:1 parity, while 0.01 absorbs the sub-perceptual +/-2/255 drift
+// headless rasterisation produces between runs and still flags any pixel
+// differing by 3 levels or more.
 export const DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD = 0;
+export const DEFAULT_VISUAL_PARITY_PIXELMATCH_THRESHOLD = 0.01;
 // Candidate (imported WordPress output) URL. The per-fixture import step runs
 // with activate=true, which sets `show_on_front=page` + `page_on_front` to the
 // imported front page (see Static_Site_Importer_Theme_Generator::front_page_id).

--- a/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -9,7 +9,7 @@
  * Internal dependencies
  */
 import {
-  DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD,
+  DEFAULT_VISUAL_PARITY_PIXELMATCH_THRESHOLD,
   DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
   DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL,
   DEFAULT_VISUAL_PARITY_VIEWPORT,
@@ -70,7 +70,12 @@ export function visualParityCompareStep(input = {}) {
         durationMs: options.duration,
         blockExternalRequests: options.blockExternalRequests,
         candidateRequiredReadinessRecord: '#static-site-importer-font-readiness',
-        threshold: options.pixelThreshold,
+        // `threshold` is pixelmatch's per-pixel colour distance, not a count of
+        // allowed pixels: wp-codebox passes it straight into
+        // `pixelmatch(..., { threshold })`. The allowed FRACTION of mismatched
+        // pixels is `pixelThreshold`, gated host-side by the visual-parity
+        // collector, and must never be sent here (Refs #1404).
+        threshold: options.pixelmatchThreshold,
         ...(options.animatedMedia ? { animatedMedia: options.animatedMedia } : {}),
         ...(options.maxExplanationElements ? { maxExplanationElements: options.maxExplanationElements } : {}),
         ...(options.maxExplanationCandidates ? { maxExplanationCandidates: options.maxExplanationCandidates } : {}),
@@ -95,7 +100,10 @@ export function visualParityCompareStep(input = {}) {
 export function normalizeVisualParityRecipeOptions(input = {}) {
   const viewport = objectValue(input.visualParityViewport || input.visual_parity_viewport || input.viewport);
   return {
-    pixelThreshold: finiteNumber(input.pixelThreshold ?? input.pixel_threshold ?? input.visualParityPixelThreshold ?? input.visual_parity_pixel_threshold, DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD),
+    // Only the colour distance belongs in recipe options. The allowed fraction of
+    // mismatched pixels never reaches the comparator, so keeping it here invited
+    // the two to be swapped (#1404); it is resolved from gate config instead.
+    pixelmatchThreshold: finiteNumber(input.visualParityPixelmatchThreshold ?? input.visual_parity_pixelmatch_threshold ?? input.pixelmatchThreshold ?? input.pixelmatch_threshold, DEFAULT_VISUAL_PARITY_PIXELMATCH_THRESHOLD),
     candidateUrl: input.visualParityCandidateUrl || input.visual_parity_candidate_url || input.candidateUrl || DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
     sourceBaseUrl: input.visualParitySourceBaseUrl || input.visual_parity_source_base_url || input.sourceBaseUrl || DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL,
     sourceEntry: input.visualParitySourceEntry || input.visual_parity_source_entry || input.sourceEntry || '',

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -773,6 +773,32 @@ test('fixture matrix run config projects an explicit visual viewport into browse
   assert.equal(fixtureMatrixHomeboySettings(config).SSI_FIXTURE_MATRIX_VISUAL_PARITY_VIEWPORT_HEIGHT, '844');
 });
 
+test('configured pixelmatch colour threshold reaches the comparator and the pixel-count gate stays host-side', () => {
+  const config = normalizeFixtureMatrixRunConfig({
+    fixtureRoot: '/tmp/fixtures',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    pixelThreshold: 0,
+    visualParityPixelmatchThreshold: 0.01,
+  });
+
+  // The colour distance must reach the recipe, because `wordpress.visual-compare`
+  // passes its `threshold` option straight into `pixelmatch`. A gate-only
+  // projection leaves the comparator on a value nobody configured (#1404).
+  const input = fixtureMatrixRecipeInput(config);
+  assert.equal(input.visualParityPixelmatchThreshold, 0.01);
+  assert.equal(fixtureMatrixGateConfig(config).visualParity.pixelmatchThreshold, 0.01);
+  assert.equal(fixtureMatrixGateConfig(config).visualParity.threshold, 0);
+
+  const comparison = visualCompareMatrixComparison(visualParityCompareStep({ fixture: { id: 'shop' }, ...input }));
+  assert.equal(comparison.threshold, 0.01, 'the comparator receives the colour distance, not the allowed pixel fraction');
+
+  // The allowed FRACTION of mismatched pixels gates host-side and must never be
+  // sent as the comparator's colour distance: at 0 it demands a bit-exact render.
+  const zeroFraction = visualCompareMatrixComparison(visualParityCompareStep({ fixture: { id: 'shop' }, pixelThreshold: 0 }));
+  assert.equal(zeroFraction.threshold, 0.01);
+  assert.notEqual(zeroFraction.threshold, 0);
+});
+
 test('runtime presentation evidence persists, merges, and reaches the Blocks Engine compilation input in order', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'runtime-presentation-evidence' });
   const defaultRecipe = buildFixtureMatrixRecipe({ matrix, artifactsDirectory: '/tmp/artifacts', staticSiteImporterPath: '/tmp/static-site-importer' });
@@ -7045,6 +7071,7 @@ test('recipe runs a wordpress.visual-compare visual-parity step after each impor
     artifactsDirectory: '/tmp/artifacts',
     staticSiteImporterPath: '/tmp/static-site-importer',
     pixelThreshold: 0.05,
+    visualParityPixelmatchThreshold: 0.05,
   });
 
   // Resolve semantic phases so transport steps can be inserted without weakening the ordering contract.
@@ -7067,7 +7094,7 @@ test('recipe runs a wordpress.visual-compare visual-parity step after each impor
   });
   const defaultThresholdVisualStep = defaultThresholdRecipe.workflow.steps.find((step) => step.command === 'wordpress.visual-compare');
   assert.equal(defaultThresholdVisualStep.command, 'wordpress.visual-compare');
-  assert.equal(visualCompareMatrixComparison(defaultThresholdVisualStep).threshold, 0, 'visual parity defaults to exact pixel parity');
+  assert.equal(visualCompareMatrixComparison(defaultThresholdVisualStep).threshold, 0.01, 'visual parity defaults to a sub-perceptual colour distance, not a bit-exact render');
 
   const disabled = buildFixtureMatrixRecipe({
     matrix,
@@ -7081,7 +7108,7 @@ test('recipe runs a wordpress.visual-compare visual-parity step after each impor
 test('visualParityCompareStep composes the existing wordpress.visual-compare command with per-fixture overrides', () => {
   const step = visualParityCompareStep({
     fixture: { id: 'shop', source_url: 'http://127.0.0.1:4173/shop/index.html', candidate_url: '/?p=42' },
-    pixelThreshold: 0.2,
+    visualParityPixelmatchThreshold: 0.2,
   });
   assert.equal(step.command, 'wordpress.visual-compare');
   assert.equal(step.allowFailure, true);
@@ -7118,7 +7145,7 @@ test('visual attribution options normalize positive limits and targeted selector
 
 test('visual parity defaults require the candidate font readiness record', () => {
   const step = visualParityCompareStep({ fixture: { id: 'shop' } });
-  assert.equal(step.args[0], 'matrix-json={"comparisons":[{"name":"shop","sourceUrl":"/wp-content/uploads/static-site-importer-fixture-matrix/shop/source/index.html","candidateUrl":"/","sourceLabel":"shop-source","candidateLabel":"shop-candidate","viewport":"1280x1600","fullPage":true,"waitFor":"duration","durationMs":"4000ms","blockExternalRequests":true,"candidateRequiredReadinessRecord":"#static-site-importer-font-readiness","threshold":0}]}');
+  assert.equal(step.args[0], 'matrix-json={"comparisons":[{"name":"shop","sourceUrl":"/wp-content/uploads/static-site-importer-fixture-matrix/shop/source/index.html","candidateUrl":"/","sourceLabel":"shop-source","candidateLabel":"shop-candidate","viewport":"1280x1600","fullPage":true,"waitFor":"duration","durationMs":"4000ms","blockExternalRequests":true,"candidateRequiredReadinessRecord":"#static-site-importer-font-readiness","threshold":0.01}]}');
 });
 
 test('visual attribution options reach every fixture matrix comparison', () => {


### PR DESCRIPTION
Closes #1404. Refs #1358.

## Problem

Two different quantities were both called "threshold", and the visual-parity recipe step sent the wrong one to the comparator.

- **`--pixel-threshold`** is the allowed *fraction of mismatched pixels*, gated host-side by the visual-parity collector. The promotion gate sets it to `0`.
- **`threshold`** in the `wordpress.visual-compare` contract is pixelmatch's *per-pixel colour distance*. wp-codebox passes it straight into `pixelmatch(..., { threshold })`.

`visual-parity-step.mjs` sent the first as the second:

```js
threshold: options.pixelThreshold,   // 0
```

So the comparator ran at colour threshold `0`, where a pixel counts as mismatched when any channel differs by `1/255`. Combined with a zero allowed fraction, the gate required a **bit-exact render** across two independent headless browser runs — which rasterisation does not guarantee.

Meanwhile `--visual-parity-pixelmatch-threshold`, the flag that is supposed to control the colour distance, projected into gate config **only**:

```js
visualParityPixelmatchThreshold: { ..., projections: { gate: 'visualParity.pixelmatchThreshold' } },
```

It never reached the recipe, so it never reached the comparator. That is why `8755c30` raising it from `0` to `0.01` for #1358 did not stop the failures: the value was inert. The failing run's own artifact records `"options": { "threshold": 0 }` while the workflow passed `0.01`.

## Change

- Project `visualParityPixelmatchThreshold` into the **recipe** as well as the gate.
- Send it as the comparison's `threshold`.
- Remove `pixelThreshold` from recipe options entirely. It has no consumer there — the collector resolves the pixel fraction from gate config — and its presence in that namespace is what invited the swap.
- Unset now defaults to `0.01` instead of `0`, with both constants documented side by side so the distinction is stated where the values live.

`0.01` rather than pixelmatch's own `0.1`: `0.1` tolerates a 27-level shift, which is visible and far too loose for a gate that exists to prove 1:1 parity. `0.01` absorbs the sub-perceptual ±2/255 drift renderers produce and still fails any pixel differing by three levels or more. `--pixel-threshold 0` and both shift tolerances are unchanged, so one perceptibly different pixel, or any layout movement, still fails the gate.

## Verification

Evaluating the exact expression the promotion gate runs (`bench/static-site-fixture-matrix.bench.mjs:446`) with the workflow's own flags:

```
comparator threshold = 0.01
```

Before this change the same expression produced `0`.

`node --test tools/fixture-matrix.test.mjs`: 281 passed. `npm test`: 70 passed. Local `homeboy review lint`: passed.

New test asserts the full chain and both directions of the distinction:

```js
assert.equal(input.visualParityPixelmatchThreshold, 0.01);              // reaches the recipe
assert.equal(comparison.threshold, 0.01);                              // reaches the comparator
assert.equal(fixtureMatrixGateConfig(config).visualParity.threshold, 0); // fraction stays host-side
assert.notEqual(zeroFraction.threshold, 0);                            // fraction never becomes colour distance
```

Three existing tests encoded the old conflated contract (`pixelThreshold` driving the comparator, and a byte-exact `matrix-json` carrying `"threshold":0`); they are updated to the corrected contract rather than worked around.

## Note on the second-order effect in #1404

The report also flagged `collectors/visual-parity.mjs` preferring the comparator's echoed `threshold` over the configured value in the alignment path. That resolves itself here: the echoed value is now the configured value, so the two agree. Left as-is rather than changing precedence, since there is no longer a disagreement to arbitrate.

## AI assistance

Claude Opus 4.5 via OpenCode traced the flag from the workflow through run-config projection and the recipe step into the wp-codebox pixelmatch call, implemented the fix, updated the tests that encoded the old contract, and verified the gate's own expression now yields the configured value. Chris Huber directed the work, reviewed the result, and remains responsible for it.