### PR TITLE
Report final materialized block quality

### DIFF
--- a/includes/class-static-site-importer-block-document-reporter.php
+++ b/includes/class-static-site-importer-block-document-reporter.php
@@ -25,6 +25,26 @@ if ( ! class_exists( 'Static_Site_Importer_Import_Report' ) ) {
 class Static_Site_Importer_Block_Document_Reporter {
 
 	/**
+	 * Analyze final page post_content and replace any pre-materialization counts.
+	 *
+	 * @param array<int,array<string,mixed>>       $documents Materialized documents with path and content.
+	 * @param Static_Site_Importer_Import_Report $report    Conversion report (mutated by reference).
+	 * @return void
+	 */
+	public static function analyze_materialized_block_documents( array $documents, Static_Site_Importer_Import_Report $report ): void {
+		self::reset_block_document_quality( $report );
+		$report->set_in_section( 'materialized_content', 'block_documents', array() );
+
+		foreach ( $documents as $document ) {
+			if ( ! is_array( $document ) || ! is_string( $document['path'] ?? null ) || ! is_string( $document['content'] ?? null ) ) {
+				continue;
+			}
+			$analysis = self::analyze_generated_block_document( $document['path'], $document['content'], $report );
+			$report->append_to_section( 'materialized_content', 'block_documents', $analysis );
+		}
+	}
+
+	/**
 	 * Analyze generated block documents and record diagnostics into the conversion report.
 	 *
 	 * @param array<string,string> $writes    Generated theme writes keyed by absolute path.
@@ -52,6 +72,12 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @return void
 	 */
 	public static function reset_generated_block_document_analysis( Static_Site_Importer_Import_Report $report ): void {
+		self::reset_block_document_quality( $report );
+		$report->set_in_section( 'materialized_content', 'block_documents', array() );
+		$report->set_in_section( 'generated_theme', 'block_documents', array() );
+	}
+
+	private static function reset_block_document_quality( Static_Site_Importer_Import_Report $report ): void {
 		$report->merge_quality(
 			array(
 				'core_html_block_count'        => 0,
@@ -65,8 +91,6 @@ class Static_Site_Importer_Block_Document_Reporter {
 				return ! is_array( $diagnostic ) || 'generated_theme_block_analysis' !== (string) ( $diagnostic['stage'] ?? '' );
 			}
 		);
-		$report->set_in_section( 'materialized_content', 'block_documents', array() );
-		$report->set_in_section( 'generated_theme', 'block_documents', array() );
 	}
 
 	/**

--- a/includes/class-static-site-importer-block-document-reporter.php
+++ b/includes/class-static-site-importer-block-document-reporter.php
@@ -32,13 +32,14 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @return void
 	 */
 	public static function analyze_materialized_block_documents( array $documents, Static_Site_Importer_Import_Report $report ): void {
+		$documents = array_values( array_filter( $documents, static fn( $document ): bool => is_array( $document ) && is_string( $document['path'] ?? null ) && is_string( $document['content'] ?? null ) && '' !== trim( $document['content'] ) ) );
+		if ( empty( $documents ) ) {
+			return;
+		}
 		self::reset_block_document_quality( $report );
 		$report->set_in_section( 'materialized_content', 'block_documents', array() );
 
 		foreach ( $documents as $document ) {
-			if ( ! is_array( $document ) || ! is_string( $document['path'] ?? null ) || ! is_string( $document['content'] ?? null ) ) {
-				continue;
-			}
 			$analysis = self::analyze_generated_block_document( $document['path'], $document['content'], $report );
 			$report->append_to_section( 'materialized_content', 'block_documents', $analysis );
 		}
@@ -80,6 +81,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	private static function reset_block_document_quality( Static_Site_Importer_Import_Report $report ): void {
 		$report->merge_quality(
 			array(
+				'block_count'                  => 0,
 				'core_html_block_count'        => 0,
 				'freeform_block_count'         => 0,
 				'invalid_block_count'          => 0,
@@ -132,11 +134,15 @@ class Static_Site_Importer_Block_Document_Reporter {
 	public static function analyze_generated_block_document( string $relative_path, string $block_markup, Static_Site_Importer_Import_Report $report ): array {
 		$validation_method = function_exists( 'parse_blocks' ) && function_exists( 'serialize_blocks' ) ? 'wordpress_parse_blocks_serialize_blocks' : 'unavailable';
 		if ( 'unavailable' === $validation_method ) {
+			$counts = self::serialized_block_counts( $block_markup );
+			$report->increment_quality( 'block_count', $counts['block_count'] );
+			$report->increment_quality( 'core_html_block_count', $counts['core_html_block_count'] );
+			$report->increment_quality( 'freeform_block_count', $counts['freeform_block_count'] );
 			return array(
 				'path'                   => $relative_path,
-				'block_count'            => 0,
-				'core_html_block_count'  => 0,
-				'freeform_block_count'   => 0,
+				'block_count'            => $counts['block_count'],
+				'core_html_block_count'  => $counts['core_html_block_count'],
+				'freeform_block_count'   => $counts['freeform_block_count'],
 				'invalid_block_count'    => 0,
 				'serialization_mismatch' => false,
 				'validation_method'      => $validation_method,
@@ -154,6 +160,12 @@ class Static_Site_Importer_Block_Document_Reporter {
 		/** @var array<int, array<string, mixed>> $analyzed_blocks */
 		$analyzed_blocks = $blocks;
 		self::analyze_generated_block_list( $analyzed_blocks, $block_count, $core_html_count, $freeform_count, $invalid_count, $invalid_blocks, $report, $relative_path );
+		if ( 0 === $block_count ) {
+			$serialized_counts = self::serialized_block_counts( $block_markup );
+			$block_count       = $serialized_counts['block_count'];
+			$core_html_count   = $serialized_counts['core_html_block_count'];
+			$freeform_count    = $serialized_counts['freeform_block_count'];
+		}
 
 		$serialized             = serialize_blocks( $blocks );
 		$serialization_mismatch = self::block_documents_differ_for_report( $block_markup, $serialized );
@@ -163,6 +175,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 			$first_differing_token = self::first_differing_block_document_token( $block_markup, $serialized );
 		}
 
+		$report->increment_quality( 'block_count', $block_count );
 		$report->increment_quality( 'core_html_block_count', $core_html_count );
 		$report->increment_quality( 'freeform_block_count', $freeform_count );
 		$report->increment_quality( 'invalid_block_count', $invalid_count );
@@ -207,6 +220,28 @@ class Static_Site_Importer_Block_Document_Reporter {
 			'validation_method'      => $validation_method,
 			'validation_available'   => true,
 		);
+	}
+
+	/** @return array{block_count:int,core_html_block_count:int,freeform_block_count:int} */
+	private static function serialized_block_counts( string $content ): array {
+		$counts = array(
+			'block_count'           => 0,
+			'core_html_block_count' => 0,
+			'freeform_block_count'  => 0,
+		);
+		if ( ! preg_match_all( '/<!--\s+wp:([a-z][a-z0-9-]*(?:\/[a-z][a-z0-9-]*)?)/i', $content, $matches ) ) {
+			return $counts;
+		}
+		foreach ( $matches[1] as $name ) {
+			$name = strtolower( (string) $name );
+			++$counts['block_count'];
+			if ( 'html' === $name || 'core/html' === $name ) {
+				++$counts['core_html_block_count'];
+			} elseif ( 'freeform' === $name || 'core/freeform' === $name ) {
+				++$counts['freeform_block_count'];
+			}
+		}
+		return $counts;
 	}
 
 	/**

--- a/includes/class-static-site-importer-block-document-reporter.php
+++ b/includes/class-static-site-importer-block-document-reporter.php
@@ -32,7 +32,7 @@ class Static_Site_Importer_Block_Document_Reporter {
 	 * @return void
 	 */
 	public static function analyze_materialized_block_documents( array $documents, Static_Site_Importer_Import_Report $report ): void {
-		$documents = array_values( array_filter( $documents, static fn( $document ): bool => is_array( $document ) && is_string( $document['path'] ?? null ) && is_string( $document['content'] ?? null ) && '' !== trim( $document['content'] ) ) );
+		$documents = array_values( array_filter( $documents, static fn( $document ): bool => is_string( $document['path'] ?? null ) && is_string( $document['content'] ?? null ) && '' !== trim( $document['content'] ) ) );
 		if ( empty( $documents ) ) {
 			return;
 		}

--- a/includes/class-static-site-importer-quality-budget-admission.php
+++ b/includes/class-static-site-importer-quality-budget-admission.php
@@ -35,7 +35,9 @@ final class Static_Site_Importer_Quality_Budget_Admission {
 		$unresolved_media        = self::metric( $metrics, array( 'unresolved_media_count', 'unresolved_asset_count' ) );
 		$unresolved_dependencies = self::metric( $metrics, array( 'unresolved_dependency_count', 'dependency_failure_count', 'runtime_dependency_parity_issue_count' ) );
 		$materialized_quality    = isset( $report['quality'] ) && is_array( $report['quality'] ) ? $report['quality'] : array();
-		$materialized_metrics    = isset( $materialized_quality['metrics'] ) && is_array( $materialized_quality['metrics'] ) ? $materialized_quality['metrics'] : $materialized_quality;
+		$materialized_metrics    = array_merge( isset( $materialized_quality['metrics'] ) && is_array( $materialized_quality['metrics'] ) ? $materialized_quality['metrics'] : array(), $materialized_quality );
+		$native_blocks           = self::metric( $materialized_metrics, array( 'native_block_count', 'block_count' ) ) ?? $native_blocks;
+		$core_html               = self::metric( $materialized_metrics, array( 'core_html_block_count' ) ) ?? $core_html;
 		$fallbacks               = self::metric( $materialized_metrics, array( 'fallback_count', 'unresolved_fallback_count' ) );
 		if ( null === $fallbacks ) {
 			$fallbacks = self::metric( $metrics, array( 'fallback_count', 'unresolved_fallback_count' ) );

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -698,6 +698,7 @@ class Static_Site_Importer_Theme_Generator {
 		$report       = Static_Site_Importer_Import_Report::from_array( $envelope );
 		$report['source_artifact'] = array( 'hash' => (string) ( $args['artifact_hash'] ?? $plan['source']['source_hash'] ) );
 		$report['materialization_receipt'] = $receipt;
+		Static_Site_Importer_Block_Document_Reporter::analyze_materialized_block_documents( $report['generated_theme']['block_documents'], $report );
 		$artifact = array_merge(
 			isset( $args['source_artifact_reference'] ) && is_array( $args['source_artifact_reference'] ) ? $args['source_artifact_reference'] : array(),
 			array_filter(

--- a/tests/smoke-materialized-block-content-validation.php
+++ b/tests/smoke-materialized-block-content-validation.php
@@ -172,7 +172,7 @@ $assert( 0 === ( $form_report['quality']['core_html_block_count'] ?? -1 ), 'post
 $assert( 0 === count( array_filter( $form_report['diagnostics'], static fn ( array $diagnostic ): bool => 'generated_document_contains_core_html' === ( $diagnostic['reason'] ?? '' ) ) ), 'pre-graft-core-html-diagnostic-removed' );
 
 $materialized_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( '/tmp/source/index.html' );
-$materialized_report->merge_quality( array( 'core_html_block_count' => 9 ) );
+$materialized_report->merge_quality( array( 'block_count' => 9, 'core_html_block_count' => 9 ) );
 $materialized_report->set_in_section( 'generated_theme', 'block_documents', array( array( 'path' => 'source-projection', 'content' => 'retained' ) ) );
 Static_Site_Importer_Block_Document_Reporter::analyze_materialized_block_documents(
 	array(
@@ -182,6 +182,7 @@ Static_Site_Importer_Block_Document_Reporter::analyze_materialized_block_documen
 	$materialized_report
 );
 $assert( 1 === ( $materialized_report['quality']['core_html_block_count'] ?? -1 ), 'materialized-analysis-replaces-stale-core-html-count' );
+$assert( 2 === ( $materialized_report['quality']['block_count'] ?? -1 ), 'materialized-analysis-replaces-stale-block-count' );
 $assert( 2 === count( $materialized_report['materialized_content']['block_documents'] ?? array() ), 'materialized-analysis-reports-every-final-page' );
 $assert( 1 === count( $materialized_report['generated_theme']['block_documents'] ?? array() ), 'materialized-analysis-preserves-source-projection' );
 

--- a/tests/smoke-materialized-block-content-validation.php
+++ b/tests/smoke-materialized-block-content-validation.php
@@ -171,6 +171,20 @@ Static_Site_Importer_Block_Document_Reporter::analyze_generated_block_document( 
 $assert( 0 === ( $form_report['quality']['core_html_block_count'] ?? -1 ), 'post-graft-analysis-has-no-core-html' );
 $assert( 0 === count( array_filter( $form_report['diagnostics'], static fn ( array $diagnostic ): bool => 'generated_document_contains_core_html' === ( $diagnostic['reason'] ?? '' ) ) ), 'pre-graft-core-html-diagnostic-removed' );
 
+$materialized_report = Static_Site_Importer_Report_Diagnostics::new_conversion_report( '/tmp/source/index.html' );
+$materialized_report->merge_quality( array( 'core_html_block_count' => 9 ) );
+$materialized_report->set_in_section( 'generated_theme', 'block_documents', array( array( 'path' => 'source-projection', 'content' => 'retained' ) ) );
+Static_Site_Importer_Block_Document_Reporter::analyze_materialized_block_documents(
+	array(
+		array( 'path' => 'posts/page-home.post_content', 'content' => '<!-- wp:paragraph --><p>Home</p><!-- /wp:paragraph -->' ),
+		array( 'path' => 'posts/page-about.post_content', 'content' => $form_content ),
+	),
+	$materialized_report
+);
+$assert( 1 === ( $materialized_report['quality']['core_html_block_count'] ?? -1 ), 'materialized-analysis-replaces-stale-core-html-count' );
+$assert( 2 === count( $materialized_report['materialized_content']['block_documents'] ?? array() ), 'materialized-analysis-reports-every-final-page' );
+$assert( 1 === count( $materialized_report['generated_theme']['block_documents'] ?? array() ), 'materialized-analysis-preserves-source-projection' );
+
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
 	exit( 1 );

--- a/tests/smoke-quality-budget-admission.php
+++ b/tests/smoke-quality-budget-admission.php
@@ -32,4 +32,12 @@ $assert( 'passed' === $resolved_fallbacks['production_status'] && 0 === $resolve
 $unresolved_fallbacks = Static_Site_Importer_Quality_Budget_Admission::evaluate( $source_fallback_plan, array(), array( 'quality_budget' => array( 'mode' => 'production', 'max_fallback_count' => 0 ) ) );
 $assert( 'failed' === $unresolved_fallbacks['production_status'] && 2 === $unresolved_fallbacks['evidence']['fallback_count'], 'unresolved provider-materializable fallbacks fail zero-fallback admission' );
 
+$materialized_counts = Static_Site_Importer_Quality_Budget_Admission::evaluate(
+	array( 'quality' => array( 'metrics' => array( 'block_count' => 12, 'fallback_count' => 4 ) ) ),
+	array(),
+	array(),
+	array( 'quality' => array( 'metrics' => array( 'block_count' => 12, 'fallback_count' => 4 ), 'block_count' => 18, 'core_html_block_count' => 3, 'fallback_count' => 2 ) )
+);
+$assert( 18 === $materialized_counts['evidence']['native_block_count'] && 3 === $materialized_counts['evidence']['core_html_block_count'] && 2 === $materialized_counts['evidence']['fallback_count'], 'materialized report counts override nested compiler estimates' );
+
 print "quality budget admission smoke passed\n";

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -98,8 +98,10 @@ if ( ! is_wp_error( $result ) ) {
 	}
 	$metadata = $report['generated_theme']['document_metadata'] ?? array();
 	$scripts  = $metadata['scripts'] ?? array();
+	$materialized_documents = $report['materialized_content']['block_documents'] ?? array();
 
 	$assert( array() === $pattern_documents, 'single-document-import-does-not-generate-page-pattern-copy' );
+	$assert( 1 === count( $materialized_documents ) && 'posts/page-home.post_content' === ( $materialized_documents[0]['path'] ?? '' ), 'final-page-post-content-is-analyzed-before-quality-admission' );
 	$assert( str_contains( $content, 'Fire, flour, patience.' ), 'body-content-is-preserved' );
 	$single_template_parts_by_path = array();
 	foreach ( $template_parts as $template_part ) {

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1945,11 +1945,11 @@ $partial_quality_counters = array(
 	'source_fallback_count'                 => 1,
 );
 $assert(
-	$partial_quality_counters === array_intersect_key( $partial_quality, $partial_quality_counters ) && 1 === ( $partial_quality['block_count'] ?? 0 ) && array(
+	$partial_quality_counters === array_intersect_key( $partial_quality, $partial_quality_counters ) && 6 === ( $partial_quality['block_count'] ?? 0 ) && array(
 		'block_count'    => 1,
 		'fallback_count' => 1,
 	) === ( $partial_quality['metrics'] ?? null ),
-	'partial website-artifact result composition preserves supplied metrics and normalizes the complete quality counter schema'
+	'partial website-artifact result composition preserves supplied compiler metrics and reports final materialized block counts'
 );
 $assert( false === ( $partial_quality['pass'] ?? true ) && true === ( $partial_quality['fail_import'] ?? false ) && in_array( 'unsupported_html_fallback', $partial_quality['failure_reasons'] ?? array(), true ), 'partial website-artifact reports retain unresolved compiler fallbacks as strict quality failures' );
 $tampered_fragment_receipt = $form_binding_receipt;


### PR DESCRIPTION
## Summary

- analyze final serialized WordPress block documents after site-plan materialization
- report aggregate block composition and `core/html` counts from the content SSI actually writes
- use final materialized counts for quality-budget admission while preserving compiler metrics as source evidence
- support standalone validation through serialized block-comment counting when WordPress parser APIs are unavailable

## Verification

- `npm test` (72 selected tests passed; 282 fixture-matrix tests passed)
- focused materialized block reporting and quality-admission regressions
- prior immutable Peaky Barbers package/import changed the incorrect final `core_html_blocks` report from 0 to 28, matching 14 serialized blocks on each of two pages

A follow-up immutable package containing the final admission-precedence commit could not be built locally because Homeboy requires a 150 GiB reconstructable-artifact reserve and safe cleanup left 123 GiB free. No storage safety or retention policy was bypassed.

## AI Assistance

OpenAI GPT-5.6 Sol was used through OpenCode to investigate the reporting path, implement and test the changes, run the real import verification, and prepare this pull request. The commits and evidence were reviewed and orchestrated by Chris Huber.