### PR TITLE
Materialize authored viewport metadata

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -52,6 +52,7 @@
     "tests/smoke-url-tls-context.php": { "environment": "standalone-php" },
     "tests/smoke-validation-runtime-diagnostics.php": { "environment": "standalone-php" },
     "tests/smoke-visual-repair-css.php": { "environment": "standalone-php" },
+    "tests/smoke-viewport-metadata-materializer.php": { "environment": "standalone-php" },
     "tests/smoke-webfont-producer-consumer.php": { "environment": "standalone-php" },
     "tests/smoke-google-fonts-cap-fallback.php": { "environment": "standalone-php" },
     "tests/smoke-google-fonts-retry-determinism.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-viewport-metadata-materializer.php
+++ b/includes/class-static-site-importer-viewport-metadata-materializer.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Materializes one site-wide authored viewport declaration into a generated theme.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class Static_Site_Importer_Viewport_Metadata_Materializer {
+	/** @param array<string,mixed> $resolved_plan @param array<string,mixed> $bootstrap_overlay */
+	public static function prepare_overlay( array $resolved_plan, array $bootstrap_overlay = array() ): array {
+		$declarations = array();
+		$missing      = array();
+		$duplicates   = array();
+		$invalid      = array();
+		$declared     = false;
+
+		foreach ( $resolved_plan['pages'] ?? array() as $page ) {
+			if ( ! is_array( $page ) ) {
+				continue;
+			}
+			$source_path = is_string( $page['source_path'] ?? null ) ? $page['source_path'] : '';
+			$metadata    = is_array( $page['document_metadata'] ?? null ) ? $page['document_metadata'] : array();
+			$rows        = array_values(
+				array_filter(
+					is_array( $metadata['meta'] ?? null ) ? $metadata['meta'] : array(),
+					static fn( mixed $row ): bool => is_array( $row ) && 'viewport' === strtolower( trim( (string) ( $row['name'] ?? '' ) ) )
+				)
+			);
+			if ( array() === $rows ) {
+				$missing[] = $source_path;
+				continue;
+			}
+			$declared = true;
+			if ( 1 !== count( $rows ) ) {
+				$duplicates[] = $source_path;
+				continue;
+			}
+			$content = self::normalize_declaration( $rows[0]['content'] ?? null );
+			if ( null === $content ) {
+				$invalid[] = $source_path;
+				continue;
+			}
+			$declarations[ $source_path ] = $content;
+		}
+
+		if ( ! $declared ) {
+			return self::result( 'not_requested' );
+		}
+		if ( array() !== $duplicates ) {
+			return self::report_only( 'viewport_metadata_duplicate', 'Authored viewport metadata remains report-only because a route declares it more than once.', $duplicates );
+		}
+		if ( array() !== $invalid ) {
+			return self::report_only( 'viewport_metadata_invalid', 'Authored viewport metadata remains report-only because a declaration is invalid.', $invalid );
+		}
+		if ( array() !== $missing ) {
+			return self::report_only( 'viewport_metadata_missing_route', 'Authored viewport metadata remains report-only because it is not declared by every route.', $missing );
+		}
+		$unique = array_values( array_unique( array_values( $declarations ) ) );
+		if ( 1 !== count( $unique ) ) {
+			return self::report_only( 'viewport_metadata_conflict', 'Authored viewport metadata remains report-only because routes declare conflicting values.', array_keys( $declarations ) );
+		}
+
+		$viewport  = $unique[0];
+		$bootstrap = self::bootstrap_content( $resolved_plan, $bootstrap_overlay );
+		$marker    = '/* Static Site Importer authored viewport metadata. */';
+		if ( ! str_contains( $bootstrap, $marker ) ) {
+			$literal    = var_export( $viewport, true );
+			$bootstrap .= "\n{$marker}\nadd_filter( 'template_include', static function ( \$template ) {\n\tremove_action( 'wp_head', '_block_template_viewport_meta_tag', 0 );\n\tadd_action( 'wp_head', static function (): void {\n\t\techo '<meta name=\"viewport\" content=\"' . esc_attr( {$literal} ) . '\" />' . \"\\n\";\n\t}, 0 );\n\treturn \$template;\n}, PHP_INT_MAX );\n";
+		}
+
+		return self::result(
+			'materialized',
+			array(
+				array(
+					'target_path' => 'functions.php',
+					'content'     => $bootstrap,
+					'encoding'    => 'utf8',
+					'source_path' => 'static-site-importer/viewport-metadata',
+				)
+			),
+			array(),
+			$viewport
+		);
+	}
+
+	private static function normalize_declaration( mixed $content ): ?string {
+		if ( ! is_string( $content ) || '' === trim( $content ) || 512 < strlen( $content ) || preg_match( '/[\x00-\x1F\x7F]/', $content ) ) {
+			return null;
+		}
+		$normalized = array();
+		$seen       = array();
+		foreach ( explode( ',', $content ) as $component ) {
+			$pair = array_map( 'trim', explode( '=', $component, 2 ) );
+			if ( 2 !== count( $pair ) || '' === $pair[0] || '' === $pair[1] ) {
+				return null;
+			}
+			$key   = strtolower( $pair[0] );
+			$value = strtolower( $pair[1] );
+			if ( isset( $seen[ $key ] ) || ! self::valid_component( $key, $value ) ) {
+				return null;
+			}
+			$seen[ $key ] = true;
+			$normalized[] = $key . '=' . $value;
+		}
+		return implode( ', ', $normalized );
+	}
+
+	private static function valid_component( string $key, string $value ): bool {
+		if ( in_array( $key, array( 'width', 'height' ), true ) ) {
+			return in_array( $value, array( 'device-width', 'device-height' ), true ) || ( ctype_digit( $value ) && 1 <= (int) $value && 10000 >= (int) $value );
+		}
+		if ( in_array( $key, array( 'initial-scale', 'minimum-scale', 'maximum-scale' ), true ) ) {
+			return 1 === preg_match( '/^(?:\d+(?:\.\d+)?|\.\d+)$/', $value ) && 0 < (float) $value && 10 >= (float) $value;
+		}
+		if ( 'user-scalable' === $key ) {
+			return in_array( $value, array( 'yes', 'no', '1', '0' ), true );
+		}
+		if ( 'viewport-fit' === $key ) {
+			return in_array( $value, array( 'auto', 'contain', 'cover' ), true );
+		}
+		if ( 'interactive-widget' === $key ) {
+			return in_array( $value, array( 'resizes-visual', 'resizes-content', 'overlays-content' ), true );
+		}
+		return false;
+	}
+
+	/** @param array<string,mixed> $resolved_plan @param array<string,mixed> $overlay */
+	private static function bootstrap_content( array $resolved_plan, array $overlay ): string {
+		foreach ( array_reverse( $overlay['writes'] ?? array() ) as $write ) {
+			if ( is_array( $write ) && 'functions.php' === ( $write['target_path'] ?? null ) && is_string( $write['content'] ?? null ) ) {
+				return $write['content'];
+			}
+		}
+		foreach ( $resolved_plan['writes'] ?? array() as $write ) {
+			if ( ! is_array( $write ) || 'functions.php' !== ( $write['target_path'] ?? null ) || ! is_array( $write['payload'] ?? null ) ) {
+				continue;
+			}
+			$content = 'base64' === ( $write['payload']['encoding'] ?? 'utf8' ) ? base64_decode( (string) ( $write['payload']['data'] ?? '' ), true ) : $write['payload']['data'] ?? null;
+			if ( is_string( $content ) && str_starts_with( ltrim( $content ), '<?php' ) ) {
+				return $content;
+			}
+		}
+		return "<?php\n";
+	}
+
+	/** @param array<int,array<string,mixed>> $writes @param array<int,array<string,mixed>> $diagnostics */
+	private static function result( string $status, array $writes = array(), array $diagnostics = array(), string $declaration = '' ): array {
+		return array(
+			'status'      => $status,
+			'declaration' => $declaration,
+			'writes'      => $writes,
+			'diagnostics' => $diagnostics,
+		);
+	}
+
+	/** @param array<int,string> $source_paths */
+	private static function report_only( string $reason_code, string $message, array $source_paths ): array {
+		return self::result(
+			'report_only',
+			array(),
+			array(
+				array(
+					'code'         => 'static_site_importer_' . $reason_code,
+					'type'         => 'static-site-importer',
+					'severity'     => 'warning',
+					'reason_code'  => $reason_code,
+					'message'      => $message,
+					'source_paths' => array_values( $source_paths ),
+				)
+			)
+		);
+	}
+}

