### PR TITLE
Route referenced artifacts through staged compilation

### DIFF
--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -162,7 +162,7 @@ class Static_Site_Importer_Canonical_Import_Service {
 		if ( isset( $payload_reader ) ) {
 			$args['_static_site_importer_payload_reader'] = $payload_reader;
 		}
-		if ( self::direct_artifact_continuation_available() && in_array( $type, array( 'html', 'files', 'zip', 'figma' ), true ) && 'resume' !== $args['runtime_lifecycle_phase'] && self::artifact_html_page_count( $artifact ) > 1 ) {
+		if ( self::direct_artifact_continuation_available() && in_array( $type, array( 'html', 'files', 'zip', 'figma' ), true ) && 'resume' !== $args['runtime_lifecycle_phase'] && ( self::artifact_html_page_count( $artifact ) > 1 || self::artifact_has_payload_references( $artifact ) ) ) {
 			if ( 'apply' === $operation && '' === $args['runtime_lifecycle_phase'] ) {
 				$args['runtime_lifecycle_phase']         = 'prepare';
 				$args['runtime_lifecycle_invocation_id'] = wp_generate_uuid4();
@@ -206,6 +206,16 @@ class Static_Site_Importer_Canonical_Import_Service {
 			}
 		}
 		return $count;
+	}
+
+	/** @param array<string,mixed> $artifact */
+	private static function artifact_has_payload_references( array $artifact ): bool {
+		foreach ( is_array( $artifact['files'] ?? null ) ? $artifact['files'] : array() as $file ) {
+			if ( is_array( $file ) && is_array( $file['payload_reference'] ?? null ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static function direct_artifact_continuation_available(): bool {


### PR DESCRIPTION
## Summary

- route reference-backed canonical artifacts through staged compilation regardless of page count
- retain inline `ArtifactCompiler::compile()` for fully materialized artifacts
- complete the request-bundle portable-manifest fix merged in #1489

## Root cause

Studio transports static source trees as metadata-only `payload_reference` records with a `payload_reader`. SSI previously selected staged compilation only when an artifact had more than one HTML page. A single-page reference-backed artifact therefore entered the public inline compiler, which has no payload-reader argument, and `index.html` normalized to empty content.

The route now depends on transport capability as well as page count. Payloads stay opaque and bounded instead of being duplicated into the portable-manifest projection.

## Verification

- `php tests/smoke-cli-import-continuation.php` (73 assertions)
- `php tests/smoke-canonical-import-ability.php`
- PHP syntax and `git diff --check`
- `npm test` (74 selected manifests, 0 failures)
- canonical development package built with Blocks Engine `bc82675a`
- Studio native PHP 8.4 imported solved fixture 89 successfully through one staged page prepare, compile, compose, and materialization
- imported WordPress front page ID 4 is published with 72,703 bytes of block content and the expected heading
- validation passed with 235 native blocks and zero fallback, core/html, freeform, invalid, content-loss, or empty-conversion blocks

Related Studio integration: Automattic/studio#4757.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the single-page payload routing failure after #1489, implemented the owning-layer routing fix, built the development package, ran the native Studio import, and verified persisted WordPress state. Chris Huber directed and reviewed the work.