### PR TITLE
Fix mainline lint findings

### DIFF
--- a/includes/class-static-site-importer-theme-exporter.php
+++ b/includes/class-static-site-importer-theme-exporter.php
@@ -406,7 +406,7 @@ class Static_Site_Importer_Theme_Exporter {
 		global $post;
 		$previous_post = $post ?? null;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Dynamic block rendering reads the exported document from the global post context.
-		$post          = $page;
+		$post = $page;
 		if ( function_exists( 'setup_postdata' ) ) {
 			setup_postdata( $page );
 		}

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -68,7 +68,10 @@ if ( ! function_exists( 'static_site_importer_cli_import' ) ) {
 	function static_site_importer_cli_import( array $input ): array {
 		$report = isset( $input['report'] ) ? (string) $input['report'] : '';
 		unset( $input['report'], $input['_cli_request_bundle_dir'] );
-		$policy_added = function_exists( 'add_filter' ) && add_filter( 'static_site_importer_direct_artifact_run_policy', 'static_site_importer_cli_direct_artifact_run_policy' );
+		$policy_added = function_exists( 'add_filter' );
+		if ( $policy_added ) {
+			add_filter( 'static_site_importer_direct_artifact_run_policy', 'static_site_importer_cli_direct_artifact_run_policy' );
+		}
 		try {
 			return Static_Site_Importer_Canonical_Import_Service::import_with_cli_report( $input, $report );
 		} finally {


### PR DESCRIPTION
## Summary

- preserve the CLI filter registration behavior without treating `add_filter()` as a meaningful boolean result
- remove stale assignment padding flagged by PHPCS
- restore a green full-scope mainline lint baseline

## Verification

- `npm test` (75 selected tests passed)
- `php tests/smoke-cli-import-continuation.php`
- `php tests/smoke-export-theme-ability.php`

Closes #1342

## AI assistance

OpenAI gpt-5.6-sol via OpenCode identified the two findings from the failed mainline Homeboy run, implemented the bounded repair, and ran local verification. Chris Huber directed the workflow and remains responsible for the submitted changes.