--- a/includes/class-static-site-importer-viewport-metadata-materializer.php
+++ b/includes/class-static-site-importer-viewport-metadata-materializer.php
@@ -68,7 +68,7 @@ final class Static_Site_Importer_Viewport_Metadata_Materializer {
 		$bootstrap = self::bootstrap_content( $resolved_plan, $bootstrap_overlay );
 		$marker    = '/* Static Site Importer authored viewport metadata. */';
 		if ( ! str_contains( $bootstrap, $marker ) ) {
-			$literal    = var_export( $viewport, true );
+			$literal    = (string) wp_json_encode( $viewport );
 			$bootstrap .= "\n{$marker}\nadd_filter( 'template_include', static function ( \$template ) {\n\tremove_action( 'wp_head', '_block_template_viewport_meta_tag', 0 );\n\tadd_action( 'wp_head', static function (): void {\n\t\techo '<meta name=\"viewport\" content=\"' . esc_attr( {$literal} ) . '\" />' . \"\\n\";\n\t}, 0 );\n\treturn \$template;\n}, PHP_INT_MAX );\n";
 		}
 
@@ -80,7 +80,7 @@ final class Static_Site_Importer_Viewport_Metadata_Materializer {
 					'content'     => $bootstrap,
 					'encoding'    => 'utf8',
 					'source_path' => 'static-site-importer/viewport-metadata',
-				)
+				),
 			),
 			array(),
 			$viewport
