### PR TITLE
Fix non-blocking quality lint

### DIFF
--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -576,9 +576,9 @@ class Static_Site_Importer_Theme_Generator {
 	 *
 	 * @param array<string,mixed> $receipt  Materialization receipt.
 	 * @param array<string,mixed> $args     Import args.
-	 * @return array<string,mixed>|WP_Error
+	 * @return array<string,mixed>
 	 */
-	private static function public_result_from_wordpress_site_plan_receipt( array $receipt, array $args, array $lifecycle = array(), array $dependencies = array(), array $entities = array() ): array|WP_Error {
+	private static function public_result_from_wordpress_site_plan_receipt( array $receipt, array $args, array $lifecycle = array(), array $dependencies = array(), array $entities = array() ): array {
 		$plan        = $receipt['plan'];
 		$theme        = $receipt['theme'];
 		$diagnostics  = Static_Site_Importer_Report_Diagnostics::after_completed_entity_bindings( isset( $plan['diagnostics'] ) && is_array( $plan['diagnostics'] ) ? $plan['diagnostics'] : array(), $receipt );

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -2554,8 +2554,8 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				array(
 					'status'     => 'failed',
 					'diagnostic' => array(
-						'reason_code'       => 'editability_policy_failed',
-						'owning_layer'      => 'blocks-engine',
+						'reason_code'        => 'editability_policy_failed',
+						'owning_layer'       => 'blocks-engine',
 						'threshold_failures' => array_slice( array_values( array_filter( $policy['failures'], 'is_array' ) ), 0, 10 ),
 					),
 				)


### PR DESCRIPTION
## Summary
- align the failed editability diagnostic array
- remove the obsolete `WP_Error` return type after quality failures became non-blocking

## Testing
- `php tests/smoke-wordpress-site-plan-materializer.php`
- PHPCS passed
- PHPStan passed
- Homeboy Lab ESLint infrastructure failed before analysis because its extension runtime could not resolve `eslint/package.json`; this PR changes PHP only

## AI assistance
OpenAI GPT-5.6 Sol was used through OpenCode to inspect the Homeboy release-gate findings, apply the two lint corrections, and run verification. Chris Huber directed the release continuation.