### PR TITLE
Update PHP transformer to 0.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   "require": {
     "php": "^8.2",
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "0.8.1"
+    "automattic/blocks-engine-php-transformer": "0.8.2"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38a60d5f999fe8365086fd27f60cb9c0",
+    "content-hash": "27929dc8b6cd52eb3f13117f9c801dd2",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "v0.8.1",
+            "version": "v0.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "3e758ad53c5b1123e849a4ed672f36a0953bde69"
+                "reference": "5776e0f9947be003a3dd9d6ce7d76f36f548909b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/3e758ad53c5b1123e849a4ed672f36a0953bde69",
-                "reference": "3e758ad53c5b1123e849a4ed672f36a0953bde69",
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/5776e0f9947be003a3dd9d6ce7d76f36f548909b",
+                "reference": "5776e0f9947be003a3dd9d6ce7d76f36f548909b",
                 "shasum": ""
             },
             "require": {
@@ -91,7 +91,7 @@
                 "issues": "https://github.com/Automattic/blocks-engine/issues",
                 "source": "https://github.com/Automattic/blocks-engine-php-transformer"
             },
-            "time": "2026-08-29T17:26:32+00:00"
+            "time": "2026-08-29T19:48:13+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/tests/smoke-webfont-producer-consumer.php
+++ b/tests/smoke-webfont-producer-consumer.php
@@ -44,7 +44,7 @@ $assert = static function ( bool $condition, string $message ): void {
 	if ( ! $condition ) throw new RuntimeException( $message );
 };
 
-$assert( 'v0.8.1' === \Composer\InstalledVersions::getPrettyVersion( 'automattic/blocks-engine-php-transformer' ), 'producer-consumer integration runs against the locked Blocks Engine php-transformer v0.8.1 dependency' );
+$assert( 'v0.8.2' === \Composer\InstalledVersions::getPrettyVersion( 'automattic/blocks-engine-php-transformer' ), 'producer-consumer integration runs against the locked Blocks Engine php-transformer v0.8.2 dependency' );
 
 $fixture_html = '<!doctype html><html><head><link rel="stylesheet" href="css/style.css"></head><body><main>Inter fixture</main></body></html>';
 $fixture_css  = "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');\n:root{--font:'Inter',system-ui,sans-serif}body{font-family:var(--font)}";


### PR DESCRIPTION
## Summary

- update the packaged Blocks Engine PHP transformer from 0.8.1 to 0.8.2
- refresh the locked immutable mirror reference
- keep the producer-consumer integration assertion aligned with the installed package

This brings the generic responsive shell, navigation, geometry, dialog trigger, form composition, and social-link improvements landed since 0.8.1 into Static Site Importer.

## Verification

- `composer validate --strict --no-check-publish`
- `php tests/smoke-webfont-producer-consumer.php`
- `npm test -- --all` (71 passed, 0 failed, 17 environment/operator-only checks intentionally skipped)

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode updated the dependency and lock assertion, ran the repository gates, and prepared this pull request under Chris Huber's direction.