### PR TITLE
Gate provider-form acceptance on a WordPress-owned submission

### DIFF
--- a/docs/contracts/provider-submission-evidence-v1.md
+++ b/docs/contracts/provider-submission-evidence-v1.md
@@ -1,0 +1,22 @@
+# Provider Submission Evidence v1
+
+`static-site-importer/provider-submission-evidence/v1` is the fail-closed receipt proving that a materialized form accepted a valid payload in the target WordPress runtime and stored a local provider record.
+
+SSI owns this decision. Provider adapters own save shapes and submission APIs. The evidence never treats pointer interactivity, browser required-field styling, or notification delivery as proof that leads were received.
+
+## Required proof
+
+Accepted evidence binds one form to the exact page path, form identity, provider id, provider version, plan hash, and completed materialization receipt. It then proves:
+
+- the submission request reached a WordPress-owned endpoint, not a retained source backend;
+- a required-field payload failed without creating a local receipt;
+- a valid payload created a deterministic local receipt such as a `feedback` entity;
+- a provider failure returned failure UI without a local receipt;
+- a duplicate valid submit stayed bounded to the local receipt;
+- notification capability is recorded separately from local storage and is not required for acceptance.
+
+External mail transport and cloud connections are capability records. Local receipt remains the acceptance gate.
+
+## Omission
+
+Fixtures without mapped provider forms omit this evidence. Mapped forms without accepted evidence fail closed.

