### PR TITLE
fix: degrade a declined provider entity instead of failing the whole import

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -36,6 +36,7 @@
     "tests/smoke-owner-handoff-evidence.php": { "environment": "standalone-php" },
     "tests/smoke-product-handoff-contract.php": { "environment": "standalone-php" },
     "tests/smoke-quality-budget-admission.php": { "environment": "standalone-php" },
+    "tests/smoke-provider-entity-decline.php": { "environment": "standalone-php" },
     "tests/smoke-provider-presentation.php": { "environment": "standalone-php" },
     "tests/smoke-site-identity.php": { "environment": "standalone-php" },
     "tests/smoke-url-import-runtime.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -615,8 +615,10 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 			$reports[ $id ] = $report;
 			$counts         = is_array( $report['counts'] ?? null ) ? $report['counts'] : array();
 			$expected       = count( is_array( $prepared['manifest']['products'] ?? null ) ? $prepared['manifest']['products'] : ( $prepared['manifest']['forms'] ?? array() ) );
-			$completed_keys = self::lifecycle_entity_has_bindings( $prepared ) ? array( 'created', 'updated', 'mapped' ) : array( 'created', 'updated', 'mapped', 'skipped' );
-			$completed      = array_sum( array_map( 'intval', array_intersect_key( $counts, array_flip( $completed_keys ) ) ) );
+			// A provider that declines one entity reports it as skipped. The compiled
+			// source fallback stays at that binding anchor, so the declaration is
+			// accounted for whether or not the entity carries a page binding.
+			$completed = array_sum( array_map( 'intval', array_intersect_key( $counts, array_flip( array( 'created', 'updated', 'mapped', 'skipped' ) ) ) ) );
 			if ( in_array( $report['status'] ?? '', array( 'failed', 'error' ), true ) || ! empty( $counts['failed'] ) || ! empty( $counts['error'] ) || ( ( ! empty( $prepared['required'] ) || self::lifecycle_entity_has_bindings( $prepared ) ) && $completed < $expected ) ) {
 				$code    = isset( $report['code'] ) && is_scalar( $report['code'] ) ? (string) $report['code'] : 'static_site_importer_entity_materialization_failed';
 				$message = isset( $report['error'] ) && is_scalar( $report['error'] ) ? (string) $report['error'] : ( isset( $report['reason'] ) && is_scalar( $report['reason'] ) && '' !== (string) $report['reason'] ? (string) $report['reason'] : 'Runtime entity materialization failed for declaration: ' . $id . '.' );
@@ -633,6 +635,21 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 			'reports' => $reports,
 			'error'   => null,
 		);
+	}
+
+	/**
+	 * Report whether a provider declined to represent one entity.
+	 *
+	 * A declined row is a deliberate provider decision -- an unsupported control
+	 * topology, or a layout the provider cannot carry without losing fidelity --
+	 * not a materialization failure. The page keeps the compiled source markup at
+	 * that binding anchor, so the binding is dropped instead of failing the import.
+	 * A result row that is absent entirely is still unresolved and stays fatal.
+	 *
+	 * @param array<string,mixed> $result Provider result row for one entity.
+	 */
+	public static function entity_result_declined( array $result ): bool {
+		return 'skipped' === ( $result['status'] ?? '' );
 	}
 
 	/** A canonical page binding makes its provider entity part of materialization. */
@@ -670,8 +687,12 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 				if ( ! is_array( $entity ) || empty( $entity['bindings'] ) ) {
 					continue;
 				}
