### PR TITLE
Add bounded page compile fanout

### DIFF
--- a/includes/class-static-site-importer-current-site-capabilities.php
+++ b/includes/class-static-site-importer-current-site-capabilities.php
@@ -103,6 +103,6 @@ final class Static_Site_Importer_Current_Site_Capabilities {
 	}
 
 	private static function is_cli(): bool {
-		return defined( 'WP_CLI' ) && WP_CLI;
+		return defined( 'WP_CLI' );
 	}
 }

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -174,6 +174,90 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		return self::execute( $workspace, $run, $args );
 	}
 
+	/** Compile one isolated page shard and publish only immutable receipt checkpoints. */
+	public static function compile_worker( string $import_id, array $page_ids ) {
+		self::$checkpoint_read_cache = array();
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $import_id ) || empty( $page_ids ) || array_values( array_unique( array_filter( $page_ids, 'is_string' ) ) ) !== array_values( $page_ids ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_worker_request_invalid', 'The direct artifact compile worker request is invalid.' );
+		}
+		$workspace = self::workspace( $import_id, false );
+		if ( is_wp_error( $workspace ) ) {
+			return $workspace;
+		}
+		$run = self::read_run( $workspace, $import_id );
+		if ( is_wp_error( $run ) ) {
+			return $run;
+		}
+		if ( self::owner() !== ( $run['binding']['owner'] ?? '' ) || self::implementation_binding() !== ( $run['binding']['implementation'] ?? null ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_worker_mismatch', 'The compile worker does not match the retained run owner or implementation.' );
+		}
+		if ( array_values( array_intersect( $run['page_ids'] ?? array(), $page_ids ) ) !== array_values( $page_ids ) || empty( $run['refs']['shared'] ) ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_worker_pages_invalid', 'The compile worker page shard is not part of the retained run.' );
+		}
+
+		try {
+			$shared_state = self::read_checkpoint( $workspace, $run, $run['refs']['shared'], 'shared' );
+			if ( is_wp_error( $shared_state ) ) {
+				return $shared_state;
+			}
+			$shared = $shared_state['plan'];
+			$plans  = array();
+			foreach ( $page_ids as $page_id ) {
+				$existing = self::existing_checkpoint_ref( $workspace, $run, self::page_file( 'receipts', $page_id ), 'receipt' );
+				if ( is_wp_error( $existing ) ) {
+					return $existing;
+				}
+				$page_state = self::read_checkpoint( $workspace, $run, $run['refs']['pages'][ $page_id ] ?? array(), 'page_plan' );
+				if ( is_wp_error( $page_state ) ) {
+					return $page_state;
+				}
+				if ( ! empty( $existing ) ) {
+					$receipt_state = self::read_checkpoint( $workspace, $run, $existing, 'receipt' );
+					$valid         = is_wp_error( $receipt_state ) ? $receipt_state : self::validate_receipt( $receipt_state['receipt'], $page_state['plan'], $shared );
+					if ( is_wp_error( $valid ) ) {
+						return $valid;
+					}
+					continue;
+				}
+				$plans[ $page_id ] = $page_state['plan'];
+			}
+			if ( empty( $plans ) ) {
+				return array(
+					'success'   => true,
+					'published' => 0,
+				);
+			}
+			$compiler      = self::compiler();
+			$compile_pages = is_wp_error( $compiler ) ? null : array( $compiler, 'compilePreparedPages' );
+			if ( is_wp_error( $compiler ) || ! is_callable( $compile_pages ) ) {
+				return is_wp_error( $compiler ) ? $compiler : new WP_Error( 'static_site_importer_invalid_transformer', 'The direct artifact compiler does not implement the staged compilation contract.' );
+			}
+			$batch = call_user_func( $compile_pages, $shared, array_values( $plans ), self::payload_reader( $workspace ) );
+			if ( ! is_array( $batch ) || array_keys( $batch ) !== array_keys( $plans ) ) {
+				return new WP_Error( 'static_site_importer_direct_artifact_receipt_set_mismatch', 'Blocks Engine did not return the exact requested compiled receipt shard.' );
+			}
+			foreach ( $plans as $page_id => $plan ) {
+				$valid = self::validate_receipt( $batch[ $page_id ], $plan, $shared );
+				if ( is_wp_error( $valid ) ) {
+					return $valid;
+				}
+				$published = self::publish_checkpoint( $workspace, $run, 'receipt', self::page_file( 'receipts', $page_id ), array(
+					'page_id' => $page_id,
+					'receipt' => $batch[ $page_id ],
+				) );
+				if ( is_wp_error( $published ) ) {
+					return $published;
+				}
+			}
+			return array(
+				'success'   => true,
+				'published' => count( $plans ),
+			);
+		} catch ( Throwable $error ) {
+			return new WP_Error( 'static_site_importer_direct_artifact_worker_failed', $error->getMessage() );
+		}
+	}
+
 	/** Continue the phase machine until its server-owned work boundary. */
 	private static function execute( Static_Site_Importer_Artifact_Run_Workspace $workspace, array $run, array $request_args ) {
 		$lock = $workspace->acquire_lock( 'execution.lock' );
@@ -388,17 +472,10 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 			}
 
