### PR TITLE
fix: scope commerce presentation to importer-owned controls

### DIFF
--- a/includes/class-static-site-importer-commerce-presentation.php
+++ b/includes/class-static-site-importer-commerce-presentation.php
@@ -21,9 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * default footprint so the materialized control blends with the surrounding
  * theme: the redundant inline price is hidden, and the button drops its filled
  * background/heavy padding to inherit adjacent control styling. All rules are
- * scoped to the inline add-to-cart control so no other WooCommerce surface is
- * affected, and the CSS is only emitted when WooCommerce actually renders on
- * the page.
+ * scoped to the importer-owned `ssi-commerce-control` marker emitted by the
+ * Woo binding paths, so native WooCommerce controls are unaffected.
  *
  * The generic delivery pipeline — hooking, admin/active guards, stylesheet
  * handle resolution, and inline enqueue — lives in the provider presentation
@@ -74,16 +73,16 @@ class Static_Site_Importer_Commerce_Presentation extends Static_Site_Importer_Pr
 				// `<p>` whose default block margins expand the surrounding flex row;
 				// these are neutralized and the control is pinned to the stepper
 				// height so the action row does not inflate the card.
-				'.woocommerce p.product.add_to_cart_inline,p.product.add_to_cart_inline,.add_to_cart_inline{display:inline-flex;align-items:center;align-self:center;gap:.5rem;margin:0;padding:0;min-height:0;height:2rem;font-size:1rem;line-height:1;border:0;background:none;}',
+				'p.product.add_to_cart_inline.ssi-commerce-control{display:inline-flex;align-items:center;align-self:center;gap:.5rem;margin:0;padding:0;min-height:0;height:2rem;font-size:1rem;line-height:1;border:0;background:none;}',
 				// Hide the price that the inline control repeats; the card already
 				// shows the canonical price above the action row.
-				'.add_to_cart_inline .woocommerce-Price-amount,.add_to_cart_inline > .amount{display:none;}',
+				'.ssi-commerce-control .woocommerce-Price-amount,.ssi-commerce-control > .amount{display:none;}',
 				// Reset the default filled button to inherit the surrounding theme
 				// styling instead of WooCommerce's opinionated background/padding.
 				// The button is sized to the quantity stepper height so the whole
 				// action row stays compact; the label is uppercased and shrunk and
 				// the border dimmed so it reads as a slim, theme-consistent control.
