### PR TITLE
Render typed SVG artwork blocks

### DIFF
--- a/.github/workflows/solved-site-promotion-pr.yml
+++ b/.github/workflows/solved-site-promotion-pr.yml
@@ -26,4 +26,4 @@ jobs:
     with:
       static-site-importer-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       static-site-importer-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      blocks-engine-sha: fe5bff79df1e7a964b2367d0a120e1dbb1797f19
+      blocks-engine-sha: 3a8cebeb2d07cf26d47a2b14c20242e2f4eb4278

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -1150,11 +1150,11 @@ $output = wp_kses(
 		'path' => array_merge( $svg_global, array( 'd' => true, 'fill' => true, 'fill-rule' => true, 'opacity' => true, 'stroke' => true, 'stroke-linecap' => true, 'stroke-linejoin' => true, 'stroke-width' => true, 'transform' => true ) ),
 		'circle' => array_merge( $svg_global, array( 'cx' => true, 'cy' => true, 'fill' => true, 'opacity' => true, 'r' => true, 'stroke' => true, 'stroke-width' => true ) ),
 		'ellipse' => array_merge( $svg_global, array( 'cx' => true, 'cy' => true, 'fill' => true, 'opacity' => true, 'rx' => true, 'ry' => true, 'stroke' => true, 'stroke-width' => true ) ),
-		'line' => array_merge( $svg_global, array( 'fill' => true, 'stroke' => true, 'stroke-linecap' => true, 'stroke-width' => true, 'x1' => true, 'x2' => true, 'y1' => true, 'y2' => true ) ),
+		'line' => array_merge( $svg_global, array( 'fill' => true, 'opacity' => true, 'stroke' => true, 'stroke-dasharray' => true, 'stroke-linecap' => true, 'stroke-width' => true, 'x1' => true, 'x2' => true, 'y1' => true, 'y2' => true ) ),
 		'polygon' => array_merge( $svg_global, array( 'fill' => true, 'points' => true, 'stroke' => true, 'stroke-linecap' => true, 'stroke-linejoin' => true, 'stroke-width' => true ) ),
 		'polyline' => array_merge( $svg_global, array( 'fill' => true, 'points' => true, 'stroke' => true, 'stroke-linecap' => true, 'stroke-linejoin' => true, 'stroke-width' => true ) ),
-		'rect' => array_merge( $svg_global, array( 'fill' => true, 'height' => true, 'opacity' => true, 'rx' => true, 'ry' => true, 'stroke' => true, 'stroke-width' => true, 'width' => true, 'x' => true, 'y' => true ) ),
-		'text' => array_merge( $svg_global, array( 'fill' => true, 'font-family' => true, 'font-size' => true, 'font-weight' => true, 'text-anchor' => true, 'x' => true, 'y' => true ) ),
+		'rect' => array_merge( $svg_global, array( 'fill' => true, 'height' => true, 'opacity' => true, 'rx' => true, 'ry' => true, 'stroke' => true, 'stroke-dasharray' => true, 'stroke-width' => true, 'width' => true, 'x' => true, 'y' => true ) ),
+		'text' => array_merge( $svg_global, array( 'fill' => true, 'font-family' => true, 'font-size' => true, 'font-weight' => true, 'letter-spacing' => true, 'text-anchor' => true, 'x' => true, 'y' => true ) ),
 		'tspan' => array_merge( $svg_global, array( 'dx' => true, 'dy' => true, 'fill' => true, 'x' => true, 'y' => true ) ), 'title' => $svg_global, 'desc' => $svg_global,
 	)
 );

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -1105,7 +1105,7 @@ $global = array(
 $flow = array_merge( $global, array( 'align' => true ) );
 $svg_global = array(
 	'aria-hidden' => true, 'aria-label' => true, 'aria-labelledby' => true, 'class' => true, 'data-*' => true,
-	'id' => true, 'role' => true, 'style' => true, 'title' => true,
+	'filter' => true, 'id' => true, 'role' => true, 'style' => true, 'title' => true,
 );
 // KSES supports data-* but not aria-* wildcards. Admit syntactically valid
 // producer attributes explicitly so SVG accessibility metadata survives.
@@ -1142,6 +1142,10 @@ $output = wp_kses(
 		'audio' => array_merge( $global, array( 'autoplay' => true, 'controls' => true, 'loop' => true, 'muted' => true, 'preload' => true, 'src' => true ) ),
 		'svg' => array_merge( $svg_global, array( 'fill' => true, 'focusable' => true, 'height' => true, 'preserveaspectratio' => true, 'stroke' => true, 'viewbox' => true, 'width' => true, 'xmlns' => true, 'xmlns:xlink' => true ) ),
 		'defs' => $svg_global, 'symbol' => array_merge( $svg_global, array( 'viewbox' => true ) ), 'lineargradient' => array_merge( $svg_global, array( 'gradientunits' => true, 'x1' => true, 'x2' => true, 'y1' => true, 'y2' => true ) ), 'radialgradient' => array_merge( $svg_global, array( 'cx' => true, 'cy' => true, 'r' => true ) ), 'stop' => array_merge( $svg_global, array( 'offset' => true, 'stop-color' => true, 'stop-opacity' => true ) ), 'clippath' => $svg_global, 'mask' => $svg_global, 'use' => array_merge( $svg_global, array( 'href' => true, 'xlink:href' => true ) ),
+		'filter' => array_merge( $svg_global, array( 'filterunits' => true, 'height' => true, 'primitiveunits' => true, 'width' => true, 'x' => true, 'y' => true ) ),
+		'fegaussianblur' => array_merge( $svg_global, array( 'height' => true, 'in' => true, 'result' => true, 'stddeviation' => true, 'width' => true, 'x' => true, 'y' => true ) ),
+		'femerge' => array_merge( $svg_global, array( 'height' => true, 'result' => true, 'width' => true, 'x' => true, 'y' => true ) ),
+		'femergenode' => array_merge( $svg_global, array( 'in' => true ) ),
 		'g' => array_merge( $svg_global, array( 'clip-path' => true, 'fill' => true, 'fill-opacity' => true, 'opacity' => true, 'stroke' => true, 'stroke-width' => true, 'transform' => true ) ),
 		'path' => array_merge( $svg_global, array( 'd' => true, 'fill' => true, 'fill-rule' => true, 'opacity' => true, 'stroke' => true, 'stroke-linecap' => true, 'stroke-linejoin' => true, 'stroke-width' => true, 'transform' => true ) ),
 		'circle' => array_merge( $svg_global, array( 'cx' => true, 'cy' => true, 'fill' => true, 'opacity' => true, 'r' => true, 'stroke' => true, 'stroke-width' => true ) ),
@@ -1160,9 +1164,13 @@ foreach ( $data_images as $placeholder => $data_image ) {
 	$output = str_replace( "src='" . $placeholder . "'", "src='" . esc_attr( $data_image ) . "'", $output );
 }
 $output = preg_replace_callback(
-	'#<svg\b[^>]*>#i',
+	'#<(?:svg|filter|fegaussianblur|femerge|femergenode)\b[^>]*>#i',
 	static function ( array $match ): string {
-		return preg_replace( array( '/\bviewbox\b/i', '/\bpreserveaspectratio\b/i' ), array( 'viewBox', 'preserveAspectRatio' ), $match[0] ) ?? $match[0];
+		return preg_replace(
+			array( '/\bviewbox\b/i', '/\bpreserveaspectratio\b/i', '/\bfilterunits\b/i', '/\bprimitiveunits\b/i', '/\bstddeviation\b/i', '/<fegaussianblur\b/i', '/<femerge(?=\s|>)/i', '/<femergenode\b/i' ),
+			array( 'viewBox', 'preserveAspectRatio', 'filterUnits', 'primitiveUnits', 'stdDeviation', '<feGaussianBlur', '<feMerge', '<feMergeNode' ),
+			$match[0]
+		) ?? $match[0];
 	},
 	$output
 ) ?? '';

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -44,6 +44,9 @@ class Static_Site_Importer_Companion_Plugin {
 	/** SSI-owned renderer available to typed responsive-layout blocks. */
 	private const RESPONSIVE_LAYOUT_RENDERER = 'blocks-engine/responsive-layout/v1';
 
+	/** SSI-owned renderer available to typed inline SVG artwork blocks. */
+	private const SVG_ARTWORK_RENDERER = 'blocks-engine/svg-artwork/v1';
+
 	/**
 	 * Payload schema identifier consumed by the scaffolder.
 	 */
@@ -123,9 +126,10 @@ class Static_Site_Importer_Companion_Plugin {
 				if ( array_key_exists( 'render', $block ) ) {
 					return new WP_Error( 'static_site_importer_companion_plugin_renderer_conflict', sprintf( 'Block %s cannot declare both render markup and a typed renderer.', $name ) );
 				}
-				$content_schema = $block['block_json']['attributes']['content'] ?? null;
+				$attribute_name = self::SVG_ARTWORK_RENDERER === $renderer ? 'svg' : 'content';
+				$content_schema = $block['block_json']['attributes'][ $attribute_name ] ?? null;
 				if ( ! is_array( $content_schema ) || 'string' !== ( $content_schema['type'] ?? null ) ) {
-					return new WP_Error( 'static_site_importer_companion_plugin_renderer_attributes_invalid', sprintf( 'Block %s typed renderer requires a string content attribute.', $name ) );
+					return new WP_Error( 'static_site_importer_companion_plugin_renderer_attributes_invalid', sprintf( 'Block %s typed renderer requires a string %s attribute.', $name, $attribute_name ) );
 				}
 			}
 			if ( isset( $block['render'] ) && is_scalar( $block['render'] ) && Static_Site_Importer_Content_Policy::contains_server_code( (string) $block['render'] ) ) {
@@ -914,13 +918,16 @@ class Static_Site_Importer_Companion_Plugin {
 	 * passes it through safe_markup_boundary(), and echoes the sanitized
 	 * $output.
 	 *
-	 * @param string $kind Renderer label for the generated doc comment.
+	 * @param string $kind      Renderer label for the generated doc comment.
+	 * @param string $attribute String attribute containing the bounded markup.
 	 * @return string
 	 */
-	private static function safe_markup_renderer( string $kind ): string {
+	private static function safe_markup_renderer( string $kind, string $attribute = 'content' ): string {
 		$prologue = sprintf(
-			"<?php\n/** Generated %s companion block render. */\n\n\$content = is_string( \$attributes['content'] ?? null ) ? \$attributes['content'] : '';\n",
-			$kind
+			"<?php\n/** Generated %s companion block render. */\n\n\$content = is_string( \$attributes['%s'] ?? null ) ? \$attributes['%s'] : '';\n",
+			$kind,
+			$attribute,
+			$attribute
 		);
 		$epilogue = 'echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- KSES-sanitized bounded markup through the shared audited safe-markup boundary.';
 		return $prologue . self::safe_markup_boundary() . "\n" . $epilogue;
@@ -1170,6 +1177,7 @@ PHP;
 	 */
 	private static function typed_renderer( string $renderer ): string {
 		$layout = self::safe_markup_renderer( 'responsive-layout' );
+		$svg    = self::safe_markup_renderer( 'svg-artwork', 'svg' );
 		$media  = <<<'PHP'
 <?php
 /** Generated responsive-media companion block render. */
@@ -1290,6 +1298,7 @@ PHP;
 		$renderers = array(
 			self::RESPONSIVE_MEDIA_RENDERER  => $media,
 			self::RESPONSIVE_LAYOUT_RENDERER => $layout,
+			self::SVG_ARTWORK_RENDERER       => $svg,
 		);
 		if ( function_exists( 'apply_filters' ) ) {
 			$renderers = apply_filters( 'static_site_importer_companion_renderers', $renderers );

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -960,11 +960,29 @@ function injectDeterministicSourceCss(filePath, sourceRoot) {
     const hasDocumentAnimation = [svg, ...svg.querySelectorAll('*')]
       .some((element) => getComputedStyle(element).animationName !== 'none');
     if (hasDocumentAnimation) {
-      for (const animation of svg.getAnimations({ subtree: true })) {
-        try {
-          animation.finish();
-          animation.pause();
-        } catch {}
+      const animations = svg.getAnimations({ subtree: true });
+      const animatedStyles = new Map();
+      for (const animation of animations) {
+        animation.currentTime = 0;
+        animation.pause();
+        const target = animation.effect && animation.effect.target;
+        if (!target) continue;
+        const properties = animatedStyles.get(target) || new Set();
+        for (const frame of animation.effect.getKeyframes()) {
+          for (const property of Object.keys(frame)) {
+            if (!['offset', 'computedOffset', 'easing', 'composite'].includes(property)) properties.add(property);
+          }
+        }
+        animatedStyles.set(target, properties);
+      }
+      for (const [target, properties] of animatedStyles) {
+        const computed = getComputedStyle(target);
+        const values = Array.from(properties, (property) => {
+          const cssProperty = property.startsWith('--') ? property : property.replace(/[A-Z]/g, (letter) => '-' + letter.toLowerCase());
+          return [cssProperty, computed.getPropertyValue(cssProperty)];
+        });
+        target.style.setProperty('animation', 'none', 'important');
+        for (const [property, value] of values) target.style.setProperty(property, value, 'important');
       }
       return;
     }

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -959,7 +959,15 @@ function injectDeterministicSourceCss(filePath, sourceRoot) {
     if (!(box.width > 0 && box.height > 0)) return;
     const hasDocumentAnimation = [svg, ...svg.querySelectorAll('*')]
       .some((element) => getComputedStyle(element).animationName !== 'none');
-    if (hasDocumentAnimation) return;
+    if (hasDocumentAnimation) {
+      for (const animation of svg.getAnimations({ subtree: true })) {
+        try {
+          animation.finish();
+          animation.pause();
+        } catch {}
+      }
+      return;
+    }
     const clone = svg.cloneNode(true);
     clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
     if (fontCss && clone.querySelector('text')) {

--- a/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -957,6 +957,9 @@ function injectDeterministicSourceCss(filePath, sourceRoot) {
   await Promise.all(Array.from(document.querySelectorAll('svg')).map(async (svg) => {
     const box = svg.getBoundingClientRect();
     if (!(box.width > 0 && box.height > 0)) return;
+    const hasDocumentAnimation = [svg, ...svg.querySelectorAll('*')]
+      .some((element) => getComputedStyle(element).animationName !== 'none');
+    if (hasDocumentAnimation) return;
     const clone = svg.cloneNode(true);
     clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
     if (fontCss && clone.querySelector('text')) {

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -441,6 +441,14 @@ $layout_renderer = $typed_renderer;
 $layout_renderer['blocks'][0]['renderer'] = 'blocks-engine/responsive-layout/v1';
 $layout_renderer['blocks'][0]['block_json']['name'] = 'example/responsive-layout';
 $assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $layout_renderer ), 'known-layout-renderer-validates' );
+$svg_renderer = $typed_renderer;
+$svg_renderer['blocks'][0]['renderer'] = 'blocks-engine/svg-artwork/v1';
+$svg_renderer['blocks'][0]['block_json']['name'] = 'example/svg-artwork';
+$svg_renderer['blocks'][0]['block_json']['attributes'] = array( 'svg' => array( 'type' => 'string', 'default' => '', 'role' => 'content' ) );
+$assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $svg_renderer ), 'known-svg-artwork-renderer-validates' );
+$invalid_svg_renderer = $svg_renderer;
+$invalid_svg_renderer['blocks'][0]['block_json']['attributes'] = array( 'content' => array( 'type' => 'string' ) );
+$assert( 'static_site_importer_companion_plugin_renderer_attributes_invalid' === Static_Site_Importer_Companion_Plugin::validate_payload( $invalid_svg_renderer )->get_error_code(), 'svg-artwork-renderer-requires-declared-string-svg' );
 $malformed_dependencies = $payload;
 $malformed_dependencies['blocks'][0]['script_dependencies'] = array( array( 'wp-blocks' ) );
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $malformed_dependencies ) ), 'script-dependency-map-must-be-an-object' );
@@ -666,6 +674,18 @@ if ( is_array( $layout_descriptor ) ) {
 	// so the two paths cannot diverge in safety or supported markup (#1361).
 	$shared_policy_input = array( 'content' => $svg_markup . $hostile_markup );
 	$assert( $render_frontend( $render, $shared_policy_input ) === $render_frontend( $layout_render, $shared_policy_input ), 'editable-and-layout-renderers-share-one-sanitization-policy' );
+}
+
+$svg_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $svg_renderer );
+$assert( is_array( $svg_descriptor ), 'svg-artwork-renderer-scaffold-returns-descriptor' );
+if ( is_array( $svg_descriptor ) ) {
+	$svg_render = $svg_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
+	$attributes = array( 'svg' => '<svg viewBox="0 0 20 20" aria-hidden="true"><path class="s1" d="M10 18V2"></path><script>alert(1)</script></svg>' );
+	ob_start();
+	eval( '?>' . $svg_render );
+	$svg_artwork_output = (string) ob_get_clean();
+	$assert( str_contains( $svg_render, 'Generated svg-artwork companion block render' ) && str_contains( $svg_artwork_output, '<path class="s1" d="M10 18V2">' ), 'svg-artwork-renderer-preserves-safe-inline-artwork' );
+	$assert( ! str_contains( strtolower( $svg_artwork_output ), '<script' ), 'svg-artwork-renderer-strips-executable-content' );
 }
 
 WP_Block_Type_Registry::$registered[] = 'example/custom-hero';

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -608,10 +608,11 @@ if ( is_array( $layout_descriptor ) ) {
 		'path' => array( 'd' => 'M0 0', 'fill' => 'url(#node-lineargradient)', 'stroke' => 'blue', 'stroke-width' => '2', 'stroke-linecap' => 'round', 'stroke-linejoin' => 'bevel' ),
 		'circle' => array( 'cx' => '1', 'cy' => '2', 'r' => '3', 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2' ),
 		'ellipse' => array( 'cx' => '1', 'cy' => '2', 'rx' => '3', 'ry' => '4', 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2' ),
-		'line' => array( 'x1' => '1', 'x2' => '2', 'y1' => '3', 'y2' => '4', 'stroke' => 'blue', 'stroke-width' => '2', 'stroke-linecap' => 'round' ),
+		'line' => array( 'x1' => '1', 'x2' => '2', 'y1' => '3', 'y2' => '4', 'opacity' => '0.5', 'stroke' => 'blue', 'stroke-dasharray' => '3 3', 'stroke-width' => '2', 'stroke-linecap' => 'round' ),
 		'polyline' => array( 'points' => '0,0 1,1', 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2', 'stroke-linecap' => 'round', 'stroke-linejoin' => 'bevel' ),
 		'polygon' => array( 'points' => '0,0 1,1 2,0', 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2', 'stroke-linecap' => 'round', 'stroke-linejoin' => 'bevel' ),
-		'rect' => array( 'x' => '1', 'y' => '2', 'width' => '3', 'height' => '4', 'rx' => '1', 'ry' => '2', 'fill' => 'red', 'stroke' => 'blue', 'stroke-width' => '2' ),
+		'rect' => array( 'x' => '1', 'y' => '2', 'width' => '3', 'height' => '4', 'rx' => '1', 'ry' => '2', 'fill' => 'red', 'stroke' => 'blue', 'stroke-dasharray' => '3 3', 'stroke-width' => '2' ),
+		'text' => array( 'x' => '1', 'y' => '2', 'fill' => 'red', 'font-family' => 'monospace', 'font-size' => '8', 'font-weight' => '600', 'letter-spacing' => '0.1em', 'text-anchor' => 'middle' ),
 		'defs' => array(),
 		'lineargradient' => array( 'gradientunits' => 'userSpaceOnUse', 'x1' => '0', 'x2' => '1', 'y1' => '0', 'y2' => '1' ),
 		'radialgradient' => array( 'cx' => '1', 'cy' => '2', 'r' => '3' ),
@@ -626,7 +627,7 @@ if ( is_array( $layout_descriptor ) ) {
 	};
 	$svg_content = '<svg ' . $svg_attributes( 'svg', $svg_shapes['svg'] ) . '>';
 	$svg_content .= '<defs ' . $svg_attributes( 'defs', $svg_shapes['defs'] ) . '><linearGradient ' . $svg_attributes( 'lineargradient', $svg_shapes['lineargradient'] ) . '><stop ' . $svg_attributes( 'stop', $svg_shapes['stop'] ) . '></stop></linearGradient><radialGradient ' . $svg_attributes( 'radialgradient', $svg_shapes['radialgradient'] ) . '></radialGradient></defs>';
-	foreach ( array( 'g', 'path', 'circle', 'ellipse', 'line', 'polyline', 'polygon', 'rect' ) as $tag ) {
+	foreach ( array( 'g', 'path', 'circle', 'ellipse', 'line', 'polyline', 'polygon', 'rect', 'text' ) as $tag ) {
 		$svg_content .= '<' . $tag . ' ' . $svg_attributes( $tag, $svg_shapes[ $tag ] ) . '></' . $tag . '>';
 	}
 	$svg_content .= '</svg>';

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -680,11 +680,12 @@ $svg_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $svg_renderer
 $assert( is_array( $svg_descriptor ), 'svg-artwork-renderer-scaffold-returns-descriptor' );
 if ( is_array( $svg_descriptor ) ) {
 	$svg_render = $svg_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
-	$attributes = array( 'svg' => '<svg viewBox="0 0 20 20" aria-hidden="true"><path class="s1" d="M10 18V2"></path><script>alert(1)</script></svg>' );
+	$attributes = array( 'svg' => '<svg viewBox="0 0 20 20" aria-hidden="true"><defs><filter id="glow"><feGaussianBlur stdDeviation="3" result="blur"></feGaussianBlur><feMerge><feMergeNode in="blur"></feMergeNode><feMergeNode in="SourceGraphic"></feMergeNode></feMerge></filter></defs><path class="s1" d="M10 18V2" filter="url(#glow)"></path><script>alert(1)</script></svg>' );
 	ob_start();
 	eval( '?>' . $svg_render );
 	$svg_artwork_output = (string) ob_get_clean();
-	$assert( str_contains( $svg_render, 'Generated svg-artwork companion block render' ) && str_contains( $svg_artwork_output, '<path class="s1" d="M10 18V2">' ), 'svg-artwork-renderer-preserves-safe-inline-artwork' );
+	$assert( str_contains( $svg_render, 'Generated svg-artwork companion block render' ) && str_contains( $svg_artwork_output, '<path class="s1" d="M10 18V2"' ), 'svg-artwork-renderer-preserves-safe-inline-artwork' );
+	$assert( str_contains( $svg_artwork_output, '<filter id="glow">' ) && str_contains( $svg_artwork_output, '<feGaussianBlur stdDeviation="3" result="blur">' ) && str_contains( $svg_artwork_output, '<feMergeNode in="SourceGraphic">' ) && str_contains( $svg_artwork_output, 'filter="url(#glow)"' ), 'svg-artwork-renderer-preserves-safe-local-filter' );
 	$assert( ! str_contains( strtolower( $svg_artwork_output ), '<script' ), 'svg-artwork-renderer-strips-executable-content' );
 }
 

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -7482,8 +7482,10 @@ test('stageFixtureSource copies the normalized fixture source into the served so
   assert.match(stagedHtml, /hasDocumentAnimation/);
   assert.match(stagedHtml, /animationName !== 'none'/);
   assert.match(stagedHtml, /svg\.getAnimations\(\{ subtree: true \}\)/);
-  assert.match(stagedHtml, /animation\.finish\(\)/);
+  assert.match(stagedHtml, /animation\.currentTime = 0/);
   assert.match(stagedHtml, /animation\.pause\(\)/);
+  assert.match(stagedHtml, /animation\.effect\.getKeyframes\(\)/);
+  assert.match(stagedHtml, /target\.style\.setProperty\('animation', 'none', 'important'\)/);
   assert.match(stagedHtml, /clone\.style\.setProperty\('color', computed\.color\)/);
   assert.match(stagedHtml, /new XMLSerializer\(\)\.serializeToString\(clone\)/);
   // The import payload (artifact.json) is still written alongside, unchanged.

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -7479,6 +7479,8 @@ test('stageFixtureSource copies the normalized fixture source into the served so
   assert.match(stagedHtml, /animation-duration: 0\.001ms !important/);
   assert.ok(stagedHtml.includes(VISUAL_PARITY_DETERMINISTIC_CSS.trim()));
   assert.match(stagedHtml, /data-ssi-visual-parity-svg-normalization/);
+  assert.match(stagedHtml, /hasDocumentAnimation/);
+  assert.match(stagedHtml, /animationName !== 'none'/);
   assert.match(stagedHtml, /clone\.style\.setProperty\('color', computed\.color\)/);
   assert.match(stagedHtml, /new XMLSerializer\(\)\.serializeToString\(clone\)/);
   // The import payload (artifact.json) is still written alongside, unchanged.

--- a/tools/fixture-matrix.test.mjs
+++ b/tools/fixture-matrix.test.mjs
@@ -7481,6 +7481,9 @@ test('stageFixtureSource copies the normalized fixture source into the served so
   assert.match(stagedHtml, /data-ssi-visual-parity-svg-normalization/);
   assert.match(stagedHtml, /hasDocumentAnimation/);
   assert.match(stagedHtml, /animationName !== 'none'/);
+  assert.match(stagedHtml, /svg\.getAnimations\(\{ subtree: true \}\)/);
+  assert.match(stagedHtml, /animation\.finish\(\)/);
+  assert.match(stagedHtml, /animation\.pause\(\)/);
   assert.match(stagedHtml, /clone\.style\.setProperty\('color', computed\.color\)/);
   assert.match(stagedHtml, /new XMLSerializer\(\)\.serializeToString\(clone\)/);
   // The import payload (artifact.json) is still written alongside, unchanged.

--- a/tools/verify-solved-site-promotion.test.mjs
+++ b/tools/verify-solved-site-promotion.test.mjs
@@ -126,7 +126,7 @@ test('pins an immutable WP Codebox release package, commit, and checksum togethe
   assert.match(workflow, /wpCodeboxSha:process\.env\.WP_CODEBOX_SHA/);
   assert.match(workflow, /"\$WP_CODEBOX_BIN" recipe validate --recipe "\$CONTRACT_RECIPE" --json/);
   assert.ok(workflow.indexOf('recipe validate --recipe') < workflow.indexOf('playwright/cli.js" install --with-deps chromium'));
-  assert.match(caller, /blocks-engine-sha: fe5bff79df1e7a964b2367d0a120e1dbb1797f19/);
+  assert.match(caller, /blocks-engine-sha: 3a8cebeb2d07cf26d47a2b14c20242e2f4eb4278/);
   assert.doesNotMatch(caller, /wp-codebox-sha:/);
 });
 


### PR DESCRIPTION
## Summary

- register the `blocks-engine/svg-artwork/v1` server renderer
- validate the typed SVG payload before rendering
- pass SVG through the existing audited SVG-aware safe-markup boundary
- retain safe SVG/path markup while stripping scripts and executable vectors

## Producer

Companion renderer for Automattic/blocks-engine#1526.

## Verification

- `php tests/smoke-companion-plugin.php` (379 assertions)
- `npm test` (77 selected repository tests plus all Node suites passed)
- built a development package with Blocks Engine PR #1526 and imported the coffee fixture into a fresh WordPress Studio site
- import quality passed with zero fallback blocks, zero `core/html`, and zero content loss
- Playwright confirmed six animated steam paths and zero console/page/request errors

## AI Assistance

Implemented and verified with OpenAI GPT-5.6 Sol using OpenCode. The model inspected the companion renderer architecture, reused the existing SVG sanitization boundary, added security regression coverage, ran the repository test suite, and verified the renderer through a packaged WordPress import.