-			$pending   = array_values( array_diff( $run['page_ids'], array_keys( $run['refs']['receipts'] ?? array() ) ) );
-			$batch_ids = self::deadline_reached( $deadline, $clock ) ? array() : array_slice( $pending, 0, $policy['compile_batch_pages'] );
+			$pending     = array_values( array_diff( $run['page_ids'], array_keys( $run['refs']['receipts'] ?? array() ) ) );
+			$batch_limit = null !== $policy['compile_fanout'] ? min( $policy['compile_batch_pages'], $policy['compile_workers'] * $policy['compile_shard_pages'] ) : $policy['compile_batch_pages'];
+			$batch_ids   = self::deadline_reached( $deadline, $clock ) ? array() : array_slice( $pending, 0, $batch_limit );
 			if ( ! empty( $batch_ids ) ) {
-				$plans = array();
-				foreach ( $batch_ids as $page_id ) {
-					$page_state = self::read_checkpoint( $workspace, $run, $run['refs']['pages'][ $page_id ] ?? array(), 'page_plan' );
-					if ( is_wp_error( $page_state ) ) {
-						return $page_state;
-					}
-					$plans[ $page_id ] = $page_state['plan'];
-				}
 				$started = microtime( true );
 				$entered = self::enter_phase( $workspace, $run, 'compile_pages', $batch_ids );
 				if ( is_wp_error( $entered ) ) {
@@ -406,40 +483,79 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				}
 				$run = $entered;
 				self::before_phase( 'compile_pages', $run, $batch_ids );
-				$batch = call_user_func( $compile_pages, $shared, array_values( $plans ), $payload_reader );
-				if ( ! is_array( $batch ) || array_keys( $batch ) !== $batch_ids ) {
+				$plans  = array();
+				$shards = array_chunk( $batch_ids, $policy['compile_shard_pages'] );
+				$fanout = null !== $policy['compile_fanout'] && 1 < count( $shards ) ? call_user_func( $policy['compile_fanout'], $run['import_id'], $shards ) : null;
+				if ( is_wp_error( $fanout ) ) {
+					return self::fail( $workspace, $run, 'compile_pages', $fanout, $batch_ids );
+				}
+				if ( true === $fanout ) {
+					$adopted = self::adopt_receipts( $workspace, $run, $shared );
+					if ( is_wp_error( $adopted ) ) {
+						return self::fail( $workspace, $run, 'compile_pages', $adopted, $batch_ids );
+					}
+					if ( array_values( array_intersect( array_keys( $adopted ), $batch_ids ) ) !== $batch_ids ) {
+						return self::fail( $workspace, $run, 'compile_pages', new WP_Error( 'static_site_importer_direct_artifact_receipt_set_mismatch', 'Compile workers did not publish the exact requested receipt shards.' ), $batch_ids );
+					}
+					$run['refs']['receipts'] = $adopted;
+					foreach ( array_keys( $adopted ) as $page_id ) {
+						$run['work']['page_compile_counts'][ $page_id ] = 1;
+					}
+					$run['work']['compile_batches']          = (int) $run['work']['compile_batches'] + count( $shards );
+					$run['work']['pages_compiled']           = count( $adopted );
+					$run['progress']['receipt_count']        = count( $adopted );
+					$run['progress']['updated_at']           = gmdate( 'c' );
+					$run['timings']['compile_pages_seconds'] = (float) ( $run['timings']['compile_pages_seconds'] ?? 0 ) + microtime( true ) - $started;
+					$write                                   = self::write_run( $workspace, $run );
+					if ( is_wp_error( $write ) ) {
+						return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, $batch_ids );
+					}
+					$batch = null;
+				} else {
+					foreach ( $batch_ids as $page_id ) {
+						$page_state = self::read_checkpoint( $workspace, $run, $run['refs']['pages'][ $page_id ] ?? array(), 'page_plan' );
+						if ( is_wp_error( $page_state ) ) {
+							return $page_state;
+						}
+						$plans[ $page_id ] = $page_state['plan'];
+					}
+					$batch = call_user_func( $compile_pages, $shared, array_values( $plans ), $payload_reader );
+				}
+				if ( null !== $batch && ( ! is_array( $batch ) || array_keys( $batch ) !== $batch_ids ) ) {
 					return self::fail( $workspace, $run, 'compile_pages', new WP_Error( 'static_site_importer_direct_artifact_receipt_set_mismatch', 'Blocks Engine did not return the exact requested compiled receipt batch.' ), $batch_ids );
 				}
-				foreach ( $batch_ids as $page_id ) {
-					$valid = self::validate_receipt( $batch[ $page_id ], $plans[ $page_id ], $shared );
-					if ( is_wp_error( $valid ) ) {
-						return self::fail( $workspace, $run, 'compile_pages', $valid, $batch_ids );
+				if ( null !== $batch ) {
+					foreach ( $batch_ids as $page_id ) {
+						$valid = self::validate_receipt( $batch[ $page_id ], $plans[ $page_id ], $shared );
+						if ( is_wp_error( $valid ) ) {
+							return self::fail( $workspace, $run, 'compile_pages', $valid, $batch_ids );
+						}
 					}
-				}
-				$run['work']['compile_batches'] = (int) $run['work']['compile_batches'] + 1;
-				foreach ( $batch_ids as $page_id ) {
-					$receipt = $batch[ $page_id ];
-					$ref     = self::publish_checkpoint( $workspace, $run, 'receipt', self::page_file( 'receipts', $page_id ), array(
-						'page_id' => $page_id,
-						'receipt' => $receipt,
-					) );
-					if ( is_wp_error( $ref ) ) {
-						return self::fail( $workspace, $run, 'compile_pages', $ref, $batch_ids );
+					$run['work']['compile_batches'] = (int) $run['work']['compile_batches'] + 1;
+					foreach ( $batch_ids as $page_id ) {
+						$receipt = $batch[ $page_id ];
+						$ref     = self::publish_checkpoint( $workspace, $run, 'receipt', self::page_file( 'receipts', $page_id ), array(
+							'page_id' => $page_id,
+							'receipt' => $receipt,
+						) );
+						if ( is_wp_error( $ref ) ) {
+							return self::fail( $workspace, $run, 'compile_pages', $ref, $batch_ids );
+						}
+						$run['refs']['receipts'][ $page_id ]            = $ref;
+						$run['work']['pages_compiled']                  = (int) $run['work']['pages_compiled'] + 1;
+						$run['work']['page_compile_counts'][ $page_id ] = (int) ( $run['work']['page_compile_counts'][ $page_id ] ?? 0 ) + 1;
+						$run['progress']['receipt_count']               = count( $run['refs']['receipts'] );
+						$run['progress']['updated_at']                  = gmdate( 'c' );
+						$write = self::write_run( $workspace, $run );
+						if ( is_wp_error( $write ) ) {
+							return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, array( $page_id ) );
+						}
 					}
-					$run['refs']['receipts'][ $page_id ]            = $ref;
-					$run['work']['pages_compiled']                  = (int) $run['work']['pages_compiled'] + 1;
-					$run['work']['page_compile_counts'][ $page_id ] = (int) ( $run['work']['page_compile_counts'][ $page_id ] ?? 0 ) + 1;
-					$run['progress']['receipt_count']               = count( $run['refs']['receipts'] );
-					$run['progress']['updated_at']                  = gmdate( 'c' );
-					$write = self::write_run( $workspace, $run );
+					$run['timings']['compile_pages_seconds'] = (float) ( $run['timings']['compile_pages_seconds'] ?? 0 ) + microtime( true ) - $started;
+					$write                                   = self::write_run( $workspace, $run );
 					if ( is_wp_error( $write ) ) {
-						return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, array( $page_id ) );
+						return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, $batch_ids );
 					}
-				}
-				$run['timings']['compile_pages_seconds'] = (float) ( $run['timings']['compile_pages_seconds'] ?? 0 ) + microtime( true ) - $started;
-				$write                                   = self::write_run( $workspace, $run );
-				if ( is_wp_error( $write ) ) {
-					return self::fail( $workspace, $run, 'compile_pages_checkpoint', $write, $batch_ids );
 				}
 			}
 
