### PR TITLE
Stop blocking imports on quality findings

### DIFF
--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -431,48 +431,6 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 		return $lifecycle;
 	}
 
-	/** Defer only quality findings backed by materializable typed form declarations. */
-	public static function can_defer_form_quality_admission( array $plan, array $lifecycle ): bool {
-		$quality         = isset( $plan['quality'] ) && is_array( $plan['quality'] ) ? $plan['quality'] : array();
-		$metrics         = isset( $quality['metrics'] ) && is_array( $quality['metrics'] ) ? $quality['metrics'] : $quality;
-		$fallback_count  = isset( $metrics['fallback_count'] ) && is_numeric( $metrics['fallback_count'] ) ? (int) $metrics['fallback_count'] : 0;
-		$failure_reasons = isset( $quality['failure_reasons'] ) && is_array( $quality['failure_reasons'] ) ? $quality['failure_reasons'] : array();
-		$diagnostics     = isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array();
-		if ( $fallback_count < 1 || empty( $failure_reasons ) || array_diff( $failure_reasons, array( 'unsupported_html_fallback' ) ) ) {
-			return false;
-		}
-		$materializable = array();
-		foreach ( $lifecycle['entities'] ?? array() as $prepared ) {
-			if ( ! is_array( $prepared ) || 'form' !== ( $prepared['adapter']['capability'] ?? null ) || 'generic/forms/v1' !== ( $prepared['declaration']['payload']['schema'] ?? null ) ) {
-				continue;
-			}
-			foreach ( $prepared['manifest']['forms'] ?? array() as $form ) {
-				if ( is_array( $form ) && ! empty( $form['bindings'] ) ) {
-					$materializable[ (string) ( $form['source_path'] ?? '' ) . "\n" . (string) ( $form['selector'] ?? '' ) ] = true;
-				}
-			}
-		}
-		$forms = 0;
-		foreach ( $diagnostics as $diagnostic ) {
-			if ( ! is_array( $diagnostic ) ) {
-				continue;
-			}
-			$is_form = 'html_form_fallback' === ( $diagnostic['diagnostic_code'] ?? $diagnostic['code'] ?? $diagnostic['reason_code'] ?? null );
-			if ( ! $is_form && 'unsupported_html_fallback' === ( $diagnostic['type'] ?? null ) ) {
-				return false;
-			}
-			if ( ! $is_form ) {
-				continue;
-			}
-			$key = (string) ( $diagnostic['source_path'] ?? $diagnostic['source'] ?? '' ) . "\n" . (string) ( $diagnostic['selector'] ?? '' );
-			if ( ! isset( $materializable[ $key ] ) ) {
-				return false;
-			}
-			++$forms;
-		}
-		return $forms === $fallback_count;
-	}
-
 	private static function runtime_declaration_is_required( array $declaration, array $declarations ): bool {
 		$key = (string) ( $declaration['kind'] ?? '' ) . ':' . (string) ( $declaration['type'] ?? $declaration['capability'] ?? '' );
 		if ( ! empty( $declaration['required_for'] ) ) {

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -26,9 +26,6 @@ if ( ! class_exists( 'Static_Site_Importer_Block_Document_Reporter' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Report_Diagnostics' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-report-diagnostics.php';
 }
-if ( ! class_exists( 'Static_Site_Importer_Failed_Plan_Validation' ) ) {
-	require_once __DIR__ . '/class-static-site-importer-failed-plan-validation.php';
-}
 if ( ! class_exists( 'Static_Site_Importer_Client_Script_Policy' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-client-script-policy.php';
 }
@@ -100,32 +97,6 @@ class Static_Site_Importer_Theme_Generator {
 		$lifecycle = Static_Site_Importer_Entity_Materializer_Registry::plan_runtime_lifecycle( $plan, $args );
 		if ( is_wp_error( $lifecycle ) ) {
 			return $lifecycle;
-		}
-		$deferred_form_quality_admission = ! empty( $args['fail_on_quality'] ) && empty( $plan['quality']['pass'] ) && Static_Site_Importer_Entity_Materializer_Registry::can_defer_form_quality_admission( $plan, $lifecycle );
-		if ( ! empty( $args['fail_on_quality'] ) && empty( $plan['quality']['pass'] ) && ! $deferred_form_quality_admission ) {
-			$compiled_evidence = isset( $compiled_import['compiled'] ) && is_array( $compiled_import['compiled'] ) ? $compiled_import['compiled'] : array();
-			$failed_plan       = Static_Site_Importer_Failed_Plan_Validation::build( $plan, $args, $compiled_evidence );
-			try {
-				$paths           = Static_Site_Importer_Failed_Plan_Validation::persist( $failed_plan, (string) ( $args['failed_plan_report_destination'] ?? $args['report'] ?? '' ) );
-				$artifact_prefix = (string) ( $args['failed_plan_artifact_prefix'] ?? '' );
-				$failed_plan['artifact_refs'] = '' !== $artifact_prefix ? Static_Site_Importer_Failed_Plan_Validation::artifact_refs( $artifact_prefix ) : $paths;
-			} catch ( Throwable $error ) {
-				$failed_plan['artifact_persistence_error'] = $error->getMessage();
-			}
-			return new WP_Error(
-				'static_site_importer_quality_gate_failed',
-				'Website artifact did not pass the canonical plan quality gate.',
-				array_merge(
-					array(
-						'quality'     => $plan['quality'] ?? array(),
-						'diagnostics' => $plan['diagnostics'] ?? array(),
-					),
-					$failed_plan
-				)
-			);
-		}
-		if ( $deferred_form_quality_admission ) {
-			$args['_static_site_importer_deferred_form_quality_admission'] = true;
 		}
 		if ( 'plan' === ( $args['runtime_lifecycle_phase'] ?? '' ) ) {
 			$encoded_artifact = wp_json_encode( $artifact );
@@ -817,30 +788,6 @@ class Static_Site_Importer_Theme_Generator {
 			}
 		}
 		$quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $report, $args );
-		if ( ! empty( $args['_static_site_importer_deferred_form_quality_admission'] ) && ! $quality['pass'] ) {
-			$existing_compensation = isset( $receipt['entity_compensation'] ) && is_array( $receipt['entity_compensation'] ) ? $receipt['entity_compensation'] : array();
-			$existing_failure_context = isset( $receipt['failure_context'] ) && is_array( $receipt['failure_context'] ) ? $receipt['failure_context'] : array();
-			$reuse_compensation = self::compensation_binding_matches( $existing_compensation, $receipt, $lifecycle, $entities );
-			$receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::rollback_receipt( $receipt, 'static_site_importer_quality_gate_failed' );
-			if ( $reuse_compensation ) {
-				$receipt['entity_compensation'] = $existing_compensation;
-				if ( ! empty( $existing_failure_context ) ) {
-					$receipt['failure_context'] = $existing_failure_context;
-				}
-			} elseif ( ! empty( $existing_compensation ) ) {
-				$receipt['previous_entity_compensation_binding_mismatch'] = true;
-			}
-			self::append_entity_compensation( $receipt, $lifecycle, $entities, 'final_quality_admission', 'static_site_importer_quality_gate_failed' );
-			return new WP_Error(
-				'static_site_importer_quality_gate_failed',
-				'Website artifact did not pass the final quality gate after provider receipt reconciliation.',
-				array(
-					'quality'                 => $quality,
-					'diagnostics'             => $report['diagnostics'],
-					'materialization_receipt' => $receipt,
-				)
-			);
-		}
 		$manifest['existing_matches'] = $receipt['existing_matches'] ?? array( 'pages' => array() );
 		$cleanup = self::cleanup_stale_generated_theme_files( $theme['dir'], $manifest, $args, $receipt );
 		if ( is_wp_error( $cleanup ) ) {

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -358,17 +358,6 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'uri'  => $theme_uri,
 			);
 			$state['quality_budget_admission'] = Static_Site_Importer_Quality_Budget_Admission::evaluate( $plan, $resolved, $args );
-			if ( Static_Site_Importer_Quality_Budget_Admission::rejects_materialization( $state['quality_budget_admission'] ) ) {
-				$state['diagnostics'][]  = array(
-					'reason_code'    => 'quality_budget_failed',
-					'quality_budget' => $state['quality_budget_admission'],
-				);
-				$state['failure_reason'] = 'quality_budget_failed';
-				return array(
-					'status'  => 'rejected',
-					'receipt' => self::receipt( 'rejected', $state ),
-				);
-			}
 			self::preflight_state( $state, ! empty( $args['overwrite'] ), (string) ( $args['import_run_id'] ?? '' ) );
 		} catch ( InvalidArgumentException $error ) {
 			if ( isset( $state['preflight_error'] ) && is_wp_error( $state['preflight_error'] ) ) {
@@ -2560,7 +2549,17 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return self::rejected_editability_report_admission( $base, 'editability_policy_invalid' );
 		}
 		if ( 'failed' === ( $policy['status'] ?? null ) ) {
-			return self::rejected_editability_report_admission( $base, 'editability_policy_failed', $policy['failures'] );
+			return array_merge(
+				$base,
+				array(
+					'status'     => 'failed',
+					'diagnostic' => array(
+						'reason_code'       => 'editability_policy_failed',
+						'owning_layer'      => 'blocks-engine',
+						'threshold_failures' => array_slice( array_values( array_filter( $policy['failures'], 'is_array' ) ), 0, 10 ),
+					),
+				)
+			);
 		}
 
 		$report = $quality['editability_report'] ?? null;

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -407,7 +407,7 @@ $failed_policy_plan['quality']['editability_policy']['failures'] = array( array(
 $failed_policy_plan['quality']['editability_report_plan_hash']  = $plan_hash( $failed_policy_plan );
 $failed_policy_plan['plan_identity']                             = WordPressSitePlan::planIdentity( $failed_policy_plan );
 $failed_policy_receipt                                          = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $failed_policy_plan, array( 'slug' => 'failed-editability-policy' ) );
-$assert( 'rejected' === $failed_policy_receipt['status'] && 'editability_policy_failed' === ( $failed_policy_receipt['errors'][0]['code'] ?? '' ) && 'about.html' === ( $failed_policy_receipt['editability_report']['diagnostic']['threshold_failures'][0]['source_path'] ?? '' ), 'failed producer thresholds hard-gate materialization with bounded source diagnostics' );
+$assert( 'completed' === $failed_policy_receipt['status'] && 'failed' === ( $failed_policy_receipt['editability_report']['status'] ?? '' ) && 'editability_policy_failed' === ( $failed_policy_receipt['editability_report']['diagnostic']['reason_code'] ?? '' ) && 'about.html' === ( $failed_policy_receipt['editability_report']['diagnostic']['threshold_failures'][0]['source_path'] ?? '' ), 'failed producer thresholds remain visible without blocking materialization' );
 
 // Gutenberg gaps are SSI receipt/report extensions and must never alter the
 // compiler-owned plan, whose schema and hash are producer contracts.
@@ -702,11 +702,7 @@ $deferred_quality_prepared     = Static_Site_Importer_WordPress_Site_Plan_Materi
 	$deferred_quality_plan,
 	array( 'slug' => 'deferred-quality-compensation', 'seed_entities' => true, 'font_materialization' => array(), 'fail_on_quality' => true, '_static_site_importer_deferred_form_quality_admission' => true ),
 );
-$deferred_quality_receipt = $deferred_quality_prepared['receipt'] ?? array();
-$deferred_quality_error   = $deferred_quality_receipt['errors'][0] ?? array();
-$deferred_quality_failure = new WP_Error( (string) ( $deferred_quality_error['code'] ?? '' ), (string) ( $deferred_quality_error['message'] ?? '' ), $deferred_quality_receipt );
-$deferred_quality_receipt = is_wp_error( $deferred_quality_failure ) ? $deferred_quality_failure->get_error_data() : array();
-$assert( is_wp_error( $deferred_quality_failure ) && 'editability_policy_failed' === $deferred_quality_failure->get_error_code() && array() === $deferred_rollback_order && ! $woo_snapshot_restored && $posts_before_deferred_quality === $GLOBALS['ssi_plan_posts'] && 'editability_policy_failed' === ( $deferred_quality_receipt['errors'][0]['code'] ?? '' ), 'failed canonical editability policy rejects before provider mutation or rollback work' );
+$assert( 'prepared' === ( $deferred_quality_prepared['status'] ?? '' ) && 'failed' === ( $deferred_quality_prepared['editability_report']['status'] ?? '' ) && 'editability_policy_failed' === ( $deferred_quality_prepared['editability_report']['diagnostic']['reason_code'] ?? '' ) && array() === $deferred_rollback_order && ! $woo_snapshot_restored && $posts_before_deferred_quality === $GLOBALS['ssi_plan_posts'], 'failed canonical editability policy remains visible without blocking materialization preparation' );
 
 $classic_artifact   = array(
 	'entrypoint' => 'index.html',
@@ -1873,27 +1869,6 @@ $assert( 0 === ( $form_quality_report['quality']['fallback_count'] ?? -1 ) && 1 
 $resolved_form_quality    = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $form_quality_report, array( 'fail_on_quality' => true ) );
 $resolved_form_validation = Static_Site_Importer_Report_Diagnostics::import_validation_result( $form_quality_report, $resolved_form_quality );
 $assert( true === ( $resolved_form_quality['pass'] ?? false ) && false === ( $resolved_form_quality['fail_import'] ?? true ) && array() === ( $resolved_form_quality['failure_reasons'] ?? null ) && 'passed' === ( $resolved_form_validation['status'] ?? '' ), 'receipt-resolved form fallback clears derived quality gates and validation status' );
-$form_admission = new ReflectionMethod( Static_Site_Importer_Entity_Materializer_Registry::class, 'can_defer_form_quality_admission' );
-$form_admission_plan = array(
-	'quality' => array( 'metrics' => array( 'fallback_count' => 1 ), 'failure_reasons' => array( 'unsupported_html_fallback' ) ),
-	'diagnostics' => array( $form_fallback ),
-);
-$form_admission_lifecycle = array(
-	'entities' => array(
-		'forms' => array(
-			'adapter' => array( 'capability' => 'form' ),
-			'declaration' => array( 'payload' => array( 'schema' => 'generic/forms/v1' ) ),
-			'manifest' => array( 'forms' => array( array( 'source_path' => 'index.html', 'selector' => 'form.newsletter', 'bindings' => array( $form_binding ) ) ) ),
-		),
-	),
-);
-$assert( true === $form_admission->invoke( null, $form_admission_plan, $form_admission_lifecycle ), 'typed provider-materializable form fallback defers only until receipt reconciliation' );
-$missing_binding_lifecycle = $form_admission_lifecycle;
-$missing_binding_lifecycle['entities']['forms']['manifest']['forms'][0]['bindings'] = array();
-$assert( false === $form_admission->invoke( null, $form_admission_plan, $missing_binding_lifecycle ), 'unbound provider form fallback remains rejected before materialization' );
-$unrelated_failure_plan = $form_admission_plan;
-$unrelated_failure_plan['quality']['failure_reasons'][] = 'core_html_block';
-$assert( false === $form_admission->invoke( null, $unrelated_failure_plan, $form_admission_lifecycle ), 'unrelated quality failures remain rejected before materialization' );
 $other_failure_report                                     = Static_Site_Importer_Import_Report::from_array( $form_quality_report->to_array() );
 $other_failure_report->merge_quality( array( 'core_html_block_count' => 1 ) );
 $other_failure_quality                                    = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $other_failure_report, array( 'fail_on_quality' => true ) );
@@ -1953,7 +1928,7 @@ $assert(
 	) === ( $partial_quality['metrics'] ?? null ),
 	'partial website-artifact result composition preserves supplied compiler metrics and reports final materialized block counts'
 );
-$assert( false === ( $partial_quality['pass'] ?? true ) && true === ( $partial_quality['fail_import'] ?? false ) && in_array( 'unsupported_html_fallback', $partial_quality['failure_reasons'] ?? array(), true ), 'partial website-artifact reports retain unresolved compiler fallbacks as strict quality failures' );
+$assert( is_array( $partial_quality_result ) && false === ( $partial_quality['pass'] ?? true ) && true === ( $partial_quality['fail_import'] ?? false ) && in_array( 'unsupported_html_fallback', $partial_quality['failure_reasons'] ?? array(), true ), 'quality failures remain reported without replacing the materialization result with an error' );
 $tampered_fragment_receipt = $form_binding_receipt;
 $tampered_fragment_receipt['completed']['runtime_declarations']['entity_bindings'][ hash( 'sha256', 'form-fallback-binding' ) ]['persisted_fragment_hash'] = hash( 'sha256', 'tampered fragment' );
 $tampered_fragment_report                              = Static_Site_Importer_Report_Diagnostics::new_conversion_report( 'index.html' );
@@ -2019,9 +1994,9 @@ $final_quality_error = $final_quality_gate->invoke(
 	array(),
 	$deferred_entities['reports']
 );
-$final_quality_receipt = is_wp_error( $final_quality_error ) ? $final_quality_error->get_error_data()['materialization_receipt'] ?? array() : array();
+$final_quality_receipt = $deferred_form_receipt;
 $entity_compensation = $final_quality_receipt['entity_compensation'] ?? array();
-$assert( is_wp_error( $final_quality_error ) && 'static_site_importer_quality_gate_failed' === $final_quality_error->get_error_code() && 1 === $provider_materializations && 1 === $provider_rollbacks && 'partial' === ( $final_quality_receipt['status'] ?? '' ) && 'rolled_back' === ( $entity_compensation['entities'][0]['status'] ?? '' ), 'mismatched deferred form receipt rejects final admission and rolls back both provider entities and the site-plan transaction' );
+$assert( ! is_wp_error( $final_quality_error ) && 1 === $provider_materializations && 0 === $provider_rollbacks && 'completed' === ( $final_quality_receipt['status'] ?? '' ), 'unresolved provider quality remains reported without rolling back materialized entities or the site-plan transaction' );
 $final_quality_receipt['plan']['quality']     = $deferred_form_receipt['plan']['quality'];
 $final_quality_receipt['plan']['diagnostics'] = $deferred_form_receipt['plan']['diagnostics'];
 $retried_quality_error = $final_quality_gate->invoke(
@@ -2032,8 +2007,8 @@ $retried_quality_error = $final_quality_gate->invoke(
 	array(),
 	$deferred_entities['reports']
 );
-$retried_quality_receipt = is_wp_error( $retried_quality_error ) ? $retried_quality_error->get_error_data()['materialization_receipt'] ?? array() : array();
-$assert( is_wp_error( $retried_quality_error ) && 1 === $provider_rollbacks && $entity_compensation === ( $retried_quality_receipt['entity_compensation'] ?? array() ), 'repeated deferred finalization reuses the recorded provider compensation receipt without re-running destructive rollback callbacks' );
+$retried_quality_receipt = $final_quality_receipt;
+$assert( ! is_wp_error( $retried_quality_error ) && 0 === $provider_rollbacks && $entity_compensation === ( $retried_quality_receipt['entity_compensation'] ?? array() ), 'repeated quality reporting does not invoke destructive rollback callbacks' );
 $cross_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
 	$deferred_form_plan,
 	array(
@@ -2055,8 +2030,8 @@ $cross_quality_error = $final_quality_gate->invoke(
 	array(),
 	$deferred_entities['reports']
 );
-$cross_quality_receipt = is_wp_error( $cross_quality_error ) ? $cross_quality_error->get_error_data()['materialization_receipt'] ?? array() : array();
-$assert( is_wp_error( $cross_quality_error ) && 2 === $provider_rollbacks && true === ( $cross_quality_receipt['entity_compensation']['superseded_binding_mismatch'] ?? false ) && $entity_compensation['binding'] !== ( $cross_quality_receipt['entity_compensation']['binding'] ?? array() ), 'cross-receipt compensation evidence cannot suppress the second receipt rollback' );
+$cross_quality_receipt = $cross_receipt;
+$assert( ! is_wp_error( $cross_quality_error ) && 0 === $provider_rollbacks && empty( $cross_quality_receipt['entity_compensation'] ), 'quality reporting does not create cross-receipt compensation work' );
 $nonce_only_cross_receipt = $final_quality_receipt;
 $nonce_only_cross_receipt['receipt_instance_id'] = str_repeat( 'a', 64 );
 $nonce_only_quality_error = $final_quality_gate->invoke(
@@ -2067,8 +2042,8 @@ $nonce_only_quality_error = $final_quality_gate->invoke(
 	array(),
 	$deferred_entities['reports']
 );
-$nonce_only_quality_receipt = is_wp_error( $nonce_only_quality_error ) ? $nonce_only_quality_error->get_error_data()['materialization_receipt'] ?? array() : array();
-$assert( is_wp_error( $nonce_only_quality_error ) && 3 === $provider_rollbacks && true === ( $nonce_only_quality_receipt['entity_compensation']['superseded_binding_mismatch'] ?? false ) && str_repeat( 'a', 64 ) !== ( $nonce_only_quality_receipt['receipt_instance_id'] ?? '' ) && ( $nonce_only_quality_receipt['receipt_instance_id'] ?? '' ) === ( $nonce_only_quality_receipt['entity_compensation']['binding']['receipt_instance_id'] ?? '' ), 'mutable receipt envelope nonces are replaced by the durable deferred transaction identity before compensation' );
+$nonce_only_quality_receipt = $nonce_only_cross_receipt;
+$assert( ! is_wp_error( $nonce_only_quality_error ) && 0 === $provider_rollbacks, 'quality reporting does not mutate receipt identities to bind compensation' );
 $nonce_only_quality_receipt['plan']['quality']     = $deferred_form_receipt['plan']['quality'];
 $nonce_only_quality_receipt['plan']['diagnostics'] = $deferred_form_receipt['plan']['diagnostics'];
 $required_changed_lifecycle = $deferred_form_lifecycle;
@@ -2081,8 +2056,8 @@ $required_changed_quality_error = $final_quality_gate->invoke(
 	array(),
 	$deferred_entities['reports']
 );
-$required_changed_quality_receipt = is_wp_error( $required_changed_quality_error ) ? $required_changed_quality_error->get_error_data()['materialization_receipt'] ?? array() : array();
-$assert( is_wp_error( $required_changed_quality_error ) && 4 === $provider_rollbacks && true === ( $required_changed_quality_receipt['entity_compensation']['superseded_binding_mismatch'] ?? false ), 'a changed required lifecycle declaration cannot reuse compensation evidence' );
+$required_changed_quality_receipt = $nonce_only_quality_receipt;
+$assert( ! is_wp_error( $required_changed_quality_error ) && 0 === $provider_rollbacks, 'a changed lifecycle declaration does not turn quality reporting into compensation' );
 $required_changed_quality_receipt['plan']['quality']     = $deferred_form_receipt['plan']['quality'];
 $required_changed_quality_receipt['plan']['diagnostics'] = $deferred_form_receipt['plan']['diagnostics'];
 $contract_changed_lifecycle = $required_changed_lifecycle;
@@ -2099,8 +2074,8 @@ $contract_changed_quality_error = $final_quality_gate->invoke(
 	array(),
 	$deferred_entities['reports']
 );
-$contract_changed_quality_receipt = is_wp_error( $contract_changed_quality_error ) ? $contract_changed_quality_error->get_error_data()['materialization_receipt'] ?? array() : array();
-$assert( is_wp_error( $contract_changed_quality_error ) && 5 === $provider_rollbacks && 'rolled_back' === ( $contract_changed_quality_receipt['entity_compensation']['entities'][0]['rollback']['status'] ?? '' ) && true === ( $contract_changed_quality_receipt['entity_compensation']['superseded_binding_mismatch'] ?? false ) && ( $required_changed_quality_receipt['entity_compensation']['binding']['rollback_contracts_hash'] ?? '' ) !== ( $contract_changed_quality_receipt['entity_compensation']['binding']['rollback_contracts_hash'] ?? '' ), 'a changed rollback contract cannot reuse compensation evidence and retains bounded rollback status' );
+$contract_changed_quality_receipt = $required_changed_quality_receipt;
+$assert( ! is_wp_error( $contract_changed_quality_error ) && 0 === $provider_rollbacks, 'a changed rollback contract remains irrelevant to non-blocking quality reporting' );
 $ordered_rollback_plan                = ( new ArtifactCompiler() )->compile(
 	array(
 		'entrypoint' => 'ordered-rollback/index.html',
@@ -2157,17 +2132,17 @@ $ordered_quality_error = $final_quality_gate->invoke(
 	array(),
 	$ordered_reports
 );
-$ordered_quality_receipt = is_wp_error( $ordered_quality_error ) ? $ordered_quality_error->get_error_data()['materialization_receipt'] ?? array() : array();
+$ordered_quality_receipt = $ordered_rollback_receipt;
 $ordered_events          = $GLOBALS['ssi_plan_rollback_events'];
 $file_events             = array_values( array_filter( $ordered_events, static fn( string $event ): bool => str_starts_with( $event, 'file:' ) ) );
 $first_file              = empty( $file_events ) ? false : array_search( $file_events[0], $ordered_events, true );
 $post_events             = array_values( array_filter( $ordered_events, static fn( string $event ): bool => str_starts_with( $event, 'post:' ) ) );
-$assert( is_wp_error( $ordered_quality_error ) && $ordered_rollback_options === $GLOBALS['ssi_plan_options'] && 'theme:before-child-theme' === $ordered_events[0] && false !== $first_file && $first_file > array_search( 'option:stylesheet', $ordered_events, true ) && array_map( static fn( int $id ): string => 'post:' . $id, array_reverse( $ordered_post_ids ) ) === $post_events && 'provider:mutated' === $ordered_events[ count( $ordered_events ) - 1 ] && array( 'mutated' ) === $ordered_provider_calls && empty( $GLOBALS['ssi_plan_posts'][ $ordered_post_ids[0] ] ) && empty( $GLOBALS['ssi_plan_posts'][ $ordered_post_ids[1] ] ) && 'rolled_back' === ( $ordered_quality_receipt['entity_compensation']['entities'][0]['status'] ?? '' ), 'production rollback restores the child stylesheet and parent template before files, removes child posts before parents, then compensates only mutated providers' );
+$assert( ! is_wp_error( $ordered_quality_error ) && array() === $ordered_events && array() === $ordered_provider_calls && isset( $GLOBALS['ssi_plan_posts'][ $ordered_post_ids[0] ], $GLOBALS['ssi_plan_posts'][ $ordered_post_ids[1] ] ), 'failed quality reporting leaves the completed site and provider state intact' );
 $events_before_ordered_retry = $ordered_events;
 $ordered_quality_receipt['plan']['quality']     = $deferred_form_receipt['plan']['quality'];
 $ordered_quality_receipt['plan']['diagnostics'] = $deferred_form_receipt['plan']['diagnostics'];
 $ordered_retry_error = $final_quality_gate->invoke( null, $ordered_quality_receipt, array( 'fail_on_quality' => true, '_static_site_importer_deferred_form_quality_admission' => true ), $ordered_lifecycle, array(), $ordered_reports );
-$assert( is_wp_error( $ordered_retry_error ) && $events_before_ordered_retry === $GLOBALS['ssi_plan_rollback_events'] && array( 'mutated' ) === $ordered_provider_calls, 'ordered production rollback preserves journal and provider compensation idempotence on retry' );
+$assert( ! is_wp_error( $ordered_retry_error ) && $events_before_ordered_retry === $GLOBALS['ssi_plan_rollback_events'] && array() === $ordered_provider_calls, 'repeated quality reporting remains non-destructive' );
 unset( $GLOBALS['ssi_plan_rollback_events'] );
 $partial_rollback_plan    = ( new ArtifactCompiler() )->compile(
 	array(


### PR DESCRIPTION
## Summary
- separate materialization success from quality validation outcomes
- keep editability and quality-budget failures in receipts and diagnostics without rejecting or rolling back imports
- remove the deferred form-quality admission and compensation path
- retain fail-closed behavior for malformed plans, invalid evidence bindings, permissions, unsafe destinations, and mechanical write failures

## Testing
- `npm test`
- 75 selected test groups passed, 0 failed

## AI assistance
OpenAI GPT-5.6 Sol was used through OpenCode to trace the quality-gate call paths, implement the refactor, update tests, and run verification. Chris Huber directed the change and reviewed the resulting behavior.