### PR TITLE
Add owner-handoff evidence report card

### DIFF
--- a/docs/contracts/owner-handoff-evidence-v1.md
+++ b/docs/contracts/owner-handoff-evidence-v1.md
@@ -1,0 +1,120 @@
+# Owner Handoff Evidence v1
+
+`static-site-importer/owner-handoff-evidence/v1` is the fail-closed owner-handoff
+contract for a generated WordPress site. It composes decisions made by owning
+evidence producers; it does not reconstruct visual, editability, provider,
+accessibility, performance, or deployment policy.
+
+The root binds to a `blocks-engine/wordpress-site-plan-identity/v1` and the
+SHA-256 of the complete canonicalized
+`static-site-importer/materialization-receipt/v2`. The receipt must carry the
+same plan identity. `bindings.verified` is false, with a stable typed gap, when
+either identity is absent or mismatched.
+
+## Evidence Inputs
+
+Each dimension accepts a content-addressed artifact reference after the terminal
+materialization receipt exists:
+
+```json
+{
+  "sha256": "<hash of artifact>",
+  "artifact": {
+    "schema": "static-site-importer/owner-handoff-dimension-evidence/v1",
+    "dimension": "visual_acceptance",
+    "subject": {
+      "plan_identity": {
+        "schema": "blocks-engine/wordpress-site-plan-identity/v1",
+        "hash": "<canonical plan hash>"
+      },
+      "materialization_receipt_sha256": "<complete receipt hash>"
+    },
+    "status": "pass",
+    "source_evidence": [{
+      "schema": "static-site-importer/owner-handoff-source-evidence/v1",
+      "sha256": "<producer artifact hash>",
+      "artifact": {
+        "schema": "static-site-importer/owner-handoff-source-evidence/v1",
+        "dimension": "visual_acceptance",
+        "status": "pass",
+        "subject": {
+          "plan_identity": { "schema": "blocks-engine/wordpress-site-plan-identity/v1", "hash": "<canonical plan hash>" },
+          "materialization_receipt_sha256": "<complete receipt hash>"
+        }
+      }
+    }],
+    "findings": []
+  }
+}
+```
+
+Owning producers adapt their policy result into the source envelope; the composer
+requires that exact versioned schema and derives the dimension status from it.
+The composer verifies each source artifact, the dimension artifact hash, and both
+subject bindings. A bare
+`status: passed`, an unsupported schema, an altered artifact, or evidence for a
+different plan/receipt becomes `evidence_gap`; none can manufacture a pass.
+Repository ownership is fixed by dimension rather than accepted from callers.
+At most 32 source artifacts and 100 bounded findings are consumed per dimension.
+
+Non-pass artifacts carry one or more findings. Every finding has a stable reason
+code, route, component, owning source-evidence reference, summary, and next
+action. The dimension status is deterministically aggregated from its findings.
+This supports several route/component findings without collapsing them into one
+aggregate assertion.
+
+The normal import report emits a post-commit baseline and does not accept
+pre-materialization caller evidence: receipt identity is not known until the
+transaction completes. Runtime/reviewer workflows compose supplied dimension
+artifacts in a post-materialization step.
+
+The materialization receipt's already validated, plan-bound
+`editability-report-admission/v1` is consumed directly. No other aggregate import
+metric is promoted automatically to a pass. Unsupported or incomplete current
+evidence remains a typed gap.
+
+## Statuses
+
+- `pass`: hash-bound mandatory evidence is present and its owning layer passed.
+- `hard_failure`: a measured failure that blocks accepted/built handoff.
+- `owner_decision`: ordinary ownership requires an explicit owner action.
+- `acceptable_conversion`: a declared, non-blocking conversion.
+- `informational`: a non-blocking finding.
+- `evidence_gap`: mandatory evidence is absent, malformed, or mismatched.
+
+## Dimensions
+
+- route and content completeness
+- desktop and mobile visual acceptance
+- meaningful editability and shared-region ownership
+- editor presentation and persisted edit operations
+- Media Library ownership for replaceable media
+- internal-link portability and external-link inventory
+- interaction and provider-functionality receipts
+- rendered metadata, site identity, and unresolved placeholders
+- keyboard/accessibility evidence
+- bounded frontend performance evidence
+- dependency, deployment, and rollback readiness
+- deterministic owner-task evidence
+
+The owner-task artifact uses `static-site-importer/owner-task-check/v1`. It must
+contain text edit, image replacement, navigation edit, shared-footer edit, and
+form-recipient edit operations. Each operation requires before/after hashes,
+an actual state change, successful save/reload and post-save validation, and source evidence. Recipient
+values are not part of this public projection.
+
+## Report Card
+
+`report_card` is a concise projection using
+`static-site-importer/owner-handoff-report-card/v1`. Its `evidence_sha256` binds
+it to the canonical root fields before `evidence_sha256` and `report_card` are
+added, so it cannot introduce a second decision.
+
+Serialized admission is never trusted alone. `admits_accepted_or_built()` requires
+the terminal receipt and original owning evidence, recomposes the document, and
+compares its canonical hash.
+
+`blocked` contains a hard failure. `not_proven` contains a mandatory gap or an
+invalid binding. `needs_owner` has only owner decisions remaining. `ready` has
+neither. Accepted/built handoff requires verified bindings and no hard failures
+or evidence gaps; caller workflows retain publication policy.

--- a/docs/contracts/owner-handoff-evidence-v1.schema.json
+++ b/docs/contracts/owner-handoff-evidence-v1.schema.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "static-site-importer/owner-handoff-evidence/v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "version", "bindings", "dimensions", "findings", "counts", "disposition", "handoff_admitted", "evidence_sha256", "report_card"],
+  "properties": {
+    "schema": { "const": "static-site-importer/owner-handoff-evidence/v1" },
+    "version": { "const": 1 },
+    "bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["plan_identity", "materialization_receipt", "verified", "gaps"],
+      "properties": {
+        "plan_identity": { "anyOf": [{ "$ref": "#/$defs/planIdentity" }, { "type": "null" }] },
+        "materialization_receipt": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["schema", "status", "sha256", "plan_identity", "receipt_instance_id"],
+              "properties": {
+                "schema": { "const": "static-site-importer/materialization-receipt/v2" },
+                "status": { "enum": ["completed", "failed", "partial", "rejected"] },
+                "sha256": { "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }] },
+                "plan_identity": { "anyOf": [{ "$ref": "#/$defs/planIdentity" }, { "type": "null" }] },
+                "receipt_instance_id": { "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }] }
+              }
+            },
+            { "type": "null" }
+          ]
+        },
+        "verified": { "type": "boolean" },
+        "gaps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["code"],
+            "properties": { "code": { "type": "string", "minLength": 1 } }
+          }
+        }
+      }
+    },
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["route_content_completeness", "visual_acceptance", "editability_and_shared_regions", "editor_presentation_and_persistence", "media_library_ownership", "link_portability", "interaction_and_provider_functionality", "document_metadata_and_identity", "accessibility", "frontend_performance", "dependency_deployment_rollback", "owner_task_check"],
+      "properties": {
+        "route_content_completeness": { "$ref": "#/$defs/dimension" },
+        "visual_acceptance": { "$ref": "#/$defs/dimension" },
+        "editability_and_shared_regions": { "$ref": "#/$defs/dimension" },
+        "editor_presentation_and_persistence": { "$ref": "#/$defs/dimension" },
+        "media_library_ownership": { "$ref": "#/$defs/dimension" },
+        "link_portability": { "$ref": "#/$defs/dimension" },
+        "interaction_and_provider_functionality": { "$ref": "#/$defs/dimension" },
+        "document_metadata_and_identity": { "$ref": "#/$defs/dimension" },
+        "accessibility": { "$ref": "#/$defs/dimension" },
+        "frontend_performance": { "$ref": "#/$defs/dimension" },
+        "dependency_deployment_rollback": { "$ref": "#/$defs/dimension" },
+        "owner_task_check": { "$ref": "#/$defs/dimension" }
+      }
+    },
+    "findings": { "type": "array", "maxItems": 1200, "items": { "$ref": "#/$defs/finding" } },
+    "counts": { "$ref": "#/$defs/counts" },
+    "disposition": { "enum": ["ready", "needs_owner", "blocked", "not_proven"] },
+    "handoff_admitted": { "type": "boolean" },
+    "evidence_sha256": { "$ref": "#/$defs/sha256" },
+    "report_card": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "evidence_sha256", "disposition", "handoff_admitted", "headline", "counts", "dimensions", "findings"],
+      "properties": {
+        "schema": { "const": "static-site-importer/owner-handoff-report-card/v1" },
+        "evidence_sha256": { "$ref": "#/$defs/sha256" },
+        "disposition": { "enum": ["ready", "needs_owner", "blocked", "not_proven"] },
+        "handoff_admitted": { "type": "boolean" },
+        "headline": { "type": "string", "minLength": 1 },
+        "counts": { "$ref": "#/$defs/counts" },
+        "dimensions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["dimension", "status"],
+            "properties": { "dimension": { "type": "string" }, "status": { "$ref": "#/$defs/status" } }
+          }
+        },
+        "findings": { "type": "array", "maxItems": 1200, "items": { "$ref": "#/$defs/finding" } }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "planIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "hash"],
+      "properties": { "schema": { "const": "blocks-engine/wordpress-site-plan-identity/v1" }, "hash": { "$ref": "#/$defs/sha256" } }
+    },
+    "status": { "enum": ["pass", "hard_failure", "owner_decision", "acceptable_conversion", "informational", "evidence_gap"] },
+    "reference": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["schema", "sha256"],
+          "properties": {
+            "schema": { "type": "string", "minLength": 1 },
+            "sha256": { "$ref": "#/$defs/sha256" },
+            "selector": { "type": "string" },
+            "sources": { "type": "array" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["schema", "state", "dimension", "reason_code"],
+          "properties": {
+            "schema": { "const": "static-site-importer/owner-handoff-dimension-evidence/v1" },
+            "state": { "const": "missing" },
+            "dimension": { "type": "string", "minLength": 1 },
+            "reason_code": { "type": "string", "minLength": 1 }
+          }
+        }
+      ]
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pass", "hard_failure", "owner_decision", "acceptable_conversion", "informational", "evidence_gap"],
+      "properties": {
+        "pass": { "type": "integer", "minimum": 0 },
+        "hard_failure": { "type": "integer", "minimum": 0 },
+        "owner_decision": { "type": "integer", "minimum": 0 },
+        "acceptable_conversion": { "type": "integer", "minimum": 0 },
+        "informational": { "type": "integer", "minimum": 0 },
+        "evidence_gap": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "dimension", "status", "reason_code", "affected", "evidence", "owning_repository", "next_action", "summary"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "dimension": { "type": "string", "minLength": 1 },
+        "status": { "$ref": "#/$defs/status" },
+        "reason_code": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "affected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["route", "component"],
+          "properties": { "route": { "type": "string", "minLength": 1, "maxLength": 2048 }, "component": { "type": "string", "minLength": 1, "maxLength": 256 } }
+        },
+        "evidence": { "$ref": "#/$defs/reference" },
+        "owning_repository": { "type": "string", "minLength": 1 },
+        "next_action": { "type": "string", "minLength": 1, "maxLength": 2048 },
+        "summary": { "type": "string", "minLength": 1, "maxLength": 2048 }
+      }
+    },
+    "dimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dimension", "status", "mandatory", "evidence", "owning_repository", "finding_ids"],
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "pass" } }, "required": ["status"] },
+          "then": { "properties": { "evidence": { "required": ["sha256"] } } }
+        }
+      ],
+      "properties": {
+        "dimension": { "type": "string", "minLength": 1 },
+        "status": { "$ref": "#/$defs/status" },
+        "mandatory": { "const": true },
+        "evidence": { "$ref": "#/$defs/reference" },
+        "owning_repository": { "type": "string", "minLength": 1 },
+        "finding_ids": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "operations": { "type": "object" }
+      }
+    }
+  }
+}

