### PR TITLE
Stream durable CLI import progress

### DIFF
--- a/includes/cli.php
+++ b/includes/cli.php
@@ -536,6 +536,33 @@ if ( ! function_exists( 'static_site_importer_cli_import_receipt' ) ) {
 	}
 }
 
+if ( ! function_exists( 'static_site_importer_cli_import_progress' ) ) {
+	/** Project bounded operator progress from the durable artifact-run evidence. */
+	function static_site_importer_cli_import_progress( array $result, int $step, float $started_at, string $event, string $resume_command = '' ): array {
+		$evidence       = is_array( $result['artifact_run'] ?? null ) ? $result['artifact_run'] : array();
+		$progress       = is_array( $evidence['progress'] ?? null ) ? $evidence['progress'] : array();
+		$total          = max( 0, (int) ( $progress['page_count'] ?? 0 ) );
+		$complete       = min( $total, max( 0, (int) ( $progress['receipt_count'] ?? 0 ) ) );
+		$event          = 'heartbeat' === $event ? 'heartbeat' : 'continuation';
+		$resume_command = str_replace( '<import-id>', (string) ( $result['import_id'] ?? '' ), $resume_command );
+		return array_filter(
+			array(
+				'schema'              => 'static-site-importer/import-cli-progress/v1',
+				'event'               => $event,
+				'import_id'           => (string) ( $result['import_id'] ?? '' ),
+				'phase'               => (string) ( $evidence['phase'] ?? 'unknown' ),
+				'completed_units'     => $complete,
+				'total_units'         => $total,
+				'elapsed_seconds'     => max( 0.0, microtime( true ) - $started_at ),
+				'continuation_reason' => (string) ( $result['continuation_reason'] ?? '' ),
+				'step'                => $step,
+				'resume_command'      => $resume_command,
+			),
+			static fn ( $value ): bool => '' !== $value
+		);
+	}
+}
+
 if ( ! function_exists( 'static_site_importer_cli_decode_import_step' ) ) {
 	function static_site_importer_cli_decode_import_step( string $output ): ?array {
 		$lines = preg_split( '/\R/', trim( $output ) );
@@ -621,12 +648,17 @@ if ( ! function_exists( 'static_site_importer_cli_run_import_host' ) ) {
 	 * @param array<string,mixed> $input
 	 * @return array<string,mixed>
 	 */
-	function static_site_importer_cli_run_import_host( array $input, ?callable $invoke = null, int $max_steps = 0 ): array {
+	function static_site_importer_cli_run_import_host( array $input, ?callable $invoke = null, int $max_steps = 0, ?callable $emit_progress = null, string $resume_command = '' ): array {
 		$invoke    = $invoke ?? 'static_site_importer_cli_import_run_fresh_runtime';
 		$max_steps = min( 1024, max( 1, $max_steps > 0 ? $max_steps : static_site_importer_cli_import_max_steps() ) );
 		$steps     = 0;
+		$started_at = microtime( true );
+		$previous   = null;
 		while ( $steps < $max_steps ) {
 			++$steps;
+			if ( is_array( $previous ) && null !== $emit_progress ) {
+				$emit_progress( static_site_importer_cli_import_progress( $previous, $steps, $started_at, 'heartbeat', $resume_command ) );
+			}
 			$result = $invoke( $input );
 			if ( ! is_array( $result ) ) {
 				$result = static_site_importer_cli_import_error( 'static_site_importer_cli_step_response_invalid', 'An import step did not return an object.' );
@@ -641,6 +673,9 @@ if ( ! function_exists( 'static_site_importer_cli_run_import_host' ) ) {
 					$steps
 				);
 			}
+			if ( null !== $emit_progress ) {
+				$emit_progress( static_site_importer_cli_import_progress( $result, $steps, $started_at, 'continuation', $resume_command ) );
+			}
 			$input = static_site_importer_cli_apply_import_id( $input, $import_id );
 			if ( 'dependencies_prepared' === ( $result['continuation_reason'] ?? '' ) ) {
 				$prepared                              = is_array( $result['result'] ?? null ) ? $result['result'] : array();
@@ -648,11 +683,27 @@ if ( ! function_exists( 'static_site_importer_cli_run_import_host' ) ) {
 				$input['runtime_lifecycle_request_id'] = (string) ( $prepared['fresh_runtime']['request_id'] ?? '' );
 				$input['runtime_lifecycle_checkpoint'] = (string) ( $prepared['fresh_runtime']['lifecycle_checkpoint_id'] ?? $prepared['runtime_lifecycle_checkpoint'] ?? '' );
 			}
+			$previous = $result;
 		}
 		return static_site_importer_cli_import_receipt(
 			static_site_importer_cli_import_error( 'static_site_importer_cli_continuation_bound_exceeded', 'The import exceeded its bounded continuation steps.' ),
 			$max_steps
 		);
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_cli_import_resume_command' ) ) {
+	/** Build the exact command that resumes a durable CLI import. */
+	function static_site_importer_cli_import_resume_command( array $assoc_args, string $import_id ): string {
+		$parts = array( 'wp', 'static-site-importer', 'import' );
+		foreach ( $assoc_args as $key => $value ) {
+			if ( in_array( $key, array( 'import-id', 'max-steps', 'single-step' ), true ) ) {
+				continue;
+			}
+			$parts[] = is_bool( $value ) ? '--' . $key : '--' . $key . '=' . escapeshellarg( (string) $value );
+		}
+		$parts[] = '--import-id=' . $import_id;
+		return implode( ' ', $parts );
 	}
 }
 
@@ -667,6 +718,17 @@ if ( ! function_exists( 'static_site_importer_cli_emit_import_receipt' ) ) {
 		if ( 'completed' !== ( $receipt['status'] ?? '' ) ) {
 			WP_CLI::halt( 1 );
 		}
+	}
+}
+
+if ( ! function_exists( 'static_site_importer_cli_emit_import_progress' ) ) {
+	/** @param array<string,mixed> $progress */
+	function static_site_importer_cli_emit_import_progress( array $progress ): void {
+		$json = wp_json_encode( $progress, JSON_UNESCAPED_SLASHES );
+		if ( false === $json ) {
+			WP_CLI::error( 'Failed to encode import progress.' );
+		}
+		WP_CLI::line( (string) $json );
 	}
 }
 
@@ -702,7 +764,16 @@ if ( ! function_exists( 'static_site_importer_cli_import_command' ) ) {
 			return;
 		}
 		$max_steps = isset( $assoc_args['max-steps'] ) ? (int) $assoc_args['max-steps'] : 0;
-		static_site_importer_cli_emit_import_receipt( static_site_importer_cli_run_import_host( $input, null, $max_steps ) );
+		$resume_command = static_site_importer_cli_import_resume_command( $assoc_args, '<import-id>' );
+		static_site_importer_cli_emit_import_receipt(
+			static_site_importer_cli_run_import_host(
+				$input,
+				null,
+				$max_steps,
+				'static_site_importer_cli_emit_import_progress',
+				$resume_command
+			)
+		);
 	}
 }
 

--- a/tests/smoke-cli-import-continuation.php
+++ b/tests/smoke-cli-import-continuation.php
@@ -275,6 +275,68 @@ $assert( 'static-site-importer/import-cli-receipt/v1' === ( $receipt['schema'] ?
 $assert( 'completed' === ( $receipt['status'] ?? '' ) && 3 === ( $receipt['steps'] ?? 0 ), 'terminal-success-status' );
 $assert( true === ( $receipt['response']['success'] ?? false ) && empty( $receipt['response']['continuation'] ), 'terminal-success-has-no-continuation' );
 
+$progress_events = array();
+$slow_queue      = array(
+	array(
+		'success'             => true,
+		'continuation'        => true,
+		'continuation_reason' => 'run_in_progress',
+		'import_id'           => 'durable-slow-run',
+		'artifact_run'        => array(
+			'phase'    => 'compile_pages',
+			'progress' => array( 'page_count' => 34, 'receipt_count' => 12 ),
+		),
+	),
+	array(
+		'success'      => true,
+		'continuation' => false,
+		'result'       => array( 'theme_slug' => 'slow-import' ),
+	),
+);
+$slow_receipt = static_site_importer_cli_run_import_host(
+	$files_input,
+	static function () use ( &$slow_queue, &$progress_events ): array {
+		// A synchronous worker starts only after the durable-phase heartbeat is emitted.
+		if ( 1 === count( $slow_queue ) && 'heartbeat' !== ( $progress_events[1]['event'] ?? '' ) ) {
+			throw new RuntimeException( 'Slow worker started without a heartbeat.' );
+		}
+		return array_shift( $slow_queue );
+	},
+	0,
+	static function ( array $event ) use ( &$progress_events ): void {
+		$progress_events[] = $event;
+	},
+	'wp static-site-importer import --request=\'/tmp/request.json\' --import-id=<import-id>'
+);
+$assert( 'completed' === ( $slow_receipt['status'] ?? '' ) && 2 === ( $slow_receipt['steps'] ?? 0 ), 'slow-work-completes-with-one-terminal-receipt' );
+$assert( 2 === count( $progress_events ), 'slow-work-emits-continuation-and-heartbeat' );
+$assert( 'continuation' === ( $progress_events[0]['event'] ?? '' ) && 'compile_pages' === ( $progress_events[0]['phase'] ?? '' ), 'continuation-projects-durable-phase' );
+$assert( 12 === ( $progress_events[0]['completed_units'] ?? -1 ) && 34 === ( $progress_events[0]['total_units'] ?? -1 ), 'continuation-projects-durable-unit-counts' );
+$assert( 'heartbeat' === ( $progress_events[1]['event'] ?? '' ) && 'run_in_progress' === ( $progress_events[1]['continuation_reason'] ?? '' ), 'slow-work-heartbeat-precedes-next-synchronous-step' );
+$assert( 'wp static-site-importer import --request=\'/tmp/request.json\' --import-id=durable-slow-run' === ( $progress_events[1]['resume_command'] ?? '' ), 'progress-includes-exact-resume-command' );
+
+$interrupted_step = array(
+	'success'             => true,
+	'continuation'        => true,
+	'continuation_reason' => 'deadline_exhausted',
+	'import_id'           => 'durable-interrupted-run',
+	'artifact_run'        => array(
+		'phase'    => 'compile_pages',
+		'progress' => array( 'page_count' => 2, 'receipt_count' => 1 ),
+	),
+);
+$resume_requests = array();
+$resumed = static_site_importer_cli_run_import_host(
+	static_site_importer_cli_apply_import_id( $files_input, (string) $interrupted_step['import_id'] ),
+	static function ( array $request ) use ( &$resume_requests ): array {
+		$resume_requests[] = $request;
+		return array( 'success' => true, 'continuation' => false, 'result' => array( 'theme_slug' => 'resumed-import' ) );
+	}
+);
+$assert( 'compile_pages' === ( $interrupted_step['artifact_run']['phase'] ?? '' ) && 1 === ( $interrupted_step['artifact_run']['progress']['receipt_count'] ?? 0 ), 'interruption-keeps-durable-progress' );
+$assert( array( 'type' => 'files', 'import_id' => 'durable-interrupted-run' ) === ( $resume_requests[0]['source'] ?? null ), 'interruption-resumes-using-existing-durable-import-id' );
+$assert( 'completed' === ( $resumed['status'] ?? '' ) && 1 === ( $resumed['steps'] ?? 0 ), 'interrupted-run-resumes-to-terminal-receipt' );
+
 $lifecycle_requests = array();
 $lifecycle_queue    = array(
 	array(
@@ -368,6 +430,12 @@ $assert( str_contains( $spec['command'], 'static-site-importer import' ) && str_
 $assert( str_contains( $spec['command'], escapeshellarg( '/tmp/ssi-step.json' ) ), 'fresh-runtime-passes-request-file' );
 $assert( ! str_contains( $spec['command'], 'content_base64' ) && ! str_contains( $spec['command'], 'website/index.html' ), 'fresh-runtime-command-has-no-source-payload' );
 
+$resume_command = static_site_importer_cli_import_resume_command(
+	array( 'url' => 'https://example.com/', 'slug' => 'example', 'activate' => true, 'max-steps' => 1 ),
+	'opaque-resume-id'
+);
+$assert( "wp static-site-importer import --url='https://example.com/' --slug='example' --activate --import-id=opaque-resume-id" === $resume_command, 'resume-command-preserves-import-arguments-and-omits-host-controls' );
+
 $decoded = static_site_importer_cli_decode_import_step( "Deprecated: noise\n{\"success\":true,\"continuation\":false}\n" );
 $assert( true === ( $decoded['success'] ?? false ) && empty( $decoded['continuation'] ), 'fresh-process-decoding-selects-final-json-line' );
 $assert( null === static_site_importer_cli_decode_import_step( 'not json' ), 'fresh-process-output-without-json-is-rejected' );
@@ -415,6 +483,15 @@ try {
 $emitted = json_decode( (string) ( WP_CLI::$lines[0] ?? '' ), true );
 $assert( is_array( $emitted ) && 'failed' === ( $emitted['status'] ?? '' ), 'terminal-failure-prints-json-receipt' );
 $assert( ! str_contains( (string) ( WP_CLI::$lines[0] ?? '' ), 'Success:' ), 'terminal-failure-does-not-print-success' );
+
+WP_CLI::$lines = array();
+WP_CLI::$halt  = null;
+static_site_importer_cli_emit_import_progress( $progress_events[0] );
+static_site_importer_cli_emit_import_receipt( $slow_receipt );
+$typed_progress = json_decode( (string) ( WP_CLI::$lines[0] ?? '' ), true );
+$terminal_after_progress = json_decode( (string) ( WP_CLI::$lines[1] ?? '' ), true );
+$assert( 'static-site-importer/import-cli-progress/v1' === ( $typed_progress['schema'] ?? '' ), 'json-consumers-receive-typed-progress-events' );
+$assert( 'static-site-importer/import-cli-receipt/v1' === ( $terminal_after_progress['schema'] ?? '' ), 'json-consumers-receive-one-terminal-receipt-after-progress' );
 
 WP_CLI::$lines = array();
 WP_CLI::$halt  = null;


### PR DESCRIPTION
## Summary
- project the existing durable artifact-run evidence into bounded typed CLI progress events
- emit a durable-phase heartbeat before each resumed synchronous runtime and retain one terminal receipt
- cover slow work, interruption, and durable resume behavior

Fixes #1470

## Testing
- `php tests/smoke-cli-import-continuation.php`
- `npm run test:inventory`
- `npm test`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented the durable-progress projection, tests, verification, commit, and draft PR under Chris Huber's direction.