### PR TITLE
Preserve SVG-masked responsive media

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -1176,7 +1176,7 @@ PHP;
 
 $content    = is_string( $attributes['content'] ?? null ) ? $attributes['content'] : '';
 $normalized = strtolower( preg_replace( '/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]+/', '', html_entity_decode( $content, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ) ?? '' );
-if ( preg_match( '/<\s*(?:script|style|iframe|object|embed|svg)\b|\son[a-z]+\s*=/i', $normalized ) ) {
+if ( preg_match( '/<\s*(?:script|style|iframe|object|embed|foreignobject|animate|animatemotion|animatetransform|set)\b|\son[a-z]+\s*=/i', $normalized ) ) {
 	return;
 }
 
@@ -1273,11 +1273,23 @@ $output = wp_kses(
 	$content,
 	array(
 		'a'          => array_merge( $global, array( 'download' => true, 'href' => true, 'rel' => true, 'target' => true ) ),
+		'div'        => $global,
+		'span'       => $global,
 		'figure'     => $global,
 		'figcaption' => $global,
 		'picture'    => $global,
-		'source'     => array_merge( $global, array( 'media' => true, 'sizes' => true, 'srcset' => true, 'type' => true ) ),
+		'source'     => array_merge( $global, array( 'media' => true, 'sizes' => true, 'src' => true, 'srcset' => true, 'type' => true ) ),
 		'img'        => array_merge( $global, array( 'alt' => true, 'height' => true, 'loading' => true, 'longdesc' => true, 'sizes' => true, 'src' => true, 'srcset' => true, 'usemap' => true, 'width' => true ) ),
+		'video'      => array_merge( $global, array( 'autoplay' => true, 'controls' => true, 'height' => true, 'loop' => true, 'muted' => true, 'playsinline' => true, 'poster' => true, 'preload' => true, 'src' => true, 'width' => true ) ),
+		'svg'        => array_merge( $global, array( 'fill' => true, 'focusable' => true, 'height' => true, 'preserveaspectratio' => true, 'stroke' => true, 'viewbox' => true, 'width' => true, 'xmlns' => true ) ),
+		'defs'       => $global,
+		'clippath'   => $global,
+		'mask'       => $global,
+		'g'          => array_merge( $global, array( 'clip-path' => true, 'fill' => true, 'opacity' => true, 'stroke' => true, 'stroke-width' => true, 'transform' => true ) ),
+		'path'       => array_merge( $global, array( 'd' => true, 'fill' => true, 'fill-rule' => true, 'opacity' => true, 'stroke' => true, 'stroke-width' => true, 'transform' => true ) ),
+		'rect'       => array_merge( $global, array( 'fill' => true, 'height' => true, 'rx' => true, 'ry' => true, 'stroke' => true, 'stroke-width' => true, 'width' => true, 'x' => true, 'y' => true ) ),
+		'text'       => array_merge( $global, array( 'fill' => true, 'font-family' => true, 'font-size' => true, 'font-weight' => true, 'text-anchor' => true, 'x' => true, 'y' => true ) ),
+		'tspan'      => array_merge( $global, array( 'dx' => true, 'dy' => true, 'fill' => true, 'x' => true, 'y' => true ) ),
 	)
 );
 foreach ( $data_images as $placeholder => $data_image ) {

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -743,6 +743,16 @@ if ( is_array( $typed_descriptor ) ) {
 	foreach ( array( 'javascript:', '%6a%61vascript:', 'data:image/svg+xml' ) as $fragment ) {
 		$assert( ! str_contains( $typed_output, $fragment ), 'typed-renderer-removes-' . $fragment );
 	}
+	$attributes = array(
+		'kind'    => 'media',
+		'content' => '<div class="masked-video"><svg viewBox="0 0 100 40"><defs><clipPath id="media-mask"><text x="0" y="20">Play</text></clipPath></defs></svg><video src="footer.mp4" autoplay muted loop style="clip-path:url(#media-mask)"></video></div>',
+	);
+	ob_start();
+	eval( '?>' . $typed_render );
+	$masked_video_output = strtolower( (string) ob_get_clean() );
+	foreach ( array( '<svg', '<clippath id="media-mask">', '<video src="footer.mp4" autoplay muted loop', 'clip-path:url(#media-mask)' ) as $fragment ) {
+		$assert( str_contains( $masked_video_output, $fragment ), 'typed-renderer-preserves-masked-video-' . sanitize_key( $fragment ) );
+	}
 	foreach ( array( '<script>alert(1)</script>', '<img src=x onerror=alert(1)>', '<a href="data:text/html;base64,PHNjcmlwdD4=">x</a>', '<img srcset=javascript:alert(1)>' ) as $unsafe_content ) {
 		$attributes = array( 'kind' => 'media', 'content' => $unsafe_content );
 		ob_start();


### PR DESCRIPTION
## Summary

- allow the audited responsive-media renderer to emit bounded SVG definitions and video consumers
- retain rejection of executable and animated SVG elements, embedded documents, scripts, styles, and event handlers
- add generated-PHP runtime coverage for a sibling SVG `clipPath` and video consumer

Fixes #1500.
Supports Automattic/blocks-engine#1534.

## Verification

- companion renderer suite passes with 379 assertions plus 29 JS seam assertions
- full local test manifest passes: 77 selected suites, zero failures
- combined LaTonia Hope import passes all mechanical quality gates with 926 native blocks and zero fallback, HTML, or invalid blocks
- desktop and mobile frontend checks retain the SVG definitions, computed clip path, and advancing muted loop video

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode was used to reproduce the empty render, trace it to the SSI-owned allowlist, implement the narrow renderer repair, add runtime coverage, and validate the combined WordPress import.
