### PR TITLE
Preserve memory across CLI import runtimes

### DIFF
--- a/includes/cli.php
+++ b/includes/cli.php
@@ -609,10 +609,8 @@ if ( ! function_exists( 'static_site_importer_cli_import_fresh_runtime_spec' ) )
 	 * @return array{command:string,options:array<string,mixed>}
 	 */
 	function static_site_importer_cli_import_fresh_runtime_spec( string $request_path, ?string $memory_limit = null ): array {
-		$memory_limit = trim( null === $memory_limit ? (string) ini_get( 'memory_limit' ) : $memory_limit );
-		$bootstrap    = '' === $memory_limit ? '' : '--exec=' . escapeshellarg( 'ini_set( "memory_limit", ' . var_export( $memory_limit, true ) . ' );' ) . ' ';
 		return array(
-			'command' => $bootstrap . 'static-site-importer import --single-step --request=' . escapeshellarg( $request_path ),
+			'command' => static_site_importer_cli_fresh_runtime_bootstrap( $memory_limit ) . 'static-site-importer import --single-step --request=' . escapeshellarg( $request_path ),
 			'options' => array(
 				'launch'     => true,
 				'exit_error' => false,
@@ -657,14 +655,7 @@ if ( ! function_exists( 'static_site_importer_cli_import_run_fresh_runtime' ) ) 
 			$stdout  = is_object( $raw ) ? (string) ( $raw->stdout ?? '' ) : ( is_string( $raw ) ? $raw : '' );
 			$decoded = static_site_importer_cli_decode_import_step( $stdout );
 			if ( ! is_array( $decoded ) ) {
-				$return_code = is_object( $raw ) ? (int) ( $raw->return_code ?? 0 ) : 0;
-				$stderr      = is_object( $raw ) ? trim( (string) ( $raw->stderr ?? '' ) ) : '';
-				$stderr      = substr( preg_replace( '/\s+/', ' ', $stderr ) ?? '', 0, 1000 );
-				$message     = sprintf( 'A fresh import runtime exited with code %d without a JSON response.', $return_code );
-				if ( '' !== $stderr ) {
-					$message .= ' ' . $stderr;
-				}
-				return static_site_importer_cli_import_error( 'static_site_importer_cli_step_response_invalid', $message );
+				return static_site_importer_cli_import_error( 'static_site_importer_cli_step_response_invalid', static_site_importer_cli_invalid_step_message( $raw ) );
 			}
 			return $decoded;
 		} finally {
@@ -1356,4 +1347,17 @@ function static_site_importer_cli_sidecar_lineage_value( $value ): string {
 function static_site_importer_cli_sidecar_route_value( $value ): string {
 	$value = static_site_importer_cli_sidecar_lineage_value( $value );
 	return '/' === substr( $value, 0, 1 ) ? $value : '';
+}
+
+function static_site_importer_cli_fresh_runtime_bootstrap( ?string $memory_limit = null ): string {
+	$memory_limit = trim( null === $memory_limit ? (string) ini_get( 'memory_limit' ) : $memory_limit );
+	return '' === $memory_limit ? '' : '--exec=' . escapeshellarg( 'ini_set( "memory_limit", ' . wp_json_encode( $memory_limit ) . ' );' ) . ' ';
+}
+
+/** Describe a malformed fresh-runtime response with bounded process evidence. */
+function static_site_importer_cli_invalid_step_message( $result ): string {
+	$return_code = is_object( $result ) ? (int) ( $result->return_code ?? 0 ) : 0;
+	$stderr      = is_object( $result ) ? trim( (string) ( $result->stderr ?? '' ) ) : '';
+	$stderr      = substr( preg_replace( '/\s+/', ' ', $stderr ) ?? '', 0, 1000 );
+	return sprintf( 'A fresh import runtime exited with code %d without a JSON response.', $return_code ) . ( '' === $stderr ? '' : ' ' . $stderr );
 }

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -608,9 +608,11 @@ if ( ! function_exists( 'static_site_importer_cli_import_fresh_runtime_spec' ) )
 	/**
 	 * @return array{command:string,options:array<string,mixed>}
 	 */
-	function static_site_importer_cli_import_fresh_runtime_spec( string $request_path ): array {
+	function static_site_importer_cli_import_fresh_runtime_spec( string $request_path, ?string $memory_limit = null ): array {
+		$memory_limit = trim( null === $memory_limit ? (string) ini_get( 'memory_limit' ) : $memory_limit );
+		$bootstrap    = '' === $memory_limit ? '' : '--exec=' . escapeshellarg( 'ini_set( "memory_limit", ' . var_export( $memory_limit, true ) . ' );' ) . ' ';
 		return array(
-			'command' => 'static-site-importer import --single-step --request=' . escapeshellarg( $request_path ),
+			'command' => $bootstrap . 'static-site-importer import --single-step --request=' . escapeshellarg( $request_path ),
 			'options' => array(
 				'launch'     => true,
 				'exit_error' => false,
@@ -655,7 +657,14 @@ if ( ! function_exists( 'static_site_importer_cli_import_run_fresh_runtime' ) ) 
 			$stdout  = is_object( $raw ) ? (string) ( $raw->stdout ?? '' ) : ( is_string( $raw ) ? $raw : '' );
 			$decoded = static_site_importer_cli_decode_import_step( $stdout );
 			if ( ! is_array( $decoded ) ) {
-				return static_site_importer_cli_import_error( 'static_site_importer_cli_step_response_invalid', 'A fresh import runtime did not return JSON.' );
+				$return_code = is_object( $raw ) ? (int) ( $raw->return_code ?? 0 ) : 0;
+				$stderr      = is_object( $raw ) ? trim( (string) ( $raw->stderr ?? '' ) ) : '';
+				$stderr      = substr( preg_replace( '/\s+/', ' ', $stderr ) ?? '', 0, 1000 );
+				$message     = sprintf( 'A fresh import runtime exited with code %d without a JSON response.', $return_code );
+				if ( '' !== $stderr ) {
+					$message .= ' ' . $stderr;
+				}
+				return static_site_importer_cli_import_error( 'static_site_importer_cli_step_response_invalid', $message );
 			}
 			return $decoded;
 		} finally {

--- a/tests/smoke-cli-import-continuation.php
+++ b/tests/smoke-cli-import-continuation.php
@@ -456,12 +456,13 @@ $leaked = static_site_importer_cli_import_receipt(
 );
 $assert( 'failed' === ( $leaked['status'] ?? '' ) && 'static_site_importer_cli_nonterminal_receipt' === ( $leaked['response']['error']['code'] ?? '' ), 'receipt-rejects-continuation-as-success' );
 
-$spec = static_site_importer_cli_import_fresh_runtime_spec( '/tmp/ssi-step.json' );
+$spec = static_site_importer_cli_import_fresh_runtime_spec( '/tmp/ssi-step.json', '768M' );
 $assert( true === ( $spec['options']['launch'] ?? null ), 'fresh-runtime-launches-new-process' );
 $assert( false === ( $spec['options']['exit_error'] ?? null ), 'fresh-runtime-does-not-halt-on-child-error' );
 $assert( 'all' === ( $spec['options']['return'] ?? null ), 'fresh-runtime-captures-full-process' );
 $assert( ! array_key_exists( 'parse', $spec['options'] ), 'fresh-runtime-decodes-stdout-locally' );
 $assert( str_contains( $spec['command'], 'static-site-importer import' ) && str_contains( $spec['command'], '--single-step' ), 'fresh-runtime-invokes-single-step-command' );
+$assert( str_contains( $spec['command'], '--exec=' ) && str_contains( $spec['command'], 'memory_limit' ) && str_contains( $spec['command'], '768M' ), 'fresh-runtime-preserves-memory-limit' );
 $assert( str_contains( $spec['command'], escapeshellarg( '/tmp/ssi-step.json' ) ), 'fresh-runtime-passes-request-file' );
 $assert( ! str_contains( $spec['command'], 'content_base64' ) && ! str_contains( $spec['command'], 'website/index.html' ), 'fresh-runtime-command-has-no-source-payload' );
 
@@ -479,6 +480,7 @@ class WP_CLI {
 	public static array $lines = array();
 	public static ?int $halt   = null;
 	public static array $commands = array();
+	public static ?object $result = null;
 	public static function line( string $text ): void {
 		self::$lines[] = $text;
 	}
@@ -494,7 +496,7 @@ class WP_CLI {
 			'command' => $command,
 			'options' => $options,
 		);
-		return (object) array(
+		return self::$result ?? (object) array(
 			'stdout'      => "notice\n" . wp_json_encode(
 				array(
 					'success' => false,
@@ -546,6 +548,15 @@ $assert( 'materialization_failed' === ( $fresh_fail['error']['code'] ?? '' ), 'f
 $assert( 1 === count( WP_CLI::$commands ), 'fresh-runtime-runcommand-once' );
 $assert( true === ( WP_CLI::$commands[0]['options']['launch'] ?? null ), 'fresh-runtime-runcommand-launch' );
 $assert( str_contains( (string) ( WP_CLI::$commands[0]['command'] ?? '' ), '--single-step' ), 'fresh-runtime-runcommand-single-step' );
+
+WP_CLI::$result = (object) array(
+	'stdout'      => '',
+	'stderr'      => "PHP Fatal error: Allowed memory size exhausted\n",
+	'return_code' => 255,
+);
+$fresh_invalid = static_site_importer_cli_import_run_fresh_runtime( array( 'source' => array( 'type' => 'html' ) ) );
+$assert( 'static_site_importer_cli_step_response_invalid' === ( $fresh_invalid['error']['code'] ?? '' ), 'fresh-runtime-invalid-response-code' );
+$assert( str_contains( (string) ( $fresh_invalid['error']['message'] ?? '' ), 'code 255' ) && str_contains( (string) ( $fresh_invalid['error']['message'] ?? '' ), 'Allowed memory size exhausted' ), 'fresh-runtime-invalid-response-reports-process-failure' );
 
 if ( $failures ) {
 	fwrite( STDERR, "Unified CLI import smoke failed:\n- " . implode( "\n- ", $failures ) . "\n" );

--- a/tests/smoke-cli-import-continuation.php
+++ b/tests/smoke-cli-import-continuation.php
@@ -461,8 +461,7 @@ $assert( true === ( $spec['options']['launch'] ?? null ), 'fresh-runtime-launche
 $assert( false === ( $spec['options']['exit_error'] ?? null ), 'fresh-runtime-does-not-halt-on-child-error' );
 $assert( 'all' === ( $spec['options']['return'] ?? null ), 'fresh-runtime-captures-full-process' );
 $assert( ! array_key_exists( 'parse', $spec['options'] ), 'fresh-runtime-decodes-stdout-locally' );
-$assert( str_contains( $spec['command'], 'static-site-importer import' ) && str_contains( $spec['command'], '--single-step' ), 'fresh-runtime-invokes-single-step-command' );
-$assert( str_contains( $spec['command'], '--exec=' ) && str_contains( $spec['command'], 'memory_limit' ) && str_contains( $spec['command'], '768M' ), 'fresh-runtime-preserves-memory-limit' );
+$assert( str_contains( $spec['command'], 'static-site-importer import' ) && str_contains( $spec['command'], '--single-step' ) && str_contains( $spec['command'], '--exec=' ) && str_contains( $spec['command'], 'memory_limit' ) && str_contains( $spec['command'], '768M' ), 'fresh-runtime-invokes-single-step-command-with-memory-limit' );
 $assert( str_contains( $spec['command'], escapeshellarg( '/tmp/ssi-step.json' ) ), 'fresh-runtime-passes-request-file' );
 $assert( ! str_contains( $spec['command'], 'content_base64' ) && ! str_contains( $spec['command'], 'website/index.html' ), 'fresh-runtime-command-has-no-source-payload' );
 
@@ -480,7 +479,6 @@ class WP_CLI {
 	public static array $lines = array();
 	public static ?int $halt   = null;
 	public static array $commands = array();
-	public static ?object $result = null;
 	public static function line( string $text ): void {
 		self::$lines[] = $text;
 	}
@@ -496,7 +494,7 @@ class WP_CLI {
 			'command' => $command,
 			'options' => $options,
 		);
-		return self::$result ?? (object) array(
+		return $GLOBALS['ssi_cli_runtime_result'] ?? (object) array(
 			'stdout'      => "notice\n" . wp_json_encode(
 				array(
 					'success' => false,
@@ -549,7 +547,7 @@ $assert( 1 === count( WP_CLI::$commands ), 'fresh-runtime-runcommand-once' );
 $assert( true === ( WP_CLI::$commands[0]['options']['launch'] ?? null ), 'fresh-runtime-runcommand-launch' );
 $assert( str_contains( (string) ( WP_CLI::$commands[0]['command'] ?? '' ), '--single-step' ), 'fresh-runtime-runcommand-single-step' );
 
-WP_CLI::$result = (object) array(
+$GLOBALS['ssi_cli_runtime_result'] = (object) array(
 	'stdout'      => '',
 	'stderr'      => "PHP Fatal error: Allowed memory size exhausted\n",
 	'return_code' => 255,


### PR DESCRIPTION
## Summary
- preserve the parent PHP memory limit in fresh WP-CLI import runtimes
- report bounded child stderr and exit status when a runtime produces no JSON
- cover both contracts in the continuation smoke test

## Verification
- `php tests/smoke-cli-import-continuation.php`
- `npm test` (77 selected entries passed)

## AI assistance
OpenAI gpt-5.6-sol via OpenCode diagnosed the fresh-runtime boundary, implemented the patch and regression coverage, and ran the verification commands. Chris Huber directed and reviewed the workflow.