@@ -139,6 +139,7 @@ final class Static_Site_Importer_Viewport_Metadata_Materializer {
 			if ( ! is_array( $write ) || 'functions.php' !== ( $write['target_path'] ?? null ) || ! is_array( $write['payload'] ?? null ) ) {
 				continue;
 			}
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes a declared plan payload encoding.
 			$content = 'base64' === ( $write['payload']['encoding'] ?? 'utf8' ) ? base64_decode( (string) ( $write['payload']['data'] ?? '' ), true ) : $write['payload']['data'] ?? null;
 			if ( is_string( $content ) && str_starts_with( ltrim( $content ), '<?php' ) ) {
 				return $content;
@@ -170,7 +171,7 @@ final class Static_Site_Importer_Viewport_Metadata_Materializer {
 					'reason_code'  => $reason_code,
 					'message'      => $message,
 					'source_paths' => array_values( $source_paths ),
-				)
+				),
 			)
 		);
 	}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -643,12 +643,12 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return self::failed_receipt_from_error( $state, $font_materialization );
 		}
 		$state['applied']['font_materialization'] = $font_materialization;
-		$viewport_materialization                = self::apply_viewport_overlay( $state, $viewport_overlay );
+		$viewport_materialization                 = self::apply_viewport_overlay( $state, $viewport_overlay );
 		if ( is_wp_error( $viewport_materialization ) ) {
 			return self::failed_receipt_from_error( $state, $viewport_materialization );
 		}
 		$state['applied']['viewport_metadata'] = $viewport_materialization;
