### PR TITLE
fix: resolve durable promotion artifacts by identity

### DIFF
--- a/tools/verify-solved-site-promotion.mjs
+++ b/tools/verify-solved-site-promotion.mjs
@@ -132,7 +132,7 @@ function verifyFixture(fixture, decision, options, requiredFiles) {
   assert(editor.results_complete === true && Number(editor.result_count) === Number(editor.total_blocks), `${id}: editor validation must include one complete recursive result per block.`);
   assert(Number(editor.total_blocks) > 0 && editor.valid_blocks === editor.total_blocks && Number(editor.invalid_blocks) === 0, `${id}: editor validation is incomplete or invalid.`);
   assert(fixture.editor_canvas?.status === 'captured', `${id}: editor canvas evidence is missing.`);
-  addRequiredFile(requiredFiles, fixture.editor_canvas?.screenshot, `${id}: editor screenshot`, options.artifactRoot);
+  addRequiredFile(requiredFiles, fixture.editor_canvas?.screenshot, `${id}: editor screenshot`, options.artifactRoot, id);
   const editorPresentation = fixture.editor_presentation || {};
   assert(editorPresentation.schema === 'static-site-importer/editor-presentation-evidence/v3', `${id}: matched editor presentation evidence is missing.`);
   assert(editorPresentation.provider_schema === 'wp-codebox/editor-presentation/v1', `${id}: editor presentation must use WP Codebox canvas evidence.`);
@@ -140,7 +140,7 @@ function verifyFixture(fixture, decision, options, requiredFiles) {
   assert(editorPresentationEvidenceComplete(editorPresentation, fixture), `${id}: editor presentation evidence is incomplete or contradictory.`);
   const matchedRendering = editorPresentation.matched_rendering || {};
   for (const [slot, label] of [['frontend_screenshot', 'matched frontend screenshot'], ['editor_screenshot', 'matched editor screenshot'], ['diff_screenshot', 'matched editor diff']]) {
-    addRequiredFile(requiredFiles, matchedRendering[slot], `${id}: ${label}`, options.artifactRoot);
+    addRequiredFile(requiredFiles, matchedRendering[slot], `${id}: ${label}`, options.artifactRoot, id);
   }
   assert(editorInteractionEvidenceComplete(fixture.editor_interaction), `${id}: editor interaction evidence is incomplete.`);
   const visual = fixture.visual_parity_artifacts || {};
@@ -151,7 +151,7 @@ function verifyFixture(fixture, decision, options, requiredFiles) {
   for (const slot of ['source_screenshot', 'imported_screenshot', 'diff_screenshot', 'visual_diff']) {
     const artifact = visual.artifacts?.[slot];
     assert(artifact?.status === 'captured', `${id}: ${slot} evidence is missing.`);
-    addRequiredFile(requiredFiles, artifact?.ref?.path, `${id}: ${slot}`, options.artifactRoot);
+    addRequiredFile(requiredFiles, artifact?.ref?.path, `${id}: ${slot}`, options.artifactRoot, id, artifact?.ref?.artifact_id);
   }
   const evidence = fixture.matrix_evidence || {};
   assert(evidence.readiness === 'verified' && (evidence.missing || []).length === 0, `${id}: runtime evidence is incomplete.`);
@@ -189,11 +189,12 @@ function artifactManifest(files, root) {
   }).sort((left, right) => left.path.localeCompare(right.path));
 }
 
-function addRequiredFile(files, value, label, root) {
+function addRequiredFile(files, value, label, root, fixtureId = '', artifactId = '') {
   assert(typeof value === 'string' && value, `${label} path is missing.`);
   const resolved = path.isAbsolute(value) ? value : path.join(root, value);
   const relative = path.relative(root, resolved);
-  if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
+  if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+    && fs.existsSync(resolved) && fs.statSync(resolved).isFile()) {
     files.push(resolved);
     return;
   }
@@ -207,9 +208,40 @@ function addRequiredFile(files, value, label, root) {
     return;
   }
   const basename = path.basename(value);
-  const matches = filesBelow(root).filter((file) => path.basename(file) === basename || path.basename(file).endsWith(`-${basename}`));
-  assert(matches.length === 1, `${label} must resolve to exactly one durable evidence file; found ${matches.length}.`);
-  files.push(matches[0]);
+  let matches = filesBelow(root).filter((file) => path.basename(file) === basename || path.basename(file).endsWith(`-${basename}`));
+  if (matches.length !== 1 && fixtureId) {
+    const artifacts = homeboyArtifacts(root);
+    matches = artifactId
+      ? artifacts.filter((artifact) => artifact.name === artifactId)
+      : artifacts.filter((artifact) => artifact.name.includes(`_${fixtureId}_`)
+        && (path.basename(artifact.path) === basename || path.basename(artifact.path).endsWith(`-${basename}`)));
+  }
+  assert(matches.length === 1, `${label} evidence file is missing or ambiguous; found ${matches.length} durable matches.`);
+  files.push(typeof matches[0] === 'string' ? matches[0] : matches[0].path);
+}
+
+function homeboyArtifacts(root) {
+  const durableFiles = filesBelow(root);
+  return durableFiles
+    .filter((file) => path.basename(file) === 'homeboy-bench-result.json')
+    .flatMap((file) => {
+      try {
+        return readJson(file, 'Homeboy bench result').data?.payload?.artifacts || [];
+      } catch {
+        return [];
+      }
+    })
+    .filter((artifact) => typeof artifact?.name === 'string' && typeof artifact?.path === 'string')
+    .map((artifact) => {
+      const relative = path.relative(root, artifact.path);
+      if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+        && fs.existsSync(artifact.path) && fs.statSync(artifact.path).isFile()) {
+        return artifact;
+      }
+      const matches = durableFiles.filter((file) => path.basename(file).startsWith(`${artifact.observation_artifact_id}-`));
+      return matches.length === 1 ? { ...artifact, path: matches[0] } : null;
+    })
+    .filter(Boolean);
 }
 
 function filesBelow(directory) {

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -112,6 +112,27 @@ test('resolves uniquely named durable copies of transient runtime evidence', () 
   assert.ok(receipt.evidence.artifacts.some((row) => row.path === 'uuid-editor.png'));
 });
 
