### PR TITLE
Clear inherited release source scope

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -45,11 +45,15 @@
   "remote_path": "wp-content/plugins/static-site-importer",
   "scopes": {
     "release": {
-      "include": [
-        "runtime-package-manifest.json",
-        "static-site-importer.php",
-        "blocks/",
-        "includes/"
+      "include": [],
+      "exclude": [
+        "bench/",
+        "homeboy-test-manifest.json",
+        "lib/",
+        "registry/",
+        "rigs/",
+        "test-manifest.json",
+        "tools/"
       ]
     }
   },

--- a/tools/runtime-package-manifest.test.mjs
+++ b/tools/runtime-package-manifest.test.mjs
@@ -23,8 +23,13 @@ test("website artifact import profile is complete and capability scoped", async 
   })
   assert.deepEqual(
     homeboy.scopes?.release?.include,
-    profile.selectors.filter(({ path }) => !path.startsWith("vendor/")).map(({ path }) => path),
-    "Homeboy release coverage must match the profile's tracked source selectors",
+    [],
+    "Homeboy release coverage must clear inherited source selectors",
+  )
+  assert.deepEqual(
+    homeboy.scopes?.release?.exclude,
+    ["bench/", "homeboy-test-manifest.json", "lib/", "registry/", "rigs/", "test-manifest.json", "tools/"],
+    "Homeboy release coverage must exclude tracked development surfaces outside the runtime profile",
   )
   assert.deepEqual(profile.abilities, [
     "static-site-importer/import",


### PR DESCRIPTION
## Summary
- explicitly clear inherited release includes before applying package exclusions
- keep development-only files out of release package completeness
- assert both halves of the portable scope contract

## Verification
- `npm run test:runtime-package`
- `npm test` (73 manifest tests passed; Node suites passed)
- `homeboy release changes static-site-importer --path ...` resolves `v1.8.3` and 11 commits

## AI assistance
OpenAI gpt-5.6-sol via OpenCode diagnosed the Homeboy portable/registered config overlay, implemented the minimal scope reset, and ran verification. I reviewed and orchestrated the release workflow.