-				'.add_to_cart_inline a.button.add_to_cart_button,.add_to_cart_inline a.add_to_cart_button.wp-element-button{display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box;height:2rem;background:transparent;background-image:none;color:inherit;font-family:inherit;font-size:.62em;font-weight:inherit;text-transform:uppercase;letter-spacing:.08em;padding:0 .9rem;margin:0;min-height:0;min-width:0;line-height:1;border:1px solid;border-color:currentColor;border-color:color-mix(in srgb,currentColor 22%,transparent);border-radius:0;box-shadow:none;white-space:nowrap;}',
+				'.ssi-commerce-control a.button.add_to_cart_button,.ssi-commerce-control a.add_to_cart_button.wp-element-button{display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box;height:2rem;background:transparent;background-image:none;color:inherit;font-family:inherit;font-size:.62em;font-weight:inherit;text-transform:uppercase;letter-spacing:.08em;padding:0 .9rem;margin:0;min-height:0;min-width:0;line-height:1;border:1px solid;border-color:currentColor;border-color:color-mix(in srgb,currentColor 22%,transparent);border-radius:0;box-shadow:none;white-space:nowrap;}',
 			)
 		);
 	}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2390,7 +2390,7 @@ class Static_Site_Importer_Report_Diagnostics {
 	 * @return string
 	 */
 	private static function add_to_cart_shortcode_block( int $product_id ): string {
-		return '<!-- wp:shortcode -->[add_to_cart id="' . $product_id . '"]<!-- /wp:shortcode -->';
+		return '<!-- wp:shortcode -->[add_to_cart id="' . $product_id . '" class="ssi-commerce-control"]<!-- /wp:shortcode -->';
 	}
 
 	/**

--- a/includes/class-static-site-importer-woo-product-seeder.php
+++ b/includes/class-static-site-importer-woo-product-seeder.php
@@ -18,7 +18,7 @@ class Static_Site_Importer_Woo_Product_Seeder {
 	public static function binding_block_markup( array $entity, array $result ): string {
 		unset( $entity );
 		$id = isset( $result['id'] ) ? (int) $result['id'] : 0;
-		return $id > 0 ? '<!-- wp:shortcode -->[add_to_cart id="' . $id . '"]<!-- /wp:shortcode -->' : '';
+		return $id > 0 ? '<!-- wp:shortcode -->[add_to_cart id="' . $id . '" class="ssi-commerce-control"]<!-- /wp:shortcode -->' : '';
 	}
 
 	/** Return fixed Woo shortcode data for a classic runtime binding. */
@@ -27,7 +27,7 @@ class Static_Site_Importer_Woo_Product_Seeder {
 		$id = isset( $result['id'] ) ? (int) $result['id'] : 0;
 		return $id > 0 ? array(
 			'kind'    => 'shortcode',
-			'content' => '[add_to_cart id="' . $id . '"]',
+			'content' => '[add_to_cart id="' . $id . '" class="ssi-commerce-control"]',
 		) : array();
 	}
 

--- a/tests/smoke-managed-classic-theme-materialization.php
+++ b/tests/smoke-managed-classic-theme-materialization.php
@@ -533,7 +533,7 @@ $form = Static_Site_Importer_Form_Seeder::binding_classic_render(
 $assert(
 	array(
 		'kind'    => 'shortcode',
-		'content' => '[add_to_cart id="42"]',
+		'content' => '[add_to_cart id="42" class="ssi-commerce-control"]',
 	) === $woo && 'blocks' === ( $form['kind'] ?? '' ) && str_contains( $form['content'] ?? '', 'jetpack/contact-form' ),
 	'Woo and Jetpack adapters expose actual provider-owned classic server render contracts'
 );

--- a/tests/smoke-product-materializer.php
+++ b/tests/smoke-product-materializer.php
@@ -342,7 +342,7 @@ namespace {
 	$graft_seeding                 = Static_Site_Importer_Report_Diagnostics::materialize_product_findings( $graft_report, array(), $page_contents );
 	$assert( 1 === ( $graft_seeding['shortcode_grafted_count'] ?? 0 ), 'shortcode-grafted-count' );
 	$assert( true === ( $graft_report['diagnostics'][0]['product_shortcode_grafted'] ?? false ), 'finding-product-shortcode-grafted' );
-	$assert( str_contains( $page_contents['website/shop.html'], '<!-- wp:shortcode -->[add_to_cart id="' ), 'page-content-has-add-to-cart-shortcode' );
+	$assert( str_contains( $page_contents['website/shop.html'], '<!-- wp:shortcode -->[add_to_cart id="' ) && str_contains( $page_contents['website/shop.html'], 'class="ssi-commerce-control"' ), 'page-content-has-marked-add-to-cart-shortcode' );
 	$assert( ! str_contains( $page_contents['website/shop.html'], '>Add to cart<' ), 'page-content-removes-static-add-to-cart' );
 	$assert( ! str_contains( $page_contents['website/shop.html'], '>Buy now<' ), 'page-content-removes-static-buy-now' );
 	$assert( str_contains( $button_region, '\\u005c' ) && str_contains( $button_region, '\\u002d\\u002d' ) && str_contains( $button_region, '\\u003c' ) && str_contains( $button_region, '\\u003e' ) && str_contains( $button_region, '\\u0026' ) && str_contains( $button_region, '\\u0022' ), 'product-graft-anchor-uses-core-sensitive-attribute-serialization' );

--- a/tests/smoke-provider-presentation.php
+++ b/tests/smoke-provider-presentation.php
@@ -144,12 +144,20 @@ namespace {
 	SSI_Test_Presentation::enqueue();
 	$assert( array() === $GLOBALS['ssi_test_registered'], 'empty-css-registers-no-handle' );
 
-	// The refactored commerce presentation preserves its own handle + CSS.
+	// Commerce CSS only matches the importer-owned marker emitted by its binding.
 	$reset();
 	SSI_Test_Presentation::$out = '.demo{color:red}';
 	\Static_Site_Importer_Commerce_Presentation::enqueue();
+	$commerce_css = $GLOBALS['ssi_test_inline_styles']['static-site-importer-commerce'] ?? '';
 	$assert( isset( $GLOBALS['ssi_test_inline_styles']['static-site-importer-commerce'] ), 'commerce-attaches-to-own-handle-name' );
-	$assert( false !== strpos( $GLOBALS['ssi_test_inline_styles']['static-site-importer-commerce'] ?? '', 'add_to_cart_inline' ), 'commerce-css-preserved' );
+	preg_match_all( '/([^{}]+)\\{/', $commerce_css, $commerce_rules );
+	$selectors = array_filter( array_map( 'trim', explode( ',', implode( ',', $commerce_rules[1] ?? array() ) ) ) );
+	$all_selectors_are_marked = ! empty( $selectors ) && count( $selectors ) === count( array_filter( $selectors, static fn( string $selector ): bool => str_contains( $selector, 'ssi-commerce-control' ) ) );
+	$assert( $all_selectors_are_marked, 'commerce-css-is-scoped-to-importer-marker' );
+	$ordinary_woo_inline_cart = '<p class="product woocommerce add_to_cart_inline"><span class="woocommerce-Price-amount">$24</span><a class="button add_to_cart_button">Add to cart</a></p>';
+	$assert( ! str_contains( $ordinary_woo_inline_cart, 'ssi-commerce-control' ) && $all_selectors_are_marked, 'ordinary-woo-inline-cart-receives-no-ssi-styling' );
+	$binding = \Static_Site_Importer_Woo_Product_Seeder::binding_block_markup( array(), array( 'id' => 42 ) );
+	$assert( str_contains( $binding, '[add_to_cart id="42" class="ssi-commerce-control"]' ) && str_contains( $commerce_css, 'ssi-commerce-control' ), 'materialized-commerce-binding-receives-ssi-styling' );
 
 	if ( $failures ) {
 		fwrite( STDERR, implode( "\n", $failures ) . "\n" );

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1574,7 +1574,7 @@ $entity_bindings       = $binding_method->invoke(
 		),
 	)
 );
-$assert( ! is_wp_error( $entity_bindings ) && '[add_to_cart id="42"]' === trim( strip_tags( $entity_bindings[0]['replacement_block_markup'] ?? '' ) ), 'provider result resolves into a canonical runtime entity binding' );
+$assert( ! is_wp_error( $entity_bindings ) && '[add_to_cart id="42" class="ssi-commerce-control"]' === trim( strip_tags( $entity_bindings[0]['replacement_block_markup'] ?? '' ) ), 'provider result resolves into a canonical runtime entity binding' );
 $assert( array( '.add-to-cart' ) === ( $entity_bindings[0]['superseded_runtime_selectors'] ?? null ), 'provider binding retains its explicit runtime-selector coverage' );
 $waived_bindings = $binding_method->invoke(
 	null,


### PR DESCRIPTION
Closes #1512

## What

Woo binding paths now emit `[add_to_cart id="…" class="ssi-commerce-control"]`, and every commerce presentation selector is scoped beneath that marker.

## Why

The presentation enqueued whenever WooCommerce or its shortcode existed and targeted generic `.add_to_cart_inline` selectors, so activating this plugin could hide prices and restyle buttons on native WooCommerce pages that had nothing to do with an import.

## Marker contract

Verified against the installed WooCommerce source: `WC_Shortcodes::product_add_to_cart()` defaults `class` to an empty string and interpolates it into the wrapper element (`<p class="product woocommerce add_to_cart_inline …">`). The marker therefore lands on the element the CSS targets and does not displace any Woo default.

## Verification

- `npm test` fast lane: 79 passed, 0 failed.
- `npm run test:inventory` passes.
- Presentation smoke asserts every emitted selector carries the marker, that ordinary Woo inline-cart markup does not match it, and that materialized bindings do.

## AI assistance

OpenAI `gpt-5.6-sol` running in OpenCode implemented the scoping, verified the shortcode attribute against the installed WooCommerce source, and ran the verification above. A human directed the work and reviewed the result.