### PR TITLE
Reuse one runtime for dependency planning and import

### DIFF
--- a/bench/static-site-fixture-matrix.bench.mjs
+++ b/bench/static-site-fixture-matrix.bench.mjs
@@ -5,7 +5,6 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 
@@ -407,9 +406,6 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     entrypoint: matrix.entrypoint,
     fixtures,
   });
-  // Discovery is deliberately a separate, short-lived Codebox runtime. It only
-  // asks SSI for its registry-derived plan; package resolution happens on the
-  // host while assembling the following fresh import runtime.
   const dependencyOverlays = normalizeFixtureMatrixDependencyOverlays({
     staticSiteImporterPath,
     staticSiteImporterPlugin: options.staticSiteImporterPlugin,
@@ -421,15 +417,11 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
   const codeboxArtifactsDirectory = batchCodeboxArtifactsDirectory(outputDirectory, batchSuffix);
   const artifactRefs = batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile, codeboxArtifactsDirectory });
 
-  let dependencyPlan = null;
-  let resolvedDependencyPlan = null;
   let batchRecipe = null;
   let batchError = null;
   let childCommandFailure = null;
 
   try {
-    dependencyPlan = await discoverFixtureDependencyPlan({ fixtures, outputDirectory, staticSiteImporterPath, options, dependencyOverlays, batchSuffix });
-    resolvedDependencyPlan = await resolveHostDependencyPlan(dependencyPlan, path.join(outputDirectory, 'dependency-cache'));
     batchRecipe = buildFixtureMatrixRecipe({
       matrix: batchMatrix,
       runId: batchMatrix.id,
@@ -440,7 +432,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       staticSiteImporterPath,
       staticSiteImporterPlugin: options.staticSiteImporterPlugin,
       staticSiteImporterSlug: options.staticSiteImporterSlug,
-      dependencyPlan: resolvedDependencyPlan,
+      phasedDependencyPlanning: true,
       dependencyOverrides,
       dependencyOverlays,
       svgFontEvidence: true,
@@ -451,7 +443,6 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     });
     writeJsonArtifact(batchRecipeFile, batchRecipe);
   } catch (error) {
-    const failureStage = !dependencyPlan ? 'dependency_discovery' : !resolvedDependencyPlan ? 'dependency_resolution' : 'recipe_build';
     batchError = error;
     childCommandFailure = buildWpCodeboxChildCommandFailure({
       error,
@@ -464,7 +455,7 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
       artifactsDir: codeboxArtifactsDirectory,
       wpCodeboxBin: options.wpCodeboxBin,
       artifactRefs,
-      failureStage,
+      failureStage: 'recipe_build',
     });
   }
 
@@ -577,9 +568,8 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     };
   }
 
