### PR TITLE
Build release ZIPs from the runtime package profile

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -21,6 +21,10 @@
         "bench_env": {
           "STATIC_SITE_IMPORTER_CODEBOX_BROWSER_EVIDENCE": "runtime-post-step"
         },
+        "package_profile": {
+          "manifest": "runtime-package-manifest.json",
+          "profile": "website-artifact-import"
+        },
         "validation_dependencies": [],
         "wordpress_runtime_post_steps": [
           {

--- a/runtime-package-manifest.json
+++ b/runtime-package-manifest.json
@@ -21,10 +21,6 @@
           "path": "static-site-importer.php"
         },
         {
-          "type": "file",
-          "path": "build-provenance.json"
-        },
-        {
           "type": "prefix",
           "path": "blocks/"
         },

--- a/tools/build-dev-package.mjs
+++ b/tools/build-dev-package.mjs
@@ -146,6 +146,11 @@ export async function buildDevelopmentPackage(options, dependencies = {}) {
     const identity = { ssiSha, ssiDiff, blocksEngineSha, blocksEngineRef: options.blocksEngineRef, composerLock }
     await writeFile(join(snapshot, packagedIdentityFile), `${JSON.stringify(buildIdentity(identity), null, 2)}\n`)
 
+    const homeboyPath = join(snapshot, "homeboy.json")
+    const homeboy = JSON.parse(await readFile(homeboyPath, "utf8"))
+    homeboy.extensions.wordpress.settings.package_profile = {}
+    await writeFile(homeboyPath, `${JSON.stringify(homeboy, null, 2)}\n`)
+
     await run("homeboy", ["review", "--placement", "local", "build", "static-site-importer", "--path", snapshot], { cwd: snapshot })
     const generatedZip = join(snapshot, "build", "static-site-importer.zip")
     if (!await exists(generatedZip)) throw new Error(`Homeboy completed without the expected artifact: ${generatedZip}`)

--- a/tools/build-dev-package.test.mjs
+++ b/tools/build-dev-package.test.mjs
@@ -69,6 +69,7 @@ test("orchestration packages modified and untracked source bytes without changin
   await mkdir(engine, { recursive: true })
   await writeFile(join(source, "composer.json"), JSON.stringify({ require: { php: "^8.1" } }))
   await writeFile(join(source, "composer.lock"), "caller lock")
+  await writeFile(join(source, "homeboy.json"), JSON.stringify({ extensions: { wordpress: { settings: { package_profile: { manifest: "runtime-package-manifest.json", profile: "website-artifact-import" } } } } }))
   await writeFile(join(source, "tracked.txt"), "modified tracked bytes")
   await writeFile(join(source, "untracked.txt"), "untracked bytes")
   await mkdir(join(source, "vendor"), { recursive: true })
@@ -88,13 +89,19 @@ test("orchestration packages modified and untracked source bytes without changin
       if (command === "composer") return writeFile(join(context.cwd, "composer.lock"), "temporary lock")
       if (command === "homeboy" && args[0] === "review") return Promise.all([readFile(join(context.cwd, "tracked.txt"), "utf8"), readFile(join(context.cwd, "untracked.txt"), "utf8"), readFile(join(context.cwd, packagedIdentityFile), "utf8")]).then(([tracked, untracked, identity]) => {
         packagedIdentity = JSON.parse(identity)
-        return mkdir(join(context.cwd, "build"), { recursive: true }).then(() => writeFile(join(context.cwd, "build/static-site-importer.zip"), `${tracked}|${untracked}`))
+        return readFile(join(context.cwd, "homeboy.json"), "utf8").then((homeboy) => {
+          assert.deepEqual(JSON.parse(homeboy).extensions.wordpress.settings.package_profile, {})
+          return mkdir(join(context.cwd, "build"), { recursive: true }).then(() => writeFile(join(context.cwd, "build/static-site-importer.zip"), `${tracked}|${untracked}`))
+        })
       })
       return Buffer.from("")
     },
     async extractArchive(_archive, destination) {
       extracted += 1
-      if (extracted === 1) await writeFile(join(destination, "composer.json"), JSON.stringify({ require: { php: "^8.1" } }))
+      if (extracted === 1) {
+        await writeFile(join(destination, "composer.json"), JSON.stringify({ require: { php: "^8.1" } }))
+        await writeFile(join(destination, "homeboy.json"), JSON.stringify({ extensions: { wordpress: { settings: { package_profile: { manifest: "runtime-package-manifest.json", profile: "website-artifact-import" } } } } }))
+      }
       else await mkdir(join(destination, "php-transformer"), { recursive: true })
     },
   })

--- a/tools/runtime-package-manifest.test.mjs
+++ b/tools/runtime-package-manifest.test.mjs
@@ -16,6 +16,11 @@ test("website artifact import profile is complete and capability scoped", async 
 
   const profile = manifest.profiles?.["website-artifact-import"]
   assert.ok(profile)
+  const homeboy = JSON.parse(await readFile(join(root, "homeboy.json"), "utf8"))
+  assert.deepEqual(homeboy.extensions?.wordpress?.settings?.package_profile, {
+    manifest: "runtime-package-manifest.json",
+    profile: "website-artifact-import",
+  })
   assert.deepEqual(profile.abilities, [
     "static-site-importer/import",
     "static-site-importer/materialize-wordpress-site-plan",
@@ -40,8 +45,21 @@ test("website artifact import profile is complete and capability scoped", async 
   assert.ok(selected.some((path) => path.startsWith("vendor/league/")))
   assert.ok(selected.length > profile.required_files.length)
 
-  for (const excluded of ["tests/", "tools/", "docs/", "lib/", "node_modules/", "vendor/automattic/blocks-engine-figma-transformer/"]) {
+  for (const excluded of ["bench/", "build/", "docs/", "lib/", "node_modules/", "tests/", "tools/", "vendor/automattic/blocks-engine-figma-transformer/"]) {
     assert.equal(selected.some((path) => path.startsWith(excluded)), false, `profile leaked excluded tree: ${excluded}`)
+  }
+  for (const excluded of ["homeboy-test-manifest.json", "test-manifest.json"]) assert.equal(selected.includes(excluded), false, `profile leaked test manifest: ${excluded}`)
+  assert.equal(selected.includes("build-provenance.json"), false, "release profile must not require development build identity")
+
+  if (process.env.STATIC_SITE_IMPORTER_PACKAGE_ZIP) {
+    const archive = execFileSync("unzip", ["-Z1", process.env.STATIC_SITE_IMPORTER_PACKAGE_ZIP], { encoding: "utf8" })
+      .trim().split("\n").filter((path) => path && !path.endsWith("/"))
+      .map((path) => {
+        const prefix = `${manifest.package_root}/`
+        assert.ok(path.startsWith(prefix), `archive entry escaped package root: ${path}`)
+        return path.slice(prefix.length)
+      }).sort()
+    assert.deepEqual(archive, selected, "release archive must contain exactly the website-artifact-import profile")
   }
 })
 


### PR DESCRIPTION
## Summary
- configure Homeboy release builds to stage exactly the `website-artifact-import` runtime package profile
- keep development packages on the full snapshot so their provenance and test tooling remain available
- assert the release ZIP inventory exactly matches the manifest-selected files and excludes development-only trees
- stop requiring development-only `build-provenance.json` in normal release packages

Closes #1397.

Depends on the generic package-profile staging added by Extra-Chill/homeboy-extensions#2733. That change is merged but not yet available in a Homeboy Extensions release, so this PR remains draft until the dependency is released and the profile-built ZIP completes the disposable WordPress/Playground acceptance flow.

## Verification
- `npm ci && npm test` (71 passed)
- `STATIC_SITE_IMPORTER_PACKAGE_ZIP="build/static-site-importer.zip" node --test tools/runtime-package-manifest.test.mjs tools/build-dev-package.test.mjs` (8 passed)
- `node tools/run-test-manifest.mjs --check`
- `php tests/smoke-webfont-producer-consumer.php`
- `homeboy review --placement local lint static-site-importer --path /Users/chubes/Developer/static-site-importer@fix-1397-release-profile`
- production build completed with PHP syntax and structure validation: 1.7 MB, 873 files
- archive inventory exactly matched the `website-artifact-import` profile

AI assistance disclosure: GPT-5.6 Sol running in OpenCode implemented the release-profile integration, added archive contract coverage, built and inspected the resulting package, and ran the verification commands under human direction.