### PR TITLE
Deduplicate theme-owned runtime scripts

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -302,6 +302,102 @@ class Static_Site_Importer_Companion_Plugin {
 	}
 
 	/**
+	 * Remove companion scripts already delivered by the generated theme.
+	 *
+	 * @param array<string,mixed>            $payload Companion-plugin payload.
+	 * @param array<int,array<string,mixed>> $assets  WordPress site-plan assets.
+	 * @return array<string,mixed>
+	 */
+	public static function without_theme_owned_scripts( array $payload, array $assets ): array {
+		$theme_hashes = self::theme_script_hashes( $assets );
+		if ( empty( $theme_hashes ) ) {
+			return $payload;
+		}
+
+		if ( isset( $payload['preserved_js'] ) && is_array( $payload['preserved_js'] ) ) {
+			$payload['preserved_js'] = array_values(
+				array_filter(
+					$payload['preserved_js'],
+					static fn( $entry ): bool => ! is_array( $entry ) || '' !== (string) ( $entry['block'] ?? '' ) || ! isset( $entry['content'] ) || ! is_scalar( $entry['content'] ) || ! isset( $theme_hashes[ hash( 'sha256', (string) $entry['content'] ) ] )
+				)
+			);
+		}
+
+		if ( isset( $payload['runtime_effects']['retained_modules'] ) && is_array( $payload['runtime_effects']['retained_modules'] ) ) {
+			$payload['runtime_effects']['retained_modules'] = array_values(
+				array_filter(
+					$payload['runtime_effects']['retained_modules'],
+					static fn( $module ): bool => ! is_array( $module ) || '' !== (string) ( $module['block'] ?? '' ) || ! isset( $module['content'] ) || ! is_scalar( $module['content'] ) || ! isset( $theme_hashes[ hash( 'sha256', (string) $module['content'] ) ] )
+				)
+			);
+		}
+
+		return $payload;
+	}
+
+	/** Whether a deduplicated payload still requires a companion plugin. */
+	public static function has_materializable_content( array $payload ): bool {
+		if ( ! empty( self::payload_blocks( $payload ) ) ) {
+			return true;
+		}
+
+		foreach ( is_array( $payload['preserved_js'] ?? null ) ? $payload['preserved_js'] : array() as $entry ) {
+			if ( is_array( $entry ) && isset( $entry['content'] ) && is_scalar( $entry['content'] ) && '' !== (string) $entry['content'] ) {
+				return true;
+			}
+		}
+		foreach ( is_array( $payload['runtime_effects']['retained_modules'] ?? null ) ? $payload['runtime_effects']['retained_modules'] : array() as $module ) {
+			if ( is_array( $module ) && isset( $module['content'] ) && is_scalar( $module['content'] ) && '' !== (string) $module['content'] ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** @param array<int,array<string,mixed>> $assets @return array<string,true> */
+	private static function theme_script_hashes( array $assets ): array {
+		$hashes = array();
+		foreach ( $assets as $asset ) {
+			if ( ! is_array( $asset ) ) {
+				continue;
+			}
+			$path = '';
+			foreach ( array( 'target_path', 'path', 'source_path' ) as $field ) {
+				if ( isset( $asset[ $field ] ) && is_scalar( $asset[ $field ] ) && '' !== trim( (string) $asset[ $field ] ) ) {
+					$path = (string) $asset[ $field ];
+					break;
+				}
+			}
+			$kind = isset( $asset['kind'] ) && is_scalar( $asset['kind'] ) ? strtolower( (string) $asset['kind'] ) : '';
+			if ( ! in_array( $kind, array( 'js', 'mjs', 'javascript', 'script' ), true ) && ! preg_match( '/\.m?js(?:$|[?#])/i', $path ) ) {
+				continue;
+			}
+
+			$content = null;
+			if ( isset( $asset['content'] ) && is_scalar( $asset['content'] ) ) {
+				$content = (string) $asset['content'];
+			} elseif ( isset( $asset['content_base64'] ) && is_string( $asset['content_base64'] ) ) {
+				$decoded = base64_decode( $asset['content_base64'], true );
+				$content = false === $decoded ? null : $decoded;
+			}
+			if ( is_string( $content ) ) {
+				$hashes[ hash( 'sha256', $content ) ] = true;
+				continue;
+			}
+			foreach ( array( 'content_hash', 'hash' ) as $field ) {
+				$hash = isset( $asset[ $field ] ) && is_scalar( $asset[ $field ] ) ? strtolower( (string) $asset[ $field ] ) : '';
+				if ( preg_match( '/^[a-f0-9]{64}$/', $hash ) ) {
+					$hashes[ $hash ] = true;
+					break;
+				}
+			}
+		}
+
+		return $hashes;
+	}
+
+	/**
 	 * Sanitized site slug from the payload.
 	 *
 	 * @param array<string,mixed> $payload Generated companion-plugin payload.

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -359,9 +359,6 @@ class Static_Site_Importer_Companion_Plugin {
 	private static function theme_script_hashes( array $assets ): array {
 		$hashes = array();
 		foreach ( $assets as $asset ) {
-			if ( ! is_array( $asset ) ) {
-				continue;
-			}
 			$path = '';
 			foreach ( array( 'target_path', 'path', 'source_path' ) as $field ) {
 				if ( isset( $asset[ $field ] ) && is_scalar( $asset[ $field ] ) && '' !== trim( (string) $asset[ $field ] ) ) {

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -375,6 +375,7 @@ class Static_Site_Importer_Companion_Plugin {
 			if ( isset( $asset['content'] ) && is_scalar( $asset['content'] ) ) {
 				$content = (string) $asset['content'];
 			} elseif ( isset( $asset['content_base64'] ) && is_string( $asset['content_base64'] ) ) {
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decode the compiler's declared asset payload.
 				$decoded = base64_decode( $asset['content_base64'], true );
 				$content = false === $decoded ? null : $decoded;
 			}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -284,11 +284,16 @@ class Static_Site_Importer_Theme_Generator {
 			if ( ! is_array( $companion_payload ) ) {
 				return new WP_Error( 'static_site_importer_companion_plugin_payload_invalid', 'Compiled companion_plugin_payload must be an object.' );
 			}
-			$companion_payload['site_slug'] = '' !== (string) ( $companion_payload['site_slug'] ?? '' ) ? (string) $companion_payload['site_slug'] : $args['slug'];
-			$companion_payload['site_name'] = '' !== (string) ( $companion_payload['site_name'] ?? '' ) ? (string) $companion_payload['site_name'] : $args['name'];
-			$companion_validation = Static_Site_Importer_Companion_Plugin::validate_payload( $companion_payload );
-			if ( is_wp_error( $companion_validation ) ) {
-				return $companion_validation;
+			$companion_payload = Static_Site_Importer_Companion_Plugin::without_theme_owned_scripts( $companion_payload, is_array( $plan['assets'] ?? null ) ? $plan['assets'] : array() );
+			if ( ! Static_Site_Importer_Companion_Plugin::has_materializable_content( $companion_payload ) ) {
+				$companion_payload = null;
+			} else {
+				$companion_payload['site_slug'] = '' !== (string) ( $companion_payload['site_slug'] ?? '' ) ? (string) $companion_payload['site_slug'] : $args['slug'];
+				$companion_payload['site_name'] = '' !== (string) ( $companion_payload['site_name'] ?? '' ) ? (string) $companion_payload['site_name'] : $args['name'];
+				$companion_validation = Static_Site_Importer_Companion_Plugin::validate_payload( $companion_payload );
+				if ( is_wp_error( $companion_validation ) ) {
+					return $companion_validation;
+				}
 			}
 		}
 		if ( isset( $args['approved_classic_plan_identity'] ) && is_array( $args['approved_classic_plan_identity'] ) && ( $plan['plan_identity'] ?? null ) !== $args['approved_classic_plan_identity'] ) {

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -150,6 +150,47 @@ $unsafe_effect = $payload;
 $unsafe_effect['runtime_effects']['retained_modules'][0]['unit_id'] = 'effect_shared';
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $unsafe_effect ) ), 'shared-runtime-unit-fails-closed' );
 
+$theme_owned_payload = $payload;
+$theme_owned_payload['preserved_js'][0]['block'] = '';
+$theme_owned_payload['runtime_effects']['retained_modules'][0]['block'] = '';
+$theme_owned_payload = Static_Site_Importer_Companion_Plugin::without_theme_owned_scripts(
+	$theme_owned_payload,
+	array(
+		array( 'kind' => 'js', 'target_path' => 'assets/site.js', 'content' => $island_body ),
+		array( 'kind' => 'mjs', 'target_path' => 'assets/carousel.mjs', 'content_base64' => base64_encode( 'document.querySelector(".carousel").classList.add("active");' ) ),
+		array( 'kind' => 'css', 'target_path' => 'assets/not-a-script.css', 'content' => $island_body ),
+	)
+);
+$assert( array() === ( $theme_owned_payload['preserved_js'] ?? null ), 'theme-owned-preserved-script-is-removed-from-companion' );
+$assert( array() === ( $theme_owned_payload['runtime_effects']['retained_modules'] ?? null ), 'theme-owned-runtime-module-is-removed-from-companion' );
+$theme_owned_script_only = $theme_owned_payload;
+$theme_owned_script_only['blocks'] = array();
+$assert( false === Static_Site_Importer_Companion_Plugin::has_materializable_content( $theme_owned_script_only ), 'fully-deduplicated-script-only-payload-needs-no-companion' );
+$block_scoped_payload = Static_Site_Importer_Companion_Plugin::without_theme_owned_scripts(
+	$payload,
+	array(
+		array( 'kind' => 'js', 'content_hash' => hash( 'sha256', $island_body ) ),
+		array( 'kind' => 'js', 'content_hash' => hash( 'sha256', 'document.querySelector(".carousel").classList.add("active");' ) ),
+	)
+);
+$assert( 1 === count( $block_scoped_payload['preserved_js'] ?? array() ) && 1 === count( $block_scoped_payload['runtime_effects']['retained_modules'] ?? array() ), 'block-scoped-scripts-remain-companion-owned' );
+
+$companion_only_payload = $payload;
+$companion_only_payload['preserved_js'][] = array(
+	'handle'      => 'companion-only',
+	'content'     => 'window.__ssiCompanionOnly=true;',
+	'block'       => 'ssi-example-site/custom-hero',
+	'selector'    => '.companion-only',
+	'source_path' => 'index.html',
+);
+$companion_only_payload = Static_Site_Importer_Companion_Plugin::without_theme_owned_scripts(
+	$companion_only_payload,
+	array( array( 'kind' => 'script', 'content_hash' => hash( 'sha256', $island_body ) ) )
+);
+$assert( 2 === count( $companion_only_payload['preserved_js'] ?? array() ) && 'companion-only' === ( $companion_only_payload['preserved_js'][1]['handle'] ?? '' ), 'unmatched-block-scoped-script-remains-companion-owned' );
+$companion_only_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $companion_only_payload );
+$assert( is_array( $companion_only_descriptor ) && in_array( 'window.__ssiCompanionOnly=true;', $companion_only_descriptor['files'] ?? array(), true ), 'companion-only-script-remains-materialized' );
+
 $script_only = $payload;
 $script_only['blocks'] = array();
 $script_only['preserved_js'][0]['block'] = '';


### PR DESCRIPTION
## Summary

- remove unscoped companion scripts when their SHA-256 content matches a JavaScript asset already owned by the generated theme
- preserve block-scoped and unmatched companion scripts
- skip companion-plugin materialization when deduplication leaves no content

Closes #1437.

## Verification

- `npm run test:companion-plugin` (29 assertions)
- `npm test`
- PHP syntax checks for the changed PHP files
- `git diff --check origin/main...HEAD`
- built SSI at `2ecfe521` with Blocks Engine `3724e478` and imported `blocks-engine/fixtures/websites/14-restaurant` into a fresh WordPress site
- confirmed `quality_pass: true`, zero fallback blocks, zero runtime dependency parity issues, and no companion `islands/` script
- browser instrumentation observed exactly one runtime script, zero page errors, and all 28 reveal targets transitioning from hidden to `in-view` to visible

## AI Assistance

GPT-5.6-sol via OpenCode was used to trace the duplicate ownership path, implement the content-hash deduplication and lifecycle handling, add regression coverage, run verification, and prepare this pull request.