### PR TITLE
Rename incomplete runtime evidence state

### DIFF
--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -243,10 +243,10 @@ type/placement, `defer`/`async`, and payload presence, SHA-256, and byte count;
 payload source is never retained in the matrix output.
 
 `summary.matrix_evidence_readiness` aggregates the fixture states. `verified`
-means provenance and a current materialization plan were captured. Historical or
-otherwise incomplete outputs are explicitly `legacy_evidence_missing` (with the
-missing fields listed), so they cannot be read as evidence of current released
-transformer behavior. A dry, unexecuted matrix is `not_captured`.
+means provenance and a current materialization plan were captured. Incomplete
+outputs are explicitly `runtime_evidence_incomplete` (with the missing fields
+listed), so they cannot be read as evidence of current released transformer
+behavior. A dry, unexecuted matrix is `not_captured`.
 
 Every matrix run also writes `visual-parity-evidence-report.json` and
 `visual-parity-evidence-report.md`. These artifacts make the staged-output proof

--- a/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/lib/fixture-matrix/collectors/run-intake.mjs
@@ -358,7 +358,7 @@ export function collectMatrixEvidence(payload, options = {}) {
     .slice(0, MATERIALIZATION_PLAN_ASSET_LIMIT);
   return {
     schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1',
-    readiness: missing.length === 0 ? 'verified' : 'legacy_evidence_missing',
+    readiness: missing.length === 0 ? 'verified' : 'runtime_evidence_incomplete',
     missing,
     transformer: provenance,
     lineage: compactObject({

--- a/lib/fixture-matrix/result.mjs
+++ b/lib/fixture-matrix/result.mjs
@@ -236,7 +236,7 @@ function normalizeSlowFixtures(value) {
 function matrixEvidenceReadiness(fixtures) {
   const rows = normalizeArray(fixtures).map((fixture) => {
     const evidence = objectValue(fixture.matrix_evidence || fixture.matrixEvidence);
-    const readiness = evidence.readiness || (fixture.raw_status === 'not_run' ? 'not_captured' : 'legacy_evidence_missing');
+    const readiness = evidence.readiness || (fixture.raw_status === 'not_run' ? 'not_captured' : 'runtime_evidence_incomplete');
     return {
       fixture_id: fixture.fixture_id,
       readiness,
@@ -246,7 +246,7 @@ function matrixEvidenceReadiness(fixtures) {
   const counts = countBy(rows, (row) => row.readiness);
   return {
     schema: 'static-site-importer/fixture-matrix-runtime-evidence-summary/v1',
-    status: counts.legacy_evidence_missing ? 'incomplete' : (counts.not_captured ? 'not_captured' : 'verified'),
+    status: counts.runtime_evidence_incomplete ? 'incomplete' : (counts.not_captured ? 'not_captured' : 'verified'),
     counts,
     fixtures: rows,
   };

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -262,7 +262,7 @@ test('matrix evidence requires and summarizes the canonical materialization rece
 
 test('matrix evidence fails closed when the materialization receipt is absent', () => {
   const evidence = collectMatrixEvidence({ import_report: { blocks_engine: { transformer: { package: 'package', version: '1.0.0', reference: 'a'.repeat(40) }, wordpress_site_plan: { schema: 'blocks-engine/wordpress-site-plan/v2', assets: [] } } } });
-  assert.equal(evidence.readiness, 'legacy_evidence_missing');
+  assert.equal(evidence.readiness, 'runtime_evidence_incomplete');
   assert.ok(evidence.missing.includes('materialization_receipt'));
 });
 
@@ -1592,10 +1592,10 @@ test('fixture matrix labels reports without runtime provenance and materializati
     codeboxOutput: { fixture_id: 'simple-site', status: 'passed', import_report: { blocks_engine: { available: true } } },
   });
 
-  assert.equal(result.fixtures[0].matrix_evidence.readiness, 'legacy_evidence_missing');
+  assert.equal(result.fixtures[0].matrix_evidence.readiness, 'runtime_evidence_incomplete');
   assert.deepEqual(result.fixtures[0].matrix_evidence.missing, ['transformer_package', 'transformer_version', 'transformer_reference', 'wordpress_site_plan', 'materialization_receipt']);
   assert.equal(result.summary.matrix_evidence_readiness.status, 'incomplete');
-  assert.equal(result.summary.matrix_evidence_readiness.counts.legacy_evidence_missing, 1);
+  assert.equal(result.summary.matrix_evidence_readiness.counts.runtime_evidence_incomplete, 1);
 });
 
 test('materialization sidecars retain bounded evidence after oversized import stdout', () => {
@@ -1992,7 +1992,7 @@ test('fixture attribution records missing lineage as a blind spot instead of def
     results: [{
       fixture_id: 'simple-site',
       status: 'failed',
-      matrix_evidence: { schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1', readiness: 'legacy_evidence_missing', missing: ['transformer_reference', 'wordpress_site_plan', 'materialization_receipt'] },
+      matrix_evidence: { schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1', readiness: 'runtime_evidence_incomplete', missing: ['transformer_reference', 'wordpress_site_plan', 'materialization_receipt'] },
       diagnostics: [{ kind: 'visual_parity_mismatch', message: 'Visual mismatch has no lineage.' }],
     }],
   });
@@ -2009,7 +2009,7 @@ test('materialization attribution reports missing transformer provenance as a bo
     results: [{
       fixture_id: 'simple-site',
       status: 'failed',
-      matrix_evidence: { schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1', readiness: 'legacy_evidence_missing', missing: ['transformer_package', 'transformer_version', 'transformer_reference'] },
+      matrix_evidence: { schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1', readiness: 'runtime_evidence_incomplete', missing: ['transformer_package', 'transformer_version', 'transformer_reference'] },
       diagnostics: [{ kind: 'missing_asset', attribution_boundary: 'materialization', candidate_repo: 'static-site-importer', message: 'Materialization omitted a stylesheet.' }],
     }],
   });
@@ -2039,7 +2039,7 @@ test('versioned fixture evidence replaces an unproven caller-supplied owner', ()
     results: [{
       fixture_id: 'simple-site',
       status: 'failed',
-      matrix_evidence: { schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1', readiness: 'legacy_evidence_missing', missing: ['transformer_reference'] },
+      matrix_evidence: { schema: 'static-site-importer/fixture-matrix-runtime-evidence/v1', readiness: 'runtime_evidence_incomplete', missing: ['transformer_reference'] },
       diagnostics: [{ kind: 'layout_shift', candidate_repo: 'blocks-engine', message: 'Strict contract lacks ownership evidence.' }],
     }],
   });


### PR DESCRIPTION
## What changed

- Rename `legacy_evidence_missing` to `runtime_evidence_incomplete`.
- Apply the current-contract name in fixture intake, summary aggregation, tests, and documentation.
- Keep `verified` and `not_captured` behavior unchanged.

## Why

The old state was emitted for any incomplete run, including newly executed matrices. Calling current missing provenance or materialization fields “legacy” was inaccurate and confused the evidence contract with unrelated legacy import implementations.

## Verification

- `node tools/fixture-matrix.test.mjs` (281 passing)
- No `legacy_evidence_missing` references remain in SSI source, tests, or docs.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced ownership of the readiness state to SSI, renamed the producer and aggregate contract, updated coverage and documentation, and ran the fixture-matrix suite. Chris Huber directed and reviewed the change.