### PR TITLE
Fix labelled radio fieldset materialization

### DIFF
--- a/includes/class-static-site-importer-computed-layout-strategy.php
+++ b/includes/class-static-site-importer-computed-layout-strategy.php
@@ -219,8 +219,12 @@ class Static_Site_Importer_Computed_Layout_Strategy {
 	private static function semantic_wrapper_losses( array $form, array $blocks ): array {
 		$serialized = self::serialized_topology_blocks( $blocks );
 		$losses     = array();
+		$represented = array_fill_keys( is_array( $form['represented_semantic_nodes'] ?? null ) ? $form['represented_semantic_nodes'] : array(), true );
 		foreach ( $form['control_topology']['nodes'] ?? array() as $node ) {
 			if ( ! is_array( $node ) || 'wrapper' !== ( $node['kind'] ?? null ) || ! is_string( $node['id'] ?? null ) ) {
+				continue;
+			}
+			if ( isset( $represented[ $node['id'] ] ) ) {
 				continue;
 			}
 			$source_tag = $node['tag'] ?? 'div';

--- a/includes/class-static-site-importer-computed-layout-strategy.php
+++ b/includes/class-static-site-importer-computed-layout-strategy.php
@@ -217,8 +217,8 @@ class Static_Site_Importer_Computed_Layout_Strategy {
 	}
 
 	private static function semantic_wrapper_losses( array $form, array $blocks ): array {
-		$serialized = self::serialized_topology_blocks( $blocks );
-		$losses     = array();
+		$serialized  = self::serialized_topology_blocks( $blocks );
+		$losses      = array();
 		$represented = array_fill_keys( is_array( $form['represented_semantic_nodes'] ?? null ) ? $form['represented_semantic_nodes'] : array(), true );
 		foreach ( $form['control_topology']['nodes'] ?? array() as $node ) {
 			if ( ! is_array( $node ) || 'wrapper' !== ( $node['kind'] ?? null ) || ! is_string( $node['id'] ?? null ) ) {

--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -1371,7 +1371,7 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 		$controls   = array();
 		$orders     = array();
 		foreach ( $nodes as $index => $node ) {
-			if ( ! is_array( $node ) || ! self::has_only_keys( $node, ( $node['kind'] ?? null ) === 'wrapper' ? array( 'id', 'kind', 'parent', 'order', 'depth', 'tag', 'source_id', 'class', 'fieldset_semantics' ) : array( 'id', 'kind', 'parent', 'order', 'depth', 'control' ) ) || ! is_string( $node['id'] ?? null ) || ! preg_match( '/^(?:wrapper|control)-[A-Za-z0-9_-]{1,80}$/D', $node['id'] ) || isset( $seen_ids[ $node['id'] ] ) || ! in_array( $node['kind'] ?? null, array( 'wrapper', 'control' ), true ) || ! is_int( $node['order'] ?? null ) || $node['order'] < 0 || ! is_int( $node['depth'] ?? null ) || $node['depth'] < 0 || $node['depth'] > $max_depth ) {
+			if ( ! is_array( $node ) || ! self::has_only_keys( $node, ( $node['kind'] ?? null ) === 'wrapper' ? array( 'id', 'kind', 'parent', 'order', 'depth', 'tag', 'source_id', 'class', 'fieldset_semantics', 'legend' ) : array( 'id', 'kind', 'parent', 'order', 'depth', 'control' ) ) || ! is_string( $node['id'] ?? null ) || ! preg_match( '/^(?:wrapper|control)-[A-Za-z0-9_-]{1,80}$/D', $node['id'] ) || isset( $seen_ids[ $node['id'] ] ) || ! in_array( $node['kind'] ?? null, array( 'wrapper', 'control' ), true ) || ! is_int( $node['order'] ?? null ) || $node['order'] < 0 || ! is_int( $node['depth'] ?? null ) || $node['depth'] < 0 || $node['depth'] > $max_depth ) {
 				return array( 'error' => 'control_topology contains an unsupported node.' );
 			}
 			$parent = $node['parent'] ?? null;
@@ -1422,6 +1422,13 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 						return array( 'error' => 'control_topology fieldset semantics must describe a fieldset wrapper.' );
 					}
 					$normalized_node['fieldset_semantics'] = $node['fieldset_semantics'];
+				}
+				if ( isset( $node['legend'] ) ) {
+					$legend = is_string( $node['legend'] ) ? trim( $node['legend'] ) : '';
+					if ( 'fieldset' !== ( $node['tag'] ?? '' ) || 'labelled_group' !== ( $node['fieldset_semantics'] ?? '' ) || '' === $legend || strlen( $legend ) > 200 ) {
+						return array( 'error' => 'control_topology fieldset legends must be bounded labelled fieldset presentation evidence.' );
+					}
+					$normalized_node['legend'] = $legend;
 				}
 			}
 			$seen_ids[ $node['id'] ]                 = $normalized_node;

--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -1371,7 +1371,7 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 		$controls   = array();
 		$orders     = array();
 		foreach ( $nodes as $index => $node ) {
-			if ( ! is_array( $node ) || ! self::has_only_keys( $node, ( $node['kind'] ?? null ) === 'wrapper' ? array( 'id', 'kind', 'parent', 'order', 'depth', 'tag', 'source_id', 'class', 'fieldset_semantics', 'legend' ) : array( 'id', 'kind', 'parent', 'order', 'depth', 'control' ) ) || ! is_string( $node['id'] ?? null ) || ! preg_match( '/^(?:wrapper|control)-[A-Za-z0-9_-]{1,80}$/D', $node['id'] ) || isset( $seen_ids[ $node['id'] ] ) || ! in_array( $node['kind'] ?? null, array( 'wrapper', 'control' ), true ) || ! is_int( $node['order'] ?? null ) || $node['order'] < 0 || ! is_int( $node['depth'] ?? null ) || $node['depth'] < 0 || $node['depth'] > $max_depth ) {
+			if ( ! is_array( $node ) || ! self::has_only_keys( $node, ( $node['kind'] ?? null ) === 'wrapper' ? array( 'id', 'kind', 'parent', 'order', 'depth', 'tag', 'source_id', 'class', 'fieldset_semantics' ) : array( 'id', 'kind', 'parent', 'order', 'depth', 'control' ) ) || ! is_string( $node['id'] ?? null ) || ! preg_match( '/^(?:wrapper|control)-[A-Za-z0-9_-]{1,80}$/D', $node['id'] ) || isset( $seen_ids[ $node['id'] ] ) || ! in_array( $node['kind'] ?? null, array( 'wrapper', 'control' ), true ) || ! is_int( $node['order'] ?? null ) || $node['order'] < 0 || ! is_int( $node['depth'] ?? null ) || $node['depth'] < 0 || $node['depth'] > $max_depth ) {
 				return array( 'error' => 'control_topology contains an unsupported node.' );
 			}
 			$parent = $node['parent'] ?? null;
@@ -1422,13 +1422,6 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 						return array( 'error' => 'control_topology fieldset semantics must describe a fieldset wrapper.' );
 					}
 					$normalized_node['fieldset_semantics'] = $node['fieldset_semantics'];
-				}
-				if ( isset( $node['legend'] ) ) {
-					$legend = is_string( $node['legend'] ) ? trim( $node['legend'] ) : '';
-					if ( 'fieldset' !== ( $node['tag'] ?? '' ) || 'labelled_group' !== ( $node['fieldset_semantics'] ?? '' ) || '' === $legend || strlen( $legend ) > 200 ) {
-						return array( 'error' => 'control_topology fieldset legends must be bounded labelled fieldset presentation evidence.' );
-					}
-					$normalized_node['legend'] = $legend;
 				}
 			}
 			$seen_ids[ $node['id'] ]                 = $normalized_node;

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -456,9 +456,9 @@ class Static_Site_Importer_Form_Seeder {
 		if ( ! $has_topology || ! $has_source_submit ) {
 			$inner_blocks[] = self::submit_button_block( $submit_text, self::layout_node_class( $scope, 'control-submit' ), $submit_presentation );
 		}
-		$form['topology_losses']             = $topology['losses'];
+		$form['topology_losses']            = $topology['losses'];
 		$form['represented_semantic_nodes'] = $radio_groups['represented_semantic_nodes'];
-		$provider_graph          = is_array( $form['layout_graph'] ?? null ) ? $form['layout_graph'] : array(
+		$provider_graph                     = is_array( $form['layout_graph'] ?? null ) ? $form['layout_graph'] : array(
 			'nodes'    => array(),
 			'variants' => array(),
 		);
@@ -605,8 +605,8 @@ class Static_Site_Importer_Form_Seeder {
 
 	/**
 	 * Aggregate only an exact labelled-fieldset radio topology that Jetpack can
-	 * represent as one field. The generic topology supplies membership and the
-	 * fieldset legend supplies the group label; no source markup is re-parsed.
+	 * represent as one field. The generic topology supplies membership and its
+	 * canonical binding supplies the source legend; no provider semantics are inferred.
 	 *
 	 * @return array{groups:array<int,array<string,mixed>>,suppressed_controls:array<int,bool>,represented_semantic_nodes:array<int,string>,operations:array<int,array<string,mixed>>}
 	 */
@@ -617,7 +617,7 @@ class Static_Site_Importer_Form_Seeder {
 			'represented_semantic_nodes' => array(),
 			'operations'                 => array(),
 		);
-		$nodes = $form['control_topology']['nodes'] ?? null;
+		$nodes  = $form['control_topology']['nodes'] ?? null;
 		if ( ! is_array( $nodes ) ) {
 			return $result;
 		}
@@ -634,6 +634,11 @@ class Static_Site_Importer_Form_Seeder {
 		}
 		unset( $siblings );
 
+		$legends = self::labelled_fieldset_legends( $form, $nodes );
+		if ( empty( $legends ) ) {
+			return $result;
+		}
+
 		$all_radio_names = array();
 		foreach ( $controls as $control_index => $control ) {
 			if ( ! is_array( $control ) || 'input' !== strtolower( trim( (string) ( $control['tag'] ?? '' ) ) ) || 'radio' !== strtolower( trim( (string) ( $control['type'] ?? '' ) ) ) ) {
@@ -646,15 +651,19 @@ class Static_Site_Importer_Form_Seeder {
 		}
 
 		foreach ( $nodes as $fieldset ) {
-			if ( ! is_array( $fieldset ) || 'wrapper' !== ( $fieldset['kind'] ?? null ) || 'fieldset' !== ( $fieldset['tag'] ?? null ) || 'labelled_group' !== ( $fieldset['fieldset_semantics'] ?? null ) || ! is_string( $fieldset['id'] ?? null ) || ! is_string( $fieldset['legend'] ?? null ) || '' === trim( $fieldset['legend'] ) ) {
+			if ( ! is_array( $fieldset ) || 'wrapper' !== ( $fieldset['kind'] ?? null ) || 'fieldset' !== ( $fieldset['tag'] ?? null ) || 'labelled_group' !== ( $fieldset['fieldset_semantics'] ?? null ) || ! is_string( $fieldset['id'] ?? null ) || ! isset( $legends[ $fieldset['id'] ] ) ) {
 				continue;
 			}
-			$members          = array();
-			$semantic_nodes   = array( $fieldset['id'] );
+			$members           = array();
+			$semantic_nodes    = array( $fieldset['id'] );
 			$unambiguous_shape = true;
-			foreach ( $children[ $fieldset['id'] ] ?? array() as $label ) {
-				$label_children = $children[ $label['id'] ?? '' ] ?? array();
-				if ( 'wrapper' !== ( $label['kind'] ?? null ) || 'label' !== ( $label['tag'] ?? null ) || ! is_string( $label['id'] ?? null ) || 1 !== count( $label_children ) || 'control' !== ( $label_children[0]['kind'] ?? null ) || ! is_int( $label_children[0]['control'] ?? null ) ) {
+			$labels            = $children[ $fieldset['id'] ] ?? array();
+			if ( 1 === count( $labels ) && 'wrapper' === ( $labels[0]['kind'] ?? null ) && 'div' === ( $labels[0]['tag'] ?? null ) && is_string( $labels[0]['id'] ?? null ) ) {
+				$labels = $children[ $labels[0]['id'] ];
+			}
+			foreach ( $labels as $label ) {
+				$label_children = is_string( $label['id'] ?? null ) ? $children[ $label['id'] ] ?? array() : array();
+				if ( 'wrapper' !== ( $label['kind'] ?? null ) || 'label' !== ( $label['tag'] ?? null ) || 1 !== count( $label_children ) || 'control' !== ( $label_children[0]['kind'] ?? null ) || ! is_int( $label_children[0]['control'] ?? null ) ) {
 					$unambiguous_shape = false;
 					break;
 				}
@@ -664,13 +673,13 @@ class Static_Site_Importer_Form_Seeder {
 			if ( ! $unambiguous_shape || ! in_array( count( $members ), array( 2, 3, 4 ), true ) || count( $members ) !== count( array_unique( $members ) ) ) {
 				continue;
 			}
-			$first       = $controls[ $members[0] ] ?? null;
-			$name        = is_array( $first ) ? trim( (string) ( $first['name'] ?? '' ) ) : '';
-			$options     = array();
-			$required    = false;
+			$first    = $controls[ $members[0] ] ?? null;
+			$name     = is_array( $first ) ? trim( (string) ( $first['name'] ?? '' ) ) : '';
+			$options  = array();
+			$required = false;
 			foreach ( $members as $control_index ) {
 				$control = $controls[ $control_index ] ?? null;
-				if ( ! is_array( $control ) || 'input' !== strtolower( trim( (string) ( $control['tag'] ?? '' ) ) ) || 'radio' !== strtolower( trim( (string) ( $control['type'] ?? '' ) ) ) || $name !== trim( (string) ( $control['name'] ?? '' ) ) ) {
+				if ( ! is_array( $control ) || 'input' !== strtolower( trim( (string) ( $control['tag'] ?? '' ) ) ) || 'radio' !== strtolower( trim( (string) ( $control['type'] ?? '' ) ) ) || trim( (string) ( $control['name'] ?? '' ) ) !== $name ) {
 					$unambiguous_shape = false;
 					break;
 				}
@@ -678,7 +687,7 @@ class Static_Site_Importer_Form_Seeder {
 					$unambiguous_shape = false;
 					break;
 				}
-				$option = self::control_text( array( 'label' => $control['label'] ) );
+				$option    = self::control_text( array( 'label' => $control['label'] ) );
 				$options[] = $option;
 				$required  = $required || ! empty( $control['required'] ) || 'true' === strtolower( trim( (string) ( $control['aria-required'] ?? $control['aria_required'] ?? '' ) ) );
 			}
@@ -687,8 +696,8 @@ class Static_Site_Importer_Form_Seeder {
 			}
 
 			$group_control            = $first;
-			$group_control['text']    = trim( $fieldset['legend'] );
-			$group_control['label']   = trim( $fieldset['legend'] );
+			$group_control['text']    = $legends[ $fieldset['id'] ];
+			$group_control['label']   = $legends[ $fieldset['id'] ];
 			$group_control['options'] = $options;
 			if ( $required ) {
 				$group_control['required'] = true;
@@ -698,7 +707,7 @@ class Static_Site_Importer_Form_Seeder {
 				$result['suppressed_controls'][ $control_index ] = true;
 			}
 			$result['represented_semantic_nodes'] = array_merge( $result['represented_semantic_nodes'], $semantic_nodes );
-			$result['operations'][]                = array(
+			$result['operations'][]               = array(
 				'dimension'     => 'semantic',
 				'strategy'      => 'provider_radio_fieldset_equivalent',
 				'target_hash'   => hash( 'sha256', $fieldset['id'] ),
@@ -708,6 +717,39 @@ class Static_Site_Importer_Form_Seeder {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Read only the source legend evidence already preserved in one canonical
+	 * binding. A count mismatch leaves every fieldset fail-closed.
+	 *
+	 * @param array<int,array<string,mixed>> $nodes
+	 * @return array<string,string>
+	 */
+	private static function labelled_fieldset_legends( array $form, array $nodes ): array {
+		$fieldset_ids = array();
+		foreach ( $nodes as $node ) {
+			if ( is_array( $node ) && 'wrapper' === ( $node['kind'] ?? null ) && 'fieldset' === ( $node['tag'] ?? null ) && 'labelled_group' === ( $node['fieldset_semantics'] ?? null ) && is_string( $node['id'] ?? null ) ) {
+				$fieldset_ids[] = $node['id'];
+			}
+		}
+		$bindings = $form['bindings'] ?? null;
+		if ( empty( $fieldset_ids ) || ! is_array( $bindings ) || 1 !== count( $bindings ) || ! is_array( $bindings[0] ?? null ) || ! is_string( $bindings[0]['search_block_markup'] ?? null ) ) {
+			return array();
+		}
+		$count   = preg_match_all( '~<fieldset\b[^>]*>\s*<legend\b[^>]*>(.*?)</legend>~is', $bindings[0]['search_block_markup'], $matches );
+		$legends = array();
+		if ( false === $count || count( $fieldset_ids ) !== $count ) {
+			return array();
+		}
+		foreach ( $matches[1] as $index => $markup ) {
+			$legend = preg_replace( '/\s+/', ' ', trim( html_entity_decode( wp_strip_all_tags( $markup ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ) );
+			if ( ! is_string( $legend ) || '' === $legend || 200 < strlen( $legend ) ) {
+				return array();
+			}
+			$legends[ $fieldset_ids[ $index ] ] = $legend;
+		}
+		return $legends;
 	}
 
 	/**

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -371,6 +371,7 @@ class Static_Site_Importer_Form_Seeder {
 		$has_topology                  = isset( $form['control_topology'] );
 		$has_source_submit             = false;
 		$textarea_height_omitted_count = (int) ( $form['form']['textarea_height_omitted_count'] ?? 0 );
+		$radio_groups                  = self::labelled_radio_groups( $form, $controls );
 		if ( ! empty( $form['form']['interleaved_context'] ) ) {
 			return array(
 				'selector'       => $selector,
@@ -390,6 +391,12 @@ class Static_Site_Importer_Form_Seeder {
 		foreach ( $controls as $control_index => $control ) {
 			if ( ! is_array( $control ) ) {
 				continue;
+			}
+			if ( isset( $radio_groups['suppressed_controls'][ $control_index ] ) ) {
+				continue;
+			}
+			if ( isset( $radio_groups['groups'][ $control_index ] ) ) {
+				$control = $radio_groups['groups'][ $control_index ];
 			}
 
 			$type = strtolower( trim( (string) ( $control['type'] ?? '' ) ) );
@@ -433,7 +440,7 @@ class Static_Site_Importer_Form_Seeder {
 			);
 		}
 
-		$topology = self::topology_inner_blocks( $form, $field_blocks, $controls );
+		$topology = self::topology_inner_blocks( $form, $field_blocks, $controls, $radio_groups['suppressed_controls'] );
 		if ( null === $topology ) {
 			return array(
 				'selector'       => $selector,
@@ -449,7 +456,8 @@ class Static_Site_Importer_Form_Seeder {
 		if ( ! $has_topology || ! $has_source_submit ) {
 			$inner_blocks[] = self::submit_button_block( $submit_text, self::layout_node_class( $scope, 'control-submit' ), $submit_presentation );
 		}
-		$form['topology_losses'] = $topology['losses'];
+		$form['topology_losses']             = $topology['losses'];
+		$form['represented_semantic_nodes'] = $radio_groups['represented_semantic_nodes'];
 		$provider_graph          = is_array( $form['layout_graph'] ?? null ) ? $form['layout_graph'] : array(
 			'nodes'    => array(),
 			'variants' => array(),
@@ -469,7 +477,7 @@ class Static_Site_Importer_Form_Seeder {
 				'omitted_count' => $textarea_height_omitted_count,
 			);
 		}
-		self::append_receipt_entries( $layout['receipt'], 'operations', $topology['operations'] );
+		self::append_receipt_entries( $layout['receipt'], 'operations', array_merge( $radio_groups['operations'], $topology['operations'] ) );
 		self::append_receipt_entries( $layout['receipt'], 'losses', $control_attribute_losses );
 		$inner_blocks                 = $layout['blocks'];
 		$form_attrs                   = self::contact_form_attributes( $form, $scope );
@@ -596,6 +604,113 @@ class Static_Site_Importer_Form_Seeder {
 	}
 
 	/**
+	 * Aggregate only an exact labelled-fieldset radio topology that Jetpack can
+	 * represent as one field. The generic topology supplies membership and the
+	 * fieldset legend supplies the group label; no source markup is re-parsed.
+	 *
+	 * @return array{groups:array<int,array<string,mixed>>,suppressed_controls:array<int,bool>,represented_semantic_nodes:array<int,string>,operations:array<int,array<string,mixed>>}
+	 */
+	private static function labelled_radio_groups( array $form, array $controls ): array {
+		$result = array(
+			'groups'                     => array(),
+			'suppressed_controls'        => array(),
+			'represented_semantic_nodes' => array(),
+			'operations'                 => array(),
+		);
+		$nodes = $form['control_topology']['nodes'] ?? null;
+		if ( ! is_array( $nodes ) ) {
+			return $result;
+		}
+
+		$children = array();
+		foreach ( $nodes as $node ) {
+			if ( ! is_array( $node ) || ! is_string( $node['id'] ?? null ) ) {
+				return $result;
+			}
+			$children[ $node['parent'] ?? '$root' ][] = $node;
+		}
+		foreach ( $children as &$siblings ) {
+			usort( $siblings, static fn ( array $left, array $right ): int => $left['order'] <=> $right['order'] );
+		}
+		unset( $siblings );
+
+		$all_radio_names = array();
+		foreach ( $controls as $control_index => $control ) {
+			if ( ! is_array( $control ) || 'input' !== strtolower( trim( (string) ( $control['tag'] ?? '' ) ) ) || 'radio' !== strtolower( trim( (string) ( $control['type'] ?? '' ) ) ) ) {
+				continue;
+			}
+			$name = trim( (string) ( $control['name'] ?? '' ) );
+			if ( '' !== $name ) {
+				$all_radio_names[ $name ][] = $control_index;
+			}
+		}
+
+		foreach ( $nodes as $fieldset ) {
+			if ( ! is_array( $fieldset ) || 'wrapper' !== ( $fieldset['kind'] ?? null ) || 'fieldset' !== ( $fieldset['tag'] ?? null ) || 'labelled_group' !== ( $fieldset['fieldset_semantics'] ?? null ) || ! is_string( $fieldset['id'] ?? null ) || ! is_string( $fieldset['legend'] ?? null ) || '' === trim( $fieldset['legend'] ) ) {
+				continue;
+			}
+			$members          = array();
+			$semantic_nodes   = array( $fieldset['id'] );
+			$unambiguous_shape = true;
+			foreach ( $children[ $fieldset['id'] ] ?? array() as $label ) {
+				$label_children = $children[ $label['id'] ?? '' ] ?? array();
+				if ( 'wrapper' !== ( $label['kind'] ?? null ) || 'label' !== ( $label['tag'] ?? null ) || ! is_string( $label['id'] ?? null ) || 1 !== count( $label_children ) || 'control' !== ( $label_children[0]['kind'] ?? null ) || ! is_int( $label_children[0]['control'] ?? null ) ) {
+					$unambiguous_shape = false;
+					break;
+				}
+				$members[]        = $label_children[0]['control'];
+				$semantic_nodes[] = $label['id'];
+			}
+			if ( ! $unambiguous_shape || ! in_array( count( $members ), array( 2, 3, 4 ), true ) || count( $members ) !== count( array_unique( $members ) ) ) {
+				continue;
+			}
+			$first       = $controls[ $members[0] ] ?? null;
+			$name        = is_array( $first ) ? trim( (string) ( $first['name'] ?? '' ) ) : '';
+			$options     = array();
+			$required    = false;
+			foreach ( $members as $control_index ) {
+				$control = $controls[ $control_index ] ?? null;
+				if ( ! is_array( $control ) || 'input' !== strtolower( trim( (string) ( $control['tag'] ?? '' ) ) ) || 'radio' !== strtolower( trim( (string) ( $control['type'] ?? '' ) ) ) || $name !== trim( (string) ( $control['name'] ?? '' ) ) ) {
+					$unambiguous_shape = false;
+					break;
+				}
+				if ( ! isset( $control['label'] ) || ! is_scalar( $control['label'] ) || '' === trim( (string) $control['label'] ) ) {
+					$unambiguous_shape = false;
+					break;
+				}
+				$option = self::control_text( array( 'label' => $control['label'] ) );
+				$options[] = $option;
+				$required  = $required || ! empty( $control['required'] ) || 'true' === strtolower( trim( (string) ( $control['aria-required'] ?? $control['aria_required'] ?? '' ) ) );
+			}
+			if ( ! $unambiguous_shape || '' === $name || count( $all_radio_names[ $name ] ?? array() ) !== count( $members ) ) {
+				continue;
+			}
+
+			$group_control            = $first;
+			$group_control['text']    = trim( $fieldset['legend'] );
+			$group_control['label']   = trim( $fieldset['legend'] );
+			$group_control['options'] = $options;
+			if ( $required ) {
+				$group_control['required'] = true;
+			}
+			$result['groups'][ $members[0] ] = $group_control;
+			foreach ( array_slice( $members, 1 ) as $control_index ) {
+				$result['suppressed_controls'][ $control_index ] = true;
+			}
+			$result['represented_semantic_nodes'] = array_merge( $result['represented_semantic_nodes'], $semantic_nodes );
+			$result['operations'][]                = array(
+				'dimension'     => 'semantic',
+				'strategy'      => 'provider_radio_fieldset_equivalent',
+				'target_hash'   => hash( 'sha256', $fieldset['id'] ),
+				'control_count' => count( $members ),
+				'required'      => $required,
+			);
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Flatten the validated generic tree into Jetpack's constrained direct-child
 	 * grammar. Equal two- and four-column grids map to provider field widths;
 	 * other wrapper semantics/layout remain explicit receipt losses.
@@ -604,7 +719,7 @@ class Static_Site_Importer_Form_Seeder {
 	 * @param array<int,array<string,mixed>> $controls
 	 * @return array{blocks:array<int,array<string,mixed>>,losses:array<int,array<string,mixed>>,operations:array<int,array<string,mixed>>,represented_layout_nodes:array<int,string>}|null
 	 */
-	private static function topology_inner_blocks( array $form, array $field_blocks, array $controls ): ?array {
+	private static function topology_inner_blocks( array $form, array $field_blocks, array $controls, array $suppressed_controls = array() ): ?array {
 		if ( ! isset( $form['control_topology'] ) ) {
 			return array(
 				'blocks'                   => array_values( $field_blocks ),
@@ -751,13 +866,15 @@ class Static_Site_Importer_Form_Seeder {
 				'node_hash'   => hash( 'sha256', $node_id ),
 			);
 		}
-		$build = static function ( string $parent_node ) use ( &$build, $children, $field_blocks, $controls, &$losses ): array {
+		$build = static function ( string $parent_node ) use ( &$build, $children, $field_blocks, $controls, $suppressed_controls, &$losses ): array {
 			$blocks = array();
 			foreach ( $children[ $parent_node ] ?? array() as $node ) {
 				if ( 'control' === ( $node['kind'] ?? null ) ) {
 					$control_index = $node['control'] ?? -1;
 					if ( isset( $field_blocks[ $control_index ] ) ) {
 						$blocks[] = $field_blocks[ $control_index ];
+					} elseif ( isset( $suppressed_controls[ $control_index ] ) ) {
+						continue;
 					} elseif ( isset( $controls[ $control_index ] ) ) {
 						$type = strtolower( trim( (string) ( $controls[ $control_index ]['type'] ?? $controls[ $control_index ]['tag'] ?? '' ) ) );
 						if ( ! self::control_carries_authored_content( $type ) ) {

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -658,11 +658,11 @@ class Static_Site_Importer_Form_Seeder {
 			$semantic_nodes    = array( $fieldset['id'] );
 			$unambiguous_shape = true;
 			$labels            = $children[ $fieldset['id'] ] ?? array();
-			if ( 1 === count( $labels ) && 'wrapper' === ( $labels[0]['kind'] ?? null ) && 'div' === ( $labels[0]['tag'] ?? null ) && is_string( $labels[0]['id'] ?? null ) ) {
+			if ( 1 === count( $labels ) && 'wrapper' === ( $labels[0]['kind'] ?? null ) && 'div' === ( $labels[0]['tag'] ?? null ) ) {
 				$labels = $children[ $labels[0]['id'] ];
 			}
 			foreach ( $labels as $label ) {
-				$label_children = is_string( $label['id'] ?? null ) ? $children[ $label['id'] ] ?? array() : array();
+				$label_children = $children[ $label['id'] ] ?? array();
 				if ( 'wrapper' !== ( $label['kind'] ?? null ) || 'label' !== ( $label['tag'] ?? null ) || 1 !== count( $label_children ) || 'control' !== ( $label_children[0]['kind'] ?? null ) || ! is_int( $label_children[0]['control'] ?? null ) ) {
 					$unambiguous_shape = false;
 					break;
@@ -729,7 +729,7 @@ class Static_Site_Importer_Form_Seeder {
 	private static function labelled_fieldset_legends( array $form, array $nodes ): array {
 		$fieldset_ids = array();
 		foreach ( $nodes as $node ) {
-			if ( is_array( $node ) && 'wrapper' === ( $node['kind'] ?? null ) && 'fieldset' === ( $node['tag'] ?? null ) && 'labelled_group' === ( $node['fieldset_semantics'] ?? null ) && is_string( $node['id'] ?? null ) ) {
+			if ( 'wrapper' === ( $node['kind'] ?? null ) && 'fieldset' === ( $node['tag'] ?? null ) && 'labelled_group' === ( $node['fieldset_semantics'] ?? null ) && is_string( $node['id'] ?? null ) ) {
 				$fieldset_ids[] = $node['id'];
 			}
 		}

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -29,6 +29,11 @@ namespace {
 			return json_encode( $value, $flags, $depth );
 		}
 	}
+	if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+		function wp_strip_all_tags( string $text ): string {
+			return strip_tags( $text );
+		}
+	}
 
 	$GLOBALS['ssi_test_hooks'] = array();
 
@@ -545,24 +550,28 @@ namespace {
 	$labelled_radio_group = array(
 		'forms' => array(
 			array(
-				'selector' => 'form.feedback',
+				'selector' => 'form.wixui-form',
 				'controls' => array(
-					array( 'tag' => 'input', 'type' => 'radio', 'name' => 'frequency', 'label' => 'Weekly', 'required' => true ),
-					array( 'tag' => 'input', 'type' => 'radio', 'name' => 'frequency', 'label' => 'Monthly' ),
-					array( 'tag' => 'input', 'type' => 'radio', 'name' => 'frequency', 'label' => 'Only for important updates' ),
-					array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send feedback' ),
+					array( 'tag' => 'input', 'type' => 'radio', 'name' => 'comp-kf7in602', 'label' => 'Chakra Healing Session', 'required' => true ),
+					array( 'tag' => 'input', 'type' => 'radio', 'name' => 'comp-kf7in602', 'label' => 'Custom Healing Session' ),
+					array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Submit' ),
+				),
+				'bindings' => array(
+					array(
+						'schema' => 'generic/block-binding/v1', 'source_path' => 'website/cchfeedback/index.html', 'occurrence' => 1, 'role' => 'form',
+						'search_block_markup' => '<form><div id="comp-kf7in602" class="wixui-radio-button-group"><fieldset role="radiogroup" aria-required="true"><legend><div data-testid="groupLabel">What was your treatment?</div></legend><div data-testid="radioGroup"><label><input type="radio" required name="comp-kf7in602" value="Chakra Healing Session"></label><label><input type="radio" name="comp-kf7in602" value="Custom Healing Session"></label></div></fieldset></div></form>',
+					),
 				),
 				'control_topology' => array(
 					'schema' => 'generic/form-control-topology/v1', 'max_depth' => 8, 'max_nodes' => 16, 'truncated' => false,
 					'nodes' => array(
-						array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 0, 'depth' => 0, 'tag' => 'fieldset', 'fieldset_semantics' => 'labelled_group', 'legend' => 'How often should we contact you?' ),
-						array( 'id' => 'wrapper-1', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'tag' => 'label' ),
-						array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-1', 'order' => 0, 'depth' => 2, 'control' => 0 ),
-						array( 'id' => 'wrapper-2', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 1, 'depth' => 1, 'tag' => 'label' ),
-						array( 'id' => 'control-1', 'kind' => 'control', 'parent' => 'wrapper-2', 'order' => 0, 'depth' => 2, 'control' => 1 ),
-						array( 'id' => 'wrapper-3', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 2, 'depth' => 1, 'tag' => 'label' ),
-						array( 'id' => 'control-2', 'kind' => 'control', 'parent' => 'wrapper-3', 'order' => 0, 'depth' => 2, 'control' => 2 ),
-						array( 'id' => 'control-3', 'kind' => 'control', 'parent' => null, 'order' => 1, 'depth' => 0, 'control' => 3 ),
+						array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 0, 'depth' => 0, 'tag' => 'fieldset', 'fieldset_semantics' => 'labelled_group' ),
+						array( 'id' => 'wrapper-1', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'tag' => 'div' ),
+						array( 'id' => 'wrapper-2', 'kind' => 'wrapper', 'parent' => 'wrapper-1', 'order' => 0, 'depth' => 2, 'tag' => 'label' ),
+						array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-2', 'order' => 0, 'depth' => 3, 'control' => 0 ),
+						array( 'id' => 'wrapper-3', 'kind' => 'wrapper', 'parent' => 'wrapper-1', 'order' => 1, 'depth' => 2, 'tag' => 'label' ),
+						array( 'id' => 'control-1', 'kind' => 'control', 'parent' => 'wrapper-3', 'order' => 0, 'depth' => 3, 'control' => 1 ),
+						array( 'id' => 'control-2', 'kind' => 'control', 'parent' => null, 'order' => 1, 'depth' => 0, 'control' => 2 ),
 					),
 				),
 			),
@@ -574,12 +583,12 @@ namespace {
 	$labelled_radio_markup     = (string) ( $labelled_radio_row['block_markup'] ?? '' );
 	$labelled_radio_receipt    = $labelled_radio_row['computed_layout_receipt'] ?? array();
 	$assert( empty( $labelled_radio_validation['errors'] ) && 'mapped' === ( $labelled_radio_row['status'] ?? '' ) && true === ( $labelled_radio_row['runtime_mapped'] ?? false ) && 1 === ( $labelled_radio_row['field_count'] ?? 0 ), 'labelled-radio-fieldset-materializes-one-runtime-field', wp_json_encode( array( 'validation' => $labelled_radio_validation, 'seed' => $labelled_radio_seed ) ) );
-	$assert( 1 === substr_count( $labelled_radio_markup, '<!-- wp:jetpack/field-radio ' ) && str_contains( $labelled_radio_markup, '<!-- wp:jetpack/label {"label":"How often should we contact you?"} /-->' ) && str_contains( $labelled_radio_markup, '"options":["Weekly","Monthly","Only for important updates"]' ) && str_contains( $labelled_radio_markup, '"required":true' ), 'labelled-radio-fieldset-serializes-legend-required-state-and-ordered-options', $labelled_radio_markup );
+	$assert( 1 === substr_count( $labelled_radio_markup, '<!-- wp:jetpack/field-radio ' ) && str_contains( $labelled_radio_markup, '<!-- wp:jetpack/label {"label":"What was your treatment?"} /-->' ) && str_contains( $labelled_radio_markup, '"options":["Chakra Healing Session","Custom Healing Session"]' ) && str_contains( $labelled_radio_markup, '"required":true' ), 'labelled-radio-fieldset-serializes-legend-required-state-and-ordered-options', $labelled_radio_markup );
 	$assert( 'provider_radio_fieldset_equivalent' === ( $labelled_radio_receipt['operations'][0]['strategy'] ?? '' ) && 'semantic' === ( $labelled_radio_receipt['operations'][0]['dimension'] ?? '' ) && ! in_array( 'unsupported_semantic_wrapper', array_column( $labelled_radio_receipt['losses'] ?? array(), 'reason_code' ), true ), 'labelled-radio-fieldset-receipt-represents-semantics-without-waiver', wp_json_encode( $labelled_radio_receipt ) );
 	$assert( $labelled_radio_markup === serialize_blocks( parse_blocks( $labelled_radio_markup ) ), 'labelled-radio-fieldset-serialized-block-round-trips-through-wordpress', $labelled_radio_markup );
 	$ambiguous_radio_group = $labelled_radio_group;
-	$ambiguous_radio_group['forms'][0]['controls'][] = array( 'tag' => 'input', 'type' => 'radio', 'name' => 'frequency', 'label' => 'Never' );
-	$ambiguous_radio_group['forms'][0]['control_topology']['nodes'][] = array( 'id' => 'control-4', 'kind' => 'control', 'parent' => null, 'order' => 2, 'depth' => 0, 'control' => 4 );
+	$ambiguous_radio_group['forms'][0]['controls'][] = array( 'tag' => 'input', 'type' => 'radio', 'name' => 'comp-kf7in602', 'label' => 'No preference' );
+	$ambiguous_radio_group['forms'][0]['control_topology']['nodes'][] = array( 'id' => 'control-3', 'kind' => 'control', 'parent' => null, 'order' => 2, 'depth' => 0, 'control' => 3 );
 	$ambiguous_radio_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $ambiguous_radio_group );
 	$ambiguous_radio_seed       = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $ambiguous_radio_validation['forms'] ?? array() ) );
 	$assert( 'error' === ( $ambiguous_radio_seed['forms'][0]['status'] ?? '' ) && 'unsupported_semantic_wrapper' === ( $ambiguous_radio_seed['forms'][0]['form_receipt_unaccepted_losses'][0]['reason_code'] ?? '' ), 'ambiguous-labelled-radio-fieldset-remains-loss-gated', wp_json_encode( $ambiguous_radio_seed ) );

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -542,6 +542,47 @@ namespace {
 	$labelled_root_fieldset_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $labelled_root_fieldset );
 	$labelled_root_fieldset_seed = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $labelled_root_fieldset_validation['forms'] ?? array() ) );
 	$assert( 'error' === ( $labelled_root_fieldset_seed['forms'][0]['status'] ?? '' ) && 'unsupported_semantic_wrapper' === ( $labelled_root_fieldset_seed['forms'][0]['form_receipt_unaccepted_losses'][0]['reason_code'] ?? '' ), 'provider-form-rejects-labelled-root-fieldset-loss', wp_json_encode( array( 'validation' => $labelled_root_fieldset_validation, 'seed' => $labelled_root_fieldset_seed ) ) );
+	$labelled_radio_group = array(
+		'forms' => array(
+			array(
+				'selector' => 'form.feedback',
+				'controls' => array(
+					array( 'tag' => 'input', 'type' => 'radio', 'name' => 'frequency', 'label' => 'Weekly', 'required' => true ),
+					array( 'tag' => 'input', 'type' => 'radio', 'name' => 'frequency', 'label' => 'Monthly' ),
+					array( 'tag' => 'input', 'type' => 'radio', 'name' => 'frequency', 'label' => 'Only for important updates' ),
+					array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send feedback' ),
+				),
+				'control_topology' => array(
+					'schema' => 'generic/form-control-topology/v1', 'max_depth' => 8, 'max_nodes' => 16, 'truncated' => false,
+					'nodes' => array(
+						array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 0, 'depth' => 0, 'tag' => 'fieldset', 'fieldset_semantics' => 'labelled_group', 'legend' => 'How often should we contact you?' ),
+						array( 'id' => 'wrapper-1', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'tag' => 'label' ),
+						array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-1', 'order' => 0, 'depth' => 2, 'control' => 0 ),
+						array( 'id' => 'wrapper-2', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 1, 'depth' => 1, 'tag' => 'label' ),
+						array( 'id' => 'control-1', 'kind' => 'control', 'parent' => 'wrapper-2', 'order' => 0, 'depth' => 2, 'control' => 1 ),
+						array( 'id' => 'wrapper-3', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 2, 'depth' => 1, 'tag' => 'label' ),
+						array( 'id' => 'control-2', 'kind' => 'control', 'parent' => 'wrapper-3', 'order' => 0, 'depth' => 2, 'control' => 2 ),
+						array( 'id' => 'control-3', 'kind' => 'control', 'parent' => null, 'order' => 1, 'depth' => 0, 'control' => 3 ),
+					),
+				),
+			),
+		),
+	);
+	$labelled_radio_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $labelled_radio_group );
+	$labelled_radio_seed       = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $labelled_radio_validation['forms'] ?? array() ) );
+	$labelled_radio_row        = $labelled_radio_seed['forms'][0] ?? array();
+	$labelled_radio_markup     = (string) ( $labelled_radio_row['block_markup'] ?? '' );
+	$labelled_radio_receipt    = $labelled_radio_row['computed_layout_receipt'] ?? array();
+	$assert( empty( $labelled_radio_validation['errors'] ) && 'mapped' === ( $labelled_radio_row['status'] ?? '' ) && true === ( $labelled_radio_row['runtime_mapped'] ?? false ) && 1 === ( $labelled_radio_row['field_count'] ?? 0 ), 'labelled-radio-fieldset-materializes-one-runtime-field', wp_json_encode( array( 'validation' => $labelled_radio_validation, 'seed' => $labelled_radio_seed ) ) );
+	$assert( 1 === substr_count( $labelled_radio_markup, '<!-- wp:jetpack/field-radio ' ) && str_contains( $labelled_radio_markup, '<!-- wp:jetpack/label {"label":"How often should we contact you?"} /-->' ) && str_contains( $labelled_radio_markup, '"options":["Weekly","Monthly","Only for important updates"]' ) && str_contains( $labelled_radio_markup, '"required":true' ), 'labelled-radio-fieldset-serializes-legend-required-state-and-ordered-options', $labelled_radio_markup );
+	$assert( 'provider_radio_fieldset_equivalent' === ( $labelled_radio_receipt['operations'][0]['strategy'] ?? '' ) && 'semantic' === ( $labelled_radio_receipt['operations'][0]['dimension'] ?? '' ) && ! in_array( 'unsupported_semantic_wrapper', array_column( $labelled_radio_receipt['losses'] ?? array(), 'reason_code' ), true ), 'labelled-radio-fieldset-receipt-represents-semantics-without-waiver', wp_json_encode( $labelled_radio_receipt ) );
+	$assert( $labelled_radio_markup === serialize_blocks( parse_blocks( $labelled_radio_markup ) ), 'labelled-radio-fieldset-serialized-block-round-trips-through-wordpress', $labelled_radio_markup );
+	$ambiguous_radio_group = $labelled_radio_group;
+	$ambiguous_radio_group['forms'][0]['controls'][] = array( 'tag' => 'input', 'type' => 'radio', 'name' => 'frequency', 'label' => 'Never' );
+	$ambiguous_radio_group['forms'][0]['control_topology']['nodes'][] = array( 'id' => 'control-4', 'kind' => 'control', 'parent' => null, 'order' => 2, 'depth' => 0, 'control' => 4 );
+	$ambiguous_radio_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $ambiguous_radio_group );
+	$ambiguous_radio_seed       = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $ambiguous_radio_validation['forms'] ?? array() ) );
+	$assert( 'error' === ( $ambiguous_radio_seed['forms'][0]['status'] ?? '' ) && 'unsupported_semantic_wrapper' === ( $ambiguous_radio_seed['forms'][0]['form_receipt_unaccepted_losses'][0]['reason_code'] ?? '' ), 'ambiguous-labelled-radio-fieldset-remains-loss-gated', wp_json_encode( $ambiguous_radio_seed ) );
 	$legacy_without_submit = $forms_manifest;
 	array_pop( $legacy_without_submit['forms'][0]['controls'] );
 	$legacy_without_submit_seed = Static_Site_Importer_Form_Seeder::seed( $legacy_without_submit );


### PR DESCRIPTION
## Summary
- aggregate exact labelled fieldset radio groups into one Jetpack radio field
- preserve the legend, required state, and source-ordered option labels
- record semantic equivalence in the receipt while leaving incomplete or ambiguous groups loss-gated

## Verification
- `php tests/form-materializer-smoke.php`
- `npm test`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode assisted with inspecting the form topology and manifest evidence, implementing the bounded aggregation and semantic receipt handling, and adding regression coverage. The implementation and verification were directed and reviewed in this worktree.