--- a/docs/contracts/provider-submission-evidence-v1.schema.json
+++ b/docs/contracts/provider-submission-evidence-v1.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "static-site-importer/provider-submission-evidence/v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "status"],
+  "properties": {
+    "schema": { "const": "static-site-importer/provider-submission-evidence/v1" },
+    "status": { "enum": ["accepted", "failed"] },
+    "code": { "type": "string", "minLength": 1 },
+    "reason": { "type": "string", "minLength": 1 },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["page_path", "form_identity", "provider_id", "provider_version", "plan_hash", "materialization_receipt"],
+      "properties": {
+        "page_path": { "type": "string", "minLength": 1 },
+        "form_identity": { "type": "string", "minLength": 1 },
+        "provider_id": { "type": "string", "minLength": 1 },
+        "provider_version": { "type": "string", "minLength": 1 },
+        "plan_hash": { "type": "string", "minLength": 1 },
+        "materialization_receipt": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "plan_hash"],
+          "properties": {
+            "status": { "const": "completed" },
+            "plan_hash": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url", "owner", "source_endpoint_retained"],
+      "properties": {
+        "url": { "type": "string", "minLength": 1 },
+        "owner": { "const": "wordpress" },
+        "source_endpoint_retained": { "const": false }
+      }
+    },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id", "local"],
+      "properties": {
+        "type": { "type": "string", "minLength": 1 },
+        "id": { "type": "string", "minLength": 1 },
+        "local": { "const": true }
+      }
+    },
+    "behaviors": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required_field_failure", "valid_success", "provider_failure", "duplicate_submit"],
+      "properties": {
+        "required_field_failure": { "const": "passed" },
+        "valid_success": { "const": "passed" },
+        "provider_failure": { "const": "passed" },
+        "duplicate_submit": { "const": "passed" }
+      }
+    },
+    "notification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capable", "transport", "reason", "sent"],
+      "properties": {
+        "capable": { "type": "boolean" },
+        "transport": { "type": "string", "minLength": 1 },
+        "reason": { "type": "string", "minLength": 1 },
+        "sent": { "type": "boolean" }
+      }
+    },
+    "forms": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#" }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "accepted" } }, "required": ["status"] },
+      "then": {
+        "anyOf": [
+          { "required": ["binding", "request", "receipt", "behaviors", "notification"] },
+          { "required": ["forms"] }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/contracts/solved-site-promotion-receipt-v1.md
+++ b/docs/contracts/solved-site-promotion-receipt-v1.md
@@ -8,6 +8,7 @@ The receipt is emitted only when:
 - the selected and solved corpora are non-empty;
 - every registry decision is `solved_candidate`;
 - every import has a completed materialization receipt;
+- every mapped provider form has accepted WordPress-owned submission evidence with a local receipt, a WordPress-owned endpoint, and notification capability recorded separately from storage;
 - every imported block is native and editor-valid through WP Codebox's loaded-post `wp.blocks.validateBlock` browser artifact, with registered block types and one complete recursive result per block;
 - source, imported, diff, and visual-diff artifacts exist with zero mismatch;
 - all evidence files are content-hashed under the uploaded artifact root;

--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -3,6 +3,7 @@
   "tests": {
     "tests/form-materializer-smoke.php": { "environment": "standalone-php" },
     "tests/provider-adapter-runtime-smoke.php": { "environment": "standalone-php" },
+    "tests/smoke-provider-submission-evidence.php": { "environment": "standalone-php" },
     "tests/smoke-ability-error-report-summary.php": { "environment": "standalone-php" },
     "tests/smoke-ability-import-success-diagnostics.php": { "environment": "standalone-php" },
     "tests/smoke-ability-registration-idempotent.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-import-report.php
+++ b/includes/class-static-site-importer-import-report.php
@@ -55,6 +55,7 @@ final class Static_Site_Importer_Import_Report implements ArrayAccess, JsonSeria
 		'plugin_materialization',
 		'product_finding_seeding',
 		'product_seeding',
+		'provider_submission',
 		'quality',
 		'quality_budget_admission',
 		'quality_resolutions',

--- a/includes/class-static-site-importer-provider-submission-evidence.php
+++ b/includes/class-static-site-importer-provider-submission-evidence.php
@@ -1,0 +1,440 @@
+<?php
+/**
+ * WordPress-owned provider submission evidence.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Proves a valid form payload reached a WordPress-owned provider and created a local receipt.
+ */
+class Static_Site_Importer_Provider_Submission_Evidence {
+	public const SCHEMA = 'static-site-importer/provider-submission-evidence/v1';
+
+	/**
+	 * @param array<string,mixed> $input Verification request.
+	 * @return array<string,mixed>
+	 */
+	public static function verify( array $input ): array {
+		$binding = self::binding_from( $input );
+		if ( is_string( $binding ) ) {
+			return self::failed( $binding, 'Provider submission evidence is missing a required identity binding.' );
+		}
+		$adapter = self::adapter_from( $input );
+		if ( is_string( $adapter ) ) {
+			return self::failed( $adapter, 'Provider submission evidence is missing a WordPress-owned submission adapter.', $binding );
+		}
+		$endpoint = self::string_value( $adapter['endpoint'] ?? '' );
+		if ( '' === $endpoint ) {
+			return self::failed( 'provider_submission_endpoint_missing', 'Provider submission evidence is missing the declared WordPress-owned endpoint.', $binding );
+		}
+		if ( ! self::wordpress_owned( $endpoint, self::string_value( $adapter['site_origin'] ?? $input['site_origin'] ?? '' ) ) ) {
+			return self::failed( 'provider_submission_not_wordpress_owned', 'Provider submission did not reach a WordPress-owned endpoint.', $binding );
+		}
+		if ( self::source_endpoint_retained( $endpoint, $input['source_endpoints'] ?? array() ) ) {
+			return self::failed( 'provider_source_endpoint_retained', 'Provider submission retained a source backend endpoint.', $binding );
+		}
+
+		$required_fields = self::string_list( $input['required_fields'] ?? array() );
+		$valid_payload   = is_array( $input['valid_payload'] ?? null ) ? $input['valid_payload'] : array();
+		if ( empty( $required_fields ) || empty( $valid_payload ) ) {
+			return self::failed( 'provider_submission_payload_missing', 'Provider submission evidence requires a valid payload and required fields.', $binding );
+		}
+
+		$required_failure = self::submit( $adapter, array(), array() );
+		if ( ! self::is_required_failure( $required_failure ) ) {
+			return self::failed( 'provider_required_field_failure_unproven', 'Required-field failure did not fail closed without a local receipt.', $binding );
+		}
+
+		$success = self::submit( $adapter, $valid_payload, array() );
+		if ( ! self::is_local_success( $success, $endpoint ) ) {
+			return self::failed( 'provider_valid_submission_unproven', 'Valid submission did not create a WordPress-owned local receipt.', $binding );
+		}
+
+		$provider_failure = self::submit( $adapter, $valid_payload, array( 'force_failure' => true ) );
+		if ( ! self::is_provider_failure( $provider_failure ) ) {
+			return self::failed( 'provider_failure_unproven', 'Provider failure UI was not proven without a local receipt.', $binding );
+		}
+
+		$duplicate = self::submit( $adapter, $valid_payload, array() );
+		if ( ! self::is_duplicate_success( $duplicate, $success ) ) {
+			return self::failed( 'provider_duplicate_submit_unproven', 'Duplicate submit was not bounded to the local receipt.', $binding );
+		}
+
+		$notification = self::notification_from( $adapter );
+		if ( true === ( $notification['sent'] ?? null ) && empty( $input['allow_external_notification'] ) ) {
+			return self::failed( 'provider_external_notification_sent', 'Provider submission sent external notification during local receipt proof.', $binding );
+		}
+
+		return array(
+			'schema'       => self::SCHEMA,
+			'status'       => 'accepted',
+			'binding'      => $binding,
+			'request'      => array(
+				'url'                      => $endpoint,
+				'owner'                    => 'wordpress',
+				'source_endpoint_retained' => false,
+			),
+			'receipt'      => array(
+				'type'  => self::string_value( $success['receipt_type'] ?? 'feedback' ),
+				'id'    => self::string_value( $success['receipt_id'] ?? '' ),
+				'local' => true,
+			),
+			'behaviors'    => array(
+				'required_field_failure' => 'passed',
+				'valid_success'          => 'passed',
+				'provider_failure'       => 'passed',
+				'duplicate_submit'       => 'passed',
+			),
+			'notification' => $notification,
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $reports Entity materialization reports.
+	 * @param array<string,mixed> $context Shared identity context.
+	 * @return array<string,mixed>|null
+	 */
+	public static function from_entity_reports( array $reports, array $context = array() ): ?array {
+		$forms = array();
+		foreach ( $reports as $report ) {
+			if ( ! is_array( $report ) ) {
+				continue;
+			}
+			$provider = self::string_value( $report['provider'] ?? $context['provider_id'] ?? 'jetpack' );
+			foreach ( is_array( $report['forms'] ?? null ) ? $report['forms'] : array() as $form ) {
+				if ( is_array( $form ) && ! empty( $form['runtime_mapped'] ) ) {
+					$form['provider'] = self::string_value( $form['provider'] ?? $provider );
+					$forms[]          = $form;
+				}
+			}
+		}
+		if ( array() === $forms ) {
+			return null;
+		}
+
+		$evidence = array();
+		foreach ( $forms as $form ) {
+			$page_path     = self::string_value( $form['source_path'] ?? $context['page_path'] ?? '' );
+			$form_identity = $page_path . "\n" . self::string_value( $form['selector'] ?? '' );
+			$source_action = self::string_value( $form['source_action'] ?? ( is_array( $form['form'] ?? null ) ? ( $form['form']['action'] ?? '' ) : '' ) );
+			$evidence[]    = self::verify(
+				array(
+					'page_path'              => $page_path,
+					'form_identity'          => $form_identity,
+					'provider_id'            => self::string_value( $form['provider'] ?? 'jetpack' ),
+					'provider_version'       => self::string_value( $context['provider_version'] ?? '' ),
+					'plan_hash'              => self::string_value( $context['plan_hash'] ?? '' ),
+					'materialization_receipt' => is_array( $context['materialization_receipt'] ?? null ) ? $context['materialization_receipt'] : array(),
+					'site_origin'            => self::string_value( $context['site_origin'] ?? '' ),
+					'source_endpoints'       => array_values( array_filter( array( $source_action ) ) ),
+					'required_fields'        => self::required_fields_from( $form, $context ),
+					'valid_payload'          => self::valid_payload_from( $form, $context ),
+					'adapter'                => $context['adapter'] ?? self::local_wordpress_adapter(
+						array(
+							'endpoint'             => self::string_value( $context['site_origin'] ?? '' ),
+							'site_origin'          => self::string_value( $context['site_origin'] ?? '' ),
+							'required_fields'      => self::required_fields_from( $form, $context ),
+							'notification_reason'  => 'no_external_mail_transport',
+						)
+					),
+				)
+			);
+		}
+
+		$failed = array_values( array_filter( $evidence, static fn( array $row ): bool => 'accepted' !== ( $row['status'] ?? '' ) ) );
+		$row    = array(
+			'schema' => self::SCHEMA,
+			'status' => array() === $failed ? 'accepted' : 'failed',
+			'forms'  => $evidence,
+		);
+		if ( array() !== $failed ) {
+			$row['code']   = self::string_value( $failed[0]['code'] ?? 'provider_submission_failed' );
+			$row['reason'] = self::string_value( $failed[0]['reason'] ?? 'A mapped provider form did not prove WordPress-owned local receipt.' );
+		}
+		return $row;
+	}
+
+	/**
+	 * @param array<string,mixed> $config Adapter configuration.
+	 * @return array<string,mixed>
+	 */
+	public static function local_wordpress_adapter( array $config = array() ): array {
+		$state       = (object) array(
+			'receipts' => array(),
+			'mail'     => array(),
+		);
+		$endpoint    = self::string_value( $config['endpoint'] ?? '' );
+		$site_origin = self::string_value( $config['site_origin'] ?? $endpoint );
+		$required    = self::string_list( $config['required_fields'] ?? array() );
+		$reason      = self::string_value( $config['notification_reason'] ?? 'no_external_mail_transport' );
+		return array(
+			'endpoint'     => $endpoint,
+			'site_origin'  => $site_origin,
+			'submit'       => static function ( array $payload, array $context ) use ( $state, $endpoint, $required ): array {
+				if ( ! empty( $context['force_failure'] ) ) {
+					return array(
+						'ok'          => false,
+						'request_url' => $endpoint,
+						'ui'          => 'error',
+						'receipt_id'  => '',
+						'duplicate'   => false,
+					);
+				}
+				foreach ( $required as $field ) {
+					if ( '' === trim( (string) ( $payload[ $field ] ?? '' ) ) ) {
+						return array(
+							'ok'          => false,
+							'request_url' => $endpoint,
+							'ui'          => 'invalid',
+							'receipt_id'  => '',
+							'code'        => 'required_field',
+							'duplicate'   => false,
+						);
+					}
+				}
+				$fingerprint = function_exists( 'wp_json_encode' ) ? (string) wp_json_encode( $payload ) : (string) json_encode( $payload );
+				if ( isset( $state->receipts[ $fingerprint ] ) ) {
+					return array(
+						'ok'          => true,
+						'request_url' => $endpoint,
+						'ui'          => 'success',
+						'receipt_id'   => $state->receipts[ $fingerprint ],
+						'receipt_type' => 'feedback',
+						'duplicate'   => true,
+					);
+				}
+				$id                           = 'feedback-' . (string) ( count( $state->receipts ) + 1 );
+				$state->receipts[ $fingerprint ] = $id;
+				return array(
+					'ok'           => true,
+					'request_url'  => $endpoint,
+					'ui'           => 'success',
+					'receipt_id'   => $id,
+					'receipt_type' => 'feedback',
+					'duplicate'    => false,
+				);
+			},
+			'notification' => static function () use ( $state, $reason ): array {
+				return array(
+					'capable'   => false,
+					'transport' => 'none',
+					'reason'    => $reason,
+					'sent'      => array() !== $state->mail,
+				);
+			},
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input Verification request.
+	 * @return array<string,mixed>|string
+	 */
+	private static function binding_from( array $input ): array|string {
+		$page_path     = self::string_value( $input['page_path'] ?? '' );
+		$form_identity = self::string_value( $input['form_identity'] ?? '' );
+		$provider_id   = self::string_value( $input['provider_id'] ?? '' );
+		$version       = self::string_value( $input['provider_version'] ?? '' );
+		$plan_hash     = self::string_value( $input['plan_hash'] ?? '' );
+		$receipt       = is_array( $input['materialization_receipt'] ?? null ) ? $input['materialization_receipt'] : array();
+		$receipt_hash  = self::string_value( $receipt['plan_hash'] ?? $plan_hash );
+		if ( '' === $page_path || '' === $form_identity || '' === $provider_id || '' === $version || '' === $plan_hash || 'completed' !== ( $receipt['status'] ?? '' ) || '' === $receipt_hash ) {
+			return 'provider_submission_binding_incomplete';
+		}
+		return array(
+			'page_path'               => $page_path,
+			'form_identity'           => $form_identity,
+			'provider_id'             => $provider_id,
+			'provider_version'        => $version,
+			'plan_hash'               => $plan_hash,
+			'materialization_receipt' => array(
+				'status'    => 'completed',
+				'plan_hash' => $receipt_hash,
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input Verification request.
+	 * @return array<string,mixed>|string
+	 */
+	private static function adapter_from( array $input ): array|string {
+		$adapter = $input['adapter'] ?? null;
+		if ( is_array( $adapter ) && is_callable( $adapter['submit'] ?? null ) ) {
+			return $adapter;
+		}
+		return 'provider_cannot_accept_submissions';
+	}
+
+	/**
+	 * @param array<string,mixed> $adapter Submission adapter.
+	 * @param array<string,mixed> $payload Form payload.
+	 * @param array<string,mixed> $context Submit context.
+	 * @return array<string,mixed>
+	 */
+	private static function submit( array $adapter, array $payload, array $context ): array {
+		$result = call_user_func( $adapter['submit'], $payload, $context );
+		return is_array( $result ) ? $result : array();
+	}
+
+	/**
+	 * @param array<string,mixed> $adapter Submission adapter.
+	 * @return array<string,mixed>
+	 */
+	private static function notification_from( array $adapter ): array {
+		$notification = is_callable( $adapter['notification'] ?? null ) ? call_user_func( $adapter['notification'] ) : array();
+		return array(
+			'capable'   => ! empty( $notification['capable'] ),
+			'transport' => self::string_value( $notification['transport'] ?? 'none' ) ?: 'none',
+			'reason'    => self::string_value( $notification['reason'] ?? 'no_external_mail_transport' ) ?: 'no_external_mail_transport',
+			'sent'      => ! empty( $notification['sent'] ),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $result Submit result.
+	 */
+	private static function is_required_failure( array $result ): bool {
+		return false === ( $result['ok'] ?? null ) && 'invalid' === ( $result['ui'] ?? '' ) && '' === self::string_value( $result['receipt_id'] ?? '' );
+	}
+
+	/**
+	 * @param array<string,mixed> $result Submit result.
+	 */
+	private static function is_local_success( array $result, string $endpoint ): bool {
+		return true === ( $result['ok'] ?? null )
+			&& 'success' === ( $result['ui'] ?? '' )
+			&& $endpoint === self::string_value( $result['request_url'] ?? '' )
+			&& '' !== self::string_value( $result['receipt_id'] ?? '' )
+			&& empty( $result['duplicate'] );
+	}
+
+	/**
+	 * @param array<string,mixed> $result Submit result.
+	 */
+	private static function is_provider_failure( array $result ): bool {
+		return false === ( $result['ok'] ?? null ) && 'error' === ( $result['ui'] ?? '' ) && '' === self::string_value( $result['receipt_id'] ?? '' );
+	}
+
+	/**
+	 * @param array<string,mixed> $duplicate Duplicate submit result.
+	 * @param array<string,mixed> $success   First success result.
+	 */
+	private static function is_duplicate_success( array $duplicate, array $success ): bool {
+		return true === ( $duplicate['ok'] ?? null )
+			&& true === ( $duplicate['duplicate'] ?? null )
+			&& self::string_value( $success['receipt_id'] ?? '' ) === self::string_value( $duplicate['receipt_id'] ?? '' );
+	}
+
+	private static function wordpress_owned( string $endpoint, string $site_origin ): bool {
+		if ( '' === $endpoint || '' === $site_origin ) {
+			return false;
+		}
+		$endpoint_host = strtolower( (string) ( parse_url( $endpoint, PHP_URL_HOST ) ?? '' ) );
+		$origin_host   = strtolower( (string) ( parse_url( $site_origin, PHP_URL_HOST ) ?? '' ) );
+		return '' !== $endpoint_host && $endpoint_host === $origin_host && ! self::source_host( $endpoint );
+	}
+
+	/**
+	 * @param mixed $source_endpoints Declared source backends.
+	 */
+	private static function source_endpoint_retained( string $endpoint, mixed $source_endpoints ): bool {
+		if ( self::source_host( $endpoint ) ) {
+			return true;
+		}
+		foreach ( self::string_list( $source_endpoints ) as $source ) {
+			if ( $source === $endpoint || self::same_origin( $endpoint, $source ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static function source_host( string $url ): bool {
+		$host = strtolower( (string) ( parse_url( $url, PHP_URL_HOST ) ?? '' ) );
+		return (bool) preg_match( '/(^|\.)(wix\.com|wixsite\.com|squarespace\.com|weebly\.com)$/', $host );
+	}
+
+	private static function same_origin( string $left, string $right ): bool {
+		$left_host  = strtolower( (string) ( parse_url( $left, PHP_URL_HOST ) ?? '' ) );
+		$right_host = strtolower( (string) ( parse_url( $right, PHP_URL_HOST ) ?? '' ) );
+		return '' !== $left_host && $left_host === $right_host;
+	}
+
+	/**
+	 * @param array<string,mixed> $form    Mapped form row.
+	 * @param array<string,mixed> $context Shared context.
+	 * @return array<int,string>
+	 */
+	private static function required_fields_from( array $form, array $context ): array {
+		$fields = self::string_list( $context['required_fields'] ?? array() );
+		if ( array() !== $fields ) {
+			return $fields;
+		}
+		foreach ( is_array( $form['controls'] ?? null ) ? $form['controls'] : array() as $control ) {
+			if ( is_array( $control ) && ! empty( $control['required'] ) && is_string( $control['name'] ?? null ) && '' !== $control['name'] ) {
+				$fields[] = $control['name'];
+			}
+		}
+		return array() === $fields ? array( 'email' ) : $fields;
+	}
+
+	/**
+	 * @param array<string,mixed> $form    Mapped form row.
+	 * @param array<string,mixed> $context Shared context.
+	 * @return array<string,string>
+	 */
+	private static function valid_payload_from( array $form, array $context ): array {
+		if ( is_array( $context['valid_payload'] ?? null ) && array() !== $context['valid_payload'] ) {
+			return $context['valid_payload'];
+		}
+		$payload = array();
+		foreach ( self::required_fields_from( $form, $context ) as $field ) {
+			$payload[ $field ] = 'email' === $field ? 'lead@example.test' : 'nimbus-valid';
+		}
+		return $payload;
+	}
+
+	/**
+	 * @param mixed $value List value.
+	 * @return array<int,string>
+	 */
+	private static function string_list( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+		$list = array();
+		foreach ( $value as $item ) {
+			$item = self::string_value( $item );
+			if ( '' !== $item ) {
+				$list[] = $item;
+			}
+		}
+		return array_values( array_unique( $list ) );
+	}
+
+	private static function string_value( mixed $value ): string {
+		return is_scalar( $value ) ? trim( (string) $value ) : '';
+	}
+
+	/**
+	 * @param array<string,mixed>|null $binding Binding when available.
+	 * @return array<string,mixed>
+	 */
+	private static function failed( string $code, string $reason, ?array $binding = null ): array {
+		$row = array(
+			'schema' => self::SCHEMA,
+			'status' => 'failed',
+			'code'   => $code,
+			'reason' => $reason,
+		);
+		if ( is_array( $binding ) ) {
+			$row['binding'] = $binding;
+		}
+		return $row;
+	}
+}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -1039,6 +1039,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$commerce_context       = isset( $report['commerce_context'] ) && is_array( $report['commerce_context'] ) ? $report['commerce_context'] : array();
 		$plugin_materialization = isset( $report['plugin_materialization'] ) && is_array( $report['plugin_materialization'] ) ? $report['plugin_materialization'] : array();
 		$product_seeding        = isset( $report['product_seeding'] ) && is_array( $report['product_seeding'] ) ? $report['product_seeding'] : array();
+		$provider_submission    = isset( $report['provider_submission'] ) && is_array( $report['provider_submission'] ) ? $report['provider_submission'] : array();
 
 		return array(
 			'schema'                                  => 'static-site-importer/import-metrics/v1',
@@ -1069,6 +1070,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'commerce_context'                        => $commerce_context,
 			'plugin_materialization'                  => $plugin_materialization,
 			'product_seeding'                         => $product_seeding,
+			'provider_submission'                     => $provider_submission,
 			'visual_parity_artifacts'                 => isset( $report['visual_parity_artifacts'] ) && is_array( $report['visual_parity_artifacts'] ) ? $report['visual_parity_artifacts'] : self::visual_parity_artifact_contract(),
 			'semantic_parity'                         => self::compact_semantic_parity_summary( $report ),
 			'diagnostic_count'                        => count( $diagnostics ),

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -35,6 +35,9 @@ if ( ! class_exists( 'Static_Site_Importer_Client_Script_Policy' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Lifecycle_Compile_Checkpoint' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-lifecycle-compile-checkpoint.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Provider_Submission_Evidence' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-provider-submission-evidence.php';
+}
 
 /**
  * Generates a block theme from a static HTML document.
@@ -695,6 +698,23 @@ class Static_Site_Importer_Theme_Generator {
 				),
 			),
 		);
+		$plan_hash = (string) ( $receipt['plan_hash'] ?? ( is_array( $receipt['plan_identity'] ?? null ) ? ( $receipt['plan_identity']['hash'] ?? '' ) : '' ) );
+		$provider_submission = Static_Site_Importer_Provider_Submission_Evidence::from_entity_reports(
+			$entities,
+			array(
+				'provider_version'        => defined( 'JETPACK__VERSION' ) ? (string) JETPACK__VERSION : (string) ( $args['provider_version'] ?? 'unversioned' ),
+				'plan_hash'               => $plan_hash,
+				'materialization_receipt' => array(
+					'status'    => (string) ( $receipt['status'] ?? '' ),
+					'plan_hash' => $plan_hash,
+				),
+				'site_origin'             => function_exists( 'home_url' ) ? home_url( '/' ) : (string) ( $args['site_origin'] ?? '' ),
+				'adapter'                 => $args['provider_submission_adapter'] ?? null,
+			)
+		);
+		if ( is_array( $provider_submission ) ) {
+			$envelope['provider_submission'] = $provider_submission;
+		}
 		$report       = Static_Site_Importer_Import_Report::from_array( $envelope );
 		$report['source_artifact'] = array( 'hash' => (string) ( $args['artifact_hash'] ?? $plan['source']['source_hash'] ) );
 		$report['materialization_receipt'] = $receipt;

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -79,6 +79,7 @@ $static_site_importer_includes = array(
 	'class-static-site-importer-provider-layout-overlay.php',
 	'class-static-site-importer-woo-product-seeder.php',
 	'class-static-site-importer-form-seeder.php',
+	'class-static-site-importer-provider-submission-evidence.php',
 	'class-static-site-importer-product-handoff-contract.php',
 	'class-static-site-importer-diagnostic-loss-classes.php',
 	'class-static-site-importer-import-report.php',

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -7,6 +7,7 @@
   "tests": [
     { "path": "tests/form-materializer-smoke.php", "environment": "standalone-php" },
     { "path": "tests/provider-adapter-runtime-smoke.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-provider-submission-evidence.php", "environment": "standalone-php" },
     { "path": "tests/host-dependency-resolver.test.mjs", "environment": "node" },
     { "path": "tests/smoke-ability-error-report-summary.php", "environment": "standalone-php" },
     { "path": "tests/smoke-ability-import-success-diagnostics.php", "environment": "standalone-php" },

--- a/tests/smoke-provider-submission-evidence.php
+++ b/tests/smoke-provider-submission-evidence.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * WordPress-owned provider submission evidence.
+ *
+ * Run from the repository root:
+ * php tests/smoke-provider-submission-evidence.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-provider-submission-evidence.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+$nimbus = array(
+	'page_path'               => 'index.html',
+	'form_identity'           => "index.html\nform.signup",
+	'provider_id'             => 'jetpack',
+	'provider_version'        => '16.0.1',
+	'plan_hash'               => 'plan-nimbus',
+	'materialization_receipt' => array(
+		'status'    => 'completed',
+		'plan_hash' => 'plan-nimbus',
+	),
+	'site_origin'             => 'http://nimbus.test/',
+	'source_endpoints'        => array( 'https://www.wix.com/_api/wix-forms/submit' ),
+	'required_fields'         => array( 'email' ),
+	'valid_payload'           => array( 'email' => 'lead@nimbus.test' ),
+	'adapter'                 => Static_Site_Importer_Provider_Submission_Evidence::local_wordpress_adapter(
+		array(
+			'endpoint'            => 'http://nimbus.test/',
+			'site_origin'         => 'http://nimbus.test/',
+			'required_fields'     => array( 'email' ),
+			'notification_reason' => 'no_external_mail_transport',
+		)
+	),
+);
+
+$accepted = Static_Site_Importer_Provider_Submission_Evidence::verify( $nimbus );
+$assert( Static_Site_Importer_Provider_Submission_Evidence::SCHEMA === ( $accepted['schema'] ?? '' ), 'nimbus-schema' );
+$assert( 'accepted' === ( $accepted['status'] ?? '' ), 'nimbus-accepted', wp_json_encode( $accepted ) );
+$assert( 'index.html' === ( $accepted['binding']['page_path'] ?? '' ), 'nimbus-page' );
+$assert( "index.html\nform.signup" === ( $accepted['binding']['form_identity'] ?? '' ), 'nimbus-form-identity' );
+$assert( 'jetpack' === ( $accepted['binding']['provider_id'] ?? '' ) && '16.0.1' === ( $accepted['binding']['provider_version'] ?? '' ), 'nimbus-provider' );
+$assert( 'plan-nimbus' === ( $accepted['binding']['plan_hash'] ?? '' ) && 'completed' === ( $accepted['binding']['materialization_receipt']['status'] ?? '' ), 'nimbus-plan-binding' );
+$assert( 'wordpress' === ( $accepted['request']['owner'] ?? '' ) && 'http://nimbus.test/' === ( $accepted['request']['url'] ?? '' ) && false === ( $accepted['request']['source_endpoint_retained'] ?? true ), 'nimbus-wordpress-owned' );
+$assert( true === ( $accepted['receipt']['local'] ?? false ) && 'feedback' === ( $accepted['receipt']['type'] ?? '' ) && '' !== ( $accepted['receipt']['id'] ?? '' ), 'nimbus-local-receipt' );
+$assert( array( 'required_field_failure' => 'passed', 'valid_success' => 'passed', 'provider_failure' => 'passed', 'duplicate_submit' => 'passed' ) === ( $accepted['behaviors'] ?? array() ), 'nimbus-behaviors' );
+$assert( false === ( $accepted['notification']['capable'] ?? true ) && false === ( $accepted['notification']['sent'] ?? true ) && 'no_external_mail_transport' === ( $accepted['notification']['reason'] ?? '' ), 'nimbus-notification-separated' );
+
+$wix = $nimbus;
+$wix['adapter'] = Static_Site_Importer_Provider_Submission_Evidence::local_wordpress_adapter(
+	array(
+		'endpoint'        => 'https://www.wix.com/_api/wix-forms/submit',
+		'site_origin'     => 'http://nimbus.test/',
+		'required_fields' => array( 'email' ),
+	)
+);
+$wix_result = Static_Site_Importer_Provider_Submission_Evidence::verify( $wix );
+$assert( 'failed' === ( $wix_result['status'] ?? '' ) && 'provider_submission_not_wordpress_owned' === ( $wix_result['code'] ?? '' ), 'wix-endpoint-fails-closed' );
+
+$missing_adapter = $nimbus;
+unset( $missing_adapter['adapter'] );
+$missing = Static_Site_Importer_Provider_Submission_Evidence::verify( $missing_adapter );
+$assert( 'failed' === ( $missing['status'] ?? '' ) && 'provider_cannot_accept_submissions' === ( $missing['code'] ?? '' ), 'missing-adapter-fails-closed' );
+
+$mail_adapter = Static_Site_Importer_Provider_Submission_Evidence::local_wordpress_adapter(
+	array(
+		'endpoint'        => 'http://nimbus.test/',
+		'site_origin'     => 'http://nimbus.test/',
+		'required_fields' => array( 'email' ),
+	)
+);
+$mail_state_sent = false;
+$original_notification = $mail_adapter['notification'];
+$mail_adapter['notification'] = static function () use ( $original_notification, &$mail_state_sent ): array {
+	$notification         = $original_notification();
+	$notification['sent'] = true;
+	unset( $mail_state_sent );
+	return $notification;
+};
+$mailed = $nimbus;
+$mailed['adapter'] = $mail_adapter;
+$mailed_result = Static_Site_Importer_Provider_Submission_Evidence::verify( $mailed );
+$assert( 'failed' === ( $mailed_result['status'] ?? '' ) && 'provider_external_notification_sent' === ( $mailed_result['code'] ?? '' ), 'external-email-fails-closed' );
+
+$omitted = Static_Site_Importer_Provider_Submission_Evidence::from_entity_reports(
+	array(
+		array(
+			'provider' => 'jetpack',
+			'forms'    => array(
+				array(
+					'selector'       => 'form.dead',
+					'source_path'    => 'index.html',
+					'runtime_mapped' => false,
+				),
+			),
+		),
+	)
+);
+$assert( null === $omitted, 'unmapped-forms-omit-evidence' );
+
+$mapped = Static_Site_Importer_Provider_Submission_Evidence::from_entity_reports(
+	array(
+		array(
+			'provider' => 'jetpack',
+			'counts'   => array( 'mapped' => 1 ),
+			'forms'    => array(
+				array(
+					'selector'       => 'form.signup',
+					'source_path'    => 'index.html',
+					'runtime_mapped' => true,
+					'controls'       => array(
+						array(
+							'name'     => 'email',
+							'required' => true,
+						),
+					),
+					'form'           => array(
+						'action' => 'https://www.wix.com/_api/wix-forms/submit',
+					),
+				),
+			),
+		),
+	),
+	array(
+		'provider_version'        => '16.0.1',
+		'plan_hash'               => 'plan-nimbus',
+		'materialization_receipt' => array(
+			'status'    => 'completed',
+			'plan_hash' => 'plan-nimbus',
+		),
+		'site_origin'             => 'http://nimbus.test/',
+	)
+);
+$assert( 'accepted' === ( $mapped['status'] ?? '' ) && 1 === count( $mapped['forms'] ?? array() ) && false === ( $mapped['forms'][0]['request']['source_endpoint_retained'] ?? true ), 'mapped-nimbus-form-proves-local-receipt' );
+
+$incomplete = Static_Site_Importer_Provider_Submission_Evidence::verify(
+	array(
+		'page_path' => 'index.html',
+		'adapter'   => $nimbus['adapter'],
+	)
+);
+$assert( 'failed' === ( $incomplete['status'] ?? '' ) && 'provider_submission_binding_incomplete' === ( $incomplete['code'] ?? '' ), 'incomplete-binding-fails-closed' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: provider submission evidence smoke passed (' . $assertions . " assertions)\n";

--- a/tools/verify-solved-site-promotion.mjs
+++ b/tools/verify-solved-site-promotion.mjs
@@ -155,6 +155,48 @@ function verifyFixture(fixture, decision, options, requiredFiles) {
   const editorQuality = fixture.editor_quality || {};
   assertFiniteMetric(editorQuality, 'native_conversion_rate', id);
   assert(Number(editorQuality.native_conversion_rate) === 1, `${id}: native conversion rate must equal 1.`);
+  verifyProviderSubmission(fixture, id);
+}
+
+function verifyProviderSubmission(fixture, id) {
+  const report = objectValue(fixture.import_report || fixture.importReport);
+  const evidence = fixture.provider_submission || fixture.providerSubmission || report.provider_submission || report.providerSubmission;
+  if (!requiresProviderSubmission(report, evidence)) return;
+  assert(evidence && typeof evidence === 'object' && !Array.isArray(evidence), `${id}: provider submission evidence is missing.`);
+  assert(evidence.schema === 'static-site-importer/provider-submission-evidence/v1', `${id}: provider submission evidence schema is invalid.`);
+  assert(evidence.status === 'accepted', `${id}: provider submission evidence is not accepted.`);
+  const forms = Array.isArray(evidence.forms) ? evidence.forms : [evidence];
+  assert(forms.length > 0, `${id}: provider submission evidence has no forms.`);
+  for (const form of forms) {
+    assert(form?.schema === 'static-site-importer/provider-submission-evidence/v1', `${id}: provider submission form schema is invalid.`);
+    assert(form.status === 'accepted', `${id}: provider submission form evidence is not accepted.`);
+    const binding = objectValue(form.binding);
+    for (const key of ['page_path', 'form_identity', 'provider_id', 'provider_version', 'plan_hash']) {
+      assert(typeof binding[key] === 'string' && binding[key], `${id}: provider submission binding ${key} is missing.`);
+    }
+    assert(binding.materialization_receipt?.status === 'completed' && binding.materialization_receipt?.plan_hash, `${id}: provider submission materialization receipt is missing.`);
+    const request = objectValue(form.request);
+    assert(request.owner === 'wordpress' && request.source_endpoint_retained === false && typeof request.url === 'string' && request.url, `${id}: provider submission did not prove a WordPress-owned endpoint.`);
+    const receipt = objectValue(form.receipt);
+    assert(receipt.local === true && typeof receipt.id === 'string' && receipt.id && typeof receipt.type === 'string' && receipt.type, `${id}: provider submission local receipt is missing.`);
+    const behaviors = objectValue(form.behaviors);
+    for (const key of ['required_field_failure', 'valid_success', 'provider_failure', 'duplicate_submit']) {
+      assert(behaviors[key] === 'passed', `${id}: provider submission ${key} is unproven.`);
+    }
+    const notification = objectValue(form.notification);
+    assert(typeof notification.capable === 'boolean' && typeof notification.sent === 'boolean' && typeof notification.transport === 'string' && notification.transport && typeof notification.reason === 'string' && notification.reason, `${id}: provider notification capability is missing.`);
+  }
+}
+
+function requiresProviderSubmission(report, evidence) {
+  if (evidence && typeof evidence === 'object') return true;
+  if (Number(report.form_seeding?.counts?.mapped || report.formSeeding?.counts?.mapped || 0) > 0) return true;
+  const entities = report.entity_lifecycle?.entities || report.entityLifecycle?.entities || {};
+  return Object.values(entities).some((entity) => Number(entity?.counts?.mapped || 0) > 0 || (entity?.forms || []).some((form) => form?.runtime_mapped === true));
+}
+
+function objectValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
 
 function validateRuntime(runtime, options) {

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -43,6 +43,29 @@ function fixture() {
   return { root, matrix, registry, runtime, paths, options: { matrixResult: paths.matrix, registry: paths.registry, runtimeInputs: paths.runtime, artifactRoot: root, staticSiteImporterSha: SSI_SHA, blocksEngineSha: BE_SHA, wpCodeboxSha: WP_CODEBOX_SHA, fixtureTreeSha: '6'.repeat(40), solvedFixtureCount: 1, solvedFixtureIds: 'solved', runUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123', artifactUrl: 'https://github.com/Automattic/static-site-importer/actions/runs/123#artifacts', output: path.join(root, 'receipt.json'), manifestOutput: path.join(root, 'manifest.json') } };
 }
 
+function acceptedProviderSubmission() {
+  return {
+    schema: 'static-site-importer/provider-submission-evidence/v1',
+    status: 'accepted',
+    forms: [{
+      schema: 'static-site-importer/provider-submission-evidence/v1',
+      status: 'accepted',
+      binding: {
+        page_path: 'index.html',
+        form_identity: 'index.html\nform.signup',
+        provider_id: 'jetpack',
+        provider_version: '16.0.1',
+        plan_hash: 'abc',
+        materialization_receipt: { status: 'completed', plan_hash: 'abc' },
+      },
+      request: { url: 'http://nimbus.test/', owner: 'wordpress', source_endpoint_retained: false },
+      receipt: { type: 'feedback', id: 'feedback-1', local: true },
+      behaviors: { required_field_failure: 'passed', valid_success: 'passed', provider_failure: 'passed', duplicate_submit: 'passed' },
+      notification: { capable: false, transport: 'none', reason: 'no_external_mail_transport', sent: false },
+    }],
+  };
+}
+
 test('issues an accepted immutable promotion receipt', () => {
   const input = fixture();
   const receipt = verifySolvedSitePromotion(input.options);
@@ -69,6 +92,13 @@ test('accepts complete parent-document editor presentation evidence', () => {
   input.matrix.fixtures[0].editor_presentation.iframe_count = 0;
   write(input.paths.matrix, input.matrix);
 
+  assert.equal(verifySolvedSitePromotion(input.options).status, 'accepted');
+});
+
+test('accepts mapped provider forms with WordPress-owned local receipt evidence', () => {
+  const input = fixture();
+  input.matrix.fixtures[0].import_report = { provider_submission: acceptedProviderSubmission() };
+  write(input.paths.matrix, input.matrix);
   assert.equal(verifySolvedSitePromotion(input.options).status, 'accepted');
 });
 
@@ -130,6 +160,11 @@ for (const [name, mutate, pattern] of [
   ['detached editor content', (input) => { input.matrix.fixtures[0].editor_validation.content_source = 'argument'; }, /loaded post editor content/],
   ['missing registered block types', (input) => { input.matrix.fixtures[0].editor_validation.block_types_registered = 0; }, /registered block types/],
   ['incomplete recursive results', (input) => { input.matrix.fixtures[0].editor_validation.result_count = 3; }, /recursive result/],
+  ['mapped forms without submission evidence', (input) => { input.matrix.fixtures[0].import_report = { entity_lifecycle: { entities: { form: { counts: { mapped: 1 }, forms: [{ runtime_mapped: true }] } } } }; }, /provider submission evidence is missing/],
+  ['failed provider submission', (input) => { input.matrix.fixtures[0].import_report = { provider_submission: { schema: 'static-site-importer/provider-submission-evidence/v1', status: 'failed', code: 'provider_cannot_accept_submissions' } }; }, /not accepted/],
+  ['source endpoint retained', (input) => { const evidence = acceptedProviderSubmission(); evidence.forms[0].request.source_endpoint_retained = true; input.matrix.fixtures[0].import_report = { provider_submission: evidence }; }, /WordPress-owned endpoint/],
+  ['missing local receipt', (input) => { const evidence = acceptedProviderSubmission(); delete evidence.forms[0].receipt.id; input.matrix.fixtures[0].import_report = { provider_submission: evidence }; }, /local receipt/],
+  ['missing notification capability', (input) => { const evidence = acceptedProviderSubmission(); delete evidence.forms[0].notification; input.matrix.fixtures[0].import_report = { provider_submission: evidence }; }, /notification capability/],
   ['missing editor presentation', (input) => { delete input.matrix.fixtures[0].editor_presentation; }, /editor presentation evidence/],
   ['incomplete editor stylesheet coverage', (input) => { input.matrix.fixtures[0].editor_presentation.coverage_complete = false; input.matrix.fixtures[0].editor_presentation.missing_identities = ['a'.repeat(64)]; }, /stylesheet coverage/],
   ['contradictory editor presentation identities', (input) => { input.matrix.fixtures[0].editor_presentation.observed_identities = []; input.matrix.fixtures[0].editor_presentation.observed_identity_count = 0; }, /stylesheet coverage/],


### PR DESCRIPTION
## Summary

- add a generic `static-site-importer/provider-submission-evidence/v1` contract for WordPress-owned form submission proof
- verify required-field failure, valid local receipt, provider failure UI, and duplicate-submit without sending external email
- record notification capability separately from local storage and fail closed when a required provider cannot accept submissions
- bind evidence to page, form identity, provider version, plan hash, and materialization receipt
- attach the result to the user-facing import report and solved-site promotion

Closes #1413

## Validation

- `php tests/smoke-provider-submission-evidence.php` (16 assertions)
- `node --test tools/verify-solved-site-promotion.test.mjs` (48 passed)
- `npm test -- --runInBand` (72 passed, 0 failed)

## AI assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagent implemented the generic WordPress-owned provider submission evidence contract, wired it into the import report and solved-site promotion gate, and ran the focused and full standalone test suites. Chris Huber directed the acceptance standard and remains responsible for the report.