### PR TITLE
Fix plugin activation after same-request install

### DIFF
--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -74,6 +74,9 @@ class Static_Site_Importer_Plugin_Materializer {
 				$report['installed'] = true;
 				$report['actions'][] = 'installed';
 			}
+			if ( function_exists( 'wp_clean_plugins_cache' ) ) {
+				wp_clean_plugins_cache( false );
+			}
 		}
 		$activation_deps = self::load_activation_dependencies();
 		if ( is_wp_error( $activation_deps ) ) {

--- a/tests/smoke-plugin-materializer-lifecycle.php
+++ b/tests/smoke-plugin-materializer-lifecycle.php
@@ -46,6 +46,7 @@ $GLOBALS['ssi_activation_outcome'] = 'success';
 $GLOBALS['ssi_activation_attempts'] = 0;
 $GLOBALS['ssi_install_attempts'] = 0;
 $GLOBALS['ssi_install_outcome'] = 'success';
+$GLOBALS['ssi_plugin_cache_cleans'] = 0;
 
 function ssi_test_callback_id( callable $callback ): string {
 	if ( is_string( $callback ) ) return $callback;
@@ -70,6 +71,10 @@ function is_plugin_active( string $plugin_file ): bool { return $GLOBALS['ssi_pl
 function plugins_api( string $action, array $args ): object {
 	unset( $action, $args );
 	return (object) array( 'download_link' => 'https://example.test/absent-plugin.zip' );
+}
+function wp_clean_plugins_cache( bool $clear_update_cache = true ): void {
+	unset( $clear_update_cache );
+	++$GLOBALS['ssi_plugin_cache_cleans'];
 }
 function activate_plugin( string $plugin_file ) {
 	unset( $plugin_file );
@@ -190,6 +195,7 @@ $absent_report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
 	static fn (): bool => true
 );
 $assert( 'installed_activated' === ( $absent_report['status'] ?? '' ) && 1 === $GLOBALS['ssi_install_attempts'] && in_array( 'install', $absent_report['attempted_actions'] ?? array(), true ) && in_array( 'activate', $absent_report['attempted_actions'] ?? array(), true ), 'absent-provider-installs-then-activates' );
+$assert( 1 === $GLOBALS['ssi_plugin_cache_cleans'], 'newly-installed-provider-refreshes-plugin-cache-before-activation' );
 
 unlink( WP_PLUGIN_DIR . '/absent-plugin/absent-plugin.php' );
 rmdir( WP_PLUGIN_DIR . '/absent-plugin' );


### PR DESCRIPTION
## Summary
- refresh WordPress plugin metadata after a successful installation
- activate the newly installed provider plugin in the same request
- cover the install-then-activate lifecycle with the existing smoke test

## Verification
- `php tests/smoke-plugin-materializer-lifecycle.php`
- `php -l includes/class-static-site-importer-plugin-materializer.php`
- `php -l tests/smoke-plugin-materializer-lifecycle.php`
- `git diff --check`

`npm test` completed with 71 passing manifest entries and two unrelated failures that reproduce independently: a stale php-transformer `v0.8.2` assertion after the `v0.8.3` release, and a staged-ZIP size-ratio expectation (`20011/980854`).

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to diagnose the same-request lifecycle failure, implement the cache refresh, run verification, and prepare this pull request.