### PR TITLE
Align release coverage with runtime package

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -43,6 +43,16 @@
   },
   "id": "static-site-importer",
   "remote_path": "wp-content/plugins/static-site-importer",
+  "scopes": {
+    "release": {
+      "include": [
+        "runtime-package-manifest.json",
+        "static-site-importer.php",
+        "blocks/",
+        "includes/"
+      ]
+    }
+  },
   "version_targets": [
     {
       "file": "static-site-importer.php",

--- a/tools/runtime-package-manifest.test.mjs
+++ b/tools/runtime-package-manifest.test.mjs
@@ -21,6 +21,11 @@ test("website artifact import profile is complete and capability scoped", async 
     manifest: "runtime-package-manifest.json",
     profile: "website-artifact-import",
   })
+  assert.deepEqual(
+    homeboy.scopes?.release?.include,
+    profile.selectors.filter(({ path }) => !path.startsWith("vendor/")).map(({ path }) => path),
+    "Homeboy release coverage must match the profile's tracked source selectors",
+  )
   assert.deepEqual(profile.abilities, [
     "static-site-importer/import",
     "static-site-importer/materialize-wordpress-site-plan",


### PR DESCRIPTION
## Summary

- scope Homeboy release completeness to the tracked files selected by the `website-artifact-import` runtime package profile
- assert the release scope remains synchronized with the manifest selectors
- preserve exact ZIP/profile parity while excluding development-only tracked runtime-like files

This fixes the `v1.8.4` release gate, which correctly refused to publish because generic package completeness still expected 55 development-only files outside the selected runtime profile. The failed release rolled back before creating a commit or tag.

## Verification

- `npm run test:runtime-package`
- `homeboy review build static-site-importer --path <worktree> --placement local`
- `STATIC_SITE_IMPORTER_PACKAGE_ZIP=build/static-site-importer.zip node --test tools/runtime-package-manifest.test.mjs`
- `npm test -- --all` (72 passed, 0 failed, 17 environment/operator-only checks intentionally skipped)

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode diagnosed the failed Homeboy release coverage boundary, implemented the synchronized component scope and contract assertion, and ran the build/package/full-suite verification under Chris Huber's direction.