--- a/docs/product-handoff-contract.md
+++ b/docs/product-handoff-contract.md
@@ -6,8 +6,9 @@ Static Site Importer's product handoff uses four machine-readable envelopes. The
 
 1. Product caller provides an input artifact with schema `blocks-engine/php-transformer/site-artifact/v1`.
 2. Blocks Engine compiles it and returns `blocks-engine/php-transformer/result/v1` with `source_reports.wordpress_site_plan` using `blocks-engine/wordpress-site-plan/v2`.
-3. SSI validates its destination, reports, caller overrides, and typed runtime declarations before mutation; it prepares declared dependencies, applies the canonical WordPress site plan, seeds declared entities, then writes report projections. The materializer receipt (`static-site-importer/materialization-receipt/v1`) is the mutation boundary and records completed pages, files, operations, and runtime declarations for partial results.
+3. SSI validates its destination, reports, caller overrides, and typed runtime declarations before mutation; it prepares declared dependencies, applies the canonical WordPress site plan, seeds declared entities, then writes report projections. The materializer receipt (`static-site-importer/materialization-receipt/v2`) is the mutation boundary and records completed pages, files, operations, and runtime declarations for partial results.
 4. Codebox may validate the WordPress result and return `wp-codebox/validation-artifact-envelope/v1` with artifact references for rendered output, visual comparison, WordPress state, import report, and diagnostics.
+5. SSI composes `static-site-importer/owner-handoff-evidence/v1` from those existing receipts and projects the same document as a user-facing report card. Missing mandatory evidence is a typed gap; hard failures refuse accepted/built handoff. Caller workflows decide whether an incomplete report blocks publication.
 
 ## Ownership
 

--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -35,6 +35,7 @@
     "tests/smoke-post-meta-rollback.php": { "environment": "standalone-php" },
     "tests/smoke-plugin-materializer-lifecycle.php": { "environment": "standalone-php" },
     "tests/smoke-product-handoff-contract.php": { "environment": "standalone-php" },
+    "tests/smoke-owner-handoff-evidence.php": { "environment": "standalone-php" },
     "tests/smoke-quality-budget-admission.php": { "environment": "standalone-php" },
     "tests/smoke-provider-presentation.php": { "environment": "standalone-php" },
     "tests/smoke-site-identity.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-import-report.php
+++ b/includes/class-static-site-importer-import-report.php
@@ -51,6 +51,7 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 		'materialization_receipt',
 		'materialized_content',
 		'notes',
+		'owner_handoff_evidence',
 		'plan_identity',
 		'plugin_materialization',
 		'product_finding_seeding',

