### PR TITLE
Fix staged source assets and capture fidelity

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -965,7 +965,7 @@ $content     = preg_replace_callback(
 
 $global = array(
 	'aria-controls' => true, 'aria-current' => true, 'aria-describedby' => true, 'aria-details' => true,
-	'aria-expanded' => true, 'aria-hidden' => true, 'aria-label' => true, 'aria-labelledby' => true,
+	'aria-disabled' => true, 'aria-expanded' => true, 'aria-hidden' => true, 'aria-label' => true, 'aria-labelledby' => true,
 	'aria-live' => true, 'class' => true, 'data-*' => true, 'dir' => true, 'hidden' => true, 'id' => true,
 	'lang' => true, 'role' => true, 'style' => true, 'tabindex' => true, 'title' => true, 'xml:lang' => true,
 );
@@ -1120,6 +1120,7 @@ $global = array(
 	'aria-current'     => true,
 	'aria-describedby' => true,
 	'aria-details'     => true,
+	'aria-disabled'    => true,
 	'aria-expanded'    => true,
 	'aria-hidden'      => true,
 	'aria-label'       => true,

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -844,9 +844,21 @@ class Static_Site_Importer_Companion_Plugin {
 $content = preg_replace( '#<\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\b[^>]*>.*?</\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\s*>#is', '', $content ) ?? '';
 $content = preg_replace( '#<\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\b[^>]*/?\s*>#is', '', $content ) ?? '';
 $content = preg_replace( '#</?\s*[a-z][a-z0-9]*-[a-z0-9-]+\b[^>]*>#i', '', $content ) ?? '';
-$content = preg_replace( '/\s+(?:on[a-z0-9_-]+|data-wp-[a-z0-9_-]+)\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $content ) ?? '';
-$content = preg_replace( '/\s+(?:on[a-z0-9_-]+|data-wp-[a-z0-9_-]+)\s*=\s*(?=\/?>)/i', '', $content ) ?? '';
-$content = preg_replace( '/\s+(?:on[a-z0-9_-]+|data-wp-[a-z0-9_-]+)(?=\s|\/?>)/i', '', $content ) ?? '';
+$content = preg_replace_callback(
+	'#<[a-z](?:"[^"]*"|\'[^\']*\'|=>|[^>])*>#i',
+	static function ( array $match ): string {
+		return preg_replace(
+			array(
+				'/\s+(?:on[a-z0-9_-]+|data-wp-[a-z0-9_-]+)\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s>]+)/i',
+				'/\s+(?:on[a-z0-9_-]+|data-wp-[a-z0-9_-]+)\s*=\s*(?=\/?>)/i',
+				'/\s+(?:on[a-z0-9_-]+|data-wp-[a-z0-9_-]+)(?=\s|\/?>)/i',
+			),
+			'',
+			$match[0]
+		) ?? '';
+	},
+	$content
+) ?? '';
 
 $safe_url = static function ( string $url, bool $image = false ): bool {
 	$normalized = strtolower( preg_replace( '/[\x00-\x20\x7f]+/', '', html_entity_decode( $url, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ) ?? '' );

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -993,6 +993,10 @@ if ( preg_match_all( '/\s+(aria-[a-z][a-z0-9-]*)\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\
 		$svg_global[ strtolower( $aria_name ) ] = true;
 	}
 }
+$safe_style_css = static function ( array $properties ): array {
+	return array_values( array_unique( array_merge( $properties, array( 'overflow-x', 'overflow-y' ) ) ) );
+};
+add_filter( 'safe_style_css', $safe_style_css );
 $output = wp_kses(
 	$content,
 	array(
@@ -1029,6 +1033,7 @@ $output = wp_kses(
 		'tspan' => array_merge( $svg_global, array( 'dx' => true, 'dy' => true, 'fill' => true, 'x' => true, 'y' => true ) ), 'title' => $svg_global, 'desc' => $svg_global,
 	)
 );
+remove_filter( 'safe_style_css', $safe_style_css );
 foreach ( $data_images as $placeholder => $data_image ) {
 	$output = str_replace( 'src="' . $placeholder . '"', 'src="' . esc_attr( $data_image ) . '"', $output );
 	$output = str_replace( "src='" . $placeholder . "'", "src='" . esc_attr( $data_image ) . "'", $output );

--- a/includes/class-static-site-importer-font-materializer.php
+++ b/includes/class-static-site-importer-font-materializer.php
@@ -44,12 +44,7 @@ final class Static_Site_Importer_Font_Materializer {
 				if ( self::uses_inferred_google_fallback( $plan ) ) {
 					$producer_faces = null;
 				} elseif ( ! empty( $diagnostics ) || ! self::resolved_plan_has_google_stylesheet( $resolved_plan ) ) {
-					return array(
-						'writes'         => array(),
-						'diagnostics'    => $diagnostics,
-						'faces'          => array(),
-						'required_faces' => array(),
-					);
+					return self::with_runtime_registration( array(), $resolved_plan, array(), $diagnostics, array(), array(), array(), false );
 				}
 			} else {
 				$materialized = self::materialize_producer_faces( $producer_faces, $diagnostics );

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -158,10 +158,16 @@ function rewriteStagedSourceHtml(html, relativePath) {
   const attributes = html.replace(/\b(href|src|poster|action)\s*=\s*(["'])(\/(?!\/)[^"']*)\2/gi, (_match, name, quote, url) => (
     `${name}=${quote}${stagedSourceUrl(url, relativePath)}${quote}`
   ));
-  return attributes.replace(/\bsrcset\s*=\s*(["'])([^"']*)\1/gi, (_match, quote, value) => {
+  const srcsets = attributes.replace(/\bsrcset\s*=\s*(["'])([^"']*)\1/gi, (_match, quote, value) => {
     const rebased = value.replace(/(^|,\s*)(\/(?!\/)[^\s,]+)/g, (_candidate, separator, url) => `${separator}${stagedSourceUrl(url, relativePath)}`);
     return `srcset=${quote}${rebased}${quote}`;
   });
+  const styleAttributes = srcsets.replace(/(\sstyle\s*=\s*)(["'])([\s\S]*?)\2/gi, (_match, prefix, quote, css) => (
+    `${prefix}${quote}${rewriteStagedSourceCss(css, relativePath)}${quote}`
+  ));
+  return styleAttributes.replace(/(<style\b[^>]*>)([\s\S]*?)(<\/style>)/gi, (_match, opening, css, closing) => (
+    `${opening}${rewriteStagedSourceCss(css, relativePath)}${closing}`
+  ));
 }
 
 function rewriteStagedSourceCss(css, relativePath) {

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -135,10 +135,10 @@ export function stageFixtureSource(fixture, fixtureDirectory, options = {}) {
     fs.mkdirSync(path.dirname(destination), { recursive: true });
     if (isHtmlPath(file.relative_path)) {
       const result = normalizeSourceHtml(fs.readFileSync(file.absolute_path, 'utf8'), `website/${file.relative_path}`);
-      fs.writeFileSync(destination, result.html);
+      fs.writeFileSync(destination, rewriteStagedSourceHtml(result.html, file.relative_path));
       injectDeterministicSourceCss(destination, sourceRoot);
     } else if (isCssPath(file.relative_path)) {
-      fs.copyFileSync(file.absolute_path, destination);
+      fs.writeFileSync(destination, rewriteStagedSourceCss(fs.readFileSync(file.absolute_path, 'utf8'), file.relative_path));
       localizeSourceFontStylesheets(destination, sourceRoot);
     } else {
       fs.copyFileSync(file.absolute_path, destination);
@@ -146,6 +146,28 @@ export function stageFixtureSource(fixture, fixtureDirectory, options = {}) {
     staged.push(file.relative_path);
   }
   return staged;
+}
+
+function stagedSourceUrl(url, relativePath) {
+  if (!url.startsWith('/') || url.startsWith('//')) return url;
+  const prefix = path.posix.relative(path.posix.dirname(relativePath.replace(/\\/g, '/')), '.') || '.';
+  return `${prefix}/${url.slice(1)}`;
+}
+
+function rewriteStagedSourceHtml(html, relativePath) {
+  const attributes = html.replace(/\b(href|src|poster|action)\s*=\s*(["'])(\/(?!\/)[^"']*)\2/gi, (_match, name, quote, url) => (
+    `${name}=${quote}${stagedSourceUrl(url, relativePath)}${quote}`
+  ));
+  return attributes.replace(/\bsrcset\s*=\s*(["'])([^"']*)\1/gi, (_match, quote, value) => {
+    const rebased = value.replace(/(^|,\s*)(\/(?!\/)[^\s,]+)/g, (_candidate, separator, url) => `${separator}${stagedSourceUrl(url, relativePath)}`);
+    return `srcset=${quote}${rebased}${quote}`;
+  });
+}
+
+function rewriteStagedSourceCss(css, relativePath) {
+  return css
+    .replace(/url\(\s*(["']?)(\/(?!\/)[^"')\s]+)\1\s*\)/gi, (_match, quote, url) => `url(${quote}${stagedSourceUrl(url, relativePath)}${quote})`)
+    .replace(/(@import\s+)(["'])(\/(?!\/)[^"']+)\2/gi, (_match, prefix, quote, url) => `${prefix}${quote}${stagedSourceUrl(url, relativePath)}${quote}`);
 }
 
 function normalizeSourceHtml(html, sourcePath) {

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -503,6 +503,8 @@ if ( is_array( $descriptor ) ) {
 	);
 	$assert( str_contains( $edited_output, $edited_url ) && str_contains( $edited_output, 'Edited hero' ) && ! str_contains( $edited_output, $canonical_url ), 'editable-render-reflects-saved-content-edit', $edited_output );
 	$assert( ! str_contains( $edited_output, '<script' ) && ! str_contains( $edited_output, 'onclick' ), 'editable-render-sanitizes-current-content-at-server-boundary', $edited_output );
+	$stateful_output = $render_frontend( $render, array( 'content' => '<div class="button" aria-disabled="false"><a href="#target">Try Me</a></div>' ) );
+	$assert( str_contains( $stateful_output, 'aria-disabled="false"' ), 'editable-render-preserves-aria-disabled-state-for-authored-selectors', $stateful_output );
 
 	// Inline SVG artwork in editable companion content renders instead of
 	// being deleted by a sanitization boundary without SVG elements (#1361).

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -171,6 +171,10 @@ if ( ! function_exists( 'add_filter' ) ) {
 	function add_filter( string $hook, callable|string $callback ): void {}
 }
 
+if ( ! function_exists( 'remove_filter' ) ) {
+	function remove_filter( string $hook, callable|string $callback ): void {}
+}
+
 if ( ! function_exists( 'register_block_type' ) ) {
 	function register_block_type( string $block, array $args = array() ): WP_Block_Type|false {
 		$name = isset( $args['name'] ) ? (string) $args['name'] : '';
@@ -535,7 +539,7 @@ $assert( is_array( $layout_descriptor ), 'layout-renderer-scaffold-returns-descr
 if ( is_array( $layout_descriptor ) ) {
 	$layout_render = $layout_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
 	$assert( str_contains( $layout_render, 'Generated responsive-layout companion block render' ) && ! str_contains( $layout_render, 'Generated responsive-media companion block render' ), 'dedicated-layout-renderer-uses-own-template' );
-	$attributes = array( 'content' => '<main class="story" style="position:absolute;inset:0 auto auto 0;width:405px;height:516.812px;overflow:hidden"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
+	$attributes = array( 'content' => '<main class="story" style="position:absolute;inset:0 auto auto 0;width:405px;height:516.812px;overflow:hidden;overflow-x:visible;overflow-y:clip"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
 	ob_start();
 	eval( '?>' . $layout_render );
 	$layout_output = (string) ob_get_clean();
@@ -544,6 +548,8 @@ if ( is_array( $layout_descriptor ) ) {
 	}
 	$assert( ! str_contains( $layout_output, '<wow-image' ), 'layout-renderer-unwraps-potentially-active-custom-elements' );
 	$assert( str_contains( $layout_output, 'position:absolute' ) && str_contains( $layout_output, 'width:405px' ) && str_contains( $layout_output, 'height:516.812px' ) && str_contains( $layout_output, 'overflow:hidden' ), 'layout-renderer-preserves-quoted-inline-geometry', $layout_output );
+	$assert( str_contains( $layout_output, 'overflow-x:visible' ) && str_contains( $layout_output, 'overflow-y:clip' ), 'layout-renderer-preserves-axis-specific-overflow', $layout_output );
+	$assert( str_contains( $layout_render, "add_filter( 'safe_style_css', \$safe_style_css )" ) && str_contains( $layout_render, "remove_filter( 'safe_style_css', \$safe_style_css )" ), 'layout-renderer-bounds-axis-overflow-css-filter', $layout_render );
 	$attributes = array( 'content' => '<p>Report in one section with online notes only once.</p><button onclick onmouseover="alert(1)" data-wp-interactive>Go</button>' );
 	ob_start();
 	eval( '?>' . $layout_render );

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -544,6 +544,12 @@ if ( is_array( $layout_descriptor ) ) {
 	}
 	$assert( ! str_contains( $layout_output, '<wow-image' ), 'layout-renderer-unwraps-potentially-active-custom-elements' );
 	$assert( str_contains( $layout_output, 'position:absolute' ) && str_contains( $layout_output, 'width:405px' ) && str_contains( $layout_output, 'height:516.812px' ) && str_contains( $layout_output, 'overflow:hidden' ), 'layout-renderer-preserves-quoted-inline-geometry', $layout_output );
+	$attributes = array( 'content' => '<p>Report in one section with online notes only once.</p><button onclick onmouseover="alert(1)" data-wp-interactive>Go</button>' );
+	ob_start();
+	eval( '?>' . $layout_render );
+	$ordinary_on_text_output = strtolower( (string) ob_get_clean() );
+	$assert( str_contains( $ordinary_on_text_output, 'report in one section with online notes only once.' ), 'layout-renderer-preserves-ordinary-on-text', $ordinary_on_text_output );
+	$assert( ! str_contains( $ordinary_on_text_output, 'onclick' ) && ! str_contains( $ordinary_on_text_output, 'onmouseover' ) && ! str_contains( $ordinary_on_text_output, 'data-wp-' ), 'layout-renderer-still-removes-executable-attributes-from-tags', $ordinary_on_text_output );
 
 	$busy_bears_contract = json_decode( (string) file_get_contents( __DIR__ . '/fixtures/busy-bears-responsive-layout-contract.json' ), true );
 	$assert( 'static-site-importer/frozen-responsive-layout-contract/v1' === ( $busy_bears_contract['schema'] ?? '' ) && 2 === count( $busy_bears_contract['pages'] ?? array() ), 'busy-bears-frozen-layout-contract-loads' );

--- a/tests/smoke-webfont-producer-consumer.php
+++ b/tests/smoke-webfont-producer-consumer.php
@@ -187,11 +187,13 @@ $local_plan['webfont_contract'] = array(
 );
 $request_count = count( $GLOBALS['ssi_webfont_requests'] );
 $local_overlay = Static_Site_Importer_Font_Materializer::prepare_overlay( $local_plan, array( 'writes' => array( array( 'target_path' => 'functions.php', 'payload' => array( 'encoding' => 'utf8', 'data' => '<?php' ) ) ) ) );
-$assert( ! is_wp_error( $local_overlay ) && array() === $local_overlay['writes'] && $request_count === count( $GLOBALS['ssi_webfont_requests'] ), 'an authoritative local-font contract never falls back to synthesized Google requests' );
+$local_write_paths = array_column( $local_overlay['writes'] ?? array(), 'target_path' );
+$assert( ! is_wp_error( $local_overlay ) && in_array( 'functions.php', $local_write_paths, true ) && in_array( 'assets/js/font-readiness.js', $local_write_paths, true ) && ! in_array( 'assets/css/embedded-fonts.css', $local_write_paths, true ) && $request_count === count( $GLOBALS['ssi_webfont_requests'] ), 'an authoritative local-font contract emits readiness without falling back to synthesized Google requests' );
 $assert( 'producer_webfont_import_unsupported_provider' === ( $local_overlay['diagnostics'][0]['reason'] ?? '' ), 'non-required local-font producer diagnostics survive the handoff without blocking import' );
 $local_plan['webfont_contract']['diagnostics'] = array();
 $local_overlay_without_diagnostics = Static_Site_Importer_Font_Materializer::prepare_overlay( $local_plan, array( 'writes' => array( array( 'target_path' => 'functions.php', 'payload' => array( 'encoding' => 'utf8', 'data' => '<?php' ) ) ) ) );
-$assert( ! is_wp_error( $local_overlay_without_diagnostics ) && array() === $local_overlay_without_diagnostics['writes'] && $request_count === count( $GLOBALS['ssi_webfont_requests'] ), 'an authoritative zero-face contract without diagnostics still suppresses legacy Google requests' );
+$local_write_paths_without_diagnostics = array_column( $local_overlay_without_diagnostics['writes'] ?? array(), 'target_path' );
+$assert( ! is_wp_error( $local_overlay_without_diagnostics ) && in_array( 'functions.php', $local_write_paths_without_diagnostics, true ) && in_array( 'assets/js/font-readiness.js', $local_write_paths_without_diagnostics, true ) && ! in_array( 'assets/css/embedded-fonts.css', $local_write_paths_without_diagnostics, true ) && $request_count === count( $GLOBALS['ssi_webfont_requests'] ), 'an authoritative zero-face contract emits readiness while suppressing legacy Google requests' );
 
 // Producer-shaped Blocks Engine #1129 contract observed in Coffee Festival.
 $direct_font_url   = 'https://cdn.coffee-festival.example/assets/ObsidianDisplay.woff2';

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -7341,6 +7341,35 @@ test('stageFixtureSource copies the normalized fixture source into the served so
   assert.ok(Number.isFinite(written.metadata.performance.artifact_writing_ms));
 });
 
+test('staged visual source rebases site-root assets without changing the import artifact', () => {
+  const fixtureDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-root-relative-source-'));
+  const sourceDirectory = path.join(fixtureDirectory, 'fixture');
+  mkdirSync(path.join(sourceDirectory, 'nested'), { recursive: true });
+  mkdirSync(path.join(sourceDirectory, 'assets', 'css'), { recursive: true });
+  writeFileSync(path.join(sourceDirectory, 'index.html'), '<link rel="stylesheet" href="/assets/css/site.css"><img src="/media/hero.jpg" srcset="/media/hero.jpg 1x, /media/hero@2x.jpg 2x"><a href="//external.test/page">External</a>');
+  writeFileSync(path.join(sourceDirectory, 'nested', 'index.html'), '<script src="/assets/app.js"></script><a href="#section">Section</a>');
+  writeFileSync(path.join(sourceDirectory, 'assets', 'css', 'site.css'), '@import "/assets/css/base.css"; .hero{background:url(\'/media/hero.jpg?size=large#crop\')} .icon{background:url(data:image/png;base64,AA)}');
+
+  const fixture = { id: 'Root Relative', directory: sourceDirectory };
+  const artifact = buildFixtureArtifact(fixture);
+  const artifactHtml = Buffer.from(artifact.files.find((file) => file.path === 'website/index.html').content_base64, 'base64').toString('utf8');
+  assert.match(artifactHtml, /href="\/assets\/css\/site\.css"/);
+
+  stageFixtureSource(fixture, fixtureDirectory);
+  const rootHtml = readFileSync(path.join(fixtureDirectory, 'source', 'index.html'), 'utf8');
+  const nestedHtml = readFileSync(path.join(fixtureDirectory, 'source', 'nested', 'index.html'), 'utf8');
+  const css = readFileSync(path.join(fixtureDirectory, 'source', 'assets', 'css', 'site.css'), 'utf8');
+  assert.match(rootHtml, /href="\.\/assets\/css\/site\.css"/);
+  assert.match(rootHtml, /src="\.\/media\/hero\.jpg"/);
+  assert.match(rootHtml, /srcset="\.\/media\/hero\.jpg 1x, \.\/media\/hero@2x\.jpg 2x"/);
+  assert.match(rootHtml, /href="\/\/external\.test\/page"/);
+  assert.match(nestedHtml, /src="\.\.\/assets\/app\.js"/);
+  assert.match(nestedHtml, /href="#section"/);
+  assert.match(css, /@import "\.\.\/\.\.\/assets\/css\/base\.css"/);
+  assert.match(css, /url\('\.\.\/\.\.\/media\/hero\.jpg\?size=large#crop'\)/);
+  assert.match(css, /url\(data:image\/png;base64,AA\)/);
+});
+
 test('platform attribution is excluded from both import artifacts and visual baselines', () => {
   const fixtureDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-platform-chrome-source-'));
   const sourceDirectory = path.join(fixtureDirectory, 'fixture');

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -7346,8 +7346,8 @@ test('staged visual source rebases site-root assets without changing the import 
   const sourceDirectory = path.join(fixtureDirectory, 'fixture');
   mkdirSync(path.join(sourceDirectory, 'nested'), { recursive: true });
   mkdirSync(path.join(sourceDirectory, 'assets', 'css'), { recursive: true });
-  writeFileSync(path.join(sourceDirectory, 'index.html'), '<link rel="stylesheet" href="/assets/css/site.css"><img src="/media/hero.jpg" srcset="/media/hero.jpg 1x, /media/hero@2x.jpg 2x"><a href="//external.test/page">External</a>');
-  writeFileSync(path.join(sourceDirectory, 'nested', 'index.html'), '<script src="/assets/app.js"></script><a href="#section">Section</a>');
+  writeFileSync(path.join(sourceDirectory, 'index.html'), '<link rel="stylesheet" href="/assets/css/site.css"><style>@font-face{src:url("/fonts/example.woff2")}</style><img src="/media/hero.jpg" srcset="/media/hero.jpg 1x, /media/hero@2x.jpg 2x" style="background:url(\'/media/hero.jpg\')"><a href="//external.test/page">External</a>');
+  writeFileSync(path.join(sourceDirectory, 'nested', 'index.html'), '<script src="/assets/app.js"></script><style>.hero{background:url(/media/hero.jpg)}</style><a href="#section">Section</a>');
   writeFileSync(path.join(sourceDirectory, 'assets', 'css', 'site.css'), '@import "/assets/css/base.css"; .hero{background:url(\'/media/hero.jpg?size=large#crop\')} .icon{background:url(data:image/png;base64,AA)}');
 
   const fixture = { id: 'Root Relative', directory: sourceDirectory };
@@ -7362,8 +7362,11 @@ test('staged visual source rebases site-root assets without changing the import 
   assert.match(rootHtml, /href="\.\/assets\/css\/site\.css"/);
   assert.match(rootHtml, /src="\.\/media\/hero\.jpg"/);
   assert.match(rootHtml, /srcset="\.\/media\/hero\.jpg 1x, \.\/media\/hero@2x\.jpg 2x"/);
+  assert.match(rootHtml, /url\("\.\/fonts\/example\.woff2"\)/);
+  assert.match(rootHtml, /style="background:url\('\.\/media\/hero\.jpg'\)"/);
   assert.match(rootHtml, /href="\/\/external\.test\/page"/);
   assert.match(nestedHtml, /src="\.\.\/assets\/app\.js"/);
+  assert.match(nestedHtml, /url\(\.\.\/media\/hero\.jpg\)/);
   assert.match(nestedHtml, /href="#section"/);
   assert.match(css, /@import "\.\.\/\.\.\/assets\/css\/base\.css"/);
   assert.match(css, /url\('\.\.\/\.\.\/media\/hero\.jpg\?size=large#crop'\)/);


### PR DESCRIPTION
## Summary

- Rebase same-site root-relative HTML and CSS asset references into the nested fixture-matrix staging tree, including nested documents and stylesheets.
- Emit a loaded font-readiness contract when a generated theme has no materialized font families, so visual capture can deterministically proceed.
- Preserve `aria-disabled`, ordinary `on*` text attributes, and axis-specific overflow styles through the companion renderer safe-markup boundary.

## Why

The fixture matrix staged source files below the WordPress uploads path while root-relative references continued resolving from the preview origin. After correcting those paths, the canonical replay exposed three additional source-to-candidate fidelity losses in readiness and companion sanitization. These changes address each owning boundary rather than compensating in the visual comparator.

Closes #1378.

## Verification

- `npm test` (70 tests)
- `npm run test:inventory`
- `php tests/smoke-companion-plugin.php` (366 assertions)
- `php tests/smoke-webfont-producer-consumer.php`
- Fixture-matrix suite (282 tests)
- PHP syntax checks
- `git diff --check origin/main...HEAD`
- Strict canonical replay for `rlj107.wixsite.com-createanchors`: status `identical`, 0 / 3,776,000 mismatched pixels, Blocks Engine visual parity `pass`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used under human direction to inspect runtime evidence, diagnose the staging and rendering boundaries, implement the fixes and regressions, and execute the verification workflow.