@@ -1288,6 +1404,9 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 	private static function run_policy(): array {
 		$policy = array(
 			'compile_batch_pages'       => 2,
+			'compile_workers'           => 1,
+			'compile_shard_pages'       => 2,
+			'compile_fanout'            => null,
 			'max_invocation_seconds'    => 20.0,
 			'freeze_continuation_bytes' => 8 * 1024 * 1024,
 			'clock'                     => static fn (): float => microtime( true ),
@@ -1299,6 +1418,9 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			}
 		}
 		$policy['compile_batch_pages']       = min( 20, max( 1, (int) $policy['compile_batch_pages'] ) );
+		$policy['compile_workers']           = min( 4, max( 1, (int) $policy['compile_workers'] ) );
+		$policy['compile_shard_pages']       = min( 4, max( 1, (int) $policy['compile_shard_pages'] ) );
+		$policy['compile_fanout']            = is_callable( $policy['compile_fanout'] ) ? $policy['compile_fanout'] : null;
 		$policy['max_invocation_seconds']    = max( 0.001, (float) $policy['max_invocation_seconds'] );
 		$policy['freeze_continuation_bytes'] = max( 1, (int) $policy['freeze_continuation_bytes'] );
 		$policy['clock']                     = is_callable( $policy['clock'] ) ? $policy['clock'] : static fn (): float => microtime( true );

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -848,7 +848,7 @@ class Static_Site_Importer_Plugin_Materializer {
 	 * @return true|WP_Error
 	 */
 	private static function install_wp_org_plugin( string $slug ) {
-		if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
+		if ( defined( 'WP_CLI' ) && class_exists( 'WP_CLI' ) ) {
 			try {
 				$result = WP_CLI::runcommand(
 					'plugin install ' . escapeshellarg( $slug ),

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -59,7 +59,93 @@ if ( ! function_exists( 'static_site_importer_cli_direct_artifact_run_policy' ) 
 	/** Use the CLI worker runtime for a larger bounded shared-analysis batch. */
 	function static_site_importer_cli_direct_artifact_run_policy( array $policy ): array {
 		$policy['compile_batch_pages'] = 20;
+		$policy['compile_workers']     = 4;
+		$policy['compile_shard_pages'] = 4;
+		$policy['compile_fanout']      = 'static_site_importer_cli_compile_artifact_pages_fanout';
 		return $policy;
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_cli_compile_artifact_pages_fanout' ) ) {
+	/** Run bounded receipt workers concurrently; return null when process spawning is unavailable. */
+	function static_site_importer_cli_compile_artifact_pages_fanout( string $import_id, array $shards ) {
+		if ( ! function_exists( 'proc_open' ) || empty( $_SERVER['argv'][0] ) ) {
+			return null;
+		}
+		$base_command = array( (string) $_SERVER['argv'][0], '--path=' . ABSPATH );
+		$config       = WP_CLI::get_runner()->config ?? array();
+		foreach ( array( 'url', 'user' ) as $key ) {
+			if ( '' !== (string) ( $config[ $key ] ?? '' ) ) {
+				$base_command[] = '--' . $key . '=' . (string) $config[ $key ];
+			}
+		}
+		$processes   = array();
+		$spawn_error = false;
+		foreach ( $shards as $index => $page_ids ) {
+			$encoded = rawurlencode( (string) wp_json_encode( array_values( $page_ids ) ) );
+			$command = array_merge( $base_command, array( 'static-site-importer', 'compile-artifact-pages', '--import-id=' . $import_id, '--pages=' . $encoded ) );
+			$pipes   = array();
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_open -- WP-CLI uses isolated local workers for bounded page compilation.
+			$process = proc_open(
+				$command,
+				array(
+					1 => array( 'pipe', 'w' ),
+					2 => array( 'pipe', 'w' ),
+				),
+				$pipes,
+				null,
+				null,
+				array( 'bypass_shell' => true )
+			);
+			if ( ! is_resource( $process ) ) {
+				$spawn_error = true;
+				break;
+			}
+			stream_set_blocking( $pipes[1], false );
+			stream_set_blocking( $pipes[2], false );
+			$processes[ $index ] = array(
+				'process' => $process,
+				'pipes'   => $pipes,
+				'output'  => '',
+				'error'   => '',
+			);
+		}
+		if ( $spawn_error && empty( $processes ) ) {
+			return null;
+		}
+
+		$failures = array();
+		while ( ! empty( $processes ) ) {
+			foreach ( $processes as $index => &$worker ) {
+				$worker['output'] = substr( $worker['output'] . (string) stream_get_contents( $worker['pipes'][1] ), -16000 );
+				$worker['error']  = substr( $worker['error'] . (string) stream_get_contents( $worker['pipes'][2] ), -16000 );
+				$status           = proc_get_status( $worker['process'] );
+				if ( $status['running'] ) {
+					continue;
+				}
+				$worker['output'] = substr( $worker['output'] . (string) stream_get_contents( $worker['pipes'][1] ), -16000 );
+				$worker['error']  = substr( $worker['error'] . (string) stream_get_contents( $worker['pipes'][2] ), -16000 );
+				fclose( $worker['pipes'][1] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the worker stdout pipe before process collection.
+				fclose( $worker['pipes'][2] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- Closes the worker stderr pipe before process collection.
+				proc_close( $worker['process'] );
+				if ( 0 !== (int) $status['exitcode'] ) {
+					$failures[] = substr( trim( $worker['error'] . "\n" . $worker['output'] ), 0, 1000 );
+				}
+				unset( $processes[ $index ] );
+			}
+			unset( $worker );
+			if ( ! empty( $processes ) ) {
+				usleep( 10000 );
+			}
+		}
+		if ( $spawn_error || ! empty( $failures ) ) {
+			return new WP_Error(
+				'static_site_importer_direct_artifact_worker_process_failed',
+				'One or more compile workers failed.',
+				array( 'worker_errors' => array_slice( $failures, 0, 4 ) )
+			);
+		}
+		return true;
 	}
 }
 
@@ -153,10 +239,10 @@ if ( ! function_exists( 'static_site_importer_cli_request_bundle_files' ) ) {
 	/** Return the bounded compiler contract for verified request-bundle files. */
 	function static_site_importer_cli_request_bundle_limits(): array {
 		return array(
-			'max_files'                 => 5000,
-			'max_file_bytes'            => 10485760,
-			'max_total_bytes'           => 268435456,
-			'generated_files_per_html'  => 5,
+			'max_files'                => 5000,
+			'max_file_bytes'           => 10485760,
+			'max_total_bytes'          => 268435456,
+			'generated_files_per_html' => 5,
 			'generated_bytes_headroom' => 67108864,
 			'compiler_max_total_bytes' => 335544320,
 		);
@@ -167,9 +253,9 @@ if ( ! function_exists( 'static_site_importer_cli_request_bundle_files' ) ) {
 		if ( ! is_dir( $directory ) ) {
 			return new WP_Error( 'static_site_importer_cli_request_bundle_invalid', 'A files request-bundle reference must resolve to a directory.' );
 		}
-		$limits     = static_site_importer_cli_request_bundle_limits();
-		$files      = array();
-		$paths      = array();
+		$limits      = static_site_importer_cli_request_bundle_limits();
+		$files       = array();
+		$paths       = array();
 		$total_bytes = 0;
 		$html_files  = 0;
 		try {
@@ -238,7 +324,7 @@ if ( ! function_exists( 'static_site_importer_cli_request_bundle_files' ) ) {
 				'max_file_bytes'  => $limits['max_file_bytes'],
 				'max_total_bytes' => min( $limits['compiler_max_total_bytes'], $limits['max_total_bytes'] + min( $limits['generated_bytes_headroom'], $limits['max_total_bytes'] ) ),
 			),
-			'payload_reader' => new class( $paths ) {
+			'payload_reader'  => new class( $paths ) {
 				/** @param array<string,string> $paths */
 				public function __construct( private array $paths ) {}
 				public function read( array $reference ): string {
@@ -614,7 +700,7 @@ if ( ! function_exists( 'static_site_importer_cli_import_command' ) ) {
 	}
 }
 
-if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
+if ( defined( 'WP_CLI' ) && class_exists( 'WP_CLI' ) ) {
 	WP_CLI::add_command(
 		'static-site-importer materialize-wordpress-site-plan',
 		static function ( array $args, array $assoc_args ): void {
@@ -643,6 +729,24 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 	);
 
 	WP_CLI::add_command( 'static-site-importer import', 'static_site_importer_cli_import_command' );
+
+	WP_CLI::add_command(
+		'static-site-importer compile-artifact-pages',
+		static function ( array $args, array $assoc_args ): void {
+			unset( $args );
+			$import_id = (string) ( $assoc_args['import-id'] ?? '' );
+			$decoded   = rawurldecode( (string) ( $assoc_args['pages'] ?? '' ) );
+			$page_ids  = json_decode( $decoded, true );
+			if ( ! is_array( $page_ids ) || ! array_is_list( $page_ids ) ) {
+				WP_CLI::error( 'Compile workers require a valid --import-id and encoded --pages shard.' );
+			}
+			$result = Static_Site_Importer_Direct_Artifact_Import::compile_worker( $import_id, $page_ids );
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::error( $result->get_error_message() );
+			}
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_UNESCAPED_SLASHES ) );
+		}
+	);
 
 	WP_CLI::add_command(
 		'static-site-importer plan-artifact-dependencies',

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -304,6 +304,60 @@ $canonical_compiled = static function ( array $result ) use ( &$canonical_compil
 };
 $assert( $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][0] ) === $canonical_compiled( $GLOBALS['ssi_direct_compiled_results'][1] ), 'clean and resumed composition must produce identical canonical plans, companion payloads, pages, writes, diagnostics, and reconciliation identities' );
 
+$successful_fanout_shards = array();
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array(
+	static function ( array $policy ) use ( &$successful_fanout_shards ): array {
+		$policy['compile_batch_pages'] = 4;
+		$policy['compile_workers']     = 2;
+		$policy['compile_shard_pages'] = 2;
+		$policy['compile_fanout']      = static function ( string $import_id, array $shards ) use ( &$successful_fanout_shards ) {
+			$successful_fanout_shards[] = array_map( 'count', $shards );
+			foreach ( $shards as $page_ids ) {
+				$result = Static_Site_Importer_Direct_Artifact_Import::compile_worker( $import_id, $page_ids );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+			}
+			return true;
+		};
+		return $policy;
+	}
+);
+$fanout_succeeded = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
+$successful_fanout_work = $fanout_succeeded['artifact_run']['work'] ?? array();
+$assert( ! empty( $fanout_succeeded['success'] ) && empty( $fanout_succeeded['continuation'] ) && array( 2, 1 ) === ( $successful_fanout_shards[0] ?? null ) && 2 === ( $successful_fanout_work['compile_batches'] ?? 0 ) && array( 1, 1, 1 ) === ( $successful_fanout_work['page_compile_counts'] ?? null ), 'successful bounded fan-out must adopt every immutable worker receipt before the coordinator composes the result' );
+
+$fanout_shards = array();
+$fail_after_first_shard = true;
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array(
+	static function ( array $policy ) use ( &$fanout_shards, &$fail_after_first_shard ): array {
+		$policy['compile_batch_pages'] = 4;
+		$policy['compile_workers']     = 2;
+		$policy['compile_shard_pages'] = 2;
+		$policy['compile_fanout']      = static function ( string $import_id, array $shards ) use ( &$fanout_shards, &$fail_after_first_shard ) {
+			$fanout_shards[] = array_map( 'count', $shards );
+			foreach ( $shards as $index => $page_ids ) {
+				$result = Static_Site_Importer_Direct_Artifact_Import::compile_worker( $import_id, $page_ids );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+				if ( $fail_after_first_shard && 0 === $index ) {
+					$fail_after_first_shard = false;
+					return new WP_Error( 'injected_compile_fanout_failure', 'Injected failure after one worker shard.' );
+				}
+			}
+			return true;
+		};
+		return $policy;
+	}
+);
+$fanout_failed = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
+$fanout_failure_data = $fanout_failed['error']['data'] ?? array();
+$assert( 'injected_compile_fanout_failure' === ( $fanout_failed['error']['code'] ?? '' ) && array( 2, 1 ) === ( $fanout_shards[0] ?? null ) && 0 === ( $fanout_failure_data['artifact_run']['progress']['receipt_count'] ?? -1 ), 'bounded fan-out must shard deterministically and leave run state coordinator-owned when a worker process fails' );
+$fanout_recovered = Static_Site_Importer_Canonical_Import_Service::import( $resume( (string) ( $fanout_failure_data['import_id'] ?? '' ), 'plan' ) );
+$fanout_work = $fanout_recovered['artifact_run']['work'] ?? array();
+$assert( ! empty( $fanout_recovered['success'] ) && empty( $fanout_recovered['continuation'] ) && array( 1, 1, 1 ) === ( $fanout_work['page_compile_counts'] ?? null ) && 3 === ( $fanout_work['pages_compiled'] ?? 0 ), 'resume must adopt completed worker receipts and compile every page exactly once after a partial fan-out failure' );
+
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array( static fn ( array $policy ): array => array_merge( $policy, array( 'compile_batch_pages' => 1 ) ) );
 $lifecycle_input = $input();
 $lifecycle_input['runtime_lifecycle_phase'] = 'prepare';
@@ -515,6 +569,38 @@ $GLOBALS['ssi_direct_materialization_error'] = null;
 $cli_report = $test_root . '/cli-import-report.json';
 Static_Site_Importer_Canonical_Import_Service::import_with_cli_report( $input(), $cli_report );
 $assert( $cli_report === ( $GLOBALS['ssi_direct_last_args']['report'] ?? '' ) && ! isset( $GLOBALS['ssi_direct_last_args']['failed_plan_report_destination'] ), 'the explicit CLI report destination remains authoritative over the owned failed-plan destination' );
+
+define( 'WP_CLI', true );
+class WP_CLI {
+	public static function get_runner(): object {
+		return (object) array( 'config' => array() );
+	}
+}
+$worker_events = $test_root . '/worker-events.log';
+$worker_script = $test_root . '/fake-wp-worker';
+$worker_source = '#!' . PHP_BINARY . "\n<?php\n"
+	. '$pages = array_values(array_filter($argv, static fn($arg) => str_starts_with($arg, "--pages=")));' . "\n"
+	. '$decoded = json_decode(rawurldecode(substr($pages[0] ?? "", 8)), true);' . "\n"
+	. '$events = $decoded[0] ?? ""; $marker = $decoded[1] ?? "missing";' . "\n"
+	. 'file_put_contents($events, "start:" . $marker . "\\n", FILE_APPEND | LOCK_EX);' . "\n"
+	. 'usleep(500000);' . "\n"
+	. 'file_put_contents($events, "end:" . $marker . "\\n", FILE_APPEND | LOCK_EX);' . "\n"
+	. 'exit("fail" === $marker ? 2 : 0);' . "\n";
+$assert( false !== file_put_contents( $worker_script, $worker_source ) && chmod( $worker_script, 0700 ), 'the process fan-out fixture worker must be executable' );
+$original_argv_zero = $_SERVER['argv'][0] ?? null;
+$_SERVER['argv'][0] = $worker_script;
+$process_fanout = static_site_importer_cli_compile_artifact_pages_fanout( str_repeat( 'a', 64 ), array( array( $worker_events, 'one' ), array( $worker_events, 'two' ), array( $worker_events, 'three' ) ) );
+$events = file( $worker_events, FILE_IGNORE_NEW_LINES );
+$starts = array_slice( is_array( $events ) ? $events : array(), 0, 3 );
+sort( $starts, SORT_STRING );
+$assert( true === $process_fanout && array( 'start:one', 'start:three', 'start:two' ) === $starts, 'the CLI fan-out adapter must start every bounded worker before waiting for completion' );
+$process_failure = static_site_importer_cli_compile_artifact_pages_fanout( str_repeat( 'b', 64 ), array( array( $worker_events, 'ok' ), array( $worker_events, 'fail' ) ) );
+$assert( is_wp_error( $process_failure ) && 'static_site_importer_direct_artifact_worker_process_failed' === $process_failure->get_error_code(), 'the CLI fan-out adapter must surface a nonzero worker exit as a structured compile failure' );
+if ( null === $original_argv_zero ) {
+	unset( $_SERVER['argv'][0] );
+} else {
+	$_SERVER['argv'][0] = $original_argv_zero;
+}
 
 Static_Site_Importer_Artifact_Run_Workspace::purge_expired_in( $test_root );
 $primitive_workspace->purge();


### PR DESCRIPTION
## Summary
- compile prepared page shards concurrently through bounded WP-CLI workers
- keep receipt publication immutable and run-state updates coordinator-owned
- fall back to the existing serial compiler path when process spawning is unavailable
- repair mainline WP-CLI lint conditions exposed by the full gate

## Verification
- `npm test` (75 selected tests passed)
- `homeboy review lint --extension wordpress --placement local`
- direct artifact fanout coverage verifies concurrent child startup, worker failure propagation, receipt adoption, and exactly-once resume behavior

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect the staged compilation architecture, implement the bounded worker orchestration, add tests, and run the repository verification gates. Chris Huber directed the architecture and landing workflow.