### PR TITLE
Checkpoint compiled pages individually

### DIFF
--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -200,8 +200,13 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 			if ( is_wp_error( $shared_state ) ) {
 				return $shared_state;
 			}
-			$shared = $shared_state['plan'];
-			$plans  = array();
+			$shared       = $shared_state['plan'];
+			$compiler     = self::compiler();
+			$compile_page = is_wp_error( $compiler ) ? null : array( $compiler, 'compilePreparedPages' );
+			if ( is_wp_error( $compiler ) || ! is_callable( $compile_page ) ) {
+				return is_wp_error( $compiler ) ? $compiler : new WP_Error( 'static_site_importer_invalid_transformer', 'The direct artifact compiler does not implement the staged compilation contract.' );
+			}
+			$published = 0;
 			foreach ( $page_ids as $page_id ) {
 				$existing = self::existing_checkpoint_ref( $workspace, $run, self::page_file( 'receipts', $page_id ), 'receipt' );
 				if ( is_wp_error( $existing ) ) {
@@ -219,39 +224,27 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 					}
 					continue;
 				}
-				$plans[ $page_id ] = $page_state['plan'];
-			}
-			if ( empty( $plans ) ) {
-				return array(
-					'success'   => true,
-					'published' => 0,
-				);
-			}
-			$compiler      = self::compiler();
-			$compile_pages = is_wp_error( $compiler ) ? null : array( $compiler, 'compilePreparedPages' );
-			if ( is_wp_error( $compiler ) || ! is_callable( $compile_pages ) ) {
-				return is_wp_error( $compiler ) ? $compiler : new WP_Error( 'static_site_importer_invalid_transformer', 'The direct artifact compiler does not implement the staged compilation contract.' );
-			}
-			$batch = call_user_func( $compile_pages, $shared, array_values( $plans ), self::payload_reader( $workspace ) );
-			if ( ! is_array( $batch ) || array_keys( $batch ) !== array_keys( $plans ) ) {
-				return new WP_Error( 'static_site_importer_direct_artifact_receipt_set_mismatch', 'Blocks Engine did not return the exact requested compiled receipt shard.' );
-			}
-			foreach ( $plans as $page_id => $plan ) {
-				$valid = self::validate_receipt( $batch[ $page_id ], $plan, $shared );
+				$plan    = $page_state['plan'];
+				$receipt = call_user_func( $compile_page, $shared, array( $plan ), self::payload_reader( $workspace ) );
+				if ( ! is_array( $receipt ) || array( $page_id ) !== array_keys( $receipt ) ) {
+					return new WP_Error( 'static_site_importer_direct_artifact_receipt_set_mismatch', 'Blocks Engine did not return the exact requested compiled page receipt.' );
+				}
+				$valid = self::validate_receipt( $receipt[ $page_id ], $plan, $shared );
 				if ( is_wp_error( $valid ) ) {
 					return $valid;
 				}
-				$published = self::publish_checkpoint( $workspace, $run, 'receipt', self::page_file( 'receipts', $page_id ), array(
+				$checkpoint = self::publish_checkpoint( $workspace, $run, 'receipt', self::page_file( 'receipts', $page_id ), array(
 					'page_id' => $page_id,
-					'receipt' => $batch[ $page_id ],
+					'receipt' => $receipt[ $page_id ],
 				) );
-				if ( is_wp_error( $published ) ) {
-					return $published;
+				if ( is_wp_error( $checkpoint ) ) {
+					return $checkpoint;
 				}
+				++$published;
 			}
 			return array(
 				'success'   => true,
-				'published' => count( $plans ),
+				'published' => $published,
 			);
 		} catch ( Throwable $error ) {
 			return new WP_Error( 'static_site_importer_direct_artifact_worker_failed', $error->getMessage() );

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -355,22 +355,38 @@ $successful_fanout_work = $fanout_succeeded['artifact_run']['work'] ?? array();
 $assert( ! empty( $fanout_succeeded['success'] ) && empty( $fanout_succeeded['continuation'] ) && array( 2, 1 ) === ( $successful_fanout_shards[0] ?? null ) && 2 === ( $successful_fanout_work['compile_batches'] ?? 0 ) && array( 1, 1, 1 ) === ( $successful_fanout_work['page_compile_counts'] ?? null ), 'successful bounded fan-out must adopt every immutable worker receipt before the coordinator composes the result' );
 
 $fanout_shards = array();
-$fail_after_first_shard = true;
+$GLOBALS['ssi_direct_worker_compile_calls'] = 0;
+$GLOBALS['ssi_direct_fail_second_worker_page'] = true;
+$interrupt_worker = static function ( object $compiler ): object {
+	return new class( $compiler ) {
+		public function __construct( private object $compiler ) {}
+
+		public function compilePreparedPages( array $shared, array $plans, ?object $payload_reader = null ) {
+			++$GLOBALS['ssi_direct_worker_compile_calls'];
+			if ( ! empty( $GLOBALS['ssi_direct_fail_second_worker_page'] ) && 2 === $GLOBALS['ssi_direct_worker_compile_calls'] ) {
+				$GLOBALS['ssi_direct_fail_second_worker_page'] = false;
+				throw new RuntimeException( 'Injected interruption within one worker shard.' );
+			}
+			return $this->compiler->compilePreparedPages( $shared, $plans, $payload_reader );
+		}
+
+		public function __call( string $method, array $arguments ) {
+			return $this->compiler->{$method}( ...$arguments );
+		}
+	};
+};
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_compiler'][] = $interrupt_worker;
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array(
-	static function ( array $policy ) use ( &$fanout_shards, &$fail_after_first_shard ): array {
+	static function ( array $policy ) use ( &$fanout_shards ): array {
 		$policy['compile_batch_pages'] = 4;
 		$policy['compile_workers']     = 2;
 		$policy['compile_shard_pages'] = 2;
-		$policy['compile_fanout']      = static function ( string $import_id, array $shards ) use ( &$fanout_shards, &$fail_after_first_shard ) {
+		$policy['compile_fanout']      = static function ( string $import_id, array $shards ) use ( &$fanout_shards ) {
 			$fanout_shards[] = array_map( 'count', $shards );
-			foreach ( $shards as $index => $page_ids ) {
+			foreach ( $shards as $page_ids ) {
 				$result = Static_Site_Importer_Direct_Artifact_Import::compile_worker( $import_id, $page_ids );
 				if ( is_wp_error( $result ) ) {
 					return $result;
-				}
-				if ( $fail_after_first_shard && 0 === $index ) {
-					$fail_after_first_shard = false;
-					return new WP_Error( 'injected_compile_fanout_failure', 'Injected failure after one worker shard.' );
 				}
 			}
 			return true;
@@ -380,10 +396,12 @@ $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'
 );
 $fanout_failed = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
 $fanout_failure_data = $fanout_failed['error']['data'] ?? array();
-$assert( 'injected_compile_fanout_failure' === ( $fanout_failed['error']['code'] ?? '' ) && array( 2, 1 ) === ( $fanout_shards[0] ?? null ) && 0 === ( $fanout_failure_data['artifact_run']['progress']['receipt_count'] ?? -1 ), 'bounded fan-out must shard deterministically and leave run state coordinator-owned when a worker process fails' );
+$interrupted_receipts = glob( $test_root . '/static-site-importer/direct-artifact-imports/.ssi-artifact-run-direct-' . ( $fanout_failure_data['import_id'] ?? '' ) . '/receipts/*.json' );
+$assert( 'static_site_importer_direct_artifact_worker_failed' === ( $fanout_failed['error']['code'] ?? '' ) && array( 2, 1 ) === ( $fanout_shards[0] ?? null ) && 1 === count( is_array( $interrupted_receipts ) ? $interrupted_receipts : array() ) && 0 === ( $fanout_failure_data['artifact_run']['progress']['receipt_count'] ?? -1 ), 'an interruption within one worker shard must leave run state coordinator-owned after publishing each completed page receipt' );
 $fanout_recovered = Static_Site_Importer_Canonical_Import_Service::import( $resume( (string) ( $fanout_failure_data['import_id'] ?? '' ), 'plan' ) );
 $fanout_work = $fanout_recovered['artifact_run']['work'] ?? array();
-$assert( ! empty( $fanout_recovered['success'] ) && empty( $fanout_recovered['continuation'] ) && array( 1, 1, 1 ) === ( $fanout_work['page_compile_counts'] ?? null ) && 3 === ( $fanout_work['pages_compiled'] ?? 0 ), 'resume must adopt completed worker receipts and compile every page exactly once after a partial fan-out failure' );
+$assert( ! empty( $fanout_recovered['success'] ) && empty( $fanout_recovered['continuation'] ) && array( 1, 1, 1 ) === ( $fanout_work['page_compile_counts'] ?? null ) && 3 === ( $fanout_work['pages_compiled'] ?? 0 ), 'resume must adopt the page published before an interrupted shard and compile every page exactly once' );
+remove_filter( 'static_site_importer_direct_artifact_compiler', $interrupt_worker );
 
 $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array( static fn ( array $policy ): array => array_merge( $policy, array( 'compile_batch_pages' => 1 ) ) );
 $lifecycle_preparations_before = $GLOBALS['ssi_direct_lifecycle_preparations'];


### PR DESCRIPTION
## Summary
- compile and publish each page receipt as soon as it completes inside a fanout worker
- retain existing shard assignment and worker concurrency while bounding per-worker memory
- resume from page receipts published before an interrupted shard

## Why
A worker previously compiled its full multi-page shard before publishing any receipt. Interrupting a large import therefore discarded every completed page in that shard and required the whole shard to be recomputed. Large receipt arrays also remained live until the shard finished.

## Verification
- `npm test` (75 passed)
- `php tests/smoke-direct-artifact-import.php`
- Homeboy lint: PHPCS passed and PHPStan passed; the overall Lab run hit an infrastructure failure in the packaged WordPress extension ESLint shim (`Cannot find module ../package.json`), with no source finding
- regression injects an interruption on page two of a two-page shard, verifies page one was already published, then resumes with every page compiled exactly once

## AI assistance
OpenAI GPT-5.6-sol via OpenCode was used to inspect the import evidence, implement the per-page checkpoint seam, add the interruption regression, and run verification. Chris Huber directed and reviewed the work.