### PR TITLE
Update PHP transformer to 0.9.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   "require": {
     "php": "^8.2",
     "automattic/blocks-engine-figma-transformer": "^0.2.0",
-    "automattic/blocks-engine-php-transformer": "0.9.2"
+    "automattic/blocks-engine-php-transformer": "0.9.3"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66e402c510959b834c67ba2ebf65c2d7",
+    "content-hash": "e4ecbae123c791b1e941e53b2c485707",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "v0.9.2",
+            "version": "v0.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "a46bcf0e5ffab82bdc4df184fd92e54346868f21"
+                "reference": "580b9a92695a6036b7aa2806425c7c67097e6464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/a46bcf0e5ffab82bdc4df184fd92e54346868f21",
-                "reference": "a46bcf0e5ffab82bdc4df184fd92e54346868f21",
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/580b9a92695a6036b7aa2806425c7c67097e6464",
+                "reference": "580b9a92695a6036b7aa2806425c7c67097e6464",
                 "shasum": ""
             },
             "require": {
@@ -91,7 +91,7 @@
                 "issues": "https://github.com/Automattic/blocks-engine/issues",
                 "source": "https://github.com/Automattic/blocks-engine-php-transformer"
             },
-            "time": "2026-09-03T15:23:32+00:00"
+            "time": "2026-09-04T13:03:53+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/tests/smoke-webfont-producer-consumer.php
+++ b/tests/smoke-webfont-producer-consumer.php
@@ -44,7 +44,7 @@ $assert = static function ( bool $condition, string $message ): void {
 	if ( ! $condition ) throw new RuntimeException( $message );
 };
 
-$assert( 'v0.9.2' === \Composer\InstalledVersions::getPrettyVersion( 'automattic/blocks-engine-php-transformer' ), 'producer-consumer integration runs against the locked Blocks Engine php-transformer v0.9.2 dependency' );
+$assert( 'v0.9.3' === \Composer\InstalledVersions::getPrettyVersion( 'automattic/blocks-engine-php-transformer' ), 'producer-consumer integration runs against the locked Blocks Engine php-transformer v0.9.3 dependency' );
 
 $fixture_html = '<!doctype html><html><head><link rel="stylesheet" href="css/style.css"></head><body><main>Inter fixture</main></body></html>';
 $fixture_css  = "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');\n:root{--font:'Inter',system-ui,sans-serif}body{font-family:var(--font)}";


### PR DESCRIPTION
## Summary

Bump the pinned Blocks Engine PHP transformer from `0.9.2` to `0.9.3`.

`php-transformer-v0.9.3` is the first release containing Automattic/blocks-engine#1545, which preserves runtime-targeted authored inputs, structured documentation navigation, breadcrumb flow geometry, syntax token styles, and native code/grid defaults.

## Changes

- `composer.json` / `composer.lock`: pin `automattic/blocks-engine-php-transformer` to `0.9.3`
- `tests/smoke-webfont-producer-consumer.php`: update the locked-dependency assertion to `v0.9.3`

## Verification

- `composer update automattic/blocks-engine-php-transformer` resolves `v0.9.3`
- Verified the vendored package contains the #1545 navigation fix
- 78 standalone PHP smoke tests pass locally
- Remaining PHPUnit classes and the solved-site promotion gate run in CI

## AI Assistance

OpenAI `gpt-5.6-sol` was used through OpenCode to perform the dependency bump, update the version assertion, run local smoke verification, and prepare this pull request. Reviewed and orchestrated by Chris Huber.