-		$svg_receipts                             = self::verify_svg_font_materialization( $state );
+		$svg_receipts                          = self::verify_svg_font_materialization( $state );
 		if ( is_wp_error( $svg_receipts ) ) {
 			return self::failed_receipt( $state, $svg_receipts->get_error_code() );
 		}
@@ -932,7 +932,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			$state['preflight_error'] = $font_overlay;
 			throw new InvalidArgumentException( sanitize_key( (string) $font_overlay->get_error_code() ) );
 		}
-		$viewport_overlay = isset( $state['viewport_overlay'] ) && is_array( $state['viewport_overlay'] )
+		$viewport_overlay               = isset( $state['viewport_overlay'] ) && is_array( $state['viewport_overlay'] )
 			? $state['viewport_overlay']
 			: Static_Site_Importer_Viewport_Metadata_Materializer::prepare_overlay( $font_resolved, $font_overlay );
 		$state['font_overlay']          = $font_overlay;
@@ -1780,7 +1780,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				array(
 					'target_path'             => $target,
 					'source_path'             => (string) ( $write['source_path'] ?? $target ),
-					'payload'                 => array( 'encoding' => 'utf8', 'data' => $content ),
+					'payload'                 => array(
+						'encoding' => 'utf8',
+						'data'     => $content,
+					),
 					'payload_hash'            => hash( 'sha256', $content ),
 					'reconciliation_identity' => hash( 'sha256', "viewport-metadata\n" . $target ),
 				)

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -530,8 +530,9 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			$state['failure_reason'] = $error->getMessage();
 			return self::receipt( 'rejected', $state );
 		}