+test('resolves fixture-specific Homeboy artifacts when canonical paths are absent', () => {
+  const input = fixture();
+  const expected = 'files/browser/editor-open/solved/presentation-frontend.png';
+  const selected = path.join(input.root, 'uuid-selected-presentation-frontend.png');
+  const other = path.join(input.root, 'uuid-other-presentation-frontend.png');
+  fs.writeFileSync(selected, 'selected fixture');
+  fs.writeFileSync(other, 'other fixture');
+  input.matrix.fixtures[0].editor_presentation.matched_rendering.frontend_screenshot = expected;
+  write(input.paths.matrix, input.matrix);
+  write(path.join(input.root, 'homeboy-bench-result.json'), {
+    data: { payload: { artifacts: [
+      { name: 'editor_canvas_solved_editor-open-screenshots-1', path: selected },
+      { name: 'editor_canvas_other_editor-open-screenshots-1', path: other },
+    ] } },
+  });
+
+  const receipt = verifySolvedSitePromotion(input.options);
+  assert.ok(receipt.evidence.artifacts.some((row) => row.path === path.basename(selected)));
+  assert.ok(!receipt.evidence.artifacts.some((row) => row.path === path.basename(other)));
+});
+
 test('materializes host runtime evidence into the durable artifact root', () => {
   const input = fixture();
   const externalRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ssi-promotion-runtime-'));


### PR DESCRIPTION
## Summary

- verify canonical promotion evidence paths exist before accepting them
- resolve relocated Homeboy artifacts through the authoritative bench artifact identity map
- disambiguate same-named artifacts by fixture and declared artifact ID

Fix-forward for #1477, which was merged while its solved-site promotion gate was red. The failed matrix itself passed; receipt issuance failed because Homeboy persisted fixture artifacts under observation IDs while the verifier trusted absent canonical relative paths.

## Verification

- `node --test tools/verify-solved-site-promotion.test.mjs` (49 passed)
- downloaded evidence from run `33459068371` successfully reverified into an accepted receipt with this change
- failed run evidence: https://github.com/Automattic/static-site-importer/actions/runs/33459068371

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to inspect the failed promotion evidence, identify the artifact identity mismatch, implement deterministic resolution, reproduce acceptance against downloaded run artifacts, and prepare this pull request.