### PR TITLE
Reuse shared analysis in CLI imports

### DIFF
--- a/includes/cli.php
+++ b/includes/cli.php
@@ -55,12 +55,27 @@ if ( ! function_exists( 'static_site_importer_cli_approved_plan' ) ) {
 	}
 }
 
+if ( ! function_exists( 'static_site_importer_cli_direct_artifact_run_policy' ) ) {
+	/** Use the CLI worker runtime for a larger bounded shared-analysis batch. */
+	function static_site_importer_cli_direct_artifact_run_policy( array $policy ): array {
+		$policy['compile_batch_pages'] = 20;
+		return $policy;
+	}
+}
+
 if ( ! function_exists( 'static_site_importer_cli_import' ) ) {
 	/** Run an import with the explicit, local WP-CLI report output seam. */
 	function static_site_importer_cli_import( array $input ): array {
 		$report = isset( $input['report'] ) ? (string) $input['report'] : '';
 		unset( $input['report'] );
-		return Static_Site_Importer_Canonical_Import_Service::import_with_cli_report( $input, $report );
+		$policy_added = function_exists( 'add_filter' ) && add_filter( 'static_site_importer_direct_artifact_run_policy', 'static_site_importer_cli_direct_artifact_run_policy' );
+		try {
+			return Static_Site_Importer_Canonical_Import_Service::import_with_cli_report( $input, $report );
+		} finally {
+			if ( $policy_added && function_exists( 'remove_filter' ) ) {
+				remove_filter( 'static_site_importer_direct_artifact_run_policy', 'static_site_importer_cli_direct_artifact_run_policy' );
+			}
+		}
 	}
 }
 

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -35,6 +35,21 @@ function apply_filters( string $hook, $value, ...$args ) {
 	}
 	return $value;
 }
+function add_filter( string $hook, callable $callback ): bool {
+	$GLOBALS['ssi_direct_filters'][ $hook ][] = $callback;
+	return true;
+}
+function remove_filter( string $hook, callable $callback ): bool {
+	$callbacks = $GLOBALS['ssi_direct_filters'][ $hook ] ?? array();
+	foreach ( $callbacks as $index => $registered ) {
+		if ( $registered === $callback ) {
+			unset( $callbacks[ $index ] );
+			$GLOBALS['ssi_direct_filters'][ $hook ] = array_values( $callbacks );
+			return true;
+		}
+	}
+	return false;
+}
 function do_action( string $hook, ...$args ): void {
 	foreach ( $GLOBALS['ssi_direct_actions'][ $hook ] ?? array() as $callback ) {
 		$callback( ...$args );
@@ -135,6 +150,7 @@ class Static_Site_Importer_Theme_Generator {
 }
 
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-canonical-import-service.php';
+require_once dirname( __DIR__ ) . '/includes/cli.php';
 
 $assert = static function ( bool $condition, string $message ): void {
 	if ( ! $condition ) {
@@ -265,13 +281,15 @@ $assert( in_array( 'entity_collection:forms', $form_dependencies[0]['required_fo
 $replay = Static_Site_Importer_Canonical_Import_Service::import( $resume( $import_id ) );
 $assert( $terminal === $replay && 1 === $GLOBALS['ssi_direct_mutations'], 'terminal replay must return the durable response without compile or mutation' );
 
-$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array( static fn ( array $policy ): array => array_merge( $policy, array( 'compile_batch_pages' => 20 ) ) );
-$clean = Static_Site_Importer_Canonical_Import_Service::import( $input() );
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array();
+$clean = static_site_importer_cli_import( $input() );
 $canonical = static function ( array $response ): array {
 	unset( $response['import_id'], $response['artifact_run'] );
 	return $response;
 };
-$assert( empty( $clean['continuation'] ) && 2 === $GLOBALS['ssi_direct_mutations'] && $canonical( $terminal ) === $canonical( $clean ), 'clean and resumed canonical apply outputs must match outside run observations' );
+$clean_work = $clean['artifact_run']['work'] ?? array();
+$assert( empty( $clean['continuation'] ) && 1 === ( $clean_work['compile_batches'] ?? 0 ) && 3 === ( $clean_work['pages_compiled'] ?? 0 ), 'the CLI worker must compile a multi-page artifact with one shared-analysis batch' );
+$assert( empty( $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] ) && 2 === $GLOBALS['ssi_direct_mutations'] && $canonical( $terminal ) === $canonical( $clean ), 'the CLI policy must remain scoped while clean and resumed canonical apply outputs match' );
 $canonical_compiled = static function ( array $result ) use ( &$canonical_compiled ): array {
 	unset( $result['metrics'], $result['work'] );
 	foreach ( $result as $key => &$value ) {


### PR DESCRIPTION
## Summary

- use the existing bounded 20-page direct-artifact batch for WP-CLI workers
- keep HTTP/request runtimes on their existing two-page default
- scope and remove the CLI policy override around each canonical import call
- prove a three-page CLI import compiles in one batch while preserving canonical output and per-page counters

Fixes #1446.

## Verification

- `php tests/smoke-direct-artifact-import.php`
- `php tests/smoke-cli-import-continuation.php`
- `php tests/smoke-website-artifact-import-input.php`
- `npm test` (73 manifest tests passed; 0 failed)
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode was used to inspect the CLI/direct-artifact lifecycle, implement the scoped policy change, and extend deterministic test coverage. The resulting behavior and test results were verified locally.