-				$key         = 'products' === $entity_key ? (string) ( $entity['slug'] ?? '' ) : (string) ( $entity['source_path'] ?? '' ) . "\n" . (string) ( $entity['selector'] ?? '' );
-				$replacement = self::binding_block_markup( $prepared['adapter'], $entity, $results[ $key ] ?? array() );
+				$key    = 'products' === $entity_key ? (string) ( $entity['slug'] ?? '' ) : (string) ( $entity['source_path'] ?? '' ) . "\n" . (string) ( $entity['selector'] ?? '' );
+				$result = is_array( $results[ $key ] ?? null ) ? $results[ $key ] : array();
+				if ( self::entity_result_declined( $result ) ) {
+					continue;
+				}
+				$replacement = self::binding_block_markup( $prepared['adapter'], $entity, $result );
 				if ( '' === $replacement ) {
 					return new WP_Error(
 						'static_site_importer_runtime_binding_unresolved',
@@ -728,9 +749,13 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 					continue;
 				}
 				$entity_key = 'products' === $key ? (string) ( $entity['slug'] ?? '' ) : (string) ( $entity['source_path'] ?? '' ) . "\n" . (string) ( $entity['selector'] ?? '' );
-				$render     = self::binding_classic_render( $prepared['adapter'], $entity, $results[ $entity_key ] ?? array() );
-				$source     = (string) ( $entity['source_path'] ?? '' );
-				$selectors  = array_filter( array( $entity['selector'] ?? '' ) );
+				$result     = is_array( $results[ $entity_key ] ?? null ) ? $results[ $entity_key ] : array();
+				if ( self::entity_result_declined( $result ) ) {
+					continue;
+				}
+				$render    = self::binding_classic_render( $prepared['adapter'], $entity, $result );
+				$source    = (string) ( $entity['source_path'] ?? '' );
+				$selectors = array_filter( array( $entity['selector'] ?? '' ) );
 				if ( empty( $render ) || '' === $source || empty( $selectors ) ) {
 					return new WP_Error( 'static_site_importer_classic_html_binding_unresolved', 'A required provider entity lacks adapter-owned server render output or a canonical HTML source selector.', array( 'declaration_id' => $declaration_id ) );
 				}
@@ -762,7 +787,9 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 		$overlays = array();
 		foreach ( $reports as $report ) {
 			foreach ( is_array( $report['forms'] ?? null ) ? $report['forms'] : array() as $form ) {
-				if ( is_array( $form['provider_layout_overlay_css'] ?? null ) && ! empty( $form['provider_layout_overlay_css'] ) ) {
+				// A declined form leaves no provider block in the page, so its overlay
+				// would target selectors that were never materialized.
+				if ( ! empty( $form['runtime_mapped'] ) && is_array( $form['provider_layout_overlay_css'] ?? null ) && ! empty( $form['provider_layout_overlay_css'] ) ) {
 					$overlays[] = $form['provider_layout_overlay_css'];
 				}
 			}

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -578,9 +578,13 @@ class Static_Site_Importer_Form_Seeder {
 			);
 		}
 		if ( ! empty( $unaccepted_losses ) ) {
+			// The layout-fidelity gate is a decision not to represent this one form
+			// with the provider, exactly like an unsupported control topology. The
+			// converted source form stays in the page, so this is a per-entity
+			// decline the registry degrades around, never an import failure.
 			$row['provider_mapped']                = true;
 			$row['runtime_mapped']                 = false;
-			$row['status']                         = 'error';
+			$row['status']                         = 'skipped';
 			$row['reason']                         = 'form_receipt_loss_unaccepted';
 			$row['form_receipt_unaccepted_losses'] = $unaccepted_losses;
 			$row['unaccepted_receipt_loss_count']  = count( $unaccepted_losses );

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -52,6 +52,93 @@ class Static_Site_Importer_Report_Diagnostics {
 	}
 
 	/**
+	 * Name every entity a provider declined to materialize.
+	 *
+	 * A provider declines one entity when it cannot represent it faithfully -- an
+	 * unsupported control topology, or a layout it cannot carry without losing
+	 * fidelity. The imported page keeps the converted source markup at that
+	 * anchor, so the outcome is a bounded, reportable preservation rather than a
+	 * failure. Without these rows the decline is only reachable by reading the
+	 * entity lifecycle, which names the declaration by hash and nothing else.
+	 *
+	 * @param array<string,mixed> $entities Provider entity reports keyed by declaration id.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function provider_entity_decline_diagnostics( array $entities ): array {
+		$diagnostics = array();
+		foreach ( $entities as $declaration_id => $report ) {
+			if ( ! is_array( $report ) ) {
+				continue;
+			}
+			$provider = isset( $report['provider'] ) && is_scalar( $report['provider'] ) ? (string) $report['provider'] : '';
+			foreach ( array(
+				'forms'    => 'form',
+				'products' => 'product',
+			) as $collection => $entity_type ) {
+				foreach ( is_array( $report[ $collection ] ?? null ) ? $report[ $collection ] : array() as $row ) {
+					if ( ! is_array( $row ) || ! Static_Site_Importer_Entity_Materializer_Registry::entity_result_declined( $row ) ) {
+						continue;
+					}
+					$diagnostics[] = self::provider_entity_decline_diagnostic( (string) $declaration_id, $provider, $entity_type, $row );
+				}
+			}
+		}
+
+		return $diagnostics;
+	}
+
+	/**
+	 * Build one declined-entity diagnostic.
+	 *
+	 * @param string              $declaration_id Runtime declaration reconciliation identity.
+	 * @param string              $provider       Provider id that declined the entity.
+	 * @param string              $entity_type    Entity type the provider declined.
+	 * @param array<string,mixed> $row            Provider result row.
+	 * @return array<string,mixed>
+	 */
+	private static function provider_entity_decline_diagnostic( string $declaration_id, string $provider, string $entity_type, array $row ): array {
+		$reason      = isset( $row['reason'] ) && is_scalar( $row['reason'] ) && '' !== (string) $row['reason'] ? (string) $row['reason'] : 'provider_declined';
+		$source_path = isset( $row['source_path'] ) && is_scalar( $row['source_path'] ) ? (string) $row['source_path'] : '';
+		$selector    = isset( $row['selector'] ) && is_scalar( $row['selector'] ) ? (string) $row['selector'] : '';
+		$slug        = isset( $row['slug'] ) && is_scalar( $row['slug'] ) ? (string) $row['slug'] : '';
+		$located     = '' !== $source_path ? $source_path : ( '' !== $slug ? $slug : 'the imported site' );
+		$loss_count  = isset( $row['unaccepted_receipt_loss_count'] ) ? (int) $row['unaccepted_receipt_loss_count'] : 0;
+		$provider_id = '' !== $provider ? $provider : 'the configured provider';
+		$diagnostic  = array(
+			'id'              => 'provider-entity-declined-' . hash( 'sha256', $declaration_id . "\n" . $entity_type . "\n" . $source_path . "\n" . ( '' !== $selector ? $selector : $slug ) ),
+			'code'            => 'provider_entity_declined',
+			'type'            => 'static-site-importer',
+			'severity'        => 'warning',
+			'stage'           => 'entity_materialization',
+			'loss_class'      => Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND,
+			'reason_code'     => $reason,
+			'reason'          => $reason,
+			'provider'        => $provider,
+			'entity_type'     => $entity_type,
+			'declaration_id'  => $declaration_id,
+			'runtime_mapped'  => false,
+			'provider_mapped' => ! empty( $row['provider_mapped'] ),
+			'runtime_carried' => ! empty( $row['runtime_carried'] ),
+			'message'         => $provider_id . ' did not materialize a ' . $entity_type . ' detected in ' . $located . ' (' . $reason . ')'
+				. ( $loss_count > 0 ? ', which would have cost ' . $loss_count . ' unaccepted layout-fidelity ' . ( 1 === $loss_count ? 'loss' : 'losses' ) : '' )
+				. '. The imported page keeps its converted source markup for that ' . $entity_type . '.',
+		);
+		foreach ( array( 'source_path', 'selector', 'slug' ) as $field ) {
+			if ( isset( $row[ $field ] ) && is_scalar( $row[ $field ] ) && '' !== (string) $row[ $field ] ) {
+				$diagnostic[ $field ] = (string) $row[ $field ];
+			}
+		}
+		if ( $loss_count > 0 ) {
+			$diagnostic['unaccepted_receipt_loss_count'] = $loss_count;
+		}
+		if ( isset( $row['form_receipt_unaccepted_losses'] ) && is_array( $row['form_receipt_unaccepted_losses'] ) ) {
+			$diagnostic['form_receipt_unaccepted_losses'] = array_slice( array_values( array_filter( $row['form_receipt_unaccepted_losses'], 'is_array' ) ), 0, 16 );
+		}
+
+		return $diagnostic;
+	}
+
+	/**
 	 * Initialize a conversion report.
 	 *
 	 * @param string              $html_path       Imported entry file.

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -596,6 +596,7 @@ class Static_Site_Importer_Theme_Generator {
 			'dependencies' => $dependencies,
 		);
 		$diagnostics = array_merge( $diagnostics, $lifecycle['diagnostics'] ?? array() );
+		$diagnostics = array_merge( $diagnostics, Static_Site_Importer_Report_Diagnostics::provider_entity_decline_diagnostics( $entities ) );
 		$gutenberg_gaps = isset( $receipt['extensions']['gutenberg_gaps'] ) && is_array( $receipt['extensions']['gutenberg_gaps'] ) ? $receipt['extensions']['gutenberg_gaps'] : array();
 		$diagnostics = array_merge( $diagnostics, $gutenberg_gaps );
 		if ( isset( $args['missing_author_stylesheet_diagnostics'] ) && is_array( $args['missing_author_stylesheet_diagnostics'] ) ) {

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -44,6 +44,7 @@
     { "path": "tests/smoke-product-handoff-contract.php", "environment": "standalone-php" },
     { "path": "tests/smoke-quality-budget-admission.php", "environment": "standalone-php" },
     { "path": "tests/smoke-product-materializer.php", "environment": "wordpress-runtime" },
+    { "path": "tests/smoke-provider-entity-decline.php", "environment": "standalone-php" },
     { "path": "tests/smoke-provider-presentation.php", "environment": "standalone-php" },
     { "path": "tests/smoke-site-identity.php", "environment": "standalone-php" },
     { "path": "tests/smoke-url-import-runtime.php", "environment": "standalone-php" },

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -569,6 +569,7 @@ namespace {
 	$assert( 'Request booking' === ( $booking_row['submit_text'] ?? '' ) && str_contains( (string) ( $booking_row['block_markup'] ?? '' ), '>Request booking</button>' ), 'canonical-control-text-preserves-request-booking-submit-label' );
 	$assert( str_contains( (string) ( $booking_row['block_markup'] ?? '' ), '"label":"Guests"' ) && str_contains( (string) ( $booking_row['block_markup'] ?? '' ), '"step":"0.5"' ) && array( 'min', 'max' ) === array_column( $booking_row['computed_layout_receipt']['losses'] ?? array(), 'attribute' ), 'number-source-attributes-preserve-supported-step-and-report-min-max-losses' );
 	$assert( false === ( $booking_row['runtime_mapped'] ?? true ) && array( 'min', 'max' ) === array_column( $booking_row['form_receipt_unaccepted_losses'] ?? array(), 'attribute' ) && 2 === ( $booking_row['unaccepted_receipt_loss_count'] ?? 0 ), 'number-unsupported-attributes-gate-form-runtime-acceptance' );
+	$assert( 'skipped' === ( $booking_row['status'] ?? '' ) && 0 === ( $booking['counts']['error'] ?? -1 ), 'gated-form-is-a-provider-decline-not-a-materialization-error' );
 	$height_controls = array();
 	$height_html     = '<form class="many-heights">';
 	for ( $height_index = 1; $height_index <= 17; ++$height_index ) {

--- a/tests/smoke-provider-entity-decline.php
+++ b/tests/smoke-provider-entity-decline.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Smoke coverage for provider entity declines degrading instead of failing an import.
+ *
+ * A provider declines one entity when it cannot represent it faithfully. The
+ * compiled source markup stays at that binding anchor, so the import completes,
+ * the binding is dropped, and the loss is named in the report diagnostics.
+ *
+ * Run from the repository root:
+ * php tests/smoke-provider-entity-decline.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.keyFound
+		$key = strtolower( (string) $key );
+
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook_name = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook_name ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook_name, $callback ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return true;
+	}
+}
+
+if ( ! function_exists( 'post_type_exists' ) ) {
+	function post_type_exists( string $post_type ): bool {
+		unset( $post_type );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'taxonomy_exists' ) ) {
+	function taxonomy_exists( string $taxonomy ): bool {
+		unset( $taxonomy );
+		return false;
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code, private string $message = '', private $data = null ) {}
+		public function get_error_code(): string {
+			return $this->code; }
+		public function get_error_message(): string {
+			return $this->message; }
+		public function get_error_data() {
+			return $this->data; }
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-woo-product-seeder.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-form-seeder.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-plugin-materializer.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-dependency-manager.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-entity-materializer-registry.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+/**
+ * Build a bound two-form lifecycle whose provider returns the supplied result rows.
+ *
+ * @param array<int,array<string,mixed>> $rows   Provider result rows, in manifest order.
+ * @param array<string,int>              $counts Provider count rollup.
+ * @return array{lifecycle:array<string,mixed>,manifest:array<string,mixed>}
+ */
+$lifecycle_for = static function ( array $rows, array $counts ): array {
+	$manifest = array(
+		'forms' => array(
+			array(
+				'source_path' => 'about.html',
+				'selector'    => 'form.enquiry',
+				'bindings'    => array(
+					array(
+						'source_path'         => 'about.html',
+						'search_block_markup' => '<!-- wp:html --><form class="enquiry"></form><!-- /wp:html -->',
+						'occurrence'          => 1,
+						'role'                => 'form',
+					),
+				),
+			),
+			array(
+				'source_path' => 'contact.html',
+				'selector'    => 'form.contact',
+				'bindings'    => array(
+					array(
+						'source_path'         => 'contact.html',
+						'search_block_markup' => '<!-- wp:html --><form class="contact"></form><!-- /wp:html -->',
+						'occurrence'          => 1,
+						'role'                => 'form',
+					),
+				),
+			),
+		),
+	);
+	$adapter  = array(
+		'provider'         => 'jetpack',
+		'waiver_arg'       => 'allow_missing_jetpack',
+		'binding_callback' => array( 'Static_Site_Importer_Form_Seeder', 'binding_block_markup' ),
+		'materializer'     => static function ( array $seeded ) use ( $rows, $counts ): array {
+			unset( $seeded );
+			return array(
+				'status'   => 'completed',
+				'provider' => 'jetpack',
+				'counts'   => $counts,
+				'forms'    => $rows,
+			);
+		},
+	);
+
+	return array(
+		'manifest'  => $manifest,
+		'lifecycle' => array(
+			'entities' => array(
+				'contact-forms' => array(
+					'adapter'  => $adapter,
+					'manifest' => $manifest,
+					'required' => true,
+				),
+			),
+		),
+	);
+};
+
+$mapped_row = array(
+	'source_path'     => 'about.html',
+	'selector'        => 'form.enquiry',
+	'provider'        => 'jetpack',
+	'status'          => 'mapped',
+	'runtime_mapped'  => true,
+	'block_markup'    => '<!-- wp:jetpack/contact-form --><div></div><!-- /wp:jetpack/contact-form -->',
+);
+
+$declined_row = array(
+	'source_path'                    => 'contact.html',
+	'selector'                       => 'form.contact',
+	'provider'                       => 'jetpack',
+	'block_name'                     => 'jetpack/contact-form',
+	'status'                         => 'skipped',
+	'reason'                         => 'form_receipt_loss_unaccepted',
+	'provider_mapped'                => true,
+	'runtime_mapped'                 => false,
+	'runtime_carried'                => true,
+	'form_receipt_unaccepted_losses' => array( array( 'dimension' => 'layout', 'reason_code' => 'unsupported_semantic_wrapper' ) ),
+	'unaccepted_receipt_loss_count'  => 8,
+);
+
+// A provider decline is a considered decision, never a materialization failure.
+$assert( true === Static_Site_Importer_Entity_Materializer_Registry::entity_result_declined( $declined_row ), 'skipped-provider-row-reads-as-declined' );
+$assert( false === Static_Site_Importer_Entity_Materializer_Registry::entity_result_declined( $mapped_row ), 'mapped-provider-row-is-not-declined' );
+
+$degraded = $lifecycle_for(
+	array( $mapped_row, $declined_row ),
+	array( 'mapped' => 1, 'skipped' => 1, 'error' => 0 )
+);
+$degraded_result = Static_Site_Importer_Entity_Materializer_Registry::materialize_lifecycle_entities( $degraded['lifecycle'], array( 'seed_entities' => false ) );
+$assert( null === $degraded_result['error'], 'declined-bound-entity-does-not-fail-the-import', wp_json_encode( $degraded_result['error'] ) );
+$assert( 1 === ( $degraded_result['reports']['contact-forms']['counts']['mapped'] ?? 0 ), 'the-other-form-still-materializes' );
+
+$degraded_bindings = Static_Site_Importer_Entity_Materializer_Registry::block_bindings( $degraded['lifecycle'], $degraded_result['reports'] );
+$assert( ! is_wp_error( $degraded_bindings ), 'declined-entity-produces-no-binding-error' );
+$assert( 1 === count( $degraded_bindings ), 'only-the-materialized-form-is-bound' );
+$assert( 'about.html' === ( $degraded_bindings[0]['source_path'] ?? '' ), 'the-declined-page-keeps-its-compiled-source-markup' );
+
+// A provider row that errored, or one that never came back at all, still fails.
+$errored = $lifecycle_for(
+	array( $mapped_row, array( 'source_path' => 'contact.html', 'selector' => 'form.contact', 'status' => 'error', 'reason' => 'provider_exploded' ) ),
+	array( 'mapped' => 1, 'error' => 1 )
+);
+$errored_result = Static_Site_Importer_Entity_Materializer_Registry::materialize_lifecycle_entities( $errored['lifecycle'], array( 'seed_entities' => false ) );
+$assert( 'static_site_importer_entity_materialization_failed' === ( $errored_result['error']['code'] ?? '' ), 'a-provider-error-row-still-fails-materialization' );
+
+$absent = $lifecycle_for( array( $mapped_row ), array( 'mapped' => 2 ) );
+$absent_result   = Static_Site_Importer_Entity_Materializer_Registry::materialize_lifecycle_entities( $absent['lifecycle'], array( 'seed_entities' => false ) );
+$absent_bindings = Static_Site_Importer_Entity_Materializer_Registry::block_bindings( $absent['lifecycle'], $absent_result['reports'] );
+$assert( is_wp_error( $absent_bindings ) && 'static_site_importer_runtime_binding_unresolved' === $absent_bindings->get_error_code(), 'an-absent-provider-result-remains-unresolved' );
+
+// The decline is named for a reader: which page, which provider, which reason.
+$diagnostics = Static_Site_Importer_Report_Diagnostics::provider_entity_decline_diagnostics(
+	array(
+		'contact-forms' => array(
+			'status'   => 'completed',
+			'provider' => 'jetpack',
+			'forms'    => array( $mapped_row, $declined_row ),
+		),
+	)
+);
+$assert( 1 === count( $diagnostics ), 'one-diagnostic-per-declined-entity' );
+$diagnostic = $diagnostics[0] ?? array();
+$assert( 'provider_entity_declined' === ( $diagnostic['code'] ?? '' ), 'decline-diagnostic-code-is-stable' );
+$assert( 'contact.html' === ( $diagnostic['source_path'] ?? '' ) && 'form.contact' === ( $diagnostic['selector'] ?? '' ), 'decline-diagnostic-names-the-page-and-the-form' );
+$assert( 'jetpack' === ( $diagnostic['provider'] ?? '' ) && 'form' === ( $diagnostic['entity_type'] ?? '' ), 'decline-diagnostic-names-the-provider-and-entity-type' );
+$assert( 'form_receipt_loss_unaccepted' === ( $diagnostic['reason_code'] ?? '' ) && 8 === ( $diagnostic['unaccepted_receipt_loss_count'] ?? 0 ), 'decline-diagnostic-names-the-reason-and-its-loss-count' );
+$assert( Static_Site_Importer_Diagnostic_Loss_Classes::PRESERVED_RUNTIME_ISLAND === ( $diagnostic['loss_class'] ?? '' ), 'a-declined-entity-is-a-preserved-runtime-island' );
+$assert( str_contains( (string) ( $diagnostic['message'] ?? '' ), 'contact.html' ) && str_contains( (string) ( $diagnostic['message'] ?? '' ), 'form_receipt_loss_unaccepted' ), 'decline-diagnostic-message-is-actionable-without-a-hash-lookup' );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo 'OK: provider entity decline smoke passed (' . $assertions . " assertions)\n";

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -860,8 +860,10 @@ $overlay            = array(
 	'bytes'  => strlen( $overlay_css ),
 );
 $collect_overlays   = new ReflectionMethod( Static_Site_Importer_Entity_Materializer_Registry::class, 'provider_layout_overlays' );
-$collected_overlays = $collect_overlays->invoke( null, array( array( 'forms' => array( array( 'provider_layout_overlay_css' => array() ), array( 'provider_layout_overlay_css' => $overlay ), array( 'provider_layout_overlay_css' => array( 'malformed' => true ) ) ) ) ) );
+$collected_overlays = $collect_overlays->invoke( null, array( array( 'forms' => array( array( 'runtime_mapped' => true, 'provider_layout_overlay_css' => array() ), array( 'runtime_mapped' => true, 'provider_layout_overlay_css' => $overlay ), array( 'runtime_mapped' => true, 'provider_layout_overlay_css' => array( 'malformed' => true ) ) ) ) ) );
 $assert( array( $overlay, array( 'malformed' => true ) ) === $collected_overlays, 'provider layout collection omits empty absence sentinels without hiding non-empty overlays from strict validation' );
+$declined_overlays = $collect_overlays->invoke( null, array( array( 'forms' => array( array( 'status' => 'skipped', 'reason' => 'form_receipt_loss_unaccepted', 'runtime_mapped' => false, 'provider_layout_overlay_css' => $overlay ) ) ) ) );
+$assert( array() === $declined_overlays, 'a declined form contributes no provider layout overlay because no provider block was materialized' );
 $overlay_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
 	$plan,
 	array(


### PR DESCRIPTION
## Problem

One contact form that **converted successfully** destroyed an entire five-page import and left a stock WordPress site (Sample Page + Hello world!, default theme) with zero imported content. Removing only the Contact page made the identical import succeed.

Reproduced with a five-page `www.maneethical.com` (Wix/thunderbolt) subset. Every page compiled, composed, and produced a receipt; the run then died in the last phase:

```
error:    static_site_importer_entity_materialization_failed
message:  "Runtime entity materialization failed for declaration: eeedca931fe2…"
progress: page_count 5, prepared 5, receipts 5, remaining 0   <- everything had succeeded
timings:  compile_pages 43.4s, compose 36.2s, then materialize FAILED after 1.1s
```

The per-entity detail that never reaches the user:

```
provider: jetpack, available: true      (Jetpack 16.1.2, ALL required jetpack/* blocks registered)
counts:   { mapped: 0, skipped: 0, error: 2 }
forms[i]: status "error", provider_mapped: true, block_name "jetpack/contact-form",
          field_count 3, submit_text "SEND",
          reason "form_receipt_loss_unaccepted", unaccepted_receipt_loss_count 8 / 10
```

The forms mapped fine. They were rejected purely on layout-fidelity accounting, and that rejection discarded ~80 s of successful work across all five pages.

## Root cause

`Static_Site_Importer_Form_Seeder::seed_form()` marks a form that fails the layout-fidelity gate as `status: 'error'` (added in f6b1231 / #1356). `Static_Site_Importer_Entity_Materializer_Registry::materialize_lifecycle_entities()` treats any `counts['error']` as a fatal transaction error, so the single non-fatal fidelity loss aborts the whole import and rolls it back.

Every *other* reason the provider cannot represent a form already reports `status: 'skipped'` and does not fail anything: `unsupported_control_topology`, `no_mappable_form_fields`, `interleaved_context_unrepresentable`, `provider_unavailable`. And the waiver path (`allow_missing_jetpack`) already completes an import for exactly this shape of outcome — it marks the entity `waived`, skips its bindings, and the page keeps the compiled source form at the binding anchor.

So the graceful path exists and is exercised. It simply was not wired for this rejection reason. The same commit also tightened the bound-entity completeness rule so that `skipped` no longer counted as accounted for when an entity carries a page binding — which means today *any* provider decline on a bound form is fatal, not just this one.

## The fix

Treat a per-entity provider decline as a degradation, adapter-agnostically:

- The fidelity gate marks the row `skipped` with its existing `reason`, `provider_mapped`, and `form_receipt_unaccepted_losses` intact — a decline, not an error.
- A bound entity counts a declined row as accounted for, because the compiled source markup stays at its anchor.
- `block_bindings()` / `classic_bindings()` drop a declined entity's binding instead of failing on empty replacement markup. A result row that is **absent** is still unresolved and still fatal (`static_site_importer_runtime_binding_unresolved`), as is a row the provider reports as `error`, and a provider-level `failed`/`error` report.
- A declined form contributes no `provider_layout_overlay_css`, since no provider block was materialized for its selectors to target.
- The import report now **names** each decline — page, selector, provider, entity type, reason, loss count — as a `provider_entity_declined` diagnostic classified `preserved_runtime_island` / `acceptable_preservation`, rather than leaving it reachable only through a hashed declaration id inside the entity lifecycle.

## Evidence

Same command, same source, same blocks-engine SHA (`a135744f`); only the SSI build differs.

**Before** (`main` @ `aab6dbf9`):

```
status: failed
error:  static_site_importer_entity_materialization_failed
        "Runtime entity materialization failed for declaration: eeedca931fe2…"
pages imported: 0    (stock WordPress: Sample Page, Hello world!, default theme)
```

**After** (this branch):

```
status: completed        page_count: 5
entity_lifecycle: counts { mapped: 0, skipped: 2, error: 0 }
  form website/contact/index.html  skipped  form_receipt_loss_unaccepted   8 losses
  form website/contact/index.html  skipped  form_receipt_loss_unaccepted  10 losses
```

Imported posts:

| slug | type | blocks | `core/html` | baseline (4-page good run) |
|---|---|---|---|---|
| index | page | 146 | 0 | 146 / 0 |
| about | page | 258 | 0 | 258 / 0 |
| contact | page | 122 | 2 | *(absent — this page is what used to kill the run)* |
| services | page | 395 | 0 | 395 / 0 |
| 7-best-salon-treatments-for-bleached-hair | **post** | 62 | 0 | 62 / 0 |

The four non-Contact pages are block-for-block identical to the known-good four-page baseline, and the blog post still materializes as a `post`. Contact imports with its two source forms (the desktop/mobile responsive pair) preserved as runtime islands carrying the real Name / Email / Message inputs and the `SEND` button.

Reported rather than silent:

```json
{
  "code": "provider_entity_declined",
  "loss_class": "preserved_runtime_island",
  "acceptability": "acceptable_preservation",
  "source_path": "website/contact/index.html",
  "selector": "… > div:nth-of-type(9) > div:nth-of-type(1) > div:nth-of-type(1) > form:nth-of-type(1)",
  "provider": "jetpack",
  "entity_type": "form",
  "reason_code": "form_receipt_loss_unaccepted",
  "unaccepted_receipt_loss_count": 8,
  "message": "jetpack did not materialize a form detected in website/contact/index.html (form_receipt_loss_unaccepted), which would have cost 8 unaccepted layout-fidelity losses. The imported page keeps its converted source markup for that form."
}
```

The degrade is not hidden from the quality gate. The run finishes `success_with_warnings` with `quality.pass: false`, `fallback_count: 2`, `core_html_block_count: 2`, `invalid_block_count: 0`, and `failure_reasons: [unsupported_html_fallback, core_html_block]` — and the compiler's own fallback rows already carry `runtime_island_type: provider_materializable_form` / `suggested_generic_repair_class: materialize_form_provider`. So the two preserved forms remain visible as a conversion-quality debt to pay down (that is the work in #765 / #757), rather than being laundered into a clean pass. What changed is that the debt no longer takes the other four pages down with it.

## Tests

New standalone smoke `tests/smoke-provider-entity-decline.php` (16 assertions), registered in both manifests, locking:

- a declined bound entity does not fail materialization, and the sibling entity still materializes;
- only the materialized entity is bound — the declined page keeps its compiled source markup;
- a provider `error` row **still** fails materialization;
- an absent provider result **still** yields `runtime_binding_unresolved`;
- the decline diagnostic names the page, selector, provider, entity type, reason and loss count, and its message is readable without a hash lookup.

Plus assertions in `tests/form-materializer-smoke.php` (the gate produces a decline, `counts.error` stays 0) and `tests/smoke-wordpress-site-plan-materializer.php` (a declined form contributes no provider layout overlay).

`npm test` — 74 passed, 0 failed. `homeboy review lint` findings unchanged from `main` (14, all pre-existing in untouched code).

## Scope

This PR fixes the whole-import abort only. The companion defect — the *terminal* error surfaced to the user is a bare hash even though the full per-form report exists at throw time, because `materialize_lifecycle_entities()` propagates only `code` and `message` while its sibling `runtime_entity_invalid` path passes `errors` — is filed separately as #1480. That is a distinct defect from #1422: #1422 documents the `static_site_importer_runtime_entity_invalid` path where the diagnostics *are* assembled and then lost to `scrub_error()` key-name matching and consumer depth truncation, whereas on the `..._entity_materialization_failed` path they are never assembled into the error at all.

Related: #1413, #765, #757. Not #848 — Jetpack activates fine here; every required block is registered.