-		$args         = $state['args'];
-		$font_overlay = $state['font_overlay'];
+		$args             = $state['args'];
+		$font_overlay     = $state['font_overlay'];
+		$viewport_overlay = $state['viewport_overlay'];
 
 		foreach ( $state['ordered_pages'] as $page ) {
 			if ( ! empty( $page['skip_materialization'] ) ) {
@@ -642,6 +643,11 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return self::failed_receipt_from_error( $state, $font_materialization );
 		}
 		$state['applied']['font_materialization'] = $font_materialization;
+		$viewport_materialization                = self::apply_viewport_overlay( $state, $viewport_overlay );
+		if ( is_wp_error( $viewport_materialization ) ) {
+			return self::failed_receipt_from_error( $state, $viewport_materialization );
+		}
+		$state['applied']['viewport_metadata'] = $viewport_materialization;
 		$svg_receipts                             = self::verify_svg_font_materialization( $state );
 		if ( is_wp_error( $svg_receipts ) ) {
 			return self::failed_receipt( $state, $svg_receipts->get_error_code() );
@@ -787,6 +793,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			'args'                              => $args,
 			'payload_reader'                    => $payload_reader,
 			'font_overlay'                      => isset( $prepared['font_overlay'] ) && is_array( $prepared['font_overlay'] ) ? $prepared['font_overlay'] : null,
+			'viewport_overlay'                  => isset( $prepared['viewport_overlay'] ) && is_array( $prepared['viewport_overlay'] ) ? $prepared['viewport_overlay'] : null,
 			'default_content'                   => isset( $prepared['default_content'] ) && is_array( $prepared['default_content'] ) ? $prepared['default_content'] : array(),
 			'rollback'                          => array(
 				'posts'   => array(),
@@ -925,8 +932,12 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			$state['preflight_error'] = $font_overlay;
 			throw new InvalidArgumentException( sanitize_key( (string) $font_overlay->get_error_code() ) );
 		}
+		$viewport_overlay = isset( $state['viewport_overlay'] ) && is_array( $state['viewport_overlay'] )
+			? $state['viewport_overlay']
+			: Static_Site_Importer_Viewport_Metadata_Materializer::prepare_overlay( $font_resolved, $font_overlay );
 		$state['font_overlay']          = $font_overlay;
-		$state['composed_theme_writes'] = array_merge( $overlay_writes, self::font_overlay_writes( $state['theme_dir'], $font_overlay ) );
+		$state['viewport_overlay']      = $viewport_overlay;
+		$state['composed_theme_writes'] = array_merge( $overlay_writes, self::font_overlay_writes( $state['theme_dir'], $font_overlay ), self::viewport_overlay_writes( $state['theme_dir'], $viewport_overlay ) );
 		foreach ( $state['resolved']['writes'] as $write ) {
 			if ( null !== self::payload_reference( $write ) && ! self::valid_payload_reference( self::payload_reference( $write ) ) ) {
 				throw new InvalidArgumentException( 'payload_reference_invalid' );
@@ -1745,6 +1756,66 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		return $writes;
 	}
 
+	/** @param array<string,mixed> $overlay */
+	private static function apply_viewport_overlay( array &$state, array $overlay ) {
+		if ( 'materialized' !== ( $overlay['status'] ?? '' ) ) {
+			return array(
+				'status'      => (string) ( $overlay['status'] ?? 'not_requested' ),
+				'declaration' => '',
+				'files'       => array(),
+				'diagnostics' => $overlay['diagnostics'] ?? array(),
+			);
+		}
+		$reports = array();
+		foreach ( $overlay['writes'] ?? array() as $write ) {
+			$target  = (string) ( $write['target_path'] ?? '' );
+			$content = (string) ( $write['content'] ?? '' );
+			if ( ! self::safe_destination( $state['theme_dir'], $target ) || ! str_starts_with( ltrim( $content ), '<?php' ) ) {
+				return new WP_Error( 'static_site_importer_viewport_metadata_materialization_invalid' );
+			}
+			$path = $state['theme_dir'] . '/' . $target;
+			self::journal_file( $state, $path );
+			$result = self::write_file(
+				$state['theme_dir'],
+				array(
+					'target_path'             => $target,
+					'source_path'             => (string) ( $write['source_path'] ?? $target ),
+					'payload'                 => array( 'encoding' => 'utf8', 'data' => $content ),
+					'payload_hash'            => hash( 'sha256', $content ),
+					'reconciliation_identity' => hash( 'sha256', "viewport-metadata\n" . $target ),
+				)
+			);
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$reports[] = $result;
+			foreach ( $state['applied']['files'] as $index => $file ) {
+				if ( ( $file['target_path'] ?? null ) === $target ) {
+					$state['applied']['files'][ $index ] = $result;
+					continue 2;
+				}
+			}
+			$state['applied']['files'][] = $result;
+		}
+		return array(
+			'status'      => 'completed',
+			'declaration' => (string) ( $overlay['declaration'] ?? '' ),
+			'files'       => $reports,
+			'diagnostics' => $overlay['diagnostics'] ?? array(),
+		);
+	}
+
+	/** @param array<string,mixed> $overlay @return array<string,string> */
+	private static function viewport_overlay_writes( string $theme_dir, array $overlay ): array {
+		$writes = array();
+		foreach ( $overlay['writes'] ?? array() as $write ) {
+			if ( is_array( $write ) && is_string( $write['target_path'] ?? null ) && is_string( $write['content'] ?? null ) ) {
+				$writes[ $theme_dir . '/' . $write['target_path'] ] = $write['content'];
+			}
+		}
+		return $writes;
+	}
+
 	/** Verify every canonical asset publication against its resolved write and references. */
 	private static function verify_asset_publications( array &$state ) {
 		$writes = array();
@@ -2417,7 +2488,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	/** @param array<string,mixed> $state @return array<string,mixed> */
 	private static function receipt( string $status, array $state ): array {
-		unset( $state['font_overlay'], $state['provider_layout_overlay_writes'], $state['composed_theme_writes'], $state['preflight_error'] );
+		unset( $state['font_overlay'], $state['viewport_overlay'], $state['provider_layout_overlay_writes'], $state['composed_theme_writes'], $state['preflight_error'] );
 		$plan                   = $state['plan'];
 		$resolved_plan          = $state['resolved'] ?? $plan;
 		$materialized_pages     = array();
@@ -2467,6 +2538,12 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 				'runtime_declarations'       => $state['applied']['runtime_declarations'] ?? array( 'asset_publications' => array() ),
 				'font_materialization'       => $state['applied']['font_materialization'] ?? array(
 					'status'      => 'not_requested',
+					'files'       => array(),
+					'diagnostics' => array(),
+				),
+				'viewport_metadata'          => $state['applied']['viewport_metadata'] ?? array(
+					'status'      => 'not_requested',
+					'declaration' => '',
 					'files'       => array(),
 					'diagnostics' => array(),
 				),

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -96,6 +96,7 @@ $static_site_importer_includes = array(
 	'class-static-site-importer-validation-runtime.php',
 	'class-static-site-importer-report-diagnostics.php',
 	'class-static-site-importer-failed-plan-validation.php',
+	'class-static-site-importer-viewport-metadata-materializer.php',
 	'class-static-site-importer-font-materializer.php',
 	'class-static-site-importer-document-type-classifier.php',
 	'class-static-site-importer-current-site-capabilities.php',

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -60,6 +60,7 @@
     { "path": "tests/smoke-url-tls-context.php", "environment": "standalone-php" },
     { "path": "tests/smoke-validation-runtime-diagnostics.php", "environment": "standalone-php" },
     { "path": "tests/smoke-visual-repair-css.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-viewport-metadata-materializer.php", "environment": "standalone-php" },
     { "path": "tests/smoke-webfont-producer-consumer.php", "environment": "standalone-php" },
     { "path": "tests/smoke-google-fonts-cap-fallback.php", "environment": "standalone-php" },
     { "path": "tests/smoke-google-fonts-retry-determinism.php", "environment": "standalone-php" },

--- a/tests/smoke-viewport-metadata-materializer.php
+++ b/tests/smoke-viewport-metadata-materializer.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ . '/' );
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-viewport-metadata-materializer.php';
+
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+};
+$page = static fn( string $path, array $meta ): array => array(
+	'source_path'      => $path,
+	'document_metadata' => array( 'meta' => $meta ),
+);
+$viewport = static fn( string $content ): array => array( 'name' => 'viewport', 'content' => $content );
+$plan = array(
+	'pages'  => array( $page( 'index.html', array( $viewport( 'width=320,user-scalable=YES' ) ) ), $page( 'about.html', array( $viewport( 'width=320, user-scalable=yes' ) ) ) ),
+	'writes' => array(),
+);
+$result = Static_Site_Importer_Viewport_Metadata_Materializer::prepare_overlay( $plan, array( 'writes' => array( array( 'target_path' => 'functions.php', 'content' => "<?php\n// Existing bootstrap.\n" ) ) ) );
+$bootstrap = (string) ( $result['writes'][0]['content'] ?? '' );
+$assert( 'materialized' === $result['status'] && 'width=320, user-scalable=yes' === $result['declaration'], 'Consistent declarations should materialize in normalized form.' );
+$assert( str_contains( $bootstrap, '// Existing bootstrap.' ) && str_contains( $bootstrap, 'template_include' ) && str_contains( $bootstrap, "remove_action( 'wp_head', '_block_template_viewport_meta_tag', 0 )" ), 'The portable theme bootstrap should replace the block-template viewport callback without dropping prior bootstrap code.' );
+
+$missing = Static_Site_Importer_Viewport_Metadata_Materializer::prepare_overlay( array( 'pages' => array( $page( 'index.html', array( $viewport( 'width=320' ) ) ), $page( 'about.html', array() ) ) ) );
+$assert( 'report_only' === $missing['status'] && 'viewport_metadata_missing_route' === ( $missing['diagnostics'][0]['reason_code'] ?? '' ) && array() === $missing['writes'], 'A declaration missing from one route should remain report-only.' );
+
+$conflict = Static_Site_Importer_Viewport_Metadata_Materializer::prepare_overlay( array( 'pages' => array( $page( 'index.html', array( $viewport( 'width=320' ) ) ), $page( 'about.html', array( $viewport( 'width=device-width' ) ) ) ) ) );
+$assert( 'report_only' === $conflict['status'] && 'viewport_metadata_conflict' === ( $conflict['diagnostics'][0]['reason_code'] ?? '' ), 'Conflicting route declarations should emit a bounded diagnostic.' );
+
+$invalid = Static_Site_Importer_Viewport_Metadata_Materializer::prepare_overlay( array( 'pages' => array( $page( 'index.html', array( $viewport( 'width=javascript:alert(1)' ) ) ) ) ) );
+$assert( 'report_only' === $invalid['status'] && 'viewport_metadata_invalid' === ( $invalid['diagnostics'][0]['reason_code'] ?? '' ), 'Invalid declarations should never enter generated PHP.' );
+
+$duplicate = Static_Site_Importer_Viewport_Metadata_Materializer::prepare_overlay( array( 'pages' => array( $page( 'index.html', array( $viewport( 'width=320' ), $viewport( 'width=320' ) ) ) ) ) );
+$assert( 'report_only' === $duplicate['status'] && 'viewport_metadata_duplicate' === ( $duplicate['diagnostics'][0]['reason_code'] ?? '' ), 'Duplicate declarations should remain report-only.' );
+
+$absent = Static_Site_Importer_Viewport_Metadata_Materializer::prepare_overlay( array( 'pages' => array( $page( 'index.html', array() ) ) ) );
+$assert( 'not_requested' === $absent['status'] && array() === $absent['diagnostics'], 'Sites without authored viewport metadata should remain unchanged.' );
+
+echo "viewport metadata materializer smoke passed\n";

--- a/tests/smoke-viewport-metadata-materializer.php
+++ b/tests/smoke-viewport-metadata-materializer.php
@@ -2,6 +2,9 @@
 declare(strict_types=1);
 
 define( 'ABSPATH', __DIR__ . '/' );
+function wp_json_encode( mixed $value ): string|false {
+	return json_encode( $value );
+}
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-viewport-metadata-materializer.php';
 
 $assert = static function ( bool $condition, string $message ): void {

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -46,7 +46,7 @@ $result = Static_Site_Importer_Theme_Generator::import_website_artifact(
 		'files'  => array(
 			array(
 				'path'    => 'index.html',
-				'content' => '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Ember & Rye</title><meta name="description" content="Wood-fired bakery"><link rel="stylesheet" href="/assets/site.css"></head><body><header class="site-header"><a href="/">Ember & Rye</a></header><main><section class="hero"><h1>Fire, flour, patience.</h1><p>Small-batch loaves.</p><div class="contact-actions"><a class="btn btn-ghost" href="/contact">Visit us</a></div><div class="hours-table"><div><span>Tue</span><strong>4–10pm</strong></div></div><figure><img class="rounded-photo reveal" src="assets/logo.svg" alt="Bakery mark"></figure><div class="glow-orb"></div></section></main><script src="assets/js/main.js" defer></script></body></html>',
+				'content' => '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=320, user-scalable=yes"><title>Ember & Rye</title><meta name="description" content="Wood-fired bakery"><link rel="stylesheet" href="/assets/site.css"></head><body><header class="site-header"><a href="/">Ember & Rye</a></header><main><section class="hero"><h1>Fire, flour, patience.</h1><p>Small-batch loaves.</p><div class="contact-actions"><a class="btn btn-ghost" href="/contact">Visit us</a></div><div class="hours-table"><div><span>Tue</span><strong>4–10pm</strong></div></div><figure><img class="rounded-photo reveal" src="assets/logo.svg" alt="Bakery mark"></figure><div class="glow-orb"></div></section></main><script src="assets/js/main.js" defer></script></body></html>',
 			),
 			array(
 				'path'    => 'assets/site.css',
@@ -179,6 +179,9 @@ if ( ! is_wp_error( $result ) ) {
 	$assert( true === ( $scripts[0]['defer'] ?? false ), 'script-defer-is-preserved-in-document-metadata' );
 	$bootstrap = $read( $theme_dir . '/functions.php' );
 	$assert( str_contains( $bootstrap, "get_theme_file_uri( 'assets/assets/site.css' )" ), 'theme-bootstrap-enqueues-the-canonical-stylesheet', $bootstrap );
+	$assert( str_contains( $bootstrap, 'Static Site Importer authored viewport metadata' ) && str_contains( $bootstrap, "'width=320, user-scalable=yes'" ) && str_contains( $bootstrap, "remove_action( 'wp_head', '_block_template_viewport_meta_tag', 0 )" ), 'theme-bootstrap-materializes-authored-viewport', $bootstrap );
+	$viewport_receipt = $result['materialization_receipt']['completed']['viewport_metadata'] ?? array();
+	$assert( 'completed' === ( $viewport_receipt['status'] ?? '' ) && 'width=320, user-scalable=yes' === ( $viewport_receipt['declaration'] ?? '' ), 'viewport-materialization-is-recorded-in-receipt' );
 	$previous_query       = $GLOBALS['wp_query'] ?? null;
 	$GLOBALS['wp_query']  = new WP_Query( array( 'page_id' => $page_id ) );
 	$rendered_route_title = wp_get_document_title();

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -296,6 +296,7 @@ function wp_parse_args( $args, array $defaults = array() ): array {
 require_once __DIR__ . '/support/wordpress-block-registry.inc';
 
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-font-materializer.php';
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-viewport-metadata-materializer.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-document-type-classifier.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require dirname( __DIR__ ) . '/includes/class-static-site-importer-wordpress-site-plan-materializer.php';


### PR DESCRIPTION
## Summary
- validate authored viewport metadata shared by every imported route
- replace WordPress's frontend block-template viewport callback through the generated portable theme bootstrap
- preserve WordPress defaults in admin/editor and report unsafe, missing, duplicate, or conflicting declarations
- journal the materialization decision in import receipts and diagnostics

Closes #1495.

## Verification
- `npm test`
- `npm test -- --check`
- `php tests/smoke-viewport-metadata-materializer.php`
- `php tests/smoke-wordpress-site-plan-materializer.php`
- `homeboy review --placement local lint static-site-importer --path .`
- WordPress 7.1 / PHP 8.4 canonical six-route import: one `width=320, user-scalable=yes` viewport tag per frontend route after SSI deactivation
- saved `parse_blocks()` result: 913 native blocks, zero freeform or responsive-layout fallback segments
- Gutenberg front-page probe: 235 blocks, zero invalid blocks, no content mutation, nested block selection succeeds
- all six routes: hidden navigation support label computes to `display:none` and `0x0`
- desktop regression: 1280x2060, no overflow or browser errors, 0.0531% pixel delta from the accepted Loop 10 baseline

## Paired acceptance build
- SSI: `a72cb26892f65096178db6c296edd86f1c2bac0d`
- Blocks Engine: `15cc71ed6b5bde3c4dbc89f295fdee8f0ef621d7` ([Automattic/blocks-engine#1544](https://github.com/Automattic/blocks-engine/pull/1544))
- Package SHA-256: `5fbacb9deace10c196298214241241602b71c4596853b537322ca7c896263361`

## AI assistance
GPT-5.6 Sol through OpenCode traced the viewport handoff, implemented and tested the materialization contract, built the provenance-pinned package, and performed the WordPress import and browser acceptance checks under human direction.