### PR TITLE
Update PHP transformer to 0.8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   "require": {
     "php": "^8.2",
     "automattic/blocks-engine-figma-transformer": "^0.1.3",
-    "automattic/blocks-engine-php-transformer": "0.8.2"
+    "automattic/blocks-engine-php-transformer": "0.8.3"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27929dc8b6cd52eb3f13117f9c801dd2",
+    "content-hash": "622061a5d791c455fc9501819faedb3a",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "v0.8.2",
+            "version": "v0.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "5776e0f9947be003a3dd9d6ce7d76f36f548909b"
+                "reference": "e897e490b1095cf972b201d37c95cd5c896f7ff5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/5776e0f9947be003a3dd9d6ce7d76f36f548909b",
-                "reference": "5776e0f9947be003a3dd9d6ce7d76f36f548909b",
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/e897e490b1095cf972b201d37c95cd5c896f7ff5",
+                "reference": "e897e490b1095cf972b201d37c95cd5c896f7ff5",
                 "shasum": ""
             },
             "require": {
@@ -91,7 +91,7 @@
                 "issues": "https://github.com/Automattic/blocks-engine/issues",
                 "source": "https://github.com/Automattic/blocks-engine-php-transformer"
             },
-            "time": "2026-08-29T19:48:13+00:00"
+            "time": "2026-08-30T04:17:58+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
## Summary

- pin `automattic/blocks-engine-php-transformer` to `0.8.3`
- refresh the Composer lock entry to split commit `e897e490`
- consume the runtime-selector projection fix released from Automattic/blocks-engine#1424

Release: https://github.com/Automattic/blocks-engine/releases/tag/php-transformer-v0.8.3

## Verification

- `composer validate --strict`
- `composer install --dry-run`
- `npm run test:companion-plugin`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol was used through OpenCode to orchestrate the release dependency update, verify the published Composer artifact, minimize the lockfile change, and run the listed checks. Chris directed and reviewed the work.