### PR TITLE
fix: propagate request bundle compiler limits

### DIFF
--- a/includes/cli.php
+++ b/includes/cli.php
@@ -147,13 +147,28 @@ if ( ! function_exists( 'static_site_importer_cli_request_bundle_path' ) ) {
 }
 
 if ( ! function_exists( 'static_site_importer_cli_request_bundle_files' ) ) {
+	/** Return the bounded compiler contract for verified request-bundle files. */
+	function static_site_importer_cli_request_bundle_limits(): array {
+		return array(
+			'max_files'                 => 5000,
+			'max_file_bytes'            => 10485760,
+			'max_total_bytes'           => 268435456,
+			'generated_files_per_html'  => 5,
+			'generated_bytes_headroom' => 67108864,
+			'compiler_max_total_bytes' => 335544320,
+		);
+	}
+
 	/** Project a local source tree as metadata-only payload references. */
 	function static_site_importer_cli_request_bundle_files( string $directory ) {
 		if ( ! is_dir( $directory ) ) {
 			return new WP_Error( 'static_site_importer_cli_request_bundle_invalid', 'A files request-bundle reference must resolve to a directory.' );
 		}
-		$files = array();
-		$paths = array();
+		$limits     = static_site_importer_cli_request_bundle_limits();
+		$files      = array();
+		$paths      = array();
+		$total_bytes = 0;
+		$html_files  = 0;
 		try {
 			$iterator = new RecursiveIteratorIterator(
 				new RecursiveDirectoryIterator( $directory, FilesystemIterator::SKIP_DOTS ),
@@ -177,7 +192,17 @@ if ( ! function_exists( 'static_site_importer_cli_request_bundle_files' ) ) {
 				if ( class_exists( 'Static_Site_Importer_Content_Policy' ) && ! Static_Site_Importer_Content_Policy::is_static_path( $relative ) ) {
 					return new WP_Error( 'static_site_importer_executable_source_rejected', 'Request-bundle source trees may contain static content only.' );
 				}
-				$bytes  = $item->getSize();
+				$bytes = $item->getSize();
+				if ( $bytes > $limits['max_file_bytes'] ) {
+					return new WP_Error( 'static_site_importer_cli_request_bundle_file_too_large', 'A request-bundle source file exceeds the 10 MiB compiler limit.' );
+				}
+				if ( $total_bytes + $bytes > $limits['max_total_bytes'] ) {
+					return new WP_Error( 'static_site_importer_cli_request_bundle_total_too_large', 'Request-bundle source files exceed the 256 MiB aggregate compiler limit.' );
+				}
+				$is_html = (bool) preg_match( '/\.html?$/i', $relative );
+				if ( count( $files ) + 1 + ( $limits['generated_files_per_html'] * ( $html_files + ( $is_html ? 1 : 0 ) ) ) > $limits['max_files'] ) {
+					return new WP_Error( 'static_site_importer_cli_request_bundle_file_limit_exceeded', 'Request-bundle source files and reserved inline expansion files exceed the 5,000-file compiler limit.' );
+				}
 				$digest = hash_file( 'sha256', $absolute );
 				if ( false === $digest ) {
 					return new WP_Error( 'static_site_importer_cli_request_bundle_invalid', 'A request-bundle source file could not be verified.' );
@@ -193,9 +218,8 @@ if ( ! function_exists( 'static_site_importer_cli_request_bundle_files' ) ) {
 						'sha256' => $digest,
 					),
 				);
-				if ( 10000 < count( $files ) ) {
-					return new WP_Error( 'static_site_importer_cli_request_bundle_invalid', 'A request-bundle source tree may contain at most 10,000 static files.' );
-				}
+				$total_bytes += $bytes;
+				$html_files  += $is_html ? 1 : 0;
 			}
 		} catch ( UnexpectedValueException $error ) {
 			return new WP_Error( 'static_site_importer_cli_request_bundle_invalid', $error->getMessage() );
@@ -205,7 +229,12 @@ if ( ! function_exists( 'static_site_importer_cli_request_bundle_files' ) ) {
 		}
 		usort( $files, static fn( array $left, array $right ): int => strcmp( $left['path'], $right['path'] ) );
 		return array(
-			'files'          => $files,
+			'files'           => $files,
+			'compiler_limits' => array(
+				'max_files'       => count( $files ) + ( $limits['generated_files_per_html'] * $html_files ),
+				'max_file_bytes'  => $limits['max_file_bytes'],
+				'max_total_bytes' => min( $limits['compiler_max_total_bytes'], $limits['max_total_bytes'] + min( $limits['generated_bytes_headroom'], $limits['max_total_bytes'] ) ),
+			),
 			'payload_reader' => new class( $paths ) {
 				/** @param array<string,string> $paths */
 				public function __construct( private array $paths ) {}
@@ -257,8 +286,9 @@ if ( ! function_exists( 'static_site_importer_cli_prepare_request_bundle' ) ) {
 					if ( 'files' === $type ) {
 						return array(
 							'source'         => array(
-								'type'  => 'files',
-								'files' => $bundle['files'],
+								'type'     => 'files',
+								'files'    => $bundle['files'],
+								'metadata' => array( 'compiler_limits' => $bundle['compiler_limits'] ),
 							),
 							'payload_reader' => $bundle['payload_reader'],
 							'provenance'     => array( 'transport' => 'cli-request-bundle' ),

--- a/tests/smoke-canonical-import-ability.php
+++ b/tests/smoke-canonical-import-ability.php
@@ -62,9 +62,10 @@ function static_site_importer_source_runtime( $source ) {
 	}
 	return array(
 		'artifact'        => array(
-			'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
-			'entrypoint' => $source['entrypoint'] ?? 'website/index.html',
-			'files'      => $files,
+			'schema'          => 'blocks-engine/php-transformer/site-artifact/v1',
+			'entrypoint'      => $source['entrypoint'] ?? 'website/index.html',
+			'compiler_limits' => $source['metadata']['compiler_limits'] ?? array(),
+			'files'           => $files,
 		),
 		'provider'        => 'canonical-source-test',
 		'source_metadata' => array(),
@@ -294,6 +295,13 @@ $reference_reader = new class() {
 $GLOBALS['ssi_filters']['static_site_importer_resolve_source_reference'] = static function ( $value, $reference, $type ) use ( $reference_reader ) {
 	return 'opaque-files-1' === $reference && 'files' === $type ? array(
 		'source'         => array(
+			'metadata' => array(
+				'compiler_limits' => array(
+					'max_files'       => 501,
+					'max_file_bytes'  => 10485760,
+					'max_total_bytes' => 335544320,
+				),
+			),
 			'files' => array(
 				array(
 					'path'              => 'website/index.html',
@@ -315,8 +323,8 @@ $referenced_files = static_site_importer_ability_import(
 		'source'    => array( 'type' => 'files', 'ref' => 'opaque-files-1' ),
 	)
 );
-if ( empty( $referenced_files['success'] ) || $reference_reader !== ( Static_Site_Importer_Theme_Generator::$last_args['_static_site_importer_payload_reader'] ?? null ) ) {
-	throw new RuntimeException( 'opaque file references must pass their server-owned payload reader to materialization' ); }
+if ( empty( $referenced_files['success'] ) || $reference_reader !== ( Static_Site_Importer_Theme_Generator::$last_args['_static_site_importer_payload_reader'] ?? null ) || 501 !== ( Static_Site_Importer_Theme_Generator::$last_artifact['compiler_limits']['max_files'] ?? null ) ) {
+	throw new RuntimeException( 'opaque file references must preserve their server-owned payload reader and compiler limits through normalization' ); }
 $GLOBALS['ssi_filters']['static_site_importer_resolve_source_reference'] = static function ( $value, $reference, $type ) {
 	return 'staged-zip-1' === $reference && 'zip' === $type ? array(
 		'source'     => array(

--- a/tests/smoke-cli-import-continuation.php
+++ b/tests/smoke-cli-import-continuation.php
@@ -131,6 +131,62 @@ rmdir( $bundle_source );
 unlink( $bundle_request );
 rmdir( $bundle_dir );
 
+$bounded_bundle_dir = sys_get_temp_dir() . '/ssi-bounded-request-bundle-' . bin2hex( random_bytes( 6 ) );
+mkdir( $bounded_bundle_dir );
+file_put_contents( $bounded_bundle_dir . '/index.html', '<h1>Bounded</h1>' );
+for ( $index = 0; $index < 500; ++$index ) {
+	file_put_contents( $bounded_bundle_dir . '/asset-' . $index . '.css', 'a{}' );
+}
+$bounded_bundle = static_site_importer_cli_request_bundle_files( $bounded_bundle_dir );
+$assert( is_array( $bounded_bundle ) && 501 === count( $bounded_bundle['files'] ?? array() ), 'request-bundle-retains-files-above-compiler-default' );
+$assert( array( 'max_files' => 506, 'max_file_bytes' => 10485760, 'max_total_bytes' => 335544320 ) === ( $bounded_bundle['compiler_limits'] ?? null ), 'request-bundle-declares-verified-compiler-limits' );
+foreach ( scandir( $bounded_bundle_dir ) as $entry ) {
+	if ( '.' !== $entry && '..' !== $entry ) {
+		unlink( $bounded_bundle_dir . '/' . $entry );
+	}
+}
+rmdir( $bounded_bundle_dir );
+
+$count_limit_dir = sys_get_temp_dir() . '/ssi-request-bundle-count-' . bin2hex( random_bytes( 6 ) );
+mkdir( $count_limit_dir );
+for ( $index = 0; $index <= 5000; ++$index ) {
+	file_put_contents( $count_limit_dir . '/asset-' . $index . '.css', '' );
+}
+$count_limit = static_site_importer_cli_request_bundle_files( $count_limit_dir );
+$assert( is_wp_error( $count_limit ) && 'static_site_importer_cli_request_bundle_file_limit_exceeded' === $count_limit->get_error_code(), 'request-bundle-rejects-file-count-over-hard-boundary' );
+foreach ( scandir( $count_limit_dir ) as $entry ) {
+	if ( '.' !== $entry && '..' !== $entry ) {
+		unlink( $count_limit_dir . '/' . $entry );
+	}
+}
+rmdir( $count_limit_dir );
+
+$file_limit_dir = sys_get_temp_dir() . '/ssi-request-bundle-file-' . bin2hex( random_bytes( 6 ) );
+mkdir( $file_limit_dir );
+$file_limit_handle = fopen( $file_limit_dir . '/asset.css', 'w' );
+ftruncate( $file_limit_handle, 10485761 );
+fclose( $file_limit_handle );
+$file_limit = static_site_importer_cli_request_bundle_files( $file_limit_dir );
+$assert( is_wp_error( $file_limit ) && 'static_site_importer_cli_request_bundle_file_too_large' === $file_limit->get_error_code(), 'request-bundle-rejects-file-bytes-over-hard-boundary' );
+unlink( $file_limit_dir . '/asset.css' );
+rmdir( $file_limit_dir );
+
+$total_limit_dir = sys_get_temp_dir() . '/ssi-request-bundle-total-' . bin2hex( random_bytes( 6 ) );
+mkdir( $total_limit_dir );
+for ( $index = 0; $index < 26; ++$index ) {
+	$total_limit_handle = fopen( $total_limit_dir . '/asset-' . $index . '.css', 'w' );
+	ftruncate( $total_limit_handle, 10485760 );
+	fclose( $total_limit_handle );
+}
+$total_limit = static_site_importer_cli_request_bundle_files( $total_limit_dir );
+$assert( is_wp_error( $total_limit ) && 'static_site_importer_cli_request_bundle_total_too_large' === $total_limit->get_error_code(), 'request-bundle-rejects-aggregate-bytes-over-hard-boundary' );
+foreach ( scandir( $total_limit_dir ) as $entry ) {
+	if ( '.' !== $entry && '..' !== $entry ) {
+		unlink( $total_limit_dir . '/' . $entry );
+	}
+}
+rmdir( $total_limit_dir );
+
 $request_path = tempnam( sys_get_temp_dir(), 'ssi-import-req-' );
 file_put_contents(
 	$request_path,


### PR DESCRIPTION
## Summary

Propagates bounded compiler limits from verified CLI request-bundle file inventories into the canonical source runtime.

Closes #1448

## Verification

- `php tests/smoke-cli-import-continuation.php` (54 assertions)
- `php tests/smoke-canonical-import-ability.php`
- `php -l includes/cli.php`
- `php -l tests/smoke-canonical-import-ability.php`
- `php -l tests/smoke-cli-import-continuation.php`

## Compatibility

Existing request-bundle traversal, symlink, executable-source, and payload-integrity protections remain intact. File intake now rejects compiler-incompatible file counts and byte sizes before payload retention.

AI assistance disclosure: GPT-5.6 Terra via OpenCode and Homeboy implemented and verified the bounded request-bundle compiler-limit contract under Chris Huber's orchestration; GPT-5.6 Sol via OpenCode completed direct publication after control-plane recovery failed.