### PR TITLE
Update PHP transformer to 0.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   "require": {
     "php": "^8.2",
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "0.8.0"
+    "automattic/blocks-engine-php-transformer": "0.8.1"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ccb8d7a38b583b9f01f30784e7089c8",
+    "content-hash": "38a60d5f999fe8365086fd27f60cb9c0",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "v0.8.0",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "154c9557e879645ea71d8de2094ce14efd60032e"
+                "reference": "3e758ad53c5b1123e849a4ed672f36a0953bde69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/154c9557e879645ea71d8de2094ce14efd60032e",
-                "reference": "154c9557e879645ea71d8de2094ce14efd60032e",
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/3e758ad53c5b1123e849a4ed672f36a0953bde69",
+                "reference": "3e758ad53c5b1123e849a4ed672f36a0953bde69",
                 "shasum": ""
             },
             "require": {
@@ -91,7 +91,7 @@
                 "issues": "https://github.com/Automattic/blocks-engine/issues",
                 "source": "https://github.com/Automattic/blocks-engine-php-transformer"
             },
-            "time": "2026-08-29T12:52:30+00:00"
+            "time": "2026-08-29T17:26:32+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/tests/smoke-webfont-producer-consumer.php
+++ b/tests/smoke-webfont-producer-consumer.php
@@ -44,7 +44,7 @@ $assert = static function ( bool $condition, string $message ): void {
 	if ( ! $condition ) throw new RuntimeException( $message );
 };
 
-$assert( 'v0.8.0' === \Composer\InstalledVersions::getPrettyVersion( 'automattic/blocks-engine-php-transformer' ), 'producer-consumer integration runs against the locked Blocks Engine php-transformer v0.8.0 dependency' );
+$assert( 'v0.8.1' === \Composer\InstalledVersions::getPrettyVersion( 'automattic/blocks-engine-php-transformer' ), 'producer-consumer integration runs against the locked Blocks Engine php-transformer v0.8.1 dependency' );
 
 $fixture_html = '<!doctype html><html><head><link rel="stylesheet" href="css/style.css"></head><body><main>Inter fixture</main></body></html>';
 $fixture_css  = "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');\n:root{--font:'Inter',system-ui,sans-serif}body{font-family:var(--font)}";


### PR DESCRIPTION
## Summary
- pin Blocks Engine PHP Transformer `0.8.1`
- refresh the immutable Composer lock reference
- update the locked producer-consumer assertion

This includes Automattic/blocks-engine#1380, which keeps nested index candidates from replacing the artifact-selected canonical route root.

## Verification
- `composer validate --strict`
- `npm run test:webfont-producer-consumer`
- `npm test` (70 selected groups passed; one unrelated collector timing threshold missed once)
- `php tests/smoke-url-site-collector.php` (rerun passed, 80 assertions)

## AI assistance
OpenAI `gpt-5.6-sol` via OpenCode updated the immutable dependency lock and version assertion, ran verification, and traced the single timing-only retry. I reviewed and orchestrated the work.