-  // Dependency discovery, host resolution, and recipe build failures are
-  // planning failures, not sandbox corruption. Re-running each fixture
-  // individually would fail identically — return the typed failure directly.
+  // Recipe-build failures are deterministic planning failures, not sandbox
+  // corruption. Re-running each fixture individually would fail identically.
   if (childCommandFailure?.failure_stage && childCommandFailure.failure_stage !== 'recipe_run') {
     return {
       batchRun,
@@ -620,105 +610,6 @@ export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outp
     error: recoveryErrors[0] || null,
     childCommandFailures: recoveryOutcomes.flatMap((outcome) => outcome.childCommandFailures || []),
   };
-}
-
-export async function resolveHostDependencyPlan(plan, cacheDirectory, fetcher = fetch) {
-  const entries = [];
-  for (const entry of plan.entries) {
-    if (entry.source_kind !== 'wordpress.org-plugin' || !/^[a-z0-9][a-z0-9-_]*$/i.test(entry.slug || '')) throw new Error('Host dependency resolver received an invalid plugin declaration.');
-    const infoUrl = new URL('https://api.wordpress.org/plugins/info/1.2/');
-    infoUrl.searchParams.set('action', 'plugin_information');
-    infoUrl.searchParams.set('request[slug]', entry.slug);
-    const infoResponse = await fetcher(infoUrl, { redirect: 'error' });
-    if (!infoResponse.ok || !/^application\/json\b/i.test(infoResponse.headers.get('content-type') || '')) throw new Error(`WordPress.org plugin info failed for ${entry.slug}.`);
-    const info = await infoResponse.json();
-    const version = String(info?.version || '');
-    const source = String(info?.download_link || '');
-    const url = new URL(source);
-    if (!/^https:$/.test(url.protocol) || url.hostname !== 'downloads.wordpress.org' || !version || !/^\d[0-9A-Za-z._+-]*$/.test(version)) throw new Error(`WordPress.org plugin info returned an invalid immutable package for ${entry.slug}.`);
-    const cacheKey = `${entry.slug}-${version}`;
-    const cachePath = path.join(cacheDirectory, cacheKey, 'package.zip');
-    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
-    let bytes;
-    if (fs.existsSync(cachePath)) bytes = fs.readFileSync(cachePath);
-    else {
-      const download = await fetcher(url, { redirect: 'error' });
-      const contentLength = Number(download.headers.get('content-length') || 0);
-      if (!download.ok || !/^application\/(zip|octet-stream)\b/i.test(download.headers.get('content-type') || '') || (contentLength && contentLength > 100 * 1024 * 1024)) throw new Error(`WordPress.org package download failed policy validation for ${entry.slug}.`);
-      bytes = Buffer.from(await download.arrayBuffer());
-      if (!bytes.length || bytes.length > 100 * 1024 * 1024) throw new Error(`WordPress.org package exceeds host size policy for ${entry.slug}.`);
-      fs.writeFileSync(cachePath, bytes);
-    }
-    const sha256 = createHash('sha256').update(bytes).digest('hex');
-    entries.push({ ...entry, host_resolution: { schema: 'static-site-importer/host-package-resolution/v1', slug: entry.slug, version, source_url: url.toString(), archive_sha256: sha256, archive_path: cachePath } });
-  }
-  return { ...plan, entries };
-}
-
-async function discoverFixtureDependencyPlan({ fixtures, outputDirectory, staticSiteImporterPath, options, dependencyOverlays = [], batchSuffix }) {
-  const plans = [];
-  for (const fixture of fixtures) {
-    const fixtureDirectory = path.join(outputDirectory, fixture.id);
-    const runtimeDirectory = `/wordpress/wp-content/uploads/static-site-importer-fixture-matrix/${fixture.id}`;
-    const planName = `dependency-plan-${batchSuffix}.json`;
-    const artifactsDir = path.join(outputDirectory, 'dependency-discovery', `${batchSuffix}-${fixture.id}`);
-    const recipeFile = path.join(artifactsDir, 'recipe.json');
-    const outputFile = path.join(artifactsDir, 'output.json');
-    fs.mkdirSync(artifactsDir, { recursive: true });
-    const recipe = {
-      schema: 'wp-codebox/workspace-recipe/v1',
-      runtime: { wp: options.wordpressVersion || 'latest', blueprint: {} },
-      inputs: {
-        stagedFiles: [{ source: path.join(fixtureDirectory, 'artifact.json'), target: path.join(runtimeDirectory, 'artifact.json') }],
-        extra_plugins: [{ source: staticSiteImporterPath, slug: options.staticSiteImporterSlug || 'static-site-importer', activate: true }],
-        ...(dependencyOverlays.length ? { dependency_overlays: dependencyOverlays } : {}),
-      },
-      workflow: { steps: [
-        { command: 'wordpress.wp-cli', args: [`command=plugin activate ${(options.staticSiteImporterPlugin || 'static-site-importer/static-site-importer.php')}`] },
-        { command: 'wordpress.wp-cli', args: [`command=static-site-importer plan-artifact-dependencies --artifact=${path.join(runtimeDirectory, 'artifact.json')} --slug=${fixture.id} --name=${JSON.stringify(fixture.label)} --output=${path.join(runtimeDirectory, planName)}`] },
-      ] },
-      artifacts: { directory: artifactsDir, typed: [{ name: 'dependency-plan', type: 'static-site-importer/runtime-dependency-plan', path: path.join(runtimeDirectory, planName), required: true, parseJson: true, contentType: 'application/json', payloadSchema: 'static-site-importer/runtime-dependency-plan/v1' }] },
-    };
-    writeJsonArtifact(recipeFile, recipe);
-    const discovery = await runWpCodeboxRecipe({ recipeFile, artifactsDir, outputFile, wpCodeboxBin: options.wpCodeboxBin, inactivityTimeoutMs: batchInactivityTimeoutMs(options) });
-    const plan = findDependencyPlan(artifactsDir);
-    if (!plan) throw new Error(`Dependency discovery did not persist a valid plan for fixture ${fixture.id}.`);
-    // Discovery only mounts SSI and its declared transformer overlays. Provider
-    // packages are resolved and activated by the final recipe's extra_plugins
-    // setup, before its workflow begins; asking this runtime for a provider
-    // receipt would incorrectly require Jetpack/Woo during planning.
-    plans.push(plan);
-  }
-  const entries = new Map();
-  for (let index = 0; index < plans.length; index += 1) {
-    const fixtureId = fixtures[index].id;
-    for (const entry of plans[index].entries) {
-      const key = `${entry.source_kind}:${entry.slug}:${entry.plugin_entrypoint}`;
-      const existing = entries.get(key);
-      entries.set(key, {
-        ...(existing || entry),
-        fixture_ids: [...new Set([...(existing?.fixture_ids || []), fixtureId])].sort(),
-      });
-    }
-  }
-  return { schema: 'static-site-importer/runtime-dependency-plan/v1', artifact_sha256: plans.map((plan) => plan.artifact_sha256).sort().join(','), entries: [...entries.values()] };
-}
-
-function findDependencyPlan(directory) {
-  const visit = (current) => {
-    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
-      const child = path.join(current, entry.name);
-      if (entry.isDirectory()) {
-        const found = visit(child);
-        if (found) return found;
-      } else if (entry.isFile() && entry.name.endsWith('.json')) {
-        const parsed = parseJsonText(fs.readFileSync(child, 'utf8'));
-        if (parsed?.schema === 'static-site-importer/runtime-dependency-plan/v1' && Array.isArray(parsed.entries)) return parsed;
-      }
-    }
-    return null;
-  };
-  return visit(directory);
 }
 
 function createFixtureMatrixProgress(matrix, options) {

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -241,11 +241,16 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const attemptId = input.attemptId || input.attempt_id || randomUUID();
   const importer = normalizeStaticSiteImporterPlugin(input);
   const dependencyOverlays = input.dependencyOverlays || input.dependency_overlays || buildDependencyOverrideSetup(input, importer).dependencyOverlays;
+  const phasedDependencyPlanning = input.phasedDependencyPlanning === true || input.phased_dependency_planning === true;
+  const dependencyPlanPath = phasedDependencyPlanning
+    ? path.join(commandArtifactsDirectory, `dependency-plan--${sidecarToken(attemptId)}.json`)
+    : '';
+  const dependencyPlanArtifactName = phasedDependencyPlanning ? `ssi-dependency-plan-${sidecarToken(attemptId)}` : '';
   const mounts = normalizeArray(input.mounts);
   const stagedFiles = normalizeArray(input.stagedFiles || input.staged_files);
   const extraPlugins = [
     importer.extraPlugin,
-    ...hostStageDependencyPlan(input.dependencyPlan || input.dependency_plan),
+    ...(phasedDependencyPlanning ? [] : hostStageDependencyPlan(input.dependencyPlan || input.dependency_plan)),
     ...normalizeArray(input.extraPlugins || input.extra_plugins),
   ];
   const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
@@ -314,6 +319,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
     workflow: {
       steps: [
         importer.activationStep,
+        ...(phasedDependencyPlanning ? dependencyPlanningSteps(matrix.fixtures, commandArtifactsDirectory, dependencyPlanPath, dependencyPlanArtifactName) : []),
         ...matrix.fixtures.flatMap((fixture) => fixtureWorkflowSteps({
           fixture,
           input,
@@ -330,12 +336,24 @@ export function buildFixtureMatrixRecipe(input = {}) {
           runtimePresentationEvidence,
           playgroundArtifactsDirectory,
           dependencyPlan: input.dependencyPlan || input.dependency_plan,
+          dependencyPlanPath,
         })),
       ],
     },
     artifacts: {
       directory: artifactsDirectory,
-      typed: matrix.fixtures.map((fixture) => ({
+      typed: [
+        ...(phasedDependencyPlanning ? [{
+          name: dependencyPlanArtifactName,
+          type: 'static-site-importer/runtime-dependency-plan',
+          path: dependencyPlanPath,
+          required: true,
+          parseJson: true,
+          contentType: 'application/json',
+          payloadSchema: 'static-site-importer/runtime-dependency-plan/v1',
+          metadata: { run_id: runId, step_id: 'dependency-plan', attempt_id: attemptId },
+        }] : []),
+        ...matrix.fixtures.map((fixture) => ({
         name: `ssi-materialization-sidecar-${fixture.id}-${sidecarToken(attemptId)}`,
         type: 'static-site-importer/materialization-runtime-sidecar',
         path: path.join(commandArtifactsDirectory, fixture.id, `materialization-receipt--${sidecarToken(attemptId)}.json`),
@@ -344,7 +362,8 @@ export function buildFixtureMatrixRecipe(input = {}) {
         contentType: 'application/json',
         payloadSchema: 'static-site-importer/materialization-runtime-sidecar/v2',
         metadata: { fixture_id: fixture.id, run_id: runId, step_id: 'import', attempt_id: attemptId },
-      })),
+        })),
+      ],
     },
     metadata: {
       surface_coverage: surfaceCoverage,
@@ -365,6 +384,58 @@ function surfaceCoverageRuntimeWarning(surfaceCoverage) {
   };
 }
 
+function dependencyPlanningSteps(fixtures, commandArtifactsDirectory, dependencyPlanPath, dependencyPlanArtifactName) {
+  const plans = fixtures.map((fixture) => ({
+    fixture,
+    path: path.join(commandArtifactsDirectory, fixture.id, 'dependency-plan.json'),
+  }));
+  const encodedPlans = Buffer.from(JSON.stringify(plans.map(({ fixture, path: planPath }) => ({ fixture_id: fixture.id, path: planPath }))), 'utf8').toString('base64');
+  const mergeCode = `$plans = json_decode(base64_decode('${encodedPlans}'), true);
+$entries = array();
+$artifact_hashes = array();
+foreach ($plans as $planned) {
+	$contents = file_get_contents((string) $planned['path']);
+	$plan = false === $contents ? null : json_decode($contents, true);
+	if (!is_array($plan) || 'static-site-importer/runtime-dependency-plan/v1' !== ($plan['schema'] ?? '') || !isset($plan['entries']) || !is_array($plan['entries'])) { WP_CLI::error('Fixture dependency plan is malformed.'); }
+	$artifact_hashes[] = (string) ($plan['artifact_sha256'] ?? '');
+	foreach ($plan['entries'] as $entry) {
+		if (!is_array($entry) || 'wordpress.org-plugin' !== ($entry['source_kind'] ?? '') || 'required' !== ($entry['activation'] ?? '') || !preg_match('/^[a-z0-9][a-z0-9-_]*$/i', (string) ($entry['slug'] ?? '')) || !preg_match('/^[a-z0-9][a-z0-9-_]*\\/[A-Za-z0-9._-]+\\.php$/', (string) ($entry['plugin_entrypoint'] ?? ''))) { WP_CLI::error('Fixture dependency plan contains an unsupported package artifact.'); }
+		$key = (string) $entry['source_kind'] . ':' . (string) $entry['slug'] . ':' . (string) $entry['plugin_entrypoint'];
+		if (!isset($entries[$key])) { $entries[$key] = $entry; $entries[$key]['fixture_ids'] = array(); }
+		$entries[$key]['fixture_ids'][] = (string) $planned['fixture_id'];
+	}
+}
+sort($artifact_hashes, SORT_STRING);
+ksort($entries, SORT_STRING);
+foreach ($entries as &$entry) { $entry['fixture_ids'] = array_values(array_unique($entry['fixture_ids'])); sort($entry['fixture_ids'], SORT_STRING); }
+unset($entry);
+$merged = array('schema' => 'static-site-importer/runtime-dependency-plan/v1', 'artifact_sha256' => implode(',', $artifact_hashes), 'entries' => array_values($entries));
+$json = wp_json_encode($merged, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+if (false === $json || false === file_put_contents(${JSON.stringify(dependencyPlanPath)}, $json . "\n")) { WP_CLI::error('Failed to persist merged fixture dependency plan.'); }
+WP_CLI::line($json);`;
+  const encodedMergeCode = Buffer.from(mergeCode, 'utf8').toString('base64');
+  return [
+    ...plans.map(({ fixture, path: planPath }) => ({
+      command: 'wordpress.wp-cli',
+      args: [`command=static-site-importer plan-artifact-dependencies --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --output=${shellToken(planPath)}`],
+      metadata: fixtureStepMetadata(fixture, 'dependency-plan', { artifact: path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'), output: planPath }),
+    })),
+    {
+      command: 'wordpress.wp-cli',
+      args: [`command=eval ${shellToken(`eval(base64_decode('${encodedMergeCode}'));`)}`],
+      pluginInput: {
+        artifact: dependencyPlanArtifactName,
+        packages: {
+          resolver: 'wordpress.org-latest-stable',
+          items: '/entries',
+          map: { slug: '/slug', pluginFile: '/plugin_entrypoint' },
+        },
+      },
+      metadata: { phase: 'dependency-plan-merge', output: dependencyPlanPath, fixture_count: fixtures.length },
+    },
+  ];
+}
+
 function fixtureWorkflowSteps(options) {
   const {
     fixture,
@@ -382,6 +453,7 @@ function fixtureWorkflowSteps(options) {
     runtimePresentationEvidence,
     playgroundArtifactsDirectory,
     dependencyPlan,
+    dependencyPlanPath,
   } = options;
   const surfaces = selectFixtureSurfaces(fixture, input);
 
@@ -406,7 +478,7 @@ function fixtureWorkflowSteps(options) {
       ];
     })() : []),
     prepareFixtureDependenciesStep(fixture, commandArtifactsDirectory, runId, attemptId, runtimePresentationEvidence ? RUNTIME_PRESENTATION_EVIDENCE_ARTIFACT_FILENAME : 'artifact.json'),
-    ...providerReadinessSteps(fixture, dependencyPlan),
+    ...(dependencyPlanPath ? [providerReadinessFromPlanStep(fixture, dependencyPlanPath)] : providerReadinessSteps(fixture, dependencyPlan)),
     importFixtureStep(fixture, commandArtifactsDirectory, runId, attemptId, runtimePresentationEvidence ? RUNTIME_PRESENTATION_EVIDENCE_ARTIFACT_FILENAME : 'artifact.json'),
     materializationSidecarReadbackStep(fixture, commandArtifactsDirectory, attemptId),
     ...(visualParityEnabled ? [materializeVisualSourceFontsStep(fixture, commandArtifactsDirectory)] : []),
@@ -635,6 +707,41 @@ function prepareFixtureDependenciesStep(fixture, commandArtifactsDirectory, runI
 function isolatedPreviewClientScriptFlags(runId, fixtureId) {
   const provenance = `fixture-matrix:${runId}:${fixtureId}`;
   return ` --client-script-policy=isolated_preview --client-script-provenance=${shellToken(provenance)} --client-script-isolated`;
+}
+
+function providerReadinessFromPlanStep(fixture, dependencyPlanPath) {
+  const code = `$contents = file_get_contents(${JSON.stringify(dependencyPlanPath)});
+$plan = false === $contents ? null : json_decode($contents, true);
+if (!is_array($plan) || 'static-site-importer/runtime-dependency-plan/v1' !== ($plan['schema'] ?? '') || !isset($plan['entries']) || !is_array($plan['entries'])) { WP_CLI::error('Merged fixture dependency plan is unavailable.'); }
+$required_blocks = array(); $required_classes = array(); $preparation_callbacks = array();
+foreach ($plan['entries'] as $entry) {
+	if (!is_array($entry) || (isset($entry['fixture_ids']) && is_array($entry['fixture_ids']) && !in_array(${JSON.stringify(fixture.id)}, $entry['fixture_ids'], true))) { continue; }
+	$readiness = isset($entry['provider_readiness']) && is_array($entry['provider_readiness']) ? $entry['provider_readiness'] : array();
+	foreach ($readiness['required_block_types'] ?? array() as $name) { if (is_string($name)) { $required_blocks[$name] = $name; } }
+	foreach ($readiness['required_classes'] ?? array() as $name) { if (is_string($name)) { $required_classes[$name] = $name; } }
+	$callback = $readiness['preparation_callback'] ?? null;
+	if (is_array($callback) && 2 === count($callback) && is_string($callback[0]) && is_string($callback[1])) { $preparation_callbacks[implode('::', $callback)] = $callback; }
+}
+$preparation_errors = array();
+foreach ($preparation_callbacks as $callback_name => $callback) {
+	if (!is_callable($callback)) { $preparation_errors[] = array('callback' => $callback_name, 'result' => 'invalid'); continue; }
+	$prepared = call_user_func($callback);
+	if (is_wp_error($prepared)) { $preparation_errors[] = array('callback' => $callback_name, 'result' => 'wp_error', 'code' => (string) $prepared->get_error_code()); }
+	elseif (false === $prepared) { $preparation_errors[] = array('callback' => $callback_name, 'result' => 'false'); }
+}
+$blocks = WP_Block_Type_Registry::get_instance();
+$missing_blocks = array_values(array_filter(array_values($required_blocks), static fn($name) => !$blocks->is_registered($name)));
+$missing_classes = array_values(array_filter(array_values($required_classes), static fn($name) => !class_exists($name)));
+$ready = empty($preparation_errors) && empty($missing_blocks) && empty($missing_classes);
+$result = array('schema' => 'static-site-importer/provider-readiness/v1', 'ready' => $ready, 'preparation_errors' => $preparation_errors, 'missing_block_types' => $missing_blocks, 'missing_classes' => $missing_classes);
+WP_CLI::line(wp_json_encode($result, JSON_UNESCAPED_SLASHES));
+if (!$ready) { WP_CLI::error('Provider dependency readiness failed.'); }`;
+  const encoded = Buffer.from(code, 'utf8').toString('base64');
+  return {
+    command: 'wordpress.wp-cli',
+    args: [`command=eval ${shellToken(`eval(base64_decode('${encoded}'));`)}`],
+    metadata: fixtureStepMetadata(fixture, 'provider-readiness', { dependency_plan: dependencyPlanPath }),
+  };
 }
 
 function providerReadinessSteps(fixture, plan) {

--- a/tests/host-dependency-resolver.test.mjs
+++ b/tests/host-dependency-resolver.test.mjs
@@ -1,30 +1,54 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { createHash } from 'node:crypto';
-import { resolveHostDependencyPlan } from '../bench/static-site-fixture-matrix.bench.mjs';
 
-const entry = (slug, file) => ({ source_kind: 'wordpress.org-plugin', slug, package: slug, plugin_entrypoint: file, activation: 'required' });
-const plan = { schema: 'static-site-importer/runtime-dependency-plan/v1', artifact_sha256: 'a'.repeat(64), entries: [entry('jetpack', 'jetpack/jetpack.php'), entry('woocommerce', 'woocommerce/woocommerce.php')] };
-const archive = Buffer.from('PK\x03\x04fixture');
-const fetcher = async (url) => String(url).includes('api.wordpress.org')
-  ? new Response(JSON.stringify({ version: '1.2.3', download_link: `https://downloads.wordpress.org/plugin/${String(url).includes('jetpack') ? 'jetpack' : 'woocommerce'}.1.2.3.zip` }), { headers: { 'content-type': 'application/json' } })
-  : new Response(archive, { headers: { 'content-type': 'application/zip', 'content-length': String(archive.length) } });
-test('resolves immutable WordPress.org plugin archives on the host', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'ssi-host-deps-'));
-  try {
-    const resolved = await resolveHostDependencyPlan(plan, root, fetcher);
-    assert.equal(resolved.entries.length, 2);
-    for (const item of resolved.entries) {
-      assert.match(item.host_resolution.archive_path, /package\.zip$/);
-      assert.equal(item.host_resolution.archive_sha256, createHash('sha256').update(archive).digest('hex'));
-      assert.match(item.host_resolution.source_url, /^https:\/\/downloads\.wordpress\.org\//);
-    }
-    assert.deepEqual((await resolveHostDependencyPlan({ ...plan, entries: [] }, root, () => { throw new Error('no fetch'); })).entries, []);
-    await assert.rejects(() => resolveHostDependencyPlan({ ...plan, entries: [entry('jetpack', 'jetpack/jetpack.php')] }, root, async () => new Response(JSON.stringify({ version: '1.2.3', download_link: 'http://evil.test/plugin.zip' }), { headers: { 'content-type': 'application/json' } })), /invalid immutable package/);
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
+import { buildFixtureMatrixRecipe } from '../lib/fixture-matrix/steps/recipe-builder.mjs';
+
+test('plans and projects provider plugins inside the import recipe', () => {
+  const recipe = buildFixtureMatrixRecipe({
+    matrix: {
+      id: 'phased-dependency-planning',
+      fixtures: ['fixture-a', 'fixture-b'].map((id) => ({
+        id,
+        label: id,
+        directory: `/fixtures/${id}`,
+        entrypoint: 'index.html',
+      })),
+    },
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    artifactsDirectory: '/tmp/artifacts',
+    phasedDependencyPlanning: true,
+    editorValidation: false,
+    visualParity: false,
+    attemptId: 'attempt-1',
+  });
+
+  const planningSteps = recipe.workflow.steps.filter((step) => step.metadata?.phase === 'dependency-plan');
+  const mergeStep = recipe.workflow.steps.find((step) => step.metadata?.phase === 'dependency-plan-merge');
+  const typedPlan = recipe.artifacts.typed.find((artifact) => artifact.type === 'static-site-importer/runtime-dependency-plan');
+  const mergeIndex = recipe.workflow.steps.indexOf(mergeStep);
+  const prepareIndex = recipe.workflow.steps.findIndex((step) => step.metadata?.phase === 'dependency-prepare');
+
+  assert.equal(planningSteps.length, 2);
+  assert.deepEqual(mergeStep.pluginInput, {
+    artifact: typedPlan.name,
+    packages: {
+      resolver: 'wordpress.org-latest-stable',
+      items: '/entries',
+      map: { slug: '/slug', pluginFile: '/plugin_entrypoint' },
+    },
+  });
+  assert.equal(typedPlan.required, true);
+  assert.equal(typedPlan.parseJson, true);
+  assert.equal(typedPlan.payloadSchema, 'static-site-importer/runtime-dependency-plan/v1');
+  assert.ok(mergeIndex > Math.max(...planningSteps.map((step) => recipe.workflow.steps.indexOf(step))));
+  assert.ok(prepareIndex > mergeIndex, 'projected plugins must be ready before dependency preparation and import');
+  assert.equal(recipe.inputs.extra_plugins.length, 1, 'provider plugins are not host-staged before the runtime starts');
+
+  const mergeCode = [...mergeStep.args[0].matchAll(/([A-Za-z0-9+/=]{100,})/g)]
+    .map((match) => Buffer.from(match[1], 'base64').toString('utf8'))
+    .find((candidate) => candidate.startsWith('$plans ='));
+  assert.ok(mergeCode, 'merge step must contain executable PHP');
+  assert.match(mergeCode, /Fixture dependency plan is malformed/);
+  assert.match(mergeCode, /Fixture dependency plan contains an unsupported package artifact/);
+  assert.match(mergeCode, /'entries' => array_values\(\$entries\)/, 'empty plans produce an empty projected package list');
 });

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -4525,12 +4525,6 @@ test('fixture matrix records generic child command failures for failed WP Codebo
 function wpCodeboxBin() { return '/tmp/wp-codebox'; }
 function wpCodeboxCommand(bin) { return { command: bin, args: [] }; }
 async function runWpCodeboxRecipe(options) {
-  const recipe = require('node:fs').readFileSync(options.recipeFile, 'utf8');
-  if (recipe.includes('plan-artifact-dependencies')) {
-    require('node:fs').mkdirSync(options.artifactsDir, { recursive: true });
-    require('node:fs').writeFileSync(require('node:path').join(options.artifactsDir, 'dependency-plan.json'), JSON.stringify({ schema: 'static-site-importer/runtime-dependency-plan/v1', artifact_sha256: 'a'.repeat(64), entries: [] }));
-    return { exitCode: 0, outputFile: options.outputFile, json: {} };
-  }
   if (options.cwd !== require('node:path').dirname(options.outputFile)) {
     throw new Error('recipe-run did not receive the matrix output directory as cwd');
   }
@@ -4651,14 +4645,6 @@ import { join } from 'node:path';
 const outputIndex = process.argv.indexOf('--output');
 const outputFile = outputIndex >= 0 ? process.argv[outputIndex + 1] : '';
 const fixtureId = process.env.SSI_TEST_FAKE_WP_CODEBOX_FIXTURE_ID || 'large-output-fixture';
-const recipeFile = process.argv[process.argv.indexOf('--recipe') + 1];
-if (readFileSync(recipeFile, 'utf8').includes('plan-artifact-dependencies')) {
-  const artifacts = process.argv[process.argv.indexOf('--artifacts') + 1];
-  mkdirSync(artifacts, { recursive: true });
-  writeFileSync(join(artifacts, 'dependency-plan.json'), JSON.stringify({ schema: 'static-site-importer/runtime-dependency-plan/v1', artifact_sha256: 'a'.repeat(64), entries: [] }));
-  if (outputFile) writeFileSync(outputFile, '{}');
-  process.exit(0);
-}
 if (outputFile) {
   writeFileSync(outputFile, JSON.stringify({ cwd: process.cwd(), results: [{ fixture_id: fixtureId, status: 'succeeded' }] }));
 }
@@ -5388,29 +5374,6 @@ async function runWpCodeboxRecipe(options = {}) {
     captured.push(JSON.parse(recipe));
     fs.writeFileSync(capturedRecipes, JSON.stringify(captured));
   }
-  if (recipe.includes('plan-artifact-dependencies')) {
-    // Parse batch number from the discovery artifacts path (e.g. .../discovery/001-fixture-01/).
-    const discoveryMatch = String(options.recipeFile).match(/discovery\\/(\\d{3})/);
-    const discoveryBatch = discoveryMatch ? Number(discoveryMatch[1]) : 0;
-    inFlight += 1;
-    peakInFlight = Math.max(peakInFlight, inFlight);
-    recordPeak();
-    const unit = Number(process.env.SSI_TEST_RECIPE_UNIT_MS || '15');
-    const delay = discoveryBatch * unit;
-    await new Promise((resolve) => setTimeout(resolve, Math.max(1, delay)));
-    inFlight -= 1;
-    const throwDiscoveryBatch = Number(process.env.SSI_TEST_RECIPE_DISCOVERY_THROW_BATCH || '0');
-    if (throwDiscoveryBatch && throwDiscoveryBatch === discoveryBatch) {
-      const error = new Error('discovery failed for batch ' + discoveryBatch);
-      error.code = 19;
-      error.stdout = '';
-      error.stderr = 'discovery boom';
-      throw error;
-    }
-    fs.mkdirSync(options.artifactsDir, { recursive: true });
-    fs.writeFileSync(require('node:path').join(options.artifactsDir, 'dependency-plan.json'), JSON.stringify({ schema: 'static-site-importer/runtime-dependency-plan/v1', artifact_sha256: 'a'.repeat(64), entries: [] }));
-    return { exitCode: 0, outputFile: options.outputFile, json: {} };
-  }
   const batchNumber = batchNumberFromOutput(options.outputFile);
   inFlight += 1;
   peakInFlight = Math.max(peakInFlight, inFlight);
@@ -5474,7 +5437,6 @@ const CONCURRENCY_ENV_KEYS = [
   'SSI_TEST_RECIPE_BATCH_COUNT',
   'SSI_TEST_RECIPE_UNIT_MS',
   'SSI_TEST_RECIPE_THROW_BATCH',
-  'SSI_TEST_RECIPE_DISCOVERY_THROW_BATCH',
   'SSI_TEST_RECIPE_CAPTURE_FILE',
 ];
 
@@ -5529,7 +5491,7 @@ test('runFixtureMatrix caps WP Codebox batches in flight at the configured concu
   }
 });
 
-test('runFixtureMatrix uses the same candidate transformer overlay for dependency discovery and final import', async () => {
+test('runFixtureMatrix uses the candidate transformer overlay for planning and import in one recipe', async () => {
   const snapshot = snapshotConcurrencyEnv();
   const workspace = setupConcurrencyWorkspace('ssi-discovery-overlay-', 1);
   const transformerPath = path.join(workspace.root, 'blocks-engine', 'php-transformer');
@@ -5556,7 +5518,8 @@ test('runFixtureMatrix uses the same candidate transformer overlay for dependenc
 
     assert.equal(runtimeError, null);
     const recipes = JSON.parse(readFileSync(captureFile, 'utf8'));
-    const discoveryRecipe = recipes.find((recipe) => recipe.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('plan-artifact-dependencies'))));
+    assert.equal(recipes.length, 1, 'planning and import execute in one WP Codebox runtime');
+    const combinedRecipe = recipes[0];
     const importRecipe = JSON.parse(readFileSync(summary.runtime.batches[0].recipe_file, 'utf8'));
     const expectedOverlay = {
       kind: 'composer-package',
@@ -5566,7 +5529,9 @@ test('runFixtureMatrix uses the same candidate transformer overlay for dependenc
       reference,
     };
 
-    assert.deepEqual(discoveryRecipe.inputs.dependency_overlays, [expectedOverlay]);
+    assert.ok(combinedRecipe.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('plan-artifact-dependencies'))));
+    assert.ok(combinedRecipe.workflow.steps.some((step) => step.metadata?.phase === 'import'));
+    assert.deepEqual(combinedRecipe.inputs.dependency_overlays, [expectedOverlay]);
     assert.deepEqual(importRecipe.inputs.dependency_overlays, [expectedOverlay]);
   } finally {
     restoreConcurrencyEnv(snapshot);
@@ -5665,49 +5630,6 @@ test('runFixtureMatrix isolates a throwing batch so sibling batches still comple
   }
 });
 
-test('runFixtureMatrix isolates a dependency-discovery failure so sibling batches still complete', async () => {
-  const snapshot = snapshotConcurrencyEnv();
-  const workspace = setupConcurrencyWorkspace('ssi-discovery-isolation-', 4);
-  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = workspace.helperPath;
-  process.env.SSI_TEST_RECIPE_BATCH_COUNT = '4';
-  process.env.SSI_TEST_RECIPE_UNIT_MS = '5';
-  process.env.SSI_TEST_RECIPE_DISCOVERY_THROW_BATCH = '2';
-
-  try {
-    const { summary, runtimeError } = await runFixtureMatrix({
-      id: 'discovery-isolation-matrix',
-      fixtureRoot: workspace.fixtureRoot,
-      outputDirectory: workspace.outputDirectory,
-      staticSiteImporterPath: workspace.staticSiteImporter,
-      run: true,
-      batchSize: 1,
-      concurrency: 4,
-      visualParity: false,
-    });
-
-    // The discovery failure surfaces as the runtime error + exit code, but the
-    // run still produced a full summary rather than rejecting.
-    assert.ok(runtimeError);
-    assert.match(runtimeError.message, /discovery failed/);
-    assert.equal(summary.runtime.exit_code, 19);
-
-    // Exactly one child-command failure with the correct stage.
-    const failures = summary.runtime.child_command_failures;
-    assert.equal(failures.length, 1);
-    assert.equal(failures[0].batch_id, 'batch-002');
-    assert.equal(failures[0].failure_stage, 'dependency_discovery');
-    assert.equal(failures[0].exit_status, 19);
-
-    // All four batches still ran; the three non-throwing siblings succeeded,
-    // proving one batch's discovery failure did not sink the others.
-    assert.equal(summary.runtime.batches.length, 4);
-    assert.equal(summary.result_summary.succeeded, 3);
-    assert.equal(summary.result_summary.failed, 1);
-  } finally {
-    restoreConcurrencyEnv(snapshot);
-  }
-});
-
 test('runFixtureMatrix recovers healthy fixtures from a poisoned batch sandbox', async () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-recovery-'));
   const staticSiteImporter = path.join(root, 'static-site-importer');
@@ -5728,12 +5650,6 @@ function fixtureIds(recipeFile) {
 function wpCodeboxBin() { return '/tmp/wp-codebox'; }
 function wpCodeboxCommand(bin) { return { command: bin, args: [] }; }
 async function runWpCodeboxRecipe(options) {
-  const recipe = fs.readFileSync(options.recipeFile, 'utf8');
-  if (recipe.includes('plan-artifact-dependencies')) {
-    fs.mkdirSync(options.artifactsDir, { recursive: true });
-    fs.writeFileSync(require('node:path').join(options.artifactsDir, 'dependency-plan.json'), JSON.stringify({ schema: 'static-site-importer/runtime-dependency-plan/v1', artifact_sha256: 'a'.repeat(64), entries: [] }));
-    return { exitCode: 0, outputFile: options.outputFile, json: {} };
-  }
   const ids = fixtureIds(options.recipeFile);
   if (ids.includes('hanging')) {
     const error = new Error('fixture hanging exceeded its deadline');
@@ -5788,14 +5704,6 @@ const fs = require('node:fs');
 const path = require('node:path');
 const recipePath = process.argv[process.argv.indexOf('--recipe') + 1];
 const recipe = fs.readFileSync(recipePath, 'utf8');
-if (recipe.includes('plan-artifact-dependencies')) {
-  const artifacts = process.argv[process.argv.indexOf('--artifacts') + 1];
-  const output = process.argv[process.argv.indexOf('--output') + 1];
-  fs.mkdirSync(artifacts, { recursive: true });
-  fs.writeFileSync(path.join(artifacts, 'dependency-plan.json'), JSON.stringify({ schema: 'static-site-importer/runtime-dependency-plan/v1', artifact_sha256: 'a'.repeat(64), entries: [] }));
-  fs.writeFileSync(output, '{}');
-  process.exit(0);
-}
 const recovery = path.basename(recipePath).match(/-recovery-(.+)\\.json$/);
 const ids = recovery ? [recovery[1]] : [...new Set(recipe.split('--slug=').slice(1).map((part) => part.split(' ')[0]))];
 if (ids.includes('hanging')) {


### PR DESCRIPTION
## Summary

- move fixture dependency planning into the final import recipe
- merge per-fixture plans into one declared typed artifact
- project required WordPress.org plugins through WP Codebox phased plugin inputs
- keep candidate Composer overlays mounted for both planning and import
- remove the standalone discovery runtime and duplicate host resolver
- retain per-batch failure attribution, replay artifacts, recovery isolation, provider readiness, Gutenberg validation, and visual evidence

Fixes #1424.

Depends on Automattic/wp-codebox#2416. The solved-site workflow currently pins released WP Codebox `v0.21.0`, so that gate rejects the new `pluginInput` recipe property until #2416 ships and this repository advances its WP Codebox pin. The PHP 8.2-8.5 and lint checks pass.

Browser proof also exercises Automattic/blocks-engine#1413 at commit `42e7c4bf39c20d4716c804def0e396645ce356f2`.

## Verification

- `npm test`: 72 selected tests passed, 0 failed
- fixture-matrix suite: 281 tests passed, 0 failed
- focused one-runtime/output tests: 5 passed, 0 failed
- `git diff --check`
- completed `1260-cascade-proof`: one runtime, one succeeded fixture, zero findings
- native conversion: `4 / 4` blocks
- editor validation: `8 / 8` blocks valid
- source and candidate screenshot SHA-256: `87718fe64a0242c49dfaefa815321b2688ecc62986331ec85c14e65363dbb528`
- visual mismatch: `0 / 2,048,000` pixels
- repeated one-runtime batch execution ranged from `161.6s` to `459.0s` under host contention, versus `589.6s` for the prior discovery plus import runtimes

## Preserved Contracts

- provider packages resolve on the host; the WordPress runtime does not download them
- planning and import use the same candidate dependency overlays
- planning, projection, package, activation, readiness, and recipe failures remain typed and batch-scoped
- poisoned batches still recover healthy fixtures independently

## AI Assistance

OpenAI GPT-5.6 Sol through OpenCode traced the SSI and WP Codebox lifecycle, implemented the one-runtime recipe integration, updated the failure and concurrency tests, ran the complete fixture suite and committed-candidate browser proof, diagnosed the released-WP-Codebox CI dependency, and prepared this pull request. Chris Huber directed the architecture and reviewed the evidence.