### PR TITLE
Preserve safe inline layout styles

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -1115,7 +1115,7 @@ if ( preg_match_all( '/\s+(aria-[a-z][a-z0-9-]*)\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\
 	}
 }
 $safe_style_css = static function ( array $properties ): array {
-	return array_values( array_unique( array_merge( $properties, array( 'overflow-x', 'overflow-y' ) ) ) );
+	return array_values( array_unique( array_merge( $properties, array( 'box-sizing', 'inset', 'overflow-x', 'overflow-y', 'transition' ) ) ) );
 };
 add_filter( 'safe_style_css', $safe_style_css );
 $output = wp_kses(

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -561,7 +561,7 @@ $assert( is_array( $layout_descriptor ), 'layout-renderer-scaffold-returns-descr
 if ( is_array( $layout_descriptor ) ) {
 	$layout_render = $layout_descriptor['files']['ssi-example-site/blocks/custom-hero/render.php'] ?? '';
 	$assert( str_contains( $layout_render, 'Generated responsive-layout companion block render' ) && ! str_contains( $layout_render, 'Generated responsive-media companion block render' ), 'dedicated-layout-renderer-uses-own-template' );
-	$attributes = array( 'content' => '<main class="story" style="position:absolute;inset:0 auto auto 0;width:405px;height:516.812px;overflow:hidden;overflow-x:visible;overflow-y:clip"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
+	$attributes = array( 'content' => '<main class="story" style="position:absolute;inset:0 auto auto 332px;width:405px;height:516.812px;box-sizing:border-box;overflow:hidden;overflow-x:visible;overflow-y:clip;transition:opacity 0.2s"><header><nav><a href="/about">About</a></nav></header><section><h1>Story</h1><p>Safe copy <strong>with emphasis</strong>.</p><button type="button">Read more</button><wow-image data-hook="hero"><img src="data:image/png;base64,aGVybw==" alt="Hero" decoding="async" fetchpriority="high"></wow-image><svg viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Mark"><path d="M0 0L10 10" stroke="#000"></path></svg></section></main>' );
 	ob_start();
 	eval( '?>' . $layout_render );
 	$layout_output = (string) ob_get_clean();
@@ -569,9 +569,9 @@ if ( is_array( $layout_descriptor ) ) {
 		$assert( str_contains( $layout_output, $fragment ), 'layout-renderer-preserves-' . $fragment );
 	}
 	$assert( ! str_contains( $layout_output, '<wow-image' ) && str_contains( $layout_output, '<div data-hook="hero"><img' ), 'layout-renderer-neutralizes-custom-elements-without-dropping-safe-wrapper-attributes' );
-	$assert( str_contains( $layout_output, 'position:absolute' ) && str_contains( $layout_output, 'width:405px' ) && str_contains( $layout_output, 'height:516.812px' ) && str_contains( $layout_output, 'overflow:hidden' ), 'layout-renderer-preserves-quoted-inline-geometry', $layout_output );
+	$assert( str_contains( $layout_output, 'position:absolute' ) && str_contains( $layout_output, 'inset:0 auto auto 332px' ) && str_contains( $layout_output, 'width:405px' ) && str_contains( $layout_output, 'height:516.812px' ) && str_contains( $layout_output, 'box-sizing:border-box' ) && str_contains( $layout_output, 'overflow:hidden' ) && str_contains( $layout_output, 'transition:opacity 0.2s' ), 'layout-renderer-preserves-quoted-inline-geometry', $layout_output );
 	$assert( str_contains( $layout_output, 'overflow-x:visible' ) && str_contains( $layout_output, 'overflow-y:clip' ), 'layout-renderer-preserves-axis-specific-overflow', $layout_output );
-	$assert( str_contains( $layout_render, "add_filter( 'safe_style_css', \$safe_style_css )" ) && str_contains( $layout_render, "remove_filter( 'safe_style_css', \$safe_style_css )" ), 'layout-renderer-bounds-axis-overflow-css-filter', $layout_render );
+	$assert( str_contains( $layout_render, "add_filter( 'safe_style_css', \$safe_style_css )" ) && str_contains( $layout_render, "remove_filter( 'safe_style_css', \$safe_style_css )" ), 'layout-renderer-bounds-inline-layout-css-filter', $layout_render );
 	$attributes = array( 'content' => '<p>Report in one section with online notes only once.</p><button onclick onmouseover="alert(1)" data-wp-interactive>Go</button>' );
 	ob_start();
 	eval( '?>' . $layout_render );


### PR DESCRIPTION
## Summary

- preserve `box-sizing`, `inset`, and `transition` while sanitizing generated responsive-layout markup
- keep the `safe_style_css` extension scoped to the generated renderer invocation
- extend the renderer regression with a non-zero authored inset and all newly admitted properties

WordPress KSES already sanitizes these property values; the generated renderer only needs to admit the bounded property names while it processes trusted compiled layout markup. Without `inset`, absolutely positioned repeated cards collapse onto the same origin.

## Testing

- `npm run test:companion-plugin` (403 PHP assertions, 29 JavaScript assertions)
- `php -l includes/class-static-site-importer-companion-plugin.php`
- `php -l tests/smoke-companion-plugin.php`
- `git diff --check origin/main...HEAD`

## Downstream Validation

- built and installed a clean profiled development package with the companion Blocks Engine editor fix
- verified authored press-card offsets at `x=230/562/894` on the frontend
- verified editor offsets at `x=562/894` with preserved `332px`/`664px` insets
- verified the 390px mobile rendering and client logos
- verified the front-page editor has 62 blocks with zero invalid, HTML, or freeform blocks

The import host was interrupted after WordPress mutation but before terminal receipt persistence; lifecycle recovery is tracked separately in #1507. The rendered and editor state was inspected directly after the interruption.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the KSES property loss, implemented and tested the bounded filter expansion, rebased and published the branch, built the downstream package, and verified frontend/mobile/editor geometry. Chris Huber directed and reviewed the work.