--- a/includes/class-static-site-importer-owner-handoff-evidence.php
+++ b/includes/class-static-site-importer-owner-handoff-evidence.php
@@ -1,0 +1,640 @@
+<?php
+/**
+ * Owner-handoff evidence and report-card composer.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Composes existing, owning-layer evidence without recreating its policy.
+ */
+final class Static_Site_Importer_Owner_Handoff_Evidence {
+
+	public const SCHEMA                    = 'static-site-importer/owner-handoff-evidence/v1';
+	public const REPORT_CARD_SCHEMA        = 'static-site-importer/owner-handoff-report-card/v1';
+	public const DIMENSION_EVIDENCE_SCHEMA = 'static-site-importer/owner-handoff-dimension-evidence/v1';
+	public const SOURCE_EVIDENCE_SCHEMA    = 'static-site-importer/owner-handoff-source-evidence/v1';
+	public const OWNER_TASK_SCHEMA         = 'static-site-importer/owner-task-check/v1';
+	public const VERSION                   = 1;
+
+	public const DIMENSION_IDS = array(
+		'route_content_completeness',
+		'visual_acceptance',
+		'editability_and_shared_regions',
+		'editor_presentation_and_persistence',
+		'media_library_ownership',
+		'link_portability',
+		'interaction_and_provider_functionality',
+		'document_metadata_and_identity',
+		'accessibility',
+		'frontend_performance',
+		'dependency_deployment_rollback',
+		'owner_task_check',
+	);
+
+	public const OWNER_TASKS = array(
+		'text_edit',
+		'image_replace',
+		'navigation_edit',
+		'shared_footer_edit',
+		'form_recipient_edit',
+	);
+
+	public const STATUSES = array(
+		'pass',
+		'hard_failure',
+		'owner_decision',
+		'acceptable_conversion',
+		'informational',
+		'evidence_gap',
+	);
+
+	private const OWNERS = array(
+		'route_content_completeness'             => 'Automattic/blocks-engine',
+		'visual_acceptance'                      => 'Automattic/static-site-importer',
+		'editability_and_shared_regions'         => 'Automattic/blocks-engine',
+		'editor_presentation_and_persistence'    => 'Automattic/static-site-importer',
+		'media_library_ownership'                => 'Automattic/static-site-importer',
+		'link_portability'                       => 'Automattic/static-site-importer',
+		'interaction_and_provider_functionality' => 'Automattic/static-site-importer',
+		'document_metadata_and_identity'         => 'Automattic/static-site-importer',
+		'accessibility'                          => 'Automattic/static-site-importer',
+		'frontend_performance'                   => 'Automattic/static-site-importer',
+		'dependency_deployment_rollback'         => 'Automattic/static-site-importer',
+		'owner_task_check'                       => 'Automattic/static-site-importer',
+	);
+
+	private const GAP_ACTIONS = array(
+		'route_content_completeness'             => 'Supply route-scoped completeness evidence from the owning conversion policy.',
+		'visual_acceptance'                      => 'Supply accepted desktop and mobile visual evidence for every required route.',
+		'editability_and_shared_regions'         => 'Supply a plan-bound Blocks Engine editability and shared-region admission.',
+		'editor_presentation_and_persistence'    => 'Supply editor presentation and persisted edit evidence from the owning runtime.',
+		'media_library_ownership'                => 'Supply per-asset Media Library attachment and block-binding evidence.',
+		'link_portability'                       => 'Supply internal-link portability and external-link inventory evidence.',
+		'interaction_and_provider_functionality' => 'Supply interaction coverage and successful provider-functionality receipts.',
+		'document_metadata_and_identity'         => 'Supply rendered metadata, site identity, and unresolved-placeholder evidence.',
+		'accessibility'                          => 'Supply bounded keyboard and accessibility evidence from the owning runtime.',
+		'frontend_performance'                   => 'Supply bounded generated-frontend performance evidence.',
+		'dependency_deployment_rollback'         => 'Supply dependency, deployment, and rollback readiness evidence.',
+		'owner_task_check'                       => 'Supply all five owner tasks with hash-bound save, reload, and validation receipts.',
+	);
+
+	/**
+	 * @param array<string,mixed> $input Plan identity, receipt, and optional evidence artifacts.
+	 * @return array<string,mixed>
+	 */
+	public static function compose( array $input ): array {
+		$receipt   = self::object( $input['materialization_receipt'] ?? null );
+		$bindings  = self::bindings( self::object( $input['plan_identity'] ?? null ), $receipt );
+		$supplied  = self::object( $input['evidence'] ?? null );
+		$dimensions = array();
+		$findings   = array();
+
+		foreach ( self::DIMENSION_IDS as $id ) {
+			if ( isset( $supplied[ $id ] ) && is_array( $supplied[ $id ] ) ) {
+				$evaluated = 'owner_task_check' === $id
+					? self::consume_owner_tasks( $supplied[ $id ], $bindings )
+					: self::consume_dimension( $id, $supplied[ $id ], $bindings );
+			} else {
+				$evaluated = self::consume_receipt_evidence( $id, $receipt, $bindings );
+			}
+			$dimensions[ $id ] = $evaluated['dimension'];
+			$findings           = array_merge( $findings, $evaluated['findings'] );
+		}
+
+		$counts      = self::counts( $dimensions );
+		$disposition = self::disposition( $counts, $bindings );
+		$admitted    = self::bindings_verified( $bindings ) && 0 === $counts['hard_failure'] && 0 === $counts['evidence_gap'];
+		$core        = array(
+			'schema'           => self::SCHEMA,
+			'version'          => self::VERSION,
+			'bindings'         => $bindings,
+			'dimensions'       => $dimensions,
+			'findings'         => $findings,
+			'counts'           => $counts,
+			'disposition'      => $disposition,
+			'handoff_admitted' => $admitted,
+		);
+		$document_hash              = self::hash_value( $core );
+		$core['evidence_sha256']     = $document_hash;
+		$core['report_card']         = self::report_card( $core );
+		return $core;
+	}
+
+	/**
+	 * @param array<string,mixed>|Static_Site_Importer_Import_Report $report Finalized import report.
+	 * @param array<string,mixed> $quality Unused compatibility argument.
+	 * @param array<string,mixed> $args Import arguments carrying optional owner_handoff_evidence.
+	 * @return array<string,mixed>
+	 */
+	public static function compose_from_report( array|Static_Site_Importer_Import_Report $report, array $quality = array(), array $args = array() ): array {
+		$payload = $report instanceof Static_Site_Importer_Import_Report ? $report->to_array() : $report;
+		unset( $payload['owner_handoff_evidence'] );
+		$receipt = self::object( $payload['materialization_receipt'] ?? null );
+		// Commit removes only this rollback journal. Bind evidence to the exact
+		// terminal receipt projection while retaining the journal until writes end.
+		unset( $receipt['transaction'] );
+		return self::compose(
+			array(
+				'plan_identity'           => self::object( $payload['plan_identity'] ?? ( $receipt['plan_identity'] ?? null ) ),
+				'materialization_receipt' => $receipt,
+				'evidence'                => self::object( $args['owner_handoff_evidence'] ?? null ),
+			)
+		);
+	}
+
+	/**
+	 * Recompose admission from authoritative receipt and source artifacts.
+	 *
+	 * @param array<string,mixed> $document Serialized owner-handoff document.
+	 * @param array<string,mixed> $receipt Terminal materialization receipt.
+	 * @param array<string,mixed> $evidence Owning source evidence used to compose the document.
+	 */
+	public static function admits_accepted_or_built( array $document, array $receipt = array(), array $evidence = array() ): bool {
+		$plan_identity = self::object( $document['bindings']['plan_identity'] ?? null );
+		if ( array() === $receipt || array() === $evidence || ! self::valid_plan_identity( $plan_identity ) ) {
+			return false;
+		}
+		$expected = self::compose(
+			array(
+				'plan_identity'           => $plan_identity,
+				'materialization_receipt' => $receipt,
+				'evidence'                => $evidence,
+			)
+		);
+		return true === ( $expected['handoff_admitted'] ?? false ) && hash_equals( self::hash_value( $expected ), self::hash_value( $document ) );
+	}
+
+	/**
+	 * Canonical hash used for complete receipts and embedded evidence artifacts.
+	 *
+	 * @param mixed $value
+	 */
+	public static function hash_value( mixed $value ): string {
+		$context = hash_init( 'sha256' );
+		self::hash_json_value( $context, $value );
+		return hash_final( $context );
+	}
+
+	/**
+	 * @param array<string,mixed> $document
+	 * @return array<string,mixed>
+	 */
+	public static function report_card( array $document ): array {
+		$rows = array();
+		foreach ( self::DIMENSION_IDS as $id ) {
+			$dimension = self::object( $document['dimensions'][ $id ] ?? null );
+			$rows[]    = array(
+				'dimension' => $id,
+				'status'    => (string) ( $dimension['status'] ?? 'evidence_gap' ),
+			);
+		}
+		return array(
+			'schema'           => self::REPORT_CARD_SCHEMA,
+			'evidence_sha256'  => (string) ( $document['evidence_sha256'] ?? '' ),
+			'disposition'      => (string) ( $document['disposition'] ?? 'not_proven' ),
+			'handoff_admitted' => true === ( $document['handoff_admitted'] ?? false ),
+			'headline'         => self::headline( (string) ( $document['disposition'] ?? 'not_proven' ) ),
+			'counts'           => self::object( $document['counts'] ?? null ),
+			'dimensions'       => $rows,
+			'findings'         => is_array( $document['findings'] ?? null ) ? $document['findings'] : array(),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function bindings( array $plan, array $receipt ): array {
+		$gaps       = array();
+		$valid_plan = self::valid_plan_identity( $plan ) ? self::plan_identity( $plan ) : null;
+		if ( null === $valid_plan ) {
+			$gaps[] = array( 'code' => 'plan_identity_missing_or_invalid' );
+		}
+
+		$receipt_binding = null;
+		if ( 'static-site-importer/materialization-receipt/v2' !== ( $receipt['schema'] ?? null ) || ! in_array( $receipt['status'] ?? null, array( 'completed', 'failed', 'partial', 'rejected' ), true ) ) {
+			$gaps[] = array( 'code' => 'materialization_receipt_missing_or_invalid' );
+		} else {
+			$receipt_plan    = self::object( $receipt['plan_identity'] ?? null );
+			$receipt_hash = self::try_hash_value( $receipt );
+			$receipt_binding = array(
+				'schema'              => (string) $receipt['schema'],
+				'status'              => (string) $receipt['status'],
+				'sha256'              => $receipt_hash,
+				'plan_identity'       => self::valid_plan_identity( $receipt_plan ) ? self::plan_identity( $receipt_plan ) : null,
+				'receipt_instance_id' => self::is_sha256( $receipt['receipt_instance_id'] ?? null ) ? (string) $receipt['receipt_instance_id'] : null,
+			);
+			if ( null === $receipt_hash ) {
+				$gaps[] = array( 'code' => 'materialization_receipt_not_hashable' );
+			} elseif ( null === $receipt_binding['receipt_instance_id'] ) {
+				$gaps[] = array( 'code' => 'receipt_instance_id_missing_or_invalid' );
+			} elseif ( null === $receipt_binding['plan_identity'] ) {
+				$gaps[] = array( 'code' => 'receipt_plan_identity_missing_or_invalid' );
+			} elseif ( null !== $valid_plan && $valid_plan !== $receipt_binding['plan_identity'] ) {
+				$gaps[] = array( 'code' => 'receipt_plan_identity_mismatch' );
+			}
+		}
+
+		return array(
+			'plan_identity'           => $valid_plan,
+			'materialization_receipt' => $receipt_binding,
+			'verified'                => array() === $gaps,
+			'gaps'                    => $gaps,
+		);
+	}
+
+	/** @return array{dimension:array<string,mixed>,findings:array<int,array<string,mixed>>} */
+	private static function consume_dimension( string $id, array $reference, array $bindings ): array {
+		$artifact = self::object( $reference['artifact'] ?? null );
+		$reason   = self::artifact_problem( $id, $reference, $artifact, $bindings, self::DIMENSION_EVIDENCE_SCHEMA );
+		if ( null !== $reason ) {
+			return self::gap( $id, $reason );
+		}
+
+		$sources = self::source_references( $artifact['source_evidence'] ?? null, $bindings, $id );
+		$status  = is_string( $artifact['status'] ?? null ) && in_array( $artifact['status'], self::STATUSES, true ) ? $artifact['status'] : null;
+		$source_status = self::source_status( $artifact['source_evidence'] ?? null );
+		if ( null === $status || array() === $sources || $status !== $source_status ) {
+			return self::gap( $id, 'dimension_evidence_incomplete' );
+		}
+
+		$raw_findings = is_array( $artifact['findings'] ?? null ) ? array_values( $artifact['findings'] ) : array();
+		$findings     = self::normalize_findings( $id, $raw_findings, $sources );
+		$derived  = self::aggregate_status( $findings );
+		if ( count( $raw_findings ) !== count( $findings ) || ( 'pass' === $status && array() !== $raw_findings ) || ( 'pass' !== $status && $status !== $derived ) ) {
+			return self::gap( $id, 'dimension_evidence_status_mismatch' );
+		}
+
+		$evidence = array(
+			'schema' => self::DIMENSION_EVIDENCE_SCHEMA,
+			'sha256' => (string) $reference['sha256'],
+			'sources' => $sources,
+		);
+		return array(
+			'dimension' => self::dimension( $id, $status, $evidence, array_column( $findings, 'id' ) ),
+			'findings'  => $findings,
+		);
+	}
+
+	/** @return array{dimension:array<string,mixed>,findings:array<int,array<string,mixed>>} */
+	private static function consume_owner_tasks( array $reference, array $bindings ): array {
+		$id       = 'owner_task_check';
+		$artifact = self::object( $reference['artifact'] ?? null );
+		$reason   = self::artifact_problem( $id, $reference, $artifact, $bindings, self::OWNER_TASK_SCHEMA, false );
+		if ( null !== $reason ) {
+			return self::gap( $id, $reason );
+		}
+
+		$operations = self::object( $artifact['operations'] ?? null );
+		$normalized = array();
+		$findings   = array();
+		foreach ( self::OWNER_TASKS as $task ) {
+			$operation = self::object( $operations[ $task ] ?? null );
+			$sources   = self::source_references( $operation['evidence'] ?? null, $bindings, $id );
+			$complete  = self::is_sha256( $operation['before_sha256'] ?? null )
+				&& self::is_sha256( $operation['after_sha256'] ?? null )
+				&& ! hash_equals( (string) $operation['before_sha256'], (string) $operation['after_sha256'] )
+				&& array() !== $sources
+				&& isset( $operation['status'], $operation['save_reload_status'], $operation['validation_status'] );
+			$failed    = $complete && in_array( 'failed', array( $operation['status'], $operation['save_reload_status'], $operation['validation_status'] ), true );
+			$status    = ! $complete ? 'evidence_gap' : ( $failed ? 'hard_failure' : ( array( 'passed', 'passed', 'passed' ) === array( $operation['status'], $operation['save_reload_status'], $operation['validation_status'] ) ? 'pass' : 'evidence_gap' ) );
+			$normalized[ $task ] = array(
+				'status' => $status,
+			);
+			if ( 'pass' !== $status ) {
+				$findings[] = self::finding(
+					$id,
+					$status,
+					'*',
+					$task,
+					'hard_failure' === $status ? 'owner_task_operation_failed' : 'owner_task_operation_evidence_missing',
+					'hard_failure' === $status ? 'An owner-task operation failed save, reload, or validation.' : 'Owner-task evidence is incomplete.',
+					self::GAP_ACTIONS[ $id ],
+					array() !== $sources ? $sources[0] : self::missing_reference( $id, 'owner_task_operation_evidence_missing' ),
+					count( $findings )
+				);
+			}
+		}
+
+		$status = self::aggregate_status( $findings );
+		return array(
+			'dimension' => self::dimension(
+				$id,
+				$status,
+				array(
+					'schema' => self::OWNER_TASK_SCHEMA,
+					'sha256' => (string) $reference['sha256'],
+				),
+				array_column( $findings, 'id' ),
+				$normalized
+			),
+			'findings'  => $findings,
+		);
+	}
+
+	/** @return array{dimension:array<string,mixed>,findings:array<int,array<string,mixed>>} */
+	private static function consume_receipt_evidence( string $id, array $receipt, array $bindings ): array {
+		if ( 'route_content_completeness' === $id && in_array( $receipt['status'] ?? null, array( 'failed', 'partial', 'rejected' ), true ) && null !== ( $bindings['materialization_receipt']['sha256'] ?? null ) ) {
+			$finding = self::finding( $id, 'hard_failure', '*', 'materialization_receipt', 'materialization_not_completed', 'Materialization did not complete.', 'Repair the materialization failure before handoff.', self::receipt_reference( $bindings ), 0 );
+			return array( 'dimension' => self::dimension( $id, 'hard_failure', self::receipt_reference( $bindings ), array( $finding['id'] ) ), 'findings' => array( $finding ) );
+		}
+
+		if ( 'editability_and_shared_regions' === $id && self::bindings_verified( $bindings ) ) {
+			$admission = self::object( $receipt['editability_report'] ?? null );
+			$reference = self::receipt_reference( $bindings, 'editability_report' );
+			if ( 'static-site-importer/editability-report-admission/v1' === ( $admission['schema'] ?? null )
+				&& 'passed' === ( $admission['status'] ?? null )
+				&& 'blocks-engine/php-transformer/editability-report/v2' === ( $admission['report_schema'] ?? null )
+				&& ( $bindings['plan_identity']['hash'] ?? null ) === ( $admission['plan_hash'] ?? null ) ) {
+				return array( 'dimension' => self::dimension( $id, 'pass', $reference ), 'findings' => array() );
+			}
+			if ( 'static-site-importer/editability-report-admission/v1' === ( $admission['schema'] ?? null ) && 'rejected' === ( $admission['status'] ?? null ) ) {
+				$finding = self::finding( $id, 'hard_failure', '*', 'editability_report', 'editability_report_rejected', 'The owning editability admission rejected the plan.', 'Repair the Blocks Engine editability findings before handoff.', $reference, 0 );
+				return array( 'dimension' => self::dimension( $id, 'hard_failure', $reference, array( $finding['id'] ) ), 'findings' => array( $finding ) );
+			}
+		}
+
+		return self::gap( $id, self::gap_reason( $id ) );
+	}
+
+	/** @return string|null */
+	private static function artifact_problem( string $id, array $reference, array $artifact, array $bindings, string $schema, bool $require_dimension = true ): ?string {
+		if ( ! self::bindings_verified( $bindings ) ) {
+			return 'subject_binding_not_verified';
+		}
+		if ( $schema !== ( $artifact['schema'] ?? null ) || ( $require_dimension && $id !== ( $artifact['dimension'] ?? null ) ) ) {
+			return 'evidence_schema_or_dimension_invalid';
+		}
+		$artifact_hash = self::try_hash_value( $artifact );
+		if ( null === $artifact_hash || ! self::is_sha256( $reference['sha256'] ?? null ) || ! hash_equals( (string) $reference['sha256'], $artifact_hash ) ) {
+			return 'evidence_hash_mismatch';
+		}
+		$subject = self::object( $artifact['subject'] ?? null );
+		if ( self::plan_identity( self::object( $subject['plan_identity'] ?? null ) ) !== $bindings['plan_identity']
+			|| ( $subject['materialization_receipt_sha256'] ?? null ) !== ( $bindings['materialization_receipt']['sha256'] ?? null ) ) {
+			return 'evidence_subject_mismatch';
+		}
+		return null;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function normalize_findings( string $id, mixed $value, array $sources ): array {
+		$normalized = array();
+		foreach ( array_slice( is_array( $value ) ? array_values( $value ) : array(), 0, 100 ) as $index => $finding ) {
+			if ( ! is_array( $finding ) || ! in_array( $finding['status'] ?? null, array_diff( self::STATUSES, array( 'pass' ) ), true ) ) {
+				continue;
+			}
+			$affected = self::object( $finding['affected'] ?? null );
+			$evidence = self::object( $finding['evidence'] ?? null );
+			if ( ! self::bounded_string( $affected['route'] ?? null, 2048 )
+				|| ! self::bounded_string( $affected['component'] ?? null, 256 )
+				|| ! self::bounded_string( $finding['reason_code'] ?? null, 128 )
+				|| ! self::bounded_string( $finding['summary'] ?? null, 2048 )
+				|| ! self::bounded_string( $finding['next_action'] ?? null, 2048 )
+				|| ! self::reference_in( $evidence, $sources ) ) {
+				continue;
+			}
+			$normalized[] = self::finding( $id, (string) $finding['status'], (string) $affected['route'], (string) $affected['component'], (string) $finding['reason_code'], (string) $finding['summary'], (string) $finding['next_action'], $evidence, $index );
+		}
+		return $normalized;
+	}
+
+	/** @return array{dimension:array<string,mixed>,findings:array<int,array<string,mixed>>} */
+	private static function gap( string $id, string $reason ): array {
+		$evidence = self::missing_reference( $id, $reason );
+		$finding  = self::finding( $id, 'evidence_gap', '*', $id, $reason, 'Mandatory owner-handoff evidence is not proven.', self::GAP_ACTIONS[ $id ], $evidence, 0 );
+		return array(
+			'dimension' => self::dimension( $id, 'evidence_gap', $evidence, array( $finding['id'] ) ),
+			'findings'  => array( $finding ),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function dimension( string $id, string $status, array $evidence, array $finding_ids = array(), array $operations = array() ): array {
+		$row = array(
+			'dimension'         => $id,
+			'status'            => $status,
+			'mandatory'         => true,
+			'evidence'          => $evidence,
+			'owning_repository' => self::OWNERS[ $id ],
+			'finding_ids'       => array_values( $finding_ids ),
+		);
+		if ( array() !== $operations ) {
+			$row['operations'] = $operations;
+		}
+		return $row;
+	}
+
+	/** @return array<string,mixed> */
+	private static function finding( string $id, string $status, string $route, string $component, string $reason, string $summary, string $action, array $evidence, int $index ): array {
+		return array(
+			'id'                => $id . ':' . $index . ':' . $reason,
+			'dimension'         => $id,
+			'status'            => $status,
+			'reason_code'       => $reason,
+			'affected'          => array( 'route' => $route, 'component' => $component ),
+			'evidence'          => $evidence,
+			'owning_repository' => self::OWNERS[ $id ],
+			'next_action'       => $action,
+			'summary'           => $summary,
+		);
+	}
+
+	/** @return array<int,array<string,string>> */
+	private static function source_references( mixed $value, array $bindings, string $id ): array {
+		$references = array();
+		foreach ( array_slice( is_array( $value ) ? array_values( $value ) : array(), 0, 32 ) as $reference ) {
+			$artifact      = self::object( is_array( $reference ) ? ( $reference['artifact'] ?? null ) : null );
+			$artifact_hash = self::try_hash_value( $artifact );
+			$subject       = self::object( $artifact['subject'] ?? null );
+			if ( is_array( $reference )
+				&& self::SOURCE_EVIDENCE_SCHEMA === ( $reference['schema'] ?? null )
+				&& ( $artifact['schema'] ?? null ) === $reference['schema']
+				&& $id === ( $artifact['dimension'] ?? null )
+				&& in_array( $artifact['status'] ?? null, self::STATUSES, true )
+				&& null !== $artifact_hash
+				&& self::is_sha256( $reference['sha256'] ?? null )
+				&& hash_equals( (string) $reference['sha256'], $artifact_hash )
+				&& self::plan_identity( self::object( $subject['plan_identity'] ?? null ) ) === ( $bindings['plan_identity'] ?? null )
+				&& ( $subject['materialization_receipt_sha256'] ?? null ) === ( $bindings['materialization_receipt']['sha256'] ?? null ) ) {
+				$references[] = array( 'schema' => $reference['schema'], 'sha256' => $reference['sha256'] );
+			}
+		}
+		return $references;
+	}
+
+	private static function source_status( mixed $value ): string {
+		$statuses = array();
+		foreach ( array_slice( is_array( $value ) ? array_values( $value ) : array(), 0, 32 ) as $reference ) {
+			$artifact = self::object( is_array( $reference ) ? ( $reference['artifact'] ?? null ) : null );
+			$statuses[] = (string) ( $artifact['status'] ?? 'evidence_gap' );
+		}
+		foreach ( array( 'hard_failure', 'evidence_gap', 'owner_decision', 'acceptable_conversion', 'informational' ) as $status ) {
+			if ( in_array( $status, $statuses, true ) ) {
+				return $status;
+			}
+		}
+		return array() === $statuses ? 'evidence_gap' : 'pass';
+	}
+
+	private static function reference_in( array $reference, array $sources ): bool {
+		return in_array( $reference, $sources, true );
+	}
+
+	/** @return array<string,string> */
+	private static function missing_reference( string $id, string $reason ): array {
+		return array(
+			'schema'      => self::DIMENSION_EVIDENCE_SCHEMA,
+			'state'       => 'missing',
+			'dimension'   => $id,
+			'reason_code' => $reason,
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function receipt_reference( array $bindings, string $selector = '' ): array {
+		$reference = array(
+			'schema' => (string) ( $bindings['materialization_receipt']['schema'] ?? '' ),
+			'sha256' => (string) ( $bindings['materialization_receipt']['sha256'] ?? '' ),
+		);
+		if ( '' !== $selector ) {
+			$reference['selector'] = $selector;
+		}
+		return $reference;
+	}
+
+	private static function aggregate_status( array $findings ): string {
+		$statuses = array_column( $findings, 'status' );
+		foreach ( array( 'hard_failure', 'evidence_gap', 'owner_decision', 'acceptable_conversion', 'informational' ) as $status ) {
+			if ( in_array( $status, $statuses, true ) ) {
+				return $status;
+			}
+		}
+		return 'pass';
+	}
+
+	/** @return array<string,int> */
+	private static function counts( array $dimensions ): array {
+		$counts = array_fill_keys( self::STATUSES, 0 );
+		foreach ( $dimensions as $dimension ) {
+			$status = is_array( $dimension ) ? (string) ( $dimension['status'] ?? '' ) : '';
+			if ( isset( $counts[ $status ] ) ) {
+				++$counts[ $status ];
+			}
+		}
+		return $counts;
+	}
+
+	private static function disposition( array $counts, array $bindings ): string {
+		if ( $counts['hard_failure'] > 0 ) {
+			return 'blocked';
+		}
+		if ( ! self::bindings_verified( $bindings ) || $counts['evidence_gap'] > 0 ) {
+			return 'not_proven';
+		}
+		return $counts['owner_decision'] > 0 ? 'needs_owner' : 'ready';
+	}
+
+	private static function bindings_verified( array $bindings ): bool {
+		return true === ( $bindings['verified'] ?? false );
+	}
+
+	private static function gap_reason( string $id ): string {
+		return match ( $id ) {
+			'visual_acceptance' => 'desktop_mobile_visual_evidence_missing',
+			'editability_and_shared_regions' => 'editability_shared_region_evidence_missing',
+			'editor_presentation_and_persistence' => 'editor_presentation_persistence_evidence_missing',
+			'media_library_ownership' => 'media_ownership_evidence_missing',
+			'link_portability' => 'link_inventory_evidence_missing',
+			'interaction_and_provider_functionality' => 'provider_functionality_evidence_missing',
+			'document_metadata_and_identity' => 'rendered_metadata_identity_evidence_missing',
+			'accessibility' => 'accessibility_evidence_missing',
+			'frontend_performance' => 'performance_evidence_missing',
+			'dependency_deployment_rollback' => 'deployment_rollback_evidence_missing',
+			'owner_task_check' => 'owner_task_evidence_missing',
+			default => 'route_content_evidence_missing',
+		};
+	}
+
+	private static function headline( string $disposition ): string {
+		return match ( $disposition ) {
+			'ready' => 'Ready for ordinary ownership.',
+			'needs_owner' => 'Owner decisions required before ordinary ownership.',
+			'blocked' => 'Hard failures block accepted/built handoff.',
+			default => 'Mandatory evidence is missing; handoff is not proven.',
+		};
+	}
+
+	private static function valid_plan_identity( array $identity ): bool {
+		return 'blocks-engine/wordpress-site-plan-identity/v1' === ( $identity['schema'] ?? null ) && self::is_sha256( $identity['hash'] ?? null );
+	}
+
+	/** @return array<string,string>|null */
+	private static function plan_identity( array $identity ): ?array {
+		return self::valid_plan_identity( $identity ) ? array( 'schema' => $identity['schema'], 'hash' => $identity['hash'] ) : null;
+	}
+
+	private static function is_sha256( mixed $value ): bool {
+		return is_string( $value ) && 1 === preg_match( '/^[a-f0-9]{64}$/', $value );
+	}
+
+	private static function bounded_string( mixed $value, int $maximum ): bool {
+		return is_string( $value ) && '' !== $value && strlen( $value ) <= $maximum;
+	}
+
+	/**
+	 * Feed canonical JSON into a digest without allocating an encoded receipt.
+	 *
+	 * @param HashContext $context Hash context.
+	 * @param mixed       $value   JSON-compatible value.
+	 */
+	private static function hash_json_value( HashContext $context, mixed $value ): void {
+		if ( ! is_array( $value ) ) {
+			if ( is_object( $value ) || is_resource( $value ) || ( is_float( $value ) && ! is_finite( $value ) ) ) {
+				throw new InvalidArgumentException( 'Owner-handoff hashes require JSON-compatible arrays and scalar values.' );
+			}
+			$encoded = json_encode( $value, JSON_UNESCAPED_SLASHES );
+			if ( ! is_string( $encoded ) ) {
+				throw new InvalidArgumentException( 'Owner-handoff hashes require valid UTF-8 JSON values.' );
+			}
+			hash_update( $context, $encoded );
+			return;
+		}
+
+		$list = array_is_list( $value );
+		hash_update( $context, $list ? '[' : '{' );
+		$keys = array_keys( $value );
+		if ( ! $list ) {
+			sort( $keys, SORT_STRING );
+		}
+		foreach ( $keys as $index => $key ) {
+			if ( $index > 0 ) {
+				hash_update( $context, ',' );
+			}
+			if ( ! $list ) {
+				$encoded_key = json_encode( (string) $key, JSON_UNESCAPED_SLASHES );
+				if ( ! is_string( $encoded_key ) ) {
+					throw new InvalidArgumentException( 'Owner-handoff hashes require valid UTF-8 JSON object keys.' );
+				}
+				hash_update( $context, $encoded_key . ':' );
+			}
+			self::hash_json_value( $context, $value[ $key ] );
+		}
+		hash_update( $context, $list ? ']' : '}' );
+	}
+
+	private static function try_hash_value( mixed $value ): ?string {
+		try {
+			return self::hash_value( $value );
+		} catch ( InvalidArgumentException ) {
+			return null;
+		}
+	}
+
+	/** @return array<string,mixed> */
+	private static function object( mixed $value ): array {
+		return is_array( $value ) ? $value : array();
+	}
+}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -18,6 +18,9 @@ if ( ! class_exists( 'Static_Site_Importer_Import_Report' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Diagnostic_Loss_Classes' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-diagnostic-loss-classes.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Owner_Handoff_Evidence' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-owner-handoff-evidence.php';
+}
 if ( ! class_exists( 'Static_Site_Importer_Entity_Materializer_Registry' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-entity-materializer-registry.php';
 }
@@ -336,6 +339,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$report['compact_summary']          = self::import_report_summary( $report, $quality );
 		$report['finding_packets']          = self::finding_packets( $report );
 		$report['import_validation_result'] = self::import_validation_result( $report, $quality );
+		$report['owner_handoff_evidence']   = Static_Site_Importer_Owner_Handoff_Evidence::compose_from_report( $report, $quality );
 
 		if ( $build_fixture && class_exists( 'Static_Site_Importer_Diagnostic_Contract' ) ) {
 			return Static_Site_Importer_Diagnostic_Contract::build(

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -892,6 +892,7 @@ class Static_Site_Importer_Theme_Generator {
 			throw new RuntimeException( 'Injected report persistence failure.' );
 		}
 		Static_Site_Importer_WordPress_Site_Plan_Materializer::commit_receipt( $receipt );
+		$report['materialization_receipt'] = $receipt;
 		return array(
 			'theme_slug'                      => $theme['slug'],
 			'theme_name'                      => isset( $args['name'] ) ? (string) $args['name'] : $theme['slug'],

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -91,6 +91,7 @@ $static_site_importer_includes = array(
 	'class-static-site-importer-document-type-classifier.php',
 	'class-static-site-importer-current-site-capabilities.php',
 	'class-static-site-importer-quality-budget-admission.php',
+	'class-static-site-importer-owner-handoff-evidence.php',
 	'class-static-site-importer-wordpress-site-plan-materializer.php',
 	'class-static-site-importer-figma-import.php',
 	'class-static-site-importer-theme-exporter.php',

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -41,6 +41,7 @@
     { "path": "tests/smoke-post-meta-rollback.php", "environment": "standalone-php" },
     { "path": "tests/smoke-plugin-materializer-lifecycle.php", "environment": "standalone-php" },
     { "path": "tests/smoke-product-handoff-contract.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-owner-handoff-evidence.php", "environment": "standalone-php" },
     { "path": "tests/smoke-quality-budget-admission.php", "environment": "standalone-php" },
     { "path": "tests/smoke-product-materializer.php", "environment": "wordpress-runtime" },
     { "path": "tests/smoke-provider-presentation.php", "environment": "standalone-php" },

--- a/tests/smoke-owner-handoff-evidence.php
+++ b/tests/smoke-owner-handoff-evidence.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * Owner-handoff evidence contract coverage.
+ *
+ * Run from the repository root:
+ * php tests/smoke-owner-handoff-evidence.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, int $options = 0, int $depth = 512 ) {
+		return json_encode( $value, $options, $depth );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-import-report.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-owner-handoff-evidence.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$plan_identity = array(
+	'schema' => 'blocks-engine/wordpress-site-plan-identity/v1',
+	'hash'   => str_repeat( 'a', 64 ),
+);
+$receipt       = array(
+	'schema'              => 'static-site-importer/materialization-receipt/v2',
+	'status'              => 'completed',
+	'plan_identity'       => $plan_identity,
+	'receipt_instance_id' => str_repeat( 'b', 64 ),
+	'completed'           => array(
+		'materialized_pages' => array(
+			'/' => array( 'post_id' => 7, 'content_hash' => str_repeat( 'c', 64 ) ),
+		),
+	),
+	'editability_report'  => array(
+		'schema'        => 'static-site-importer/editability-report-admission/v1',
+		'status'        => 'passed',
+		'report_schema' => 'blocks-engine/php-transformer/editability-report/v2',
+		'plan_hash'     => $plan_identity['hash'],
+	),
+);
+$receipt_hash  = Static_Site_Importer_Owner_Handoff_Evidence::hash_value( $receipt );
+$source_for = static function ( string $id, string $status = 'pass' ) use ( $plan_identity, $receipt_hash ): array {
+	$artifact = array(
+		'schema'    => Static_Site_Importer_Owner_Handoff_Evidence::SOURCE_EVIDENCE_SCHEMA,
+		'dimension' => $id,
+		'status'    => $status,
+		'subject'   => array(
+			'plan_identity'                  => $plan_identity,
+			'materialization_receipt_sha256' => $receipt_hash,
+		),
+	);
+	return array(
+		'schema'   => $artifact['schema'],
+		'sha256'   => Static_Site_Importer_Owner_Handoff_Evidence::hash_value( $artifact ),
+		'artifact' => $artifact,
+	);
+};
+
+$dimension_reference = static function ( string $id, string $status = 'pass', array $findings = array() ) use ( $plan_identity, $receipt_hash, $source_for ): array {
+	$source           = $source_for( $id, $status );
+	$source_reference = array( 'schema' => $source['schema'], 'sha256' => $source['sha256'] );
+	foreach ( $findings as &$finding ) {
+		$finding['evidence'] = $source_reference;
+	}
+	unset( $finding );
+	$artifact = array(
+		'schema'          => Static_Site_Importer_Owner_Handoff_Evidence::DIMENSION_EVIDENCE_SCHEMA,
+		'dimension'       => $id,
+		'subject'         => array(
+			'plan_identity'                        => $plan_identity,
+			'materialization_receipt_sha256'       => $receipt_hash,
+		),
+		'status'          => $status,
+		'source_evidence' => array( $source ),
+		'findings'        => $findings,
+	);
+	return array(
+		'artifact' => $artifact,
+		'sha256'   => Static_Site_Importer_Owner_Handoff_Evidence::hash_value( $artifact ),
+	);
+};
+
+$finding = static function ( string $status, string $reason, string $route = '/', string $component = 'hero' ): array {
+	return array(
+		'status'      => $status,
+		'reason_code' => $reason,
+		'affected'    => array( 'route' => $route, 'component' => $component ),
+		'summary'     => 'Owning evidence reported a scoped result.',
+		'next_action' => 'Resolve or acknowledge the owning evidence result.',
+	);
+};
+
+$owner_task_reference = static function ( array $overrides = array() ) use ( $plan_identity, $receipt_hash, $source_for ): array {
+	$source     = $source_for( 'owner_task_check' );
+	$operations = array();
+	foreach ( Static_Site_Importer_Owner_Handoff_Evidence::OWNER_TASKS as $task ) {
+		$operations[ $task ] = array(
+			'status'             => 'passed',
+			'save_reload_status' => 'passed',
+			'validation_status'  => 'passed',
+			'before_sha256'      => hash( 'sha256', $task . ':before' ),
+			'after_sha256'       => hash( 'sha256', $task . ':after' ),
+			'evidence'           => array( $source ),
+		);
+	}
+	$operations = array_replace( $operations, $overrides );
+	$artifact   = array(
+		'schema'     => Static_Site_Importer_Owner_Handoff_Evidence::OWNER_TASK_SCHEMA,
+		'subject'    => array(
+			'plan_identity'                  => $plan_identity,
+			'materialization_receipt_sha256' => $receipt_hash,
+		),
+		'operations' => $operations,
+	);
+	return array(
+		'artifact' => $artifact,
+		'sha256'   => Static_Site_Importer_Owner_Handoff_Evidence::hash_value( $artifact ),
+	);
+};
+
+$complete_evidence = static function () use ( $dimension_reference, $owner_task_reference ): array {
+	$evidence = array();
+	foreach ( Static_Site_Importer_Owner_Handoff_Evidence::DIMENSION_IDS as $id ) {
+		$evidence[ $id ] = 'owner_task_check' === $id ? $owner_task_reference() : $dimension_reference( $id );
+	}
+	return $evidence;
+};
+
+$compose = static function ( array $evidence, array $overrides = array() ) use ( $plan_identity, $receipt ): array {
+	return Static_Site_Importer_Owner_Handoff_Evidence::compose(
+		array_replace(
+			array(
+				'plan_identity'           => $plan_identity,
+				'materialization_receipt' => $receipt,
+				'evidence'                => $evidence,
+			),
+			$overrides
+		)
+	);
+};
+
+$empty = Static_Site_Importer_Owner_Handoff_Evidence::compose( array() );
+$assert( Static_Site_Importer_Owner_Handoff_Evidence::SCHEMA === ( $empty['schema'] ?? '' ), 'empty-schema' );
+$assert( 'not_proven' === ( $empty['disposition'] ?? '' ), 'empty-not-proven' );
+$assert( false === Static_Site_Importer_Owner_Handoff_Evidence::admits_accepted_or_built( $empty ), 'empty-not-admitted' );
+$assert( 12 === ( $empty['counts']['evidence_gap'] ?? 0 ), 'empty-all-gaps' );
+$assert( false === ( $empty['bindings']['verified'] ?? true ), 'empty-bindings-unverified' );
+$assert( 'plan_identity_missing_or_invalid' === ( $empty['bindings']['gaps'][0]['code'] ?? '' ), 'empty-binding-gap-typed' );
+
+$ready_evidence = $complete_evidence();
+$ready = $compose( $ready_evidence );
+$assert( 'ready' === ( $ready['disposition'] ?? '' ), 'complete-ready' );
+$assert( true === Static_Site_Importer_Owner_Handoff_Evidence::admits_accepted_or_built( $ready, $receipt, $ready_evidence ), 'complete-admitted' );
+$assert( 12 === ( $ready['counts']['pass'] ?? 0 ), 'complete-all-pass' );
+$assert( array() === ( $ready['findings'] ?? null ), 'complete-no-findings' );
+$assert( $receipt_hash === ( $ready['bindings']['materialization_receipt']['sha256'] ?? '' ), 'complete-full-receipt-hash' );
+$assert( $ready['evidence_sha256'] === ( $ready['report_card']['evidence_sha256'] ?? null ), 'report-card-hash-bound' );
+$assert( 12 === count( $ready['report_card']['dimensions'] ?? array() ), 'report-card-dimension-rows' );
+$assert( false === Static_Site_Importer_Owner_Handoff_Evidence::admits_accepted_or_built( array( 'handoff_admitted' => true ) ), 'forged-admission-boolean-rejected' );
+$tampered_ready = $ready;
+$tampered_ready['counts']['pass'] = 11;
+$assert( false === Static_Site_Importer_Owner_Handoff_Evidence::admits_accepted_or_built( $tampered_ready, $receipt, $ready_evidence ), 'tampered-admitted-document-rejected' );
+
+$reordered_receipt = array_reverse( $receipt, true );
+$assert( $receipt_hash === Static_Site_Importer_Owner_Handoff_Evidence::hash_value( $reordered_receipt ), 'canonical-hash-key-order-independent' );
+$mutated_receipt = $receipt;
+$mutated_receipt['completed']['materialized_pages']['/']['post_id'] = 8;
+$mutated = $compose( $complete_evidence(), array( 'materialization_receipt' => $mutated_receipt ) );
+$assert( $receipt_hash !== ( $mutated['bindings']['materialization_receipt']['sha256'] ?? '' ), 'complete-receipt-mutation-changes-hash' );
+$assert( 'evidence_gap' === ( $mutated['dimensions']['visual_acceptance']['status'] ?? '' ), 'old-evidence-rejected-after-receipt-mutation' );
+$assert( 'evidence_subject_mismatch' === ( $mutated['findings'][1]['reason_code'] ?? '' ), 'receipt-mutation-has-subject-gap' );
+
+$forged = $compose( array( 'visual_acceptance' => array( 'status' => 'passed' ) ) );
+$assert( 'evidence_gap' === ( $forged['dimensions']['visual_acceptance']['status'] ?? '' ), 'bare-status-cannot-pass' );
+$assert( 'evidence_schema_or_dimension_invalid' === ( $forged['findings'][1]['reason_code'] ?? '' ), 'bare-status-typed-gap' );
+
+$tampered_evidence = $complete_evidence();
+$tampered_evidence['visual_acceptance']['artifact']['status'] = 'hard_failure';
+$tampered = $compose( $tampered_evidence );
+$assert( 'evidence_gap' === ( $tampered['dimensions']['visual_acceptance']['status'] ?? '' ), 'tampered-artifact-cannot-pass' );
+$assert( 'evidence_hash_mismatch' === ( $tampered['findings'][0]['reason_code'] ?? '' ), 'tampered-artifact-typed-gap' );
+
+$wrong_plan = $plan_identity;
+$wrong_plan['hash'] = str_repeat( 'e', 64 );
+$mismatched = $compose( $complete_evidence(), array( 'plan_identity' => $wrong_plan ) );
+$assert( false === ( $mismatched['bindings']['verified'] ?? true ), 'receipt-plan-mismatch-unverified' );
+$assert( 'receipt_plan_identity_mismatch' === ( $mismatched['bindings']['gaps'][0]['code'] ?? '' ), 'receipt-plan-mismatch-typed' );
+$assert( false === Static_Site_Importer_Owner_Handoff_Evidence::admits_accepted_or_built( $mismatched ), 'receipt-plan-mismatch-not-admitted' );
+
+$visual_reference = $dimension_reference(
+	'visual_acceptance',
+	'hard_failure',
+	array(
+		$finding( 'informational', 'desktop_minor_difference', '/', 'header' ),
+		$finding( 'hard_failure', 'mobile_visual_mismatch', '/pricing', 'footer' ),
+	)
+);
+$visual_evidence = $complete_evidence();
+$visual_evidence['visual_acceptance'] = $visual_reference;
+$visual_fail = $compose( $visual_evidence );
+$assert( 'blocked' === ( $visual_fail['disposition'] ?? '' ), 'visual-fail-blocked' );
+$assert( 2 === count( $visual_fail['dimensions']['visual_acceptance']['finding_ids'] ?? array() ), 'multiple-scoped-findings-retained' );
+$assert( '/pricing' === ( $visual_fail['findings'][1]['affected']['route'] ?? '' ), 'finding-route-retained' );
+$assert( 'Automattic/static-site-importer' === ( $visual_fail['findings'][1]['owning_repository'] ?? '' ), 'owner-fixed-by-dimension' );
+
+$owner_reference = $dimension_reference(
+	'document_metadata_and_identity',
+	'owner_decision',
+	array( $finding( 'owner_decision', 'site_identity_confirmation_required', '/', 'site_identity' ) )
+);
+$owner_evidence = $complete_evidence();
+$owner_evidence['document_metadata_and_identity'] = $owner_reference;
+$needs_owner = $compose( $owner_evidence );
+$assert( 'needs_owner' === ( $needs_owner['disposition'] ?? '' ), 'owner-decision-needs-owner' );
+$assert( true === Static_Site_Importer_Owner_Handoff_Evidence::admits_accepted_or_built( $needs_owner, $receipt, $owner_evidence ), 'owner-decision-does-not-block-accepted-built' );
+
+$missing_task = $owner_task_reference();
+unset( $missing_task['artifact']['operations']['form_recipient_edit'] );
+$missing_task['sha256'] = Static_Site_Importer_Owner_Handoff_Evidence::hash_value( $missing_task['artifact'] );
+$task_evidence = $complete_evidence();
+$task_evidence['owner_task_check'] = $missing_task;
+$task_gap = $compose( $task_evidence );
+$assert( 'evidence_gap' === ( $task_gap['dimensions']['owner_task_check']['status'] ?? '' ), 'missing-owner-task-is-gap' );
+$assert( 'form_recipient_edit' === ( $task_gap['findings'][0]['affected']['component'] ?? '' ), 'missing-owner-task-component' );
+
+$owner_source = $source_for( 'owner_task_check' );
+$failed_operation = array(
+	'status'             => 'passed',
+	'save_reload_status' => 'failed',
+	'validation_status'  => 'passed',
+	'before_sha256'      => str_repeat( '1', 64 ),
+	'after_sha256'       => str_repeat( '2', 64 ),
+	'evidence'           => array( $owner_source ),
+);
+$failed_task = $owner_task_reference( array( 'text_edit' => $failed_operation ) );
+$task_evidence['owner_task_check'] = $failed_task;
+$task_fail = $compose( $task_evidence );
+$assert( 'hard_failure' === ( $task_fail['dimensions']['owner_task_check']['status'] ?? '' ), 'failed-save-reload-is-hard-failure' );
+$assert( false === Static_Site_Importer_Owner_Handoff_Evidence::admits_accepted_or_built( $task_fail ), 'failed-save-reload-not-admitted' );
+
+$no_op_task = $owner_task_reference();
+$no_op_task['artifact']['operations']['text_edit']['after_sha256'] = $no_op_task['artifact']['operations']['text_edit']['before_sha256'];
+$no_op_task['sha256'] = Static_Site_Importer_Owner_Handoff_Evidence::hash_value( $no_op_task['artifact'] );
+$task_evidence['owner_task_check'] = $no_op_task;
+$no_op = $compose( $task_evidence );
+$assert( 'evidence_gap' === ( $no_op['dimensions']['owner_task_check']['status'] ?? '' ), 'no-op-owner-task-is-gap' );
+
+$unsupported_evidence = $complete_evidence();
+$unsupported_evidence['visual_acceptance']['artifact']['source_evidence'][0]['schema'] = 'example/unsupported/v1';
+$unsupported_evidence['visual_acceptance']['artifact']['source_evidence'][0]['artifact']['schema'] = 'example/unsupported/v1';
+$unsupported_evidence['visual_acceptance']['artifact']['source_evidence'][0]['sha256'] = Static_Site_Importer_Owner_Handoff_Evidence::hash_value( $unsupported_evidence['visual_acceptance']['artifact']['source_evidence'][0]['artifact'] );
+$unsupported_evidence['visual_acceptance']['sha256'] = Static_Site_Importer_Owner_Handoff_Evidence::hash_value( $unsupported_evidence['visual_acceptance']['artifact'] );
+$unsupported = $compose( $unsupported_evidence );
+$assert( 'evidence_gap' === ( $unsupported['dimensions']['visual_acceptance']['status'] ?? '' ), 'unsupported-source-schema-is-gap' );
+
+$malformed_reference = $dimension_reference( 'visual_acceptance', 'hard_failure', array( $finding( 'hard_failure', 'mobile_visual_mismatch' ) ) );
+unset( $malformed_reference['artifact']['findings'][0]['next_action'] );
+$malformed_reference['sha256'] = Static_Site_Importer_Owner_Handoff_Evidence::hash_value( $malformed_reference['artifact'] );
+$malformed_evidence = $complete_evidence();
+$malformed_evidence['visual_acceptance'] = $malformed_reference;
+$malformed = $compose( $malformed_evidence );
+$assert( 'evidence_gap' === ( $malformed['dimensions']['visual_acceptance']['status'] ?? '' ), 'malformed-finding-is-gap' );
+
+$unhashable_receipt = $receipt;
+$unhashable_receipt['transaction'] = new stdClass();
+$unhashable = Static_Site_Importer_Owner_Handoff_Evidence::compose(
+	array(
+		'plan_identity'           => $plan_identity,
+		'materialization_receipt' => $unhashable_receipt,
+	)
+);
+$assert( false === ( $unhashable['bindings']['verified'] ?? true ), 'unhashable-receipt-fails-closed' );
+$assert( 'materialization_receipt_not_hashable' === ( $unhashable['bindings']['gaps'][0]['code'] ?? '' ), 'unhashable-receipt-typed-gap' );
+
+$automatic = Static_Site_Importer_Owner_Handoff_Evidence::compose(
+	array(
+		'plan_identity'           => $plan_identity,
+		'materialization_receipt' => $receipt,
+	)
+);
+$assert( 'pass' === ( $automatic['dimensions']['editability_and_shared_regions']['status'] ?? '' ), 'verified-receipt-editability-consumed' );
+$assert( 11 === ( $automatic['counts']['evidence_gap'] ?? 0 ), 'unsupported-aggregate-evidence-stays-gap' );
+
+$compatibility_receipt = $receipt;
+$compatibility_receipt['editability_report'] = array(
+	'schema' => 'static-site-importer/editability-report-admission/v1',
+	'status' => 'compatibility_policy_only',
+);
+$report = Static_Site_Importer_Import_Report::from_array(
+	array(
+		'schema'                  => Static_Site_Importer_Import_Report::SCHEMA,
+		'status'                  => 'completed',
+		'plan_identity'           => $plan_identity,
+		'materialization_receipt' => $compatibility_receipt,
+		'quality'                 => array( 'fallback_count' => 0, 'content_loss_count' => 0, 'empty_conversion_count' => 0 ),
+		'source_documents'        => array( 'unresolved_link_count' => 0 ),
+		'visual_fidelity'         => array( 'status' => 'requires_runtime_visual_parity_check' ),
+	)
+);
+$from_report = Static_Site_Importer_Owner_Handoff_Evidence::compose_from_report( $report, $report->section( 'quality' ) );
+$assert( 12 === ( $from_report['counts']['evidence_gap'] ?? 0 ), 'aggregate-zeroes-do-not-fabricate-passes' );
+$assert( 'evidence_gap' === ( $from_report['dimensions']['link_portability']['status'] ?? '' ), 'unresolved-zero-is-not-external-inventory' );
+$assert( 'evidence_gap' === ( $from_report['dimensions']['media_library_ownership']['status'] ?? '' ), 'theme-assets-are-not-media-ownership' );
+
+$failed_receipt = $receipt;
+$failed_receipt['status'] = 'failed';
+$failed = Static_Site_Importer_Owner_Handoff_Evidence::compose(
+	array(
+		'plan_identity'           => $plan_identity,
+		'materialization_receipt' => $failed_receipt,
+	)
+);
+$assert( 'hard_failure' === ( $failed['dimensions']['route_content_completeness']['status'] ?? '' ), 'failed-materialization-is-hard-failure' );
+$assert( 'blocked' === ( $failed['disposition'] ?? '' ), 'failed-materialization-blocks' );
+
+$schema = json_decode( (string) file_get_contents( dirname( __DIR__ ) . '/docs/contracts/owner-handoff-evidence-v1.schema.json' ), true );
+$assert( is_array( $schema ) && Static_Site_Importer_Owner_Handoff_Evidence::SCHEMA === ( $schema['$id'] ?? '' ), 'json-schema-parses' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: owner handoff evidence smoke passed (' . $assertions . " assertions)\n";


### PR DESCRIPTION
## Summary

- define `static-site-importer/owner-handoff-evidence/v1` as a first-class, versioned owner-handoff contract bound to `blocks-engine/wordpress-site-plan-identity/v1` and the canonical `static-site-importer/materialization-receipt/v2` hash
- compose existing owning-layer receipts instead of duplicating visual, editability, media, provider, metadata, accessibility, performance, or deployment policy
- distinguish `hard_failure`, `owner_decision`, `acceptable_conversion`, `informational`, and typed `evidence_gap`; every non-pass finding includes route/component, evidence reference, owning repository, and next action
- fail closed for missing mandatory evidence, including the owner-task check for text, image, navigation, shared footer, and form-recipient edits with save/reload validation
- project the same document as `static-site-importer/owner-handoff-report-card/v1` and refuse accepted/built handoff when the report contains hard failures or evidence gaps

## Verification

- `php tests/smoke-owner-handoff-evidence.php` (49 passed)
- `php tests/smoke-import-report.php` (22 passed)
- `php tests/smoke-import-diagnostic-contract.php` (96 passed)
- `php tests/smoke-product-handoff-contract.php` (53 passed)
- `npm test -- --runInBand` (72 selected entries passed; 13 WordPress-runtime, 1 browser-WP-Codebox, and 3 operator-only entries skipped by manifest policy)

Closes #1414

## Remaining producer dependencies

The contract is honest about current producer coverage. Until those owning layers emit hash-bound dimension artifacts, the report stays `not_proven` rather than fabricating passes:

- visual desktop/mobile acceptance (#673, Blocks Engine runtime comparison)
- shared-region editability beyond plan-bound `editability-report-admission/v1` (Blocks Engine #868 / #1367)
- editor presentation and persisted edits (#961)
- Media Library attachment ownership (#272)
- public document-title materialization (#1410)
- interaction/provider receipts, accessibility, performance, and deployment/rollback evidence

## AI assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagent implemented the bounded contract, schema, and focused tests after inspecting #489, #673, #961, #272, #1410, and Blocks Engine #868/#1367. Chris Huber directed the product standard and remains responsible for the submitted changes.